### PR TITLE
DropdownMenu: open-only entrance animation

### DIFF
--- a/docs/superpowers/plans/2026-05-19-dropdown-menu-open-animation.md
+++ b/docs/superpowers/plans/2026-05-19-dropdown-menu-open-animation.md
@@ -38,8 +38,8 @@ In `tokens.scss`, find the line `--opacity-disabled: 0.5;` (around line 140). Th
 Replace the existing `--opacity-disabled: 0.5;` line with the pair:
 
 ```scss
-  --opacity-disabled: 0.5;
-  --opacity-hidden: 0;
+--opacity-disabled: 0.5;
+--opacity-hidden: 0;
 ```
 
 Match the indentation of surrounding tokens (the block sits inside `:root { ... }`, so use the same leading whitespace as `--opacity-disabled`).
@@ -79,31 +79,31 @@ The goal of this task is to make Floating UI position via inline `top` / `left` 
 Open `DropdownMenu.test.tsx`. Find the end of the `describe('DropdownMenu — Content', ...)` block — its closing `});` is at the line just before `describe('DropdownMenu — Item / Separator', ...)`. Insert this new test just before the closing `});` of that block:
 
 ```tsx
-  it('positions Content via inline top/left, not transform (animation contract)', async () => {
-    // Animation hooks `transform` for the scale-fade entrance. If Floating UI
-    // ever switches back to transform-based positioning, our animation
-    // transform would clobber the position. This test locks the contract in.
-    const user = userEvent.setup();
-    render(
-      <DropdownMenu>
-        <DropdownMenu.Trigger>
-          <button type="button">Open</button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content>
-          <div>menu body</div>
-        </DropdownMenu.Content>
-      </DropdownMenu>,
-    );
-    await user.click(screen.getByRole('button', { name: 'Open' }));
-    const menu = screen.getByRole('menu');
-    const style = menu.getAttribute('style') ?? '';
-    expect(style).toMatch(/top:/);
-    expect(style).toMatch(/left:/);
-    // Floating UI writes either nothing or `transform: translate(...)` —
-    // assert it does NOT contain a translate(...) (the giveaway signature
-    // of transform-based positioning).
-    expect(style).not.toMatch(/translate\(/);
-  });
+it('positions Content via inline top/left, not transform (animation contract)', async () => {
+  // Animation hooks `transform` for the scale-fade entrance. If Floating UI
+  // ever switches back to transform-based positioning, our animation
+  // transform would clobber the position. This test locks the contract in.
+  const user = userEvent.setup();
+  render(
+    <DropdownMenu>
+      <DropdownMenu.Trigger>
+        <button type="button">Open</button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <div>menu body</div>
+      </DropdownMenu.Content>
+    </DropdownMenu>,
+  );
+  await user.click(screen.getByRole('button', { name: 'Open' }));
+  const menu = screen.getByRole('menu');
+  const style = menu.getAttribute('style') ?? '';
+  expect(style).toMatch(/top:/);
+  expect(style).toMatch(/left:/);
+  // Floating UI writes either nothing or `transform: translate(...)` —
+  // assert it does NOT contain a translate(...) (the giveaway signature
+  // of transform-based positioning).
+  expect(style).not.toMatch(/translate\(/);
+});
 ```
 
 - [ ] **Step 2: Run the new test and confirm it fails**
@@ -119,34 +119,34 @@ Expected: FAIL — the style attribute will contain `transform: translate(...)` 
 In `Content.tsx`, find the `useFloating({ ... })` call (around line 67). Add `transform: false` between `placement` and `middleware`:
 
 ```tsx
-  const {
-    refs,
-    floatingStyles,
-    placement: resolvedPlacement,
-  } = useFloating({
-    open: ctx.open,
-    placement,
-    transform: false,
-    middleware: [
-      offset(sideOffset),
-      flip(),
-      shift({ padding: 8 }),
-      size({
-        apply({ availableHeight, rects, elements }) {
-          Object.assign(elements.floating.style, {
-            maxHeight: `${availableHeight}px`,
-            minWidth:
-              typeof minWidth === 'number'
-                ? `${minWidth}px`
-                : ((minWidth as string | undefined) ?? `${rects.reference.width}px`),
-          });
-        },
-        padding: 8,
-      }),
-    ],
-    whileElementsMounted: autoUpdate,
-    elements: { reference: ctx.triggerRef.current },
-  });
+const {
+  refs,
+  floatingStyles,
+  placement: resolvedPlacement,
+} = useFloating({
+  open: ctx.open,
+  placement,
+  transform: false,
+  middleware: [
+    offset(sideOffset),
+    flip(),
+    shift({ padding: 8 }),
+    size({
+      apply({ availableHeight, rects, elements }) {
+        Object.assign(elements.floating.style, {
+          maxHeight: `${availableHeight}px`,
+          minWidth:
+            typeof minWidth === 'number'
+              ? `${minWidth}px`
+              : ((minWidth as string | undefined) ?? `${rects.reference.width}px`),
+        });
+      },
+      padding: 8,
+    }),
+  ],
+  whileElementsMounted: autoUpdate,
+  elements: { reference: ctx.triggerRef.current },
+});
 ```
 
 - [ ] **Step 4: Run the same test again and confirm it now passes**
@@ -224,19 +224,27 @@ Append the following block to the END of `DropdownMenu.module.scss`. Do NOT modi
 
 .content[data-side='bottom'] {
   transform-origin: top center;
-  @starting-style { transform: scale(0.96) translateY(-4px); }
+  @starting-style {
+    transform: scale(0.96) translateY(-4px);
+  }
 }
 .content[data-side='top'] {
   transform-origin: bottom center;
-  @starting-style { transform: scale(0.96) translateY(4px); }
+  @starting-style {
+    transform: scale(0.96) translateY(4px);
+  }
 }
 .content[data-side='right'] {
   transform-origin: left center;
-  @starting-style { transform: scale(0.96) translateX(-4px); }
+  @starting-style {
+    transform: scale(0.96) translateX(-4px);
+  }
 }
 .content[data-side='left'] {
   transform-origin: right center;
-  @starting-style { transform: scale(0.96) translateX(4px); }
+  @starting-style {
+    transform: scale(0.96) translateX(4px);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -253,6 +261,7 @@ make lint
 ```
 
 Expected outcome — one of:
+
 - PASS: stylelint accepts `@starting-style` and the new rules cleanly. Proceed.
 - FAIL with `at-rule-no-unknown` complaining about `@starting-style`: fall through to Step 3.
 
@@ -318,58 +327,58 @@ transition, which neutralises @starting-style (panel snaps in)."
 Locate the `describe('DropdownMenu — Content', ...)` block. Insert this new test just before its closing `});` (same location strategy as Task 2's test):
 
 ```tsx
-  it('declares an @starting-style rule for the content selector (animation hook)', () => {
-    // Animation is CSS-only and uses @starting-style for the entrance.
-    // jsdom does not run the animation, but it does parse the rules into
-    // CSSOM. Confirm the rule exists so a future refactor doesn't silently
-    // drop the animation.
-    render(
-      <DropdownMenu>
-        <DropdownMenu.Trigger>
-          <button type="button">Open</button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content>
-          <div>menu body</div>
-        </DropdownMenu.Content>
-      </DropdownMenu>,
-    );
+it('declares an @starting-style rule for the content selector (animation hook)', () => {
+  // Animation is CSS-only and uses @starting-style for the entrance.
+  // jsdom does not run the animation, but it does parse the rules into
+  // CSSOM. Confirm the rule exists so a future refactor doesn't silently
+  // drop the animation.
+  render(
+    <DropdownMenu>
+      <DropdownMenu.Trigger>
+        <button type="button">Open</button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <div>menu body</div>
+      </DropdownMenu.Content>
+    </DropdownMenu>,
+  );
 
-    let foundStartingStyle = false;
-    for (const sheet of Array.from(document.styleSheets)) {
-      let rules: CSSRuleList | null = null;
-      try {
-        rules = sheet.cssRules;
-      } catch {
-        continue;
+  let foundStartingStyle = false;
+  for (const sheet of Array.from(document.styleSheets)) {
+    let rules: CSSRuleList | null = null;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      continue;
+    }
+    if (!rules) continue;
+    for (const rule of Array.from(rules)) {
+      // CSSStartingStyleRule has cssText starting with `@starting-style`.
+      // We don't rely on a specific rule-type constant because jsdom's
+      // CSSRule constants may not include CSSStartingStyleRule.
+      const text = (rule as CSSRule).cssText ?? '';
+      if (text.includes('@starting-style') && text.includes('content')) {
+        foundStartingStyle = true;
+        break;
       }
-      if (!rules) continue;
-      for (const rule of Array.from(rules)) {
-        // CSSStartingStyleRule has cssText starting with `@starting-style`.
-        // We don't rely on a specific rule-type constant because jsdom's
-        // CSSRule constants may not include CSSStartingStyleRule.
-        const text = (rule as CSSRule).cssText ?? '';
-        if (text.includes('@starting-style') && text.includes('content')) {
-          foundStartingStyle = true;
-          break;
-        }
-        // Walk into nested rules (e.g. inside another at-rule) in case the
-        // CSS Modules processor wraps them.
-        const inner = (rule as unknown as { cssRules?: CSSRuleList }).cssRules;
-        if (inner) {
-          for (const child of Array.from(inner)) {
-            const childText = (child as CSSRule).cssText ?? '';
-            if (childText.includes('@starting-style')) {
-              foundStartingStyle = true;
-              break;
-            }
+      // Walk into nested rules (e.g. inside another at-rule) in case the
+      // CSS Modules processor wraps them.
+      const inner = (rule as unknown as { cssRules?: CSSRuleList }).cssRules;
+      if (inner) {
+        for (const child of Array.from(inner)) {
+          const childText = (child as CSSRule).cssText ?? '';
+          if (childText.includes('@starting-style')) {
+            foundStartingStyle = true;
+            break;
           }
         }
-        if (foundStartingStyle) break;
       }
       if (foundStartingStyle) break;
     }
-    expect(foundStartingStyle).toBe(true);
-  });
+    if (foundStartingStyle) break;
+  }
+  expect(foundStartingStyle).toBe(true);
+});
 ```
 
 - [ ] **Step 2: Run the new test**
@@ -379,6 +388,7 @@ npm test -w @eocrm/design-system -- --run src/components/DropdownMenu/DropdownMe
 ```
 
 Expected: PASS. If FAIL, the SCSS-to-CSSOM pipeline didn't include the rule. Two likely causes:
+
 - The Vitest CSS Modules processor stripped the `@starting-style` block. Inspect the rendered stylesheet text to see what made it through; if needed, switch the assertion to match the substring more loosely (e.g. drop the `content` requirement and rely only on `@starting-style`).
 - jsdom's CSS parser doesn't understand `@starting-style` and silently drops the rule. If this is the case, the test is unprovable in jsdom — replace it with a regex check against the raw SCSS file contents (read the file with `fs`, assert the string appears). That's a weaker but verifiable contract.
 
@@ -432,6 +442,7 @@ in a background terminal.
 Open `http://localhost:8080/components/dropdown-menu` in a browser (or use Playwright MCP to drive it).
 
 Check each:
+
 1. Click a default-bottom-aligned trigger — panel scales/fades down from the trigger's bottom edge.
 2. Click a trigger configured with `side="top"` (if the demo has one — otherwise rely on collision-flip near the viewport edge) — panel scales/fades up from the trigger's top edge.
 3. Open a SubContent (hover or click a SubTrigger) — submenu scales/fades from its left edge (default `side="right"`).
@@ -529,6 +540,7 @@ Output as Critical / Important / Nice-to-have / Regression-watch + final verdict
 - [ ] **Step 3: Fix every Critical and every Important finding**
 
 For each finding:
+
 - If valid: fix, re-stage, and create a NEW commit per the project's commit-message style.
 - If deliberately skipped: leave a one-line justification in your response so the next reviewer doesn't re-flag it.
 
@@ -545,6 +557,7 @@ Repeat from Step 2.
 - [ ] **Step 6: Loop until verdict is `clean enough to stop`**
 
 Exit criteria:
+
 - 0 Critical, 0 Important (or each remaining has an explicit documented skip rationale)
 - All four gates green
 - `npm pack --dry-run` tarball clean

--- a/docs/superpowers/plans/2026-05-19-dropdown-menu-open-animation.md
+++ b/docs/superpowers/plans/2026-05-19-dropdown-menu-open-animation.md
@@ -1,0 +1,626 @@
+# DropdownMenu Open-Only Entrance Animation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `DropdownMenu.Content` and `SubContent` open with a short scale-fade from the trigger side (140 ms `ease-out`), while keeping close instant.
+
+**Architecture:** Pure CSS via `@starting-style` interpolates the panel from a translated/scaled/transparent state to its rest state on initial paint. Floating UI is reconfigured with `transform: false` so it positions via `top` / `left`, freeing `transform` for the entrance animation. The `data-side` attribute already set on Content drives a direction-aware `transform-origin` and translate offset.
+
+**Tech Stack:** React 19, TypeScript, CSS Modules (SCSS), Vitest + Testing Library, `@floating-ui/react-dom`. No new dependencies.
+
+**Spec:** [`docs/superpowers/specs/2026-05-19-dropdown-menu-open-animation-design.md`](../specs/2026-05-19-dropdown-menu-open-animation-design.md)
+
+---
+
+## Pre-flight (already done; do not re-do)
+
+- ✅ Spec written and committed (`bf72f5b`).
+- ✅ Branch `feat/dropdown-open-animation` created off fresh `main`.
+- ✅ `--transition-base` (140ms ease-out) already exists in `tokens.scss`.
+- ✅ `--opacity-disabled` (0.5) exists; this plan adds `--opacity-hidden` (0) alongside it.
+- ✅ Confirmed: `DropdownMenu.test.tsx` uses `userEvent.click(trigger)` to open and `screen.getByRole('menu')` to access the floating Content.
+- ✅ Confirmed: `data-side` is already written on Content (`Content.tsx:347`).
+
+---
+
+## Task 1: Add the `--opacity-hidden` token
+
+**Files:**
+
+- Modify: `packages/design-system/src/styles/tokens.scss`
+
+- [ ] **Step 1: Locate the opacity token block**
+
+In `tokens.scss`, find the line `--opacity-disabled: 0.5;` (around line 140). The new token goes next to it.
+
+- [ ] **Step 2: Add `--opacity-hidden` directly after `--opacity-disabled`**
+
+Replace the existing `--opacity-disabled: 0.5;` line with the pair:
+
+```scss
+  --opacity-disabled: 0.5;
+  --opacity-hidden: 0;
+```
+
+Match the indentation of surrounding tokens (the block sits inside `:root { ... }`, so use the same leading whitespace as `--opacity-disabled`).
+
+- [ ] **Step 3: Run stylelint to confirm the new token doesn't trip any rule**
+
+```bash
+make lint
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/styles/tokens.scss
+git commit -m "tokens: add --opacity-hidden (0) alongside --opacity-disabled
+
+Needed by the DropdownMenu open animation. Naming pairs with the
+existing --opacity-disabled (0.5) token instead of inventing a new
+prefix."
+```
+
+---
+
+## Task 2: Switch Floating UI to `transform: false` and add a contract test
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/DropdownMenu/Content.tsx`
+- Modify: `packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx`
+
+The goal of this task is to make Floating UI position via inline `top` / `left` instead of `transform`. We do this first so the test that locks in the contract goes through TDD (red → green) cleanly.
+
+- [ ] **Step 1: Add a failing test that asserts Content positions via `top`/`left`**
+
+Open `DropdownMenu.test.tsx`. Find the end of the `describe('DropdownMenu — Content', ...)` block — its closing `});` is at the line just before `describe('DropdownMenu — Item / Separator', ...)`. Insert this new test just before the closing `});` of that block:
+
+```tsx
+  it('positions Content via inline top/left, not transform (animation contract)', async () => {
+    // Animation hooks `transform` for the scale-fade entrance. If Floating UI
+    // ever switches back to transform-based positioning, our animation
+    // transform would clobber the position. This test locks the contract in.
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <button type="button">Open</button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <div>menu body</div>
+        </DropdownMenu.Content>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    const menu = screen.getByRole('menu');
+    const style = menu.getAttribute('style') ?? '';
+    expect(style).toMatch(/top:/);
+    expect(style).toMatch(/left:/);
+    // Floating UI writes either nothing or `transform: translate(...)` —
+    // assert it does NOT contain a translate(...) (the giveaway signature
+    // of transform-based positioning).
+    expect(style).not.toMatch(/translate\(/);
+  });
+```
+
+- [ ] **Step 2: Run the new test and confirm it fails**
+
+```bash
+npm test -w @eocrm/design-system -- --run src/components/DropdownMenu/DropdownMenu.test.tsx -t "positions Content via inline top/left"
+```
+
+Expected: FAIL — the style attribute will contain `transform: translate(...)` from Floating UI's default behavior, so `not.toMatch(/translate\(/)` fails.
+
+- [ ] **Step 3: Update `Content.tsx` — add `transform: false` to `useFloating`**
+
+In `Content.tsx`, find the `useFloating({ ... })` call (around line 67). Add `transform: false` between `placement` and `middleware`:
+
+```tsx
+  const {
+    refs,
+    floatingStyles,
+    placement: resolvedPlacement,
+  } = useFloating({
+    open: ctx.open,
+    placement,
+    transform: false,
+    middleware: [
+      offset(sideOffset),
+      flip(),
+      shift({ padding: 8 }),
+      size({
+        apply({ availableHeight, rects, elements }) {
+          Object.assign(elements.floating.style, {
+            maxHeight: `${availableHeight}px`,
+            minWidth:
+              typeof minWidth === 'number'
+                ? `${minWidth}px`
+                : ((minWidth as string | undefined) ?? `${rects.reference.width}px`),
+          });
+        },
+        padding: 8,
+      }),
+    ],
+    whileElementsMounted: autoUpdate,
+    elements: { reference: ctx.triggerRef.current },
+  });
+```
+
+- [ ] **Step 4: Run the same test again and confirm it now passes**
+
+```bash
+npm test -w @eocrm/design-system -- --run src/components/DropdownMenu/DropdownMenu.test.tsx -t "positions Content via inline top/left"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full DropdownMenu suite to confirm no regression**
+
+```bash
+npm test -w @eocrm/design-system -- --run src/components/DropdownMenu/DropdownMenu.test.tsx
+```
+
+Expected: all tests pass (the 100+ existing tests plus the new one).
+
+- [ ] **Step 6: Run the full library suite to be doubly sure**
+
+```bash
+npm test -w @eocrm/design-system -- --run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/DropdownMenu/Content.tsx packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+git commit -m "DropdownMenu: position via top/left (transform: false) for animation
+
+The entrance animation in the next commit uses CSS \`transform\` for
+the scale-fade. Floating UI's default transform-based positioning
+would override it, so switch to top/left positioning. Same auto-update
+mechanism, different write target."
+```
+
+---
+
+## Task 3: Add the entrance animation CSS
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss`
+
+- [ ] **Step 1: Append the animation rules**
+
+Append the following block to the END of `DropdownMenu.module.scss`. Do NOT modify the existing `.content` block; the new rules layer on top via cascade order.
+
+```scss
+// --- Open-only entrance animation -----------------------------------------
+// Content (and SubContent, which composes it) animates in on mount. On close
+// Content returns null — there is no exit animation by design.
+//
+// Floating UI positions via top/left (see `transform: false` in Content.tsx)
+// so the `transform` property below is free for the scale + translate
+// entrance without clobbering placement.
+//
+// @starting-style only applies when a transition is active. Under
+// `prefers-reduced-motion: reduce` we kill the transition, which neutralises
+// @starting-style — the panel renders directly at its computed style.
+.content {
+  transform: none;
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base);
+}
+
+.content {
+  @starting-style {
+    opacity: var(--opacity-hidden);
+  }
+}
+
+.content[data-side='bottom'] {
+  transform-origin: top center;
+  @starting-style { transform: scale(0.96) translateY(-4px); }
+}
+.content[data-side='top'] {
+  transform-origin: bottom center;
+  @starting-style { transform: scale(0.96) translateY(4px); }
+}
+.content[data-side='right'] {
+  transform-origin: left center;
+  @starting-style { transform: scale(0.96) translateX(-4px); }
+}
+.content[data-side='left'] {
+  transform-origin: right center;
+  @starting-style { transform: scale(0.96) translateX(4px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .content {
+    transition: none;
+  }
+}
+```
+
+- [ ] **Step 2: Run stylelint**
+
+```bash
+make lint
+```
+
+Expected outcome — one of:
+- PASS: stylelint accepts `@starting-style` and the new rules cleanly. Proceed.
+- FAIL with `at-rule-no-unknown` complaining about `@starting-style`: fall through to Step 3.
+
+- [ ] **Step 3: If stylelint blocked `@starting-style`, update `.stylelintrc.json`**
+
+Open `/home/dpws/projects/design-system/.stylelintrc.json`. The top-level `rules` object currently does not configure `at-rule-no-unknown` explicitly (it inherits from `stylelint-config-standard-scss`). Add an explicit override that allows `@starting-style`:
+
+```json
+    "at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": ["starting-style"]
+      }
+    ],
+```
+
+Place this entry in the `rules` object alongside the other top-level rule keys (next to `"color-function-notation"` for instance — order doesn't matter). Then re-run `make lint`. Expected: PASS.
+
+If stylelint complains about `scss/at-rule-no-unknown` instead, repeat the same pattern with that key name. Use the failure message as the guide; do not guess at a third name if neither of those is what stylelint reports.
+
+- [ ] **Step 4: Run the full library test suite**
+
+```bash
+npm test -w @eocrm/design-system -- --run
+```
+
+Expected: all tests pass (no regressions).
+
+- [ ] **Step 5: Run typecheck and build**
+
+```bash
+npm run typecheck -w @eocrm/design-system && make build
+```
+
+Expected: exit 0 for both.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
+# If stylelint config was modified in step 3, also include:
+git add .stylelintrc.json 2>/dev/null || true
+git commit -m "DropdownMenu: scale-fade entrance via @starting-style
+
+Content (and SubContent) animates from opacity-hidden + scale(0.96)
+with a 4px directional translate to its rest state on mount.
+data-side drives transform-origin so the panel always appears to grow
+toward the trigger. 140ms ease-out via --transition-base. Closes
+instantly by design. prefers-reduced-motion: reduce disables the
+transition, which neutralises @starting-style (panel snaps in)."
+```
+
+---
+
+## Task 4: Add a CSSOM test verifying `@starting-style` is present
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx`
+
+- [ ] **Step 1: Add the test at the end of the `describe('DropdownMenu — Content', ...)` block**
+
+Locate the `describe('DropdownMenu — Content', ...)` block. Insert this new test just before its closing `});` (same location strategy as Task 2's test):
+
+```tsx
+  it('declares an @starting-style rule for the content selector (animation hook)', () => {
+    // Animation is CSS-only and uses @starting-style for the entrance.
+    // jsdom does not run the animation, but it does parse the rules into
+    // CSSOM. Confirm the rule exists so a future refactor doesn't silently
+    // drop the animation.
+    render(
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <button type="button">Open</button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <div>menu body</div>
+        </DropdownMenu.Content>
+      </DropdownMenu>,
+    );
+
+    let foundStartingStyle = false;
+    for (const sheet of Array.from(document.styleSheets)) {
+      let rules: CSSRuleList | null = null;
+      try {
+        rules = sheet.cssRules;
+      } catch {
+        continue;
+      }
+      if (!rules) continue;
+      for (const rule of Array.from(rules)) {
+        // CSSStartingStyleRule has cssText starting with `@starting-style`.
+        // We don't rely on a specific rule-type constant because jsdom's
+        // CSSRule constants may not include CSSStartingStyleRule.
+        const text = (rule as CSSRule).cssText ?? '';
+        if (text.includes('@starting-style') && text.includes('content')) {
+          foundStartingStyle = true;
+          break;
+        }
+        // Walk into nested rules (e.g. inside another at-rule) in case the
+        // CSS Modules processor wraps them.
+        const inner = (rule as unknown as { cssRules?: CSSRuleList }).cssRules;
+        if (inner) {
+          for (const child of Array.from(inner)) {
+            const childText = (child as CSSRule).cssText ?? '';
+            if (childText.includes('@starting-style')) {
+              foundStartingStyle = true;
+              break;
+            }
+          }
+        }
+        if (foundStartingStyle) break;
+      }
+      if (foundStartingStyle) break;
+    }
+    expect(foundStartingStyle).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run the new test**
+
+```bash
+npm test -w @eocrm/design-system -- --run src/components/DropdownMenu/DropdownMenu.test.tsx -t "@starting-style"
+```
+
+Expected: PASS. If FAIL, the SCSS-to-CSSOM pipeline didn't include the rule. Two likely causes:
+- The Vitest CSS Modules processor stripped the `@starting-style` block. Inspect the rendered stylesheet text to see what made it through; if needed, switch the assertion to match the substring more loosely (e.g. drop the `content` requirement and rely only on `@starting-style`).
+- jsdom's CSS parser doesn't understand `@starting-style` and silently drops the rule. If this is the case, the test is unprovable in jsdom — replace it with a regex check against the raw SCSS file contents (read the file with `fs`, assert the string appears). That's a weaker but verifiable contract.
+
+Use the actual failure output to decide which fallback to apply. Do not pre-emptively weaken the test.
+
+- [ ] **Step 3: Run the full DropdownMenu test file to confirm no regressions**
+
+```bash
+npm test -w @eocrm/design-system -- --run src/components/DropdownMenu/DropdownMenu.test.tsx
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+git commit -m "DropdownMenu: test @starting-style rule existence
+
+Locks in the animation contract — a future SCSS refactor that drops
+the @starting-style block will fail this test rather than silently
+remove the entrance animation."
+```
+
+---
+
+## Task 5: Visual verification in the playground
+
+**Files:**
+
+- (none — visual check only)
+
+- [ ] **Step 1: Start the playground**
+
+A dev server may already be running on port 8080 (vite HMR will pick up the new code automatically). Verify with:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080
+```
+
+If `200`, skip starting one. Otherwise run:
+
+```bash
+make dev
+```
+
+in a background terminal.
+
+- [ ] **Step 2: Navigate to the DropdownMenu demo and verify open animations**
+
+Open `http://localhost:8080/components/dropdown-menu` in a browser (or use Playwright MCP to drive it).
+
+Check each:
+1. Click a default-bottom-aligned trigger — panel scales/fades down from the trigger's bottom edge.
+2. Click a trigger configured with `side="top"` (if the demo has one — otherwise rely on collision-flip near the viewport edge) — panel scales/fades up from the trigger's top edge.
+3. Open a SubContent (hover or click a SubTrigger) — submenu scales/fades from its left edge (default `side="right"`).
+4. Close any open menu — panel disappears instantly with no animation.
+
+- [ ] **Step 3: Verify `prefers-reduced-motion`**
+
+In Chrome/Edge DevTools → Rendering → "Emulate CSS media feature prefers-reduced-motion" → set to "reduce". Reopen a menu. Confirm: panel appears at its rest state with no animation.
+
+- [ ] **Step 4: No commit needed — visual check only**
+
+If any check fails, fix the underlying SCSS or JS, re-run gates from Task 3 / 4, then redo the visual check.
+
+---
+
+## Task 6: Update `AGENTS.md`
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Locate the DropdownMenu section**
+
+Find `### `<DropdownMenu>` — action menus from a trigger` (around line 178 in the current `AGENTS.md`).
+
+- [ ] **Step 2: Append one bullet to the existing bullet list in that section**
+
+Find the last bullet of the DropdownMenu section — currently the line starting `- For value selection (pick a status, country, etc.), use \`<Select>\`...`. Insert a new bullet just before it (so the "use Select instead" guidance remains the last, most important bullet):
+
+```markdown
+- Opens with a short scale-fade from the trigger side (140 ms `ease-out`). Closes instantly by design — menu close should feel like "get out of the way", not "play a transition". Respects `prefers-reduced-motion: reduce`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/AGENTS.md
+git commit -m "AGENTS.md: note DropdownMenu entrance animation"
+```
+
+---
+
+## Task 7: Pre-push review-fix loop (mandatory per Hard Rule 8)
+
+**Files:**
+
+- (none — gates + reviewer dispatch + fixes)
+
+This is **required** by `packages/design-system/CLAUDE.md` Hard Rule 8. The library is consumed by AI agents; missed token slips, broken JSDoc, or unintended cross-cutting changes propagate.
+
+- [ ] **Step 1: Run all four gates**
+
+```bash
+npm test -w @eocrm/design-system -- --run \
+  && npm run typecheck -w @eocrm/design-system \
+  && make lint \
+  && make build \
+  && npm pack --dry-run -w @eocrm/design-system
+```
+
+All must pass. The `npm pack --dry-run` output must NOT contain `.test.tsx` files or internal-only paths.
+
+- [ ] **Step 2: Dispatch a fresh-context review agent (`general-purpose`)**
+
+Brief it as follows:
+
+```
+Review the changes on branch feat/dropdown-open-animation in packages/design-system/.
+
+Read first:
+- packages/design-system/CLAUDE.md (especially Hard Rule 8's 10 categories)
+- packages/design-system/AGENTS.md
+- packages/design-system/README.md
+- docs/superpowers/specs/2026-05-19-dropdown-menu-open-animation-design.md
+
+Then review the diff:
+  git diff main...HEAD -- packages/design-system/ .stylelintrc.json
+
+Categories:
+1. Bugs / correctness — Floating UI transform: false behavior; @starting-style + transition interaction; rapid open/close behavior; submenu inheritance; portal/CSS Modules interaction.
+2. Accessibility — animation doesn't break aria-controls, role="menu", focus management.
+3. API consistency — no new public props or types.
+4. Type safety.
+5. Rule violations (Rules 1–7).
+6. Test coverage — does the @starting-style test actually verify the contract under jsdom's limitations?
+7. Token discipline — `--opacity-hidden: 0` naming, no other raw values.
+8. SCSS quality — Rule 4 still respected. Cascade order between the existing `.content` block (top of file) and the new animation block (bottom).
+9. Cross-package leakage — none expected; verify.
+10. Package / distribution — `npm pack --dry-run` clean.
+
+Output as Critical / Important / Nice-to-have / Regression-watch + final verdict
+("clean enough to stop" OR "keep iterating"). Be specific (file:line).
+```
+
+- [ ] **Step 3: Fix every Critical and every Important finding**
+
+For each finding:
+- If valid: fix, re-stage, and create a NEW commit per the project's commit-message style.
+- If deliberately skipped: leave a one-line justification in your response so the next reviewer doesn't re-flag it.
+
+Nice-to-have is judgment; address when cheap.
+
+- [ ] **Step 4: Re-run all four gates after fixes**
+
+Same command as Step 1.
+
+- [ ] **Step 5: Dispatch another fresh-context reviewer with the same brief**
+
+Repeat from Step 2.
+
+- [ ] **Step 6: Loop until verdict is `clean enough to stop`**
+
+Exit criteria:
+- 0 Critical, 0 Important (or each remaining has an explicit documented skip rationale)
+- All four gates green
+- `npm pack --dry-run` tarball clean
+
+---
+
+## Task 8: Push branch and open PR
+
+**Files:**
+
+- (none — git + gh)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/dropdown-open-animation
+```
+
+The Husky `pre-push` hook will run prettier, stylelint, and typecheck. If prettier fails, run `npx prettier --write <files>` and commit the formatting, then push again. Never use `--no-verify` without explicit user authorization.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "DropdownMenu: open-only entrance animation" --body "$(cat <<'EOF'
+## Summary
+- Top-level `Content` and `SubContent` open with a 140 ms `ease-out` scale-fade originating from the trigger side. Close is instant by design (see spec for rationale).
+- CSS-only via `@starting-style`; the only JS change is `transform: false` on Floating UI so its inline positioning uses `top` / `left` instead of `transform`, freeing `transform` for the animation.
+- Respects `prefers-reduced-motion: reduce`. No new public API. No new dependencies. No "animation engine."
+
+Spec: [`docs/superpowers/specs/2026-05-19-dropdown-menu-open-animation-design.md`](../blob/feat/dropdown-open-animation/docs/superpowers/specs/2026-05-19-dropdown-menu-open-animation-design.md)
+
+## Test plan
+- [x] Existing DropdownMenu tests pass unchanged
+- [x] New contract test: Floating UI writes `top` / `left`, not `transform`
+- [x] New CSSOM test: `@starting-style` rule exists for the content selector
+- [x] Full library suite green
+- [x] Typecheck, stylelint, build, and `npm pack --dry-run` all clean
+- [x] Husky pre-push hook green
+- [x] Playground: visual check on each `data-side` plus reduced-motion emulation
+- [x] Two-round pre-push review-fix loop complete; verdict: clean enough to stop
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for `Quality / check` to pass**
+
+```bash
+gh pr checks --watch
+```
+
+If the check fails, investigate via `gh pr checks` and the workflow logs, fix locally, push again. Do not merge before the check is green.
+
+- [ ] **Step 4: Surface the PR URL to the user**
+
+---
+
+## Done criteria
+
+- All 8 tasks' checkboxes ticked.
+- PR open with `Quality / check` green.
+- Open animation visible in playground for all four `side` values; reduced-motion path snaps in.
+
+## Spec coverage check (self-review)
+
+Mapping spec sections → tasks:
+
+- Spec "Goal" → Tasks 3, 5.
+- Spec "The one JS change" → Task 2.
+- Spec "The CSS" → Tasks 1 (token), 3 (animation rules).
+- Spec "Files changed" #1 → Task 2; #2 → Task 3; #3 → Tasks 2, 4; #4 → Task 6.
+- Spec "Tests" — Floating UI top/left contract → Task 2; `@starting-style` rule existence → Task 4.
+- Spec "Playground" → Task 5.
+- Spec "Docs" → Task 6.
+- Spec "Risks & mitigations" — stylelint trip → Task 3 Step 3; transform conflict → Task 2; etc.
+- Spec "Acceptance" → Tasks 5, 7, 8.
+
+No gaps.

--- a/docs/superpowers/specs/2026-05-19-dropdown-menu-open-animation-design.md
+++ b/docs/superpowers/specs/2026-05-19-dropdown-menu-open-animation-design.md
@@ -1,0 +1,136 @@
+# DropdownMenu: open-only entrance animation
+
+**Status:** approved, ready for plan
+**Author:** dpws + Claude
+**Date:** 2026-05-19
+**Scope:** `packages/design-system/src/components/DropdownMenu/`
+
+## Goal
+
+When `DropdownMenu.Content` (and `SubContent`) opens, the panel scale-fades in from the trigger side using a short, restrained motion (140 ms `ease-out`, 4 % scale, 4 px directional translate). When the panel closes, it disappears instantly.
+
+## Non-goals
+
+- **No close animation.** `Content` returns `null` the instant `open` flips false, exactly as today. Adding exit animation requires a mount-lifecycle state machine that this change explicitly avoids.
+- **No item-level animation.** Menu hover/focus highlights remain instantaneous. Material 3 and Apple HIG both call this out — transitioning the highlight introduces perceived input lag and is wrong for menus.
+- **No "animation engine," motion module, or shared primitive.** Same posture as Tabs: extract only when 3+ components prove the need.
+- **No new public API.** `Content` props are unchanged. Consumers do not opt in or out of animation; it just happens.
+
+## Approach
+
+Use CSS `@starting-style` to interpolate from a pre-mount state (`opacity: 0; transform: scale(0.96) translate(...)`) to the resting state (`opacity: 1; transform: none`) on initial render. The `data-side` attribute that `Content` already sets drives `transform-origin` and the translate direction so the panel always appears to come *toward* the trigger.
+
+`@starting-style` browser support in May 2026: Chrome 117+ (Sep 2023), Safari 17.5+ (May 2024), Firefox 129+ (Aug 2024) — universal across the last two major versions of every supported browser. Falls back gracefully (panel just appears at final state, no animation) on older browsers.
+
+### The one JS change
+
+`Content.tsx` calls `useFloating(...)`. Floating UI positions the panel by setting `transform: translate(Xpx, Ypx)` on the floating element by default. If we also animate the panel with `transform: scale(...) translate(...)`, our CSS `transform` **overrides Floating UI's positioning transform**, breaking placement.
+
+The standard fix is to pass `transform: false` to `useFloating`, which makes Floating UI position the element via inline `top` / `left` instead of `transform`. This is the documented escape hatch for exactly this situation. Negligible paint-perf impact (top/left instead of transform-layer promotion) for an element that exists only for the duration of an interaction.
+
+### The CSS
+
+The project's `.stylelintrc.json` polices `opacity` via `scale-unlimited/declaration-strict-value`. Existing code uses `var(--opacity-disabled)` (0.5). For the `0` end of the animation, add a paired token `--opacity-hidden: 0` to `src/styles/tokens.scss`. The resting state's `opacity: 1` is the CSS default, so it never needs to be written — only the `@starting-style` block names opacity, via the token.
+
+Append to `DropdownMenu.module.scss`:
+
+```scss
+// Base resting state for the animated open. transition + transform-origin
+// here; the @starting-style blocks below set the pre-paint state per side.
+// On close, Content returns null — there is no exit animation by design.
+.content {
+  // ...existing rules unchanged...
+  transform: none;
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base);
+
+  @starting-style {
+    opacity: var(--opacity-hidden);
+  }
+}
+
+// Direction-aware transform-origin + initial offset. The panel always
+// appears to grow toward the trigger.
+.content[data-side='bottom'] {
+  transform-origin: top center;
+  @starting-style { transform: scale(0.96) translateY(-4px); }
+}
+.content[data-side='top'] {
+  transform-origin: bottom center;
+  @starting-style { transform: scale(0.96) translateY(4px); }
+}
+.content[data-side='right'] {
+  transform-origin: left center;
+  @starting-style { transform: scale(0.96) translateX(-4px); }
+}
+.content[data-side='left'] {
+  transform-origin: right center;
+  @starting-style { transform: scale(0.96) translateX(4px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  // @starting-style only applies when a transition is active. With transition: none
+  // the @starting-style block above becomes inert and the panel renders directly
+  // at its computed style (opacity: 1, transform: none — both CSS defaults).
+  .content {
+    transition: none;
+  }
+}
+```
+
+**Note on stylelint:** `@starting-style` may not be in `stylelint-config-standard-scss`'s built-in at-rule allowlist yet. If `make lint` flags it (`at-rule-no-unknown` or similar), add `@starting-style` to an allowlist or disable the rule for that file. Verify before committing.
+
+### Token usage
+
+- `--transition-base` (`140ms ease-out`, exists) — controls both the opacity and transform transitions.
+- All other values (`scale(0.96)`, `4px`, `top center`, etc.) are intrinsic animation parameters, not design tokens. Adding tokens for one-off animation magic numbers would be premature abstraction.
+
+## Implementation
+
+### Files changed
+
+1. `packages/design-system/src/components/DropdownMenu/Content.tsx` — add `transform: false` to `useFloating` options.
+2. `packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss` — append the rules above.
+3. `packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx` — add two tests (see below).
+4. `packages/design-system/AGENTS.md` — one line under the DropdownMenu section noting the entrance animation + reduced-motion respect.
+
+### Tests
+
+Two new tests in `DropdownMenu.test.tsx`:
+
+1. **Floating UI positions via `top` / `left`, not `transform`.** Open a menu, assert that the rendered Content element has inline `top` and `left` styles, and that its inline `transform` style is either empty or `none`. This locks in the `transform: false` contract so a future refactor doesn't silently break the animation by re-enabling Floating UI's transform-based positioning.
+2. **`@starting-style` rule exists for `.content`.** Use the same CSSOM-traversal pattern as the Tabs reduced-motion test: walk `document.styleSheets`, find a rule matching `.content` (or a substring match), confirm it has a `@starting-style` block. This passes in jsdom because the CSS is parsed; the actual animation doesn't run.
+
+Existing 100+ DropdownMenu tests must still pass. None of them assert on Floating UI's specific transform output (verified during exploration).
+
+### Playground
+
+No new demo. The existing `DropdownMenuDemo` in `packages/playground/src/pages/components/DropdownMenuDemo.tsx` already exercises open/close. Verify visually in `make up`.
+
+### Docs
+
+`packages/design-system/AGENTS.md`, in the DropdownMenu section: append a single bullet like:
+
+> Opens with a short scale-fade from the trigger side (140 ms). Closes instantly by design (menu close = "get out of the way", not "perform a transition"). Respects `prefers-reduced-motion: reduce`.
+
+No JSDoc changes — the animation is implementation detail, not API.
+
+## Risks & mitigations
+
+- **Stylelint trips on `@starting-style`.** Likely if `.stylelintrc.json` uses `at-rule-no-unknown`. Mitigation: extend the allowlist. Catch in CI via `make lint` before push.
+- **Consumer CSS reaches into the portal and overrides `transform`.** Very unlikely; consumers shouldn't be targeting our portal's inline styles. Documented in AGENTS.md.
+- **Floating UI's `transform: false` mode interacts subtly with auto-update during scroll.** Same auto-update mechanism, different write target (top/left vs transform). Verified by reading Floating UI docs; no behavior change at the layout level.
+- **Performance.** Animating `transform` + `opacity` is the cheap pair (compositor-only). `top`/`left` writes from Floating UI cause layout but only on open + on scroll/resize while open, identical to the existing autoUpdate cadence. Net: imperceptible.
+- **Rapid open/close in quick succession.** Each open re-mounts `Content`, so `@starting-style` re-runs every time. Animation plays from start on each reopen. Close is instant. No animation queue, no half-closed state. Robust by construction.
+
+## Acceptance
+
+- `make test` green (existing + 2 new tests).
+- `make typecheck`, `make lint`, `make build`, `npm pack --dry-run` green.
+- Visual in `make up`:
+  - Open a top-level DropdownMenu: panel scales/fades in from above the trigger (default `side="bottom"`). Close: panel vanishes instantly.
+  - Open a SubContent: same effect anchored to the left edge (default `side="right"`).
+  - Open menus on each `side` (top / bottom / left / right) via the demo: origin and translate direction flip correctly.
+  - DevTools → Rendering → "Emulate CSS media feature prefers-reduced-motion" = "reduce": menu appears instantly with no transform or fade.
+- Hard Rule 8 pre-push review-fix loop completes with verdict `clean enough to stop`.

--- a/docs/superpowers/specs/2026-05-19-dropdown-menu-open-animation-design.md
+++ b/docs/superpowers/specs/2026-05-19-dropdown-menu-open-animation-design.md
@@ -18,7 +18,7 @@ When `DropdownMenu.Content` (and `SubContent`) opens, the panel scale-fades in f
 
 ## Approach
 
-Use CSS `@starting-style` to interpolate from a pre-mount state (`opacity: 0; transform: scale(0.96) translate(...)`) to the resting state (`opacity: 1; transform: none`) on initial render. The `data-side` attribute that `Content` already sets drives `transform-origin` and the translate direction so the panel always appears to come *toward* the trigger.
+Use CSS `@starting-style` to interpolate from a pre-mount state (`opacity: 0; transform: scale(0.96) translate(...)`) to the resting state (`opacity: 1; transform: none`) on initial render. The `data-side` attribute that `Content` already sets drives `transform-origin` and the translate direction so the panel always appears to come _toward_ the trigger.
 
 `@starting-style` browser support in May 2026: Chrome 117+ (Sep 2023), Safari 17.5+ (May 2024), Firefox 129+ (Aug 2024) — universal across the last two major versions of every supported browser. Falls back gracefully (panel just appears at final state, no animation) on older browsers.
 
@@ -54,19 +54,27 @@ Append to `DropdownMenu.module.scss`:
 // appears to grow toward the trigger.
 .content[data-side='bottom'] {
   transform-origin: top center;
-  @starting-style { transform: scale(0.96) translateY(-4px); }
+  @starting-style {
+    transform: scale(0.96) translateY(-4px);
+  }
 }
 .content[data-side='top'] {
   transform-origin: bottom center;
-  @starting-style { transform: scale(0.96) translateY(4px); }
+  @starting-style {
+    transform: scale(0.96) translateY(4px);
+  }
 }
 .content[data-side='right'] {
   transform-origin: left center;
-  @starting-style { transform: scale(0.96) translateX(-4px); }
+  @starting-style {
+    transform: scale(0.96) translateX(-4px);
+  }
 }
 .content[data-side='left'] {
   transform-origin: right center;
-  @starting-style { transform: scale(0.96) translateX(4px); }
+  @starting-style {
+    transform: scale(0.96) translateX(4px);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -201,6 +201,7 @@ const [tab, setTab] = useState('overview');
 - `<Item>` props: `onSelect` (required), `disabled`, `tone` (`'default'` | `'danger'`), `icon`, `shortcut`.
 - `<Content>` props: `side` (`'top'` | `'bottom'`, default `'bottom'`), `align` (`'start'` | `'center'` | `'end'`, default `'start'`), `sideOffset` (default `4`), `minWidth`.
 - Keyboard: Enter/Space/ArrowDown on trigger opens with first item active; ArrowUp opens with last; Arrow/Home/End navigate skipping disabled and separators; Enter/Space activates; Escape closes and returns focus to trigger; Tab closes and returns focus to trigger (then continues normal traversal); typeahead jumps to first matching label (500ms debounce).
+- Opens with a short scale-fade from the trigger side (140 ms `ease-out`). Closes instantly by design — menu close should feel like "get out of the way", not "play a transition". Respects `prefers-reduced-motion: reduce`.
 - For value selection (pick a status, country, etc.), use `<Select>` (not yet shipped) — DropdownMenu is for actions, not form values.
 
 #### v2 — submenus, checkboxes, radios, groups

--- a/packages/design-system/src/components/DropdownMenu/Content.tsx
+++ b/packages/design-system/src/components/DropdownMenu/Content.tsx
@@ -67,6 +67,7 @@ export const Content = forwardRef<HTMLDivElement, DropdownMenuContentProps>(func
   } = useFloating({
     open: ctx.open,
     placement,
+    transform: false,
     middleware: [
       offset(sideOffset),
       flip(),

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
@@ -1,3 +1,8 @@
+// `.content` carries both the visual chrome and the open-only entrance
+// animation. The animation half (transition + @starting-style + per-side
+// transform-origin rules below) relies on Floating UI being in `transform:
+// false` mode (see Content.tsx) so the CSS `transform` property is free for
+// the scale/translate entrance without clobbering placement.
 .content {
   display: flex;
   flex-direction: column;
@@ -10,6 +15,18 @@
   box-shadow: var(--shadow-md);
   z-index: var(--z-dropdown);
   outline: none;
+  transform: none;
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base);
+
+  // Open-only entrance — Content unmounts on close so there is no exit.
+  // @starting-style only applies while a transition is active; the
+  // prefers-reduced-motion override below disables the transition, which
+  // neutralises @starting-style (panel renders directly at its rest style).
+  @starting-style {
+    opacity: var(--opacity-hidden);
+  }
 }
 
 .item {
@@ -155,4 +172,46 @@
 
 .subTrigger[data-state='open'] {
   background: var(--color-bg-muted);
+}
+
+// --- Open-only entrance: per-side origin + starting-transform -------------
+// Each data-side variant sets transform-origin so the panel appears to grow
+// toward the trigger, and a 4px directional translate in @starting-style for
+// a subtle slide cue layered on top of the scale-fade declared on .content.
+.content[data-side='bottom'] {
+  transform-origin: top center;
+
+  @starting-style {
+    transform: scale(0.96) translateY(-4px);
+  }
+}
+
+.content[data-side='top'] {
+  transform-origin: bottom center;
+
+  @starting-style {
+    transform: scale(0.96) translateY(4px);
+  }
+}
+
+.content[data-side='right'] {
+  transform-origin: left center;
+
+  @starting-style {
+    transform: scale(0.96) translateX(-4px);
+  }
+}
+
+.content[data-side='left'] {
+  transform-origin: right center;
+
+  @starting-style {
+    transform: scale(0.96) translateX(4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .content {
+    transition: none;
+  }
 }

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
@@ -15,6 +15,7 @@
   box-shadow: var(--shadow-md);
   z-index: var(--z-dropdown);
   outline: none;
+
   // Explicit so each per-side @starting-style transform has a defined
   // resting target to interpolate to. `none` is the CSS default; declaring
   // it here prevents a future cleanup PR from removing the "redundant" line.

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
@@ -15,6 +15,9 @@
   box-shadow: var(--shadow-md);
   z-index: var(--z-dropdown);
   outline: none;
+  // Explicit so each per-side @starting-style transform has a defined
+  // resting target to interpolate to. `none` is the CSS default; declaring
+  // it here prevents a future cleanup PR from removing the "redundant" line.
   transform: none;
   transition:
     opacity var(--transition-base),

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1,5 +1,7 @@
 import { act, configure, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { createRef, type ReactNode } from 'react';
 import { DropdownMenu } from './DropdownMenu';
 
@@ -193,6 +195,26 @@ describe('DropdownMenu — Content', () => {
     // assert it does NOT contain a translate(...) (the giveaway signature
     // of transform-based positioning).
     expect(style).not.toMatch(/translate\(/);
+  });
+
+  it('declares an @starting-style rule for the content selector (animation hook)', () => {
+    // Animation is CSS-only and uses @starting-style for the entrance.
+    //
+    // We tried walking CSSOM (document.styleSheets) here — vitest with the
+    // jsdom environment + CSS-modules plugin does NOT inject component
+    // stylesheets into the DOM (CSS modules return a class-name map only,
+    // the rules never reach document.styleSheets). So a CSSOM walk yields
+    // an empty list and gives no real contract guarantee.
+    //
+    // Fallback: read the SCSS source directly and assert the animation hooks
+    // are present. Weaker than a parsed-CSSOM check (it doesn't validate the
+    // rule actually compiles) but it catches the regression we care about:
+    // a future refactor silently dropping the @starting-style block or the
+    // --opacity-hidden token reference.
+    const scssPath = resolve(__dirname, 'DropdownMenu.module.scss');
+    const scss = readFileSync(scssPath, 'utf8');
+    expect(scss).toMatch(/@starting-style/);
+    expect(scss).toMatch(/var\(--opacity-hidden\)/);
   });
 });
 

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -168,6 +168,32 @@ describe('DropdownMenu — Content', () => {
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
     expect(ref.current?.className).toMatch(/custom-content/);
   });
+
+  it('positions Content via inline top/left, not transform (animation contract)', async () => {
+    // Animation hooks `transform` for the scale-fade entrance. If Floating UI
+    // ever switches back to transform-based positioning, our animation
+    // transform would clobber the position. This test locks the contract in.
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <button type="button">Open</button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <div>menu body</div>
+        </DropdownMenu.Content>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    const menu = screen.getByRole('menu');
+    const style = menu.getAttribute('style') ?? '';
+    expect(style).toMatch(/top:/);
+    expect(style).toMatch(/left:/);
+    // Floating UI writes either nothing or `transform: translate(...)` —
+    // assert it does NOT contain a translate(...) (the giveaway signature
+    // of transform-based positioning).
+    expect(style).not.toMatch(/translate\(/);
+  });
 });
 
 describe('DropdownMenu — Item / Separator', () => {

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -175,6 +175,10 @@ describe('DropdownMenu — Content', () => {
     // Animation hooks `transform` for the scale-fade entrance. If Floating UI
     // ever switches back to transform-based positioning, our animation
     // transform would clobber the position. This test locks the contract in.
+    //
+    // Brittleness note: the regex matches `top:` / `left:` literally. If a
+    // future Floating UI version writes `inset:` shorthand instead, this test
+    // will fail noisily — that's desired, not a bug. Re-validate manually.
     const user = userEvent.setup();
     render(
       <DropdownMenu>
@@ -215,6 +219,10 @@ describe('DropdownMenu — Content', () => {
     const scss = readFileSync(scssPath, 'utf8');
     expect(scss).toMatch(/@starting-style/);
     expect(scss).toMatch(/var\(--opacity-hidden\)/);
+    // Locality: ensure the @starting-style block is anchored inside (or close
+    // to) a `.content` selector. Catches the "moved to wrong selector" case
+    // a bare substring match would miss.
+    expect(scss).toMatch(/\.content[^{]*\{[\s\S]{0,500}?@starting-style/);
   });
 });
 

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -138,6 +138,7 @@
 
   // States
   --opacity-disabled: 0.5;
+  --opacity-hidden: 0;
 
   // Shadows — Atlassian uses subtle elevation
   --shadow-sm: 0 1px 2px rgb(9 30 66 / 8%);


### PR DESCRIPTION
## Summary
- `Content` and `SubContent` open with a 140 ms `ease-out` scale-fade originating from the trigger side. Close is instant by design.
- CSS-only via `@starting-style`; the only JS change is `transform: false` on `useFloating` so Floating UI positions via `top` / `left` instead of `transform`, freeing `transform` for the entrance animation.
- One new token (`--opacity-hidden: 0`) alongside the existing `--opacity-disabled: 0.5` — needed because stylelint policies forbid raw `opacity` values.
- `data-side` (already set on Content) drives `transform-origin` and the translate direction so the panel always appears to come toward the trigger.
- Respects `prefers-reduced-motion: reduce` (transition cleared → `@starting-style` becomes inert → panel snaps in).
- No new public API. No new dependencies. No "animation engine."

Spec: [`docs/superpowers/specs/2026-05-19-dropdown-menu-open-animation-design.md`](../blob/feat/dropdown-open-animation/docs/superpowers/specs/2026-05-19-dropdown-menu-open-animation-design.md)

## Test plan
- [x] Existing DropdownMenu tests pass unchanged
- [x] New contract test: Floating UI writes `top` / `left`, not `transform`
- [x] New animation-hook tripwire: SCSS source contains `@starting-style` block anchored within `.content`
- [x] Full library suite green (238 / 238)
- [x] Typecheck, stylelint, build, and `npm pack --dry-run` all clean
- [x] Husky pre-push hook green
- [x] Playground (`http://localhost:8080/components/dropdown-menu`) verified live via Playwright: at t+1f the panel is at `transform: matrix(0.96,0,0,0.96,0,-3.84)` + `opacity: 0`; at t+200ms it's at `transform: none` + `opacity: 1`. `transition-duration: 0.14s` for both opacity and transform. `transform-origin` resolves to `top center` for `data-side="bottom"`.
- [x] Hard Rule 8 review-fix loop: round 1 verdict `clean enough to stop` with three nice-to-haves applied (tighter test regex + two clarifying comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)