### PR TITLE
Button: add xs size + iconOnly prop for square icon-only buttons

### DIFF
--- a/docs/superpowers/plans/2026-05-20-button-xs-size.md
+++ b/docs/superpowers/plans/2026-05-20-button-xs-size.md
@@ -21,25 +21,31 @@
 - [ ] **Step 1: Confirm the branch and a clean working tree**
 
 Run:
+
 ```bash
 git status
 git rev-parse --abbrev-ref HEAD
 git log --oneline -4
 ```
+
 Expected: working tree clean; current branch is `feat/button-xs`; the top three commits include the spec + plan additions, with the fourth being an earlier merge into `main`. If anything else, stop and surface the unexpected state.
 
 - [ ] **Step 2: Verify hooks are wired**
 
 Run:
+
 ```bash
 git config --get core.hooksPath
 test -x .husky/pre-push && echo OK
 ```
+
 Expected:
+
 ```
 .husky/_
 OK
 ```
+
 If either fails, run `npm install` from the repo root and re-check. Do not proceed until both pass.
 
 ---
@@ -47,25 +53,28 @@ If either fails, run `npm install` from the repo root and re-check. Do not proce
 ## Task 2: Add `--size-xs` token
 
 **Files:**
+
 - Modify: `packages/design-system/src/styles/tokens.scss:105-108`
 
 - [ ] **Step 1: Insert `--size-xs` above `--size-sm`**
 
 Find the block:
+
 ```scss
-  // Control sizes
-  --size-sm: 24px;
-  --size-md: 32px;
-  --size-lg: 40px;
+// Control sizes
+--size-sm: 24px;
+--size-md: 32px;
+--size-lg: 40px;
 ```
 
 Replace with:
+
 ```scss
-  // Control sizes
-  --size-xs: 20px;
-  --size-sm: 24px;
-  --size-md: 32px;
-  --size-lg: 40px;
+// Control sizes
+--size-xs: 20px;
+--size-sm: 24px;
+--size-md: 32px;
+--size-lg: 40px;
 ```
 
 - [ ] **Step 2: Verify the file still parses**
@@ -76,6 +85,7 @@ Expected: exits 0. (Token additions can't violate the existing rules.)
 - [ ] **Step 3: Commit**
 
 Run:
+
 ```bash
 git add packages/design-system/src/styles/tokens.scss
 git commit -m "Tokens: add --size-xs (20px) to control size scale"
@@ -86,6 +96,7 @@ git commit -m "Tokens: add --size-xs (20px) to control size scale"
 ## Task 3: TDD — add `xs` class assertion (red)
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Button/Button.test.tsx:17-26`
 
 - [ ] **Step 1: Extend the existing class-name test**
@@ -93,21 +104,21 @@ git commit -m "Tokens: add --size-xs (20px) to control size scale"
 Replace lines 17–26 (the whole `'applies the variant and size class names'` block) with:
 
 ```tsx
-  it('applies the variant and size class names', () => {
-    render(
-      <Button variant="danger" size="lg">
-        Delete
-      </Button>,
-    );
-    const btn = screen.getByRole('button', { name: 'Delete' });
-    expect(btn.className).toMatch(/danger/);
-    expect(btn.className).toMatch(/lg/);
-  });
+it('applies the variant and size class names', () => {
+  render(
+    <Button variant="danger" size="lg">
+      Delete
+    </Button>,
+  );
+  const btn = screen.getByRole('button', { name: 'Delete' });
+  expect(btn.className).toMatch(/danger/);
+  expect(btn.className).toMatch(/lg/);
+});
 
-  it('applies the xs size class', () => {
-    render(<Button size="xs">Tiny</Button>);
-    expect(screen.getByRole('button', { name: 'Tiny' }).className).toMatch(/xs/);
-  });
+it('applies the xs size class', () => {
+  render(<Button size="xs">Tiny</Button>);
+  expect(screen.getByRole('button', { name: 'Tiny' }).className).toMatch(/xs/);
+});
 ```
 
 - [ ] **Step 2: Run only the Button tests to verify they fail**
@@ -122,16 +133,20 @@ If the test passes here, stop — something is wrong with the test setup.
 ## Task 4: Add `xs` to the union and SCSS (green)
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Button/Button.tsx:9`
 - Modify: `packages/design-system/src/components/Button/Button.module.scss:31-36`
 
 - [ ] **Step 1: Extend `ButtonSize`**
 
 In `Button.tsx`, line 9, replace:
+
 ```ts
 export type ButtonSize = 'sm' | 'md' | 'lg';
 ```
+
 with:
+
 ```ts
 export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 ```
@@ -139,6 +154,7 @@ export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 - [ ] **Step 2: Add the `.xs` SCSS block above `.sm`**
 
 In `Button.module.scss`, find the block:
+
 ```scss
 // Sizes
 .sm {
@@ -149,6 +165,7 @@ In `Button.module.scss`, find the block:
 ```
 
 Replace with:
+
 ```scss
 // Sizes
 .xs {
@@ -175,15 +192,18 @@ Expected: all Button tests PASS, including both `'applies the variant and size c
 - [ ] **Step 4: Run stylelint and typecheck**
 
 Run:
+
 ```bash
 npm run lint:css
 npm run typecheck
 ```
+
 Expected: both exit 0.
 
 - [ ] **Step 5: Commit**
 
 Run:
+
 ```bash
 git add packages/design-system/src/components/Button/Button.tsx packages/design-system/src/components/Button/Button.module.scss packages/design-system/src/components/Button/Button.test.tsx
 git commit -m "Button: add xs size (20px) for icon-only and dense actions"
@@ -194,6 +214,7 @@ git commit -m "Button: add xs size (20px) for icon-only and dense actions"
 ## Task 5: Add icon-only render test
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Button/Button.test.tsx` (append to the describe block)
 
 - [ ] **Step 1: Add the icon-only test**
@@ -201,15 +222,15 @@ git commit -m "Button: add xs size (20px) for icon-only and dense actions"
 Find the last test in the file (the `'forwards a ref to the underlying button element'` test ending at line 66). Append a new test inside the `describe('Button', ...)` block, before the closing `});`:
 
 ```tsx
-  it('renders as an icon-only button at size xs with an accessible name', () => {
-    render(
-      <Button size="xs" aria-label="Remove">
-        <svg data-testid="icon" aria-hidden="true" />
-      </Button>,
-    );
-    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
-    expect(screen.getByTestId('icon')).toBeInTheDocument();
-  });
+it('renders as an icon-only button at size xs with an accessible name', () => {
+  render(
+    <Button size="xs" aria-label="Remove">
+      <svg data-testid="icon" aria-hidden="true" />
+    </Button>,
+  );
+  expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+  expect(screen.getByTestId('icon')).toBeInTheDocument();
+});
 ```
 
 - [ ] **Step 2: Run the Button tests**
@@ -220,6 +241,7 @@ Expected: all tests pass. The new test was always going to pass once Task 4 land
 - [ ] **Step 3: Commit**
 
 Run:
+
 ```bash
 git add packages/design-system/src/components/Button/Button.test.tsx
 git commit -m "Button: test icon-only xs button exposes the accessible name"
@@ -230,12 +252,14 @@ git commit -m "Button: test icon-only xs button exposes the accessible name"
 ## Task 6: Update Button JSDoc
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Button/Button.tsx:25-31` (size prop JSDoc)
 - Modify: `packages/design-system/src/components/Button/Button.tsx:39-77` (component JSDoc — add `@example` and `@remarks` entries)
 
 - [ ] **Step 1: Update the `size` prop JSDoc**
 
 Find this block (around lines 25-31):
+
 ```ts
   /**
    * Control height (matches the shared `--size-*` scale used by Input and Avatar).
@@ -247,6 +271,7 @@ Find this block (around lines 25-31):
 ```
 
 Replace with:
+
 ```ts
   /**
    * Control height (matches the shared `--size-*` scale used by Input and Avatar).
@@ -263,6 +288,7 @@ Replace with:
 - [ ] **Step 2: Add an `@example` for icon-only xs**
 
 Find the existing `@example` block that shows the danger sm Delete button (around lines 42-46):
+
 ```ts
  * @example
  * <Button variant="danger" size="sm" onClick={remove}>
@@ -272,6 +298,7 @@ Find the existing `@example` block that shows the danger sm Delete button (aroun
 ```
 
 Immediately after it (and before the form-footer `@example`), insert:
+
 ```ts
  * @example
  * // Icon-only at xs — pass `aria-label` so screen readers announce the action.
@@ -286,6 +313,7 @@ Immediately after it (and before the form-footer `@example`), insert:
 Find the `@remarks Anti-patterns` block (starts around line 85). It currently ends with the `❌ Rendering <Button variant="success">Save</Button> on initial mount` entry.
 
 Add a new bullet at the end of that block, just before the closing `*/`:
+
 ```ts
  * - ❌ Using `size="xs"` for the primary or most prominent action in a
  *   section. `xs` is for inline density, not emphasis — reach for `md` or
@@ -301,6 +329,7 @@ Expected: exits 0. Any malformed JSDoc that breaks TypeScript parsing fails here
 - [ ] **Step 5: Commit**
 
 Run:
+
 ```bash
 git add packages/design-system/src/components/Button/Button.tsx
 git commit -m "Button: document xs size, icon-only example, and anti-pattern"
@@ -311,16 +340,19 @@ git commit -m "Button: document xs size, icon-only example, and anti-pattern"
 ## Task 7: Update AGENTS.md TL;DR
 
 **Files:**
+
 - Modify: `packages/design-system/AGENTS.md:43`
 
 - [ ] **Step 1: Update the size list**
 
 Line 43 currently reads:
+
 ```
 - `size`: `sm` / `md` (default) / `lg`
 ```
 
 Replace with:
+
 ```
 - `size`: `xs` / `sm` / `md` (default) / `lg` — use `xs` for icon-only or dense inline actions; pass `aria-label` when icon-only.
 ```
@@ -328,6 +360,7 @@ Replace with:
 - [ ] **Step 2: Commit**
 
 Run:
+
 ```bash
 git add packages/design-system/AGENTS.md
 git commit -m "AGENTS.md: list xs in Button size options"
@@ -338,6 +371,7 @@ git commit -m "AGENTS.md: list xs in Button size options"
 ## Task 8: Extend playground ButtonDemo
 
 **Files:**
+
 - Modify: `packages/playground/src/pages/components/ButtonDemo.tsx:2` (icon imports)
 - Modify: `packages/playground/src/pages/components/ButtonDemo.tsx:102-114` (Sizes example)
 - Modify: `packages/playground/src/pages/components/ButtonDemo.tsx` (add a new `<Example>` after Sizes)
@@ -345,11 +379,13 @@ git commit -m "AGENTS.md: list xs in Button size options"
 - [ ] **Step 1: Add `X` and `Pencil` to the lucide-react import**
 
 Line 2 currently reads:
+
 ```ts
 import { Check, Plus, Search, Trash2 } from 'lucide-react';
 ```
 
 Replace with:
+
 ```ts
 import { Check, Pencil, Plus, Search, Trash2, X } from 'lucide-react';
 ```
@@ -357,39 +393,41 @@ import { Check, Pencil, Plus, Search, Trash2, X } from 'lucide-react';
 - [ ] **Step 2: Extend the Sizes example**
 
 Find the Sizes `<Example>` block (around lines 102-114):
+
 ```tsx
-      <Example
-        title="Sizes"
-        description="Three sizes. sm for dense toolbars/tables, md (default) for most contexts, lg for emphasis."
-        code={`<Button size="sm">Small</Button>
+<Example
+  title="Sizes"
+  description="Three sizes. sm for dense toolbars/tables, md (default) for most contexts, lg for emphasis."
+  code={`<Button size="sm">Small</Button>
 <Button size="md">Medium</Button>
 <Button size="lg">Large</Button>`}
-      >
-        <Cluster gap="sm" align="center">
-          <Button size="sm">Small</Button>
-          <Button size="md">Medium</Button>
-          <Button size="lg">Large</Button>
-        </Cluster>
-      </Example>
+>
+  <Cluster gap="sm" align="center">
+    <Button size="sm">Small</Button>
+    <Button size="md">Medium</Button>
+    <Button size="lg">Large</Button>
+  </Cluster>
+</Example>
 ```
 
 Replace with:
+
 ```tsx
-      <Example
-        title="Sizes"
-        description="Four sizes. xs for icon-only or very dense inline actions, sm for dense toolbars/tables, md (default) for most contexts, lg for emphasis."
-        code={`<Button size="xs">Extra small</Button>
+<Example
+  title="Sizes"
+  description="Four sizes. xs for icon-only or very dense inline actions, sm for dense toolbars/tables, md (default) for most contexts, lg for emphasis."
+  code={`<Button size="xs">Extra small</Button>
 <Button size="sm">Small</Button>
 <Button size="md">Medium</Button>
 <Button size="lg">Large</Button>`}
-      >
-        <Cluster gap="sm" align="center">
-          <Button size="xs">Extra small</Button>
-          <Button size="sm">Small</Button>
-          <Button size="md">Medium</Button>
-          <Button size="lg">Large</Button>
-        </Cluster>
-      </Example>
+>
+  <Cluster gap="sm" align="center">
+    <Button size="xs">Extra small</Button>
+    <Button size="sm">Small</Button>
+    <Button size="md">Medium</Button>
+    <Button size="lg">Large</Button>
+  </Cluster>
+</Example>
 ```
 
 - [ ] **Step 3: Add the Icon-only at xs example**
@@ -397,25 +435,25 @@ Replace with:
 Immediately after the Sizes `<Example>` (and before the "With icons" example), insert:
 
 ```tsx
-      <Example
-        title="Icon-only at xs"
-        description="For inline density — row controls, chip-adjacent actions. Always pass an aria-label so screen readers announce what the button does."
-        code={`<Button size="xs" variant="ghost" aria-label="Remove">
+<Example
+  title="Icon-only at xs"
+  description="For inline density — row controls, chip-adjacent actions. Always pass an aria-label so screen readers announce what the button does."
+  code={`<Button size="xs" variant="ghost" aria-label="Remove">
   <X size={12} />
 </Button>
 <Button size="xs" variant="secondary" aria-label="Edit">
   <Pencil size={12} />
 </Button>`}
-      >
-        <Cluster gap="sm" align="center">
-          <Button size="xs" variant="ghost" aria-label="Remove">
-            <X size={12} />
-          </Button>
-          <Button size="xs" variant="secondary" aria-label="Edit">
-            <Pencil size={12} />
-          </Button>
-        </Cluster>
-      </Example>
+>
+  <Cluster gap="sm" align="center">
+    <Button size="xs" variant="ghost" aria-label="Remove">
+      <X size={12} />
+    </Button>
+    <Button size="xs" variant="secondary" aria-label="Edit">
+      <Pencil size={12} />
+    </Button>
+  </Cluster>
+</Example>
 ```
 
 - [ ] **Step 4: Run the playground typecheck**
@@ -436,6 +474,7 @@ Stop the dev server before continuing.
 - [ ] **Step 6: Commit**
 
 Run:
+
 ```bash
 git add packages/playground/src/pages/components/ButtonDemo.tsx
 git commit -m "ButtonDemo: show xs size + icon-only example"
@@ -521,6 +560,7 @@ Expected: pre-push hook runs prettier, stylelint, typecheck. Push succeeds. **Ne
 - [ ] **Step 2: Open the pull request**
 
 Run:
+
 ```bash
 gh pr create --title "Button: add xs size for icon-only and dense inline actions" --body "$(cat <<'EOF'
 ## Summary

--- a/docs/superpowers/plans/2026-05-20-button-xs-size.md
+++ b/docs/superpowers/plans/2026-05-20-button-xs-size.md
@@ -12,33 +12,23 @@
 
 ---
 
-## Task 1: Branch from fresh main
+## Task 1: Verify branch + hooks are ready
+
+**Branch state at the start of implementation:** `feat/button-xs` has already been branched from a fresh `main`, with this spec and plan committed on top of it. The executor starts work on that branch — do **not** re-create or rebase the branch.
 
 **Files:** (no edits — git only)
 
-- [ ] **Step 1: Confirm a clean working tree**
-
-Run: `git status`
-Expected: working tree clean. If not, stop and surface the dirty state to the user before proceeding.
-
-- [ ] **Step 2: Update local main**
+- [ ] **Step 1: Confirm the branch and a clean working tree**
 
 Run:
 ```bash
-git checkout main
-git pull --ff-only
+git status
+git rev-parse --abbrev-ref HEAD
+git log --oneline -4
 ```
-Expected: fast-forward (or "Already up to date").
+Expected: working tree clean; current branch is `feat/button-xs`; the top three commits include the spec + plan additions, with the fourth being an earlier merge into `main`. If anything else, stop and surface the unexpected state.
 
-- [ ] **Step 3: Create the feature branch**
-
-Run:
-```bash
-git checkout -b feat/button-xs
-```
-Expected: switches to a new branch tracking from current main.
-
-- [ ] **Step 4: Verify hooks are wired**
+- [ ] **Step 2: Verify hooks are wired**
 
 Run:
 ```bash

--- a/docs/superpowers/plans/2026-05-20-button-xs-size.md
+++ b/docs/superpowers/plans/2026-05-20-button-xs-size.md
@@ -1,0 +1,571 @@
+# Button xs Size Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `xs` size to `Button` (20px height) so consumers can use it for icon-only and dense inline actions, while still supporting an optional short text label.
+
+**Architecture:** Single component change. Extend the `ButtonSize` union, add a matching `.xs` SCSS rule, add `--size-xs: 20px` to the shared token scale. Update Button's JSDoc, the playground demo, AGENTS.md TL;DR, and add two new unit tests (class assertion + icon-only render with `aria-label`).
+
+**Tech Stack:** React + TypeScript, SCSS modules, Vitest + React Testing Library, lucide-react icons in the playground only.
+
+**Spec:** [docs/superpowers/specs/2026-05-20-button-xs-size-design.md](../specs/2026-05-20-button-xs-size-design.md)
+
+---
+
+## Task 1: Branch from fresh main
+
+**Files:** (no edits — git only)
+
+- [ ] **Step 1: Confirm a clean working tree**
+
+Run: `git status`
+Expected: working tree clean. If not, stop and surface the dirty state to the user before proceeding.
+
+- [ ] **Step 2: Update local main**
+
+Run:
+```bash
+git checkout main
+git pull --ff-only
+```
+Expected: fast-forward (or "Already up to date").
+
+- [ ] **Step 3: Create the feature branch**
+
+Run:
+```bash
+git checkout -b feat/button-xs
+```
+Expected: switches to a new branch tracking from current main.
+
+- [ ] **Step 4: Verify hooks are wired**
+
+Run:
+```bash
+git config --get core.hooksPath
+test -x .husky/pre-push && echo OK
+```
+Expected:
+```
+.husky/_
+OK
+```
+If either fails, run `npm install` from the repo root and re-check. Do not proceed until both pass.
+
+---
+
+## Task 2: Add `--size-xs` token
+
+**Files:**
+- Modify: `packages/design-system/src/styles/tokens.scss:105-108`
+
+- [ ] **Step 1: Insert `--size-xs` above `--size-sm`**
+
+Find the block:
+```scss
+  // Control sizes
+  --size-sm: 24px;
+  --size-md: 32px;
+  --size-lg: 40px;
+```
+
+Replace with:
+```scss
+  // Control sizes
+  --size-xs: 20px;
+  --size-sm: 24px;
+  --size-md: 32px;
+  --size-lg: 40px;
+```
+
+- [ ] **Step 2: Verify the file still parses**
+
+Run: `npm run lint:css`
+Expected: exits 0. (Token additions can't violate the existing rules.)
+
+- [ ] **Step 3: Commit**
+
+Run:
+```bash
+git add packages/design-system/src/styles/tokens.scss
+git commit -m "Tokens: add --size-xs (20px) to control size scale"
+```
+
+---
+
+## Task 3: TDD — add `xs` class assertion (red)
+
+**Files:**
+- Modify: `packages/design-system/src/components/Button/Button.test.tsx:17-26`
+
+- [ ] **Step 1: Extend the existing class-name test**
+
+Replace lines 17–26 (the whole `'applies the variant and size class names'` block) with:
+
+```tsx
+  it('applies the variant and size class names', () => {
+    render(
+      <Button variant="danger" size="lg">
+        Delete
+      </Button>,
+    );
+    const btn = screen.getByRole('button', { name: 'Delete' });
+    expect(btn.className).toMatch(/danger/);
+    expect(btn.className).toMatch(/lg/);
+  });
+
+  it('applies the xs size class', () => {
+    render(<Button size="xs">Tiny</Button>);
+    expect(screen.getByRole('button', { name: 'Tiny' }).className).toMatch(/xs/);
+  });
+```
+
+- [ ] **Step 2: Run only the Button tests to verify they fail**
+
+Run: `npx vitest run packages/design-system/src/components/Button/Button.test.tsx`
+Expected: TypeScript compile error or runtime failure — `size="xs"` is not assignable to `ButtonSize` (which is `'sm' | 'md' | 'lg'` at this point). This is the desired RED state.
+
+If the test passes here, stop — something is wrong with the test setup.
+
+---
+
+## Task 4: Add `xs` to the union and SCSS (green)
+
+**Files:**
+- Modify: `packages/design-system/src/components/Button/Button.tsx:9`
+- Modify: `packages/design-system/src/components/Button/Button.module.scss:31-36`
+
+- [ ] **Step 1: Extend `ButtonSize`**
+
+In `Button.tsx`, line 9, replace:
+```ts
+export type ButtonSize = 'sm' | 'md' | 'lg';
+```
+with:
+```ts
+export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
+```
+
+- [ ] **Step 2: Add the `.xs` SCSS block above `.sm`**
+
+In `Button.module.scss`, find the block:
+```scss
+// Sizes
+.sm {
+  height: var(--size-sm);
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-sm);
+}
+```
+
+Replace with:
+```scss
+// Sizes
+.xs {
+  height: var(--size-xs);
+  padding: 0 var(--space-2);
+  font-size: var(--font-size-xs);
+  gap: var(--space-1);
+}
+
+.sm {
+  height: var(--size-sm);
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-sm);
+}
+```
+
+The `gap: var(--space-1)` line is intentional — it tightens the inter-child gap at xs by overriding the base `.button { gap: var(--space-2) }` rule. `.xs` is declared after the base block so specificity-tie is resolved by source order, in our favor.
+
+- [ ] **Step 3: Run the Button tests — they should now pass**
+
+Run: `npx vitest run packages/design-system/src/components/Button/Button.test.tsx`
+Expected: all Button tests PASS, including both `'applies the variant and size class names'` and `'applies the xs size class'`.
+
+- [ ] **Step 4: Run stylelint and typecheck**
+
+Run:
+```bash
+npm run lint:css
+npm run typecheck
+```
+Expected: both exit 0.
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add packages/design-system/src/components/Button/Button.tsx packages/design-system/src/components/Button/Button.module.scss packages/design-system/src/components/Button/Button.test.tsx
+git commit -m "Button: add xs size (20px) for icon-only and dense actions"
+```
+
+---
+
+## Task 5: Add icon-only render test
+
+**Files:**
+- Modify: `packages/design-system/src/components/Button/Button.test.tsx` (append to the describe block)
+
+- [ ] **Step 1: Add the icon-only test**
+
+Find the last test in the file (the `'forwards a ref to the underlying button element'` test ending at line 66). Append a new test inside the `describe('Button', ...)` block, before the closing `});`:
+
+```tsx
+  it('renders as an icon-only button at size xs with an accessible name', () => {
+    render(
+      <Button size="xs" aria-label="Remove">
+        <svg data-testid="icon" aria-hidden="true" />
+      </Button>,
+    );
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the Button tests**
+
+Run: `npx vitest run packages/design-system/src/components/Button/Button.test.tsx`
+Expected: all tests pass. The new test was always going to pass once Task 4 landed — it's here as a regression guard for the icon-only accessibility contract, not a TDD red→green step.
+
+- [ ] **Step 3: Commit**
+
+Run:
+```bash
+git add packages/design-system/src/components/Button/Button.test.tsx
+git commit -m "Button: test icon-only xs button exposes the accessible name"
+```
+
+---
+
+## Task 6: Update Button JSDoc
+
+**Files:**
+- Modify: `packages/design-system/src/components/Button/Button.tsx:25-31` (size prop JSDoc)
+- Modify: `packages/design-system/src/components/Button/Button.tsx:39-77` (component JSDoc — add `@example` and `@remarks` entries)
+
+- [ ] **Step 1: Update the `size` prop JSDoc**
+
+Find this block (around lines 25-31):
+```ts
+  /**
+   * Control height (matches the shared `--size-*` scale used by Input and Avatar).
+   * - `sm` (24px) — dense toolbars, tables, inline actions.
+   * - `md` (32px, default) — most contexts.
+   * - `lg` (40px) — marketing-style empty states or emphasized primary actions.
+   */
+  size?: ButtonSize;
+```
+
+Replace with:
+```ts
+  /**
+   * Control height (matches the shared `--size-*` scale used by Input and Avatar).
+   * - `xs` (20px) — icon-only or very dense inline actions (row controls,
+   *   chip-adjacent buttons). Pass `aria-label` when icon-only. Below WCAG
+   *   2.5.5 Level AAA touch-target guidance; reserve for desktop-first surfaces.
+   * - `sm` (24px) — dense toolbars, tables, inline actions.
+   * - `md` (32px, default) — most contexts.
+   * - `lg` (40px) — marketing-style empty states or emphasized primary actions.
+   */
+  size?: ButtonSize;
+```
+
+- [ ] **Step 2: Add an `@example` for icon-only xs**
+
+Find the existing `@example` block that shows the danger sm Delete button (around lines 42-46):
+```ts
+ * @example
+ * <Button variant="danger" size="sm" onClick={remove}>
+ *   <Trash2 size={14} /> Delete
+ * </Button>
+ *
+```
+
+Immediately after it (and before the form-footer `@example`), insert:
+```ts
+ * @example
+ * // Icon-only at xs — pass `aria-label` so screen readers announce the action.
+ * <Button size="xs" variant="ghost" aria-label="Remove">
+ *   <X size={12} />
+ * </Button>
+ *
+```
+
+- [ ] **Step 3: Add the anti-pattern entry**
+
+Find the `@remarks Anti-patterns` block (starts around line 85). It currently ends with the `❌ Rendering <Button variant="success">Save</Button> on initial mount` entry.
+
+Add a new bullet at the end of that block, just before the closing `*/`:
+```ts
+ * - ❌ Using `size="xs"` for the primary or most prominent action in a
+ *   section. `xs` is for inline density, not emphasis — reach for `md` or
+ *   `lg` when the button should draw the eye.
+ */
+```
+
+- [ ] **Step 4: Verify the JSDoc renders cleanly**
+
+Run: `npm run typecheck`
+Expected: exits 0. Any malformed JSDoc that breaks TypeScript parsing fails here.
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add packages/design-system/src/components/Button/Button.tsx
+git commit -m "Button: document xs size, icon-only example, and anti-pattern"
+```
+
+---
+
+## Task 7: Update AGENTS.md TL;DR
+
+**Files:**
+- Modify: `packages/design-system/AGENTS.md:43`
+
+- [ ] **Step 1: Update the size list**
+
+Line 43 currently reads:
+```
+- `size`: `sm` / `md` (default) / `lg`
+```
+
+Replace with:
+```
+- `size`: `xs` / `sm` / `md` (default) / `lg` — use `xs` for icon-only or dense inline actions; pass `aria-label` when icon-only.
+```
+
+- [ ] **Step 2: Commit**
+
+Run:
+```bash
+git add packages/design-system/AGENTS.md
+git commit -m "AGENTS.md: list xs in Button size options"
+```
+
+---
+
+## Task 8: Extend playground ButtonDemo
+
+**Files:**
+- Modify: `packages/playground/src/pages/components/ButtonDemo.tsx:2` (icon imports)
+- Modify: `packages/playground/src/pages/components/ButtonDemo.tsx:102-114` (Sizes example)
+- Modify: `packages/playground/src/pages/components/ButtonDemo.tsx` (add a new `<Example>` after Sizes)
+
+- [ ] **Step 1: Add `X` and `Pencil` to the lucide-react import**
+
+Line 2 currently reads:
+```ts
+import { Check, Plus, Search, Trash2 } from 'lucide-react';
+```
+
+Replace with:
+```ts
+import { Check, Pencil, Plus, Search, Trash2, X } from 'lucide-react';
+```
+
+- [ ] **Step 2: Extend the Sizes example**
+
+Find the Sizes `<Example>` block (around lines 102-114):
+```tsx
+      <Example
+        title="Sizes"
+        description="Three sizes. sm for dense toolbars/tables, md (default) for most contexts, lg for emphasis."
+        code={`<Button size="sm">Small</Button>
+<Button size="md">Medium</Button>
+<Button size="lg">Large</Button>`}
+      >
+        <Cluster gap="sm" align="center">
+          <Button size="sm">Small</Button>
+          <Button size="md">Medium</Button>
+          <Button size="lg">Large</Button>
+        </Cluster>
+      </Example>
+```
+
+Replace with:
+```tsx
+      <Example
+        title="Sizes"
+        description="Four sizes. xs for icon-only or very dense inline actions, sm for dense toolbars/tables, md (default) for most contexts, lg for emphasis."
+        code={`<Button size="xs">Extra small</Button>
+<Button size="sm">Small</Button>
+<Button size="md">Medium</Button>
+<Button size="lg">Large</Button>`}
+      >
+        <Cluster gap="sm" align="center">
+          <Button size="xs">Extra small</Button>
+          <Button size="sm">Small</Button>
+          <Button size="md">Medium</Button>
+          <Button size="lg">Large</Button>
+        </Cluster>
+      </Example>
+```
+
+- [ ] **Step 3: Add the Icon-only at xs example**
+
+Immediately after the Sizes `<Example>` (and before the "With icons" example), insert:
+
+```tsx
+      <Example
+        title="Icon-only at xs"
+        description="For inline density — row controls, chip-adjacent actions. Always pass an aria-label so screen readers announce what the button does."
+        code={`<Button size="xs" variant="ghost" aria-label="Remove">
+  <X size={12} />
+</Button>
+<Button size="xs" variant="secondary" aria-label="Edit">
+  <Pencil size={12} />
+</Button>`}
+      >
+        <Cluster gap="sm" align="center">
+          <Button size="xs" variant="ghost" aria-label="Remove">
+            <X size={12} />
+          </Button>
+          <Button size="xs" variant="secondary" aria-label="Edit">
+            <Pencil size={12} />
+          </Button>
+        </Cluster>
+      </Example>
+```
+
+- [ ] **Step 4: Run the playground typecheck**
+
+Run: `npm run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 5: Sanity-check the dev server renders**
+
+Run: `npm run dev -w playground` in a background terminal or another shell, open `http://localhost:8080/components/button`, and confirm:
+
+- The Sizes row shows four buttons (xs, sm, md, lg) of progressively increasing height.
+- The new "Icon-only at xs" example renders two icon-only buttons; hovering each reveals their hover state; tabbing reaches both with a visible focus ring.
+- Disabled, focused, and hovered states on the xs buttons all read correctly (no clipped focus ring, no invisible disabled state). If the disabled ghost xs renders nearly-invisibly, note it as a finding for Task 10's review.
+
+Stop the dev server before continuing.
+
+- [ ] **Step 6: Commit**
+
+Run:
+```bash
+git add packages/playground/src/pages/components/ButtonDemo.tsx
+git commit -m "ButtonDemo: show xs size + icon-only example"
+```
+
+---
+
+## Task 9: Run all quality gates locally
+
+**Files:** (none — verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test`
+Expected: all suites pass.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 3: Run stylelint**
+
+Run: `npm run lint:css`
+Expected: exits 0.
+
+- [ ] **Step 4: Run the full build**
+
+Run: `npm run build`
+Expected: both packages build successfully. The playground build doubles as a smoke test of the library import path.
+
+- [ ] **Step 5: Verify the published tarball would be clean**
+
+Run: `npm pack --dry-run -w @eocrm/design-system`
+Expected: tarball contents include `src/`, `AGENTS.md`, `README.md`, `package.json` only. Confirm no test files (`*.test.tsx`), no demos, no internal-only paths.
+
+If any of steps 1–5 fail, fix and re-run before proceeding to Task 10.
+
+---
+
+## Task 10: Hard Rule 8 review-fix cycle
+
+This task implements `packages/design-system/CLAUDE.md` Rule 8. It is **mandatory** for this change — `feedback_review_loop_mandatory` confirms the rule applies even to small library tweaks.
+
+**Files:** (none directly — review may surface fixes)
+
+- [ ] **Step 1: Confirm Task 9 gates were all green**
+
+If you skipped or failed any gate in Task 9, return to it before spawning the reviewer.
+
+- [ ] **Step 2: Spawn a fresh-context reviewer**
+
+Use the `general-purpose` agent. The prompt must explicitly brief it on the 10 review categories (bugs, a11y, API inconsistencies, type safety, rule violations Rules 1–7, test coverage, token discipline, SCSS, cross-package leakage, package/distribution) and ask for output as Critical / Important / Nice-to-have / Regression-watch plus a final verdict (`clean enough to stop` or `keep iterating`). Tell it to read `packages/design-system/CLAUDE.md`, `AGENTS.md`, and `README.md` first. Target scope: `packages/design-system/` plus `packages/playground/src/pages/components/ButtonDemo.tsx`.
+
+- [ ] **Step 3: Fix every Critical and Important finding**
+
+For each finding you act on, make the fix in a small, focused commit. For each finding you deliberately skip, note the reason inline in your handoff so the next reviewer does not re-flag it.
+
+- [ ] **Step 4: Re-run gates**
+
+Run the same five gates from Task 9.
+
+- [ ] **Step 5: Spawn another reviewer with the same prompt**
+
+Repeat steps 2–4 until the verdict is `clean enough to stop` and:
+
+- 0 Critical findings
+- 0 Important findings (or each one has an explicit documented skip)
+- All five gates green
+- `npm pack --dry-run` shows a clean tarball
+
+---
+
+## Task 11: Push, open PR, wait for CI
+
+**Files:** (none — git + GitHub only)
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin feat/button-xs`
+Expected: pre-push hook runs prettier, stylelint, typecheck. Push succeeds. **Never use `--no-verify` on your own initiative** — if the hook blocks, fix the issue or surface it to the user for an explicit override.
+
+- [ ] **Step 2: Open the pull request**
+
+Run:
+```bash
+gh pr create --title "Button: add xs size for icon-only and dense inline actions" --body "$(cat <<'EOF'
+## Summary
+- Adds `xs` (20px) to `Button`'s size scale alongside `sm`/`md`/`lg`.
+- Primary use: icon-only buttons in dense surfaces; also supports a short text label.
+- Adds `--size-xs: 20px` to the shared `--size-*` token scale.
+- Demo, AGENTS.md TL;DR, and JSDoc updated; two new unit tests cover the class application and icon-only accessible-name path.
+
+## Test plan
+- [ ] `npm test` green
+- [ ] `npm run typecheck` green
+- [ ] `npm run lint:css` green
+- [ ] `npm run build` green
+- [ ] `npm pack --dry-run -w @eocrm/design-system` shows no test files or internal-only paths
+- [ ] Playground `Button` demo renders the new Sizes row and the Icon-only example with working focus rings and aria-labels
+- [ ] Hard Rule 8 review-fix cycle reached `clean enough to stop`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for `Quality / check` to pass**
+
+Run: `gh pr checks --watch`
+Expected: `Quality / check` status check completes successfully. If it fails, fix on the branch and re-push (which will re-trigger CI).
+
+- [ ] **Step 4: Report PR URL back to the user**
+
+The user merges (squash or merge commit — their choice). Do not merge on their behalf without an explicit instruction.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Every section of the spec maps to a task — token (Task 2), SCSS + union (Tasks 3–4), tests (Tasks 3, 5), JSDoc + anti-pattern + when-not-to-use (Task 6), AGENTS.md (Task 7), demo (Task 8), verification (Tasks 9–10), open risks resurfaced in Task 8 step 5 for visual check.
+- **Type consistency:** `ButtonSize = 'xs' | 'sm' | 'md' | 'lg'` consistent across Tasks 3, 4, 6. SCSS class name `xs` consistent across SCSS rule and test assertions.
+- **Frequent commits:** 7 separate commits across Tasks 2–8; review-cycle commits in Task 10; PR in Task 11.

--- a/docs/superpowers/specs/2026-05-20-button-xs-size-design.md
+++ b/docs/superpowers/specs/2026-05-20-button-xs-size-design.md
@@ -131,3 +131,36 @@ Manual visual check at `make up`:
 
 - **Disabled visual at xs.** A 12px icon at `--opacity-disabled` on a ghost background may read as nearly invisible. If the manual visual check confirms this, raise it during the review-fix cycle and consider lifting disabled opacity slightly at xs (token addition, not Button-local override).
 - **Touch targets.** Below WCAG 2.5.5 AAA guidance. Accepted for desktop-first CRM; documented in JSDoc so consumers see the constraint at the point of use.
+
+## Addendum — 2026-05-20 — `iconOnly` boolean prop
+
+After visually checking the xs Icon-only example at `/components/button`, the rectangular shape (~28×20 with 8px horizontal padding) looked off compared to the square icon-only buttons used by Material, Radix, Ant, and Bootstrap. The initial decision was to leave Button with one padding rule and let icon-only shake out as a slightly-wider rectangle. We are reversing that — adding an opt-in `iconOnly` boolean prop.
+
+**What changes from the original spec:**
+
+- Add `iconOnly?: boolean` to `ButtonProps`.
+- When `iconOnly` is `true`, the button renders as a square: `aspect-ratio: 1; padding: 0;`. Width derives from the size's `height` token (`xs` → 20×20, `sm` → 24×24, `md` → 32×32, `lg` → 40×40).
+- The prop is independent of `size` — works at every step on the scale, not just `xs`.
+- Consumer must pass `aria-label`. JSDoc says so prominently. No type-level enforcement in this iteration (would require a discriminated union over `ButtonHTMLAttributes`); revisit if misuse appears in code review.
+- `IconButton` stays off the wishlist as a separate component — the prop covers the same ground without duplicating Button's variant/disabled/focus story.
+
+**SCSS approach:**
+
+```scss
+.iconOnly {
+  aspect-ratio: 1;
+  padding: 0;
+}
+```
+
+Source order matters — `.iconOnly` is declared **after** all size blocks so its `padding: 0` overrides the size-class horizontal padding. `aspect-ratio: 1` is not a layout property in the sense Rule 4 prohibits (it derives width from already-set height; it doesn't take parent space).
+
+**Files affected by the addendum (delta from original file list):**
+
+- `packages/design-system/src/components/Button/Button.tsx` — add `iconOnly?: boolean` to `ButtonProps`, JSDoc, class wiring.
+- `packages/design-system/src/components/Button/Button.module.scss` — add `.iconOnly` rule at the bottom of the size section.
+- `packages/design-system/src/components/Button/Button.test.tsx` — add a test that `iconOnly` adds the class.
+- `packages/playground/src/pages/components/ButtonDemo.tsx` — update the Icon-only at xs example to pass `iconOnly`; update the inline code string to match. Optionally add an md `iconOnly` example for contrast.
+- `packages/design-system/AGENTS.md` — mention `iconOnly` in the Button section.
+
+**Visual verification:** Re-screenshot `/components/button` after implementation and confirm the icon-only buttons render as 20×20 squares (xs) with the icon centered.

--- a/docs/superpowers/specs/2026-05-20-button-xs-size-design.md
+++ b/docs/superpowers/specs/2026-05-20-button-xs-size-design.md
@@ -155,7 +155,7 @@ After visually checking the xs Icon-only example at `/components/button`, the re
 
 Source order matters — `.iconOnly` is declared **after** all size blocks so its `padding` overrides the size-class horizontal padding. `aspect-ratio: 1` is not a layout property in the sense Rule 4 prohibits (it derives width from already-set height; it doesn't take parent space).
 
-`padding: var(--space-1)` (4px) gives the icon a small inset on all four sides so it doesn't sit flush against the border. With `box-sizing: border-box` and a 12px icon at xs, the content area is 12×12, the icon fills it, and the 4px padding shows as breathing room. At larger sizes the padding stays at 4px and the additional space goes to flex centering — the icon never looks cramped.
+`padding: var(--space-1)` (4px) gives the icon a small inset on all four sides so it doesn't sit flush against the border. With `box-sizing: border-box` at xs, the box is 20×20, the 1px border and 4px padding each subtract from inside: content area is 10×10. A 12px icon overflows the 10×10 content box by 1px on each side, extending into the padding zone but still clearing the border by ~3px. At larger sizes the padding stays at 4px and the additional space goes to flex centering — the icon never looks cramped.
 
 **Files affected by the addendum (delta from original file list):**
 

--- a/docs/superpowers/specs/2026-05-20-button-xs-size-design.md
+++ b/docs/superpowers/specs/2026-05-20-button-xs-size-design.md
@@ -91,7 +91,7 @@ Both tests use the existing global Vitest setup (`globals: true`) and the same i
 
    Code snippet shows both, with `aria-label` highlighted as required.
 
-`Pencil` icon import comes from `lucide-react` (already used elsewhere in the playground).
+`X` and `Pencil` are added to the existing `lucide-react` import in `ButtonDemo.tsx` (the file currently imports `Check, Plus, Search, Trash2`; `lucide-react` is already a playground dependency).
 
 ## `AGENTS.md` update
 

--- a/docs/superpowers/specs/2026-05-20-button-xs-size-design.md
+++ b/docs/superpowers/specs/2026-05-20-button-xs-size-design.md
@@ -149,11 +149,13 @@ After visually checking the xs Icon-only example at `/components/button`, the re
 ```scss
 .iconOnly {
   aspect-ratio: 1;
-  padding: 0;
+  padding: var(--space-1);
 }
 ```
 
-Source order matters — `.iconOnly` is declared **after** all size blocks so its `padding: 0` overrides the size-class horizontal padding. `aspect-ratio: 1` is not a layout property in the sense Rule 4 prohibits (it derives width from already-set height; it doesn't take parent space).
+Source order matters — `.iconOnly` is declared **after** all size blocks so its `padding` overrides the size-class horizontal padding. `aspect-ratio: 1` is not a layout property in the sense Rule 4 prohibits (it derives width from already-set height; it doesn't take parent space).
+
+`padding: var(--space-1)` (4px) gives the icon a small inset on all four sides so it doesn't sit flush against the border. With `box-sizing: border-box` and a 12px icon at xs, the content area is 12×12, the icon fills it, and the 4px padding shows as breathing room. At larger sizes the padding stays at 4px and the additional space goes to flex centering — the icon never looks cramped.
 
 **Files affected by the addendum (delta from original file list):**
 

--- a/docs/superpowers/specs/2026-05-20-button-xs-size-design.md
+++ b/docs/superpowers/specs/2026-05-20-button-xs-size-design.md
@@ -1,0 +1,133 @@
+# Button — `xs` size
+
+**Date:** 2026-05-20
+**Status:** Spec — awaiting review
+**Component:** `packages/design-system/src/components/Button/`
+
+## Goal
+
+Add an `xs` size to `Button` for icon-only and dense inline actions. It must continue to support a short text label alongside an icon — that requirement is why this is a size variant rather than a dedicated `IconButton` component.
+
+## Non-goals
+
+- Building a separate `IconButton` component. The wishlist entry in `packages/design-system/CLAUDE.md` stays open in case a strictly-icon API later proves ergonomically necessary, but it is not part of this change.
+- Extending `xs` to `Input` or `Avatar`. Their size unions stay as-is. The `--size-xs` token is added to the shared scale but no other component opts in.
+
+## Sizing & token
+
+- Height: **20px**.
+- Token: add `--size-xs: 20px` to `packages/design-system/src/styles/tokens.scss`, slotted directly above `--size-sm: 24px`.
+- `--font-size-xs: 11px` already exists in tokens and is used for the label.
+- `--space-1` (4px) and `--space-2` (8px) already exist and are reused for gap/padding.
+
+Avatar's JSDoc claim that its diameter "matches the shared `--size-*` scale" stays accurate — adding `--size-xs` extends the scale, it does not require every component to support every step.
+
+## SCSS
+
+Add an `.xs` block to `Button.module.scss`, ordered above `.sm`:
+
+```scss
+.xs {
+  height: var(--size-xs);
+  padding: 0 var(--space-2);
+  font-size: var(--font-size-xs);
+  gap: var(--space-1);
+}
+```
+
+Notes:
+
+- `padding: 0 var(--space-2)` (8px horizontal) gives icon-only buttons a tidy ~28×20 footprint with a 12px icon and works for the short-text case without needing a second rule.
+- `gap: var(--space-1)` overrides the base `.button { gap: var(--space-2) }` because `.xs` is declared after the base block. Tighter inter-child gap reads correctly at this size.
+- No icon-only special case (no `iconOnly` prop, no `:has(> svg:only-child)` rule). Consumer passes a single icon child + `aria-label`. YAGNI confirmed during brainstorming.
+
+## Component code (`Button.tsx`)
+
+1. Extend `ButtonSize` union:
+   ```ts
+   export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
+   ```
+2. Update the `size` prop JSDoc to list `xs` first:
+   ```
+   - `xs` (20px) — icon-only or very dense inline actions (row controls,
+     chip-adjacent buttons). Pass `aria-label` when icon-only.
+   - `sm` (24px) — dense toolbars, tables, inline actions.
+   - `md` (32px, default) — most contexts.
+   - `lg` (40px) — marketing-style empty states or emphasized primary actions.
+   ```
+3. Add an `@example` for icon-only:
+   ```tsx
+   <Button size="xs" variant="ghost" aria-label="Remove">
+     <X size={12} />
+   </Button>
+   ```
+4. Add an anti-pattern to the `@remarks Anti-patterns` block:
+   ```
+   - ❌ Using `size="xs"` for the primary or most prominent action in a
+     section. `xs` is for inline density, not emphasis.
+   ```
+5. Add a "When NOT to use" entry on touch-target acceptance:
+   ```
+   - On a touch-first surface, prefer `sm` or larger. `xs` is acceptable on
+     this codebase because the CRM is desktop-first, but 20×~28 is below
+     WCAG 2.5.5 Level AAA guidance (24×24).
+   ```
+
+No change to the spread order or `forwardRef` shape.
+
+## Tests (`Button.test.tsx`)
+
+1. Extend the existing `'applies the variant and size class names'` test to also assert `size="xs"` adds the `xs` class.
+2. Add a new test: `'renders icon-only at xs with aria-label'` — render `<Button size="xs" aria-label="Remove"><svg data-testid="icon" /></Button>`, assert the button has the accessible name "Remove" and the icon is present.
+
+Both tests use the existing global Vitest setup (`globals: true`) and the same imports already used elsewhere in the file.
+
+## Demo (`ButtonDemo.tsx`)
+
+1. **Sizes example.** Add `<Button size="xs">Extra small</Button>` to the existing "Sizes" Example, ordered first. Update the inlined `code={`…`}` string so the snippet stays self-contained (per the recent inline-constants pattern in `e383598`).
+2. **New icon-only example.** Add a new `<Example>` titled "Icon-only at xs" with two buttons in a `Cluster gap="sm"`:
+   - `<Button size="xs" variant="ghost" aria-label="Remove"><X size={12} /></Button>`
+   - `<Button size="xs" variant="secondary" aria-label="Edit"><Pencil size={12} /></Button>`
+
+   Code snippet shows both, with `aria-label` highlighted as required.
+
+`Pencil` icon import comes from `lucide-react` (already used elsewhere in the playground).
+
+## `AGENTS.md` update
+
+Replace line 43:
+
+```
+- `size`: `sm` / `md` (default) / `lg`
+```
+
+with:
+
+```
+- `size`: `xs` / `sm` / `md` (default) / `lg` — `xs` for icon-only or dense inline actions; pass `aria-label` when icon-only.
+```
+
+## Files touched
+
+- `packages/design-system/src/styles/tokens.scss` — add `--size-xs: 20px`
+- `packages/design-system/src/components/Button/Button.tsx` — union, JSDoc, anti-pattern, when-not-to-use note
+- `packages/design-system/src/components/Button/Button.module.scss` — `.xs` block
+- `packages/design-system/src/components/Button/Button.test.tsx` — extend class assertion + icon-only render test
+- `packages/design-system/AGENTS.md` — size list update on line 43
+- `packages/playground/src/pages/components/ButtonDemo.tsx` — extend Sizes example, add Icon-only example
+
+## Verification (post-implementation)
+
+This change touches `packages/design-system/**`, so Hard rule 8 (pre-push review-fix cycle) applies. Gates: `npm test`, `npm run typecheck`, `npm run lint:css`, `npm run build`, `npm pack --dry-run -w @eocrm/design-system`. Then a fresh-context reviewer pass until verdict is `clean enough to stop`.
+
+Manual visual check at `make up`:
+
+- `xs` buttons across all five variants render correctly and stay legible at 11px.
+- Disabled `xs` icon-only ghost button is still visually readable (the open risk flagged during design).
+- Focus ring at `xs` is not clipped or visually awkward.
+- Icon at 12px is centered and not cramped against the edges.
+
+## Risks
+
+- **Disabled visual at xs.** A 12px icon at `--opacity-disabled` on a ghost background may read as nearly invisible. If the manual visual check confirms this, raise it during the review-fix cycle and consider lifting disabled opacity slightly at xs (token addition, not Button-local override).
+- **Touch targets.** Below WCAG 2.5.5 AAA guidance. Accepted for desktop-first CRM; documented in JSDoc so consumers see the constraint at the point of use.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -41,6 +41,7 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 
 - `variant`: `primary` (default — one per section) / `secondary` / `ghost` / `danger` / `success`
 - `size`: `xs` / `sm` / `md` (default) / `lg` — use `xs` for icon-only or dense inline actions; pass `aria-label` when icon-only.
+- `iconOnly`: boolean. Renders a square icon-only button (`aspect-ratio: 1`, tight 4px padding). Width tracks the size's height token. **Always pair with `aria-label`** — there's no other accessible name.
 - Always renders `<button type="button">` unless you pass `type="submit"`.
 - `variant="success"` is a **transient confirmation state**, not an action intent. Flip to it for ~1.5s after the action resolves, then flip back to `primary`. The timer is the consumer's responsibility — Button stays stateless. Never render a button as `success` on initial mount. Track the timer in a `useRef` and clear on unmount + on rapid re-clicks so the flash doesn't outlive the component or get cut short.
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -40,7 +40,7 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 ```
 
 - `variant`: `primary` (default — one per section) / `secondary` / `ghost` / `danger` / `success`
-- `size`: `sm` / `md` (default) / `lg`
+- `size`: `xs` / `sm` / `md` (default) / `lg` — use `xs` for icon-only or dense inline actions; pass `aria-label` when icon-only.
 - Always renders `<button type="button">` unless you pass `type="submit"`.
 - `variant="success"` is a **transient confirmation state**, not an action intent. Flip to it for ~1.5s after the action resolves, then flip back to `primary`. The timer is the consumer's responsibility — Button stays stateless. Never render a button as `success` on initial mount. Track the timer in a `useRef` and clear on unmount + on rapid re-clicks so the flash doesn't outlive the component or get cut short.
 

--- a/packages/design-system/src/components/Button/Button.module.scss
+++ b/packages/design-system/src/components/Button/Button.module.scss
@@ -54,6 +54,7 @@
   font-size: var(--font-size-lg);
 }
 
+// MUST stay below the size blocks so `padding` overrides their horizontal padding.
 .iconOnly {
   aspect-ratio: 1;
   padding: var(--space-1);

--- a/packages/design-system/src/components/Button/Button.module.scss
+++ b/packages/design-system/src/components/Button/Button.module.scss
@@ -54,6 +54,11 @@
   font-size: var(--font-size-lg);
 }
 
+.iconOnly {
+  aspect-ratio: 1;
+  padding: var(--space-1);
+}
+
 // Variants
 .primary {
   background: var(--color-accent);

--- a/packages/design-system/src/components/Button/Button.module.scss
+++ b/packages/design-system/src/components/Button/Button.module.scss
@@ -29,6 +29,13 @@
 }
 
 // Sizes
+.xs {
+  height: var(--size-xs);
+  padding: 0 var(--space-2);
+  font-size: var(--font-size-xs);
+  gap: var(--space-1);
+}
+
 .sm {
   height: var(--size-sm);
   padding: 0 var(--space-3);

--- a/packages/design-system/src/components/Button/Button.test.tsx
+++ b/packages/design-system/src/components/Button/Button.test.tsx
@@ -25,6 +25,11 @@ describe('Button', () => {
     expect(btn.className).toMatch(/lg/);
   });
 
+  it('applies the xs size class', () => {
+    render(<Button size="xs">Tiny</Button>);
+    expect(screen.getByRole('button', { name: 'Tiny' }).className).toMatch(/xs/);
+  });
+
   it('applies the success variant class name', () => {
     render(<Button variant="success">Saved!</Button>);
     expect(screen.getByRole('button', { name: 'Saved!' }).className).toMatch(/success/);

--- a/packages/design-system/src/components/Button/Button.test.tsx
+++ b/packages/design-system/src/components/Button/Button.test.tsx
@@ -79,4 +79,13 @@ describe('Button', () => {
     expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
     expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
+
+  it('applies the iconOnly class when iconOnly is set', () => {
+    render(
+      <Button iconOnly aria-label="Remove">
+        <svg data-testid="icon" aria-hidden="true" />
+      </Button>,
+    );
+    expect(screen.getByRole('button', { name: 'Remove' }).className).toMatch(/iconOnly/);
+  });
 });

--- a/packages/design-system/src/components/Button/Button.test.tsx
+++ b/packages/design-system/src/components/Button/Button.test.tsx
@@ -69,4 +69,14 @@ describe('Button', () => {
     expect(ref.current).toBeInstanceOf(HTMLButtonElement);
     expect(ref.current?.textContent).toBe('Hi');
   });
+
+  it('renders as an icon-only button at size xs with an accessible name', () => {
+    render(
+      <Button size="xs" aria-label="Remove">
+        <svg data-testid="icon" aria-hidden="true" />
+      </Button>,
+    );
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
 });

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -32,6 +32,20 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    * - `lg` (40px) — marketing-style empty states or emphasized primary actions.
    */
   size?: ButtonSize;
+  /**
+   * Render the button as a square icon-only target — `aspect-ratio` is forced
+   * to 1 so width tracks the size's `height` token (`xs` → 20×20, `sm` → 24×24,
+   * `md` → 32×32, `lg` → 40×40) and `padding` is tightened to a small inset
+   * (4px) so the icon has breathing room without changing the outer shape.
+   *
+   * **Always pass `aria-label`** when `iconOnly` is set, otherwise the button
+   * has no accessible name. Pass a single icon as `children`.
+   *
+   * Use for inline density (row controls, chip-adjacent actions, toolbar
+   * affordances). For an icon + short text label, leave `iconOnly` off — the
+   * button will lay out as a normal rectangle with the existing gap.
+   */
+  iconOnly?: boolean;
 }
 
 /**
@@ -48,8 +62,9 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  * </Button>
  *
  * @example
- * // Icon-only at xs — pass `aria-label` so screen readers announce the action.
- * <Button size="xs" variant="ghost" aria-label="Remove">
+ * // Icon-only square button — pass `iconOnly` for a square shape (20×20 at
+ * // xs, 32×32 at md, etc.) and `aria-label` so screen readers announce it.
+ * <Button size="xs" variant="ghost" iconOnly aria-label="Remove">
  *   <X size={12} />
  * </Button>
  *
@@ -90,6 +105,9 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  *   a Button with internal state.
  * - A clickable table row → make the row itself the interactive surface;
  *   don't nest a button.
+ * - On touch-first surfaces, prefer `size="sm"` or larger. `xs` (20px×~28px, or
+ *   20×20 with `iconOnly`) is below WCAG 2.5.5 Level AAA touch-target
+ *   guidance (24×24); acceptable here because the CRM is desktop-first.
  *
  * @remarks Anti-patterns
  * - ❌ Two `variant="primary"` Buttons in the same section. Pick one; others
@@ -106,16 +124,25 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  * - ❌ Using `size="xs"` for the primary or most prominent action in a
  *   section. `xs` is for inline density, not emphasis — reach for `md` or
  *   `lg` when the button should draw the eye.
+ * - ❌ `<Button iconOnly><X /></Button>` without `aria-label`. The button has
+ *   no accessible name; screen readers announce nothing. Always pair
+ *   `iconOnly` with `aria-label="…"`.
  */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { variant = 'primary', size = 'md', className, type = 'button', ...props },
+  { variant = 'primary', size = 'md', iconOnly = false, className, type = 'button', ...props },
   ref,
 ) {
   return (
     <button
       ref={ref}
       type={type}
-      className={clsx(styles.button, styles[variant], styles[size], className)}
+      className={clsx(
+        styles.button,
+        styles[variant],
+        styles[size],
+        iconOnly && styles.iconOnly,
+        className,
+      )}
       {...props}
     />
   );

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -24,6 +24,9 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   /**
    * Control height (matches the shared `--size-*` scale used by Input and Avatar).
+   * - `xs` (20px) — icon-only or very dense inline actions (row controls,
+   *   chip-adjacent buttons). Pass `aria-label` when icon-only. Below WCAG
+   *   2.5.5 Level AAA touch-target guidance; reserve for desktop-first surfaces.
    * - `sm` (24px) — dense toolbars, tables, inline actions.
    * - `md` (32px, default) — most contexts.
    * - `lg` (40px) — marketing-style empty states or emphasized primary actions.
@@ -42,6 +45,12 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  * @example
  * <Button variant="danger" size="sm" onClick={remove}>
  *   <Trash2 size={14} /> Delete
+ * </Button>
+ *
+ * @example
+ * // Icon-only at xs — pass `aria-label` so screen readers announce the action.
+ * <Button size="xs" variant="ghost" aria-label="Remove">
+ *   <X size={12} />
  * </Button>
  *
  * @example
@@ -94,6 +103,9 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  * - ❌ Rendering `<Button variant="success">Save</Button>` on initial mount.
  *   `success` is a confirmation state, not an action intent — start as
  *   `primary` and flip to `success` after the action resolves.
+ * - ❌ Using `size="xs"` for the primary or most prominent action in a
+ *   section. `xs` is for inline density, not emphasis — reach for `md` or
+ *   `lg` when the button should draw the eye.
  */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   { variant = 'primary', size = 'md', className, type = 'button', ...props },

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -6,7 +6,7 @@ import styles from './Button.module.scss';
 export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'success';
 
 /** Control height. See ButtonProps#size for when to use each. */
-export type ButtonSize = 'sm' | 'md' | 'lg';
+export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -103,6 +103,7 @@
   --line-height-normal: 1.42857;
 
   // Control sizes
+  --size-xs: 20px;
   --size-sm: 24px;
   --size-md: 32px;
   --size-lg: 40px;

--- a/packages/playground/src/pages/components/ButtonDemo.tsx
+++ b/packages/playground/src/pages/components/ButtonDemo.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Check, Plus, Search, Trash2 } from 'lucide-react';
+import { Check, Pencil, Plus, Search, Trash2, X } from 'lucide-react';
 import { Button, Cluster } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
@@ -101,15 +101,37 @@ export function ButtonDemo() {
 
       <Example
         title="Sizes"
-        description="Three sizes. sm for dense toolbars/tables, md (default) for most contexts, lg for emphasis."
-        code={`<Button size="sm">Small</Button>
+        description="Four sizes. xs for icon-only or very dense inline actions, sm for dense toolbars/tables, md (default) for most contexts, lg for emphasis."
+        code={`<Button size="xs">Extra small</Button>
+<Button size="sm">Small</Button>
 <Button size="md">Medium</Button>
 <Button size="lg">Large</Button>`}
       >
         <Cluster gap="sm" align="center">
+          <Button size="xs">Extra small</Button>
           <Button size="sm">Small</Button>
           <Button size="md">Medium</Button>
           <Button size="lg">Large</Button>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Icon-only at xs"
+        description="For inline density — row controls, chip-adjacent actions. Always pass an aria-label so screen readers announce what the button does."
+        code={`<Button size="xs" variant="ghost" aria-label="Remove">
+  <X size={12} />
+</Button>
+<Button size="xs" variant="secondary" aria-label="Edit">
+  <Pencil size={12} />
+</Button>`}
+      >
+        <Cluster gap="sm" align="center">
+          <Button size="xs" variant="ghost" aria-label="Remove">
+            <X size={12} />
+          </Button>
+          <Button size="xs" variant="secondary" aria-label="Edit">
+            <Pencil size={12} />
+          </Button>
         </Cluster>
       </Example>
 

--- a/packages/playground/src/pages/components/ButtonDemo.tsx
+++ b/packages/playground/src/pages/components/ButtonDemo.tsx
@@ -116,21 +116,27 @@ export function ButtonDemo() {
       </Example>
 
       <Example
-        title="Icon-only at xs"
-        description="For inline density — row controls, chip-adjacent actions. Always pass an aria-label so screen readers announce what the button does."
-        code={`<Button size="xs" variant="ghost" aria-label="Remove">
+        title="Icon-only (square)"
+        description="Pass iconOnly for a square shape that tracks the size's height — 20×20 at xs, 32×32 at md. Always pair iconOnly with aria-label."
+        code={`<Button size="xs" variant="ghost" iconOnly aria-label="Remove">
   <X size={12} />
 </Button>
-<Button size="xs" variant="secondary" aria-label="Edit">
+<Button size="xs" variant="secondary" iconOnly aria-label="Edit">
   <Pencil size={12} />
+</Button>
+<Button size="md" variant="secondary" iconOnly aria-label="Search">
+  <Search size={16} />
 </Button>`}
       >
         <Cluster gap="sm" align="center">
-          <Button size="xs" variant="ghost" aria-label="Remove">
+          <Button size="xs" variant="ghost" iconOnly aria-label="Remove">
             <X size={12} />
           </Button>
-          <Button size="xs" variant="secondary" aria-label="Edit">
+          <Button size="xs" variant="secondary" iconOnly aria-label="Edit">
             <Pencil size={12} />
+          </Button>
+          <Button size="md" variant="secondary" iconOnly aria-label="Search">
+            <Search size={16} />
           </Button>
         </Cluster>
       </Example>
@@ -159,15 +165,21 @@ export function ButtonDemo() {
         title="Disabled"
         description="Native disabled attribute. Visually muted, pointer-events disabled."
         code={`<Button disabled>Primary</Button>
-<Button variant="secondary" disabled>Secondary</Button>`}
+<Button variant="secondary" disabled>Secondary</Button>
+<Button size="xs" variant="ghost" iconOnly disabled aria-label="Remove">
+  <X size={12} />
+</Button>`}
       >
-        <Cluster gap="sm">
+        <Cluster gap="sm" align="center">
           <Button disabled>Primary</Button>
           <Button variant="secondary" disabled>
             Secondary
           </Button>
           <Button variant="danger" disabled>
             Danger
+          </Button>
+          <Button size="xs" variant="ghost" iconOnly disabled aria-label="Remove">
+            <X size={12} />
           </Button>
         </Cluster>
       </Example>


### PR DESCRIPTION
## Summary

- Adds `xs` (20px height) to `Button`'s size scale alongside `sm`/`md`/`lg`.
- Adds `iconOnly?: boolean` prop to `Button` — renders a square button (`aspect-ratio: 1`, 4px padding) that tracks the size's `height` token (xs → 20×20, sm → 24×24, md → 32×32, lg → 40×40).
- New `--size-xs: 20px` shared token in `src/styles/tokens.scss`.
- JSDoc, AGENTS.md TL;DR, and playground demo updated; touch-target trade-off (below WCAG 2.5.5 AAA at xs) documented at the call site.
- Three new unit tests: xs class assertion, icon-only render with accessible name, iconOnly class assertion.
- Spec + plan committed under `docs/superpowers/{specs,plans}/`. Spec carries an addendum documenting why we reversed the original "rectangular icon-only is fine" call after seeing it in the browser.

## Test plan

- [ ] CI `Quality / check` green
- [ ] `npm test` — 464 passing
- [ ] `npm run typecheck` — clean (both workspaces)
- [ ] `npm run lint:css` — clean
- [ ] `npm run build` — clean
- [ ] `npm pack --dry-run -w @eocrm/design-system` — 77 files, no `*.test.tsx` in tarball
- [ ] Visual check at `/components/button`: Sizes row shows four buttons (xs/sm/md/lg); Icon-only (square) example shows three square buttons (xs ghost ✕, xs secondary pencil, md secondary search); Disabled section includes a disabled xs ghost ✕ so the highest-risk visual case is inspectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)