### PR TITLE
Add Badge dot prop (start/end status indicator)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -148,6 +148,7 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 
 - `tone`: `neutral` (default) / `info` / `success` / `warning` / `danger` / `purple`
 - `size`: `md` (20, default) / `sm` (16). `md` is the uppercase tracked "loud label" pill. `sm` drops the uppercase + tracking and renders case as-typed — use it for dense table cells, compact toolbars, or anywhere the uppercase treatment shouts next to body copy.
+- `dot`: `start` / `end` — adds a small filled circle in the badge's text color before or after the content. Use for Slack/GitHub-style status indicators (`<Badge tone="success" dot="start">Online</Badge>`). Decorative only (`aria-hidden`); the text is still the accessible label.
 - **Non-interactive.** If it's clickable, use `<Button>` instead.
 - Doesn't auto-add `role="status"`. Wrap in `aria-live` if a state change should be announced.
 

--- a/packages/design-system/src/components/Badge/Badge.module.scss
+++ b/packages/design-system/src/components/Badge/Badge.module.scss
@@ -53,3 +53,11 @@
   background: var(--color-badge-purple-bg);
   color: var(--color-badge-purple-fg);
 }
+
+.dot {
+  width: var(--size-badge-dot);
+  height: var(--size-badge-dot);
+  border-radius: var(--radius-full);
+  background: currentColor;
+  flex-shrink: 0;
+}

--- a/packages/design-system/src/components/Badge/Badge.test.tsx
+++ b/packages/design-system/src/components/Badge/Badge.test.tsx
@@ -42,4 +42,34 @@ describe('Badge', () => {
     render(<Badge ref={ref}>x</Badge>);
     expect(ref.current).toBeInstanceOf(HTMLSpanElement);
   });
+
+  it('does not render a dot by default', () => {
+    const { container } = render(<Badge>x</Badge>);
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it('renders a dot before the content when dot="start"', () => {
+    const { container } = render(<Badge dot="start">Active</Badge>);
+    const root = container.firstChild as HTMLElement;
+    const dot = root.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(dot).not.toBeNull();
+    expect(dot.className).toMatch(/dot/);
+    expect(root.firstChild).toBe(dot);
+  });
+
+  it('renders a dot after the content when dot="end"', () => {
+    const { container } = render(<Badge dot="end">Active</Badge>);
+    const root = container.firstChild as HTMLElement;
+    const dot = root.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(dot).not.toBeNull();
+    expect(dot.className).toMatch(/dot/);
+    expect(root.lastChild).toBe(dot);
+  });
+
+  it('marks the dot as decorative so the badge text remains the accessible label', () => {
+    const { container } = render(<Badge dot="start">Active</Badge>);
+    const dot = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(dot.getAttribute('aria-hidden')).toBe('true');
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
 });

--- a/packages/design-system/src/components/Badge/Badge.tsx
+++ b/packages/design-system/src/components/Badge/Badge.tsx
@@ -12,6 +12,9 @@ export type BadgeTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger' | 
  */
 export type BadgeSize = 'sm' | 'md';
 
+/** Position of the optional status dot relative to the badge content. */
+export type BadgeDot = 'start' | 'end';
+
 export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   /**
    * Semantic tone.
@@ -34,6 +37,17 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
    *   `Active`). Same 11px size and semibold weight as `md`.
    */
   size?: BadgeSize;
+  /**
+   * Render a small filled circle in the badge's text color alongside the
+   * content. Useful when the dot is the primary status signal and the label
+   * is supporting context ("● Active", "Failed ●").
+   * - `start` — dot before the content.
+   * - `end` — dot after the content.
+   *
+   * Omit for no dot. The dot is purely decorative (`aria-hidden`) — the badge
+   * text remains the accessible label.
+   */
+  dot?: BadgeDot;
 }
 
 const toneClass: Record<BadgeTone, string> = {
@@ -89,7 +103,7 @@ const sizeClass: Record<BadgeSize, string> = {
  *   with an appropriate variant instead.
  */
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
-  { tone = 'neutral', size = 'md', className, ...props },
+  { tone = 'neutral', size = 'md', dot, className, children, ...props },
   ref,
 ) {
   // {...props} last so consumer overrides win (Pattern A).
@@ -98,6 +112,10 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
       ref={ref}
       className={clsx(styles.badge, toneClass[tone], sizeClass[size], className)}
       {...props}
-    />
+    >
+      {dot === 'start' && <span aria-hidden="true" className={styles.dot} />}
+      {children}
+      {dot === 'end' && <span aria-hidden="true" className={styles.dot} />}
+    </span>
   );
 });

--- a/packages/design-system/src/components/Badge/index.ts
+++ b/packages/design-system/src/components/Badge/index.ts
@@ -1,2 +1,2 @@
 export { Badge } from './Badge';
-export type { BadgeProps, BadgeTone, BadgeSize } from './Badge';
+export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot } from './Badge';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -18,7 +18,7 @@ export { Avatar } from './components/Avatar';
 export type { AvatarProps, AvatarSize } from './components/Avatar';
 
 export { Badge } from './components/Badge';
-export type { BadgeProps, BadgeTone, BadgeSize } from './components/Badge';
+export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot } from './components/Badge';
 
 export { Tabs } from './components/Tabs';
 export type { TabsProps, TabItem, TabsActivationMode, TabsOrientation } from './components/Tabs';

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -104,6 +104,7 @@
   // Inline elements (badges, count chips)
   --size-badge: 20px;
   --size-badge-sm: 16px;
+  --size-badge-dot: 6px;
   --size-chip: 18px;
 
   // Border weights — emphasis = tab underline/focus rings; strong = accent

--- a/packages/playground/src/pages/components/BadgeDemo.tsx
+++ b/packages/playground/src/pages/components/BadgeDemo.tsx
@@ -89,6 +89,79 @@ export function BadgeDemo() {
       </Example>
 
       <Example
+        title="Status dot"
+        description={`Add dot="start" or dot="end" to render a small filled circle in the badge's text color. Useful when the dot is the primary status signal (Slack/GitHub-style online/offline indicators) and the label is supporting context. Works with every tone and both sizes.`}
+        code={`// Dot at the start
+<Badge tone="success" dot="start">Active</Badge>
+<Badge tone="warning" dot="start">Pending</Badge>
+<Badge tone="danger" dot="start">Failed</Badge>
+
+// Dot at the end
+<Badge tone="info" dot="end">Lead</Badge>
+
+// Works at sm size too
+<Badge size="sm" tone="success" dot="start">Online</Badge>
+<Badge size="sm" tone="neutral" dot="start">Away</Badge>`}
+      >
+        <Stack gap="md">
+          <Cluster gap="sm" align="center">
+            <Badge tone="neutral" dot="start">
+              Neutral
+            </Badge>
+            <Badge tone="info" dot="start">
+              Info
+            </Badge>
+            <Badge tone="success" dot="start">
+              Success
+            </Badge>
+            <Badge tone="warning" dot="start">
+              Warning
+            </Badge>
+            <Badge tone="danger" dot="start">
+              Danger
+            </Badge>
+            <Badge tone="purple" dot="start">
+              Purple
+            </Badge>
+          </Cluster>
+          <Cluster gap="sm" align="center">
+            <Badge tone="neutral" dot="end">
+              Neutral
+            </Badge>
+            <Badge tone="info" dot="end">
+              Info
+            </Badge>
+            <Badge tone="success" dot="end">
+              Success
+            </Badge>
+            <Badge tone="warning" dot="end">
+              Warning
+            </Badge>
+            <Badge tone="danger" dot="end">
+              Danger
+            </Badge>
+            <Badge tone="purple" dot="end">
+              Purple
+            </Badge>
+          </Cluster>
+          <Cluster gap="sm" align="center">
+            <Badge size="sm" tone="success" dot="start">
+              Online
+            </Badge>
+            <Badge size="sm" tone="warning" dot="start">
+              Away
+            </Badge>
+            <Badge size="sm" tone="danger" dot="start">
+              Offline
+            </Badge>
+            <Badge size="sm" tone="neutral" dot="start">
+              Unknown
+            </Badge>
+          </Cluster>
+        </Stack>
+      </Example>
+
+      <Example
         title="Status patterns"
         description="The most common CRM usage: status pill on a contact, deal, or invitation."
         code={`// Contact statuses


### PR DESCRIPTION
## Summary

- Adds `dot?: 'start' | 'end'` to `<Badge>`. Renders a small `currentColor` circle before or after the content for Slack/GitHub-style status pills (`● Active`, `Failed ●`).
- Decorative only (`aria-hidden`); the badge text remains the accessible label.
- Adds `--size-badge-dot: 6px` token. Dot uses `var(--radius-full)`, `currentColor`, and `flex-shrink: 0`. No layout properties, no raw values.
- Demo: new "Status dot" Example in `BadgeDemo.tsx` covering all six tones × start/end × the sm size.
- Exports `BadgeDot` from both the component barrel and `src/index.ts`. AGENTS.md primer updated with one line under the Badge section.

## Implementation note

Dot is vertically centered via the badge's existing `inline-flex; align-items: center` — pure geometric centering, no transform nudges. Across browsers / system fonts (Segoe UI vs SF vs DejaVu) the text glyph optical center drifts slightly relative to the line-box midline; a pixel nudge tuned to one font misses in another, so the badge anchors on the dot's true center and accepts the sub-pixel optical asymmetry.

## Test plan

- [x] `npm test` — 4 new cases (no-dot default, start position, end position, aria-hidden decorative); all 138 pass
- [x] `npm run typecheck` clean (both workspaces)
- [x] `npm run lint:css` clean
- [x] `npm run build` clean
- [x] `npm pack --dry-run -w @eocrm/design-system` — no leakage; library tarball unchanged in scope
- [x] Visual check at http://localhost:8080/components/badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)