### PR TITLE
Add Badge size prop (sm variant)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -147,6 +147,7 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 ```
 
 - `tone`: `neutral` (default) / `info` / `success` / `warning` / `danger` / `purple`
+- `size`: `md` (20, default) / `sm` (16). `md` is the uppercase tracked "loud label" pill. `sm` drops the uppercase + tracking and renders case as-typed — use it for dense table cells, compact toolbars, or anywhere the uppercase treatment shouts next to body copy.
 - **Non-interactive.** If it's clickable, use `<Button>` instead.
 - Doesn't auto-add `role="status"`. Wrap in `aria-live` if a state change should be announced.
 
@@ -191,7 +192,7 @@ All available as CSS custom properties after you import `global.scss`:
 | Font sizes      | `--font-size-xs/sm/md/lg/xl/2xl/3xl`, `--font-size-code` (0.92em for inline mono)                                                                                                                   |
 | Font weights    | `--font-weight-regular/medium/semibold/bold`                                                                                                                                                        |
 | Line heights    | `--line-height-tight` / `--line-height-normal` / `--line-height-none` (1)                                                                                                                           |
-| Control sizes   | `--size-sm/md/lg` (heights), `--size-badge` (20), `--size-chip` (18)                                                                                                                                |
+| Control sizes   | `--size-sm/md/lg` (heights), `--size-badge` (20), `--size-badge-sm` (16), `--size-chip` (18)                                                                                                        |
 | Borders         | `--border-width` (1) / `--border-width-emphasis` (2) / `--border-width-strong` (3)                                                                                                                  |
 | Letter spacing  | `--letter-spacing-caps` (0.03em)                                                                                                                                                                    |
 | Shadows         | `--shadow-sm` / `--shadow-md` / `--shadow-lg`                                                                                                                                                       |

--- a/packages/design-system/src/components/Badge/Badge.module.scss
+++ b/packages/design-system/src/components/Badge/Badge.module.scss
@@ -2,8 +2,6 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  height: var(--size-badge);
-  padding: 0 var(--space-2);
   border-radius: var(--radius-sm);
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
@@ -11,6 +9,19 @@
   text-transform: uppercase;
   white-space: nowrap;
   line-height: var(--line-height-none);
+}
+
+// Sizes
+.sm {
+  height: var(--size-badge-sm);
+  padding: 0 var(--space-1);
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.md {
+  height: var(--size-badge);
+  padding: 0 var(--space-2);
 }
 
 .neutral {

--- a/packages/design-system/src/components/Badge/Badge.test.tsx
+++ b/packages/design-system/src/components/Badge/Badge.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { createRef } from 'react';
-import { Badge, type BadgeTone } from './Badge';
+import { Badge, type BadgeSize, type BadgeTone } from './Badge';
 
 describe('Badge', () => {
   it('renders its children', () => {
@@ -20,6 +20,16 @@ describe('Badge', () => {
       expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(tone));
     },
   );
+
+  it('defaults to the md size', () => {
+    const { container } = render(<Badge>x</Badge>);
+    expect((container.firstChild as HTMLElement).className).toMatch(/md/);
+  });
+
+  it.each<BadgeSize>(['sm', 'md'])('applies the %s size class', (size) => {
+    const { container } = render(<Badge size={size}>x</Badge>);
+    expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(size));
+  });
 
   it('merges the className prop with internal classes', () => {
     const { container } = render(<Badge className="external">x</Badge>);

--- a/packages/design-system/src/components/Badge/Badge.tsx
+++ b/packages/design-system/src/components/Badge/Badge.tsx
@@ -5,6 +5,13 @@ import styles from './Badge.module.scss';
 /** Semantic tone. Use consistently across pages — `success` should never mean "bad". */
 export type BadgeTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger' | 'purple';
 
+/**
+ * Pill height. See BadgeProps#size for when to use each. Intentionally only
+ * two heights — a 40px badge would be Button-shaped. If you need something
+ * larger, use `<Button>` or rethink the layout.
+ */
+export type BadgeSize = 'sm' | 'md';
+
 export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   /**
    * Semantic tone.
@@ -16,6 +23,17 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
    * - `purple` — special / highlighted categories ("Enterprise", "VIP").
    */
   tone?: BadgeTone;
+  /**
+   * Pill height and emphasis.
+   * - `md` (20px, default) — the standard "loud label" pill. Uppercase, tracked,
+   *   semibold. Reads as a deliberate status marker.
+   * - `sm` (16px) — quieter inline tag for tight table cells, compact toolbars,
+   *   or anywhere a 20px uppercase pill visually crowds adjacent text. Drops
+   *   the uppercase transform and caps tracking so it sits next to body copy
+   *   without shouting; case is preserved as-typed (write `Active`, get
+   *   `Active`). Same 11px size and semibold weight as `md`.
+   */
+  size?: BadgeSize;
 }
 
 const toneClass: Record<BadgeTone, string> = {
@@ -25,6 +43,11 @@ const toneClass: Record<BadgeTone, string> = {
   warning: styles.warning,
   danger: styles.danger,
   purple: styles.purple,
+};
+
+const sizeClass: Record<BadgeSize, string> = {
+  sm: styles.sm,
+  md: styles.md,
 };
 
 /**
@@ -66,8 +89,15 @@ const toneClass: Record<BadgeTone, string> = {
  *   with an appropriate variant instead.
  */
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
-  { tone = 'neutral', className, ...props },
+  { tone = 'neutral', size = 'md', className, ...props },
   ref,
 ) {
-  return <span ref={ref} className={clsx(styles.badge, toneClass[tone], className)} {...props} />;
+  // {...props} last so consumer overrides win (Pattern A).
+  return (
+    <span
+      ref={ref}
+      className={clsx(styles.badge, toneClass[tone], sizeClass[size], className)}
+      {...props}
+    />
+  );
 });

--- a/packages/design-system/src/components/Badge/index.ts
+++ b/packages/design-system/src/components/Badge/index.ts
@@ -1,2 +1,2 @@
 export { Badge } from './Badge';
-export type { BadgeProps, BadgeTone } from './Badge';
+export type { BadgeProps, BadgeTone, BadgeSize } from './Badge';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -18,7 +18,7 @@ export { Avatar } from './components/Avatar';
 export type { AvatarProps, AvatarSize } from './components/Avatar';
 
 export { Badge } from './components/Badge';
-export type { BadgeProps, BadgeTone } from './components/Badge';
+export type { BadgeProps, BadgeTone, BadgeSize } from './components/Badge';
 
 export { Tabs } from './components/Tabs';
 export type { TabsProps, TabItem, TabsActivationMode, TabsOrientation } from './components/Tabs';

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -103,6 +103,7 @@
 
   // Inline elements (badges, count chips)
   --size-badge: 20px;
+  --size-badge-sm: 16px;
   --size-chip: 18px;
 
   // Border weights — emphasis = tab underline/focus rings; strong = accent

--- a/packages/playground/src/pages/components/BadgeDemo.tsx
+++ b/packages/playground/src/pages/components/BadgeDemo.tsx
@@ -38,6 +38,45 @@ export function BadgeDemo() {
       </Example>
 
       <Example
+        title="Sizes"
+        description="Two emphases. md (20px, default) is the loud label pill — uppercase and tracked. sm (16px) is the quiet inline tag — case as-typed, no tracking. Use sm in dense table cells, compact toolbars, or anywhere the uppercase treatment shouts next to body copy."
+        code={`// md (default), all tones
+<Badge tone="neutral">Neutral</Badge>
+<Badge tone="info">Info</Badge>
+<Badge tone="success">Success</Badge>
+<Badge tone="warning">Warning</Badge>
+<Badge tone="danger">Danger</Badge>
+<Badge tone="purple">Purple</Badge>
+
+// sm, all tones
+<Badge size="sm" tone="neutral">Neutral</Badge>
+<Badge size="sm" tone="info">Info</Badge>
+<Badge size="sm" tone="success">Success</Badge>
+<Badge size="sm" tone="warning">Warning</Badge>
+<Badge size="sm" tone="danger">Danger</Badge>
+<Badge size="sm" tone="purple">Purple</Badge>`}
+      >
+        <Stack gap="md">
+          <Cluster gap="sm" align="center">
+            <Badge tone="neutral">Neutral</Badge>
+            <Badge tone="info">Info</Badge>
+            <Badge tone="success">Success</Badge>
+            <Badge tone="warning">Warning</Badge>
+            <Badge tone="danger">Danger</Badge>
+            <Badge tone="purple">Purple</Badge>
+          </Cluster>
+          <Cluster gap="sm" align="center">
+            <Badge size="sm" tone="neutral">Neutral</Badge>
+            <Badge size="sm" tone="info">Info</Badge>
+            <Badge size="sm" tone="success">Success</Badge>
+            <Badge size="sm" tone="warning">Warning</Badge>
+            <Badge size="sm" tone="danger">Danger</Badge>
+            <Badge size="sm" tone="purple">Purple</Badge>
+          </Cluster>
+        </Stack>
+      </Example>
+
+      <Example
         title="Status patterns"
         description="The most common CRM usage: status pill on a contact, deal, or invitation."
         code={`// Contact statuses

--- a/packages/playground/src/pages/components/BadgeDemo.tsx
+++ b/packages/playground/src/pages/components/BadgeDemo.tsx
@@ -66,12 +66,24 @@ export function BadgeDemo() {
             <Badge tone="purple">Purple</Badge>
           </Cluster>
           <Cluster gap="sm" align="center">
-            <Badge size="sm" tone="neutral">Neutral</Badge>
-            <Badge size="sm" tone="info">Info</Badge>
-            <Badge size="sm" tone="success">Success</Badge>
-            <Badge size="sm" tone="warning">Warning</Badge>
-            <Badge size="sm" tone="danger">Danger</Badge>
-            <Badge size="sm" tone="purple">Purple</Badge>
+            <Badge size="sm" tone="neutral">
+              Neutral
+            </Badge>
+            <Badge size="sm" tone="info">
+              Info
+            </Badge>
+            <Badge size="sm" tone="success">
+              Success
+            </Badge>
+            <Badge size="sm" tone="warning">
+              Warning
+            </Badge>
+            <Badge size="sm" tone="danger">
+              Danger
+            </Badge>
+            <Badge size="sm" tone="purple">
+              Purple
+            </Badge>
           </Cluster>
         </Stack>
       </Example>


### PR DESCRIPTION
## Summary

- Adds a `size` prop to `<Badge>` with values `'sm' | 'md'` (default `md`).
- `md` keeps the existing 20px uppercase + tracked "loud label" pill.
- `sm` is a quieter 16px variant — drops the uppercase transform and caps tracking and renders case as-typed. Use for dense table cells, compact toolbars, or anywhere a 20px pill visually crowds adjacent text.
- New `--size-badge-sm: 16px` token (next to `--size-badge`).
- `BadgeSize` is intentionally only `sm | md` — no `lg` (a 40px badge would be Button-shaped). JSDoc documents the choice.
- Demo `Sizes` example shows both sizes across all six tones.
- `AGENTS.md` Badge TL;DR + tokens table updated.

## Reviewed against Rule 8

Two fresh-context review cycles ran against `packages/design-system/`. Cycle 1 surfaced one Important finding (token table omitted `--size-badge-sm`) + four Nice-to-have. Cycle 2 verdict: `clean enough to stop` (0 Critical / 0 Important). Subsequent sm-differentiation change (uppercase + tracking drop) was verified directly in the browser via Playwright — default Badge renders at 20px with uppercase, `size="sm"` renders at 16px with `text-transform: none` and `letter-spacing: normal`.

## Test plan

- [x] `npm test -w @eocrm/design-system` (134 passed)
- [x] `npm run typecheck -w @eocrm/design-system`
- [x] `make lint` (stylelint clean)
- [x] `make build` (playground builds; library smoke-typechecked)
- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files leaked
- [x] Live browser check at `/components/badge`: default = 20px / uppercase / tracked, `size="sm"` = 16px / as-typed / no tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)