### PR TITLE
Popover + ConfirmationPopover

### DIFF
--- a/docs/superpowers/plans/2026-05-19-popover.md
+++ b/docs/superpowers/plans/2026-05-19-popover.md
@@ -638,7 +638,15 @@ export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function Content(
-  { side: _side = 'bottom', align: _align = 'center', sideOffset: _sideOffset = 10, minWidth: _minWidth, className, children, ...rest },
+  {
+    side: _side = 'bottom',
+    align: _align = 'center',
+    sideOffset: _sideOffset = 10,
+    minWidth: _minWidth,
+    className,
+    children,
+    ...rest
+  },
   forwardedRef,
 ) {
   const ctx = usePopoverContext('Content');
@@ -1257,7 +1265,15 @@ export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function Content(
-  { side: _side = 'bottom', align: _align = 'center', sideOffset: _sideOffset = 10, minWidth: _minWidth, className, children, ...rest },
+  {
+    side: _side = 'bottom',
+    align: _align = 'center',
+    sideOffset: _sideOffset = 10,
+    minWidth: _minWidth,
+    className,
+    children,
+    ...rest
+  },
   forwardedRef,
 ) {
   const ctx = usePopoverContext('Content');
@@ -1419,24 +1435,24 @@ Expected: the outside-click test fails (closes don't happen yet). The inside-pan
 Update `packages/design-system/src/components/Popover/Content.tsx` — insert this `useEffect` next to the existing Escape `useEffect`:
 
 ```tsx
-  // Outside-click: close if pointerdown lands outside the panel AND outside
-  // the trigger. Capture phase fires before focused widgets that may
-  // stopPropagation. The check uses contains() so clicks on descendants of
-  // the panel (e.g. a button inside) don't dismiss.
-  useEffect(() => {
-    if (!ctx.open) return;
-    const onPointerDown = (e: PointerEvent) => {
-      const target = e.target as Node | null;
-      if (!target) return;
-      const panel = ctx.contentRef.current;
-      const trigger = ctx.triggerRef.current;
-      if (panel && panel.contains(target)) return;
-      if (trigger && trigger.contains(target)) return;
-      ctx.setOpen(false);
-    };
-    document.addEventListener('pointerdown', onPointerDown, true);
-    return () => document.removeEventListener('pointerdown', onPointerDown, true);
-  }, [ctx.open, ctx.contentRef, ctx.triggerRef, ctx.setOpen]);
+// Outside-click: close if pointerdown lands outside the panel AND outside
+// the trigger. Capture phase fires before focused widgets that may
+// stopPropagation. The check uses contains() so clicks on descendants of
+// the panel (e.g. a button inside) don't dismiss.
+useEffect(() => {
+  if (!ctx.open) return;
+  const onPointerDown = (e: PointerEvent) => {
+    const target = e.target as Node | null;
+    if (!target) return;
+    const panel = ctx.contentRef.current;
+    const trigger = ctx.triggerRef.current;
+    if (panel && panel.contains(target)) return;
+    if (trigger && trigger.contains(target)) return;
+    ctx.setOpen(false);
+  };
+  document.addEventListener('pointerdown', onPointerDown, true);
+  return () => document.removeEventListener('pointerdown', onPointerDown, true);
+}, [ctx.open, ctx.contentRef, ctx.triggerRef, ctx.setOpen]);
 ```
 
 - [ ] **Step 4: Run tests**
@@ -1592,20 +1608,15 @@ export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function 
     open: ctx.open,
     placement,
     transform: false,
-    middleware: [
-      offset(sideOffset),
-      flip(),
-      shift({ padding: 8 }),
-      arrow({ element: arrowRef }),
-    ],
+    middleware: [offset(sideOffset), flip(), shift({ padding: 8 }), arrow({ element: arrowRef })],
     whileElementsMounted: autoUpdate,
     elements: { reference: ctx.triggerRef.current },
   });
 
   const resolvedSide = resolvedPlacement.split('-')[0] as PopoverSide;
-  const staticSide = (
-    { top: 'bottom', bottom: 'top', left: 'right', right: 'left' } as const
-  )[resolvedSide];
+  const staticSide = ({ top: 'bottom', bottom: 'top', left: 'right', right: 'left' } as const)[
+    resolvedSide
+  ];
 
   // Focus the panel on open. preventScroll matches DropdownMenu/Tooltip.
   useLayoutEffect(() => {
@@ -2391,7 +2402,10 @@ Append to `packages/design-system/src/index.ts`:
 
 ```ts
 export { ConfirmationPopover } from './components/ConfirmationPopover';
-export type { ConfirmationPopoverProps, ConfirmationVariant } from './components/ConfirmationPopover';
+export type {
+  ConfirmationPopoverProps,
+  ConfirmationVariant,
+} from './components/ConfirmationPopover';
 ```
 
 - [ ] **Step 6: Run tests**
@@ -2485,7 +2499,10 @@ describe('ConfirmationPopover — content rendering (sync)', () => {
     // The library's Button component sets data-variant on the rendered button.
     // We check that the Confirm button has the right data-variant value.
     // (If the actual library Button uses a different attribute, adjust below.)
-    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveAttribute('data-variant', 'primary');
+    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveAttribute(
+      'data-variant',
+      'primary',
+    );
 
     rerender(
       <ConfirmationPopover title="Default?" variant="danger" onConfirm={() => {}}>
@@ -2494,7 +2511,10 @@ describe('ConfirmationPopover — content rendering (sync)', () => {
     );
     // Confirm button reflects the new variant after re-render (popover stays
     // open because the trigger re-renders).
-    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveAttribute('data-variant', 'danger');
+    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveAttribute(
+      'data-variant',
+      'danger',
+    );
   });
 
   it('aria-labelledby points at the title; aria-describedby points at the description', async () => {
@@ -2758,30 +2778,38 @@ Update `ConfirmationPopover.tsx`:
 Add imports:
 
 ```tsx
-import { useCallback, useEffect, useId, useRef, useState, type ReactElement, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 ```
 
 Add the ref and effect inside the function body, after `const handleOpenChange = …`:
 
 ```tsx
-  const cancelRef = useRef<HTMLButtonElement | null>(null);
+const cancelRef = useRef<HTMLButtonElement | null>(null);
 
-  // Focus the Cancel button after Popover.Content focuses the panel.
-  // queueMicrotask runs after Popover.Content's own focus effect (which also
-  // uses queueMicrotask), so by the time this runs, the panel has focus and
-  // we override it with Cancel.
-  useEffect(() => {
-    if (!open) return;
-    queueMicrotask(() => cancelRef.current?.focus({ preventScroll: true }));
-  }, [open]);
+// Focus the Cancel button after Popover.Content focuses the panel.
+// queueMicrotask runs after Popover.Content's own focus effect (which also
+// uses queueMicrotask), so by the time this runs, the panel has focus and
+// we override it with Cancel.
+useEffect(() => {
+  if (!open) return;
+  queueMicrotask(() => cancelRef.current?.focus({ preventScroll: true }));
+}, [open]);
 ```
 
 Pass the ref to the Cancel button:
 
 ```tsx
-            <Button ref={cancelRef} variant="secondary" size="sm" onClick={handleCancel}>
-              {cancelLabel}
-            </Button>
+<Button ref={cancelRef} variant="secondary" size="sm" onClick={handleCancel}>
+  {cancelLabel}
+</Button>
 ```
 
 The library's `<Button>` must accept a ref (it uses forwardRef per the design system's hard rules — verify by reading `packages/design-system/src/components/Button/Button.tsx`).
@@ -2912,8 +2940,8 @@ describe('ConfirmationPopover — async onConfirm', () => {
     await user.click(screen.getByRole('button', { name: 'Open' }));
     const confirmBtn = screen.getByRole('button', { name: 'Confirm' });
     await user.click(confirmBtn);
-    await user.click(confirmBtn);  // disabled → ignored
-    await user.click(confirmBtn);  // disabled → ignored
+    await user.click(confirmBtn); // disabled → ignored
+    await user.click(confirmBtn); // disabled → ignored
 
     expect(onConfirm).toHaveBeenCalledTimes(1);
     await act(async () => {
@@ -2938,35 +2966,35 @@ Update `ConfirmationPopover.tsx` — replace `handleConfirm` with the async-awar
 Find:
 
 ```tsx
-  const handleConfirm = useCallback(() => {
-    onConfirm();
-    setOpen(false);
-  }, [onConfirm, setOpen]);
+const handleConfirm = useCallback(() => {
+  onConfirm();
+  setOpen(false);
+}, [onConfirm, setOpen]);
 ```
 
 Replace with:
 
 ```tsx
-  const [pending, setPending] = useState(false);
+const [pending, setPending] = useState(false);
 
-  const handleConfirm = useCallback(() => {
-    if (pending) return;
-    const result = onConfirm();
-    if (result instanceof Promise) {
-      setPending(true);
-      result
-        .then(() => {
-          setPending(false);
-          setOpen(false);
-        })
-        .catch(() => {
-          setPending(false);
-          // Popover stays open. onCancel NOT fired — failure is its own state.
-        });
-    } else {
-      setOpen(false);
-    }
-  }, [pending, onConfirm, setOpen]);
+const handleConfirm = useCallback(() => {
+  if (pending) return;
+  const result = onConfirm();
+  if (result instanceof Promise) {
+    setPending(true);
+    result
+      .then(() => {
+        setPending(false);
+        setOpen(false);
+      })
+      .catch(() => {
+        setPending(false);
+        // Popover stays open. onCancel NOT fired — failure is its own state.
+      });
+  } else {
+    setOpen(false);
+  }
+}, [pending, onConfirm, setOpen]);
 ```
 
 Pass `disabled={pending}` to both buttons:
@@ -3033,54 +3061,60 @@ EOF
 Append to `ConfirmationPopover.test.tsx`, inside the existing `describe('ConfirmationPopover — async onConfirm', …)` block:
 
 ```tsx
-  it('while pending: Escape does NOT close', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    let resolveFn: () => void = () => {};
-    const onConfirm = vi.fn(
-      () => new Promise<void>((resolve) => { resolveFn = resolve; }),
-    );
+it('while pending: Escape does NOT close', async () => {
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  let resolveFn: () => void = () => {};
+  const onConfirm = vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveFn = resolve;
+      }),
+  );
 
-    render(
+  render(
+    <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
+      <button type="button">Open</button>
+    </ConfirmationPopover>,
+  );
+  await user.click(screen.getByRole('button', { name: 'Open' }));
+  await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+  });
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  await act(async () => {
+    resolveFn();
+  });
+});
+
+it('while pending: click-outside does NOT close', async () => {
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  let resolveFn: () => void = () => {};
+  const onConfirm = vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveFn = resolve;
+      }),
+  );
+
+  render(
+    <>
       <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
         <button type="button">Open</button>
-      </ConfirmationPopover>,
-    );
-    await user.click(screen.getByRole('button', { name: 'Open' }));
-    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+      </ConfirmationPopover>
+      <div data-testid="elsewhere">elsewhere</div>
+    </>,
+  );
+  await user.click(screen.getByRole('button', { name: 'Open' }));
+  await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
-    act(() => {
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-    });
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
-    await act(async () => {
-      resolveFn();
-    });
+  await user.pointer({ keys: '[MouseLeft>]', target: screen.getByTestId('elsewhere') });
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  await act(async () => {
+    resolveFn();
   });
-
-  it('while pending: click-outside does NOT close', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    let resolveFn: () => void = () => {};
-    const onConfirm = vi.fn(
-      () => new Promise<void>((resolve) => { resolveFn = resolve; }),
-    );
-
-    render(
-      <>
-        <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
-          <button type="button">Open</button>
-        </ConfirmationPopover>
-        <div data-testid="elsewhere">elsewhere</div>
-      </>,
-    );
-    await user.click(screen.getByRole('button', { name: 'Open' }));
-    await user.click(screen.getByRole('button', { name: 'Confirm' }));
-
-    await user.pointer({ keys: '[MouseLeft>]', target: screen.getByTestId('elsewhere') });
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
-    await act(async () => {
-      resolveFn();
-    });
-  });
+});
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -3096,16 +3130,16 @@ Expected: 2 new tests fail (Escape/click-outside currently close the popover via
 Update `ConfirmationPopover.tsx` — modify `handleOpenChange` to short-circuit closes during pending:
 
 ```tsx
-  const handleOpenChange = useCallback(
-    (next: boolean) => {
-      // Block close while a confirm is pending — the in-flight Promise
-      // should resolve before we tear down the popover.
-      if (pending && !next) return;
-      if (!next) onCancel?.();
-      setOpen(next);
-    },
-    [pending, onCancel, setOpen],
-  );
+const handleOpenChange = useCallback(
+  (next: boolean) => {
+    // Block close while a confirm is pending — the in-flight Promise
+    // should resolve before we tear down the popover.
+    if (pending && !next) return;
+    if (!next) onCancel?.();
+    setOpen(next);
+  },
+  [pending, onCancel, setOpen],
+);
 ```
 
 This works because Popover's Escape and outside-click handlers both call `setOpen(false)`, which (via the controlled mode) calls our `handleOpenChange(false)`. Our wrapper short-circuits when `pending && !next`.
@@ -3188,15 +3222,15 @@ Replace `packages/design-system/src/components/ConfirmationPopover/ConfirmationP
 Update the Confirm button in `ConfirmationPopover.tsx`:
 
 ```tsx
-            <Button
-              variant={variant === 'danger' ? 'danger' : 'primary'}
-              size="sm"
-              disabled={pending}
-              onClick={handleConfirm}
-            >
-              {pending && <span className={styles.spinner} aria-hidden="true" />}
-              {confirmLabel}
-            </Button>
+<Button
+  variant={variant === 'danger' ? 'danger' : 'primary'}
+  size="sm"
+  disabled={pending}
+  onClick={handleConfirm}
+>
+  {pending && <span className={styles.spinner} aria-hidden="true" />}
+  {confirmLabel}
+</Button>
 ```
 
 - [ ] **Step 3: Run tests + stylelint**
@@ -4020,10 +4054,14 @@ In `packages/design-system/AGENTS.md`, find the existing line marking the end of
       {/* …form controls… */}
       <Cluster justify="end" gap="sm">
         <Popover.Close>
-          <Button variant="secondary" size="sm">Cancel</Button>
+          <Button variant="secondary" size="sm">
+            Cancel
+          </Button>
         </Popover.Close>
         <Popover.Close>
-          <Button size="sm" onClick={apply}>Apply</Button>
+          <Button size="sm" onClick={apply}>
+            Apply
+          </Button>
         </Popover.Close>
       </Cluster>
     </Stack>
@@ -4075,7 +4113,7 @@ Find the "Layer (z-index)" row. Currently it lists `--z-dropdown / --z-modal / -
 Find the "Control sizes" row. Currently it ends with `--size-dropdown-min-width: 160, --size-dropdown-indicator: 16`. Update to include `--size-popover-min-width`:
 
 ```markdown
-| Control sizes   | `--size-sm/md/lg` (heights), `--size-badge` (20), `--size-badge-sm` (16), `--size-chip` (18), `--size-dropdown-min-width` (160), `--size-popover-min-width` (220), `--size-dropdown-indicator` (16) |
+| Control sizes | `--size-sm/md/lg` (heights), `--size-badge` (20), `--size-badge-sm` (16), `--size-chip` (18), `--size-dropdown-min-width` (160), `--size-popover-min-width` (220), `--size-dropdown-indicator` (16) |
 ```
 
 - [ ] **Step 3: Add anti-pattern rows**
@@ -4083,9 +4121,9 @@ Find the "Control sizes" row. Currently it ends with `--size-dropdown-min-width:
 Find the anti-patterns table near the bottom. Add three new rows after the existing Tooltip-related rows:
 
 ```markdown
-| `<Popover.Trigger><Button disabled>…</Button></Popover.Trigger>`                       | `disabled` buttons don't fire click; render with `aria-disabled="true"` + intercept the click, or wrap in `<span>`. |
-| `<Popover.Content>` with no `<Popover.Close>` AND non-obvious outside-click dismissal | Keyboard / screen-reader users get no clear close affordance. Add a `<Popover.Close>` close button.                  |
-| `<ConfirmationPopover>` with `onConfirm` that never settles                           | v1 has no timeout — popover stays in pending state forever. Add a timeout/abort inside your `onConfirm` if relevant.   |
+| `<Popover.Trigger><Button disabled>…</Button></Popover.Trigger>` | `disabled` buttons don't fire click; render with `aria-disabled="true"` + intercept the click, or wrap in `<span>`. |
+| `<Popover.Content>` with no `<Popover.Close>` AND non-obvious outside-click dismissal | Keyboard / screen-reader users get no clear close affordance. Add a `<Popover.Close>` close button. |
+| `<ConfirmationPopover>` with `onConfirm` that never settles | v1 has no timeout — popover stays in pending state forever. Add a timeout/abort inside your `onConfirm` if relevant. |
 ```
 
 - [ ] **Step 4: Prettier-format the file**
@@ -4125,8 +4163,8 @@ EOF
 In `packages/design-system/README.md`, find the components overview table. Add two new rows after the existing Tooltip row, matching the format of existing rows. Look at the existing Tooltip row to mirror column structure exactly:
 
 ```markdown
-| `<Popover>`             | Non-modal floating panel for arbitrary small surfaces (filters, mini-forms, quick pickers).             |
-| `<ConfirmationPopover>` | "Are you sure?" preset on top of Popover, with async-aware Confirm and Cancel-default focus.            |
+| `<Popover>` | Non-modal floating panel for arbitrary small surfaces (filters, mini-forms, quick pickers). |
+| `<ConfirmationPopover>` | "Are you sure?" preset on top of Popover, with async-aware Confirm and Cancel-default focus. |
 ```
 
 - [ ] **Step 2: Prettier-format**
@@ -4346,36 +4384,36 @@ Watch the `Quality / check` status on the PR. Once green, merge (squash or merge
 
 Mapping every spec section to a task:
 
-| Spec section                                        | Task(s)              |
-| --------------------------------------------------- | -------------------- |
-| Goal + Non-goals                                    | covered globally     |
-| Popover public API — Root + Trigger + Content + Heading + Close | Tasks 2–6, 12 |
-| ConfirmationPopover public API                      | Tasks 13–19          |
-| Popover ARIA wiring                                 | Tasks 2, 3, 4, 5     |
-| ConfirmationPopover ARIA                            | Task 14              |
-| Open / close triggers (Popover)                     | Tasks 3, 6, 7, 8     |
-| Open / close triggers (ConfirmationPopover)         | Tasks 14, 16, 17     |
-| Focus management (panel on open, trigger on close)  | Task 7, 11           |
-| Focus management (Cancel on open for Confirmation)  | Task 15              |
-| Click-outside detection                             | Task 8               |
-| Escape handling                                     | Task 7               |
-| Touch & disabled triggers                           | documented in JSDoc (Task 12) + AGENTS.md (Task 23) |
-| Multiple popovers                                   | implicit — each instance owns its state |
-| Floating UI middleware stack                        | Task 9               |
-| Arrow                                               | Tasks 9, 10          |
-| Visual chrome                                       | Task 10              |
-| Z-index — `--z-popover` token                       | Task 1               |
-| `--size-popover-min-width` token                    | Task 1               |
-| Animation (`@starting-style` per side + reduced motion) | Task 10          |
-| Popover compound parts (file layout)                | Tasks 2–6            |
-| ConfirmationPopover (file layout)                   | Task 13              |
-| Shared helpers reused from Tooltip (`_internal/refs`) | imports throughout |
-| Popover tests (~25)                                 | Tasks 2–11           |
-| ConfirmationPopover tests (~15)                     | Tasks 13–17          |
-| Playground demos                                    | Tasks 20–22          |
-| Playground wiring                                   | Task 22              |
-| JSDoc + AGENTS.md + README.md                       | Tasks 12, 19, 23, 24 |
-| Risks                                               | Mitigated by Tasks 7, 11, 15, 16, 17 |
-| Acceptance (quality gates + review-fix + push)      | Tasks 25, 26, 27     |
+| Spec section                                                    | Task(s)                                             |
+| --------------------------------------------------------------- | --------------------------------------------------- |
+| Goal + Non-goals                                                | covered globally                                    |
+| Popover public API — Root + Trigger + Content + Heading + Close | Tasks 2–6, 12                                       |
+| ConfirmationPopover public API                                  | Tasks 13–19                                         |
+| Popover ARIA wiring                                             | Tasks 2, 3, 4, 5                                    |
+| ConfirmationPopover ARIA                                        | Task 14                                             |
+| Open / close triggers (Popover)                                 | Tasks 3, 6, 7, 8                                    |
+| Open / close triggers (ConfirmationPopover)                     | Tasks 14, 16, 17                                    |
+| Focus management (panel on open, trigger on close)              | Task 7, 11                                          |
+| Focus management (Cancel on open for Confirmation)              | Task 15                                             |
+| Click-outside detection                                         | Task 8                                              |
+| Escape handling                                                 | Task 7                                              |
+| Touch & disabled triggers                                       | documented in JSDoc (Task 12) + AGENTS.md (Task 23) |
+| Multiple popovers                                               | implicit — each instance owns its state             |
+| Floating UI middleware stack                                    | Task 9                                              |
+| Arrow                                                           | Tasks 9, 10                                         |
+| Visual chrome                                                   | Task 10                                             |
+| Z-index — `--z-popover` token                                   | Task 1                                              |
+| `--size-popover-min-width` token                                | Task 1                                              |
+| Animation (`@starting-style` per side + reduced motion)         | Task 10                                             |
+| Popover compound parts (file layout)                            | Tasks 2–6                                           |
+| ConfirmationPopover (file layout)                               | Task 13                                             |
+| Shared helpers reused from Tooltip (`_internal/refs`)           | imports throughout                                  |
+| Popover tests (~25)                                             | Tasks 2–11                                          |
+| ConfirmationPopover tests (~15)                                 | Tasks 13–17                                         |
+| Playground demos                                                | Tasks 20–22                                         |
+| Playground wiring                                               | Task 22                                             |
+| JSDoc + AGENTS.md + README.md                                   | Tasks 12, 19, 23, 24                                |
+| Risks                                                           | Mitigated by Tasks 7, 11, 15, 16, 17                |
+| Acceptance (quality gates + review-fix + push)                  | Tasks 25, 26, 27                                    |
 
 No gaps.

--- a/docs/superpowers/plans/2026-05-19-popover.md
+++ b/docs/superpowers/plans/2026-05-19-popover.md
@@ -1,0 +1,4381 @@
+# Popover + ConfirmationPopover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Popover>` (compound: Root, Trigger, Content, Heading, Close) and `<ConfirmationPopover>` (opinionated preset on top) per the design spec — non-modal floating panel + opinionated async-aware confirmation prompt.
+
+**Architecture:** Popover compound mirrors DropdownMenu's shape: PopoverRoot is a provider, Trigger uses `cloneElement` to inject ARIA + click handler, Content portals to `document.body` and positions via Floating UI (`transform: false`, offset+flip+shift+arrow middleware), Heading registers an `aria-labelledby` id via context, Close uses `cloneElement` to chain its onClick. Focus moves to the panel on open, returns to the trigger on close, Tab traverses out of the panel into the page. ConfirmationPopover hoists open state internally so it can close-after-resolve, blocks dismissal while `pending`, and focuses Cancel via a layout effect that runs after Popover.Content's panel-focus effect.
+
+**Tech Stack:** React 19, TypeScript, CSS Modules (SCSS), Vitest + Testing Library, `@floating-ui/react-dom` (already installed). No new runtime dependencies.
+
+**Spec:** [`docs/superpowers/specs/2026-05-19-popover-design.md`](../specs/2026-05-19-popover-design.md)
+
+---
+
+## Pre-flight (already done; do not re-do)
+
+- ✅ Spec written and committed on `feat/popover` (`a5eec7a`).
+- ✅ Branch `feat/popover` created off freshly-pulled `main` (which already includes the Tooltip work, commit `ba2f2ad`).
+- ✅ Shared helpers (`mergeRefs`, `chain`, `sanitizeId`, `mergeAriaDescribedby`) live at `packages/design-system/src/components/_internal/refs.ts` from the Tooltip work — Popover and ConfirmationPopover import from there.
+- ✅ Existing layer-token values verified: `--z-dropdown: 1000`, `--z-modal: 1100`, `--z-toast: 1200`, `--z-tooltip: 1300`. New token `--z-popover` goes at `1050` (between dropdown and modal).
+- ✅ `--opacity-hidden` (0) and `--transition-base` (140ms) already exist.
+- ✅ `@starting-style` is on stylelint's allowlist.
+- ✅ `@floating-ui/react-dom` is in `packages/design-system/package.json` dependencies.
+- ✅ Playground wiring is 4 places per `packages/playground/CLAUDE.md`: `App.tsx`, `AppShell/AppShell.tsx` (Overlays group), `ComponentsIndex.tsx`, `mockups/registry.ts`.
+- ✅ Workspace name for the playground is `playground`, NOT `@eocrm/playground`.
+
+---
+
+## Task 1: Add `--z-popover` and `--size-popover-min-width` tokens
+
+**Files:**
+
+- Modify: `packages/design-system/src/styles/tokens.scss`
+
+- [ ] **Step 1: Add `--z-popover` after `--z-dropdown`**
+
+In `packages/design-system/src/styles/tokens.scss`, find the line `--z-dropdown: 1000;`. Insert the new layer immediately after it. Change:
+
+```scss
+--z-dropdown: 1000;
+--z-modal: 1100;
+```
+
+to:
+
+```scss
+--z-dropdown: 1000;
+--z-popover: 1050; // above dropdown, below modal — popover can open from a menu item
+--z-modal: 1100;
+```
+
+- [ ] **Step 2: Add `--size-popover-min-width` near other size tokens**
+
+Find the existing `--size-dropdown-min-width: 160px;` line (in the Control sizes block — around the existing size tokens). Insert immediately after it:
+
+```scss
+--size-dropdown-min-width: 160px;
+--size-popover-min-width: 220px; // slightly wider than dropdown — popovers carry richer content
+```
+
+- [ ] **Step 3: Run stylelint to confirm tokens are accepted**
+
+```bash
+npm run lint:css
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/styles/tokens.scss
+git commit -m "$(cat <<'EOF'
+tokens: add --z-popover (1050) and --size-popover-min-width (220px)
+
+--z-popover slots between --z-dropdown and --z-modal so a popover
+opened from a DropdownMenu item appears above the menu, while Modal
+(when it lands) still buries Popover behind its backdrop. Tooltips
+inside Popovers stay on top (--z-tooltip: 1300).
+
+--size-popover-min-width is the panel's min-width — slightly wider
+than DropdownMenu's 160px because Popover content is typically
+form-style (multiple rows, padded chrome).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Scaffold the Popover folder + context + first failing test
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Popover/context.ts`
+- Create: `packages/design-system/src/components/Popover/PopoverRoot.tsx`
+- Create: `packages/design-system/src/components/Popover/Popover.tsx`
+- Create: `packages/design-system/src/components/Popover/Popover.module.scss`
+- Create: `packages/design-system/src/components/Popover/Popover.test.tsx`
+- Create: `packages/design-system/src/components/Popover/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+The structure meta-test (`src/structure.test.ts`) enforces that every directory under `components/` has `<Name>.tsx`, `<Name>.test.tsx`, `<Name>.module.scss`, and `index.ts`, AND a re-export from `src/index.ts`. We add all of that here.
+
+- [ ] **Step 1: Create the context file**
+
+Create `packages/design-system/src/components/Popover/context.ts`:
+
+```ts
+import { createContext, useContext, type RefObject } from 'react';
+
+export interface PopoverContextValue {
+  open: boolean;
+  setOpen: (next: boolean) => void;
+  triggerRef: RefObject<HTMLElement | null>;
+  contentRef: RefObject<HTMLDivElement | null>;
+  contentId: string;
+  headingId: string | null;
+  setHeadingId: (id: string | null) => void;
+  closeAll: () => void;
+}
+
+export const PopoverContext = createContext<PopoverContextValue | null>(null);
+
+export function usePopoverContext(componentName: string): PopoverContextValue {
+  const ctx = useContext(PopoverContext);
+  if (!ctx) {
+    throw new Error(`<Popover.${componentName}> must be used inside <Popover>.`);
+  }
+  return ctx;
+}
+```
+
+- [ ] **Step 2: Create the minimal PopoverRoot**
+
+Create `packages/design-system/src/components/Popover/PopoverRoot.tsx`:
+
+```tsx
+import { useCallback, useId, useRef, useState, type ReactNode } from 'react';
+import { PopoverContext, type PopoverContextValue } from './context';
+import { sanitizeId } from '../_internal/refs';
+
+export interface PopoverProps {
+  /** Must contain exactly one `<Popover.Trigger>` and one `<Popover.Content>`. */
+  children: ReactNode;
+  /** Controlled open state. Provide alongside `onOpenChange`. */
+  open?: boolean;
+  /** Fired whenever Popover wants to change open state. Required when `open` is provided. */
+  onOpenChange?: (open: boolean) => void;
+  /** Default open state for uncontrolled usage. Defaults to `false`. */
+  defaultOpen?: boolean;
+  /**
+   * Reserved future hint. v1 ignores the value and always renders non-modal.
+   * Will gate focus-trap + inert background once `<Modal>` lands.
+   */
+  modal?: boolean;
+}
+
+export function PopoverRoot({
+  children,
+  open: controlledOpen,
+  onOpenChange,
+  defaultOpen = false,
+  modal: _modal = false,
+}: PopoverProps) {
+  const isControlled = controlledOpen !== undefined;
+  const [uncontrolled, setUncontrolled] = useState(defaultOpen);
+  const open = isControlled ? (controlledOpen as boolean) : uncontrolled;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      onOpenChange?.(next);
+      if (!isControlled) setUncontrolled(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const reactId = useId();
+  const contentId = `popover-${sanitizeId(reactId)}`;
+  const [headingId, setHeadingId] = useState<string | null>(null);
+
+  const closeAll = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus({ preventScroll: true });
+  }, [setOpen]);
+
+  const value: PopoverContextValue = {
+    open,
+    setOpen,
+    triggerRef,
+    contentRef,
+    contentId,
+    headingId,
+    setHeadingId,
+    closeAll,
+  };
+
+  return <PopoverContext.Provider value={value}>{children}</PopoverContext.Provider>;
+}
+```
+
+- [ ] **Step 3: Create the namespace assembly file**
+
+Create `packages/design-system/src/components/Popover/Popover.tsx`:
+
+```tsx
+import { PopoverRoot } from './PopoverRoot';
+
+// Sub-component re-exports are wired in later tasks; for now Popover is just
+// the Root function. The namespace assembly grows as each sub-component
+// lands. The final shape (post-task-7) will be:
+//   Popover.Trigger, Popover.Content, Popover.Heading, Popover.Close
+export const Popover = PopoverRoot;
+```
+
+- [ ] **Step 4: Create the empty SCSS module**
+
+Create `packages/design-system/src/components/Popover/Popover.module.scss`:
+
+```scss
+/* stylelint-disable block-no-empty */
+// Chrome + animation rules land in Task 9. Empty placeholders for now so
+// the import resolves and CSS-Modules generates class hooks.
+.content {
+}
+.arrow {
+}
+/* stylelint-enable block-no-empty */
+```
+
+- [ ] **Step 5: Create the test file with the first failing test**
+
+Create `packages/design-system/src/components/Popover/Popover.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { Popover } from './Popover';
+
+describe('Popover — initial render', () => {
+  it('renders nothing portaled on mount when defaultOpen is false', () => {
+    render(
+      <Popover>
+        <div data-testid="children-marker">trigger and content go here later</div>
+      </Popover>,
+    );
+    expect(screen.getByTestId('children-marker')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 6: Create the folder's index.ts**
+
+Create `packages/design-system/src/components/Popover/index.ts`:
+
+```ts
+export { Popover } from './Popover';
+export type { PopoverProps } from './PopoverRoot';
+```
+
+- [ ] **Step 7: Add the public export to `src/index.ts`**
+
+In `packages/design-system/src/index.ts`, append after the existing `Tooltip` export block:
+
+```ts
+export { Popover } from './components/Popover';
+export type { PopoverProps } from './components/Popover';
+```
+
+(More types — `PopoverTriggerProps`, `PopoverContentProps`, etc. — get added in their respective tasks.)
+
+- [ ] **Step 8: Run the test to confirm it passes and the structure meta-test is green**
+
+```bash
+npm test -w @eocrm/design-system
+```
+
+Expected: all tests pass — including `structure.test.ts` which automatically picks up the new `Popover/` folder.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/design-system/src/components/Popover/ packages/design-system/src/index.ts
+git commit -m "$(cat <<'EOF'
+Popover: scaffold root + namespace + context + first render test
+
+PopoverRoot is the state-machine provider (controlled/uncontrolled
+open, refs, content/heading ids). Popover (namespace) is currently
+just an alias for PopoverRoot; Trigger/Content/Heading/Close are
+wired in subsequent tasks. Empty SCSS placeholders stylelint-disabled
+until Task 9 fills them in.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Popover.Trigger — cloneElement + ARIA + click toggle
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Popover/Trigger.tsx`
+- Modify: `packages/design-system/src/components/Popover/Popover.tsx`
+- Modify: `packages/design-system/src/components/Popover/Popover.test.tsx`
+- Modify: `packages/design-system/src/components/Popover/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+- [ ] **Step 1: Write failing tests for Trigger**
+
+Append to `Popover.test.tsx` (after the existing `describe('Popover — initial render', …)` block):
+
+```tsx
+import userEvent from '@testing-library/user-event';
+
+describe('Popover.Trigger', () => {
+  it('renders its child unchanged and sets aria-haspopup="dialog" and aria-expanded="false"', () => {
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+      </Popover>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('toggles aria-expanded on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+      </Popover>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('opens on Enter or Space when focused', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+      </Popover>,
+    );
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Open' })).toHaveFocus();
+    await user.keyboard('{Enter}');
+    expect(screen.getByRole('button', { name: 'Open' })).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('throws a clear error when children is not a valid React element', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      render(
+        <Popover>
+          {/* @ts-expect-error — intentionally invalid */}
+          <Popover.Trigger>{null}</Popover.Trigger>
+        </Popover>,
+      ),
+    ).toThrow(/exactly one React element/);
+    spy.mockRestore();
+  });
+
+  it('chains consumer onClick (consumer runs first)', async () => {
+    const user = userEvent.setup();
+    const consumer = vi.fn();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button" onClick={consumer}>
+            Open
+          </button>
+        </Popover.Trigger>
+      </Popover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(consumer).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 5 new tests fail because `Popover.Trigger` doesn't exist yet.
+
+- [ ] **Step 3: Implement Trigger**
+
+Create `packages/design-system/src/components/Popover/Trigger.tsx`:
+
+```tsx
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactElement,
+  type Ref,
+} from 'react';
+import { usePopoverContext } from './context';
+import { chain, mergeRefs } from '../_internal/refs';
+
+export interface PopoverTriggerProps {
+  /**
+   * Exactly one React element that accepts a ref. The Trigger clones this
+   * element to inject `aria-haspopup="dialog"`, `aria-expanded`,
+   * `aria-controls`, a click handler that toggles the popover, and a keydown
+   * handler that opens on Enter/Space. `<Button>` and raw `<button>` both
+   * qualify; a custom component without `forwardRef` does not.
+   */
+  children: ReactElement;
+}
+
+export function Trigger({ children }: PopoverTriggerProps) {
+  const ctx = usePopoverContext('Trigger');
+
+  if (!isValidElement(children)) {
+    throw new Error('<Popover.Trigger> requires exactly one React element child.');
+  }
+
+  const childProps = children.props as {
+    ref?: Ref<HTMLElement>;
+    onClick?: (e: ReactMouseEvent<HTMLElement>) => void;
+    onKeyDown?: (e: ReactKeyboardEvent<HTMLElement>) => void;
+  };
+
+  const handleClick = useCallback(
+    (_e: ReactMouseEvent<HTMLElement>) => {
+      ctx.setOpen(!ctx.open);
+    },
+    [ctx],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLElement>) => {
+      if (ctx.open) return;
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        ctx.setOpen(true);
+      }
+    },
+    [ctx],
+  );
+
+  return cloneElement(children, {
+    ref: mergeRefs(ctx.triggerRef, childProps.ref),
+    'aria-haspopup': 'dialog',
+    'aria-expanded': ctx.open,
+    'aria-controls': ctx.open ? ctx.contentId : undefined,
+    onClick: chain(childProps.onClick, handleClick),
+    onKeyDown: chain(childProps.onKeyDown, handleKeyDown),
+  } as object);
+}
+```
+
+- [ ] **Step 4: Wire Trigger into the namespace**
+
+Replace the contents of `packages/design-system/src/components/Popover/Popover.tsx` with:
+
+```tsx
+import { PopoverRoot } from './PopoverRoot';
+import { Trigger } from './Trigger';
+
+type PopoverNamespace = typeof PopoverRoot & {
+  Trigger: typeof Trigger;
+};
+
+const Popover = PopoverRoot as PopoverNamespace;
+Popover.Trigger = Trigger;
+
+export { Popover };
+```
+
+- [ ] **Step 5: Export the Trigger props type**
+
+Update `packages/design-system/src/components/Popover/index.ts`:
+
+```ts
+export { Popover } from './Popover';
+export type { PopoverProps } from './PopoverRoot';
+export type { PopoverTriggerProps } from './Trigger';
+```
+
+Update `packages/design-system/src/index.ts` — extend the Popover export block:
+
+```ts
+export { Popover } from './components/Popover';
+export type { PopoverProps, PopoverTriggerProps } from './components/Popover';
+```
+
+- [ ] **Step 6: Run tests to verify all pass**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/Popover/Trigger.tsx \
+        packages/design-system/src/components/Popover/Popover.{tsx,test.tsx} \
+        packages/design-system/src/components/Popover/index.ts \
+        packages/design-system/src/index.ts
+git commit -m "$(cat <<'EOF'
+Popover.Trigger: cloneElement + ARIA + click/keydown toggle
+
+Same forwardRef-required contract as DropdownMenu.Trigger and
+Tooltip — child must accept a ref. Trigger clones to inject
+aria-haspopup="dialog", aria-expanded, aria-controls (only while open),
+and chained click + keydown handlers. Enter/Space opens; click toggles.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Popover.Content — minimal portal + role=dialog + tabIndex
+
+This task lands Content as a portaled `<div role="dialog">`. Floating UI positioning, focus-on-open, and document listeners come in later tasks.
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Popover/Content.tsx`
+- Modify: `packages/design-system/src/components/Popover/Popover.tsx`
+- Modify: `packages/design-system/src/components/Popover/Popover.test.tsx`
+- Modify: `packages/design-system/src/components/Popover/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `Popover.test.tsx`:
+
+```tsx
+describe('Popover.Content — minimal portal', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders the panel as a portaled dialog when defaultOpen', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const panel = screen.getByRole('dialog');
+    expect(panel).toHaveTextContent('panel body');
+    expect(panel).toHaveAttribute('aria-modal', 'false');
+    expect(panel).toHaveAttribute('tabIndex', '-1');
+    // Portaled to document.body, NOT inside the test container.
+    expect(document.body.contains(panel)).toBe(true);
+  });
+
+  it('panel id matches the trigger aria-controls when open', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    const panel = screen.getByRole('dialog');
+    expect(trigger.getAttribute('aria-controls')).toBe(panel.id);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 3 new tests fail.
+
+- [ ] **Step 3: Implement Content (minimal — no Floating UI yet)**
+
+Create `packages/design-system/src/components/Popover/Content.tsx`:
+
+```tsx
+import { forwardRef, type HTMLAttributes } from 'react';
+import { createPortal } from 'react-dom';
+import clsx from 'clsx';
+import { usePopoverContext } from './context';
+import { mergeRefs } from '../_internal/refs';
+import styles from './Popover.module.scss';
+
+/** Which side of the trigger the popover prefers. Floating UI auto-flips on collision. */
+export type PopoverSide = 'top' | 'right' | 'bottom' | 'left';
+/** Which edge of the popover aligns to the corresponding trigger edge. */
+export type PopoverAlign = 'start' | 'center' | 'end';
+
+export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {
+  /** Preferred side. Default `'bottom'`. Auto-flips on collision via Floating UI. */
+  side?: PopoverSide;
+  /** Edge alignment. Default `'center'`. */
+  align?: PopoverAlign;
+  /** Gap in px between trigger and panel. Default `10` (room for the arrow). */
+  sideOffset?: number;
+  /** Minimum width in px or any CSS length. Defaults to `--size-popover-min-width` (220). */
+  minWidth?: number | string;
+}
+
+export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function Content(
+  { side: _side = 'bottom', align: _align = 'center', sideOffset: _sideOffset = 10, minWidth: _minWidth, className, children, ...rest },
+  forwardedRef,
+) {
+  const ctx = usePopoverContext('Content');
+
+  // Floating UI integration lands in Task 8. For now the panel is portaled
+  // with no positioning — useful only for verifying ARIA + structure.
+  if (!ctx.open) return null;
+
+  return createPortal(
+    <div
+      {...rest}
+      ref={mergeRefs(ctx.contentRef, forwardedRef)}
+      id={ctx.contentId}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={ctx.headingId ?? undefined}
+      tabIndex={-1}
+      data-side="bottom"
+      data-popover-content=""
+      className={clsx(styles.content, className)}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+});
+```
+
+You may need to install `clsx` if it isn't already present. Check:
+
+```bash
+grep '"clsx"' packages/design-system/package.json
+```
+
+If empty, run:
+
+```bash
+npm install -w @eocrm/design-system clsx
+```
+
+(DropdownMenu and Tooltip already use clsx, so it's almost certainly there.)
+
+- [ ] **Step 4: Wire Content into the namespace**
+
+Update `packages/design-system/src/components/Popover/Popover.tsx`:
+
+```tsx
+import { PopoverRoot } from './PopoverRoot';
+import { Trigger } from './Trigger';
+import { Content } from './Content';
+
+type PopoverNamespace = typeof PopoverRoot & {
+  Trigger: typeof Trigger;
+  Content: typeof Content;
+};
+
+const Popover = PopoverRoot as PopoverNamespace;
+Popover.Trigger = Trigger;
+Popover.Content = Content;
+
+export { Popover };
+```
+
+- [ ] **Step 5: Export the types**
+
+Update `packages/design-system/src/components/Popover/index.ts`:
+
+```ts
+export { Popover } from './Popover';
+export type { PopoverProps } from './PopoverRoot';
+export type { PopoverTriggerProps } from './Trigger';
+export type { PopoverContentProps, PopoverSide, PopoverAlign } from './Content';
+```
+
+Update `packages/design-system/src/index.ts`:
+
+```ts
+export { Popover } from './components/Popover';
+export type {
+  PopoverProps,
+  PopoverTriggerProps,
+  PopoverContentProps,
+  PopoverSide,
+  PopoverAlign,
+} from './components/Popover';
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 9 Popover tests pass + structure.test.ts still green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/Popover/Content.tsx \
+        packages/design-system/src/components/Popover/Popover.{tsx,test.tsx} \
+        packages/design-system/src/components/Popover/index.ts \
+        packages/design-system/src/index.ts
+git commit -m "$(cat <<'EOF'
+Popover.Content: minimal portaled role=dialog panel
+
+createPortal to document.body; <div role="dialog" aria-modal="false"
+tabIndex=-1 aria-labelledby={headingId}>. No Floating UI positioning
+yet — Task 8 adds that. No focus management — Task 6 adds that.
+No document listeners — Task 7 adds those.
+
+data-side is hardcoded to "bottom" pending Floating UI integration;
+the SCSS [data-side] rules in Task 9 will work either way.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Popover.Heading — semantic + aria-labelledby wiring
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Popover/Heading.tsx`
+- Modify: `packages/design-system/src/components/Popover/Popover.tsx`
+- Modify: `packages/design-system/src/components/Popover/Popover.test.tsx`
+- Modify: `packages/design-system/src/components/Popover/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `Popover.test.tsx`:
+
+```tsx
+describe('Popover.Heading', () => {
+  it('renders as h3 by default with an auto id', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Heading>Filters</Popover.Heading>
+        </Popover.Content>
+      </Popover>,
+    );
+    const heading = screen.getByRole('heading', { name: 'Filters', level: 3 });
+    expect(heading.id).toMatch(/^popover-heading-/);
+  });
+
+  it('respects the `as` prop', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Heading as="h2">Filters</Popover.Heading>
+        </Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('heading', { name: 'Filters', level: 2 })).toBeInTheDocument();
+  });
+
+  it('wires aria-labelledby on Content to the heading id', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Heading>Filters</Popover.Heading>
+        </Popover.Content>
+      </Popover>,
+    );
+    const dialog = screen.getByRole('dialog');
+    const heading = screen.getByRole('heading', { name: 'Filters' });
+    expect(dialog.getAttribute('aria-labelledby')).toBe(heading.id);
+  });
+
+  it('Content has no aria-labelledby when no Heading is present', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>plain body</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-labelledby');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 4 new tests fail.
+
+- [ ] **Step 3: Implement Heading**
+
+Create `packages/design-system/src/components/Popover/Heading.tsx`:
+
+```tsx
+import { useId, useLayoutEffect, type HTMLAttributes, type JSX } from 'react';
+import { usePopoverContext } from './context';
+import { sanitizeId } from '../_internal/refs';
+
+export interface PopoverHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
+  /** Heading level. Defaults to `'h3'`. */
+  as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
+export function Heading({ as: As = 'h3', id: idProp, children, ...rest }: PopoverHeadingProps) {
+  const ctx = usePopoverContext('Heading');
+  const reactId = useId();
+  const id = idProp ?? `popover-heading-${sanitizeId(reactId)}`;
+
+  useLayoutEffect(() => {
+    ctx.setHeadingId(id);
+    return () => ctx.setHeadingId(null);
+    // ctx.setHeadingId is stable per Popover instance; id changes only if
+    // consumer provides one — re-fire is correct in that case.
+  }, [ctx.setHeadingId, id]);
+
+  const Tag = As as keyof JSX.IntrinsicElements;
+  return (
+    <Tag id={id} {...rest}>
+      {children}
+    </Tag>
+  );
+}
+```
+
+- [ ] **Step 4: Wire Heading into the namespace**
+
+Update `packages/design-system/src/components/Popover/Popover.tsx`:
+
+```tsx
+import { PopoverRoot } from './PopoverRoot';
+import { Trigger } from './Trigger';
+import { Content } from './Content';
+import { Heading } from './Heading';
+
+type PopoverNamespace = typeof PopoverRoot & {
+  Trigger: typeof Trigger;
+  Content: typeof Content;
+  Heading: typeof Heading;
+};
+
+const Popover = PopoverRoot as PopoverNamespace;
+Popover.Trigger = Trigger;
+Popover.Content = Content;
+Popover.Heading = Heading;
+
+export { Popover };
+```
+
+- [ ] **Step 5: Export Heading type**
+
+Update `packages/design-system/src/components/Popover/index.ts`:
+
+```ts
+export { Popover } from './Popover';
+export type { PopoverProps } from './PopoverRoot';
+export type { PopoverTriggerProps } from './Trigger';
+export type { PopoverContentProps, PopoverSide, PopoverAlign } from './Content';
+export type { PopoverHeadingProps } from './Heading';
+```
+
+Update `packages/design-system/src/index.ts`:
+
+```ts
+export { Popover } from './components/Popover';
+export type {
+  PopoverProps,
+  PopoverTriggerProps,
+  PopoverContentProps,
+  PopoverHeadingProps,
+  PopoverSide,
+  PopoverAlign,
+} from './components/Popover';
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 13 tests pass total.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/Popover/Heading.tsx \
+        packages/design-system/src/components/Popover/Popover.{tsx,test.tsx} \
+        packages/design-system/src/components/Popover/index.ts \
+        packages/design-system/src/index.ts
+git commit -m "$(cat <<'EOF'
+Popover.Heading: semantic h-tag + aria-labelledby registration
+
+Registers its auto-generated id via context on mount; unregisters on
+unmount. Content reads ctx.headingId and sets aria-labelledby
+accordingly. Default tag is h3; `as` prop accepts h2–h6.
+
+Without a Heading, Content has no aria-labelledby — verified by test.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Popover.Close — cloneElement + chained close handler
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Popover/Close.tsx`
+- Modify: `packages/design-system/src/components/Popover/Popover.tsx`
+- Modify: `packages/design-system/src/components/Popover/Popover.test.tsx`
+- Modify: `packages/design-system/src/components/Popover/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `Popover.test.tsx`:
+
+```tsx
+describe('Popover.Close', () => {
+  it('clicking the wrapped child closes the popover', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Close>
+            <button type="button">Done</button>
+          </Popover.Close>
+        </Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('chains the consumer onClick (consumer first, then close)', async () => {
+    const user = userEvent.setup();
+    const consumer = vi.fn();
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Close>
+            <button type="button" onClick={consumer}>
+              Done
+            </button>
+          </Popover.Close>
+        </Popover.Content>
+      </Popover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+    expect(consumer).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('throws when children is not a valid React element', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      render(
+        <Popover defaultOpen>
+          <Popover.Trigger>
+            <button type="button">Open</button>
+          </Popover.Trigger>
+          <Popover.Content>
+            {/* @ts-expect-error — intentionally invalid */}
+            <Popover.Close>{null}</Popover.Close>
+          </Popover.Content>
+        </Popover>,
+      ),
+    ).toThrow(/exactly one React element/);
+    spy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 3 new tests fail.
+
+- [ ] **Step 3: Implement Close**
+
+Create `packages/design-system/src/components/Popover/Close.tsx`:
+
+```tsx
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  type MouseEvent as ReactMouseEvent,
+  type ReactElement,
+} from 'react';
+import { usePopoverContext } from './context';
+import { chain } from '../_internal/refs';
+
+export interface PopoverCloseProps {
+  /**
+   * Exactly one React element. The Close clones this element to inject an
+   * `onClick` that closes the popover, chained with the child's existing
+   * `onClick` (consumer runs first).
+   */
+  children: ReactElement;
+}
+
+export function Close({ children }: PopoverCloseProps) {
+  const ctx = usePopoverContext('Close');
+
+  if (!isValidElement(children)) {
+    throw new Error('<Popover.Close> requires exactly one React element child.');
+  }
+
+  const childProps = children.props as {
+    onClick?: (e: ReactMouseEvent<HTMLElement>) => void;
+  };
+
+  const handleClick = useCallback(
+    (_e: ReactMouseEvent<HTMLElement>) => {
+      ctx.closeAll();
+    },
+    [ctx],
+  );
+
+  return cloneElement(children, {
+    onClick: chain(childProps.onClick, handleClick),
+  } as object);
+}
+```
+
+- [ ] **Step 4: Wire Close into the namespace**
+
+Update `packages/design-system/src/components/Popover/Popover.tsx`:
+
+```tsx
+import { PopoverRoot } from './PopoverRoot';
+import { Trigger } from './Trigger';
+import { Content } from './Content';
+import { Heading } from './Heading';
+import { Close } from './Close';
+
+type PopoverNamespace = typeof PopoverRoot & {
+  Trigger: typeof Trigger;
+  Content: typeof Content;
+  Heading: typeof Heading;
+  Close: typeof Close;
+};
+
+const Popover = PopoverRoot as PopoverNamespace;
+Popover.Trigger = Trigger;
+Popover.Content = Content;
+Popover.Heading = Heading;
+Popover.Close = Close;
+
+export { Popover };
+```
+
+- [ ] **Step 5: Export Close type**
+
+Update `packages/design-system/src/components/Popover/index.ts`:
+
+```ts
+export { Popover } from './Popover';
+export type { PopoverProps } from './PopoverRoot';
+export type { PopoverTriggerProps } from './Trigger';
+export type { PopoverContentProps, PopoverSide, PopoverAlign } from './Content';
+export type { PopoverHeadingProps } from './Heading';
+export type { PopoverCloseProps } from './Close';
+```
+
+Update `packages/design-system/src/index.ts`:
+
+```ts
+export { Popover } from './components/Popover';
+export type {
+  PopoverProps,
+  PopoverTriggerProps,
+  PopoverContentProps,
+  PopoverHeadingProps,
+  PopoverCloseProps,
+  PopoverSide,
+  PopoverAlign,
+} from './components/Popover';
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 16 tests pass total.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/Popover/Close.tsx \
+        packages/design-system/src/components/Popover/Popover.{tsx,test.tsx} \
+        packages/design-system/src/components/Popover/index.ts \
+        packages/design-system/src/index.ts
+git commit -m "$(cat <<'EOF'
+Popover.Close: cloneElement + chained close handler
+
+Wraps any single element with an onClick that calls ctx.closeAll().
+Consumer's onClick chains and runs first. closeAll also returns focus
+to the trigger (already implemented in PopoverRoot).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Focus-on-open + document Escape listener
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Popover/Content.tsx`
+- Modify: `packages/design-system/src/components/Popover/Popover.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `Popover.test.tsx`:
+
+```tsx
+import { act } from '@testing-library/react';
+
+describe('Popover — focus + Escape', () => {
+  it('moves focus to the panel when opened', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(document.activeElement).toBe(screen.getByRole('dialog'));
+  });
+
+  it('Escape closes the popover and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    await user.click(trigger);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(trigger);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 2 new tests fail.
+
+- [ ] **Step 3: Update Content with focus + Escape**
+
+Replace `packages/design-system/src/components/Popover/Content.tsx` with:
+
+```tsx
+import { forwardRef, useEffect, useLayoutEffect, type HTMLAttributes } from 'react';
+import { createPortal } from 'react-dom';
+import clsx from 'clsx';
+import { usePopoverContext } from './context';
+import { mergeRefs } from '../_internal/refs';
+import styles from './Popover.module.scss';
+
+export type PopoverSide = 'top' | 'right' | 'bottom' | 'left';
+export type PopoverAlign = 'start' | 'center' | 'end';
+
+export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {
+  side?: PopoverSide;
+  align?: PopoverAlign;
+  sideOffset?: number;
+  minWidth?: number | string;
+}
+
+export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function Content(
+  { side: _side = 'bottom', align: _align = 'center', sideOffset: _sideOffset = 10, minWidth: _minWidth, className, children, ...rest },
+  forwardedRef,
+) {
+  const ctx = usePopoverContext('Content');
+
+  // Focus the panel on open. preventScroll: same reason DropdownMenu uses
+  // it — the portal renders at document origin before Floating UI positions
+  // it, focusing without preventScroll would yank the page.
+  useLayoutEffect(() => {
+    if (!ctx.open) return;
+    queueMicrotask(() => ctx.contentRef.current?.focus({ preventScroll: true }));
+  }, [ctx.open, ctx.contentRef]);
+
+  // Document Escape listener while open. Capture phase so it runs before
+  // focused widgets that may stopPropagation.
+  useEffect(() => {
+    if (!ctx.open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        ctx.closeAll();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [ctx.open, ctx.closeAll]);
+
+  if (!ctx.open) return null;
+
+  return createPortal(
+    <div
+      {...rest}
+      ref={mergeRefs(ctx.contentRef, forwardedRef)}
+      id={ctx.contentId}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={ctx.headingId ?? undefined}
+      tabIndex={-1}
+      data-side="bottom"
+      data-popover-content=""
+      className={clsx(styles.content, className)}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+});
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 18 tests pass total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Popover/Content.tsx \
+        packages/design-system/src/components/Popover/Popover.test.tsx
+git commit -m "$(cat <<'EOF'
+Popover.Content: focus-on-open + Escape dismissal
+
+useLayoutEffect + queueMicrotask focuses the panel (tabIndex=-1) on
+open so Escape works from inside. Document-level keydown listener
+(capture phase) closes on Escape; closeAll returns focus to the
+trigger.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Outside-click dismissal (document pointerdown)
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Popover/Content.tsx`
+- Modify: `packages/design-system/src/components/Popover/Popover.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `Popover.test.tsx`:
+
+```tsx
+describe('Popover — outside click dismissal', () => {
+  it('closes when pointerdown fires outside the panel and outside the trigger', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <Popover>
+          <Popover.Trigger>
+            <button type="button">Open</button>
+          </Popover.Trigger>
+          <Popover.Content>panel body</Popover.Content>
+        </Popover>
+        <div data-testid="elsewhere">elsewhere</div>
+      </>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.pointer({ keys: '[MouseLeft>]', target: screen.getByTestId('elsewhere') });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('does NOT close when pointerdown fires inside the panel', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <div data-testid="inside">panel body</div>
+        </Popover.Content>
+      </Popover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.pointer({ keys: '[MouseLeft>]', target: screen.getByTestId('inside') });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('does NOT close when pointerdown fires on the trigger (trigger toggles it)', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    await user.click(trigger);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    // Clicking the trigger again toggles it closed, but that's the trigger
+    // handler — NOT the outside-click logic — doing the work. Verify by
+    // confirming aria-expanded toggles.
+    await user.click(trigger);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: the outside-click test fails (closes don't happen yet). The inside-panel test happens to pass (no close logic anywhere). The trigger-toggle test passes (trigger already toggles). Confirm at least one red.
+
+- [ ] **Step 3: Add the pointerdown listener to Content**
+
+Update `packages/design-system/src/components/Popover/Content.tsx` — insert this `useEffect` next to the existing Escape `useEffect`:
+
+```tsx
+  // Outside-click: close if pointerdown lands outside the panel AND outside
+  // the trigger. Capture phase fires before focused widgets that may
+  // stopPropagation. The check uses contains() so clicks on descendants of
+  // the panel (e.g. a button inside) don't dismiss.
+  useEffect(() => {
+    if (!ctx.open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      const panel = ctx.contentRef.current;
+      const trigger = ctx.triggerRef.current;
+      if (panel && panel.contains(target)) return;
+      if (trigger && trigger.contains(target)) return;
+      ctx.setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [ctx.open, ctx.contentRef, ctx.triggerRef, ctx.setOpen]);
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 21 tests pass total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Popover/Content.tsx \
+        packages/design-system/src/components/Popover/Popover.test.tsx
+git commit -m "$(cat <<'EOF'
+Popover.Content: outside-click dismissal via document pointerdown
+
+Capture-phase pointerdown listener while open: if the click target is
+neither inside the panel nor inside the trigger, close. Trigger gets
+excluded because its own click handler toggles open — letting both
+fire would close-then-open as a single mouse press.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Floating UI integration + arrow
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Popover/Content.tsx`
+- Modify: `packages/design-system/src/components/Popover/Popover.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `Popover.test.tsx`:
+
+```tsx
+describe('Popover — Floating UI positioning + arrow', () => {
+  beforeEach(() => {
+    window.ResizeObserver = class ResizeObserverMock {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  });
+
+  it('data-side reflects the configured side (default bottom)', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog').getAttribute('data-side')).toBe('bottom');
+  });
+
+  it('respects side="top"', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content side="top">panel body</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog').getAttribute('data-side')).toBe('top');
+  });
+
+  it('renders an arrow span with aria-hidden inside the panel', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const panel = screen.getByRole('dialog');
+    const arrow = panel.querySelector('span[aria-hidden="true"]');
+    expect(arrow).not.toBeNull();
+    expect((arrow as HTMLElement).className).toMatch(/arrow/);
+  });
+});
+```
+
+Make sure the file-level `beforeEach` has the ResizeObserver shim if other describes also need it. Hoist if necessary (mirror Tooltip.test.tsx's pattern).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 3 new tests fail (arrow doesn't exist, data-side is hardcoded to bottom).
+
+- [ ] **Step 3: Replace Content with Floating UI integration**
+
+Replace `packages/design-system/src/components/Popover/Content.tsx` entirely:
+
+```tsx
+import { forwardRef, useEffect, useLayoutEffect, useRef, type HTMLAttributes } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  arrow,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useFloating,
+  type Placement,
+} from '@floating-ui/react-dom';
+import clsx from 'clsx';
+import { usePopoverContext } from './context';
+import { mergeRefs } from '../_internal/refs';
+import styles from './Popover.module.scss';
+
+export type PopoverSide = 'top' | 'right' | 'bottom' | 'left';
+export type PopoverAlign = 'start' | 'center' | 'end';
+
+export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {
+  /** Preferred side. Default `'bottom'`. Auto-flips on collision via Floating UI. */
+  side?: PopoverSide;
+  /** Edge alignment. Default `'center'`. */
+  align?: PopoverAlign;
+  /** Gap in px between trigger and panel. Default `10` (room for the arrow). */
+  sideOffset?: number;
+  /** Minimum width in px or any CSS length. Defaults to `--size-popover-min-width` (220). */
+  minWidth?: number | string;
+}
+
+export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function Content(
+  { side = 'bottom', align = 'center', sideOffset = 10, minWidth, className, children, ...rest },
+  forwardedRef,
+) {
+  const ctx = usePopoverContext('Content');
+  const arrowRef = useRef<HTMLSpanElement | null>(null);
+
+  const placement: Placement = (align === 'center' ? side : `${side}-${align}`) as Placement;
+
+  const {
+    refs,
+    floatingStyles,
+    placement: resolvedPlacement,
+    middlewareData,
+  } = useFloating({
+    open: ctx.open,
+    placement,
+    transform: false,
+    middleware: [
+      offset(sideOffset),
+      flip(),
+      shift({ padding: 8 }),
+      arrow({ element: arrowRef }),
+    ],
+    whileElementsMounted: autoUpdate,
+    elements: { reference: ctx.triggerRef.current },
+  });
+
+  const resolvedSide = resolvedPlacement.split('-')[0] as PopoverSide;
+  const staticSide = (
+    { top: 'bottom', bottom: 'top', left: 'right', right: 'left' } as const
+  )[resolvedSide];
+
+  // Focus the panel on open. preventScroll matches DropdownMenu/Tooltip.
+  useLayoutEffect(() => {
+    if (!ctx.open) return;
+    queueMicrotask(() => ctx.contentRef.current?.focus({ preventScroll: true }));
+  }, [ctx.open, ctx.contentRef]);
+
+  // Escape closes; capture phase fires before focused widgets that may
+  // stopPropagation.
+  useEffect(() => {
+    if (!ctx.open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        ctx.closeAll();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [ctx.open, ctx.closeAll]);
+
+  // Outside-click closes.
+  useEffect(() => {
+    if (!ctx.open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      const panel = ctx.contentRef.current;
+      const trigger = ctx.triggerRef.current;
+      if (panel && panel.contains(target)) return;
+      if (trigger && trigger.contains(target)) return;
+      ctx.setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [ctx.open, ctx.contentRef, ctx.triggerRef, ctx.setOpen]);
+
+  if (!ctx.open) return null;
+
+  const arrowXY = middlewareData.arrow;
+  const minWidthStyle =
+    minWidth !== undefined
+      ? typeof minWidth === 'number'
+        ? `${minWidth}px`
+        : minWidth
+      : undefined;
+
+  return createPortal(
+    <div
+      {...rest}
+      ref={mergeRefs(ctx.contentRef, refs.setFloating, forwardedRef)}
+      id={ctx.contentId}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={ctx.headingId ?? undefined}
+      tabIndex={-1}
+      data-side={resolvedSide}
+      data-popover-content=""
+      style={{ ...floatingStyles, minWidth: minWidthStyle }}
+      className={clsx(styles.content, className)}
+    >
+      {children}
+      <span
+        ref={arrowRef}
+        aria-hidden="true"
+        className={styles.arrow}
+        style={{
+          left: typeof arrowXY?.x === 'number' ? `${arrowXY.x}px` : undefined,
+          top: typeof arrowXY?.y === 'number' ? `${arrowXY.y}px` : undefined,
+          [staticSide]: '-6px',
+        }}
+      />
+    </div>,
+    document.body,
+  );
+});
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 24 tests pass total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Popover/Content.tsx \
+        packages/design-system/src/components/Popover/Popover.test.tsx
+git commit -m "$(cat <<'EOF'
+Popover.Content: Floating UI positioning + arrow
+
+useFloating in transform:false mode so CSS transform stays free for the
+entrance animation. offset/flip/shift/arrow middleware (same stack
+Tooltip uses, with larger default offset 10 for the bigger arrow).
+Arrow is an aria-hidden span anchored to the trigger-facing side via
+inline style; per-side SCSS rotation lands in Task 10.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: SCSS — chrome + arrow + @starting-style entrance
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Popover/Popover.module.scss`
+- Modify: `packages/design-system/src/components/Popover/Popover.test.tsx`
+
+- [ ] **Step 1: Write failing test for the animation contract**
+
+Append to `Popover.test.tsx`:
+
+```tsx
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('Popover — animation contract', () => {
+  it('the compiled .content rule contains an @starting-style block', () => {
+    const scss = readFileSync(resolve(__dirname, './Popover.module.scss'), 'utf8');
+    expect(scss).toMatch(/\.content\s*{[\s\S]*@starting-style/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: the new test fails (SCSS is still empty placeholders).
+
+- [ ] **Step 3: Write the SCSS**
+
+Replace `packages/design-system/src/components/Popover/Popover.module.scss` with:
+
+```scss
+// `.content` carries chrome + the open-only scale-fade entrance. The animation
+// (transition + @starting-style + per-side transform-origin) relies on
+// Floating UI being in `transform: false` mode (see Content.tsx) so the CSS
+// `transform` property is free for the entrance.
+.content {
+  position: relative;
+  min-width: var(--size-popover-min-width);
+  max-width: 360px;
+  padding: var(--space-3);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: var(--z-popover);
+  outline: none;
+
+  // Explicit so each per-side @starting-style transform has a defined
+  // resting target to interpolate to.
+  transform: none;
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base);
+
+  @starting-style {
+    opacity: var(--opacity-hidden);
+  }
+}
+
+.arrow {
+  position: absolute;
+  width: var(--space-3);
+  height: var(--space-3);
+  background: var(--color-bg);
+  border-right: var(--border-width) solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
+  transform: rotate(45deg);
+  pointer-events: none;
+}
+
+// Each data-side rotates the arrow so the "visible" two borders face outward
+// (i.e. away from the panel chrome). The default rule above uses bottom +
+// right borders (panel above trigger → arrow pokes downward), which matches
+// data-side='top'. Override for the other three sides:
+.content[data-side='bottom'] .arrow {
+  border-top: var(--border-width) solid var(--color-border);
+  border-left: var(--border-width) solid var(--color-border);
+  border-right: 0;
+  border-bottom: 0;
+}
+
+.content[data-side='left'] .arrow {
+  border-top: var(--border-width) solid var(--color-border);
+  border-right: var(--border-width) solid var(--color-border);
+  border-bottom: 0;
+  border-left: 0;
+}
+
+.content[data-side='right'] .arrow {
+  border-bottom: var(--border-width) solid var(--color-border);
+  border-left: var(--border-width) solid var(--color-border);
+  border-top: 0;
+  border-right: 0;
+}
+
+// --- Open-only entrance: per-side origin + starting transform -----------
+.content[data-side='top'] {
+  transform-origin: bottom center;
+
+  @starting-style {
+    transform: scale(0.95) translateY(4px);
+  }
+}
+
+.content[data-side='bottom'] {
+  transform-origin: top center;
+
+  @starting-style {
+    transform: scale(0.95) translateY(-4px);
+  }
+}
+
+.content[data-side='left'] {
+  transform-origin: right center;
+
+  @starting-style {
+    transform: scale(0.95) translateX(4px);
+  }
+}
+
+.content[data-side='right'] {
+  transform-origin: left center;
+
+  @starting-style {
+    transform: scale(0.95) translateX(-4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .content {
+    transition: none;
+  }
+}
+```
+
+Note: the `max-width: 360px` literal is an intrinsic geometric constraint (same posture as Tooltip's `max-width: 240px`). If stylelint flags it, add `360px` to the file's `declaration-strict-value` allowlist or use `/* stylelint-disable-next-line */` for that one line.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 25 tests pass.
+
+- [ ] **Step 5: Run stylelint**
+
+```bash
+npm run lint:css
+```
+
+Expected: exit 0. If it complains about `max-width: 360px`:
+
+- Option A: add a `/* stylelint-disable-next-line scale-unlimited/declaration-strict-value */` comment immediately above the `max-width` line.
+- Option B: extend the lint rule's `ignoreProperties` for `max-width`.
+
+Pick Option A — narrower scope, doesn't change rule for other files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Popover/Popover.{module.scss,test.tsx}
+git commit -m "$(cat <<'EOF'
+Popover: chrome + arrow + open-only scale-fade entrance
+
+Panel: var(--color-bg), --shadow-lg, min-width --size-popover-min-width
+(220), max-width 360px (intrinsic geometric constraint), padding
+--space-3. Arrow is a 45° rotated square with two adjacent borders
+matching the panel's border so it visually fuses with the chrome;
+per-side selectors swap which two borders are visible.
+
+Animation mirrors DropdownMenu/Tooltip's @starting-style recipe with
+scale(0.95) and 4px translate — proportional to the larger panel.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Cleanup + Tab-traverses-out behavior tests
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Popover/Popover.test.tsx`
+
+No source changes — these tests lock in cleanup contract and the Tab traversal behavior (popover does NOT trap focus).
+
+- [ ] **Step 1: Append the tests**
+
+```tsx
+describe('Popover — cleanup + Tab traversal', () => {
+  it('removes document-level listeners on unmount while open', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const { unmount } = render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    unmount();
+    expect(removeSpy.mock.calls.some(([type]) => type === 'pointerdown')).toBe(true);
+    expect(removeSpy.mock.calls.some(([type]) => type === 'keydown')).toBe(true);
+    removeSpy.mockRestore();
+  });
+
+  it('Tab from inside the panel walks to the next page-focusable; popover stays open', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <Popover defaultOpen>
+          <Popover.Trigger>
+            <button type="button">Open</button>
+          </Popover.Trigger>
+          <Popover.Content>
+            <button type="button">inside-1</button>
+          </Popover.Content>
+        </Popover>
+        <button type="button">after</button>
+      </>,
+    );
+
+    // The panel itself has focus on open; Tab moves to the first focusable inside (inside-1).
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'inside-1' })).toHaveFocus();
+
+    // Another Tab walks out of the panel to the next page focusable (after).
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'after' })).toHaveFocus();
+
+    // Popover stays open.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('preserves consumer props on the cloned trigger (className, data-*)', () => {
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button" className="consumer" data-testid="t">
+            Open
+          </button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const trigger = screen.getByTestId('t');
+    expect(trigger).toHaveClass('consumer');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: 28 tests pass total.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/Popover/Popover.test.tsx
+git commit -m "$(cat <<'EOF'
+Popover: cleanup + Tab traversal tests
+
+Locks in (1) unmount-while-open removes both document listeners
+(pointerdown + keydown), (2) Tab from inside the panel walks past
+the panel to the next page focusable — popover does NOT trap focus,
+(3) consumer className/data-* survive cloneElement.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Full JSDoc on Popover + sub-components (Rule 7)
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Popover/PopoverRoot.tsx`
+- Modify: `packages/design-system/src/components/Popover/Trigger.tsx`
+- Modify: `packages/design-system/src/components/Popover/Content.tsx`
+- Modify: `packages/design-system/src/components/Popover/Heading.tsx`
+- Modify: `packages/design-system/src/components/Popover/Close.tsx`
+
+- [ ] **Step 1: Add JSDoc to `PopoverRoot`**
+
+In `PopoverRoot.tsx`, replace the `export function PopoverRoot(` line with the version below, JSDoc block above it:
+
+```tsx
+/**
+ * Non-modal floating panel that opens from a trigger and contains arbitrary
+ * interactive content. Compound API — pair `<Trigger>`, `<Content>`,
+ * optionally `<Heading>` and `<Close>`, as direct or nested children.
+ *
+ * Implements the WAI-ARIA non-modal dialog pattern: `role="dialog"` on
+ * Content, `aria-haspopup="dialog"` on Trigger, focus moves to the panel
+ * on open, Tab traverses out of the panel into the page behind, click
+ * outside or Escape dismisses. Page is NOT inert. Tooltip-grade animation
+ * via `@starting-style`.
+ *
+ * @example
+ * <Popover>
+ *   <Popover.Trigger>
+ *     <Button variant="secondary">Filters</Button>
+ *   </Popover.Trigger>
+ *   <Popover.Content>
+ *     <Stack gap="sm">
+ *       <Popover.Heading>Filter results</Popover.Heading>
+ *       {/* …form controls… */}
+ *       <Cluster justify="end" gap="sm">
+ *         <Popover.Close>
+ *           <Button variant="secondary" size="sm">Cancel</Button>
+ *         </Popover.Close>
+ *         <Popover.Close>
+ *           <Button size="sm" onClick={apply}>Apply</Button>
+ *         </Popover.Close>
+ *       </Cluster>
+ *     </Stack>
+ *   </Popover.Content>
+ * </Popover>
+ *
+ * @example
+ * // Controlled (rare — usually let Popover manage state):
+ * const [open, setOpen] = useState(false);
+ * <Popover open={open} onOpenChange={setOpen}>…</Popover>
+ *
+ * @remarks When NOT to use
+ * - For a passive hint on hover/focus → use `<Tooltip>`.
+ * - For a list of actions → use `<DropdownMenu>`.
+ * - For a focus-locked confirmation that demands full attention → use
+ *   `<Modal>` (not yet shipped) once available; until then, `<Popover>`
+ *   with explicit Confirm/Cancel buttons is acceptable.
+ *
+ * @remarks Anti-patterns
+ * - ❌ `<Popover.Trigger><Button disabled>…</Button></Popover.Trigger>` —
+ *   disabled buttons do not fire click. Use `aria-disabled="true"` +
+ *   intercept the click, or wrap in `<span>`.
+ * - ❌ `<Popover.Content>` with no `<Popover.Close>` button AND content
+ *   that isn't obviously dismissable by clicking outside — keyboard /
+ *   screen-reader users get no clear close affordance. Add `<Popover.Close>`
+ *   or rely on outside-click only when the popover is small and obvious.
+ * - ❌ Multiple `<Popover.Heading>` instances inside one `<Popover.Content>`
+ *   — second mount overwrites `aria-labelledby`. Use one Heading per Popover.
+ */
+export function PopoverRoot({
+```
+
+Also annotate each prop in `PopoverProps`. Replace the interface with:
+
+```tsx
+export interface PopoverProps {
+  /**
+   * Must contain exactly one `<Popover.Trigger>` and one `<Popover.Content>`.
+   * `<Popover.Heading>` and `<Popover.Close>` are optional and may appear
+   * anywhere inside `<Popover.Content>`.
+   */
+  children: ReactNode;
+  /**
+   * Controlled open state. Provide alongside `onOpenChange` to drive open
+   * externally. Omit both to let Popover own its state (the common case).
+   */
+  open?: boolean;
+  /** Fired whenever Popover wants to change open state. Required when `open` is provided. */
+  onOpenChange?: (open: boolean) => void;
+  /** Default open state for uncontrolled usage. Defaults to `false`. */
+  defaultOpen?: boolean;
+  /**
+   * Reserved future hint. v1 ignores the value and always renders non-modal.
+   * Will gate focus-trap + inert-background once `<Modal>` lands.
+   */
+  modal?: boolean;
+}
+```
+
+- [ ] **Step 2: Add JSDoc to `Trigger`**
+
+In `Trigger.tsx`, the `PopoverTriggerProps` interface JSDoc already exists. Add a paragraph-level JSDoc above `export function Trigger(`:
+
+```tsx
+/**
+ * Clones its single child element to inject ref + ARIA + the click handler
+ * that toggles the popover. Child must accept a ref (`forwardRef` if it's
+ * a custom component; raw `<button>` or this library's `<Button>` both
+ * qualify).
+ *
+ * @example
+ * <Popover.Trigger>
+ *   <Button variant="secondary">Filters</Button>
+ * </Popover.Trigger>
+ */
+export function Trigger({ children }: PopoverTriggerProps) {
+```
+
+- [ ] **Step 3: Add JSDoc to `Content` and each prop**
+
+In `Content.tsx`, replace the `PopoverContentProps` interface with the documented version:
+
+```tsx
+export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {
+  /** Preferred side. Default `'bottom'`. Auto-flips on collision via Floating UI. */
+  side?: PopoverSide;
+  /** Edge alignment. Default `'center'`. */
+  align?: PopoverAlign;
+  /** Gap in px between trigger and panel. Default `10` (room for the arrow). */
+  sideOffset?: number;
+  /**
+   * Minimum width in px or any CSS length. Defaults to the token
+   * `--size-popover-min-width` (220px) applied via SCSS.
+   */
+  minWidth?: number | string;
+}
+```
+
+Add a JSDoc block above `export const Content = forwardRef(`:
+
+```tsx
+/**
+ * The floating panel itself. Portaled to `document.body`, positioned by
+ * Floating UI (auto-flip, viewport-aware), animated via `@starting-style`
+ * on open. `role="dialog"`, `aria-modal="false"`, `tabIndex={-1}` so it
+ * can receive focus on open. Renders an aria-hidden arrow that tracks
+ * the trigger.
+ */
+export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function Content(
+```
+
+Also add one-line JSDoc to the two exported types at the top of the file:
+
+```tsx
+/** Which side of the trigger the popover prefers. Floating UI auto-flips if it doesn't fit. */
+export type PopoverSide = 'top' | 'right' | 'bottom' | 'left';
+
+/** Which edge of the popover aligns to the corresponding trigger edge. */
+export type PopoverAlign = 'start' | 'center' | 'end';
+```
+
+- [ ] **Step 4: Add JSDoc to `Heading`**
+
+In `Heading.tsx`, replace the `PopoverHeadingProps` interface with:
+
+```tsx
+export interface PopoverHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
+  /**
+   * Heading level. Defaults to `'h3'`. Pick the level that fits the
+   * surrounding document outline (Popover content is usually a level 3
+   * inside a level 2 section).
+   */
+  as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+```
+
+Add JSDoc above `export function Heading(`:
+
+```tsx
+/**
+ * Renders a semantic heading element (default `h3`) and registers its
+ * auto-generated id via context so `<Popover.Content>` can wire
+ * `aria-labelledby` to it. The registration unsubscribes on unmount.
+ *
+ * @example
+ * <Popover.Content>
+ *   <Popover.Heading>Filter results</Popover.Heading>
+ *   {/* …content… */}
+ * </Popover.Content>
+ */
+export function Heading({ as: As = 'h3', id: idProp, children, ...rest }: PopoverHeadingProps) {
+```
+
+- [ ] **Step 5: Add JSDoc to `Close`**
+
+In `Close.tsx`, replace the JSDoc on the interface (already there) with:
+
+```tsx
+export interface PopoverCloseProps {
+  /**
+   * Exactly one React element. The Close clones this element to inject an
+   * `onClick` that closes the popover, chained with the child's existing
+   * `onClick` (consumer runs first).
+   */
+  children: ReactElement;
+}
+```
+
+Add JSDoc above `export function Close(`:
+
+```tsx
+/**
+ * Wraps any single element with an onClick that closes the popover.
+ * Useful for "Cancel", "Apply", or "✕" buttons inside `<Popover.Content>`.
+ * Consumer's onClick chains and runs first.
+ *
+ * @example
+ * <Popover.Close>
+ *   <Button variant="secondary" size="sm">Cancel</Button>
+ * </Popover.Close>
+ */
+export function Close({ children }: PopoverCloseProps) {
+```
+
+- [ ] **Step 6: Typecheck + tests**
+
+```bash
+npm run typecheck -w @eocrm/design-system
+npm test -w @eocrm/design-system -- Popover
+```
+
+Expected: both exit 0; test count unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/Popover/
+git commit -m "$(cat <<'EOF'
+Popover: full JSDoc per library rule 7
+
+Component-level prose on PopoverRoot covers the non-modal dialog
+pattern, focus contract, dismissal, and the three @remarks bullet
+sets (when not to use, anti-patterns). Each sub-component (Trigger,
+Content, Heading, Close) carries its own JSDoc + canonical snippet.
+Every prop is documented; PopoverSide and PopoverAlign each get a
+one-line description.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Scaffold ConfirmationPopover + first render test
+
+**Files:**
+
+- Create: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx`
+- Create: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.module.scss`
+- Create: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx`
+- Create: `packages/design-system/src/components/ConfirmationPopover/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+- [ ] **Step 1: Create the SCSS placeholder**
+
+Create `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.module.scss`:
+
+```scss
+/* stylelint-disable block-no-empty */
+// Rules land in Task 18. Empty for now so the import resolves.
+.title {
+}
+.description {
+}
+.spinner {
+}
+/* stylelint-enable block-no-empty */
+```
+
+- [ ] **Step 2: Write the first failing test**
+
+Create `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { ConfirmationPopover } from './ConfirmationPopover';
+
+describe('ConfirmationPopover — initial render', () => {
+  it('renders only the trigger when closed', () => {
+    render(
+      <ConfirmationPopover
+        title="Delete record?"
+        description="This action cannot be undone."
+        variant="danger"
+        onConfirm={() => {}}
+      >
+        <button type="button">Delete</button>
+      </ConfirmationPopover>,
+    );
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Create the minimal component**
+
+Create `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx`:
+
+```tsx
+import type { ReactElement, ReactNode } from 'react';
+import { Popover } from '../Popover';
+
+export type ConfirmationVariant = 'default' | 'danger';
+
+export interface ConfirmationPopoverProps {
+  /** The trigger element. Same forwardRef-required contract as Popover.Trigger. */
+  children: ReactElement;
+  /** Heading text. Wires aria-labelledby. */
+  title: string;
+  /** Optional body text. Wires aria-describedby when present. */
+  description?: ReactNode;
+  /** Confirm button label. Defaults to `'Confirm'`. */
+  confirmLabel?: string;
+  /** Cancel button label. Defaults to `'Cancel'`. */
+  cancelLabel?: string;
+  /** `'danger'` swaps Confirm to a danger-variant button. Defaults to `'default'`. */
+  variant?: ConfirmationVariant;
+  /**
+   * Async-aware confirm handler. May return a Promise; while pending, both
+   * buttons disable and dismissal is blocked. On resolve, the popover closes.
+   * On reject, the popover stays open and buttons re-enable.
+   */
+  onConfirm: () => void | Promise<void>;
+  /** Optional. Fired on Cancel click, Escape, or click-outside dismissal. */
+  onCancel?: () => void;
+  /** Preferred side. Default `'top'`. */
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  /** Edge alignment. Default `'center'`. */
+  align?: 'start' | 'center' | 'end';
+  /** Gap in px between trigger and panel. Default `10`. */
+  sideOffset?: number;
+  /** Controlled open state. */
+  open?: boolean;
+  /** Open-change callback. Required when `open` is provided. */
+  onOpenChange?: (open: boolean) => void;
+  /** Default open state for uncontrolled usage. Defaults to `false`. */
+  defaultOpen?: boolean;
+}
+
+export function ConfirmationPopover({
+  children,
+  side = 'top',
+  align = 'center',
+  sideOffset = 10,
+  open: controlledOpen,
+  onOpenChange,
+  defaultOpen = false,
+}: ConfirmationPopoverProps) {
+  // Minimal scaffold — internal state, focus management, buttons, async-aware
+  // onConfirm, and pending-blocks-dismissal land in subsequent tasks. For now
+  // ConfirmationPopover delegates entirely to Popover so the first render
+  // test passes (trigger only when closed).
+  return (
+    <Popover open={controlledOpen} onOpenChange={onOpenChange} defaultOpen={defaultOpen}>
+      <Popover.Trigger>{children}</Popover.Trigger>
+      <Popover.Content side={side} align={align} sideOffset={sideOffset}>
+        {/* Content body lands in Task 14 */}
+      </Popover.Content>
+    </Popover>
+  );
+}
+```
+
+- [ ] **Step 4: Create the index.ts**
+
+Create `packages/design-system/src/components/ConfirmationPopover/index.ts`:
+
+```ts
+export { ConfirmationPopover } from './ConfirmationPopover';
+export type { ConfirmationPopoverProps, ConfirmationVariant } from './ConfirmationPopover';
+```
+
+- [ ] **Step 5: Re-export from `src/index.ts`**
+
+Append to `packages/design-system/src/index.ts`:
+
+```ts
+export { ConfirmationPopover } from './components/ConfirmationPopover';
+export type { ConfirmationPopoverProps, ConfirmationVariant } from './components/ConfirmationPopover';
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+npm test -w @eocrm/design-system
+```
+
+Expected: all tests pass — including structure.test.ts (picks up the new folder + verifies the re-export).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/ConfirmationPopover/ packages/design-system/src/index.ts
+git commit -m "$(cat <<'EOF'
+ConfirmationPopover: scaffold + first render test
+
+Delegates entirely to Popover for now (trigger + empty Content).
+Props interface is the full final shape including async-aware
+onConfirm — implementation lands in subsequent tasks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: ConfirmationPopover — render content (title + description + buttons, sync confirm)
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx`
+- Modify: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `ConfirmationPopover.test.tsx`:
+
+```tsx
+import userEvent from '@testing-library/user-event';
+
+describe('ConfirmationPopover — content rendering (sync)', () => {
+  it('opens with title, description, Cancel and Confirm buttons', async () => {
+    const user = userEvent.setup();
+    render(
+      <ConfirmationPopover
+        title="Delete record?"
+        description="This action cannot be undone."
+        variant="danger"
+        onConfirm={() => {}}
+      >
+        <button type="button">Delete</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(screen.getByRole('heading', { name: 'Delete record?' })).toBeInTheDocument();
+    expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete', hidden: false })).toBeInTheDocument();
+    // ↑ second Delete is the Confirm button — confirmLabel defaults to the
+    // trigger's text in this test? NO — confirmLabel default is 'Confirm'.
+    // Fix the assertion below.
+  });
+
+  it('respects custom confirmLabel and cancelLabel', async () => {
+    const user = userEvent.setup();
+    render(
+      <ConfirmationPopover
+        title="Archive?"
+        confirmLabel="Archive"
+        cancelLabel="Keep"
+        onConfirm={() => {}}
+      >
+        <button type="button">Archive…</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Archive…' }));
+    expect(screen.getByRole('button', { name: 'Keep' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Archive' })).toBeInTheDocument();
+  });
+
+  it('default variant uses primary button; danger variant uses danger button', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ConfirmationPopover title="Default?" onConfirm={() => {}}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    // The library's Button component sets data-variant on the rendered button.
+    // We check that the Confirm button has the right data-variant value.
+    // (If the actual library Button uses a different attribute, adjust below.)
+    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveAttribute('data-variant', 'primary');
+
+    rerender(
+      <ConfirmationPopover title="Default?" variant="danger" onConfirm={() => {}}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    // Confirm button reflects the new variant after re-render (popover stays
+    // open because the trigger re-renders).
+    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveAttribute('data-variant', 'danger');
+  });
+
+  it('aria-labelledby points at the title; aria-describedby points at the description', async () => {
+    const user = userEvent.setup();
+    render(
+      <ConfirmationPopover title="Delete?" description="Cannot be undone." onConfirm={() => {}}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    const dialog = screen.getByRole('dialog');
+    const heading = screen.getByRole('heading', { name: 'Delete?' });
+    expect(dialog.getAttribute('aria-labelledby')).toBe(heading.id);
+
+    const description = screen.getByText('Cannot be undone.');
+    expect(dialog.getAttribute('aria-describedby')).toBe(description.id);
+  });
+
+  it('sync onConfirm: click Confirm → onConfirm runs once → popover closes', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('Cancel click closes + fires onCancel', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(
+      <ConfirmationPopover title="Confirm?" onConfirm={() => {}} onCancel={onCancel}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+```
+
+Before running these tests, verify that the library's `<Button>` exposes a `data-variant` attribute. Open `packages/design-system/src/components/Button/Button.tsx` and look for `data-variant`. If the prop is rendered differently (e.g., as a className like `variant-primary`), update the assertions in test #3 above to match. Common alternatives:
+
+- `data-variant="primary"` — preferred (most common in design systems)
+- className containing `primary` or `variant-primary`
+
+Use whichever pattern the existing Button uses. The plan assumes `data-variant` based on convention; verify and adjust before committing.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -w @eocrm/design-system -- ConfirmationPopover
+```
+
+Expected: all new tests fail because the Content is empty.
+
+- [ ] **Step 3: Implement content rendering**
+
+Replace `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx` with:
+
+```tsx
+import { useCallback, useId, useState, type ReactElement, type ReactNode } from 'react';
+import { Button } from '../Button';
+import { Cluster } from '../Cluster';
+import { Stack } from '../Stack';
+import { Popover } from '../Popover';
+import { sanitizeId } from '../_internal/refs';
+import styles from './ConfirmationPopover.module.scss';
+
+export type ConfirmationVariant = 'default' | 'danger';
+
+export interface ConfirmationPopoverProps {
+  children: ReactElement;
+  title: string;
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: ConfirmationVariant;
+  onConfirm: () => void | Promise<void>;
+  onCancel?: () => void;
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  align?: 'start' | 'center' | 'end';
+  sideOffset?: number;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  defaultOpen?: boolean;
+}
+
+export function ConfirmationPopover({
+  children,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'default',
+  onConfirm,
+  onCancel,
+  side = 'top',
+  align = 'center',
+  sideOffset = 10,
+  open: controlledOpen,
+  onOpenChange,
+  defaultOpen = false,
+}: ConfirmationPopoverProps) {
+  // Hoist open state into ConfirmationPopover so we can close after a
+  // successful sync/async onConfirm without going through the consumer.
+  const isConsumerControlled = controlledOpen !== undefined;
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const open = isConsumerControlled ? (controlledOpen as boolean) : internalOpen;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      onOpenChange?.(next);
+      if (!isConsumerControlled) setInternalOpen(next);
+    },
+    [isConsumerControlled, onOpenChange],
+  );
+
+  const reactId = useId();
+  const descriptionId = description ? `confirm-desc-${sanitizeId(reactId)}` : undefined;
+
+  // Wrap Popover's onOpenChange to fire onCancel when the popover closes
+  // via Escape / click-outside (i.e. a close that didn't come from Confirm).
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) onCancel?.();
+      setOpen(next);
+    },
+    [onCancel, setOpen],
+  );
+
+  const handleConfirm = useCallback(() => {
+    onConfirm();
+    setOpen(false);
+  }, [onConfirm, setOpen]);
+
+  const handleCancel = useCallback(() => {
+    onCancel?.();
+    setOpen(false);
+  }, [onCancel, setOpen]);
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <Popover.Trigger>{children}</Popover.Trigger>
+      <Popover.Content
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+        aria-describedby={descriptionId}
+      >
+        <Stack gap="sm">
+          <Popover.Heading>{title}</Popover.Heading>
+          {description && (
+            <p id={descriptionId} className={styles.description}>
+              {description}
+            </p>
+          )}
+          <Cluster justify="end" gap="sm">
+            <Button variant="secondary" size="sm" onClick={handleCancel}>
+              {cancelLabel}
+            </Button>
+            <Button
+              variant={variant === 'danger' ? 'danger' : 'primary'}
+              size="sm"
+              onClick={handleConfirm}
+            >
+              {confirmLabel}
+            </Button>
+          </Cluster>
+        </Stack>
+      </Popover.Content>
+    </Popover>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test -w @eocrm/design-system -- ConfirmationPopover
+```
+
+Expected: 7 tests pass total (1 from Task 13 + 6 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.{tsx,test.tsx}
+git commit -m "$(cat <<'EOF'
+ConfirmationPopover: content rendering + sync confirm flow
+
+Opens with Popover.Heading (title) + optional <p> (description) + Stack
+of Cancel/Confirm buttons. variant='danger' makes Confirm a
+<Button variant='danger'>; default is variant='primary'. aria-labelledby
+(via Heading) and aria-describedby (via description id) wired. Sync
+onConfirm: click → onConfirm() → close. Cancel + outside-close fire
+onCancel. Open state hoisted into ConfirmationPopover so it can close
+itself; consumer's open/onOpenChange still pass through.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: ConfirmationPopover — initial focus on Cancel
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx`
+- Modify: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `ConfirmationPopover.test.tsx`:
+
+```tsx
+describe('ConfirmationPopover — initial focus', () => {
+  it('focuses the Cancel button after open (both variants)', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ConfirmationPopover title="Confirm?" onConfirm={() => {}}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+
+    rerender(
+      <ConfirmationPopover title="Confirm?" variant="danger" onConfirm={() => {}}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    // Re-rendering with a new variant keeps the popover open; focus has
+    // already moved to Cancel on the original open. Verify it's still there.
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -w @eocrm/design-system -- ConfirmationPopover
+```
+
+Expected: fails because focus is on the panel (`<div role="dialog">`), not Cancel.
+
+- [ ] **Step 3: Implement focus-on-Cancel**
+
+Update `ConfirmationPopover.tsx`:
+
+Add imports:
+
+```tsx
+import { useCallback, useEffect, useId, useRef, useState, type ReactElement, type ReactNode } from 'react';
+```
+
+Add the ref and effect inside the function body, after `const handleOpenChange = …`:
+
+```tsx
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
+
+  // Focus the Cancel button after Popover.Content focuses the panel.
+  // queueMicrotask runs after Popover.Content's own focus effect (which also
+  // uses queueMicrotask), so by the time this runs, the panel has focus and
+  // we override it with Cancel.
+  useEffect(() => {
+    if (!open) return;
+    queueMicrotask(() => cancelRef.current?.focus({ preventScroll: true }));
+  }, [open]);
+```
+
+Pass the ref to the Cancel button:
+
+```tsx
+            <Button ref={cancelRef} variant="secondary" size="sm" onClick={handleCancel}>
+              {cancelLabel}
+            </Button>
+```
+
+The library's `<Button>` must accept a ref (it uses forwardRef per the design system's hard rules — verify by reading `packages/design-system/src/components/Button/Button.tsx`).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test -w @eocrm/design-system -- ConfirmationPopover
+```
+
+Expected: 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.{tsx,test.tsx}
+git commit -m "$(cat <<'EOF'
+ConfirmationPopover: initial focus on Cancel button
+
+useEffect + queueMicrotask focuses the Cancel button after Popover.Content
+focuses the panel. queueMicrotask ordering: Popover's own
+focus-on-open also queues a microtask, so by the time our microtask
+runs the panel has focus; we then move it to Cancel. Cancel-default
+is safer than Confirm — keyboard 'Enter' never accidentally confirms.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: ConfirmationPopover — async onConfirm + pending state + spinner placeholder
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx`
+- Modify: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `ConfirmationPopover.test.tsx`:
+
+```tsx
+describe('ConfirmationPopover — async onConfirm', () => {
+  beforeEach(() => {
+    // Match Tooltip's test setup for fake-timer + RTL act() cooperation.
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('async onConfirm: pending → buttons disabled → resolve → close', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    let resolveFn: () => void = () => {};
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+
+    render(
+      <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFn();
+    });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('async onConfirm rejects → popover stays open, buttons re-enable, onCancel NOT fired', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onCancel = vi.fn();
+    let rejectFn: (e: Error) => void = () => {};
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((_, reject) => {
+          rejectFn = reject;
+        }),
+    );
+
+    render(
+      <ConfirmationPopover title="Confirm?" onConfirm={onConfirm} onCancel={onCancel}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await act(async () => {
+      rejectFn(new Error('boom'));
+    });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Confirm' })).not.toBeDisabled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('double-click Confirm during pending → onConfirm runs once', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    let resolveFn: () => void = () => {};
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+
+    render(
+      <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    const confirmBtn = screen.getByRole('button', { name: 'Confirm' });
+    await user.click(confirmBtn);
+    await user.click(confirmBtn);  // disabled → ignored
+    await user.click(confirmBtn);  // disabled → ignored
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveFn();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -w @eocrm/design-system -- ConfirmationPopover
+```
+
+Expected: 3 new tests fail (no pending state yet — sync confirm path is wrong for async).
+
+- [ ] **Step 3: Implement pending state**
+
+Update `ConfirmationPopover.tsx` — replace `handleConfirm` with the async-aware version, add the pending state:
+
+Find:
+
+```tsx
+  const handleConfirm = useCallback(() => {
+    onConfirm();
+    setOpen(false);
+  }, [onConfirm, setOpen]);
+```
+
+Replace with:
+
+```tsx
+  const [pending, setPending] = useState(false);
+
+  const handleConfirm = useCallback(() => {
+    if (pending) return;
+    const result = onConfirm();
+    if (result instanceof Promise) {
+      setPending(true);
+      result
+        .then(() => {
+          setPending(false);
+          setOpen(false);
+        })
+        .catch(() => {
+          setPending(false);
+          // Popover stays open. onCancel NOT fired — failure is its own state.
+        });
+    } else {
+      setOpen(false);
+    }
+  }, [pending, onConfirm, setOpen]);
+```
+
+Pass `disabled={pending}` to both buttons:
+
+```tsx
+            <Button
+              ref={cancelRef}
+              variant="secondary"
+              size="sm"
+              disabled={pending}
+              onClick={handleCancel}
+            >
+              {cancelLabel}
+            </Button>
+            <Button
+              variant={variant === 'danger' ? 'danger' : 'primary'}
+              size="sm"
+              disabled={pending}
+              onClick={handleConfirm}
+            >
+              {confirmLabel}
+            </Button>
+```
+
+Also, the `pending` state must not be reset on the next mount if the consumer remounts the same ConfirmationPopover with `open={true}`. The state is local; this is fine for v1.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test -w @eocrm/design-system -- ConfirmationPopover
+```
+
+Expected: 11 tests pass total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.{tsx,test.tsx}
+git commit -m "$(cat <<'EOF'
+ConfirmationPopover: async-aware onConfirm + pending state
+
+When onConfirm returns a Promise: set pending → buttons disable → wait
+for resolution. Resolve → close. Reject → re-enable, popover stays
+open, onCancel NOT fired. Double-clicks during pending are ignored
+(disabled buttons block them, and the handler has an explicit early
+return as a belt-and-braces).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: ConfirmationPopover — block dismissal while pending
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx`
+- Modify: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `ConfirmationPopover.test.tsx`, inside the existing `describe('ConfirmationPopover — async onConfirm', …)` block:
+
+```tsx
+  it('while pending: Escape does NOT close', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    let resolveFn: () => void = () => {};
+    const onConfirm = vi.fn(
+      () => new Promise<void>((resolve) => { resolveFn = resolve; }),
+    );
+
+    render(
+      <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await act(async () => {
+      resolveFn();
+    });
+  });
+
+  it('while pending: click-outside does NOT close', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    let resolveFn: () => void = () => {};
+    const onConfirm = vi.fn(
+      () => new Promise<void>((resolve) => { resolveFn = resolve; }),
+    );
+
+    render(
+      <>
+        <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
+          <button type="button">Open</button>
+        </ConfirmationPopover>
+        <div data-testid="elsewhere">elsewhere</div>
+      </>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await user.pointer({ keys: '[MouseLeft>]', target: screen.getByTestId('elsewhere') });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await act(async () => {
+      resolveFn();
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -w @eocrm/design-system -- ConfirmationPopover
+```
+
+Expected: 2 new tests fail (Escape/click-outside currently close the popover via Popover's own listeners).
+
+- [ ] **Step 3: Block dismissal while pending**
+
+Update `ConfirmationPopover.tsx` — modify `handleOpenChange` to short-circuit closes during pending:
+
+```tsx
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      // Block close while a confirm is pending — the in-flight Promise
+      // should resolve before we tear down the popover.
+      if (pending && !next) return;
+      if (!next) onCancel?.();
+      setOpen(next);
+    },
+    [pending, onCancel, setOpen],
+  );
+```
+
+This works because Popover's Escape and outside-click handlers both call `setOpen(false)`, which (via the controlled mode) calls our `handleOpenChange(false)`. Our wrapper short-circuits when `pending && !next`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test -w @eocrm/design-system -- ConfirmationPopover
+```
+
+Expected: 13 tests pass total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.{tsx,test.tsx}
+git commit -m "$(cat <<'EOF'
+ConfirmationPopover: block dismissal while pending
+
+Escape and click-outside route through Popover's own listeners, which
+call our handleOpenChange wrapper. The wrapper now short-circuits
+close attempts when pending is true — the in-flight Promise must
+resolve or reject before the popover tears down. Confirm and Cancel
+buttons are already disabled during pending (Task 16), so the user
+has no UI affordance to dismiss until the Promise settles.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 18: ConfirmationPopover — spinner in Confirm button + SCSS
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx`
+- Modify: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.module.scss`
+
+- [ ] **Step 1: Write the SCSS**
+
+Replace `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.module.scss` with:
+
+```scss
+.description {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  color: var(--color-fg-muted);
+}
+
+.spinner {
+  display: inline-block;
+  width: var(--space-3);
+  height: var(--space-3);
+  margin-right: var(--space-1);
+  border: var(--border-width-emphasis) solid currentColor;
+  border-top-color: transparent;
+  border-radius: var(--radius-full);
+  animation: confirm-spin 0.6s linear infinite;
+  vertical-align: middle;
+}
+
+@keyframes confirm-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+  }
+}
+```
+
+- [ ] **Step 2: Render the spinner inside the Confirm button when pending**
+
+Update the Confirm button in `ConfirmationPopover.tsx`:
+
+```tsx
+            <Button
+              variant={variant === 'danger' ? 'danger' : 'primary'}
+              size="sm"
+              disabled={pending}
+              onClick={handleConfirm}
+            >
+              {pending && <span className={styles.spinner} aria-hidden="true" />}
+              {confirmLabel}
+            </Button>
+```
+
+- [ ] **Step 3: Run tests + stylelint**
+
+```bash
+npm test -w @eocrm/design-system -- ConfirmationPopover
+npm run lint:css
+```
+
+Expected: 13 tests still pass (the existing async tests now also exercise the spinner DOM); stylelint exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.{tsx,module.scss}
+git commit -m "$(cat <<'EOF'
+ConfirmationPopover: spinner inside Confirm + SCSS
+
+While pending, an aria-hidden span with the spinner class renders to
+the left of confirmLabel. Spinner is a CSS-only border-rotation
+indicator (no inline SVG, no new <Spinner> component for now); honors
+prefers-reduced-motion by disabling the animation. .description gets
+muted typography to differentiate from the heading.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 19: ConfirmationPopover — full JSDoc
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx`
+
+- [ ] **Step 1: Add JSDoc to the function and to each prop**
+
+Replace the `export function ConfirmationPopover(` line and the `ConfirmationPopoverProps` interface with the fully documented versions:
+
+```tsx
+/** `'danger'` swaps Confirm to a danger-variant button; `'default'` uses primary. */
+export type ConfirmationVariant = 'default' | 'danger';
+
+export interface ConfirmationPopoverProps {
+  /**
+   * The trigger element. Same forwardRef-required contract as
+   * `<Popover.Trigger>` — `<Button>` qualifies; a custom component without
+   * `forwardRef` does not.
+   */
+  children: ReactElement;
+
+  /**
+   * Heading text. Renders inside `<Popover.Heading>` (an `<h3>`) and wires
+   * `aria-labelledby` on the dialog automatically.
+   */
+  title: string;
+
+  /**
+   * Optional body text below the title. When provided, wires
+   * `aria-describedby` so screen readers announce it.
+   */
+  description?: ReactNode;
+
+  /** Confirm button label. Defaults to `'Confirm'`. */
+  confirmLabel?: string;
+
+  /** Cancel button label. Defaults to `'Cancel'`. */
+  cancelLabel?: string;
+
+  /** `'danger'` makes Confirm a danger-variant button. Defaults to `'default'` (primary). */
+  variant?: ConfirmationVariant;
+
+  /**
+   * Async-aware confirm handler. May return a Promise; while pending,
+   * both buttons disable, the Confirm button shows a small spinner, and
+   * Escape / click-outside dismissal is blocked.
+   *
+   * - Resolve → popover closes.
+   * - Reject → popover stays open, buttons re-enable. `onCancel` is NOT
+   *   fired (the user neither confirmed nor cancelled — it's an error
+   *   state owned by the consumer).
+   *
+   * The consumer is expected to surface error feedback externally (toast,
+   * inline message, etc.). ConfirmationPopover does NOT render errors.
+   */
+  onConfirm: () => void | Promise<void>;
+
+  /** Optional. Fires on Cancel click, Escape, or click-outside dismissal. NOT fired if `onConfirm` rejects. */
+  onCancel?: () => void;
+
+  /** Preferred side. Default `'top'` — confirmations anchor above the trigger by convention. */
+  side?: 'top' | 'right' | 'bottom' | 'left';
+
+  /** Edge alignment. Default `'center'`. */
+  align?: 'start' | 'center' | 'end';
+
+  /** Gap in px between trigger and panel. Default `10`. */
+  sideOffset?: number;
+
+  /** Controlled open state. Pair with `onOpenChange`. */
+  open?: boolean;
+
+  /** Open-change callback. Required when `open` is provided. */
+  onOpenChange?: (open: boolean) => void;
+
+  /** Default open state for uncontrolled usage. Defaults to `false`. */
+  defaultOpen?: boolean;
+}
+
+/**
+ * Opinionated "Are you sure?" preset on top of `<Popover>`. Renders a
+ * compact panel with a title, optional description, Cancel button, and
+ * Confirm button. Anchors above the trigger by default to keep the user's
+ * eye near where they clicked.
+ *
+ * - **Initial focus** lands on Cancel for both variants. Safer default —
+ *   keyboard "Enter" never accidentally confirms; the user must Tab once
+ *   to Confirm.
+ * - **Async-aware** `onConfirm`. While the returned Promise is in flight,
+ *   both buttons disable, the Confirm shows a spinner, and Escape /
+ *   click-outside dismissal is blocked.
+ * - **Failure mode**. If `onConfirm` rejects, the popover stays open and
+ *   buttons re-enable. The consumer surfaces the error.
+ *
+ * @example
+ * <ConfirmationPopover
+ *   title="Delete record?"
+ *   description="This action cannot be undone."
+ *   variant="danger"
+ *   onConfirm={async () => {
+ *     await api.deleteRecord(id);
+ *   }}
+ * >
+ *   <Button variant="danger">Delete</Button>
+ * </ConfirmationPopover>
+ *
+ * @example
+ * // Default variant — lighter-weight (archive, publish, etc.):
+ * <ConfirmationPopover
+ *   title="Archive this contact?"
+ *   description="You can unarchive later from the archive view."
+ *   onConfirm={() => archive(id)}
+ * >
+ *   <Button variant="secondary">Archive</Button>
+ * </ConfirmationPopover>
+ *
+ * @remarks When NOT to use
+ * - For a multi-step flow ("type the name to confirm") → use Modal (when
+ *   shipped). ConfirmationPopover is for one-tap confirmations.
+ * - For a non-blocking heads-up that doesn't need a yes/no answer → use
+ *   a Toast (when shipped) or inline UI.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Hanging-forever `onConfirm` Promise. v1 has no timeout — the
+ *   popover stays in pending state indefinitely. Add a timeout / abort
+ *   inside your `onConfirm` if the operation may stall.
+ * - ❌ Rendering an inline error from `onConfirm`'s rejection inside the
+ *   tooltip body. ConfirmationPopover doesn't render errors — surface
+ *   them via toast or page-level UI instead.
+ * - ❌ Combining controlled `open` + relying on pending-blocks-close. If
+ *   you provide `open` / `onOpenChange`, you can force-close from outside
+ *   while we're pending. Coordinate `pending` in your own code if that
+ *   matters.
+ */
+export function ConfirmationPopover({
+```
+
+- [ ] **Step 2: Typecheck + tests**
+
+```bash
+npm run typecheck -w @eocrm/design-system
+npm test -w @eocrm/design-system -- ConfirmationPopover
+```
+
+Expected: both exit 0; 13 tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
+git commit -m "$(cat <<'EOF'
+ConfirmationPopover: full JSDoc per library rule 7
+
+Component-level prose covers the opinionated defaults (focus-Cancel,
+async-aware, failure-stays-open). Two @example blocks (danger + default
+variant). @remarks When NOT to use and Anti-patterns cover Modal
+boundaries, hanging Promises, inline error rendering, and controlled-
+open + pending coordination caveats. Every prop documented.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 20: Playground demo — PopoverDemo.tsx
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/PopoverDemo.tsx`
+
+- [ ] **Step 1: Create the demo file**
+
+Create `packages/playground/src/pages/components/PopoverDemo.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { Button, Cluster, DropdownMenu, Popover, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Popover/Popover.tsx?raw';
+import scssSource from '@lib-source/components/Popover/Popover.module.scss?raw';
+
+export function PopoverDemo() {
+  return (
+    <DemoLayout
+      name="Popover"
+      componentName="Popover"
+      description="Non-modal floating panel for arbitrary small surfaces. Compound API — pair Trigger / Content / optionally Heading / Close. Focus moves to the panel on open; Tab traverses out; click-outside or Escape dismisses."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Popover.tsx"
+      scssFilename="Popover.module.scss"
+    >
+      <Example
+        title="Default — filter panel"
+        description="The canonical popover: a button trigger, a small panel of controls, and an Apply / Cancel footer."
+        code={`<Popover>
+  <Popover.Trigger>
+    <Button variant="secondary">Filters</Button>
+  </Popover.Trigger>
+  <Popover.Content>
+    <Stack gap="sm">
+      <Popover.Heading>Filter results</Popover.Heading>
+      <div>(form controls go here)</div>
+      <Cluster justify="end" gap="sm">
+        <Popover.Close>
+          <Button variant="secondary" size="sm">Cancel</Button>
+        </Popover.Close>
+        <Popover.Close>
+          <Button size="sm">Apply</Button>
+        </Popover.Close>
+      </Cluster>
+    </Stack>
+  </Popover.Content>
+</Popover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <Popover>
+            <Popover.Trigger>
+              <Button variant="secondary">Filters</Button>
+            </Popover.Trigger>
+            <Popover.Content>
+              <Stack gap="sm">
+                <Popover.Heading>Filter results</Popover.Heading>
+                <div>(form controls would go here once Checkbox lands)</div>
+                <Cluster justify="end" gap="sm">
+                  <Popover.Close>
+                    <Button variant="secondary" size="sm">
+                      Cancel
+                    </Button>
+                  </Popover.Close>
+                  <Popover.Close>
+                    <Button size="sm">Apply</Button>
+                  </Popover.Close>
+                </Cluster>
+              </Stack>
+            </Popover.Content>
+          </Popover>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Sides"
+        description="Floating UI auto-flips on collision; this row pins each popover to a specific side."
+        code={`<Popover><Popover.Trigger><Button>Top</Button></Popover.Trigger><Popover.Content side="top">Top</Popover.Content></Popover>
+<Popover><Popover.Trigger><Button>Right</Button></Popover.Trigger><Popover.Content side="right">Right</Popover.Content></Popover>
+<Popover><Popover.Trigger><Button>Bottom</Button></Popover.Trigger><Popover.Content side="bottom">Bottom</Popover.Content></Popover>
+<Popover><Popover.Trigger><Button>Left</Button></Popover.Trigger><Popover.Content side="left">Left</Popover.Content></Popover>`}
+      >
+        <Cluster gap="md" justify="center">
+          {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+            <Popover key={side}>
+              <Popover.Trigger>
+                <Button variant="secondary">{side}</Button>
+              </Popover.Trigger>
+              <Popover.Content side={side}>
+                <Stack gap="xs">
+                  <Popover.Heading>{`Side: ${side}`}</Popover.Heading>
+                  <div>The arrow points back at the trigger.</div>
+                </Stack>
+              </Popover.Content>
+            </Popover>
+          ))}
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Rich content with multiple Close buttons"
+        description="A popover can contain any interactive content. Wrap each closing element in <Popover.Close>."
+        code={`<Popover>
+  <Popover.Trigger>
+    <Button variant="secondary">Actions</Button>
+  </Popover.Trigger>
+  <Popover.Content>
+    <Stack gap="sm">
+      <Popover.Heading>Choose</Popover.Heading>
+      <Popover.Close><Button variant="secondary" size="sm">Save and exit</Button></Popover.Close>
+      <Popover.Close><Button variant="secondary" size="sm">Discard</Button></Popover.Close>
+      <Popover.Close><Button variant="ghost" size="sm">Stay</Button></Popover.Close>
+    </Stack>
+  </Popover.Content>
+</Popover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <Popover>
+            <Popover.Trigger>
+              <Button variant="secondary">Actions</Button>
+            </Popover.Trigger>
+            <Popover.Content>
+              <Stack gap="sm">
+                <Popover.Heading>Choose</Popover.Heading>
+                <Stack gap="xs">
+                  <Popover.Close>
+                    <Button variant="secondary" size="sm">
+                      Save and exit
+                    </Button>
+                  </Popover.Close>
+                  <Popover.Close>
+                    <Button variant="secondary" size="sm">
+                      Discard
+                    </Button>
+                  </Popover.Close>
+                  <Popover.Close>
+                    <Button variant="ghost" size="sm">
+                      Stay
+                    </Button>
+                  </Popover.Close>
+                </Stack>
+              </Stack>
+            </Popover.Content>
+          </Popover>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Inside a DropdownMenu — z-index sanity"
+        description="Tooltip's z-layer is above DropdownMenu's; same is true for Popover (--z-popover: 1050 > --z-dropdown: 1000)."
+        code={`<DropdownMenu>
+  <DropdownMenu.Trigger><Button variant="secondary">Actions</Button></DropdownMenu.Trigger>
+  <DropdownMenu.Content>
+    <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+    <DropdownMenu.Item onSelect={() => {}}>
+      <Popover>
+        <Popover.Trigger><span>Move to…</span></Popover.Trigger>
+        <Popover.Content>… picker …</Popover.Content>
+      </Popover>
+    </DropdownMenu.Item>
+  </DropdownMenu.Content>
+</DropdownMenu>`}
+      >
+        <Cluster gap="md" justify="center">
+          <DropdownMenu>
+            <DropdownMenu.Trigger>
+              <Button variant="secondary">Actions</Button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}}>
+                <Popover>
+                  <Popover.Trigger>
+                    <span>Move to…</span>
+                  </Popover.Trigger>
+                  <Popover.Content>
+                    <Stack gap="xs">
+                      <Popover.Heading>Move to folder</Popover.Heading>
+                      <div>(folder picker would go here)</div>
+                    </Stack>
+                  </Popover.Content>
+                </Popover>
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Controlled open"
+        description="Drive open externally — useful for orchestrating with other UI state."
+        code={`const [open, setOpen] = useState(false);
+<Popover open={open} onOpenChange={setOpen}>
+  <Popover.Trigger>
+    <Button onClick={() => setOpen((o) => !o)}>Toggle</Button>
+  </Popover.Trigger>
+  <Popover.Content>…</Popover.Content>
+</Popover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <ControlledExample />
+        </Cluster>
+      </Example>
+    </DemoLayout>
+  );
+}
+
+function ControlledExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger>
+        <Button onClick={() => setOpen((o) => !o)}>{open ? 'Close' : 'Open'}</Button>
+      </Popover.Trigger>
+      <Popover.Content>
+        <Stack gap="sm">
+          <Popover.Heading>Controlled</Popover.Heading>
+          <div>This popover is driven from external state.</div>
+          <Cluster justify="end">
+            <Popover.Close>
+              <Button size="sm">Close</Button>
+            </Popover.Close>
+          </Cluster>
+        </Stack>
+      </Popover.Content>
+    </Popover>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck -w playground
+```
+
+Expected: exit 0. NO commit at this step — wiring lands in Task 22 which commits everything together.
+
+---
+
+## Task 21: Playground demo — ConfirmationPopoverDemo.tsx
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx`
+
+- [ ] **Step 1: Create the demo file**
+
+Create `packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { Button, Cluster, ConfirmationPopover, DropdownMenu } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/ConfirmationPopover/ConfirmationPopover.tsx?raw';
+import scssSource from '@lib-source/components/ConfirmationPopover/ConfirmationPopover.module.scss?raw';
+
+const fakeDelay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export function ConfirmationPopoverDemo() {
+  const [archiveCount, setArchiveCount] = useState(0);
+  const [deleteCount, setDeleteCount] = useState(0);
+
+  return (
+    <DemoLayout
+      name="ConfirmationPopover"
+      componentName="ConfirmationPopover"
+      description="Opinionated 'Are you sure?' preset on top of Popover. Title + optional description + Cancel + Confirm. Initial focus on Cancel; async-aware onConfirm with pending state."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="ConfirmationPopover.tsx"
+      scssFilename="ConfirmationPopover.module.scss"
+    >
+      <Example
+        title="Default variant — Archive"
+        description="Sync onConfirm. Lighter-weight confirmation for non-destructive actions like archive or publish."
+        code={`<ConfirmationPopover
+  title="Archive this contact?"
+  description="You can unarchive later from the archive view."
+  onConfirm={() => archive(id)}
+>
+  <Button variant="secondary">Archive</Button>
+</ConfirmationPopover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <ConfirmationPopover
+            title="Archive this contact?"
+            description="You can unarchive later from the archive view."
+            onConfirm={() => setArchiveCount((n) => n + 1)}
+          >
+            <Button variant="secondary">Archive</Button>
+          </ConfirmationPopover>
+          <span>Archived {archiveCount} time(s)</span>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Danger variant — Delete"
+        description="variant='danger' makes Confirm a danger button. Initial focus is on Cancel, so keyboard Enter never accidentally deletes."
+        code={`<ConfirmationPopover
+  title="Delete record?"
+  description="This action cannot be undone."
+  confirmLabel="Delete"
+  variant="danger"
+  onConfirm={() => deleteRecord(id)}
+>
+  <Button variant="danger">Delete</Button>
+</ConfirmationPopover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <ConfirmationPopover
+            title="Delete record?"
+            description="This action cannot be undone."
+            confirmLabel="Delete"
+            variant="danger"
+            onConfirm={() => setDeleteCount((n) => n + 1)}
+          >
+            <Button variant="danger">Delete</Button>
+          </ConfirmationPopover>
+          <span>Deleted {deleteCount} time(s)</span>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Async success — pending spinner"
+        description="onConfirm returns a Promise that resolves after 1.5s. While pending, both buttons disable, Confirm shows a spinner, and dismissal is blocked. On resolve the popover closes."
+        code={`<ConfirmationPopover
+  title="Submit?"
+  onConfirm={async () => {
+    await submitToServer();   // 1.5s
+  }}
+>
+  <Button>Submit</Button>
+</ConfirmationPopover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <ConfirmationPopover
+            title="Submit?"
+            description="Simulated 1.5s server round-trip."
+            onConfirm={async () => {
+              await fakeDelay(1500);
+            }}
+          >
+            <Button>Submit</Button>
+          </ConfirmationPopover>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Async failure — popover stays open"
+        description="onConfirm returns a Promise that rejects after 1s. The popover stays open and buttons re-enable. The consumer is expected to surface the error externally (we just console.log here)."
+        code={`<ConfirmationPopover
+  title="Submit?"
+  onConfirm={async () => {
+    await fakeDelay(1000);
+    throw new Error('network down');
+  }}
+>
+  <Button>Submit (will fail)</Button>
+</ConfirmationPopover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <ConfirmationPopover
+            title="Submit?"
+            description="Simulated server failure after 1s. Buttons re-enable; popover stays open."
+            onConfirm={async () => {
+              await fakeDelay(1000);
+              throw new Error('demo failure');
+            }}
+          >
+            <Button>Submit (will fail)</Button>
+          </ConfirmationPopover>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Inside a DropdownMenu — kebab Delete"
+        description="A common pattern: the kebab menu's Delete item opens a ConfirmationPopover. Popover z-layer is above DropdownMenu's, so the confirmation appears over the menu."
+        code={`<DropdownMenu>
+  <DropdownMenu.Trigger><Button variant="ghost" aria-label="Row actions">⋯</Button></DropdownMenu.Trigger>
+  <DropdownMenu.Content>
+    <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+    <DropdownMenu.Item onSelect={() => {}}>
+      <ConfirmationPopover title="Delete?" variant="danger" onConfirm={remove}>
+        <span>Delete</span>
+      </ConfirmationPopover>
+    </DropdownMenu.Item>
+  </DropdownMenu.Content>
+</DropdownMenu>`}
+      >
+        <Cluster gap="md" justify="center">
+          <DropdownMenu>
+            <DropdownMenu.Trigger>
+              <Button variant="ghost" aria-label="Row actions">
+                ⋯
+              </Button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}} tone="danger">
+                <ConfirmationPopover
+                  title="Delete record?"
+                  description="This action cannot be undone."
+                  variant="danger"
+                  confirmLabel="Delete"
+                  onConfirm={() => setDeleteCount((n) => n + 1)}
+                >
+                  <span>Delete</span>
+                </ConfirmationPopover>
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu>
+        </Cluster>
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck -w playground
+```
+
+Expected: exit 0. NO commit at this step — wiring lands in Task 22.
+
+---
+
+## Task 22: Wire both demos into playground (4 places each) + commit Tasks 20+21+22 together
+
+**Files:**
+
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Add routes to App.tsx**
+
+In `packages/playground/src/App.tsx`, add the imports alongside the other Demo imports (alphabetical):
+
+```tsx
+import { ConfirmationPopoverDemo } from './pages/components/ConfirmationPopoverDemo';
+import { PopoverDemo } from './pages/components/PopoverDemo';
+```
+
+Add the routes alongside the other component routes (after the tooltip route):
+
+```tsx
+<Route path="/components/popover" element={<PopoverDemo />} />
+<Route path="/components/confirmation-popover" element={<ConfirmationPopoverDemo />} />
+```
+
+- [ ] **Step 2: Add nav entries to AppShell**
+
+In `packages/playground/src/layout/AppShell/AppShell.tsx`, find the `Overlays` group:
+
+```tsx
+{
+  heading: 'Overlays',
+  items: [
+    { to: '/components/dropdown-menu', label: 'DropdownMenu', icon: MoreHorizontal, end: false },
+    { to: '/components/tooltip', label: 'Tooltip', icon: MessageSquare, end: false },
+  ],
+},
+```
+
+Change to:
+
+```tsx
+{
+  heading: 'Overlays',
+  items: [
+    { to: '/components/dropdown-menu', label: 'DropdownMenu', icon: MoreHorizontal, end: false },
+    { to: '/components/tooltip', label: 'Tooltip', icon: MessageSquare, end: false },
+    { to: '/components/popover', label: 'Popover', icon: PanelLeft, end: false },
+    { to: '/components/confirmation-popover', label: 'ConfirmationPopover', icon: ShieldCheck, end: false },
+  ],
+},
+```
+
+Add `PanelLeft` and `ShieldCheck` to the `lucide-react` import (alphabetical). If `ShieldCheck` doesn't feel right for confirmation, alternatives: `ShieldAlert`, `Check`, `ClipboardCheck`. Pick one — decorative only.
+
+- [ ] **Step 3: Add cards to ComponentsIndex**
+
+In `packages/playground/src/pages/components/ComponentsIndex.tsx`, add to the imports:
+
+```tsx
+import { ConfirmationPopover, Popover } from '@eocrm/design-system';
+```
+
+Add two new entries to the `items` array (after the Tooltip entry):
+
+```tsx
+{
+  to: '/components/popover',
+  name: 'Popover',
+  description: 'Non-modal floating panel for arbitrary small surfaces.',
+  preview: (
+    <Cluster gap="sm" justify="center">
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <Button size="sm" variant="secondary">
+            Filters
+          </Button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Stack gap="xs">
+            <Popover.Heading>Filters</Popover.Heading>
+            <div>(controls)</div>
+          </Stack>
+        </Popover.Content>
+      </Popover>
+    </Cluster>
+  ),
+},
+{
+  to: '/components/confirmation-popover',
+  name: 'ConfirmationPopover',
+  description: '"Are you sure?" prompt with async-aware Confirm.',
+  preview: (
+    <Cluster gap="sm" justify="center">
+      <ConfirmationPopover
+        defaultOpen
+        title="Delete?"
+        description="Cannot be undone."
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => undefined}
+      >
+        <Button size="sm" variant="danger">
+          Delete
+        </Button>
+      </ConfirmationPopover>
+    </Cluster>
+  ),
+},
+```
+
+- [ ] **Step 4: Extend the ComponentName union**
+
+In `packages/playground/src/pages/mockups/registry.ts`, add `'Popover'` and `'ConfirmationPopover'` to the union:
+
+```ts
+export type ComponentName =
+  | 'Button'
+  | 'Input'
+  | 'Card'
+  | 'Stack'
+  | 'Cluster'
+  | 'Avatar'
+  | 'Badge'
+  | 'Tabs'
+  | 'DropdownMenu'
+  | 'Tooltip'
+  | 'Popover'
+  | 'ConfirmationPopover';
+```
+
+- [ ] **Step 5: Run the full build**
+
+```bash
+make build
+```
+
+Expected: full build (typecheck + vite bundle) passes. The build is the canonical wiring check — if any of the 4 wiring places drifts, the build fails.
+
+- [ ] **Step 6: Commit Tasks 20 + 21 + 22 together**
+
+```bash
+git add packages/playground/src/App.tsx \
+        packages/playground/src/layout/AppShell/AppShell.tsx \
+        packages/playground/src/pages/components/PopoverDemo.tsx \
+        packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx \
+        packages/playground/src/pages/components/ComponentsIndex.tsx \
+        packages/playground/src/pages/mockups/registry.ts
+git commit -m "$(cat <<'EOF'
+Playground: Popover + ConfirmationPopover demos + nav + grid + registry
+
+Popover demo: 5 examples (default filter panel, sides grid, rich content
+with multiple Close buttons, inside-DropdownMenu z-index sanity,
+controlled open). ConfirmationPopover demo: 5 examples (default variant
+Archive, danger variant Delete, async success with spinner, async
+failure stays open, inside-DropdownMenu kebab Delete). Both wired into
+App routes, AppShell Overlays group, ComponentsIndex grid, and the
+mockup-cross-link registry's ComponentName union.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 23: AGENTS.md — Popover + ConfirmationPopover TL;DR + anti-patterns
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Insert the Popover TL;DR section**
+
+In `packages/design-system/AGENTS.md`, find the existing line marking the end of the Tooltip section (something like the closing bullet of the Tooltip TL;DR). Insert immediately after, before the `---` that precedes `## Tokens`:
+
+````markdown
+### `<Popover>` — non-modal floating panel for interactive content
+
+```tsx
+<Popover>
+  <Popover.Trigger>
+    <Button variant="secondary">Filters</Button>
+  </Popover.Trigger>
+  <Popover.Content>
+    <Stack gap="sm">
+      <Popover.Heading>Filter results</Popover.Heading>
+      {/* …form controls… */}
+      <Cluster justify="end" gap="sm">
+        <Popover.Close>
+          <Button variant="secondary" size="sm">Cancel</Button>
+        </Popover.Close>
+        <Popover.Close>
+          <Button size="sm" onClick={apply}>Apply</Button>
+        </Popover.Close>
+      </Cluster>
+    </Stack>
+  </Popover.Content>
+</Popover>
+```
+
+- Compound API: `<Popover>` is the provider; `<Popover.Trigger>` clones its single child to inject ARIA + click; `<Popover.Content>` portals to `document.body` and positions via Floating UI; `<Popover.Heading>` (optional) wires `aria-labelledby`; `<Popover.Close>` clones its child to inject a close-onClick.
+- Trigger child must accept a ref (`forwardRef`). `<Button>` does.
+- **Non-modal**: focus moves to the panel on open; Tab traverses INTO content, then OUT to the page behind. Click-outside or Escape dismisses. Page is NOT inert.
+- `<Popover.Content>` props: `side` (`'top'` | `'right'` | `'bottom'` | `'left'`, default `'bottom'`), `align` (default `'center'`), `sideOffset` (default `10`), `minWidth`.
+- `<Popover.Heading>` props: `as` (`'h2'` – `'h6'`, default `'h3'`).
+- Opens with a short scale-fade from the trigger side (140ms). Closes instantly. Respects `prefers-reduced-motion: reduce`.
+- Z-layer `--z-popover: 1050` — above dropdown, below modal/toast/tooltip.
+- For passive hover/focus hints → `<Tooltip>`. For lists of actions → `<DropdownMenu>`. For focus-locked dialogs → `<Modal>` (not yet shipped).
+
+### `<ConfirmationPopover>` — opinionated "Are you sure?" preset
+
+```tsx
+<ConfirmationPopover
+  title="Delete record?"
+  description="This action cannot be undone."
+  confirmLabel="Delete"
+  variant="danger"
+  onConfirm={async () => {
+    await api.deleteRecord(id);
+  }}
+>
+  <Button variant="danger">Delete</Button>
+</ConfirmationPopover>
+```
+
+- Built on top of `<Popover>`. Declarative: `title` / `description` / `confirmLabel` / `cancelLabel` / `variant` / `onConfirm` / `onCancel`.
+- `variant`: `'default'` (Confirm is primary) | `'danger'` (Confirm is danger).
+- **Initial focus on Cancel** for both variants — keyboard Enter never accidentally confirms. Tab once to Confirm.
+- **Async-aware** `onConfirm`. May return a Promise. While pending, both buttons disable, Confirm shows a spinner, and Escape / click-outside are blocked.
+- **Failure mode**: on reject, popover stays open and buttons re-enable. Consumer surfaces the error externally — ConfirmationPopover does NOT render inline errors.
+- Anchors above the trigger by default (`side="top"`).
+````
+
+- [ ] **Step 2: Update the Tokens table**
+
+Find the "Layer (z-index)" row. Currently it lists `--z-dropdown / --z-modal / --z-toast / --z-tooltip`. Update to include `--z-popover` in numerical-value order:
+
+```markdown
+| Layer (z-index) | `--z-dropdown` / `--z-popover` / `--z-modal` / `--z-toast` / `--z-tooltip` |
+```
+
+Find the "Control sizes" row. Currently it ends with `--size-dropdown-min-width: 160, --size-dropdown-indicator: 16`. Update to include `--size-popover-min-width`:
+
+```markdown
+| Control sizes   | `--size-sm/md/lg` (heights), `--size-badge` (20), `--size-badge-sm` (16), `--size-chip` (18), `--size-dropdown-min-width` (160), `--size-popover-min-width` (220), `--size-dropdown-indicator` (16) |
+```
+
+- [ ] **Step 3: Add anti-pattern rows**
+
+Find the anti-patterns table near the bottom. Add three new rows after the existing Tooltip-related rows:
+
+```markdown
+| `<Popover.Trigger><Button disabled>…</Button></Popover.Trigger>`                       | `disabled` buttons don't fire click; render with `aria-disabled="true"` + intercept the click, or wrap in `<span>`. |
+| `<Popover.Content>` with no `<Popover.Close>` AND non-obvious outside-click dismissal | Keyboard / screen-reader users get no clear close affordance. Add a `<Popover.Close>` close button.                  |
+| `<ConfirmationPopover>` with `onConfirm` that never settles                           | v1 has no timeout — popover stays in pending state forever. Add a timeout/abort inside your `onConfirm` if relevant.   |
+```
+
+- [ ] **Step 4: Prettier-format the file**
+
+```bash
+npx prettier --write packages/design-system/AGENTS.md
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/AGENTS.md
+git commit -m "$(cat <<'EOF'
+AGENTS.md: Popover + ConfirmationPopover TL;DR + anti-patterns
+
+Two new sections after Tooltip: Popover (compound API, dismissal
+contract, focus behavior, z-popover token) and ConfirmationPopover
+(opinionated preset, async-aware contract, failure-stays-open caveat).
+Tokens table updated with --z-popover and --size-popover-min-width.
+Three new anti-pattern rows.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 24: README.md — Popover + ConfirmationPopover rows
+
+**Files:**
+
+- Modify: `packages/design-system/README.md`
+
+- [ ] **Step 1: Add rows to the components table**
+
+In `packages/design-system/README.md`, find the components overview table. Add two new rows after the existing Tooltip row, matching the format of existing rows. Look at the existing Tooltip row to mirror column structure exactly:
+
+```markdown
+| `<Popover>`             | Non-modal floating panel for arbitrary small surfaces (filters, mini-forms, quick pickers).             |
+| `<ConfirmationPopover>` | "Are you sure?" preset on top of Popover, with async-aware Confirm and Cancel-default focus.            |
+```
+
+- [ ] **Step 2: Prettier-format**
+
+```bash
+npx prettier --write packages/design-system/README.md
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/README.md
+git commit -m "$(cat <<'EOF'
+README: add Popover + ConfirmationPopover to components table
+
+Matches the format of existing rows.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 25: Full quality gates
+
+- [ ] **Step 1: Tests**
+
+```bash
+make test
+```
+
+Expected: all tests pass. Should be roughly 275 (pre-branch) + 28 (Popover) + 13 (ConfirmationPopover) = ~316. Numbers may differ if there have been intermediate adjustments.
+
+- [ ] **Step 2: Library typecheck**
+
+```bash
+make build-lib
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Playground typecheck**
+
+```bash
+npm run typecheck -w playground
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Stylelint**
+
+```bash
+make lint
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Full build**
+
+```bash
+make build
+```
+
+Expected: exit 0.
+
+- [ ] **Step 6: Tarball sanity**
+
+```bash
+npm pack --dry-run -w @eocrm/design-system
+```
+
+Expected output lists:
+
+- `src/components/Popover/{Popover.tsx, PopoverRoot.tsx, Trigger.tsx, Content.tsx, Heading.tsx, Close.tsx, context.ts, Popover.module.scss, index.ts}` — all present.
+- `src/components/ConfirmationPopover/{ConfirmationPopover.tsx, ConfirmationPopover.module.scss, index.ts}` — all present.
+- NO `.test.tsx` files.
+- `_internal/refs.ts` still present from the Tooltip work.
+
+- [ ] **Step 7: Commit any auto-formatter changes**
+
+If `git status` shows uncommitted changes after the gates:
+
+```bash
+git add -u
+git commit -m "$(cat <<'EOF'
+Prettier: format popover files
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If clean: skip.
+
+---
+
+## Task 26: Pre-push review-fix loop (Hard Rule 8)
+
+Library changes touched `packages/design-system/**` extensively — this loop is mandatory per `packages/design-system/CLAUDE.md` Rule 8 and the user memory `feedback_review_loop_mandatory`.
+
+- [ ] **Step 1: Dispatch a fresh-context reviewer**
+
+Use the `general-purpose` agent with the following prompt (paste into the agent tool):
+
+```
+Review the changes on the current branch `feat/popover` in
+/home/dpws/projects/design-system. Compare to `main`.
+
+You are reviewing two new components plus their wiring:
+
+  - <Popover> at packages/design-system/src/components/Popover/
+    (compound: Root, Trigger, Content, Heading, Close)
+  - <ConfirmationPopover> at packages/design-system/src/components/ConfirmationPopover/
+  - New tokens --z-popover (1050) and --size-popover-min-width (220px)
+  - Public exports added to src/index.ts
+  - Playground demos + nav wiring (4 places per packages/playground/CLAUDE.md)
+  - AGENTS.md two new TL;DR sections + token table + anti-patterns
+  - README.md two new components-table rows
+
+REQUIRED reading before reviewing:
+  - packages/design-system/CLAUDE.md (the 8 hard rules)
+  - packages/design-system/AGENTS.md
+  - packages/design-system/README.md
+  - packages/playground/CLAUDE.md
+  - docs/superpowers/specs/2026-05-19-popover-design.md
+
+Evaluate against these 10 categories:
+  1. Bugs (runtime, logic, race conditions, memory leaks)
+  2. Accessibility (ARIA, focus behavior, keyboard, prefers-reduced-motion)
+  3. API inconsistencies vs DropdownMenu and Tooltip
+  4. Type safety (any unsafe casts, lost type info, missing generics)
+  5. Library rule violations — rules 1-7 in design-system/CLAUDE.md
+  6. Test coverage gaps (including async pending blocks dismissal, failure mode)
+  7. Token discipline (no raw values in SCSS beyond intrinsic geometric/animation params)
+  8. SCSS quality (specificity wars, layout properties on the component, the arrow border-swap trick)
+  9. Cross-package leakage
+  10. Package/distribution (npm pack tarball is sane)
+
+Output as four sections — Critical / Important / Nice-to-have /
+Regression-watch — and a final verdict: `clean enough to stop` or
+`keep iterating`.
+```
+
+- [ ] **Step 2: Fix every Critical and Important finding**
+
+Make the fixes, re-run gates (`make test`, `make build-lib`, `make lint`, `make build`), commit each focused change.
+
+- [ ] **Step 3: For every nice-to-have finding you deliberately skip, document why**
+
+Brief one-line comment in the response or in a follow-up commit message.
+
+- [ ] **Step 4: Re-spawn a fresh reviewer with the same prompt**
+
+Repeat until the verdict is `clean enough to stop`.
+
+- [ ] **Step 5: Hard exit criteria — verify before pushing**
+
+- 0 Critical, 0 Important findings (or each remaining has an explicit documented skip).
+- All five gates green (test, library typecheck, playground typecheck, lint, build).
+- `npm pack --dry-run -w @eocrm/design-system` shows no test files and the new component paths.
+
+---
+
+## Task 27: Push the branch and open the PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/popover
+```
+
+The pre-push hook will run prettier, stylelint, and typecheck. If any flag failures: fix them (do NOT use `--no-verify` unless the user explicitly authorizes).
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "Popover + ConfirmationPopover" --body "$(cat <<'EOF'
+## Summary
+
+- New `<Popover>` compound (Root, Trigger, Content, Heading, Close): non-modal floating panel on Floating UI. Focus moves to the panel on open, Tab traverses out, click-outside or Escape dismisses. Arrow on by default.
+- New `<ConfirmationPopover>`: opinionated "Are you sure?" preset on top of Popover. Async-aware `onConfirm` with pending state (buttons disable, spinner, dismissal blocked). Failure leaves the popover open. Initial focus on Cancel for both variants.
+- New tokens `--z-popover: 1050` (above dropdown, below modal/toast/tooltip) and `--size-popover-min-width: 220px`.
+- Playground demos for both + 4-place nav wiring.
+- `AGENTS.md` two new TL;DR sections + token table updates + three new anti-pattern rows.
+- `README.md` two new components-table rows.
+
+Spec: [`docs/superpowers/specs/2026-05-19-popover-design.md`](docs/superpowers/specs/2026-05-19-popover-design.md)
+Plan: [`docs/superpowers/plans/2026-05-19-popover.md`](docs/superpowers/plans/2026-05-19-popover.md)
+
+Pre-push review-fix loop completed with verdict `clean enough to stop`.
+
+## Test plan
+
+- [ ] CI `Quality / check` is green
+- [ ] `make up` → `/components/popover` shows all 5 examples
+- [ ] `make up` → `/components/confirmation-popover` shows all 5 examples
+- [ ] Filter popover: Tab walks through content + out of the panel; Escape closes; click-outside closes; `<Popover.Close>` buttons close
+- [ ] Confirmation: Cancel is focused on open; danger variant renders the Confirm button in danger color
+- [ ] Async success demo: spinner appears, buttons disable, popover closes on resolve
+- [ ] Async failure demo: spinner appears, buttons disable, popover STAYS OPEN, buttons re-enable, no console error
+- [ ] Inside-DropdownMenu demos: popover/confirmation appears above the menu
+- [ ] DevTools → emulate `prefers-reduced-motion: reduce` → popovers appear instantly; confirmation spinner stops rotating
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI**
+
+Watch the `Quality / check` status on the PR. Once green, merge (squash or merge commit — caller's choice).
+
+---
+
+## Spec coverage check
+
+Mapping every spec section to a task:
+
+| Spec section                                        | Task(s)              |
+| --------------------------------------------------- | -------------------- |
+| Goal + Non-goals                                    | covered globally     |
+| Popover public API — Root + Trigger + Content + Heading + Close | Tasks 2–6, 12 |
+| ConfirmationPopover public API                      | Tasks 13–19          |
+| Popover ARIA wiring                                 | Tasks 2, 3, 4, 5     |
+| ConfirmationPopover ARIA                            | Task 14              |
+| Open / close triggers (Popover)                     | Tasks 3, 6, 7, 8     |
+| Open / close triggers (ConfirmationPopover)         | Tasks 14, 16, 17     |
+| Focus management (panel on open, trigger on close)  | Task 7, 11           |
+| Focus management (Cancel on open for Confirmation)  | Task 15              |
+| Click-outside detection                             | Task 8               |
+| Escape handling                                     | Task 7               |
+| Touch & disabled triggers                           | documented in JSDoc (Task 12) + AGENTS.md (Task 23) |
+| Multiple popovers                                   | implicit — each instance owns its state |
+| Floating UI middleware stack                        | Task 9               |
+| Arrow                                               | Tasks 9, 10          |
+| Visual chrome                                       | Task 10              |
+| Z-index — `--z-popover` token                       | Task 1               |
+| `--size-popover-min-width` token                    | Task 1               |
+| Animation (`@starting-style` per side + reduced motion) | Task 10          |
+| Popover compound parts (file layout)                | Tasks 2–6            |
+| ConfirmationPopover (file layout)                   | Task 13              |
+| Shared helpers reused from Tooltip (`_internal/refs`) | imports throughout |
+| Popover tests (~25)                                 | Tasks 2–11           |
+| ConfirmationPopover tests (~15)                     | Tasks 13–17          |
+| Playground demos                                    | Tasks 20–22          |
+| Playground wiring                                   | Task 22              |
+| JSDoc + AGENTS.md + README.md                       | Tasks 12, 19, 23, 24 |
+| Risks                                               | Mitigated by Tasks 7, 11, 15, 16, 17 |
+| Acceptance (quality gates + review-fix + push)      | Tasks 25, 26, 27     |
+
+No gaps.

--- a/docs/superpowers/specs/2026-05-19-popover-design.md
+++ b/docs/superpowers/specs/2026-05-19-popover-design.md
@@ -37,42 +37,50 @@ import { Popover } from '@eocrm/design-system';
       <Cluster justify="between" align="center">
         <Popover.Heading>Filter results</Popover.Heading>
         <Popover.Close>
-          <Button variant="ghost" size="sm" aria-label="Close">✕</Button>
+          <Button variant="ghost" size="sm" aria-label="Close">
+            ✕
+          </Button>
         </Popover.Close>
       </Cluster>
       {/* …form controls… */}
       <Cluster justify="end" gap="sm">
         <Popover.Close>
-          <Button variant="secondary" size="sm">Cancel</Button>
+          <Button variant="secondary" size="sm">
+            Cancel
+          </Button>
         </Popover.Close>
         <Popover.Close>
-          <Button size="sm" onClick={applyFilters}>Apply</Button>
+          <Button size="sm" onClick={applyFilters}>
+            Apply
+          </Button>
         </Popover.Close>
       </Cluster>
     </Stack>
   </Popover.Content>
-</Popover>
+</Popover>;
 
 // Controlled (rare):
 const [open, setOpen] = useState(false);
-<Popover open={open} onOpenChange={setOpen}>…</Popover>
+<Popover open={open} onOpenChange={setOpen}>
+  …
+</Popover>;
 ```
 
 ### `<Popover>` root props
 
-| Prop           | Type                      | Default | Notes                                                                                          |
-| -------------- | ------------------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| Prop           | Type                      | Default | Notes                                                                                            |
+| -------------- | ------------------------- | ------- | ------------------------------------------------------------------------------------------------ |
 | `children`     | `ReactNode`               | —       | Must contain exactly one `<Popover.Trigger>` and one `<Popover.Content>` (validated at runtime). |
-| `open`         | `boolean`                 | —       | Optional controlled state.                                                                     |
-| `onOpenChange` | `(open: boolean) => void` | —       | Required when `open` is provided.                                                              |
-| `defaultOpen`  | `boolean`                 | `false` | Uncontrolled initial state.                                                                    |
-| `modal`        | `boolean`                 | `false` | Reserved future hint. v1 ignores the value and always renders non-modal.                       |
+| `open`         | `boolean`                 | —       | Optional controlled state.                                                                       |
+| `onOpenChange` | `(open: boolean) => void` | —       | Required when `open` is provided.                                                                |
+| `defaultOpen`  | `boolean`                 | `false` | Uncontrolled initial state.                                                                      |
+| `modal`        | `boolean`                 | `false` | Reserved future hint. v1 ignores the value and always renders non-modal.                         |
 
 ### `<Popover.Trigger>` props
 
-| Prop       | Type           | Default | Notes                                                                                                                                |
-| ---------- | -------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `children` | `ReactElement` | —       | Exactly one element that accepts a ref. Same `forwardRef`-required contract as `<DropdownMenu.Trigger>`. `<Button>` qualifies.        |
+| Prop       | Type           | Default | Notes                                                                                                                          |
+| ---------- | -------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `children` | `ReactElement` | —       | Exactly one element that accepts a ref. Same `forwardRef`-required contract as `<DropdownMenu.Trigger>`. `<Button>` qualifies. |
 
 Trigger clones its child to inject:
 
@@ -85,29 +93,29 @@ Trigger clones its child to inject:
 
 ### `<Popover.Content>` props
 
-| Prop         | Type                                     | Default      | Notes                                                                  |
-| ------------ | ---------------------------------------- | ------------ | ---------------------------------------------------------------------- |
-| `children`   | `ReactNode`                              | —            | Free-form. Compose with `<Stack>` / `<Cluster>` / etc.                 |
-| `side`       | `'top' \| 'right' \| 'bottom' \| 'left'` | `'bottom'`   | Preferred placement. Floating UI auto-flips on collision.              |
-| `align`      | `'start' \| 'center' \| 'end'`           | `'center'`   | Edge alignment.                                                        |
-| `sideOffset` | `number`                                 | `10`         | Gap in px between trigger and panel. Larger than Tooltip's 6 to fit the arrow on a larger panel. |
-| `minWidth`   | `number \| string`                       | token-driven | Override the panel's minimum width. Default uses `--size-popover-min-width` (220px). |
-| `className`  | `string`                                 | —            | Composed with the component's own className.                           |
+| Prop         | Type                                     | Default      | Notes                                                                                                            |
+| ------------ | ---------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `children`   | `ReactNode`                              | —            | Free-form. Compose with `<Stack>` / `<Cluster>` / etc.                                                           |
+| `side`       | `'top' \| 'right' \| 'bottom' \| 'left'` | `'bottom'`   | Preferred placement. Floating UI auto-flips on collision.                                                        |
+| `align`      | `'start' \| 'center' \| 'end'`           | `'center'`   | Edge alignment.                                                                                                  |
+| `sideOffset` | `number`                                 | `10`         | Gap in px between trigger and panel. Larger than Tooltip's 6 to fit the arrow on a larger panel.                 |
+| `minWidth`   | `number \| string`                       | token-driven | Override the panel's minimum width. Default uses `--size-popover-min-width` (220px).                             |
+| `className`  | `string`                                 | —            | Composed with the component's own className.                                                                     |
 | `style`      | reserved                                 | —            | Floating UI sets inline `position`/`top`/`left`; consumer `style` is silently overridden — same as DropdownMenu. |
 
 ### `<Popover.Heading>` props
 
-| Prop       | Type                                       | Default | Notes                                                                                |
-| ---------- | ------------------------------------------ | ------- | ------------------------------------------------------------------------------------ |
-| `children` | `ReactNode`                                | —       | The heading text.                                                                    |
-| `as`       | `'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'`     | `'h3'`  | Semantic tag.                                                                        |
+| Prop       | Type                                   | Default | Notes             |
+| ---------- | -------------------------------------- | ------- | ----------------- |
+| `children` | `ReactNode`                            | —       | The heading text. |
+| `as`       | `'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'` | `'h3'`  | Semantic tag.     |
 
 When present, `<Popover.Content>` gets `aria-labelledby` pointing at the heading's auto-generated id. The heading registers via context on mount and unregisters on unmount.
 
 ### `<Popover.Close>` props
 
-| Prop       | Type           | Default | Notes                                                                                |
-| ---------- | -------------- | ------- | ------------------------------------------------------------------------------------ |
+| Prop       | Type           | Default | Notes                                                                                                                    |
+| ---------- | -------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `children` | `ReactElement` | —       | Exactly one element. Cloned to inject an `onClick` that closes the popover, chained with the child's existing `onClick`. |
 
 Exported types: `PopoverProps`, `PopoverTriggerProps`, `PopoverContentProps`, `PopoverHeadingProps`, `PopoverCloseProps`, `PopoverSide`, `PopoverAlign`.
@@ -143,20 +151,20 @@ import { ConfirmationPopover } from '@eocrm/design-system';
 
 ### Props
 
-| Prop           | Type                              | Default                     | Notes                                                                                                                                                                                                                                                                                                                                                       |
-| -------------- | --------------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `children`     | `ReactElement`                    | — (required)                | The trigger. Same forwardRef-required contract.                                                                                                                                                                                                                                                                                                              |
-| `title`        | `string`                          | — (required)                | Renders inside `<Popover.Heading>`. Wires `aria-labelledby`.                                                                                                                                                                                                                                                                                                |
-| `description`  | `ReactNode`                       | —                           | Optional body text under the title. Wires `aria-describedby` when present.                                                                                                                                                                                                                                                                                  |
-| `confirmLabel` | `string`                          | `'Confirm'`                 | Confirm button text.                                                                                                                                                                                                                                                                                                                                        |
-| `cancelLabel`  | `string`                          | `'Cancel'`                  | Cancel button text.                                                                                                                                                                                                                                                                                                                                         |
-| `variant`      | `'default' \| 'danger'`           | `'default'`                 | `'danger'` → Confirm renders as `<Button variant="danger">`. Default → `<Button variant="primary">`.                                                                                                                                                                                                                                                          |
-| `onConfirm`    | `() => void \| Promise<void>`     | — (required)                | Async-aware. Click on Confirm runs `onConfirm()`. If it returns a Promise, both buttons disable and dismissal paths are blocked until resolve. On resolve, popover closes. On reject, popover stays open, buttons re-enable, `onCancel` is NOT fired. ConfirmationPopover does NOT render the error — the consumer surfaces it externally.                  |
-| `onCancel`     | `() => void`                      | —                           | Optional. Fires on Cancel click, Escape, or click-outside dismissal. Does NOT fire if `onConfirm` rejects.                                                                                                                                                                                                                                                  |
-| `side`         | (same as `<Popover.Content>`)     | `'top'`                     | Confirmations anchor above the trigger by default — keeps the user's eye near where they clicked.                                                                                                                                                                                                                                                          |
-| `align`        | (same as `<Popover.Content>`)     | `'center'`                  | —                                                                                                                                                                                                                                                                                                                                                           |
-| `sideOffset`   | `number`                          | `10`                        | —                                                                                                                                                                                                                                                                                                                                                           |
-| `open` / `onOpenChange` / `defaultOpen` | (same as `<Popover>`)   | —                           | Optional controlled state, forwarded to the underlying Popover.                                                                                                                                                                                                                                                                                              |
+| Prop                                    | Type                          | Default      | Notes                                                                                                                                                                                                                                                                                                                                      |
+| --------------------------------------- | ----------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `children`                              | `ReactElement`                | — (required) | The trigger. Same forwardRef-required contract.                                                                                                                                                                                                                                                                                            |
+| `title`                                 | `string`                      | — (required) | Renders inside `<Popover.Heading>`. Wires `aria-labelledby`.                                                                                                                                                                                                                                                                               |
+| `description`                           | `ReactNode`                   | —            | Optional body text under the title. Wires `aria-describedby` when present.                                                                                                                                                                                                                                                                 |
+| `confirmLabel`                          | `string`                      | `'Confirm'`  | Confirm button text.                                                                                                                                                                                                                                                                                                                       |
+| `cancelLabel`                           | `string`                      | `'Cancel'`   | Cancel button text.                                                                                                                                                                                                                                                                                                                        |
+| `variant`                               | `'default' \| 'danger'`       | `'default'`  | `'danger'` → Confirm renders as `<Button variant="danger">`. Default → `<Button variant="primary">`.                                                                                                                                                                                                                                       |
+| `onConfirm`                             | `() => void \| Promise<void>` | — (required) | Async-aware. Click on Confirm runs `onConfirm()`. If it returns a Promise, both buttons disable and dismissal paths are blocked until resolve. On resolve, popover closes. On reject, popover stays open, buttons re-enable, `onCancel` is NOT fired. ConfirmationPopover does NOT render the error — the consumer surfaces it externally. |
+| `onCancel`                              | `() => void`                  | —            | Optional. Fires on Cancel click, Escape, or click-outside dismissal. Does NOT fire if `onConfirm` rejects.                                                                                                                                                                                                                                 |
+| `side`                                  | (same as `<Popover.Content>`) | `'top'`      | Confirmations anchor above the trigger by default — keeps the user's eye near where they clicked.                                                                                                                                                                                                                                          |
+| `align`                                 | (same as `<Popover.Content>`) | `'center'`   | —                                                                                                                                                                                                                                                                                                                                          |
+| `sideOffset`                            | `number`                      | `10`         | —                                                                                                                                                                                                                                                                                                                                          |
+| `open` / `onOpenChange` / `defaultOpen` | (same as `<Popover>`)         | —            | Optional controlled state, forwarded to the underlying Popover.                                                                                                                                                                                                                                                                            |
 
 Exported types: `ConfirmationPopoverProps`, `ConfirmationVariant`.
 
@@ -187,15 +195,15 @@ Exported types: `ConfirmationPopoverProps`, `ConfirmationVariant`.
 
 ### Open / close triggers
 
-| Event                                            | Popover                                                              | ConfirmationPopover                                                                                  |
-| ------------------------------------------------ | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Trigger click (or Enter / Space on focused trigger) | Toggle open.                                                       | Open.                                                                                                |
-| Click anywhere inside `<Popover.Content>`        | **No close** unless wrapped in `<Popover.Close>`.                    | Confirm runs `onConfirm`; Cancel closes + `onCancel`; other clicks ignored.                          |
-| `<Popover.Close>`-wrapped element click          | Close (chains with consumer's `onClick`).                            | n/a — internal.                                                                                      |
-| Click outside content + trigger                  | Close.                                                               | Close + `onCancel`. **Blocked while pending.**                                                       |
-| `Escape` anywhere while open                     | Close. Focus returns to trigger.                                     | Close + `onCancel`. **Blocked while pending.**                                                       |
-| `Tab` from inside content past the last focusable | Continues to next focusable on the page; popover **stays open**.   | Same.                                                                                                |
-| Trigger unmount while open                       | Cleanup listeners; ref check guards against stale state.             | Same.                                                                                                |
+| Event                                               | Popover                                                          | ConfirmationPopover                                                         |
+| --------------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Trigger click (or Enter / Space on focused trigger) | Toggle open.                                                     | Open.                                                                       |
+| Click anywhere inside `<Popover.Content>`           | **No close** unless wrapped in `<Popover.Close>`.                | Confirm runs `onConfirm`; Cancel closes + `onCancel`; other clicks ignored. |
+| `<Popover.Close>`-wrapped element click             | Close (chains with consumer's `onClick`).                        | n/a — internal.                                                             |
+| Click outside content + trigger                     | Close.                                                           | Close + `onCancel`. **Blocked while pending.**                              |
+| `Escape` anywhere while open                        | Close. Focus returns to trigger.                                 | Close + `onCancel`. **Blocked while pending.**                              |
+| `Tab` from inside content past the last focusable   | Continues to next focusable on the page; popover **stays open**. | Same.                                                                       |
+| Trigger unmount while open                          | Cleanup listeners; ref check guards against stale state.         | Same.                                                                       |
 
 ### Focus management
 
@@ -231,13 +239,13 @@ Each `<Popover>` instance manages its own state and listeners. Opening Popover B
 ```ts
 useFloating({
   open,
-  placement,                              // computed from side + align
-  transform: false,                       // CSS transform reserved for entrance animation
+  placement, // computed from side + align
+  transform: false, // CSS transform reserved for entrance animation
   middleware: [
-    offset(sideOffset),                   // default 10
-    flip(),                               // auto-flip on collision
-    shift({ padding: 8 }),                // viewport edge padding
-    arrow({ element: arrowRef }),         // populates middlewareData.arrow.{x, y}
+    offset(sideOffset), // default 10
+    flip(), // auto-flip on collision
+    shift({ padding: 8 }), // viewport edge padding
+    arrow({ element: arrowRef }), // populates middlewareData.arrow.{x, y}
   ],
   whileElementsMounted: autoUpdate,
   elements: { reference: triggerRef.current },
@@ -261,14 +269,14 @@ Same `transform: false` as Tooltip — Floating UI writes `top` / `left` instead
 ```scss
 .content {
   position: relative;
-  min-width: var(--size-popover-min-width);  /* 220px — new token */
-  max-width: 360px;                          /* intrinsic geometric constraint, raw value OK */
+  min-width: var(--size-popover-min-width); /* 220px — new token */
+  max-width: 360px; /* intrinsic geometric constraint, raw value OK */
   padding: var(--space-3);
   background: var(--color-bg);
   color: var(--color-fg);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-lg);              /* heavier than Tooltip's --shadow-md */
+  box-shadow: var(--shadow-lg); /* heavier than Tooltip's --shadow-md */
   z-index: var(--z-popover);
   outline: none;
   /* …animation rules below… */
@@ -280,7 +288,7 @@ Same `transform: false` as Tooltip — Floating UI writes `top` / `left` instead
 Add to `tokens.scss`:
 
 ```scss
---z-popover: 1050;   /* above dropdown (1000), below modal (1100), toast (1200), tooltip (1300) */
+--z-popover: 1050; /* above dropdown (1000), below modal (1100), toast (1200), tooltip (1300) */
 ```
 
 Full layer hierarchy after this change:
@@ -319,13 +327,35 @@ Reuses DropdownMenu / Tooltip's `@starting-style` scale-fade pattern. Tuned for 
   }
 }
 
-.content[data-side='top']    { transform-origin: bottom center; @starting-style { transform: scale(0.95) translateY(4px); } }
-.content[data-side='bottom'] { transform-origin: top center;    @starting-style { transform: scale(0.95) translateY(-4px); } }
-.content[data-side='right']  { transform-origin: left center;   @starting-style { transform: scale(0.95) translateX(-4px); } }
-.content[data-side='left']   { transform-origin: right center;  @starting-style { transform: scale(0.95) translateX(4px); } }
+.content[data-side='top'] {
+  transform-origin: bottom center;
+  @starting-style {
+    transform: scale(0.95) translateY(4px);
+  }
+}
+.content[data-side='bottom'] {
+  transform-origin: top center;
+  @starting-style {
+    transform: scale(0.95) translateY(-4px);
+  }
+}
+.content[data-side='right'] {
+  transform-origin: left center;
+  @starting-style {
+    transform: scale(0.95) translateX(-4px);
+  }
+}
+.content[data-side='left'] {
+  transform-origin: right center;
+  @starting-style {
+    transform: scale(0.95) translateX(4px);
+  }
+}
 
 @media (prefers-reduced-motion: reduce) {
-  .content { transition: none; }
+  .content {
+    transition: none;
+  }
 }
 ```
 
@@ -386,7 +416,7 @@ export function PopoverRoot({
   open: controlledOpen,
   onOpenChange,
   defaultOpen = false,
-  modal: _modal = false,  // reserved future hint; v1 ignores
+  modal: _modal = false, // reserved future hint; v1 ignores
 }: PopoverProps) {
   const isControlled = controlledOpen !== undefined;
   const [uncontrolled, setUncontrolled] = useState(defaultOpen);
@@ -412,7 +442,14 @@ export function PopoverRoot({
   }, [setOpen]);
 
   const value: PopoverContextValue = {
-    open, setOpen, triggerRef, contentRef, contentId, headingId, setHeadingId, closeAll,
+    open,
+    setOpen,
+    triggerRef,
+    contentRef,
+    contentId,
+    headingId,
+    setHeadingId,
+    closeAll,
   };
 
   return <PopoverContext.Provider value={value}>{children}</PopoverContext.Provider>;
@@ -439,9 +476,13 @@ export function Heading({ children, as: As = 'h3', ...rest }: PopoverHeadingProp
   useLayoutEffect(() => {
     ctx.setHeadingId(id);
     return () => ctx.setHeadingId(null);
-  }, [id]);  // eslint-disable-line react-hooks/exhaustive-deps — ctx is stable per Popover instance
+  }, [id]); // eslint-disable-line react-hooks/exhaustive-deps — ctx is stable per Popover instance
 
-  return <As id={id} {...rest}>{children}</As>;
+  return (
+    <As id={id} {...rest}>
+      {children}
+    </As>
+  );
 }
 ```
 
@@ -484,7 +525,7 @@ export function ConfirmationPopover({
   // onOpenChange the consumer provided and short-circuiting when pending.
   const handleOpenChange = useCallback(
     (next: boolean) => {
-      if (pending && !next) return;  // don't allow close while pending
+      if (pending && !next) return; // don't allow close while pending
       onOpenChange?.(next);
       if (!next) onCancel?.();
     },
@@ -518,7 +559,12 @@ export function ConfirmationPopover({
   return (
     <Popover open={controlledOpen} onOpenChange={handleOpenChange} defaultOpen={defaultOpen}>
       <Popover.Trigger>{children}</Popover.Trigger>
-      <Popover.Content side={side} align={align} sideOffset={sideOffset} aria-describedby={descriptionId}>
+      <Popover.Content
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+        aria-describedby={descriptionId}
+      >
         <Stack gap="sm">
           <Popover.Heading>{title}</Popover.Heading>
           {description && <p id={descriptionId}>{description}</p>}
@@ -552,7 +598,7 @@ export function ConfirmationPopover({
 **Note:** the sketch above glosses over a few coordination details that the implementation plan must resolve:
 
 - How ConfirmationPopover triggers Popover to close after a successful `onConfirm` (probably by hoisting open state into ConfirmationPopover itself and passing it controlled to Popover).
-- How focus moves to the Cancel button after Popover focuses the panel. The cleanest approach is `useLayoutEffect` on `open` inside ConfirmationPopover that runs *after* Popover's own focus-on-open layout effect, since both fire after mount but ConfirmationPopover's effect fires after Popover's (parent effects run after child effects in React's commit phase). The plan must verify this ordering. If timing is brittle, fall back to a `queueMicrotask` from a content-level effect.
+- How focus moves to the Cancel button after Popover focuses the panel. The cleanest approach is `useLayoutEffect` on `open` inside ConfirmationPopover that runs _after_ Popover's own focus-on-open layout effect, since both fire after mount but ConfirmationPopover's effect fires after Popover's (parent effects run after child effects in React's commit phase). The plan must verify this ordering. If timing is brittle, fall back to a `queueMicrotask` from a content-level effect.
 - The `<Spinner>` is a 12×12 inline SVG owned by `ConfirmationPopover.tsx` (~10 lines). Not a separate component.
 
 ### Shared helpers — already promoted

--- a/docs/superpowers/specs/2026-05-19-popover-design.md
+++ b/docs/superpowers/specs/2026-05-19-popover-design.md
@@ -1,0 +1,759 @@
+# Popover + ConfirmationPopover — design
+
+**Status:** approved, ready for plan
+**Author:** dpws + Claude
+**Date:** 2026-05-19
+**Scope:** two new components — `packages/design-system/src/components/Popover/` and `packages/design-system/src/components/ConfirmationPopover/`
+
+## Goal
+
+Ship the next two floating-UI primitives from the wishlist in `packages/design-system/CLAUDE.md`:
+
+1. `<Popover>` — generalized non-menu floating panel. Hand-rolled on `@floating-ui/react-dom`. Compound API (`Popover.Trigger`, `Popover.Content`, `Popover.Heading`, `Popover.Close`). Non-modal: focus moves into the panel on open, Tab continues to traverse out of the panel into the page behind, click-outside or Escape dismisses.
+2. `<ConfirmationPopover>` — opinionated preset on top of Popover. Declarative API (`title` / `description` / `confirmLabel` / `cancelLabel` / `variant` / `onConfirm`). Async-aware: while `onConfirm`'s Promise is in flight, buttons disable and dismissal is blocked. Initial focus on Cancel for both variants.
+
+## Non-goals
+
+- **No modal popover in v1.** The `<Popover>` root accepts a `modal?: boolean` prop reserved as a future type hint, but in v1 it is always non-modal (no focus trap, no inert background, `aria-modal="false"`). True modal behavior is what `<Modal>` will be for.
+- **No arrow toggle.** Arrow is always on, matching Tooltip's posture. If a chromeless floating panel is needed later, that's a separate component.
+- **No `initialFocus` override on ConfirmationPopover.** Cancel is the safe default for both variants; revisit if a real use case appears.
+- **No inline error rendering in ConfirmationPopover.** When `onConfirm` rejects, the popover stays open and buttons re-enable — the consumer surfaces the error externally (toast, inline message, etc.).
+- **No multi-step confirmations** ("Type the name to confirm"). That's Modal territory.
+- **No animation on close.** Same posture as DropdownMenu / Tooltip — panel unmounts on close.
+- **No `<Popover.Description>` slot.** `<Popover.Content>` body is consumer markup; there is no opinionated description slot. ConfirmationPopover renders its own description internally because it is an opinionated preset.
+
+## Popover public API
+
+```tsx
+import { Popover } from '@eocrm/design-system';
+
+// Canonical use — a filter panel:
+<Popover>
+  <Popover.Trigger>
+    <Button variant="secondary">Filters</Button>
+  </Popover.Trigger>
+  <Popover.Content>
+    <Stack gap="sm">
+      <Cluster justify="between" align="center">
+        <Popover.Heading>Filter results</Popover.Heading>
+        <Popover.Close>
+          <Button variant="ghost" size="sm" aria-label="Close">✕</Button>
+        </Popover.Close>
+      </Cluster>
+      {/* …form controls… */}
+      <Cluster justify="end" gap="sm">
+        <Popover.Close>
+          <Button variant="secondary" size="sm">Cancel</Button>
+        </Popover.Close>
+        <Popover.Close>
+          <Button size="sm" onClick={applyFilters}>Apply</Button>
+        </Popover.Close>
+      </Cluster>
+    </Stack>
+  </Popover.Content>
+</Popover>
+
+// Controlled (rare):
+const [open, setOpen] = useState(false);
+<Popover open={open} onOpenChange={setOpen}>…</Popover>
+```
+
+### `<Popover>` root props
+
+| Prop           | Type                      | Default | Notes                                                                                          |
+| -------------- | ------------------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `children`     | `ReactNode`               | —       | Must contain exactly one `<Popover.Trigger>` and one `<Popover.Content>` (validated at runtime). |
+| `open`         | `boolean`                 | —       | Optional controlled state.                                                                     |
+| `onOpenChange` | `(open: boolean) => void` | —       | Required when `open` is provided.                                                              |
+| `defaultOpen`  | `boolean`                 | `false` | Uncontrolled initial state.                                                                    |
+| `modal`        | `boolean`                 | `false` | Reserved future hint. v1 ignores the value and always renders non-modal.                       |
+
+### `<Popover.Trigger>` props
+
+| Prop       | Type           | Default | Notes                                                                                                                                |
+| ---------- | -------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `children` | `ReactElement` | —       | Exactly one element that accepts a ref. Same `forwardRef`-required contract as `<DropdownMenu.Trigger>`. `<Button>` qualifies.        |
+
+Trigger clones its child to inject:
+
+- `ref` merged with the consumer's ref (via `mergeRefs`).
+- `aria-haspopup="dialog"`.
+- `aria-expanded={open}`.
+- `aria-controls={contentId}` while open.
+- `onClick` chained with the consumer's onClick (consumer runs first).
+- `onKeyDown` chained for Enter / Space activation.
+
+### `<Popover.Content>` props
+
+| Prop         | Type                                     | Default      | Notes                                                                  |
+| ------------ | ---------------------------------------- | ------------ | ---------------------------------------------------------------------- |
+| `children`   | `ReactNode`                              | —            | Free-form. Compose with `<Stack>` / `<Cluster>` / etc.                 |
+| `side`       | `'top' \| 'right' \| 'bottom' \| 'left'` | `'bottom'`   | Preferred placement. Floating UI auto-flips on collision.              |
+| `align`      | `'start' \| 'center' \| 'end'`           | `'center'`   | Edge alignment.                                                        |
+| `sideOffset` | `number`                                 | `10`         | Gap in px between trigger and panel. Larger than Tooltip's 6 to fit the arrow on a larger panel. |
+| `minWidth`   | `number \| string`                       | token-driven | Override the panel's minimum width. Default uses `--size-popover-min-width` (220px). |
+| `className`  | `string`                                 | —            | Composed with the component's own className.                           |
+| `style`      | reserved                                 | —            | Floating UI sets inline `position`/`top`/`left`; consumer `style` is silently overridden — same as DropdownMenu. |
+
+### `<Popover.Heading>` props
+
+| Prop       | Type                                       | Default | Notes                                                                                |
+| ---------- | ------------------------------------------ | ------- | ------------------------------------------------------------------------------------ |
+| `children` | `ReactNode`                                | —       | The heading text.                                                                    |
+| `as`       | `'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'`     | `'h3'`  | Semantic tag.                                                                        |
+
+When present, `<Popover.Content>` gets `aria-labelledby` pointing at the heading's auto-generated id. The heading registers via context on mount and unregisters on unmount.
+
+### `<Popover.Close>` props
+
+| Prop       | Type           | Default | Notes                                                                                |
+| ---------- | -------------- | ------- | ------------------------------------------------------------------------------------ |
+| `children` | `ReactElement` | —       | Exactly one element. Cloned to inject an `onClick` that closes the popover, chained with the child's existing `onClick`. |
+
+Exported types: `PopoverProps`, `PopoverTriggerProps`, `PopoverContentProps`, `PopoverHeadingProps`, `PopoverCloseProps`, `PopoverSide`, `PopoverAlign`.
+
+## ConfirmationPopover public API
+
+```tsx
+import { ConfirmationPopover } from '@eocrm/design-system';
+
+// Destructive confirmation:
+<ConfirmationPopover
+  title="Delete record?"
+  description="This action cannot be undone."
+  confirmLabel="Delete"
+  cancelLabel="Cancel"
+  variant="danger"
+  onConfirm={async () => {
+    await api.deleteRecord(id);
+  }}
+>
+  <Button variant="danger">Delete</Button>
+</ConfirmationPopover>
+
+// Default variant (lighter weight, e.g., archive / publish):
+<ConfirmationPopover
+  title="Archive this contact?"
+  description="You can unarchive later from the archive view."
+  onConfirm={() => archive(id)}
+>
+  <Button variant="secondary">Archive</Button>
+</ConfirmationPopover>
+```
+
+### Props
+
+| Prop           | Type                              | Default                     | Notes                                                                                                                                                                                                                                                                                                                                                       |
+| -------------- | --------------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children`     | `ReactElement`                    | — (required)                | The trigger. Same forwardRef-required contract.                                                                                                                                                                                                                                                                                                              |
+| `title`        | `string`                          | — (required)                | Renders inside `<Popover.Heading>`. Wires `aria-labelledby`.                                                                                                                                                                                                                                                                                                |
+| `description`  | `ReactNode`                       | —                           | Optional body text under the title. Wires `aria-describedby` when present.                                                                                                                                                                                                                                                                                  |
+| `confirmLabel` | `string`                          | `'Confirm'`                 | Confirm button text.                                                                                                                                                                                                                                                                                                                                        |
+| `cancelLabel`  | `string`                          | `'Cancel'`                  | Cancel button text.                                                                                                                                                                                                                                                                                                                                         |
+| `variant`      | `'default' \| 'danger'`           | `'default'`                 | `'danger'` → Confirm renders as `<Button variant="danger">`. Default → `<Button variant="primary">`.                                                                                                                                                                                                                                                          |
+| `onConfirm`    | `() => void \| Promise<void>`     | — (required)                | Async-aware. Click on Confirm runs `onConfirm()`. If it returns a Promise, both buttons disable and dismissal paths are blocked until resolve. On resolve, popover closes. On reject, popover stays open, buttons re-enable, `onCancel` is NOT fired. ConfirmationPopover does NOT render the error — the consumer surfaces it externally.                  |
+| `onCancel`     | `() => void`                      | —                           | Optional. Fires on Cancel click, Escape, or click-outside dismissal. Does NOT fire if `onConfirm` rejects.                                                                                                                                                                                                                                                  |
+| `side`         | (same as `<Popover.Content>`)     | `'top'`                     | Confirmations anchor above the trigger by default — keeps the user's eye near where they clicked.                                                                                                                                                                                                                                                          |
+| `align`        | (same as `<Popover.Content>`)     | `'center'`                  | —                                                                                                                                                                                                                                                                                                                                                           |
+| `sideOffset`   | `number`                          | `10`                        | —                                                                                                                                                                                                                                                                                                                                                           |
+| `open` / `onOpenChange` / `defaultOpen` | (same as `<Popover>`)   | —                           | Optional controlled state, forwarded to the underlying Popover.                                                                                                                                                                                                                                                                                              |
+
+Exported types: `ConfirmationPopoverProps`, `ConfirmationVariant`.
+
+### Behavior specifics
+
+- **Initial focus** lands on the **Cancel button** regardless of variant. Industry conventions split (GitHub/Linear focus Cancel, Notion focuses Confirm); going with Cancel for safety — keyboard "Enter" never accidentally confirms a destructive action; the user must Tab once to Confirm.
+- **Pending state.** While the Promise returned by `onConfirm` is unresolved:
+  - Both Cancel and Confirm get the `disabled` attribute.
+  - Confirm shows a small spinner (12×12 inline SVG, `currentColor`) to the left of the label.
+  - Escape and click-outside are no-oped.
+  - An internal `pending` boolean state, reset on resolve / reject.
+- **Failure mode.** `onConfirm` rejects → `pending` flips back to `false`, buttons re-enable, popover stays open, `onCancel` not fired. The consumer is expected to render their own error feedback (toast, inline message, etc.).
+- **Double-click guard.** While pending, additional Confirm clicks are ignored (no second `onConfirm` invocation).
+
+## Accessibility & dismissal
+
+### Popover ARIA wiring
+
+- `<Popover.Content>`: `role="dialog"`, `aria-modal="false"`, `tabIndex={-1}` (so it can receive programmatic focus on open), `id={contentId}`.
+- `<Popover.Heading>` (optional): renders as the configured semantic tag (default `h3`), with auto-generated `id`. When present, `<Popover.Content>` gets `aria-labelledby={headingId}`. Heading registers via context on mount; unregisters on unmount.
+- `<Popover.Trigger>`: clones its child to add `aria-haspopup="dialog"`, `aria-expanded={open}`, `aria-controls={contentId}` (only when open).
+
+### ConfirmationPopover ARIA
+
+- Internally uses `<Popover.Heading>` for `title` → `aria-labelledby` wired automatically.
+- When `description` is provided, it renders inside a `<p id="…">` and `<Popover.Content>` gets `aria-describedby` pointing at it.
+- Cancel and Confirm buttons receive their labels via `cancelLabel` / `confirmLabel`; no extra ARIA needed beyond what `<Button>` provides.
+
+### Open / close triggers
+
+| Event                                            | Popover                                                              | ConfirmationPopover                                                                                  |
+| ------------------------------------------------ | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Trigger click (or Enter / Space on focused trigger) | Toggle open.                                                       | Open.                                                                                                |
+| Click anywhere inside `<Popover.Content>`        | **No close** unless wrapped in `<Popover.Close>`.                    | Confirm runs `onConfirm`; Cancel closes + `onCancel`; other clicks ignored.                          |
+| `<Popover.Close>`-wrapped element click          | Close (chains with consumer's `onClick`).                            | n/a — internal.                                                                                      |
+| Click outside content + trigger                  | Close.                                                               | Close + `onCancel`. **Blocked while pending.**                                                       |
+| `Escape` anywhere while open                     | Close. Focus returns to trigger.                                     | Close + `onCancel`. **Blocked while pending.**                                                       |
+| `Tab` from inside content past the last focusable | Continues to next focusable on the page; popover **stays open**.   | Same.                                                                                                |
+| Trigger unmount while open                       | Cleanup listeners; ref check guards against stale state.             | Same.                                                                                                |
+
+### Focus management
+
+- **On open**: render the portaled `<Popover.Content>`, then `queueMicrotask(() => contentRef.current?.focus({ preventScroll: true }))`. Focus lands on the panel itself (`tabIndex={-1}`). `preventScroll` matches DropdownMenu's pattern — the portal starts at document origin until Floating UI computes coords, so focusing without `preventScroll` would yank the page.
+- **ConfirmationPopover** overrides this: after the content mounts, internal logic focuses the Cancel button via an internal ref (consumer cannot override in v1).
+- **On close**: `triggerRef.current?.focus({ preventScroll: true })`. Same recipe DropdownMenu uses.
+
+### Click-outside detection
+
+Same `pointerdown` + capture-phase document listener pattern DropdownMenu uses. The handler checks:
+
+1. Target is inside `<Popover.Content>` → ignore.
+2. Target is inside `<Popover.Trigger>` → ignore (the trigger's own click handler toggles).
+3. Otherwise → close.
+
+ConfirmationPopover wraps the same logic with a `pending`-check short-circuit.
+
+### Escape handling
+
+Document-level capture-phase `keydown` listener while open. Closes the popover and returns focus to the trigger. ConfirmationPopover wraps with the same `pending`-check.
+
+### Touch & disabled triggers
+
+- **Touch**: tap fires `click`, which opens the popover normally — no special-case logic needed (unlike Tooltip, which has no tap-to-open by design).
+- **Disabled triggers**: same anti-pattern as Tooltip. `<button disabled>` does not fire `click`, so the popover won't open. Documented JSDoc anti-pattern: use `aria-disabled="true"` + intercept click if you need a popover on a disabled-looking control, or wrap the control in a span.
+
+### Multiple popovers
+
+Each `<Popover>` instance manages its own state and listeners. Opening Popover B while Popover A is open does not automatically close A — A only closes if the click that opens B is outside A's content + trigger (which it usually is, so A naturally closes via outside-click).
+
+## Positioning
+
+```ts
+useFloating({
+  open,
+  placement,                              // computed from side + align
+  transform: false,                       // CSS transform reserved for entrance animation
+  middleware: [
+    offset(sideOffset),                   // default 10
+    flip(),                               // auto-flip on collision
+    shift({ padding: 8 }),                // viewport edge padding
+    arrow({ element: arrowRef }),         // populates middlewareData.arrow.{x, y}
+  ],
+  whileElementsMounted: autoUpdate,
+  elements: { reference: triggerRef.current },
+});
+```
+
+Same `transform: false` as Tooltip — Floating UI writes `top` / `left` instead of `transform: translate`, leaving the CSS `transform` property free for the entrance animation.
+
+**No `size` middleware.** Popover content is consumer-determined; if it's tall enough to need scrolling, that's Modal territory.
+
+### Arrow
+
+- 10×10 (vs Tooltip's 8×8) — proportional to the larger panel.
+- Inline-positioned by `middlewareData.arrow.{x, y}` on the cross-axis. The trigger-facing edge is anchored by SCSS `[data-side]` rules (same recipe Tooltip uses).
+- Background `var(--color-bg)` (panel-colored), matching the panel.
+- 1px border on the two outward-facing edges so the arrow visually fuses with the panel chrome. Exact rendering recipe (clip-path vs rotated span with synthetic `box-shadow` borders vs inline SVG) deferred to implementation — same posture as Tooltip's spec.
+- `aria-hidden="true"`, `pointer-events: none`.
+
+## Visual chrome
+
+```scss
+.content {
+  position: relative;
+  min-width: var(--size-popover-min-width);  /* 220px — new token */
+  max-width: 360px;                          /* intrinsic geometric constraint, raw value OK */
+  padding: var(--space-3);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);              /* heavier than Tooltip's --shadow-md */
+  z-index: var(--z-popover);
+  outline: none;
+  /* …animation rules below… */
+}
+```
+
+### Z-index — new token
+
+Add to `tokens.scss`:
+
+```scss
+--z-popover: 1050;   /* above dropdown (1000), below modal (1100), toast (1200), tooltip (1300) */
+```
+
+Full layer hierarchy after this change:
+
+```
+--z-dropdown: 1000;
+--z-popover:  1050;   ← new
+--z-modal:    1100;
+--z-toast:    1200;
+--z-tooltip:  1300;
+```
+
+Rationale: a popover opened from inside a DropdownMenu item must appear above the menu (1050 > 1000). A Modal opened on top of a Popover must bury the popover behind its backdrop (1100 > 1050). Tooltips inside popovers stay on top (1300 > 1050).
+
+### New token — `--size-popover-min-width`
+
+```scss
+--size-popover-min-width: 220px;
+```
+
+Slightly wider than DropdownMenu's `--size-dropdown-min-width: 160px` because popover content is typically richer (form-style, with multiple rows).
+
+## Animation
+
+Reuses DropdownMenu / Tooltip's `@starting-style` scale-fade pattern. Tuned for the larger panel:
+
+```scss
+.content {
+  transform: none;
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base);
+
+  @starting-style {
+    opacity: var(--opacity-hidden);
+  }
+}
+
+.content[data-side='top']    { transform-origin: bottom center; @starting-style { transform: scale(0.95) translateY(4px); } }
+.content[data-side='bottom'] { transform-origin: top center;    @starting-style { transform: scale(0.95) translateY(-4px); } }
+.content[data-side='right']  { transform-origin: left center;   @starting-style { transform: scale(0.95) translateX(-4px); } }
+.content[data-side='left']   { transform-origin: right center;  @starting-style { transform: scale(0.95) translateX(4px); } }
+
+@media (prefers-reduced-motion: reduce) {
+  .content { transition: none; }
+}
+```
+
+Differences from Tooltip's animation:
+
+- `scale(0.95)` instead of `0.92` — the larger panel needs less aggressive scale-down.
+- `4px` translate (matches DropdownMenu) instead of Tooltip's `2px` — proportional to the larger panel.
+- Same `--transition-base` duration (140ms) for cross-component consistency.
+
+No close animation. Same rationale as DropdownMenu / Tooltip: "get out of the way" beats "play a transition."
+
+## Internal structure
+
+### Popover (compound)
+
+```
+context.ts                ← PopoverContext: open, setOpen, triggerRef, contentRef, contentId, headingId, setHeadingId, closeAll
+PopoverRoot.tsx           ← PopoverRoot function (state machine + provider)
+Popover.tsx               ← namespace assembly: Popover = PopoverRoot; Popover.Trigger = Trigger; etc.
+Trigger.tsx               ← cloneElement + aria + click/key handlers
+Content.tsx               ← createPortal + useFloating + arrow + focus-on-open + document listeners
+Heading.tsx               ← <h{level} id> + heading-id registration via context
+Close.tsx                 ← cloneElement + chained onClick that calls ctx.setOpen(false)
+Popover.module.scss       ← chrome + arrow + per-side @starting-style
+index.ts                  ← export { Popover }; export type { … }
+```
+
+`Popover.tsx`:
+
+```tsx
+import { Trigger } from './Trigger';
+import { Content } from './Content';
+import { Heading } from './Heading';
+import { Close } from './Close';
+import { PopoverRoot } from './PopoverRoot';
+
+type PopoverNamespace = typeof PopoverRoot & {
+  Trigger: typeof Trigger;
+  Content: typeof Content;
+  Heading: typeof Heading;
+  Close: typeof Close;
+};
+
+const Popover = PopoverRoot as PopoverNamespace;
+Popover.Trigger = Trigger;
+Popover.Content = Content;
+Popover.Heading = Heading;
+Popover.Close = Close;
+
+export { Popover };
+```
+
+`PopoverRoot.tsx`:
+
+```tsx
+export function PopoverRoot({
+  children,
+  open: controlledOpen,
+  onOpenChange,
+  defaultOpen = false,
+  modal: _modal = false,  // reserved future hint; v1 ignores
+}: PopoverProps) {
+  const isControlled = controlledOpen !== undefined;
+  const [uncontrolled, setUncontrolled] = useState(defaultOpen);
+  const open = isControlled ? (controlledOpen as boolean) : uncontrolled;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      onOpenChange?.(next);
+      if (!isControlled) setUncontrolled(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const reactId = useId();
+  const contentId = `popover-${sanitizeId(reactId)}`;
+  const [headingId, setHeadingId] = useState<string | null>(null);
+
+  const closeAll = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus({ preventScroll: true });
+  }, [setOpen]);
+
+  const value: PopoverContextValue = {
+    open, setOpen, triggerRef, contentRef, contentId, headingId, setHeadingId, closeAll,
+  };
+
+  return <PopoverContext.Provider value={value}>{children}</PopoverContext.Provider>;
+}
+```
+
+`Trigger.tsx` — cloneElement injecting `ref`, `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls`, and chained click/keydown handlers. Pattern identical to DropdownMenu's `Trigger.tsx`.
+
+`Content.tsx` — the heaviest file:
+
+- `useFloating` with `transform: false` + offset / flip / shift / arrow middleware
+- Document-level `pointerdown` listener (capture) → close on outside click
+- Document-level `keydown` listener (capture) → close on Escape, return focus to trigger
+- `useLayoutEffect` on open → focus the panel (`contentRef.current?.focus({ preventScroll: true })`)
+- Renders `createPortal(<div role="dialog" ref={…} tabIndex={-1} aria-labelledby={headingId ?? undefined} …>{children}<span ref={arrowRef} …/></div>, document.body)`
+
+`Heading.tsx`:
+
+```tsx
+export function Heading({ children, as: As = 'h3', ...rest }: PopoverHeadingProps) {
+  const ctx = usePopoverContext('Heading');
+  const id = `popover-heading-${sanitizeId(useId())}`;
+
+  useLayoutEffect(() => {
+    ctx.setHeadingId(id);
+    return () => ctx.setHeadingId(null);
+  }, [id]);  // eslint-disable-line react-hooks/exhaustive-deps — ctx is stable per Popover instance
+
+  return <As id={id} {...rest}>{children}</As>;
+}
+```
+
+`Close.tsx` — cloneElement injecting an onClick that calls `ctx.closeAll()`, chained with the consumer's onClick (chain order: consumer first, then close).
+
+### ConfirmationPopover (single component)
+
+```
+ConfirmationPopover.tsx              ← single component; uses Popover internally
+ConfirmationPopover.module.scss      ← title/description typography + spinner keyframes
+ConfirmationPopover.test.tsx
+index.ts
+```
+
+`ConfirmationPopover.tsx` (sketch):
+
+```tsx
+export function ConfirmationPopover({
+  children,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'default',
+  onConfirm,
+  onCancel,
+  side = 'top',
+  align = 'center',
+  sideOffset = 10,
+  open: controlledOpen,
+  onOpenChange,
+  defaultOpen = false,
+}: ConfirmationPopoverProps) {
+  const [pending, setPending] = useState(false);
+  const cancelButtonRef = useRef<HTMLButtonElement | null>(null);
+  const reactId = useId();
+  const descriptionId = description ? `confirm-desc-${sanitizeId(reactId)}` : undefined;
+
+  // We layer our own dismissal-blocking on top of Popover by wrapping the
+  // onOpenChange the consumer provided and short-circuiting when pending.
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (pending && !next) return;  // don't allow close while pending
+      onOpenChange?.(next);
+      if (!next) onCancel?.();
+    },
+    [pending, onOpenChange, onCancel],
+  );
+
+  // Focus Cancel after Popover opens. Popover focuses the panel; we move it.
+  // useLayoutEffect on the visibility transition runs after the panel is mounted.
+  // Implementation detail: we observe open via a controlled-uncontrolled hybrid
+  // similar to PopoverRoot, or rely on rendering pattern. See implementation plan.
+
+  const onConfirmClick = useCallback(async () => {
+    if (pending) return;
+    const result = onConfirm();
+    if (result instanceof Promise) {
+      setPending(true);
+      try {
+        await result;
+        setPending(false);
+        // close — this requires controlled-or-internal-state coordination;
+        // see implementation plan for the exact wiring
+      } catch {
+        setPending(false);
+        // popover stays open
+      }
+    } else {
+      // sync confirm → close immediately
+    }
+  }, [pending, onConfirm]);
+
+  return (
+    <Popover open={controlledOpen} onOpenChange={handleOpenChange} defaultOpen={defaultOpen}>
+      <Popover.Trigger>{children}</Popover.Trigger>
+      <Popover.Content side={side} align={align} sideOffset={sideOffset} aria-describedby={descriptionId}>
+        <Stack gap="sm">
+          <Popover.Heading>{title}</Popover.Heading>
+          {description && <p id={descriptionId}>{description}</p>}
+          <Cluster justify="end" gap="sm">
+            <Button
+              ref={cancelButtonRef}
+              variant="secondary"
+              size="sm"
+              disabled={pending}
+              onClick={() => handleOpenChange(false)}
+            >
+              {cancelLabel}
+            </Button>
+            <Button
+              variant={variant === 'danger' ? 'danger' : 'primary'}
+              size="sm"
+              disabled={pending}
+              onClick={onConfirmClick}
+            >
+              {pending && <Spinner />}
+              {confirmLabel}
+            </Button>
+          </Cluster>
+        </Stack>
+      </Popover.Content>
+    </Popover>
+  );
+}
+```
+
+**Note:** the sketch above glosses over a few coordination details that the implementation plan must resolve:
+
+- How ConfirmationPopover triggers Popover to close after a successful `onConfirm` (probably by hoisting open state into ConfirmationPopover itself and passing it controlled to Popover).
+- How focus moves to the Cancel button after Popover focuses the panel. The cleanest approach is `useLayoutEffect` on `open` inside ConfirmationPopover that runs *after* Popover's own focus-on-open layout effect, since both fire after mount but ConfirmationPopover's effect fires after Popover's (parent effects run after child effects in React's commit phase). The plan must verify this ordering. If timing is brittle, fall back to a `queueMicrotask` from a content-level effect.
+- The `<Spinner>` is a 12×12 inline SVG owned by `ConfirmationPopover.tsx` (~10 lines). Not a separate component.
+
+### Shared helpers — already promoted
+
+`mergeRefs`, `chain`, `sanitizeId`, `mergeAriaDescribedby` already live at `packages/design-system/src/components/_internal/refs.ts` from the Tooltip work. Popover and ConfirmationPopover import from there. No new shared helpers needed for v1.
+
+## File layout
+
+```
+packages/design-system/src/components/
+  Popover/
+    Popover.tsx                       ← namespace export
+    PopoverRoot.tsx                   ← PopoverRoot function + props interface
+    Trigger.tsx
+    Content.tsx
+    Heading.tsx
+    Close.tsx
+    Popover.module.scss
+    Popover.test.tsx
+    context.ts
+    index.ts                          ← export { Popover }; export type { … }
+
+  ConfirmationPopover/
+    ConfirmationPopover.tsx
+    ConfirmationPopover.module.scss
+    ConfirmationPopover.test.tsx
+    index.ts                          ← export { ConfirmationPopover }; export type { … }
+```
+
+Plus:
+
+- `packages/design-system/src/styles/tokens.scss` — add `--z-popover: 1050` and `--size-popover-min-width: 220px`.
+- `packages/design-system/src/index.ts` — re-export `Popover` (the namespace) + `ConfirmationPopover` + all the type names.
+- `packages/design-system/AGENTS.md` — two new TL;DR sections (Popover + ConfirmationPopover) after the Tooltip section. Token table updated. Anti-patterns rows added.
+- `packages/design-system/README.md` — two new rows in the components table.
+- `packages/playground/src/pages/components/PopoverDemo.tsx` — playground demo (~6 examples).
+- `packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx` — playground demo (~5 examples covering default + danger + async + error + on-DropdownMenu-item).
+- `packages/playground/src/App.tsx` — two new routes.
+- `packages/playground/src/layout/AppShell/AppShell.tsx` — two new entries in the Overlays group.
+- `packages/playground/src/pages/components/ComponentsIndex.tsx` — two new grid cards.
+- `packages/playground/src/pages/mockups/registry.ts` — extend `ComponentName` union with `'Popover'` and `'ConfirmationPopover'`.
+
+## Tests
+
+### `Popover.test.tsx` — ~25 tests
+
+**Rendering & API:**
+
+1. Renders trigger as-is; no portaled content on mount.
+2. Throws when `<Popover.Trigger>` has non-element children.
+3. `defaultOpen={true}` renders the panel on mount.
+4. Controlled `open` + `onOpenChange` round-trip.
+5. Rerender from `open={false}` to `open={true}` flips the panel; rerender back closes it.
+
+**Trigger contract:**
+
+6. Trigger has `aria-haspopup="dialog"` and `aria-expanded="false"` initially.
+7. Click on trigger opens the popover; `aria-expanded="true"`.
+8. Second click on trigger closes it.
+9. Enter / Space on focused trigger opens.
+10. Consumer `ref`, `className`, `data-*`, `onClick` all preserved; consumer `onClick` chains and runs first.
+
+**Content portal & ARIA:**
+
+11. Open → panel renders in `document.body` with `role="dialog"`, `aria-modal="false"`, `tabIndex={-1}`.
+12. `data-side` reflects resolved placement (default `'bottom'`).
+13. `<Popover.Heading>` renders as the configured tag (default `h3`); `<Popover.Content>` gets `aria-labelledby` pointing at it.
+14. Without `<Popover.Heading>`, `<Popover.Content>` has no `aria-labelledby`.
+
+**Focus:**
+
+15. Open → focus moves to the panel.
+16. Close (Escape) → focus returns to trigger.
+17. Close (outside click) → focus returns to trigger.
+18. Close (`<Popover.Close>` click) → focus returns to trigger.
+
+**Dismissal:**
+
+19. Escape from inside the panel closes.
+20. `pointerdown` outside the panel + outside the trigger closes.
+21. `pointerdown` inside the panel does NOT close.
+22. `<Popover.Close>`-wrapped element click closes AND fires the consumer's `onClick`.
+
+**Tab behavior:**
+
+23. Tab from inside the panel walks through focusable children, then exits to the page; popover stays open (NOT a focus trap).
+
+**Cleanup:**
+
+24. Unmount-while-open removes document `pointerdown` + `keydown` listeners.
+
+**Animation contract:**
+
+25. `Popover.module.scss` contains `.content { … @starting-style … }` (substring assertion).
+
+**Arrow:**
+
+26. Content contains a `span[aria-hidden="true"]` with the arrow class.
+
+Test infrastructure: reuse the `asyncWrapper` + `configure` shim from Tooltip's test file (already established for fake-timer + RTL `act()` cooperation).
+
+### `ConfirmationPopover.test.tsx` — ~15 tests
+
+Doesn't re-test Popover internals.
+
+1. Renders trigger as-is; no popover on mount.
+2. Click trigger → popover renders with `title` as the heading and `description` as accessible text.
+3. `variant="danger"` makes Confirm a `<Button variant="danger">`; default uses `primary`.
+4. Custom `confirmLabel` / `cancelLabel` reflected.
+5. `aria-labelledby` (title) and `aria-describedby` (description) wired.
+6. On open, focus lands on the Cancel button (both variants).
+7. Confirm click → sync `onConfirm` invoked once → popover closes.
+8. Confirm doesn't fire `onCancel`.
+9. Async `onConfirm` returns Promise → both buttons disabled → resolve → popover closes.
+10. While pending: Escape does NOT close.
+11. While pending: click-outside does NOT close.
+12. `onConfirm` rejects → popover stays open, buttons re-enable, `onCancel` not fired.
+13. Double-click Confirm during pending → only one invocation.
+14. Cancel click → close + `onCancel`.
+15. Escape (non-pending) → close + `onCancel`.
+16. Outside click (non-pending) → close + `onCancel`.
+
+### Out of scope for unit tests
+
+- Real positioning math (Floating UI's job; visual in playground demo).
+- Real arrow rendering (visual only).
+- `prefers-reduced-motion` actual disabling (CSS; the `@starting-style` substring test is the proxy).
+
+## Playground
+
+### `PopoverDemo.tsx` — ~6 Examples
+
+1. **Default — filter panel** — `Filters` button → popover with form-style content + Apply / Cancel.
+2. **Sides grid** — four triggers, one per side; verifies arrow rotation and Floating UI flip.
+3. **With Popover.Heading** — visually confirms the heading style + `aria-labelledby` wiring.
+4. **On a DropdownMenu item** — z-index sanity check (popover > dropdown).
+5. **Controlled open** — toggle button drives `open` externally.
+6. **Rich content** — popover containing a small list + a footer with multiple `<Popover.Close>`-wrapped buttons.
+
+### `ConfirmationPopoverDemo.tsx` — ~5 Examples
+
+1. **Default variant** — Archive contact, sync `onConfirm`.
+2. **Danger variant** — Delete record, sync `onConfirm`.
+3. **Async (success)** — `onConfirm` returns a Promise that resolves after a fake 1.5s delay; visually confirms the pending spinner.
+4. **Async (failure)** — `onConfirm` returns a Promise that rejects after 1s; visually confirms the popover stays open + buttons re-enable.
+5. **Inside a DropdownMenu** — kebab-menu's Delete item opens a ConfirmationPopover.
+
+## Docs
+
+### JSDoc (Rule 7)
+
+Every exported member gets full JSDoc:
+
+- `Popover` (the namespace) — one-paragraph description + 2–3 `@example` blocks + `@remarks When NOT to use` + `@remarks Anti-patterns`. Uses the rule-7 pattern Tooltip established.
+- `PopoverRoot` (internal) — keep JSDoc minimal; the public API is the namespace.
+- Each sub-component (`Trigger`, `Content`, `Heading`, `Close`) — one paragraph + canonical snippet.
+- `ConfirmationPopover` — full prose with 2–3 examples (canonical, danger variant, async).
+- Every prop in every interface.
+- Both exported union types (`PopoverSide`, `PopoverAlign`, `ConfirmationVariant`).
+
+### `AGENTS.md`
+
+Two new TL;DR sections after the Tooltip section, mirroring its shape:
+
+- `<Popover>` — compound API, snippets, props summary, dismissal contract, focus behavior, z-popover token.
+- `<ConfirmationPopover>` — opinionated preset, snippets (default + danger), async-aware contract, anti-pattern callouts.
+
+Token table updated with `--z-popover` and `--size-popover-min-width`.
+
+Anti-patterns table extended:
+
+- `<Popover><DisabledThing /></Popover>` → disabled buttons don't fire click; use `aria-disabled` or wrap in a span.
+- Putting required action confirmation in a Popover that can be dismissed by click-outside → use `<ConfirmationPopover>` (blocks dismissal while pending) or a Modal.
+- `<Popover.Content>` with no `<Popover.Close>` button AND content that isn't dismissable by clicking outside → keyboard / screen-reader users have no obvious close affordance. Add a `<Popover.Close>` close button or document why outside-click is enough.
+
+### `README.md`
+
+Two new rows in the components table, format-matched to existing rows.
+
+## Risks & mitigations
+
+- **Focus ordering between PopoverRoot's focus-on-open and ConfirmationPopover's focus-on-Cancel.** Both use `useLayoutEffect`. React fires child effects before parent effects, so PopoverRoot's effect (in `Content.tsx`) runs first, then ConfirmationPopover's. Net: panel focuses first, then Cancel gets focus — correct. The plan must verify this with a test that asserts `document.activeElement` after open is the Cancel button. If the test reveals timing brittleness, fall back to `queueMicrotask`.
+- **`useFloating` runs unconditionally even when `isEmpty` / not open.** Same pattern Tooltip uses; safe because the hook returns stable refs/styles regardless of `open`. Only the portal render is gated by `open`.
+- **Popover with no focusable content** — Tab inside the panel finds nothing focusable and walks straight out. Escape still works because the panel itself has `tabIndex={-1}` and receives focus on open. Verified by test #23.
+- **`<Popover.Trigger>` child that doesn't accept a ref** — same forwardRef-required contract as DropdownMenu and Tooltip. Throws at runtime; documented as anti-pattern.
+- **Multiple `<Popover.Heading>` instances inside one `<Popover.Content>`** — the second mount overwrites `headingId`. Behavior: `aria-labelledby` points at the last-mounted heading. Acceptable — having two headings is itself an anti-pattern; we document it but don't enforce.
+- **`onConfirm` that never settles** — Promise that hangs forever. The popover would stay pending forever. v1 accepts this; the consumer is responsible for adding their own timeout if needed. Documented as a consumer-responsibility note in the JSDoc.
+- **ConfirmationPopover with controlled `open`** — when the consumer provides `open`, our internal `pending`-check still works because we wrap their `onOpenChange`. But the consumer could force-close from outside while we're pending. Documented as: "If you provide `open`/`onOpenChange`, ConfirmationPopover cannot block your external close; coordinate `pending` state in your own code."
+
+## Acceptance
+
+- `make test` green: existing suite + ~25 Popover tests + ~15 ConfirmationPopover tests.
+- `make build-lib`, `npm run typecheck -w playground`, `make lint`, `make build`, `npm pack --dry-run -w @eocrm/design-system` all green.
+- Visual in `make up`:
+  - `/components/popover` shows all 6 examples; arrow tracks each side; Tab walks out of the panel; Escape closes; outside-click closes; `<Popover.Close>` buttons close.
+  - `/components/confirmation-popover` shows all 5 examples; pending spinner appears during async; failure leaves popover open + buttons re-enabled; Cancel button has initial focus.
+  - DevTools → emulate `prefers-reduced-motion: reduce` → both components appear instantly.
+- Hard Rule 8 pre-push review-fix loop completes with verdict `clean enough to stop`.
+
+## Open decisions deferred to implementation
+
+- Exact arrow rendering recipe (clip-path vs rotated span with synthetic borders vs inline SVG). All three work; choice made when wiring against real chrome.
+- Whether ConfirmationPopover's `Spinner` is inline SVG with CSS rotation or a CSS-only `border` spinner. Both fine; pick during implementation.
+- Whether ConfirmationPopover internally hoists open state (with controlled-or-uncontrolled hybrid) or finds another coordination pattern to close-after-resolve. The plan must pick one and verify focus return works.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -198,7 +198,7 @@ const [tab, setTab] = useState('overview');
 
 - Compound API: `<DropdownMenu>` is the provider; `<Trigger>` clones its single child to inject ARIA + handlers; `<Content>` portals to `document.body` and positions itself with Floating UI; `<Item>` renders a `menuitem`; `<Separator>` renders a divider.
 - Trigger child must accept a ref via `forwardRef`. `<Button>` does.
-- `<Item>` props: `onSelect` (required), `disabled`, `tone` (`'default'` | `'danger'`), `icon`, `shortcut`.
+- `<Item>` props: `onSelect` (required), `disabled`, `tone` (`'default'` | `'danger'`), `icon`, `shortcut`, `closeOnSelect` (default `true`; set to `false` when wrapping the Item in a `<Popover.Trigger>` or `<ConfirmationPopover>` — otherwise the menu close would unmount the popover before it can render).
 - `<Content>` props: `side` (`'top'` | `'bottom'`, default `'bottom'`), `align` (`'start'` | `'center'` | `'end'`, default `'start'`), `sideOffset` (default `4`), `minWidth`.
 - Keyboard: Enter/Space/ArrowDown on trigger opens with first item active; ArrowUp opens with last; Arrow/Home/End navigate skipping disabled and separators; Enter/Space activates; Escape closes and returns focus to trigger; Tab closes and returns focus to trigger (then continues normal traversal); typeahead jumps to first matching label (500ms debounce).
 - Opens with a short scale-fade from the trigger side (140 ms `ease-out`). Closes instantly by design — menu close should feel like "get out of the way", not "play a transition". Respects `prefers-reduced-motion: reduce`.
@@ -311,6 +311,7 @@ const [tab, setTab] = useState('overview');
 - `<Popover.Content>` props: `side` (`'top'` | `'right'` | `'bottom'` | `'left'`, default `'bottom'`), `align` (default `'center'`), `sideOffset` (default `10`), `minWidth`.
 - `<Popover.Heading>` props: `as` (`'h2'` – `'h6'`, default `'h3'`).
 - Opens with a short scale-fade from the trigger side (140ms). Closes instantly. Respects `prefers-reduced-motion: reduce`.
+- **From a DropdownMenu item.** Wrap a `<DropdownMenu.Item closeOnSelect={false}>` as the `<Popover.Trigger>` child — the Item itself becomes the trigger, so the full highlighted row opens the popover. `closeOnSelect={false}` keeps the menu open while the popover is shown.
 - Z-layer `--z-popover: 1050` — above dropdown, below modal/toast/tooltip.
 - For passive hover/focus hints → `<Tooltip>`. For lists of actions → `<DropdownMenu>`. For focus-locked dialogs → `<Modal>` (not yet shipped).
 
@@ -336,6 +337,7 @@ const [tab, setTab] = useState('overview');
 - **Async-aware** `onConfirm`. May return a Promise. While pending, both buttons disable, Confirm shows a spinner, and Escape / click-outside are blocked.
 - **Failure mode**: on reject, popover stays open and buttons re-enable. Consumer surfaces the error externally — ConfirmationPopover does NOT render inline errors.
 - Anchors above the trigger by default (`side="top"`).
+- **From a DropdownMenu item (kebab Delete pattern).** Wrap a `<DropdownMenu.Item closeOnSelect={false}>` as the trigger — clicking anywhere on the row opens the confirmation. The menu stays open until the user dismisses it (Escape or click outside). To close the menu after the action resolves, drive `DropdownMenu`'s `open` state externally and call `setMenuOpen(false)` inside `onConfirm`.
 
 ---
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -277,6 +277,66 @@ const [tab, setTab] = useState('overview');
 - Opens with a short scale-fade (140 ms) from the trigger side. Closes instantly. Respects `prefers-reduced-motion: reduce`.
 - Z-layer `--z-tooltip: 1300` is above modal and toast, so tooltips inside any host UI remain visible.
 
+### `<Popover>` — non-modal floating panel for interactive content
+
+```tsx
+<Popover>
+  <Popover.Trigger>
+    <Button variant="secondary">Filters</Button>
+  </Popover.Trigger>
+  <Popover.Content>
+    <Stack gap="sm">
+      <Popover.Heading>Filter results</Popover.Heading>
+      {/* …form controls… */}
+      <Cluster justify="end" gap="sm">
+        <Popover.Close>
+          <Button variant="secondary" size="sm">
+            Cancel
+          </Button>
+        </Popover.Close>
+        <Popover.Close>
+          <Button size="sm" onClick={apply}>
+            Apply
+          </Button>
+        </Popover.Close>
+      </Cluster>
+    </Stack>
+  </Popover.Content>
+</Popover>
+```
+
+- Compound API: `<Popover>` is the provider; `<Popover.Trigger>` clones its single child to inject ARIA + click; `<Popover.Content>` portals to `document.body` and positions via Floating UI; `<Popover.Heading>` (optional) wires `aria-labelledby`; `<Popover.Close>` clones its child to inject a close-onClick.
+- Trigger child must accept a ref (`forwardRef`). `<Button>` does.
+- **Non-modal**: focus moves to the panel on open; Tab traverses INTO content, then OUT to the page behind. Click-outside or Escape dismisses. Page is NOT inert.
+- `<Popover.Content>` props: `side` (`'top'` | `'right'` | `'bottom'` | `'left'`, default `'bottom'`), `align` (default `'center'`), `sideOffset` (default `10`), `minWidth`.
+- `<Popover.Heading>` props: `as` (`'h2'` – `'h6'`, default `'h3'`).
+- Opens with a short scale-fade from the trigger side (140ms). Closes instantly. Respects `prefers-reduced-motion: reduce`.
+- Z-layer `--z-popover: 1050` — above dropdown, below modal/toast/tooltip.
+- For passive hover/focus hints → `<Tooltip>`. For lists of actions → `<DropdownMenu>`. For focus-locked dialogs → `<Modal>` (not yet shipped).
+
+### `<ConfirmationPopover>` — opinionated "Are you sure?" preset
+
+```tsx
+<ConfirmationPopover
+  title="Delete record?"
+  description="This action cannot be undone."
+  confirmLabel="Delete"
+  variant="danger"
+  onConfirm={async () => {
+    await api.deleteRecord(id);
+  }}
+>
+  <Button variant="danger">Delete</Button>
+</ConfirmationPopover>
+```
+
+- Built on top of `<Popover>`. Declarative: `title` / `description` / `confirmLabel` / `cancelLabel` / `variant` / `onConfirm` / `onCancel`.
+- `variant`: `'default'` (Confirm is primary) | `'danger'` (Confirm is danger).
+- **Initial focus on Cancel** for both variants — keyboard Enter never accidentally confirms. Tab once to Confirm.
+- **Async-aware** `onConfirm`. May return a Promise. While pending, both buttons disable, Confirm shows a spinner, and Escape / click-outside are blocked.
+- **Failure mode**: on reject, popover stays open and buttons re-enable. Consumer surfaces the error externally — ConfirmationPopover does NOT render inline errors.
+- Anchors above the trigger by default (`side="top"`).
+
 ---
 
 ## Tokens (the only "values" you write)
@@ -295,13 +355,13 @@ All available as CSS custom properties after you import `global.scss`:
 | Font sizes      | `--font-size-xs/sm/md/lg/xl/2xl/3xl`, `--font-size-code` (0.92em for inline mono)                                                                                                                   |
 | Font weights    | `--font-weight-regular/medium/semibold/bold`                                                                                                                                                        |
 | Line heights    | `--line-height-tight` / `--line-height-normal` / `--line-height-none` (1)                                                                                                                           |
-| Control sizes   | `--size-sm/md/lg` (heights), `--size-badge` (20), `--size-badge-sm` (16), `--size-chip` (18), `--size-dropdown-min-width` (160), `--size-dropdown-indicator` (16)                                   |
+| Control sizes   | `--size-sm/md/lg` (heights), `--size-badge` (20), `--size-badge-sm` (16), `--size-chip` (18), `--size-dropdown-min-width` (160), `--size-popover-min-width` (220), `--size-dropdown-indicator` (16) |
 | Borders         | `--border-width` (1) / `--border-width-emphasis` (2) / `--border-width-strong` (3)                                                                                                                  |
 | Letter spacing  | `--letter-spacing-caps` (0.03em)                                                                                                                                                                    |
 | Shadows         | `--shadow-sm` / `--shadow-md` / `--shadow-lg`                                                                                                                                                       |
 | Focus rings     | `--ring-accent` / `--ring-danger` / `--ring-success` / `--ring-width`                                                                                                                               |
 | Motion          | `--transition-fast` (100ms) / `--transition-base` (140ms)                                                                                                                                           |
-| Layer (z-index) | `--z-dropdown` / `--z-modal` / `--z-toast` / `--z-tooltip`                                                                                                                                          |
+| Layer (z-index) | `--z-dropdown` / `--z-popover` / `--z-modal` / `--z-toast` / `--z-tooltip`                                                                                                                          |
 
 ---
 
@@ -330,6 +390,9 @@ All available as CSS custom properties after you import `global.scss`:
 | `<Tooltip><Button disabled>…</Button></Tooltip>`                                      | `disabled` buttons don't fire pointer/focus events; render with `aria-disabled="true"` + intercept the click, or wrap in `<span>`. |
 | Putting essential info _only_ in a tooltip                                            | Make it visible in copy or in the trigger's `aria-label`. Touch users will never see the tooltip.                                  |
 | `<Tooltip content="">…</Tooltip>` expecting a no-op listener attach                   | Empty content **is** a no-op — listeners and aria are skipped entirely. That's by design.                                          |
+| `<Popover.Trigger><Button disabled>…</Button></Popover.Trigger>`                      | `disabled` buttons don't fire click; render with `aria-disabled="true"` + intercept the click, or wrap in `<span>`.                |
+| `<Popover.Content>` with no `<Popover.Close>` AND non-obvious outside-click dismissal | Keyboard / screen-reader users get no clear close affordance. Add a `<Popover.Close>` close button.                                |
+| `<ConfirmationPopover>` with `onConfirm` that never settles                           | v1 has no timeout — popover stays in pending state forever. Add a timeout/abort inside your `onConfirm` if relevant.               |
 
 ---
 

--- a/packages/design-system/CLAUDE.md
+++ b/packages/design-system/CLAUDE.md
@@ -36,6 +36,33 @@ When adding `src/components/<Name>/`, the same change must add `packages/playgro
 
 Colors, spacing, radii, shadows, font sizes — all via `var(--...)`. If you need a value that isn't a token, **add it to `src/styles/tokens.scss` first**, then use it. Stylelint blocks `color: #fff` and `background: red`-style raw values.
 
+### 3a. Focus styling — `:focus-visible`, not `:focus`
+
+For buttons, menu items, tabs, and other **non-input focusable elements**, style focus with `:focus-visible`, not `:focus`. The difference matters for mouse interaction:
+
+- `:focus` matches whenever the element has focus — including after a mouse click. The element stays styled until something else takes focus. Clicking a DropdownMenu.Item or a Button leaves it visually highlighted even after the cursor moves away.
+- `:focus-visible` matches only when focus arrived via the keyboard (Tab, Arrow keys, programmatic focus following a keydown). Mouse-click focus doesn't trigger it. This matches the actual UX intent — "highlight this so the user can see where they are on the keyboard."
+
+Wrong:
+
+```scss
+.item:hover,
+.item:focus { /* stays red after mouse click */
+  background: var(--color-bg-danger-subtle);
+}
+```
+
+Right:
+
+```scss
+.item:hover,
+.item:focus-visible {
+  background: var(--color-bg-danger-subtle);
+}
+```
+
+**Exception — text inputs and textareas.** A text input always needs a visible focus ring when typed into, regardless of how focus arrived. Modern browsers treat typing as keyboard interaction, so `:focus-visible` works fine here too — the library's `<Input>` uses `:focus-visible` for consistency. `:focus` is also acceptable for text inputs. Either is fine; pick one and stay consistent in a given file.
+
 ### 4. No layout properties on components
 
 Forbidden inside a component's `.module.scss`:

--- a/packages/design-system/CLAUDE.md
+++ b/packages/design-system/CLAUDE.md
@@ -47,7 +47,8 @@ Wrong:
 
 ```scss
 .item:hover,
-.item:focus { /* stays red after mouse click */
+.item:focus {
+  /* stays red after mouse click */
   background: var(--color-bg-danger-subtle);
 }
 ```

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -74,18 +74,20 @@ If TypeScript can't resolve types, set `moduleResolution: "bundler"` (or `"node1
 
 ## Components
 
-| Component        | One-line                          | Detail                    |
-| ---------------- | --------------------------------- | ------------------------- |
-| `<Button>`       | Action triggers                   | Hover in editor for JSDoc |
-| `<Input>`        | Single-line text                  | Hover in editor for JSDoc |
-| `<Card>`         | Bordered content container        | Hover in editor for JSDoc |
-| `<Stack>`        | Vertical layout primitive         | Hover in editor for JSDoc |
-| `<Cluster>`      | Horizontal layout (wraps)         | Hover in editor for JSDoc |
-| `<Avatar>`       | Profile circle                    | Hover in editor for JSDoc |
-| `<Badge>`        | Status / category pill            | Hover in editor for JSDoc |
-| `<Tabs>`         | Horizontal tab strip              | Hover in editor for JSDoc |
-| `<DropdownMenu>` | Action menu from a trigger        | Hover in editor for JSDoc |
-| `<Tooltip>`      | Supplementary hint on hover/focus | Hover in editor for JSDoc |
+| Component               | One-line                                                                                     | Detail                    |
+| ----------------------- | -------------------------------------------------------------------------------------------- | ------------------------- |
+| `<Button>`              | Action triggers                                                                              | Hover in editor for JSDoc |
+| `<Input>`               | Single-line text                                                                             | Hover in editor for JSDoc |
+| `<Card>`                | Bordered content container                                                                   | Hover in editor for JSDoc |
+| `<Stack>`               | Vertical layout primitive                                                                    | Hover in editor for JSDoc |
+| `<Cluster>`             | Horizontal layout (wraps)                                                                    | Hover in editor for JSDoc |
+| `<Avatar>`              | Profile circle                                                                               | Hover in editor for JSDoc |
+| `<Badge>`               | Status / category pill                                                                       | Hover in editor for JSDoc |
+| `<Tabs>`                | Horizontal tab strip                                                                         | Hover in editor for JSDoc |
+| `<DropdownMenu>`        | Action menu from a trigger                                                                   | Hover in editor for JSDoc |
+| `<Tooltip>`             | Supplementary hint on hover/focus                                                            | Hover in editor for JSDoc |
+| `<Popover>`             | Non-modal floating panel for arbitrary small surfaces (filters, mini-forms, quick pickers).  | Hover in editor for JSDoc |
+| `<ConfirmationPopover>` | "Are you sure?" preset on top of Popover, with async-aware Confirm and Cancel-default focus. | Hover in editor for JSDoc |
 
 Every prop and variant is JSDoc'd at the source. For a quick reference + canonical snippets + tokens table + anti-patterns, see [AGENTS.md](./AGENTS.md).
 

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.module.scss
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.module.scss
@@ -1,9 +1,32 @@
-/* stylelint-disable block-no-empty */
-// Rules land in Task 18. Empty for now so the import resolves.
-.title {
-}
 .description {
+  /* stylelint-disable-next-line property-disallowed-list -- neutralizing UA <p> default, not component layout */
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  color: var(--color-fg-muted);
 }
+
 .spinner {
+  display: inline-block;
+  width: var(--space-3);
+  height: var(--space-3);
+  /* stylelint-disable-next-line property-disallowed-list -- internal spacing between spinner disc and label inside Button */
+  margin-right: var(--space-1);
+  border: var(--border-width-emphasis) solid currentColor;
+  border-top-color: transparent;
+  border-radius: var(--radius-full);
+  animation: confirm-spin 0.6s linear infinite;
+  vertical-align: middle;
 }
-/* stylelint-enable block-no-empty */
+
+@keyframes confirm-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+  }
+}

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.module.scss
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.module.scss
@@ -1,0 +1,9 @@
+/* stylelint-disable block-no-empty */
+// Rules land in Task 18. Empty for now so the import resolves.
+.title {
+}
+.description {
+}
+.spinner {
+}
+/* stylelint-enable block-no-empty */

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx
@@ -125,3 +125,25 @@ describe('ConfirmationPopover — content rendering (sync)', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });
+
+describe('ConfirmationPopover — initial focus', () => {
+  it('focuses the Cancel button after open (both variants)', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ConfirmationPopover title="Confirm?" onConfirm={() => {}}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+
+    rerender(
+      <ConfirmationPopover title="Confirm?" variant="danger" onConfirm={() => {}}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    // Re-rendering with a new variant keeps the popover open; focus has
+    // already moved to Cancel on the original open. Verify it's still there.
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+  });
+});

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ConfirmationPopover } from './ConfirmationPopover';
 
 describe('ConfirmationPopover — initial render', () => {
@@ -14,6 +15,113 @@ describe('ConfirmationPopover — initial render', () => {
       </ConfirmationPopover>,
     );
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+
+describe('ConfirmationPopover — content rendering (sync)', () => {
+  it('opens with title, description, Cancel and Confirm buttons', async () => {
+    const user = userEvent.setup();
+    render(
+      <ConfirmationPopover
+        title="Delete record?"
+        description="This action cannot be undone."
+        variant="danger"
+        onConfirm={() => {}}
+      >
+        <button type="button">Delete</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(screen.getByRole('heading', { name: 'Delete record?' })).toBeInTheDocument();
+    expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    // The Confirm button defaults to label 'Confirm' (since confirmLabel
+    // prop is not provided here). The trigger 'Delete' button is no longer
+    // the active focus context once the panel opens.
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+  });
+
+  it('respects custom confirmLabel and cancelLabel', async () => {
+    const user = userEvent.setup();
+    render(
+      <ConfirmationPopover
+        title="Archive?"
+        confirmLabel="Archive"
+        cancelLabel="Keep"
+        onConfirm={() => {}}
+      >
+        <button type="button">Archive…</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Archive…' }));
+    expect(screen.getByRole('button', { name: 'Keep' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Archive' })).toBeInTheDocument();
+  });
+
+  it('default variant uses primary button; danger variant uses danger button', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ConfirmationPopover title="Default?" onConfirm={() => {}}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    // Button doesn't use data-variant — it composes a CSS-Module class
+    // named after the variant (e.g. `styles.primary`). The compiled class
+    // ends up containing the substring 'primary' / 'danger', so match on
+    // that. Bare class equality would be brittle across module hashing.
+    expect(screen.getByRole('button', { name: 'Confirm' }).className).toMatch(/primary/);
+
+    rerender(
+      <ConfirmationPopover title="Default?" variant="danger" onConfirm={() => {}}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    expect(screen.getByRole('button', { name: 'Confirm' }).className).toMatch(/danger/);
+  });
+
+  it('aria-labelledby points at the title; aria-describedby points at the description', async () => {
+    const user = userEvent.setup();
+    render(
+      <ConfirmationPopover title="Delete?" description="Cannot be undone." onConfirm={() => {}}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    const dialog = screen.getByRole('dialog');
+    const heading = screen.getByRole('heading', { name: 'Delete?' });
+    expect(dialog.getAttribute('aria-labelledby')).toBe(heading.id);
+
+    const description = screen.getByText('Cannot be undone.');
+    expect(dialog.getAttribute('aria-describedby')).toBe(description.id);
+  });
+
+  it('sync onConfirm: click Confirm → onConfirm runs once → popover closes', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('Cancel click closes + fires onCancel', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(
+      <ConfirmationPopover title="Confirm?" onConfirm={() => {}} onCancel={onCancel}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx
@@ -255,4 +255,59 @@ describe('ConfirmationPopover — async onConfirm', () => {
       resolveFn();
     });
   });
+
+  it('while pending: Escape does NOT close', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    let resolveFn: () => void = () => {};
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+
+    render(
+      <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await act(async () => {
+      resolveFn();
+    });
+  });
+
+  it('while pending: click-outside does NOT close', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    let resolveFn: () => void = () => {};
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+
+    render(
+      <>
+        <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
+          <button type="button">Open</button>
+        </ConfirmationPopover>
+        <div data-testid="elsewhere">elsewhere</div>
+      </>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await user.pointer({ keys: '[MouseLeft>]', target: screen.getByTestId('elsewhere') });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await act(async () => {
+      resolveFn();
+    });
+  });
 });

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { ConfirmationPopover } from './ConfirmationPopover';
+
+describe('ConfirmationPopover — initial render', () => {
+  it('renders only the trigger when closed', () => {
+    render(
+      <ConfirmationPopover
+        title="Delete record?"
+        description="This action cannot be undone."
+        variant="danger"
+        onConfirm={() => {}}
+      >
+        <button type="button">Delete</button>
+      </ConfirmationPopover>,
+    );
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, configure, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ConfirmationPopover } from './ConfirmationPopover';
 
@@ -145,5 +145,114 @@ describe('ConfirmationPopover — initial focus', () => {
     // Re-rendering with a new variant keeps the popover open; focus has
     // already moved to Cancel on the original open. Verify it's still there.
     expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+  });
+});
+
+describe('ConfirmationPopover — async onConfirm', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // @testing-library/react's asyncWrapper has a setTimeout(0) drain step
+    // that only knows how to advance Jest fake timers. Override it to also
+    // advance Vitest fake timers (matches the pattern Tooltip uses).
+    configure({
+      asyncWrapper: async (cb) => {
+        const result = await cb();
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+          vi.advanceTimersByTime(0);
+        });
+        return result;
+      },
+    });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    configure({ asyncWrapper: async (cb) => cb() });
+  });
+
+  it('async onConfirm: pending → buttons disabled → resolve → close', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    let resolveFn: () => void = () => {};
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+
+    render(
+      <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFn();
+    });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('async onConfirm rejects → popover stays open, buttons re-enable, onCancel NOT fired', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onCancel = vi.fn();
+    let rejectFn: (e: Error) => void = () => {};
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((_, reject) => {
+          rejectFn = reject;
+        }),
+    );
+
+    render(
+      <ConfirmationPopover title="Confirm?" onConfirm={onConfirm} onCancel={onCancel}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await act(async () => {
+      rejectFn(new Error('boom'));
+    });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Confirm' })).not.toBeDisabled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('double-click Confirm during pending → onConfirm runs once', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    let resolveFn: () => void = () => {};
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+
+    render(
+      <ConfirmationPopover title="Confirm?" onConfirm={onConfirm}>
+        <button type="button">Open</button>
+      </ConfirmationPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    const confirmBtn = screen.getByRole('button', { name: 'Confirm' });
+    await user.click(confirmBtn);
+    await user.click(confirmBtn); // disabled → ignored
+    await user.click(confirmBtn); // disabled → ignored
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveFn();
+    });
   });
 });

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useState, type ReactElement, type ReactNode } from 'react';
+import { useCallback, useEffect, useId, useRef, useState, type ReactElement, type ReactNode } from 'react';
 import { Button } from '../Button';
 import { Cluster } from '../Cluster';
 import { Stack } from '../Stack';
@@ -86,6 +86,17 @@ export function ConfirmationPopover({
     [onCancel, setOpen],
   );
 
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
+
+  // Focus the Cancel button after Popover.Content focuses the panel.
+  // queueMicrotask runs after Popover.Content's own focus effect (which also
+  // uses queueMicrotask), so by the time this runs, the panel has focus and
+  // we override it with Cancel.
+  useEffect(() => {
+    if (!open) return;
+    queueMicrotask(() => cancelRef.current?.focus({ preventScroll: true }));
+  }, [open]);
+
   const handleConfirm = useCallback(() => {
     onConfirm();
     setOpen(false);
@@ -113,7 +124,7 @@ export function ConfirmationPopover({
             </p>
           )}
           <Cluster justify="end" gap="sm">
-            <Button variant="secondary" size="sm" onClick={handleCancel}>
+            <Button ref={cancelRef} variant="secondary" size="sm" onClick={handleCancel}>
               {cancelLabel}
             </Button>
             <Button

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
@@ -158,6 +158,7 @@ export function ConfirmationPopover({
               disabled={pending}
               onClick={handleConfirm}
             >
+              {pending && <span className={styles.spinner} aria-hidden="true" />}
               {confirmLabel}
             </Button>
           </Cluster>

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
@@ -97,10 +97,26 @@ export function ConfirmationPopover({
     queueMicrotask(() => cancelRef.current?.focus({ preventScroll: true }));
   }, [open]);
 
+  const [pending, setPending] = useState(false);
+
   const handleConfirm = useCallback(() => {
-    onConfirm();
-    setOpen(false);
-  }, [onConfirm, setOpen]);
+    if (pending) return;
+    const result = onConfirm();
+    if (result instanceof Promise) {
+      setPending(true);
+      result
+        .then(() => {
+          setPending(false);
+          setOpen(false);
+        })
+        .catch(() => {
+          setPending(false);
+          // Popover stays open. onCancel NOT fired — failure is its own state.
+        });
+    } else {
+      setOpen(false);
+    }
+  }, [pending, onConfirm, setOpen]);
 
   const handleCancel = useCallback(() => {
     onCancel?.();
@@ -124,12 +140,19 @@ export function ConfirmationPopover({
             </p>
           )}
           <Cluster justify="end" gap="sm">
-            <Button ref={cancelRef} variant="secondary" size="sm" onClick={handleCancel}>
+            <Button
+              ref={cancelRef}
+              variant="secondary"
+              size="sm"
+              disabled={pending}
+              onClick={handleCancel}
+            >
               {cancelLabel}
             </Button>
             <Button
               variant={variant === 'danger' ? 'danger' : 'primary'}
               size="sm"
+              disabled={pending}
               onClick={handleConfirm}
             >
               {confirmLabel}

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
@@ -6,43 +6,130 @@ import { Popover } from '../Popover';
 import { sanitizeId } from '../_internal/refs';
 import styles from './ConfirmationPopover.module.scss';
 
+/** `'danger'` swaps Confirm to a danger-variant button; `'default'` uses primary. */
 export type ConfirmationVariant = 'default' | 'danger';
 
 export interface ConfirmationPopoverProps {
-  /** The trigger element. Same forwardRef-required contract as Popover.Trigger. */
+  /**
+   * The trigger element. Same forwardRef-required contract as
+   * `<Popover.Trigger>` — `<Button>` qualifies; a custom component without
+   * `forwardRef` does not.
+   */
   children: ReactElement;
-  /** Heading text. Wires aria-labelledby. */
+
+  /**
+   * Heading text. Renders inside `<Popover.Heading>` (an `<h3>`) and wires
+   * `aria-labelledby` on the dialog automatically.
+   */
   title: string;
-  /** Optional body text. Wires aria-describedby when present. */
+
+  /**
+   * Optional body text below the title. When provided, wires
+   * `aria-describedby` so screen readers announce it.
+   */
   description?: ReactNode;
+
   /** Confirm button label. Defaults to `'Confirm'`. */
   confirmLabel?: string;
+
   /** Cancel button label. Defaults to `'Cancel'`. */
   cancelLabel?: string;
-  /** `'danger'` swaps Confirm to a danger-variant button. Defaults to `'default'`. */
+
+  /** `'danger'` makes Confirm a danger-variant button. Defaults to `'default'` (primary). */
   variant?: ConfirmationVariant;
+
   /**
-   * Async-aware confirm handler. May return a Promise; while pending, both
-   * buttons disable and dismissal is blocked. On resolve, the popover closes.
-   * On reject, the popover stays open and buttons re-enable.
+   * Async-aware confirm handler. May return a Promise; while pending,
+   * both buttons disable, the Confirm button shows a small spinner, and
+   * Escape / click-outside dismissal is blocked.
+   *
+   * - Resolve → popover closes.
+   * - Reject → popover stays open, buttons re-enable. `onCancel` is NOT
+   *   fired (the user neither confirmed nor cancelled — it's an error
+   *   state owned by the consumer).
+   *
+   * The consumer is expected to surface error feedback externally (toast,
+   * inline message, etc.). ConfirmationPopover does NOT render errors.
    */
   onConfirm: () => void | Promise<void>;
-  /** Optional. Fired on Cancel click, Escape, or click-outside dismissal. */
+
+  /** Optional. Fires on Cancel click, Escape, or click-outside dismissal. NOT fired if `onConfirm` rejects. */
   onCancel?: () => void;
-  /** Preferred side. Default `'top'`. */
+
+  /** Preferred side. Default `'top'` — confirmations anchor above the trigger by convention. */
   side?: 'top' | 'right' | 'bottom' | 'left';
+
   /** Edge alignment. Default `'center'`. */
   align?: 'start' | 'center' | 'end';
+
   /** Gap in px between trigger and panel. Default `10`. */
   sideOffset?: number;
-  /** Controlled open state. */
+
+  /** Controlled open state. Pair with `onOpenChange`. */
   open?: boolean;
+
   /** Open-change callback. Required when `open` is provided. */
   onOpenChange?: (open: boolean) => void;
+
   /** Default open state for uncontrolled usage. Defaults to `false`. */
   defaultOpen?: boolean;
 }
 
+/**
+ * Opinionated "Are you sure?" preset on top of `<Popover>`. Renders a
+ * compact panel with a title, optional description, Cancel button, and
+ * Confirm button. Anchors above the trigger by default to keep the user's
+ * eye near where they clicked.
+ *
+ * - **Initial focus** lands on Cancel for both variants. Safer default —
+ *   keyboard "Enter" never accidentally confirms; the user must Tab once
+ *   to Confirm.
+ * - **Async-aware** `onConfirm`. While the returned Promise is in flight,
+ *   both buttons disable, the Confirm shows a spinner, and Escape /
+ *   click-outside dismissal is blocked.
+ * - **Failure mode**. If `onConfirm` rejects, the popover stays open and
+ *   buttons re-enable. The consumer surfaces the error.
+ *
+ * @example
+ * <ConfirmationPopover
+ *   title="Delete record?"
+ *   description="This action cannot be undone."
+ *   variant="danger"
+ *   onConfirm={async () => {
+ *     await api.deleteRecord(id);
+ *   }}
+ * >
+ *   <Button variant="danger">Delete</Button>
+ * </ConfirmationPopover>
+ *
+ * @example
+ * // Default variant — lighter-weight (archive, publish, etc.):
+ * <ConfirmationPopover
+ *   title="Archive this contact?"
+ *   description="You can unarchive later from the archive view."
+ *   onConfirm={() => archive(id)}
+ * >
+ *   <Button variant="secondary">Archive</Button>
+ * </ConfirmationPopover>
+ *
+ * @remarks When NOT to use
+ * - For a multi-step flow ("type the name to confirm") → use Modal (when
+ *   shipped). ConfirmationPopover is for one-tap confirmations.
+ * - For a non-blocking heads-up that doesn't need a yes/no answer → use
+ *   a Toast (when shipped) or inline UI.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Hanging-forever `onConfirm` Promise. v1 has no timeout — the
+ *   popover stays in pending state indefinitely. Add a timeout / abort
+ *   inside your `onConfirm` if the operation may stall.
+ * - ❌ Rendering an inline error from `onConfirm`'s rejection inside the
+ *   popover body. ConfirmationPopover doesn't render errors — surface
+ *   them via toast or page-level UI instead.
+ * - ❌ Combining controlled `open` + relying on pending-blocks-close. If
+ *   you provide `open` / `onOpenChange`, you can force-close from outside
+ *   while we're pending. Coordinate `pending` in your own code if that
+ *   matters.
+ */
 export function ConfirmationPopover({
   children,
   title,

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
@@ -76,14 +76,19 @@ export function ConfirmationPopover({
   const reactId = useId();
   const descriptionId = description ? `confirm-desc-${sanitizeId(reactId)}` : undefined;
 
+  const [pending, setPending] = useState(false);
+
   // Wrap Popover's onOpenChange to fire onCancel when the popover closes
   // via Escape / click-outside (i.e. a close that didn't come from Confirm).
   const handleOpenChange = useCallback(
     (next: boolean) => {
+      // Block close while a confirm is pending — the in-flight Promise
+      // should resolve before we tear down the popover.
+      if (pending && !next) return;
       if (!next) onCancel?.();
       setOpen(next);
     },
-    [onCancel, setOpen],
+    [pending, onCancel, setOpen],
   );
 
   const cancelRef = useRef<HTMLButtonElement | null>(null);
@@ -96,8 +101,6 @@ export function ConfirmationPopover({
     if (!open) return;
     queueMicrotask(() => cancelRef.current?.focus({ preventScroll: true }));
   }, [open]);
-
-  const [pending, setPending] = useState(false);
 
   const handleConfirm = useCallback(() => {
     if (pending) return;

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useId, useRef, useState, type ReactElement, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 import { Button } from '../Button';
 import { Cluster } from '../Cluster';
 import { Stack } from '../Stack';

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
@@ -1,5 +1,10 @@
-import type { ReactElement, ReactNode } from 'react';
+import { useCallback, useId, useState, type ReactElement, type ReactNode } from 'react';
+import { Button } from '../Button';
+import { Cluster } from '../Cluster';
+import { Stack } from '../Stack';
 import { Popover } from '../Popover';
+import { sanitizeId } from '../_internal/refs';
+import styles from './ConfirmationPopover.module.scss';
 
 export type ConfirmationVariant = 'default' | 'danger';
 
@@ -40,6 +45,13 @@ export interface ConfirmationPopoverProps {
 
 export function ConfirmationPopover({
   children,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'default',
+  onConfirm,
+  onCancel,
   side = 'top',
   align = 'center',
   sideOffset = 10,
@@ -47,15 +59,72 @@ export function ConfirmationPopover({
   onOpenChange,
   defaultOpen = false,
 }: ConfirmationPopoverProps) {
-  // Minimal scaffold — internal state, focus management, buttons, async-aware
-  // onConfirm, and pending-blocks-dismissal land in subsequent tasks. For now
-  // ConfirmationPopover delegates entirely to Popover so the first render
-  // test passes (trigger only when closed).
+  // Hoist open state into ConfirmationPopover so we can close after a
+  // successful sync/async onConfirm without going through the consumer.
+  const isConsumerControlled = controlledOpen !== undefined;
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const open = isConsumerControlled ? (controlledOpen as boolean) : internalOpen;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      onOpenChange?.(next);
+      if (!isConsumerControlled) setInternalOpen(next);
+    },
+    [isConsumerControlled, onOpenChange],
+  );
+
+  const reactId = useId();
+  const descriptionId = description ? `confirm-desc-${sanitizeId(reactId)}` : undefined;
+
+  // Wrap Popover's onOpenChange to fire onCancel when the popover closes
+  // via Escape / click-outside (i.e. a close that didn't come from Confirm).
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) onCancel?.();
+      setOpen(next);
+    },
+    [onCancel, setOpen],
+  );
+
+  const handleConfirm = useCallback(() => {
+    onConfirm();
+    setOpen(false);
+  }, [onConfirm, setOpen]);
+
+  const handleCancel = useCallback(() => {
+    onCancel?.();
+    setOpen(false);
+  }, [onCancel, setOpen]);
+
   return (
-    <Popover open={controlledOpen} onOpenChange={onOpenChange} defaultOpen={defaultOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <Popover.Trigger>{children}</Popover.Trigger>
-      <Popover.Content side={side} align={align} sideOffset={sideOffset}>
-        {/* Content body lands in Task 14 */}
+      <Popover.Content
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+        aria-describedby={descriptionId}
+      >
+        <Stack gap="sm">
+          <Popover.Heading>{title}</Popover.Heading>
+          {description && (
+            <p id={descriptionId} className={styles.description}>
+              {description}
+            </p>
+          )}
+          <Cluster justify="end" gap="sm">
+            <Button variant="secondary" size="sm" onClick={handleCancel}>
+              {cancelLabel}
+            </Button>
+            <Button
+              variant={variant === 'danger' ? 'danger' : 'primary'}
+              size="sm"
+              onClick={handleConfirm}
+            >
+              {confirmLabel}
+            </Button>
+          </Cluster>
+        </Stack>
       </Popover.Content>
     </Popover>
   );

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
@@ -1,0 +1,62 @@
+import type { ReactElement, ReactNode } from 'react';
+import { Popover } from '../Popover';
+
+export type ConfirmationVariant = 'default' | 'danger';
+
+export interface ConfirmationPopoverProps {
+  /** The trigger element. Same forwardRef-required contract as Popover.Trigger. */
+  children: ReactElement;
+  /** Heading text. Wires aria-labelledby. */
+  title: string;
+  /** Optional body text. Wires aria-describedby when present. */
+  description?: ReactNode;
+  /** Confirm button label. Defaults to `'Confirm'`. */
+  confirmLabel?: string;
+  /** Cancel button label. Defaults to `'Cancel'`. */
+  cancelLabel?: string;
+  /** `'danger'` swaps Confirm to a danger-variant button. Defaults to `'default'`. */
+  variant?: ConfirmationVariant;
+  /**
+   * Async-aware confirm handler. May return a Promise; while pending, both
+   * buttons disable and dismissal is blocked. On resolve, the popover closes.
+   * On reject, the popover stays open and buttons re-enable.
+   */
+  onConfirm: () => void | Promise<void>;
+  /** Optional. Fired on Cancel click, Escape, or click-outside dismissal. */
+  onCancel?: () => void;
+  /** Preferred side. Default `'top'`. */
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  /** Edge alignment. Default `'center'`. */
+  align?: 'start' | 'center' | 'end';
+  /** Gap in px between trigger and panel. Default `10`. */
+  sideOffset?: number;
+  /** Controlled open state. */
+  open?: boolean;
+  /** Open-change callback. Required when `open` is provided. */
+  onOpenChange?: (open: boolean) => void;
+  /** Default open state for uncontrolled usage. Defaults to `false`. */
+  defaultOpen?: boolean;
+}
+
+export function ConfirmationPopover({
+  children,
+  side = 'top',
+  align = 'center',
+  sideOffset = 10,
+  open: controlledOpen,
+  onOpenChange,
+  defaultOpen = false,
+}: ConfirmationPopoverProps) {
+  // Minimal scaffold — internal state, focus management, buttons, async-aware
+  // onConfirm, and pending-blocks-dismissal land in subsequent tasks. For now
+  // ConfirmationPopover delegates entirely to Popover so the first render
+  // test passes (trigger only when closed).
+  return (
+    <Popover open={controlledOpen} onOpenChange={onOpenChange} defaultOpen={defaultOpen}>
+      <Popover.Trigger>{children}</Popover.Trigger>
+      <Popover.Content side={side} align={align} sideOffset={sideOffset}>
+        {/* Content body lands in Task 14 */}
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/packages/design-system/src/components/ConfirmationPopover/index.ts
+++ b/packages/design-system/src/components/ConfirmationPopover/index.ts
@@ -1,0 +1,2 @@
+export { ConfirmationPopover } from './ConfirmationPopover';
+export type { ConfirmationPopoverProps, ConfirmationVariant } from './ConfirmationPopover';

--- a/packages/design-system/src/components/DropdownMenu/Content.tsx
+++ b/packages/design-system/src/components/DropdownMenu/Content.tsx
@@ -109,8 +109,11 @@ export const Content = forwardRef<HTMLDivElement, DropdownMenuContentProps>(func
 
   // Outside-click: pointerdown on document, target is neither inside this
   // Content nor inside the Trigger, AND not inside any other open submenu
-  // panel (recognised by [data-dropdown-menu-content]). Excluding the trigger
-  // prevents fighting the trigger's own toggle handler.
+  // panel (recognised by [data-dropdown-menu-content]) OR any open popover
+  // panel (recognised by [data-popover-content]). Excluding the trigger
+  // prevents fighting the trigger's own toggle handler. Excluding popovers
+  // lets a Popover opened from inside a menu item handle its own clicks
+  // (Cancel/Confirm buttons, form controls) without collapsing the menu.
   useEffect(() => {
     if (!ctx.open) return;
     const onPointerDown = (e: globalThis.PointerEvent) => {
@@ -120,8 +123,11 @@ export const Content = forwardRef<HTMLDivElement, DropdownMenuContentProps>(func
       const trigger = ctx.triggerRef.current;
       if (content && content.contains(target)) return;
       if (trigger && trigger.contains(target)) return;
-      // If the click is inside a deeper submenu panel, let that sub handle it.
-      const allPanels = document.querySelectorAll('[data-dropdown-menu-content]');
+      // If the click is inside a deeper submenu panel or any popover panel,
+      // let that surface handle it.
+      const allPanels = document.querySelectorAll(
+        '[data-dropdown-menu-content], [data-popover-content]',
+      );
       for (const panel of allPanels) {
         if (panel !== content && panel.contains(target)) return;
       }

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
@@ -48,7 +48,7 @@
 }
 
 .item:hover:not([aria-disabled='true']),
-.item:focus:not([aria-disabled='true']) {
+.item:focus-visible:not([aria-disabled='true']) {
   background: var(--color-bg-muted);
 }
 
@@ -57,7 +57,7 @@
 }
 
 .item[data-tone='danger']:hover:not([aria-disabled='true']),
-.item[data-tone='danger']:focus:not([aria-disabled='true']) {
+.item[data-tone='danger']:focus-visible:not([aria-disabled='true']) {
   background: var(--color-bg-danger-subtle);
   color: var(--color-danger);
 }
@@ -85,7 +85,7 @@
 // with `.item[data-tone='danger']:hover` — equal specificity means later
 // rule wins, and this rule would silently suppress the danger color.
 .item[aria-checked='true']:hover:not([aria-disabled='true']),
-.item[aria-checked='true']:focus:not([aria-disabled='true']) {
+.item[aria-checked='true']:focus-visible:not([aria-disabled='true']) {
   background: var(--color-badge-info-bg);
   color: var(--color-badge-info-fg);
 }

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -661,6 +661,75 @@ describe('DropdownMenu — placement props', () => {
   });
 });
 
+describe('DropdownMenu — Item closeOnSelect + consumer onClick chain', () => {
+  it('closeOnSelect={false} keeps the menu open after click; onSelect still fires', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <button type="button">Open</button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item closeOnSelect={false} onSelect={onSelect}>
+            Stay open
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Stay open' }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  it('chains a consumer-supplied onClick before onSelect+closeAll', async () => {
+    // Locks in the contract Popover.Trigger relies on when it clones onto a
+    // <DropdownMenu.Item>: the injected onClick must run inside Item's
+    // click handler, not be overridden by Item's own handler.
+    const user = userEvent.setup();
+    const order: string[] = [];
+    const consumerOnClick = () => order.push('consumer');
+    const onSelect = () => order.push('onSelect');
+    render(
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <button type="button">Open</button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item onSelect={onSelect} onClick={consumerOnClick}>
+            Action
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Action' }));
+    expect(order).toEqual(['consumer', 'onSelect']);
+  });
+
+  it('consumer onClick e.preventDefault() short-circuits onSelect+closeAll', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <button type="button">Open</button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item onSelect={onSelect} onClick={(e) => e.preventDefault()}>
+            Guarded
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Guarded' }));
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+});
+
 describe('DropdownMenu — Item variants', () => {
   it('applies data-tone="danger" to danger items', async () => {
     const user = userEvent.setup();

--- a/packages/design-system/src/components/DropdownMenu/Item.tsx
+++ b/packages/design-system/src/components/DropdownMenu/Item.tsx
@@ -30,6 +30,15 @@ export interface DropdownMenuItemProps extends Omit<HTMLAttributes<HTMLDivElemen
   shortcut?: string;
   /** Disabled items are skipped by keyboard nav, dimmed, and don't fire `onSelect` on click. */
   disabled?: boolean;
+  /**
+   * Whether to close the menu after `onSelect` fires. Defaults to `true`.
+   *
+   * Set to `false` when this item is wrapped in a Popover/ConfirmationPopover
+   * trigger — the trigger will open its panel on this click; closing the
+   * menu would unmount the popover before the user could interact with it.
+   * The menu can be dismissed separately (Escape or outside-click).
+   */
+  closeOnSelect?: boolean;
 }
 
 /**
@@ -37,7 +46,18 @@ export interface DropdownMenuItemProps extends Omit<HTMLAttributes<HTMLDivElemen
  * keyboard navigation and typeahead. Fires `onSelect` on activation.
  */
 export const Item = forwardRef<HTMLDivElement, DropdownMenuItemProps>(function Item(
-  { onSelect, tone = 'default', icon, shortcut, disabled = false, className, children, ...rest },
+  {
+    onSelect,
+    tone = 'default',
+    icon,
+    shortcut,
+    disabled = false,
+    closeOnSelect = true,
+    className,
+    children,
+    onClick: consumerOnClick,
+    ...rest
+  },
   forwardedRef,
 ) {
   const ctx = useDropdownMenuContext('Item');
@@ -57,15 +77,24 @@ export const Item = forwardRef<HTMLDivElement, DropdownMenuItemProps>(function I
   const index = ctx.itemsRef.current.findIndex((x) => x.id === id);
   const isActive = index !== -1 && index === ctx.activeIndex;
 
-  const handleClick = (_e: MouseEvent) => {
+  const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     if (disabled) return;
+    // Run consumer's onClick first (e.g., injected by <Popover.Trigger> when
+    // this Item is wrapped as a popover trigger). Consumer can call
+    // `e.preventDefault()` to short-circuit the default onSelect+closeAll;
+    // otherwise we proceed.
+    consumerOnClick?.(e);
+    if (e.defaultPrevented) return;
     onSelect();
-    ctx.closeAll();
+    if (closeOnSelect) ctx.closeAll();
   };
 
   return (
     // {...rest} first so consumer-supplied props don't override the menuitem
     // ARIA contract (role/tabIndex/aria-disabled) or our event wiring.
+    // onClick is owned by Item — we chain the consumer's onClick inside
+    // handleClick instead of letting {...rest} spread it (it would be
+    // overridden anyway by the explicit onClick below).
     <div
       {...rest}
       ref={mergeRefs<HTMLDivElement>(itemRef, forwardedRef)}

--- a/packages/design-system/src/components/Popover/Close.tsx
+++ b/packages/design-system/src/components/Popover/Close.tsx
@@ -17,6 +17,16 @@ export interface PopoverCloseProps {
   children: ReactElement;
 }
 
+/**
+ * Wraps any single element with an onClick that closes the popover.
+ * Useful for "Cancel", "Apply", or "✕" buttons inside `<Popover.Content>`.
+ * Consumer's onClick chains and runs first.
+ *
+ * @example
+ * <Popover.Close>
+ *   <Button variant="secondary" size="sm">Cancel</Button>
+ * </Popover.Close>
+ */
 export function Close({ children }: PopoverCloseProps) {
   const ctx = usePopoverContext('Close');
 

--- a/packages/design-system/src/components/Popover/Close.tsx
+++ b/packages/design-system/src/components/Popover/Close.tsx
@@ -1,0 +1,41 @@
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  type MouseEvent as ReactMouseEvent,
+  type ReactElement,
+} from 'react';
+import { usePopoverContext } from './context';
+import { chain } from '../_internal/refs';
+
+export interface PopoverCloseProps {
+  /**
+   * Exactly one React element. The Close clones this element to inject an
+   * `onClick` that closes the popover, chained with the child's existing
+   * `onClick` (consumer runs first).
+   */
+  children: ReactElement;
+}
+
+export function Close({ children }: PopoverCloseProps) {
+  const ctx = usePopoverContext('Close');
+
+  if (!isValidElement(children)) {
+    throw new Error('<Popover.Close> requires exactly one React element child.');
+  }
+
+  const childProps = children.props as {
+    onClick?: (e: ReactMouseEvent<HTMLElement>) => void;
+  };
+
+  const handleClick = useCallback(
+    (_e: ReactMouseEvent<HTMLElement>) => {
+      ctx.closeAll();
+    },
+    [ctx],
+  );
+
+  return cloneElement(children, {
+    onClick: chain(childProps.onClick, handleClick),
+  } as object);
+}

--- a/packages/design-system/src/components/Popover/Content.tsx
+++ b/packages/design-system/src/components/Popover/Content.tsx
@@ -1,5 +1,14 @@
-import { forwardRef, useEffect, useLayoutEffect, type HTMLAttributes } from 'react';
+import { forwardRef, useEffect, useLayoutEffect, useRef, type HTMLAttributes } from 'react';
 import { createPortal } from 'react-dom';
+import {
+  arrow,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useFloating,
+  type Placement,
+} from '@floating-ui/react-dom';
 import clsx from 'clsx';
 import { usePopoverContext } from './context';
 import { mergeRefs } from '../_internal/refs';
@@ -22,29 +31,46 @@ export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function Content(
-  {
-    side: _side = 'bottom',
-    align: _align = 'center',
-    sideOffset: _sideOffset = 10,
-    minWidth: _minWidth,
-    className,
-    children,
-    ...rest
-  },
+  { side = 'bottom', align = 'center', sideOffset = 10, minWidth, className, children, ...rest },
   forwardedRef,
 ) {
   const ctx = usePopoverContext('Content');
+  const arrowRef = useRef<HTMLSpanElement | null>(null);
 
-  // Focus the panel on open. preventScroll: same reason DropdownMenu uses
-  // it — the portal renders at document origin before Floating UI positions
-  // it, focusing without preventScroll would yank the page.
+  const placement: Placement = (align === 'center' ? side : `${side}-${align}`) as Placement;
+
+  const {
+    refs,
+    floatingStyles,
+    placement: resolvedPlacement,
+    middlewareData,
+  } = useFloating({
+    open: ctx.open,
+    placement,
+    transform: false,
+    middleware: [
+      offset(sideOffset),
+      flip(),
+      shift({ padding: 8 }),
+      arrow({ element: arrowRef }),
+    ],
+    whileElementsMounted: autoUpdate,
+    elements: { reference: ctx.triggerRef.current },
+  });
+
+  const resolvedSide = resolvedPlacement.split('-')[0] as PopoverSide;
+  const staticSide = (
+    { top: 'bottom', bottom: 'top', left: 'right', right: 'left' } as const
+  )[resolvedSide];
+
+  // Focus the panel on open. preventScroll matches DropdownMenu/Tooltip.
   useLayoutEffect(() => {
     if (!ctx.open) return;
     queueMicrotask(() => ctx.contentRef.current?.focus({ preventScroll: true }));
   }, [ctx.open, ctx.contentRef]);
 
-  // Document Escape listener while open. Capture phase so it runs before
-  // focused widgets that may stopPropagation.
+  // Escape closes; capture phase fires before focused widgets that may
+  // stopPropagation.
   useEffect(() => {
     if (!ctx.open) return;
     const onKeyDown = (e: KeyboardEvent) => {
@@ -57,10 +83,7 @@ export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function 
     return () => document.removeEventListener('keydown', onKeyDown, true);
   }, [ctx.open, ctx.closeAll]);
 
-  // Outside-click: close if pointerdown lands outside the panel AND outside
-  // the trigger. Capture phase fires before focused widgets that may
-  // stopPropagation. The check uses contains() so clicks on descendants of
-  // the panel (e.g. a button inside) don't dismiss.
+  // Outside-click closes.
   useEffect(() => {
     if (!ctx.open) return;
     const onPointerDown = (e: PointerEvent) => {
@@ -78,20 +101,39 @@ export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function 
 
   if (!ctx.open) return null;
 
+  const arrowXY = middlewareData.arrow;
+  const minWidthStyle =
+    minWidth !== undefined
+      ? typeof minWidth === 'number'
+        ? `${minWidth}px`
+        : minWidth
+      : undefined;
+
   return createPortal(
     <div
       {...rest}
-      ref={mergeRefs(ctx.contentRef, forwardedRef)}
+      ref={mergeRefs(ctx.contentRef, refs.setFloating, forwardedRef)}
       id={ctx.contentId}
       role="dialog"
       aria-modal="false"
       aria-labelledby={ctx.headingId ?? undefined}
       tabIndex={-1}
-      data-side="bottom"
+      data-side={resolvedSide}
       data-popover-content=""
+      style={{ ...floatingStyles, minWidth: minWidthStyle }}
       className={clsx(styles.content, className)}
     >
       {children}
+      <span
+        ref={arrowRef}
+        aria-hidden="true"
+        className={styles.arrow}
+        style={{
+          left: typeof arrowXY?.x === 'number' ? `${arrowXY.x}px` : undefined,
+          top: typeof arrowXY?.y === 'number' ? `${arrowXY.y}px` : undefined,
+          [staticSide]: '-6px',
+        }}
+      />
     </div>,
     document.body,
   );

--- a/packages/design-system/src/components/Popover/Content.tsx
+++ b/packages/design-system/src/components/Popover/Content.tsx
@@ -1,0 +1,59 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import { createPortal } from 'react-dom';
+import clsx from 'clsx';
+import { usePopoverContext } from './context';
+import { mergeRefs } from '../_internal/refs';
+import styles from './Popover.module.scss';
+
+/** Which side of the trigger the popover prefers. Floating UI auto-flips on collision. */
+export type PopoverSide = 'top' | 'right' | 'bottom' | 'left';
+/** Which edge of the popover aligns to the corresponding trigger edge. */
+export type PopoverAlign = 'start' | 'center' | 'end';
+
+export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {
+  /** Preferred side. Default `'bottom'`. Auto-flips on collision via Floating UI. */
+  side?: PopoverSide;
+  /** Edge alignment. Default `'center'`. */
+  align?: PopoverAlign;
+  /** Gap in px between trigger and panel. Default `10` (room for the arrow). */
+  sideOffset?: number;
+  /** Minimum width in px or any CSS length. Defaults to `--size-popover-min-width` (220). */
+  minWidth?: number | string;
+}
+
+export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function Content(
+  {
+    side: _side = 'bottom',
+    align: _align = 'center',
+    sideOffset: _sideOffset = 10,
+    minWidth: _minWidth,
+    className,
+    children,
+    ...rest
+  },
+  forwardedRef,
+) {
+  const ctx = usePopoverContext('Content');
+
+  // Floating UI integration lands in Task 9. For now the panel is portaled
+  // with no positioning — useful only for verifying ARIA + structure.
+  if (!ctx.open) return null;
+
+  return createPortal(
+    <div
+      {...rest}
+      ref={mergeRefs(ctx.contentRef, forwardedRef)}
+      id={ctx.contentId}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={ctx.headingId ?? undefined}
+      tabIndex={-1}
+      data-side="bottom"
+      data-popover-content=""
+      className={clsx(styles.content, className)}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+});

--- a/packages/design-system/src/components/Popover/Content.tsx
+++ b/packages/design-system/src/components/Popover/Content.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type HTMLAttributes } from 'react';
+import { forwardRef, useEffect, useLayoutEffect, type HTMLAttributes } from 'react';
 import { createPortal } from 'react-dom';
 import clsx from 'clsx';
 import { usePopoverContext } from './context';
@@ -35,8 +35,28 @@ export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function 
 ) {
   const ctx = usePopoverContext('Content');
 
-  // Floating UI integration lands in Task 9. For now the panel is portaled
-  // with no positioning — useful only for verifying ARIA + structure.
+  // Focus the panel on open. preventScroll: same reason DropdownMenu uses
+  // it — the portal renders at document origin before Floating UI positions
+  // it, focusing without preventScroll would yank the page.
+  useLayoutEffect(() => {
+    if (!ctx.open) return;
+    queueMicrotask(() => ctx.contentRef.current?.focus({ preventScroll: true }));
+  }, [ctx.open, ctx.contentRef]);
+
+  // Document Escape listener while open. Capture phase so it runs before
+  // focused widgets that may stopPropagation.
+  useEffect(() => {
+    if (!ctx.open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        ctx.closeAll();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [ctx.open, ctx.closeAll]);
+
   if (!ctx.open) return null;
 
   return createPortal(

--- a/packages/design-system/src/components/Popover/Content.tsx
+++ b/packages/design-system/src/components/Popover/Content.tsx
@@ -57,6 +57,25 @@ export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function 
     return () => document.removeEventListener('keydown', onKeyDown, true);
   }, [ctx.open, ctx.closeAll]);
 
+  // Outside-click: close if pointerdown lands outside the panel AND outside
+  // the trigger. Capture phase fires before focused widgets that may
+  // stopPropagation. The check uses contains() so clicks on descendants of
+  // the panel (e.g. a button inside) don't dismiss.
+  useEffect(() => {
+    if (!ctx.open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      const panel = ctx.contentRef.current;
+      const trigger = ctx.triggerRef.current;
+      if (panel && panel.contains(target)) return;
+      if (trigger && trigger.contains(target)) return;
+      ctx.setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [ctx.open, ctx.contentRef, ctx.triggerRef, ctx.setOpen]);
+
   if (!ctx.open) return null;
 
   return createPortal(

--- a/packages/design-system/src/components/Popover/Content.tsx
+++ b/packages/design-system/src/components/Popover/Content.tsx
@@ -122,7 +122,7 @@ export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function 
   return createPortal(
     <div
       {...rest}
-      ref={mergeRefs(ctx.contentRef, refs.setFloating, forwardedRef)}
+      ref={mergeRefs<HTMLDivElement>(ctx.contentRef, refs.setFloating, forwardedRef)}
       id={ctx.contentId}
       role="dialog"
       aria-modal="false"

--- a/packages/design-system/src/components/Popover/Content.tsx
+++ b/packages/design-system/src/components/Popover/Content.tsx
@@ -14,7 +14,7 @@ import { usePopoverContext } from './context';
 import { mergeRefs } from '../_internal/refs';
 import styles from './Popover.module.scss';
 
-/** Which side of the trigger the popover prefers. Floating UI auto-flips on collision. */
+/** Which side of the trigger the popover prefers. Floating UI auto-flips if it doesn't fit. */
 export type PopoverSide = 'top' | 'right' | 'bottom' | 'left';
 /** Which edge of the popover aligns to the corresponding trigger edge. */
 export type PopoverAlign = 'start' | 'center' | 'end';
@@ -26,10 +26,20 @@ export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {
   align?: PopoverAlign;
   /** Gap in px between trigger and panel. Default `10` (room for the arrow). */
   sideOffset?: number;
-  /** Minimum width in px or any CSS length. Defaults to `--size-popover-min-width` (220). */
+  /**
+   * Minimum width in px or any CSS length. Defaults to the token
+   * `--size-popover-min-width` (220px) applied via SCSS.
+   */
   minWidth?: number | string;
 }
 
+/**
+ * The floating panel itself. Portaled to `document.body`, positioned by
+ * Floating UI (auto-flip, viewport-aware), animated via `@starting-style`
+ * on open. `role="dialog"`, `aria-modal="false"`, `tabIndex={-1}` so it
+ * can receive focus on open. Renders an aria-hidden arrow that tracks
+ * the trigger.
+ */
 export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function Content(
   { side = 'bottom', align = 'center', sideOffset = 10, minWidth, className, children, ...rest },
   forwardedRef,

--- a/packages/design-system/src/components/Popover/Content.tsx
+++ b/packages/design-system/src/components/Popover/Content.tsx
@@ -58,20 +58,15 @@ export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function 
     open: ctx.open,
     placement,
     transform: false,
-    middleware: [
-      offset(sideOffset),
-      flip(),
-      shift({ padding: 8 }),
-      arrow({ element: arrowRef }),
-    ],
+    middleware: [offset(sideOffset), flip(), shift({ padding: 8 }), arrow({ element: arrowRef })],
     whileElementsMounted: autoUpdate,
     elements: { reference: ctx.triggerRef.current },
   });
 
   const resolvedSide = resolvedPlacement.split('-')[0] as PopoverSide;
-  const staticSide = (
-    { top: 'bottom', bottom: 'top', left: 'right', right: 'left' } as const
-  )[resolvedSide];
+  const staticSide = ({ top: 'bottom', bottom: 'top', left: 'right', right: 'left' } as const)[
+    resolvedSide
+  ];
 
   // Focus the panel on open. preventScroll matches DropdownMenu/Tooltip.
   useLayoutEffect(() => {

--- a/packages/design-system/src/components/Popover/Heading.tsx
+++ b/packages/design-system/src/components/Popover/Heading.tsx
@@ -1,0 +1,25 @@
+import { createElement, useId, useLayoutEffect, type HTMLAttributes } from 'react';
+import { usePopoverContext } from './context';
+import { sanitizeId } from '../_internal/refs';
+
+export interface PopoverHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
+  /** Heading level. Defaults to `'h3'`. */
+  as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
+export function Heading({ as = 'h3', id: idProp, children, ...rest }: PopoverHeadingProps) {
+  const ctx = usePopoverContext('Heading');
+  const reactId = useId();
+  const id = idProp ?? `popover-heading-${sanitizeId(reactId)}`;
+
+  useLayoutEffect(() => {
+    ctx.setHeadingId(id);
+    return () => ctx.setHeadingId(null);
+    // ctx.setHeadingId is stable per Popover instance; id changes only if
+    // consumer provides one — re-fire is correct in that case.
+  }, [ctx.setHeadingId, id]);
+
+  // `createElement` keeps the dynamic tag type-safe across h2–h6 without
+  // tripping JSX.IntrinsicElements' SVG-tag variance issue.
+  return createElement(as, { id, ...rest }, children);
+}

--- a/packages/design-system/src/components/Popover/Heading.tsx
+++ b/packages/design-system/src/components/Popover/Heading.tsx
@@ -3,10 +3,24 @@ import { usePopoverContext } from './context';
 import { sanitizeId } from '../_internal/refs';
 
 export interface PopoverHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
-  /** Heading level. Defaults to `'h3'`. */
+  /**
+   * Heading level. Defaults to `'h3'`. Pick the level that fits the
+   * surrounding document outline (Popover content is usually a level 3
+   * inside a level 2 section).
+   */
   as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
 
+/**
+ * Renders a semantic heading element (default `h3`) and registers its
+ * auto-generated id via context so `<Popover.Content>` can wire
+ * `aria-labelledby` to it. The registration unsubscribes on unmount.
+ *
+ * @example
+ * <Popover.Content>
+ *   <Popover.Heading>Filter results</Popover.Heading>
+ * </Popover.Content>
+ */
 export function Heading({ as = 'h3', id: idProp, children, ...rest }: PopoverHeadingProps) {
   const ctx = usePopoverContext('Heading');
   const reactId = useId();

--- a/packages/design-system/src/components/Popover/Popover.module.scss
+++ b/packages/design-system/src/components/Popover/Popover.module.scss
@@ -1,8 +1,103 @@
-/* stylelint-disable block-no-empty */
-// Chrome + animation rules land in Task 9. Empty placeholders for now so
-// the import resolves and CSS-Modules generates class hooks.
+// `.content` carries chrome + the open-only scale-fade entrance. The animation
+// (transition + @starting-style + per-side transform-origin) relies on
+// Floating UI being in `transform: false` mode (see Content.tsx) so the CSS
+// `transform` property is free for the entrance.
 .content {
+  position: relative;
+  min-width: var(--size-popover-min-width);
+  max-width: 360px;
+  padding: var(--space-3);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: var(--z-popover);
+  outline: none;
+
+  // Explicit so each per-side @starting-style transform has a defined
+  // resting target to interpolate to.
+  transform: none;
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base);
+
+  @starting-style {
+    opacity: var(--opacity-hidden);
+  }
 }
+
 .arrow {
+  position: absolute;
+  width: var(--space-3);
+  height: var(--space-3);
+  background: var(--color-bg);
+  border-right: var(--border-width) solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
+  transform: rotate(45deg);
+  pointer-events: none;
 }
-/* stylelint-enable block-no-empty */
+
+// Each data-side rotates the arrow so the "visible" two borders face outward
+// (i.e. away from the panel chrome). The default rule above uses bottom +
+// right borders (panel above trigger → arrow pokes downward), which matches
+// data-side='top'. Override for the other three sides:
+.content[data-side='bottom'] .arrow {
+  border-top: var(--border-width) solid var(--color-border);
+  border-left: var(--border-width) solid var(--color-border);
+  border-right: 0;
+  border-bottom: 0;
+}
+
+.content[data-side='left'] .arrow {
+  border-top: var(--border-width) solid var(--color-border);
+  border-right: var(--border-width) solid var(--color-border);
+  border-bottom: 0;
+  border-left: 0;
+}
+
+.content[data-side='right'] .arrow {
+  border-bottom: var(--border-width) solid var(--color-border);
+  border-left: var(--border-width) solid var(--color-border);
+  border-top: 0;
+  border-right: 0;
+}
+
+// --- Open-only entrance: per-side origin + starting transform -----------
+.content[data-side='top'] {
+  transform-origin: bottom center;
+
+  @starting-style {
+    transform: scale(0.95) translateY(4px);
+  }
+}
+
+.content[data-side='bottom'] {
+  transform-origin: top center;
+
+  @starting-style {
+    transform: scale(0.95) translateY(-4px);
+  }
+}
+
+.content[data-side='left'] {
+  transform-origin: right center;
+
+  @starting-style {
+    transform: scale(0.95) translateX(4px);
+  }
+}
+
+.content[data-side='right'] {
+  transform-origin: left center;
+
+  @starting-style {
+    transform: scale(0.95) translateX(-4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .content {
+    transition: none;
+  }
+}

--- a/packages/design-system/src/components/Popover/Popover.module.scss
+++ b/packages/design-system/src/components/Popover/Popover.module.scss
@@ -1,0 +1,8 @@
+/* stylelint-disable block-no-empty */
+// Chrome + animation rules land in Task 9. Empty placeholders for now so
+// the import resolves and CSS-Modules generates class hooks.
+.content {
+}
+.arrow {
+}
+/* stylelint-enable block-no-empty */

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -194,3 +194,64 @@ describe('Popover.Heading', () => {
     expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-labelledby');
   });
 });
+
+describe('Popover.Close', () => {
+  it('clicking the wrapped child closes the popover', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Close>
+            <button type="button">Done</button>
+          </Popover.Close>
+        </Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('chains the consumer onClick (consumer first, then close)', async () => {
+    const user = userEvent.setup();
+    const consumer = vi.fn();
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Close>
+            <button type="button" onClick={consumer}>
+              Done
+            </button>
+          </Popover.Close>
+        </Popover.Content>
+      </Popover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+    expect(consumer).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('throws when children is not a valid React element', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      render(
+        <Popover defaultOpen>
+          <Popover.Trigger>
+            <button type="button">Open</button>
+          </Popover.Trigger>
+          <Popover.Content>
+            {/* @ts-expect-error — intentionally invalid */}
+            <Popover.Close>{null}</Popover.Close>
+          </Popover.Content>
+        </Popover>,
+      ),
+    ).toThrow(/exactly one React element/);
+    spy.mockRestore();
+  });
+});

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { Popover } from './Popover';
+
+describe('Popover — initial render', () => {
+  it('renders nothing portaled on mount when defaultOpen is false', () => {
+    render(
+      <Popover>
+        <div data-testid="children-marker">trigger and content go here later</div>
+      </Popover>,
+    );
+    expect(screen.getByTestId('children-marker')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Popover } from './Popover';
 
 describe('Popover — initial render', () => {
@@ -10,5 +11,82 @@ describe('Popover — initial render', () => {
     );
     expect(screen.getByTestId('children-marker')).toBeInTheDocument();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+
+describe('Popover.Trigger', () => {
+  it('renders its child unchanged and sets aria-haspopup="dialog" and aria-expanded="false"', () => {
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+      </Popover>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('toggles aria-expanded on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+      </Popover>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('opens on Enter or Space when focused', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+      </Popover>,
+    );
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Open' })).toHaveFocus();
+    await user.keyboard('{Enter}');
+    expect(screen.getByRole('button', { name: 'Open' })).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('throws a clear error when children is not a valid React element', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      render(
+        <Popover>
+          {/* @ts-expect-error — intentionally invalid */}
+          <Popover.Trigger>{null}</Popover.Trigger>
+        </Popover>,
+      ),
+    ).toThrow(/exactly one React element/);
+    spy.mockRestore();
+  });
+
+  it('chains consumer onClick (consumer runs first)', async () => {
+    const user = userEvent.setup();
+    const consumer = vi.fn();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button" onClick={consumer}>
+            Open
+          </button>
+        </Popover.Trigger>
+      </Popover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(consumer).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -472,4 +472,25 @@ describe('Popover — cleanup + Tab traversal', () => {
     const trigger = screen.getByTestId('t');
     expect(trigger).toHaveClass('consumer');
   });
+
+  it('Trigger click does not bubble to ancestor click handlers', async () => {
+    // Locks in the fix for "<ConfirmationPopover> inside <DropdownMenu.Item>
+    // closes the dropdown instead of opening the popover" — the trigger
+    // should consume the click and not let it bubble to an ancestor.
+    const user = userEvent.setup();
+    const ancestorClick = vi.fn();
+    render(
+      <div onClick={ancestorClick}>
+        <Popover>
+          <Popover.Trigger>
+            <button type="button">Open</button>
+          </Popover.Trigger>
+          <Popover.Content>panel body</Popover.Content>
+        </Popover>
+      </div>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(ancestorClick).not.toHaveBeenCalled();
+  });
 });

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Popover } from './Popover';
 
@@ -253,5 +253,41 @@ describe('Popover.Close', () => {
       ),
     ).toThrow(/exactly one React element/);
     spy.mockRestore();
+  });
+});
+
+describe('Popover — focus + Escape', () => {
+  it('moves focus to the panel when opened', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(document.activeElement).toBe(screen.getByRole('dialog'));
+  });
+
+  it('Escape closes the popover and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    await user.click(trigger);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(trigger);
   });
 });

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -347,3 +347,52 @@ describe('Popover — outside click dismissal', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 });
+
+describe('Popover — Floating UI positioning + arrow', () => {
+  beforeEach(() => {
+    window.ResizeObserver = class ResizeObserverMock {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  });
+
+  it('data-side reflects the configured side (default bottom)', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog').getAttribute('data-side')).toBe('bottom');
+  });
+
+  it('respects side="top"', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content side="top">panel body</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog').getAttribute('data-side')).toBe('top');
+  });
+
+  it('renders an arrow span with aria-hidden inside the panel', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const panel = screen.getByRole('dialog');
+    const arrow = panel.querySelector('span[aria-hidden="true"]');
+    expect(arrow).not.toBeNull();
+    expect((arrow as HTMLElement).className).toMatch(/arrow/);
+  });
+});

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -90,3 +90,48 @@ describe('Popover.Trigger', () => {
     expect(consumer).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('Popover.Content — minimal portal', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders the panel as a portaled dialog when defaultOpen', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const panel = screen.getByRole('dialog');
+    expect(panel).toHaveTextContent('panel body');
+    expect(panel).toHaveAttribute('aria-modal', 'false');
+    expect(panel).toHaveAttribute('tabIndex', '-1');
+    // Portaled to document.body, NOT inside the test container.
+    expect(document.body.contains(panel)).toBe(true);
+  });
+
+  it('panel id matches the trigger aria-controls when open', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    const panel = screen.getByRole('dialog');
+    expect(trigger.getAttribute('aria-controls')).toBe(panel.id);
+  });
+});

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -291,3 +291,59 @@ describe('Popover — focus + Escape', () => {
     expect(document.activeElement).toBe(trigger);
   });
 });
+
+describe('Popover — outside click dismissal', () => {
+  it('closes when pointerdown fires outside the panel and outside the trigger', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <Popover>
+          <Popover.Trigger>
+            <button type="button">Open</button>
+          </Popover.Trigger>
+          <Popover.Content>panel body</Popover.Content>
+        </Popover>
+        <div data-testid="elsewhere">elsewhere</div>
+      </>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.pointer({ keys: '[MouseLeft>]', target: screen.getByTestId('elsewhere') });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('does NOT close when pointerdown fires inside the panel', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <div data-testid="inside">panel body</div>
+        </Popover.Content>
+      </Popover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.pointer({ keys: '[MouseLeft>]', target: screen.getByTestId('inside') });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('does NOT close when pointerdown fires on the trigger (trigger toggles it)', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    await user.click(trigger);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.click(trigger);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -405,3 +405,71 @@ describe('Popover — animation contract', () => {
     expect(scss).toMatch(/\.content\s*{[\s\S]*@starting-style/);
   });
 });
+
+describe('Popover — cleanup + Tab traversal', () => {
+  it('removes document-level listeners on unmount while open', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const { unmount } = render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    unmount();
+    expect(removeSpy.mock.calls.some(([type]) => type === 'pointerdown')).toBe(true);
+    expect(removeSpy.mock.calls.some(([type]) => type === 'keydown')).toBe(true);
+    removeSpy.mockRestore();
+  });
+
+  it('Tab from inside the panel walks past the panel; popover stays open (no focus trap)', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <Popover defaultOpen>
+          <Popover.Trigger>
+            <button type="button">Open</button>
+          </Popover.Trigger>
+          <Popover.Content>
+            <button type="button">inside-1</button>
+          </Popover.Content>
+        </Popover>
+        <button type="button">after</button>
+      </>,
+    );
+
+    // The panel itself has focus on open; Tab moves to the first focusable inside (inside-1).
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'inside-1' })).toHaveFocus();
+
+    // Another Tab walks out of the panel. Because Content portals to document.body
+    // (the end of the body), the panel's contents are last in document order — so
+    // Tab from inside-1 wraps past the panel rather than cycling back inside it.
+    // The exact next-focused element is JSDOM-specific; the contract we lock in
+    // is that focus LEAVES the panel and the popover stays open.
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'inside-1' })).not.toHaveFocus();
+    expect(screen.getByRole('dialog')).not.toContainElement(
+      document.activeElement as HTMLElement | null,
+    );
+
+    // Popover stays open (no focus trap).
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('preserves consumer props on the cloned trigger (className, data-*)', () => {
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type="button" className="consumer" data-testid="t">
+            Open
+          </button>
+        </Popover.Trigger>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const trigger = screen.getByTestId('t');
+    expect(trigger).toHaveClass('consumer');
+  });
+});

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -135,3 +135,62 @@ describe('Popover.Content — minimal portal', () => {
     expect(trigger.getAttribute('aria-controls')).toBe(panel.id);
   });
 });
+
+describe('Popover.Heading', () => {
+  it('renders as h3 by default with an auto id', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Heading>Filters</Popover.Heading>
+        </Popover.Content>
+      </Popover>,
+    );
+    const heading = screen.getByRole('heading', { name: 'Filters', level: 3 });
+    expect(heading.id).toMatch(/^popover-heading-/);
+  });
+
+  it('respects the `as` prop', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Heading as="h2">Filters</Popover.Heading>
+        </Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('heading', { name: 'Filters', level: 2 })).toBeInTheDocument();
+  });
+
+  it('wires aria-labelledby on Content to the heading id', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Heading>Filters</Popover.Heading>
+        </Popover.Content>
+      </Popover>,
+    );
+    const dialog = screen.getByRole('dialog');
+    const heading = screen.getByRole('heading', { name: 'Filters' });
+    expect(dialog.getAttribute('aria-labelledby')).toBe(heading.id);
+  });
+
+  it('Content has no aria-labelledby when no Heading is present', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>plain body</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-labelledby');
+  });
+});

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Popover } from './Popover';
@@ -394,5 +396,12 @@ describe('Popover — Floating UI positioning + arrow', () => {
     const arrow = panel.querySelector('span[aria-hidden="true"]');
     expect(arrow).not.toBeNull();
     expect((arrow as HTMLElement).className).toMatch(/arrow/);
+  });
+});
+
+describe('Popover — animation contract', () => {
+  it('the compiled .content rule contains an @starting-style block', () => {
+    const scss = readFileSync(resolve(__dirname, './Popover.module.scss'), 'utf8');
+    expect(scss).toMatch(/\.content\s*{[\s\S]*@starting-style/);
   });
 });

--- a/packages/design-system/src/components/Popover/Popover.tsx
+++ b/packages/design-system/src/components/Popover/Popover.tsx
@@ -1,0 +1,7 @@
+import { PopoverRoot } from './PopoverRoot';
+
+// Sub-component re-exports are wired in later tasks; for now Popover is just
+// the Root function. The namespace assembly grows as each sub-component
+// lands. The final shape (post-task-7) will be:
+//   Popover.Trigger, Popover.Content, Popover.Heading, Popover.Close
+export const Popover = PopoverRoot;

--- a/packages/design-system/src/components/Popover/Popover.tsx
+++ b/packages/design-system/src/components/Popover/Popover.tsx
@@ -1,11 +1,14 @@
 import { PopoverRoot } from './PopoverRoot';
 import { Trigger } from './Trigger';
+import { Content } from './Content';
 
 type PopoverNamespace = typeof PopoverRoot & {
   Trigger: typeof Trigger;
+  Content: typeof Content;
 };
 
 const Popover = PopoverRoot as PopoverNamespace;
 Popover.Trigger = Trigger;
+Popover.Content = Content;
 
 export { Popover };

--- a/packages/design-system/src/components/Popover/Popover.tsx
+++ b/packages/design-system/src/components/Popover/Popover.tsx
@@ -2,16 +2,19 @@ import { PopoverRoot } from './PopoverRoot';
 import { Trigger } from './Trigger';
 import { Content } from './Content';
 import { Heading } from './Heading';
+import { Close } from './Close';
 
 type PopoverNamespace = typeof PopoverRoot & {
   Trigger: typeof Trigger;
   Content: typeof Content;
   Heading: typeof Heading;
+  Close: typeof Close;
 };
 
 const Popover = PopoverRoot as PopoverNamespace;
 Popover.Trigger = Trigger;
 Popover.Content = Content;
 Popover.Heading = Heading;
+Popover.Close = Close;
 
 export { Popover };

--- a/packages/design-system/src/components/Popover/Popover.tsx
+++ b/packages/design-system/src/components/Popover/Popover.tsx
@@ -1,7 +1,11 @@
 import { PopoverRoot } from './PopoverRoot';
+import { Trigger } from './Trigger';
 
-// Sub-component re-exports are wired in later tasks; for now Popover is just
-// the Root function. The namespace assembly grows as each sub-component
-// lands. The final shape (post-task-7) will be:
-//   Popover.Trigger, Popover.Content, Popover.Heading, Popover.Close
-export const Popover = PopoverRoot;
+type PopoverNamespace = typeof PopoverRoot & {
+  Trigger: typeof Trigger;
+};
+
+const Popover = PopoverRoot as PopoverNamespace;
+Popover.Trigger = Trigger;
+
+export { Popover };

--- a/packages/design-system/src/components/Popover/Popover.tsx
+++ b/packages/design-system/src/components/Popover/Popover.tsx
@@ -1,14 +1,17 @@
 import { PopoverRoot } from './PopoverRoot';
 import { Trigger } from './Trigger';
 import { Content } from './Content';
+import { Heading } from './Heading';
 
 type PopoverNamespace = typeof PopoverRoot & {
   Trigger: typeof Trigger;
   Content: typeof Content;
+  Heading: typeof Heading;
 };
 
 const Popover = PopoverRoot as PopoverNamespace;
 Popover.Trigger = Trigger;
 Popover.Content = Content;
+Popover.Heading = Heading;
 
 export { Popover };

--- a/packages/design-system/src/components/Popover/PopoverRoot.tsx
+++ b/packages/design-system/src/components/Popover/PopoverRoot.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useId, useRef, useState, type ReactNode } from 'react';
+import { PopoverContext, type PopoverContextValue } from './context';
+import { sanitizeId } from '../_internal/refs';
+
+export interface PopoverProps {
+  /** Must contain exactly one `<Popover.Trigger>` and one `<Popover.Content>`. */
+  children: ReactNode;
+  /** Controlled open state. Provide alongside `onOpenChange`. */
+  open?: boolean;
+  /** Fired whenever Popover wants to change open state. Required when `open` is provided. */
+  onOpenChange?: (open: boolean) => void;
+  /** Default open state for uncontrolled usage. Defaults to `false`. */
+  defaultOpen?: boolean;
+  /**
+   * Reserved future hint. v1 ignores the value and always renders non-modal.
+   * Will gate focus-trap + inert background once `<Modal>` lands.
+   */
+  modal?: boolean;
+}
+
+export function PopoverRoot({
+  children,
+  open: controlledOpen,
+  onOpenChange,
+  defaultOpen = false,
+  modal: _modal = false,
+}: PopoverProps) {
+  const isControlled = controlledOpen !== undefined;
+  const [uncontrolled, setUncontrolled] = useState(defaultOpen);
+  const open = isControlled ? (controlledOpen as boolean) : uncontrolled;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      onOpenChange?.(next);
+      if (!isControlled) setUncontrolled(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const reactId = useId();
+  const contentId = `popover-${sanitizeId(reactId)}`;
+  const [headingId, setHeadingId] = useState<string | null>(null);
+
+  const closeAll = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus({ preventScroll: true });
+  }, [setOpen]);
+
+  const value: PopoverContextValue = {
+    open,
+    setOpen,
+    triggerRef,
+    contentRef,
+    contentId,
+    headingId,
+    setHeadingId,
+    closeAll,
+  };
+
+  return <PopoverContext.Provider value={value}>{children}</PopoverContext.Provider>;
+}

--- a/packages/design-system/src/components/Popover/PopoverRoot.tsx
+++ b/packages/design-system/src/components/Popover/PopoverRoot.tsx
@@ -3,9 +3,16 @@ import { PopoverContext, type PopoverContextValue } from './context';
 import { sanitizeId } from '../_internal/refs';
 
 export interface PopoverProps {
-  /** Must contain exactly one `<Popover.Trigger>` and one `<Popover.Content>`. */
+  /**
+   * Must contain exactly one `<Popover.Trigger>` and one `<Popover.Content>`.
+   * `<Popover.Heading>` and `<Popover.Close>` are optional and may appear
+   * anywhere inside `<Popover.Content>`.
+   */
   children: ReactNode;
-  /** Controlled open state. Provide alongside `onOpenChange`. */
+  /**
+   * Controlled open state. Provide alongside `onOpenChange` to drive open
+   * externally. Omit both to let Popover own its state (the common case).
+   */
   open?: boolean;
   /** Fired whenever Popover wants to change open state. Required when `open` is provided. */
   onOpenChange?: (open: boolean) => void;
@@ -13,11 +20,65 @@ export interface PopoverProps {
   defaultOpen?: boolean;
   /**
    * Reserved future hint. v1 ignores the value and always renders non-modal.
-   * Will gate focus-trap + inert background once `<Modal>` lands.
+   * Will gate focus-trap + inert-background once `<Modal>` lands.
    */
   modal?: boolean;
 }
 
+/**
+ * Non-modal floating panel that opens from a trigger and contains arbitrary
+ * interactive content. Compound API — pair `<Trigger>`, `<Content>`,
+ * optionally `<Heading>` and `<Close>`, as direct or nested children.
+ *
+ * Implements the WAI-ARIA non-modal dialog pattern: `role="dialog"` on
+ * Content, `aria-haspopup="dialog"` on Trigger, focus moves to the panel
+ * on open, Tab traverses out of the panel into the page behind, click
+ * outside or Escape dismisses. Page is NOT inert. Tooltip-grade animation
+ * via `@starting-style`.
+ *
+ * @example
+ * <Popover>
+ *   <Popover.Trigger>
+ *     <Button variant="secondary">Filters</Button>
+ *   </Popover.Trigger>
+ *   <Popover.Content>
+ *     <Stack gap="sm">
+ *       <Popover.Heading>Filter results</Popover.Heading>
+ *       <Cluster justify="end" gap="sm">
+ *         <Popover.Close>
+ *           <Button variant="secondary" size="sm">Cancel</Button>
+ *         </Popover.Close>
+ *         <Popover.Close>
+ *           <Button size="sm" onClick={apply}>Apply</Button>
+ *         </Popover.Close>
+ *       </Cluster>
+ *     </Stack>
+ *   </Popover.Content>
+ * </Popover>
+ *
+ * @example
+ * // Controlled (rare — usually let Popover manage state):
+ * const [open, setOpen] = useState(false);
+ * <Popover open={open} onOpenChange={setOpen}>…</Popover>
+ *
+ * @remarks When NOT to use
+ * - For a passive hint on hover/focus → use `<Tooltip>`.
+ * - For a list of actions → use `<DropdownMenu>`.
+ * - For a focus-locked confirmation that demands full attention → use
+ *   `<Modal>` (not yet shipped) once available; until then, `<Popover>`
+ *   with explicit Confirm/Cancel buttons is acceptable.
+ *
+ * @remarks Anti-patterns
+ * - ❌ `<Popover.Trigger><Button disabled>…</Button></Popover.Trigger>` —
+ *   disabled buttons do not fire click. Use `aria-disabled="true"` +
+ *   intercept the click, or wrap in `<span>`.
+ * - ❌ `<Popover.Content>` with no `<Popover.Close>` button AND content
+ *   that isn't obviously dismissable by clicking outside — keyboard /
+ *   screen-reader users get no clear close affordance. Add `<Popover.Close>`
+ *   or rely on outside-click only when the popover is small and obvious.
+ * - ❌ Multiple `<Popover.Heading>` instances inside one `<Popover.Content>`
+ *   — second mount overwrites `aria-labelledby`. Use one Heading per Popover.
+ */
 export function PopoverRoot({
   children,
   open: controlledOpen,

--- a/packages/design-system/src/components/Popover/Trigger.tsx
+++ b/packages/design-system/src/components/Popover/Trigger.tsx
@@ -45,8 +45,14 @@ export function Trigger({ children }: PopoverTriggerProps) {
     onKeyDown?: (e: ReactKeyboardEvent<HTMLElement>) => void;
   };
 
+  // stopPropagation: prevents the click from bubbling to an ancestor that
+  // might also act on it (e.g., a <DropdownMenu.Item> whose onClick fires
+  // onSelect and closes the menu, which would unmount this Popover before
+  // it gets a chance to open). The trigger's job is to consume the click;
+  // nothing meaningful should run on parents.
   const handleClick = useCallback(
-    (_e: ReactMouseEvent<HTMLElement>) => {
+    (e: ReactMouseEvent<HTMLElement>) => {
+      e.stopPropagation();
       ctx.setOpen(!ctx.open);
     },
     [ctx],
@@ -57,6 +63,7 @@ export function Trigger({ children }: PopoverTriggerProps) {
       if (ctx.open) return;
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
+        e.stopPropagation();
         ctx.setOpen(true);
       }
     },

--- a/packages/design-system/src/components/Popover/Trigger.tsx
+++ b/packages/design-system/src/components/Popover/Trigger.tsx
@@ -21,6 +21,17 @@ export interface PopoverTriggerProps {
   children: ReactElement;
 }
 
+/**
+ * Clones its single child element to inject ref + ARIA + the click handler
+ * that toggles the popover. Child must accept a ref (`forwardRef` if it's
+ * a custom component; raw `<button>` or this library's `<Button>` both
+ * qualify).
+ *
+ * @example
+ * <Popover.Trigger>
+ *   <Button variant="secondary">Filters</Button>
+ * </Popover.Trigger>
+ */
 export function Trigger({ children }: PopoverTriggerProps) {
   const ctx = usePopoverContext('Trigger');
 

--- a/packages/design-system/src/components/Popover/Trigger.tsx
+++ b/packages/design-system/src/components/Popover/Trigger.tsx
@@ -1,0 +1,63 @@
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactElement,
+  type Ref,
+} from 'react';
+import { usePopoverContext } from './context';
+import { chain, mergeRefs } from '../_internal/refs';
+
+export interface PopoverTriggerProps {
+  /**
+   * Exactly one React element that accepts a ref. The Trigger clones this
+   * element to inject `aria-haspopup="dialog"`, `aria-expanded`,
+   * `aria-controls`, a click handler that toggles the popover, and a keydown
+   * handler that opens on Enter/Space. `<Button>` and raw `<button>` both
+   * qualify; a custom component without `forwardRef` does not.
+   */
+  children: ReactElement;
+}
+
+export function Trigger({ children }: PopoverTriggerProps) {
+  const ctx = usePopoverContext('Trigger');
+
+  if (!isValidElement(children)) {
+    throw new Error('<Popover.Trigger> requires exactly one React element child.');
+  }
+
+  const childProps = children.props as {
+    ref?: Ref<HTMLElement>;
+    onClick?: (e: ReactMouseEvent<HTMLElement>) => void;
+    onKeyDown?: (e: ReactKeyboardEvent<HTMLElement>) => void;
+  };
+
+  const handleClick = useCallback(
+    (_e: ReactMouseEvent<HTMLElement>) => {
+      ctx.setOpen(!ctx.open);
+    },
+    [ctx],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLElement>) => {
+      if (ctx.open) return;
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        ctx.setOpen(true);
+      }
+    },
+    [ctx],
+  );
+
+  return cloneElement(children, {
+    ref: mergeRefs(ctx.triggerRef, childProps.ref),
+    'aria-haspopup': 'dialog',
+    'aria-expanded': ctx.open,
+    'aria-controls': ctx.open ? ctx.contentId : undefined,
+    onClick: chain(childProps.onClick, handleClick),
+    onKeyDown: chain(childProps.onKeyDown, handleKeyDown),
+  } as object);
+}

--- a/packages/design-system/src/components/Popover/context.ts
+++ b/packages/design-system/src/components/Popover/context.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext, type RefObject } from 'react';
+
+export interface PopoverContextValue {
+  open: boolean;
+  setOpen: (next: boolean) => void;
+  triggerRef: RefObject<HTMLElement | null>;
+  contentRef: RefObject<HTMLDivElement | null>;
+  contentId: string;
+  headingId: string | null;
+  setHeadingId: (id: string | null) => void;
+  closeAll: () => void;
+}
+
+export const PopoverContext = createContext<PopoverContextValue | null>(null);
+
+export function usePopoverContext(componentName: string): PopoverContextValue {
+  const ctx = useContext(PopoverContext);
+  if (!ctx) {
+    throw new Error(`<Popover.${componentName}> must be used inside <Popover>.`);
+  }
+  return ctx;
+}

--- a/packages/design-system/src/components/Popover/index.ts
+++ b/packages/design-system/src/components/Popover/index.ts
@@ -1,3 +1,4 @@
 export { Popover } from './Popover';
 export type { PopoverProps } from './PopoverRoot';
 export type { PopoverTriggerProps } from './Trigger';
+export type { PopoverContentProps, PopoverSide, PopoverAlign } from './Content';

--- a/packages/design-system/src/components/Popover/index.ts
+++ b/packages/design-system/src/components/Popover/index.ts
@@ -1,0 +1,2 @@
+export { Popover } from './Popover';
+export type { PopoverProps } from './PopoverRoot';

--- a/packages/design-system/src/components/Popover/index.ts
+++ b/packages/design-system/src/components/Popover/index.ts
@@ -1,2 +1,3 @@
 export { Popover } from './Popover';
 export type { PopoverProps } from './PopoverRoot';
+export type { PopoverTriggerProps } from './Trigger';

--- a/packages/design-system/src/components/Popover/index.ts
+++ b/packages/design-system/src/components/Popover/index.ts
@@ -3,3 +3,4 @@ export type { PopoverProps } from './PopoverRoot';
 export type { PopoverTriggerProps } from './Trigger';
 export type { PopoverContentProps, PopoverSide, PopoverAlign } from './Content';
 export type { PopoverHeadingProps } from './Heading';
+export type { PopoverCloseProps } from './Close';

--- a/packages/design-system/src/components/Popover/index.ts
+++ b/packages/design-system/src/components/Popover/index.ts
@@ -2,3 +2,4 @@ export { Popover } from './Popover';
 export type { PopoverProps } from './PopoverRoot';
 export type { PopoverTriggerProps } from './Trigger';
 export type { PopoverContentProps, PopoverSide, PopoverAlign } from './Content';
+export type { PopoverHeadingProps } from './Heading';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -46,3 +46,6 @@ export type {
 
 export { Tooltip } from './components/Tooltip';
 export type { TooltipProps, TooltipSide, TooltipAlign } from './components/Tooltip';
+
+export { Popover } from './components/Popover';
+export type { PopoverProps } from './components/Popover';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -48,4 +48,10 @@ export { Tooltip } from './components/Tooltip';
 export type { TooltipProps, TooltipSide, TooltipAlign } from './components/Tooltip';
 
 export { Popover } from './components/Popover';
-export type { PopoverProps, PopoverTriggerProps } from './components/Popover';
+export type {
+  PopoverProps,
+  PopoverTriggerProps,
+  PopoverContentProps,
+  PopoverSide,
+  PopoverAlign,
+} from './components/Popover';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -53,6 +53,7 @@ export type {
   PopoverTriggerProps,
   PopoverContentProps,
   PopoverHeadingProps,
+  PopoverCloseProps,
   PopoverSide,
   PopoverAlign,
 } from './components/Popover';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -52,6 +52,7 @@ export type {
   PopoverProps,
   PopoverTriggerProps,
   PopoverContentProps,
+  PopoverHeadingProps,
   PopoverSide,
   PopoverAlign,
 } from './components/Popover';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -48,4 +48,4 @@ export { Tooltip } from './components/Tooltip';
 export type { TooltipProps, TooltipSide, TooltipAlign } from './components/Tooltip';
 
 export { Popover } from './components/Popover';
-export type { PopoverProps } from './components/Popover';
+export type { PopoverProps, PopoverTriggerProps } from './components/Popover';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -59,4 +59,7 @@ export type {
 } from './components/Popover';
 
 export { ConfirmationPopover } from './components/ConfirmationPopover';
-export type { ConfirmationPopoverProps, ConfirmationVariant } from './components/ConfirmationPopover';
+export type {
+  ConfirmationPopoverProps,
+  ConfirmationVariant,
+} from './components/ConfirmationPopover';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -57,3 +57,6 @@ export type {
   PopoverSide,
   PopoverAlign,
 } from './components/Popover';
+
+export { ConfirmationPopover } from './components/ConfirmationPopover';
+export type { ConfirmationPopoverProps, ConfirmationVariant } from './components/ConfirmationPopover';

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -117,6 +117,7 @@
   // Popover). Picks a value wide enough for short labels without overflowing
   // trigger-tight clusters.
   --size-dropdown-min-width: 160px;
+  --size-popover-min-width: 220px; // slightly wider than dropdown — popovers carry richer content
 
   // Width/height of the leading indicator slot in DropdownMenu checkbox/radio items.
   --size-dropdown-indicator: 16px;
@@ -152,6 +153,7 @@
   // Layering — only library-relevant layers are defined here. App-shell layers
   // (sidebar, topbar) live in the consuming app's own SCSS.
   --z-dropdown: 1000;
+  --z-popover: 1050; // above dropdown, below modal — popover can open from a menu item
   --z-modal: 1100;
   --z-toast: 1200;
   --z-tooltip: 1300; // above modal + toast so tooltips remain visible inside any host UI

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -17,6 +17,8 @@ import { BadgeDemo } from './pages/components/BadgeDemo';
 import { TabsDemo } from './pages/components/TabsDemo';
 import { DropdownMenuDemo } from './pages/components/DropdownMenuDemo';
 import { TooltipDemo } from './pages/components/TooltipDemo';
+import { PopoverDemo } from './pages/components/PopoverDemo';
+import { ConfirmationPopoverDemo } from './pages/components/ConfirmationPopoverDemo';
 
 export default function App() {
   return (
@@ -43,6 +45,8 @@ export default function App() {
           <Route path="/components/tabs" element={<TabsDemo />} />
           <Route path="/components/dropdown-menu" element={<DropdownMenuDemo />} />
           <Route path="/components/tooltip" element={<TooltipDemo />} />
+          <Route path="/components/popover" element={<PopoverDemo />} />
+          <Route path="/components/confirmation-popover" element={<ConfirmationPopoverDemo />} />
         </Routes>
       </AppShell>
     </BrowserRouter>

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -21,6 +21,8 @@ import {
   ArrowRight,
   MessageSquare,
   MoreHorizontal,
+  PanelLeft,
+  ShieldCheck,
   type LucideIcon,
 } from 'lucide-react';
 import { Avatar } from '@eocrm/design-system';
@@ -74,6 +76,13 @@ const componentGroups = [
     items: [
       { to: '/components/dropdown-menu', label: 'DropdownMenu', icon: MoreHorizontal, end: false },
       { to: '/components/tooltip', label: 'Tooltip', icon: MessageSquare, end: false },
+      { to: '/components/popover', label: 'Popover', icon: PanelLeft, end: false },
+      {
+        to: '/components/confirmation-popover',
+        label: 'ConfirmationPopover',
+        icon: ShieldCheck,
+        end: false,
+      },
     ],
   },
 ];

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -10,6 +10,7 @@ import { Stack } from '@eocrm/design-system';
 import { Tabs } from '@eocrm/design-system';
 import { DropdownMenu } from '@eocrm/design-system';
 import { Tooltip } from '@eocrm/design-system';
+import { ConfirmationPopover, Popover } from '@eocrm/design-system';
 import styles from './ComponentsIndex.module.scss';
 
 const items: { to: string; name: string; description: string; preview: React.ReactNode }[] = [
@@ -147,6 +148,49 @@ const items: { to: string; name: string; description: string; preview: React.Rea
             Save
           </Button>
         </Tooltip>
+      </Cluster>
+    ),
+  },
+  {
+    to: '/components/popover',
+    name: 'Popover',
+    description: 'Non-modal floating panel for arbitrary small surfaces.',
+    preview: (
+      <Cluster gap="sm" justify="center">
+        <Popover defaultOpen>
+          <Popover.Trigger>
+            <Button size="sm" variant="secondary">
+              Filters
+            </Button>
+          </Popover.Trigger>
+          <Popover.Content>
+            <Stack gap="xs">
+              <Popover.Heading>Filters</Popover.Heading>
+              <div>(controls)</div>
+            </Stack>
+          </Popover.Content>
+        </Popover>
+      </Cluster>
+    ),
+  },
+  {
+    to: '/components/confirmation-popover',
+    name: 'ConfirmationPopover',
+    description: '"Are you sure?" preset on top of Popover, with async-aware Confirm.',
+    preview: (
+      <Cluster gap="sm" justify="center">
+        <ConfirmationPopover
+          defaultOpen
+          title="Delete?"
+          description="Cannot be undone."
+          confirmLabel="Delete"
+          variant="danger"
+          onConfirm={() => undefined}
+        >
+          <Button size="sm" variant="danger">
+            Delete
+          </Button>
+        </ConfirmationPopover>
       </Cluster>
     ),
   },

--- a/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
+++ b/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
@@ -125,8 +125,10 @@ export function ConfirmationPopoverDemo() {
 
       <Example
         title="Inside a DropdownMenu — kebab Delete"
-        description="Wrap a <DropdownMenu.Item closeOnSelect={false}> as ConfirmationPopover's trigger. Clicking anywhere on the item opens the popover; the menu stays open while the confirmation is shown (close it via Escape or click outside)."
-        code={`<DropdownMenu>
+        description="Wrap a <DropdownMenu.Item closeOnSelect={false}> as ConfirmationPopover's trigger. To close the menu after a successful confirm, drive DropdownMenu's open state externally and call setMenuOpen(false) inside onConfirm."
+        code={`const [menuOpen, setMenuOpen] = useState(false);
+
+<DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
   <DropdownMenu.Trigger>
     <Button variant="ghost" aria-label="Row actions">⋯</Button>
   </DropdownMenu.Trigger>
@@ -137,7 +139,10 @@ export function ConfirmationPopoverDemo() {
       description="This action cannot be undone."
       variant="danger"
       confirmLabel="Delete"
-      onConfirm={remove}
+      onConfirm={async () => {
+        await remove();
+        setMenuOpen(false);  // ← close the menu after the action resolves
+      }}
     >
       <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}} tone="danger">
         Delete
@@ -147,30 +152,40 @@ export function ConfirmationPopoverDemo() {
 </DropdownMenu>`}
       >
         <Cluster gap="md" justify="center">
-          <DropdownMenu>
-            <DropdownMenu.Trigger>
-              <Button variant="ghost" aria-label="Row actions">
-                ⋯
-              </Button>
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content align="end">
-              <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-              <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
-              <ConfirmationPopover
-                title="Delete record?"
-                description="This action cannot be undone."
-                variant="danger"
-                confirmLabel="Delete"
-                onConfirm={() => setDeleteCount((n) => n + 1)}
-              >
-                <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}} tone="danger">
-                  Delete
-                </DropdownMenu.Item>
-              </ConfirmationPopover>
-            </DropdownMenu.Content>
-          </DropdownMenu>
+          <KebabDeleteExample onDelete={() => setDeleteCount((n) => n + 1)} />
         </Cluster>
       </Example>
     </DemoLayout>
+  );
+}
+
+function KebabDeleteExample({ onDelete }: { onDelete: () => void }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  return (
+    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+      <DropdownMenu.Trigger>
+        <Button variant="ghost" aria-label="Row actions">
+          ⋯
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content align="end">
+        <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+        <ConfirmationPopover
+          title="Delete record?"
+          description="This action cannot be undone."
+          variant="danger"
+          confirmLabel="Delete"
+          onConfirm={() => {
+            onDelete();
+            setMenuOpen(false);
+          }}
+        >
+          <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}} tone="danger">
+            Delete
+          </DropdownMenu.Item>
+        </ConfirmationPopover>
+      </DropdownMenu.Content>
+    </DropdownMenu>
   );
 }

--- a/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
+++ b/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
@@ -124,45 +124,71 @@ export function ConfirmationPopoverDemo() {
       </Example>
 
       <Example
-        title="Inside a DropdownMenu — kebab Delete"
-        description="A common pattern: the kebab menu's Delete item opens a ConfirmationPopover. Popover z-layer is above DropdownMenu's, so the confirmation appears over the menu."
-        code={`<DropdownMenu>
-  <DropdownMenu.Trigger><Button variant="ghost" aria-label="Row actions">⋯</Button></DropdownMenu.Trigger>
-  <DropdownMenu.Content>
-    <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-    <DropdownMenu.Item onSelect={() => {}}>
-      <ConfirmationPopover title="Delete?" variant="danger" onConfirm={remove}>
-        <span>Delete</span>
-      </ConfirmationPopover>
-    </DropdownMenu.Item>
-  </DropdownMenu.Content>
-</DropdownMenu>`}
+        title="Triggered from a kebab menu (controlled pattern)"
+        description="Recommended pattern: the menu item's onSelect drives the popover's open state. The popover lives OUTSIDE the menu so its tree doesn't unmount when the menu closes. The popover anchors to a wrapper element next to the kebab button."
+        code={`const [open, setOpen] = useState(false);
+
+<Cluster gap="sm" align="center">
+  <DropdownMenu>
+    <DropdownMenu.Trigger>
+      <Button variant="ghost" aria-label="Row actions">⋯</Button>
+    </DropdownMenu.Trigger>
+    <DropdownMenu.Content align="end">
+      <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+      <DropdownMenu.Item onSelect={() => setOpen(true)} tone="danger">
+        Delete
+      </DropdownMenu.Item>
+    </DropdownMenu.Content>
+  </DropdownMenu>
+
+  <ConfirmationPopover
+    open={open}
+    onOpenChange={setOpen}
+    title="Delete record?"
+    variant="danger"
+    onConfirm={async () => { await remove(id); }}
+  >
+    {/* Hidden anchor — never clicked; popover positions relative to it. */}
+    <span aria-hidden="true" />
+  </ConfirmationPopover>
+</Cluster>`}
       >
-        <Cluster gap="md" justify="center">
-          <DropdownMenu>
-            <DropdownMenu.Trigger>
-              <Button variant="ghost" aria-label="Row actions">
-                ⋯
-              </Button>
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content>
-              <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-              <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
-              <DropdownMenu.Item onSelect={() => {}} tone="danger">
-                <ConfirmationPopover
-                  title="Delete record?"
-                  description="This action cannot be undone."
-                  variant="danger"
-                  confirmLabel="Delete"
-                  onConfirm={() => setDeleteCount((n) => n + 1)}
-                >
-                  <span>Delete</span>
-                </ConfirmationPopover>
-              </DropdownMenu.Item>
-            </DropdownMenu.Content>
-          </DropdownMenu>
-        </Cluster>
+        <KebabConfirmExample onConfirm={() => setDeleteCount((n) => n + 1)} />
       </Example>
     </DemoLayout>
+  );
+}
+
+function KebabConfirmExample({ onConfirm }: { onConfirm: () => void | Promise<void> }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Cluster gap="sm" align="center" justify="center">
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="ghost" aria-label="Row actions">
+            ⋯
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="end">
+          <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => setOpen(true)} tone="danger">
+            Delete
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+
+      <ConfirmationPopover
+        open={open}
+        onOpenChange={setOpen}
+        title="Delete record?"
+        description="This action cannot be undone."
+        variant="danger"
+        confirmLabel="Delete"
+        onConfirm={onConfirm}
+      >
+        <span aria-hidden="true" />
+      </ConfirmationPopover>
+    </Cluster>
   );
 }

--- a/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
+++ b/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
@@ -132,6 +132,7 @@ export function ConfirmationPopoverDemo() {
   </DropdownMenu.Trigger>
   <DropdownMenu.Content align="end">
     <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+    <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
     <ConfirmationPopover
       title="Delete record?"
       description="This action cannot be undone."

--- a/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
+++ b/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
@@ -125,10 +125,8 @@ export function ConfirmationPopoverDemo() {
 
       <Example
         title="Inside a DropdownMenu — kebab Delete"
-        description="Wrap a <DropdownMenu.Item closeOnSelect={false}> as ConfirmationPopover's trigger. To close the menu after a successful confirm, drive DropdownMenu's open state externally and call setMenuOpen(false) inside onConfirm."
-        code={`const [menuOpen, setMenuOpen] = useState(false);
-
-<DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+        description="Wrap a <DropdownMenu.Item closeOnSelect={false}> as ConfirmationPopover's trigger. The Item IS the trigger, so the full highlighted row opens the confirmation. The menu stays open until the user dismisses it (Escape, click outside, or pick another item)."
+        code={`<DropdownMenu>
   <DropdownMenu.Trigger>
     <Button variant="ghost" aria-label="Row actions">⋯</Button>
   </DropdownMenu.Trigger>
@@ -139,10 +137,7 @@ export function ConfirmationPopoverDemo() {
       description="This action cannot be undone."
       variant="danger"
       confirmLabel="Delete"
-      onConfirm={async () => {
-        await remove();
-        setMenuOpen(false);  // ← close the menu after the action resolves
-      }}
+      onConfirm={remove}
     >
       <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}} tone="danger">
         Delete
@@ -152,40 +147,30 @@ export function ConfirmationPopoverDemo() {
 </DropdownMenu>`}
       >
         <Cluster gap="md" justify="center">
-          <KebabDeleteExample onDelete={() => setDeleteCount((n) => n + 1)} />
+          <DropdownMenu>
+            <DropdownMenu.Trigger>
+              <Button variant="ghost" aria-label="Row actions">
+                ⋯
+              </Button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content align="end">
+              <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+              <ConfirmationPopover
+                title="Delete record?"
+                description="This action cannot be undone."
+                variant="danger"
+                confirmLabel="Delete"
+                onConfirm={() => setDeleteCount((n) => n + 1)}
+              >
+                <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}} tone="danger">
+                  Delete
+                </DropdownMenu.Item>
+              </ConfirmationPopover>
+            </DropdownMenu.Content>
+          </DropdownMenu>
         </Cluster>
       </Example>
     </DemoLayout>
-  );
-}
-
-function KebabDeleteExample({ onDelete }: { onDelete: () => void }) {
-  const [menuOpen, setMenuOpen] = useState(false);
-  return (
-    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-      <DropdownMenu.Trigger>
-        <Button variant="ghost" aria-label="Row actions">
-          ⋯
-        </Button>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content align="end">
-        <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-        <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
-        <ConfirmationPopover
-          title="Delete record?"
-          description="This action cannot be undone."
-          variant="danger"
-          confirmLabel="Delete"
-          onConfirm={() => {
-            onDelete();
-            setMenuOpen(false);
-          }}
-        >
-          <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}} tone="danger">
-            Delete
-          </DropdownMenu.Item>
-        </ConfirmationPopover>
-      </DropdownMenu.Content>
-    </DropdownMenu>
   );
 }

--- a/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
+++ b/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
@@ -124,71 +124,53 @@ export function ConfirmationPopoverDemo() {
       </Example>
 
       <Example
-        title="Triggered from a kebab menu (controlled pattern)"
-        description="Recommended pattern: the menu item's onSelect drives the popover's open state. The popover lives OUTSIDE the menu so its tree doesn't unmount when the menu closes. The popover anchors to a wrapper element next to the kebab button."
-        code={`const [open, setOpen] = useState(false);
-
-<Cluster gap="sm" align="center">
-  <DropdownMenu>
-    <DropdownMenu.Trigger>
-      <Button variant="ghost" aria-label="Row actions">⋯</Button>
-    </DropdownMenu.Trigger>
-    <DropdownMenu.Content align="end">
-      <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-      <DropdownMenu.Item onSelect={() => setOpen(true)} tone="danger">
+        title="Inside a DropdownMenu — kebab Delete"
+        description="Wrap a <DropdownMenu.Item closeOnSelect={false}> as ConfirmationPopover's trigger. Clicking anywhere on the item opens the popover; the menu stays open while the confirmation is shown (close it via Escape or click outside)."
+        code={`<DropdownMenu>
+  <DropdownMenu.Trigger>
+    <Button variant="ghost" aria-label="Row actions">⋯</Button>
+  </DropdownMenu.Trigger>
+  <DropdownMenu.Content align="end">
+    <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+    <ConfirmationPopover
+      title="Delete record?"
+      description="This action cannot be undone."
+      variant="danger"
+      confirmLabel="Delete"
+      onConfirm={remove}
+    >
+      <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}} tone="danger">
         Delete
       </DropdownMenu.Item>
-    </DropdownMenu.Content>
-  </DropdownMenu>
-
-  <ConfirmationPopover
-    open={open}
-    onOpenChange={setOpen}
-    title="Delete record?"
-    variant="danger"
-    onConfirm={async () => { await remove(id); }}
-  >
-    {/* Hidden anchor — never clicked; popover positions relative to it. */}
-    <span aria-hidden="true" />
-  </ConfirmationPopover>
-</Cluster>`}
+    </ConfirmationPopover>
+  </DropdownMenu.Content>
+</DropdownMenu>`}
       >
-        <KebabConfirmExample onConfirm={() => setDeleteCount((n) => n + 1)} />
+        <Cluster gap="md" justify="center">
+          <DropdownMenu>
+            <DropdownMenu.Trigger>
+              <Button variant="ghost" aria-label="Row actions">
+                ⋯
+              </Button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content align="end">
+              <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+              <ConfirmationPopover
+                title="Delete record?"
+                description="This action cannot be undone."
+                variant="danger"
+                confirmLabel="Delete"
+                onConfirm={() => setDeleteCount((n) => n + 1)}
+              >
+                <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}} tone="danger">
+                  Delete
+                </DropdownMenu.Item>
+              </ConfirmationPopover>
+            </DropdownMenu.Content>
+          </DropdownMenu>
+        </Cluster>
       </Example>
     </DemoLayout>
-  );
-}
-
-function KebabConfirmExample({ onConfirm }: { onConfirm: () => void | Promise<void> }) {
-  const [open, setOpen] = useState(false);
-  return (
-    <Cluster gap="sm" align="center" justify="center">
-      <DropdownMenu>
-        <DropdownMenu.Trigger>
-          <Button variant="ghost" aria-label="Row actions">
-            ⋯
-          </Button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content align="end">
-          <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={() => setOpen(true)} tone="danger">
-            Delete
-          </DropdownMenu.Item>
-        </DropdownMenu.Content>
-      </DropdownMenu>
-
-      <ConfirmationPopover
-        open={open}
-        onOpenChange={setOpen}
-        title="Delete record?"
-        description="This action cannot be undone."
-        variant="danger"
-        confirmLabel="Delete"
-        onConfirm={onConfirm}
-      >
-        <span aria-hidden="true" />
-      </ConfirmationPopover>
-    </Cluster>
   );
 }

--- a/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
+++ b/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import { Button, Cluster, ConfirmationPopover, DropdownMenu } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/ConfirmationPopover/ConfirmationPopover.tsx?raw';
+import scssSource from '@lib-source/components/ConfirmationPopover/ConfirmationPopover.module.scss?raw';
+
+const fakeDelay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export function ConfirmationPopoverDemo() {
+  const [archiveCount, setArchiveCount] = useState(0);
+  const [deleteCount, setDeleteCount] = useState(0);
+
+  return (
+    <DemoLayout
+      name="ConfirmationPopover"
+      componentName="ConfirmationPopover"
+      description="Opinionated 'Are you sure?' preset on top of Popover. Title + optional description + Cancel + Confirm. Initial focus on Cancel; async-aware onConfirm with pending state."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="ConfirmationPopover.tsx"
+      scssFilename="ConfirmationPopover.module.scss"
+    >
+      <Example
+        title="Default variant — Archive"
+        description="Sync onConfirm. Lighter-weight confirmation for non-destructive actions like archive or publish."
+        code={`<ConfirmationPopover
+  title="Archive this contact?"
+  description="You can unarchive later from the archive view."
+  onConfirm={() => archive(id)}
+>
+  <Button variant="secondary">Archive</Button>
+</ConfirmationPopover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <ConfirmationPopover
+            title="Archive this contact?"
+            description="You can unarchive later from the archive view."
+            onConfirm={() => setArchiveCount((n) => n + 1)}
+          >
+            <Button variant="secondary">Archive</Button>
+          </ConfirmationPopover>
+          <span>Archived {archiveCount} time(s)</span>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Danger variant — Delete"
+        description="variant='danger' makes Confirm a danger button. Initial focus is on Cancel, so keyboard Enter never accidentally deletes."
+        code={`<ConfirmationPopover
+  title="Delete record?"
+  description="This action cannot be undone."
+  confirmLabel="Delete"
+  variant="danger"
+  onConfirm={() => deleteRecord(id)}
+>
+  <Button variant="danger">Delete</Button>
+</ConfirmationPopover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <ConfirmationPopover
+            title="Delete record?"
+            description="This action cannot be undone."
+            confirmLabel="Delete"
+            variant="danger"
+            onConfirm={() => setDeleteCount((n) => n + 1)}
+          >
+            <Button variant="danger">Delete</Button>
+          </ConfirmationPopover>
+          <span>Deleted {deleteCount} time(s)</span>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Async success — pending spinner"
+        description="onConfirm returns a Promise that resolves after 1.5s. While pending, both buttons disable, Confirm shows a spinner, and dismissal is blocked. On resolve the popover closes."
+        code={`<ConfirmationPopover
+  title="Submit?"
+  onConfirm={async () => {
+    await submitToServer();   // 1.5s
+  }}
+>
+  <Button>Submit</Button>
+</ConfirmationPopover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <ConfirmationPopover
+            title="Submit?"
+            description="Simulated 1.5s server round-trip."
+            onConfirm={async () => {
+              await fakeDelay(1500);
+            }}
+          >
+            <Button>Submit</Button>
+          </ConfirmationPopover>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Async failure — popover stays open"
+        description="onConfirm returns a Promise that rejects after 1s. The popover stays open and buttons re-enable. The consumer is expected to surface the error externally (we just console.log here)."
+        code={`<ConfirmationPopover
+  title="Submit?"
+  onConfirm={async () => {
+    await fakeDelay(1000);
+    throw new Error('network down');
+  }}
+>
+  <Button>Submit (will fail)</Button>
+</ConfirmationPopover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <ConfirmationPopover
+            title="Submit?"
+            description="Simulated server failure after 1s. Buttons re-enable; popover stays open."
+            onConfirm={async () => {
+              await fakeDelay(1000);
+              throw new Error('demo failure');
+            }}
+          >
+            <Button>Submit (will fail)</Button>
+          </ConfirmationPopover>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Inside a DropdownMenu — kebab Delete"
+        description="A common pattern: the kebab menu's Delete item opens a ConfirmationPopover. Popover z-layer is above DropdownMenu's, so the confirmation appears over the menu."
+        code={`<DropdownMenu>
+  <DropdownMenu.Trigger><Button variant="ghost" aria-label="Row actions">⋯</Button></DropdownMenu.Trigger>
+  <DropdownMenu.Content>
+    <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+    <DropdownMenu.Item onSelect={() => {}}>
+      <ConfirmationPopover title="Delete?" variant="danger" onConfirm={remove}>
+        <span>Delete</span>
+      </ConfirmationPopover>
+    </DropdownMenu.Item>
+  </DropdownMenu.Content>
+</DropdownMenu>`}
+      >
+        <Cluster gap="md" justify="center">
+          <DropdownMenu>
+            <DropdownMenu.Trigger>
+              <Button variant="ghost" aria-label="Row actions">
+                ⋯
+              </Button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}} tone="danger">
+                <ConfirmationPopover
+                  title="Delete record?"
+                  description="This action cannot be undone."
+                  variant="danger"
+                  confirmLabel="Delete"
+                  onConfirm={() => setDeleteCount((n) => n + 1)}
+                >
+                  <span>Delete</span>
+                </ConfirmationPopover>
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu>
+        </Cluster>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/components/PopoverDemo.tsx
+++ b/packages/playground/src/pages/components/PopoverDemo.tsx
@@ -138,44 +138,36 @@ export function PopoverDemo() {
       </Example>
 
       <Example
-        title="Inside a DropdownMenu — z-index sanity"
-        description="Popover's z-layer is above DropdownMenu's (--z-popover: 1050 > --z-dropdown: 1000)."
-        code={`<DropdownMenu>
-  <DropdownMenu.Trigger><Button variant="secondary">Actions</Button></DropdownMenu.Trigger>
-  <DropdownMenu.Content>
-    <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-    <DropdownMenu.Item onSelect={() => {}}>
-      <Popover>
-        <Popover.Trigger><span>Move to…</span></Popover.Trigger>
-        <Popover.Content>… picker …</Popover.Content>
-      </Popover>
-    </DropdownMenu.Item>
-  </DropdownMenu.Content>
-</DropdownMenu>`}
+        title="Triggered from a menu item (controlled pattern)"
+        description="A Popover.Trigger nested INSIDE a DropdownMenu.Item only catches clicks on its inner element — the menu item's own click handler still owns the rest of the row, which closes the menu. The right pattern: drive the popover's open state from the item's onSelect, with the popover anchored to a separate element (here, a hidden span next to the kebab)."
+        code={`const [open, setOpen] = useState(false);
+
+<Cluster gap="sm" align="center">
+  <DropdownMenu>
+    <DropdownMenu.Trigger>
+      <Button variant="secondary">Actions</Button>
+    </DropdownMenu.Trigger>
+    <DropdownMenu.Content>
+      <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+      <DropdownMenu.Item onSelect={() => setOpen(true)}>Move to…</DropdownMenu.Item>
+    </DropdownMenu.Content>
+  </DropdownMenu>
+
+  <Popover open={open} onOpenChange={setOpen}>
+    <Popover.Trigger>
+      <span aria-hidden="true" />
+    </Popover.Trigger>
+    <Popover.Content>
+      <Stack gap="xs">
+        <Popover.Heading>Move to folder</Popover.Heading>
+        <div>(folder picker would go here)</div>
+      </Stack>
+    </Popover.Content>
+  </Popover>
+</Cluster>`}
       >
         <Cluster gap="md" justify="center">
-          <DropdownMenu>
-            <DropdownMenu.Trigger>
-              <Button variant="secondary">Actions</Button>
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content>
-              <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-              <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
-              <DropdownMenu.Item onSelect={() => {}}>
-                <Popover>
-                  <Popover.Trigger>
-                    <span>Move to…</span>
-                  </Popover.Trigger>
-                  <Popover.Content>
-                    <Stack gap="xs">
-                      <Popover.Heading>Move to folder</Popover.Heading>
-                      <div>(folder picker would go here)</div>
-                    </Stack>
-                  </Popover.Content>
-                </Popover>
-              </DropdownMenu.Item>
-            </DropdownMenu.Content>
-          </DropdownMenu>
+          <MoveToFolderExample />
         </Cluster>
       </Example>
 
@@ -195,6 +187,41 @@ export function PopoverDemo() {
         </Cluster>
       </Example>
     </DemoLayout>
+  );
+}
+
+function MoveToFolderExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Cluster gap="sm" align="center" justify="center">
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="secondary">Actions</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => setOpen(true)}>Move to…</DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+
+      <Popover open={open} onOpenChange={setOpen}>
+        <Popover.Trigger>
+          <span aria-hidden="true" />
+        </Popover.Trigger>
+        <Popover.Content>
+          <Stack gap="xs">
+            <Popover.Heading>Move to folder</Popover.Heading>
+            <div>(folder picker would go here)</div>
+            <Cluster justify="end">
+              <Popover.Close>
+                <Button size="sm">Done</Button>
+              </Popover.Close>
+            </Cluster>
+          </Stack>
+        </Popover.Content>
+      </Popover>
+    </Cluster>
   );
 }
 

--- a/packages/playground/src/pages/components/PopoverDemo.tsx
+++ b/packages/playground/src/pages/components/PopoverDemo.tsx
@@ -146,6 +146,7 @@ export function PopoverDemo() {
   </DropdownMenu.Trigger>
   <DropdownMenu.Content>
     <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+    <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
     <Popover>
       <Popover.Trigger>
         <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}}>

--- a/packages/playground/src/pages/components/PopoverDemo.tsx
+++ b/packages/playground/src/pages/components/PopoverDemo.tsx
@@ -1,0 +1,221 @@
+import { useState } from 'react';
+import { Button, Cluster, DropdownMenu, Popover, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Popover/Popover.tsx?raw';
+import scssSource from '@lib-source/components/Popover/Popover.module.scss?raw';
+
+export function PopoverDemo() {
+  return (
+    <DemoLayout
+      name="Popover"
+      componentName="Popover"
+      description="Non-modal floating panel for arbitrary small surfaces. Compound API — pair Trigger / Content / optionally Heading / Close. Focus moves to the panel on open; Tab traverses out; click-outside or Escape dismisses."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Popover.tsx"
+      scssFilename="Popover.module.scss"
+    >
+      <Example
+        title="Default — filter panel"
+        description="The canonical popover: a button trigger, a small panel of controls, and an Apply / Cancel footer."
+        code={`<Popover>
+  <Popover.Trigger>
+    <Button variant="secondary">Filters</Button>
+  </Popover.Trigger>
+  <Popover.Content>
+    <Stack gap="sm">
+      <Popover.Heading>Filter results</Popover.Heading>
+      <div>(form controls go here)</div>
+      <Cluster justify="end" gap="sm">
+        <Popover.Close>
+          <Button variant="secondary" size="sm">Cancel</Button>
+        </Popover.Close>
+        <Popover.Close>
+          <Button size="sm">Apply</Button>
+        </Popover.Close>
+      </Cluster>
+    </Stack>
+  </Popover.Content>
+</Popover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <Popover>
+            <Popover.Trigger>
+              <Button variant="secondary">Filters</Button>
+            </Popover.Trigger>
+            <Popover.Content>
+              <Stack gap="sm">
+                <Popover.Heading>Filter results</Popover.Heading>
+                <div>(form controls would go here once Checkbox lands)</div>
+                <Cluster justify="end" gap="sm">
+                  <Popover.Close>
+                    <Button variant="secondary" size="sm">
+                      Cancel
+                    </Button>
+                  </Popover.Close>
+                  <Popover.Close>
+                    <Button size="sm">Apply</Button>
+                  </Popover.Close>
+                </Cluster>
+              </Stack>
+            </Popover.Content>
+          </Popover>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Sides"
+        description="Floating UI auto-flips on collision; this row pins each popover to a specific side."
+        code={`<Popover><Popover.Trigger><Button>Top</Button></Popover.Trigger><Popover.Content side="top">Top</Popover.Content></Popover>
+<Popover><Popover.Trigger><Button>Right</Button></Popover.Trigger><Popover.Content side="right">Right</Popover.Content></Popover>
+<Popover><Popover.Trigger><Button>Bottom</Button></Popover.Trigger><Popover.Content side="bottom">Bottom</Popover.Content></Popover>
+<Popover><Popover.Trigger><Button>Left</Button></Popover.Trigger><Popover.Content side="left">Left</Popover.Content></Popover>`}
+      >
+        <Cluster gap="md" justify="center">
+          {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+            <Popover key={side}>
+              <Popover.Trigger>
+                <Button variant="secondary">{side}</Button>
+              </Popover.Trigger>
+              <Popover.Content side={side}>
+                <Stack gap="xs">
+                  <Popover.Heading>{`Side: ${side}`}</Popover.Heading>
+                  <div>The arrow points back at the trigger.</div>
+                </Stack>
+              </Popover.Content>
+            </Popover>
+          ))}
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Rich content with multiple Close buttons"
+        description="A popover can contain any interactive content. Wrap each closing element in <Popover.Close>."
+        code={`<Popover>
+  <Popover.Trigger>
+    <Button variant="secondary">Actions</Button>
+  </Popover.Trigger>
+  <Popover.Content>
+    <Stack gap="sm">
+      <Popover.Heading>Choose</Popover.Heading>
+      <Popover.Close><Button variant="secondary" size="sm">Save and exit</Button></Popover.Close>
+      <Popover.Close><Button variant="secondary" size="sm">Discard</Button></Popover.Close>
+      <Popover.Close><Button variant="ghost" size="sm">Stay</Button></Popover.Close>
+    </Stack>
+  </Popover.Content>
+</Popover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <Popover>
+            <Popover.Trigger>
+              <Button variant="secondary">Actions</Button>
+            </Popover.Trigger>
+            <Popover.Content>
+              <Stack gap="sm">
+                <Popover.Heading>Choose</Popover.Heading>
+                <Stack gap="xs">
+                  <Popover.Close>
+                    <Button variant="secondary" size="sm">
+                      Save and exit
+                    </Button>
+                  </Popover.Close>
+                  <Popover.Close>
+                    <Button variant="secondary" size="sm">
+                      Discard
+                    </Button>
+                  </Popover.Close>
+                  <Popover.Close>
+                    <Button variant="ghost" size="sm">
+                      Stay
+                    </Button>
+                  </Popover.Close>
+                </Stack>
+              </Stack>
+            </Popover.Content>
+          </Popover>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Inside a DropdownMenu — z-index sanity"
+        description="Popover's z-layer is above DropdownMenu's (--z-popover: 1050 > --z-dropdown: 1000)."
+        code={`<DropdownMenu>
+  <DropdownMenu.Trigger><Button variant="secondary">Actions</Button></DropdownMenu.Trigger>
+  <DropdownMenu.Content>
+    <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+    <DropdownMenu.Item onSelect={() => {}}>
+      <Popover>
+        <Popover.Trigger><span>Move to…</span></Popover.Trigger>
+        <Popover.Content>… picker …</Popover.Content>
+      </Popover>
+    </DropdownMenu.Item>
+  </DropdownMenu.Content>
+</DropdownMenu>`}
+      >
+        <Cluster gap="md" justify="center">
+          <DropdownMenu>
+            <DropdownMenu.Trigger>
+              <Button variant="secondary">Actions</Button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}}>
+                <Popover>
+                  <Popover.Trigger>
+                    <span>Move to…</span>
+                  </Popover.Trigger>
+                  <Popover.Content>
+                    <Stack gap="xs">
+                      <Popover.Heading>Move to folder</Popover.Heading>
+                      <div>(folder picker would go here)</div>
+                    </Stack>
+                  </Popover.Content>
+                </Popover>
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Controlled open"
+        description="Drive open externally — useful for orchestrating with other UI state."
+        code={`const [open, setOpen] = useState(false);
+<Popover open={open} onOpenChange={setOpen}>
+  <Popover.Trigger>
+    <Button onClick={() => setOpen((o) => !o)}>Toggle</Button>
+  </Popover.Trigger>
+  <Popover.Content>…</Popover.Content>
+</Popover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <ControlledExample />
+        </Cluster>
+      </Example>
+    </DemoLayout>
+  );
+}
+
+function ControlledExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger>
+        <Button onClick={() => setOpen((o) => !o)}>{open ? 'Close' : 'Open'}</Button>
+      </Popover.Trigger>
+      <Popover.Content>
+        <Stack gap="sm">
+          <Popover.Heading>Controlled</Popover.Heading>
+          <div>This popover is driven from external state.</div>
+          <Cluster justify="end">
+            <Popover.Close>
+              <Button size="sm">Close</Button>
+            </Popover.Close>
+          </Cluster>
+        </Stack>
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/packages/playground/src/pages/components/PopoverDemo.tsx
+++ b/packages/playground/src/pages/components/PopoverDemo.tsx
@@ -138,36 +138,63 @@ export function PopoverDemo() {
       </Example>
 
       <Example
-        title="Triggered from a menu item (controlled pattern)"
-        description="A Popover.Trigger nested INSIDE a DropdownMenu.Item only catches clicks on its inner element — the menu item's own click handler still owns the rest of the row, which closes the menu. The right pattern: drive the popover's open state from the item's onSelect, with the popover anchored to a separate element (here, a hidden span next to the kebab)."
-        code={`const [open, setOpen] = useState(false);
-
-<Cluster gap="sm" align="center">
-  <DropdownMenu>
-    <DropdownMenu.Trigger>
-      <Button variant="secondary">Actions</Button>
-    </DropdownMenu.Trigger>
-    <DropdownMenu.Content>
-      <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-      <DropdownMenu.Item onSelect={() => setOpen(true)}>Move to…</DropdownMenu.Item>
-    </DropdownMenu.Content>
-  </DropdownMenu>
-
-  <Popover open={open} onOpenChange={setOpen}>
-    <Popover.Trigger>
-      <span aria-hidden="true" />
-    </Popover.Trigger>
-    <Popover.Content>
-      <Stack gap="xs">
-        <Popover.Heading>Move to folder</Popover.Heading>
-        <div>(folder picker would go here)</div>
-      </Stack>
-    </Popover.Content>
-  </Popover>
-</Cluster>`}
+        title="Inside a DropdownMenu — z-index sanity"
+        description="Wrap a <DropdownMenu.Item closeOnSelect={false}> as the Popover trigger. Popover's z-layer is above DropdownMenu's (--z-popover: 1050 > --z-dropdown: 1000), so the popover floats over the menu."
+        code={`<DropdownMenu>
+  <DropdownMenu.Trigger>
+    <Button variant="secondary">Actions</Button>
+  </DropdownMenu.Trigger>
+  <DropdownMenu.Content>
+    <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+    <Popover>
+      <Popover.Trigger>
+        <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}}>
+          Move to…
+        </DropdownMenu.Item>
+      </Popover.Trigger>
+      <Popover.Content>
+        <Stack gap="xs">
+          <Popover.Heading>Move to folder</Popover.Heading>
+          <div>(folder picker)</div>
+          <Cluster justify="end">
+            <Popover.Close>
+              <Button size="sm">Done</Button>
+            </Popover.Close>
+          </Cluster>
+        </Stack>
+      </Popover.Content>
+    </Popover>
+  </DropdownMenu.Content>
+</DropdownMenu>`}
       >
         <Cluster gap="md" justify="center">
-          <MoveToFolderExample />
+          <DropdownMenu>
+            <DropdownMenu.Trigger>
+              <Button variant="secondary">Actions</Button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+              <Popover>
+                <Popover.Trigger>
+                  <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}}>
+                    Move to…
+                  </DropdownMenu.Item>
+                </Popover.Trigger>
+                <Popover.Content>
+                  <Stack gap="xs">
+                    <Popover.Heading>Move to folder</Popover.Heading>
+                    <div>(folder picker would go here)</div>
+                    <Cluster justify="end">
+                      <Popover.Close>
+                        <Button size="sm">Done</Button>
+                      </Popover.Close>
+                    </Cluster>
+                  </Stack>
+                </Popover.Content>
+              </Popover>
+            </DropdownMenu.Content>
+          </DropdownMenu>
         </Cluster>
       </Example>
 
@@ -187,41 +214,6 @@ export function PopoverDemo() {
         </Cluster>
       </Example>
     </DemoLayout>
-  );
-}
-
-function MoveToFolderExample() {
-  const [open, setOpen] = useState(false);
-  return (
-    <Cluster gap="sm" align="center" justify="center">
-      <DropdownMenu>
-        <DropdownMenu.Trigger>
-          <Button variant="secondary">Actions</Button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content>
-          <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={() => setOpen(true)}>Move to…</DropdownMenu.Item>
-        </DropdownMenu.Content>
-      </DropdownMenu>
-
-      <Popover open={open} onOpenChange={setOpen}>
-        <Popover.Trigger>
-          <span aria-hidden="true" />
-        </Popover.Trigger>
-        <Popover.Content>
-          <Stack gap="xs">
-            <Popover.Heading>Move to folder</Popover.Heading>
-            <div>(folder picker would go here)</div>
-            <Cluster justify="end">
-              <Popover.Close>
-                <Button size="sm">Done</Button>
-              </Popover.Close>
-            </Cluster>
-          </Stack>
-        </Popover.Content>
-      </Popover>
-    </Cluster>
   );
 }
 

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -10,7 +10,9 @@ export type ComponentName =
   | 'Badge'
   | 'Tabs'
   | 'DropdownMenu'
-  | 'Tooltip';
+  | 'Tooltip'
+  | 'Popover'
+  | 'ConfirmationPopover';
 
 export interface MockupEntry {
   slug: string;


### PR DESCRIPTION
## Summary

- **New `<Popover>` compound** (Root, Trigger, Content, Heading, Close): non-modal floating panel on Floating UI. Focus moves to the panel on open, Tab traverses out, click-outside or Escape dismisses. Arrow on by default, scale-fade entrance matching DropdownMenu/Tooltip.
- **New `<ConfirmationPopover>`**: opinionated "Are you sure?" preset on top of Popover. Async-aware `onConfirm` with pending state (buttons disable, spinner, dismissal blocked). Failure leaves the popover open. Initial focus on Cancel for both variants.
- **New tokens** `--z-popover: 1050` (above dropdown, below modal/toast/tooltip) and `--size-popover-min-width: 220px`.
- **DropdownMenu.Item: `closeOnSelect` prop + chained-consumer-onClick** (commit `9f9fdca`). Default `true`. Set to `false` when wrapping the Item in a `<Popover.Trigger>` or `<ConfirmationPopover>` so the menu doesn't unmount the popover before it can render. Item's `handleClick` now chains any consumer-supplied onClick (via `{...rest}`) before running `onSelect`+`closeAll`; consumer can `e.preventDefault()` to short-circuit.
- **DropdownMenu.Item: `:focus` → `:focus-visible`** (commit `bdfa964`). Fixes the bug where clicking an Item left the hover background stuck because mouse-click focus matched `:focus`. Three SCSS rules updated (default, danger, checked).
- **DropdownMenu outside-click exclusion** now also recognizes `[data-popover-content]` panels, so a Popover opened from inside a menu item doesn't get collapsed when the user clicks Cancel/Confirm.
- **Popover.Trigger stopPropagation** on click + Enter/Space — keeps the click from bubbling to any ancestor handler.
- **CLAUDE.md Rule 3a** added: `:focus-visible` for non-input focusable elements, with text-input exception. AGENTS.md TL;DR sections for Popover + ConfirmationPopover, token-table updates, anti-pattern rows. README components-table rows for both.
- **Playground demos** for both components (5 examples each). Kebab-Delete and Move-to-folder use the wrap-around-Item pattern with `closeOnSelect={false}`.

Spec: [`docs/superpowers/specs/2026-05-19-popover-design.md`](docs/superpowers/specs/2026-05-19-popover-design.md)
Plan: [`docs/superpowers/plans/2026-05-19-popover.md`](docs/superpowers/plans/2026-05-19-popover.md)

Three rounds of pre-push review (plus a final round) all returned `clean enough to stop`. 324/324 tests passing.

## Test plan

- [x] CI `Quality / check` is green
- [ ] `make up` → `/components/popover` shows all 5 examples
- [ ] `make up` → `/components/confirmation-popover` shows all 5 examples
- [ ] Filter popover: Tab walks through content and out of the panel; Escape closes; click-outside closes; `<Popover.Close>` buttons close
- [ ] Confirmation: Cancel is focused on open; danger variant renders Confirm in danger color
- [ ] Async success demo: spinner appears, buttons disable, popover closes on resolve
- [ ] Async failure demo: spinner appears, buttons disable, popover STAYS OPEN, buttons re-enable, no console error
- [ ] Kebab → Delete: clicking anywhere on the highlighted Delete row opens the confirmation (full row is the trigger); menu stays open; Cancel/Confirm dismiss the popover
- [ ] Click on Delete row a second time toggles the popover closed and DOES NOT leave the row with a stuck red background after the cursor moves away
- [ ] Popover-from-menu-item demo (Move to…) shows the popover above the menu
- [ ] DevTools → emulate `prefers-reduced-motion: reduce` → popovers appear instantly; ConfirmationPopover spinner stops rotating

🤖 Generated with [Claude Code](https://claude.com/claude-code)