### PR TITLE
Add Prettier + enforce in Quality CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: "22"
 
       - name: Install
         run: npm ci

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,11 +22,14 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install
         run: npm ci
+
+      - name: Prettier
+        run: npm run format:check
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,14 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/**'
-      - '.github/workflows/**'
+      - "packages/**"
+      - ".github/workflows/**"
 
 permissions:
-  contents: write   # push the new git tag
-  packages: write   # publish to GitHub Packages
-  pages: write      # forwarded to the chained deploy-playground job
-  id-token: write   # forwarded to the chained deploy-playground job
+  contents: write # push the new git tag
+  packages: write # publish to GitHub Packages
+  pages: write # forwarded to the chained deploy-playground job
+  id-token: write # forwarded to the chained deploy-playground job
 
 env:
   BUMP: patch
@@ -84,11 +84,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: "22"
           # This writes .npmrc with the @eocrm scope pointed at GitHub Packages
           # and wires NODE_AUTH_TOKEN for the publish step below.
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@eocrm'
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@eocrm"
 
       - name: Install
         run: npm ci

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,20 @@
+# Build output
+dist/
+dist-ssr/
+**/dist/
+*.tsbuildinfo
+
+# Dependencies
+node_modules/
+
+# Lockfiles — managed by the package manager
+package-lock.json
+
+# Vite caches
+.vite/
+
+# Tooling caches
+.playwright-mcp/
+
+# Screenshots captured by dev workflow
+*.png

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,27 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "jsxSingleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "overrides": [
+    {
+      "files": ["*.md"],
+      "options": {
+        "proseWrap": "preserve"
+      }
+    },
+    {
+      "files": ["*.yml", "*.yaml"],
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,19 +33,21 @@ Missing any of these = component does not exist as far as the design system is c
 **Code, configs, and workflows go through PRs — direct pushes to `main` are prohibited.**
 
 Applies to:
+
 - Source code (`*.ts`, `*.tsx`, `*.scss`, `*.css`, `*.js`)
 - Build / lint / test config (`package.json`, `tsconfig*.json`, `.stylelintrc.json`, `vite.config.ts`, `vitest.*.ts`, `Makefile`)
 - GitHub workflows (`.github/workflows/**`)
 - `.gitignore`, `.npmignore`, `.npmrc`, anything that affects the build, test, or release pipeline
 
 Process for those:
+
 1. Branch off `main` (`git checkout -b <kind>/<short-description>`)
 2. Commit + push the branch
 3. Open a PR (`gh pr create`)
 4. Wait for the `Quality / check` status check to pass
 5. Merge (squash or merge commit — caller's choice)
 
-**Standalone docs may be direct-pushed.** A `.md` change that is NOT bundled with a code/config/workflow change — typo fixes, restructures, new clarifications, JSDoc-style markdown — can go straight to `main`. Examples: editing root `README.md`, root `CLAUDE.md`, `packages/design-system/AGENTS.md`, `packages/design-system/guidance.md`. If the doc change is *part of* a code change (e.g., adding a component AND its guidance.md entry), it goes through the same PR as the code.
+**Standalone docs may be direct-pushed.** A `.md` change that is NOT bundled with a code/config/workflow change — typo fixes, restructures, new clarifications, JSDoc-style markdown — can go straight to `main`. Examples: editing root `README.md`, root `CLAUDE.md`, `packages/design-system/AGENTS.md`, `packages/design-system/guidance.md`. If the doc change is _part of_ a code change (e.g., adding a component AND its guidance.md entry), it goes through the same PR as the code.
 
 **Explicit override**: the user may authorize a direct push for any specific change ("just push it", "no PR needed", etc.). When in doubt, default to branch + PR for code; default to direct-push for standalone docs.
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ eocrm/design-system/
 
 ## CI/CD
 
-| Trigger | What runs |
-|---|---|
-| **Pull request** | `quality.yml` — typecheck + test + lint + build + tarball-contents check |
+| Trigger            | What runs                                                                                                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pull request**   | `quality.yml` — typecheck + test + lint + build + tarball-contents check                                                                                                      |
 | **Push to `main`** | `release.yml` → quality, then auto-bumps patch version, publishes `@eocrm/design-system` to GitHub Packages, creates `vX.Y.Z` git tag, deploys the playground to GitHub Pages |
 
 Every release is gated by quality. There are no manual workflow buttons — the only way to release is to merge to `main`. To force a minor/major bump, edit `BUMP` in `release.yml` on a branch and merge.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "prettier": "3.8.3",
         "stylelint": "^16.12.0",
         "stylelint-config-standard-scss": "^14.0.0",
         "stylelint-declaration-strict-value": "^1.10.7",
@@ -3771,6 +3772,22 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,13 @@
     "build:lib": "npm run typecheck -w @eocrm/design-system",
     "preview": "npm run preview -w playground",
     "lint:css": "stylelint \"packages/**/src/**/*.{css,scss}\"",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "test": "npm test --workspaces --if-present"
   },
   "devDependencies": {
+    "prettier": "3.8.3",
     "stylelint": "^16.12.0",
     "stylelint-config-standard-scss": "^14.0.0",
     "stylelint-declaration-strict-value": "^1.10.7",

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -61,7 +61,7 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
   };
   <Button variant={saved ? 'success' : 'primary'} onClick={handleSave}>
     {saved ? 'Saved!' : 'Save'}
-  </Button>
+  </Button>;
   ```
 
 ### `<Input>` — single-line text
@@ -162,8 +162,10 @@ const [tab, setTab] = useState('overview');
   ]}
   activeId={tab}
   onChange={setTab}
-/>
-{tab === 'overview' && <OverviewPanel />}
+/>;
+{
+  tab === 'overview' && <OverviewPanel />;
+}
 ```
 
 - `items: { id, label, count? }[]` — `id` must be unique.
@@ -177,46 +179,46 @@ const [tab, setTab] = useState('overview');
 
 All available as CSS custom properties after you import `global.scss`:
 
-| Family | Tokens |
-|---|---|
-| Neutral colors | `--color-bg`, `--color-bg-subtle`, `--color-bg-muted`, `--color-bg-sunken`, `--color-border`, `--color-border-strong`, `--color-fg`, `--color-fg-muted`, `--color-fg-subtle`, `--color-fg-disabled` |
-| Accent colors | `--color-accent`, `--color-accent-hover`, `--color-accent-pressed`, `--color-accent-fg`, `--color-accent-subtle-bg` |
-| Semantic colors | `--color-danger`, `--color-danger-hover`, `--color-danger-fg`, `--color-success`, `--color-success-hover`, `--color-success-fg`, `--color-warning`, `--color-info` |
-| Badge palette | `--color-badge-{neutral,info,success,warning,danger,purple}-{bg,fg}` |
-| Avatar palette | `--color-avatar-fg`, `--color-avatar-1` through `--color-avatar-6` |
-| Spacing | `--space-0` `--space-1` (4) `--space-2` (8) `--space-3` (12) `--space-4` (16) `--space-5` (20) `--space-6` (24) `--space-8` (32) `--space-10` (40) `--space-12` (48) `--space-16` (64) |
-| Radii | `--radius-sm` (3) / `--radius-md` (4) / `--radius-lg` (8) / `--radius-full` |
-| Font sizes | `--font-size-xs/sm/md/lg/xl/2xl/3xl`, `--font-size-code` (0.92em for inline mono) |
-| Font weights | `--font-weight-regular/medium/semibold/bold` |
-| Line heights | `--line-height-tight` / `--line-height-normal` / `--line-height-none` (1) |
-| Control sizes | `--size-sm/md/lg` (heights), `--size-badge` (20), `--size-chip` (18) |
-| Borders | `--border-width` (1) / `--border-width-emphasis` (2) / `--border-width-strong` (3) |
-| Letter spacing | `--letter-spacing-caps` (0.03em) |
-| Shadows | `--shadow-sm` / `--shadow-md` / `--shadow-lg` |
-| Focus rings | `--ring-accent` / `--ring-danger` / `--ring-success` / `--ring-width` |
-| Motion | `--transition-fast` (100ms) / `--transition-base` (140ms) |
-| Layer (z-index) | `--z-dropdown` / `--z-modal` / `--z-toast` |
+| Family          | Tokens                                                                                                                                                                                              |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Neutral colors  | `--color-bg`, `--color-bg-subtle`, `--color-bg-muted`, `--color-bg-sunken`, `--color-border`, `--color-border-strong`, `--color-fg`, `--color-fg-muted`, `--color-fg-subtle`, `--color-fg-disabled` |
+| Accent colors   | `--color-accent`, `--color-accent-hover`, `--color-accent-pressed`, `--color-accent-fg`, `--color-accent-subtle-bg`                                                                                 |
+| Semantic colors | `--color-danger`, `--color-danger-hover`, `--color-danger-fg`, `--color-success`, `--color-success-hover`, `--color-success-fg`, `--color-warning`, `--color-info`                                  |
+| Badge palette   | `--color-badge-{neutral,info,success,warning,danger,purple}-{bg,fg}`                                                                                                                                |
+| Avatar palette  | `--color-avatar-fg`, `--color-avatar-1` through `--color-avatar-6`                                                                                                                                  |
+| Spacing         | `--space-0` `--space-1` (4) `--space-2` (8) `--space-3` (12) `--space-4` (16) `--space-5` (20) `--space-6` (24) `--space-8` (32) `--space-10` (40) `--space-12` (48) `--space-16` (64)              |
+| Radii           | `--radius-sm` (3) / `--radius-md` (4) / `--radius-lg` (8) / `--radius-full`                                                                                                                         |
+| Font sizes      | `--font-size-xs/sm/md/lg/xl/2xl/3xl`, `--font-size-code` (0.92em for inline mono)                                                                                                                   |
+| Font weights    | `--font-weight-regular/medium/semibold/bold`                                                                                                                                                        |
+| Line heights    | `--line-height-tight` / `--line-height-normal` / `--line-height-none` (1)                                                                                                                           |
+| Control sizes   | `--size-sm/md/lg` (heights), `--size-badge` (20), `--size-chip` (18)                                                                                                                                |
+| Borders         | `--border-width` (1) / `--border-width-emphasis` (2) / `--border-width-strong` (3)                                                                                                                  |
+| Letter spacing  | `--letter-spacing-caps` (0.03em)                                                                                                                                                                    |
+| Shadows         | `--shadow-sm` / `--shadow-md` / `--shadow-lg`                                                                                                                                                       |
+| Focus rings     | `--ring-accent` / `--ring-danger` / `--ring-success` / `--ring-width`                                                                                                                               |
+| Motion          | `--transition-fast` (100ms) / `--transition-base` (140ms)                                                                                                                                           |
+| Layer (z-index) | `--z-dropdown` / `--z-modal` / `--z-toast`                                                                                                                                                          |
 
 ---
 
 ## Anti-patterns to never generate
 
-| Don't write | Write instead |
-|---|---|
-| `color: #ffffff` in any SCSS | `color: var(--color-bg)` (or the right semantic token) |
-| `border: 1px solid var(--color-border)` | `border: var(--border-width) solid var(--color-border)` |
-| `opacity: 0.5` | `opacity: var(--opacity-disabled)` (or use the `disabled` attribute) |
-| `<button onClick={...}>Save</button>` | `<Button onClick={...}>Save</Button>` |
-| `<input value={...} onChange={...} />` | `<Input value={...} onChange={...} />` |
-| `<Card><Card>...</Card></Card>` | Use spacing or a divider inside one card |
-| `<Button style={{ marginLeft: 'auto' }}>` | `<Cluster justify="between">` or `<Cluster justify="end">` |
-| Two `<Button variant="primary">` in the same section | One primary, others `secondary` |
-| `<Button variant="success">Save</Button>` rendered on initial mount | `success` is transient — start as `primary`, flip to `success` for ~1.5s after the action resolves, flip back |
-| `<Avatar name="" />` | `name` is required and is the accessible label |
-| `import { Button } from '@eocrm/design-system/src/components/Button'` | `import { Button } from '@eocrm/design-system'` |
-| `<Badge onClick={...}>` | Badges are non-interactive — use a `Button` |
-| 3-digit hex (`#fff`) anywhere | Always 6-digit (`#ffffff`) |
-| `margin` on or around design-system components in your SCSS | Wrap in `<Stack>` / `<Cluster>` or set spacing on the parent's flex/grid |
+| Don't write                                                           | Write instead                                                                                                 |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `color: #ffffff` in any SCSS                                          | `color: var(--color-bg)` (or the right semantic token)                                                        |
+| `border: 1px solid var(--color-border)`                               | `border: var(--border-width) solid var(--color-border)`                                                       |
+| `opacity: 0.5`                                                        | `opacity: var(--opacity-disabled)` (or use the `disabled` attribute)                                          |
+| `<button onClick={...}>Save</button>`                                 | `<Button onClick={...}>Save</Button>`                                                                         |
+| `<input value={...} onChange={...} />`                                | `<Input value={...} onChange={...} />`                                                                        |
+| `<Card><Card>...</Card></Card>`                                       | Use spacing or a divider inside one card                                                                      |
+| `<Button style={{ marginLeft: 'auto' }}>`                             | `<Cluster justify="between">` or `<Cluster justify="end">`                                                    |
+| Two `<Button variant="primary">` in the same section                  | One primary, others `secondary`                                                                               |
+| `<Button variant="success">Save</Button>` rendered on initial mount   | `success` is transient — start as `primary`, flip to `success` for ~1.5s after the action resolves, flip back |
+| `<Avatar name="" />`                                                  | `name` is required and is the accessible label                                                                |
+| `import { Button } from '@eocrm/design-system/src/components/Button'` | `import { Button } from '@eocrm/design-system'`                                                               |
+| `<Badge onClick={...}>`                                               | Badges are non-interactive — use a `Button`                                                                   |
+| 3-digit hex (`#fff`) anywhere                                         | Always 6-digit (`#ffffff`)                                                                                    |
+| `margin` on or around design-system components in your SCSS           | Wrap in `<Stack>` / `<Cluster>` or set spacing on the parent's flex/grid                                      |
 
 ---
 

--- a/packages/design-system/CLAUDE.md
+++ b/packages/design-system/CLAUDE.md
@@ -21,6 +21,7 @@ A new `<Name>.tsx` requires `<Name>.test.tsx` next to it. Minimum coverage:
 **Vitest is configured with `globals: true`.** Tests do NOT import `describe`, `it`, `expect`, or `vi` — they're global. React Testing Library auto-cleans the DOM between tests.
 
 Imports tests DO need:
+
 - `render`, `screen` from `@testing-library/react`
 - `userEvent` (default) from `@testing-library/user-event`
 - The component under test
@@ -46,7 +47,7 @@ Forbidden inside a component's `.module.scss`:
 - `width` other than `100%` of intrinsic / `auto`
 - `grid-column` / `grid-row`
 
-These are the *parent's* responsibility. If a CRM page needs to position a Button, it does so via its own `.module.scss` (passed via `className`) or by wrapping in `Stack`/`Cluster`.
+These are the _parent's_ responsibility. If a CRM page needs to position a Button, it does so via its own `.module.scss` (passed via `className`) or by wrapping in `Stack`/`Cluster`.
 
 ### 5. Export discipline
 
@@ -112,6 +113,7 @@ Before pushing changes that touch `packages/design-system/**`, run the review-fi
 7. **Repeat** until the verdict is `clean enough to stop`.
 
 **Hard exit criteria**:
+
 - 0 Critical, 0 Important findings (or each remaining one has an explicit documented skip)
 - All four gates (test, typecheck, lint, build) green
 - `npm pack --dry-run` shows no test files or internal-only paths in the tarball
@@ -143,6 +145,7 @@ src/components/<Name>/
 ```
 
 Then:
+
 - Update `src/index.ts` (rule 5)
 - Add the playground demo (rule 2)
 - Update `AGENTS.md` with a one-section TL;DR + canonical snippet for the new component

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -32,9 +32,7 @@ npm install @eocrm/design-system
 import '@eocrm/design-system/styles/global.scss';
 
 // Anywhere:
-import {
-  Button, Input, Card, Stack, Cluster, Badge, Avatar, Tabs,
-} from '@eocrm/design-system';
+import { Button, Input, Card, Stack, Cluster, Badge, Avatar, Tabs } from '@eocrm/design-system';
 ```
 
 ---
@@ -66,16 +64,16 @@ If TypeScript can't resolve types, set `moduleResolution: "bundler"` (or `"node1
 
 ## Components
 
-| Component | One-line | Detail |
-|---|---|---|
-| `<Button>` | Action triggers | Hover in editor for JSDoc |
-| `<Input>` | Single-line text | Hover in editor for JSDoc |
-| `<Card>` | Bordered content container | Hover in editor for JSDoc |
-| `<Stack>` | Vertical layout primitive | Hover in editor for JSDoc |
-| `<Cluster>` | Horizontal layout (wraps) | Hover in editor for JSDoc |
-| `<Avatar>` | Profile circle | Hover in editor for JSDoc |
-| `<Badge>` | Status / category pill | Hover in editor for JSDoc |
-| `<Tabs>` | Horizontal tab strip | Hover in editor for JSDoc |
+| Component   | One-line                   | Detail                    |
+| ----------- | -------------------------- | ------------------------- |
+| `<Button>`  | Action triggers            | Hover in editor for JSDoc |
+| `<Input>`   | Single-line text           | Hover in editor for JSDoc |
+| `<Card>`    | Bordered content container | Hover in editor for JSDoc |
+| `<Stack>`   | Vertical layout primitive  | Hover in editor for JSDoc |
+| `<Cluster>` | Horizontal layout (wraps)  | Hover in editor for JSDoc |
+| `<Avatar>`  | Profile circle             | Hover in editor for JSDoc |
+| `<Badge>`   | Status / category pill     | Hover in editor for JSDoc |
+| `<Tabs>`    | Horizontal tab strip       | Hover in editor for JSDoc |
 
 Every prop and variant is JSDoc'd at the source. For a quick reference + canonical snippets + tokens table + anti-patterns, see [AGENTS.md](./AGENTS.md).
 
@@ -90,6 +88,7 @@ The library publishes to GitHub Packages via a manual GitHub Actions workflow (`
 3. Choose a bump (`patch` default) or set an explicit version.
 
 The workflow:
+
 - Reads the latest `v*` git tag and computes the next version (or uses your override).
 - Refuses if the tag already exists.
 - Runs `typecheck`, `test`, and a playground smoke build.

--- a/packages/design-system/src/components/Avatar/Avatar.test.tsx
+++ b/packages/design-system/src/components/Avatar/Avatar.test.tsx
@@ -99,10 +99,22 @@ describe('Avatar', () => {
   it('avatarColorIndex covers the full 1–6 palette over a varied input set', () => {
     // 16 distinct names should hit every palette slot at least once.
     const names = [
-      'Alex Rivera', 'Jordan Park', 'Sam Chen', 'Maya Owens',
-      'Priya Shah', 'Marcus Lin', 'Diana Okafor', 'Tomás Reyes',
-      'Ola Berg', 'Hideo Tanaka', 'Lena Ivanova', 'Aki Tanaka',
-      'Chris Park', 'Noah West', 'Emma Bell', 'Kai Fischer',
+      'Alex Rivera',
+      'Jordan Park',
+      'Sam Chen',
+      'Maya Owens',
+      'Priya Shah',
+      'Marcus Lin',
+      'Diana Okafor',
+      'Tomás Reyes',
+      'Ola Berg',
+      'Hideo Tanaka',
+      'Lena Ivanova',
+      'Aki Tanaka',
+      'Chris Park',
+      'Noah West',
+      'Emma Bell',
+      'Kai Fischer',
     ];
     const slots = new Set(names.map((n) => avatarColorIndex(n)));
     expect(slots.size).toBeGreaterThanOrEqual(5);
@@ -127,9 +139,7 @@ describe('Avatar', () => {
   });
 
   it('does not emit an empty style attribute when the consumer passes style={{}}', () => {
-    const { container } = render(
-      <Avatar name="Alex" src="https://example.com/a.jpg" style={{}} />,
-    );
+    const { container } = render(<Avatar name="Alex" src="https://example.com/a.jpg" style={{}} />);
     expect(container.firstChild).not.toHaveAttribute('style');
   });
 });

--- a/packages/design-system/src/components/Avatar/Avatar.tsx
+++ b/packages/design-system/src/components/Avatar/Avatar.tsx
@@ -1,10 +1,4 @@
-import {
-  forwardRef,
-  useEffect,
-  useState,
-  type CSSProperties,
-  type HTMLAttributes,
-} from 'react';
+import { forwardRef, useEffect, useState, type CSSProperties, type HTMLAttributes } from 'react';
 import clsx from 'clsx';
 import styles from './Avatar.module.scss';
 
@@ -113,8 +107,7 @@ export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(function Avatar(
 
   // Treat empty/whitespace `src` as "no image" so we don't render <img src="">.
   // Same effect when the image fails to load — fall back to initials.
-  const hasImage =
-    typeof src === 'string' && src.trim() !== '' && !imageBroken;
+  const hasImage = typeof src === 'string' && src.trim() !== '' && !imageBroken;
 
   // Always derive a safe label/alt — even if the consumer passes a whitespace
   // name with an image, we want a meaningful accessible name.
@@ -128,9 +121,7 @@ export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(function Avatar(
   // Only emit a style attribute when we actually have something to set —
   // checking truthiness alone would let an empty `style={{}}` prop emit `style=""`.
   const mergedStyle: StyleWithVars | undefined =
-    hasOwnProps(fallbackStyle) || hasOwnProps(style)
-      ? { ...fallbackStyle, ...style }
-      : undefined;
+    hasOwnProps(fallbackStyle) || hasOwnProps(style) ? { ...fallbackStyle, ...style } : undefined;
 
   if (hasImage) {
     // When showing a real image, the <img> itself carries the image role
@@ -146,11 +137,7 @@ export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(function Avatar(
         className={clsx(styles.avatar, sizeClass[size], className)}
         style={mergedStyle}
       >
-        <img
-          src={src}
-          alt={accessibleName}
-          onError={() => setImageBroken(true)}
-        />
+        <img src={src} alt={accessibleName} onError={() => setImageBroken(true)} />
       </span>
     );
   }

--- a/packages/design-system/src/components/Badge/Badge.tsx
+++ b/packages/design-system/src/components/Badge/Badge.tsx
@@ -69,11 +69,5 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
   { tone = 'neutral', className, ...props },
   ref,
 ) {
-  return (
-    <span
-      ref={ref}
-      className={clsx(styles.badge, toneClass[tone], className)}
-      {...props}
-    />
-  );
+  return <span ref={ref} className={clsx(styles.badge, toneClass[tone], className)} {...props} />;
 });

--- a/packages/design-system/src/components/Card/Card.test.tsx
+++ b/packages/design-system/src/components/Card/Card.test.tsx
@@ -13,16 +13,11 @@ describe('Card', () => {
     expect((container.firstChild as HTMLElement).className).toMatch(/paddingMd/);
   });
 
-  it.each<CardPadding>(['none', 'sm', 'md', 'lg'])(
-    'applies the %s padding class',
-    (padding) => {
-      const { container } = render(<Card padding={padding}>x</Card>);
-      const cap = padding[0].toUpperCase() + padding.slice(1);
-      expect((container.firstChild as HTMLElement).className).toMatch(
-        new RegExp(`padding${cap}`),
-      );
-    },
-  );
+  it.each<CardPadding>(['none', 'sm', 'md', 'lg'])('applies the %s padding class', (padding) => {
+    const { container } = render(<Card padding={padding}>x</Card>);
+    const cap = padding[0].toUpperCase() + padding.slice(1);
+    expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(`padding${cap}`));
+  });
 
   it('merges the className prop', () => {
     const { container } = render(<Card className="external">x</Card>);

--- a/packages/design-system/src/components/Card/Card.tsx
+++ b/packages/design-system/src/components/Card/Card.tsx
@@ -69,10 +69,6 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
   ref,
 ) {
   return (
-    <div
-      ref={ref}
-      className={clsx(styles.card, paddingClass[padding], className)}
-      {...props}
-    />
+    <div ref={ref} className={clsx(styles.card, paddingClass[padding], className)} {...props} />
   );
 });

--- a/packages/design-system/src/components/Cluster/Cluster.module.scss
+++ b/packages/design-system/src/components/Cluster/Cluster.module.scss
@@ -3,21 +3,62 @@
   flex-direction: row;
 }
 
-.wrap { flex-wrap: wrap; }
+.wrap {
+  flex-wrap: wrap;
+}
 
-.gapXs { gap: var(--space-1); }
-.gapSm { gap: var(--space-2); }
-.gapMd { gap: var(--space-3); }
-.gapLg { gap: var(--space-4); }
-.gapXl { gap: var(--space-6); }
-.gap2xl { gap: var(--space-8); }
+.gapXs {
+  gap: var(--space-1);
+}
 
-.justifyStart { justify-content: flex-start; }
-.justifyCenter { justify-content: center; }
-.justifyEnd { justify-content: flex-end; }
-.justifyBetween { justify-content: space-between; }
+.gapSm {
+  gap: var(--space-2);
+}
 
-.alignStart { align-items: flex-start; }
-.alignCenter { align-items: center; }
-.alignEnd { align-items: flex-end; }
-.alignBaseline { align-items: baseline; }
+.gapMd {
+  gap: var(--space-3);
+}
+
+.gapLg {
+  gap: var(--space-4);
+}
+
+.gapXl {
+  gap: var(--space-6);
+}
+
+.gap2xl {
+  gap: var(--space-8);
+}
+
+.justifyStart {
+  justify-content: flex-start;
+}
+
+.justifyCenter {
+  justify-content: center;
+}
+
+.justifyEnd {
+  justify-content: flex-end;
+}
+
+.justifyBetween {
+  justify-content: space-between;
+}
+
+.alignStart {
+  align-items: flex-start;
+}
+
+.alignCenter {
+  align-items: center;
+}
+
+.alignEnd {
+  align-items: flex-end;
+}
+
+.alignBaseline {
+  align-items: baseline;
+}

--- a/packages/design-system/src/components/Cluster/Cluster.test.tsx
+++ b/packages/design-system/src/components/Cluster/Cluster.test.tsx
@@ -1,11 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { createRef } from 'react';
-import {
-  Cluster,
-  type ClusterAlign,
-  type ClusterGap,
-  type ClusterJustify,
-} from './Cluster';
+import { Cluster, type ClusterAlign, type ClusterGap, type ClusterJustify } from './Cluster';
 
 const capitalize = (s: string) => s[0].toUpperCase() + s.slice(1);
 
@@ -24,14 +19,11 @@ describe('Cluster', () => {
     expect(el.className).toMatch(/wrap/);
   });
 
-  it.each<ClusterGap>(['xs', 'sm', 'md', 'lg', 'xl', '2xl'])(
-    'applies the %s gap class',
-    (gap) => {
-      const { container } = render(<Cluster gap={gap}>x</Cluster>);
-      const expected = gap === '2xl' ? 'gap2xl' : `gap${capitalize(gap)}`;
-      expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(expected));
-    },
-  );
+  it.each<ClusterGap>(['xs', 'sm', 'md', 'lg', 'xl', '2xl'])('applies the %s gap class', (gap) => {
+    const { container } = render(<Cluster gap={gap}>x</Cluster>);
+    const expected = gap === '2xl' ? 'gap2xl' : `gap${capitalize(gap)}`;
+    expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(expected));
+  });
 
   it.each<ClusterJustify>(['start', 'center', 'end', 'between'])(
     'applies the %s justify class',

--- a/packages/design-system/src/components/Input/Input.test.tsx
+++ b/packages/design-system/src/components/Input/Input.test.tsx
@@ -13,13 +13,7 @@ describe('Input', () => {
   it('round-trips a controlled value via onChange', async () => {
     function Wrapper() {
       const [v, setV] = useState('');
-      return (
-        <Input
-          placeholder="email"
-          value={v}
-          onChange={(e) => setV(e.target.value)}
-        />
-      );
+      return <Input placeholder="email" value={v} onChange={(e) => setV(e.target.value)} />;
     }
     const user = userEvent.setup();
     render(<Wrapper />);
@@ -54,9 +48,7 @@ describe('Input', () => {
   });
 
   it('forwards native HTML attributes (type, autoComplete)', () => {
-    render(
-      <Input placeholder="email" type="email" autoComplete="email" />,
-    );
+    render(<Input placeholder="email" type="email" autoComplete="email" />);
     const input = screen.getByPlaceholderText('email');
     expect(input).toHaveAttribute('type', 'email');
     expect(input).toHaveAttribute('autocomplete', 'email');
@@ -84,9 +76,7 @@ describe('Input', () => {
   it('honors readOnly — the attribute is set and typing does not change the value', async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
-    render(
-      <Input placeholder="email" value="locked" readOnly onChange={onChange} />,
-    );
+    render(<Input placeholder="email" value="locked" readOnly onChange={onChange} />);
     const input = screen.getByPlaceholderText('email') as HTMLInputElement;
     expect(input).toHaveAttribute('readonly');
     await user.type(input, 'x');

--- a/packages/design-system/src/components/Stack/Stack.module.scss
+++ b/packages/design-system/src/components/Stack/Stack.module.scss
@@ -3,14 +3,42 @@
   flex-direction: column;
 }
 
-.gapXs { gap: var(--space-1); }
-.gapSm { gap: var(--space-2); }
-.gapMd { gap: var(--space-3); }
-.gapLg { gap: var(--space-4); }
-.gapXl { gap: var(--space-6); }
-.gap2xl { gap: var(--space-8); }
+.gapXs {
+  gap: var(--space-1);
+}
 
-.alignStart { align-items: flex-start; }
-.alignCenter { align-items: center; }
-.alignEnd { align-items: flex-end; }
-.alignStretch { align-items: stretch; }
+.gapSm {
+  gap: var(--space-2);
+}
+
+.gapMd {
+  gap: var(--space-3);
+}
+
+.gapLg {
+  gap: var(--space-4);
+}
+
+.gapXl {
+  gap: var(--space-6);
+}
+
+.gap2xl {
+  gap: var(--space-8);
+}
+
+.alignStart {
+  align-items: flex-start;
+}
+
+.alignCenter {
+  align-items: center;
+}
+
+.alignEnd {
+  align-items: flex-end;
+}
+
+.alignStretch {
+  align-items: stretch;
+}

--- a/packages/design-system/src/components/Stack/Stack.test.tsx
+++ b/packages/design-system/src/components/Stack/Stack.test.tsx
@@ -17,24 +17,18 @@ describe('Stack', () => {
     expect(el.className).toMatch(/alignStretch/);
   });
 
-  it.each<StackGap>(['xs', 'sm', 'md', 'lg', 'xl', '2xl'])(
-    'applies the %s gap class',
-    (gap) => {
-      const { container } = render(<Stack gap={gap}>x</Stack>);
-      const expected = gap === '2xl' ? 'gap2xl' : `gap${capitalize(gap)}`;
-      expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(expected));
-    },
-  );
+  it.each<StackGap>(['xs', 'sm', 'md', 'lg', 'xl', '2xl'])('applies the %s gap class', (gap) => {
+    const { container } = render(<Stack gap={gap}>x</Stack>);
+    const expected = gap === '2xl' ? 'gap2xl' : `gap${capitalize(gap)}`;
+    expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(expected));
+  });
 
-  it.each<StackAlign>(['start', 'center', 'end', 'stretch'])(
-    'applies the %s align class',
-    (a) => {
-      const { container } = render(<Stack align={a}>x</Stack>);
-      expect((container.firstChild as HTMLElement).className).toMatch(
-        new RegExp(`align${capitalize(a)}`),
-      );
-    },
-  );
+  it.each<StackAlign>(['start', 'center', 'end', 'stretch'])('applies the %s align class', (a) => {
+    const { container } = render(<Stack align={a}>x</Stack>);
+    expect((container.firstChild as HTMLElement).className).toMatch(
+      new RegExp(`align${capitalize(a)}`),
+    );
+  });
 
   it('merges the className prop', () => {
     const { container } = render(<Stack className="external">x</Stack>);

--- a/packages/design-system/src/components/Tabs/Tabs.test.tsx
+++ b/packages/design-system/src/components/Tabs/Tabs.test.tsx
@@ -24,11 +24,7 @@ describe('Tabs', () => {
   it('marks only the active tab with aria-selected="true"', () => {
     render(<Tabs items={items} activeId="b" onChange={noop} />);
     const tabs = screen.getAllByRole('tab');
-    expect(tabs.map((t) => t.getAttribute('aria-selected'))).toEqual([
-      'false',
-      'true',
-      'false',
-    ]);
+    expect(tabs.map((t) => t.getAttribute('aria-selected'))).toEqual(['false', 'true', 'false']);
   });
 
   it('renders count chips for items with a count', () => {
@@ -68,20 +64,12 @@ describe('Tabs', () => {
     const user = userEvent.setup();
     render(<Wrapper />);
     await user.click(screen.getByRole('tab', { name: /Notes/ }));
-    expect(screen.getByRole('tab', { name: /Notes/ })).toHaveAttribute(
-      'aria-selected',
-      'true',
-    );
-    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
-      'aria-selected',
-      'false',
-    );
+    expect(screen.getByRole('tab', { name: /Notes/ })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'false');
   });
 
   it('merges the className prop on the tablist', () => {
-    render(
-      <Tabs items={items} activeId="a" onChange={noop} className="external" />,
-    );
+    render(<Tabs items={items} activeId="a" onChange={noop} className="external" />);
     expect(screen.getByRole('tablist').className).toMatch(/external/);
   });
 
@@ -183,14 +171,7 @@ describe('Tabs', () => {
     it('moves focus on arrow keys without firing onChange', async () => {
       const onChange = vi.fn();
       const user = userEvent.setup();
-      render(
-        <Tabs
-          items={items}
-          activeId="a"
-          onChange={onChange}
-          activationMode="manual"
-        />,
-      );
+      render(<Tabs items={items} activeId="a" onChange={onChange} activationMode="manual" />);
       screen.getByRole('tab', { name: 'Overview' }).focus();
       await user.keyboard('{ArrowRight}');
       expect(document.activeElement).toBe(screen.getByRole('tab', { name: /Activity/ }));
@@ -205,14 +186,7 @@ describe('Tabs', () => {
     it('fires onChange when the user presses Enter on a focused tab', async () => {
       const onChange = vi.fn();
       const user = userEvent.setup();
-      render(
-        <Tabs
-          items={items}
-          activeId="a"
-          onChange={onChange}
-          activationMode="manual"
-        />,
-      );
+      render(<Tabs items={items} activeId="a" onChange={onChange} activationMode="manual" />);
       screen.getByRole('tab', { name: 'Overview' }).focus();
       await user.keyboard('{ArrowRight}');
       await user.keyboard('{Enter}');
@@ -222,14 +196,7 @@ describe('Tabs', () => {
     it('fires onChange when the user presses Space on a focused tab', async () => {
       const onChange = vi.fn();
       const user = userEvent.setup();
-      render(
-        <Tabs
-          items={items}
-          activeId="a"
-          onChange={onChange}
-          activationMode="manual"
-        />,
-      );
+      render(<Tabs items={items} activeId="a" onChange={onChange} activationMode="manual" />);
       screen.getByRole('tab', { name: 'Overview' }).focus();
       await user.keyboard('{ArrowRight}');
       await user.keyboard(' ');

--- a/packages/design-system/src/components/Tabs/Tabs.tsx
+++ b/packages/design-system/src/components/Tabs/Tabs.tsx
@@ -71,8 +71,7 @@ function sanitizeId(raw: string): string {
 
 // Some consumer environments (RSC, edge runtimes) don't define `process`.
 // Read NODE_ENV defensively so the library never throws at module init.
-const IS_DEV =
-  typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production';
+const IS_DEV = typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production';
 
 /**
  * Horizontal tab strip with optional count chips. Controlled by the caller —
@@ -159,8 +158,7 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(function Tabs(
   // empty). When `focusedId` doesn't match any item — e.g. activeId is invalid
   // or the active item was just deleted — we fall back to items[0] so the
   // tablist stays keyboard-reachable.
-  const effectiveFocusedId =
-    items.find((i) => i.id === focusedId)?.id ?? items[0]?.id ?? null;
+  const effectiveFocusedId = items.find((i) => i.id === focusedId)?.id ?? items[0]?.id ?? null;
 
   const focusTab = (id: string) => {
     setFocusedId(id);

--- a/packages/design-system/src/components/Tabs/index.ts
+++ b/packages/design-system/src/components/Tabs/index.ts
@@ -1,7 +1,2 @@
 export { Tabs } from './Tabs';
-export type {
-  TabsProps,
-  TabItem,
-  TabsActivationMode,
-  TabsOrientation,
-} from './Tabs';
+export type { TabsProps, TabItem, TabsActivationMode, TabsOrientation } from './Tabs';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -12,12 +12,7 @@ export { Stack } from './components/Stack';
 export type { StackProps, StackGap, StackAlign } from './components/Stack';
 
 export { Cluster } from './components/Cluster';
-export type {
-  ClusterProps,
-  ClusterGap,
-  ClusterJustify,
-  ClusterAlign,
-} from './components/Cluster';
+export type { ClusterProps, ClusterGap, ClusterJustify, ClusterAlign } from './components/Cluster';
 
 export { Avatar } from './components/Avatar';
 export type { AvatarProps, AvatarSize } from './components/Avatar';
@@ -26,9 +21,4 @@ export { Badge } from './components/Badge';
 export type { BadgeProps, BadgeTone } from './components/Badge';
 
 export { Tabs } from './components/Tabs';
-export type {
-  TabsProps,
-  TabItem,
-  TabsActivationMode,
-  TabsOrientation,
-} from './components/Tabs';
+export type { TabsProps, TabItem, TabsActivationMode, TabsOrientation } from './components/Tabs';

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -79,9 +79,9 @@
   --radius-full: 9999px;
 
   // Typography
-  --font-family-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
-  --font-family-mono: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  --font-family-sans:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-family-mono: ui-monospace, 'SF Mono', Menlo, Monaco, Consolas, monospace;
   --font-size-xs: 11px;
   --font-size-sm: 12px;
   --font-size-md: 14px;
@@ -126,8 +126,7 @@
   // Shadows — Atlassian uses subtle elevation
   --shadow-sm: 0 1px 2px rgb(9 30 66 / 8%);
   --shadow-md: 0 2px 4px rgb(9 30 66 / 8%), 0 0 1px rgb(9 30 66 / 31%);
-  --shadow-lg: 0 4px 8px -2px rgb(9 30 66 / 25%),
-    0 0 1px rgb(9 30 66 / 31%);
+  --shadow-lg: 0 4px 8px -2px rgb(9 30 66 / 25%), 0 0 1px rgb(9 30 66 / 31%);
 
   // Motion
   --transition-fast: 100ms ease-out;

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -3,10 +3,5 @@
   "compilerOptions": {
     "types": ["vitest/globals"]
   },
-  "include": [
-    "src",
-    "types",
-    "vitest.config.ts",
-    "vitest.setup.ts"
-  ]
+  "include": ["src", "types", "vitest.config.ts", "vitest.setup.ts"]
 }

--- a/packages/playground/CLAUDE.md
+++ b/packages/playground/CLAUDE.md
@@ -13,14 +13,16 @@ If `@eocrm/design-system` exports a component and the playground doesn't have a 
 ### 2. Imports use `@eocrm/design-system` — never relative paths into the library
 
 Yes:
+
 ```ts
 import { Button } from '@eocrm/design-system';
 import '@eocrm/design-system/styles/global.scss';
 ```
 
 No:
+
 ```ts
-import { Button } from '../../../design-system/src/components/Button';  // ❌
+import { Button } from '../../../design-system/src/components/Button'; // ❌
 ```
 
 The whole point of the workspace split is that the playground exercises the library's public API the same way the CRM does. Relative imports defeat that.
@@ -72,14 +74,14 @@ Skipping any of these → users can navigate to the URL but the page is unreacha
 
 ## What goes here vs in the library
 
-| | Playground | Library |
-|---|---|---|
-| `pages/`, `layout/AppShell` | ✅ | ❌ |
-| Mock data (`data/mock.ts`) | ✅ | ❌ |
-| Demo helpers (`CodeBlock`, `Example`, `DemoLayout`) | ✅ | ❌ |
-| Prism setup | ✅ | ❌ |
-| Reusable visual primitives (`Button`, `Card`, `Stack`...) | ❌ | ✅ |
-| Tokens, reset, typography, mixins | ❌ | ✅ |
+|                                                           | Playground | Library |
+| --------------------------------------------------------- | ---------- | ------- |
+| `pages/`, `layout/AppShell`                               | ✅         | ❌      |
+| Mock data (`data/mock.ts`)                                | ✅         | ❌      |
+| Demo helpers (`CodeBlock`, `Example`, `DemoLayout`)       | ✅         | ❌      |
+| Prism setup                                               | ✅         | ❌      |
+| Reusable visual primitives (`Button`, `Card`, `Stack`...) | ❌         | ✅      |
+| Tokens, reset, typography, mixins                         | ❌         | ✅      |
 
 Heuristic: "would the CRM benefit from this?" If yes → library. If no → playground.
 

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -13,7 +13,9 @@
           var decoded = l.search
             .slice(1)
             .split('&')
-            .map(function (s) { return s.replace(/~and~/g, '&'); })
+            .map(function (s) {
+              return s.replace(/~and~/g, '&');
+            })
             .join('?');
           window.history.replaceState(null, '', l.pathname.slice(0, -1) + decoded + l.hash);
         }

--- a/packages/playground/public/404.html
+++ b/packages/playground/public/404.html
@@ -1,28 +1,40 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta http-equiv="refresh" content="0">
-  <title>Redirecting…</title>
-  <script>
-    // SPA routing on GitHub Pages — adapted from https://github.com/rafgraph/spa-github-pages
-    // GitHub Pages returns this 404.html for any unmatched path. We rewrite the
-    // URL to /<repo>/?/<encoded-path> and bounce to the SPA root, where the
-    // snippet in index.html decodes it back into the real URL via
-    // history.replaceState — so the React Router sees the right path.
-    //
-    // pathSegmentsToKeep = 1 because GH Pages project sites prefix one segment
-    // (the repo name). On a user/org root site it would be 0.
-    var pathSegmentsToKeep = 1;
-    var l = window.location;
-    l.replace(
-      l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
-      l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
-      l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
-      (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
-      l.hash
-    );
-  </script>
-</head>
-<body></body>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0" />
+    <title>Redirecting…</title>
+    <script>
+      // SPA routing on GitHub Pages — adapted from https://github.com/rafgraph/spa-github-pages
+      // GitHub Pages returns this 404.html for any unmatched path. We rewrite the
+      // URL to /<repo>/?/<encoded-path> and bounce to the SPA root, where the
+      // snippet in index.html decodes it back into the real URL via
+      // history.replaceState — so the React Router sees the right path.
+      //
+      // pathSegmentsToKeep = 1 because GH Pages project sites prefix one segment
+      // (the repo name). On a user/org root site it would be 0.
+      var pathSegmentsToKeep = 1;
+      var l = window.location;
+      l.replace(
+        l.protocol +
+          '//' +
+          l.hostname +
+          (l.port ? ':' + l.port : '') +
+          l.pathname
+            .split('/')
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join('/') +
+          '/?/' +
+          l.pathname
+            .slice(1)
+            .split('/')
+            .slice(pathSegmentsToKeep)
+            .join('/')
+            .replace(/&/g, '~and~') +
+          (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+          l.hash,
+      );
+    </script>
+  </head>
+  <body></body>
 </html>

--- a/packages/playground/src/layout/AppShell/AppShell.module.scss
+++ b/packages/playground/src/layout/AppShell/AppShell.module.scss
@@ -11,8 +11,8 @@
   grid-template-columns: var(--sidebar-width) 1fr;
   grid-template-rows: var(--topbar-height) 1fr;
   grid-template-areas:
-    "sidebar topbar"
-    "sidebar content";
+    'sidebar topbar'
+    'sidebar content';
   min-height: 100vh;
   background: var(--color-bg-subtle);
 }

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -29,9 +29,7 @@ const navItems = [
   { to: '/contacts', label: 'Contacts', icon: Users, end: false },
 ];
 
-const settingsItems = [
-  { to: '/members', label: 'Members', icon: UserCog, end: false },
-];
+const settingsItems = [{ to: '/members', label: 'Members', icon: UserCog, end: false }];
 
 const demoItems = [
   { to: '/demo', label: 'Overview', icon: Component, end: true },

--- a/packages/playground/src/pages/Dashboard/Dashboard.tsx
+++ b/packages/playground/src/pages/Dashboard/Dashboard.tsx
@@ -33,8 +33,18 @@ const stats = [
 ];
 
 const activity = [
-  { who: 'Priya Shah', what: 'replied to your email', when: '12m ago', target: 'Acme team plan upgrade' },
-  { who: 'Jordan Park', what: 'moved a deal to Proposal', when: '1h ago', target: 'Multi-region rollout' },
+  {
+    who: 'Priya Shah',
+    what: 'replied to your email',
+    when: '12m ago',
+    target: 'Acme team plan upgrade',
+  },
+  {
+    who: 'Jordan Park',
+    what: 'moved a deal to Proposal',
+    when: '1h ago',
+    target: 'Multi-region rollout',
+  },
   { who: 'Diana Okafor', what: 'booked a demo', when: '3h ago', target: 'Globex' },
   { who: 'Sam Chen', what: 'added a note on', when: 'Yesterday', target: 'Pilot conversion' },
   { who: 'Maya Owens', what: 'created a deal', when: '2d ago', target: 'Add-on: API gateway' },

--- a/packages/playground/src/pages/Deals/Deals.module.scss
+++ b/packages/playground/src/pages/Deals/Deals.module.scss
@@ -69,10 +69,21 @@
   border-radius: var(--radius-full);
 }
 
-.stage-lead { background: var(--color-fg-disabled); }
-.stage-qualified { background: var(--color-info); }
-.stage-proposal { background: var(--color-warning); }
-.stage-won { background: var(--color-success); }
+.stage-lead {
+  background: var(--color-fg-disabled);
+}
+
+.stage-qualified {
+  background: var(--color-info);
+}
+
+.stage-proposal {
+  background: var(--color-warning);
+}
+
+.stage-won {
+  background: var(--color-success);
+}
 
 .columnList {
   flex: 1;

--- a/packages/playground/src/pages/Deals/Deals.tsx
+++ b/packages/playground/src/pages/Deals/Deals.tsx
@@ -33,7 +33,10 @@ export function Deals() {
             <section key={stage.id} className={styles.column}>
               <header className={styles.columnHeader}>
                 <Cluster gap="sm" align="center">
-                  <span className={`${styles.stageDot} ${styles[`stage-${stage.id}`]}`} aria-hidden />
+                  <span
+                    className={`${styles.stageDot} ${styles[`stage-${stage.id}`]}`}
+                    aria-hidden
+                  />
                   <span className={styles.columnTitle}>{stage.label}</span>
                   <span className={styles.columnCount}>{stageDeals.length}</span>
                 </Cluster>
@@ -45,11 +48,7 @@ export function Deals() {
                   <article key={d.id} className={styles.dealCard}>
                     <Cluster justify="between" align="start" gap="sm" wrap={false}>
                       <span className={styles.dealId}>{d.id}</span>
-                      <button
-                        type="button"
-                        aria-label="More"
-                        className={styles.cardActionBtn}
-                      >
+                      <button type="button" aria-label="More" className={styles.cardActionBtn}>
                         <MoreHorizontal size={14} />
                       </button>
                     </Cluster>

--- a/packages/playground/src/pages/Members/Members.tsx
+++ b/packages/playground/src/pages/Members/Members.tsx
@@ -8,13 +8,7 @@ import { Cluster } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { Tabs } from '@eocrm/design-system';
 import { Input } from '@eocrm/design-system';
-import {
-  members,
-  pendingInvites,
-  roleTone,
-  roleLabel,
-  seatLimit,
-} from '../../data/mock';
+import { members, pendingInvites, roleTone, roleLabel, seatLimit } from '../../data/mock';
 import styles from './Members.module.scss';
 
 export function Members() {
@@ -32,9 +26,7 @@ export function Members() {
       <Cluster justify="between" align="end" gap="md">
         <div>
           <h1 className={styles.title}>Members</h1>
-          <p className={styles.subtitle}>
-            People with access to your Orbit CRM workspace.
-          </p>
+          <p className={styles.subtitle}>People with access to your Orbit CRM workspace.</p>
         </div>
         <Button>
           <UserPlus size={14} /> Invite members

--- a/packages/playground/src/pages/demo/BadgeDemo.tsx
+++ b/packages/playground/src/pages/demo/BadgeDemo.tsx
@@ -51,7 +51,13 @@ export function BadgeDemo() {
       >
         <Stack gap="md">
           <div>
-            <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)', marginBottom: 6 }}>
+            <div
+              style={{
+                fontSize: 'var(--font-size-sm)',
+                color: 'var(--color-fg-subtle)',
+                marginBottom: 6,
+              }}
+            >
               Contact status
             </div>
             <Cluster gap="sm">
@@ -61,7 +67,13 @@ export function BadgeDemo() {
             </Cluster>
           </div>
           <div>
-            <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)', marginBottom: 6 }}>
+            <div
+              style={{
+                fontSize: 'var(--font-size-sm)',
+                color: 'var(--color-fg-subtle)',
+                marginBottom: 6,
+              }}
+            >
               Member role
             </div>
             <Cluster gap="sm">
@@ -71,7 +83,13 @@ export function BadgeDemo() {
             </Cluster>
           </div>
           <div>
-            <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)', marginBottom: 6 }}>
+            <div
+              style={{
+                fontSize: 'var(--font-size-sm)',
+                color: 'var(--color-fg-subtle)',
+                marginBottom: 6,
+              }}
+            >
               Deal stage
             </div>
             <Cluster gap="sm">

--- a/packages/playground/src/pages/demo/CardDemo.tsx
+++ b/packages/playground/src/pages/demo/CardDemo.tsx
@@ -31,9 +31,15 @@ export function CardDemo() {
           <Card padding="none" style={{ minWidth: 100, textAlign: 'center' }}>
             <div style={{ padding: 4 }}>none</div>
           </Card>
-          <Card padding="sm" style={{ minWidth: 100 }}>sm</Card>
-          <Card padding="md" style={{ minWidth: 100 }}>md</Card>
-          <Card padding="lg" style={{ minWidth: 100 }}>lg</Card>
+          <Card padding="sm" style={{ minWidth: 100 }}>
+            sm
+          </Card>
+          <Card padding="md" style={{ minWidth: 100 }}>
+            md
+          </Card>
+          <Card padding="lg" style={{ minWidth: 100 }}>
+            lg
+          </Card>
         </Cluster>
       </Example>
 

--- a/packages/playground/src/pages/demo/ClusterDemo.tsx
+++ b/packages/playground/src/pages/demo/ClusterDemo.tsx
@@ -106,7 +106,9 @@ export function ClusterDemo() {
   {tags.map(t => <Badge tone={t.tone}>{t.label}</Badge>)}
 </Cluster>`}
       >
-        <div style={{ maxWidth: 360, border: '1px dashed var(--color-border-strong)', padding: 12 }}>
+        <div
+          style={{ maxWidth: 360, border: '1px dashed var(--color-border-strong)', padding: 12 }}
+        >
           <Cluster gap="xs">
             <Badge tone="purple">Enterprise</Badge>
             <Badge tone="info">Pipeline 2026</Badge>

--- a/packages/playground/src/pages/demo/CodeBlock.tsx
+++ b/packages/playground/src/pages/demo/CodeBlock.tsx
@@ -31,12 +31,7 @@ export function CodeBlock({ code, language = 'tsx', filename, className }: CodeB
     <div className={clsx(styles.block, className)}>
       <div className={styles.bar}>
         <span className={styles.filename}>{filename ?? language.toUpperCase()}</span>
-        <button
-          type="button"
-          className={styles.copyBtn}
-          onClick={onCopy}
-          aria-label="Copy code"
-        >
+        <button type="button" className={styles.copyBtn} onClick={onCopy} aria-label="Copy code">
           {copied ? <Check size={12} /> : <Copy size={12} />}
           {copied ? 'Copied' : 'Copy'}
         </button>

--- a/packages/playground/src/pages/demo/DemoIndex.tsx
+++ b/packages/playground/src/pages/demo/DemoIndex.tsx
@@ -124,7 +124,8 @@ export function DemoIndex() {
         <h1 className={styles.title}>Component library</h1>
         <p className={styles.description}>
           Every component shipped with this design system. Each page shows the live component, the
-          source of <code>.tsx</code> and <code>.module.scss</code>, and usage snippets you can copy.
+          source of <code>.tsx</code> and <code>.module.scss</code>, and usage snippets you can
+          copy.
         </p>
       </header>
 

--- a/packages/playground/src/pages/demo/InputDemo.tsx
+++ b/packages/playground/src/pages/demo/InputDemo.tsx
@@ -50,11 +50,7 @@ export function InputDemo() {
 />`}
       >
         <div style={{ maxWidth: 320 }}>
-          <Input
-            invalid
-            value={invalidValue}
-            onChange={(e) => setInvalidValue(e.target.value)}
-          />
+          <Input invalid value={invalidValue} onChange={(e) => setInvalidValue(e.target.value)} />
         </div>
       </Example>
 


### PR DESCRIPTION
## Summary
- Adds `prettier@3.8.3` at the workspace root with a shared `.prettierrc.json` (printWidth 100, single quotes, trailing commas, LF endings).
- Reformats the whole repo in one shot and wires `npm run format:check` into the Quality workflow so unformatted code blocks PRs (and, by extension, releases).
- Pins LF via `.gitattributes` so the prettier check stays stable across contributors regardless of `core.autocrlf`.

## Why these rules
Generic, low-friction defaults. The only opinionated choices: `printWidth: 100` (JSX-friendly), `singleQuote: true` (matches existing TS/SCSS), `jsxSingleQuote: false` (matches HTML), `trailingComma: "all"` (smaller diffs). YAML gets `singleQuote: false` per Prettier convention.

## Tool reconciliation
Stylelint's `rule-empty-line-before` (from `stylelint-config-standard-scss`) wants a blank line between sibling rules; Prettier does not add one but preserves it when present. Resolved by running `stylelint --fix` once — both tools now agree on the resulting layout. No stylelint rules were disabled.

## Test plan
- [x] `npm run format:check` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 131/131 pass
- [x] `npm run lint:css` — clean
- [x] `npm run build` — succeeds
- [ ] CI `Quality / check` green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)