### PR TITLE
Add success variant to Button

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -39,9 +39,30 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 <Button variant="secondary" disabled>Cancel</Button>
 ```
 
-- `variant`: `primary` (default — one per section) / `secondary` / `ghost` / `danger`
+- `variant`: `primary` (default — one per section) / `secondary` / `ghost` / `danger` / `success`
 - `size`: `sm` / `md` (default) / `lg`
 - Always renders `<button type="button">` unless you pass `type="submit"`.
+- `variant="success"` is a **transient confirmation state**, not an action intent. Flip to it for ~1.5s after the action resolves, then flip back to `primary`. The timer is the consumer's responsibility — Button stays stateless. Never render a button as `success` on initial mount. Track the timer in a `useRef` and clear on unmount + on rapid re-clicks so the flash doesn't outlive the component or get cut short.
+
+  ```tsx
+  const [saved, setSaved] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    [],
+  );
+  const handleSave = async () => {
+    await save();
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setSaved(true);
+    timerRef.current = setTimeout(() => setSaved(false), 1500);
+  };
+  <Button variant={saved ? 'success' : 'primary'} onClick={handleSave}>
+    {saved ? 'Saved!' : 'Save'}
+  </Button>
+  ```
 
 ### `<Input>` — single-line text
 
@@ -160,7 +181,7 @@ All available as CSS custom properties after you import `global.scss`:
 |---|---|
 | Neutral colors | `--color-bg`, `--color-bg-subtle`, `--color-bg-muted`, `--color-bg-sunken`, `--color-border`, `--color-border-strong`, `--color-fg`, `--color-fg-muted`, `--color-fg-subtle`, `--color-fg-disabled` |
 | Accent colors | `--color-accent`, `--color-accent-hover`, `--color-accent-pressed`, `--color-accent-fg`, `--color-accent-subtle-bg` |
-| Semantic colors | `--color-danger`, `--color-danger-hover`, `--color-danger-fg`, `--color-success`, `--color-warning`, `--color-info` |
+| Semantic colors | `--color-danger`, `--color-danger-hover`, `--color-danger-fg`, `--color-success`, `--color-success-hover`, `--color-success-fg`, `--color-warning`, `--color-info` |
 | Badge palette | `--color-badge-{neutral,info,success,warning,danger,purple}-{bg,fg}` |
 | Avatar palette | `--color-avatar-fg`, `--color-avatar-1` through `--color-avatar-6` |
 | Spacing | `--space-0` `--space-1` (4) `--space-2` (8) `--space-3` (12) `--space-4` (16) `--space-5` (20) `--space-6` (24) `--space-8` (32) `--space-10` (40) `--space-12` (48) `--space-16` (64) |
@@ -172,7 +193,7 @@ All available as CSS custom properties after you import `global.scss`:
 | Borders | `--border-width` (1) / `--border-width-emphasis` (2) / `--border-width-strong` (3) |
 | Letter spacing | `--letter-spacing-caps` (0.03em) |
 | Shadows | `--shadow-sm` / `--shadow-md` / `--shadow-lg` |
-| Focus rings | `--ring-accent` / `--ring-danger` / `--ring-width` |
+| Focus rings | `--ring-accent` / `--ring-danger` / `--ring-success` / `--ring-width` |
 | Motion | `--transition-fast` (100ms) / `--transition-base` (140ms) |
 | Layer (z-index) | `--z-dropdown` / `--z-modal` / `--z-toast` |
 
@@ -190,6 +211,7 @@ All available as CSS custom properties after you import `global.scss`:
 | `<Card><Card>...</Card></Card>` | Use spacing or a divider inside one card |
 | `<Button style={{ marginLeft: 'auto' }}>` | `<Cluster justify="between">` or `<Cluster justify="end">` |
 | Two `<Button variant="primary">` in the same section | One primary, others `secondary` |
+| `<Button variant="success">Save</Button>` rendered on initial mount | `success` is transient — start as `primary`, flip to `success` for ~1.5s after the action resolves, flip back |
 | `<Avatar name="" />` | `name` is required and is the accessible label |
 | `import { Button } from '@eocrm/design-system/src/components/Button'` | `import { Button } from '@eocrm/design-system'` |
 | `<Badge onClick={...}>` | Badges are non-interactive — use a `Button` |

--- a/packages/design-system/src/components/Button/Button.module.scss
+++ b/packages/design-system/src/components/Button/Button.module.scss
@@ -88,3 +88,16 @@
     @include focus-ring(var(--ring-danger));
   }
 }
+
+.success {
+  background: var(--color-success);
+  color: var(--color-success-fg);
+
+  &:hover:not(:disabled) {
+    background: var(--color-success-hover);
+  }
+
+  &:focus-visible {
+    @include focus-ring(var(--ring-success));
+  }
+}

--- a/packages/design-system/src/components/Button/Button.test.tsx
+++ b/packages/design-system/src/components/Button/Button.test.tsx
@@ -25,6 +25,11 @@ describe('Button', () => {
     expect(btn.className).toMatch(/lg/);
   });
 
+  it('applies the success variant class name', () => {
+    render(<Button variant="success">Saved!</Button>);
+    expect(screen.getByRole('button', { name: 'Saved!' }).className).toMatch(/success/);
+  });
+
   it('merges the className prop with internal classes', () => {
     render(<Button className="external">Hi</Button>);
     const btn = screen.getByRole('button', { name: 'Hi' });

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import styles from './Button.module.scss';
 
 /** Visual variant. See ButtonProps#variant for when to use each. */
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'success';
 
 /** Control height. See ButtonProps#size for when to use each. */
 export type ButtonSize = 'sm' | 'md' | 'lg';
@@ -15,6 +15,11 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    * - `secondary` — supporting actions like "Cancel", "Export", "Filter".
    * - `ghost` — tertiary actions in dense UIs (toolbar buttons, row actions).
    * - `danger` — destructive operations only (Delete, Revoke, Remove). Pair with a confirmation if irreversible.
+   * - `success` — **transient confirmation only**, not an initial state. Flip to
+   *   `success` for ~1.5s after an action resolves (Save → "Saved!"), then
+   *   flip back. Never render a button as `success` on mount — it has no
+   *   action-intent meaning, only post-action feedback. See the `@example`
+   *   below for the timer pattern.
    */
   variant?: ButtonVariant;
   /**
@@ -46,6 +51,30 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  *   <Button type="submit">Save</Button>
  * </Cluster>
  *
+ * @example
+ * // Transient success confirmation (~1.5s). The timer is the consumer's
+ * // responsibility — the variant is just paint. Track the timer in a ref so
+ * // you can clear it on unmount (prevents a setState-after-unmount warning)
+ * // and on a rapid second click (prevents the new flash from being cut short
+ * // by the previous timer firing).
+ * const [saved, setSaved] = useState(false);
+ * const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+ * useEffect(
+ *   () => () => {
+ *     if (timerRef.current) clearTimeout(timerRef.current);
+ *   },
+ *   [],
+ * );
+ * const handleSave = async () => {
+ *   await save();
+ *   if (timerRef.current) clearTimeout(timerRef.current);
+ *   setSaved(true);
+ *   timerRef.current = setTimeout(() => setSaved(false), 1500);
+ * };
+ * <Button variant={saved ? 'success' : 'primary'} onClick={handleSave}>
+ *   {saved ? 'Saved!' : 'Save'}
+ * </Button>
+ *
  * @remarks When NOT to use
  * - Navigation to another URL → use a router-aware `<Link>` (not yet shipped).
  * - Toggle state (on/off) → use `Switch` or `Checkbox` (not yet shipped), not
@@ -62,6 +91,9 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  *   visual size, that's a missing variant — request it, don't hack it.
  * - ❌ Using `variant="ghost"` for the page's primary action. Users won't
  *   discover it.
+ * - ❌ Rendering `<Button variant="success">Save</Button>` on initial mount.
+ *   `success` is a confirmation state, not an action intent — start as
+ *   `primary` and flip to `success` after the action resolves.
  */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   { variant = 'primary', size = 'md', className, type = 'button', ...props },

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -23,6 +23,8 @@
   --color-danger-hover: #bf2600;
   --color-danger-fg: #ffffff;
   --color-success: #00875a;
+  --color-success-hover: #006644;
+  --color-success-fg: #ffffff;
   --color-warning: #ff991f;
   --color-info: #0052cc;
 
@@ -54,6 +56,7 @@
   // Focus rings
   --ring-accent: rgb(76 154 255 / 50%);
   --ring-danger: rgb(222 53 11 / 40%);
+  --ring-success: rgb(0 135 90 / 40%);
   --ring-width: 2px;
 
   // Spacing — 4px scale

--- a/packages/playground/src/pages/demo/ButtonDemo.tsx
+++ b/packages/playground/src/pages/demo/ButtonDemo.tsx
@@ -1,10 +1,42 @@
-import { Plus, Search, Trash2 } from 'lucide-react';
-import { Button } from '@eocrm/design-system';
-import { Cluster } from '@eocrm/design-system';
+import { useEffect, useRef, useState } from 'react';
+import { Check, Plus, Search, Trash2 } from 'lucide-react';
+import { Button, Cluster } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import tsxSource from '@lib-source/components/Button/Button.tsx?raw';
 import scssSource from '@lib-source/components/Button/Button.module.scss?raw';
+
+function SaveWithSuccessFlash() {
+  const [saved, setSaved] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    [],
+  );
+
+  const handleClick = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setSaved(true);
+    timerRef.current = setTimeout(() => setSaved(false), 1500);
+  };
+
+  return (
+    <Cluster gap="sm">
+      <Button variant={saved ? 'success' : 'primary'} onClick={handleClick}>
+        {saved ? (
+          <>
+            <Check size={14} /> Saved!
+          </>
+        ) : (
+          'Save'
+        )}
+      </Button>
+    </Cluster>
+  );
+}
 
 export function ButtonDemo() {
   return (
@@ -18,18 +50,52 @@ export function ButtonDemo() {
     >
       <Example
         title="Variants"
-        description="Four visual variants. Use primary for the page's main action, secondary for supporting actions, ghost for tertiary actions in dense UIs, danger for destructive operations."
+        description="Five visual variants. Use primary for the page's main action, secondary for supporting actions, ghost for tertiary actions in dense UIs, danger for destructive operations. The success variant is a transient confirmation state — see the next example."
         code={`<Button variant="primary">Primary</Button>
 <Button variant="secondary">Secondary</Button>
 <Button variant="ghost">Ghost</Button>
-<Button variant="danger">Danger</Button>`}
+<Button variant="danger">Danger</Button>
+<Button variant="success">Success</Button>`}
       >
         <Cluster gap="sm">
           <Button variant="primary">Primary</Button>
           <Button variant="secondary">Secondary</Button>
           <Button variant="ghost">Ghost</Button>
           <Button variant="danger">Danger</Button>
+          <Button variant="success">Success</Button>
         </Cluster>
+      </Example>
+
+      <Example
+        title="Success flash (transient confirmation)"
+        description="Use the success variant for ~1.5s after an action resolves, then flip back. The timer lives in the consumer, not in Button — this keeps Button stateless and lets you pick any duration. Click Save to try it."
+        code={`function SaveWithSuccessFlash() {
+  const [saved, setSaved] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    [],
+  );
+
+  const handleClick = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setSaved(true);
+    timerRef.current = setTimeout(() => setSaved(false), 1500);
+  };
+
+  return (
+    <Cluster gap="sm">
+      <Button variant={saved ? 'success' : 'primary'} onClick={handleClick}>
+        {saved ? <><Check size={14} /> Saved!</> : 'Save'}
+      </Button>
+    </Cluster>
+  );
+}`}
+      >
+        <SaveWithSuccessFlash />
       </Example>
 
       <Example


### PR DESCRIPTION
## Summary

- New `variant="success"` for `<Button>` — a transient confirmation state (~1.5s after an action resolves), not an action intent. Timer lives in the consumer so Button stays stateless and the duration is callsite-flexible.
- New tokens: `--color-success-hover`, `--color-success-fg`, `--ring-success` (success bg already existed).
- Canonical agent-facing example uses `useRef` + `useEffect` cleanup so consumers don't copy a `setTimeout`-without-cleanup footgun. Same pattern mirrored in JSDoc, AGENTS.md, and the playground demo.
- Anti-pattern documented in JSDoc and the AGENTS.md anti-patterns table: never render `success` on initial mount.

## Test plan

- [x] `npm test` — 131 passing (added one variant-class assertion in `Button.test.tsx`)
- [x] `npm run typecheck` — both workspaces clean
- [x] `npm run lint:css` — clean
- [x] `npm run build` — playground builds
- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files in tarball; 33 files, 23 kB
- [x] Rule 8 review-fix loop: two passes; second verdict `clean enough to stop`
- [ ] Manually click through the new "Success flash" demo at `/demo/button` and confirm the green-flash → primary revert behavior

## Design notes

- `success` is shipped as a stateless variant (no internal timer). Other variants are paint-only, and baking ~1500ms of state into one variant would couple the visual to a behavior and hard-code the duration. Consumer pattern is documented end-to-end.
- Test coverage matches the depth of existing variants (class-application only); deeper success-only behavioral tests would be asymmetric with `danger`/`ghost`/`secondary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)