### PR TITLE
Enforce pre-push linters via Husky

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# Pre-push linters. Mirrors the static checks in .github/workflows/quality.yml.
+# Tests and the playground build are NOT run here — run `make build` / `make test`
+# manually if you want the full gate locally.
+#
+# To skip in an emergency: `git push --no-verify` (don't make a habit of it).
+
+set -e
+
+echo "▶ prettier --check"
+npm run format:check
+
+echo "▶ stylelint"
+npm run lint:css
+
+echo "▶ typecheck"
+npm run typecheck
+
+echo "✓ pre-push linters passed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,23 @@ Process for those:
 
 **Explicit override**: the user may authorize a direct push for any specific change ("just push it", "no PR needed", etc.). When in doubt, default to branch + PR for code; default to direct-push for standalone docs.
 
+## Git hooks
+
+**Hooks MUST be installed.** A `pre-push` hook (managed by Husky) runs prettier, stylelint, and typecheck before every push. It exists because the CI quality gate runs the same checks — local failures are cheaper than a red PR.
+
+Installation is automatic: `npm install` (or `make install`) triggers the `prepare` script which sets `core.hooksPath` to `.husky/_` and wires every hook in `.husky/`.
+
+Before doing any work in this repo, verify:
+
+```bash
+git config --get core.hooksPath   # must print: .husky/_
+test -x .husky/pre-push           # exit 0
+```
+
+If either fails, run `npm install` again — do not proceed with code changes until both pass.
+
+**Never bypass with `--no-verify` on your own initiative.** If the hook blocks a push you believe is correct, the right move is to (a) fix the failing check, or (b) explain the failure to the user and let them decide whether to authorize the bypass. A hook bypass without authorization defeats the purpose of having the hook.
+
 ## Common commands
 
 - `make up` — start playground at http://localhost:8080 (browser opens automatically)

--- a/README.md
+++ b/README.md
@@ -45,12 +45,25 @@ Per-component contracts: hover any import for JSDoc; see [`packages/design-syste
 ## Quickstart (contributing)
 
 ```bash
-make install          # npm install (sets up workspaces)
+make install          # npm install (sets up workspaces AND installs git hooks)
 make up               # dev server at http://localhost:8080 + opens browser
 make test             # Vitest (library only)
 make lint             # stylelint
 make build            # production build of playground (also typechecks library)
 ```
+
+### Git hooks (mandatory)
+
+`npm install` auto-installs a `pre-push` hook via Husky that runs **prettier**, **stylelint**, and **typecheck**. Pushes are blocked if any of those fail — this catches the static-analysis subset of the CI quality gate before you wait on CI.
+
+Verify the hook is wired:
+
+```bash
+git config --get core.hooksPath   # must print: .husky/_
+ls .husky/pre-push                # must exist
+```
+
+If either check fails, run `npm install` again. **Do not push with `--no-verify`** unless you've coordinated the bypass with a reviewer — the hook exists to catch issues that will otherwise come back as red CI on the PR.
 
 Repo conventions live in [`CLAUDE.md`](./CLAUDE.md) (cross-package) and [`packages/design-system/CLAUDE.md`](./packages/design-system/CLAUDE.md) (library-specific rules).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "husky": "^9.1.7",
         "prettier": "3.8.3",
         "stylelint": "^16.12.0",
         "stylelint-config-standard-scss": "^14.0.0",
@@ -3103,6 +3104,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "npm run typecheck --workspaces --if-present",
-    "test": "npm test --workspaces --if-present"
+    "test": "npm test --workspaces --if-present",
+    "prepare": "husky"
   },
   "devDependencies": {
+    "husky": "^9.1.7",
     "prettier": "3.8.3",
     "stylelint": "^16.12.0",
     "stylelint-config-standard-scss": "^14.0.0",


### PR DESCRIPTION
## Summary

- Adds a Husky `pre-push` hook running prettier --check, stylelint, and typecheck — the static-analysis subset of the CI quality gate
- Hook is auto-installed by `npm install` via a new `prepare` script (`"prepare": "husky"`)
- `husky` (v9.1.7) added to root devDependencies
- Root `README.md` contributing section now documents hook install + verification
- Root `CLAUDE.md` now contains a "Git hooks" section stating hooks MUST be installed, with the verification commands and an explicit no-bypass policy

## Why pre-push, not pre-commit

Pre-commit needs to be sub-second to not break flow; the three linters here take ~2s, which is fine on push but annoying on every commit. Pre-push also matches the natural "before it hits the remote" boundary the user is enforcing.

## Why only linters (not tests + build)

Strict reading of the request ("Run all linters"). Tests + build run in CI on every PR and locally via `make test` / `make build`. Including them in pre-push would add ~5-10s and isn't what was asked for. Easy to extend later if needed.

## Test plan

- [x] `npm install` triggers `prepare` and wires `core.hooksPath` to `.husky/_`
- [x] `.husky/pre-push` exists, is executable, and runs all three linters in sequence
- [x] Direct invocation `.husky/pre-push` exits 0 on clean tree
- [x] Synthetic prettier failure → hook exits 1 (verified via `set -o pipefail` test)
- [x] Real `git push` of this branch ran the hook end-to-end and passed before pushing to origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)