### PR TITLE
Select: generalist value picker (single, multi, async, creatable)

### DIFF
--- a/docs/superpowers/plans/2026-05-20-select.md
+++ b/docs/superpowers/plans/2026-05-20-select.md
@@ -1,0 +1,6237 @@
+# Select Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Select>` — the generalist Select/Combobox primitive covering single, multi (chips and summary), searchable, async-loaded, grouped, creatable, and custom-render-aware modes.
+
+**Architecture:** Single declarative component `<Select>` with render-prop escape hatches. Mode matrix is `multiple` × `triggerDisplay: 'chips' | 'summary'` × `searchable`. WAI-ARIA combobox 1.2 semantics. Hand-rolled on `@floating-ui/react-dom` (same as `<DropdownMenu>` and `<Popover>`). All a11y, focus, keyboard, dismissal hand-rolled per WAI-ARIA APG.
+
+**Tech Stack:** React 18, TypeScript, `@floating-ui/react-dom`, Vitest (globals), React Testing Library, `@testing-library/user-event`, SCSS modules with token-only values (stylelint enforced), `clsx`.
+
+**Reference design:** `docs/superpowers/specs/2026-05-20-select-design.md`. Read this first.
+
+**Reference patterns in the existing codebase:**
+- `packages/design-system/src/components/Popover/` — Floating UI usage (`useFloating`, `offset`, `flip`, `shift`, `autoUpdate`), portal-to-body Content, click-outside + Escape dismissal pattern.
+- `packages/design-system/src/components/DropdownMenu/` — keyboard model (Arrow/Home/End/typeahead with 500ms debounce), `:focus-visible` row backgrounds, scale-fade open animation.
+- `packages/design-system/src/components/Input/` — visual contract (border, focus ring, size scale 24/32/40px, `invalid` styling).
+- `packages/design-system/src/components/_internal/refs.ts` — `mergeRefs`, `chain`, `sanitizeId`, `mergeAriaDescribedby`.
+
+**Hard rules** (from `packages/design-system/CLAUDE.md`): every component has `<Name>.tsx`, `<Name>.test.tsx`, `<Name>.module.scss`, `index.ts`. Tokens only (no raw values). No layout properties on the component. `:focus-visible` for non-input focusables. `forwardRef` + spread HTMLAttributes. JSDoc on every export. Re-export from `src/index.ts`. Playground demo + nav wiring. AGENTS.md TL;DR entry. Pre-push review-fix loop at the end.
+
+**Branch:** `feat/select` (already cut from fresh `main` at `0755b2d`). Final PR opened against `main`.
+
+---
+
+## File structure (locked in upfront)
+
+```
+packages/design-system/src/components/Select/
+  Select.tsx                ← public component, forwardRef, prop dispatch to internal variants
+  Select.module.scss        ← all visual tokens, no layout properties
+  Select.test.tsx           ← unit tests (~1500–2000 LOC)
+  Trigger.tsx               ← internal: picks one of 6 trigger variants by props
+  Listbox.tsx               ← internal: portaled panel, Floating UI, option rendering, ARIA
+  Chip.tsx                  ← internal: removable chip used by chips-mode trigger
+  Empty.tsx                 ← internal: default empty-state row
+  Loading.tsx               ← internal: default loading-state row + spinner
+  Error.tsx                 ← internal: default error-state row + Retry button
+  HiddenInputs.tsx          ← internal: hidden <input>(s) for native form submit
+  useSelectState.ts         ← internal hook: controlled/uncontrolled value + open + active row reducer
+  useAsyncOptions.ts        ← internal hook: debounce + AbortController + cache lifecycle
+  context.ts                ← internal context shared by Trigger/Listbox/Chip
+  utils.ts                  ← internal: flatten groups, filter, normalize, exact-match detection
+  index.ts                  ← export { Select } + exported types
+```
+
+Public exports: `Select`, `SelectProps`, `SelectOption`, `SelectGroup`, `SelectOptions`, `SelectSize`, `SelectTriggerDisplay`. Internal modules are NOT re-exported from `index.ts`.
+
+---
+
+## Task ordering rationale
+
+We build a working single-non-searchable Select first (tasks 1–8), so we have end-to-end value selection + keyboard nav + ARIA before adding modes. Then we layer grouped options, searchable, multi-summary, multi-chips, async, creatable, form integration, and ergonomics. JSDoc/exports/playground/AGENTS happen near the end. Review-fix loop runs last.
+
+Each task ends with a green test suite and a commit. The end of each "phase" is a sensible PR-able checkpoint.
+
+---
+
+## Phase 1 — Foundation
+
+### Task 1: Scaffold the Select folder
+
+**Files:**
+- Create: `packages/design-system/src/components/Select/Select.tsx`
+- Create: `packages/design-system/src/components/Select/Select.module.scss`
+- Create: `packages/design-system/src/components/Select/Select.test.tsx`
+- Create: `packages/design-system/src/components/Select/index.ts`
+
+- [ ] **Step 1: Write the failing structure test**
+
+The repo has a meta-test (`src/structure.test.ts`) that asserts every component folder has the four required files and is re-exported from `src/index.ts`. Run it first to see it fail.
+
+Run: `npm test -w @eocrm/design-system -- structure.test`
+Expected: FAIL — `Select` folder doesn't exist yet OR `Select` is not re-exported.
+
+- [ ] **Step 2: Create the four required files**
+
+Create `packages/design-system/src/components/Select/Select.tsx`:
+
+```tsx
+import { forwardRef, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './Select.module.scss';
+
+export interface SelectProps extends HTMLAttributes<HTMLDivElement> {}
+
+export const Select = forwardRef<HTMLDivElement, SelectProps>(function Select(
+  { className, ...rest },
+  ref,
+) {
+  return <div ref={ref} {...rest} className={clsx(styles.root, className)} data-select="" />;
+});
+```
+
+Create `packages/design-system/src/components/Select/Select.module.scss`:
+
+```scss
+.root {
+  // populated in later tasks
+  display: inline-block;
+}
+```
+
+Create `packages/design-system/src/components/Select/Select.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { Select } from './Select';
+
+describe('Select', () => {
+  it('renders without crashing', () => {
+    render(<Select data-testid="root" />);
+    expect(screen.getByTestId('root')).toBeInTheDocument();
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Select ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('merges className', () => {
+    const { container } = render(<Select className="extra" />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/extra/);
+    // It also has the styles.root class, not just "extra":
+    expect(root.className.split(' ').length).toBeGreaterThan(1);
+  });
+});
+```
+
+Create `packages/design-system/src/components/Select/index.ts`:
+
+```ts
+export { Select } from './Select';
+export type { SelectProps } from './Select';
+```
+
+- [ ] **Step 3: Re-export from `src/index.ts`**
+
+Modify `packages/design-system/src/index.ts`. Append at the end (after the ConfirmationPopover block):
+
+```ts
+export { Select } from './components/Select';
+export type { SelectProps } from './components/Select';
+```
+
+- [ ] **Step 4: Run the meta-test and Select tests**
+
+Run: `npm test -w @eocrm/design-system -- structure.test Select.test`
+Expected: PASS — both files green.
+
+- [ ] **Step 5: Run typecheck and stylelint to confirm nothing's red**
+
+Run: `npm run typecheck -w @eocrm/design-system && npm run lint:css`
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/ packages/design-system/src/index.ts
+git commit -m "Select: scaffold component folder + structure-test green"
+```
+
+---
+
+### Task 2: Define core types (`SelectOption`, `SelectGroup`, `SelectOptions`)
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Select.tsx`
+- Create: `packages/design-system/src/components/Select/utils.ts`
+- Create: `packages/design-system/src/components/Select/utils.test.ts`
+- Modify: `packages/design-system/src/components/Select/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+- [ ] **Step 1: Write the failing utils test**
+
+Create `packages/design-system/src/components/Select/utils.test.ts`:
+
+```ts
+import { isGrouped, flattenOptions, findOption } from './utils';
+import type { SelectOption, SelectGroup } from './Select';
+
+describe('utils', () => {
+  describe('isGrouped', () => {
+    it('returns false for flat option array', () => {
+      const opts: SelectOption[] = [{ value: 'a', label: 'A' }];
+      expect(isGrouped(opts)).toBe(false);
+    });
+
+    it('returns true when the first element has an `options` field', () => {
+      const opts: SelectGroup[] = [{ label: 'G', options: [{ value: 'a', label: 'A' }] }];
+      expect(isGrouped(opts)).toBe(true);
+    });
+
+    it('returns false for empty array', () => {
+      expect(isGrouped([])).toBe(false);
+    });
+  });
+
+  describe('flattenOptions', () => {
+    it('returns rows with `kind: option` for flat input', () => {
+      const opts: SelectOption[] = [
+        { value: 'a', label: 'A' },
+        { value: 'b', label: 'B' },
+      ];
+      expect(flattenOptions(opts)).toEqual([
+        { kind: 'option', option: opts[0] },
+        { kind: 'option', option: opts[1] },
+      ]);
+    });
+
+    it('emits header rows before each group for grouped input', () => {
+      const opts: SelectGroup[] = [
+        { label: 'G1', options: [{ value: 'a', label: 'A' }] },
+        { label: 'G2', options: [{ value: 'b', label: 'B' }] },
+      ];
+      const flat = flattenOptions(opts);
+      expect(flat).toHaveLength(4);
+      expect(flat[0]).toEqual({ kind: 'header', label: 'G1' });
+      expect(flat[1]).toEqual({ kind: 'option', option: opts[0].options[0], groupLabel: 'G1' });
+      expect(flat[2]).toEqual({ kind: 'header', label: 'G2' });
+      expect(flat[3]).toEqual({ kind: 'option', option: opts[1].options[0], groupLabel: 'G2' });
+    });
+  });
+
+  describe('findOption', () => {
+    it('returns the option matching value, flat input', () => {
+      const opts: SelectOption[] = [
+        { value: 'a', label: 'A' },
+        { value: 'b', label: 'B' },
+      ];
+      expect(findOption(opts, 'b')).toEqual(opts[1]);
+    });
+
+    it('returns the option matching value, grouped input', () => {
+      const opts: SelectGroup[] = [
+        { label: 'G', options: [{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }] },
+      ];
+      expect(findOption(opts, 'b')).toEqual(opts[0].options[1]);
+    });
+
+    it('returns null when no match', () => {
+      expect(findOption([{ value: 'a', label: 'A' }], 'x')).toBeNull();
+    });
+  });
+});
+```
+
+Run: `npm test -w @eocrm/design-system -- utils.test`
+Expected: FAIL — `utils.ts` doesn't export those functions yet.
+
+- [ ] **Step 2: Add types to `Select.tsx`**
+
+Replace the contents of `packages/design-system/src/components/Select/Select.tsx`:
+
+```tsx
+import { forwardRef, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './Select.module.scss';
+
+/** Visual size of the trigger. Mirrors `<Input>` and `<Button>` size scale. */
+export type SelectSize = 'sm' | 'md' | 'lg';
+
+/** How a multi-select renders its selections in the trigger. */
+export type SelectTriggerDisplay = 'chips' | 'summary';
+
+/** A single selectable option. `value` is the key emitted by `onChange`. */
+export interface SelectOption<T = unknown> {
+  /** Unique key. What `onChange` emits. */
+  value: string;
+  /** Displayed text. Used for substring search when `searchable` is on. */
+  label: string;
+  /** Optional secondary line shown under the label in default render. */
+  description?: string;
+  /** When true, the option is dimmed, `aria-disabled`, and skipped in keyboard nav. */
+  disabled?: boolean;
+  /** Arbitrary payload — surfaces in render escape hatches. */
+  data?: T;
+}
+
+/** A header + its member options. */
+export interface SelectGroup<T = unknown> {
+  /** Header text shown above the group's options. */
+  label: string;
+  /** Members of the group. */
+  options: SelectOption<T>[];
+}
+
+/**
+ * Either a flat list of options or a list of groups. Discriminated at runtime
+ * by checking whether the first element has an `options` field. Mixing flat
+ * and grouped at the same level is not supported.
+ */
+export type SelectOptions<T = unknown> = SelectOption<T>[] | SelectGroup<T>[];
+
+export interface SelectProps extends HTMLAttributes<HTMLDivElement> {}
+
+export const Select = forwardRef<HTMLDivElement, SelectProps>(function Select(
+  { className, ...rest },
+  ref,
+) {
+  return <div ref={ref} {...rest} className={clsx(styles.root, className)} data-select="" />;
+});
+```
+
+- [ ] **Step 3: Create `utils.ts`**
+
+Create `packages/design-system/src/components/Select/utils.ts`:
+
+```ts
+import type { SelectOption, SelectGroup, SelectOptions } from './Select';
+
+/**
+ * Returns true when the input is a list of `SelectGroup`s. Discriminates by
+ * checking whether the first element has an `options` field.
+ */
+export function isGrouped<T>(opts: SelectOptions<T>): opts is SelectGroup<T>[] {
+  if (opts.length === 0) return false;
+  return Object.prototype.hasOwnProperty.call(opts[0], 'options');
+}
+
+/**
+ * A row in the flattened option list. Either a group header (non-focusable)
+ * or an option (focusable). `groupLabel` on an option row records which
+ * group it came from so ARIA wiring can build `aria-labelledby`.
+ */
+export type FlatRow<T = unknown> =
+  | { kind: 'header'; label: string }
+  | { kind: 'option'; option: SelectOption<T>; groupLabel?: string };
+
+/**
+ * Flattens `SelectOptions` into a single linear array of rows so the listbox
+ * can render and the keyboard model can step through them uniformly. Headers
+ * appear before their group's options.
+ */
+export function flattenOptions<T>(opts: SelectOptions<T>): FlatRow<T>[] {
+  if (!isGrouped(opts)) {
+    return opts.map((option) => ({ kind: 'option' as const, option }));
+  }
+  const rows: FlatRow<T>[] = [];
+  for (const group of opts) {
+    rows.push({ kind: 'header', label: group.label });
+    for (const option of group.options) {
+      rows.push({ kind: 'option', option, groupLabel: group.label });
+    }
+  }
+  return rows;
+}
+
+/** Returns the option whose `value` matches, or `null`. */
+export function findOption<T>(opts: SelectOptions<T>, value: string): SelectOption<T> | null {
+  if (!isGrouped(opts)) {
+    return opts.find((o) => o.value === value) ?? null;
+  }
+  for (const g of opts) {
+    const hit = g.options.find((o) => o.value === value);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/** Returns all options whose `value` is in the given set, in option order. */
+export function findOptions<T>(opts: SelectOptions<T>, values: string[]): SelectOption<T>[] {
+  const set = new Set(values);
+  const out: SelectOption<T>[] = [];
+  if (!isGrouped(opts)) {
+    for (const o of opts) if (set.has(o.value)) out.push(o);
+    return out;
+  }
+  for (const g of opts) {
+    for (const o of g.options) if (set.has(o.value)) out.push(o);
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Re-export the new types from `src/components/Select/index.ts`**
+
+Replace `packages/design-system/src/components/Select/index.ts`:
+
+```ts
+export { Select } from './Select';
+export type {
+  SelectProps,
+  SelectOption,
+  SelectGroup,
+  SelectOptions,
+  SelectSize,
+  SelectTriggerDisplay,
+} from './Select';
+```
+
+- [ ] **Step 5: Re-export from `src/index.ts`**
+
+Modify `packages/design-system/src/index.ts`. Replace the Select block from Task 1 with:
+
+```ts
+export { Select } from './components/Select';
+export type {
+  SelectProps,
+  SelectOption,
+  SelectGroup,
+  SelectOptions,
+  SelectSize,
+  SelectTriggerDisplay,
+} from './components/Select';
+```
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `npm test -w @eocrm/design-system -- utils.test Select.test && npm run typecheck -w @eocrm/design-system`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/ packages/design-system/src/index.ts
+git commit -m "Select: core types + options flattening utils"
+```
+
+---
+
+### Task 3: `useSelectState` — controlled/uncontrolled value + open state
+
+**Files:**
+- Create: `packages/design-system/src/components/Select/useSelectState.ts`
+- Create: `packages/design-system/src/components/Select/useSelectState.test.ts`
+
+- [ ] **Step 1: Write the failing hook test**
+
+Create `packages/design-system/src/components/Select/useSelectState.test.ts`:
+
+```ts
+import { renderHook, act } from '@testing-library/react';
+import { useSelectState } from './useSelectState';
+
+describe('useSelectState — single', () => {
+  it('initializes uncontrolled with defaultValue', () => {
+    const { result } = renderHook(() => useSelectState({ multiple: false, defaultValue: 'a' }));
+    expect(result.current.value).toBe('a');
+  });
+
+  it('reflects controlled value', () => {
+    const { result, rerender } = renderHook(
+      ({ v }) => useSelectState({ multiple: false, value: v }),
+      { initialProps: { v: 'a' } },
+    );
+    expect(result.current.value).toBe('a');
+    rerender({ v: 'b' });
+    expect(result.current.value).toBe('b');
+  });
+
+  it('setValue updates uncontrolled state and fires onChange', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: false, defaultValue: 'a', onChange }),
+    );
+    act(() => result.current.setValue('b'));
+    expect(result.current.value).toBe('b');
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('setValue does NOT update uncontrolled state when value is controlled', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: false, value: 'a', onChange }),
+    );
+    act(() => result.current.setValue('b'));
+    expect(result.current.value).toBe('a'); // parent must rerender with new value
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+});
+
+describe('useSelectState — multi', () => {
+  it('initializes uncontrolled with defaultValue array', () => {
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: true, defaultValue: ['a', 'b'] }),
+    );
+    expect(result.current.value).toEqual(['a', 'b']);
+  });
+
+  it('toggleValue adds a missing value', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: true, defaultValue: ['a'], onChange }),
+    );
+    act(() => result.current.toggleValue('b'));
+    expect(result.current.value).toEqual(['a', 'b']);
+    expect(onChange).toHaveBeenCalledWith(['a', 'b']);
+  });
+
+  it('toggleValue removes an existing value', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: true, defaultValue: ['a', 'b'], onChange }),
+    );
+    act(() => result.current.toggleValue('a'));
+    expect(result.current.value).toEqual(['b']);
+  });
+});
+
+describe('useSelectState — open', () => {
+  it('initializes closed by default', () => {
+    const { result } = renderHook(() => useSelectState({ multiple: false }));
+    expect(result.current.open).toBe(false);
+  });
+
+  it('respects defaultOpen', () => {
+    const { result } = renderHook(() => useSelectState({ multiple: false, defaultOpen: true }));
+    expect(result.current.open).toBe(true);
+  });
+
+  it('setOpen toggles uncontrolled state and fires onOpenChange', () => {
+    const onOpenChange = vi.fn();
+    const { result } = renderHook(() => useSelectState({ multiple: false, onOpenChange }));
+    act(() => result.current.setOpen(true));
+    expect(result.current.open).toBe(true);
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it('respects controlled open', () => {
+    const { result } = renderHook(() => useSelectState({ multiple: false, open: true }));
+    expect(result.current.open).toBe(true);
+  });
+});
+```
+
+Run: `npm test -w @eocrm/design-system -- useSelectState.test`
+Expected: FAIL — hook not yet implemented.
+
+- [ ] **Step 2: Implement `useSelectState`**
+
+Create `packages/design-system/src/components/Select/useSelectState.ts`:
+
+```ts
+import { useCallback, useState } from 'react';
+
+/**
+ * Args accepted by `useSelectState`. `multiple` switches the value type:
+ * `false` → `string`, `true` → `string[]`.
+ */
+export interface UseSelectStateArgs {
+  multiple: boolean;
+
+  // value
+  value?: string | string[];
+  defaultValue?: string | string[];
+  onChange?: (value: string | string[]) => void;
+
+  // open
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export interface UseSelectStateReturn {
+  /** Current value — `string` for single, `string[]` for multi. */
+  value: string | string[];
+  /** Replaces the value (single) or sets the full array (multi). Fires `onChange`. */
+  setValue: (next: string | string[]) => void;
+  /** Multi only: toggles membership of `v` in the value array. */
+  toggleValue: (v: string) => void;
+  /** Whether the popover is open. */
+  open: boolean;
+  /** Sets open state. Fires `onOpenChange`. */
+  setOpen: (next: boolean) => void;
+}
+
+/**
+ * Reducer-like hook combining controlled/uncontrolled value and open state
+ * for `<Select>`. Single source of truth for everything mode-related.
+ */
+export function useSelectState(args: UseSelectStateArgs): UseSelectStateReturn {
+  const { multiple, value, defaultValue, onChange, open, defaultOpen, onOpenChange } = args;
+
+  const initial: string | string[] = multiple
+    ? (Array.isArray(defaultValue) ? defaultValue : [])
+    : (typeof defaultValue === 'string' ? defaultValue : '');
+
+  const [uncontrolledValue, setUncontrolledValue] = useState<string | string[]>(initial);
+  const isValueControlled = value !== undefined;
+  const currentValue = isValueControlled ? (value as string | string[]) : uncontrolledValue;
+
+  const setValue = useCallback(
+    (next: string | string[]) => {
+      onChange?.(next);
+      if (!isValueControlled) setUncontrolledValue(next);
+    },
+    [isValueControlled, onChange],
+  );
+
+  const toggleValue = useCallback(
+    (v: string) => {
+      if (!multiple) {
+        setValue(v);
+        return;
+      }
+      const arr = Array.isArray(currentValue) ? currentValue : [];
+      const next = arr.includes(v) ? arr.filter((x) => x !== v) : [...arr, v];
+      setValue(next);
+    },
+    [multiple, currentValue, setValue],
+  );
+
+  const [uncontrolledOpen, setUncontrolledOpen] = useState<boolean>(defaultOpen ?? false);
+  const isOpenControlled = open !== undefined;
+  const currentOpen = isOpenControlled ? (open as boolean) : uncontrolledOpen;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      onOpenChange?.(next);
+      if (!isOpenControlled) setUncontrolledOpen(next);
+    },
+    [isOpenControlled, onOpenChange],
+  );
+
+  return {
+    value: currentValue,
+    setValue,
+    toggleValue,
+    open: currentOpen,
+    setOpen,
+  };
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npm test -w @eocrm/design-system -- useSelectState.test`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/useSelectState.ts packages/design-system/src/components/Select/useSelectState.test.ts
+git commit -m "Select: useSelectState hook (controlled/uncontrolled value + open)"
+```
+
+---
+
+## Phase 2 — Single, non-searchable (button trigger + listbox)
+
+End of phase = a working single-select with click-to-open, keyboard navigation, ARIA roles, full unit-test coverage of that mode. No multi, no search, no async, no groups, no creatable, no form integration. This is the smallest end-to-end Select.
+
+### Task 4: Context + skeletal Select.tsx wiring (single mode plumbing)
+
+**Files:**
+- Create: `packages/design-system/src/components/Select/context.ts`
+- Modify: `packages/design-system/src/components/Select/Select.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Write the failing test — Select accepts options + value props**
+
+Append to `packages/design-system/src/components/Select/Select.test.tsx`:
+
+```tsx
+import userEvent from '@testing-library/user-event';
+import type { SelectOption } from './Select';
+
+const STATUSES: SelectOption[] = [
+  { value: 'active', label: 'Active' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'archived', label: 'Archived' },
+];
+
+describe('Select — single, non-searchable, sync', () => {
+  it('renders a button trigger with placeholder when no value', () => {
+    render(<Select options={STATUSES} placeholder="Pick one" />);
+    expect(screen.getByRole('button')).toHaveTextContent('Pick one');
+  });
+
+  it('renders the selected label when value is set', () => {
+    render(<Select options={STATUSES} value="pending" />);
+    expect(screen.getByRole('button')).toHaveTextContent('Pending');
+  });
+});
+```
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: FAIL — `Select` doesn't yet accept `options` / `value` / `placeholder`.
+
+- [ ] **Step 2: Create the context module**
+
+Create `packages/design-system/src/components/Select/context.ts`:
+
+```ts
+import { createContext, useContext, type RefObject } from 'react';
+import type { SelectOption, SelectOptions, FlatRow } from './utils-types';
+
+// `utils-types` is a tiny re-export module to avoid circular imports.
+// We'll create it in the next step.
+
+export interface SelectContextValue<T = unknown> {
+  // mode flags
+  multiple: boolean;
+  searchable: boolean;
+  creatable: boolean;
+  triggerDisplay: 'chips' | 'summary';
+
+  // data
+  rows: FlatRow<T>[];
+  loading: boolean;
+  error: Error | null;
+
+  // value
+  value: string | string[];
+  setValue: (next: string | string[]) => void;
+  toggleValue: (v: string) => void;
+
+  // open
+  open: boolean;
+  setOpen: (next: boolean) => void;
+
+  // active (keyboard cursor)
+  activeIndex: number;
+  setActiveIndex: (i: number) => void;
+
+  // search (only used when searchable)
+  query: string;
+  setQuery: (q: string) => void;
+
+  // ids
+  listboxId: string;
+  triggerId: string;
+  getOptionId: (value: string) => string;
+  getGroupHeaderId: (label: string) => string;
+
+  // refs
+  triggerRef: RefObject<HTMLElement | null>;
+  listboxRef: RefObject<HTMLUListElement | null>;
+
+  // imperative
+  closeAndFocusTrigger: () => void;
+  retry: () => void;
+
+  // render overrides (passed through from props)
+  renderOption?: (
+    opt: SelectOption<T>,
+    state: { active: boolean; selected: boolean },
+  ) => React.ReactNode;
+  renderValue?: (opt: SelectOption<T>) => React.ReactNode;
+  renderTag?: (opt: SelectOption<T>, remove: () => void) => React.ReactNode;
+  renderEmpty?: (query: string) => React.ReactNode;
+  renderLoading?: () => React.ReactNode;
+  renderError?: (err: Error, retry: () => void) => React.ReactNode;
+}
+
+export const SelectContext = createContext<SelectContextValue | null>(null);
+
+export function useSelectContext<T = unknown>(componentName: string): SelectContextValue<T> {
+  const ctx = useContext(SelectContext);
+  if (!ctx) {
+    throw new Error(`<Select> internals (${componentName}) must be rendered inside <Select>.`);
+  }
+  return ctx as SelectContextValue<T>;
+}
+```
+
+Then create `packages/design-system/src/components/Select/utils-types.ts` (re-exports the types so context doesn't import `Select.tsx` which would create a cycle):
+
+```ts
+export type { SelectOption, SelectGroup, SelectOptions } from './Select';
+export type { FlatRow } from './utils';
+```
+
+- [ ] **Step 3: Implement the minimal Select dispatching to a stub trigger**
+
+Replace the body of `packages/design-system/src/components/Select/Select.tsx` with:
+
+```tsx
+import { forwardRef, useId, useMemo, useRef, useState, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './Select.module.scss';
+import { SelectContext, type SelectContextValue } from './context';
+import { sanitizeId } from '../_internal/refs';
+import { useSelectState } from './useSelectState';
+import { flattenOptions, findOption, findOptions } from './utils';
+import { Trigger } from './Trigger';
+import { Listbox } from './Listbox';
+
+export type SelectSize = 'sm' | 'md' | 'lg';
+export type SelectTriggerDisplay = 'chips' | 'summary';
+
+export interface SelectOption<T = unknown> {
+  value: string;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+  data?: T;
+}
+
+export interface SelectGroup<T = unknown> {
+  label: string;
+  options: SelectOption<T>[];
+}
+
+export type SelectOptions<T = unknown> = SelectOption<T>[] | SelectGroup<T>[];
+
+export interface SelectProps<T = unknown>
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue'> {
+  options?: SelectOptions<T>;
+  // mode
+  multiple?: boolean;
+  triggerDisplay?: SelectTriggerDisplay;
+  searchable?: boolean;
+  creatable?: boolean;
+  // value
+  value?: string | string[];
+  defaultValue?: string | string[];
+  onChange?: (
+    value: string | string[],
+    option: SelectOption<T> | SelectOption<T>[] | null,
+  ) => void;
+  // open
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  // visuals
+  size?: SelectSize;
+  invalid?: boolean;
+  placeholder?: string;
+  clearable?: boolean;
+  // states
+  disabled?: boolean;
+  readOnly?: boolean;
+  // ARIA
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+  // render escape hatches (declared here so JSDoc is on the type; implementation in later tasks)
+}
+
+export const Select = forwardRef<HTMLDivElement, SelectProps>(function Select<T = unknown>(
+  props: SelectProps<T>,
+  ref: React.Ref<HTMLDivElement>,
+) {
+  const {
+    options = [],
+    multiple = false,
+    triggerDisplay = 'chips',
+    searchable = false,
+    creatable = false,
+    value: controlledValue,
+    defaultValue,
+    onChange,
+    open: controlledOpen,
+    defaultOpen,
+    onOpenChange,
+    size = 'md',
+    invalid = false,
+    placeholder,
+    clearable,
+    disabled = false,
+    readOnly = false,
+    className,
+    ...rest
+  } = props;
+
+  const reactId = useId();
+  const idBase = sanitizeId(reactId);
+  const listboxId = `select-listbox-${idBase}`;
+  const triggerId = `select-trigger-${idBase}`;
+  const getOptionId = (v: string) => `select-opt-${idBase}-${sanitizeId(v)}`;
+  const getGroupHeaderId = (label: string) => `select-grp-${idBase}-${sanitizeId(label)}`;
+
+  const state = useSelectState({
+    multiple,
+    value: controlledValue,
+    defaultValue,
+    onChange: (v) => {
+      if (multiple) {
+        const opts = findOptions(options, Array.isArray(v) ? v : []);
+        onChange?.(v, opts);
+      } else {
+        const opt = typeof v === 'string' && v !== '' ? findOption(options, v) : null;
+        onChange?.(v, opt);
+      }
+    },
+    open: controlledOpen,
+    defaultOpen,
+    onOpenChange,
+  });
+
+  const rows = useMemo(() => flattenOptions(options), [options]);
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
+  const [query, setQuery] = useState<string>('');
+
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const listboxRef = useRef<HTMLUListElement | null>(null);
+
+  const closeAndFocusTrigger = () => {
+    state.setOpen(false);
+    queueMicrotask(() => triggerRef.current?.focus({ preventScroll: true }));
+  };
+
+  const ctxValue: SelectContextValue<T> = {
+    multiple,
+    searchable,
+    creatable,
+    triggerDisplay,
+    rows,
+    loading: false, // populated in async phase
+    error: null,
+    value: state.value,
+    setValue: state.setValue,
+    toggleValue: state.toggleValue,
+    open: state.open,
+    setOpen: state.setOpen,
+    activeIndex,
+    setActiveIndex,
+    query,
+    setQuery,
+    listboxId,
+    triggerId,
+    getOptionId,
+    getGroupHeaderId,
+    triggerRef,
+    listboxRef,
+    closeAndFocusTrigger,
+    retry: () => {}, // populated in async phase
+  };
+
+  return (
+    <SelectContext.Provider value={ctxValue as SelectContextValue}>
+      <div
+        ref={ref}
+        {...rest}
+        className={clsx(
+          styles.root,
+          styles[`size-${size}`],
+          invalid && styles.invalid,
+          disabled && styles.disabled,
+          readOnly && styles.readOnly,
+          className,
+        )}
+        data-select=""
+      >
+        <Trigger
+          placeholder={placeholder}
+          disabled={disabled}
+          readOnly={readOnly}
+          invalid={invalid}
+          clearable={clearable}
+          aria-label={props['aria-label']}
+          aria-labelledby={props['aria-labelledby']}
+          aria-describedby={props['aria-describedby']}
+        />
+        {state.open && <Listbox />}
+      </div>
+    </SelectContext.Provider>
+  );
+}) as <T = unknown>(
+  props: SelectProps<T> & { ref?: React.Ref<HTMLDivElement> },
+) => React.ReactElement;
+```
+
+- [ ] **Step 4: Stub Trigger and Listbox to compile**
+
+Create `packages/design-system/src/components/Select/Trigger.tsx`:
+
+```tsx
+import { useSelectContext } from './context';
+
+export interface TriggerProps {
+  placeholder?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  invalid?: boolean;
+  clearable?: boolean;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+}
+
+export function Trigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  const selectedLabel =
+    !ctx.multiple && typeof ctx.value === 'string' && ctx.value !== ''
+      ? ctx.rows.find((r) => r.kind === 'option' && r.option.value === ctx.value)
+      : null;
+  const label =
+    selectedLabel && selectedLabel.kind === 'option' ? selectedLabel.option.label : props.placeholder ?? '';
+
+  return (
+    <button
+      type="button"
+      id={ctx.triggerId}
+      ref={ctx.triggerRef as React.Ref<HTMLButtonElement>}
+      aria-haspopup="listbox"
+      aria-expanded={ctx.open}
+      aria-controls={ctx.open ? ctx.listboxId : undefined}
+      aria-label={props['aria-label']}
+      aria-labelledby={props['aria-labelledby']}
+      aria-describedby={props['aria-describedby']}
+      aria-invalid={props.invalid || undefined}
+      aria-readonly={props.readOnly || undefined}
+      disabled={props.disabled}
+      onClick={() => {
+        if (props.disabled || props.readOnly) return;
+        ctx.setOpen(!ctx.open);
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+```
+
+Create `packages/design-system/src/components/Select/Listbox.tsx`:
+
+```tsx
+import { useSelectContext } from './context';
+
+export function Listbox() {
+  const ctx = useSelectContext('Listbox');
+  return (
+    <ul
+      ref={ctx.listboxRef}
+      id={ctx.listboxId}
+      role="listbox"
+      aria-multiselectable={ctx.multiple || undefined}
+    >
+      {ctx.rows.map((row, i) =>
+        row.kind === 'header' ? (
+          <li key={`h-${i}`} role="presentation">
+            {row.label}
+          </li>
+        ) : (
+          <li
+            key={row.option.value}
+            id={ctx.getOptionId(row.option.value)}
+            role="option"
+            aria-selected={
+              ctx.multiple
+                ? (ctx.value as string[]).includes(row.option.value)
+                : ctx.value === row.option.value
+            }
+            aria-disabled={row.option.disabled || undefined}
+          >
+            {row.option.label}
+          </li>
+        ),
+      )}
+    </ul>
+  );
+}
+```
+
+- [ ] **Step 5: Run the new tests**
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: pass. The trigger renders the selected label or placeholder.
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `npm run typecheck -w @eocrm/design-system`
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: context + skeletal Select/Trigger/Listbox wiring (single, click-to-open)"
+```
+
+---
+
+### Task 5: Click-to-open behavior + Listbox portal + Floating UI positioning
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Listbox.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.module.scss`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Write the failing test — clicking the trigger opens the listbox in a portal**
+
+Append to `Select.test.tsx`:
+
+```tsx
+describe('Select — open/close', () => {
+  it('opens the listbox on trigger click', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} placeholder="Pick" />);
+    expect(screen.queryByRole('listbox')).toBeNull();
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    // Options visible:
+    expect(screen.getByRole('option', { name: 'Active' })).toBeInTheDocument();
+  });
+
+  it('listbox renders in a portal at document.body level', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Select options={STATUSES} />);
+    await user.click(screen.getByRole('button'));
+    // The listbox's parent should not be the Select root div:
+    const listbox = screen.getByRole('listbox');
+    expect(container.contains(listbox)).toBe(false);
+  });
+
+  it('closes on second click of trigger', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    const trigger = screen.getByRole('button');
+    await user.click(trigger);
+    expect(screen.queryByRole('listbox')).toBeInTheDocument();
+    await user.click(trigger);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('aria-expanded reflects open state', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('aria-controls points at the listbox id when open', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    const trigger = screen.getByRole('button');
+    await user.click(trigger);
+    const listbox = screen.getByRole('listbox');
+    expect(trigger.getAttribute('aria-controls')).toBe(listbox.id);
+  });
+});
+```
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: FAIL — listbox is currently rendered inline; portal test fails. Other tests pass.
+
+- [ ] **Step 2: Wrap the listbox in a portal + position with Floating UI**
+
+Replace `packages/design-system/src/components/Select/Listbox.tsx`:
+
+```tsx
+import { useEffect, useLayoutEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { autoUpdate, flip, offset, shift, size as floatingSize, useFloating } from '@floating-ui/react-dom';
+import clsx from 'clsx';
+import { useSelectContext } from './context';
+import styles from './Select.module.scss';
+
+export function Listbox() {
+  const ctx = useSelectContext('Listbox');
+
+  const { refs, floatingStyles } = useFloating({
+    open: ctx.open,
+    placement: 'bottom-start',
+    middleware: [
+      offset(4),
+      flip(),
+      shift({ padding: 8 }),
+      // Match listbox width to trigger width.
+      floatingSize({
+        apply({ rects, elements }) {
+          Object.assign(elements.floating.style, {
+            width: `${rects.reference.width}px`,
+            maxHeight: '320px',
+          });
+        },
+      }),
+    ],
+    whileElementsMounted: autoUpdate,
+    elements: { reference: ctx.triggerRef.current },
+  });
+
+  // Outside-click closes
+  useEffect(() => {
+    if (!ctx.open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      const panel = ctx.listboxRef.current;
+      const trigger = ctx.triggerRef.current;
+      if (panel && panel.contains(target)) return;
+      if (trigger && trigger.contains(target)) return;
+      ctx.setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [ctx.open, ctx.listboxRef, ctx.triggerRef, ctx]);
+
+  // Escape closes and returns focus to trigger
+  useEffect(() => {
+    if (!ctx.open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        ctx.closeAndFocusTrigger();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [ctx.open, ctx]);
+
+  // Reset active row to first selectable option (or first selected) on open
+  useLayoutEffect(() => {
+    if (!ctx.open) return;
+    const firstSelectedIdx = ctx.rows.findIndex(
+      (r) =>
+        r.kind === 'option' &&
+        !r.option.disabled &&
+        (ctx.multiple
+          ? (ctx.value as string[]).includes(r.option.value)
+          : ctx.value === r.option.value),
+    );
+    if (firstSelectedIdx >= 0) {
+      ctx.setActiveIndex(firstSelectedIdx);
+      return;
+    }
+    const firstSelectableIdx = ctx.rows.findIndex(
+      (r) => r.kind === 'option' && !r.option.disabled,
+    );
+    ctx.setActiveIndex(firstSelectableIdx >= 0 ? firstSelectableIdx : -1);
+    // We only want this on open transitions, not on every rows change:
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ctx.open]);
+
+  return createPortal(
+    <ul
+      ref={(node) => {
+        (ctx.listboxRef as React.MutableRefObject<HTMLUListElement | null>).current = node;
+        refs.setFloating(node);
+      }}
+      id={ctx.listboxId}
+      role="listbox"
+      aria-multiselectable={ctx.multiple || undefined}
+      aria-labelledby={ctx.triggerId}
+      tabIndex={-1}
+      className={clsx(styles.listbox)}
+      style={floatingStyles}
+    >
+      {ctx.rows.map((row, i) => {
+        if (row.kind === 'header') {
+          return (
+            <li
+              key={`h-${i}`}
+              id={ctx.getGroupHeaderId(row.label)}
+              role="presentation"
+              className={styles.groupHeader}
+            >
+              {row.label}
+            </li>
+          );
+        }
+        const selected = ctx.multiple
+          ? (ctx.value as string[]).includes(row.option.value)
+          : ctx.value === row.option.value;
+        const active = ctx.activeIndex === i;
+        return (
+          <li
+            key={row.option.value}
+            id={ctx.getOptionId(row.option.value)}
+            role="option"
+            aria-selected={selected}
+            aria-disabled={row.option.disabled || undefined}
+            className={clsx(
+              styles.option,
+              active && styles.optionActive,
+              selected && styles.optionSelected,
+              row.option.disabled && styles.optionDisabled,
+            )}
+            onPointerDown={(e) => {
+              // Prevent the outside-click handler from firing for this click
+              e.preventDefault();
+            }}
+            onClick={() => {
+              if (row.option.disabled) return;
+              if (ctx.multiple) {
+                ctx.toggleValue(row.option.value);
+              } else {
+                ctx.setValue(row.option.value);
+                ctx.closeAndFocusTrigger();
+              }
+            }}
+            onMouseEnter={() => {
+              if (!row.option.disabled) ctx.setActiveIndex(i);
+            }}
+          >
+            {row.option.label}
+          </li>
+        );
+      })}
+    </ul>,
+    document.body,
+  );
+}
+```
+
+- [ ] **Step 3: Add the minimum visual styling to `Select.module.scss` to make tests deterministic**
+
+Replace `packages/design-system/src/components/Select/Select.module.scss`:
+
+```scss
+@use '../../styles/mixins' as *;
+
+.root {
+  display: inline-block;
+}
+
+.listbox {
+  z-index: var(--z-popover, 1100);
+  overflow-y: auto;
+  padding: var(--space-1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md, 0 4px 12px rgb(9 30 66 / 15%));
+  list-style: none;
+}
+
+.groupHeader {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  user-select: none;
+}
+
+.option {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-md);
+  color: var(--color-fg);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+
+.optionActive {
+  background: var(--color-bg-muted);
+}
+
+.optionSelected {
+  background: var(--color-accent-subtle-bg);
+  box-shadow: inset 2px 0 0 var(--color-accent);
+}
+
+.optionDisabled {
+  color: var(--color-fg-disabled);
+  cursor: not-allowed;
+}
+
+// Visual states populated in later tasks
+.size-sm,
+.size-md,
+.size-lg,
+.invalid,
+.disabled,
+.readOnly {
+  /* placeholder selectors; rules added in later tasks */
+}
+```
+
+If `_internal/mixins` doesn't exist, drop the `@use` line. Check first: `ls packages/design-system/src/styles/`.
+
+Also drop the `mixins` import if not needed; the rules above only use tokens.
+
+Simplify by removing the `@use` line if not used:
+
+```scss
+.root {
+  display: inline-block;
+}
+/* rest unchanged */
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: all pass.
+
+- [ ] **Step 5: Stylelint sanity**
+
+Run: `npm run lint:css`
+Expected: pass. If `--shadow-md` is unknown to stylelint's strict-value rule, add it to `tokens.scss` (it likely already exists from Popover work — check `packages/design-system/src/styles/tokens.scss`). If absent, add `--shadow-md: 0 4px 12px rgb(9 30 66 / 15%);` to `:root`. If `--z-popover` is absent, add `--z-popover: 1100;`. After adding tokens, re-run lint.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/ packages/design-system/src/styles/tokens.scss
+git commit -m "Select: portaled Listbox + Floating UI positioning + outside-click/Escape dismissal"
+```
+
+---
+
+### Task 6: Click-to-select + onChange round-trip
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Write the failing tests for selection**
+
+Append to `Select.test.tsx`:
+
+```tsx
+describe('Select — selection (single)', () => {
+  it('selecting an option fires onChange(value, option) and closes the popover', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Select options={STATUSES} onChange={onChange} />);
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('option', { name: 'Pending' }));
+    expect(onChange).toHaveBeenCalledWith('pending', STATUSES[1]);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('controlled value round-trip — parent re-renders new value, trigger updates', async () => {
+    const user = userEvent.setup();
+    const Wrapper = () => {
+      const [v, setV] = React.useState<string>('');
+      return (
+        <Select
+          options={STATUSES}
+          value={v}
+          onChange={(next) => setV(next as string)}
+          placeholder="Pick"
+        />
+      );
+    };
+    render(<Wrapper />);
+    expect(screen.getByRole('button')).toHaveTextContent('Pick');
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('option', { name: 'Archived' }));
+    expect(screen.getByRole('button')).toHaveTextContent('Archived');
+  });
+
+  it('clicking a disabled option does nothing', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const opts = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B', disabled: true },
+    ];
+    render(<Select options={opts} onChange={onChange} />);
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('option', { name: 'B' }));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('listbox')).toBeInTheDocument(); // didn't close
+  });
+});
+```
+
+Top of file, add `import React from 'react';` if not already present (needed for `React.useState`).
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: most pass; the disabled-option non-action test should already pass thanks to Listbox's `if (row.option.disabled) return;` guard. The controlled round-trip should pass.
+
+- [ ] **Step 2: Verify all pass**
+
+If any failed: inspect Listbox click handler — re-confirm `setValue` is called before `closeAndFocusTrigger`, and the popover is unmounted by `state.open=false` triggering re-render.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/Select.test.tsx
+git commit -m "Select: tests — single selection round-trip, controlled value, disabled option"
+```
+
+---
+
+### Task 7: Keyboard navigation — open, ArrowUp/Down/Home/End, Enter, Escape, Tab
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Trigger.tsx`
+- Modify: `packages/design-system/src/components/Select/Listbox.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Write the failing keyboard tests**
+
+Append to `Select.test.tsx`:
+
+```tsx
+describe('Select — keyboard (single, non-searchable)', () => {
+  it('ArrowDown on closed trigger opens with first option active', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    const trigger = screen.getByRole('button');
+    trigger.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    const active = screen.getByRole('option', { name: 'Active' });
+    expect(trigger).toHaveAttribute('aria-activedescendant', active.id);
+  });
+
+  it('ArrowUp on closed trigger opens with last option active', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    const trigger = screen.getByRole('button');
+    trigger.focus();
+    await user.keyboard('{ArrowUp}');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    const active = screen.getByRole('option', { name: 'Archived' });
+    expect(trigger).toHaveAttribute('aria-activedescendant', active.id);
+  });
+
+  it('Enter on closed trigger opens', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{Enter}');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('ArrowDown moves active row +1', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}'); // open, active = Active
+    await user.keyboard('{ArrowDown}'); // active = Pending
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Pending' }).id,
+    );
+  });
+
+  it('Home jumps to first, End jumps to last', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}{End}');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Archived' }).id,
+    );
+    await user.keyboard('{Home}');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Active' }).id,
+    );
+  });
+
+  it('Enter on open selects the active row and closes', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Select options={STATUSES} onChange={onChange} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+    expect(onChange).toHaveBeenCalledWith('pending', STATUSES[1]);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('Escape closes without changing selection', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Select options={STATUSES} value="active" onChange={onChange} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{Enter}{ArrowDown}{Escape}');
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('button')).toHaveTextContent('Active');
+  });
+
+  it('Tab closes and commits', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{Enter}{Tab}');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('ArrowDown skips disabled options', async () => {
+    const user = userEvent.setup();
+    const opts = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B', disabled: true },
+      { value: 'c', label: 'C' },
+    ];
+    render(<Select options={opts} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}{ArrowDown}');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'C' }).id,
+    );
+  });
+});
+```
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: FAIL — keyboard handling not wired.
+
+- [ ] **Step 2: Add keyboard handling to the Trigger**
+
+Replace `packages/design-system/src/components/Select/Trigger.tsx`:
+
+```tsx
+import { useCallback, type KeyboardEvent } from 'react';
+import clsx from 'clsx';
+import { useSelectContext } from './context';
+import styles from './Select.module.scss';
+
+export interface TriggerProps {
+  placeholder?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  invalid?: boolean;
+  clearable?: boolean;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+}
+
+export function Trigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+
+  // Single, non-searchable trigger only in this task. Other variants in later tasks.
+  const selectedRow =
+    !ctx.multiple && typeof ctx.value === 'string' && ctx.value !== ''
+      ? ctx.rows.find((r) => r.kind === 'option' && r.option.value === ctx.value)
+      : null;
+  const label =
+    selectedRow && selectedRow.kind === 'option' ? selectedRow.option.label : props.placeholder ?? '';
+
+  const firstSelectableIdx = ctx.rows.findIndex((r) => r.kind === 'option' && !r.option.disabled);
+  const lastSelectableIdx = (() => {
+    for (let i = ctx.rows.length - 1; i >= 0; i--) {
+      const r = ctx.rows[i];
+      if (r.kind === 'option' && !r.option.disabled) return i;
+    }
+    return -1;
+  })();
+
+  const moveActive = useCallback(
+    (delta: number) => {
+      const { rows, activeIndex } = ctx;
+      if (rows.length === 0) return;
+      const len = rows.length;
+      let i = activeIndex;
+      for (let step = 0; step < len; step++) {
+        i = (i + delta + len) % len;
+        const r = rows[i];
+        if (r.kind === 'option' && !r.option.disabled) {
+          ctx.setActiveIndex(i);
+          return;
+        }
+      }
+    },
+    [ctx],
+  );
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (props.disabled || props.readOnly) return;
+    if (!ctx.open) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        ctx.setOpen(true);
+        // Active row is set by Listbox's useLayoutEffect on open.
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        ctx.setOpen(true);
+        // Active = last selectable; defer until Listbox mounts and applies its own effect,
+        // then override:
+        queueMicrotask(() => ctx.setActiveIndex(lastSelectableIdx));
+        return;
+      }
+      return;
+    }
+    // Open
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        moveActive(+1);
+        return;
+      case 'ArrowUp':
+        e.preventDefault();
+        moveActive(-1);
+        return;
+      case 'Home':
+        e.preventDefault();
+        if (firstSelectableIdx >= 0) ctx.setActiveIndex(firstSelectableIdx);
+        return;
+      case 'End':
+        e.preventDefault();
+        if (lastSelectableIdx >= 0) ctx.setActiveIndex(lastSelectableIdx);
+        return;
+      case 'PageDown':
+        e.preventDefault();
+        for (let step = 0; step < 5; step++) moveActive(+1);
+        return;
+      case 'PageUp':
+        e.preventDefault();
+        for (let step = 0; step < 5; step++) moveActive(-1);
+        return;
+      case 'Enter':
+      case ' ': {
+        e.preventDefault();
+        const row = ctx.rows[ctx.activeIndex];
+        if (row && row.kind === 'option' && !row.option.disabled) {
+          if (ctx.multiple) {
+            ctx.toggleValue(row.option.value);
+          } else {
+            ctx.setValue(row.option.value);
+            ctx.closeAndFocusTrigger();
+          }
+        }
+        return;
+      }
+      case 'Escape':
+        e.preventDefault();
+        ctx.closeAndFocusTrigger();
+        return;
+      case 'Tab':
+        ctx.setOpen(false);
+        return;
+      default:
+        return;
+    }
+  };
+
+  const activeOptionId =
+    ctx.open && ctx.activeIndex >= 0 && ctx.rows[ctx.activeIndex]?.kind === 'option'
+      ? ctx.getOptionId((ctx.rows[ctx.activeIndex] as { option: { value: string } }).option.value)
+      : undefined;
+
+  return (
+    <button
+      type="button"
+      id={ctx.triggerId}
+      ref={ctx.triggerRef as React.Ref<HTMLButtonElement>}
+      className={clsx(styles.trigger, styles.triggerButton)}
+      aria-haspopup="listbox"
+      aria-expanded={ctx.open}
+      aria-controls={ctx.open ? ctx.listboxId : undefined}
+      aria-activedescendant={activeOptionId}
+      aria-label={props['aria-label']}
+      aria-labelledby={props['aria-labelledby']}
+      aria-describedby={props['aria-describedby']}
+      aria-invalid={props.invalid || undefined}
+      aria-readonly={props.readOnly || undefined}
+      disabled={props.disabled}
+      onClick={() => {
+        if (props.disabled || props.readOnly) return;
+        ctx.setOpen(!ctx.open);
+      }}
+      onKeyDown={handleKeyDown}
+    >
+      {label || <span className={styles.placeholder}>{props.placeholder}</span>}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 3: Add `.trigger`, `.triggerButton`, `.placeholder` styles**
+
+Append to `Select.module.scss`:
+
+```scss
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: var(--size-md);
+  padding: 0 var(--space-3);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-md);
+  color: var(--color-fg);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 var(--ring-width) var(--ring-accent);
+  }
+
+  &[disabled] {
+    color: var(--color-fg-disabled);
+    background: var(--color-bg-subtle);
+    cursor: not-allowed;
+  }
+}
+
+.triggerButton {
+  text-align: left;
+}
+
+.placeholder {
+  color: var(--color-fg-muted);
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: keyboard nav (ArrowUp/Down/Home/End/PageUp/PageDown/Enter/Escape/Tab) + aria-activedescendant"
+```
+
+---
+
+### Task 8: Typeahead (printable-char buffer) for non-searchable
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Trigger.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Select.test.tsx`:
+
+```tsx
+describe('Select — typeahead (non-searchable)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('typing a letter jumps active row to first option starting with it', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<Select options={STATUSES} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}'); // open
+    await user.keyboard('p'); // matches "Pending"
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Pending' }).id,
+    );
+  });
+
+  it('typing a sequence within 500ms matches the joined prefix', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const opts = [
+      { value: '1', label: 'Aardvark' },
+      { value: '2', label: 'Albatross' },
+      { value: '3', label: 'Antelope' },
+    ];
+    render(<Select options={opts} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}'); // open
+    await user.keyboard('al');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Albatross' }).id,
+    );
+  });
+
+  it('buffer resets after 500ms idle', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const opts = [
+      { value: '1', label: 'Apple' },
+      { value: '2', label: 'Banana' },
+    ];
+    render(<Select options={opts} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('a'); // → Apple
+    vi.advanceTimersByTime(600);
+    await user.keyboard('b'); // → Banana
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Banana' }).id,
+    );
+  });
+});
+```
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: FAIL — typeahead not implemented.
+
+- [ ] **Step 2: Add typeahead to Trigger**
+
+In `Trigger.tsx`, add a ref-based buffer. Add inside the function body, before `handleKeyDown`:
+
+```tsx
+import { useRef } from 'react';
+// ...
+
+const typeaheadBufferRef = useRef('');
+const typeaheadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+const stepTypeahead = (char: string) => {
+  if (typeaheadTimerRef.current) clearTimeout(typeaheadTimerRef.current);
+  typeaheadBufferRef.current += char.toLowerCase();
+  const buffer = typeaheadBufferRef.current;
+  const start = ctx.activeIndex >= 0 ? ctx.activeIndex : 0;
+  const len = ctx.rows.length;
+  for (let i = 0; i < len; i++) {
+    const idx = (start + i + (buffer.length === 1 ? 1 : 0)) % len;
+    const r = ctx.rows[idx];
+    if (r.kind !== 'option' || r.option.disabled) continue;
+    if (r.option.label.toLowerCase().startsWith(buffer)) {
+      ctx.setActiveIndex(idx);
+      break;
+    }
+  }
+  typeaheadTimerRef.current = setTimeout(() => {
+    typeaheadBufferRef.current = '';
+  }, 500);
+};
+```
+
+Then in `handleKeyDown`, after the existing `switch` returns, add a printable-char branch. Replace the final `default: return;` with:
+
+```tsx
+default: {
+  if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    // Printable char — typeahead
+    e.preventDefault();
+    if (!ctx.open) ctx.setOpen(true);
+    stepTypeahead(e.key);
+  }
+  return;
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/Trigger.tsx packages/design-system/src/components/Select/Select.test.tsx
+git commit -m "Select: typeahead (500ms buffer) for non-searchable trigger"
+```
+
+---
+
+## Phase 3 — Grouped options
+
+### Task 9: Group headers in the Listbox (sync only)
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Listbox.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Select.test.tsx`:
+
+```tsx
+describe('Select — grouped options', () => {
+  const GROUPED = [
+    { label: 'Active', options: [{ value: 'a1', label: 'Foo' }, { value: 'a2', label: 'Bar' }] },
+    { label: 'Archived', options: [{ value: 'b1', label: 'Baz' }] },
+  ];
+
+  it('renders group headers in order before their options', async () => {
+    const user = userEvent.setup();
+    render(<Select options={GROUPED} />);
+    await user.click(screen.getByRole('button'));
+    const listbox = screen.getByRole('listbox');
+    const headers = listbox.querySelectorAll('[data-group-header]');
+    expect(headers).toHaveLength(2);
+    expect(headers[0]).toHaveTextContent('Active');
+    expect(headers[1]).toHaveTextContent('Archived');
+  });
+
+  it('group is wrapped in role=group with aria-labelledby to the header id', async () => {
+    const user = userEvent.setup();
+    render(<Select options={GROUPED} />);
+    await user.click(screen.getByRole('button'));
+    const groups = screen.getAllByRole('group');
+    expect(groups).toHaveLength(2);
+    const header0 = screen.getByText('Active');
+    expect(groups[0].getAttribute('aria-labelledby')).toBe(header0.id);
+  });
+
+  it('ArrowDown skips group headers', async () => {
+    const user = userEvent.setup();
+    render(<Select options={GROUPED} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}'); // open + 2 steps
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Baz' }).id,
+    );
+  });
+});
+```
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: FAIL — current Listbox renders headers but they're not grouped, no `data-group-header`, no `role="group"`.
+
+- [ ] **Step 2: Update the Listbox to render `<ul role="listbox">` containing `<li role="group">` wrappers when grouped**
+
+Replace the row-mapping section of `Listbox.tsx`. Where `ctx.rows.map(...)` is, replace with:
+
+```tsx
+{(() => {
+  // Walk the flat row list and re-group it for DOM, while preserving the
+  // flat index so keyboard nav stays correct.
+  const nodes: React.ReactNode[] = [];
+  let i = 0;
+  while (i < ctx.rows.length) {
+    const row = ctx.rows[i];
+    if (row.kind === 'header') {
+      // Open a group wrapper containing this header + all following option
+      // rows that belong to it.
+      const headerLabel = row.label;
+      const headerId = ctx.getGroupHeaderId(headerLabel);
+      const groupChildren: React.ReactNode[] = [];
+      groupChildren.push(
+        <li
+          key={`h-${i}`}
+          id={headerId}
+          data-group-header=""
+          className={styles.groupHeader}
+          aria-hidden="false"
+        >
+          {headerLabel}
+        </li>,
+      );
+      let j = i + 1;
+      while (j < ctx.rows.length && ctx.rows[j].kind === 'option') {
+        const optRow = ctx.rows[j] as Extract<typeof ctx.rows[number], { kind: 'option' }>;
+        const selected = ctx.multiple
+          ? (ctx.value as string[]).includes(optRow.option.value)
+          : ctx.value === optRow.option.value;
+        const active = ctx.activeIndex === j;
+        groupChildren.push(renderOptionRow(optRow.option, j, selected, active, ctx));
+        j++;
+      }
+      nodes.push(
+        <li role="group" key={`g-${i}`} aria-labelledby={headerId}>
+          <ul role="none" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {groupChildren}
+          </ul>
+        </li>,
+      );
+      i = j;
+      continue;
+    }
+    // Ungrouped option
+    const optRow = row as Extract<typeof row, { kind: 'option' }>;
+    const selected = ctx.multiple
+      ? (ctx.value as string[]).includes(optRow.option.value)
+      : ctx.value === optRow.option.value;
+    const active = ctx.activeIndex === i;
+    nodes.push(renderOptionRow(optRow.option, i, selected, active, ctx));
+    i++;
+  }
+  return nodes;
+})()}
+```
+
+Then extract `renderOptionRow` as a module-local helper outside the component:
+
+```tsx
+function renderOptionRow<T>(
+  opt: import('./Select').SelectOption<T>,
+  i: number,
+  selected: boolean,
+  active: boolean,
+  ctx: ReturnType<typeof useSelectContext<T>>,
+): React.ReactNode {
+  return (
+    <li
+      key={opt.value}
+      id={ctx.getOptionId(opt.value)}
+      role="option"
+      aria-selected={selected}
+      aria-disabled={opt.disabled || undefined}
+      className={clsx(
+        styles.option,
+        active && styles.optionActive,
+        selected && styles.optionSelected,
+        opt.disabled && styles.optionDisabled,
+      )}
+      onPointerDown={(e) => e.preventDefault()}
+      onClick={() => {
+        if (opt.disabled) return;
+        if (ctx.multiple) {
+          ctx.toggleValue(opt.value);
+        } else {
+          ctx.setValue(opt.value);
+          ctx.closeAndFocusTrigger();
+        }
+      }}
+      onMouseEnter={() => {
+        if (!opt.disabled) ctx.setActiveIndex(i);
+      }}
+    >
+      {opt.label}
+    </li>
+  );
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: all pass. Existing keyboard-nav-skips-headers test passes because headers are `kind: 'header'` in the flat rows and the Trigger keyboard already skips them.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: grouped options (role=group + aria-labelledby + nested ul, keyboard skips headers)"
+```
+
+---
+
+## Phase 4 — Single, searchable (combobox input-as-trigger)
+
+End of phase = `searchable={true}` works for single mode. Trigger is an input; typing replaces displayed label with the query and filters the list. Escape reverts; click-outside reverts; Enter or click commits.
+
+### Task 10: Combobox-input trigger variant for single + searchable
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Trigger.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.module.scss`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Select.test.tsx`:
+
+```tsx
+describe('Select — single, searchable (combobox input)', () => {
+  it('renders the trigger as an input with role=combobox', () => {
+    render(<Select searchable options={STATUSES} placeholder="Pick" />);
+    const input = screen.getByRole('combobox');
+    expect(input.tagName).toBe('INPUT');
+    expect(input).toHaveAttribute('aria-autocomplete', 'list');
+  });
+
+  it('shows selected label as input value when closed', () => {
+    render(<Select searchable options={STATUSES} value="pending" />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    expect(input.value).toBe('Pending');
+  });
+
+  it('typing replaces the label with the query and opens', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable options={STATUSES} value="pending" />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    input.focus();
+    await user.keyboard('a');
+    expect(input.value).toBe('a');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('typing filters options by label (case-insensitive)', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable options={STATUSES} />);
+    const input = screen.getByRole('combobox');
+    input.focus();
+    await user.keyboard('arc');
+    expect(screen.queryByRole('option', { name: 'Active' })).toBeNull();
+    expect(screen.queryByRole('option', { name: 'Pending' })).toBeNull();
+    expect(screen.getByRole('option', { name: 'Archived' })).toBeInTheDocument();
+  });
+
+  it('Escape reverts query to selected label', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable options={STATUSES} defaultValue="pending" />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    input.focus();
+    await user.keyboard('arc');
+    expect(input.value).toBe('arc');
+    await user.keyboard('{Escape}');
+    expect(input.value).toBe('Pending');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('Click on row commits the selection and replaces input value with new label', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Select searchable options={STATUSES} onChange={onChange} />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.click(screen.getByRole('option', { name: 'Pending' }));
+    expect(onChange).toHaveBeenCalledWith('pending', STATUSES[1]);
+    expect(input.value).toBe('Pending');
+  });
+
+  it('Click outside reverts query without selecting', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <div>
+        <Select searchable options={STATUSES} defaultValue="active" onChange={onChange} />
+        <button data-testid="outside">outside</button>
+      </div>,
+    );
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    input.focus();
+    await user.keyboard('arc');
+    expect(input.value).toBe('arc');
+    await user.click(screen.getByTestId('outside'));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input.value).toBe('Active');
+  });
+
+  it('ArrowDown on focused-but-closed combobox opens without replacing input value', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable options={STATUSES} value="pending" />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    input.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(input.value).toBe('Pending');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+});
+```
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: FAIL — no combobox-input variant yet.
+
+- [ ] **Step 2: Split Trigger into ButtonTrigger + ComboboxInputTrigger**
+
+Replace `Trigger.tsx` with two internal renderers dispatched by props. Keep keyboard logic shared via a hook.
+
+Replace the full contents of `packages/design-system/src/components/Select/Trigger.tsx`:
+
+```tsx
+import { useCallback, useEffect, useRef, type KeyboardEvent } from 'react';
+import clsx from 'clsx';
+import { useSelectContext } from './context';
+import { findOption } from './utils';
+import type { SelectOption } from './Select';
+import styles from './Select.module.scss';
+
+export interface TriggerProps {
+  placeholder?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  invalid?: boolean;
+  clearable?: boolean;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+}
+
+/**
+ * Returns the active option id for aria-activedescendant, or undefined.
+ */
+function useActiveOptionId() {
+  const ctx = useSelectContext('Trigger');
+  if (!ctx.open || ctx.activeIndex < 0) return undefined;
+  const row = ctx.rows[ctx.activeIndex];
+  if (!row || row.kind !== 'option') return undefined;
+  return ctx.getOptionId(row.option.value);
+}
+
+/**
+ * Shared keyboard navigation logic used by both ButtonTrigger and
+ * ComboboxInputTrigger. Returns the handler + helpers.
+ */
+function useTriggerKeyboard(opts: { disabled?: boolean; readOnly?: boolean }) {
+  const ctx = useSelectContext('Trigger');
+  const typeaheadBufferRef = useRef('');
+  const typeaheadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const findLastSelectable = () => {
+    for (let i = ctx.rows.length - 1; i >= 0; i--) {
+      const r = ctx.rows[i];
+      if (r.kind === 'option' && !r.option.disabled) return i;
+    }
+    return -1;
+  };
+
+  const findFirstSelectable = () =>
+    ctx.rows.findIndex((r) => r.kind === 'option' && !r.option.disabled);
+
+  const moveActive = useCallback(
+    (delta: number) => {
+      const { rows, activeIndex } = ctx;
+      if (rows.length === 0) return;
+      const len = rows.length;
+      let i = activeIndex;
+      for (let step = 0; step < len; step++) {
+        i = (i + delta + len) % len;
+        const r = rows[i];
+        if (r.kind === 'option' && !r.option.disabled) {
+          ctx.setActiveIndex(i);
+          return;
+        }
+      }
+    },
+    [ctx],
+  );
+
+  const stepTypeahead = (char: string) => {
+    if (typeaheadTimerRef.current) clearTimeout(typeaheadTimerRef.current);
+    typeaheadBufferRef.current += char.toLowerCase();
+    const buffer = typeaheadBufferRef.current;
+    const len = ctx.rows.length;
+    const start = ctx.activeIndex >= 0 ? ctx.activeIndex : 0;
+    for (let i = 0; i < len; i++) {
+      const idx = (start + i + (buffer.length === 1 ? 1 : 0)) % len;
+      const r = ctx.rows[idx];
+      if (r.kind !== 'option' || r.option.disabled) continue;
+      if (r.option.label.toLowerCase().startsWith(buffer)) {
+        ctx.setActiveIndex(idx);
+        break;
+      }
+    }
+    typeaheadTimerRef.current = setTimeout(() => {
+      typeaheadBufferRef.current = '';
+    }, 500);
+  };
+
+  /**
+   * Common navigation keys (Arrow/Home/End/PageUp/PageDown/Enter/Escape/Tab).
+   * Returns true if the key was handled.
+   */
+  const handleNavKey = (e: KeyboardEvent<HTMLElement>): boolean => {
+    if (opts.disabled || opts.readOnly) return false;
+    if (!ctx.open) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter') {
+        e.preventDefault();
+        ctx.setOpen(true);
+        return true;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        ctx.setOpen(true);
+        queueMicrotask(() => ctx.setActiveIndex(findLastSelectable()));
+        return true;
+      }
+      return false;
+    }
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        moveActive(+1);
+        return true;
+      case 'ArrowUp':
+        e.preventDefault();
+        moveActive(-1);
+        return true;
+      case 'Home':
+        e.preventDefault();
+        if (findFirstSelectable() >= 0) ctx.setActiveIndex(findFirstSelectable());
+        return true;
+      case 'End':
+        e.preventDefault();
+        if (findLastSelectable() >= 0) ctx.setActiveIndex(findLastSelectable());
+        return true;
+      case 'PageDown':
+        e.preventDefault();
+        for (let s = 0; s < 5; s++) moveActive(+1);
+        return true;
+      case 'PageUp':
+        e.preventDefault();
+        for (let s = 0; s < 5; s++) moveActive(-1);
+        return true;
+      case 'Enter': {
+        e.preventDefault();
+        const row = ctx.rows[ctx.activeIndex];
+        if (row && row.kind === 'option' && !row.option.disabled) {
+          if (ctx.multiple) {
+            ctx.toggleValue(row.option.value);
+          } else {
+            ctx.setValue(row.option.value);
+            ctx.closeAndFocusTrigger();
+          }
+        }
+        return true;
+      }
+      case 'Escape':
+        e.preventDefault();
+        ctx.closeAndFocusTrigger();
+        return true;
+      case 'Tab':
+        ctx.setOpen(false);
+        return false; // let Tab traverse normally
+      default:
+        return false;
+    }
+  };
+
+  return { handleNavKey, stepTypeahead, moveActive };
+}
+
+function ButtonTrigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  const { handleNavKey, stepTypeahead } = useTriggerKeyboard({
+    disabled: props.disabled,
+    readOnly: props.readOnly,
+  });
+  const activeOptionId = useActiveOptionId();
+
+  const selectedRow =
+    !ctx.multiple && typeof ctx.value === 'string' && ctx.value !== ''
+      ? ctx.rows.find((r) => r.kind === 'option' && r.option.value === ctx.value)
+      : null;
+  const label =
+    selectedRow && selectedRow.kind === 'option' ? selectedRow.option.label : '';
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (handleNavKey(e)) return;
+    if (e.key === ' ') {
+      e.preventDefault();
+      if (!ctx.open) ctx.setOpen(true);
+      else {
+        const row = ctx.rows[ctx.activeIndex];
+        if (row && row.kind === 'option' && !row.option.disabled) {
+          if (ctx.multiple) ctx.toggleValue(row.option.value);
+          else {
+            ctx.setValue(row.option.value);
+            ctx.closeAndFocusTrigger();
+          }
+        }
+      }
+      return;
+    }
+    if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
+      if (!ctx.open) ctx.setOpen(true);
+      stepTypeahead(e.key);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      id={ctx.triggerId}
+      ref={ctx.triggerRef as React.Ref<HTMLButtonElement>}
+      className={clsx(styles.trigger, styles.triggerButton)}
+      aria-haspopup="listbox"
+      aria-expanded={ctx.open}
+      aria-controls={ctx.open ? ctx.listboxId : undefined}
+      aria-activedescendant={activeOptionId}
+      aria-label={props['aria-label']}
+      aria-labelledby={props['aria-labelledby']}
+      aria-describedby={props['aria-describedby']}
+      aria-invalid={props.invalid || undefined}
+      aria-readonly={props.readOnly || undefined}
+      disabled={props.disabled}
+      onClick={() => {
+        if (props.disabled || props.readOnly) return;
+        ctx.setOpen(!ctx.open);
+      }}
+      onKeyDown={handleKeyDown}
+    >
+      {label || <span className={styles.placeholder}>{props.placeholder}</span>}
+    </button>
+  );
+}
+
+function ComboboxInputTrigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  const { handleNavKey } = useTriggerKeyboard({
+    disabled: props.disabled,
+    readOnly: props.readOnly,
+  });
+  const activeOptionId = useActiveOptionId();
+  const inputRef = ctx.triggerRef as React.MutableRefObject<HTMLInputElement | null>;
+
+  // Sync the input's displayed value to the selected label when closed,
+  // to the query when open. The selected label is treated as the "committed"
+  // state; the query is transient.
+  const selected = !ctx.multiple && typeof ctx.value === 'string' && ctx.value !== ''
+    ? findOption(ctx.rows.flatMap((r) => (r.kind === 'option' ? [r.option] : [])), ctx.value as string)
+    : null;
+  const selectedLabel = selected ? selected.label : '';
+  const displayValue = ctx.open ? ctx.query : selectedLabel;
+
+  // When opening, copy the selected label into the query iff the open
+  // happened via mouse-click or arrow-key (not typing). The Trigger's
+  // own onChange handles the typing case (replacing query).
+  useEffect(() => {
+    if (!ctx.open) {
+      // On close, reset query so subsequent open shows the selected label.
+      if (ctx.query !== '') ctx.setQuery('');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ctx.open]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (handleNavKey(e)) return;
+    // Printable chars + Backspace etc. land in onChange below.
+    // Don't intercept Space — it's a literal space in the query.
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (props.disabled || props.readOnly) return;
+    const next = e.target.value;
+    if (!ctx.open) ctx.setOpen(true);
+    ctx.setQuery(next);
+  };
+
+  return (
+    <input
+      type="text"
+      id={ctx.triggerId}
+      ref={(node) => {
+        inputRef.current = node;
+      }}
+      className={clsx(styles.trigger, styles.triggerInput)}
+      role="combobox"
+      aria-autocomplete="list"
+      aria-haspopup="listbox"
+      aria-expanded={ctx.open}
+      aria-controls={ctx.open ? ctx.listboxId : undefined}
+      aria-activedescendant={activeOptionId}
+      aria-label={props['aria-label']}
+      aria-labelledby={props['aria-labelledby']}
+      aria-describedby={props['aria-describedby']}
+      aria-invalid={props.invalid || undefined}
+      aria-readonly={props.readOnly || undefined}
+      disabled={props.disabled}
+      readOnly={props.readOnly}
+      placeholder={selectedLabel === '' ? props.placeholder : undefined}
+      value={displayValue}
+      onClick={() => {
+        if (props.disabled || props.readOnly) return;
+        if (!ctx.open) ctx.setOpen(true);
+      }}
+      onFocus={() => {
+        // Focus alone doesn't open — matches Headless UI Combobox.
+      }}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+    />
+  );
+}
+
+/**
+ * Internal dispatcher — picks the right trigger variant by props.
+ */
+export function Trigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  // Future tasks add chips/summary multi variants here. For now:
+  if (!ctx.multiple && ctx.searchable) {
+    return <ComboboxInputTrigger {...props} />;
+  }
+  // Single non-searchable, multi-non-chips-non-searchable (multi UI not yet wired):
+  return <ButtonTrigger {...props} />;
+}
+```
+
+- [ ] **Step 3: Update Listbox to filter rows by `ctx.query` when searchable (local filter only)**
+
+Modify `Listbox.tsx` to compute filtered rows. Right after `useFloating`, add:
+
+```tsx
+const filteredRows = (() => {
+  if (!ctx.searchable || ctx.query.trim() === '') return ctx.rows;
+  const q = ctx.query.toLowerCase();
+  // Strip groups whose options all filter out; keep header only if at least one
+  // child option matches.
+  const out: typeof ctx.rows = [];
+  let pendingHeader: typeof ctx.rows[number] | null = null;
+  for (const row of ctx.rows) {
+    if (row.kind === 'header') {
+      pendingHeader = row;
+      continue;
+    }
+    const matches =
+      row.option.label.toLowerCase().includes(q) ||
+      (row.option.description?.toLowerCase().includes(q) ?? false);
+    if (matches) {
+      if (pendingHeader) {
+        out.push(pendingHeader);
+        pendingHeader = null;
+      }
+      out.push(row);
+    }
+  }
+  return out;
+})();
+```
+
+Then change the render-row loop and the `useLayoutEffect` to operate on `filteredRows` instead of `ctx.rows`. Wherever `ctx.rows` appears inside the JSX/effect of Listbox, replace with `filteredRows`. The keyboard handler in Trigger continues to operate on `ctx.rows` indices, but we need it to operate on the filtered view. Resolve by storing the filtered rows in the context.
+
+Simpler: keep `ctx.rows` filtered inside the context. Modify `Select.tsx` to compute and pass filtered rows. Replace the existing `rows` line in `Select.tsx`:
+
+```tsx
+const allRows = useMemo(() => flattenOptions(options), [options]);
+const rows = useMemo(() => {
+  if (!searchable || query.trim() === '') return allRows;
+  const q = query.toLowerCase();
+  const out: typeof allRows = [];
+  let pendingHeader: typeof allRows[number] | null = null;
+  for (const row of allRows) {
+    if (row.kind === 'header') {
+      pendingHeader = row;
+      continue;
+    }
+    const matches =
+      row.option.label.toLowerCase().includes(q) ||
+      (row.option.description?.toLowerCase().includes(q) ?? false);
+    if (matches) {
+      if (pendingHeader) {
+        out.push(pendingHeader);
+        pendingHeader = null;
+      }
+      out.push(row);
+    }
+  }
+  return out;
+}, [allRows, searchable, query]);
+```
+
+Now `ctx.rows` is the filtered view. Listbox doesn't need its own filter logic — undo the `filteredRows` change above if you applied it.
+
+- [ ] **Step 4: Add `.triggerInput` style**
+
+Append to `Select.module.scss`:
+
+```scss
+.triggerInput {
+  cursor: text;
+
+  &::placeholder {
+    color: var(--color-fg-muted);
+  }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: single+searchable combobox-input trigger (typing filters, Escape reverts)"
+```
+
+---
+
+## Phase 5 — Multi mode (summary + searchable inside popover)
+
+End of phase = multi-select works with `triggerDisplay='summary'`. Either searchable (search input inside popover) or non-searchable. Toggling rows doesn't close.
+
+### Task 11: Multi mode foundation — summary trigger + toggle-without-close
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Trigger.tsx`
+- Modify: `packages/design-system/src/components/Select/Listbox.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `Select.test.tsx`:
+
+```tsx
+describe('Select — multi, summary, non-searchable', () => {
+  const OWNERS = [
+    { value: 'a', label: 'Alex' },
+    { value: 'b', label: 'Bea' },
+    { value: 'c', label: 'Cam' },
+  ];
+
+  it('placeholder shown when nothing selected', () => {
+    render(<Select multiple triggerDisplay="summary" options={OWNERS} placeholder="Owners" />);
+    expect(screen.getByRole('button')).toHaveTextContent('Owners');
+  });
+
+  it('renders comma-joined labels when selections exist', () => {
+    render(
+      <Select multiple triggerDisplay="summary" options={OWNERS} value={['a', 'c']} />,
+    );
+    expect(screen.getByRole('button')).toHaveTextContent('Alex, Cam');
+  });
+
+  it('clicking a row toggles selection and does NOT close', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select multiple triggerDisplay="summary" options={OWNERS} onChange={onChange} />,
+    );
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('option', { name: 'Alex' }));
+    expect(onChange).toHaveBeenCalledWith(['a'], [OWNERS[0]]);
+    expect(screen.getByRole('listbox')).toBeInTheDocument(); // still open
+    await user.click(screen.getByRole('option', { name: 'Bea' }));
+    expect(onChange).toHaveBeenLastCalledWith(['a', 'b'], [OWNERS[0], OWNERS[1]]);
+  });
+
+  it('clicking a selected row removes it', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select multiple triggerDisplay="summary" options={OWNERS} defaultValue={['a']} onChange={onChange} />,
+    );
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('option', { name: 'Alex' }));
+    expect(onChange).toHaveBeenCalledWith([], []);
+  });
+
+  it('aria-multiselectable=true on the listbox', async () => {
+    const user = userEvent.setup();
+    render(<Select multiple triggerDisplay="summary" options={OWNERS} />);
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByRole('listbox')).toHaveAttribute('aria-multiselectable', 'true');
+  });
+});
+```
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: PASS for most (multi value/toggle already works because of `useSelectState.toggleValue`). The summary-text render is the main thing to verify — likely needs trigger update because current Trigger only handles `!ctx.multiple` label. Expect FAIL there.
+
+- [ ] **Step 2: Update `ButtonTrigger` to render multi-summary text**
+
+In `Trigger.tsx`, replace the `selectedRow` / `label` block in `ButtonTrigger` with:
+
+```tsx
+const label = (() => {
+  if (ctx.multiple) {
+    const selectedValues = Array.isArray(ctx.value) ? ctx.value : [];
+    if (selectedValues.length === 0) return '';
+    const labels: string[] = [];
+    for (const row of ctx.rows) {
+      if (row.kind === 'option' && selectedValues.includes(row.option.value)) {
+        labels.push(row.option.label);
+      }
+    }
+    return labels.join(', ');
+  }
+  const selRow = ctx.rows.find(
+    (r) => r.kind === 'option' && r.option.value === (ctx.value as string),
+  );
+  return selRow && selRow.kind === 'option' ? selRow.option.label : '';
+})();
+```
+
+Important: in the `ButtonTrigger` dispatch, multi+summary needs the full unfiltered rows list to derive labels (so that filtering doesn't drop them from the trigger). For now, since the search filter is only applied when `searchable` is true and we're handling summary+non-searchable first, `ctx.rows` is the unfiltered list. We'll revisit when adding multi-summary-searchable in Task 12.
+
+Update the Trigger dispatcher at the bottom of `Trigger.tsx`:
+
+```tsx
+export function Trigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  if (!ctx.multiple && ctx.searchable) {
+    return <ComboboxInputTrigger {...props} />;
+  }
+  // multi-chips trigger added in Phase 6; for now multi always uses button.
+  return <ButtonTrigger {...props} />;
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: all pass. The Listbox already handles multi-toggle via `if (ctx.multiple) ctx.toggleValue(...)` (no close call). The aria-multiselectable test passes because Listbox sets it from `ctx.multiple`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: multi-summary trigger (comma-joined labels, toggle without close)"
+```
+
+---
+
+### Task 12: Summary text ellipsis + aria-label includes full list
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Trigger.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.module.scss`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+```tsx
+describe('Select — multi-summary aria-label', () => {
+  const OPTS = [
+    { value: 'a', label: 'Alex' },
+    { value: 'b', label: 'Bea' },
+  ];
+
+  it('aria-label carries the full label list when summary is truncated visually', () => {
+    render(<Select multiple triggerDisplay="summary" options={OPTS} value={['a', 'b']} />);
+    const trigger = screen.getByRole('button');
+    expect(trigger.getAttribute('aria-label')).toContain('Alex');
+    expect(trigger.getAttribute('aria-label')).toContain('Bea');
+  });
+
+  it('does not override an explicit aria-label from props', () => {
+    render(
+      <Select
+        multiple
+        triggerDisplay="summary"
+        options={OPTS}
+        value={['a']}
+        aria-label="Owners filter"
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Owners filter');
+  });
+});
+```
+
+Run: expected FAIL on the first.
+
+- [ ] **Step 2: Update Trigger to set fallback aria-label for multi-summary**
+
+In `ButtonTrigger`, after computing `label`, derive the effective aria-label:
+
+```tsx
+const computedAriaLabel = (() => {
+  if (props['aria-label']) return props['aria-label'];
+  if (ctx.multiple && label) return `Selected: ${label}`;
+  return undefined;
+})();
+```
+
+Replace `aria-label={props['aria-label']}` with `aria-label={computedAriaLabel}` in the JSX.
+
+- [ ] **Step 3: Add SCSS for visual truncation**
+
+Append to `Select.module.scss`:
+
+```scss
+.triggerButton {
+  // Multi-summary needs single-line ellipsis; chips-mode wraps and overrides this.
+  & > :not(.placeholder) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+```
+
+(Wrap the label in a span in `ButtonTrigger`'s JSX so the rule has a target):
+
+```tsx
+{label ? <span>{label}</span> : <span className={styles.placeholder}>{props.placeholder}</span>}
+```
+
+- [ ] **Step 4: Run tests + lint:css**
+
+Run: `npm test -w @eocrm/design-system -- Select.test && npm run lint:css`
+Expected: both pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: multi-summary visual ellipsis + aria-label fallback carries full list"
+```
+
+---
+
+### Task 13: Multi + summary + searchable — search input inside popover
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Listbox.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.module.scss`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+```tsx
+describe('Select — multi-summary-searchable', () => {
+  const OPTS = [
+    { value: 'a', label: 'Alex' },
+    { value: 'b', label: 'Bea' },
+    { value: 'c', label: 'Cam' },
+  ];
+
+  it('renders a search input inside the popover when multi+summary+searchable', async () => {
+    const user = userEvent.setup();
+    render(<Select multiple triggerDisplay="summary" searchable options={OPTS} />);
+    await user.click(screen.getByRole('button'));
+    // Search input is the one with role=combobox inside the listbox panel:
+    const inputs = screen.getAllByRole('combobox');
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0].tagName).toBe('INPUT');
+  });
+
+  it('typing into the popover search filters options', async () => {
+    const user = userEvent.setup();
+    render(<Select multiple triggerDisplay="summary" searchable options={OPTS} />);
+    await user.click(screen.getByRole('button'));
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'be');
+    expect(screen.queryByRole('option', { name: 'Alex' })).toBeNull();
+    expect(screen.getByRole('option', { name: 'Bea' })).toBeInTheDocument();
+  });
+
+  it('selecting an option keeps popover open and refocuses search input', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select multiple triggerDisplay="summary" searchable options={OPTS} onChange={onChange} />,
+    );
+    await user.click(screen.getByRole('button'));
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'al');
+    await user.click(screen.getByRole('option', { name: 'Alex' }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(document.activeElement).toBe(input);
+  });
+});
+```
+
+Run: expected FAIL — no popover-search yet.
+
+- [ ] **Step 2: Add a `<input>` at the top of the listbox panel when multi+summary+searchable**
+
+Modify `Listbox.tsx` to render an in-panel search input when the mode is multi-summary-searchable. The trigger keeps its `aria-controls`; the in-panel input gets the `role="combobox"` and `aria-activedescendant`. The button trigger's `aria-activedescendant` is dropped when an in-panel input owns it.
+
+This is involved enough that we add a sub-component. Inside `Listbox.tsx`, add:
+
+```tsx
+function InPanelSearchInput() {
+  const ctx = useSelectContext('Listbox.SearchInput');
+  const ref = useRef<HTMLInputElement>(null);
+  useLayoutEffect(() => {
+    ref.current?.focus({ preventScroll: true });
+  }, []);
+  const activeOptionId =
+    ctx.activeIndex >= 0 && ctx.rows[ctx.activeIndex]?.kind === 'option'
+      ? ctx.getOptionId((ctx.rows[ctx.activeIndex] as { option: { value: string } }).option.value)
+      : undefined;
+  return (
+    <input
+      ref={ref}
+      type="text"
+      role="combobox"
+      aria-expanded="true"
+      aria-controls={ctx.listboxId}
+      aria-activedescendant={activeOptionId}
+      aria-autocomplete="list"
+      className={styles.popoverSearch}
+      placeholder="Search…"
+      value={ctx.query}
+      onChange={(e) => ctx.setQuery(e.target.value)}
+      onKeyDown={(e) => {
+        // Reuse the same nav as the trigger via a thin handler that calls
+        // back into the same logic. For DRY, inline it here:
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+          e.preventDefault();
+          // Cycle through selectable rows
+          const delta = e.key === 'ArrowDown' ? +1 : -1;
+          const len = ctx.rows.length;
+          let i = ctx.activeIndex;
+          for (let s = 0; s < len; s++) {
+            i = (i + delta + len) % len;
+            const r = ctx.rows[i];
+            if (r.kind === 'option' && !r.option.disabled) {
+              ctx.setActiveIndex(i);
+              break;
+            }
+          }
+        } else if (e.key === 'Enter') {
+          e.preventDefault();
+          const row = ctx.rows[ctx.activeIndex];
+          if (row && row.kind === 'option' && !row.option.disabled) {
+            ctx.toggleValue(row.option.value);
+          }
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          ctx.closeAndFocusTrigger();
+        }
+      }}
+    />
+  );
+}
+```
+
+In Listbox's main JSX, before the row mapping, conditionally render the search:
+
+```tsx
+{ctx.multiple && ctx.triggerDisplay === 'summary' && ctx.searchable && <InPanelSearchInput />}
+```
+
+Also drop the trigger's `aria-controls` / `aria-activedescendant` in that mode — but a simpler approach is to keep them both; assistive tech navigates to whichever they focus. Leave the trigger's wiring intact.
+
+- [ ] **Step 3: Add `.popoverSearch` SCSS**
+
+Append to `Select.module.scss`:
+
+```scss
+.popoverSearch {
+  display: block;
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-md);
+  color: var(--color-fg);
+  background: var(--color-bg);
+  border: 0;
+  border-bottom: 1px solid var(--color-border);
+  outline: none;
+
+  &::placeholder {
+    color: var(--color-fg-muted);
+  }
+
+  &:focus-visible {
+    border-bottom-color: var(--color-accent);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: multi-summary-searchable — in-panel search input, focus on open, keyboard nav"
+```
+
+---
+
+## Phase 6 — Multi-chips
+
+End of phase = `triggerDisplay='chips'` works. Chips render inline, removable via ✕ or keyboard. Searchable chips mode has an inline caret editor after the last chip.
+
+### Task 14: Chip subcomponent + chips-mode button trigger (non-searchable)
+
+**Files:**
+- Create: `packages/design-system/src/components/Select/Chip.tsx`
+- Modify: `packages/design-system/src/components/Select/Trigger.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.module.scss`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+describe('Select — multi-chips, non-searchable', () => {
+  const OPTS = [
+    { value: 'a', label: 'Alpha' },
+    { value: 'b', label: 'Beta' },
+  ];
+
+  it('renders chips for each selected option inside the trigger', () => {
+    render(<Select multiple triggerDisplay="chips" options={OPTS} value={['a', 'b']} />);
+    const chips = screen.getAllByRole('button', { name: /Remove/ });
+    expect(chips).toHaveLength(2);
+    expect(chips[0]).toHaveAttribute('aria-label', 'Remove Alpha');
+  });
+
+  it('clicking a chip\'s ✕ removes that option', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        options={OPTS}
+        defaultValue={['a', 'b']}
+        onChange={onChange}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Remove Alpha' }));
+    expect(onChange).toHaveBeenCalledWith(['b'], [OPTS[1]]);
+  });
+
+  it('clicking on the trigger (not a chip) opens the popover', async () => {
+    const user = userEvent.setup();
+    render(<Select multiple triggerDisplay="chips" options={OPTS} placeholder="Pick" />);
+    // Trigger root is the outermost div with role=button (we'll wire it below):
+    await user.click(screen.getByLabelText('Open select'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+});
+```
+
+Run: expected FAIL.
+
+- [ ] **Step 2: Create the Chip subcomponent**
+
+Create `packages/design-system/src/components/Select/Chip.tsx`:
+
+```tsx
+import clsx from 'clsx';
+import styles from './Select.module.scss';
+
+export interface ChipProps {
+  label: string;
+  onRemove: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * Removable chip rendered inside a chips-mode Select trigger. The whole chip
+ * is non-interactive; only the trailing ✕ is a focusable button.
+ */
+export function Chip({ label, onRemove, disabled }: ChipProps) {
+  return (
+    <span className={clsx(styles.chip, disabled && styles.chipDisabled)}>
+      <span className={styles.chipLabel}>{label}</span>
+      <button
+        type="button"
+        className={styles.chipRemove}
+        aria-label={`Remove ${label}`}
+        disabled={disabled}
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+          <path d="M1 1 L9 9 M9 1 L1 9" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      </button>
+    </span>
+  );
+}
+```
+
+- [ ] **Step 3: Add the chips-mode `ChipsButtonTrigger` variant**
+
+Add to `Trigger.tsx`:
+
+```tsx
+import { Chip } from './Chip';
+
+function ChipsButtonTrigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  const { handleNavKey, stepTypeahead } = useTriggerKeyboard({
+    disabled: props.disabled,
+    readOnly: props.readOnly,
+  });
+  const activeOptionId = useActiveOptionId();
+
+  const selectedValues = Array.isArray(ctx.value) ? (ctx.value as string[]) : [];
+  const selectedOptions: { value: string; label: string }[] = [];
+  for (const row of ctx.rows) {
+    if (row.kind === 'option' && selectedValues.includes(row.option.value)) {
+      selectedOptions.push({ value: row.option.value, label: row.option.label });
+    }
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (handleNavKey(e)) return;
+    if (e.key === ' ') {
+      e.preventDefault();
+      if (!ctx.open) ctx.setOpen(true);
+      return;
+    }
+    if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
+      if (!ctx.open) ctx.setOpen(true);
+      stepTypeahead(e.key);
+    }
+  };
+
+  return (
+    <div
+      ref={ctx.triggerRef as React.Ref<HTMLDivElement>}
+      id={ctx.triggerId}
+      role="button"
+      tabIndex={props.disabled ? -1 : 0}
+      className={clsx(styles.trigger, styles.triggerChips)}
+      aria-haspopup="listbox"
+      aria-expanded={ctx.open}
+      aria-controls={ctx.open ? ctx.listboxId : undefined}
+      aria-activedescendant={activeOptionId}
+      aria-label={props['aria-label'] ?? 'Open select'}
+      aria-labelledby={props['aria-labelledby']}
+      aria-describedby={props['aria-describedby']}
+      aria-invalid={props.invalid || undefined}
+      aria-readonly={props.readOnly || undefined}
+      aria-disabled={props.disabled || undefined}
+      onClick={() => {
+        if (props.disabled || props.readOnly) return;
+        ctx.setOpen(!ctx.open);
+      }}
+      onKeyDown={handleKeyDown}
+    >
+      {selectedOptions.map((o) => (
+        <Chip
+          key={o.value}
+          label={o.label}
+          disabled={props.disabled}
+          onRemove={() => {
+            if (props.disabled || props.readOnly) return;
+            ctx.toggleValue(o.value);
+          }}
+        />
+      ))}
+      {selectedOptions.length === 0 && (
+        <span className={styles.placeholder}>{props.placeholder}</span>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Update Trigger dispatcher**
+
+At the bottom of `Trigger.tsx`:
+
+```tsx
+export function Trigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  if (!ctx.multiple && ctx.searchable) return <ComboboxInputTrigger {...props} />;
+  if (ctx.multiple && ctx.triggerDisplay === 'chips' && !ctx.searchable) {
+    return <ChipsButtonTrigger {...props} />;
+  }
+  // Multi-chips-searchable added next task.
+  return <ButtonTrigger {...props} />;
+}
+```
+
+- [ ] **Step 5: Add chip + chips-trigger SCSS**
+
+Append to `Select.module.scss`:
+
+```scss
+.triggerChips {
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 2px var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-badge-neutral-fg);
+  background: var(--color-badge-neutral-bg);
+  border-radius: var(--radius-sm);
+  user-select: none;
+}
+
+.chipLabel {
+  line-height: 1.4;
+}
+
+.chipRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: inherit;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-sm);
+
+  &:hover,
+  &:focus-visible {
+    color: var(--color-danger);
+    background: var(--color-bg-danger-subtle);
+  }
+}
+
+.chipDisabled {
+  color: var(--color-fg-disabled);
+  cursor: not-allowed;
+}
+```
+
+- [ ] **Step 6: Run tests + lint**
+
+Run: `npm test -w @eocrm/design-system -- Select.test && npm run lint:css && npm run typecheck -w @eocrm/design-system`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: multi-chips-non-searchable trigger (Chip subcomponent + role=button shell)"
+```
+
+---
+
+### Task 15: Multi-chips-searchable — inline caret editor + Backspace removes last chip
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Trigger.tsx`
+- Modify: `packages/design-system/src/components/Select/Listbox.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.module.scss`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+describe('Select — multi-chips-searchable', () => {
+  const OPTS = [
+    { value: 'a', label: 'Alpha' },
+    { value: 'b', label: 'Beta' },
+    { value: 'c', label: 'Gamma' },
+  ];
+
+  it('renders an inline input alongside chips', () => {
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        searchable
+        options={OPTS}
+        value={['a']}
+        placeholder="Add tag…"
+      />,
+    );
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove Alpha' })).toBeInTheDocument();
+  });
+
+  it('typing filters and selecting adds a chip + clears query', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        searchable
+        options={OPTS}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, 'be');
+    expect(screen.getByRole('option', { name: 'Beta' })).toBeInTheDocument();
+    await user.click(screen.getByRole('option', { name: 'Beta' }));
+    expect(onChange).toHaveBeenCalledWith(['b'], [OPTS[1]]);
+    expect(input.value).toBe('');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('Backspace on empty input removes the trailing chip', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        searchable
+        options={OPTS}
+        defaultValue={['a', 'b']}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    input.focus();
+    await user.keyboard('{Backspace}');
+    expect(onChange).toHaveBeenCalledWith(['a'], [OPTS[0]]);
+  });
+
+  it('Backspace on non-empty input does NOT remove a chip', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        searchable
+        options={OPTS}
+        defaultValue={['a']}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.type(input, 'be');
+    await user.keyboard('{Backspace}'); // deletes 'e' from 'be', not the chip
+    expect(input.value).toBe('b');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+```
+
+Run: expected FAIL.
+
+- [ ] **Step 2: Add `ChipsInputTrigger` variant**
+
+Add to `Trigger.tsx`:
+
+```tsx
+function ChipsInputTrigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  const { handleNavKey } = useTriggerKeyboard({
+    disabled: props.disabled,
+    readOnly: props.readOnly,
+  });
+  const activeOptionId = useActiveOptionId();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const selectedValues = Array.isArray(ctx.value) ? (ctx.value as string[]) : [];
+  // Selected options must come from the FULL options list, not filtered ctx.rows
+  // (otherwise chips disappear during search). The async/v1 sync impl keeps
+  // ctx.rows = filtered; we need an unfiltered lookup. For now we walk ctx.rows
+  // and rely on the fact that selected values' labels are usually in the
+  // current filter result anyway. Edge case fix in Task 16 once we expose
+  // `allRows` on the context.
+  const selectedOptions: { value: string; label: string }[] = [];
+  for (const row of ctx.rows) {
+    if (row.kind === 'option' && selectedValues.includes(row.option.value)) {
+      selectedOptions.push({ value: row.option.value, label: row.option.label });
+    }
+  }
+
+  // Make the wrapper open on click (excluding clicks on chips/✕):
+  const handleWrapperClick = () => {
+    if (props.disabled || props.readOnly) return;
+    inputRef.current?.focus();
+    if (!ctx.open) ctx.setOpen(true);
+  };
+
+  const handleInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (handleNavKey(e)) return;
+    if (e.key === 'Backspace' && ctx.query === '' && selectedOptions.length > 0) {
+      e.preventDefault();
+      const last = selectedOptions[selectedOptions.length - 1];
+      ctx.toggleValue(last.value);
+    }
+    if (e.key === 'Enter') {
+      // After commit, clear query so the input is empty for the next pick.
+      // Enter selection is handled by handleNavKey above; this is the cleanup:
+      if (ctx.open) {
+        // schedule clear after toggle resolves:
+        queueMicrotask(() => ctx.setQuery(''));
+      }
+    }
+  };
+
+  return (
+    <div
+      ref={ctx.triggerRef as React.Ref<HTMLDivElement>}
+      className={clsx(styles.trigger, styles.triggerChips, styles.triggerChipsInput)}
+      onClick={handleWrapperClick}
+      onPointerDown={(e) => {
+        // Don't take focus away from the input
+        if (e.target !== inputRef.current) {
+          e.preventDefault();
+          inputRef.current?.focus();
+        }
+      }}
+    >
+      {selectedOptions.map((o) => (
+        <Chip
+          key={o.value}
+          label={o.label}
+          disabled={props.disabled}
+          onRemove={() => {
+            if (props.disabled || props.readOnly) return;
+            ctx.toggleValue(o.value);
+            inputRef.current?.focus();
+          }}
+        />
+      ))}
+      <input
+        ref={inputRef}
+        type="text"
+        id={ctx.triggerId}
+        role="combobox"
+        aria-autocomplete="list"
+        aria-haspopup="listbox"
+        aria-expanded={ctx.open}
+        aria-controls={ctx.open ? ctx.listboxId : undefined}
+        aria-activedescendant={activeOptionId}
+        aria-label={props['aria-label']}
+        aria-labelledby={props['aria-labelledby']}
+        aria-describedby={props['aria-describedby']}
+        aria-invalid={props.invalid || undefined}
+        disabled={props.disabled}
+        readOnly={props.readOnly}
+        className={styles.chipsInput}
+        placeholder={selectedOptions.length === 0 ? props.placeholder : undefined}
+        value={ctx.query}
+        onChange={(e) => {
+          if (!ctx.open) ctx.setOpen(true);
+          ctx.setQuery(e.target.value);
+        }}
+        onKeyDown={handleInputKeyDown}
+      />
+    </div>
+  );
+}
+```
+
+Also, after a selection toggle in multi-mode (in the Listbox click handler), clear the query so the user can pick again. In `Listbox.tsx`, update the option click handler:
+
+```tsx
+onClick={() => {
+  if (opt.disabled) return;
+  if (ctx.multiple) {
+    ctx.toggleValue(opt.value);
+    if (ctx.searchable) ctx.setQuery('');
+  } else {
+    ctx.setValue(opt.value);
+    ctx.closeAndFocusTrigger();
+  }
+}}
+```
+
+- [ ] **Step 3: Update Trigger dispatcher**
+
+At the bottom of `Trigger.tsx`:
+
+```tsx
+export function Trigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  if (!ctx.multiple && ctx.searchable) return <ComboboxInputTrigger {...props} />;
+  if (ctx.multiple && ctx.triggerDisplay === 'chips') {
+    return ctx.searchable ? <ChipsInputTrigger {...props} /> : <ChipsButtonTrigger {...props} />;
+  }
+  return <ButtonTrigger {...props} />;
+}
+```
+
+- [ ] **Step 4: Add `.triggerChipsInput` and `.chipsInput` SCSS**
+
+Append:
+
+```scss
+.triggerChipsInput {
+  cursor: text;
+}
+
+.chipsInput {
+  flex: 0 1 4ch;
+  min-width: 4ch;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  outline: none;
+}
+```
+
+Note `.chipsInput { flex: ... }` violates Rule 4 (no `flex-grow` etc. on the component) — but here `flex: 0 1 4ch` is on a CHILD of the component's internal structure, not on the component's root. Rule 4 governs how a Select positions itself in the parent, not its own internal flex children. This is consistent with Stack/Cluster which use flex internally.
+
+- [ ] **Step 5: Run tests + lint:css + typecheck**
+
+Run: `npm test -w @eocrm/design-system -- Select.test && npm run lint:css && npm run typecheck -w @eocrm/design-system`
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: multi-chips-searchable trigger (inline input, Backspace-on-empty removes last chip)"
+```
+
+---
+
+### Task 16: Expose `allRows` for chip-label resolution during search
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/context.ts`
+- Modify: `packages/design-system/src/components/Select/Select.tsx`
+- Modify: `packages/design-system/src/components/Select/Trigger.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+```tsx
+it('chips remain visible with their correct labels while typing filters the popover', async () => {
+  const user = userEvent.setup();
+  const OPTS = [
+    { value: 'a', label: 'Alpha' },
+    { value: 'b', label: 'Beta' },
+  ];
+  render(
+    <Select
+      multiple
+      triggerDisplay="chips"
+      searchable
+      options={OPTS}
+      defaultValue={['a']}
+    />,
+  );
+  // Alpha chip is present
+  expect(screen.getByRole('button', { name: 'Remove Alpha' })).toBeInTheDocument();
+  // Type a query that filters Alpha out of the listbox
+  const input = screen.getByRole('combobox');
+  await user.click(input);
+  await user.type(input, 'be');
+  // Alpha chip MUST still render — its label comes from allRows, not filtered rows
+  expect(screen.getByRole('button', { name: 'Remove Alpha' })).toBeInTheDocument();
+});
+```
+
+Run: expected FAIL — chip disappears because filtered `ctx.rows` no longer contains Alpha.
+
+- [ ] **Step 2: Add `allRows` to context**
+
+Update `context.ts`:
+
+```ts
+export interface SelectContextValue<T = unknown> {
+  // ...
+  rows: FlatRow<T>[];     // possibly filtered (search applied)
+  allRows: FlatRow<T>[];  // unfiltered, full list
+  // ...
+}
+```
+
+In `Select.tsx`, where we compute `rows`, also pass `allRows`:
+
+```tsx
+const allRows = useMemo(() => flattenOptions(options), [options]);
+const rows = useMemo(() => {
+  if (!searchable || query.trim() === '') return allRows;
+  // ...same filter as before
+  return out;
+}, [allRows, searchable, query]);
+// ...
+const ctxValue: SelectContextValue<T> = {
+  // ...
+  rows,
+  allRows,
+  // ...
+};
+```
+
+- [ ] **Step 3: Use `allRows` for chip-label resolution in chips triggers**
+
+In `Trigger.tsx`, replace the `for (const row of ctx.rows)` chip-label loop in both `ChipsButtonTrigger` and `ChipsInputTrigger` with `for (const row of ctx.allRows)`.
+
+Also update `ButtonTrigger`'s multi-summary label derivation to use `ctx.allRows`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: expose unfiltered allRows on context so chips/summary survive search filter"
+```
+
+---
+
+## Phase 7 — Async `loadOptions`
+
+End of phase = `loadOptions(query, signal)` is supported. Debounce, AbortController, loading/error/empty states all live in the component. Retry button on error.
+
+### Task 17: `useAsyncOptions` hook (debounced fetch + abort)
+
+**Files:**
+- Create: `packages/design-system/src/components/Select/useAsyncOptions.ts`
+- Create: `packages/design-system/src/components/Select/useAsyncOptions.test.ts`
+
+- [ ] **Step 1: Failing hook tests**
+
+Create `packages/design-system/src/components/Select/useAsyncOptions.test.ts`:
+
+```ts
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAsyncOptions } from './useAsyncOptions';
+import type { SelectOptions } from './Select';
+
+const A: SelectOptions = [{ value: 'a', label: 'A' }];
+const B: SelectOptions = [{ value: 'b', label: 'B' }];
+
+describe('useAsyncOptions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does NOT call loadOptions until enabled=true (loadOnOpen gate)', async () => {
+    const loadOptions = vi.fn(async () => A);
+    renderHook(() => useAsyncOptions({ loadOptions, query: '', enabled: false, debounceMs: 100 }));
+    await vi.advanceTimersByTimeAsync(200);
+    expect(loadOptions).not.toHaveBeenCalled();
+  });
+
+  it('calls loadOptions("") on first enable', async () => {
+    const loadOptions = vi.fn(async () => A);
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useAsyncOptions({ loadOptions, query: '', enabled, debounceMs: 100 }),
+      { initialProps: { enabled: false } },
+    );
+    rerender({ enabled: true });
+    await vi.advanceTimersByTimeAsync(150);
+    expect(loadOptions).toHaveBeenCalledTimes(1);
+    expect(loadOptions.mock.calls[0][0]).toBe('');
+    await waitFor(() => expect(result.current.options).toEqual(A));
+  });
+
+  it('debounces query changes', async () => {
+    const loadOptions = vi.fn(async (q: string) => (q === 'b' ? B : A));
+    const { rerender } = renderHook(
+      ({ query }) => useAsyncOptions({ loadOptions, query, enabled: true, debounceMs: 100 }),
+      { initialProps: { query: '' } },
+    );
+    await vi.advanceTimersByTimeAsync(150);
+    expect(loadOptions).toHaveBeenCalledTimes(1);
+    rerender({ query: 'b' });
+    await vi.advanceTimersByTimeAsync(50); // not yet debounced
+    expect(loadOptions).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(60);
+    expect(loadOptions).toHaveBeenCalledTimes(2);
+    expect(loadOptions.mock.calls[1][0]).toBe('b');
+  });
+
+  it('aborts the previous request when query changes mid-flight', async () => {
+    const signals: AbortSignal[] = [];
+    const loadOptions = vi.fn(async (q: string, signal: AbortSignal) => {
+      signals.push(signal);
+      // never resolve until we explicitly resolve later
+      await new Promise((res) => setTimeout(res, 10000));
+      return A;
+    });
+    const { rerender } = renderHook(
+      ({ query }) => useAsyncOptions({ loadOptions, query, enabled: true, debounceMs: 100 }),
+      { initialProps: { query: '' } },
+    );
+    await vi.advanceTimersByTimeAsync(150);
+    expect(signals).toHaveLength(1);
+    rerender({ query: 'b' });
+    await vi.advanceTimersByTimeAsync(150);
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[1].aborted).toBe(false);
+  });
+
+  it('renders error state on rejection (non-abort)', async () => {
+    const loadOptions = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const { result } = renderHook(() =>
+      useAsyncOptions({ loadOptions, query: '', enabled: true, debounceMs: 0 }),
+    );
+    await vi.advanceTimersByTimeAsync(10);
+    await waitFor(() => expect(result.current.error?.message).toBe('boom'));
+    expect(result.current.loading).toBe(false);
+  });
+});
+```
+
+Run: `npm test -w @eocrm/design-system -- useAsyncOptions.test`
+Expected: FAIL — hook not implemented.
+
+- [ ] **Step 2: Implement the hook**
+
+Create `packages/design-system/src/components/Select/useAsyncOptions.ts`:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SelectOptions } from './Select';
+
+export interface UseAsyncOptionsArgs<T = unknown> {
+  loadOptions?: (query: string, signal: AbortSignal) => Promise<SelectOptions<T>>;
+  query: string;
+  enabled: boolean;
+  debounceMs: number;
+}
+
+export interface UseAsyncOptionsReturn<T = unknown> {
+  options: SelectOptions<T>;
+  loading: boolean;
+  error: Error | null;
+  retry: () => void;
+}
+
+/**
+ * Owns the async lifecycle for `<Select>` when `loadOptions` is provided.
+ * Debounces query changes, aborts stale in-flight requests, and exposes
+ * `options` / `loading` / `error` plus a `retry` action.
+ *
+ * `enabled` is the "loadOnOpen" gate: until the popover has opened at least
+ * once, no fetch happens.
+ */
+export function useAsyncOptions<T = unknown>(
+  args: UseAsyncOptionsArgs<T>,
+): UseAsyncOptionsReturn<T> {
+  const { loadOptions, query, enabled, debounceMs } = args;
+
+  const [options, setOptions] = useState<SelectOptions<T>>([] as SelectOption<T>[] as SelectOptions<T>);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [retryToken, setRetryToken] = useState<number>(0);
+
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const runFetch = useCallback(
+    (q: string) => {
+      if (!loadOptions) return;
+      if (abortRef.current) abortRef.current.abort();
+      const ac = new AbortController();
+      abortRef.current = ac;
+      setLoading(true);
+      setError(null);
+      loadOptions(q, ac.signal)
+        .then((next) => {
+          if (ac.signal.aborted) return;
+          setOptions(next);
+          setLoading(false);
+        })
+        .catch((err) => {
+          if (ac.signal.aborted) return;
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setLoading(false);
+        });
+    },
+    [loadOptions],
+  );
+
+  // Debounced effect on query / enabled / retryToken
+  useEffect(() => {
+    if (!enabled || !loadOptions) return;
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = setTimeout(() => {
+      runFetch(query);
+    }, debounceMs);
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    };
+  }, [query, enabled, debounceMs, retryToken, runFetch, loadOptions]);
+
+  // Cleanup: abort on unmount
+  useEffect(() => {
+    return () => {
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, []);
+
+  const retry = useCallback(() => {
+    setRetryToken((n) => n + 1);
+  }, []);
+
+  return { options, loading, error, retry };
+}
+
+// Local type re-import to keep `SelectOption` available without
+// circular imports through Select.tsx:
+import type { SelectOption } from './Select';
+```
+
+- [ ] **Step 3: Run hook tests**
+
+Run: `npm test -w @eocrm/design-system -- useAsyncOptions.test`
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/useAsyncOptions.ts packages/design-system/src/components/Select/useAsyncOptions.test.ts
+git commit -m "Select: useAsyncOptions hook (debounce + AbortController + retry token)"
+```
+
+---
+
+### Task 18: Wire `loadOptions` into Select.tsx (loadOnOpen + Listbox loading/error UI)
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Select.tsx`
+- Create: `packages/design-system/src/components/Select/Loading.tsx`
+- Create: `packages/design-system/src/components/Select/Error.tsx`
+- Create: `packages/design-system/src/components/Select/Empty.tsx`
+- Modify: `packages/design-system/src/components/Select/Listbox.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.module.scss`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing tests for async wiring**
+
+```tsx
+describe('Select — async loadOptions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls loadOptions("") on first open when loadOnOpen=true (default)', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const loadOptions = vi.fn(async () => [
+      { value: 'a', label: 'A' },
+    ]);
+    render(<Select searchable loadOptions={loadOptions} />);
+    await user.click(screen.getByRole('combobox'));
+    await vi.advanceTimersByTimeAsync(300);
+    expect(loadOptions).toHaveBeenCalledTimes(1);
+    expect(loadOptions.mock.calls[0][0]).toBe('');
+  });
+
+  it('shows loading state while a request is in flight', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    let resolveFn: (opts: any[]) => void = () => {};
+    const loadOptions = vi.fn(
+      () => new Promise<any[]>((res) => (resolveFn = res)),
+    );
+    render(<Select searchable loadOptions={loadOptions} />);
+    await user.click(screen.getByRole('combobox'));
+    await vi.advanceTimersByTimeAsync(300);
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    act(() => resolveFn([{ value: 'a', label: 'A' }]));
+    await waitFor(() => {
+      expect(screen.queryByText(/loading/i)).toBeNull();
+      expect(screen.getByRole('option', { name: 'A' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state with Retry that re-fires loadOptions', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const loadOptions = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce([{ value: 'a', label: 'A' }]);
+    render(<Select searchable loadOptions={loadOptions} />);
+    await user.click(screen.getByRole('combobox'));
+    await vi.advanceTimersByTimeAsync(300);
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    await vi.advanceTimersByTimeAsync(300);
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'A' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when async result is []', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const loadOptions = vi.fn(async () => []);
+    render(<Select searchable loadOptions={loadOptions} />);
+    await user.click(screen.getByRole('combobox'));
+    await vi.advanceTimersByTimeAsync(300);
+    await waitFor(() => {
+      expect(screen.getByText(/no options/i)).toBeInTheDocument();
+    });
+  });
+
+  it('does not call loadOptions before the popover opens (loadOnOpen)', async () => {
+    const loadOptions = vi.fn(async () => []);
+    render(<Select searchable loadOptions={loadOptions} />);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(loadOptions).not.toHaveBeenCalled();
+  });
+});
+```
+
+Need to import `act` and `waitFor` from `@testing-library/react`. Add to the imports at the top of `Select.test.tsx`:
+
+```tsx
+import { render, screen, act, waitFor } from '@testing-library/react';
+```
+
+Run: `npm test -w @eocrm/design-system -- Select.test`
+Expected: FAIL — wiring missing.
+
+- [ ] **Step 2: Create the three state-row subcomponents**
+
+Create `packages/design-system/src/components/Select/Empty.tsx`:
+
+```tsx
+import styles from './Select.module.scss';
+
+export interface EmptyProps {
+  query?: string;
+}
+
+/** Default empty-state row. Override via the Select's `renderEmpty` prop. */
+export function Empty({ query }: EmptyProps) {
+  return (
+    <li className={styles.stateRow} role="presentation">
+      {query && query.trim() !== '' ? `No results for "${query}".` : 'No options.'}
+    </li>
+  );
+}
+```
+
+Create `packages/design-system/src/components/Select/Loading.tsx`:
+
+```tsx
+import styles from './Select.module.scss';
+
+/** Default loading-state row. Override via the Select's `renderLoading` prop. */
+export function Loading() {
+  return (
+    <li className={styles.stateRow} role="presentation" aria-live="polite">
+      <span className={styles.spinner} aria-hidden="true" />
+      <span>Loading…</span>
+    </li>
+  );
+}
+```
+
+Create `packages/design-system/src/components/Select/Error.tsx`:
+
+```tsx
+import styles from './Select.module.scss';
+
+export interface ErrorProps {
+  error: Error;
+  onRetry: () => void;
+}
+
+/** Default error-state row + Retry. Override via the Select's `renderError` prop. */
+export function ErrorRow({ error, onRetry }: ErrorProps) {
+  return (
+    <li className={styles.stateRow} role="alert">
+      <span>Failed to load options.</span>
+      <button type="button" className={styles.retryButton} onClick={onRetry}>
+        Retry
+      </button>
+    </li>
+  );
+}
+```
+
+- [ ] **Step 3: Wire `loadOptions` into Select.tsx**
+
+Modify `Select.tsx`. Add `loadOptions`, `loadOnOpen`, `searchDebounceMs` to props destructuring. Add an `enabled` flag that flips true after the first `open` transition. Use `useAsyncOptions`:
+
+```tsx
+import { useAsyncOptions } from './useAsyncOptions';
+
+// inside the component:
+const [hasOpenedOnce, setHasOpenedOnce] = useState(false);
+useEffect(() => {
+  if (state.open && !hasOpenedOnce) setHasOpenedOnce(true);
+}, [state.open, hasOpenedOnce]);
+
+const asyncEnabled = !!loadOptions && (loadOnOpen ?? true) && hasOpenedOnce;
+const async = useAsyncOptions({
+  loadOptions,
+  query,
+  enabled: asyncEnabled,
+  debounceMs: searchDebounceMs ?? 250,
+});
+
+// loadOptions takes precedence over `options`:
+const effectiveOptions = loadOptions ? async.options : options;
+// dev warning
+if (process.env.NODE_ENV !== 'production' && loadOptions && options && (options as unknown[]).length > 0) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    '<Select> received both `options` and `loadOptions`. `loadOptions` wins; `options` is ignored.',
+  );
+}
+
+const allRows = useMemo(() => flattenOptions(effectiveOptions), [effectiveOptions]);
+// rows = filtered allRows (unchanged from earlier task)
+
+// In ctxValue, populate loading/error/retry:
+const ctxValue: SelectContextValue<T> = {
+  // ...
+  loading: async.loading,
+  error: async.error,
+  // ...
+  retry: async.retry,
+  // ...
+};
+```
+
+Add `loadOptions`, `loadOnOpen`, `searchDebounceMs` to the `SelectProps` interface in `Select.tsx`:
+
+```tsx
+export interface SelectProps<T = unknown>
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue'> {
+  options?: SelectOptions<T>;
+  loadOptions?: (query: string, signal: AbortSignal) => Promise<SelectOptions<T>>;
+  loadOnOpen?: boolean;
+  searchDebounceMs?: number;
+  // ... (existing props)
+}
+```
+
+- [ ] **Step 4: Update Listbox to render state rows**
+
+In `Listbox.tsx`, replace the row mapping section. Before the rows loop, branch on state:
+
+```tsx
+const showLoading = ctx.loading && ctx.rows.length === 0;
+const showError = !!ctx.error && !ctx.loading;
+const showEmpty = !ctx.loading && !ctx.error && ctx.rows.length === 0;
+
+let body: React.ReactNode;
+if (showLoading) {
+  body = <Loading />;
+} else if (showError) {
+  body = <ErrorRow error={ctx.error!} onRetry={ctx.retry} />;
+} else if (showEmpty) {
+  body = <Empty query={ctx.query} />;
+} else {
+  body = (/* the existing grouped/flat row mapping */);
+}
+```
+
+Then render `{body}` instead of the inline loop.
+
+- [ ] **Step 5: Add `.stateRow`, `.spinner`, `.retryButton` SCSS**
+
+Append to `Select.module.scss`:
+
+```scss
+.stateRow {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-3);
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+}
+
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--color-border-strong);
+  border-top-color: var(--color-accent);
+  border-radius: var(--radius-full);
+  animation: select-spin 0.8s linear infinite;
+}
+
+@keyframes select-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.retryButton {
+  padding: 2px var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-accent);
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+
+  &:hover,
+  &:focus-visible {
+    background: var(--color-bg-muted);
+  }
+}
+```
+
+- [ ] **Step 6: Run tests + lint + typecheck**
+
+Run: `npm test -w @eocrm/design-system -- Select.test useAsyncOptions.test && npm run lint:css && npm run typecheck -w @eocrm/design-system`
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: async loadOptions wired (loadOnOpen, loading/error/empty rows, Retry)"
+```
+
+---
+
+### Task 19: `options` + `loadOptions` dev warning + AbortSignal forwarding test
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+describe('Select — async edge cases', () => {
+  it('warns in dev when both options and loadOptions are passed', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <Select
+        searchable
+        options={[{ value: 'a', label: 'A' }]}
+        loadOptions={async () => [{ value: 'b', label: 'B' }]}
+      />,
+    );
+    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy.mock.calls[0][0]).toMatch(/loadOptions/);
+    warnSpy.mockRestore();
+  });
+
+  it('passes an AbortSignal to loadOptions', async () => {
+    vi.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const loadOptions = vi.fn(async (q: string, signal: AbortSignal) => {
+      expect(signal).toBeInstanceOf(AbortSignal);
+      return [{ value: 'a', label: 'A' }];
+    });
+    render(<Select searchable loadOptions={loadOptions} />);
+    await user.click(screen.getByRole('combobox'));
+    await vi.advanceTimersByTimeAsync(300);
+    expect(loadOptions).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});
+```
+
+Run: should pass given Task 17 + 18 wiring. If the warning test fails because warnings only fire in NODE_ENV=test... we use a one-time check; the test environment should report `process.env.NODE_ENV` as `test`. The check in Select.tsx is `!== 'production'` which matches `test`, so the warning fires. Confirm by running.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/Select.test.tsx
+git commit -m "Select: tests — options+loadOptions warning + AbortSignal forwarding"
+```
+
+---
+
+## Phase 8 — Creatable
+
+End of phase = `creatable + searchable` adds a "+ Create" row when no exact match exists. Activating it fires `onCreate` and adds to selection.
+
+### Task 20: Creatable — render the create row when no exact match
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Select.tsx`
+- Modify: `packages/design-system/src/components/Select/utils.ts`
+- Modify: `packages/design-system/src/components/Select/Listbox.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+describe('Select — creatable', () => {
+  const OPTS = [{ value: 'a', label: 'Alpha' }];
+
+  it('throws in dev when creatable && !searchable', () => {
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      render(<Select creatable options={OPTS} />);
+    }).toThrow(/searchable/);
+  });
+
+  it('shows "+ Create" row when query has no exact match', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable creatable options={OPTS} />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, 'Foo');
+    expect(screen.getByText(/\+ Create "Foo"/i)).toBeInTheDocument();
+  });
+
+  it('hides "+ Create" row when query EXACTLY matches an existing option (case-insensitive)', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable creatable options={OPTS} />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, 'alpha');
+    expect(screen.queryByText(/\+ Create/i)).toBeNull();
+  });
+
+  it('activating the create row fires onCreate + onChange with the new value (multi)', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+    const onChange = vi.fn();
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        searchable
+        creatable
+        options={OPTS}
+        onCreate={onCreate}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, 'Beta');
+    await user.click(screen.getByText(/\+ Create "Beta"/i));
+    expect(onCreate).toHaveBeenCalledWith('Beta');
+    expect(onChange).toHaveBeenCalledWith(['Beta'], [{ value: 'Beta', label: 'Beta' }]);
+  });
+
+  it('activating the create row in single mode replaces selection + closes', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+    const onChange = vi.fn();
+    render(
+      <Select searchable creatable options={OPTS} onCreate={onCreate} onChange={onChange} />,
+    );
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, 'Foo');
+    await user.click(screen.getByText(/\+ Create "Foo"/i));
+    expect(onChange).toHaveBeenCalledWith('Foo', { value: 'Foo', label: 'Foo' });
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('hides "+ Create" row when query is in current multi selection (no dup)', async () => {
+    const user = userEvent.setup();
+    render(
+      <Select
+        multiple
+        searchable
+        creatable
+        triggerDisplay="chips"
+        options={OPTS}
+        defaultValue={['Foo']}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.type(input, 'Foo');
+    expect(screen.queryByText(/\+ Create "Foo"/i)).toBeNull();
+  });
+});
+```
+
+Run: expected FAIL.
+
+- [ ] **Step 2: Add the creatable assertion in dev**
+
+In `Select.tsx`, near the top of the component body (after destructuring):
+
+```tsx
+if (process.env.NODE_ENV !== 'production' && creatable && !searchable) {
+  throw new Error(
+    '<Select>: `creatable` requires `searchable`. A creatable picker without a search input has no way to capture the new label.',
+  );
+}
+```
+
+- [ ] **Step 3: Add a creatable row representation in `utils.ts`**
+
+Append to `utils.ts`:
+
+```ts
+/**
+ * Returns `true` if any option in `opts` has a label case-insensitively
+ * matching `query` (after trim).
+ */
+export function hasExactLabelMatch<T>(opts: SelectOptions<T>, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q === '') return false;
+  if (!isGrouped(opts)) {
+    return opts.some((o) => o.label.toLowerCase() === q);
+  }
+  for (const g of opts) {
+    if (g.options.some((o) => o.label.toLowerCase() === q)) return true;
+  }
+  return false;
+}
+```
+
+- [ ] **Step 4: Compute the creatable row in Select.tsx and inject it into `rows`**
+
+In `Select.tsx`, alongside the `rows` `useMemo`:
+
+```tsx
+const createRow: FlatRow<T> | null = useMemo(() => {
+  const trimmed = query.trim();
+  if (!creatable || !searchable || trimmed === '') return null;
+  // Suppress when an exact label match exists in effectiveOptions:
+  if (hasExactLabelMatch(effectiveOptions, trimmed)) return null;
+  // Suppress when the new label is already selected (multi only):
+  if (multiple) {
+    const currentValues = Array.isArray(state.value) ? (state.value as string[]) : [];
+    if (currentValues.some((v) => v.toLowerCase() === trimmed.toLowerCase())) return null;
+  }
+  return {
+    kind: 'option',
+    option: {
+      value: trimmed,
+      label: trimmed,
+      data: { __create: true } as unknown as T,
+    },
+  };
+}, [creatable, searchable, query, effectiveOptions, multiple, state.value]);
+
+const rowsWithCreate = useMemo(() => {
+  return createRow ? [...rows, createRow] : rows;
+}, [rows, createRow]);
+```
+
+Pass `rowsWithCreate` into `ctxValue.rows`.
+
+Add `__create` marker (a sentinel on `option.data`) so the Listbox can render it distinctly. Define a helper:
+
+```ts
+// in utils.ts
+export function isCreateRow<T>(opt: SelectOption<T>): boolean {
+  return (
+    typeof opt.data === 'object' &&
+    opt.data !== null &&
+    Object.prototype.hasOwnProperty.call(opt.data, '__create') &&
+    (opt.data as { __create?: boolean }).__create === true
+  );
+}
+```
+
+- [ ] **Step 5: Render the create row distinctly in Listbox**
+
+In `Listbox.tsx`'s `renderOptionRow` helper, branch on `isCreateRow(opt)`:
+
+```tsx
+if (isCreateRow(opt)) {
+  return (
+    <li
+      key="__create__"
+      id={ctx.getOptionId(opt.value)}
+      role="option"
+      aria-selected={false}
+      className={clsx(styles.option, styles.optionCreate, active && styles.optionActive)}
+      onPointerDown={(e) => e.preventDefault()}
+      onClick={() => {
+        // fire onCreate then add to selection
+        ctx.onCreate?.(opt.label);
+        if (ctx.multiple) {
+          const next = [...((ctx.value as string[]) ?? []), opt.value];
+          ctx.setValue(next);
+          if (ctx.searchable) ctx.setQuery('');
+        } else {
+          ctx.setValue(opt.value);
+          ctx.closeAndFocusTrigger();
+        }
+      }}
+      onMouseEnter={() => ctx.setActiveIndex(i)}
+    >
+      + Create "{opt.label}"
+    </li>
+  );
+}
+```
+
+- [ ] **Step 6: Thread `onCreate` through context**
+
+Add `onCreate` to `SelectContextValue` in `context.ts`:
+
+```ts
+onCreate?: (label: string) => void;
+```
+
+In `Select.tsx`, accept `onCreate` from props and pass it into `ctxValue`.
+
+In `SelectProps`:
+
+```tsx
+onCreate?: (label: string) => void;
+```
+
+- [ ] **Step 7: Update Enter handler in keyboard to invoke onCreate path**
+
+In `Trigger.tsx`'s `useTriggerKeyboard.handleNavKey` Enter case: when the active row's option is a "create" row, fire `onCreate` and use the create flow rather than `setValue`/`toggleValue` directly. Easiest: inspect `row.option.data` for the `__create` sentinel.
+
+Replace the Enter case:
+
+```tsx
+case 'Enter': {
+  e.preventDefault();
+  const row = ctx.rows[ctx.activeIndex];
+  if (row && row.kind === 'option' && !row.option.disabled) {
+    if (
+      typeof row.option.data === 'object' &&
+      row.option.data !== null &&
+      (row.option.data as { __create?: boolean }).__create
+    ) {
+      ctx.onCreate?.(row.option.label);
+      if (ctx.multiple) {
+        const next = [...((ctx.value as string[]) ?? []), row.option.value];
+        ctx.setValue(next);
+        if (ctx.searchable) ctx.setQuery('');
+      } else {
+        ctx.setValue(row.option.value);
+        ctx.closeAndFocusTrigger();
+      }
+    } else if (ctx.multiple) {
+      ctx.toggleValue(row.option.value);
+      if (ctx.searchable) ctx.setQuery('');
+    } else {
+      ctx.setValue(row.option.value);
+      ctx.closeAndFocusTrigger();
+    }
+  }
+  return true;
+}
+```
+
+- [ ] **Step 8: Add `.optionCreate` SCSS**
+
+```scss
+.optionCreate {
+  font-style: italic;
+  color: var(--color-accent);
+}
+```
+
+- [ ] **Step 9: Run tests + lint + typecheck**
+
+Run: `npm test -w @eocrm/design-system -- Select.test && npm run lint:css && npm run typecheck -w @eocrm/design-system`
+Expected: all pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: creatable — '+ Create' row, onCreate callback, exact-match + dup suppression"
+```
+
+---
+
+## Phase 9 — Form integration (hidden inputs, name, required, form)
+
+End of phase = `name` + `required` make the Select behave like a real input under native form submit (FormData/RHF/etc).
+
+### Task 21: Hidden inputs for single mode + `name` / `required` / `form`
+
+**Files:**
+- Create: `packages/design-system/src/components/Select/HiddenInputs.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+describe('Select — form integration (single)', () => {
+  it('renders a hidden input named `name` with the current value', () => {
+    const { container } = render(
+      <Select options={STATUSES} value="pending" name="status" />,
+    );
+    const hidden = container.querySelector<HTMLInputElement>('input[name="status"]');
+    expect(hidden).not.toBeNull();
+    expect(hidden!.type).toBe('hidden');
+    expect(hidden!.value).toBe('pending');
+  });
+
+  it('hidden input is required when `required`', () => {
+    const { container } = render(
+      <Select options={STATUSES} name="status" required />,
+    );
+    const hidden = container.querySelector<HTMLInputElement>('input[name="status"]');
+    expect(hidden!.required).toBe(true);
+  });
+
+  it('FormData picks up the value on submit', () => {
+    let captured: FormData | null = null;
+    render(
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          captured = new FormData(e.currentTarget);
+        }}
+      >
+        <Select options={STATUSES} name="status" defaultValue="active" />
+        <button type="submit">Go</button>
+      </form>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    expect(captured!.get('status')).toBe('active');
+  });
+});
+```
+
+Add `fireEvent` to the `@testing-library/react` import.
+
+Run: expected FAIL.
+
+- [ ] **Step 2: Create HiddenInputs**
+
+Create `packages/design-system/src/components/Select/HiddenInputs.tsx`:
+
+```tsx
+export interface HiddenInputsProps {
+  name?: string;
+  value: string | string[];
+  multiple: boolean;
+  required: boolean;
+  form?: string;
+  disabled: boolean;
+}
+
+/**
+ * Renders the hidden `<input>`(s) so native `FormData` picks up the Select's
+ * value. Single mode renders one input. Multi mode renders one per selected
+ * value; or, when empty and required, a single empty required input so native
+ * validation blocks submit.
+ */
+export function HiddenInputs(props: HiddenInputsProps) {
+  if (!props.name) return null;
+  const { name, value, multiple, required, form, disabled } = props;
+
+  if (!multiple) {
+    const v = typeof value === 'string' ? value : '';
+    return (
+      <input
+        type="hidden"
+        name={name}
+        value={v}
+        required={required}
+        form={form}
+        disabled={disabled}
+      />
+    );
+  }
+  const arr = Array.isArray(value) ? value : [];
+  if (arr.length === 0 && required) {
+    // Required + empty multi: render one empty required input so the browser
+    // blocks submit.
+    return (
+      <input type="hidden" name={name} value="" required form={form} disabled={disabled} />
+    );
+  }
+  return (
+    <>
+      {arr.map((v) => (
+        <input
+          key={v}
+          type="hidden"
+          name={name}
+          value={v}
+          form={form}
+          disabled={disabled}
+        />
+      ))}
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Render `<HiddenInputs>` in Select.tsx**
+
+In `Select.tsx`'s return JSX, add `<HiddenInputs ... />` as a child of the root `<div>`:
+
+```tsx
+<div ...>
+  <Trigger ... />
+  {state.open && <Listbox />}
+  <HiddenInputs
+    name={name}
+    value={state.value}
+    multiple={multiple}
+    required={required}
+    form={form}
+    disabled={disabled}
+  />
+</div>
+```
+
+Accept `name`, `required`, `form` in `SelectProps` and destructure. Default `required={false}`.
+
+- [ ] **Step 4: Run tests + lint**
+
+Run: `npm test -w @eocrm/design-system -- Select.test && npm run lint:css`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: hidden inputs for native form integration (name, required, form)"
+```
+
+---
+
+### Task 22: Multi-mode form integration tests
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+describe('Select — form integration (multi)', () => {
+  const OPTS = [
+    { value: 'a', label: 'A' },
+    { value: 'b', label: 'B' },
+  ];
+
+  it('renders one hidden input per selected value', () => {
+    const { container } = render(
+      <Select multiple options={OPTS} value={['a', 'b']} name="tags" />,
+    );
+    const hiddens = container.querySelectorAll<HTMLInputElement>('input[name="tags"]');
+    expect(hiddens).toHaveLength(2);
+    expect(Array.from(hiddens).map((h) => h.value).sort()).toEqual(['a', 'b']);
+  });
+
+  it('FormData.getAll returns the array', () => {
+    let captured: FormData | null = null;
+    render(
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          captured = new FormData(e.currentTarget);
+        }}
+      >
+        <Select multiple options={OPTS} defaultValue={['a', 'b']} name="tags" />
+        <button type="submit">Go</button>
+      </form>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    expect(captured!.getAll('tags')).toEqual(['a', 'b']);
+  });
+
+  it('empty + required renders one empty required input', () => {
+    const { container } = render(
+      <Select multiple options={OPTS} value={[]} name="tags" required />,
+    );
+    const hiddens = container.querySelectorAll<HTMLInputElement>('input[name="tags"]');
+    expect(hiddens).toHaveLength(1);
+    expect(hiddens[0].required).toBe(true);
+    expect(hiddens[0].value).toBe('');
+  });
+
+  it('with values + required, no input is required (the presence is enough)', () => {
+    const { container } = render(
+      <Select multiple options={OPTS} value={['a']} name="tags" required />,
+    );
+    const hiddens = container.querySelectorAll<HTMLInputElement>('input[name="tags"]');
+    expect(hiddens).toHaveLength(1);
+    expect(hiddens[0].required).toBe(false);
+  });
+});
+```
+
+Run: should pass (HiddenInputs already implements this). If any fail, debug.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/Select.test.tsx
+git commit -m "Select: multi-mode form integration tests (getAll, empty+required swap)"
+```
+
+---
+
+## Phase 10 — Visual states, sizes, clearable, render escape hatches
+
+### Task 23: `size`, `invalid`, `disabled`, `readOnly` styling
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Select.module.scss`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+describe('Select — visual states', () => {
+  it('size="sm" applies the sm class', () => {
+    const { container } = render(<Select options={STATUSES} size="sm" />);
+    expect(container.firstElementChild!.className).toMatch(/size-sm/);
+  });
+
+  it('size="lg" applies the lg class', () => {
+    const { container } = render(<Select options={STATUSES} size="lg" />);
+    expect(container.firstElementChild!.className).toMatch(/size-lg/);
+  });
+
+  it('invalid sets aria-invalid on the trigger and adds the invalid class', () => {
+    const { container } = render(<Select options={STATUSES} invalid />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-invalid', 'true');
+    expect(container.firstElementChild!.className).toMatch(/invalid/);
+  });
+
+  it('disabled disables the trigger and prevents opening', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} disabled />);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toBeDisabled();
+    await user.click(trigger);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('readOnly prevents opening on click', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} readOnly value="pending" />);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveAttribute('aria-readonly', 'true');
+    await user.click(trigger);
+    expect(screen.queryByRole('listbox')).toBeNull();
+    // Still shows the value:
+    expect(trigger).toHaveTextContent('Pending');
+  });
+});
+```
+
+Run: most should pass given existing wiring. The size-class tests will fail if the SCSS module doesn't expose `size-sm`/`size-md`/`size-lg` selectors yet.
+
+- [ ] **Step 2: Add size-specific styling**
+
+In `Select.module.scss`, replace the placeholder `.size-*` block with:
+
+```scss
+.size-sm .trigger {
+  min-height: var(--size-sm);
+  padding: 0 var(--space-2);
+  font-size: var(--font-size-sm);
+}
+
+.size-md .trigger {
+  min-height: var(--size-md);
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-md);
+}
+
+.size-lg .trigger {
+  min-height: var(--size-lg);
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-lg);
+}
+
+.invalid .trigger {
+  border-color: var(--color-danger);
+
+  &:focus-visible {
+    box-shadow: 0 0 0 var(--ring-width) var(--ring-danger);
+  }
+}
+
+.disabled .trigger,
+.readOnly .trigger {
+  color: var(--color-fg-disabled);
+  cursor: not-allowed;
+  background: var(--color-bg-subtle);
+}
+```
+
+- [ ] **Step 3: Run tests + lint**
+
+Run: `npm test -w @eocrm/design-system -- Select.test && npm run lint:css`
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: size (sm/md/lg), invalid, disabled, readOnly styling"
+```
+
+---
+
+### Task 24: `clearable` ✕ on the trigger
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Trigger.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.module.scss`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+describe('Select — clearable', () => {
+  it('shows ✕ button when single + clearable + has value (default behavior, not required)', () => {
+    render(<Select options={STATUSES} value="pending" />);
+    expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument();
+  });
+
+  it('clicking ✕ clears the selection', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Select options={STATUSES} defaultValue="pending" onChange={onChange} />);
+    await user.click(screen.getByRole('button', { name: /clear selection/i }));
+    expect(onChange).toHaveBeenCalledWith('', null);
+  });
+
+  it('does NOT show ✕ when required', () => {
+    render(<Select options={STATUSES} value="pending" required name="x" />);
+    expect(screen.queryByRole('button', { name: /clear selection/i })).toBeNull();
+  });
+
+  it('does NOT show ✕ when no value', () => {
+    render(<Select options={STATUSES} />);
+    expect(screen.queryByRole('button', { name: /clear selection/i })).toBeNull();
+  });
+
+  it('does NOT show ✕ in multi mode by default', () => {
+    render(
+      <Select
+        multiple
+        options={STATUSES}
+        value={['active']}
+        triggerDisplay="summary"
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /clear selection/i })).toBeNull();
+  });
+
+  it('shows ✕ in multi mode when explicitly clearable=true', () => {
+    render(
+      <Select
+        multiple
+        options={STATUSES}
+        value={['active']}
+        triggerDisplay="summary"
+        clearable
+      />,
+    );
+    expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument();
+  });
+
+  it('clicking ✕ in multi clears the entire array', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select
+        multiple
+        options={STATUSES}
+        defaultValue={['active', 'pending']}
+        triggerDisplay="summary"
+        clearable
+        onChange={onChange}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /clear selection/i }));
+    expect(onChange).toHaveBeenCalledWith([], []);
+  });
+});
+```
+
+Run: expected FAIL.
+
+- [ ] **Step 2: Compute `effectiveClearable` and render the ✕**
+
+In `Select.tsx`, compute the effective default:
+
+```tsx
+const effectiveClearable =
+  clearable === undefined ? (!multiple && !required) : clearable;
+```
+
+Pass to Trigger via prop:
+
+```tsx
+<Trigger ... clearable={effectiveClearable} />
+```
+
+In `Trigger.tsx`, render a ✕ button inside `ButtonTrigger` (and later other variants) when:
+- `effectiveClearable` (passed via `props.clearable`)
+- the current value is non-empty
+
+Add inside `ButtonTrigger`'s JSX, between the label and the closing `</button>`:
+
+Actually, the ✕ can't be a `<button>` inside a `<button>`. Restructure: ButtonTrigger keeps the wrapper as a button, but the ✕ is rendered as a sibling visually overlapping — or we split the trigger into a non-button wrapper.
+
+Simpler approach: render the ✕ outside the `<button>` as a sibling, using `position` (allowed within the component because it's relative to a wrapping container inside the trigger root — not a layout property leaking out).
+
+Better still: render the wrapper as `<div>` with `role="button"` (matching the ChipsButtonTrigger pattern) so the ✕ can be a real child `<button>`. Refactor `ButtonTrigger` to use a `<div role="button">` wrapper around a label span + optional ✕ button.
+
+Replace `ButtonTrigger`'s JSX:
+
+```tsx
+const hasValue = ctx.multiple
+  ? Array.isArray(ctx.value) && (ctx.value as string[]).length > 0
+  : typeof ctx.value === 'string' && ctx.value !== '';
+
+return (
+  <div
+    ref={ctx.triggerRef as React.Ref<HTMLDivElement>}
+    id={ctx.triggerId}
+    role="button"
+    tabIndex={props.disabled ? -1 : 0}
+    className={clsx(styles.trigger, styles.triggerButton)}
+    aria-haspopup="listbox"
+    aria-expanded={ctx.open}
+    aria-controls={ctx.open ? ctx.listboxId : undefined}
+    aria-activedescendant={activeOptionId}
+    aria-label={computedAriaLabel}
+    aria-labelledby={props['aria-labelledby']}
+    aria-describedby={props['aria-describedby']}
+    aria-invalid={props.invalid || undefined}
+    aria-readonly={props.readOnly || undefined}
+    aria-disabled={props.disabled || undefined}
+    onClick={() => {
+      if (props.disabled || props.readOnly) return;
+      ctx.setOpen(!ctx.open);
+    }}
+    onKeyDown={handleKeyDown}
+  >
+    {label ? <span className={styles.triggerLabel}>{label}</span> : <span className={styles.placeholder}>{props.placeholder}</span>}
+    {props.clearable && hasValue && (
+      <button
+        type="button"
+        className={styles.clearButton}
+        aria-label="Clear selection"
+        onClick={(e) => {
+          e.stopPropagation();
+          if (ctx.multiple) {
+            ctx.setValue([]);
+          } else {
+            ctx.setValue('');
+          }
+        }}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        ✕
+      </button>
+    )}
+    <span className={styles.chevron} aria-hidden="true">
+      ▾
+    </span>
+  </div>
+);
+```
+
+The keyboard handler signature changes from `KeyboardEvent<HTMLButtonElement>` to `KeyboardEvent<HTMLDivElement>`. Update accordingly.
+
+- [ ] **Step 3: Apply the same pattern to ComboboxInputTrigger + chips variants**
+
+For input-style triggers (ComboboxInputTrigger, ChipsInputTrigger): wrap the input in a parent `<div>` that also hosts the ✕ and chevron.
+
+For ComboboxInputTrigger, restructure the return:
+
+```tsx
+return (
+  <div className={clsx(styles.trigger, styles.triggerInputWrapper)}>
+    <input ... className={styles.bareInput} />
+    {props.clearable && /* has value */ (
+      <button .../>
+    )}
+    <span className={styles.chevron} aria-hidden="true">▾</span>
+  </div>
+);
+```
+
+The `ctx.triggerRef` still points at the input. The wrapper div is unsized in the ref system.
+
+Apply similar to ChipsInputTrigger and ChipsButtonTrigger.
+
+- [ ] **Step 4: SCSS for chevron + clearButton**
+
+```scss
+.triggerLabel {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chevron {
+  flex: 0 0 auto;
+  margin-left: var(--space-2);
+  color: var(--color-fg-muted);
+  pointer-events: none;
+}
+
+.clearButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin-right: var(--space-1);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-sm);
+
+  &:hover,
+  &:focus-visible {
+    color: var(--color-fg);
+    background: var(--color-bg-muted);
+  }
+}
+```
+
+- [ ] **Step 5: Run tests + lint**
+
+Run: `npm test -w @eocrm/design-system -- Select.test && npm run lint:css`
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: clearable ✕ + chevron, restructure triggers as div+role=button so ✕ can nest"
+```
+
+---
+
+### Task 25: Render escape hatches — `renderOption`, `renderValue`, `renderTag`, `renderEmpty`, `renderLoading`, `renderError`
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Select.tsx`
+- Modify: `packages/design-system/src/components/Select/context.ts`
+- Modify: `packages/design-system/src/components/Select/Listbox.tsx`
+- Modify: `packages/design-system/src/components/Select/Trigger.tsx`
+- Modify: `packages/design-system/src/components/Select/Chip.tsx`
+- Modify: `packages/design-system/src/components/Select/Select.test.tsx`
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+describe('Select — render escape hatches', () => {
+  it('renderOption replaces the option row content', async () => {
+    const user = userEvent.setup();
+    render(
+      <Select
+        options={STATUSES}
+        renderOption={(opt, state) => (
+          <div data-testid={`opt-${opt.value}`}>
+            <span>{opt.label}</span>
+            <span>{state.selected ? '★' : '☆'}</span>
+          </div>
+        )}
+        value="pending"
+      />,
+    );
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByTestId('opt-pending')).toHaveTextContent('Pending★');
+    expect(screen.getByTestId('opt-active')).toHaveTextContent('Active☆');
+  });
+
+  it('renderValue replaces the single trigger label', () => {
+    render(
+      <Select
+        options={STATUSES}
+        value="pending"
+        renderValue={(opt) => <em>~~{opt.label}~~</em>}
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveTextContent('~~Pending~~');
+  });
+
+  it('renderTag replaces chip rendering', () => {
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        options={STATUSES}
+        value={['pending']}
+        renderTag={(opt, remove) => (
+          <span data-testid={`tag-${opt.value}`} onClick={remove}>
+            {opt.label}
+          </span>
+        )}
+      />,
+    );
+    expect(screen.getByTestId('tag-pending')).toHaveTextContent('Pending');
+  });
+
+  it('renderEmpty replaces the empty state', async () => {
+    const user = userEvent.setup();
+    render(
+      <Select
+        searchable
+        options={STATUSES}
+        renderEmpty={(q) => <span>Nothing for "{q}"</span>}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.type(input, 'zzz');
+    expect(screen.getByText('Nothing for "zzz"')).toBeInTheDocument();
+  });
+});
+```
+
+Run: expected FAIL.
+
+- [ ] **Step 2: Thread render props through context**
+
+In `context.ts`, the render-prop fields are already on the interface from Task 4. Confirm and add if missing:
+
+```ts
+onCreate?: (label: string) => void;
+renderOption?: ...
+renderValue?: ...
+renderTag?: ...
+renderEmpty?: ...
+renderLoading?: ...
+renderError?: ...
+```
+
+In `Select.tsx`, populate them on `ctxValue`:
+
+```tsx
+renderOption: props.renderOption,
+renderValue: props.renderValue,
+renderTag: props.renderTag,
+renderEmpty: props.renderEmpty,
+renderLoading: props.renderLoading,
+renderError: props.renderError,
+```
+
+And add them to `SelectProps`:
+
+```tsx
+renderOption?: (opt: SelectOption<T>, state: { active: boolean; selected: boolean }) => ReactNode;
+renderValue?: (opt: SelectOption<T>) => ReactNode;
+renderTag?: (opt: SelectOption<T>, remove: () => void) => ReactNode;
+renderEmpty?: (query: string) => ReactNode;
+renderLoading?: () => ReactNode;
+renderError?: (err: Error, retry: () => void) => ReactNode;
+```
+
+Import `ReactNode` from 'react'.
+
+- [ ] **Step 3: Use renderOption in Listbox**
+
+In `Listbox.tsx`'s `renderOptionRow` helper, before the default markup branch:
+
+```tsx
+function renderOptionRow<T>(opt, i, selected, active, ctx) {
+  // ... isCreateRow branch unchanged ...
+  const body = ctx.renderOption
+    ? ctx.renderOption(opt, { active, selected })
+    : opt.label;
+  return (
+    <li ... >
+      {body}
+    </li>
+  );
+}
+```
+
+- [ ] **Step 4: Use renderValue in single-mode triggers**
+
+In `ButtonTrigger`'s label derivation, when single + selected option present:
+
+```tsx
+const label = (() => {
+  if (ctx.multiple) {
+    // unchanged
+  }
+  const selRow = ctx.allRows.find(
+    (r) => r.kind === 'option' && r.option.value === (ctx.value as string),
+  );
+  if (selRow && selRow.kind === 'option') {
+    return ctx.renderValue ? ctx.renderValue(selRow.option) : selRow.option.label;
+  }
+  return '';
+})();
+```
+
+Same for ComboboxInputTrigger: when computing the displayed selected label string, only `string` types are valid for the `value` prop, so `renderValue` is awkward in the input. For now in v1: `renderValue` applies only to button-styled single triggers, NOT to the combobox input. Document this in JSDoc later.
+
+- [ ] **Step 5: Use renderTag in Chip rendering**
+
+In both `ChipsButtonTrigger` and `ChipsInputTrigger`, replace the `<Chip ... />` map:
+
+```tsx
+{selectedOptions.map((o) => {
+  if (ctx.renderTag) {
+    return (
+      <span key={o.value}>
+        {ctx.renderTag(o, () => ctx.toggleValue(o.value))}
+      </span>
+    );
+  }
+  return (
+    <Chip
+      key={o.value}
+      label={o.label}
+      disabled={props.disabled}
+      onRemove={() => ctx.toggleValue(o.value)}
+    />
+  );
+})}
+```
+
+`selectedOptions` here is the array of `{value, label, ...}` from `ctx.allRows`. Update its typing to carry the full `SelectOption` so renderTag receives all fields:
+
+```tsx
+const selectedOptions: SelectOption<T>[] = [];
+for (const row of ctx.allRows) {
+  if (row.kind === 'option' && selectedValues.includes(row.option.value)) {
+    selectedOptions.push(row.option as SelectOption<T>);
+  }
+}
+```
+
+- [ ] **Step 6: Use renderEmpty / renderLoading / renderError in Listbox state branches**
+
+```tsx
+if (showLoading) {
+  body = ctx.renderLoading ? <li className={styles.stateRow}>{ctx.renderLoading()}</li> : <Loading />;
+} else if (showError) {
+  body = ctx.renderError ? <li className={styles.stateRow}>{ctx.renderError(ctx.error!, ctx.retry)}</li> : <ErrorRow error={ctx.error!} onRetry={ctx.retry} />;
+} else if (showEmpty) {
+  body = ctx.renderEmpty ? <li className={styles.stateRow}>{ctx.renderEmpty(ctx.query)}</li> : <Empty query={ctx.query} />;
+}
+```
+
+- [ ] **Step 7: Run tests + typecheck + lint**
+
+Run: `npm test -w @eocrm/design-system -- Select.test && npm run typecheck -w @eocrm/design-system && npm run lint:css`
+Expected: pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/
+git commit -m "Select: render escape hatches (renderOption/renderValue/renderTag/renderEmpty/renderLoading/renderError)"
+```
+
+---
+
+## Phase 11 — Open/close animation
+
+### Task 26: Scale-fade animation on open (match DropdownMenu/Popover)
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Select.module.scss`
+
+- [ ] **Step 1: Add the animation**
+
+Append to `Select.module.scss`:
+
+```scss
+.listbox {
+  // Existing rules...
+  animation: select-open 140ms ease-out;
+  transform-origin: var(--select-origin, top);
+}
+
+@keyframes select-open {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .listbox {
+    animation: none;
+  }
+}
+```
+
+- [ ] **Step 2: Run lint + visual check**
+
+Run: `npm run lint:css`
+Expected: pass.
+
+Manually verify with the playground (later in plan) once it's wired.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/Select.module.scss
+git commit -m "Select: 140ms scale-fade open animation + reduced-motion respect"
+```
+
+---
+
+## Phase 12 — JSDoc, exports, src/index.ts confirmation
+
+### Task 27: Full JSDoc per Hard Rule 7
+
+**Files:**
+- Modify: `packages/design-system/src/components/Select/Select.tsx`
+
+- [ ] **Step 1: Add JSDoc to the Select component and each exported prop**
+
+In `Select.tsx`, add a JSDoc block above `export const Select`:
+
+```tsx
+/**
+ * Value picker — covers single, multi (chips and summary), searchable,
+ * grouped, async-loaded, and creatable patterns in one component. Implements
+ * the WAI-ARIA combobox 1.2 pattern with `role="listbox"` popup, full
+ * keyboard navigation, and ARIA wiring suitable for screen readers.
+ *
+ * The mode matrix is `multiple` × `triggerDisplay: 'chips' | 'summary'` ×
+ * `searchable`. Tag input is `multiple + searchable + creatable + triggerDisplay='chips'`.
+ *
+ * @example
+ * // Single, non-searchable status picker
+ * <Select
+ *   options={[{ value: 'active', label: 'Active' }, { value: 'pending', label: 'Pending' }]}
+ *   value={status}
+ *   onChange={(v) => setStatus(v as Status)}
+ *   placeholder="Pick a status"
+ * />
+ *
+ * @example
+ * // Async assignee picker with custom rendering
+ * <Select
+ *   searchable
+ *   loadOptions={async (q, signal) => {
+ *     const users = await api.searchUsers(q, { signal });
+ *     return users.map((u) => ({ value: u.id, label: u.name, data: u }));
+ *   }}
+ *   renderOption={(opt) => (
+ *     <Cluster gap="sm">
+ *       <Avatar name={opt.label} src={opt.data?.avatarUrl} size="sm" />
+ *       <span>{opt.label}</span>
+ *     </Cluster>
+ *   )}
+ *   value={assigneeId}
+ *   onChange={(id) => setAssigneeId(id as string)}
+ * />
+ *
+ * @example
+ * // Tag input with creatable
+ * <Select
+ *   multiple
+ *   searchable
+ *   creatable
+ *   options={existingTags}
+ *   value={tags}
+ *   onChange={(v) => setTags(v as string[])}
+ *   onCreate={(label) => api.tags.create({ label })}
+ *   placeholder="Add tags…"
+ * />
+ *
+ * @remarks When NOT to use
+ * - For action menus (Edit/Delete/Duplicate) → use `<DropdownMenu>`.
+ * - For free-form text → use `<Input>`.
+ * - For yes/no/maybe with strong defaults → use `<Tabs>` or radio buttons.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Passing both `options` and `loadOptions`. `loadOptions` always wins; the prop is logged as a dev warning.
+ * - ❌ `creatable` without `searchable`. There's no way to capture the new label without a search input. Throws in dev.
+ * - ❌ Using `triggerDisplay='summary'` for tag input. Summary collapses the active filter set into a comma-joined line; chips communicate selection at a glance.
+ * - ❌ Embedding business logic inside `loadOptions` that depends on stale closures. `loadOptions` is called fresh on every debounced query — use the latest props from a stable reference (e.g. `useCallback` in the consumer).
+ */
+```
+
+Add per-prop JSDoc on every field in `SelectProps`. Pattern:
+
+```tsx
+export interface SelectProps<T = unknown> /* ... */ {
+  /**
+   * Sync options. Either a flat list or a list of `{ label, options }` groups
+   * (discriminated at runtime by the presence of `options`). Ignored when
+   * `loadOptions` is set.
+   */
+  options?: SelectOptions<T>;
+
+  /**
+   * Async options. Receives the current query and an `AbortSignal` that's
+   * fired when a newer query supersedes this one. Debounced (default 250ms,
+   * configurable via `searchDebounceMs`). Initial empty-query load happens
+   * on first open when `loadOnOpen !== false`.
+   */
+  loadOptions?: (query: string, signal: AbortSignal) => Promise<SelectOptions<T>>;
+
+  /**
+   * Whether to call `loadOptions('')` on first open. Default `true`. Set to
+   * `false` if you only want to fetch after the user types.
+   */
+  loadOnOpen?: boolean;
+
+  /**
+   * Debounce window in ms for `loadOptions` calls (and local-filter
+   * recomputation). Default `250`.
+   */
+  searchDebounceMs?: number;
+
+  /** When `true`, value is `string[]` and the trigger renders multiple selections. Default `false`. */
+  multiple?: boolean;
+
+  /**
+   * How a multi-select renders its selections in the trigger.
+   * - `'chips'` (default) — inline removable chips; trigger wraps to multiple lines as needed.
+   * - `'summary'` — comma-joined labels with ellipsis on overflow.
+   *
+   * Ignored when `multiple` is `false`.
+   */
+  triggerDisplay?: SelectTriggerDisplay;
+
+  /** Enables typing-to-filter and (with `loadOptions`) async search. Default `false`. */
+  searchable?: boolean;
+
+  /**
+   * When `true`, adds a `+ Create "<query>"` row when no exact label match
+   * exists. Activating it calls `onCreate(label)` and adds the new value to
+   * the selection. Requires `searchable`. Default `false`.
+   */
+  creatable?: boolean;
+
+  /** Controlled value. `string` for single, `string[]` for multi. */
+  value?: string | string[];
+
+  /** Uncontrolled initial value. */
+  defaultValue?: string | string[];
+
+  /**
+   * Fired on every selection change.
+   * - Single: `(value: string, option: SelectOption | null)` — `option` is `null` when cleared.
+   * - Multi: `(value: string[], options: SelectOption[])`.
+   */
+  onChange?: (
+    value: string | string[],
+    option: SelectOption<T> | SelectOption<T>[] | null,
+  ) => void;
+
+  /**
+   * Fired when the user activates a `+ Create` row. The new value is added
+   * to the selection immediately (optimistic); persist the new option on
+   * your backend in response to this callback.
+   */
+  onCreate?: (label: string) => void;
+
+  /** Controlled open state. */
+  open?: boolean;
+  /** Uncontrolled initial open state. */
+  defaultOpen?: boolean;
+  /** Fired when Select wants to change open state. */
+  onOpenChange?: (open: boolean) => void;
+
+  /** Visual size of the trigger. Default `'md'`. */
+  size?: SelectSize;
+  /** Adds error border + `aria-invalid="true"`. Pair with `aria-describedby` to an error message. */
+  invalid?: boolean;
+  /** Placeholder shown when no value is selected. */
+  placeholder?: string;
+  /**
+   * Adds a `✕` button on the trigger that clears the entire selection.
+   * Default: `true` for single + not-required, `false` otherwise. Multi mode
+   * handles per-chip removal regardless.
+   */
+  clearable?: boolean;
+
+  /** Renders the trigger non-interactive. */
+  disabled?: boolean;
+  /** Renders the trigger readable but non-interactive (no click-to-open). */
+  readOnly?: boolean;
+
+  /** Form field name. When set, hidden inputs render so `FormData` picks up the value. */
+  name?: string;
+  /** When `true`, native form-submit blocks on empty selection. */
+  required?: boolean;
+  /** Target form id, for when the Select lives outside its `<form>`. */
+  form?: string;
+
+  /**
+   * Custom render for each option row. Receives the option and its current
+   * `{ active, selected }` flags. The library wraps your returned node in a
+   * `<li role="option">` — return only the row's INNER content.
+   */
+  renderOption?: (
+    opt: SelectOption<T>,
+    state: { active: boolean; selected: boolean },
+  ) => ReactNode;
+
+  /** Custom render for the single-trigger displayed value. Defaults to `opt.label`. */
+  renderValue?: (opt: SelectOption<T>) => ReactNode;
+
+  /**
+   * Custom render for chips in `triggerDisplay='chips'` mode. The second arg
+   * is a `remove()` callback that unselects this option.
+   */
+  renderTag?: (opt: SelectOption<T>, remove: () => void) => ReactNode;
+
+  /** Custom render for the empty-results state. */
+  renderEmpty?: (query: string) => ReactNode;
+  /** Custom render for the loading state during async load. */
+  renderLoading?: () => ReactNode;
+  /** Custom render for the error state; receives a `retry()` action that re-fires `loadOptions`. */
+  renderError?: (err: Error, retry: () => void) => ReactNode;
+
+  /** ARIA: a label for the trigger. Use when there's no visible `<label>` text. */
+  'aria-label'?: string;
+  /** ARIA: an id of an element labeling the trigger. */
+  'aria-labelledby'?: string;
+  /** ARIA: an id of an element describing the trigger (e.g., error message id). */
+  'aria-describedby'?: string;
+}
+```
+
+And JSDoc the exported types in the file body:
+
+```tsx
+/**
+ * Visual size of the trigger. Mirrors `<Input>` and `<Button>` sizes.
+ * - `'sm'` — 24px tall; dense toolbars and tables.
+ * - `'md'` — 32px tall (default).
+ * - `'lg'` — 40px tall; hero-form prominence.
+ */
+export type SelectSize = 'sm' | 'md' | 'lg';
+
+/**
+ * How a multi-select renders its selections.
+ * - `'chips'` — inline removable chips inside the trigger; wraps vertically.
+ * - `'summary'` — comma-joined labels with ellipsis on overflow.
+ */
+export type SelectTriggerDisplay = 'chips' | 'summary';
+
+/**
+ * A single selectable option.
+ *
+ * `value` is the unique key emitted by `onChange`. `label` is the displayed
+ * text and the substring-search target. `data` is an arbitrary payload
+ * surfaced in `renderOption`/`renderValue`/`renderTag`.
+ */
+export interface SelectOption<T = unknown> { ... }
+
+/** A header + its member options. Use to express grouped option lists. */
+export interface SelectGroup<T = unknown> { ... }
+
+/**
+ * Either a flat list of options or a list of groups. Discriminated at
+ * runtime by checking whether the first element has an `options` field.
+ */
+export type SelectOptions<T = unknown> = SelectOption<T>[] | SelectGroup<T>[];
+```
+
+- [ ] **Step 2: Verify typecheck and tests still pass**
+
+Run: `npm run typecheck -w @eocrm/design-system && npm test -w @eocrm/design-system -- Select.test`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/Select/Select.tsx
+git commit -m "Select: full JSDoc per Hard Rule 7"
+```
+
+---
+
+### Task 28: Confirm src/index.ts re-exports
+
+**Files:**
+- Verify: `packages/design-system/src/index.ts`
+
+- [ ] **Step 1: Re-read the file**
+
+Confirm it contains:
+
+```ts
+export { Select } from './components/Select';
+export type {
+  SelectProps,
+  SelectOption,
+  SelectGroup,
+  SelectOptions,
+  SelectSize,
+  SelectTriggerDisplay,
+} from './components/Select';
+```
+
+If anything's missing, add it.
+
+- [ ] **Step 2: Run typecheck and structure-test**
+
+Run: `npm test -w @eocrm/design-system -- structure.test && npm run typecheck -w @eocrm/design-system`
+Expected: pass.
+
+- [ ] **Step 3: Skip commit unless changes made**
+
+If no changes were needed, skip. Otherwise:
+
+```bash
+git add packages/design-system/src/index.ts
+git commit -m "Select: verify src/index.ts exports complete"
+```
+
+---
+
+## Phase 13 — Playground demo + nav wiring
+
+### Task 29: Build the SelectDemo page
+
+**Files:**
+- Create: `packages/playground/src/pages/components/SelectDemo.tsx`
+
+- [ ] **Step 1: Build the demo file**
+
+Create `packages/playground/src/pages/components/SelectDemo.tsx`:
+
+```tsx
+import { useState } from 'react';
+import {
+  Avatar,
+  Badge,
+  Cluster,
+  Select,
+  Stack,
+  type SelectOption,
+} from '@eocrm/design-system';
+
+// ── Demo data ───────────────────────────────────────────────────────────────
+
+const STATUSES: SelectOption[] = [
+  { value: 'active', label: 'Active' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'archived', label: 'Archived' },
+];
+
+const COUNTRIES = [
+  {
+    label: 'Americas',
+    options: [
+      { value: 'us', label: 'United States' },
+      { value: 'ca', label: 'Canada' },
+      { value: 'br', label: 'Brazil' },
+    ],
+  },
+  {
+    label: 'Europe',
+    options: [
+      { value: 'de', label: 'Germany' },
+      { value: 'fr', label: 'France' },
+      { value: 'gb', label: 'United Kingdom' },
+    ],
+  },
+  {
+    label: 'Asia-Pacific',
+    options: [
+      { value: 'jp', label: 'Japan' },
+      { value: 'au', label: 'Australia' },
+    ],
+  },
+];
+
+const MOCK_USERS = [
+  { id: 'u1', name: 'Alex Rivera', email: 'alex@example.com' },
+  { id: 'u2', name: 'Bea Chen', email: 'bea@example.com' },
+  { id: 'u3', name: 'Cam Patel', email: 'cam@example.com' },
+  { id: 'u4', name: 'Dani Kowalski', email: 'dani@example.com' },
+  { id: 'u5', name: 'Eli Goldberg', email: 'eli@example.com' },
+];
+
+async function fakeFetchUsers(query: string, signal: AbortSignal): Promise<SelectOption[]> {
+  await new Promise((r) => setTimeout(r, 250));
+  if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+  const q = query.toLowerCase();
+  return MOCK_USERS.filter((u) => u.name.toLowerCase().includes(q)).map((u) => ({
+    value: u.id,
+    label: u.name,
+    description: u.email,
+    data: u,
+  }));
+}
+
+async function flakyFetch(query: string, signal: AbortSignal): Promise<SelectOption[]> {
+  await new Promise((r) => setTimeout(r, 200));
+  if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+  if (Math.random() < 0.5) {
+    throw new Error('Network glitched. Try again.');
+  }
+  return MOCK_USERS.slice(0, 3).map((u) => ({ value: u.id, label: u.name }));
+}
+
+// ── Page ────────────────────────────────────────────────────────────────────
+
+export function SelectDemo() {
+  const [status, setStatus] = useState<string>('');
+  const [country, setCountry] = useState<string>('');
+  const [assignee, setAssignee] = useState<string>('');
+  const [statusFilter, setStatusFilter] = useState<string[]>([]);
+  const [owners, setOwners] = useState<string[]>([]);
+  const [tags, setTags] = useState<string[]>(['shipping']);
+  const [createdLog, setCreatedLog] = useState<string[]>([]);
+
+  return (
+    <Stack gap="xl">
+      <h1>Select</h1>
+
+      <Stack gap="md">
+        <h2>1 — Status (single, non-searchable)</h2>
+        <Select
+          options={STATUSES}
+          value={status}
+          onChange={(v) => setStatus(v as string)}
+          placeholder="Pick a status"
+        />
+        <p>
+          Current: <code>{status || '(none)'}</code>
+        </p>
+      </Stack>
+
+      <Stack gap="md">
+        <h2>2 — Country (single, searchable, grouped)</h2>
+        <Select
+          searchable
+          options={COUNTRIES}
+          value={country}
+          onChange={(v) => setCountry(v as string)}
+          placeholder="Search countries…"
+        />
+        <p>
+          Current: <code>{country || '(none)'}</code>
+        </p>
+      </Stack>
+
+      <Stack gap="md">
+        <h2>3 — Assignee (single, async with custom render)</h2>
+        <Select
+          searchable
+          loadOptions={fakeFetchUsers}
+          value={assignee}
+          onChange={(v) => setAssignee(v as string)}
+          placeholder="Find a user…"
+          renderOption={(opt) => (
+            <Cluster gap="sm" align="center">
+              <Avatar name={opt.label} size="sm" />
+              <Stack gap="xs">
+                <span>{opt.label}</span>
+                <small style={{ color: 'var(--color-fg-muted)' }}>{opt.description}</small>
+              </Stack>
+            </Cluster>
+          )}
+        />
+      </Stack>
+
+      <Stack gap="md">
+        <h2>4 — Async + error retry (flaky 50%)</h2>
+        <Select searchable loadOptions={flakyFetch} placeholder="Pick a user (may fail)" />
+      </Stack>
+
+      <Stack gap="md">
+        <h2>5 — Status filter (multi, summary, searchable)</h2>
+        <Select
+          multiple
+          triggerDisplay="summary"
+          searchable
+          options={STATUSES}
+          value={statusFilter}
+          onChange={(v) => setStatusFilter(v as string[])}
+          placeholder="Filter by status"
+        />
+        <Cluster gap="xs">
+          {statusFilter.map((v) => (
+            <Badge key={v} tone="info">
+              {v}
+            </Badge>
+          ))}
+        </Cluster>
+      </Stack>
+
+      <Stack gap="md">
+        <h2>6 — Owners (multi, chips, searchable)</h2>
+        <Select
+          multiple
+          triggerDisplay="chips"
+          searchable
+          loadOptions={fakeFetchUsers}
+          value={owners}
+          onChange={(v) => setOwners(v as string[])}
+          placeholder="Pick owners…"
+        />
+      </Stack>
+
+      <Stack gap="md">
+        <h2>7 — Tags (multi, chips, searchable, creatable)</h2>
+        <Select
+          multiple
+          searchable
+          creatable
+          triggerDisplay="chips"
+          options={[
+            { value: 'shipping', label: 'shipping' },
+            { value: 'urgent', label: 'urgent' },
+            { value: 'vip', label: 'vip' },
+          ]}
+          value={tags}
+          onChange={(v) => setTags(v as string[])}
+          onCreate={(label) => setCreatedLog((log) => [...log, label])}
+          placeholder="Add tags…"
+        />
+        {createdLog.length > 0 && (
+          <p>
+            Created: <code>{createdLog.join(', ')}</code>
+          </p>
+        )}
+      </Stack>
+
+      <Stack gap="md">
+        <h2>8 — Visual states</h2>
+        <Cluster gap="md" wrap>
+          <div style={{ minWidth: 200 }}>
+            <Select options={STATUSES} disabled value="pending" />
+          </div>
+          <div style={{ minWidth: 200 }}>
+            <Select options={STATUSES} readOnly value="active" />
+          </div>
+          <div style={{ minWidth: 200 }}>
+            <Select options={STATUSES} invalid placeholder="Required" />
+          </div>
+        </Cluster>
+      </Stack>
+
+      <Stack gap="md">
+        <h2>9 — Sizes (sm / md / lg)</h2>
+        <Cluster gap="md" wrap>
+          <div style={{ width: 200 }}>
+            <Select options={STATUSES} size="sm" placeholder="sm" />
+          </div>
+          <div style={{ width: 200 }}>
+            <Select options={STATUSES} size="md" placeholder="md" />
+          </div>
+          <div style={{ width: 200 }}>
+            <Select options={STATUSES} size="lg" placeholder="lg" />
+          </div>
+        </Cluster>
+      </Stack>
+
+      <Stack gap="md">
+        <h2>10 — Form integration</h2>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            const data = new FormData(e.currentTarget);
+            // eslint-disable-next-line no-alert
+            alert(
+              `status = ${data.get('status') ?? '(empty)'}\ntags = ${JSON.stringify(data.getAll('tags'))}`,
+            );
+          }}
+        >
+          <Stack gap="md">
+            <Select options={STATUSES} name="status" required placeholder="Status (required)" />
+            <Select
+              multiple
+              triggerDisplay="chips"
+              searchable
+              creatable
+              options={[
+                { value: 'a', label: 'a' },
+                { value: 'b', label: 'b' },
+              ]}
+              name="tags"
+              placeholder="Tags"
+            />
+            <button type="submit">Submit</button>
+          </Stack>
+        </form>
+      </Stack>
+    </Stack>
+  );
+}
+```
+
+- [ ] **Step 2: Manually verify the demo compiles**
+
+Run: `npm run typecheck -w @eocrm/playground`
+Expected: pass. If `SelectOption` isn't exported from `@eocrm/design-system`, fix the export. If demo imports anything that doesn't exist, fix it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/playground/src/pages/components/SelectDemo.tsx
+git commit -m "Playground: SelectDemo page (10 scenarios across all modes)"
+```
+
+---
+
+### Task 30: Wire SelectDemo into App route + sidebar + components index
+
+**Files:**
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+
+- [ ] **Step 1: Inspect each file**
+
+Read the three files. Each has an entry pattern for existing demos (Popover, ConfirmationPopover, DropdownMenu, etc). Replicate the pattern for Select.
+
+Run: `cat packages/playground/src/App.tsx packages/playground/src/layout/AppShell/AppShell.tsx packages/playground/src/pages/components/ComponentsIndex.tsx`
+
+- [ ] **Step 2: Add the route in App.tsx**
+
+Add an import:
+
+```tsx
+import { SelectDemo } from './pages/components/SelectDemo';
+```
+
+Add a route in the existing `<Routes>` block, placed alphabetically among component demos:
+
+```tsx
+<Route path="/components/select" element={<SelectDemo />} />
+```
+
+- [ ] **Step 3: Add the nav entry in AppShell**
+
+In the components section of the sidebar nav array, add (alphabetically):
+
+```tsx
+{ to: '/components/select', label: 'Select' },
+```
+
+- [ ] **Step 4: Add the tile in ComponentsIndex**
+
+Add to the tile array (alphabetically):
+
+```tsx
+{
+  to: '/components/select',
+  title: 'Select',
+  blurb:
+    'Value picker — single, multi (chips and summary), searchable, async, creatable. The generalist.',
+},
+```
+
+- [ ] **Step 5: Run the playground build to catch wiring errors**
+
+Run: `npm run build -w @eocrm/playground`
+Expected: pass.
+
+- [ ] **Step 6: Manually start the playground and click through every scenario**
+
+Run: `make dev`. Open http://localhost:8080/components/select. Verify each scenario:
+
+- Status picker: opens, ArrowDown selects, Escape closes, clearable ✕ shows.
+- Country picker: type "uni" → both UK and US filter in; group headers visible.
+- Assignee: opens, loads initial, type "be" → Bea appears, Avatar in the row.
+- Flaky async: open → if errors, "Retry" works.
+- Status filter (multi-summary): comma-joined labels in trigger.
+- Owners (multi-chips async): chips appear; Backspace on empty removes last chip; typing filters async.
+- Tags (multi-chips creatable): type "newtag", "+ Create" row appears, click → chip appears + log entry.
+- Visual states: disabled looks dim, readOnly shows value but doesn't open, invalid has red border.
+- Sizes: lined up next to each other look proportional to Input.
+- Form: status required → empty submit blocked; submit with status filled → alert shows correct FormData.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/playground/src/
+git commit -m "Playground: route + sidebar + index tile for SelectDemo"
+```
+
+---
+
+## Phase 14 — AGENTS.md update
+
+### Task 31: Append the Select TL;DR to packages/design-system/AGENTS.md
+
+**Files:**
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Read the existing structure**
+
+Existing entries follow a pattern: `### \`<Name>\` — short description`, then a code block, then bullet rules, then anti-patterns. The ConfirmationPopover section is the last one. Append after it.
+
+- [ ] **Step 2: Add the Select section**
+
+Append to `packages/design-system/AGENTS.md`:
+
+```md
+### `<Select>` — value picker (single, multi, searchable, async, creatable)
+
+```tsx
+// Form field — single:
+<Select
+  options={statuses}
+  value={status}
+  onChange={(v) => setStatus(v as Status)}
+  placeholder="Pick a status"
+/>
+
+// Table filter — multi, summary:
+<Select
+  multiple
+  triggerDisplay="summary"
+  searchable
+  options={owners}
+  value={selectedOwners}
+  onChange={(v) => setSelectedOwners(v as string[])}
+  placeholder="Filter by owner"
+/>
+
+// Tag input — multi, chips, creatable:
+<Select
+  multiple
+  searchable
+  creatable
+  options={existingTags}
+  value={tags}
+  onChange={(v) => setTags(v as string[])}
+  onCreate={api.tags.create}
+  placeholder="Add tags…"
+/>
+
+// Async with custom row render:
+<Select
+  searchable
+  loadOptions={async (q, signal) => {
+    const users = await api.searchUsers(q, { signal });
+    return users.map((u) => ({ value: u.id, label: u.name, data: u }));
+  }}
+  renderOption={(opt) => (
+    <Cluster gap="sm">
+      <Avatar name={opt.label} src={opt.data?.avatarUrl} size="sm" />
+      <span>{opt.label}</span>
+    </Cluster>
+  )}
+  value={assigneeId}
+  onChange={(id) => setAssigneeId(id as string)}
+/>
+```
+
+- One generalist; the mode matrix is `multiple` × `triggerDisplay: 'chips' | 'summary'` × `searchable`. See the JSDoc on `<Select>` for the matrix and anti-patterns.
+- **Async**: pass `loadOptions(query, signal)`. Debounce (250ms default, configurable via `searchDebounceMs`) and `AbortSignal` cancellation are built-in. Do NOT debounce externally.
+- **Tag input pattern** = `multiple + searchable + creatable + triggerDisplay='chips'`. There is no separate `<Tags>` component.
+- **Form integration**: pass `name` (and `required`/`form` if needed). Hidden inputs render so `new FormData(form)` works. Multi mode renders one hidden input per selected value; `FormData.getAll(name)` returns the array.
+- **`onChange` signature** is `(value, option | options | null)` — the second arg is the matched option(s), saving you a lookup.
+- **Render escape hatches**: `renderOption`, `renderValue`, `renderTag`, `renderEmpty`, `renderLoading`, `renderError`. Use when defaults don't suffice; default rendering is always token-correct.
+- For **action menus** (Edit/Delete/Duplicate buttons), use `<DropdownMenu>` — Select is for value selection, not actions.
+- For **free-form text**, use `<Input>`. Select always picks from a (possibly async) set.
+- Don't reach for `triggerDisplay='summary'` for tag input — chips communicate the active filter set at a glance.
+- `creatable` requires `searchable` (throws in dev). Passing both `options` and `loadOptions` is also flagged (loadOptions wins).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/AGENTS.md
+git commit -m "AGENTS: Select TL;DR + canonical snippets + anti-patterns"
+```
+
+---
+
+## Phase 15 — Pre-push review-fix loop (Hard Rule 8)
+
+### Task 32: Run gates, then the review-fix cycle to clean
+
+**Files:**
+- All under `packages/design-system/**` are in scope for the review.
+
+- [ ] **Step 1: Run all gates locally**
+
+Run in order; do not proceed until each passes:
+
+```bash
+npm test -w @eocrm/design-system
+npm run typecheck -w @eocrm/design-system
+npm run lint:css
+npm run build -w @eocrm/design-system   # or `make build`
+npm pack --dry-run -w @eocrm/design-system
+```
+
+- [ ] **Step 2: Inspect `npm pack --dry-run` output**
+
+Confirm: no `*.test.tsx` files included; no `_internal` paths leaking; tarball contains only `src/`, `AGENTS.md`, and `README.md`. If a test file appears, check that `package.json`'s `files` field is `["src", "AGENTS.md"]` AND `.npmignore` excludes `**/*.test.*`. If `.npmignore` exists, ensure it has the right patterns.
+
+- [ ] **Step 3: Spawn a fresh-context review agent**
+
+Use the Agent tool with `subagent_type: general-purpose`. Brief it:
+
+> "Review the `<Select>` component just added at `packages/design-system/src/components/Select/`. Before reading the component, read `packages/design-system/CLAUDE.md`, `packages/design-system/AGENTS.md`, and `packages/design-system/README.md`. Then review the Select component against the 10 review categories: bugs, a11y (full WAI-ARIA combobox 1.2), API inconsistencies, type safety, rule violations (Rules 1–7 from CLAUDE.md), test coverage, token discipline (no raw values in SCSS), SCSS quality, cross-package leakage (no playground imports leaking into the library), package/distribution (`npm pack --dry-run` clean). Output as Critical / Important / Nice-to-have / Regression-watch lists, plus a final verdict: `clean enough to stop` or `keep iterating`."
+
+- [ ] **Step 4: Fix every Critical + Important finding**
+
+For Nice-to-have, use judgment (fix when cheap). For every finding deliberately skipped, leave a one-line explanation in your task notes.
+
+After fixes, commit:
+
+```bash
+git add packages/design-system/
+git commit -m "Select: review-pass fixes — <one-line summary>"
+```
+
+- [ ] **Step 5: Re-run gates**
+
+```bash
+npm test -w @eocrm/design-system && npm run typecheck -w @eocrm/design-system && npm run lint:css && npm run build -w @eocrm/design-system && npm pack --dry-run -w @eocrm/design-system
+```
+
+All must be green before the next review.
+
+- [ ] **Step 6: Spawn another reviewer with the same prompt**
+
+If verdict is `keep iterating`, repeat steps 3–5.
+If verdict is `clean enough to stop`, advance.
+
+- [ ] **Step 7: Final hard exit criteria check**
+
+Must hold:
+
+- 0 Critical findings (or each documented with skip rationale)
+- 0 Important findings (or each documented with skip rationale)
+- All four gates green
+- `npm pack --dry-run` clean (no test files, no internal-only paths)
+
+If anything fails, return to step 3.
+
+- [ ] **Step 8: Push the branch**
+
+The husky pre-push hook will re-run prettier + stylelint + typecheck. It should pass since you just ran the gates locally. Do NOT `--no-verify`.
+
+```bash
+git push -u origin feat/select
+```
+
+- [ ] **Step 9: Open the PR**
+
+```bash
+gh pr create --title "Select: generalist value picker (single, multi, async, creatable)" --body "$(cat <<'EOF'
+## Summary
+- New `<Select>` component covering all modes: single, multi (chips and summary), searchable, async (`loadOptions` + AbortSignal + debounce + retry), grouped, creatable.
+- Hand-rolled on `@floating-ui/react-dom` with WAI-ARIA combobox 1.2 semantics.
+- Render escape hatches (`renderOption`/`renderValue`/`renderTag`/`renderEmpty`/`renderLoading`/`renderError`).
+- Native form integration via hidden inputs (`name`/`required`/`form`).
+- Demo + sidebar wiring + ComponentsIndex tile + AGENTS.md TL;DR.
+
+## Test plan
+- [ ] `npm test -w @eocrm/design-system` — all tests pass
+- [ ] `npm run typecheck -w @eocrm/design-system` — clean
+- [ ] `npm run lint:css` — clean
+- [ ] `npm run build -w @eocrm/design-system` — clean
+- [ ] `npm pack --dry-run -w @eocrm/design-system` — no test files in tarball
+- [ ] Manual click-through of all 10 playground scenarios (see SelectDemo.tsx) on Chrome + Firefox
+- [ ] Keyboard-only navigation of all modes (Arrow, Home, End, Page keys, Enter, Escape, Tab, Backspace on empty)
+- [ ] Screen-reader smoke test with VoiceOver: role announcements, selection state, group labels
+EOF
+)"
+```
+
+- [ ] **Step 10: Wait for CI `Quality / check` and request review**
+
+When CI is green and human review approves, merge (squash or merge commit per repo norm).
+
+---
+
+## Self-review checklist (run before declaring the plan ready)
+
+1. **Spec coverage:** every numbered section of `2026-05-20-select-design.md` is implemented by at least one task above.
+   - Mode matrix → Tasks 4, 10, 11, 13, 14, 15
+   - Public API + types → Tasks 2, 18 (loadOptions), 25 (render hatches), 27 (JSDoc)
+   - Prop defaults → Task 2 (size, multiple), Task 4 (triggerDisplay, searchable, creatable), Task 17/18 (loadOnOpen, searchDebounceMs), Task 21 (required), Task 24 (clearable)
+   - Keyboard model → Tasks 7, 8 (typeahead), 10 (combobox keyboard), 13 (in-panel input keyboard), 15 (Backspace-on-empty)
+   - ARIA → Tasks 4 (button/listbox/option), 9 (group + aria-labelledby), 10 (combobox role), 14 (chip aria-label)
+   - Async lifecycle → Tasks 17, 18
+   - Creatable → Task 20
+   - Form integration → Tasks 21, 22
+   - Width/sizing → Task 5 (matches trigger width, max-height 320)
+   - Animation → Task 26
+   - Visual rules → Tasks 23 (sizes/invalid), 14 (chips), 25 (render hatches use existing token tokens)
+   - File layout → matches the file structure block at the top
+   - Testing matrix → distributed across tasks; coverage groups #1-15 all hit
+   - Demo plan → Tasks 29, 30
+   - AGENTS.md update → Task 31
+   - Non-goals → respected throughout (no virtualization, no sticky group headers, etc.)
+
+2. **Placeholder scan:** searched for "TBD", "TODO", "fill in", "similar to" — none present. Code blocks contain complete content in every step.
+
+3. **Type consistency:**
+   - `SelectOption.value: string` — consistent everywhere.
+   - `onChange(value, option | options | null)` — consistent across Tasks 3, 11, 25.
+   - `loadOptions(query, signal): Promise<SelectOptions>` — consistent across Tasks 17, 18, 19.
+   - `useSelectState` return shape — consistent between Tasks 3 and 4.
+   - `FlatRow<T>` type — used consistently in Tasks 2, 4, 9, 17.
+   - `isCreateRow` sentinel via `data: { __create: true }` — consistent between Tasks 20 (creation) and Trigger.tsx Enter handler (consumption).
+
+4. **Scope check:** This plan covers the v1 spec only. Future-work items in the spec are NOT touched. The plan does not assume a Modal, virtualization, or async pagination.
+
+5. **Ambiguity check:**
+   - "search input inside the popover" only appears for multi-summary-searchable (Task 13). Single-searchable uses the input-as-trigger (Task 10). Chips-multi-searchable uses the inline-input-after-chips (Task 15).
+   - `clearable` default is computed in Select.tsx (Task 24) as `!multiple && !required`. Always evaluated against `required`, not a stale boolean.
+
+If you discover an issue during execution that this plan doesn't anticipate, follow the existing pattern, write the failing test first, and commit with a clear message.
+
+---
+
+## End of plan

--- a/docs/superpowers/plans/2026-05-20-select.md
+++ b/docs/superpowers/plans/2026-05-20-select.md
@@ -11,6 +11,7 @@
 **Reference design:** `docs/superpowers/specs/2026-05-20-select-design.md`. Read this first.
 
 **Reference patterns in the existing codebase:**
+
 - `packages/design-system/src/components/Popover/` — Floating UI usage (`useFloating`, `offset`, `flip`, `shift`, `autoUpdate`), portal-to-body Content, click-outside + Escape dismissal pattern.
 - `packages/design-system/src/components/DropdownMenu/` — keyboard model (Arrow/Home/End/typeahead with 500ms debounce), `:focus-visible` row backgrounds, scale-fade open animation.
 - `packages/design-system/src/components/Input/` — visual contract (border, focus ring, size scale 24/32/40px, `invalid` styling).
@@ -60,6 +61,7 @@ Each task ends with a green test suite and a commit. The end of each "phase" is 
 ### Task 1: Scaffold the Select folder
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Select/Select.tsx`
 - Create: `packages/design-system/src/components/Select/Select.module.scss`
 - Create: `packages/design-system/src/components/Select/Select.test.tsx`
@@ -167,6 +169,7 @@ git commit -m "Select: scaffold component folder + structure-test green"
 ### Task 2: Define core types (`SelectOption`, `SelectGroup`, `SelectOptions`)
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Select.tsx`
 - Create: `packages/design-system/src/components/Select/utils.ts`
 - Create: `packages/design-system/src/components/Select/utils.test.ts`
@@ -235,7 +238,13 @@ describe('utils', () => {
 
     it('returns the option matching value, grouped input', () => {
       const opts: SelectGroup[] = [
-        { label: 'G', options: [{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }] },
+        {
+          label: 'G',
+          options: [
+            { value: 'a', label: 'A' },
+            { value: 'b', label: 'B' },
+          ],
+        },
       ];
       expect(findOption(opts, 'b')).toEqual(opts[0].options[1]);
     });
@@ -424,6 +433,7 @@ git commit -m "Select: core types + options flattening utils"
 ### Task 3: `useSelectState` — controlled/uncontrolled value + open state
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Select/useSelectState.ts`
 - Create: `packages/design-system/src/components/Select/useSelectState.test.ts`
 
@@ -463,9 +473,7 @@ describe('useSelectState — single', () => {
 
   it('setValue does NOT update uncontrolled state when value is controlled', () => {
     const onChange = vi.fn();
-    const { result } = renderHook(() =>
-      useSelectState({ multiple: false, value: 'a', onChange }),
-    );
+    const { result } = renderHook(() => useSelectState({ multiple: false, value: 'a', onChange }));
     act(() => result.current.setValue('b'));
     expect(result.current.value).toBe('a'); // parent must rerender with new value
     expect(onChange).toHaveBeenCalledWith('b');
@@ -575,8 +583,12 @@ export function useSelectState(args: UseSelectStateArgs): UseSelectStateReturn {
   const { multiple, value, defaultValue, onChange, open, defaultOpen, onOpenChange } = args;
 
   const initial: string | string[] = multiple
-    ? (Array.isArray(defaultValue) ? defaultValue : [])
-    : (typeof defaultValue === 'string' ? defaultValue : '');
+    ? Array.isArray(defaultValue)
+      ? defaultValue
+      : []
+    : typeof defaultValue === 'string'
+      ? defaultValue
+      : '';
 
   const [uncontrolledValue, setUncontrolledValue] = useState<string | string[]>(initial);
   const isValueControlled = value !== undefined;
@@ -646,6 +658,7 @@ End of phase = a working single-select with click-to-open, keyboard navigation, 
 ### Task 4: Context + skeletal Select.tsx wiring (single mode plumbing)
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Select/context.ts`
 - Modify: `packages/design-system/src/components/Select/Select.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
@@ -797,8 +810,10 @@ export interface SelectGroup<T = unknown> {
 
 export type SelectOptions<T = unknown> = SelectOption<T>[] | SelectGroup<T>[];
 
-export interface SelectProps<T = unknown>
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue'> {
+export interface SelectProps<T = unknown> extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'defaultValue'
+> {
   options?: SelectOptions<T>;
   // mode
   multiple?: boolean;
@@ -808,10 +823,7 @@ export interface SelectProps<T = unknown>
   // value
   value?: string | string[];
   defaultValue?: string | string[];
-  onChange?: (
-    value: string | string[],
-    option: SelectOption<T> | SelectOption<T>[] | null,
-  ) => void;
+  onChange?: (value: string | string[], option: SelectOption<T> | SelectOption<T>[] | null) => void;
   // open
   open?: boolean;
   defaultOpen?: boolean;
@@ -980,7 +992,9 @@ export function Trigger(props: TriggerProps) {
       ? ctx.rows.find((r) => r.kind === 'option' && r.option.value === ctx.value)
       : null;
   const label =
-    selectedLabel && selectedLabel.kind === 'option' ? selectedLabel.option.label : props.placeholder ?? '';
+    selectedLabel && selectedLabel.kind === 'option'
+      ? selectedLabel.option.label
+      : (props.placeholder ?? '');
 
   return (
     <button
@@ -1069,6 +1083,7 @@ git commit -m "Select: context + skeletal Select/Trigger/Listbox wiring (single,
 ### Task 5: Click-to-open behavior + Listbox portal + Floating UI positioning
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Listbox.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.module.scss`
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
@@ -1138,7 +1153,14 @@ Replace `packages/design-system/src/components/Select/Listbox.tsx`:
 ```tsx
 import { useEffect, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { autoUpdate, flip, offset, shift, size as floatingSize, useFloating } from '@floating-ui/react-dom';
+import {
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  size as floatingSize,
+  useFloating,
+} from '@floating-ui/react-dom';
 import clsx from 'clsx';
 import { useSelectContext } from './context';
 import styles from './Select.module.scss';
@@ -1211,9 +1233,7 @@ export function Listbox() {
       ctx.setActiveIndex(firstSelectedIdx);
       return;
     }
-    const firstSelectableIdx = ctx.rows.findIndex(
-      (r) => r.kind === 'option' && !r.option.disabled,
-    );
+    const firstSelectableIdx = ctx.rows.findIndex((r) => r.kind === 'option' && !r.option.disabled);
     ctx.setActiveIndex(firstSelectableIdx >= 0 ? firstSelectableIdx : -1);
     // We only want this on open transitions, not on every rows change:
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1389,6 +1409,7 @@ git commit -m "Select: portaled Listbox + Floating UI positioning + outside-clic
 ### Task 6: Click-to-select + onChange round-trip
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
 
 - [ ] **Step 1: Write the failing tests for selection**
@@ -1464,6 +1485,7 @@ git commit -m "Select: tests — single selection round-trip, controlled value, 
 ### Task 7: Keyboard navigation — open, ArrowUp/Down/Home/End, Enter, Escape, Tab
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Trigger.tsx`
 - Modify: `packages/design-system/src/components/Select/Listbox.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
@@ -1612,7 +1634,9 @@ export function Trigger(props: TriggerProps) {
       ? ctx.rows.find((r) => r.kind === 'option' && r.option.value === ctx.value)
       : null;
   const label =
-    selectedRow && selectedRow.kind === 'option' ? selectedRow.option.label : props.placeholder ?? '';
+    selectedRow && selectedRow.kind === 'option'
+      ? selectedRow.option.label
+      : (props.placeholder ?? '');
 
   const firstSelectableIdx = ctx.rows.findIndex((r) => r.kind === 'option' && !r.option.disabled);
   const lastSelectableIdx = (() => {
@@ -1804,6 +1828,7 @@ git commit -m "Select: keyboard nav (ArrowUp/Down/Home/End/PageUp/PageDown/Enter
 ### Task 8: Typeahead (printable-char buffer) for non-searchable
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Trigger.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
 
@@ -1937,6 +1962,7 @@ git commit -m "Select: typeahead (500ms buffer) for non-searchable trigger"
 ### Task 9: Group headers in the Listbox (sync only)
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Listbox.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
 
@@ -1947,7 +1973,13 @@ Append to `Select.test.tsx`:
 ```tsx
 describe('Select — grouped options', () => {
   const GROUPED = [
-    { label: 'Active', options: [{ value: 'a1', label: 'Foo' }, { value: 'a2', label: 'Bar' }] },
+    {
+      label: 'Active',
+      options: [
+        { value: 'a1', label: 'Foo' },
+        { value: 'a2', label: 'Bar' },
+      ],
+    },
     { label: 'Archived', options: [{ value: 'b1', label: 'Baz' }] },
   ];
 
@@ -1993,61 +2025,63 @@ Expected: FAIL — current Listbox renders headers but they're not grouped, no `
 Replace the row-mapping section of `Listbox.tsx`. Where `ctx.rows.map(...)` is, replace with:
 
 ```tsx
-{(() => {
-  // Walk the flat row list and re-group it for DOM, while preserving the
-  // flat index so keyboard nav stays correct.
-  const nodes: React.ReactNode[] = [];
-  let i = 0;
-  while (i < ctx.rows.length) {
-    const row = ctx.rows[i];
-    if (row.kind === 'header') {
-      // Open a group wrapper containing this header + all following option
-      // rows that belong to it.
-      const headerLabel = row.label;
-      const headerId = ctx.getGroupHeaderId(headerLabel);
-      const groupChildren: React.ReactNode[] = [];
-      groupChildren.push(
-        <li
-          key={`h-${i}`}
-          id={headerId}
-          data-group-header=""
-          className={styles.groupHeader}
-          aria-hidden="false"
-        >
-          {headerLabel}
-        </li>,
-      );
-      let j = i + 1;
-      while (j < ctx.rows.length && ctx.rows[j].kind === 'option') {
-        const optRow = ctx.rows[j] as Extract<typeof ctx.rows[number], { kind: 'option' }>;
-        const selected = ctx.multiple
-          ? (ctx.value as string[]).includes(optRow.option.value)
-          : ctx.value === optRow.option.value;
-        const active = ctx.activeIndex === j;
-        groupChildren.push(renderOptionRow(optRow.option, j, selected, active, ctx));
-        j++;
+{
+  (() => {
+    // Walk the flat row list and re-group it for DOM, while preserving the
+    // flat index so keyboard nav stays correct.
+    const nodes: React.ReactNode[] = [];
+    let i = 0;
+    while (i < ctx.rows.length) {
+      const row = ctx.rows[i];
+      if (row.kind === 'header') {
+        // Open a group wrapper containing this header + all following option
+        // rows that belong to it.
+        const headerLabel = row.label;
+        const headerId = ctx.getGroupHeaderId(headerLabel);
+        const groupChildren: React.ReactNode[] = [];
+        groupChildren.push(
+          <li
+            key={`h-${i}`}
+            id={headerId}
+            data-group-header=""
+            className={styles.groupHeader}
+            aria-hidden="false"
+          >
+            {headerLabel}
+          </li>,
+        );
+        let j = i + 1;
+        while (j < ctx.rows.length && ctx.rows[j].kind === 'option') {
+          const optRow = ctx.rows[j] as Extract<(typeof ctx.rows)[number], { kind: 'option' }>;
+          const selected = ctx.multiple
+            ? (ctx.value as string[]).includes(optRow.option.value)
+            : ctx.value === optRow.option.value;
+          const active = ctx.activeIndex === j;
+          groupChildren.push(renderOptionRow(optRow.option, j, selected, active, ctx));
+          j++;
+        }
+        nodes.push(
+          <li role="group" key={`g-${i}`} aria-labelledby={headerId}>
+            <ul role="none" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+              {groupChildren}
+            </ul>
+          </li>,
+        );
+        i = j;
+        continue;
       }
-      nodes.push(
-        <li role="group" key={`g-${i}`} aria-labelledby={headerId}>
-          <ul role="none" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-            {groupChildren}
-          </ul>
-        </li>,
-      );
-      i = j;
-      continue;
+      // Ungrouped option
+      const optRow = row as Extract<typeof row, { kind: 'option' }>;
+      const selected = ctx.multiple
+        ? (ctx.value as string[]).includes(optRow.option.value)
+        : ctx.value === optRow.option.value;
+      const active = ctx.activeIndex === i;
+      nodes.push(renderOptionRow(optRow.option, i, selected, active, ctx));
+      i++;
     }
-    // Ungrouped option
-    const optRow = row as Extract<typeof row, { kind: 'option' }>;
-    const selected = ctx.multiple
-      ? (ctx.value as string[]).includes(optRow.option.value)
-      : ctx.value === optRow.option.value;
-    const active = ctx.activeIndex === i;
-    nodes.push(renderOptionRow(optRow.option, i, selected, active, ctx));
-    i++;
-  }
-  return nodes;
-})()}
+    return nodes;
+  })();
+}
 ```
 
 Then extract `renderOptionRow` as a module-local helper outside the component:
@@ -2114,6 +2148,7 @@ End of phase = `searchable={true}` works for single mode. Trigger is an input; t
 ### Task 10: Combobox-input trigger variant for single + searchable
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Trigger.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.module.scss`
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
@@ -2393,8 +2428,7 @@ function ButtonTrigger(props: TriggerProps) {
     !ctx.multiple && typeof ctx.value === 'string' && ctx.value !== ''
       ? ctx.rows.find((r) => r.kind === 'option' && r.option.value === ctx.value)
       : null;
-  const label =
-    selectedRow && selectedRow.kind === 'option' ? selectedRow.option.label : '';
+  const label = selectedRow && selectedRow.kind === 'option' ? selectedRow.option.label : '';
 
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
     if (handleNavKey(e)) return;
@@ -2459,9 +2493,13 @@ function ComboboxInputTrigger(props: TriggerProps) {
   // Sync the input's displayed value to the selected label when closed,
   // to the query when open. The selected label is treated as the "committed"
   // state; the query is transient.
-  const selected = !ctx.multiple && typeof ctx.value === 'string' && ctx.value !== ''
-    ? findOption(ctx.rows.flatMap((r) => (r.kind === 'option' ? [r.option] : [])), ctx.value as string)
-    : null;
+  const selected =
+    !ctx.multiple && typeof ctx.value === 'string' && ctx.value !== ''
+      ? findOption(
+          ctx.rows.flatMap((r) => (r.kind === 'option' ? [r.option] : [])),
+          ctx.value as string,
+        )
+      : null;
   const selectedLabel = selected ? selected.label : '';
   const displayValue = ctx.open ? ctx.query : selectedLabel;
 
@@ -2550,7 +2588,7 @@ const filteredRows = (() => {
   // Strip groups whose options all filter out; keep header only if at least one
   // child option matches.
   const out: typeof ctx.rows = [];
-  let pendingHeader: typeof ctx.rows[number] | null = null;
+  let pendingHeader: (typeof ctx.rows)[number] | null = null;
   for (const row of ctx.rows) {
     if (row.kind === 'header') {
       pendingHeader = row;
@@ -2581,7 +2619,7 @@ const rows = useMemo(() => {
   if (!searchable || query.trim() === '') return allRows;
   const q = query.toLowerCase();
   const out: typeof allRows = [];
-  let pendingHeader: typeof allRows[number] | null = null;
+  let pendingHeader: (typeof allRows)[number] | null = null;
   for (const row of allRows) {
     if (row.kind === 'header') {
       pendingHeader = row;
@@ -2639,6 +2677,7 @@ End of phase = multi-select works with `triggerDisplay='summary'`. Either search
 ### Task 11: Multi mode foundation — summary trigger + toggle-without-close
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Trigger.tsx`
 - Modify: `packages/design-system/src/components/Select/Listbox.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
@@ -2661,18 +2700,14 @@ describe('Select — multi, summary, non-searchable', () => {
   });
 
   it('renders comma-joined labels when selections exist', () => {
-    render(
-      <Select multiple triggerDisplay="summary" options={OWNERS} value={['a', 'c']} />,
-    );
+    render(<Select multiple triggerDisplay="summary" options={OWNERS} value={['a', 'c']} />);
     expect(screen.getByRole('button')).toHaveTextContent('Alex, Cam');
   });
 
   it('clicking a row toggles selection and does NOT close', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    render(
-      <Select multiple triggerDisplay="summary" options={OWNERS} onChange={onChange} />,
-    );
+    render(<Select multiple triggerDisplay="summary" options={OWNERS} onChange={onChange} />);
     await user.click(screen.getByRole('button'));
     await user.click(screen.getByRole('option', { name: 'Alex' }));
     expect(onChange).toHaveBeenCalledWith(['a'], [OWNERS[0]]);
@@ -2685,7 +2720,13 @@ describe('Select — multi, summary, non-searchable', () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(
-      <Select multiple triggerDisplay="summary" options={OWNERS} defaultValue={['a']} onChange={onChange} />,
+      <Select
+        multiple
+        triggerDisplay="summary"
+        options={OWNERS}
+        defaultValue={['a']}
+        onChange={onChange}
+      />,
     );
     await user.click(screen.getByRole('button'));
     await user.click(screen.getByRole('option', { name: 'Alex' }));
@@ -2760,6 +2801,7 @@ git commit -m "Select: multi-summary trigger (comma-joined labels, toggle withou
 ### Task 12: Summary text ellipsis + aria-label includes full list
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Trigger.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.module.scss`
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
@@ -2829,7 +2871,9 @@ Append to `Select.module.scss`:
 (Wrap the label in a span in `ButtonTrigger`'s JSX so the rule has a target):
 
 ```tsx
-{label ? <span>{label}</span> : <span className={styles.placeholder}>{props.placeholder}</span>}
+{
+  label ? <span>{label}</span> : <span className={styles.placeholder}>{props.placeholder}</span>;
+}
 ```
 
 - [ ] **Step 4: Run tests + lint:css**
@@ -2849,6 +2893,7 @@ git commit -m "Select: multi-summary visual ellipsis + aria-label fallback carri
 ### Task 13: Multi + summary + searchable — search input inside popover
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Listbox.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.module.scss`
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
@@ -2967,7 +3012,9 @@ function InPanelSearchInput() {
 In Listbox's main JSX, before the row mapping, conditionally render the search:
 
 ```tsx
-{ctx.multiple && ctx.triggerDisplay === 'summary' && ctx.searchable && <InPanelSearchInput />}
+{
+  ctx.multiple && ctx.triggerDisplay === 'summary' && ctx.searchable && <InPanelSearchInput />;
+}
 ```
 
 Also drop the trigger's `aria-controls` / `aria-activedescendant` in that mode — but a simpler approach is to keep them both; assistive tech navigates to whichever they focus. Leave the trigger's wiring intact.
@@ -3020,6 +3067,7 @@ End of phase = `triggerDisplay='chips'` works. Chips render inline, removable vi
 ### Task 14: Chip subcomponent + chips-mode button trigger (non-searchable)
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Select/Chip.tsx`
 - Modify: `packages/design-system/src/components/Select/Trigger.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.module.scss`
@@ -3041,7 +3089,7 @@ describe('Select — multi-chips, non-searchable', () => {
     expect(chips[0]).toHaveAttribute('aria-label', 'Remove Alpha');
   });
 
-  it('clicking a chip\'s ✕ removes that option', async () => {
+  it("clicking a chip's ✕ removes that option", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(
@@ -3275,6 +3323,7 @@ git commit -m "Select: multi-chips-non-searchable trigger (Chip subcomponent + r
 ### Task 15: Multi-chips-searchable — inline caret editor + Backspace removes last chip
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Trigger.tsx`
 - Modify: `packages/design-system/src/components/Select/Listbox.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.module.scss`
@@ -3309,13 +3358,7 @@ describe('Select — multi-chips-searchable', () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(
-      <Select
-        multiple
-        triggerDisplay="chips"
-        searchable
-        options={OPTS}
-        onChange={onChange}
-      />,
+      <Select multiple triggerDisplay="chips" searchable options={OPTS} onChange={onChange} />,
     );
     const input = screen.getByRole('combobox') as HTMLInputElement;
     await user.click(input);
@@ -3547,6 +3590,7 @@ git commit -m "Select: multi-chips-searchable trigger (inline input, Backspace-o
 ### Task 16: Expose `allRows` for chip-label resolution during search
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/context.ts`
 - Modify: `packages/design-system/src/components/Select/Select.tsx`
 - Modify: `packages/design-system/src/components/Select/Trigger.tsx`
@@ -3561,15 +3605,7 @@ it('chips remain visible with their correct labels while typing filters the popo
     { value: 'a', label: 'Alpha' },
     { value: 'b', label: 'Beta' },
   ];
-  render(
-    <Select
-      multiple
-      triggerDisplay="chips"
-      searchable
-      options={OPTS}
-      defaultValue={['a']}
-    />,
-  );
+  render(<Select multiple triggerDisplay="chips" searchable options={OPTS} defaultValue={['a']} />);
   // Alpha chip is present
   expect(screen.getByRole('button', { name: 'Remove Alpha' })).toBeInTheDocument();
   // Type a query that filters Alpha out of the listbox
@@ -3590,8 +3626,8 @@ Update `context.ts`:
 ```ts
 export interface SelectContextValue<T = unknown> {
   // ...
-  rows: FlatRow<T>[];     // possibly filtered (search applied)
-  allRows: FlatRow<T>[];  // unfiltered, full list
+  rows: FlatRow<T>[]; // possibly filtered (search applied)
+  allRows: FlatRow<T>[]; // unfiltered, full list
   // ...
 }
 ```
@@ -3641,6 +3677,7 @@ End of phase = `loadOptions(query, signal)` is supported. Debounce, AbortControl
 ### Task 17: `useAsyncOptions` hook (debounced fetch + abort)
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Select/useAsyncOptions.ts`
 - Create: `packages/design-system/src/components/Select/useAsyncOptions.test.ts`
 
@@ -3674,8 +3711,7 @@ describe('useAsyncOptions', () => {
   it('calls loadOptions("") on first enable', async () => {
     const loadOptions = vi.fn(async () => A);
     const { result, rerender } = renderHook(
-      ({ enabled }) =>
-        useAsyncOptions({ loadOptions, query: '', enabled, debounceMs: 100 }),
+      ({ enabled }) => useAsyncOptions({ loadOptions, query: '', enabled, debounceMs: 100 }),
       { initialProps: { enabled: false } },
     );
     rerender({ enabled: true });
@@ -3773,7 +3809,9 @@ export function useAsyncOptions<T = unknown>(
 ): UseAsyncOptionsReturn<T> {
   const { loadOptions, query, enabled, debounceMs } = args;
 
-  const [options, setOptions] = useState<SelectOptions<T>>([] as SelectOption<T>[] as SelectOptions<T>);
+  const [options, setOptions] = useState<SelectOptions<T>>(
+    [] as SelectOption<T>[] as SelectOptions<T>,
+  );
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
   const [retryToken, setRetryToken] = useState<number>(0);
@@ -3852,6 +3890,7 @@ git commit -m "Select: useAsyncOptions hook (debounce + AbortController + retry 
 ### Task 18: Wire `loadOptions` into Select.tsx (loadOnOpen + Listbox loading/error UI)
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Select.tsx`
 - Create: `packages/design-system/src/components/Select/Loading.tsx`
 - Create: `packages/design-system/src/components/Select/Error.tsx`
@@ -3873,9 +3912,7 @@ describe('Select — async loadOptions', () => {
 
   it('calls loadOptions("") on first open when loadOnOpen=true (default)', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    const loadOptions = vi.fn(async () => [
-      { value: 'a', label: 'A' },
-    ]);
+    const loadOptions = vi.fn(async () => [{ value: 'a', label: 'A' }]);
     render(<Select searchable loadOptions={loadOptions} />);
     await user.click(screen.getByRole('combobox'));
     await vi.advanceTimersByTimeAsync(300);
@@ -3886,9 +3923,7 @@ describe('Select — async loadOptions', () => {
   it('shows loading state while a request is in flight', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     let resolveFn: (opts: any[]) => void = () => {};
-    const loadOptions = vi.fn(
-      () => new Promise<any[]>((res) => (resolveFn = res)),
-    );
+    const loadOptions = vi.fn(() => new Promise<any[]>((res) => (resolveFn = res)));
     render(<Select searchable loadOptions={loadOptions} />);
     await user.click(screen.getByRole('combobox'));
     await vi.advanceTimersByTimeAsync(300);
@@ -4032,7 +4067,12 @@ const async = useAsyncOptions({
 // loadOptions takes precedence over `options`:
 const effectiveOptions = loadOptions ? async.options : options;
 // dev warning
-if (process.env.NODE_ENV !== 'production' && loadOptions && options && (options as unknown[]).length > 0) {
+if (
+  process.env.NODE_ENV !== 'production' &&
+  loadOptions &&
+  options &&
+  (options as unknown[]).length > 0
+) {
   // eslint-disable-next-line no-console
   console.warn(
     '<Select> received both `options` and `loadOptions`. `loadOptions` wins; `options` is ignored.',
@@ -4056,8 +4096,10 @@ const ctxValue: SelectContextValue<T> = {
 Add `loadOptions`, `loadOnOpen`, `searchDebounceMs` to the `SelectProps` interface in `Select.tsx`:
 
 ```tsx
-export interface SelectProps<T = unknown>
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue'> {
+export interface SelectProps<T = unknown> extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'defaultValue'
+> {
   options?: SelectOptions<T>;
   loadOptions?: (query: string, signal: AbortSignal) => Promise<SelectOptions<T>>;
   loadOnOpen?: boolean;
@@ -4153,6 +4195,7 @@ git commit -m "Select: async loadOptions wired (loadOnOpen, loading/error/empty 
 ### Task 19: `options` + `loadOptions` dev warning + AbortSignal forwarding test
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
 
 - [ ] **Step 1: Failing tests**
@@ -4207,6 +4250,7 @@ End of phase = `creatable + searchable` adds a "+ Create" row when no exact matc
 ### Task 20: Creatable — render the create row when no exact match
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Select.tsx`
 - Modify: `packages/design-system/src/components/Select/utils.ts`
 - Modify: `packages/design-system/src/components/Select/Listbox.tsx`
@@ -4270,9 +4314,7 @@ describe('Select — creatable', () => {
     const user = userEvent.setup();
     const onCreate = vi.fn();
     const onChange = vi.fn();
-    render(
-      <Select searchable creatable options={OPTS} onCreate={onCreate} onChange={onChange} />,
-    );
+    render(<Select searchable creatable options={OPTS} onCreate={onCreate} onChange={onChange} />);
     const input = screen.getByRole('combobox') as HTMLInputElement;
     await user.click(input);
     await user.type(input, 'Foo');
@@ -4500,6 +4542,7 @@ End of phase = `name` + `required` make the Select behave like a real input unde
 ### Task 21: Hidden inputs for single mode + `name` / `required` / `form`
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Select/HiddenInputs.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
@@ -4509,9 +4552,7 @@ End of phase = `name` + `required` make the Select behave like a real input unde
 ```tsx
 describe('Select — form integration (single)', () => {
   it('renders a hidden input named `name` with the current value', () => {
-    const { container } = render(
-      <Select options={STATUSES} value="pending" name="status" />,
-    );
+    const { container } = render(<Select options={STATUSES} value="pending" name="status" />);
     const hidden = container.querySelector<HTMLInputElement>('input[name="status"]');
     expect(hidden).not.toBeNull();
     expect(hidden!.type).toBe('hidden');
@@ -4519,9 +4560,7 @@ describe('Select — form integration (single)', () => {
   });
 
   it('hidden input is required when `required`', () => {
-    const { container } = render(
-      <Select options={STATUSES} name="status" required />,
-    );
+    const { container } = render(<Select options={STATUSES} name="status" required />);
     const hidden = container.querySelector<HTMLInputElement>('input[name="status"]');
     expect(hidden!.required).toBe(true);
   });
@@ -4590,21 +4629,12 @@ export function HiddenInputs(props: HiddenInputsProps) {
   if (arr.length === 0 && required) {
     // Required + empty multi: render one empty required input so the browser
     // blocks submit.
-    return (
-      <input type="hidden" name={name} value="" required form={form} disabled={disabled} />
-    );
+    return <input type="hidden" name={name} value="" required form={form} disabled={disabled} />;
   }
   return (
     <>
       {arr.map((v) => (
-        <input
-          key={v}
-          type="hidden"
-          name={name}
-          value={v}
-          form={form}
-          disabled={disabled}
-        />
+        <input key={v} type="hidden" name={name} value={v} form={form} disabled={disabled} />
       ))}
     </>
   );
@@ -4649,6 +4679,7 @@ git commit -m "Select: hidden inputs for native form integration (name, required
 ### Task 22: Multi-mode form integration tests
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
 
 - [ ] **Step 1: Failing tests**
@@ -4661,12 +4692,14 @@ describe('Select — form integration (multi)', () => {
   ];
 
   it('renders one hidden input per selected value', () => {
-    const { container } = render(
-      <Select multiple options={OPTS} value={['a', 'b']} name="tags" />,
-    );
+    const { container } = render(<Select multiple options={OPTS} value={['a', 'b']} name="tags" />);
     const hiddens = container.querySelectorAll<HTMLInputElement>('input[name="tags"]');
     expect(hiddens).toHaveLength(2);
-    expect(Array.from(hiddens).map((h) => h.value).sort()).toEqual(['a', 'b']);
+    expect(
+      Array.from(hiddens)
+        .map((h) => h.value)
+        .sort(),
+    ).toEqual(['a', 'b']);
   });
 
   it('FormData.getAll returns the array', () => {
@@ -4723,6 +4756,7 @@ git commit -m "Select: multi-mode form integration tests (getAll, empty+required
 ### Task 23: `size`, `invalid`, `disabled`, `readOnly` styling
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Select.module.scss`
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
 
@@ -4826,6 +4860,7 @@ git commit -m "Select: size (sm/md/lg), invalid, disabled, readOnly styling"
 ### Task 24: `clearable` ✕ on the trigger
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Trigger.tsx`
 - Modify: `packages/design-system/src/components/Select/Select.module.scss`
 - Modify: `packages/design-system/src/components/Select/Select.test.tsx`
@@ -4858,26 +4893,13 @@ describe('Select — clearable', () => {
   });
 
   it('does NOT show ✕ in multi mode by default', () => {
-    render(
-      <Select
-        multiple
-        options={STATUSES}
-        value={['active']}
-        triggerDisplay="summary"
-      />,
-    );
+    render(<Select multiple options={STATUSES} value={['active']} triggerDisplay="summary" />);
     expect(screen.queryByRole('button', { name: /clear selection/i })).toBeNull();
   });
 
   it('shows ✕ in multi mode when explicitly clearable=true', () => {
     render(
-      <Select
-        multiple
-        options={STATUSES}
-        value={['active']}
-        triggerDisplay="summary"
-        clearable
-      />,
+      <Select multiple options={STATUSES} value={['active']} triggerDisplay="summary" clearable />,
     );
     expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument();
   });
@@ -4908,8 +4930,7 @@ Run: expected FAIL.
 In `Select.tsx`, compute the effective default:
 
 ```tsx
-const effectiveClearable =
-  clearable === undefined ? (!multiple && !required) : clearable;
+const effectiveClearable = clearable === undefined ? !multiple && !required : clearable;
 ```
 
 Pass to Trigger via prop:
@@ -4919,6 +4940,7 @@ Pass to Trigger via prop:
 ```
 
 In `Trigger.tsx`, render a ✕ button inside `ButtonTrigger` (and later other variants) when:
+
 - `effectiveClearable` (passed via `props.clearable`)
 - the current value is non-empty
 
@@ -4960,7 +4982,11 @@ return (
     }}
     onKeyDown={handleKeyDown}
   >
-    {label ? <span className={styles.triggerLabel}>{label}</span> : <span className={styles.placeholder}>{props.placeholder}</span>}
+    {label ? (
+      <span className={styles.triggerLabel}>{label}</span>
+    ) : (
+      <span className={styles.placeholder}>{props.placeholder}</span>
+    )}
     {props.clearable && hasValue && (
       <button
         type="button"
@@ -5064,6 +5090,7 @@ git commit -m "Select: clearable ✕ + chevron, restructure triggers as div+role
 ### Task 25: Render escape hatches — `renderOption`, `renderValue`, `renderTag`, `renderEmpty`, `renderLoading`, `renderError`
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Select.tsx`
 - Modify: `packages/design-system/src/components/Select/context.ts`
 - Modify: `packages/design-system/src/components/Select/Listbox.tsx`
@@ -5096,11 +5123,7 @@ describe('Select — render escape hatches', () => {
 
   it('renderValue replaces the single trigger label', () => {
     render(
-      <Select
-        options={STATUSES}
-        value="pending"
-        renderValue={(opt) => <em>~~{opt.label}~~</em>}
-      />,
+      <Select options={STATUSES} value="pending" renderValue={(opt) => <em>~~{opt.label}~~</em>} />,
     );
     expect(screen.getByRole('button')).toHaveTextContent('~~Pending~~');
   });
@@ -5125,11 +5148,7 @@ describe('Select — render escape hatches', () => {
   it('renderEmpty replaces the empty state', async () => {
     const user = userEvent.setup();
     render(
-      <Select
-        searchable
-        options={STATUSES}
-        renderEmpty={(q) => <span>Nothing for "{q}"</span>}
-      />,
+      <Select searchable options={STATUSES} renderEmpty={(q) => <span>Nothing for "{q}"</span>} />,
     );
     const input = screen.getByRole('combobox');
     await user.click(input);
@@ -5223,23 +5242,21 @@ Same for ComboboxInputTrigger: when computing the displayed selected label strin
 In both `ChipsButtonTrigger` and `ChipsInputTrigger`, replace the `<Chip ... />` map:
 
 ```tsx
-{selectedOptions.map((o) => {
-  if (ctx.renderTag) {
+{
+  selectedOptions.map((o) => {
+    if (ctx.renderTag) {
+      return <span key={o.value}>{ctx.renderTag(o, () => ctx.toggleValue(o.value))}</span>;
+    }
     return (
-      <span key={o.value}>
-        {ctx.renderTag(o, () => ctx.toggleValue(o.value))}
-      </span>
+      <Chip
+        key={o.value}
+        label={o.label}
+        disabled={props.disabled}
+        onRemove={() => ctx.toggleValue(o.value)}
+      />
     );
-  }
-  return (
-    <Chip
-      key={o.value}
-      label={o.label}
-      disabled={props.disabled}
-      onRemove={() => ctx.toggleValue(o.value)}
-    />
-  );
-})}
+  });
+}
 ```
 
 `selectedOptions` here is the array of `{value, label, ...}` from `ctx.allRows`. Update its typing to carry the full `SelectOption` so renderTag receives all fields:
@@ -5257,11 +5274,23 @@ for (const row of ctx.allRows) {
 
 ```tsx
 if (showLoading) {
-  body = ctx.renderLoading ? <li className={styles.stateRow}>{ctx.renderLoading()}</li> : <Loading />;
+  body = ctx.renderLoading ? (
+    <li className={styles.stateRow}>{ctx.renderLoading()}</li>
+  ) : (
+    <Loading />
+  );
 } else if (showError) {
-  body = ctx.renderError ? <li className={styles.stateRow}>{ctx.renderError(ctx.error!, ctx.retry)}</li> : <ErrorRow error={ctx.error!} onRetry={ctx.retry} />;
+  body = ctx.renderError ? (
+    <li className={styles.stateRow}>{ctx.renderError(ctx.error!, ctx.retry)}</li>
+  ) : (
+    <ErrorRow error={ctx.error!} onRetry={ctx.retry} />
+  );
 } else if (showEmpty) {
-  body = ctx.renderEmpty ? <li className={styles.stateRow}>{ctx.renderEmpty(ctx.query)}</li> : <Empty query={ctx.query} />;
+  body = ctx.renderEmpty ? (
+    <li className={styles.stateRow}>{ctx.renderEmpty(ctx.query)}</li>
+  ) : (
+    <Empty query={ctx.query} />
+  );
 }
 ```
 
@@ -5284,6 +5313,7 @@ git commit -m "Select: render escape hatches (renderOption/renderValue/renderTag
 ### Task 26: Scale-fade animation on open (match DropdownMenu/Popover)
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Select.module.scss`
 
 - [ ] **Step 1: Add the animation**
@@ -5336,6 +5366,7 @@ git commit -m "Select: 140ms scale-fade open animation + reduced-motion respect"
 ### Task 27: Full JSDoc per Hard Rule 7
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Select/Select.tsx`
 
 - [ ] **Step 1: Add JSDoc to the Select component and each exported prop**
@@ -5469,10 +5500,7 @@ export interface SelectProps<T = unknown> /* ... */ {
    * - Single: `(value: string, option: SelectOption | null)` — `option` is `null` when cleared.
    * - Multi: `(value: string[], options: SelectOption[])`.
    */
-  onChange?: (
-    value: string | string[],
-    option: SelectOption<T> | SelectOption<T>[] | null,
-  ) => void;
+  onChange?: (value: string | string[], option: SelectOption<T> | SelectOption<T>[] | null) => void;
 
   /**
    * Fired when the user activates a `+ Create` row. The new value is added
@@ -5518,10 +5546,7 @@ export interface SelectProps<T = unknown> /* ... */ {
    * `{ active, selected }` flags. The library wraps your returned node in a
    * `<li role="option">` — return only the row's INNER content.
    */
-  renderOption?: (
-    opt: SelectOption<T>,
-    state: { active: boolean; selected: boolean },
-  ) => ReactNode;
+  renderOption?: (opt: SelectOption<T>, state: { active: boolean; selected: boolean }) => ReactNode;
 
   /** Custom render for the single-trigger displayed value. Defaults to `opt.label`. */
   renderValue?: (opt: SelectOption<T>) => ReactNode;
@@ -5602,6 +5627,7 @@ git commit -m "Select: full JSDoc per Hard Rule 7"
 ### Task 28: Confirm src/index.ts re-exports
 
 **Files:**
+
 - Verify: `packages/design-system/src/index.ts`
 
 - [ ] **Step 1: Re-read the file**
@@ -5643,6 +5669,7 @@ git commit -m "Select: verify src/index.ts exports complete"
 ### Task 29: Build the SelectDemo page
 
 **Files:**
+
 - Create: `packages/playground/src/pages/components/SelectDemo.tsx`
 
 - [ ] **Step 1: Build the demo file**
@@ -5651,14 +5678,7 @@ Create `packages/playground/src/pages/components/SelectDemo.tsx`:
 
 ```tsx
 import { useState } from 'react';
-import {
-  Avatar,
-  Badge,
-  Cluster,
-  Select,
-  Stack,
-  type SelectOption,
-} from '@eocrm/design-system';
+import { Avatar, Badge, Cluster, Select, Stack, type SelectOption } from '@eocrm/design-system';
 
 // ── Demo data ───────────────────────────────────────────────────────────────
 
@@ -5929,6 +5949,7 @@ git commit -m "Playground: SelectDemo page (10 scenarios across all modes)"
 ### Task 30: Wire SelectDemo into App route + sidebar + components index
 
 **Files:**
+
 - Modify: `packages/playground/src/App.tsx`
 - Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
 - Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
@@ -6008,6 +6029,7 @@ git commit -m "Playground: route + sidebar + index tile for SelectDemo"
 ### Task 31: Append the Select TL;DR to packages/design-system/AGENTS.md
 
 **Files:**
+
 - Modify: `packages/design-system/AGENTS.md`
 
 - [ ] **Step 1: Read the existing structure**
@@ -6018,7 +6040,7 @@ Existing entries follow a pattern: `### \`<Name>\` — short description`, then 
 
 Append to `packages/design-system/AGENTS.md`:
 
-```md
+````md
 ### `<Select>` — value picker (single, multi, searchable, async, creatable)
 
 ```tsx
@@ -6070,6 +6092,7 @@ Append to `packages/design-system/AGENTS.md`:
   onChange={(id) => setAssigneeId(id as string)}
 />
 ```
+````
 
 - One generalist; the mode matrix is `multiple` × `triggerDisplay: 'chips' | 'summary'` × `searchable`. See the JSDoc on `<Select>` for the matrix and anti-patterns.
 - **Async**: pass `loadOptions(query, signal)`. Debounce (250ms default, configurable via `searchDebounceMs`) and `AbortSignal` cancellation are built-in. Do NOT debounce externally.
@@ -6081,14 +6104,15 @@ Append to `packages/design-system/AGENTS.md`:
 - For **free-form text**, use `<Input>`. Select always picks from a (possibly async) set.
 - Don't reach for `triggerDisplay='summary'` for tag input — chips communicate the active filter set at a glance.
 - `creatable` requires `searchable` (throws in dev). Passing both `options` and `loadOptions` is also flagged (loadOptions wins).
-```
+
+````
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add packages/design-system/AGENTS.md
 git commit -m "AGENTS: Select TL;DR + canonical snippets + anti-patterns"
-```
+````
 
 ---
 
@@ -6097,6 +6121,7 @@ git commit -m "AGENTS: Select TL;DR + canonical snippets + anti-patterns"
 ### Task 32: Run gates, then the review-fix cycle to clean
 
 **Files:**
+
 - All under `packages/design-system/**` are in scope for the review.
 
 - [ ] **Step 1: Run all gates locally**

--- a/docs/superpowers/specs/2026-05-20-select-design.md
+++ b/docs/superpowers/specs/2026-05-20-select-design.md
@@ -1,0 +1,590 @@
+# Select — design
+
+**Status:** approved, ready for plan
+**Author:** dpws + Claude
+**Date:** 2026-05-20
+**Scope:** new component `packages/design-system/src/components/Select/`
+
+## Goal
+
+Ship `<Select>` — the Select/Combobox primitive listed first in the wishlist in `packages/design-system/CLAUDE.md`. One generalist component that covers the three high-frequency CRM use cases: form-field value pickers, table-filter multi-selects, and tag-input fields. Hand-rolled on `@floating-ui/react-dom` (same as `<DropdownMenu>` and `<Popover>`), declarative API with render-prop escape hatches, full WAI-ARIA combobox 1.2 semantics.
+
+## Non-goals
+
+- **No virtualization in v1.** Long lists render every option. Revisit when CRM hits a real 500+ option case.
+- **No sticky group headers** while scrolling the listbox. Headers scroll with content. Cheap to add later if needed.
+- **No "Select all" / "Clear all"** affordances inside the listbox.
+- **No max-selections cap** in v1.
+- **No async pagination** ("load more on scroll"). `loadOptions` returns the full set per query.
+- **No `minSearchChars` gate.** Consumer can early-return `[]` from `loadOptions` when the query is too short.
+- **No `searchPlacement` override.** Search lives in the trigger for input-style modes (combobox single, chips-multi) and inside the popover for button-style modes (summary-multi). Not configurable.
+- **No async `onCreate`.** Creatable rows fire `onCreate(label)` and add `{ value: label, label }` to the selection optimistically. Consumer persists on their own; if persistence fails they remove the value externally.
+- **No native mobile fallback** to `<select>`. The combobox UI is used on every viewport.
+- **No multi-select chips _outside_ the trigger.** Selections always live in the trigger (chips or summary).
+- **No animation on close.** Same posture as DropdownMenu / Tooltip / Popover — panel unmounts immediately.
+
+## Public API
+
+```tsx
+import { Select } from '@eocrm/design-system';
+
+// 1. Form field — single, no search:
+<Select
+  options={[
+    { value: 'active', label: 'Active' },
+    { value: 'pending', label: 'Pending' },
+    { value: 'archived', label: 'Archived' },
+  ]}
+  value={status}
+  onChange={(v) => setStatus(v as Status)}
+  placeholder="Pick a status"
+/>;
+
+// 2. Form field — single, searchable, grouped:
+<Select
+  searchable
+  options={[
+    { label: 'Americas', options: [{ value: 'us', label: 'United States' }, ...] },
+    { label: 'Europe',   options: [{ value: 'de', label: 'Germany' }, ...] },
+  ]}
+  value={country}
+  onChange={(v) => setCountry(v as CountryCode)}
+/>;
+
+// 3. Assignee picker — single, async:
+<Select
+  searchable
+  loadOptions={async (q, signal) => {
+    const users = await api.searchUsers(q, { signal });
+    return users.map((u) => ({ value: u.id, label: u.name, data: u }));
+  }}
+  renderOption={(opt) => (
+    <Cluster gap="sm">
+      <Avatar name={opt.label} src={opt.data?.avatarUrl} size="sm" />
+      <span>{opt.label}</span>
+    </Cluster>
+  )}
+  value={assigneeId}
+  onChange={(id) => setAssigneeId(id as string)}
+/>;
+
+// 4. Table filter — multi, summary, searchable:
+<Select
+  multiple
+  triggerDisplay="summary"
+  searchable
+  options={statusOptions}
+  value={selected}
+  onChange={(values) => setSelected(values as string[])}
+  placeholder="Filter by status"
+/>;
+
+// 5. Tag input — multi, chips, searchable, creatable:
+<Select
+  multiple
+  triggerDisplay="chips"
+  searchable
+  creatable
+  options={existingTags}
+  value={tags}
+  onChange={(values) => setTags(values as string[])}
+  onCreate={(label) => api.tags.create({ label })}
+  placeholder="Add tags…"
+/>;
+```
+
+### Types
+
+```ts
+export type SelectSize = 'sm' | 'md' | 'lg';
+export type SelectTriggerDisplay = 'chips' | 'summary';
+
+export type SelectOption<T = unknown> = {
+  /** Unique key. What `onChange` emits. */
+  value: string;
+  /** Displayed text. Used for substring search when `searchable` is on. */
+  label: string;
+  /** Optional secondary line shown under the label in default render. */
+  description?: string;
+  /** When true, the option is dimmed, `aria-disabled`, and skipped in keyboard nav. */
+  disabled?: boolean;
+  /** Arbitrary payload — surfaces in `renderOption`, `renderValue`, `renderTag`. */
+  data?: T;
+};
+
+export type SelectGroup<T = unknown> = {
+  /** Header text shown above the group's options. */
+  label: string;
+  /** Members of the group. */
+  options: SelectOption<T>[];
+};
+
+/**
+ * Discriminated at runtime: if the first element has an `options` field, it's a grouped shape.
+ * Mixing groups and ungrouped options at the same level is not supported.
+ */
+export type SelectOptions<T = unknown> = SelectOption<T>[] | SelectGroup<T>[];
+
+export type SelectProps<T = unknown> = {
+  // ─── data ─────────────────────────────────────────────────────────────────
+  options?: SelectOptions<T>;
+  loadOptions?: (query: string, signal: AbortSignal) => Promise<SelectOptions<T>>;
+  /** Fire `loadOptions('', signal)` on first open. Default `true`. Ignored when no `loadOptions`. */
+  loadOnOpen?: boolean;
+  /** Debounce window for `loadOptions` calls and local-filter recomputation. Default `250`. */
+  searchDebounceMs?: number;
+
+  // ─── mode ─────────────────────────────────────────────────────────────────
+  /** Default `false`. When `true`, `value`/`onChange` operate on `string[]`. */
+  multiple?: boolean;
+  /** Default `'chips'`. Ignored when `multiple` is `false`. */
+  triggerDisplay?: SelectTriggerDisplay;
+  /** Enables typing-to-filter and (with `loadOptions`) async search. Default `false`. */
+  searchable?: boolean;
+  /** Adds a "+ Create '<query>'" row when no exact match exists. Requires `searchable`. Default `false`. */
+  creatable?: boolean;
+
+  // ─── value ────────────────────────────────────────────────────────────────
+  value?: string | string[];
+  defaultValue?: string | string[];
+  /**
+   * Fired on every selection change. Second arg is the matched option(s):
+   *  - single: the SelectOption or `null` (when cleared)
+   *  - multi: the array of currently selected options
+   */
+  onChange?: (
+    value: string | string[],
+    option: SelectOption<T> | SelectOption<T>[] | null,
+  ) => void;
+  /** Fired when the user activates a "+ Create" row. `onChange` fires immediately after with the new value included. */
+  onCreate?: (label: string) => void;
+
+  // ─── open state (controlled, rare) ────────────────────────────────────────
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+
+  // ─── visuals ──────────────────────────────────────────────────────────────
+  size?: SelectSize; // default 'md'
+  /** Adds error border + `aria-invalid="true"`. Pair with `aria-describedby` to an error message. */
+  invalid?: boolean;
+  placeholder?: string;
+  /**
+   * Adds a ✕ on the trigger that clears the entire selection.
+   * Default: `true` when `!multiple && !required`, `false` otherwise.
+   * Multi mode handles per-chip removal regardless.
+   */
+  clearable?: boolean;
+
+  // ─── states ───────────────────────────────────────────────────────────────
+  disabled?: boolean;
+  /** Renders the trigger non-interactive (no click, no focus-to-open) but still shows the current value. */
+  readOnly?: boolean;
+
+  // ─── form integration ─────────────────────────────────────────────────────
+  /** Renders hidden `<input>`(s) so `new FormData(form)` picks up the value. */
+  name?: string;
+  /** Sets `required` on the underlying input(s) (single) or runs our own validation (multi — see Behaviors). */
+  required?: boolean;
+  /** Targets a specific form by id when the Select is rendered outside the form. */
+  form?: string;
+
+  // ─── render escape hatches ────────────────────────────────────────────────
+  renderOption?: (
+    opt: SelectOption<T>,
+    state: { active: boolean; selected: boolean },
+  ) => ReactNode;
+  /** Renders the selected label in single-mode triggers. Defaults to `opt.label`. */
+  renderValue?: (opt: SelectOption<T>) => ReactNode;
+  /** Renders a single chip in chips-mode triggers. Defaults to `<Chip>{opt.label}</Chip>` with ✕. */
+  renderTag?: (opt: SelectOption<T>, remove: () => void) => ReactNode;
+  renderEmpty?: (query: string) => ReactNode;
+  renderLoading?: () => ReactNode;
+  renderError?: (err: Error, retry: () => void) => ReactNode;
+
+  // ─── ARIA + DOM forwarding ────────────────────────────────────────────────
+  id?: string;
+  className?: string;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+};
+```
+
+### Prop defaults table
+
+| Prop | Default | Notes |
+|---|---|---|
+| `multiple` | `false` | — |
+| `triggerDisplay` | `'chips'` | Ignored when `!multiple` |
+| `searchable` | `false` | — |
+| `creatable` | `false` | Throws in dev when `creatable && !searchable` |
+| `loadOnOpen` | `true` | Only consulted when `loadOptions` is set |
+| `searchDebounceMs` | `250` | — |
+| `size` | `'md'` | Mirrors `<Input>` |
+| `invalid` | `false` | — |
+| `clearable` | `!multiple && !required` | Multi handles per-chip removal regardless |
+| `disabled` | `false` | — |
+| `readOnly` | `false` | — |
+| `required` | `false` | — |
+
+## Mode matrix
+
+| `multiple` | `triggerDisplay` | `searchable` | Trigger | Search input lives in |
+|---|---|---|---|---|
+| `false` | (n/a) | `false` | Button-styled, chevron right | — |
+| `false` | (n/a) | `true` | **Combobox input** — typing replaces displayed label and filters | trigger itself |
+| `true` | `'chips'` | `false` | Input-shell with inline chips, no caret editor | — |
+| `true` | `'chips'` | `true` | Input-shell with inline chips + inline caret editor after last chip | trigger itself |
+| `true` | `'summary'` | `false` | Button-styled, shows "Foo, Bar, …" or "N selected" | — |
+| `true` | `'summary'` | `true` | Button-styled, shows summary | inside popover, top |
+
+Tag-input pattern is `multiple={true} triggerDisplay='chips' searchable={true} creatable={true}` — no separate component.
+
+### Summary text logic
+
+When `triggerDisplay='summary'` with N selections:
+
+- N = 0 → render `placeholder` text in muted color.
+- N ≥ 1 → render comma-joined labels (`"Foo, Bar, Baz"`), truncated with ellipsis when overflowing the trigger width. Whole text is the `aria-label` of the trigger so SR users hear all of them.
+
+We deliberately avoid the `"N selected"` shortcut by default — the comma-joined form is denser information and ellipsis handles overflow. `renderValue` is single-mode only in v1 (signature: one option). Customizing the multi-summary text (e.g. `"N selected"`) is deferred to v2 — see the future-work list.
+
+## Behaviors
+
+### Single, non-searchable
+
+- Trigger: button-styled, identical metrics to `<Input>` (border, focus ring, sizes). Right edge has chevron-down icon; on `clearable && hasValue`, a `✕` appears before the chevron.
+- Open triggers: click, `Enter`, `Space`, `ArrowDown` (opens with first selectable item active), `ArrowUp` (opens with last selectable item active), typeahead (printable character — starts a 500ms typeahead buffer like `<DropdownMenu>`).
+- While open: `ArrowDown`/`ArrowUp` move active row; `Home`/`End` jump; `PageDown`/`PageUp` ±5; `Enter`/`Space` selects active and closes; `Escape` closes without changing selection; `Tab` closes and commits the selection.
+
+### Single, searchable (combobox input-as-trigger)
+
+- Trigger: an actual `<input>` styled exactly like `<Input>`. When closed and a value is selected, the input shows the selected label (read-only-looking but actually focusable + editable).
+- Focusing the trigger does NOT open the listbox. Open triggers: click, `ArrowDown`/`ArrowUp`, or any printable keystroke. When opening via keystroke, the typed char replaces the displayed label and becomes the query (first keystroke is preserved). The selected label is restored on close-without-change.
+- Behavior matches Headless UI's Combobox / Radix's Combobox v2 / MUI Autocomplete.
+- Selection: `Enter` on the active row or click. Closes immediately, focus returns to trigger, input shows new label.
+- Dismissal: `Escape` closes and reverts the query to the selected label. Click-outside closes without changing the selection (active-row highlight is not "applied" on outside click — only explicit `Enter` or click on a row commits). The input reverts to the selected label. `Tab` is the same as click-outside.
+- `Backspace` on the empty input does NOT remove the selection — clearable handles that. (Backspace-clears-on-empty is a chips-mode behavior, not a single-mode one.)
+
+### Multi, chips, searchable
+
+- Trigger: input-shell that grows vertically as chips wrap. Chips render left-to-right top-to-bottom; the editable caret area is the last child, taking remaining width with `min-width: 4ch` so it always has somewhere to type.
+- Adding: typing filters, `Enter` selects active row (and immediately keeps popover open, clears query, refocuses input caret).
+- Removing: click on a chip's `✕` removes that one; `Backspace` on an empty caret removes the trailing chip and moves focus to its `✕` (next `Backspace` removes again, or arrow-keys navigate among chips like macOS pill UI).
+- `ArrowLeft` at start of empty input → focus moves to the trailing chip's `✕`. `ArrowLeft`/`ArrowRight` while on a chip navigate between chips. `Enter`/`Backspace`/`Delete` on a focused chip removes it. `Escape` returns focus to caret without removing.
+
+### Multi, chips, non-searchable
+
+- Trigger: same shape as searchable-chips, but no inline caret editor — clicking anywhere on the trigger opens the popover.
+- Chip removal via click on `✕`, or keyboard chip-nav as described above.
+
+### Multi, summary, searchable
+
+- Trigger: button-styled, shows comma-joined labels or `placeholder`. Click opens.
+- Popover has a search input at the top of the panel. Pattern matches `<DropdownMenu.Content>` with a leading input + listbox.
+- Selecting a row toggles its membership without closing the popover. Search input retains focus.
+
+### Multi, summary, non-searchable
+
+- Same trigger as the searchable variant; popover has no search input, just the listbox.
+- Toggling rows does not close the popover.
+
+### Common keyboard model (across all modes)
+
+| Key | Closed | Open |
+|---|---|---|
+| `Enter` | Open (single/chips), open + activate (button-styled) | Select active row; close on single, keep on multi |
+| `Space` | Open (button-styled triggers only) | Button-styled triggers: same as `Enter`. Input-style triggers (searchable single, chips-multi): Space is a literal space char in the query |
+| `ArrowDown` | Open with first active | Move active +1 (skips disabled, header rows, separators) |
+| `ArrowUp` | Open with last active | Move active -1 |
+| `Home` | (no-op) | Active = first option |
+| `End` | (no-op) | Active = last option |
+| `PageDown` | (no-op) | Active +5 (clamped) |
+| `PageUp` | (no-op) | Active -5 (clamped) |
+| `Escape` | (no-op) | Close, revert search query to last selected label (single-search) |
+| `Tab` | (no-op, normal traversal) | Close, commit current selection |
+| Printable char | Typeahead-open for non-searchable; first char of query for searchable | Typeahead step in non-searchable; query input in searchable |
+| `Backspace` | (no-op) | Remove last chip in chips-mode if input is empty; otherwise normal input behavior |
+
+### ARIA
+
+- **Single, non-searchable trigger:** `<button>` with `aria-haspopup="listbox"`, `aria-expanded`, `aria-controls={listboxId}` while open.
+- **Single, searchable trigger:** `<input role="combobox" aria-autocomplete="list" aria-expanded aria-controls={listboxId} aria-activedescendant={activeOptionId}>`.
+- **Multi, chips trigger:** searchable variant — the inline `<input role="combobox" aria-autocomplete="list" aria-expanded aria-controls={listboxId} aria-activedescendant={activeOptionId}>` carries the combobox role; the surrounding `<div>` is a presentational shell. Non-searchable variant — surrounding `<div role="button" tabIndex={0}>` (or a `<button>` wrapper) with `aria-haspopup="listbox"`. Each chip is a `<button type="button" aria-label="Remove {label}">` so chips are individually focusable and removable.
+- **Multi, summary trigger:** `<button>` with `aria-haspopup="listbox" aria-expanded`. The popover's search input (if any) is `role="combobox"` inside the panel.
+- **Listbox:** `<ul role="listbox" aria-multiselectable={multiple} aria-labelledby={triggerId}>`. Active row tracked via `aria-activedescendant` on the trigger (or on the in-panel search input for summary-multi-searchable).
+- **Options:** `<li role="option" id={optionId} aria-selected={isSelected} aria-disabled={isDisabled}>`. Default render also visually flags selection via background tint, but `aria-selected` is the truth.
+- **Groups:** `<li role="group" aria-labelledby={groupHeaderId}>` wraps the group's options; the header is a non-focusable `<div id={groupHeaderId}>` with `aria-hidden="false"` (it's a label, not an option).
+
+### Async lifecycle
+
+- **Initial:** if `loadOptions` is set and `loadOnOpen` is `true`, the first time the popover opens for a given mount the component calls `loadOptions('', signal)` and shows the loading state until the promise resolves. Subsequent opens reuse the cached results until the query changes.
+- **On query change:** debounced `searchDebounceMs` (default 250). On every actual fire, the in-flight request (if any) is aborted via `AbortController` and a new `loadOptions(currentQuery, signal)` is issued.
+- **Resolved:** options render. Active row resets to the first non-disabled item.
+- **Rejected (non-abort):** `renderError(err, retry)` is invoked. `retry` calls `loadOptions(currentQuery, freshSignal)` afresh. Default error UI: `"Failed to load options."` text + `<Button size="sm" variant="secondary">Retry</Button>`.
+- **Aborted:** swallowed silently. The next response takes over.
+- **`options` + `loadOptions` together:** `loadOptions` wins. In dev, a `console.warn` flags the redundant `options` prop.
+
+### Creatable
+
+- Enabled by `creatable && searchable`. Throws in dev when `creatable && !searchable` (an opaque sync-only "creatable picker without a query field" is incoherent).
+- When the current query (trimmed, non-empty) does NOT exactly match any option's label (case-insensitive), a special row is appended after all real options:
+  - Label: `+ Create "<query>"` (the literal label uses curly quotes; the visible query is trimmed; tab characters dropped).
+  - `role="option"`, focusable like any other option.
+- Activating the row:
+  1. Calls `onCreate(trimmedQuery)`.
+  2. Adds `{ value: trimmedQuery, label: trimmedQuery }` to the selection (multi) or replaces selection (single).
+  3. Fires `onChange` with the post-update value and matched option(s) including the newly created one.
+  4. Closes the popover (single) or clears the query and keeps open (multi).
+- The created option is NOT added to `options` — that's the consumer's job in response to `onCreate`. Until the consumer persists and updates `options`, the chip's label is the only place the value exists in the UI.
+- Duplicate guard: if the trimmed query case-insensitively matches an already-selected value, the create row is hidden (we don't offer to recreate something already picked).
+
+### Clear
+
+- Single mode, `clearable` true, value set → ✕ icon appears in the trigger before the chevron. Click → `onChange('', null)`, popover stays closed.
+- Multi mode, `clearable` true (uncommon — chips already handle this), value non-empty → ✕ icon at the right of the trigger. Click → `onChange([], [])`. Chips also have their own ✕ for per-item removal.
+
+### Form integration
+
+- When `name` is set:
+  - Single mode: render one `<input type="hidden" name={name} value={selectedValue} required={required} form={form}>`. The empty selection renders `value=""`; with `required`, native form-submit will block on it (browsers respect `required` on hidden inputs).
+  - Multi mode with at least one selection: render one hidden input per selected value with the same `name`, no `required` attribute. `new FormData(form).getAll(name)` returns the array.
+  - Multi mode with **zero** selections + `required={true}`: render a single hidden input `<input type="hidden" name={name} value="" required form={form}>`. The empty `required` blocks native submit until the user picks at least one. Once the first selection arrives, swap to the per-value form above (no `required`).
+- `form` attribute on the hidden inputs lets a Select live outside its target `<form>`.
+- `aria-required` is set on the trigger when `required={true}`.
+- The hidden inputs are not focusable or labeled — the trigger carries all the a11y wiring. The hidden inputs exist only so FormData picks them up.
+
+### Width / sizing
+
+- Trigger: takes full width of its parent (`width: 100%`), same as `<Input>`. Consumers control width by wrapping with `<Stack>` / `<Cluster>` or sizing the parent.
+- Popover listbox: matches trigger width by default. Default `max-height: 320px` with `overflow-y: auto` beyond. Width override and max-height override are NOT exposed on the public API in v1 — consumers needing custom popover sizing wait for v2 (tracked in future-work). Internal `<Listbox>` carries the dimensions as constants for now.
+- Listbox scroll: vertical only; `overflow-y: auto`.
+
+### Animation
+
+- Open: scale-fade in 140ms `ease-out` from the trigger's anchor edge — same as `<DropdownMenu>` and `<Popover>`.
+- Close: instant unmount.
+- `prefers-reduced-motion: reduce` strips the transition.
+
+### Dismissal
+
+- Click-outside: closes. For single + searchable, commits the current selection (Escape behavior reverts query; click-outside accepts).
+- Escape: closes. For single + searchable, reverts query to selected label. For multi-summary + searchable, just closes; selections are already committed.
+- Tab: closes and commits.
+- Blur of trigger without focus moving into the popover: closes immediately (handled via Floating UI's `useDismiss` + manual focus tracking).
+
+## Visual rules
+
+All values come from tokens (Rule 3); no layout properties on the component (Rule 4).
+
+- **Trigger background/border:** identical to `<Input>` for input-style modes (`--color-border-default`, `--color-bg-surface`, focus ring via `--color-border-focus`). Button-style modes use the same border tokens but with `--color-bg-button-secondary` for the background, matching the secondary Button.
+- **Trigger sizes:** `sm` 28px, `md` 36px, `lg` 44px tall — same scale as `<Input>` and `<Button>`. When chip-wrap pushes the trigger taller, the minimum height tracks the size.
+- **Chips inside trigger:** small rounded pill, neutral background (`--color-bg-neutral-subtle`), text color `--color-text-default`. ✕ icon on hover and keyboard focus. Use the same chip token set used by `<Badge size="sm">`.
+- **Listbox panel:** `--color-bg-surface`, `--color-border-default`, `--radius-md`, `--shadow-md`. Matches `<DropdownMenu.Content>` and `<Popover.Content>` exactly.
+- **Option row:** padding from `--space-2` / `--space-3`. Active row (keyboard or mouse hover): `--color-bg-subtle`. Selected row: `--color-bg-info-subtle` + 2px left accent (`--color-border-info`) — matches `<DropdownMenu.CheckboxItem>`.
+- **Disabled option:** `--color-text-muted`, `cursor: not-allowed`, no hover bg, `aria-disabled`.
+- **Group header:** `--color-text-muted`, `font-size` one step smaller than option label, `--space-2` top padding, `--space-3` horizontal padding, `text-transform: uppercase`, `letter-spacing` small. Non-interactive, non-focusable.
+- **Empty/loading/error rows:** centered text in the listbox area, `--color-text-muted`. Loading row uses the existing spinner styles from `<ConfirmationPopover>` (extract to `_internal/Spinner` if needed).
+- **Focus ring:** `:focus-visible` on the trigger (Rule 3a). Mouse click on trigger does not get the keyboard ring.
+- **Chevron + ✕ icons:** inline SVG, `currentColor`, sized to match the trigger size token (12/14/16px for sm/md/lg).
+- **Z-layer:** uses the existing popover z-layer (`--z-popover`). Tooltip stays above it per existing tokens.
+
+## File layout
+
+```
+src/components/Select/
+  Select.tsx               ← public component (forwardRef on the trigger element)
+  Select.module.scss
+  Select.test.tsx
+  Trigger.tsx              ← internal: picks one of 6 trigger variants based on props
+  Listbox.tsx              ← internal: panel + option rendering + ARIA roles
+  Chip.tsx                 ← internal: removable chip for chips-mode trigger
+  Empty.tsx                ← internal: default empty-state row
+  Loading.tsx              ← internal: default loading-state row
+  Error.tsx                ← internal: default error-state row with Retry button
+  useSelectState.ts        ← internal: open/active/value reducer, controlled/uncontrolled merge
+  useAsyncOptions.ts       ← internal: debounce + AbortController + cache lifecycle
+  context.ts               ← internal context for Trigger/Listbox/Chip to read state
+  utils.ts                 ← internal: flatten groups, filter logic, normalize value
+  index.ts                 ← export { Select } + types
+```
+
+Public API exports only `Select`. Internal files are not re-exported.
+
+## src/index.ts additions
+
+```ts
+export { Select } from './components/Select';
+export type {
+  SelectProps,
+  SelectOption,
+  SelectGroup,
+  SelectOptions,
+  SelectSize,
+  SelectTriggerDisplay,
+} from './components/Select';
+```
+
+## Testing matrix (minimum)
+
+Follow `<DropdownMenu>`'s depth (~1800 LoC test file is acceptable). Vitest globals, `userEvent` from `@testing-library/user-event`.
+
+Coverage groups:
+
+1. **Render & structure**
+   - Renders without crashing in every mode (single/multi × chips/summary × searchable/non-searchable).
+   - `ref` forwards to the trigger DOM node.
+   - `className` merges, not replaces, on the trigger.
+   - `id`, `aria-label`, `aria-labelledby`, `aria-describedby` thread to the trigger.
+2. **Sync options**
+   - Flat options render. Grouped options render headers in order.
+   - `disabled` options are dimmed and `aria-disabled`.
+   - Mixed flat + grouped is detected as grouped (per first-element rule) and flat items are ignored — log a dev warning.
+3. **Multi-chips**
+   - Selecting a row adds a chip; clicking chip ✕ removes; chip-keyboard nav works (arrows, Backspace, Delete).
+   - Wrap behavior with N=20 chips renders multi-line trigger; popover anchors to the bottom edge.
+4. **Multi-summary**
+   - Trigger shows comma-joined labels; ellipsis on overflow; `aria-label` carries the full list.
+   - In-popover search filters; selecting toggles without closing.
+5. **Single, searchable (combobox)**
+   - Closed shows selected label. Click opens, label remains. Typing replaces label with query.
+   - Escape reverts query to selected label. Click-outside commits with current selection.
+   - Open-by-arrow-key activates the selected row.
+6. **Async load**
+   - `loadOptions` invoked once on first open when `loadOnOpen`.
+   - Debounce coalesces rapid keystrokes to a single call after 250ms (use `vi.useFakeTimers`).
+   - Stale promise aborted via signal when query changes (assert `signal.aborted` was checked or the rejection is swallowed).
+   - Rejection renders the error state; clicking Retry re-invokes `loadOptions` with the current query.
+   - `options` + `loadOptions` together: `loadOptions` wins; dev warning fires.
+7. **Creatable**
+   - With a unique query, create row appears as last option.
+   - Activating create row fires `onCreate(query)`, then `onChange` with the new value.
+   - Exact-match (case-insensitive) suppresses the create row.
+   - Already-selected value (in multi) is not offered for re-creation.
+   - `creatable && !searchable` throws in dev.
+8. **Keyboard**
+   - Every key in the matrix in every mode (focus on the trigger, simulate, assert the next state).
+9. **ARIA**
+   - Roles: combobox (where applicable), listbox, option, group.
+   - `aria-expanded`, `aria-controls`, `aria-activedescendant`, `aria-multiselectable`, `aria-selected`, `aria-disabled` set correctly across state transitions.
+10. **Form integration**
+    - With `name`, single renders one hidden input; multi renders one per value.
+    - `FormData(form).getAll(name)` returns the multi values.
+    - `required` blocks submit on empty single (via the hidden input).
+    - `required` blocks submit on empty multi (via our own intercept).
+    - `form` attribute lets a Select sibling-of-form submit into it.
+11. **Controlled vs uncontrolled**
+    - `defaultValue` initializes; `value` overrides; `onChange` fires on every interaction.
+    - `defaultOpen` initializes the open state; controlled `open` + `onOpenChange` round-trips.
+12. **Disabled / readOnly / invalid**
+    - `disabled` — no click, no focus-to-open.
+    - `readOnly` — focus works but click/Enter don't open; existing value still shows.
+    - `invalid` — adds the right class + `aria-invalid="true"`.
+13. **Clearable**
+    - Default-on for single-non-required, default-off for single-required and for multi.
+    - Clicking ✕ fires `onChange('', null)` for single, `onChange([], [])` for multi (when manually enabled).
+14. **Render escape hatches**
+    - `renderOption` receives `{active, selected}` and renders.
+    - `renderValue`/`renderTag`/`renderEmpty`/`renderLoading`/`renderError` all wire through.
+15. **Sizes**
+    - `sm` / `md` / `lg` apply the right classes on the trigger.
+
+## Demo plan
+
+`packages/playground/src/pages/components/SelectDemo.tsx` covers:
+
+1. **Status picker** — single, non-searchable, 3 options. Smallest possible Select.
+2. **Country picker** — single, searchable, grouped (Americas / Europe / Asia-Pacific).
+3. **Assignee picker** — single, async, custom `renderOption` with `<Avatar>`. Includes a forced error+retry interaction.
+4. **Status filter** — multi-summary, searchable, simulating a table-filter toolbar Cluster.
+5. **Owner filter** — multi-chips, searchable.
+6. **Tags input** — multi-chips, searchable, creatable. Show the `onCreate` callback wiring (logging to a paragraph above the field).
+7. **Disabled / readOnly / invalid** — three side-by-side small Selects.
+8. **Sizes** — sm / md / lg in a row, all with `<Input>` siblings so visual parity is obvious.
+
+Wire into:
+
+- `packages/playground/src/App.tsx` — route `/demo/select`.
+- `packages/playground/src/layout/AppShell/AppShell.tsx` — sidebar nav entry, alphabetical-ish among existing demos.
+- `packages/playground/src/pages/components/ComponentsIndex.tsx` — overview grid tile.
+
+## AGENTS.md update
+
+Add a new section after `<ConfirmationPopover>`:
+
+```md
+### `<Select>` — value picker (single, multi, searchable, async, creatable)
+
+```tsx
+// Form field — single:
+<Select
+  options={statuses}
+  value={status}
+  onChange={(v) => setStatus(v as Status)}
+  placeholder="Pick a status"
+/>
+
+// Filter — multi, summary:
+<Select
+  multiple
+  triggerDisplay="summary"
+  searchable
+  options={owners}
+  value={selectedOwners}
+  onChange={(v) => setSelectedOwners(v as string[])}
+/>
+
+// Tag input — multi, chips, creatable:
+<Select
+  multiple
+  searchable
+  creatable
+  options={existingTags}
+  value={tags}
+  onChange={(v) => setTags(v as string[])}
+  onCreate={api.tags.create}
+/>
+```
+
+- One generalist; the mode matrix is `multiple` × `triggerDisplay` × `searchable`. See JSDoc for the matrix.
+- Async via `loadOptions(query, signal)`. Debounce and AbortSignal are built-in; do NOT debounce externally.
+- Tag input pattern = `multiple + searchable + creatable + triggerDisplay='chips'`. No separate Tags component.
+- For pure ACTION menus (Edit/Delete buttons), use `<DropdownMenu>`. Select is for value selection.
+- For free-form text, use `<Input>`. Select always picks from a (possibly async) set.
+- Don't reach for `triggerDisplay='summary'` for tag input — chips communicate the active filter set at a glance.
+```
+
+## Open / future-work items (NOT v1)
+
+Listed so plan reviewers know what's deliberately excluded:
+
+- Virtualization (`react-window` or hand-rolled). Add when CRM hits a real perf wall.
+- Sticky group headers (`position: sticky` inside listbox).
+- "Select all" / "Clear all" row at top of listbox in multi mode.
+- `maxSelections?: number` cap with auto-disable of unselected rows.
+- Async pagination (load-more-on-scroll). Would extend `loadOptions` to return a cursor.
+- `minSearchChars` gate.
+- `searchPlacement` override.
+- Async `onCreate` returning `Promise<string>` for deferred adoption.
+- `multiple + summary` with `"N selected"` shortened render (consumer-overridable via an extended `renderValue` or a new `renderSummary` prop). Today summary is always comma-joined-with-ellipsis.
+- Popover width override (e.g., `popoverWidth: 'trigger' | 'auto' | number`) and `maxHeight` override on the listbox.
+
+## Implementation order (suggestion for the plan)
+
+1. Scaffold + smoke test (renders, ref forwards, className merges).
+2. `useSelectState` — controlled/uncontrolled value + open + active row.
+3. Trigger variants (button-style first; then combobox-input; then chips-shell).
+4. Listbox + sync options (flat then grouped) + option rendering.
+5. Keyboard (every key in the matrix), one mode at a time, with tests.
+6. Multi mode (chips + summary).
+7. Searchable (local filter only).
+8. Async (loadOptions + debounce + AbortSignal + loading/error/empty states + retry).
+9. Creatable.
+10. Form integration (hidden inputs).
+11. Clearable, disabled, readOnly, invalid, sizes.
+12. Render escape hatches.
+13. JSDoc pass per Rule 7.
+14. Playground demo + nav wiring.
+15. AGENTS.md update.
+16. Pre-push review-fix cycle (Rule 8) until clean.

--- a/docs/superpowers/specs/2026-05-20-select-design.md
+++ b/docs/superpowers/specs/2026-05-20-select-design.md
@@ -152,10 +152,7 @@ export type SelectProps<T = unknown> = {
    *  - single: the SelectOption or `null` (when cleared)
    *  - multi: the array of currently selected options
    */
-  onChange?: (
-    value: string | string[],
-    option: SelectOption<T> | SelectOption<T>[] | null,
-  ) => void;
+  onChange?: (value: string | string[], option: SelectOption<T> | SelectOption<T>[] | null) => void;
   /** Fired when the user activates a "+ Create" row. `onChange` fires immediately after with the new value included. */
   onCreate?: (label: string) => void;
 
@@ -190,10 +187,7 @@ export type SelectProps<T = unknown> = {
   form?: string;
 
   // ─── render escape hatches ────────────────────────────────────────────────
-  renderOption?: (
-    opt: SelectOption<T>,
-    state: { active: boolean; selected: boolean },
-  ) => ReactNode;
+  renderOption?: (opt: SelectOption<T>, state: { active: boolean; selected: boolean }) => ReactNode;
   /** Renders the selected label in single-mode triggers. Defaults to `opt.label`. */
   renderValue?: (opt: SelectOption<T>) => ReactNode;
   /** Renders a single chip in chips-mode triggers. Defaults to `<Chip>{opt.label}</Chip>` with ✕. */
@@ -213,31 +207,31 @@ export type SelectProps<T = unknown> = {
 
 ### Prop defaults table
 
-| Prop | Default | Notes |
-|---|---|---|
-| `multiple` | `false` | — |
-| `triggerDisplay` | `'chips'` | Ignored when `!multiple` |
-| `searchable` | `false` | — |
-| `creatable` | `false` | Throws in dev when `creatable && !searchable` |
-| `loadOnOpen` | `true` | Only consulted when `loadOptions` is set |
-| `searchDebounceMs` | `250` | — |
-| `size` | `'md'` | Mirrors `<Input>` |
-| `invalid` | `false` | — |
-| `clearable` | `!multiple && !required` | Multi handles per-chip removal regardless |
-| `disabled` | `false` | — |
-| `readOnly` | `false` | — |
-| `required` | `false` | — |
+| Prop               | Default                  | Notes                                         |
+| ------------------ | ------------------------ | --------------------------------------------- |
+| `multiple`         | `false`                  | —                                             |
+| `triggerDisplay`   | `'chips'`                | Ignored when `!multiple`                      |
+| `searchable`       | `false`                  | —                                             |
+| `creatable`        | `false`                  | Throws in dev when `creatable && !searchable` |
+| `loadOnOpen`       | `true`                   | Only consulted when `loadOptions` is set      |
+| `searchDebounceMs` | `250`                    | —                                             |
+| `size`             | `'md'`                   | Mirrors `<Input>`                             |
+| `invalid`          | `false`                  | —                                             |
+| `clearable`        | `!multiple && !required` | Multi handles per-chip removal regardless     |
+| `disabled`         | `false`                  | —                                             |
+| `readOnly`         | `false`                  | —                                             |
+| `required`         | `false`                  | —                                             |
 
 ## Mode matrix
 
-| `multiple` | `triggerDisplay` | `searchable` | Trigger | Search input lives in |
-|---|---|---|---|---|
-| `false` | (n/a) | `false` | Button-styled, chevron right | — |
-| `false` | (n/a) | `true` | **Combobox input** — typing replaces displayed label and filters | trigger itself |
-| `true` | `'chips'` | `false` | Input-shell with inline chips, no caret editor | — |
-| `true` | `'chips'` | `true` | Input-shell with inline chips + inline caret editor after last chip | trigger itself |
-| `true` | `'summary'` | `false` | Button-styled, shows "Foo, Bar, …" or "N selected" | — |
-| `true` | `'summary'` | `true` | Button-styled, shows summary | inside popover, top |
+| `multiple` | `triggerDisplay` | `searchable` | Trigger                                                             | Search input lives in |
+| ---------- | ---------------- | ------------ | ------------------------------------------------------------------- | --------------------- |
+| `false`    | (n/a)            | `false`      | Button-styled, chevron right                                        | —                     |
+| `false`    | (n/a)            | `true`       | **Combobox input** — typing replaces displayed label and filters    | trigger itself        |
+| `true`     | `'chips'`        | `false`      | Input-shell with inline chips, no caret editor                      | —                     |
+| `true`     | `'chips'`        | `true`       | Input-shell with inline chips + inline caret editor after last chip | trigger itself        |
+| `true`     | `'summary'`      | `false`      | Button-styled, shows "Foo, Bar, …" or "N selected"                  | —                     |
+| `true`     | `'summary'`      | `true`       | Button-styled, shows summary                                        | inside popover, top   |
 
 Tag-input pattern is `multiple={true} triggerDisplay='chips' searchable={true} creatable={true}` — no separate component.
 
@@ -291,20 +285,20 @@ We deliberately avoid the `"N selected"` shortcut by default — the comma-joine
 
 ### Common keyboard model (across all modes)
 
-| Key | Closed | Open |
-|---|---|---|
-| `Enter` | Open (single/chips), open + activate (button-styled) | Select active row; close on single, keep on multi |
-| `Space` | Open (button-styled triggers only) | Button-styled triggers: same as `Enter`. Input-style triggers (searchable single, chips-multi): Space is a literal space char in the query |
-| `ArrowDown` | Open with first active | Move active +1 (skips disabled, header rows, separators) |
-| `ArrowUp` | Open with last active | Move active -1 |
-| `Home` | (no-op) | Active = first option |
-| `End` | (no-op) | Active = last option |
-| `PageDown` | (no-op) | Active +5 (clamped) |
-| `PageUp` | (no-op) | Active -5 (clamped) |
-| `Escape` | (no-op) | Close, revert search query to last selected label (single-search) |
-| `Tab` | (no-op, normal traversal) | Close, commit current selection |
-| Printable char | Typeahead-open for non-searchable; first char of query for searchable | Typeahead step in non-searchable; query input in searchable |
-| `Backspace` | (no-op) | Remove last chip in chips-mode if input is empty; otherwise normal input behavior |
+| Key            | Closed                                                                | Open                                                                                                                                       |
+| -------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Enter`        | Open (single/chips), open + activate (button-styled)                  | Select active row; close on single, keep on multi                                                                                          |
+| `Space`        | Open (button-styled triggers only)                                    | Button-styled triggers: same as `Enter`. Input-style triggers (searchable single, chips-multi): Space is a literal space char in the query |
+| `ArrowDown`    | Open with first active                                                | Move active +1 (skips disabled, header rows, separators)                                                                                   |
+| `ArrowUp`      | Open with last active                                                 | Move active -1                                                                                                                             |
+| `Home`         | (no-op)                                                               | Active = first option                                                                                                                      |
+| `End`          | (no-op)                                                               | Active = last option                                                                                                                       |
+| `PageDown`     | (no-op)                                                               | Active +5 (clamped)                                                                                                                        |
+| `PageUp`       | (no-op)                                                               | Active -5 (clamped)                                                                                                                        |
+| `Escape`       | (no-op)                                                               | Close, revert search query to last selected label (single-search)                                                                          |
+| `Tab`          | (no-op, normal traversal)                                             | Close, commit current selection                                                                                                            |
+| Printable char | Typeahead-open for non-searchable; first char of query for searchable | Typeahead step in non-searchable; query input in searchable                                                                                |
+| `Backspace`    | (no-op)                                                               | Remove last chip in chips-mode if input is empty; otherwise normal input behavior                                                          |
 
 ### ARIA
 
@@ -512,7 +506,7 @@ Wire into:
 
 Add a new section after `<ConfirmationPopover>`:
 
-```md
+````md
 ### `<Select>` — value picker (single, multi, searchable, async, creatable)
 
 ```tsx
@@ -545,6 +539,7 @@ Add a new section after `<ConfirmationPopover>`:
   onCreate={api.tags.create}
 />
 ```
+````
 
 - One generalist; the mode matrix is `multiple` × `triggerDisplay` × `searchable`. See JSDoc for the matrix.
 - Async via `loadOptions(query, signal)`. Debounce and AbortSignal are built-in; do NOT debounce externally.
@@ -552,6 +547,7 @@ Add a new section after `<ConfirmationPopover>`:
 - For pure ACTION menus (Edit/Delete buttons), use `<DropdownMenu>`. Select is for value selection.
 - For free-form text, use `<Input>`. Select always picks from a (possibly async) set.
 - Don't reach for `triggerDisplay='summary'` for tag input — chips communicate the active filter set at a glance.
+
 ```
 
 ## Open / future-work items (NOT v1)
@@ -587,3 +583,4 @@ Listed so plan reviewers know what's deliberately excluded:
 14. Playground demo + nav wiring.
 15. AGENTS.md update.
 16. Pre-push review-fix cycle (Rule 8) until clean.
+```

--- a/docs/superpowers/specs/2026-05-20-select-design.md
+++ b/docs/superpowers/specs/2026-05-20-select-design.md
@@ -271,8 +271,7 @@ We deliberately avoid the `"N selected"` shortcut by default — the comma-joine
 
 - Trigger: input-shell that grows vertically as chips wrap. Chips render left-to-right top-to-bottom; the editable caret area is the last child, taking remaining width with `min-width: 4ch` so it always has somewhere to type.
 - Adding: typing filters, `Enter` selects active row (and immediately keeps popover open, clears query, refocuses input caret).
-- Removing: click on a chip's `✕` removes that one; `Backspace` on an empty caret removes the trailing chip and moves focus to its `✕` (next `Backspace` removes again, or arrow-keys navigate among chips like macOS pill UI).
-- `ArrowLeft` at start of empty input → focus moves to the trailing chip's `✕`. `ArrowLeft`/`ArrowRight` while on a chip navigate between chips. `Enter`/`Backspace`/`Delete` on a focused chip removes it. `Escape` returns focus to caret without removing.
+- Removing: click on a chip's `✕` removes that one; `Backspace` on an empty caret removes the trailing chip. (Full chip-to-chip arrow navigation — ArrowLeft from empty input stepping into chips, ArrowLeft/Right cycling chips, Enter/Delete on focused chip — is deferred to v2.)
 
 ### Multi, chips, non-searchable
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -339,6 +339,69 @@ const [tab, setTab] = useState('overview');
 - Anchors above the trigger by default (`side="top"`).
 - **From a DropdownMenu item (kebab Delete pattern).** Wrap a `<DropdownMenu.Item closeOnSelect={false}>` as the trigger — clicking anywhere on the row opens the confirmation. The menu stays open until the user dismisses it (Escape or click outside). To close the menu after the action resolves, drive `DropdownMenu`'s `open` state externally and call `setMenuOpen(false)` inside `onConfirm`.
 
+### `<Select>` — value picker (single, multi, searchable, async, creatable)
+
+```tsx
+// Form field — single:
+<Select
+  options={statuses}
+  value={status}
+  onChange={(v) => setStatus(v as Status)}
+  placeholder="Pick a status"
+/>
+
+// Table filter — multi, summary:
+<Select
+  multiple
+  triggerDisplay="summary"
+  searchable
+  options={owners}
+  value={selectedOwners}
+  onChange={(v) => setSelectedOwners(v as string[])}
+  placeholder="Filter by owner"
+/>
+
+// Tag input — multi, chips, creatable:
+<Select
+  multiple
+  searchable
+  creatable
+  options={existingTags}
+  value={tags}
+  onChange={(v) => setTags(v as string[])}
+  onCreate={api.tags.create}
+  placeholder="Add tags…"
+/>
+
+// Async with custom row render:
+<Select
+  searchable
+  loadOptions={async (q, signal) => {
+    const users = await api.searchUsers(q, { signal });
+    return users.map((u) => ({ value: u.id, label: u.name, data: u }));
+  }}
+  renderOption={(opt) => (
+    <Cluster gap="sm">
+      <Avatar name={opt.label} src={opt.data?.avatarUrl} size="sm" />
+      <span>{opt.label}</span>
+    </Cluster>
+  )}
+  value={assigneeId}
+  onChange={(id) => setAssigneeId(id as string)}
+/>
+```
+
+- One generalist; the mode matrix is `multiple` × `triggerDisplay: 'chips' | 'summary'` × `searchable`. See the JSDoc on `<Select>` for the matrix and anti-patterns.
+- **Async**: pass `loadOptions(query, signal)`. Debounce (250ms default, configurable via `searchDebounceMs`) and `AbortSignal` cancellation are built-in. Do NOT debounce externally.
+- **Tag input pattern** = `multiple + searchable + creatable + triggerDisplay='chips'`. There is no separate `<Tags>` component.
+- **Form integration**: pass `name` (and `required`/`form` if needed). Hidden inputs render so `new FormData(form)` works. Multi mode renders one hidden input per selected value; `FormData.getAll(name)` returns the array.
+- **`onChange` signature** is `(value, option | options | null)` — the second arg is the matched option(s), saving you a lookup.
+- **Render escape hatches**: `renderOption`, `renderValue`, `renderTag`, `renderEmpty`, `renderLoading`, `renderError`. Use when defaults don't suffice; default rendering is always token-correct.
+- For **action menus** (Edit/Delete/Duplicate buttons), use `<DropdownMenu>` — Select is for value selection, not actions.
+- For **free-form text**, use `<Input>`. Select always picks from a (possibly async) set.
+- Don't reach for `triggerDisplay='summary'` for tag input — chips communicate the active filter set at a glance.
+- `creatable` requires `searchable` (throws in dev). Passing both `options` and `loadOptions` is also flagged (loadOptions wins).
+
 ---
 
 ## Tokens (the only "values" you write)

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -392,6 +392,7 @@ const [tab, setTab] = useState('overview');
 ```
 
 - One generalist; the mode matrix is `multiple` × `triggerDisplay: 'chips' | 'summary'` × `searchable`. See the JSDoc on `<Select>` for the matrix and anti-patterns.
+- `triggerDisplay` defaults to `'chips'` when `multiple` is set. Use `'summary'` for table-filter UIs where chips would crowd the toolbar.
 - **Async**: pass `loadOptions(query, signal)`. Debounce (250ms default, configurable via `searchDebounceMs`) and `AbortSignal` cancellation are built-in. Do NOT debounce externally.
 - **Tag input pattern** = `multiple + searchable + creatable + triggerDisplay='chips'`. There is no separate `<Tags>` component.
 - **Form integration**: pass `name` (and `required`/`form` if needed). Hidden inputs render so `new FormData(form)` works. Multi mode renders one hidden input per selected value; `FormData.getAll(name)` returns the array.

--- a/packages/design-system/CLAUDE.md
+++ b/packages/design-system/CLAUDE.md
@@ -185,7 +185,6 @@ Wishlist for the CRM, in rough priority order. Until each exists, CRM pages shou
 
 **Dependency policy:** No UI / component libraries. `@floating-ui/react-dom` is used for collision-aware positioning (DropdownMenu and any future popover-shaped component); everything else — ARIA, focus, keyboard, dismissal — is hand-rolled per WAI-ARIA APG patterns. When CSS anchor positioning has acceptable browser support, Floating UI can be removed without changing public APIs.
 
-- `Select` / `Combobox` (hand-roll on Floating UI)
 - `Modal` / `Dialog` (hand-roll, no positioning needed; needs focus trap + scroll lock)
 - `Tooltip` (hand-roll on Floating UI; lightweight, no focus trap)
 - `Popover` (hand-roll on Floating UI; generalized non-menu floating panel)

--- a/packages/design-system/src/components/Select/Chip.tsx
+++ b/packages/design-system/src/components/Select/Chip.tsx
@@ -1,0 +1,43 @@
+import clsx from 'clsx';
+import styles from './Select.module.scss';
+
+/**
+ * Internal subcomponent rendered inside chips-mode Select triggers
+ * (`multiple + triggerDisplay='chips'`). Each Chip represents one selected
+ * option: a label plus a ✕ button that removes it.
+ *
+ * The ✕ is a real `<button>` so keyboard / AT users can focus and activate
+ * it. `onPointerDown` is stopped so the click doesn't bubble to the chips
+ * trigger wrapper (which would toggle the popover open/closed); `onClick`
+ * is also stopped so the wrapper's click handler doesn't fire.
+ *
+ * Not exported from the package. The chips trigger is the only call site.
+ */
+export interface ChipProps {
+  label: string;
+  onRemove: () => void;
+  disabled?: boolean;
+}
+
+export function Chip({ label, onRemove, disabled }: ChipProps) {
+  return (
+    <span className={clsx(styles.chip, disabled && styles.chipDisabled)}>
+      <span className={styles.chipLabel}>{label}</span>
+      <button
+        type="button"
+        className={styles.chipRemove}
+        aria-label={`Remove ${label}`}
+        disabled={disabled}
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+          <path d="M1 1 L9 9 M9 1 L1 9" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      </button>
+    </span>
+  );
+}

--- a/packages/design-system/src/components/Select/Empty.tsx
+++ b/packages/design-system/src/components/Select/Empty.tsx
@@ -1,0 +1,33 @@
+import styles from './Select.module.scss';
+
+/**
+ * Props for the default empty-state row. `query` shapes the message
+ * ("No results for X." vs "No options.") so the user understands whether
+ * the listbox is empty because their filter matched nothing or because
+ * the source has no options at all.
+ */
+export interface EmptyProps {
+  /**
+   * Current search query, if any. Empty string / undefined renders the
+   * "no options at all" copy; a non-empty value renders the "no results
+   * for this query" copy.
+   */
+  query?: string;
+}
+
+/**
+ * Default empty-state row rendered inside the listbox when there are no
+ * options to show. Consumers can override via `renderEmpty` on `<Select>`.
+ *
+ * Rendered as a non-interactive `<li role="presentation">` so it occupies
+ * a row visually but isn't reachable by keyboard or counted in the option
+ * walk. Carries `aria-live="polite"` so screen readers announce the empty
+ * state when it appears mid-session.
+ */
+export function Empty({ query }: EmptyProps) {
+  return (
+    <li className={styles.stateRow} role="presentation" aria-live="polite">
+      {query && query.trim() !== '' ? `No results for "${query}".` : 'No options.'}
+    </li>
+  );
+}

--- a/packages/design-system/src/components/Select/Error.tsx
+++ b/packages/design-system/src/components/Select/Error.tsx
@@ -1,0 +1,38 @@
+import styles from './Select.module.scss';
+
+/**
+ * Props for the default error-state row.
+ *
+ * `error` mirrors the consumer-facing `renderError(err, retry)` signature
+ * so a custom override can drop in without prop-name churn. It's not used
+ * in the default body, which prints a generic "Failed to load options."
+ * message — exposing the raw error message in the listbox would surface
+ * stack traces or HTTP detail strings to end users.
+ */
+export interface ErrorRowProps {
+  /** Original error, kept on the prop surface to match `renderError`. */
+  error: Error;
+  /** Re-fires `loadOptions` with the current query. */
+  onRetry: () => void;
+}
+
+/**
+ * Default error-state row, rendered inside the listbox when an async
+ * `loadOptions` request rejects. Carries `role="alert"` so screen readers
+ * announce the failure as soon as it appears. The Retry button calls back
+ * into the async hook's `retry()`, which bumps the retry token and
+ * re-fires the current query with no debounce delay.
+ */
+export function ErrorRow({ error: _error, onRetry }: ErrorRowProps) {
+  // `error` stays on the prop surface so the props match `renderError(err,
+  // retry)`. The default body intentionally doesn't show the raw error.
+  void _error;
+  return (
+    <li className={styles.stateRow} role="alert">
+      <span>Failed to load options.</span>
+      <button type="button" className={styles.retryButton} onClick={onRetry}>
+        Retry
+      </button>
+    </li>
+  );
+}

--- a/packages/design-system/src/components/Select/HiddenInputs.tsx
+++ b/packages/design-system/src/components/Select/HiddenInputs.tsx
@@ -1,0 +1,60 @@
+export interface HiddenInputsProps {
+  name?: string;
+  value: string | string[];
+  multiple: boolean;
+  required: boolean;
+  form?: string;
+  disabled: boolean;
+}
+
+/**
+ * Renders the hidden `<input>`(s) so native `FormData` picks up the Select's
+ * value. Single mode renders one input. Multi mode renders one per selected
+ * value; or, when empty and required, a single empty required input so native
+ * validation blocks submit.
+ */
+export function HiddenInputs(props: HiddenInputsProps) {
+  if (!props.name) return null;
+  const { name, value, multiple, required, form, disabled } = props;
+
+  if (!multiple) {
+    const v = typeof value === 'string' ? value : '';
+    return (
+      <input
+        type="hidden"
+        name={name}
+        value={v}
+        required={required}
+        form={form}
+        disabled={disabled}
+      />
+    );
+  }
+  const arr = Array.isArray(value) ? value : [];
+  if (arr.length === 0 && required) {
+    return (
+      <input
+        type="hidden"
+        name={name}
+        value=""
+        required
+        form={form}
+        disabled={disabled}
+      />
+    );
+  }
+  return (
+    <>
+      {arr.map((v) => (
+        <input
+          key={v}
+          type="hidden"
+          name={name}
+          value={v}
+          form={form}
+          disabled={disabled}
+        />
+      ))}
+    </>
+  );
+}

--- a/packages/design-system/src/components/Select/HiddenInputs.tsx
+++ b/packages/design-system/src/components/Select/HiddenInputs.tsx
@@ -32,28 +32,12 @@ export function HiddenInputs(props: HiddenInputsProps) {
   }
   const arr = Array.isArray(value) ? value : [];
   if (arr.length === 0 && required) {
-    return (
-      <input
-        type="hidden"
-        name={name}
-        value=""
-        required
-        form={form}
-        disabled={disabled}
-      />
-    );
+    return <input type="hidden" name={name} value="" required form={form} disabled={disabled} />;
   }
   return (
     <>
       {arr.map((v) => (
-        <input
-          key={v}
-          type="hidden"
-          name={name}
-          value={v}
-          form={form}
-          disabled={disabled}
-        />
+        <input key={v} type="hidden" name={name} value={v} form={form} disabled={disabled} />
       ))}
     </>
   );

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -1,41 +1,182 @@
+import { useEffect, useLayoutEffect } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  size as floatingSize,
+  useFloating,
+} from '@floating-ui/react-dom';
+import clsx from 'clsx';
 import { useSelectContext } from './context';
+import styles from './Select.module.scss';
 
 /**
- * Skeletal Listbox — inline (not portaled yet). Task 5 lifts this into a
- * portaled, Floating-UI-positioned panel with outside-click + Escape
- * dismissal. Phase 2 starts with the simplest possible rendering so the
- * Trigger + state plumbing can be exercised first.
+ * Portaled listbox panel. Positioned by Floating UI relative to the
+ * trigger, dismissed on outside-click and Escape, restores active row
+ * to the current selection (or first selectable) on open.
+ *
+ * Only mounted when `ctx.open` is true — there is no exit animation
+ * because the node is unmounted. Click-to-select is wired here; the
+ * keyboard handlers live on the Trigger so the trigger keeps focus
+ * while the listbox is open (combobox / single-mode-button pattern).
  */
 export function Listbox() {
   const ctx = useSelectContext('Listbox');
-  return (
+
+  const { refs, floatingStyles } = useFloating({
+    open: ctx.open,
+    placement: 'bottom-start',
+    middleware: [
+      offset(4),
+      flip(),
+      shift({ padding: 8 }),
+      // Match listbox width to trigger width and clamp height so a long
+      // option list scrolls inside the panel instead of pushing the
+      // viewport bounds.
+      floatingSize({
+        apply({ rects, elements }) {
+          Object.assign(elements.floating.style, {
+            width: `${rects.reference.width}px`,
+            maxHeight: '320px',
+          });
+        },
+      }),
+    ],
+    whileElementsMounted: autoUpdate,
+    elements: { reference: ctx.triggerRef.current },
+  });
+
+  // Outside-click closes. Capture-phase pointerdown fires before any
+  // focused widget's handlers, matching the Popover / DropdownMenu
+  // patterns. Clicks on the trigger are excluded so its own toggle
+  // handler isn't double-fired; clicks on the panel are excluded so
+  // option clicks aren't swallowed (they also preventDefault on
+  // pointerdown — belt-and-suspenders).
+  useEffect(() => {
+    if (!ctx.open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      const panel = ctx.listboxRef.current;
+      const trigger = ctx.triggerRef.current;
+      if (panel && panel.contains(target)) return;
+      if (trigger && trigger.contains(target)) return;
+      ctx.setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [ctx, ctx.open, ctx.listboxRef, ctx.triggerRef]);
+
+  // Escape closes and returns focus to the trigger. Capture-phase so a
+  // future in-panel input (Phase 5/6 search input) can't stop the event
+  // before we see it.
+  useEffect(() => {
+    if (!ctx.open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        ctx.closeAndFocusTrigger();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [ctx, ctx.open]);
+
+  // On open: pre-highlight the current selection (if any), else the
+  // first non-disabled option. Trigger's ArrowUp handler may override
+  // this via a queueMicrotask to "last selectable" — that's fine, this
+  // layout effect runs first and the microtask wins.
+  // Only fires on the `ctx.open` transition; row changes mid-open don't
+  // reset the cursor.
+  useLayoutEffect(() => {
+    if (!ctx.open) return;
+    const firstSelectedIdx = ctx.rows.findIndex(
+      (r) =>
+        r.kind === 'option' &&
+        !r.option.disabled &&
+        (ctx.multiple
+          ? (ctx.value as string[]).includes(r.option.value)
+          : ctx.value === r.option.value),
+    );
+    if (firstSelectedIdx >= 0) {
+      ctx.setActiveIndex(firstSelectedIdx);
+      return;
+    }
+    const firstSelectableIdx = ctx.rows.findIndex((r) => r.kind === 'option' && !r.option.disabled);
+    ctx.setActiveIndex(firstSelectableIdx >= 0 ? firstSelectableIdx : -1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ctx.open]);
+
+  return createPortal(
     <ul
-      ref={ctx.listboxRef}
+      ref={(node) => {
+        (ctx.listboxRef as React.MutableRefObject<HTMLUListElement | null>).current = node;
+        refs.setFloating(node);
+      }}
       id={ctx.listboxId}
       role="listbox"
       aria-multiselectable={ctx.multiple || undefined}
+      aria-labelledby={ctx.triggerId}
+      tabIndex={-1}
+      className={clsx(styles.listbox)}
+      style={floatingStyles}
     >
-      {ctx.rows.map((row, i) =>
-        row.kind === 'header' ? (
-          <li key={`h-${i}`} role="presentation">
-            {row.label}
-          </li>
-        ) : (
+      {ctx.rows.map((row, i) => {
+        if (row.kind === 'header') {
+          return (
+            <li
+              key={`h-${i}`}
+              id={ctx.getGroupHeaderId(row.label)}
+              role="presentation"
+              className={styles.groupHeader}
+            >
+              {row.label}
+            </li>
+          );
+        }
+        const selected = ctx.multiple
+          ? (ctx.value as string[]).includes(row.option.value)
+          : ctx.value === row.option.value;
+        const active = ctx.activeIndex === i;
+        return (
           <li
             key={row.option.value}
             id={ctx.getOptionId(row.option.value)}
             role="option"
-            aria-selected={
-              ctx.multiple
-                ? (ctx.value as string[]).includes(row.option.value)
-                : ctx.value === row.option.value
-            }
+            aria-selected={selected}
             aria-disabled={row.option.disabled || undefined}
+            className={clsx(
+              styles.option,
+              active && styles.optionActive,
+              selected && styles.optionSelected,
+              row.option.disabled && styles.optionDisabled,
+            )}
+            onPointerDown={(e) => {
+              // Stop the document-level outside-click pointerdown handler
+              // from closing the listbox before the click resolves. The
+              // click handler still fires and commits the selection.
+              e.preventDefault();
+            }}
+            onClick={() => {
+              if (row.option.disabled) return;
+              if (ctx.multiple) {
+                ctx.toggleValue(row.option.value);
+              } else {
+                ctx.setValue(row.option.value);
+                ctx.closeAndFocusTrigger();
+              }
+            }}
+            onMouseEnter={() => {
+              if (!row.option.disabled) ctx.setActiveIndex(i);
+            }}
           >
             {row.option.label}
           </li>
-        ),
-      )}
-    </ul>
+        );
+      })}
+    </ul>,
+    document.body,
   );
 }

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -238,6 +238,10 @@ function renderOptionRow<T>(
         if (opt.disabled) return;
         if (ctx.multiple) {
           ctx.toggleValue(opt.value);
+          // Multi + searchable mode (chips-input or in-panel search):
+          // clear the query so the user can immediately pick another
+          // option without manually erasing the previous filter.
+          if (ctx.searchable) ctx.setQuery('');
         } else {
           ctx.setValue(opt.value);
           ctx.closeAndFocusTrigger();

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -10,6 +10,7 @@ import {
 } from '@floating-ui/react-dom';
 import clsx from 'clsx';
 import { useSelectContext } from './context';
+import { mergeRefs } from '../_internal/refs';
 import styles from './Select.module.scss';
 
 /**
@@ -67,7 +68,7 @@ export function Listbox() {
     };
     document.addEventListener('pointerdown', onPointerDown, true);
     return () => document.removeEventListener('pointerdown', onPointerDown, true);
-  }, [ctx, ctx.open, ctx.listboxRef, ctx.triggerRef]);
+  }, [ctx.open, ctx.listboxRef, ctx.triggerRef, ctx.setOpen]);
 
   // Escape closes and returns focus to the trigger. Capture-phase so a
   // future in-panel input (Phase 5/6 search input) can't stop the event
@@ -82,7 +83,7 @@ export function Listbox() {
     };
     document.addEventListener('keydown', onKeyDown, true);
     return () => document.removeEventListener('keydown', onKeyDown, true);
-  }, [ctx, ctx.open]);
+  }, [ctx.open, ctx.closeAndFocusTrigger]);
 
   // On open: pre-highlight the current selection (if any), else the
   // first non-disabled option. Trigger's ArrowUp handler may override
@@ -106,15 +107,16 @@ export function Listbox() {
     }
     const firstSelectableIdx = ctx.rows.findIndex((r) => r.kind === 'option' && !r.option.disabled);
     ctx.setActiveIndex(firstSelectableIdx >= 0 ? firstSelectableIdx : -1);
+    // Intentionally only depends on `ctx.open`: this effect seeds the active
+    // row on the open transition, and must NOT re-run when `ctx.rows` or
+    // `ctx.value` shift mid-open (that would yank the cursor out from under
+    // the user's keyboard / mouse navigation).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ctx.open]);
 
   return createPortal(
     <ul
-      ref={(node) => {
-        (ctx.listboxRef as React.MutableRefObject<HTMLUListElement | null>).current = node;
-        refs.setFloating(node);
-      }}
+      ref={mergeRefs<HTMLUListElement>(ctx.listboxRef, refs.setFloating)}
       id={ctx.listboxId}
       role="listbox"
       aria-multiselectable={ctx.multiple || undefined}

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -12,6 +12,7 @@ import clsx from 'clsx';
 import { useSelectContext, type SelectContextValue } from './context';
 import { mergeRefs } from '../_internal/refs';
 import type { SelectOption } from './utils-types';
+import { isCreateRow } from './utils';
 import { Empty } from './Empty';
 import { Loading } from './Loading';
 import { ErrorRow } from './Error';
@@ -134,9 +135,7 @@ export function Listbox() {
           (ComboboxInputTrigger) since there's no second trigger to compete
           with; multi-summary needs the trigger to remain a button that
           shows the summary, so the search input lives inside the panel. */}
-      {ctx.multiple && ctx.triggerDisplay === 'summary' && ctx.searchable && (
-        <InPanelSearchInput />
-      )}
+      {ctx.multiple && ctx.triggerDisplay === 'summary' && ctx.searchable && <InPanelSearchInput />}
       {renderListboxBody(ctx)}
     </ul>,
     document.body,
@@ -207,12 +206,7 @@ function renderListboxBody<T>(ctx: SelectContextValue<T>): ReactNode {
       // grouped-options tests query against (avoids relying on the hashed
       // CSS-module class name).
       groupChildren.push(
-        <li
-          key={`h-${i}`}
-          id={headerId}
-          data-group-header=""
-          className={styles.groupHeader}
-        >
+        <li key={`h-${i}`} id={headerId} data-group-header="" className={styles.groupHeader}>
           {headerLabel}
         </li>,
       );
@@ -264,6 +258,35 @@ function renderOptionRow<T>(
   active: boolean,
   ctx: SelectContextValue<T>,
 ): ReactNode {
+  // Creatable "+ Create <query>" row. Rendered distinctly (italic + accent
+  // colour via `.optionCreate`) and dispatches `onCreate` plus the same
+  // single-vs-multi commit flow as a normal option click.
+  if (isCreateRow(opt)) {
+    return (
+      <li
+        key="__create__"
+        id={ctx.getOptionId(opt.value)}
+        role="option"
+        aria-selected={false}
+        className={clsx(styles.option, styles.optionCreate, active && styles.optionActive)}
+        onPointerDown={(e) => e.preventDefault()}
+        onClick={() => {
+          ctx.onCreate?.(opt.label);
+          if (ctx.multiple) {
+            const next = [...((ctx.value as string[]) ?? []), opt.value];
+            ctx.setValue(next);
+            if (ctx.searchable) ctx.setQuery('');
+          } else {
+            ctx.setValue(opt.value);
+            ctx.closeAndFocusTrigger();
+          }
+        }}
+        onMouseEnter={() => ctx.setActiveIndex(i)}
+      >
+        + Create &quot;{opt.label}&quot;
+      </li>
+    );
+  }
   return (
     <li
       key={opt.value}
@@ -367,7 +390,14 @@ function InPanelSearchInput() {
           e.preventDefault();
           const row = ctx.rows[ctx.activeIndex];
           if (row && row.kind === 'option' && !row.option.disabled) {
-            ctx.toggleValue(row.option.value);
+            if (isCreateRow(row.option)) {
+              ctx.onCreate?.(row.option.label);
+              const next = [...((ctx.value as string[]) ?? []), row.option.value];
+              ctx.setValue(next);
+              ctx.setQuery('');
+            } else {
+              ctx.toggleValue(row.option.value);
+            }
           }
         } else if (e.key === 'Escape') {
           e.preventDefault();

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -287,6 +287,11 @@ function renderOptionRow<T>(
       </li>
     );
   }
+  // Consumer's `renderOption` wins over the default label rendering. The
+  // create-row branch above intentionally does NOT pass through here —
+  // "+ Create" is internal chrome the consumer doesn't know about.
+  const body = ctx.renderOption ? ctx.renderOption(opt, { active, selected }) : opt.label;
+
   return (
     <li
       key={opt.value}
@@ -323,7 +328,7 @@ function renderOptionRow<T>(
         if (!opt.disabled) ctx.setActiveIndex(i);
       }}
     >
-      {opt.label}
+      {body}
     </li>
   );
 }

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -1,0 +1,41 @@
+import { useSelectContext } from './context';
+
+/**
+ * Skeletal Listbox — inline (not portaled yet). Task 5 lifts this into a
+ * portaled, Floating-UI-positioned panel with outside-click + Escape
+ * dismissal. Phase 2 starts with the simplest possible rendering so the
+ * Trigger + state plumbing can be exercised first.
+ */
+export function Listbox() {
+  const ctx = useSelectContext('Listbox');
+  return (
+    <ul
+      ref={ctx.listboxRef}
+      id={ctx.listboxId}
+      role="listbox"
+      aria-multiselectable={ctx.multiple || undefined}
+    >
+      {ctx.rows.map((row, i) =>
+        row.kind === 'header' ? (
+          <li key={`h-${i}`} role="presentation">
+            {row.label}
+          </li>
+        ) : (
+          <li
+            key={row.option.value}
+            id={ctx.getOptionId(row.option.value)}
+            role="option"
+            aria-selected={
+              ctx.multiple
+                ? (ctx.value as string[]).includes(row.option.value)
+                : ctx.value === row.option.value
+            }
+            aria-disabled={row.option.disabled || undefined}
+          >
+            {row.option.label}
+          </li>
+        ),
+      )}
+    </ul>
+  );
+}

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -12,6 +12,9 @@ import clsx from 'clsx';
 import { useSelectContext, type SelectContextValue } from './context';
 import { mergeRefs } from '../_internal/refs';
 import type { SelectOption } from './utils-types';
+import { Empty } from './Empty';
+import { Loading } from './Loading';
+import { ErrorRow } from './Error';
 import styles from './Select.module.scss';
 
 /**
@@ -134,69 +137,115 @@ export function Listbox() {
       {ctx.multiple && ctx.triggerDisplay === 'summary' && ctx.searchable && (
         <InPanelSearchInput />
       )}
-      {(() => {
-        // Walk the flat rows array, wrapping each header + its following
-        // option rows in `<li role="group" aria-labelledby={headerId}>` so
-        // the listbox exposes proper grouping semantics. The flat index
-        // `i` is preserved across the wrapping — Trigger's keyboard logic
-        // computes `aria-activedescendant` from it, so option rows inside
-        // groups MUST keep the same index they would have had in the flat
-        // map.
-        const nodes: ReactNode[] = [];
-        let i = 0;
-        while (i < ctx.rows.length) {
-          const row = ctx.rows[i];
-          if (row.kind === 'header') {
-            const headerLabel = row.label;
-            const headerId = ctx.getGroupHeaderId(headerLabel);
-            const groupChildren: ReactNode[] = [];
-            // Non-focusable header row; `data-group-header` is the hook
-            // grouped-options tests query against (avoids relying on the
-            // hashed CSS-module class name).
-            groupChildren.push(
-              <li
-                key={`h-${i}`}
-                id={headerId}
-                data-group-header=""
-                className={styles.groupHeader}
-              >
-                {headerLabel}
-              </li>,
-            );
-            let j = i + 1;
-            while (j < ctx.rows.length && ctx.rows[j].kind === 'option') {
-              const optRow = ctx.rows[j] as Extract<(typeof ctx.rows)[number], { kind: 'option' }>;
-              const selected = ctx.multiple
-                ? (ctx.value as string[]).includes(optRow.option.value)
-                : ctx.value === optRow.option.value;
-              const active = ctx.activeIndex === j;
-              groupChildren.push(renderOptionRow(optRow.option, j, selected, active, ctx));
-              j++;
-            }
-            nodes.push(
-              <li role="group" key={`g-${i}`} aria-labelledby={headerId}>
-                <ul role="none" className={styles.groupList}>
-                  {groupChildren}
-                </ul>
-              </li>,
-            );
-            i = j;
-            continue;
-          }
-          // Ungrouped (flat) option row.
-          const optRow = row;
-          const selected = ctx.multiple
-            ? (ctx.value as string[]).includes(optRow.option.value)
-            : ctx.value === optRow.option.value;
-          const active = ctx.activeIndex === i;
-          nodes.push(renderOptionRow(optRow.option, i, selected, active, ctx));
-          i++;
-        }
-        return nodes;
-      })()}
+      {renderListboxBody(ctx)}
     </ul>,
     document.body,
   );
+}
+
+/**
+ * Decide what goes in the listbox body. Three short-circuits ahead of the
+ * normal row walk:
+ *
+ * 1. Loading — async request is in flight AND we have nothing else to show.
+ *    Once a previous result is in `rows`, we keep showing it instead of
+ *    swapping to a spinner (UI doesn't flicker between every keystroke).
+ * 2. Error — the latest async request rejected. Surfaces a Retry button.
+ * 3. Empty — no rows after filtering and we're not loading or in error.
+ *
+ * Each branch consults the consumer's `renderLoading` / `renderError` /
+ * `renderEmpty` first, falling back to the bundled defaults.
+ */
+function renderListboxBody<T>(ctx: SelectContextValue<T>): ReactNode {
+  const showLoading = ctx.loading && ctx.rows.length === 0;
+  const showError = !!ctx.error && !ctx.loading;
+  const showEmpty = !ctx.loading && !ctx.error && ctx.rows.length === 0;
+
+  if (showLoading) {
+    return ctx.renderLoading ? (
+      <li className={styles.stateRow} role="presentation">
+        {ctx.renderLoading()}
+      </li>
+    ) : (
+      <Loading />
+    );
+  }
+  if (showError) {
+    return ctx.renderError ? (
+      <li className={styles.stateRow} role="presentation">
+        {ctx.renderError(ctx.error as Error, ctx.retry)}
+      </li>
+    ) : (
+      <ErrorRow error={ctx.error as Error} onRetry={ctx.retry} />
+    );
+  }
+  if (showEmpty) {
+    return ctx.renderEmpty ? (
+      <li className={styles.stateRow} role="presentation">
+        {ctx.renderEmpty(ctx.query)}
+      </li>
+    ) : (
+      <Empty query={ctx.query} />
+    );
+  }
+
+  // Walk the flat rows array, wrapping each header + its following option
+  // rows in `<li role="group" aria-labelledby={headerId}>` so the listbox
+  // exposes proper grouping semantics. The flat index `i` is preserved
+  // across the wrapping — Trigger's keyboard logic computes
+  // `aria-activedescendant` from it, so option rows inside groups MUST
+  // keep the same index they would have had in the flat map.
+  const nodes: ReactNode[] = [];
+  let i = 0;
+  while (i < ctx.rows.length) {
+    const row = ctx.rows[i];
+    if (row.kind === 'header') {
+      const headerLabel = row.label;
+      const headerId = ctx.getGroupHeaderId(headerLabel);
+      const groupChildren: ReactNode[] = [];
+      // Non-focusable header row; `data-group-header` is the hook
+      // grouped-options tests query against (avoids relying on the hashed
+      // CSS-module class name).
+      groupChildren.push(
+        <li
+          key={`h-${i}`}
+          id={headerId}
+          data-group-header=""
+          className={styles.groupHeader}
+        >
+          {headerLabel}
+        </li>,
+      );
+      let j = i + 1;
+      while (j < ctx.rows.length && ctx.rows[j].kind === 'option') {
+        const optRow = ctx.rows[j] as Extract<(typeof ctx.rows)[number], { kind: 'option' }>;
+        const selected = ctx.multiple
+          ? (ctx.value as string[]).includes(optRow.option.value)
+          : ctx.value === optRow.option.value;
+        const active = ctx.activeIndex === j;
+        groupChildren.push(renderOptionRow(optRow.option, j, selected, active, ctx));
+        j++;
+      }
+      nodes.push(
+        <li role="group" key={`g-${i}`} aria-labelledby={headerId}>
+          <ul role="none" className={styles.groupList}>
+            {groupChildren}
+          </ul>
+        </li>,
+      );
+      i = j;
+      continue;
+    }
+    // Ungrouped (flat) option row.
+    const optRow = row;
+    const selected = ctx.multiple
+      ? (ctx.value as string[]).includes(optRow.option.value)
+      : ctx.value === optRow.option.value;
+    const active = ctx.activeIndex === i;
+    nodes.push(renderOptionRow(optRow.option, i, selected, active, ctx));
+    i++;
+  }
+  return nodes;
 }
 
 /**

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect } from 'react';
+import { useEffect, useLayoutEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import {
   autoUpdate,
@@ -9,8 +9,9 @@ import {
   useFloating,
 } from '@floating-ui/react-dom';
 import clsx from 'clsx';
-import { useSelectContext } from './context';
+import { useSelectContext, type SelectContextValue } from './context';
 import { mergeRefs } from '../_internal/refs';
+import type { SelectOption } from './utils-types';
 import styles from './Select.module.scss';
 
 /**
@@ -125,60 +126,120 @@ export function Listbox() {
       className={clsx(styles.listbox)}
       style={floatingStyles}
     >
-      {ctx.rows.map((row, i) => {
-        if (row.kind === 'header') {
-          return (
-            <li
-              key={`h-${i}`}
-              id={ctx.getGroupHeaderId(row.label)}
-              role="presentation"
-              className={styles.groupHeader}
-            >
-              {row.label}
-            </li>
-          );
+      {(() => {
+        // Walk the flat rows array, wrapping each header + its following
+        // option rows in `<li role="group" aria-labelledby={headerId}>` so
+        // the listbox exposes proper grouping semantics. The flat index
+        // `i` is preserved across the wrapping — Trigger's keyboard logic
+        // computes `aria-activedescendant` from it, so option rows inside
+        // groups MUST keep the same index they would have had in the flat
+        // map.
+        const nodes: ReactNode[] = [];
+        let i = 0;
+        while (i < ctx.rows.length) {
+          const row = ctx.rows[i];
+          if (row.kind === 'header') {
+            const headerLabel = row.label;
+            const headerId = ctx.getGroupHeaderId(headerLabel);
+            const groupChildren: ReactNode[] = [];
+            // Non-focusable header row; `data-group-header` is the hook
+            // grouped-options tests query against (avoids relying on the
+            // hashed CSS-module class name).
+            groupChildren.push(
+              <li
+                key={`h-${i}`}
+                id={headerId}
+                data-group-header=""
+                className={styles.groupHeader}
+              >
+                {headerLabel}
+              </li>,
+            );
+            let j = i + 1;
+            while (j < ctx.rows.length && ctx.rows[j].kind === 'option') {
+              const optRow = ctx.rows[j] as Extract<(typeof ctx.rows)[number], { kind: 'option' }>;
+              const selected = ctx.multiple
+                ? (ctx.value as string[]).includes(optRow.option.value)
+                : ctx.value === optRow.option.value;
+              const active = ctx.activeIndex === j;
+              groupChildren.push(renderOptionRow(optRow.option, j, selected, active, ctx));
+              j++;
+            }
+            nodes.push(
+              <li role="group" key={`g-${i}`} aria-labelledby={headerId}>
+                <ul role="none" className={styles.groupList}>
+                  {groupChildren}
+                </ul>
+              </li>,
+            );
+            i = j;
+            continue;
+          }
+          // Ungrouped (flat) option row.
+          const optRow = row;
+          const selected = ctx.multiple
+            ? (ctx.value as string[]).includes(optRow.option.value)
+            : ctx.value === optRow.option.value;
+          const active = ctx.activeIndex === i;
+          nodes.push(renderOptionRow(optRow.option, i, selected, active, ctx));
+          i++;
         }
-        const selected = ctx.multiple
-          ? (ctx.value as string[]).includes(row.option.value)
-          : ctx.value === row.option.value;
-        const active = ctx.activeIndex === i;
-        return (
-          <li
-            key={row.option.value}
-            id={ctx.getOptionId(row.option.value)}
-            role="option"
-            aria-selected={selected}
-            aria-disabled={row.option.disabled || undefined}
-            className={clsx(
-              styles.option,
-              active && styles.optionActive,
-              selected && styles.optionSelected,
-              row.option.disabled && styles.optionDisabled,
-            )}
-            onPointerDown={(e) => {
-              // Stop the document-level outside-click pointerdown handler
-              // from closing the listbox before the click resolves. The
-              // click handler still fires and commits the selection.
-              e.preventDefault();
-            }}
-            onClick={() => {
-              if (row.option.disabled) return;
-              if (ctx.multiple) {
-                ctx.toggleValue(row.option.value);
-              } else {
-                ctx.setValue(row.option.value);
-                ctx.closeAndFocusTrigger();
-              }
-            }}
-            onMouseEnter={() => {
-              if (!row.option.disabled) ctx.setActiveIndex(i);
-            }}
-          >
-            {row.option.label}
-          </li>
-        );
-      })}
+        return nodes;
+      })()}
     </ul>,
     document.body,
+  );
+}
+
+/**
+ * Render one `<li role="option">` row. Extracted as a module-local helper
+ * so the listbox loop can call it from two call sites — the in-group path
+ * and the flat-options path — without duplicating the JSX.
+ *
+ * `i` is the flat index into `ctx.rows`; it MUST match the index Trigger's
+ * keyboard handlers compute against, since `aria-activedescendant` and
+ * `ctx.setActiveIndex` both key off it.
+ */
+function renderOptionRow<T>(
+  opt: SelectOption<T>,
+  i: number,
+  selected: boolean,
+  active: boolean,
+  ctx: SelectContextValue<T>,
+): ReactNode {
+  return (
+    <li
+      key={opt.value}
+      id={ctx.getOptionId(opt.value)}
+      role="option"
+      aria-selected={selected}
+      aria-disabled={opt.disabled || undefined}
+      className={clsx(
+        styles.option,
+        active && styles.optionActive,
+        selected && styles.optionSelected,
+        opt.disabled && styles.optionDisabled,
+      )}
+      onPointerDown={(e) => {
+        // Stop the document-level outside-click pointerdown handler from
+        // closing the listbox before the click resolves. The click handler
+        // still fires and commits the selection.
+        e.preventDefault();
+      }}
+      onClick={() => {
+        if (opt.disabled) return;
+        if (ctx.multiple) {
+          ctx.toggleValue(opt.value);
+        } else {
+          ctx.setValue(opt.value);
+          ctx.closeAndFocusTrigger();
+        }
+      }}
+      onMouseEnter={() => {
+        if (!opt.disabled) ctx.setActiveIndex(i);
+      }}
+    >
+      {opt.label}
+    </li>
   );
 }

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -34,6 +34,14 @@ export function Listbox() {
   const { refs, floatingStyles } = useFloating({
     open: ctx.open,
     placement: 'bottom-start',
+    // `transform: false` — emit `top` / `left` positioning instead of an
+    // inline `transform: translate(...)`. The open animation in
+    // Select.module.scss animates `transform: scale(...)` on the panel; if
+    // Floating UI also wrote `transform`, the keyframe would clobber the
+    // inline translate and the panel would visibly snap to the document
+    // origin before jumping to the trigger. Matches DropdownMenu and
+    // Popover Content.
+    transform: false,
     middleware: [
       offset(4),
       flip(),

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, type ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useRef, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import {
   autoUpdate,
@@ -126,6 +126,14 @@ export function Listbox() {
       className={clsx(styles.listbox)}
       style={floatingStyles}
     >
+      {/* In-panel search for multi-summary-searchable mode. Single-mode
+          searchable Select keeps the search input AS the trigger
+          (ComboboxInputTrigger) since there's no second trigger to compete
+          with; multi-summary needs the trigger to remain a button that
+          shows the summary, so the search input lives inside the panel. */}
+      {ctx.multiple && ctx.triggerDisplay === 'summary' && ctx.searchable && (
+        <InPanelSearchInput />
+      )}
       {(() => {
         // Walk the flat rows array, wrapping each header + its following
         // option rows in `<li role="group" aria-labelledby={headerId}>` so
@@ -241,5 +249,78 @@ function renderOptionRow<T>(
     >
       {opt.label}
     </li>
+  );
+}
+
+/**
+ * Search input rendered inside the listbox panel for the multi-summary-
+ * searchable variant. The trigger remains a button that shows the
+ * comma-joined selection summary; the input lives in the popover so the
+ * user can filter without losing the selection summary.
+ *
+ * Owns its own keyboard handling: ArrowUp/Down cycle the active option,
+ * Enter toggles selection, Escape closes and returns focus to the trigger.
+ * This duplicates a small slice of `useTriggerKeyboard.moveActive` —
+ * deliberate, since the trigger hook is button-shaped and pulling the
+ * cycle logic into a shared hook would obscure both call sites at this
+ * scale. Revisit if Phase 6's chips trigger lands a third copy.
+ */
+function InPanelSearchInput() {
+  const ctx = useSelectContext('Listbox.SearchInput');
+  const ref = useRef<HTMLInputElement>(null);
+
+  // Auto-focus on mount so the user starts typing immediately after
+  // clicking the trigger. `preventScroll` avoids the portaled panel
+  // yanking the viewport on focus.
+  useLayoutEffect(() => {
+    ref.current?.focus({ preventScroll: true });
+  }, []);
+
+  const activeRow = ctx.activeIndex >= 0 ? ctx.rows[ctx.activeIndex] : undefined;
+  const activeOptionId =
+    activeRow && activeRow.kind === 'option' ? ctx.getOptionId(activeRow.option.value) : undefined;
+
+  return (
+    <input
+      ref={ref}
+      type="text"
+      role="combobox"
+      aria-expanded="true"
+      aria-controls={ctx.listboxId}
+      aria-activedescendant={activeOptionId}
+      aria-autocomplete="list"
+      className={styles.popoverSearch}
+      placeholder="Search…"
+      autoComplete="off"
+      spellCheck={false}
+      value={ctx.query}
+      onChange={(e) => ctx.setQuery(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+          e.preventDefault();
+          const delta = e.key === 'ArrowDown' ? +1 : -1;
+          const len = ctx.rows.length;
+          if (len === 0) return;
+          let i = ctx.activeIndex;
+          for (let s = 0; s < len; s++) {
+            i = (i + delta + len) % len;
+            const r = ctx.rows[i];
+            if (r.kind === 'option' && !r.option.disabled) {
+              ctx.setActiveIndex(i);
+              break;
+            }
+          }
+        } else if (e.key === 'Enter') {
+          e.preventDefault();
+          const row = ctx.rows[ctx.activeIndex];
+          if (row && row.kind === 'option' && !row.option.disabled) {
+            ctx.toggleValue(row.option.value);
+          }
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          ctx.closeAndFocusTrigger();
+        }
+      }}
+    />
   );
 }

--- a/packages/design-system/src/components/Select/Loading.tsx
+++ b/packages/design-system/src/components/Select/Loading.tsx
@@ -1,0 +1,19 @@
+import styles from './Select.module.scss';
+
+/**
+ * Default loading-state row, rendered inside the listbox while an async
+ * `loadOptions` request is in flight and the previous result has not yet
+ * arrived (i.e. there are no rows to show alongside it).
+ *
+ * Non-interactive `<li role="presentation">` with an `aria-live="polite"`
+ * announcement so screen reader users hear the state change. The spinner
+ * is `aria-hidden` — the textual "Loading…" carries the message.
+ */
+export function Loading() {
+  return (
+    <li className={styles.stateRow} role="presentation" aria-live="polite">
+      <span className={styles.spinner} aria-hidden="true" />
+      <span>Loading…</span>
+    </li>
+  );
+}

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -1,0 +1,3 @@
+.root {
+  display: inline-block;
+}

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -197,6 +197,34 @@
   cursor: not-allowed;
 }
 
+// Chips-mode + inline input variant. `.triggerChipsInput` is composed on
+// the wrapper alongside `.triggerChips`; this rule only adds a text caret
+// (the wrapper is the click target that focuses the embedded input).
+.triggerChipsInput {
+  cursor: text;
+}
+
+// Inline search input rendered alongside chips. `flex: 0 1 4ch` is a flex
+// shorthand on a CHILD of the trigger — Rule 4 governs positioning the
+// COMPONENT in its parent, not internal flex children, so this is allowed
+// (same as Stack/Cluster's internal flex). The `4ch` basis gives the
+// input enough width to start typing without being so wide that it
+// pushes chips onto an unnecessary second line.
+.chipsInput {
+  flex: 0 1 4ch;
+  min-width: 4ch;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  outline: none;
+
+  &::placeholder {
+    color: var(--color-fg-muted);
+  }
+}
+
 // ─── Visual state hooks (populated in Phase 10) ─────────────────────────────
 .size-sm,
 .size-md,

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -116,6 +116,31 @@
   cursor: not-allowed;
 }
 
+// ─── In-panel search input (multi-summary-searchable variant) ──────────────
+// Sits at the top of the listbox panel, above the option rows. Hard Rule 4
+// allows `width: 100%` (intrinsic 100%) — it's the natural fit for "fill
+// the parent panel". No margin / position / flex-grow here.
+.popoverSearch {
+  display: block;
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-md);
+  color: var(--color-fg);
+  background: var(--color-bg);
+  border: 0;
+  border-bottom: var(--border-width) solid var(--color-border);
+  outline: none;
+
+  &::placeholder {
+    color: var(--color-fg-muted);
+  }
+
+  &:focus-visible {
+    border-bottom-color: var(--color-accent);
+  }
+}
+
 // ─── Visual state hooks (populated in Phase 10) ─────────────────────────────
 .size-sm,
 .size-md,

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -62,6 +62,15 @@
   user-select: none;
 }
 
+// Reset on the nested <ul role="none"> inside each group wrapper. Padding
+// + list-style only — `margin: 0` is forbidden by Hard Rule 4 (layout is
+// the parent's job). The global UA reset zeroes ul margins, so omitting
+// it here is fine.
+.groupList {
+  padding: 0;
+  list-style: none;
+}
+
 .option {
   padding: var(--space-2) var(--space-3);
   font-size: var(--font-size-md);

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -134,6 +134,15 @@
 }
 
 // ─── Listbox panel ──────────────────────────────────────────────────────────
+// Open animation uses CSS `@keyframes` (NOT DropdownMenu's `@starting-style`
+// + `transition: transform` pattern) because Floating UI runs in default
+// `transform: true` mode here — the positioning transform on the floating
+// element is needed every frame, so we can't repurpose the `transform`
+// property for an entrance animation. Keyframes leave the inline transform
+// from Floating UI alone and animate via the `animation` property instead.
+// `transform-origin: top` is a static approximation (panel scales from the
+// top edge). A future polish task can wire dynamic origin off Floating UI's
+// resolved placement so the panel grows toward the trigger on flip.
 .listbox {
   z-index: var(--z-popover);
   overflow-y: auto;
@@ -143,6 +152,26 @@
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-md);
   list-style: none;
+  animation: select-open 140ms ease-out;
+  transform-origin: top;
+}
+
+@keyframes select-open {
+  from {
+    opacity: var(--opacity-hidden);
+    transform: scale(0.96);
+  }
+
+  to {
+    opacity: var(--opacity-visible);
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .listbox {
+    animation: none;
+  }
 }
 
 .groupHeader {

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -1,15 +1,17 @@
 .root {
-  display: inline-block;
+  display: block;
+  width: 100%;
 }
 
 // ─── Trigger wrapper ────────────────────────────────────────────────────────
 // `position: relative` is a Hard Rule 4 "internal child anchor" exception —
 // the absolutely-positioned ✕ + chevron sit ON the wrapper, not escape its
-// box. Inline-block + width 100% lets the wrapper match the (intrinsic)
-// width the consumer asks for via the Select root.
+// box. Block + width: 100% means Select fills its parent's column the same
+// way <Input> does — wrap in a sized container (Stack, fixed-width div, form
+// field cell) to control width.
 .triggerWrap {
   position: relative;
-  display: inline-block;
+  display: block;
   width: 100%;
 }
 
@@ -254,6 +256,7 @@
   flex-wrap: wrap;
   gap: var(--space-1);
   align-items: center;
+  justify-content: flex-start;
   padding: var(--space-1) var(--space-2);
   white-space: normal;
 }
@@ -315,7 +318,10 @@
 // input enough width to start typing without being so wide that it
 // pushes chips onto an unnecessary second line.
 .chipsInput {
-  flex: 0 1 4ch;
+  // grow into whatever row space is left after chips (so an empty trigger
+  // shows the full placeholder); shrink to `min-width: 4ch` when chips
+  // crowd the last line, then wrap onto a new line below.
+  flex: 1 1 4ch;
   min-width: 4ch;
   padding: 0;
   font: inherit;
@@ -421,9 +427,17 @@
   }
 }
 
-.disabled .trigger,
-.readOnly .trigger {
+// `disabled` is fully inert: dim text + not-allowed cursor signals "this
+// control is off." `readOnly` keeps the normal text color so the value
+// reads cleanly — only the subtle bg + default cursor signal "you can see
+// this but not edit." Matches the convention used by native form controls.
+.disabled .trigger {
   color: var(--color-fg-disabled);
   cursor: not-allowed;
+  background: var(--color-bg-subtle);
+}
+
+.readOnly .trigger {
+  cursor: default;
   background: var(--color-bg-subtle);
 }

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -2,39 +2,71 @@
   display: inline-block;
 }
 
-// size / state hooks — populated with real visuals in Task 7 + Phase 10.
-.size-sm {
-  // populated in Task 7
+// ─── Listbox panel ──────────────────────────────────────────────────────────
+// Portaled out of the Select root by `Listbox.tsx` and positioned by
+// Floating UI. The token fallback on box-shadow / z-index lets the
+// component degrade gracefully in apps that haven't loaded `tokens.scss`
+// (test environments, isolated stories).
+.listbox {
+  z-index: var(--z-popover);
+  overflow-y: auto;
+  padding: var(--space-1);
+  background: var(--color-bg);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  list-style: none;
 }
 
-.size-md {
-  // populated in Task 7
+.groupHeader {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-caps);
+  user-select: none;
 }
 
-.size-lg {
-  // populated in Task 7
+.option {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-md);
+  color: var(--color-fg);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
 }
 
-.invalid {
-  // populated in Task 7 / Phase 10
+.optionActive {
+  background: var(--color-bg-muted);
 }
 
-.disabled {
-  // populated in Task 7 / Phase 10
+.optionSelected {
+  background: var(--color-accent-subtle-bg);
+  box-shadow: inset var(--border-width-emphasis) 0 0 var(--color-accent);
 }
 
-.readOnly {
-  // populated in Task 7 / Phase 10
+.optionDisabled {
+  color: var(--color-fg-disabled);
+  cursor: not-allowed;
 }
 
+// ─── Trigger + states (populated in Task 7) ─────────────────────────────────
 .trigger {
-  // populated in Task 7
+  /* populated in Task 7 */
 }
 
 .triggerButton {
-  // populated in Task 7
+  /* populated in Task 7 */
 }
 
 .placeholder {
-  // populated in Task 7
+  /* populated in Task 7 */
+}
+
+.size-sm,
+.size-md,
+.size-lg,
+.invalid,
+.disabled,
+.readOnly {
+  /* placeholder selectors; visual rules populated in Phase 10 */
 }

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -37,6 +37,18 @@
   text-align: left;
 }
 
+// Combobox-input trigger (Phase 4 — single + searchable). Inherits the
+// `.trigger` box styling, focus ring, and disabled colors; this modifier
+// only flips the cursor (text caret over the input vs pointer over the
+// button) and styles the native HTML placeholder pseudo-element.
+.triggerInput {
+  cursor: text;
+
+  &::placeholder {
+    color: var(--color-fg-muted);
+  }
+}
+
 .placeholder {
   color: var(--color-fg-muted);
 }

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -35,6 +35,17 @@
 
 .triggerButton {
   text-align: left;
+
+  // Multi-summary text can grow longer than the trigger width — clip with
+  // an ellipsis rather than wrapping. The chips-mode trigger (Phase 6)
+  // will wrap and override this on its own variant.
+  // The `.placeholder` span is excluded because it carries the placeholder
+  // text only, never a comma-joined selection list.
+  & > :not(.placeholder) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 // Combobox-input trigger (Phase 4 — single + searchable). Inherits the

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -283,12 +283,50 @@
   }
 }
 
-// ─── Visual state hooks (populated in Phase 10) ─────────────────────────────
-.size-sm,
-.size-md,
-.size-lg,
-.invalid,
-.disabled,
-.readOnly {
-  /* placeholder selectors; visual rules populated in Phase 10 */
+// ─── Visual state hooks (size / invalid / disabled / readOnly) ──────────────
+// These selectors compose with `.trigger` (and its variants —
+// `.triggerButton` / `.triggerInput` / `.triggerChips` / `.triggerChipsInput`).
+// `:not(.triggerChips)` keeps the vertical padding of chips triggers intact
+// (chips wrap onto multiple lines and need the existing `--space-1` Y-padding
+// instead of a flat `0`); height-bearing `min-height` still applies.
+.size-sm .trigger {
+  min-height: var(--size-sm);
+  font-size: var(--font-size-sm);
+
+  &:not(.triggerChips) {
+    padding: 0 var(--space-2);
+  }
+}
+
+.size-md .trigger {
+  min-height: var(--size-md);
+  font-size: var(--font-size-md);
+
+  &:not(.triggerChips) {
+    padding: 0 var(--space-3);
+  }
+}
+
+.size-lg .trigger {
+  min-height: var(--size-lg);
+  font-size: var(--font-size-lg);
+
+  &:not(.triggerChips) {
+    padding: 0 var(--space-3);
+  }
+}
+
+.invalid .trigger {
+  border-color: var(--color-danger);
+
+  &:focus-visible {
+    box-shadow: 0 0 0 var(--ring-width) var(--ring-danger);
+  }
+}
+
+.disabled .trigger,
+.readOnly .trigger {
+  color: var(--color-fg-disabled);
+  cursor: not-allowed;
+  background: var(--color-bg-subtle);
 }

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -116,6 +116,13 @@
   cursor: not-allowed;
 }
 
+// Creatable "+ Create <query>" row. Italic + accent colour to visually
+// separate it from real options without inventing a new pattern.
+.optionCreate {
+  font-style: italic;
+  color: var(--color-accent);
+}
+
 // ─── In-panel search input (multi-summary-searchable variant) ──────────────
 // Sits at the top of the listbox panel, above the option rows. Hard Rule 4
 // allows `width: 100%` (intrinsic 100%) — it's the natural fit for "fill

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -141,6 +141,62 @@
   }
 }
 
+// ─── Chips-mode trigger (Phase 6) ───────────────────────────────────────────
+// Wraps content (chips + optional input) onto multiple lines. Drops the
+// `.triggerButton` ellipsis rule (`white-space: nowrap`) so the chip list
+// can stack. Vertical padding shrinks from the default 0 to `--space-1`
+// so wrapped chip rows have breathing room.
+.triggerChips {
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
+  white-space: normal;
+}
+
+// Chip — single removable token rendered inside the chips trigger.
+// 4px vertical / 8px horizontal padding (the smallest available token
+// pair); a literal 2px-vertical would be tighter, but Rule 3 forbids
+// raw values so we accept the slightly taller chip.
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-badge-neutral-fg);
+  background: var(--color-badge-neutral-bg);
+  border-radius: var(--radius-sm);
+  user-select: none;
+}
+
+.chipLabel {
+  line-height: 1.4;
+}
+
+.chipRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: inherit;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-sm);
+
+  &:hover,
+  &:focus-visible {
+    color: var(--color-danger);
+    background: var(--color-bg-danger-subtle);
+  }
+}
+
+.chipDisabled {
+  color: var(--color-fg-disabled);
+  cursor: not-allowed;
+}
+
 // ─── Visual state hooks (populated in Phase 10) ─────────────────────────────
 .size-sm,
 .size-md,

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -2,6 +2,17 @@
   display: inline-block;
 }
 
+// ─── Trigger wrapper ────────────────────────────────────────────────────────
+// `position: relative` is a Hard Rule 4 "internal child anchor" exception —
+// the absolutely-positioned ✕ + chevron sit ON the wrapper, not escape its
+// box. Inline-block + width 100% lets the wrapper match the (intrinsic)
+// width the consumer asks for via the Select root.
+.triggerWrap {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
 // ─── Trigger ────────────────────────────────────────────────────────────────
 // `:focus-visible` (Hard Rule 3a) rather than `:focus`: mouse-clicking the
 // trigger shouldn't leave the focus ring visible.
@@ -34,6 +45,10 @@
 }
 
 .triggerButton {
+  // Reserve `--space-8` on the right for the chevron (and the ✕ when
+  // clearable). The chevron sits at `right: var(--space-3)`, the ✕ sits
+  // at `right: var(--space-6)` — both inside the `.triggerWrap`'s padding.
+  padding-right: var(--space-8);
   text-align: left;
 
   // Multi-summary text can grow longer than the trigger width — clip with
@@ -53,6 +68,9 @@
 // only flips the cursor (text caret over the input vs pointer over the
 // button) and styles the native HTML placeholder pseudo-element.
 .triggerInput {
+  // Same right-side reservation as `.triggerButton` — chevron + ✕ overlay
+  // need clear space inside the `.triggerWrap`.
+  padding-right: var(--space-8);
   cursor: text;
 
   &::placeholder {
@@ -62,6 +80,57 @@
 
 .placeholder {
   color: var(--color-fg-muted);
+}
+
+// ─── Chevron + clear-✕ inside the trigger wrap ─────────────────────────────
+// Both are absolutely positioned siblings of the `.trigger` element. The
+// position rule lives on a CHILD of the component — Rule 4's "internal
+// child anchor" exception applies (the `.triggerWrap` is `position:relative`).
+.chevron {
+  position: absolute;
+  top: 50%;
+  right: var(--space-3);
+  color: var(--color-fg-muted);
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.clearButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-sm);
+
+  &:hover,
+  &:focus-visible {
+    color: var(--color-fg);
+    background: var(--color-bg-muted);
+  }
+}
+
+// Overlay variant — used by the single-mode triggers (ButtonTrigger,
+// ComboboxInputTrigger). Pinned right of the trigger box, sitting just
+// inside the chevron.
+.clearButton:not(.clearButtonInline) {
+  position: absolute;
+  top: 50%;
+  right: var(--space-6);
+  width: var(--space-4);
+  height: var(--space-4);
+  transform: translateY(-50%);
+}
+
+// Inline variant — used by the chips triggers where the ✕ sits as a flex
+// child alongside chips + (optionally) an input. No `position`; layout is
+// handled by the parent's flex.
+.clearButtonInline {
+  width: var(--space-4);
+  height: var(--space-4);
 }
 
 // ─── Listbox panel ──────────────────────────────────────────────────────────

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -2,11 +2,46 @@
   display: inline-block;
 }
 
+// ─── Trigger ────────────────────────────────────────────────────────────────
+// `:focus-visible` (Hard Rule 3a) rather than `:focus`: mouse-clicking the
+// trigger shouldn't leave the focus ring visible.
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: var(--size-md);
+  padding: 0 var(--space-3);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-md);
+  color: var(--color-fg);
+  background: var(--color-bg);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 var(--ring-width) var(--ring-accent);
+  }
+
+  &[disabled] {
+    color: var(--color-fg-disabled);
+    background: var(--color-bg-subtle);
+    cursor: not-allowed;
+  }
+}
+
+.triggerButton {
+  text-align: left;
+}
+
+.placeholder {
+  color: var(--color-fg-muted);
+}
+
 // ─── Listbox panel ──────────────────────────────────────────────────────────
-// Portaled out of the Select root by `Listbox.tsx` and positioned by
-// Floating UI. The token fallback on box-shadow / z-index lets the
-// component degrade gracefully in apps that haven't loaded `tokens.scss`
-// (test environments, isolated stories).
 .listbox {
   z-index: var(--z-popover);
   overflow-y: auto;
@@ -49,19 +84,7 @@
   cursor: not-allowed;
 }
 
-// ─── Trigger + states (populated in Task 7) ─────────────────────────────────
-.trigger {
-  /* populated in Task 7 */
-}
-
-.triggerButton {
-  /* populated in Task 7 */
-}
-
-.placeholder {
-  /* populated in Task 7 */
-}
-
+// ─── Visual state hooks (populated in Phase 10) ─────────────────────────────
 .size-sm,
 .size-md,
 .size-lg,

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -1,3 +1,40 @@
 .root {
   display: inline-block;
 }
+
+// size / state hooks — populated with real visuals in Task 7 + Phase 10.
+.size-sm {
+  // populated in Task 7
+}
+
+.size-md {
+  // populated in Task 7
+}
+
+.size-lg {
+  // populated in Task 7
+}
+
+.invalid {
+  // populated in Task 7 / Phase 10
+}
+
+.disabled {
+  // populated in Task 7 / Phase 10
+}
+
+.readOnly {
+  // populated in Task 7 / Phase 10
+}
+
+.trigger {
+  // populated in Task 7
+}
+
+.triggerButton {
+  // populated in Task 7
+}
+
+.placeholder {
+  // populated in Task 7
+}

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -134,12 +134,11 @@
 }
 
 // ─── Listbox panel ──────────────────────────────────────────────────────────
-// Open animation uses CSS `@keyframes` (NOT DropdownMenu's `@starting-style`
-// + `transition: transform` pattern) because Floating UI runs in default
-// `transform: true` mode here — the positioning transform on the floating
-// element is needed every frame, so we can't repurpose the `transform`
-// property for an entrance animation. Keyframes leave the inline transform
-// from Floating UI alone and animate via the `animation` property instead.
+// Open animation uses CSS `@keyframes` for the scale-fade. Floating UI is
+// configured with `transform: false` in Listbox.tsx so positioning is
+// emitted as inline `top` / `left` — that leaves the `transform` property
+// free for the keyframe's `transform: scale(...)` without fighting an
+// inline translate. Matches DropdownMenu and Popover Content.
 // `transform-origin: top` is a static approximation (panel scales from the
 // top edge). A future polish task can wire dynamic origin off Floating UI's
 // resolved placement so the panel grows toward the trigger on flip.

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -225,6 +225,57 @@
   }
 }
 
+// ─── State rows (loading / error / empty) ─────────────────────────────────
+// Rendered as `<li>`s inside the listbox `<ul>` instead of an option row
+// when there's no actual data to show (loading spinner, "no results",
+// failure + Retry). Centred so they read as a single status indicator
+// rather than aligning with the option text on the left.
+.stateRow {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-3);
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+}
+
+// Indeterminate circular spinner. The 2-state border (most of it muted,
+// one side accent) plus rotation creates the spin. Decorative — the
+// adjacent "Loading…" label carries the meaning for screen readers.
+.spinner {
+  display: inline-block;
+  width: var(--size-spinner);
+  height: var(--size-spinner);
+  border: var(--border-width) solid var(--color-border-strong);
+  border-top-color: var(--color-accent);
+  border-radius: var(--radius-full);
+  animation: select-spin 0.8s linear infinite;
+}
+
+@keyframes select-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+// Retry button inside the error state row. Subtle so it doesn't compete
+// with the message; `:focus-visible` per Hard Rule 3a (not `:focus`).
+.retryButton {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-accent);
+  cursor: pointer;
+  background: transparent;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-sm);
+
+  &:hover,
+  &:focus-visible {
+    background: var(--color-bg-muted);
+  }
+}
+
 // ─── Visual state hooks (populated in Phase 10) ─────────────────────────────
 .size-sm,
 .size-md,

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -690,4 +690,25 @@ describe('Select — multi-chips-searchable', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it('chips remain visible with their correct labels while typing filters the popover', async () => {
+    const user = userEvent.setup();
+    const OPTS_LOCAL = [
+      { value: 'a', label: 'Alpha' },
+      { value: 'b', label: 'Beta' },
+    ];
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        searchable
+        options={OPTS_LOCAL}
+        defaultValue={['a']}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Remove Alpha' })).toBeInTheDocument();
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.type(input, 'be');
+    expect(screen.getByRole('button', { name: 'Remove Alpha' })).toBeInTheDocument();
+  });
 });

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1138,3 +1138,67 @@ describe('Select — clearable', () => {
     expect(onChange).toHaveBeenCalledWith([], []);
   });
 });
+
+describe('Select — render escape hatches', () => {
+  it('renderOption replaces the option row content', async () => {
+    const user = userEvent.setup();
+    render(
+      <Select
+        options={STATUSES}
+        renderOption={(opt, state) => (
+          <div data-testid={`opt-${opt.value}`}>
+            <span>{opt.label}</span>
+            <span>{state.selected ? '★' : '☆'}</span>
+          </div>
+        )}
+        value="pending"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /Pending/i }));
+    expect(screen.getByTestId('opt-pending')).toHaveTextContent('Pending★');
+    expect(screen.getByTestId('opt-active')).toHaveTextContent('Active☆');
+  });
+
+  it('renderValue replaces the single trigger label', () => {
+    render(
+      <Select
+        options={STATUSES}
+        value="pending"
+        renderValue={(opt) => <em>~~{opt.label}~~</em>}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /~~Pending~~/ })).toHaveTextContent('~~Pending~~');
+  });
+
+  it('renderTag replaces chip rendering', () => {
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        options={STATUSES}
+        value={['pending']}
+        renderTag={(opt, remove) => (
+          <span data-testid={`tag-${opt.value}`} onClick={remove}>
+            {opt.label}
+          </span>
+        )}
+      />,
+    );
+    expect(screen.getByTestId('tag-pending')).toHaveTextContent('Pending');
+  });
+
+  it('renderEmpty replaces the empty state', async () => {
+    const user = userEvent.setup();
+    render(
+      <Select
+        searchable
+        options={STATUSES}
+        renderEmpty={(q) => <span>Nothing for "{q}"</span>}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.type(input, 'zzz');
+    expect(screen.getByText('Nothing for "zzz"')).toBeInTheDocument();
+  });
+});

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -819,3 +819,50 @@ describe('Select — async loadOptions', () => {
     expect(loadOptions).not.toHaveBeenCalled();
   });
 });
+
+describe('Select — async edge cases', () => {
+  it('warns in dev when both options and loadOptions are passed', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <Select
+        searchable
+        options={[{ value: 'a', label: 'A' }]}
+        loadOptions={async () => [{ value: 'b', label: 'B' }]}
+      />,
+    );
+    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy.mock.calls[0][0]).toMatch(/loadOptions/);
+    warnSpy.mockRestore();
+  });
+
+  it('passes an AbortSignal to loadOptions', async () => {
+    vi.useFakeTimers();
+    configure({
+      asyncWrapper: async (cb) => {
+        const result = await cb();
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+          vi.advanceTimersByTime(0);
+        });
+        return result;
+      },
+    });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const loadOptions = vi.fn(async (_q: string, signal: AbortSignal) => {
+        expect(signal).toBeInstanceOf(AbortSignal);
+        return [{ value: 'a', label: 'A' }];
+      });
+      render(<Select searchable loadOptions={loadOptions} />);
+      await user.click(screen.getByRole('combobox'));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.runAllTimersAsync();
+      });
+      expect(loadOptions).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      configure({ asyncWrapper: async (cb) => cb() });
+    }
+  });
+});

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import { createRef } from 'react';
 import { Select } from './Select';
+import styles from './Select.module.scss';
 
 describe('Select — Phase 1 scaffold', () => {
   it('renders an empty root div with the data-select marker', () => {
@@ -19,7 +20,7 @@ describe('Select — Phase 1 scaffold', () => {
   it('merges the className prop (does not replace the internal class)', () => {
     const { container } = render(<Select className="external" />);
     const root = container.firstChild as HTMLElement;
-    expect(root.className).toMatch(/external/);
-    expect(root.className).toMatch(/root/);
+    expect(root.className).toContain('external');
+    expect(root.className).toContain(styles.root);
   });
 });

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -507,3 +507,30 @@ describe('Select — multi, summary, non-searchable', () => {
     expect(screen.getByRole('listbox')).toHaveAttribute('aria-multiselectable', 'true');
   });
 });
+
+describe('Select — multi-summary aria-label', () => {
+  const OPTS = [
+    { value: 'a', label: 'Alex' },
+    { value: 'b', label: 'Bea' },
+  ];
+
+  it('aria-label carries the full label list when summary is truncated visually', () => {
+    render(<Select multiple triggerDisplay="summary" options={OPTS} value={['a', 'b']} />);
+    const trigger = screen.getByRole('button');
+    expect(trigger.getAttribute('aria-label')).toContain('Alex');
+    expect(trigger.getAttribute('aria-label')).toContain('Bea');
+  });
+
+  it('does not override an explicit aria-label from props', () => {
+    render(
+      <Select
+        multiple
+        triggerDisplay="summary"
+        options={OPTS}
+        value={['a']}
+        aria-label="Owners filter"
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Owners filter');
+  });
+});

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -612,3 +612,82 @@ describe('Select — multi-chips, non-searchable', () => {
     expect(screen.getByRole('listbox')).toBeInTheDocument();
   });
 });
+
+describe('Select — multi-chips-searchable', () => {
+  const OPTS = [
+    { value: 'a', label: 'Alpha' },
+    { value: 'b', label: 'Beta' },
+    { value: 'c', label: 'Gamma' },
+  ];
+
+  it('renders an inline input alongside chips', () => {
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        searchable
+        options={OPTS}
+        value={['a']}
+        placeholder="Add tag…"
+      />,
+    );
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove Alpha' })).toBeInTheDocument();
+  });
+
+  it('typing filters and selecting adds a chip + clears query', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select multiple triggerDisplay="chips" searchable options={OPTS} onChange={onChange} />,
+    );
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, 'be');
+    expect(screen.getByRole('option', { name: 'Beta' })).toBeInTheDocument();
+    await user.click(screen.getByRole('option', { name: 'Beta' }));
+    expect(onChange).toHaveBeenCalledWith(['b'], [OPTS[1]]);
+    expect(input.value).toBe('');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('Backspace on empty input removes the trailing chip', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        searchable
+        options={OPTS}
+        defaultValue={['a', 'b']}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    input.focus();
+    await user.keyboard('{Backspace}');
+    expect(onChange).toHaveBeenCalledWith(['a'], [OPTS[0]]);
+  });
+
+  it('Backspace on non-empty input does NOT remove a chip', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        searchable
+        options={OPTS}
+        defaultValue={['a']}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.type(input, 'be');
+    await user.keyboard('{Backspace}'); // deletes 'e' from 'be', not the chip
+    expect(input.value).toBe('b');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+});

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -752,9 +752,7 @@ describe('Select — async loadOptions', () => {
   it('shows loading state while a request is in flight', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     let resolveFn: (opts: SelectOption[]) => void = () => {};
-    const loadOptions = vi.fn(
-      () => new Promise<SelectOption[]>((res) => (resolveFn = res)),
-    );
+    const loadOptions = vi.fn(() => new Promise<SelectOption[]>((res) => (resolveFn = res)));
     render(<Select searchable loadOptions={loadOptions} />);
     await user.click(screen.getByRole('combobox'));
     await act(async () => {
@@ -864,5 +862,92 @@ describe('Select — async edge cases', () => {
       vi.useRealTimers();
       configure({ asyncWrapper: async (cb) => cb() });
     }
+  });
+});
+
+describe('Select — creatable', () => {
+  const OPTS: SelectOption[] = [{ value: 'a', label: 'Alpha' }];
+
+  it('throws in dev when creatable && !searchable', () => {
+    // React 18 logs the error to console.error too; suppress to keep
+    // test output clean.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => {
+      render(<Select creatable options={OPTS} />);
+    }).toThrow(/searchable/);
+    errSpy.mockRestore();
+  });
+
+  it('shows "+ Create" row when query has no exact match', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable creatable options={OPTS} />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, 'Foo');
+    expect(screen.getByText(/\+ Create "Foo"/i)).toBeInTheDocument();
+  });
+
+  it('hides "+ Create" row when query EXACTLY matches an existing option (case-insensitive)', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable creatable options={OPTS} />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, 'alpha');
+    expect(screen.queryByText(/\+ Create/i)).toBeNull();
+  });
+
+  it('activating the create row fires onCreate + onChange with the new value (multi)', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+    const onChange = vi.fn();
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        searchable
+        creatable
+        options={OPTS}
+        onCreate={onCreate}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, 'Beta');
+    await user.click(screen.getByText(/\+ Create "Beta"/i));
+    expect(onCreate).toHaveBeenCalledWith('Beta');
+    expect(onChange).toHaveBeenCalledWith(['Beta'], [{ value: 'Beta', label: 'Beta' }]);
+  });
+
+  it('activating the create row in single mode replaces selection + closes', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+    const onChange = vi.fn();
+    render(<Select searchable creatable options={OPTS} onCreate={onCreate} onChange={onChange} />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, 'Foo');
+    await user.click(screen.getByText(/\+ Create "Foo"/i));
+    expect(onCreate).toHaveBeenCalledWith('Foo');
+    expect(onChange).toHaveBeenCalledWith('Foo', { value: 'Foo', label: 'Foo' });
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('hides "+ Create" row when query is in current multi selection (no dup)', async () => {
+    const user = userEvent.setup();
+    render(
+      <Select
+        multiple
+        searchable
+        creatable
+        triggerDisplay="chips"
+        options={OPTS}
+        defaultValue={['Foo']}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.type(input, 'Foo');
+    expect(screen.queryByText(/\+ Create "Foo"/i)).toBeNull();
   });
 });

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -33,7 +33,9 @@ describe('Select — single, non-searchable, sync', () => {
 
   it('renders the selected label when value is set', () => {
     render(<Select options={STATUSES} value="pending" />);
-    expect(screen.getByRole('button')).toHaveTextContent('Pending');
+    // Two buttons in the DOM once `value` is set: the main trigger and the
+    // overlay clear ✕. Filter by accessible name so the trigger is unambiguous.
+    expect(screen.getByRole('button', { name: 'Pending' })).toBeInTheDocument();
   });
 });
 
@@ -109,10 +111,12 @@ describe('Select — selection (single)', () => {
       );
     };
     render(<Wrapper />);
+    // Closed + no value → only one button (the trigger w/ placeholder text).
     expect(screen.getByRole('button')).toHaveTextContent('Pick');
     await user.click(screen.getByRole('button'));
     await user.click(screen.getByRole('option', { name: 'Archived' }));
-    expect(screen.getByRole('button')).toHaveTextContent('Archived');
+    // After selection, the clear ✕ also renders, so name-filter the trigger.
+    expect(screen.getByRole('button', { name: 'Archived' })).toBeInTheDocument();
   });
 
   it('clicking a disabled option does nothing', async () => {
@@ -202,11 +206,14 @@ describe('Select — keyboard (single, non-searchable)', () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(<Select options={STATUSES} value="active" onChange={onChange} />);
-    screen.getByRole('button').focus();
+    // `value="active"` triggers the clear ✕ overlay, so filter by name to
+    // get only the main trigger.
+    const trigger = screen.getByRole('button', { name: 'Active' });
+    trigger.focus();
     await user.keyboard('{Enter}{ArrowDown}{Escape}');
     expect(screen.queryByRole('listbox')).toBeNull();
     expect(onChange).not.toHaveBeenCalled();
-    expect(screen.getByRole('button')).toHaveTextContent('Active');
+    expect(trigger).toHaveTextContent('Active');
   });
 
   it('Tab closes and commits', async () => {
@@ -1075,5 +1082,59 @@ describe('Select — visual states', () => {
     await user.click(trigger);
     expect(screen.queryByRole('listbox')).toBeNull();
     expect(trigger).toHaveTextContent('Pending');
+  });
+});
+
+describe('Select — clearable', () => {
+  it('shows ✕ button when single + clearable + has value (default behavior, not required)', () => {
+    render(<Select options={STATUSES} value="pending" />);
+    expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument();
+  });
+
+  it('clicking ✕ clears the selection', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Select options={STATUSES} defaultValue="pending" onChange={onChange} />);
+    await user.click(screen.getByRole('button', { name: /clear selection/i }));
+    expect(onChange).toHaveBeenCalledWith('', null);
+  });
+
+  it('does NOT show ✕ when required', () => {
+    render(<Select options={STATUSES} value="pending" required name="x" />);
+    expect(screen.queryByRole('button', { name: /clear selection/i })).toBeNull();
+  });
+
+  it('does NOT show ✕ when no value', () => {
+    render(<Select options={STATUSES} />);
+    expect(screen.queryByRole('button', { name: /clear selection/i })).toBeNull();
+  });
+
+  it('does NOT show ✕ in multi mode by default', () => {
+    render(<Select multiple options={STATUSES} value={['active']} triggerDisplay="summary" />);
+    expect(screen.queryByRole('button', { name: /clear selection/i })).toBeNull();
+  });
+
+  it('shows ✕ in multi mode when explicitly clearable=true', () => {
+    render(
+      <Select multiple options={STATUSES} value={['active']} triggerDisplay="summary" clearable />,
+    );
+    expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument();
+  });
+
+  it('clicking ✕ in multi clears the entire array', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select
+        multiple
+        options={STATUSES}
+        defaultValue={['active', 'pending']}
+        triggerDisplay="summary"
+        clearable
+        onChange={onChange}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /clear selection/i }));
+    expect(onChange).toHaveBeenCalledWith([], []);
   });
 });

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -534,3 +534,44 @@ describe('Select — multi-summary aria-label', () => {
     expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Owners filter');
   });
 });
+
+describe('Select — multi-summary-searchable', () => {
+  const OPTS = [
+    { value: 'a', label: 'Alex' },
+    { value: 'b', label: 'Bea' },
+    { value: 'c', label: 'Cam' },
+  ];
+
+  it('renders a search input inside the popover when multi+summary+searchable', async () => {
+    const user = userEvent.setup();
+    render(<Select multiple triggerDisplay="summary" searchable options={OPTS} />);
+    await user.click(screen.getByRole('button'));
+    const inputs = screen.getAllByRole('combobox');
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0].tagName).toBe('INPUT');
+  });
+
+  it('typing into the popover search filters options', async () => {
+    const user = userEvent.setup();
+    render(<Select multiple triggerDisplay="summary" searchable options={OPTS} />);
+    await user.click(screen.getByRole('button'));
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'be');
+    expect(screen.queryByRole('option', { name: 'Alex' })).toBeNull();
+    expect(screen.getByRole('option', { name: 'Bea' })).toBeInTheDocument();
+  });
+
+  it('selecting an option keeps popover open and refocuses search input', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select multiple triggerDisplay="summary" searchable options={OPTS} onChange={onChange} />,
+    );
+    await user.click(screen.getByRole('button'));
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'al');
+    await user.click(screen.getByRole('option', { name: 'Alex' }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1137,6 +1137,26 @@ describe('Select — clearable', () => {
     await user.click(screen.getByRole('button', { name: /clear selection/i }));
     expect(onChange).toHaveBeenCalledWith([], []);
   });
+
+  it('clear ✕ button is focusable via keyboard', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} defaultValue="active" />);
+    const trigger = screen.getByRole('button', { name: /Active/i });
+    trigger.focus();
+    await user.tab(); // moves to next focusable
+    const clearBtn = screen.getByRole('button', { name: /clear selection/i });
+    expect(document.activeElement).toBe(clearBtn);
+  });
+
+  it('Enter on focused clear ✕ clears the selection', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Select options={STATUSES} defaultValue="pending" onChange={onChange} />);
+    const clearBtn = screen.getByRole('button', { name: /clear selection/i });
+    clearBtn.focus();
+    await user.keyboard('{Enter}');
+    expect(onChange).toHaveBeenCalledWith('', null);
+  });
 });
 
 describe('Select — render escape hatches', () => {

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -453,3 +453,57 @@ describe('Select — grouped options', () => {
     );
   });
 });
+
+describe('Select — multi, summary, non-searchable', () => {
+  const OWNERS = [
+    { value: 'a', label: 'Alex' },
+    { value: 'b', label: 'Bea' },
+    { value: 'c', label: 'Cam' },
+  ];
+
+  it('placeholder shown when nothing selected', () => {
+    render(<Select multiple triggerDisplay="summary" options={OWNERS} placeholder="Owners" />);
+    expect(screen.getByRole('button')).toHaveTextContent('Owners');
+  });
+
+  it('renders comma-joined labels when selections exist', () => {
+    render(<Select multiple triggerDisplay="summary" options={OWNERS} value={['a', 'c']} />);
+    expect(screen.getByRole('button')).toHaveTextContent('Alex, Cam');
+  });
+
+  it('clicking a row toggles selection and does NOT close', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Select multiple triggerDisplay="summary" options={OWNERS} onChange={onChange} />);
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('option', { name: 'Alex' }));
+    expect(onChange).toHaveBeenCalledWith(['a'], [OWNERS[0]]);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    await user.click(screen.getByRole('option', { name: 'Bea' }));
+    expect(onChange).toHaveBeenLastCalledWith(['a', 'b'], [OWNERS[0], OWNERS[1]]);
+  });
+
+  it('clicking a selected row removes it', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select
+        multiple
+        triggerDisplay="summary"
+        options={OWNERS}
+        defaultValue={['a']}
+        onChange={onChange}
+      />,
+    );
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('option', { name: 'Alex' }));
+    expect(onChange).toHaveBeenCalledWith([], []);
+  });
+
+  it('aria-multiselectable=true on the listbox', async () => {
+    const user = userEvent.setup();
+    render(<Select multiple triggerDisplay="summary" options={OWNERS} />);
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByRole('listbox')).toHaveAttribute('aria-multiselectable', 'true');
+  });
+});

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1040,3 +1040,40 @@ describe('Select — form integration (multi)', () => {
     expect(hiddens[0].required).toBe(false);
   });
 });
+
+describe('Select — visual states', () => {
+  it('size="sm" applies the sm class', () => {
+    const { container } = render(<Select options={STATUSES} size="sm" />);
+    expect(container.firstElementChild!.className).toMatch(/size-sm/);
+  });
+
+  it('size="lg" applies the lg class', () => {
+    const { container } = render(<Select options={STATUSES} size="lg" />);
+    expect(container.firstElementChild!.className).toMatch(/size-lg/);
+  });
+
+  it('invalid sets aria-invalid on the trigger and adds the invalid class', () => {
+    const { container } = render(<Select options={STATUSES} invalid />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-invalid', 'true');
+    expect(container.firstElementChild!.className).toMatch(/invalid/);
+  });
+
+  it('disabled disables the trigger and prevents opening', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} disabled />);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toBeDisabled();
+    await user.click(trigger);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('readOnly prevents opening on click', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} readOnly value="pending" />);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveAttribute('aria-readonly', 'true');
+    await user.click(trigger);
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(trigger).toHaveTextContent('Pending');
+  });
+});

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1,26 +1,37 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { createRef } from 'react';
-import { Select } from './Select';
+import { Select, type SelectOption } from './Select';
 import styles from './Select.module.scss';
 
-describe('Select — Phase 1 scaffold', () => {
-  it('renders an empty root div with the data-select marker', () => {
-    const { container } = render(<Select />);
-    const root = container.firstChild as HTMLElement;
-    expect(root).toBeInstanceOf(HTMLDivElement);
-    expect(root).toHaveAttribute('data-select', '');
-  });
+const STATUSES: SelectOption[] = [
+  { value: 'active', label: 'Active' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'archived', label: 'Archived' },
+];
 
+describe('Select — Phase 1 scaffold', () => {
   it('forwards refs to the underlying div', () => {
     const ref = createRef<HTMLDivElement>();
-    render(<Select ref={ref} />);
+    render(<Select ref={ref} options={STATUSES} />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });
 
   it('merges the className prop (does not replace the internal class)', () => {
-    const { container } = render(<Select className="external" />);
+    const { container } = render(<Select options={STATUSES} className="external" />);
     const root = container.firstChild as HTMLElement;
     expect(root.className).toContain('external');
     expect(root.className).toContain(styles.root);
+  });
+});
+
+describe('Select — single, non-searchable, sync', () => {
+  it('renders a button trigger with placeholder when no value', () => {
+    render(<Select options={STATUSES} placeholder="Pick one" />);
+    expect(screen.getByRole('button')).toHaveTextContent('Pick one');
+  });
+
+  it('renders the selected label when value is set', () => {
+    render(<Select options={STATUSES} value="pending" />);
+    expect(screen.getByRole('button')).toHaveTextContent('Pending');
   });
 });

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -129,3 +129,107 @@ describe('Select — selection (single)', () => {
     expect(screen.queryByRole('listbox')).toBeInTheDocument();
   });
 });
+
+describe('Select — keyboard (single, non-searchable)', () => {
+  it('ArrowDown on closed trigger opens with first option active', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    const trigger = screen.getByRole('button');
+    trigger.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    const active = screen.getByRole('option', { name: 'Active' });
+    expect(trigger).toHaveAttribute('aria-activedescendant', active.id);
+  });
+
+  it('ArrowUp on closed trigger opens with last option active', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    const trigger = screen.getByRole('button');
+    trigger.focus();
+    await user.keyboard('{ArrowUp}');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    const active = screen.getByRole('option', { name: 'Archived' });
+    expect(trigger).toHaveAttribute('aria-activedescendant', active.id);
+  });
+
+  it('Enter on closed trigger opens', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{Enter}');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('ArrowDown moves active row +1', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}{ArrowDown}');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Pending' }).id,
+    );
+  });
+
+  it('Home jumps to first, End jumps to last', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}{End}');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Archived' }).id,
+    );
+    await user.keyboard('{Home}');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Active' }).id,
+    );
+  });
+
+  it('Enter on open selects the active row and closes', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Select options={STATUSES} onChange={onChange} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+    expect(onChange).toHaveBeenCalledWith('pending', STATUSES[1]);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('Escape closes without changing selection', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Select options={STATUSES} value="active" onChange={onChange} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{Enter}{ArrowDown}{Escape}');
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('button')).toHaveTextContent('Active');
+  });
+
+  it('Tab closes and commits', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{Enter}{Tab}');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('ArrowDown skips disabled options', async () => {
+    const user = userEvent.setup();
+    const opts: SelectOption[] = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B', disabled: true },
+      { value: 'c', label: 'C' },
+    ];
+    render(<Select options={opts} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}{ArrowDown}');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'C' }).id,
+    );
+  });
+});

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import { Select, type SelectOption } from './Select';
 import styles from './Select.module.scss';
@@ -33,5 +34,52 @@ describe('Select — single, non-searchable, sync', () => {
   it('renders the selected label when value is set', () => {
     render(<Select options={STATUSES} value="pending" />);
     expect(screen.getByRole('button')).toHaveTextContent('Pending');
+  });
+});
+
+describe('Select — open/close', () => {
+  it('opens the listbox on trigger click', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} placeholder="Pick" />);
+    expect(screen.queryByRole('listbox')).toBeNull();
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Active' })).toBeInTheDocument();
+  });
+
+  it('listbox renders in a portal at document.body level', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Select options={STATUSES} />);
+    await user.click(screen.getByRole('button'));
+    const listbox = screen.getByRole('listbox');
+    expect(container.contains(listbox)).toBe(false);
+  });
+
+  it('closes on second click of trigger', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    const trigger = screen.getByRole('button');
+    await user.click(trigger);
+    expect(screen.queryByRole('listbox')).toBeInTheDocument();
+    await user.click(trigger);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('aria-expanded reflects open state', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('aria-controls points at the listbox id when open', async () => {
+    const user = userEvent.setup();
+    render(<Select options={STATUSES} />);
+    const trigger = screen.getByRole('button');
+    await user.click(trigger);
+    const listbox = screen.getByRole('listbox');
+    expect(trigger.getAttribute('aria-controls')).toBe(listbox.id);
   });
 });

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -321,3 +321,48 @@ describe('Select — typeahead (non-searchable)', () => {
     );
   });
 });
+
+describe('Select — grouped options', () => {
+  const GROUPED = [
+    {
+      label: 'Active',
+      options: [
+        { value: 'a1', label: 'Foo' },
+        { value: 'a2', label: 'Bar' },
+      ],
+    },
+    { label: 'Archived', options: [{ value: 'b1', label: 'Baz' }] },
+  ];
+
+  it('renders group headers in order before their options', async () => {
+    const user = userEvent.setup();
+    render(<Select options={GROUPED} />);
+    await user.click(screen.getByRole('button'));
+    const listbox = screen.getByRole('listbox');
+    const headers = listbox.querySelectorAll('[data-group-header]');
+    expect(headers).toHaveLength(2);
+    expect(headers[0]).toHaveTextContent('Active');
+    expect(headers[1]).toHaveTextContent('Archived');
+  });
+
+  it('group is wrapped in role=group with aria-labelledby to the header id', async () => {
+    const user = userEvent.setup();
+    render(<Select options={GROUPED} />);
+    await user.click(screen.getByRole('button'));
+    const groups = screen.getAllByRole('group');
+    expect(groups).toHaveLength(2);
+    const header0 = screen.getByText('Active');
+    expect(groups[0].getAttribute('aria-labelledby')).toBe(header0.id);
+  });
+
+  it('ArrowDown skips group headers', async () => {
+    const user = userEvent.setup();
+    render(<Select options={GROUPED} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}'); // open + 2 steps
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Baz' }).id,
+    );
+  });
+});

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createRef } from 'react';
+import React, { createRef } from 'react';
 import { Select, type SelectOption } from './Select';
 import styles from './Select.module.scss';
 
@@ -81,5 +81,51 @@ describe('Select — open/close', () => {
     await user.click(trigger);
     const listbox = screen.getByRole('listbox');
     expect(trigger.getAttribute('aria-controls')).toBe(listbox.id);
+  });
+});
+
+describe('Select — selection (single)', () => {
+  it('selecting an option fires onChange(value, option) and closes the popover', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Select options={STATUSES} onChange={onChange} />);
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('option', { name: 'Pending' }));
+    expect(onChange).toHaveBeenCalledWith('pending', STATUSES[1]);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('controlled value round-trip — parent re-renders new value, trigger updates', async () => {
+    const user = userEvent.setup();
+    const Wrapper = () => {
+      const [v, setV] = React.useState<string>('');
+      return (
+        <Select
+          options={STATUSES}
+          value={v}
+          onChange={(next) => setV(next as string)}
+          placeholder="Pick"
+        />
+      );
+    };
+    render(<Wrapper />);
+    expect(screen.getByRole('button')).toHaveTextContent('Pick');
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('option', { name: 'Archived' }));
+    expect(screen.getByRole('button')).toHaveTextContent('Archived');
+  });
+
+  it('clicking a disabled option does nothing', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const opts: SelectOption[] = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B', disabled: true },
+    ];
+    render(<Select options={opts} onChange={onChange} />);
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('option', { name: 'B' }));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('listbox')).toBeInTheDocument();
   });
 });

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -322,6 +322,93 @@ describe('Select — typeahead (non-searchable)', () => {
   });
 });
 
+describe('Select — single, searchable (combobox input)', () => {
+  it('renders the trigger as an input with role=combobox', () => {
+    render(<Select searchable options={STATUSES} placeholder="Pick" />);
+    const input = screen.getByRole('combobox');
+    expect(input.tagName).toBe('INPUT');
+    expect(input).toHaveAttribute('aria-autocomplete', 'list');
+  });
+
+  it('shows selected label as input value when closed', () => {
+    render(<Select searchable options={STATUSES} value="pending" />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    expect(input.value).toBe('Pending');
+  });
+
+  it('typing replaces the label with the query and opens', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable options={STATUSES} value="pending" />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    input.focus();
+    await user.keyboard('a');
+    expect(input.value).toBe('a');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('typing filters options by label (case-insensitive)', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable options={STATUSES} />);
+    const input = screen.getByRole('combobox');
+    input.focus();
+    await user.keyboard('arc');
+    expect(screen.queryByRole('option', { name: 'Active' })).toBeNull();
+    expect(screen.queryByRole('option', { name: 'Pending' })).toBeNull();
+    expect(screen.getByRole('option', { name: 'Archived' })).toBeInTheDocument();
+  });
+
+  it('Escape reverts query to selected label', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable options={STATUSES} defaultValue="pending" />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    input.focus();
+    await user.keyboard('arc');
+    expect(input.value).toBe('arc');
+    await user.keyboard('{Escape}');
+    expect(input.value).toBe('Pending');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('Click on row commits the selection and replaces input value with new label', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Select searchable options={STATUSES} onChange={onChange} />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    await user.click(screen.getByRole('option', { name: 'Pending' }));
+    expect(onChange).toHaveBeenCalledWith('pending', STATUSES[1]);
+    expect(input.value).toBe('Pending');
+  });
+
+  it('Click outside reverts query without selecting', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <div>
+        <Select searchable options={STATUSES} defaultValue="active" onChange={onChange} />
+        <button data-testid="outside">outside</button>
+      </div>,
+    );
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    input.focus();
+    await user.keyboard('arc');
+    expect(input.value).toBe('arc');
+    await user.click(screen.getByTestId('outside'));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input.value).toBe('Active');
+  });
+
+  it('ArrowDown on focused-but-closed combobox opens without replacing input value', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable options={STATUSES} value="pending" />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    input.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(input.value).toBe('Pending');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+});
+
 describe('Select — grouped options', () => {
   const GROUPED = [
     {

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1,4 +1,4 @@
-import { configure, render, screen } from '@testing-library/react';
+import { act, configure, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { createRef } from 'react';
 import { Select, type SelectOption } from './Select';
@@ -710,5 +710,112 @@ describe('Select — multi-chips-searchable', () => {
     await user.click(input);
     await user.type(input, 'be');
     expect(screen.getByRole('button', { name: 'Remove Alpha' })).toBeInTheDocument();
+  });
+});
+
+describe('Select — async loadOptions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // RTL's waitFor polls via setInterval; under fake timers it needs an
+    // explicit tick to actually fire. Same shim ConfirmationPopover uses.
+    configure({
+      asyncWrapper: async (cb) => {
+        const result = await cb();
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+          vi.advanceTimersByTime(0);
+        });
+        return result;
+      },
+    });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    configure({ asyncWrapper: async (cb) => cb() });
+  });
+
+  it('calls loadOptions("") on first open when loadOnOpen=true (default)', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const loadOptions = vi.fn(async (_q: string, _signal: AbortSignal) => [
+      { value: 'a', label: 'A' },
+    ]);
+    render(<Select searchable loadOptions={loadOptions} />);
+    await user.click(screen.getByRole('combobox'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+      await vi.runAllTimersAsync();
+    });
+    expect(loadOptions).toHaveBeenCalledTimes(1);
+    expect(loadOptions.mock.calls[0][0]).toBe('');
+  });
+
+  it('shows loading state while a request is in flight', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    let resolveFn: (opts: SelectOption[]) => void = () => {};
+    const loadOptions = vi.fn(
+      () => new Promise<SelectOption[]>((res) => (resolveFn = res)),
+    );
+    render(<Select searchable loadOptions={loadOptions} />);
+    await user.click(screen.getByRole('combobox'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    await act(async () => {
+      resolveFn([{ value: 'a', label: 'A' }]);
+      await vi.runAllTimersAsync();
+    });
+    await waitFor(() => {
+      expect(screen.queryByText(/loading/i)).toBeNull();
+      expect(screen.getByRole('option', { name: 'A' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state with Retry that re-fires loadOptions', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const loadOptions = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce([{ value: 'a', label: 'A' }]);
+    render(<Select searchable loadOptions={loadOptions} />);
+    await user.click(screen.getByRole('combobox'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+      await vi.runAllTimersAsync();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+      await vi.runAllTimersAsync();
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'A' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when async result is []', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const loadOptions = vi.fn(async () => []);
+    render(<Select searchable loadOptions={loadOptions} />);
+    await user.click(screen.getByRole('combobox'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+      await vi.runAllTimersAsync();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/no options/i)).toBeInTheDocument();
+    });
+  });
+
+  it('does not call loadOptions before the popover opens (loadOnOpen)', async () => {
+    const loadOptions = vi.fn(async () => []);
+    render(<Select searchable loadOptions={loadOptions} />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(loadOptions).not.toHaveBeenCalled();
   });
 });

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import { createRef } from 'react';
+import { Select } from './Select';
+
+describe('Select — Phase 1 scaffold', () => {
+  it('renders an empty root div with the data-select marker', () => {
+    const { container } = render(<Select />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toBeInstanceOf(HTMLDivElement);
+    expect(root).toHaveAttribute('data-select', '');
+  });
+
+  it('forwards refs to the underlying div', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Select ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('merges the className prop (does not replace the internal class)', () => {
+    const { container } = render(<Select className="external" />);
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).toMatch(/external/);
+    expect(root.className).toMatch(/root/);
+  });
+});

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -575,3 +575,40 @@ describe('Select — multi-summary-searchable', () => {
     expect(document.activeElement).toBe(input);
   });
 });
+
+describe('Select — multi-chips, non-searchable', () => {
+  const OPTS = [
+    { value: 'a', label: 'Alpha' },
+    { value: 'b', label: 'Beta' },
+  ];
+
+  it('renders chips for each selected option inside the trigger', () => {
+    render(<Select multiple triggerDisplay="chips" options={OPTS} value={['a', 'b']} />);
+    const chips = screen.getAllByRole('button', { name: /Remove/ });
+    expect(chips).toHaveLength(2);
+    expect(chips[0]).toHaveAttribute('aria-label', 'Remove Alpha');
+  });
+
+  it("clicking a chip's ✕ removes that option", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select
+        multiple
+        triggerDisplay="chips"
+        options={OPTS}
+        defaultValue={['a', 'b']}
+        onChange={onChange}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Remove Alpha' }));
+    expect(onChange).toHaveBeenCalledWith(['b'], [OPTS[1]]);
+  });
+
+  it('clicking on the trigger (not a chip) opens the popover', async () => {
+    const user = userEvent.setup();
+    render(<Select multiple triggerDisplay="chips" options={OPTS} placeholder="Pick" />);
+    await user.click(screen.getByLabelText('Open select'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+});

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -961,9 +961,7 @@ describe('Select — creatable', () => {
 
 describe('Select — form integration (single)', () => {
   it('renders a hidden input named `name` with the current value', () => {
-    const { container } = render(
-      <Select options={STATUSES} value="pending" name="status" />,
-    );
+    const { container } = render(<Select options={STATUSES} value="pending" name="status" />);
     const hidden = container.querySelector<HTMLInputElement>('input[name="status"]');
     expect(hidden).not.toBeNull();
     expect(hidden!.type).toBe('hidden');
@@ -971,9 +969,7 @@ describe('Select — form integration (single)', () => {
   });
 
   it('hidden input is required when `required`', () => {
-    const { container } = render(
-      <Select options={STATUSES} name="status" required />,
-    );
+    const { container } = render(<Select options={STATUSES} name="status" required />);
     const hidden = container.querySelector<HTMLInputElement>('input[name="status"]');
     expect(hidden!.required).toBe(true);
   });
@@ -1003,12 +999,14 @@ describe('Select — form integration (multi)', () => {
   ];
 
   it('renders one hidden input per selected value', () => {
-    const { container } = render(
-      <Select multiple options={OPTS} value={['a', 'b']} name="tags" />,
-    );
+    const { container } = render(<Select multiple options={OPTS} value={['a', 'b']} name="tags" />);
     const hiddens = container.querySelectorAll<HTMLInputElement>('input[name="tags"]');
     expect(hiddens).toHaveLength(2);
-    expect(Array.from(hiddens).map((h) => h.value).sort()).toEqual(['a', 'b']);
+    expect(
+      Array.from(hiddens)
+        .map((h) => h.value)
+        .sort(),
+    ).toEqual(['a', 'b']);
   });
 
   it('FormData.getAll returns the array', () => {
@@ -1181,11 +1179,7 @@ describe('Select — render escape hatches', () => {
 
   it('renderValue replaces the single trigger label', () => {
     render(
-      <Select
-        options={STATUSES}
-        value="pending"
-        renderValue={(opt) => <em>~~{opt.label}~~</em>}
-      />,
+      <Select options={STATUSES} value="pending" renderValue={(opt) => <em>~~{opt.label}~~</em>} />,
     );
     expect(screen.getByRole('button', { name: /~~Pending~~/ })).toHaveTextContent('~~Pending~~');
   });
@@ -1210,11 +1204,7 @@ describe('Select — render escape hatches', () => {
   it('renderEmpty replaces the empty state', async () => {
     const user = userEvent.setup();
     render(
-      <Select
-        searchable
-        options={STATUSES}
-        renderEmpty={(q) => <span>Nothing for "{q}"</span>}
-      />,
+      <Select searchable options={STATUSES} renderEmpty={(q) => <span>Nothing for "{q}"</span>} />,
     );
     const input = screen.getByRole('combobox');
     await user.click(input);

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { configure, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { createRef } from 'react';
 import { Select, type SelectOption } from './Select';
@@ -230,6 +230,77 @@ describe('Select — keyboard (single, non-searchable)', () => {
     expect(screen.getByRole('button')).toHaveAttribute(
       'aria-activedescendant',
       screen.getByRole('option', { name: 'C' }).id,
+    );
+  });
+});
+
+describe('Select — typeahead (non-searchable)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // RTL's asyncWrapper drains with a setTimeout(0); under Vitest fake
+    // timers it needs an explicit `advanceTimersByTime` to actually fire.
+    // Without this, `userEvent.keyboard` queues forever and the test
+    // hangs to the suite timeout. Mirrors ConfirmationPopover's setup.
+    configure({
+      asyncWrapper: async (cb) => {
+        const result = await cb();
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+          vi.advanceTimersByTime(0);
+        });
+        return result;
+      },
+    });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    configure({ asyncWrapper: async (cb) => cb() });
+  });
+
+  it('typing a letter jumps active row to first option starting with it', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<Select options={STATUSES} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('p');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Pending' }).id,
+    );
+  });
+
+  it('typing a sequence within 500ms matches the joined prefix', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const opts: SelectOption[] = [
+      { value: '1', label: 'Aardvark' },
+      { value: '2', label: 'Albatross' },
+      { value: '3', label: 'Antelope' },
+    ];
+    render(<Select options={opts} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('al');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Albatross' }).id,
+    );
+  });
+
+  it('buffer resets after 500ms idle', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const opts: SelectOption[] = [
+      { value: '1', label: 'Apple' },
+      { value: '2', label: 'Banana' },
+    ];
+    render(<Select options={opts} />);
+    screen.getByRole('button').focus();
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('a');
+    vi.advanceTimersByTime(600);
+    await user.keyboard('b');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Banana' }).id,
     );
   });
 });

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -303,4 +303,21 @@ describe('Select — typeahead (non-searchable)', () => {
       screen.getByRole('option', { name: 'Banana' }).id,
     );
   });
+
+  it('typing the first letter from closed state finds the first matching option (no off-by-one)', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const opts = [
+      { value: '1', label: 'Apple' },
+      { value: '2', label: 'Banana' },
+      { value: '3', label: 'Cherry' },
+    ];
+    render(<Select options={opts} />);
+    screen.getByRole('button').focus();
+    // From CLOSED state, typing 'a' must land on Apple (index 0), not skip past it
+    await user.keyboard('a');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Apple' }).id,
+    );
+  });
 });

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -988,3 +988,55 @@ describe('Select — form integration (single)', () => {
     expect(captured!.get('status')).toBe('active');
   });
 });
+
+describe('Select — form integration (multi)', () => {
+  const OPTS = [
+    { value: 'a', label: 'A' },
+    { value: 'b', label: 'B' },
+  ];
+
+  it('renders one hidden input per selected value', () => {
+    const { container } = render(
+      <Select multiple options={OPTS} value={['a', 'b']} name="tags" />,
+    );
+    const hiddens = container.querySelectorAll<HTMLInputElement>('input[name="tags"]');
+    expect(hiddens).toHaveLength(2);
+    expect(Array.from(hiddens).map((h) => h.value).sort()).toEqual(['a', 'b']);
+  });
+
+  it('FormData.getAll returns the array', () => {
+    let captured: FormData | null = null;
+    render(
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          captured = new FormData(e.currentTarget);
+        }}
+      >
+        <Select multiple options={OPTS} defaultValue={['a', 'b']} name="tags" />
+        <button type="submit">Go</button>
+      </form>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    expect(captured!.getAll('tags')).toEqual(['a', 'b']);
+  });
+
+  it('empty + required renders one empty required input', () => {
+    const { container } = render(
+      <Select multiple options={OPTS} value={[]} name="tags" required />,
+    );
+    const hiddens = container.querySelectorAll<HTMLInputElement>('input[name="tags"]');
+    expect(hiddens).toHaveLength(1);
+    expect(hiddens[0].required).toBe(true);
+    expect(hiddens[0].value).toBe('');
+  });
+
+  it('with values + required, no input is required (the presence is enough)', () => {
+    const { container } = render(
+      <Select multiple options={OPTS} value={['a']} name="tags" required />,
+    );
+    const hiddens = container.querySelectorAll<HTMLInputElement>('input[name="tags"]');
+    expect(hiddens).toHaveLength(1);
+    expect(hiddens[0].required).toBe(false);
+  });
+});

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1,4 +1,4 @@
-import { act, configure, render, screen, waitFor } from '@testing-library/react';
+import { act, configure, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { createRef } from 'react';
 import { Select, type SelectOption } from './Select';
@@ -949,5 +949,42 @@ describe('Select — creatable', () => {
     await user.click(input);
     await user.type(input, 'Foo');
     expect(screen.queryByText(/\+ Create "Foo"/i)).toBeNull();
+  });
+});
+
+describe('Select — form integration (single)', () => {
+  it('renders a hidden input named `name` with the current value', () => {
+    const { container } = render(
+      <Select options={STATUSES} value="pending" name="status" />,
+    );
+    const hidden = container.querySelector<HTMLInputElement>('input[name="status"]');
+    expect(hidden).not.toBeNull();
+    expect(hidden!.type).toBe('hidden');
+    expect(hidden!.value).toBe('pending');
+  });
+
+  it('hidden input is required when `required`', () => {
+    const { container } = render(
+      <Select options={STATUSES} name="status" required />,
+    );
+    const hidden = container.querySelector<HTMLInputElement>('input[name="status"]');
+    expect(hidden!.required).toBe(true);
+  });
+
+  it('FormData picks up the value on submit', () => {
+    let captured: FormData | null = null;
+    render(
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          captured = new FormData(e.currentTarget);
+        }}
+      >
+        <Select options={STATUSES} name="status" defaultValue="active" />
+        <button type="submit">Go</button>
+      </form>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    expect(captured!.get('status')).toBe('active');
   });
 });

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -361,6 +361,16 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
   const triggerRef = useRef<HTMLElement | null>(null);
   const listboxRef = useRef<HTMLUListElement | null>(null);
 
+  // `clearable` default depends on cardinality + `required`. Single-mode
+  // pickers usually want a clear button (the only way for a user to reach
+  // the empty state without typing); multi-mode users typically clear chip
+  // by chip and a "clear all" affordance is opt-in. `required` forces the
+  // ✕ off — a required field with no other selection escape would be a
+  // form-validation foot-gun. `disabled` / `readOnly` also suppress because
+  // the trigger is non-interactive in those states.
+  const effectiveClearable =
+    (clearable === undefined ? !multiple && !required : clearable) && !disabled && !readOnly;
+
   // Defined inline rather than via useCallback because it captures the
   // current `setOpen` and `triggerRef` — both stable identities — and is
   // only consumed downstream via context, which already memoizes nothing.
@@ -423,7 +433,7 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
           disabled={disabled}
           readOnly={readOnly}
           invalid={invalid}
-          clearable={clearable}
+          clearable={effectiveClearable}
           aria-label={props['aria-label']}
           aria-labelledby={props['aria-labelledby']}
           aria-describedby={props['aria-describedby']}

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -1,6 +1,22 @@
-import { forwardRef, type HTMLAttributes } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+  type Ref,
+} from 'react';
 import clsx from 'clsx';
 import styles from './Select.module.scss';
+import { SelectContext, type SelectContextValue } from './context';
+import { sanitizeId } from '../_internal/refs';
+import { useSelectState } from './useSelectState';
+import { flattenOptions, findOption, findOptions } from './utils';
+import { Trigger } from './Trigger';
+import { Listbox } from './Listbox';
 
 /** Trigger height + type-scale step. Mirrors `<Input>`'s `size`. */
 export type SelectSize = 'sm' | 'md' | 'lg';
@@ -8,7 +24,7 @@ export type SelectSize = 'sm' | 'md' | 'lg';
 /**
  * How multi-select renders the selected value(s) inside the trigger.
  * - `'chips'` — render one removable chip per value (the default).
- * - `'summary'` — render a single condensed string like "3 selected".
+ * - `'summary'` — render a single condensed string like "Foo, Bar, …".
  */
 export type SelectTriggerDisplay = 'chips' | 'summary';
 
@@ -52,17 +68,231 @@ export interface SelectGroup<T = unknown> {
  */
 export type SelectOptions<T = unknown> = SelectOption<T>[] | SelectGroup<T>[];
 
-export interface SelectProps extends HTMLAttributes<HTMLDivElement> {}
+export interface SelectProps<T = unknown> extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'defaultValue'
+> {
+  // ─── data ─────────────────────────────────────────────────────────────────
+  options?: SelectOptions<T>;
+
+  // ─── mode ─────────────────────────────────────────────────────────────────
+  multiple?: boolean;
+  triggerDisplay?: SelectTriggerDisplay;
+  searchable?: boolean;
+  creatable?: boolean;
+
+  // ─── value ────────────────────────────────────────────────────────────────
+  value?: string | string[];
+  defaultValue?: string | string[];
+  onChange?: (value: string | string[], option: SelectOption<T> | SelectOption<T>[] | null) => void;
+
+  // ─── open state (controlled, rare) ────────────────────────────────────────
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+
+  // ─── visuals ──────────────────────────────────────────────────────────────
+  size?: SelectSize;
+  invalid?: boolean;
+  placeholder?: string;
+  clearable?: boolean;
+
+  // ─── states ───────────────────────────────────────────────────────────────
+  disabled?: boolean;
+  readOnly?: boolean;
+
+  // ─── form integration (wired in later phases) ─────────────────────────────
+  name?: string;
+  required?: boolean;
+  form?: string;
+
+  // ─── render escape hatches (wired in later phases) ────────────────────────
+  renderOption?: (opt: SelectOption<T>, state: { active: boolean; selected: boolean }) => ReactNode;
+  renderValue?: (opt: SelectOption<T>) => ReactNode;
+  renderTag?: (opt: SelectOption<T>, remove: () => void) => ReactNode;
+  renderEmpty?: (query: string) => ReactNode;
+  renderLoading?: () => ReactNode;
+  renderError?: (err: Error, retry: () => void) => ReactNode;
+
+  // ─── ARIA ─────────────────────────────────────────────────────────────────
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+}
+
+const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
+  props: SelectProps,
+  ref: Ref<HTMLDivElement>,
+) {
+  const {
+    options = [],
+    multiple = false,
+    triggerDisplay = 'chips',
+    searchable = false,
+    creatable = false,
+    value: controlledValue,
+    defaultValue,
+    onChange,
+    open: controlledOpen,
+    defaultOpen,
+    onOpenChange,
+    size = 'md',
+    invalid = false,
+    placeholder,
+    clearable,
+    disabled = false,
+    readOnly = false,
+    name: _name,
+    required: _required,
+    form: _form,
+    renderOption,
+    renderValue,
+    renderTag,
+    renderEmpty,
+    renderLoading,
+    renderError,
+    className,
+    ...rest
+  } = props;
+
+  // `_name` / `_required` / `_form` are accepted in the prop surface so the
+  // public API is stable across phases; form integration is wired in Phase 9.
+  void _name;
+  void _required;
+  void _form;
+
+  const reactId = useId();
+  const idBase = sanitizeId(reactId);
+  const listboxId = `select-listbox-${idBase}`;
+  const triggerId = `select-trigger-${idBase}`;
+  const getOptionId = useCallback((v: string) => `select-opt-${idBase}-${sanitizeId(v)}`, [idBase]);
+  const getGroupHeaderId = useCallback(
+    (label: string) => `select-grp-${idBase}-${sanitizeId(label)}`,
+    [idBase],
+  );
+
+  // `onChange` is wrapped to look up the SelectOption(s) and pass them as
+  // the second arg. `findOption` / `findOptions` are O(n); for the option
+  // counts a Select handles in practice this is fine and keeps the public
+  // API ergonomic (consumers get the matched payload, not just the id).
+  const state = useSelectState({
+    multiple,
+    value: controlledValue,
+    defaultValue,
+    onChange: (v) => {
+      if (multiple) {
+        const opts = findOptions(options, Array.isArray(v) ? v : []);
+        onChange?.(v, opts);
+      } else {
+        const opt = typeof v === 'string' && v !== '' ? findOption(options, v) : null;
+        onChange?.(v, opt);
+      }
+    },
+    open: controlledOpen,
+    defaultOpen,
+    onOpenChange,
+  });
+
+  // Phase 2: no filter yet, so `rows` and `allRows` are identical. Phase 4
+  // (searchable) splits them — `rows` becomes the filtered subset.
+  const allRows = useMemo(() => flattenOptions(options), [options]);
+  const rows = allRows;
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
+  const [query, setQuery] = useState<string>('');
+
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const listboxRef = useRef<HTMLUListElement | null>(null);
+
+  // Defined inline rather than via useCallback because it captures the
+  // current `setOpen` and `triggerRef` — both stable identities — and is
+  // only consumed downstream via context, which already memoizes nothing.
+  const closeAndFocusTrigger = () => {
+    state.setOpen(false);
+    queueMicrotask(() => triggerRef.current?.focus({ preventScroll: true }));
+  };
+
+  const ctxValue: SelectContextValue = {
+    multiple,
+    searchable,
+    creatable,
+    triggerDisplay,
+    rows,
+    allRows,
+    loading: false,
+    error: null,
+    value: state.value,
+    setValue: state.setValue,
+    toggleValue: state.toggleValue,
+    open: state.open,
+    setOpen: state.setOpen,
+    activeIndex,
+    setActiveIndex,
+    query,
+    setQuery,
+    listboxId,
+    triggerId,
+    getOptionId,
+    getGroupHeaderId,
+    triggerRef,
+    listboxRef,
+    closeAndFocusTrigger,
+    retry: () => {},
+    renderOption: renderOption as SelectContextValue['renderOption'],
+    renderValue: renderValue as SelectContextValue['renderValue'],
+    renderTag: renderTag as SelectContextValue['renderTag'],
+    renderEmpty,
+    renderLoading,
+    renderError,
+  };
+
+  return (
+    <SelectContext.Provider value={ctxValue}>
+      <div
+        ref={ref}
+        {...rest}
+        className={clsx(
+          styles.root,
+          styles[`size-${size}`],
+          invalid && styles.invalid,
+          disabled && styles.disabled,
+          readOnly && styles.readOnly,
+          className,
+        )}
+      >
+        <Trigger
+          placeholder={placeholder}
+          disabled={disabled}
+          readOnly={readOnly}
+          invalid={invalid}
+          clearable={clearable}
+          aria-label={props['aria-label']}
+          aria-labelledby={props['aria-labelledby']}
+          aria-describedby={props['aria-describedby']}
+        />
+        {state.open && <Listbox />}
+      </div>
+    </SelectContext.Provider>
+  );
+});
 
 /**
- * Scaffold root for the Select component. Phase 1 only renders an empty
- * forwardRef'd `<div>` so the rest of the foundation work (types, utils,
- * state hook) can land before Trigger / Listbox / Content are wired in
- * Phase 2.
+ * `<Select>` — combo of trigger + popover listbox.
+ *
+ * Phase 2 covers the single-value, non-searchable, sync-options shape:
+ * button-styled trigger that opens a portaled listbox. Click an option
+ * (or `Enter` on the active row) to select; `Escape` / outside click
+ * dismisses. The full prop surface is declared on `SelectProps` so the
+ * type-level contract is stable across later phases.
+ *
+ * @example
+ *   const [status, setStatus] = useState('');
+ *   <Select
+ *     options={STATUSES}
+ *     value={status}
+ *     onChange={(v) => setStatus(v as string)}
+ *     placeholder="Pick one"
+ *   />
  */
-export const Select = forwardRef<HTMLDivElement, SelectProps>(function Select(
-  { className, ...props },
-  ref,
-) {
-  return <div ref={ref} data-select="" className={clsx(styles.root, className)} {...props} />;
-});
+export const Select = SelectImpl as <T = unknown>(
+  props: SelectProps<T> & { ref?: Ref<HTMLDivElement> },
+) => React.ReactElement;

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -16,7 +16,8 @@ import { SelectContext, type SelectContextValue } from './context';
 import { sanitizeId } from '../_internal/refs';
 import { useSelectState } from './useSelectState';
 import { useAsyncOptions } from './useAsyncOptions';
-import { flattenOptions, findOption, findOptions } from './utils';
+import { flattenOptions, findOption, findOptions, hasExactLabelMatch } from './utils';
+import type { FlatRow } from './utils';
 import { Trigger } from './Trigger';
 import { Listbox } from './Listbox';
 
@@ -101,6 +102,18 @@ export interface SelectProps<T = unknown> extends Omit<
   triggerDisplay?: SelectTriggerDisplay;
   searchable?: boolean;
   creatable?: boolean;
+  /**
+   * Fires when the user activates the "+ Create" row (creatable mode).
+   * The trimmed query string is passed as `label`. After this fires,
+   * the Select also calls `onChange` with the new value: in single mode
+   * the value replaces the current selection and the listbox closes; in
+   * multi mode the value is appended to the current selection and the
+   * query is cleared.
+   *
+   * Consumers typically use this hook to persist the new option upstream
+   * (e.g. POST to a backend) and reconcile their `options` array.
+   */
+  onCreate?: (label: string) => void;
 
   // ─── value ────────────────────────────────────────────────────────────────
   value?: string | string[];
@@ -154,6 +167,7 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     triggerDisplay = 'chips',
     searchable = false,
     creatable = false,
+    onCreate,
     value: controlledValue,
     defaultValue,
     onChange,
@@ -185,6 +199,15 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
   void _required;
   void _form;
 
+  // Dev-only invariant: a creatable picker without a search input has no
+  // way to capture the new label. Throw early so the misconfiguration is
+  // obvious during development; stripped in prod builds.
+  if (process.env.NODE_ENV !== 'production' && creatable && !searchable) {
+    throw new Error(
+      '<Select>: `creatable` requires `searchable`. A creatable picker without a search input has no way to capture the new label.',
+    );
+  }
+
   const reactId = useId();
   const idBase = sanitizeId(reactId);
   const listboxId = `select-listbox-${idBase}`;
@@ -199,17 +222,29 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
   // the second arg. `findOption` / `findOptions` are O(n); for the option
   // counts a Select handles in practice this is fine and keeps the public
   // API ergonomic (consumers get the matched payload, not just the id).
+  //
+  // Creatable: when the user accepts the "+ Create" row, the new value is
+  // not in `options`. Back-fill a synthetic `{ value: v, label: v }` so
+  // consumers still receive a stable option payload for the new row —
+  // mirrors the shape the create-row carries internally.
   const state = useSelectState({
     multiple,
     value: controlledValue,
     defaultValue,
     onChange: (v) => {
       if (multiple) {
-        const opts = findOptions(options, Array.isArray(v) ? v : []);
+        const values = Array.isArray(v) ? v : [];
+        const found = findOptions(options, values);
+        const byValue = new Map(found.map((o) => [o.value, o]));
+        const opts = values.map((val) => byValue.get(val) ?? { value: val, label: val });
         onChange?.(v, opts);
       } else {
-        const opt = typeof v === 'string' && v !== '' ? findOption(options, v) : null;
-        onChange?.(v, opt);
+        if (typeof v === 'string' && v !== '') {
+          const opt = findOption(options, v) ?? { value: v, label: v };
+          onChange?.(v, opt);
+        } else {
+          onChange?.(v, null);
+        }
       }
     },
     open: controlledOpen,
@@ -296,6 +331,38 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     return out;
   }, [allRows, searchable, query, loadOptions]);
 
+  // Creatable: compute an extra "+ Create <query>" row when the trimmed
+  // query has no exact label match in the available options AND, in multi
+  // mode, isn't already in the current selection. The sentinel
+  // `{ __create: true }` on `data` is what `isCreateRow` matches, and what
+  // the listbox + keyboard handlers branch on to fire `onCreate` instead
+  // of the normal select/toggle flow.
+  const createRow: FlatRow | null = useMemo(() => {
+    const trimmed = query.trim();
+    if (!creatable || !searchable || trimmed === '') return null;
+    if (hasExactLabelMatch(effectiveOptions, trimmed)) return null;
+    if (multiple) {
+      const currentValues = Array.isArray(state.value) ? (state.value as string[]) : [];
+      if (currentValues.some((v) => v.toLowerCase() === trimmed.toLowerCase())) return null;
+    }
+    return {
+      kind: 'option' as const,
+      option: {
+        value: trimmed,
+        label: trimmed,
+        data: { __create: true } as unknown,
+      },
+    };
+  }, [creatable, searchable, query, effectiveOptions, multiple, state.value]);
+
+  // Append the create row to the end of the filtered (or async) rows. The
+  // unfiltered `allRows` deliberately does NOT include the create row —
+  // chip / summary label lookups walk `allRows` and the create row has no
+  // selected counterpart there.
+  const rowsWithCreate = useMemo(() => {
+    return createRow ? [...rows, createRow] : rows;
+  }, [rows, createRow]);
+
   const triggerRef = useRef<HTMLElement | null>(null);
   const listboxRef = useRef<HTMLUListElement | null>(null);
 
@@ -312,7 +379,7 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     searchable,
     creatable,
     triggerDisplay,
-    rows,
+    rows: rowsWithCreate,
     allRows,
     loading: loadOptions ? asyncResult.loading : false,
     error: loadOptions ? asyncResult.error : null,
@@ -333,6 +400,7 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     listboxRef,
     closeAndFocusTrigger,
     retry: asyncResult.retry,
+    onCreate,
     renderOption: renderOption as SelectContextValue['renderOption'],
     renderValue: renderValue as SelectContextValue['renderValue'],
     renderTag: renderTag as SelectContextValue['renderTag'],

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -193,12 +193,41 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     onOpenChange,
   });
 
-  // Phase 2: no filter yet, so `rows` and `allRows` are identical. Phase 4
-  // (searchable) splits them — `rows` becomes the filtered subset.
   const allRows = useMemo(() => flattenOptions(options), [options]);
-  const rows = allRows;
   const [activeIndex, setActiveIndex] = useState<number>(-1);
   const [query, setQuery] = useState<string>('');
+
+  // When `searchable`, filter `allRows` by the query (case-insensitive
+  // substring on label OR description). Group headers are retained only
+  // when at least one option underneath them matches — a header sitting
+  // alone in the listbox is noise.
+  //
+  // Empty query short-circuits to the unfiltered list so the open-effect
+  // in Listbox lands on the user's selected row, and so the first
+  // ArrowDown after open lands on row 0 instead of row 0-of-filtered.
+  const rows = useMemo(() => {
+    if (!searchable || query.trim() === '') return allRows;
+    const q = query.toLowerCase();
+    const out: typeof allRows = [];
+    let pendingHeader: (typeof allRows)[number] | null = null;
+    for (const row of allRows) {
+      if (row.kind === 'header') {
+        pendingHeader = row;
+        continue;
+      }
+      const matches =
+        row.option.label.toLowerCase().includes(q) ||
+        (row.option.description?.toLowerCase().includes(q) ?? false);
+      if (matches) {
+        if (pendingHeader) {
+          out.push(pendingHeader);
+          pendingHeader = null;
+        }
+        out.push(row);
+      }
+    }
+    return out;
+  }, [allRows, searchable, query]);
 
   const triggerRef = useRef<HTMLElement | null>(null);
   const listboxRef = useRef<HTMLUListElement | null>(null);

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -22,13 +22,18 @@ import { Trigger } from './Trigger';
 import { Listbox } from './Listbox';
 import { HiddenInputs } from './HiddenInputs';
 
-/** Trigger height + type-scale step. Mirrors `<Input>`'s `size`. */
+/**
+ * Visual size of the trigger. Mirrors `<Input>` and `<Button>` sizes.
+ * - `'sm'` — 24px tall; dense toolbars and tables.
+ * - `'md'` — 32px tall (default).
+ * - `'lg'` — 40px tall; hero-form prominence.
+ */
 export type SelectSize = 'sm' | 'md' | 'lg';
 
 /**
- * How multi-select renders the selected value(s) inside the trigger.
- * - `'chips'` — render one removable chip per value (the default).
- * - `'summary'` — render a single condensed string like "Foo, Bar, …".
+ * How a multi-select renders its selections inside the trigger.
+ * - `'chips'` — inline removable chips; wraps vertically as needed (default).
+ * - `'summary'` — comma-joined labels with ellipsis on overflow; reads as a single line.
  */
 export type SelectTriggerDisplay = 'chips' | 'summary';
 
@@ -77,6 +82,12 @@ export interface SelectProps<T = unknown> extends Omit<
   'onChange' | 'defaultValue'
 > {
   // ─── data ─────────────────────────────────────────────────────────────────
+  /**
+   * Sync options — flat list or list of groups. Ignored when `loadOptions`
+   * is provided (dev warning fires if both are non-empty). For grouped
+   * input, every element must carry an `options` field; mixing flat options
+   * with groups at the same level is not supported.
+   */
   options?: SelectOptions<T>;
 
   // ─── async data ───────────────────────────────────────────────────────────
@@ -84,7 +95,9 @@ export interface SelectProps<T = unknown> extends Omit<
    * Async fetcher that returns the options for a given query. When set, the
    * Select switches to async mode: the local substring filter is bypassed
    * (the server filters), loading/error/empty rows replace the listbox
-   * body, and `options` is ignored (with a dev warning).
+   * body, and `options` is ignored (with a dev warning). The `signal`
+   * argument is aborted whenever a newer query supersedes this one — wire
+   * it through to `fetch` to cancel in-flight requests.
    */
   loadOptions?: (query: string, signal: AbortSignal) => Promise<SelectOptions<T>>;
   /**
@@ -93,15 +106,34 @@ export interface SelectProps<T = unknown> extends Omit<
    */
   loadOnOpen?: boolean;
   /**
-   * Debounce window (ms) between the last `query` keystroke and the next
-   * `loadOptions` call. Default 250 ms.
+   * Debounce window (ms) between the last query keystroke and the next
+   * `loadOptions` call. Default `250`.
    */
   searchDebounceMs?: number;
 
   // ─── mode ─────────────────────────────────────────────────────────────────
+  /**
+   * Enables multi-select. `value` / `defaultValue` become `string[]` and
+   * `onChange` emits arrays. Picking a row toggles it in/out of the
+   * selection instead of replacing-and-closing.
+   */
   multiple?: boolean;
+  /**
+   * How the trigger renders the selected value(s) in multi mode. Ignored
+   * in single mode. See `SelectTriggerDisplay`. Defaults to `'chips'`.
+   */
   triggerDisplay?: SelectTriggerDisplay;
+  /**
+   * Renders the trigger as a combobox text input with substring filtering
+   * over the (sync) options. In async mode the filter is delegated to the
+   * server. Required by `creatable`.
+   */
   searchable?: boolean;
+  /**
+   * Adds a "+ Create <query>" row when the trimmed query has no exact
+   * label match. Activating it fires `onCreate(label)` and folds the new
+   * value into the selection. Requires `searchable` (throws in dev otherwise).
+   */
   creatable?: boolean;
   /**
    * Fires when the user activates the "+ Create" row (creatable mode).
@@ -117,41 +149,136 @@ export interface SelectProps<T = unknown> extends Omit<
   onCreate?: (label: string) => void;
 
   // ─── value ────────────────────────────────────────────────────────────────
+  /**
+   * Controlled selection. `string` in single mode, `string[]` in multi.
+   * Provide alongside `onChange` to drive the value externally.
+   */
   value?: string | string[];
+  /**
+   * Initial selection for uncontrolled usage. `string` in single mode,
+   * `string[]` in multi. Ignored when `value` is provided.
+   */
   defaultValue?: string | string[];
+  /**
+   * Fires when the selection changes. The first argument is the next
+   * value (`string` in single mode, `string[]` in multi). The second
+   * argument is the matched `SelectOption` (single), the matched array
+   * (multi), or `null` when the selection clears in single mode. For
+   * creatable rows not present in `options`, a synthetic
+   * `{ value, label: value }` is supplied.
+   */
   onChange?: (value: string | string[], option: SelectOption<T> | SelectOption<T>[] | null) => void;
 
   // ─── open state (controlled, rare) ────────────────────────────────────────
+  /**
+   * Controlled open state. Pair with `onOpenChange`. Omit both to let
+   * Select own its open state (the common case).
+   */
   open?: boolean;
+  /** Initial open state for uncontrolled usage. Defaults to `false`. */
   defaultOpen?: boolean;
+  /** Fires whenever Select wants to change open state. */
   onOpenChange?: (open: boolean) => void;
 
   // ─── visuals ──────────────────────────────────────────────────────────────
+  /** Trigger height + type scale. See `SelectSize`. Defaults to `'md'`. */
   size?: SelectSize;
+  /**
+   * Marks the trigger as invalid — applies the error border + sets
+   * `aria-invalid="true"`. Pair with an external error message linked via
+   * `aria-describedby`.
+   */
   invalid?: boolean;
+  /**
+   * Placeholder shown when nothing is selected. In searchable mode, also
+   * the input's `placeholder` until the user types.
+   */
   placeholder?: string;
+  /**
+   * Shows a `✕` button in the trigger that clears the selection. Default
+   * is `true` in single mode (when not `required`), `false` in multi mode.
+   * Forced `false` when `disabled` or `readOnly`.
+   */
   clearable?: boolean;
 
   // ─── states ───────────────────────────────────────────────────────────────
+  /**
+   * Disables the trigger entirely — non-interactive, dimmed, focusable
+   * only via assistive tech. Hidden form inputs are also disabled.
+   */
   disabled?: boolean;
+  /**
+   * Read-only — trigger is focusable but cannot open or change the
+   * selection. Useful for displaying a value inside a form that's not yet
+   * editable.
+   */
   readOnly?: boolean;
 
-  // ─── form integration (wired in later phases) ─────────────────────────────
+  // ─── form integration ─────────────────────────────────────────────────────
+  /**
+   * Name attribute for native form submission. In multi mode, one hidden
+   * `<input>` per selected value is emitted (so `FormData.getAll(name)`
+   * returns the array).
+   */
   name?: string;
+  /**
+   * Marks the field as required for native form validation. When `true`,
+   * `clearable` defaults to `false` and an empty selection blocks submit.
+   */
   required?: boolean;
+  /** `form` attribute forwarded to the hidden `<input>` elements. */
   form?: string;
 
-  // ─── render escape hatches (wired in later phases) ────────────────────────
+  // ─── render escape hatches ────────────────────────────────────────────────
+  /**
+   * Custom renderer for a row inside the listbox. Receives the option and
+   * its current `{ active, selected }` state (active = keyboard-focused
+   * row, selected = part of the current value). The returned node
+   * replaces the default label / description layout — chrome (padding,
+   * background, `aria-*`) stays.
+   */
   renderOption?: (opt: SelectOption<T>, state: { active: boolean; selected: boolean }) => ReactNode;
+  /**
+   * Custom renderer for the selected value inside the single-mode trigger.
+   * Ignored in multi mode (see `renderTag`).
+   */
   renderValue?: (opt: SelectOption<T>) => ReactNode;
+  /**
+   * Custom renderer for a chip inside the multi-mode `chips` trigger.
+   * Receives the option and a `remove` callback that deselects it. Ignored
+   * in single mode and in `triggerDisplay='summary'`.
+   */
   renderTag?: (opt: SelectOption<T>, remove: () => void) => ReactNode;
+  /**
+   * Custom empty-state renderer. Fires when the filtered listbox has no
+   * rows. Receives the current trimmed query for use in messages like
+   * "No matches for 'foo'".
+   */
   renderEmpty?: (query: string) => ReactNode;
+  /** Custom loading-state renderer for async mode. */
   renderLoading?: () => ReactNode;
+  /**
+   * Custom error-state renderer for async mode. Receives the thrown
+   * `Error` and a `retry` callback that re-invokes `loadOptions` with the
+   * current query.
+   */
   renderError?: (err: Error, retry: () => void) => ReactNode;
 
   // ─── ARIA ─────────────────────────────────────────────────────────────────
+  /**
+   * Accessible name for the trigger. Use this when a visible `<label>` is
+   * not present. Mutually exclusive with `aria-labelledby`.
+   */
   'aria-label'?: string;
+  /**
+   * ID of an element that labels the trigger. Use when the label is a
+   * sibling node (e.g. a `<Field>` label).
+   */
   'aria-labelledby'?: string;
+  /**
+   * ID of an element that describes the trigger — e.g. an error message
+   * or helper hint paired with `invalid`.
+   */
   'aria-describedby'?: string;
 }
 
@@ -453,23 +580,81 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
 });
 
 /**
- * `<Select>` — combo of trigger + popover listbox.
+ * Value picker — covers single, multi (chips and summary), searchable,
+ * grouped, async-loaded, and creatable patterns in one component.
+ * Implements the WAI-ARIA combobox 1.2 pattern with a `role="listbox"`
+ * popup, full keyboard navigation (Arrow keys, Home/End, typeahead,
+ * Enter/Space to select, Escape to dismiss), and ARIA wiring suitable for
+ * screen readers.
  *
- * Phase 2 covers the single-value, non-searchable, sync-options shape:
- * button-styled trigger that opens a portaled listbox. Click an option
- * (or `Enter` on the active row) to select; `Escape` / outside click
- * dismisses. The full prop surface is declared on `SelectProps` so the
- * type-level contract is stable across later phases.
+ * The mode matrix is `multiple` × `triggerDisplay: 'chips' | 'summary'` ×
+ * `searchable`. Tag-input is the composition
+ * `multiple + searchable + creatable + triggerDisplay='chips'`.
  *
  * @example
- *   const [status, setStatus] = useState('');
- *   <Select
- *     options={STATUSES}
- *     value={status}
- *     onChange={(v) => setStatus(v as string)}
- *     placeholder="Pick one"
- *   />
+ * // Single, non-searchable status picker
+ * <Select
+ *   options={[{ value: 'active', label: 'Active' }, { value: 'pending', label: 'Pending' }]}
+ *   value={status}
+ *   onChange={(v) => setStatus(v as Status)}
+ *   placeholder="Pick a status"
+ * />
+ *
+ * @example
+ * // Async assignee picker with custom rendering
+ * <Select
+ *   searchable
+ *   loadOptions={async (q, signal) => {
+ *     const users = await api.searchUsers(q, { signal });
+ *     return users.map((u) => ({ value: u.id, label: u.name, data: u }));
+ *   }}
+ *   renderOption={(opt) => (
+ *     <Cluster gap="sm">
+ *       <Avatar name={opt.label} src={opt.data?.avatarUrl} size="sm" />
+ *       <span>{opt.label}</span>
+ *     </Cluster>
+ *   )}
+ *   value={assigneeId}
+ *   onChange={(id) => setAssigneeId(id as string)}
+ * />
+ *
+ * @example
+ * // Tag input with creatable
+ * <Select
+ *   multiple
+ *   searchable
+ *   creatable
+ *   options={existingTags}
+ *   value={tags}
+ *   onChange={(v) => setTags(v as string[])}
+ *   onCreate={(label) => api.tags.create({ label })}
+ *   placeholder="Add tags…"
+ * />
+ *
+ * @remarks When NOT to use
+ * - For action menus (Edit / Delete / Duplicate) → use `<DropdownMenu>`.
+ * - For free-form text with no constrained value set → use `<Input>`.
+ * - For yes/no/maybe with strong defaults → use `<Tabs>` or radio buttons.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Passing both `options` and `loadOptions`. `loadOptions` always
+ *   wins; the conflict is logged as a dev warning.
+ * - ❌ `creatable` without `searchable`. There's no way to capture the
+ *   new label without a search input. Throws in dev.
+ * - ❌ Using `triggerDisplay='summary'` for tag input. Summary collapses
+ *   the active set into a comma-joined line; chips communicate selection
+ *   at a glance and expose per-item remove affordances.
+ * - ❌ Embedding stale-closure business logic in `loadOptions`. The
+ *   fetcher is called on every debounced query — read fresh props from a
+ *   stable reference (e.g. `useCallback` in the consumer) instead of
+ *   capturing values that drift.
  */
+// `Select` is exposed via a cast so the public type is generic over `T`
+// — `forwardRef` does not preserve the generic parameter through its own
+// signature. Internally `SelectImpl` is the forwardRef component; the cast
+// only rewrites its type surface. Do not "fix" this by dropping the cast —
+// you'll lose the `T` inference that flows from `options` into `onChange`'s
+// option payload.
 export const Select = SelectImpl as <T = unknown>(
   props: SelectProps<T> & { ref?: Ref<HTMLDivElement> },
 ) => React.ReactElement;

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -20,6 +20,7 @@ import { flattenOptions, findOption, findOptions, hasExactLabelMatch } from './u
 import type { FlatRow } from './utils';
 import { Trigger } from './Trigger';
 import { Listbox } from './Listbox';
+import { HiddenInputs } from './HiddenInputs';
 
 /** Trigger height + type-scale step. Mirrors `<Input>`'s `size`. */
 export type SelectSize = 'sm' | 'md' | 'lg';
@@ -180,9 +181,9 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     clearable,
     disabled = false,
     readOnly = false,
-    name: _name,
-    required: _required,
-    form: _form,
+    name,
+    required,
+    form,
     renderOption,
     renderValue,
     renderTag,
@@ -192,12 +193,6 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     className,
     ...rest
   } = props;
-
-  // `_name` / `_required` / `_form` are accepted in the prop surface so the
-  // public API is stable across phases; form integration is wired in Phase 9.
-  void _name;
-  void _required;
-  void _form;
 
   // Dev-only invariant: a creatable picker without a search input has no
   // way to capture the new label. Throw early so the misconfiguration is
@@ -434,6 +429,14 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
           aria-describedby={props['aria-describedby']}
         />
         {state.open && <Listbox />}
+        <HiddenInputs
+          name={name}
+          value={state.value}
+          multiple={multiple}
+          required={required ?? false}
+          form={form}
+          disabled={disabled}
+        />
       </div>
     </SelectContext.Provider>
   );

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -1,6 +1,7 @@
 import {
   forwardRef,
   useCallback,
+  useEffect,
   useId,
   useMemo,
   useRef,
@@ -14,6 +15,7 @@ import styles from './Select.module.scss';
 import { SelectContext, type SelectContextValue } from './context';
 import { sanitizeId } from '../_internal/refs';
 import { useSelectState } from './useSelectState';
+import { useAsyncOptions } from './useAsyncOptions';
 import { flattenOptions, findOption, findOptions } from './utils';
 import { Trigger } from './Trigger';
 import { Listbox } from './Listbox';
@@ -75,6 +77,25 @@ export interface SelectProps<T = unknown> extends Omit<
   // ─── data ─────────────────────────────────────────────────────────────────
   options?: SelectOptions<T>;
 
+  // ─── async data ───────────────────────────────────────────────────────────
+  /**
+   * Async fetcher that returns the options for a given query. When set, the
+   * Select switches to async mode: the local substring filter is bypassed
+   * (the server filters), loading/error/empty rows replace the listbox
+   * body, and `options` is ignored (with a dev warning).
+   */
+  loadOptions?: (query: string, signal: AbortSignal) => Promise<SelectOptions<T>>;
+  /**
+   * When `true` (default), defers the first `loadOptions` call until the
+   * user opens the listbox. Set to `false` to fetch eagerly on mount.
+   */
+  loadOnOpen?: boolean;
+  /**
+   * Debounce window (ms) between the last `query` keystroke and the next
+   * `loadOptions` call. Default 250 ms.
+   */
+  searchDebounceMs?: number;
+
   // ─── mode ─────────────────────────────────────────────────────────────────
   multiple?: boolean;
   triggerDisplay?: SelectTriggerDisplay;
@@ -126,6 +147,9 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
 ) {
   const {
     options = [],
+    loadOptions,
+    loadOnOpen = true,
+    searchDebounceMs = 250,
     multiple = false,
     triggerDisplay = 'chips',
     searchable = false,
@@ -193,9 +217,47 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     onOpenChange,
   });
 
-  const allRows = useMemo(() => flattenOptions(options), [options]);
+  // Dev-only sanity check: a Select can't sensibly take both `options` and
+  // `loadOptions`. We pick `loadOptions` (the more specific API) and warn
+  // so the consumer notices their config conflict during dev. Stripped in
+  // prod builds by the bundler dead-code path.
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    loadOptions &&
+    Array.isArray(options) &&
+    options.length > 0
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '<Select> received both `options` and `loadOptions`. `loadOptions` wins; `options` is ignored.',
+    );
+  }
+
   const [activeIndex, setActiveIndex] = useState<number>(-1);
   const [query, setQuery] = useState<string>('');
+
+  // `hasOpenedOnce` gates the first async fetch. The `loadOnOpen` semantic
+  // is: don't fetch anything until the user opens the popover at least
+  // once. `loadOnOpen=false` flips the gate immediately on mount.
+  const [hasOpenedOnce, setHasOpenedOnce] = useState<boolean>(!loadOnOpen);
+  useEffect(() => {
+    if (state.open && !hasOpenedOnce) setHasOpenedOnce(true);
+  }, [state.open, hasOpenedOnce]);
+
+  const asyncEnabled = !!loadOptions && hasOpenedOnce;
+  const asyncResult = useAsyncOptions({
+    loadOptions,
+    query,
+    enabled: asyncEnabled,
+    debounceMs: searchDebounceMs,
+  });
+
+  // In async mode, the backend's response replaces the local `options`
+  // entirely. The label cache for already-selected values is a Phase 8+
+  // concern — chips may temporarily render `<unknown>` while the latest
+  // server response filters their option out.
+  const effectiveOptions = loadOptions ? asyncResult.options : options;
+  const allRows = useMemo(() => flattenOptions(effectiveOptions), [effectiveOptions]);
 
   // When `searchable`, filter `allRows` by the query (case-insensitive
   // substring on label OR description). Group headers are retained only
@@ -206,6 +268,11 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
   // in Listbox lands on the user's selected row, and so the first
   // ArrowDown after open lands on row 0 instead of row 0-of-filtered.
   const rows = useMemo(() => {
+    // Async mode: the backend already filtered to the current query, so
+    // local re-filtering would double-filter (e.g. backend matches by
+    // word-prefix, we'd then drop rows whose label doesn't contain the
+    // exact substring).
+    if (loadOptions) return allRows;
     if (!searchable || query.trim() === '') return allRows;
     const q = query.toLowerCase();
     const out: typeof allRows = [];
@@ -227,7 +294,7 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
       }
     }
     return out;
-  }, [allRows, searchable, query]);
+  }, [allRows, searchable, query, loadOptions]);
 
   const triggerRef = useRef<HTMLElement | null>(null);
   const listboxRef = useRef<HTMLUListElement | null>(null);
@@ -247,8 +314,8 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     triggerDisplay,
     rows,
     allRows,
-    loading: false,
-    error: null,
+    loading: loadOptions ? asyncResult.loading : false,
+    error: loadOptions ? asyncResult.error : null,
     value: state.value,
     setValue: state.setValue,
     toggleValue: state.toggleValue,
@@ -265,7 +332,7 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     triggerRef,
     listboxRef,
     closeAndFocusTrigger,
-    retry: () => {},
+    retry: asyncResult.retry,
     renderOption: renderOption as SelectContextValue['renderOption'],
     renderValue: renderValue as SelectContextValue['renderValue'],
     renderTag: renderTag as SelectContextValue['renderTag'],

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -2,6 +2,56 @@ import { forwardRef, type HTMLAttributes } from 'react';
 import clsx from 'clsx';
 import styles from './Select.module.scss';
 
+/** Trigger height + type-scale step. Mirrors `<Input>`'s `size`. */
+export type SelectSize = 'sm' | 'md' | 'lg';
+
+/**
+ * How multi-select renders the selected value(s) inside the trigger.
+ * - `'chips'` — render one removable chip per value (the default).
+ * - `'summary'` — render a single condensed string like "3 selected".
+ */
+export type SelectTriggerDisplay = 'chips' | 'summary';
+
+/**
+ * One row of selectable data.
+ *
+ * `value` is the identity that `onChange` emits and that `value` /
+ * `defaultValue` reference. `label` is what the user sees and what
+ * the substring filter searches against. `data` is an opaque payload
+ * that flows through to `renderOption`, `renderValue`, and `renderTag`.
+ */
+export interface SelectOption<T = unknown> {
+  /** Unique key. What `onChange` emits. */
+  value: string;
+  /** Displayed text. Used for substring search when `searchable` is on. */
+  label: string;
+  /** Optional secondary line shown under the label in default render. */
+  description?: string;
+  /** When true, the option is dimmed, `aria-disabled`, and skipped in keyboard nav. */
+  disabled?: boolean;
+  /** Arbitrary payload — surfaces in `renderOption`, `renderValue`, `renderTag`. */
+  data?: T;
+}
+
+/**
+ * A labelled bucket of options. Use grouped input when you want a header
+ * row to appear above a chunk of options. Mixing flat options and groups
+ * at the same level is not supported — the input must be all-flat or
+ * all-grouped.
+ */
+export interface SelectGroup<T = unknown> {
+  /** Header text shown above the group's options. */
+  label: string;
+  /** Members of the group. */
+  options: SelectOption<T>[];
+}
+
+/**
+ * Either a flat list of options or a list of groups, discriminated at
+ * runtime by inspecting whether the first element has an `options` field.
+ */
+export type SelectOptions<T = unknown> = SelectOption<T>[] | SelectGroup<T>[];
+
 export interface SelectProps extends HTMLAttributes<HTMLDivElement> {}
 
 /**

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -1,0 +1,18 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './Select.module.scss';
+
+export interface SelectProps extends HTMLAttributes<HTMLDivElement> {}
+
+/**
+ * Scaffold root for the Select component. Phase 1 only renders an empty
+ * forwardRef'd `<div>` so the rest of the foundation work (types, utils,
+ * state hook) can land before Trigger / Listbox / Content are wired in
+ * Phase 2.
+ */
+export const Select = forwardRef<HTMLDivElement, SelectProps>(function Select(
+  { className, ...props },
+  ref,
+) {
+  return <div ref={ref} data-select="" className={clsx(styles.root, className)} {...props} />;
+});

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -648,6 +648,11 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
  *   fetcher is called on every debounced query — read fresh props from a
  *   stable reference (e.g. `useCallback` in the consumer) instead of
  *   capturing values that drift.
+ *
+ * @remarks Keyboard limitations (v1)
+ * - In chips-mode, Backspace on an empty input removes the trailing chip;
+ *   full chip-to-chip arrow navigation (ArrowLeft from empty input stepping
+ *   into chips, ArrowLeft/Right cycling chips) is not implemented in v1.
  */
 // `Select` is exposed via a cast so the public type is generic over `T`
 // — `forwardRef` does not preserve the generic parameter through its own

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -88,7 +88,10 @@ export function Trigger(props: TriggerProps) {
     if (typeaheadTimerRef.current) clearTimeout(typeaheadTimerRef.current);
     typeaheadBufferRef.current += char.toLowerCase();
     const buffer = typeaheadBufferRef.current;
-    const start = ctx.activeIndex >= 0 ? ctx.activeIndex : 0;
+    // When activeIndex is -1 (no current cursor — typeahead opening the menu
+    // from the closed state), use -1 as the start so the `+1` first-char
+    // offset lands on index 0 instead of skipping past it.
+    const start = ctx.activeIndex >= 0 ? ctx.activeIndex : -1;
     const len = ctx.rows.length;
     for (let i = 0; i < len; i++) {
       const idx = (start + i + (buffer.length === 1 ? 1 : 0)) % len;

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type KeyboardEvent, type Ref } from 'react';
+import { useCallback, useEffect, useRef, type KeyboardEvent, type Ref } from 'react';
 import clsx from 'clsx';
 import { useSelectContext } from './context';
 import styles from './Select.module.scss';
@@ -70,6 +70,40 @@ export function Trigger(props: TriggerProps) {
     [ctx],
   );
 
+  // Typeahead: 500ms buffer that resets on idle. Mirrors DropdownMenu's
+  // pattern. Walks rows starting from `activeIndex + 1` on the first
+  // char (so successive typing of the same letter cycles through
+  // matches) and from `activeIndex` thereafter (so 'al' refines 'a'
+  // without skipping the current candidate).
+  const typeaheadBufferRef = useRef('');
+  const typeaheadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (typeaheadTimerRef.current) clearTimeout(typeaheadTimerRef.current);
+    };
+  }, []);
+
+  const stepTypeahead = (char: string) => {
+    if (typeaheadTimerRef.current) clearTimeout(typeaheadTimerRef.current);
+    typeaheadBufferRef.current += char.toLowerCase();
+    const buffer = typeaheadBufferRef.current;
+    const start = ctx.activeIndex >= 0 ? ctx.activeIndex : 0;
+    const len = ctx.rows.length;
+    for (let i = 0; i < len; i++) {
+      const idx = (start + i + (buffer.length === 1 ? 1 : 0)) % len;
+      const r = ctx.rows[idx];
+      if (r.kind !== 'option' || r.option.disabled) continue;
+      if (r.option.label.toLowerCase().startsWith(buffer)) {
+        ctx.setActiveIndex(idx);
+        break;
+      }
+    }
+    typeaheadTimerRef.current = setTimeout(() => {
+      typeaheadBufferRef.current = '';
+    }, 500);
+  };
+
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
     if (props.disabled || props.readOnly) return;
 
@@ -88,6 +122,13 @@ export function Trigger(props: TriggerProps) {
         // microtask so this runs after the Listbox mounts and sets it.
         queueMicrotask(() => ctx.setActiveIndex(lastSelectableIdx));
         return;
+      }
+      // Typeahead-open: any printable char (no modifiers) opens the
+      // listbox and seeds the typeahead buffer with that char.
+      if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        ctx.setOpen(true);
+        stepTypeahead(e.key);
       }
       return;
     }
@@ -140,8 +181,16 @@ export function Trigger(props: TriggerProps) {
         // (now-closed) trigger to the next focusable element.
         ctx.setOpen(false);
         return;
-      default:
+      default: {
+        // Printable char (single char, no modifier keys) → typeahead.
+        // Sits after the explicit cases so Enter/Space/' ' etc. above
+        // are handled first.
+        if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+          e.preventDefault();
+          stepTypeahead(e.key);
+        }
         return;
+      }
     }
   };
 

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -11,6 +11,7 @@ import {
 import clsx from 'clsx';
 import { useSelectContext } from './context';
 import { Chip } from './Chip';
+import type { SelectOption } from './Select';
 import styles from './Select.module.scss';
 
 export interface TriggerProps {
@@ -381,6 +382,29 @@ function ButtonTrigger(props: TriggerProps) {
 
   const showClear = props.clearable && hasValue;
 
+  // Resolve the visible label node. In single mode, `renderValue` (if
+  // supplied) replaces the bare string with whatever the consumer returns.
+  // Multi-summary deliberately stays as the comma-joined string — applying
+  // `renderValue` to it would mean passing N options, which doesn't fit the
+  // single-option signature; for richer multi labels use `renderTag` on
+  // chips mode instead.
+  //
+  // The accessible-name computation falls back to the option label string,
+  // not the rendered node, so screen readers still hear "Pending" even if
+  // the consumer wraps it in decoration.
+  const labelNode: React.ReactNode = (() => {
+    if (!label) return null;
+    if (!ctx.multiple && ctx.renderValue) {
+      const selRow = ctx.allRows.find(
+        (r) => r.kind === 'option' && r.option.value === (ctx.value as string),
+      );
+      if (selRow && selRow.kind === 'option') {
+        return ctx.renderValue(selRow.option as SelectOption);
+      }
+    }
+    return label;
+  })();
+
   return (
     <div className={styles.triggerWrap}>
       <button
@@ -405,7 +429,7 @@ function ButtonTrigger(props: TriggerProps) {
         onKeyDown={handleKeyDown}
       >
         {label ? (
-          <span>{label}</span>
+          <span>{labelNode}</span>
         ) : (
           <span className={styles.placeholder}>{props.placeholder ?? ''}</span>
         )}
@@ -417,6 +441,11 @@ function ButtonTrigger(props: TriggerProps) {
     </div>
   );
 }
+
+// `renderValue` deliberately does NOT apply to the ComboboxInputTrigger
+// variant: the input's `value` prop must be a string, but `renderValue`
+// returns a ReactNode. Consumers using `searchable` who want decorated
+// labels should look at non-searchable mode or compose at the option level.
 
 // ────────────────────────────────────────────────────────────────────────────
 // ComboboxInputTrigger — single + searchable (WAI-ARIA combobox 1.2
@@ -582,11 +611,13 @@ function ChipsInputTrigger(props: TriggerProps) {
 
   const selectedValues = Array.isArray(ctx.value) ? (ctx.value as string[]) : [];
   // Walk `allRows` so chip labels persist even while typing filters
-  // `rows` down to a subset that excludes them.
-  const selectedOptions: { value: string; label: string }[] = [];
+  // `rows` down to a subset that excludes them. Preserve the full
+  // SelectOption — `renderTag` callbacks receive `data` and `description`
+  // too, not just `value` / `label`.
+  const selectedOptions: SelectOption[] = [];
   for (const row of ctx.allRows) {
     if (row.kind === 'option' && selectedValues.includes(row.option.value)) {
-      selectedOptions.push({ value: row.option.value, label: row.option.label });
+      selectedOptions.push(row.option as SelectOption);
     }
   }
 
@@ -640,18 +671,19 @@ function ChipsInputTrigger(props: TriggerProps) {
       onClick={handleWrapperClick}
       onPointerDown={handleWrapperPointerDown}
     >
-      {selectedOptions.map((o) => (
-        <Chip
-          key={o.value}
-          label={o.label}
-          disabled={props.disabled}
-          onRemove={() => {
-            if (props.disabled || props.readOnly) return;
-            ctx.toggleValue(o.value);
-            inputRef.current?.focus();
-          }}
-        />
-      ))}
+      {selectedOptions.map((o) => {
+        const remove = () => {
+          if (props.disabled || props.readOnly) return;
+          ctx.toggleValue(o.value);
+          inputRef.current?.focus();
+        };
+        if (ctx.renderTag) {
+          // Wrap in a keyed Fragment so React can track ordering. The
+          // consumer owns the inner markup (click handlers, styling, etc.).
+          return <span key={o.value}>{ctx.renderTag(o, remove)}</span>;
+        }
+        return <Chip key={o.value} label={o.label} disabled={props.disabled} onRemove={remove} />;
+      })}
       <input
         ref={inputRef}
         type="text"
@@ -719,10 +751,12 @@ function ChipsButtonTrigger(props: TriggerProps) {
   const selectedValues = Array.isArray(ctx.value) ? (ctx.value as string[]) : [];
   // Walk `allRows` (not `rows`) so chips remain present even when a future
   // search query filters the popover — selection is independent of filter.
-  const selectedOptions: { value: string; label: string }[] = [];
+  // Preserve full SelectOption so `renderTag` callbacks get `data` /
+  // `description` access, not just `value` / `label`.
+  const selectedOptions: SelectOption[] = [];
   for (const row of ctx.allRows) {
     if (row.kind === 'option' && selectedValues.includes(row.option.value)) {
-      selectedOptions.push({ value: row.option.value, label: row.option.label });
+      selectedOptions.push(row.option as SelectOption);
     }
   }
 
@@ -772,17 +806,16 @@ function ChipsButtonTrigger(props: TriggerProps) {
       }}
       onKeyDown={handleKeyDown}
     >
-      {selectedOptions.map((o) => (
-        <Chip
-          key={o.value}
-          label={o.label}
-          disabled={props.disabled}
-          onRemove={() => {
-            if (props.disabled || props.readOnly) return;
-            ctx.toggleValue(o.value);
-          }}
-        />
-      ))}
+      {selectedOptions.map((o) => {
+        const remove = () => {
+          if (props.disabled || props.readOnly) return;
+          ctx.toggleValue(o.value);
+        };
+        if (ctx.renderTag) {
+          return <span key={o.value}>{ctx.renderTag(o, remove)}</span>;
+        }
+        return <Chip key={o.value} label={o.label} disabled={props.disabled} onRemove={remove} />;
+      })}
       {selectedOptions.length === 0 && (
         <span className={styles.placeholder}>{props.placeholder ?? ''}</span>
       )}

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -1,3 +1,4 @@
+import { useCallback, type KeyboardEvent, type Ref } from 'react';
 import clsx from 'clsx';
 import { useSelectContext } from './context';
 import styles from './Select.module.scss';
@@ -16,31 +17,148 @@ export interface TriggerProps {
 /**
  * Button-styled trigger for the single, non-searchable Select mode.
  *
- * Phase 2 scope only — Phase 4 will add the searchable combobox-input
- * variant and Phase 6 the chips-input shell. The current implementation
- * stays focused on the button.
+ * Owns the keyboard interaction for the closed-and-open lifecycle:
+ *  - Closed: ArrowDown / Enter / Space open with the Listbox's default
+ *    "first selectable" active row. ArrowUp opens and overrides the
+ *    active row to the last selectable (via a microtask so it runs
+ *    AFTER Listbox's open-effect picks the first one).
+ *  - Open: ArrowUp/Down step through rows (skipping headers + disabled),
+ *    Home/End jump to ends, PageUp/Down move ±5, Enter/Space commit the
+ *    active option (single mode → close; multi → toggle), Escape closes
+ *    without changing selection, Tab closes (no preventDefault — normal
+ *    browser traversal continues).
+ *
+ * Phase 4 (searchable) and Phase 6 (chips) will introduce separate
+ * trigger variants; this file stays scoped to the button.
  */
 export function Trigger(props: TriggerProps) {
   const ctx = useSelectContext('Trigger');
+
   const selectedRow =
     !ctx.multiple && typeof ctx.value === 'string' && ctx.value !== ''
       ? ctx.allRows.find((r) => r.kind === 'option' && r.option.value === ctx.value)
       : null;
   const hasValue = selectedRow !== null && selectedRow !== undefined;
-  const label =
-    hasValue && selectedRow.kind === 'option'
-      ? selectedRow.option.label
-      : (props.placeholder ?? '');
+  const label = hasValue && selectedRow.kind === 'option' ? selectedRow.option.label : '';
+
+  const firstSelectableIdx = ctx.rows.findIndex((r) => r.kind === 'option' && !r.option.disabled);
+  const lastSelectableIdx = (() => {
+    for (let i = ctx.rows.length - 1; i >= 0; i--) {
+      const r = ctx.rows[i];
+      if (r.kind === 'option' && !r.option.disabled) return i;
+    }
+    return -1;
+  })();
+
+  // Cyclic step through rows skipping headers + disabled options.
+  // `delta` of ±1 maps to ArrowDown/Up; PageDown/Up call this 5 times.
+  const moveActive = useCallback(
+    (delta: number) => {
+      const { rows, activeIndex } = ctx;
+      if (rows.length === 0) return;
+      const len = rows.length;
+      let i = activeIndex;
+      for (let step = 0; step < len; step++) {
+        i = (i + delta + len) % len;
+        const r = rows[i];
+        if (r.kind === 'option' && !r.option.disabled) {
+          ctx.setActiveIndex(i);
+          return;
+        }
+      }
+    },
+    [ctx],
+  );
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (props.disabled || props.readOnly) return;
+
+    if (!ctx.open) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        ctx.setOpen(true);
+        // Listbox's open-effect sets active to first selectable; nothing
+        // more to do here.
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        ctx.setOpen(true);
+        // Override the open-effect's "first selectable" pick in a
+        // microtask so this runs after the Listbox mounts and sets it.
+        queueMicrotask(() => ctx.setActiveIndex(lastSelectableIdx));
+        return;
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        moveActive(+1);
+        return;
+      case 'ArrowUp':
+        e.preventDefault();
+        moveActive(-1);
+        return;
+      case 'Home':
+        e.preventDefault();
+        if (firstSelectableIdx >= 0) ctx.setActiveIndex(firstSelectableIdx);
+        return;
+      case 'End':
+        e.preventDefault();
+        if (lastSelectableIdx >= 0) ctx.setActiveIndex(lastSelectableIdx);
+        return;
+      case 'PageDown':
+        e.preventDefault();
+        for (let step = 0; step < 5; step++) moveActive(+1);
+        return;
+      case 'PageUp':
+        e.preventDefault();
+        for (let step = 0; step < 5; step++) moveActive(-1);
+        return;
+      case 'Enter':
+      case ' ': {
+        e.preventDefault();
+        const row = ctx.rows[ctx.activeIndex];
+        if (row && row.kind === 'option' && !row.option.disabled) {
+          if (ctx.multiple) {
+            ctx.toggleValue(row.option.value);
+          } else {
+            ctx.setValue(row.option.value);
+            ctx.closeAndFocusTrigger();
+          }
+        }
+        return;
+      }
+      case 'Escape':
+        e.preventDefault();
+        ctx.closeAndFocusTrigger();
+        return;
+      case 'Tab':
+        // No preventDefault — browser continues Tab traversal from the
+        // (now-closed) trigger to the next focusable element.
+        ctx.setOpen(false);
+        return;
+      default:
+        return;
+    }
+  };
+
+  const activeRow = ctx.open && ctx.activeIndex >= 0 ? ctx.rows[ctx.activeIndex] : undefined;
+  const activeOptionId =
+    activeRow && activeRow.kind === 'option' ? ctx.getOptionId(activeRow.option.value) : undefined;
 
   return (
     <button
       type="button"
       id={ctx.triggerId}
-      ref={ctx.triggerRef as React.Ref<HTMLButtonElement>}
+      ref={ctx.triggerRef as Ref<HTMLButtonElement>}
       className={clsx(styles.trigger, styles.triggerButton, !hasValue && styles.placeholder)}
       aria-haspopup="listbox"
       aria-expanded={ctx.open}
       aria-controls={ctx.open ? ctx.listboxId : undefined}
+      aria-activedescendant={activeOptionId}
       aria-label={props['aria-label']}
       aria-labelledby={props['aria-labelledby']}
       aria-describedby={props['aria-describedby']}
@@ -51,8 +169,9 @@ export function Trigger(props: TriggerProps) {
         if (props.disabled || props.readOnly) return;
         ctx.setOpen(!ctx.open);
       }}
+      onKeyDown={handleKeyDown}
     >
-      {label}
+      {label || props.placeholder || ''}
     </button>
   );
 }

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useRef, type KeyboardEvent, type Ref } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type KeyboardEvent,
+  type MutableRefObject,
+  type Ref,
+} from 'react';
 import clsx from 'clsx';
 import { useSelectContext } from './context';
 import styles from './Select.module.scss';
@@ -14,33 +22,46 @@ export interface TriggerProps {
   'aria-describedby'?: string;
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// Shared helpers
+// ────────────────────────────────────────────────────────────────────────────
+
 /**
- * Button-styled trigger for the single, non-searchable Select mode.
- *
- * Owns the keyboard interaction for the closed-and-open lifecycle:
- *  - Closed: ArrowDown / Enter / Space open with the Listbox's default
- *    "first selectable" active row. ArrowUp opens and overrides the
- *    active row to the last selectable (via a microtask so it runs
- *    AFTER Listbox's open-effect picks the first one).
- *  - Open: ArrowUp/Down step through rows (skipping headers + disabled),
- *    Home/End jump to ends, PageUp/Down move ±5, Enter/Space commit the
- *    active option (single mode → close; multi → toggle), Escape closes
- *    without changing selection, Tab closes (no preventDefault — normal
- *    browser traversal continues).
- *
- * Phase 4 (searchable) and Phase 6 (chips) will introduce separate
- * trigger variants; this file stays scoped to the button.
+ * Computes the `aria-activedescendant` value for whichever trigger is
+ * currently mounted. Returns `undefined` when the listbox is closed,
+ * when the active row is a group header, or when no row is active —
+ * those states must omit the attribute entirely rather than dangling
+ * a stale id (screen readers will announce a non-existent element).
  */
-export function Trigger(props: TriggerProps) {
+function useActiveOptionId(): string | undefined {
+  const ctx = useSelectContext('Trigger');
+  if (!ctx.open || ctx.activeIndex < 0) return undefined;
+  const row = ctx.rows[ctx.activeIndex];
+  if (!row || row.kind !== 'option') return undefined;
+  return ctx.getOptionId(row.option.value);
+}
+
+/**
+ * Shared keyboard navigation hook for both trigger variants.
+ *
+ * Returns `handleNavKey(e)` which:
+ *  - Returns `true` if the key was a navigation key the trigger handled
+ *    (caller should NOT continue to its own variant-specific branch).
+ *  - Returns `false` for keys this hook doesn't own — Tab, printable
+ *    chars, anything not in the WAI-ARIA combobox navigation contract —
+ *    so the caller can layer its own behaviour (typeahead for the button
+ *    variant, query updates for the combobox-input variant).
+ *
+ * Tab returns `false` (and does NOT preventDefault) so the browser
+ * continues normal tab traversal after the side-effect of closing
+ * the popover.
+ */
+function useTriggerKeyboard(opts: { disabled?: boolean; readOnly?: boolean }) {
   const ctx = useSelectContext('Trigger');
 
-  const selectedRow =
-    !ctx.multiple && typeof ctx.value === 'string' && ctx.value !== ''
-      ? ctx.allRows.find((r) => r.kind === 'option' && r.option.value === ctx.value)
-      : null;
-  const hasValue = selectedRow !== null && selectedRow !== undefined;
-  const label = hasValue && selectedRow.kind === 'option' ? selectedRow.option.label : '';
-
+  // Recompute on every render — these are cheap O(n) walks and depending
+  // on stable identity here means memoising over `ctx.rows`, which already
+  // re-creates per render of `<Select>`.
   const firstSelectableIdx = ctx.rows.findIndex((r) => r.kind === 'option' && !r.option.disabled);
   const lastSelectableIdx = (() => {
     for (let i = ctx.rows.length - 1; i >= 0; i--) {
@@ -70,11 +91,8 @@ export function Trigger(props: TriggerProps) {
     [ctx],
   );
 
-  // Typeahead: 500ms buffer that resets on idle. Mirrors DropdownMenu's
-  // pattern. Walks rows starting from `activeIndex + 1` on the first
-  // char (so successive typing of the same letter cycles through
-  // matches) and from `activeIndex` thereafter (so 'al' refines 'a'
-  // without skipping the current candidate).
+  // Typeahead state (only used by ButtonTrigger but lives here so the
+  // hook owns its own timer cleanup).
   const typeaheadBufferRef = useRef('');
   const typeaheadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -84,85 +102,78 @@ export function Trigger(props: TriggerProps) {
     };
   }, []);
 
-  const stepTypeahead = (char: string) => {
-    if (typeaheadTimerRef.current) clearTimeout(typeaheadTimerRef.current);
-    typeaheadBufferRef.current += char.toLowerCase();
-    const buffer = typeaheadBufferRef.current;
-    // When activeIndex is -1 (no current cursor — typeahead opening the menu
-    // from the closed state), use -1 as the start so the `+1` first-char
-    // offset lands on index 0 instead of skipping past it.
-    const start = ctx.activeIndex >= 0 ? ctx.activeIndex : -1;
-    const len = ctx.rows.length;
-    for (let i = 0; i < len; i++) {
-      const idx = (start + i + (buffer.length === 1 ? 1 : 0)) % len;
-      const r = ctx.rows[idx];
-      if (r.kind !== 'option' || r.option.disabled) continue;
-      if (r.option.label.toLowerCase().startsWith(buffer)) {
-        ctx.setActiveIndex(idx);
-        break;
+  const stepTypeahead = useCallback(
+    (char: string) => {
+      if (typeaheadTimerRef.current) clearTimeout(typeaheadTimerRef.current);
+      typeaheadBufferRef.current += char.toLowerCase();
+      const buffer = typeaheadBufferRef.current;
+      // When activeIndex is -1 (no current cursor — typeahead opening the menu
+      // from the closed state), use -1 as the start so the `+1` first-char
+      // offset lands on index 0 instead of skipping past it.
+      const start = ctx.activeIndex >= 0 ? ctx.activeIndex : -1;
+      const len = ctx.rows.length;
+      for (let i = 0; i < len; i++) {
+        const idx = (start + i + (buffer.length === 1 ? 1 : 0)) % len;
+        const r = ctx.rows[idx];
+        if (r.kind !== 'option' || r.option.disabled) continue;
+        if (r.option.label.toLowerCase().startsWith(buffer)) {
+          ctx.setActiveIndex(idx);
+          break;
+        }
       }
-    }
-    typeaheadTimerRef.current = setTimeout(() => {
-      typeaheadBufferRef.current = '';
-    }, 500);
-  };
+      typeaheadTimerRef.current = setTimeout(() => {
+        typeaheadBufferRef.current = '';
+      }, 500);
+    },
+    [ctx],
+  );
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
-    if (props.disabled || props.readOnly) return;
+  const handleNavKey = (e: KeyboardEvent<HTMLElement>): boolean => {
+    if (opts.disabled || opts.readOnly) return false;
 
     if (!ctx.open) {
-      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+      if (e.key === 'ArrowDown' || e.key === 'Enter') {
         e.preventDefault();
         ctx.setOpen(true);
-        // Listbox's open-effect sets active to first selectable; nothing
-        // more to do here.
-        return;
+        return true;
       }
       if (e.key === 'ArrowUp') {
         e.preventDefault();
         ctx.setOpen(true);
-        // Override the open-effect's "first selectable" pick in a
-        // microtask so this runs after the Listbox mounts and sets it.
+        // Override the Listbox open-effect's "first selectable" pick in
+        // a microtask so this runs after Listbox mounts and sets it.
         queueMicrotask(() => ctx.setActiveIndex(lastSelectableIdx));
-        return;
+        return true;
       }
-      // Typeahead-open: any printable char (no modifiers) opens the
-      // listbox and seeds the typeahead buffer with that char.
-      if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
-        e.preventDefault();
-        ctx.setOpen(true);
-        stepTypeahead(e.key);
-      }
-      return;
+      return false;
     }
 
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault();
         moveActive(+1);
-        return;
+        return true;
       case 'ArrowUp':
         e.preventDefault();
         moveActive(-1);
-        return;
+        return true;
       case 'Home':
         e.preventDefault();
         if (firstSelectableIdx >= 0) ctx.setActiveIndex(firstSelectableIdx);
-        return;
+        return true;
       case 'End':
         e.preventDefault();
         if (lastSelectableIdx >= 0) ctx.setActiveIndex(lastSelectableIdx);
-        return;
+        return true;
       case 'PageDown':
         e.preventDefault();
         for (let step = 0; step < 5; step++) moveActive(+1);
-        return;
+        return true;
       case 'PageUp':
         e.preventDefault();
         for (let step = 0; step < 5; step++) moveActive(-1);
-        return;
-      case 'Enter':
-      case ' ': {
+        return true;
+      case 'Enter': {
         e.preventDefault();
         const row = ctx.rows[ctx.activeIndex];
         if (row && row.kind === 'option' && !row.option.disabled) {
@@ -173,33 +184,100 @@ export function Trigger(props: TriggerProps) {
             ctx.closeAndFocusTrigger();
           }
         }
-        return;
+        return true;
       }
       case 'Escape':
         e.preventDefault();
         ctx.closeAndFocusTrigger();
-        return;
+        return true;
       case 'Tab':
         // No preventDefault — browser continues Tab traversal from the
-        // (now-closed) trigger to the next focusable element.
+        // (now-closed) trigger to the next focusable element. Return
+        // false so the caller doesn't think it owns the keystroke.
         ctx.setOpen(false);
-        return;
-      default: {
-        // Printable char (single char, no modifier keys) → typeahead.
-        // Sits after the explicit cases so Enter/Space/' ' etc. above
-        // are handled first.
-        if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
-          e.preventDefault();
-          stepTypeahead(e.key);
-        }
-        return;
-      }
+        return false;
+      default:
+        return false;
     }
   };
 
-  const activeRow = ctx.open && ctx.activeIndex >= 0 ? ctx.rows[ctx.activeIndex] : undefined;
-  const activeOptionId =
-    activeRow && activeRow.kind === 'option' ? ctx.getOptionId(activeRow.option.value) : undefined;
+  return { handleNavKey, stepTypeahead, moveActive };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// ButtonTrigger — single, non-searchable; also the fallback for multi-mode
+// before Phase 5/6 lands their dedicated triggers.
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Button-styled trigger for the single, non-searchable Select mode.
+ *
+ * Owns the keyboard interaction for the closed-and-open lifecycle:
+ *  - Closed: ArrowDown / Enter / Space open with the Listbox's default
+ *    "first selectable" active row. ArrowUp opens and overrides the
+ *    active row to the last selectable (via a microtask so it runs
+ *    AFTER Listbox's open-effect picks the first one).
+ *  - Open: ArrowUp/Down step through rows (skipping headers + disabled),
+ *    Home/End jump to ends, PageUp/Down move ±5, Enter/Space commit the
+ *    active option (single mode → close; multi → toggle), Escape closes
+ *    without changing selection, Tab closes (no preventDefault — normal
+ *    browser traversal continues).
+ *
+ * Printable chars (no modifier keys) drive the 500ms typeahead buffer —
+ * mirrors the DropdownMenu pattern.
+ */
+function ButtonTrigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  const { handleNavKey, stepTypeahead } = useTriggerKeyboard({
+    disabled: props.disabled,
+    readOnly: props.readOnly,
+  });
+
+  const selectedRow =
+    !ctx.multiple && typeof ctx.value === 'string' && ctx.value !== ''
+      ? ctx.allRows.find((r) => r.kind === 'option' && r.option.value === ctx.value)
+      : null;
+  const hasValue = selectedRow !== null && selectedRow !== undefined;
+  const label = hasValue && selectedRow.kind === 'option' ? selectedRow.option.label : '';
+
+  const activeOptionId = useActiveOptionId();
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (props.disabled || props.readOnly) return;
+
+    // Nav keys (Arrow/Home/End/Page/Enter/Escape/Tab) — let the shared
+    // hook handle. Returns true if it claimed the keystroke.
+    if (handleNavKey(e)) return;
+
+    // Space: same semantics as Enter (open-or-commit). The shared hook
+    // doesn't claim Space because the combobox-input variant needs it
+    // as a literal character in the query string.
+    if (e.key === ' ') {
+      e.preventDefault();
+      if (!ctx.open) {
+        ctx.setOpen(true);
+        return;
+      }
+      const row = ctx.rows[ctx.activeIndex];
+      if (row && row.kind === 'option' && !row.option.disabled) {
+        if (ctx.multiple) {
+          ctx.toggleValue(row.option.value);
+        } else {
+          ctx.setValue(row.option.value);
+          ctx.closeAndFocusTrigger();
+        }
+      }
+      return;
+    }
+
+    // Printable char (no modifiers) → typeahead. Opens the menu first if
+    // closed so the user sees the highlighted option.
+    if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
+      if (!ctx.open) ctx.setOpen(true);
+      stepTypeahead(e.key);
+    }
+  };
 
   return (
     <button
@@ -226,4 +304,148 @@ export function Trigger(props: TriggerProps) {
       {label || props.placeholder || ''}
     </button>
   );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// ComboboxInputTrigger — single + searchable (WAI-ARIA combobox 1.2
+// "input as trigger" pattern). Headless UI Combobox shape: focusing the
+// input does NOT auto-open; clicking the input opens; typing opens and
+// filters; Escape reverts the query to the selected label.
+// ────────────────────────────────────────────────────────────────────────────
+
+function ComboboxInputTrigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  const { handleNavKey } = useTriggerKeyboard({
+    disabled: props.disabled,
+    readOnly: props.readOnly,
+  });
+
+  // Resolve the selected label from `allRows` (NOT `rows`). When the user
+  // types "arc" and the selected option "Pending" filters out of `rows`,
+  // we still need its label as the closed-state display + Escape fallback.
+  const selectedLabel = useMemo(() => {
+    if (ctx.multiple) return '';
+    if (typeof ctx.value !== 'string' || ctx.value === '') return '';
+    const row = ctx.allRows.find((r) => r.kind === 'option' && r.option.value === ctx.value);
+    return row && row.kind === 'option' ? row.option.label : '';
+  }, [ctx.multiple, ctx.value, ctx.allRows]);
+
+  // Reset the query to '' whenever the listbox closes, so the next open
+  // shows the full option list (instead of the stale filter) and the
+  // input falls back to displaying the selected label.
+  //
+  // Depends only on `ctx.open` (not query / setQuery) — the goal is to
+  // run exactly once per close transition; including `ctx.query` in the
+  // deps would re-fire on every keystroke and wipe the user's input.
+  useEffect(() => {
+    if (!ctx.open) {
+      ctx.setQuery('');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ctx.open]);
+
+  // Display rules:
+  //  - closed → always show the selected label (query is reset to '' by
+  //    the effect below when `ctx.open` flips false).
+  //  - open & query is empty → show the selected label as a "ghost"
+  //    starting value. The first onChange will detect the user typing
+  //    "over" this label and strip the prefix.
+  //  - open & query is non-empty → show the live query.
+  //
+  // This mirrors Headless UI's Combobox where the selected label sits
+  // in the input until the user starts editing, then is replaced.
+  const displayValue = ctx.open && ctx.query !== '' ? ctx.query : selectedLabel;
+
+  const activeOptionId = useActiveOptionId();
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (props.disabled || props.readOnly) return;
+    // Nav keys (Arrow/Home/End/Page/Enter/Escape/Tab). Crucially we do
+    // NOT layer typeahead on top — typing IS the filter mechanism here,
+    // handled by `onChange` below. Space is a literal char in the query
+    // and must reach the input's default `change` event, so the shared
+    // hook deliberately doesn't claim it.
+    handleNavKey(e);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (props.disabled || props.readOnly) return;
+    let next = e.target.value;
+    // When the input was sitting on the selected label (closed, or open
+    // with an empty query), the browser's native key handling appends
+    // the typed char — producing `"<selectedLabel><typed>"`. Strip the
+    // prefix so the user's *intent* (replace, not append) wins.
+    if (ctx.query === '' && selectedLabel !== '' && next.startsWith(selectedLabel)) {
+      next = next.slice(selectedLabel.length);
+    }
+    if (!ctx.open) ctx.setOpen(true);
+    ctx.setQuery(next);
+  };
+
+  // `ctx.triggerRef` is typed as `RefObject<HTMLElement | null>`. Cast at
+  // the assignment site rather than widening the context shape; both
+  // <button> and <input> are HTMLElement and the callers that read this
+  // ref only need `.focus()` / `.contains()` which are on HTMLElement.
+  const inputRefHolder = ctx.triggerRef as MutableRefObject<HTMLInputElement | null>;
+
+  return (
+    <input
+      type="text"
+      id={ctx.triggerId}
+      ref={(node) => {
+        inputRefHolder.current = node;
+      }}
+      className={clsx(styles.trigger, styles.triggerInput, !selectedLabel && styles.placeholder)}
+      role="combobox"
+      aria-autocomplete="list"
+      aria-haspopup="listbox"
+      aria-expanded={ctx.open}
+      aria-controls={ctx.open ? ctx.listboxId : undefined}
+      aria-activedescendant={activeOptionId}
+      aria-label={props['aria-label']}
+      aria-labelledby={props['aria-labelledby']}
+      aria-describedby={props['aria-describedby']}
+      aria-invalid={props.invalid || undefined}
+      aria-readonly={props.readOnly || undefined}
+      autoComplete="off"
+      spellCheck={false}
+      disabled={props.disabled}
+      readOnly={props.readOnly}
+      value={displayValue}
+      placeholder={selectedLabel === '' ? props.placeholder : undefined}
+      onClick={() => {
+        if (props.disabled || props.readOnly) return;
+        // Click opens but does NOT toggle — matches Headless UI Combobox
+        // and avoids the surprising "click the focused input to close
+        // it" behaviour.
+        if (!ctx.open) ctx.setOpen(true);
+      }}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+    />
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Dispatcher — picks the variant based on context flags. The public
+// `Trigger` export is what `<Select>` renders; the variants stay module-
+// local so the future Phase 5/6 multi-mode variants slot in here too.
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Internal dispatcher rendered by `<Select>`. Routes to the appropriate
+ * trigger variant based on mode flags from context.
+ *
+ *  - `single + !searchable` → `ButtonTrigger`
+ *  - `single + searchable`  → `ComboboxInputTrigger`
+ *  - `multi`                → `ButtonTrigger` for now; replaced by
+ *                              `SummaryTrigger` / `ChipsInputTrigger` in
+ *                              Phase 5 / 6.
+ */
+export function Trigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  if (!ctx.multiple && ctx.searchable) {
+    return <ComboboxInputTrigger {...props} />;
+  }
+  return <ButtonTrigger {...props} />;
 }

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -179,8 +179,28 @@ function useTriggerKeyboard(opts: { disabled?: boolean; readOnly?: boolean }) {
         e.preventDefault();
         const row = ctx.rows[ctx.activeIndex];
         if (row && row.kind === 'option' && !row.option.disabled) {
-          if (ctx.multiple) {
+          // Creatable: when the active row is the synthetic "+ Create"
+          // row, fire `onCreate` and commit the new value. The sentinel
+          // is `data.__create === true`; inline-detect it here rather
+          // than importing `isCreateRow` to keep the keyboard handler
+          // self-contained.
+          if (
+            typeof row.option.data === 'object' &&
+            row.option.data !== null &&
+            (row.option.data as { __create?: boolean }).__create
+          ) {
+            ctx.onCreate?.(row.option.label);
+            if (ctx.multiple) {
+              const next = [...((ctx.value as string[]) ?? []), row.option.value];
+              ctx.setValue(next);
+              if (ctx.searchable) ctx.setQuery('');
+            } else {
+              ctx.setValue(row.option.value);
+              ctx.closeAndFocusTrigger();
+            }
+          } else if (ctx.multiple) {
             ctx.toggleValue(row.option.value);
+            if (ctx.searchable) ctx.setQuery('');
           } else {
             ctx.setValue(row.option.value);
             ctx.closeAndFocusTrigger();
@@ -731,11 +751,7 @@ export function Trigger(props: TriggerProps) {
     return <ComboboxInputTrigger {...props} />;
   }
   if (ctx.multiple && ctx.triggerDisplay === 'chips') {
-    return ctx.searchable ? (
-      <ChipsInputTrigger {...props} />
-    ) : (
-      <ChipsButtonTrigger {...props} />
-    );
+    return ctx.searchable ? <ChipsInputTrigger {...props} /> : <ChipsButtonTrigger {...props} />;
   }
   // Multi-summary (both searchable + non-searchable) renders as the
   // comma-joined button trigger.

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -1,0 +1,58 @@
+import clsx from 'clsx';
+import { useSelectContext } from './context';
+import styles from './Select.module.scss';
+
+export interface TriggerProps {
+  placeholder?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  invalid?: boolean;
+  clearable?: boolean;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+}
+
+/**
+ * Button-styled trigger for the single, non-searchable Select mode.
+ *
+ * Phase 2 scope only — Phase 4 will add the searchable combobox-input
+ * variant and Phase 6 the chips-input shell. The current implementation
+ * stays focused on the button.
+ */
+export function Trigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  const selectedRow =
+    !ctx.multiple && typeof ctx.value === 'string' && ctx.value !== ''
+      ? ctx.allRows.find((r) => r.kind === 'option' && r.option.value === ctx.value)
+      : null;
+  const hasValue = selectedRow !== null && selectedRow !== undefined;
+  const label =
+    hasValue && selectedRow.kind === 'option'
+      ? selectedRow.option.label
+      : (props.placeholder ?? '');
+
+  return (
+    <button
+      type="button"
+      id={ctx.triggerId}
+      ref={ctx.triggerRef as React.Ref<HTMLButtonElement>}
+      className={clsx(styles.trigger, styles.triggerButton, !hasValue && styles.placeholder)}
+      aria-haspopup="listbox"
+      aria-expanded={ctx.open}
+      aria-controls={ctx.open ? ctx.listboxId : undefined}
+      aria-label={props['aria-label']}
+      aria-labelledby={props['aria-labelledby']}
+      aria-describedby={props['aria-describedby']}
+      aria-invalid={props.invalid || undefined}
+      aria-readonly={props.readOnly || undefined}
+      disabled={props.disabled}
+      onClick={() => {
+        if (props.disabled || props.readOnly) return;
+        ctx.setOpen(!ctx.open);
+      }}
+    >
+      {label}
+    </button>
+  );
+}

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -266,6 +266,16 @@ function ButtonTrigger(props: TriggerProps) {
 
   const activeOptionId = useActiveOptionId();
 
+  // When multi-summary text overflows it's truncated with CSS ellipsis,
+  // so screen-reader users would miss the tail of the selection. Surface
+  // the full comma-joined list via aria-label, but ONLY when the consumer
+  // didn't pass their own aria-label — their string is authoritative.
+  const computedAriaLabel = (() => {
+    if (props['aria-label']) return props['aria-label'];
+    if (ctx.multiple && label) return `Selected: ${label}`;
+    return undefined;
+  })();
+
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
     if (props.disabled || props.readOnly) return;
 
@@ -313,7 +323,7 @@ function ButtonTrigger(props: TriggerProps) {
       aria-expanded={ctx.open}
       aria-controls={ctx.open ? ctx.listboxId : undefined}
       aria-activedescendant={activeOptionId}
-      aria-label={props['aria-label']}
+      aria-label={computedAriaLabel}
       aria-labelledby={props['aria-labelledby']}
       aria-describedby={props['aria-describedby']}
       aria-invalid={props.invalid || undefined}
@@ -325,7 +335,11 @@ function ButtonTrigger(props: TriggerProps) {
       }}
       onKeyDown={handleKeyDown}
     >
-      {label || props.placeholder || ''}
+      {label ? (
+        <span>{label}</span>
+      ) : (
+        <span className={styles.placeholder}>{props.placeholder ?? ''}</span>
+      )}
     </button>
   );
 }

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   type KeyboardEvent,
   type MutableRefObject,
+  type PointerEvent,
   type Ref,
 } from 'react';
 import clsx from 'clsx';
@@ -466,6 +467,143 @@ function ComboboxInputTrigger(props: TriggerProps) {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// ChipsInputTrigger — multi + chips + searchable. Selected options render as
+// removable chips alongside an inline `<input role="combobox">` that owns
+// the live filter query. Backspace on an empty input removes the trailing
+// chip (matches GitHub label picker, Material UI Autocomplete multiple,
+// Headless UI tag inputs). Pattern reference: WAI-ARIA APG combobox + the
+// de-facto tag-input convention.
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Chips trigger with an inline `role="combobox"` input. Wrapper is a plain
+ * `<div>` (no role) because the input IS the WAI-ARIA combobox; assigning
+ * `role="button"` to the wrapper would create two competing focus targets.
+ * Outside-click detection still works — `ctx.triggerRef` points at the
+ * wrapper, and `wrapper.contains(input) === true` and `wrapper.contains(chip) === true`.
+ *
+ * Backspace behaviour: removes the trailing chip ONLY when `ctx.query === ''`.
+ * On non-empty input it falls through to the browser's native text-deletion.
+ *
+ * Enter behaviour: `useTriggerKeyboard.handleNavKey` toggles the active
+ * option in multi mode but does NOT clear the query — we clear it here in
+ * a microtask so the input is empty for the next pick. Listbox's option
+ * click handler also clears the query for multi+searchable so mouse
+ * selection follows the same UX.
+ */
+function ChipsInputTrigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  const { handleNavKey } = useTriggerKeyboard({
+    disabled: props.disabled,
+    readOnly: props.readOnly,
+  });
+  const activeOptionId = useActiveOptionId();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const selectedValues = Array.isArray(ctx.value) ? (ctx.value as string[]) : [];
+  // Walk `allRows` so chip labels persist even while typing filters
+  // `rows` down to a subset that excludes them.
+  const selectedOptions: { value: string; label: string }[] = [];
+  for (const row of ctx.allRows) {
+    if (row.kind === 'option' && selectedValues.includes(row.option.value)) {
+      selectedOptions.push({ value: row.option.value, label: row.option.label });
+    }
+  }
+
+  const handleWrapperPointerDown = (e: PointerEvent<HTMLDivElement>) => {
+    if (props.disabled || props.readOnly) return;
+    // Redirect any pointer landing on the wrapper itself (gap between
+    // chips, padding area) into the input so the caret position stays
+    // predictable. Don't steal events that already target the input —
+    // the browser owns selection/caret placement there.
+    if (e.target !== inputRef.current) {
+      e.preventDefault();
+      inputRef.current?.focus();
+    }
+  };
+
+  const handleWrapperClick = () => {
+    if (props.disabled || props.readOnly) return;
+    inputRef.current?.focus();
+    if (!ctx.open) ctx.setOpen(true);
+  };
+
+  const handleInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (props.disabled || props.readOnly) return;
+    // Enter handling is layered: handleNavKey toggles in multi mode but
+    // doesn't clear the query. Schedule the clear AFTER the toggle so the
+    // input is empty for the next selection. Microtask + open-guard so we
+    // don't blow away a query if the user pressed Enter while closed.
+    if (e.key === 'Enter' && ctx.open) {
+      queueMicrotask(() => ctx.setQuery(''));
+    }
+    if (handleNavKey(e)) return;
+    // Backspace on empty input removes the trailing chip. On non-empty
+    // input we DO NOT preventDefault — the browser handles char deletion.
+    if (e.key === 'Backspace' && ctx.query === '' && selectedOptions.length > 0) {
+      e.preventDefault();
+      const last = selectedOptions[selectedOptions.length - 1];
+      ctx.toggleValue(last.value);
+    }
+  };
+
+  // `ctx.triggerRef` is the wrapper div, NOT the input. This is correct
+  // for outside-click detection (everything inside the wrapper — chips,
+  // ✕ buttons, the input — is "inside the trigger"). The input gets its
+  // own local ref for focus management.
+  const wrapperRef = ctx.triggerRef as Ref<HTMLDivElement>;
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={clsx(styles.trigger, styles.triggerChips, styles.triggerChipsInput)}
+      onClick={handleWrapperClick}
+      onPointerDown={handleWrapperPointerDown}
+    >
+      {selectedOptions.map((o) => (
+        <Chip
+          key={o.value}
+          label={o.label}
+          disabled={props.disabled}
+          onRemove={() => {
+            if (props.disabled || props.readOnly) return;
+            ctx.toggleValue(o.value);
+            inputRef.current?.focus();
+          }}
+        />
+      ))}
+      <input
+        ref={inputRef}
+        type="text"
+        id={ctx.triggerId}
+        role="combobox"
+        aria-autocomplete="list"
+        aria-haspopup="listbox"
+        aria-expanded={ctx.open}
+        aria-controls={ctx.open ? ctx.listboxId : undefined}
+        aria-activedescendant={activeOptionId}
+        aria-label={props['aria-label']}
+        aria-labelledby={props['aria-labelledby']}
+        aria-describedby={props['aria-describedby']}
+        aria-invalid={props.invalid || undefined}
+        disabled={props.disabled}
+        readOnly={props.readOnly}
+        autoComplete="off"
+        spellCheck={false}
+        className={styles.chipsInput}
+        placeholder={selectedOptions.length === 0 ? props.placeholder : undefined}
+        value={ctx.query}
+        onChange={(e) => {
+          if (!ctx.open) ctx.setOpen(true);
+          ctx.setQuery(e.target.value);
+        }}
+        onKeyDown={handleInputKeyDown}
+      />
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // ChipsButtonTrigger — multi + chips + !searchable. Renders selected options
 // as removable inline chips inside a div with role="button". Cannot be a
 // native <button> because chip ✕ buttons nest inside it (no <button> in
@@ -592,10 +730,14 @@ export function Trigger(props: TriggerProps) {
   if (!ctx.multiple && ctx.searchable) {
     return <ComboboxInputTrigger {...props} />;
   }
-  if (ctx.multiple && ctx.triggerDisplay === 'chips' && !ctx.searchable) {
-    return <ChipsButtonTrigger {...props} />;
+  if (ctx.multiple && ctx.triggerDisplay === 'chips') {
+    return ctx.searchable ? (
+      <ChipsInputTrigger {...props} />
+    ) : (
+      <ChipsButtonTrigger {...props} />
+    );
   }
   // Multi-summary (both searchable + non-searchable) renders as the
-  // comma-joined button. Multi-chips-searchable is added next task.
+  // comma-joined button trigger.
   return <ButtonTrigger {...props} />;
 }

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import clsx from 'clsx';
 import { useSelectContext } from './context';
+import { Chip } from './Chip';
 import styles from './Select.module.scss';
 
 export interface TriggerProps {
@@ -465,6 +466,112 @@ function ComboboxInputTrigger(props: TriggerProps) {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// ChipsButtonTrigger — multi + chips + !searchable. Renders selected options
+// as removable inline chips inside a div with role="button". Cannot be a
+// native <button> because chip ✕ buttons nest inside it (no <button> in
+// <button>). Outside-click detection still works because Listbox tests
+// `triggerRef.contains(target)` and the wrapper IS the triggerRef.
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Chips trigger for multi-select without inline search. Wrapper is a
+ * keyboard-focusable `<div role="button">` (so the chips' own ✕ buttons
+ * can nest). Chip resolution walks `ctx.allRows`, not `ctx.rows`, so the
+ * chip list stays stable even if a future hover-search filters the
+ * popover — unselected options never show as chips, but selected ones
+ * never disappear.
+ *
+ * Keyboard:
+ *  - Closed: ArrowDown/Up/Enter open via the shared hook; printable chars
+ *    open + start typeahead; Space opens.
+ *  - Open: shared hook owns Arrow/Home/End/PageUp/Down/Enter/Escape/Tab.
+ *    Enter toggles the active option without closing (multi semantics).
+ *  - Backspace is NOT bound here (no input to detect emptiness against);
+ *    the searchable variant handles it.
+ */
+function ChipsButtonTrigger(props: TriggerProps) {
+  const ctx = useSelectContext('Trigger');
+  const { handleNavKey, stepTypeahead } = useTriggerKeyboard({
+    disabled: props.disabled,
+    readOnly: props.readOnly,
+  });
+  const activeOptionId = useActiveOptionId();
+
+  const selectedValues = Array.isArray(ctx.value) ? (ctx.value as string[]) : [];
+  // Walk `allRows` (not `rows`) so chips remain present even when a future
+  // search query filters the popover — selection is independent of filter.
+  const selectedOptions: { value: string; label: string }[] = [];
+  for (const row of ctx.allRows) {
+    if (row.kind === 'option' && selectedValues.includes(row.option.value)) {
+      selectedOptions.push({ value: row.option.value, label: row.option.label });
+    }
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (props.disabled || props.readOnly) return;
+    if (handleNavKey(e)) return;
+    if (e.key === ' ') {
+      e.preventDefault();
+      if (!ctx.open) ctx.setOpen(true);
+      return;
+    }
+    if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
+      if (!ctx.open) ctx.setOpen(true);
+      stepTypeahead(e.key);
+    }
+  };
+
+  // Mirrors ButtonTrigger's computedAriaLabel pattern: consumer's
+  // aria-label wins; otherwise synthesize from selections so screen
+  // readers hear the full list even when chips overflow visually.
+  const labelForAria = selectedOptions.map((o) => o.label).join(', ');
+  const computedAriaLabel =
+    props['aria-label'] ??
+    (selectedOptions.length > 0 ? `Selected: ${labelForAria}` : 'Open select');
+
+  return (
+    <div
+      ref={ctx.triggerRef as Ref<HTMLDivElement>}
+      id={ctx.triggerId}
+      role="button"
+      tabIndex={props.disabled ? -1 : 0}
+      className={clsx(styles.trigger, styles.triggerChips)}
+      aria-haspopup="listbox"
+      aria-expanded={ctx.open}
+      aria-controls={ctx.open ? ctx.listboxId : undefined}
+      aria-activedescendant={activeOptionId}
+      aria-label={computedAriaLabel}
+      aria-labelledby={props['aria-labelledby']}
+      aria-describedby={props['aria-describedby']}
+      aria-invalid={props.invalid || undefined}
+      aria-readonly={props.readOnly || undefined}
+      aria-disabled={props.disabled || undefined}
+      onClick={() => {
+        if (props.disabled || props.readOnly) return;
+        ctx.setOpen(!ctx.open);
+      }}
+      onKeyDown={handleKeyDown}
+    >
+      {selectedOptions.map((o) => (
+        <Chip
+          key={o.value}
+          label={o.label}
+          disabled={props.disabled}
+          onRemove={() => {
+            if (props.disabled || props.readOnly) return;
+            ctx.toggleValue(o.value);
+          }}
+        />
+      ))}
+      {selectedOptions.length === 0 && (
+        <span className={styles.placeholder}>{props.placeholder ?? ''}</span>
+      )}
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Dispatcher — picks the variant based on context flags. The public
 // `Trigger` export is what `<Select>` renders; the variants stay module-
 // local so the future Phase 5/6 multi-mode variants slot in here too.
@@ -474,18 +581,21 @@ function ComboboxInputTrigger(props: TriggerProps) {
  * Internal dispatcher rendered by `<Select>`. Routes to the appropriate
  * trigger variant based on mode flags from context.
  *
- *  - `single + !searchable` → `ButtonTrigger`
- *  - `single + searchable`  → `ComboboxInputTrigger`
- *  - `multi`                → `ButtonTrigger` for now; replaced by
- *                              `SummaryTrigger` / `ChipsInputTrigger` in
- *                              Phase 5 / 6.
+ *  - `single + !searchable`            → `ButtonTrigger`
+ *  - `single + searchable`             → `ComboboxInputTrigger`
+ *  - `multi + chips + !searchable`     → `ChipsButtonTrigger`
+ *  - `multi + chips + searchable`      → `ChipsInputTrigger` (Phase 6 task 15)
+ *  - `multi + summary` (both forms)    → `ButtonTrigger` w/ comma-joined labels
  */
 export function Trigger(props: TriggerProps) {
   const ctx = useSelectContext('Trigger');
   if (!ctx.multiple && ctx.searchable) {
     return <ComboboxInputTrigger {...props} />;
   }
-  // Multi-chips trigger lands in Phase 6; until then, multi always uses
-  // ButtonTrigger which now renders comma-joined summary labels.
+  if (ctx.multiple && ctx.triggerDisplay === 'chips' && !ctx.searchable) {
+    return <ChipsButtonTrigger {...props} />;
+  }
+  // Multi-summary (both searchable + non-searchable) renders as the
+  // comma-joined button. Multi-chips-searchable is added next task.
   return <ButtonTrigger {...props} />;
 }

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -233,12 +233,36 @@ function ButtonTrigger(props: TriggerProps) {
     readOnly: props.readOnly,
   });
 
-  const selectedRow =
-    !ctx.multiple && typeof ctx.value === 'string' && ctx.value !== ''
-      ? ctx.allRows.find((r) => r.kind === 'option' && r.option.value === ctx.value)
-      : null;
-  const hasValue = selectedRow !== null && selectedRow !== undefined;
-  const label = hasValue && selectedRow.kind === 'option' ? selectedRow.option.label : '';
+  // Resolve the visible label string for both single and multi modes.
+  //
+  // Multi: walk `ctx.allRows` (NOT `ctx.rows` which is filtered when
+  // searchable) and comma-join the labels of every selected value so chip
+  // labels don't drop out of the summary when the user types a filter
+  // query that excludes them.
+  //
+  // Single: same `allRows` lookup as before — keeps the closed-state label
+  // visible while the user is filtering in the open searchable variant
+  // (which actually renders the combobox-input trigger, but symmetry here
+  // is harmless and keeps the resolution logic in one place).
+  const label = (() => {
+    if (ctx.multiple) {
+      const selectedValues = Array.isArray(ctx.value) ? ctx.value : [];
+      if (selectedValues.length === 0) return '';
+      const labels: string[] = [];
+      for (const row of ctx.allRows) {
+        if (row.kind === 'option' && selectedValues.includes(row.option.value)) {
+          labels.push(row.option.label);
+        }
+      }
+      return labels.join(', ');
+    }
+    if (typeof ctx.value !== 'string' || ctx.value === '') return '';
+    const selRow = ctx.allRows.find(
+      (r) => r.kind === 'option' && r.option.value === (ctx.value as string),
+    );
+    return selRow && selRow.kind === 'option' ? selRow.option.label : '';
+  })();
+  const hasValue = label !== '';
 
   const activeOptionId = useActiveOptionId();
 
@@ -447,5 +471,7 @@ export function Trigger(props: TriggerProps) {
   if (!ctx.multiple && ctx.searchable) {
     return <ComboboxInputTrigger {...props} />;
   }
+  // Multi-chips trigger lands in Phase 6; until then, multi always uses
+  // ButtonTrigger which now renders comma-joined summary labels.
   return <ButtonTrigger {...props} />;
 }

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -616,16 +616,18 @@ function ChipsInputTrigger(props: TriggerProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const selectedValues = Array.isArray(ctx.value) ? (ctx.value as string[]) : [];
-  // Walk `allRows` so chip labels persist even while typing filters
-  // `rows` down to a subset that excludes them. Preserve the full
-  // SelectOption — `renderTag` callbacks receive `data` and `description`
-  // too, not just `value` / `label`.
-  const selectedOptions: SelectOption[] = [];
+  // Walk `selectedValues` (selection order — `ctx.value` appends new picks
+  // to the end via `useSelectState.toggleValue`) so the latest selected chip
+  // renders last. Look options up from `allRows` so labels persist while
+  // typing filters `rows` down. Synthetic `{value, label: value}` fallback
+  // covers creatable values not yet in `allRows`.
+  const optionByValue = new Map<string, SelectOption>();
   for (const row of ctx.allRows) {
-    if (row.kind === 'option' && selectedValues.includes(row.option.value)) {
-      selectedOptions.push(row.option as SelectOption);
-    }
+    if (row.kind === 'option') optionByValue.set(row.option.value, row.option as SelectOption);
   }
+  const selectedOptions: SelectOption[] = selectedValues.map(
+    (v) => optionByValue.get(v) ?? { value: v, label: v },
+  );
 
   const handleWrapperPointerDown = (e: PointerEvent<HTMLDivElement>) => {
     if (props.disabled || props.readOnly) return;
@@ -755,16 +757,18 @@ function ChipsButtonTrigger(props: TriggerProps) {
   const activeOptionId = useActiveOptionId();
 
   const selectedValues = Array.isArray(ctx.value) ? (ctx.value as string[]) : [];
-  // Walk `allRows` (not `rows`) so chips remain present even when a future
-  // search query filters the popover — selection is independent of filter.
-  // Preserve full SelectOption so `renderTag` callbacks get `data` /
-  // `description` access, not just `value` / `label`.
-  const selectedOptions: SelectOption[] = [];
+  // Walk `selectedValues` (selection order — `ctx.value` appends new picks
+  // to the end via `useSelectState.toggleValue`) so the latest selected chip
+  // renders last. Look options up from `allRows` so labels persist while
+  // searching. Synthetic `{value, label: value}` fallback covers creatable
+  // values not yet in `allRows`.
+  const optionByValue = new Map<string, SelectOption>();
   for (const row of ctx.allRows) {
-    if (row.kind === 'option' && selectedValues.includes(row.option.value)) {
-      selectedOptions.push(row.option as SelectOption);
-    }
+    if (row.kind === 'option') optionByValue.set(row.option.value, row.option as SelectOption);
   }
+  const selectedOptions: SelectOption[] = selectedValues.map(
+    (v) => optionByValue.get(v) ?? { value: v, label: v },
+  );
 
   const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (props.disabled || props.readOnly) return;

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -25,6 +25,50 @@ export interface TriggerProps {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// ClearButton — the trailing ✕ rendered inside the trigger when
+// `effectiveClearable` is true AND a value is set. Wired by every variant.
+//
+// Wired as a real `<button>` so screen readers announce a focusable
+// "Clear selection" action. `stopPropagation` on both pointerdown + click
+// keeps the parent trigger's own toggle handler from firing (clicking ✕
+// must NOT also open or close the listbox), and the explicit
+// `setValue('')` / `setValue([])` path bypasses `toggleValue` so a
+// multi-select wipe is one event, not N.
+// ────────────────────────────────────────────────────────────────────────────
+function ClearButton({ variant }: { variant: 'overlay' | 'inline' }) {
+  const ctx = useSelectContext('Trigger.ClearButton');
+  return (
+    <button
+      type="button"
+      tabIndex={-1}
+      className={clsx(styles.clearButton, variant === 'inline' && styles.clearButtonInline)}
+      aria-label="Clear selection"
+      onPointerDown={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (ctx.multiple) {
+          ctx.setValue([]);
+        } else {
+          ctx.setValue('');
+        }
+      }}
+    >
+      <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+        <path d="M1 1 L9 9 M9 1 L1 9" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      </svg>
+    </button>
+  );
+}
+
+/** Helper: does this Select currently have a non-empty selection? */
+function selectHasValue(value: string | string[], multiple: boolean): boolean {
+  return multiple
+    ? Array.isArray(value) && value.length > 0
+    : typeof value === 'string' && value !== '';
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Shared helpers
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -335,34 +379,42 @@ function ButtonTrigger(props: TriggerProps) {
     }
   };
 
+  const showClear = props.clearable && hasValue;
+
   return (
-    <button
-      type="button"
-      id={ctx.triggerId}
-      ref={ctx.triggerRef as Ref<HTMLButtonElement>}
-      className={clsx(styles.trigger, styles.triggerButton, !hasValue && styles.placeholder)}
-      aria-haspopup="listbox"
-      aria-expanded={ctx.open}
-      aria-controls={ctx.open ? ctx.listboxId : undefined}
-      aria-activedescendant={activeOptionId}
-      aria-label={computedAriaLabel}
-      aria-labelledby={props['aria-labelledby']}
-      aria-describedby={props['aria-describedby']}
-      aria-invalid={props.invalid || undefined}
-      aria-readonly={props.readOnly || undefined}
-      disabled={props.disabled}
-      onClick={() => {
-        if (props.disabled || props.readOnly) return;
-        ctx.setOpen(!ctx.open);
-      }}
-      onKeyDown={handleKeyDown}
-    >
-      {label ? (
-        <span>{label}</span>
-      ) : (
-        <span className={styles.placeholder}>{props.placeholder ?? ''}</span>
-      )}
-    </button>
+    <div className={styles.triggerWrap}>
+      <button
+        type="button"
+        id={ctx.triggerId}
+        ref={ctx.triggerRef as Ref<HTMLButtonElement>}
+        className={clsx(styles.trigger, styles.triggerButton, !hasValue && styles.placeholder)}
+        aria-haspopup="listbox"
+        aria-expanded={ctx.open}
+        aria-controls={ctx.open ? ctx.listboxId : undefined}
+        aria-activedescendant={activeOptionId}
+        aria-label={computedAriaLabel}
+        aria-labelledby={props['aria-labelledby']}
+        aria-describedby={props['aria-describedby']}
+        aria-invalid={props.invalid || undefined}
+        aria-readonly={props.readOnly || undefined}
+        disabled={props.disabled}
+        onClick={() => {
+          if (props.disabled || props.readOnly) return;
+          ctx.setOpen(!ctx.open);
+        }}
+        onKeyDown={handleKeyDown}
+      >
+        {label ? (
+          <span>{label}</span>
+        ) : (
+          <span className={styles.placeholder}>{props.placeholder ?? ''}</span>
+        )}
+      </button>
+      {showClear && <ClearButton variant="overlay" />}
+      <span className={styles.chevron} aria-hidden="true">
+        ▾
+      </span>
+    </div>
   );
 }
 
@@ -448,41 +500,49 @@ function ComboboxInputTrigger(props: TriggerProps) {
   // ref only need `.focus()` / `.contains()` which are on HTMLElement.
   const inputRefHolder = ctx.triggerRef as MutableRefObject<HTMLInputElement | null>;
 
+  const showClear = props.clearable && selectHasValue(ctx.value, ctx.multiple);
+
   return (
-    <input
-      type="text"
-      id={ctx.triggerId}
-      ref={(node) => {
-        inputRefHolder.current = node;
-      }}
-      className={clsx(styles.trigger, styles.triggerInput, !selectedLabel && styles.placeholder)}
-      role="combobox"
-      aria-autocomplete="list"
-      aria-haspopup="listbox"
-      aria-expanded={ctx.open}
-      aria-controls={ctx.open ? ctx.listboxId : undefined}
-      aria-activedescendant={activeOptionId}
-      aria-label={props['aria-label']}
-      aria-labelledby={props['aria-labelledby']}
-      aria-describedby={props['aria-describedby']}
-      aria-invalid={props.invalid || undefined}
-      aria-readonly={props.readOnly || undefined}
-      autoComplete="off"
-      spellCheck={false}
-      disabled={props.disabled}
-      readOnly={props.readOnly}
-      value={displayValue}
-      placeholder={selectedLabel === '' ? props.placeholder : undefined}
-      onClick={() => {
-        if (props.disabled || props.readOnly) return;
-        // Click opens but does NOT toggle — matches Headless UI Combobox
-        // and avoids the surprising "click the focused input to close
-        // it" behaviour.
-        if (!ctx.open) ctx.setOpen(true);
-      }}
-      onChange={handleChange}
-      onKeyDown={handleKeyDown}
-    />
+    <div className={styles.triggerWrap}>
+      <input
+        type="text"
+        id={ctx.triggerId}
+        ref={(node) => {
+          inputRefHolder.current = node;
+        }}
+        className={clsx(styles.trigger, styles.triggerInput, !selectedLabel && styles.placeholder)}
+        role="combobox"
+        aria-autocomplete="list"
+        aria-haspopup="listbox"
+        aria-expanded={ctx.open}
+        aria-controls={ctx.open ? ctx.listboxId : undefined}
+        aria-activedescendant={activeOptionId}
+        aria-label={props['aria-label']}
+        aria-labelledby={props['aria-labelledby']}
+        aria-describedby={props['aria-describedby']}
+        aria-invalid={props.invalid || undefined}
+        aria-readonly={props.readOnly || undefined}
+        autoComplete="off"
+        spellCheck={false}
+        disabled={props.disabled}
+        readOnly={props.readOnly}
+        value={displayValue}
+        placeholder={selectedLabel === '' ? props.placeholder : undefined}
+        onClick={() => {
+          if (props.disabled || props.readOnly) return;
+          // Click opens but does NOT toggle — matches Headless UI Combobox
+          // and avoids the surprising "click the focused input to close
+          // it" behaviour.
+          if (!ctx.open) ctx.setOpen(true);
+        }}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+      />
+      {showClear && <ClearButton variant="overlay" />}
+      <span className={styles.chevron} aria-hidden="true">
+        ▾
+      </span>
+    </div>
   );
 }
 
@@ -619,6 +679,7 @@ function ChipsInputTrigger(props: TriggerProps) {
         }}
         onKeyDown={handleInputKeyDown}
       />
+      {props.clearable && selectedOptions.length > 0 && <ClearButton variant="inline" />}
     </div>
   );
 }
@@ -725,6 +786,7 @@ function ChipsButtonTrigger(props: TriggerProps) {
       {selectedOptions.length === 0 && (
         <span className={styles.placeholder}>{props.placeholder ?? ''}</span>
       )}
+      {props.clearable && selectedOptions.length > 0 && <ClearButton variant="inline" />}
     </div>
   );
 }

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -35,13 +35,19 @@ export interface TriggerProps {
 // must NOT also open or close the listbox), and the explicit
 // `setValue('')` / `setValue([])` path bypasses `toggleValue` so a
 // multi-select wipe is one event, not N.
+//
+// `tabIndex={0}` (not `-1`) — the clear button MUST be reachable by
+// keyboard for accessibility. The default Tab order takes the user from
+// the trigger to ✕ and then on to the next focusable element on the page;
+// Enter/Space on the focused ✕ activates the native button's `onClick` so
+// no extra keyboard handler is needed.
 // ────────────────────────────────────────────────────────────────────────────
 function ClearButton({ variant }: { variant: 'overlay' | 'inline' }) {
   const ctx = useSelectContext('Trigger.ClearButton');
   return (
     <button
       type="button"
-      tabIndex={-1}
+      tabIndex={0}
       className={clsx(styles.clearButton, variant === 'inline' && styles.clearButtonInline)}
       aria-label="Clear selection"
       onPointerDown={(e) => e.stopPropagation()}

--- a/packages/design-system/src/components/Select/context.ts
+++ b/packages/design-system/src/components/Select/context.ts
@@ -1,0 +1,90 @@
+import { createContext, useContext, type ReactNode, type RefObject } from 'react';
+import type { SelectOption, FlatRow } from './utils-types';
+
+/**
+ * Internal context published by `<Select>` to its subcomponents (Trigger,
+ * Listbox, future ChipsInputTrigger, etc.). Not part of the public API —
+ * all consumer-facing customization happens through `SelectProps`.
+ *
+ * The shape includes fields that some phases don't yet populate (e.g.
+ * `loading`, `error`, render escape hatches, `onCreate`). Those are wired
+ * in later phases; right now they're declared so subcomponents written
+ * against the full interface don't need to grow new optional reads later.
+ */
+export interface SelectContextValue<T = unknown> {
+  // ─── mode flags ───────────────────────────────────────────────────────────
+  multiple: boolean;
+  searchable: boolean;
+  creatable: boolean;
+  triggerDisplay: 'chips' | 'summary';
+
+  // ─── data ─────────────────────────────────────────────────────────────────
+  /**
+   * Currently-rendered rows. When `searchable`, this is the filtered set;
+   * otherwise identical to `allRows`. Phase 2 has no filter yet, so the
+   * two are the same.
+   */
+  rows: FlatRow<T>[];
+  /**
+   * The full flattened option list, independent of any active query. Used
+   * by chip-mode renderers to resolve labels for selected values that have
+   * been filtered out of the visible list.
+   */
+  allRows: FlatRow<T>[];
+  loading: boolean;
+  error: Error | null;
+
+  // ─── value ────────────────────────────────────────────────────────────────
+  value: string | string[];
+  setValue: (next: string | string[]) => void;
+  toggleValue: (v: string) => void;
+
+  // ─── open ─────────────────────────────────────────────────────────────────
+  open: boolean;
+  setOpen: (next: boolean) => void;
+
+  // ─── active (keyboard cursor) ─────────────────────────────────────────────
+  activeIndex: number;
+  setActiveIndex: (i: number) => void;
+
+  // ─── search (only meaningful when `searchable`) ───────────────────────────
+  query: string;
+  setQuery: (q: string) => void;
+
+  // ─── ids ──────────────────────────────────────────────────────────────────
+  listboxId: string;
+  triggerId: string;
+  getOptionId: (value: string) => string;
+  getGroupHeaderId: (label: string) => string;
+
+  // ─── refs ─────────────────────────────────────────────────────────────────
+  triggerRef: RefObject<HTMLElement | null>;
+  listboxRef: RefObject<HTMLUListElement | null>;
+
+  // ─── imperative ───────────────────────────────────────────────────────────
+  closeAndFocusTrigger: () => void;
+  retry: () => void;
+
+  // ─── render overrides + onCreate (populated in later phases) ──────────────
+  onCreate?: (label: string) => void;
+  renderOption?: (opt: SelectOption<T>, state: { active: boolean; selected: boolean }) => ReactNode;
+  renderValue?: (opt: SelectOption<T>) => ReactNode;
+  renderTag?: (opt: SelectOption<T>, remove: () => void) => ReactNode;
+  renderEmpty?: (query: string) => ReactNode;
+  renderLoading?: () => ReactNode;
+  renderError?: (err: Error, retry: () => void) => ReactNode;
+}
+
+export const SelectContext = createContext<SelectContextValue | null>(null);
+
+/**
+ * Read the SelectContext. Throws when called outside a `<Select>` so a
+ * misuse (e.g. rendering `<Trigger>` directly) fails loudly during dev.
+ */
+export function useSelectContext<T = unknown>(componentName: string): SelectContextValue<T> {
+  const ctx = useContext(SelectContext);
+  if (!ctx) {
+    throw new Error(`<Select> internals (${componentName}) must be rendered inside <Select>.`);
+  }
+  return ctx as SelectContextValue<T>;
+}

--- a/packages/design-system/src/components/Select/index.ts
+++ b/packages/design-system/src/components/Select/index.ts
@@ -1,0 +1,2 @@
+export { Select } from './Select';
+export type { SelectProps } from './Select';

--- a/packages/design-system/src/components/Select/index.ts
+++ b/packages/design-system/src/components/Select/index.ts
@@ -1,2 +1,9 @@
 export { Select } from './Select';
-export type { SelectProps } from './Select';
+export type {
+  SelectProps,
+  SelectOption,
+  SelectGroup,
+  SelectOptions,
+  SelectSize,
+  SelectTriggerDisplay,
+} from './Select';

--- a/packages/design-system/src/components/Select/useAsyncOptions.test.ts
+++ b/packages/design-system/src/components/Select/useAsyncOptions.test.ts
@@ -1,0 +1,108 @@
+import { act, configure, renderHook } from '@testing-library/react';
+import { useAsyncOptions } from './useAsyncOptions';
+import type { SelectOptions } from './Select';
+
+const A: SelectOptions = [{ value: 'a', label: 'A' }];
+const B: SelectOptions = [{ value: 'b', label: 'B' }];
+
+describe('useAsyncOptions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // RTL's waitFor polls via setInterval; under fake timers the interval
+    // never ticks unless we advance timers. The asyncWrapper drains a
+    // microtask + setTimeout(0) on each yield so waitFor's poll fires.
+    configure({
+      asyncWrapper: async (cb) => {
+        const result = await cb();
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+          vi.advanceTimersByTime(0);
+        });
+        return result;
+      },
+    });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    configure({ asyncWrapper: async (cb) => cb() });
+  });
+
+  it('does NOT call loadOptions until enabled=true (loadOnOpen gate)', async () => {
+    const loadOptions = vi.fn(async () => A);
+    renderHook(() =>
+      useAsyncOptions({ loadOptions, query: '', enabled: false, debounceMs: 100 }),
+    );
+    await vi.advanceTimersByTimeAsync(200);
+    expect(loadOptions).not.toHaveBeenCalled();
+  });
+
+  it('calls loadOptions("") on first enable', async () => {
+    const loadOptions = vi.fn(async () => A);
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useAsyncOptions({ loadOptions, query: '', enabled, debounceMs: 100 }),
+      { initialProps: { enabled: false } },
+    );
+    rerender({ enabled: true });
+    // Drain the debounce window, then run all pending timers/microtasks so
+    // the loadOptions promise resolution settles into state before assert.
+    // The state updates fire from the promise resolution, so the timer
+    // advance must run inside `act()` to keep RTL happy.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+      await vi.runAllTimersAsync();
+    });
+    expect(loadOptions).toHaveBeenCalledTimes(1);
+    expect(loadOptions.mock.calls[0][0]).toBe('');
+    expect(result.current.options).toEqual(A);
+  });
+
+  it('debounces query changes', async () => {
+    const loadOptions = vi.fn(async (q: string) => (q === 'b' ? B : A));
+    const { rerender } = renderHook(
+      ({ query }) => useAsyncOptions({ loadOptions, query, enabled: true, debounceMs: 100 }),
+      { initialProps: { query: '' } },
+    );
+    await vi.advanceTimersByTimeAsync(150);
+    expect(loadOptions).toHaveBeenCalledTimes(1);
+    rerender({ query: 'b' });
+    await vi.advanceTimersByTimeAsync(50);
+    expect(loadOptions).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(60);
+    expect(loadOptions).toHaveBeenCalledTimes(2);
+    expect(loadOptions.mock.calls[1][0]).toBe('b');
+  });
+
+  it('aborts the previous request when query changes mid-flight', async () => {
+    const signals: AbortSignal[] = [];
+    const loadOptions = vi.fn(async (_q: string, signal: AbortSignal) => {
+      signals.push(signal);
+      await new Promise((res) => setTimeout(res, 10000));
+      return A;
+    });
+    const { rerender } = renderHook(
+      ({ query }) => useAsyncOptions({ loadOptions, query, enabled: true, debounceMs: 100 }),
+      { initialProps: { query: '' } },
+    );
+    await vi.advanceTimersByTimeAsync(150);
+    expect(signals).toHaveLength(1);
+    rerender({ query: 'b' });
+    await vi.advanceTimersByTimeAsync(150);
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[1].aborted).toBe(false);
+  });
+
+  it('renders error state on rejection (non-abort)', async () => {
+    const loadOptions = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const { result } = renderHook(() =>
+      useAsyncOptions({ loadOptions, query: '', enabled: true, debounceMs: 0 }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.runAllTimersAsync();
+    });
+    expect(result.current.error?.message).toBe('boom');
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/packages/design-system/src/components/Select/useAsyncOptions.test.ts
+++ b/packages/design-system/src/components/Select/useAsyncOptions.test.ts
@@ -37,7 +37,7 @@ describe('useAsyncOptions', () => {
   });
 
   it('calls loadOptions("") on first enable', async () => {
-    const loadOptions = vi.fn(async () => A);
+    const loadOptions = vi.fn(async (_q: string, _signal: AbortSignal) => A);
     const { result, rerender } = renderHook(
       ({ enabled }) => useAsyncOptions({ loadOptions, query: '', enabled, debounceMs: 100 }),
       { initialProps: { enabled: false } },

--- a/packages/design-system/src/components/Select/useAsyncOptions.test.ts
+++ b/packages/design-system/src/components/Select/useAsyncOptions.test.ts
@@ -29,9 +29,7 @@ describe('useAsyncOptions', () => {
 
   it('does NOT call loadOptions until enabled=true (loadOnOpen gate)', async () => {
     const loadOptions = vi.fn(async () => A);
-    renderHook(() =>
-      useAsyncOptions({ loadOptions, query: '', enabled: false, debounceMs: 100 }),
-    );
+    renderHook(() => useAsyncOptions({ loadOptions, query: '', enabled: false, debounceMs: 100 }));
     await vi.advanceTimersByTimeAsync(200);
     expect(loadOptions).not.toHaveBeenCalled();
   });

--- a/packages/design-system/src/components/Select/useAsyncOptions.ts
+++ b/packages/design-system/src/components/Select/useAsyncOptions.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SelectOptions } from './Select';
+
+/**
+ * Args accepted by `useAsyncOptions`.
+ *
+ * `loadOptions` is the consumer-supplied fetcher; the hook is a no-op when
+ * it's `undefined`. `query` and `enabled` drive when fetches happen:
+ * `enabled` gates the very first request (the `loadOnOpen` semantic — wait
+ * until the popover opens), `query` is what gets debounced and passed to
+ * each call. `debounceMs` is the delay between the last `query` change and
+ * the actual `loadOptions` invocation.
+ */
+export interface UseAsyncOptionsArgs<T = unknown> {
+  /** Async fetcher. Receives the current query and an `AbortSignal`. */
+  loadOptions?: (query: string, signal: AbortSignal) => Promise<SelectOptions<T>>;
+  /** Current search query string. Empty string is a valid fetch trigger. */
+  query: string;
+  /** When `false`, no fetches happen. Wired to "has the popover ever opened". */
+  enabled: boolean;
+  /** Debounce window before firing `loadOptions` after a query change. */
+  debounceMs: number;
+}
+
+/**
+ * Return value of `useAsyncOptions`.
+ *
+ * `options` is `[]` until the first successful fetch resolves. `loading` is
+ * `true` while a request is in flight (but flips back to `false` on abort
+ * too — the next request's `loading=true` takes over immediately). `error`
+ * is set on non-abort rejections and cleared at the start of each new
+ * fetch. `retry()` re-runs the current query (no debounce).
+ */
+export interface UseAsyncOptionsReturn<T = unknown> {
+  options: SelectOptions<T>;
+  loading: boolean;
+  error: Error | null;
+  retry: () => void;
+}
+
+/**
+ * Hook that wraps an async `loadOptions(query, signal)` into a state-row
+ * friendly shape (options/loading/error + retry). Handles three concerns
+ * the Select would otherwise reinvent:
+ *
+ * 1. Debouncing — collapses keystroke bursts into one request.
+ * 2. Cancellation — aborts the in-flight request when a new one starts, so
+ *    a slow response from query "ab" can't overwrite a fresh result for
+ *    "abc".
+ * 3. Lifecycle — aborts on unmount.
+ *
+ * The hook is gated by `enabled`: until the popover has opened at least
+ * once, no fetches fire. This matches the `loadOnOpen` prop semantic on
+ * `<Select>`.
+ */
+export function useAsyncOptions<T = unknown>(
+  args: UseAsyncOptionsArgs<T>,
+): UseAsyncOptionsReturn<T> {
+  const { loadOptions, query, enabled, debounceMs } = args;
+
+  const [options, setOptions] = useState<SelectOptions<T>>([] as SelectOptions<T>);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [retryToken, setRetryToken] = useState<number>(0);
+
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // `runFetch` aborts any in-flight request before starting a new one, so a
+  // slow response can never overwrite a fresher one. `signal.aborted` is
+  // checked again on both resolution paths to handle the race where the
+  // abort fires AFTER the network call resolved but BEFORE React processes
+  // the `.then`.
+  const runFetch = useCallback(
+    (q: string) => {
+      if (!loadOptions) return;
+      if (abortRef.current) abortRef.current.abort();
+      const ac = new AbortController();
+      abortRef.current = ac;
+      setLoading(true);
+      setError(null);
+      loadOptions(q, ac.signal)
+        .then((next) => {
+          if (ac.signal.aborted) return;
+          setOptions(next);
+          setLoading(false);
+        })
+        .catch((err) => {
+          if (ac.signal.aborted) return;
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setLoading(false);
+        });
+    },
+    [loadOptions],
+  );
+
+  // Debounced trigger: any time `query`, `enabled`, or the retry token
+  // changes, queue a fetch `debounceMs` later. The cleanup clears the
+  // pending timer so rapid changes collapse to a single fetch.
+  useEffect(() => {
+    if (!enabled || !loadOptions) return;
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = setTimeout(() => {
+      runFetch(query);
+    }, debounceMs);
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    };
+  }, [query, enabled, debounceMs, retryToken, runFetch, loadOptions]);
+
+  // Abort on unmount so a still-in-flight request can't write into a
+  // dead component.
+  useEffect(() => {
+    return () => {
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, []);
+
+  const retry = useCallback(() => {
+    setRetryToken((n) => n + 1);
+  }, []);
+
+  return { options, loading, error, retry };
+}

--- a/packages/design-system/src/components/Select/useSelectState.test.ts
+++ b/packages/design-system/src/components/Select/useSelectState.test.ts
@@ -3,9 +3,7 @@ import { useSelectState } from './useSelectState';
 
 describe('useSelectState — single mode', () => {
   it('initializes uncontrolled value from defaultValue', () => {
-    const { result } = renderHook(() =>
-      useSelectState({ multiple: false, defaultValue: 'a' }),
-    );
+    const { result } = renderHook(() => useSelectState({ multiple: false, defaultValue: 'a' }));
     expect(result.current.value).toBe('a');
   });
 
@@ -37,9 +35,7 @@ describe('useSelectState — single mode', () => {
 
   it('setValue in controlled mode fires onChange but does NOT update internal state', () => {
     const onChange = vi.fn();
-    const { result } = renderHook(() =>
-      useSelectState({ multiple: false, value: 'a', onChange }),
-    );
+    const { result } = renderHook(() => useSelectState({ multiple: false, value: 'a', onChange }));
     act(() => {
       result.current.setValue('b');
     });
@@ -107,9 +103,7 @@ describe('useSelectState — multi mode', () => {
 
   it('toggleValue in controlled mode fires onChange but does NOT update internal state', () => {
     const onChange = vi.fn();
-    const { result } = renderHook(() =>
-      useSelectState({ multiple: true, value: ['a'], onChange }),
-    );
+    const { result } = renderHook(() => useSelectState({ multiple: true, value: ['a'], onChange }));
     act(() => {
       result.current.toggleValue('b');
     });
@@ -125,17 +119,13 @@ describe('useSelectState — open state', () => {
   });
 
   it('respects defaultOpen', () => {
-    const { result } = renderHook(() =>
-      useSelectState({ multiple: false, defaultOpen: true }),
-    );
+    const { result } = renderHook(() => useSelectState({ multiple: false, defaultOpen: true }));
     expect(result.current.open).toBe(true);
   });
 
   it('setOpen toggles uncontrolled state and fires onOpenChange', () => {
     const onOpenChange = vi.fn();
-    const { result } = renderHook(() =>
-      useSelectState({ multiple: false, onOpenChange }),
-    );
+    const { result } = renderHook(() => useSelectState({ multiple: false, onOpenChange }));
     act(() => {
       result.current.setOpen(true);
     });

--- a/packages/design-system/src/components/Select/useSelectState.test.ts
+++ b/packages/design-system/src/components/Select/useSelectState.test.ts
@@ -1,0 +1,172 @@
+import { act, renderHook } from '@testing-library/react';
+import { useSelectState } from './useSelectState';
+
+describe('useSelectState — single mode', () => {
+  it('initializes uncontrolled value from defaultValue', () => {
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: false, defaultValue: 'a' }),
+    );
+    expect(result.current.value).toBe('a');
+  });
+
+  it("defaults uncontrolled value to '' when no defaultValue is provided", () => {
+    const { result } = renderHook(() => useSelectState({ multiple: false }));
+    expect(result.current.value).toBe('');
+  });
+
+  it('setValue updates internal state and fires onChange in uncontrolled mode', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useSelectState({ multiple: false, onChange }));
+    act(() => {
+      result.current.setValue('a');
+    });
+    expect(result.current.value).toBe('a');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('a');
+  });
+
+  it('reflects controlled value after rerender', () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useSelectState({ multiple: false, value }),
+      { initialProps: { value: 'a' } },
+    );
+    expect(result.current.value).toBe('a');
+    rerender({ value: 'b' });
+    expect(result.current.value).toBe('b');
+  });
+
+  it('setValue in controlled mode fires onChange but does NOT update internal state', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: false, value: 'a', onChange }),
+    );
+    act(() => {
+      result.current.setValue('b');
+    });
+    expect(result.current.value).toBe('a');
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('toggleValue in single mode behaves like setValue', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useSelectState({ multiple: false, onChange }));
+    act(() => {
+      result.current.toggleValue('a');
+    });
+    expect(result.current.value).toBe('a');
+    expect(onChange).toHaveBeenCalledWith('a');
+  });
+});
+
+describe('useSelectState — multi mode', () => {
+  it('initializes uncontrolled value from defaultValue array', () => {
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: true, defaultValue: ['a', 'b'] }),
+    );
+    expect(result.current.value).toEqual(['a', 'b']);
+  });
+
+  it('defaults uncontrolled value to [] when no defaultValue is provided', () => {
+    const { result } = renderHook(() => useSelectState({ multiple: true }));
+    expect(result.current.value).toEqual([]);
+  });
+
+  it('toggleValue appends a value that is not present', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: true, defaultValue: ['a'], onChange }),
+    );
+    act(() => {
+      result.current.toggleValue('b');
+    });
+    expect(result.current.value).toEqual(['a', 'b']);
+    expect(onChange).toHaveBeenLastCalledWith(['a', 'b']);
+  });
+
+  it('toggleValue removes a value that is already present', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: true, defaultValue: ['a', 'b'], onChange }),
+    );
+    act(() => {
+      result.current.toggleValue('a');
+    });
+    expect(result.current.value).toEqual(['b']);
+    expect(onChange).toHaveBeenLastCalledWith(['b']);
+  });
+
+  it('reflects controlled value array after rerender', () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string[] }) => useSelectState({ multiple: true, value }),
+      { initialProps: { value: ['a'] } },
+    );
+    expect(result.current.value).toEqual(['a']);
+    rerender({ value: ['a', 'b'] });
+    expect(result.current.value).toEqual(['a', 'b']);
+  });
+
+  it('toggleValue in controlled mode fires onChange but does NOT update internal state', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: true, value: ['a'], onChange }),
+    );
+    act(() => {
+      result.current.toggleValue('b');
+    });
+    expect(result.current.value).toEqual(['a']);
+    expect(onChange).toHaveBeenLastCalledWith(['a', 'b']);
+  });
+});
+
+describe('useSelectState — open state', () => {
+  it('defaults to closed', () => {
+    const { result } = renderHook(() => useSelectState({ multiple: false }));
+    expect(result.current.open).toBe(false);
+  });
+
+  it('respects defaultOpen', () => {
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: false, defaultOpen: true }),
+    );
+    expect(result.current.open).toBe(true);
+  });
+
+  it('setOpen toggles uncontrolled state and fires onOpenChange', () => {
+    const onOpenChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: false, onOpenChange }),
+    );
+    act(() => {
+      result.current.setOpen(true);
+    });
+    expect(result.current.open).toBe(true);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    act(() => {
+      result.current.setOpen(false);
+    });
+    expect(result.current.open).toBe(false);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('honors controlled open prop after rerender', () => {
+    const { result, rerender } = renderHook(
+      ({ open }: { open: boolean }) => useSelectState({ multiple: false, open }),
+      { initialProps: { open: false } },
+    );
+    expect(result.current.open).toBe(false);
+    rerender({ open: true });
+    expect(result.current.open).toBe(true);
+  });
+
+  it('setOpen in controlled mode fires onOpenChange but does NOT update internal state', () => {
+    const onOpenChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectState({ multiple: false, open: false, onOpenChange }),
+    );
+    act(() => {
+      result.current.setOpen(true);
+    });
+    expect(result.current.open).toBe(false);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/packages/design-system/src/components/Select/useSelectState.ts
+++ b/packages/design-system/src/components/Select/useSelectState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 export interface UseSelectStateArgs {
   /** When `true`, value is a `string[]`; when `false`, a `string`. */
@@ -17,11 +17,15 @@ export interface UseSelectStateArgs {
   onOpenChange?: (open: boolean) => void;
 }
 
-export interface UseSelectStateReturn {
+/**
+ * Return shape of `useSelectState`, parameterized by the value type so
+ * overloads can narrow `value` / `setValue` based on `multiple`.
+ */
+export interface UseSelectStateReturn<V extends string | string[] = string | string[]> {
   /** Current value — `string` in single mode, `string[]` in multi. */
-  value: string | string[];
+  value: V;
   /** Replace the entire selection. */
-  setValue: (next: string | string[]) => void;
+  setValue: (next: V) => void;
   /**
    * Multi: toggle membership of `v` (add when missing, remove when present).
    * Single: equivalent to `setValue(v)`.
@@ -31,6 +35,15 @@ export interface UseSelectStateReturn {
   open: boolean;
   /** Set open state. */
   setOpen: (next: boolean) => void;
+}
+
+interface StateRefShape {
+  multiple: boolean;
+  isControlledValue: boolean;
+  isControlledOpen: boolean;
+  currentValue: string | string[];
+  onChange?: (value: string | string[]) => void;
+  onOpenChange?: (open: boolean) => void;
 }
 
 const emptyValue = (multiple: boolean): string | string[] => (multiple ? [] : '');
@@ -44,8 +57,28 @@ const emptyValue = (multiple: boolean): string | string[] => (multiple ? [] : ''
  *    `onChange` but do NOT update internal state.
  *  - `open !== undefined` → controlled. `setOpen` fires `onOpenChange`
  *    but does NOT update internal state.
+ *
+ * @example
+ *   const { value, setValue } = useSelectState({ multiple: false });
+ *   // value is typed as `string`
+ *
+ * @example
+ *   const { value, setValue } = useSelectState({ multiple: true });
+ *   // value is typed as `string[]`
  */
-export function useSelectState(args: UseSelectStateArgs): UseSelectStateReturn {
+export function useSelectState(
+  args: UseSelectStateArgs & { multiple: false },
+): UseSelectStateReturn<string>;
+export function useSelectState(
+  args: UseSelectStateArgs & { multiple: true },
+): UseSelectStateReturn<string[]>;
+export function useSelectState(args: UseSelectStateArgs): UseSelectStateReturn;
+// Implementation signature: intentionally permissive — public callers see one
+// of the three overloads above. `UseSelectStateReturn<string | string[]>`
+// would not be a valid supertype of `UseSelectStateReturn<string>` because
+// `setValue` is contravariant in V.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useSelectState(args: UseSelectStateArgs): UseSelectStateReturn<any> {
   const { multiple, value, defaultValue, onChange, open, defaultOpen, onOpenChange } = args;
 
   const [internalValue, setInternalValue] = useState<string | string[]>(
@@ -57,23 +90,29 @@ export function useSelectState(args: UseSelectStateArgs): UseSelectStateReturn {
   const isControlledOpen = open !== undefined;
 
   // Stable refs so the returned callbacks have stable identity even though
-  // they read fresh values on every invocation.
-  const stateRef = useRef({
+  // they read fresh values on every invocation. The ref is seeded with the
+  // initial values and refreshed in a layout effect — assigning during render
+  // would violate React's render-purity rule under StrictMode / concurrent
+  // rendering (a discarded render could mutate state observed by a
+  // not-yet-committed update).
+  const stateRef = useRef<StateRefShape>({
     multiple,
     isControlledValue,
     isControlledOpen,
-    currentValue: isControlledValue ? value : internalValue,
+    currentValue: isControlledValue ? (value as string | string[]) : internalValue,
     onChange,
     onOpenChange,
   });
-  stateRef.current = {
-    multiple,
-    isControlledValue,
-    isControlledOpen,
-    currentValue: isControlledValue ? value : internalValue,
-    onChange,
-    onOpenChange,
-  };
+  useLayoutEffect(() => {
+    stateRef.current = {
+      multiple,
+      isControlledValue,
+      isControlledOpen,
+      currentValue: isControlledValue ? (value as string | string[]) : internalValue,
+      onChange,
+      onOpenChange,
+    };
+  });
 
   const setValue = useCallback((next: string | string[]) => {
     const s = stateRef.current;

--- a/packages/design-system/src/components/Select/useSelectState.ts
+++ b/packages/design-system/src/components/Select/useSelectState.ts
@@ -1,0 +1,118 @@
+import { useCallback, useRef, useState } from 'react';
+
+export interface UseSelectStateArgs {
+  /** When `true`, value is a `string[]`; when `false`, a `string`. */
+  multiple: boolean;
+  /** Controlled value. When defined, internal state is bypassed. */
+  value?: string | string[];
+  /** Initial value when uncontrolled. Falls back to `''` (single) / `[]` (multi). */
+  defaultValue?: string | string[];
+  /** Fires on every commit, including in controlled mode (where state stays put). */
+  onChange?: (value: string | string[]) => void;
+  /** Controlled open. When defined, internal open state is bypassed. */
+  open?: boolean;
+  /** Initial open when uncontrolled. Defaults to `false`. */
+  defaultOpen?: boolean;
+  /** Fires on every commit to open state, including in controlled mode. */
+  onOpenChange?: (open: boolean) => void;
+}
+
+export interface UseSelectStateReturn {
+  /** Current value — `string` in single mode, `string[]` in multi. */
+  value: string | string[];
+  /** Replace the entire selection. */
+  setValue: (next: string | string[]) => void;
+  /**
+   * Multi: toggle membership of `v` (add when missing, remove when present).
+   * Single: equivalent to `setValue(v)`.
+   */
+  toggleValue: (v: string) => void;
+  /** Current open state. */
+  open: boolean;
+  /** Set open state. */
+  setOpen: (next: boolean) => void;
+}
+
+const emptyValue = (multiple: boolean): string | string[] => (multiple ? [] : '');
+
+/**
+ * Combined reducer-like state for Select: controlled/uncontrolled value
+ * and open state, plus a multi-aware `toggleValue` helper.
+ *
+ * Controlled vs. uncontrolled is decided per-axis (value, open):
+ *  - `value !== undefined` → controlled. `setValue` / `toggleValue` fire
+ *    `onChange` but do NOT update internal state.
+ *  - `open !== undefined` → controlled. `setOpen` fires `onOpenChange`
+ *    but does NOT update internal state.
+ */
+export function useSelectState(args: UseSelectStateArgs): UseSelectStateReturn {
+  const { multiple, value, defaultValue, onChange, open, defaultOpen, onOpenChange } = args;
+
+  const [internalValue, setInternalValue] = useState<string | string[]>(
+    () => defaultValue ?? emptyValue(multiple),
+  );
+  const [internalOpen, setInternalOpen] = useState<boolean>(defaultOpen ?? false);
+
+  const isControlledValue = value !== undefined;
+  const isControlledOpen = open !== undefined;
+
+  // Stable refs so the returned callbacks have stable identity even though
+  // they read fresh values on every invocation.
+  const stateRef = useRef({
+    multiple,
+    isControlledValue,
+    isControlledOpen,
+    currentValue: isControlledValue ? value : internalValue,
+    onChange,
+    onOpenChange,
+  });
+  stateRef.current = {
+    multiple,
+    isControlledValue,
+    isControlledOpen,
+    currentValue: isControlledValue ? value : internalValue,
+    onChange,
+    onOpenChange,
+  };
+
+  const setValue = useCallback((next: string | string[]) => {
+    const s = stateRef.current;
+    if (!s.isControlledValue) {
+      setInternalValue(next);
+    }
+    s.onChange?.(next);
+  }, []);
+
+  const toggleValue = useCallback((v: string) => {
+    const s = stateRef.current;
+    if (!s.multiple) {
+      if (!s.isControlledValue) {
+        setInternalValue(v);
+      }
+      s.onChange?.(v);
+      return;
+    }
+    const current = (s.currentValue as string[]) ?? [];
+    const next = current.includes(v) ? current.filter((x) => x !== v) : [...current, v];
+    if (!s.isControlledValue) {
+      setInternalValue(next);
+    }
+    s.onChange?.(next);
+  }, []);
+
+  const setOpen = useCallback((next: boolean) => {
+    const s = stateRef.current;
+    if (!s.isControlledOpen) {
+      setInternalOpen(next);
+    }
+    s.onOpenChange?.(next);
+  }, []);
+
+  return {
+    value: isControlledValue ? (value as string | string[]) : internalValue,
+    setValue,
+    toggleValue,
+    open: isControlledOpen ? (open as boolean) : internalOpen,
+    setOpen,
+  };
+}

--- a/packages/design-system/src/components/Select/utils-types.ts
+++ b/packages/design-system/src/components/Select/utils-types.ts
@@ -1,0 +1,7 @@
+// Tiny re-export module that breaks the circular import that would
+// otherwise exist between `Select.tsx` (which imports the SelectContext
+// from `./context`) and `context.ts` (which needs `SelectOption` etc.
+// declared in `Select.tsx`). Subcomponents and `context.ts` import these
+// types from here rather than from `./Select` directly.
+export type { SelectOption, SelectGroup, SelectOptions } from './Select';
+export type { FlatRow } from './utils';

--- a/packages/design-system/src/components/Select/utils.test.ts
+++ b/packages/design-system/src/components/Select/utils.test.ts
@@ -1,5 +1,12 @@
 import type { SelectGroup, SelectOption, SelectOptions } from './Select';
-import { findOption, findOptions, flattenOptions, isGrouped } from './utils';
+import {
+  findOption,
+  findOptions,
+  flattenOptions,
+  hasExactLabelMatch,
+  isCreateRow,
+  isGrouped,
+} from './utils';
 
 const flat: SelectOption[] = [
   { value: 'a', label: 'Apple' },
@@ -108,5 +115,36 @@ describe('findOptions', () => {
 
   it('returns an empty array for an empty input', () => {
     expect(findOptions([] as SelectOptions, ['a'])).toEqual([]);
+  });
+});
+
+describe('hasExactLabelMatch', () => {
+  it('returns false for empty query', () => {
+    expect(hasExactLabelMatch([{ value: 'a', label: 'A' }], '')).toBe(false);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(hasExactLabelMatch([{ value: 'a', label: 'Alpha' }], 'alpha')).toBe(true);
+    expect(hasExactLabelMatch([{ value: 'a', label: 'Alpha' }], 'ALPHA')).toBe(true);
+  });
+
+  it('requires exact match, not substring', () => {
+    expect(hasExactLabelMatch([{ value: 'a', label: 'Alpha' }], 'Alph')).toBe(false);
+  });
+
+  it('walks grouped options', () => {
+    const opts: SelectGroup[] = [{ label: 'G', options: [{ value: 'a', label: 'Alpha' }] }];
+    expect(hasExactLabelMatch(opts, 'alpha')).toBe(true);
+  });
+});
+
+describe('isCreateRow', () => {
+  it('returns true when data has __create: true', () => {
+    expect(isCreateRow({ data: { __create: true } })).toBe(true);
+  });
+
+  it('returns false for plain options', () => {
+    expect(isCreateRow({ data: { id: 'x' } })).toBe(false);
+    expect(isCreateRow({})).toBe(false);
   });
 });

--- a/packages/design-system/src/components/Select/utils.test.ts
+++ b/packages/design-system/src/components/Select/utils.test.ts
@@ -1,0 +1,112 @@
+import type { SelectGroup, SelectOption, SelectOptions } from './Select';
+import { findOption, findOptions, flattenOptions, isGrouped } from './utils';
+
+const flat: SelectOption[] = [
+  { value: 'a', label: 'Apple' },
+  { value: 'b', label: 'Banana' },
+  { value: 'c', label: 'Cherry', disabled: true },
+];
+
+const grouped: SelectGroup[] = [
+  {
+    label: 'Fruits',
+    options: [
+      { value: 'a', label: 'Apple' },
+      { value: 'b', label: 'Banana' },
+    ],
+  },
+  {
+    label: 'Vegetables',
+    options: [{ value: 'c', label: 'Carrot' }],
+  },
+];
+
+describe('isGrouped', () => {
+  it('returns false for a flat option list', () => {
+    expect(isGrouped(flat)).toBe(false);
+  });
+
+  it('returns true for a grouped option list', () => {
+    expect(isGrouped(grouped)).toBe(true);
+  });
+
+  it('returns false for an empty list (no first element to inspect)', () => {
+    expect(isGrouped([] as SelectOptions)).toBe(false);
+  });
+});
+
+describe('flattenOptions', () => {
+  it('returns just option rows for a flat list', () => {
+    const rows = flattenOptions(flat);
+    expect(rows).toEqual([
+      { kind: 'option', option: flat[0] },
+      { kind: 'option', option: flat[1] },
+      { kind: 'option', option: flat[2] },
+    ]);
+  });
+
+  it('emits a header row before each group and tags options with groupLabel', () => {
+    const rows = flattenOptions(grouped);
+    expect(rows).toEqual([
+      { kind: 'header', label: 'Fruits' },
+      { kind: 'option', option: grouped[0].options[0], groupLabel: 'Fruits' },
+      { kind: 'option', option: grouped[0].options[1], groupLabel: 'Fruits' },
+      { kind: 'header', label: 'Vegetables' },
+      { kind: 'option', option: grouped[1].options[0], groupLabel: 'Vegetables' },
+    ]);
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(flattenOptions([] as SelectOptions)).toEqual([]);
+  });
+});
+
+describe('findOption', () => {
+  it('returns the matching option from a flat list', () => {
+    expect(findOption(flat, 'b')).toEqual({ value: 'b', label: 'Banana' });
+  });
+
+  it('returns the matching option from a grouped list (searches inside groups)', () => {
+    expect(findOption(grouped, 'c')).toEqual({ value: 'c', label: 'Carrot' });
+  });
+
+  it('returns null when the value is not found', () => {
+    expect(findOption(flat, 'zzz')).toBeNull();
+    expect(findOption(grouped, 'zzz')).toBeNull();
+  });
+
+  it('returns null for an empty input', () => {
+    expect(findOption([] as SelectOptions, 'a')).toBeNull();
+  });
+});
+
+describe('findOptions', () => {
+  it('returns matching options preserving the order of options (not the values arg)', () => {
+    expect(findOptions(flat, ['b', 'a'])).toEqual([
+      { value: 'a', label: 'Apple' },
+      { value: 'b', label: 'Banana' },
+    ]);
+  });
+
+  it('skips values that are not found (no nulls in the result)', () => {
+    expect(findOptions(flat, ['a', 'zzz', 'c'])).toEqual([
+      { value: 'a', label: 'Apple' },
+      { value: 'c', label: 'Cherry', disabled: true },
+    ]);
+  });
+
+  it('works on grouped lists, preserving option order across groups', () => {
+    expect(findOptions(grouped, ['c', 'a'])).toEqual([
+      { value: 'a', label: 'Apple' },
+      { value: 'c', label: 'Carrot' },
+    ]);
+  });
+
+  it('returns an empty array when the values arg is empty', () => {
+    expect(findOptions(flat, [])).toEqual([]);
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(findOptions([] as SelectOptions, ['a'])).toEqual([]);
+  });
+});

--- a/packages/design-system/src/components/Select/utils.ts
+++ b/packages/design-system/src/components/Select/utils.ts
@@ -83,3 +83,40 @@ export function findOptions<T>(opts: SelectOptions<T>, values: string[]): Select
   }
   return out;
 }
+
+/**
+ * Returns true if any option in `opts` has a label case-insensitively
+ * matching `query` (after trim). Used by the creatable Select to decide
+ * whether to render a "+ Create" row — when the typed query already
+ * matches an existing label, the create row would be a no-op duplicate.
+ *
+ * The empty / whitespace-only query case returns `false` so the create
+ * row never appears for blank input.
+ */
+export function hasExactLabelMatch<T>(opts: SelectOptions<T>, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q === '') return false;
+  if (!isGrouped(opts)) {
+    return opts.some((o) => o.label.toLowerCase() === q);
+  }
+  for (const g of opts) {
+    if (g.options.some((o) => o.label.toLowerCase() === q)) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns true if an option carries the internal `__create` sentinel on
+ * its `data` payload. The sentinel is injected by `<Select>` when it
+ * synthesises the "+ Create" row, and the listbox + Trigger keyboard
+ * handlers branch on it to fire `onCreate` instead of the normal
+ * select/toggle flow.
+ */
+export function isCreateRow<T>(opt: { data?: T }): boolean {
+  return (
+    typeof opt.data === 'object' &&
+    opt.data !== null &&
+    Object.prototype.hasOwnProperty.call(opt.data, '__create') &&
+    (opt.data as { __create?: boolean }).__create === true
+  );
+}

--- a/packages/design-system/src/components/Select/utils.ts
+++ b/packages/design-system/src/components/Select/utils.ts
@@ -1,0 +1,85 @@
+import type { SelectGroup, SelectOption, SelectOptions } from './Select';
+
+/**
+ * Discriminator for `SelectOptions`: returns `true` when the input is a
+ * `SelectGroup[]` (i.e. the first element exposes an `options` array),
+ * `false` for a flat `SelectOption[]` and for an empty list.
+ *
+ * Mixing groups and flat options at the same level is not supported;
+ * only the first element is inspected.
+ */
+export function isGrouped<T>(opts: SelectOptions<T>): opts is SelectGroup<T>[] {
+  if (opts.length === 0) return false;
+  const first = opts[0] as SelectOption<T> | SelectGroup<T>;
+  return Array.isArray((first as SelectGroup<T>).options);
+}
+
+/**
+ * One row in the flattened render list — either a non-selectable group
+ * header or a selectable option. `groupLabel` is set on option rows when
+ * they belong to a group, so the renderer can group them visually or in
+ * `aria-` attributes without re-walking the original tree.
+ */
+export type FlatRow<T = unknown> =
+  | { kind: 'header'; label: string }
+  | { kind: 'option'; option: SelectOption<T>; groupLabel?: string };
+
+/**
+ * Walk `SelectOptions` into a flat array of render rows.
+ *
+ * - Flat input → one `'option'` row per option (no `groupLabel`).
+ * - Grouped input → for each group: one `'header'` row then one
+ *   `'option'` row per member (each tagged with its `groupLabel`).
+ */
+export function flattenOptions<T>(opts: SelectOptions<T>): FlatRow<T>[] {
+  if (!isGrouped(opts)) {
+    return (opts as SelectOption<T>[]).map((option) => ({ kind: 'option', option }));
+  }
+  const rows: FlatRow<T>[] = [];
+  for (const group of opts) {
+    rows.push({ kind: 'header', label: group.label });
+    for (const option of group.options) {
+      rows.push({ kind: 'option', option, groupLabel: group.label });
+    }
+  }
+  return rows;
+}
+
+/**
+ * Find a single option by `value`. Walks groups when the input is
+ * grouped. Returns `null` when no match exists.
+ */
+export function findOption<T>(opts: SelectOptions<T>, value: string): SelectOption<T> | null {
+  if (isGrouped(opts)) {
+    for (const group of opts) {
+      const hit = group.options.find((o) => o.value === value);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  return (opts as SelectOption<T>[]).find((o) => o.value === value) ?? null;
+}
+
+/**
+ * Find every option whose `value` appears in `values`. The returned
+ * array preserves the order of options in `opts` (NOT the order of the
+ * `values` argument), and values with no match are skipped silently —
+ * the result contains no nulls and no duplicates beyond what's in `opts`.
+ */
+export function findOptions<T>(opts: SelectOptions<T>, values: string[]): SelectOption<T>[] {
+  if (values.length === 0) return [];
+  const wanted = new Set(values);
+  const out: SelectOption<T>[] = [];
+  if (isGrouped(opts)) {
+    for (const group of opts) {
+      for (const option of group.options) {
+        if (wanted.has(option.value)) out.push(option);
+      }
+    }
+    return out;
+  }
+  for (const option of opts as SelectOption<T>[]) {
+    if (wanted.has(option.value)) out.push(option);
+  }
+  return out;
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -63,3 +63,6 @@ export type {
   ConfirmationPopoverProps,
   ConfirmationVariant,
 } from './components/ConfirmationPopover';
+
+export { Select } from './components/Select';
+export type { SelectProps } from './components/Select';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -65,4 +65,11 @@ export type {
 } from './components/ConfirmationPopover';
 
 export { Select } from './components/Select';
-export type { SelectProps } from './components/Select';
+export type {
+  SelectProps,
+  SelectOption,
+  SelectGroup,
+  SelectOptions,
+  SelectSize,
+  SelectTriggerDisplay,
+} from './components/Select';

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -113,6 +113,11 @@
   --size-badge-dot: 6px;
   --size-chip: 18px;
 
+  // Indeterminate loading spinner (Select listbox loading row). Small
+  // enough to fit inline next to the "Loading…" label without dominating
+  // the row.
+  --size-spinner: 14px;
+
   // Minimum width for popover-shaped surfaces (DropdownMenu, future Tooltip,
   // Popover). Picks a value wide enough for short labels without overflowing
   // trigger-tight clusters.

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -145,6 +145,7 @@
   // States
   --opacity-disabled: 0.5;
   --opacity-hidden: 0;
+  --opacity-visible: 1;
 
   // Shadows — Atlassian uses subtle elevation
   --shadow-sm: 0 1px 2px rgb(9 30 66 / 8%);

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -9,6 +9,7 @@ import { Members } from './pages/mockups/Members/Members';
 import { ComponentsIndex } from './pages/components/ComponentsIndex';
 import { ButtonDemo } from './pages/components/ButtonDemo';
 import { InputDemo } from './pages/components/InputDemo';
+import { SelectDemo } from './pages/components/SelectDemo';
 import { CardDemo } from './pages/components/CardDemo';
 import { StackDemo } from './pages/components/StackDemo';
 import { ClusterDemo } from './pages/components/ClusterDemo';
@@ -37,6 +38,7 @@ export default function App() {
           <Route path="/components" element={<ComponentsIndex />} />
           <Route path="/components/button" element={<ButtonDemo />} />
           <Route path="/components/input" element={<InputDemo />} />
+          <Route path="/components/select" element={<SelectDemo />} />
           <Route path="/components/card" element={<CardDemo />} />
           <Route path="/components/stack" element={<StackDemo />} />
           <Route path="/components/cluster" element={<ClusterDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -11,6 +11,7 @@ import {
   Component,
   MousePointer2,
   TextCursorInput,
+  ChevronsUpDown,
   RectangleHorizontal,
   Rows3,
   Columns3,
@@ -58,6 +59,7 @@ const componentGroups = [
     items: [
       { to: '/components/button', label: 'Button', icon: MousePointer2, end: false },
       { to: '/components/input', label: 'Input', icon: TextCursorInput, end: false },
+      { to: '/components/select', label: 'Select', icon: ChevronsUpDown, end: false },
     ],
   },
   {

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -6,6 +6,7 @@ import { Button } from '@eocrm/design-system';
 import { Card } from '@eocrm/design-system';
 import { Cluster } from '@eocrm/design-system';
 import { Input } from '@eocrm/design-system';
+import { Select } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { Tabs } from '@eocrm/design-system';
 import { DropdownMenu } from '@eocrm/design-system';
@@ -34,6 +35,24 @@ const items: { to: string; name: string; description: string; preview: React.Rea
     preview: (
       <div style={{ width: 200 }}>
         <Input placeholder="Type here…" />
+      </div>
+    ),
+  },
+  {
+    to: '/components/select',
+    name: 'Select',
+    description:
+      'Value picker — single, multi (chips and summary), searchable, async, creatable. The generalist.',
+    preview: (
+      <div style={{ width: 200 }}>
+        <Select
+          options={[
+            { value: 'active', label: 'Active' },
+            { value: 'pending', label: 'Pending' },
+            { value: 'archived', label: 'Archived' },
+          ]}
+          placeholder="Pick a status"
+        />
       </div>
     ),
   },

--- a/packages/playground/src/pages/components/SelectDemo.tsx
+++ b/packages/playground/src/pages/components/SelectDemo.tsx
@@ -1,5 +1,13 @@
 import { useState } from 'react';
-import { Avatar, Badge, Button, Cluster, Select, Stack, type SelectOption } from '@eocrm/design-system';
+import {
+  Avatar,
+  Badge,
+  Button,
+  Cluster,
+  Select,
+  Stack,
+  type SelectOption,
+} from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import tsxSource from '@lib-source/components/Select/Select.tsx?raw';

--- a/packages/playground/src/pages/components/SelectDemo.tsx
+++ b/packages/playground/src/pages/components/SelectDemo.tsx
@@ -1,12 +1,5 @@
 import { useState } from 'react';
-import {
-  Avatar,
-  Badge,
-  Cluster,
-  Select,
-  Stack,
-  type SelectOption,
-} from '@eocrm/design-system';
+import { Avatar, Badge, Cluster, Select, Stack, type SelectOption } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import tsxSource from '@lib-source/components/Select/Select.tsx?raw';

--- a/packages/playground/src/pages/components/SelectDemo.tsx
+++ b/packages/playground/src/pages/components/SelectDemo.tsx
@@ -1,0 +1,456 @@
+import { useState } from 'react';
+import {
+  Avatar,
+  Badge,
+  Cluster,
+  Select,
+  Stack,
+  type SelectOption,
+} from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Select/Select.tsx?raw';
+import scssSource from '@lib-source/components/Select/Select.module.scss?raw';
+
+// ── Demo data ───────────────────────────────────────────────────────────────
+
+const STATUSES: SelectOption[] = [
+  { value: 'active', label: 'Active' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'archived', label: 'Archived' },
+];
+
+const COUNTRIES = [
+  {
+    label: 'Americas',
+    options: [
+      { value: 'us', label: 'United States' },
+      { value: 'ca', label: 'Canada' },
+      { value: 'br', label: 'Brazil' },
+    ],
+  },
+  {
+    label: 'Europe',
+    options: [
+      { value: 'de', label: 'Germany' },
+      { value: 'fr', label: 'France' },
+      { value: 'gb', label: 'United Kingdom' },
+    ],
+  },
+  {
+    label: 'Asia-Pacific',
+    options: [
+      { value: 'jp', label: 'Japan' },
+      { value: 'au', label: 'Australia' },
+    ],
+  },
+];
+
+const MOCK_USERS = [
+  { id: 'u1', name: 'Alex Rivera', email: 'alex@example.com' },
+  { id: 'u2', name: 'Bea Chen', email: 'bea@example.com' },
+  { id: 'u3', name: 'Cam Patel', email: 'cam@example.com' },
+  { id: 'u4', name: 'Dani Kowalski', email: 'dani@example.com' },
+  { id: 'u5', name: 'Eli Goldberg', email: 'eli@example.com' },
+];
+
+async function fakeFetchUsers(query: string, signal: AbortSignal): Promise<SelectOption[]> {
+  await new Promise((r) => setTimeout(r, 250));
+  if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+  const q = query.toLowerCase();
+  return MOCK_USERS.filter((u) => u.name.toLowerCase().includes(q)).map((u) => ({
+    value: u.id,
+    label: u.name,
+    description: u.email,
+    data: u,
+  }));
+}
+
+async function flakyFetch(_query: string, signal: AbortSignal): Promise<SelectOption[]> {
+  await new Promise((r) => setTimeout(r, 200));
+  if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+  if (Math.random() < 0.5) {
+    throw new Error('Network glitched. Try again.');
+  }
+  return MOCK_USERS.slice(0, 3).map((u) => ({ value: u.id, label: u.name }));
+}
+
+// ── Page ────────────────────────────────────────────────────────────────────
+
+export function SelectDemo() {
+  return (
+    <DemoLayout
+      name="Select"
+      description="Value picker — single, multi (chips and summary), searchable, async, creatable. The generalist."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Select.tsx"
+      scssFilename="Select.module.scss"
+    >
+      <Example
+        title="Status — single, non-searchable"
+        description="The simplest case. Static options, single value, no search input."
+        code={`const [status, setStatus] = useState('');
+<Select
+  options={STATUSES}
+  value={status}
+  onChange={(v) => setStatus(v as string)}
+  placeholder="Pick a status"
+/>`}
+      >
+        <Cluster gap="md" justify="center">
+          <StatusExample />
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Country — single, searchable, grouped"
+        description="Options can be nested under group labels. Type to filter; arrow keys traverse across groups."
+        code={`<Select
+  searchable
+  options={COUNTRIES}
+  value={country}
+  onChange={(v) => setCountry(v as string)}
+  placeholder="Search countries…"
+/>`}
+      >
+        <Cluster gap="md" justify="center">
+          <CountryExample />
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Assignee — single, async with custom render"
+        description="Pass `loadOptions(query, signal)` to fetch on demand. `renderOption` lets the dropdown show whatever you need — avatar + name + email here."
+        code={`<Select
+  searchable
+  loadOptions={fetchUsers}
+  value={assignee}
+  onChange={(v) => setAssignee(v as string)}
+  placeholder="Find a user…"
+  renderOption={(opt) => (
+    <Cluster gap="sm" align="center">
+      <Avatar name={opt.label} size="sm" />
+      <Stack gap="xs">
+        <span>{opt.label}</span>
+        <small>{opt.description}</small>
+      </Stack>
+    </Cluster>
+  )}
+/>`}
+      >
+        <Cluster gap="md" justify="center">
+          <AssigneeExample />
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Async + error retry"
+        description="The flaky fetch fails ~50% of the time. The listbox surfaces the error with a Retry affordance."
+        code={`<Select searchable loadOptions={flakyFetch} placeholder="Pick a user (may fail)" />`}
+      >
+        <Cluster gap="md" justify="center">
+          <Select searchable loadOptions={flakyFetch} placeholder="Pick a user (may fail)" />
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Status filter — multi, summary trigger"
+        description="`multiple` + `triggerDisplay='summary'` shows '2 selected' in the trigger. Best for compact filter bars."
+        code={`<Select
+  multiple
+  triggerDisplay="summary"
+  searchable
+  options={STATUSES}
+  value={statusFilter}
+  onChange={(v) => setStatusFilter(v as string[])}
+  placeholder="Filter by status"
+/>`}
+      >
+        <Cluster gap="md" justify="center">
+          <StatusFilterExample />
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Owners — multi, chips trigger"
+        description="`triggerDisplay='chips'` (the default for multi) renders each selection as a removable chip in the trigger."
+        code={`<Select
+  multiple
+  triggerDisplay="chips"
+  searchable
+  loadOptions={fetchUsers}
+  value={owners}
+  onChange={(v) => setOwners(v as string[])}
+  placeholder="Pick owners…"
+/>`}
+      >
+        <Cluster gap="md" justify="center">
+          <OwnersExample />
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Tags — multi, chips, searchable, creatable"
+        description="`creatable` shows a 'Create &quot;…&quot;' row when the query has no exact match. `onCreate(label)` fires when the user picks it; you decide what to do with the new value."
+        code={`<Select
+  multiple
+  searchable
+  creatable
+  triggerDisplay="chips"
+  options={tagOptions}
+  value={tags}
+  onChange={(v) => setTags(v as string[])}
+  onCreate={(label) => addTag(label)}
+  placeholder="Add tags…"
+/>`}
+      >
+        <Cluster gap="md" justify="center">
+          <TagsExample />
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Visual states — disabled, readOnly, invalid"
+        description="`disabled` blocks all interaction. `readOnly` shows the value but blocks editing. `invalid` paints the trigger with the error ring."
+        code={`<Select options={STATUSES} disabled value="pending" />
+<Select options={STATUSES} readOnly value="active" />
+<Select options={STATUSES} invalid placeholder="Required" />`}
+      >
+        <Cluster gap="md" wrap justify="center">
+          <div style={{ minWidth: 200 }}>
+            <Select options={STATUSES} disabled value="pending" />
+          </div>
+          <div style={{ minWidth: 200 }}>
+            <Select options={STATUSES} readOnly value="active" />
+          </div>
+          <div style={{ minWidth: 200 }}>
+            <Select options={STATUSES} invalid placeholder="Required" />
+          </div>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Sizes — sm / md / lg"
+        description="`size` controls the trigger height and font size. The listbox typography scales to match."
+        code={`<Select options={STATUSES} size="sm" placeholder="sm" />
+<Select options={STATUSES} size="md" placeholder="md" />
+<Select options={STATUSES} size="lg" placeholder="lg" />`}
+      >
+        <Cluster gap="md" wrap justify="center">
+          <div style={{ width: 200 }}>
+            <Select options={STATUSES} size="sm" placeholder="sm" />
+          </div>
+          <div style={{ width: 200 }}>
+            <Select options={STATUSES} size="md" placeholder="md" />
+          </div>
+          <div style={{ width: 200 }}>
+            <Select options={STATUSES} size="lg" placeholder="lg" />
+          </div>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Form integration"
+        description="`name` makes Select participate in native FormData. Single values become one entry; multi values become repeated entries. `required` blocks submit when empty."
+        code={`<form onSubmit={(e) => {
+  e.preventDefault();
+  const data = new FormData(e.currentTarget);
+  console.log(data.get('status'), data.getAll('tags'));
+}}>
+  <Select options={STATUSES} name="status" required placeholder="Status (required)" />
+  <Select multiple triggerDisplay="chips" searchable creatable
+    options={tagOptions} name="tags" placeholder="Tags" />
+  <button type="submit">Submit</button>
+</form>`}
+      >
+        <FormExample />
+      </Example>
+    </DemoLayout>
+  );
+}
+
+// ── Example components (kept local; they own their state) ───────────────────
+
+function StatusExample() {
+  const [status, setStatus] = useState<string>('');
+  return (
+    <Stack gap="sm">
+      <div style={{ width: 240 }}>
+        <Select
+          options={STATUSES}
+          value={status}
+          onChange={(v) => setStatus(v as string)}
+          placeholder="Pick a status"
+        />
+      </div>
+      <small>
+        Current: <code>{status || '(none)'}</code>
+      </small>
+    </Stack>
+  );
+}
+
+function CountryExample() {
+  const [country, setCountry] = useState<string>('');
+  return (
+    <Stack gap="sm">
+      <div style={{ width: 260 }}>
+        <Select
+          searchable
+          options={COUNTRIES}
+          value={country}
+          onChange={(v) => setCountry(v as string)}
+          placeholder="Search countries…"
+        />
+      </div>
+      <small>
+        Current: <code>{country || '(none)'}</code>
+      </small>
+    </Stack>
+  );
+}
+
+function AssigneeExample() {
+  const [assignee, setAssignee] = useState<string>('');
+  return (
+    <Stack gap="sm">
+      <div style={{ width: 280 }}>
+        <Select
+          searchable
+          loadOptions={fakeFetchUsers}
+          value={assignee}
+          onChange={(v) => setAssignee(v as string)}
+          placeholder="Find a user…"
+          renderOption={(opt) => (
+            <Cluster gap="sm" align="center">
+              <Avatar name={opt.label} size="sm" />
+              <Stack gap="xs">
+                <span>{opt.label}</span>
+                <small style={{ color: 'var(--color-fg-muted)' }}>{opt.description}</small>
+              </Stack>
+            </Cluster>
+          )}
+        />
+      </div>
+      <small>
+        Current: <code>{assignee || '(none)'}</code>
+      </small>
+    </Stack>
+  );
+}
+
+function StatusFilterExample() {
+  const [statusFilter, setStatusFilter] = useState<string[]>([]);
+  return (
+    <Stack gap="sm">
+      <div style={{ width: 260 }}>
+        <Select
+          multiple
+          triggerDisplay="summary"
+          searchable
+          options={STATUSES}
+          value={statusFilter}
+          onChange={(v) => setStatusFilter(v as string[])}
+          placeholder="Filter by status"
+        />
+      </div>
+      <Cluster gap="xs">
+        {statusFilter.length === 0 ? (
+          <small>(none)</small>
+        ) : (
+          statusFilter.map((v) => (
+            <Badge key={v} tone="info">
+              {v}
+            </Badge>
+          ))
+        )}
+      </Cluster>
+    </Stack>
+  );
+}
+
+function OwnersExample() {
+  const [owners, setOwners] = useState<string[]>([]);
+  return (
+    <div style={{ width: 340 }}>
+      <Select
+        multiple
+        triggerDisplay="chips"
+        searchable
+        loadOptions={fakeFetchUsers}
+        value={owners}
+        onChange={(v) => setOwners(v as string[])}
+        placeholder="Pick owners…"
+      />
+    </div>
+  );
+}
+
+function TagsExample() {
+  const [tags, setTags] = useState<string[]>(['shipping']);
+  const [createdLog, setCreatedLog] = useState<string[]>([]);
+  return (
+    <Stack gap="sm">
+      <div style={{ width: 340 }}>
+        <Select
+          multiple
+          searchable
+          creatable
+          triggerDisplay="chips"
+          options={[
+            { value: 'shipping', label: 'shipping' },
+            { value: 'urgent', label: 'urgent' },
+            { value: 'vip', label: 'vip' },
+          ]}
+          value={tags}
+          onChange={(v) => setTags(v as string[])}
+          onCreate={(label) => setCreatedLog((log) => [...log, label])}
+          placeholder="Add tags…"
+        />
+      </div>
+      {createdLog.length > 0 && (
+        <small>
+          Created: <code>{createdLog.join(', ')}</code>
+        </small>
+      )}
+    </Stack>
+  );
+}
+
+function FormExample() {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const data = new FormData(e.currentTarget);
+        alert(
+          `status = ${data.get('status') ?? '(empty)'}\ntags = ${JSON.stringify(data.getAll('tags'))}`,
+        );
+      }}
+    >
+      <Stack gap="md">
+        <div style={{ width: 280 }}>
+          <Select options={STATUSES} name="status" required placeholder="Status (required)" />
+        </div>
+        <div style={{ width: 340 }}>
+          <Select
+            multiple
+            triggerDisplay="chips"
+            searchable
+            creatable
+            options={[
+              { value: 'a', label: 'a' },
+              { value: 'b', label: 'b' },
+            ]}
+            name="tags"
+            placeholder="Tags"
+          />
+        </div>
+        <Cluster>
+          <button type="submit">Submit</button>
+        </Cluster>
+      </Stack>
+    </form>
+  );
+}

--- a/packages/playground/src/pages/components/SelectDemo.tsx
+++ b/packages/playground/src/pages/components/SelectDemo.tsx
@@ -81,6 +81,7 @@ export function SelectDemo() {
   return (
     <DemoLayout
       name="Select"
+      componentName="Select"
       description="Value picker — single, multi (chips and summary), searchable, async, creatable. The generalist."
       tsxSource={tsxSource}
       scssSource={scssSource}

--- a/packages/playground/src/pages/components/SelectDemo.tsx
+++ b/packages/playground/src/pages/components/SelectDemo.tsx
@@ -84,7 +84,14 @@ export function SelectDemo() {
       <Example
         title="Status — single, non-searchable"
         description="The simplest case. Static options, single value, no search input."
-        code={`const [status, setStatus] = useState('');
+        code={`const STATUSES = [
+  { value: 'active', label: 'Active' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'archived', label: 'Archived' },
+];
+
+const [status, setStatus] = useState('');
+
 <Select
   options={STATUSES}
   value={status}
@@ -100,7 +107,33 @@ export function SelectDemo() {
       <Example
         title="Country — single, searchable, grouped"
         description="Options can be nested under group labels. Type to filter; arrow keys traverse across groups."
-        code={`<Select
+        code={`const COUNTRIES = [
+  {
+    label: 'Americas',
+    options: [
+      { value: 'us', label: 'United States' },
+      { value: 'ca', label: 'Canada' },
+      { value: 'br', label: 'Brazil' },
+    ],
+  },
+  {
+    label: 'Europe',
+    options: [
+      { value: 'de', label: 'Germany' },
+      { value: 'fr', label: 'France' },
+      { value: 'gb', label: 'United Kingdom' },
+    ],
+  },
+  {
+    label: 'Asia-Pacific',
+    options: [
+      { value: 'jp', label: 'Japan' },
+      { value: 'au', label: 'Australia' },
+    ],
+  },
+];
+
+<Select
   searchable
   options={COUNTRIES}
   value={country}
@@ -116,7 +149,17 @@ export function SelectDemo() {
       <Example
         title="Assignee — single, async with custom render"
         description="Pass `loadOptions(query, signal)` to fetch on demand. `renderOption` lets the dropdown show whatever you need — avatar + name + email here."
-        code={`<Select
+        code={`async function fetchUsers(query, signal) {
+  const users = await api.searchUsers(query, { signal });
+  return users.map((u) => ({
+    value: u.id,
+    label: u.name,
+    description: u.email,
+    data: u,
+  }));
+}
+
+<Select
   searchable
   loadOptions={fetchUsers}
   value={assignee}
@@ -141,7 +184,20 @@ export function SelectDemo() {
       <Example
         title="Async + error retry"
         description="The flaky fetch fails ~50% of the time. The listbox surfaces the error with a Retry affordance."
-        code={`<Select searchable loadOptions={flakyFetch} placeholder="Pick a user (may fail)" />`}
+        code={`async function flakyFetch(query, signal) {
+  await delay(200);
+  if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+  if (Math.random() < 0.5) {
+    throw new Error('Network glitched. Try again.');
+  }
+  return [
+    { value: 'u1', label: 'Alex Rivera' },
+    { value: 'u2', label: 'Bea Chen' },
+    { value: 'u3', label: 'Cam Patel' },
+  ];
+}
+
+<Select searchable loadOptions={flakyFetch} placeholder="Pick a user (may fail)" />`}
       >
         <Cluster gap="md" justify="center">
           <div style={{ width: 320 }}>
@@ -153,7 +209,15 @@ export function SelectDemo() {
       <Example
         title="Status filter — multi, summary trigger"
         description="`multiple` + `triggerDisplay='summary'` shows '2 selected' in the trigger. Best for compact filter bars."
-        code={`<Select
+        code={`const STATUSES = [
+  { value: 'active', label: 'Active' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'archived', label: 'Archived' },
+];
+
+const [statusFilter, setStatusFilter] = useState<string[]>([]);
+
+<Select
   multiple
   triggerDisplay="summary"
   searchable
@@ -171,7 +235,12 @@ export function SelectDemo() {
       <Example
         title="Owners — multi, chips trigger"
         description="`triggerDisplay='chips'` (the default for multi) renders each selection as a removable chip in the trigger."
-        code={`<Select
+        code={`async function fetchUsers(query, signal) {
+  const users = await api.searchUsers(query, { signal });
+  return users.map((u) => ({ value: u.id, label: u.name }));
+}
+
+<Select
   multiple
   triggerDisplay="chips"
   searchable
@@ -189,7 +258,15 @@ export function SelectDemo() {
       <Example
         title="Tags — multi, chips, searchable, creatable"
         description="`creatable` shows a 'Create &quot;…&quot;' row when the query has no exact match. `onCreate(label)` fires when the user picks it; you decide what to do with the new value."
-        code={`<Select
+        code={`const tagOptions = [
+  { value: 'shipping', label: 'shipping' },
+  { value: 'urgent', label: 'urgent' },
+  { value: 'vip', label: 'vip' },
+];
+
+const [tags, setTags] = useState<string[]>(['shipping']);
+
+<Select
   multiple
   searchable
   creatable
@@ -209,7 +286,13 @@ export function SelectDemo() {
       <Example
         title="Visual states — disabled, readOnly, invalid"
         description="`disabled` blocks all interaction. `readOnly` shows the value but blocks editing. `invalid` paints the trigger with the error ring."
-        code={`<Select options={STATUSES} disabled value="pending" />
+        code={`const STATUSES = [
+  { value: 'active', label: 'Active' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'archived', label: 'Archived' },
+];
+
+<Select options={STATUSES} disabled value="pending" />
 <Select options={STATUSES} readOnly value="active" />
 <Select options={STATUSES} invalid placeholder="Required" />`}
       >
@@ -229,7 +312,13 @@ export function SelectDemo() {
       <Example
         title="Sizes — sm / md / lg"
         description="`size` controls the trigger height and font size. The listbox typography scales to match."
-        code={`<Select options={STATUSES} size="sm" placeholder="sm" />
+        code={`const STATUSES = [
+  { value: 'active', label: 'Active' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'archived', label: 'Archived' },
+];
+
+<Select options={STATUSES} size="sm" placeholder="sm" />
 <Select options={STATUSES} size="md" placeholder="md" />
 <Select options={STATUSES} size="lg" placeholder="lg" />`}
       >
@@ -249,7 +338,18 @@ export function SelectDemo() {
       <Example
         title="Form integration"
         description="`name` makes Select participate in native FormData. Single values become one entry; multi values become repeated entries. `required` blocks submit when empty."
-        code={`<form onSubmit={(e) => {
+        code={`const STATUSES = [
+  { value: 'active', label: 'Active' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'archived', label: 'Archived' },
+];
+
+const tagOptions = [
+  { value: 'a', label: 'a' },
+  { value: 'b', label: 'b' },
+];
+
+<form onSubmit={(e) => {
   e.preventDefault();
   const data = new FormData(e.currentTarget);
   console.log(data.get('status'), data.getAll('tags'));
@@ -257,7 +357,7 @@ export function SelectDemo() {
   <Select options={STATUSES} name="status" required placeholder="Status (required)" />
   <Select multiple triggerDisplay="chips" searchable creatable
     options={tagOptions} name="tags" placeholder="Tags" />
-  <button type="submit">Submit</button>
+  <Button type="submit" size="sm">Submit</Button>
 </form>`}
       >
         <FormExample />

--- a/packages/playground/src/pages/components/SelectDemo.tsx
+++ b/packages/playground/src/pages/components/SelectDemo.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Avatar, Badge, Cluster, Select, Stack, type SelectOption } from '@eocrm/design-system';
+import { Avatar, Badge, Button, Cluster, Select, Stack, type SelectOption } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import tsxSource from '@lib-source/components/Select/Select.tsx?raw';
@@ -144,7 +144,9 @@ export function SelectDemo() {
         code={`<Select searchable loadOptions={flakyFetch} placeholder="Pick a user (may fail)" />`}
       >
         <Cluster gap="md" justify="center">
-          <Select searchable loadOptions={flakyFetch} placeholder="Pick a user (may fail)" />
+          <div style={{ width: 320 }}>
+            <Select searchable loadOptions={flakyFetch} placeholder="Pick a user (may fail)" />
+          </div>
         </Cluster>
       </Example>
 
@@ -212,13 +214,13 @@ export function SelectDemo() {
 <Select options={STATUSES} invalid placeholder="Required" />`}
       >
         <Cluster gap="md" wrap justify="center">
-          <div style={{ minWidth: 200 }}>
+          <div style={{ width: 320 }}>
             <Select options={STATUSES} disabled value="pending" />
           </div>
-          <div style={{ minWidth: 200 }}>
+          <div style={{ width: 320 }}>
             <Select options={STATUSES} readOnly value="active" />
           </div>
-          <div style={{ minWidth: 200 }}>
+          <div style={{ width: 320 }}>
             <Select options={STATUSES} invalid placeholder="Required" />
           </div>
         </Cluster>
@@ -232,13 +234,13 @@ export function SelectDemo() {
 <Select options={STATUSES} size="lg" placeholder="lg" />`}
       >
         <Cluster gap="md" wrap justify="center">
-          <div style={{ width: 200 }}>
+          <div style={{ width: 320 }}>
             <Select options={STATUSES} size="sm" placeholder="sm" />
           </div>
-          <div style={{ width: 200 }}>
+          <div style={{ width: 320 }}>
             <Select options={STATUSES} size="md" placeholder="md" />
           </div>
-          <div style={{ width: 200 }}>
+          <div style={{ width: 320 }}>
             <Select options={STATUSES} size="lg" placeholder="lg" />
           </div>
         </Cluster>
@@ -269,8 +271,8 @@ export function SelectDemo() {
 function StatusExample() {
   const [status, setStatus] = useState<string>('');
   return (
-    <Stack gap="sm">
-      <div style={{ width: 240 }}>
+    <Stack gap="sm" align="start">
+      <div style={{ width: 320 }}>
         <Select
           options={STATUSES}
           value={status}
@@ -278,9 +280,7 @@ function StatusExample() {
           placeholder="Pick a status"
         />
       </div>
-      <small>
-        Current: <code>{status || '(none)'}</code>
-      </small>
+      {status ? <Badge tone="info">{status}</Badge> : <Badge tone="neutral">none</Badge>}
     </Stack>
   );
 }
@@ -288,8 +288,8 @@ function StatusExample() {
 function CountryExample() {
   const [country, setCountry] = useState<string>('');
   return (
-    <Stack gap="sm">
-      <div style={{ width: 260 }}>
+    <Stack gap="sm" align="start">
+      <div style={{ width: 320 }}>
         <Select
           searchable
           options={COUNTRIES}
@@ -298,9 +298,7 @@ function CountryExample() {
           placeholder="Search countries…"
         />
       </div>
-      <small>
-        Current: <code>{country || '(none)'}</code>
-      </small>
+      {country ? <Badge tone="info">{country}</Badge> : <Badge tone="neutral">none</Badge>}
     </Stack>
   );
 }
@@ -308,8 +306,8 @@ function CountryExample() {
 function AssigneeExample() {
   const [assignee, setAssignee] = useState<string>('');
   return (
-    <Stack gap="sm">
-      <div style={{ width: 280 }}>
+    <Stack gap="sm" align="start">
+      <div style={{ width: 320 }}>
         <Select
           searchable
           loadOptions={fakeFetchUsers}
@@ -327,9 +325,7 @@ function AssigneeExample() {
           )}
         />
       </div>
-      <small>
-        Current: <code>{assignee || '(none)'}</code>
-      </small>
+      {assignee ? <Badge tone="info">{assignee}</Badge> : <Badge tone="neutral">none</Badge>}
     </Stack>
   );
 }
@@ -337,8 +333,8 @@ function AssigneeExample() {
 function StatusFilterExample() {
   const [statusFilter, setStatusFilter] = useState<string[]>([]);
   return (
-    <Stack gap="sm">
-      <div style={{ width: 260 }}>
+    <Stack gap="sm" align="start">
+      <div style={{ width: 320 }}>
         <Select
           multiple
           triggerDisplay="summary"
@@ -351,7 +347,7 @@ function StatusFilterExample() {
       </div>
       <Cluster gap="xs">
         {statusFilter.length === 0 ? (
-          <small>(none)</small>
+          <Badge tone="neutral">none</Badge>
         ) : (
           statusFilter.map((v) => (
             <Badge key={v} tone="info">
@@ -367,7 +363,7 @@ function StatusFilterExample() {
 function OwnersExample() {
   const [owners, setOwners] = useState<string[]>([]);
   return (
-    <div style={{ width: 340 }}>
+    <div style={{ width: 320 }}>
       <Select
         multiple
         triggerDisplay="chips"
@@ -385,8 +381,8 @@ function TagsExample() {
   const [tags, setTags] = useState<string[]>(['shipping']);
   const [createdLog, setCreatedLog] = useState<string[]>([]);
   return (
-    <Stack gap="sm">
-      <div style={{ width: 340 }}>
+    <Stack gap="sm" align="start">
+      <div style={{ width: 320 }}>
         <Select
           multiple
           searchable
@@ -424,10 +420,10 @@ function FormExample() {
       }}
     >
       <Stack gap="md">
-        <div style={{ width: 280 }}>
+        <div style={{ width: 320 }}>
           <Select options={STATUSES} name="status" required placeholder="Status (required)" />
         </div>
-        <div style={{ width: 340 }}>
+        <div style={{ width: 320 }}>
           <Select
             multiple
             triggerDisplay="chips"
@@ -442,7 +438,9 @@ function FormExample() {
           />
         </div>
         <Cluster>
-          <button type="submit">Submit</button>
+          <Button type="submit" size="sm">
+            Submit
+          </Button>
         </Cluster>
       </Stack>
     </form>

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -3,6 +3,7 @@
 export type ComponentName =
   | 'Button'
   | 'Input'
+  | 'Select'
   | 'Card'
   | 'Stack'
   | 'Cluster'


### PR DESCRIPTION
## Summary

New `<Select>` component covering all modes in one generalist API:

- **Single** + **multi** (with `triggerDisplay='chips'` or `'summary'`)
- **Searchable** (combobox-input for single, in-panel for multi-summary, inline-input for multi-chips)
- **Async** via `loadOptions(query, signal)` — built-in 250ms debounce + AbortController + loading/error/empty rows + Retry
- **Grouped options** (nested `{ label, options }[]` shape, `role="group"` + `aria-labelledby`)
- **Creatable** — `+ Create "foo"` row when query has no exact match, fires `onCreate(label)`
- **Form integration** — `name`/`required`/`form` render hidden inputs so `FormData` and `FormData.getAll()` work
- **Render escape hatches** — `renderOption`, `renderValue`, `renderTag`, `renderEmpty`, `renderLoading`, `renderError`
- **Visual contract matches `<Input>`** — `size: sm | md | lg`, `invalid`, `disabled`, `readOnly`, `:focus-visible`, all tokens

Hand-rolled on `@floating-ui/react-dom`. WAI-ARIA combobox 1.2 semantics throughout. 140ms scale-fade open animation with `prefers-reduced-motion` respect.

35 commits, 461 tests passing.

- Spec: `docs/superpowers/specs/2026-05-20-select-design.md`
- Plan: `docs/superpowers/plans/2026-05-20-select.md`
- Demo: `/components/select` in the playground (10 scenarios)
- Primer: new `<Select>` section in `packages/design-system/AGENTS.md`

## Test plan

- [x] `npm test -w @eocrm/design-system` — **461 / 461** passing
- [x] `npm run typecheck -w @eocrm/design-system` — clean
- [x] `npm run lint:css` — clean
- [x] `npm run build` (playground) — clean (1733 modules)
- [x] `npm pack --dry-run -w @eocrm/design-system` — 0 test files in tarball
- [x] Pre-push hook (prettier + stylelint + typecheck via husky) — green
- [x] Two-round Phase-15 review-fix loop with fresh-context reviewers — verdict `clean enough to stop`
- [ ] Manual click-through of all 10 playground scenarios on Chrome + Firefox
- [ ] Keyboard-only nav of all modes (Arrow, Home, End, Page keys, Enter, Escape, Tab, Backspace on empty)
- [ ] Screen-reader smoke (VoiceOver): role announcements, selection state, group labels

## Notes for review

- Trigger.tsx (854 lines) hosts four trigger variants + a shared keyboard hook. The variants pull in different ARIA contracts (button-style vs combobox-input vs chips-with-input); a future split is plausible but not necessary.
- Listbox.tsx uses Floating UI with `transform: false` (matching DropdownMenu/Popover) so the open keyframe can animate `transform: scale(...)` without fighting positioning styles.
- The clear ✕ is keyboard-reachable (`tabIndex={0}`) for single-mode + multi-summary; tested.
- Full chip-to-chip arrow navigation in chips-mode is **deferred to v2** (spec section "Multi chips searchable" notes; `Select.tsx` JSDoc `@remarks Keyboard limitations (v1)` notes). v1 ships with Backspace-on-empty-input → remove-trailing-chip, which covers the common case.
- One new token: `--size-spinner: 14px` (used by the loading state). `--opacity-visible: 1` also added because stylelint enforces strict-value on `opacity`.
- `Select` line removed from the wishlist in `packages/design-system/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)