### PR TITLE
Playground: 2-column Examples grid on wide screens

### DIFF
--- a/packages/playground/src/pages/components/DemoLayout.module.scss
+++ b/packages/playground/src/pages/components/DemoLayout.module.scss
@@ -100,3 +100,16 @@
   font-weight: var(--font-weight-semibold);
   color: var(--color-fg);
 }
+
+.examplesGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-8);
+  align-items: start;
+}
+
+@media (min-width: 1200px) {
+  .examplesGrid {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/packages/playground/src/pages/components/DemoLayout.tsx
+++ b/packages/playground/src/pages/components/DemoLayout.tsx
@@ -69,7 +69,7 @@ export function DemoLayout({
       </Card>
 
       <h2 className={styles.sectionTitle}>Examples</h2>
-      <Stack gap="xl">{children}</Stack>
+      <div className={styles.examplesGrid}>{children}</div>
 
       {componentName && <CrossLinks kind="component" name={componentName} />}
     </Stack>


### PR DESCRIPTION
## Summary

Replaces the single-column `<Stack>` wrapping the Examples on each component demo page with a CSS Grid that switches to two columns at ≥ 1200px viewport width. Single column below that.

- `align-items: start` so unequal-height Examples don't stretch to match each other.
- `gap: var(--space-8)` between rows/columns.
- The header, source-code disclosure, section title, and CrossLinks footer stay full-width — only the Examples grid is multi-column.

## Test plan

- [ ] CI Quality check passes.
- [ ] At ≥ 1200px viewport: every component demo page shows Examples in two columns. Try `/components/dropdown-menu` (lots of examples) and `/components/badge` (varied widths).
- [ ] Below 1200px: layout falls back to single column without overflow.
- [ ] Examples with wider previews (e.g., DropdownMenu "Nested actions") don't get cramped — confirm code blocks scroll horizontally within their column rather than blowing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)