### PR TITLE
Calendar PR 3: Week + Day views with hour grid

### DIFF
--- a/docs/superpowers/plans/2026-05-20-calendar-week-day-views.md
+++ b/docs/superpowers/plans/2026-05-20-calendar-week-day-views.md
@@ -1,0 +1,2177 @@
+# Calendar PR 3 Implementation Plan (Week + Day views)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `<WeekView>` and `<DayView>` to the Calendar surface with an hour-grid primitive, collision layout for overlapping timed events, an all-day band, a "now" indicator, and a view switcher in the Calendar shell.
+
+**Architecture:** New `<HourGrid>` internal primitive (column×hour CSS grid) used by both `<WeekView>` (7 cols) and `<DayView>` (1 col). `<TimedEvent>` blocks position absolutely inside their day column. `<AllDayBand>` reuses the month-bar continuation pattern. `<ViewSwitcher>` wraps `<Tabs>` as a segmented control. `layoutEventsForHourGrid` in `utils.ts` runs greedy lane assignment + sweep-based collision-group laneCount.
+
+**Tech Stack:** React 18 + TypeScript, SCSS modules, Vitest + RTL.
+
+**Spec:** [docs/superpowers/specs/2026-05-20-calendar-week-day-views-design.md](../specs/2026-05-20-calendar-week-day-views-design.md)
+
+**Branch state at start:** `feat/calendar-week-day-views` branched from fresh `main` (with PR #20 merged in). Spec is committed on top.
+
+---
+
+## Task 1: Verify branch + hooks
+
+**Files:** (no edits — git only)
+
+- [ ] **Step 1: Confirm branch + clean tree**
+
+```bash
+git status
+git rev-parse --abbrev-ref HEAD
+git log --oneline -4
+```
+
+Expected: branch `feat/calendar-week-day-views`; top commits include the Calendar PR 3 spec. Tree clean.
+
+- [ ] **Step 2: Verify hooks**
+
+```bash
+git config --get core.hooksPath
+test -x .husky/pre-push && echo OK
+```
+
+Expected: `.husky/_` + `OK`.
+
+---
+
+## Task 2: Extend `types.ts`
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Calendar/types.ts`
+
+- [ ] **Step 1: Extend `CalendarView` and add new types**
+
+Replace `export type CalendarView = 'month';` and add the new shapes. The full updated `types.ts`:
+
+```ts
+export type CalendarEventTone = 'neutral' | 'accent' | 'success' | 'warning' | 'danger';
+
+/**
+ * One event to render on the Calendar.
+ *
+ * - `startsAt` is the local-time start instant. `endsAt` (optional) is the
+ *   local-time end instant. For multi-day events, the bar extends from the
+ *   start day through the end day inclusive; week boundaries split it into
+ *   continuous bars with flattened edges.
+ * - `allDay: true` renders a tone-filled band without a time prefix
+ *   (birthdays, vacations). Default `false` renders a tone-tinted bar with
+ *   a hour-formatted time prefix.
+ */
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  startsAt: Date;
+  endsAt?: Date;
+  tone?: CalendarEventTone;
+  allDay?: boolean;
+}
+
+/** Calendar views. Month + week + day in v3. Agenda lands in PR 4. */
+export type CalendarView = 'month' | 'week' | 'day';
+
+/**
+ * One placed event bar inside the month grid. Produced by
+ * `layoutEventsForMonth` and consumed by `MonthView`.
+ */
+export interface EventBar {
+  event: CalendarEvent;
+  weekIndex: number;
+  startCol: number;
+  endCol: number;
+  lane: number;
+  continuesLeft: boolean;
+  continuesRight: boolean;
+}
+
+/** Result of `layoutEventsForMonth`. */
+export interface MonthLayout {
+  bars: readonly EventBar[];
+  hiddenCounts: ReadonlyMap<string, number>;
+}
+
+/**
+ * One positioned timed-event block inside an `<HourGrid>` column.
+ * Produced by `layoutEventsForHourGrid` and consumed by `WeekView`/`DayView`.
+ */
+export interface TimedEventBlock {
+  event: CalendarEvent;
+  /** 0..N-1 — column index within the rendered view (0 for DayView). */
+  dayIndex: number;
+  /** Minutes from `hourRange[0] * 60`. May be negative if the event started earlier. */
+  startMinutes: number;
+  /** Minutes from `hourRange[0] * 60`. May exceed `(hourRange[1] - hourRange[0]) * 60`. */
+  endMinutes: number;
+  /** 0..laneCount-1 — horizontal lane within the day's collision group. */
+  lane: number;
+  /** Number of lanes in this block's collision group; bar width = `100% / laneCount`. */
+  laneCount: number;
+}
+
+/**
+ * One bar in the AllDayBand. Multi-day events span columns; the bar is a
+ * single visual element across `startCol..endCol`.
+ */
+export interface AllDayBar {
+  event: CalendarEvent;
+  startCol: number;
+  endCol: number;
+  lane: number;
+  continuesLeft: boolean;
+  continuesRight: boolean;
+}
+
+/** Result of `layoutEventsForHourGrid`. */
+export interface HourGridLayout {
+  timedBlocks: readonly TimedEventBlock[];
+  allDayBars: readonly AllDayBar[];
+}
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add packages/design-system/src/components/Calendar/types.ts
+git commit -m "calendar/week-day: types — CalendarView 'week'/'day', TimedEventBlock, AllDayBar"
+```
+
+Expected typecheck: exit 0.
+
+---
+
+## Task 3: `layoutEventsForHourGrid` algorithm (TDD)
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Calendar/utils.ts` (add new function)
+- Modify: `packages/design-system/src/components/Calendar/utils.test.tsx` (add new describe block)
+
+- [ ] **Step 1: Append tests to `utils.test.tsx`**
+
+Add these tests **inside** the existing test file, after the `describe('layoutEventsForMonth', ...)` block:
+
+```tsx
+import { layoutEventsForHourGrid } from './utils';
+
+describe('layoutEventsForHourGrid', () => {
+  // Helper: a list of 1 day = May 20 2026 (Wed)
+  const day1 = [{ date: new Date(2026, 4, 20), key: '2026-05-20' }];
+
+  // Helper: a list of 7 days = May 17..23 (Sun-Sat)
+  const week7 = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(2026, 4, 17 + i);
+    return { date: d, key: `2026-05-${String(17 + i).padStart(2, '0')}` };
+  });
+
+  function tev(id: string, day: number, startHour: number, endHour: number): CalendarEvent {
+    return {
+      id,
+      title: id,
+      startsAt: new Date(2026, 4, day, startHour, 0),
+      endsAt: new Date(2026, 4, day, endHour, 0),
+    };
+  }
+
+  it('returns empty layout for no events', () => {
+    const out = layoutEventsForHourGrid([], day1, [7, 19]);
+    expect(out.timedBlocks).toEqual([]);
+    expect(out.allDayBars).toEqual([]);
+  });
+
+  it('places a single timed event in column 0 with lane=0, laneCount=1', () => {
+    const out = layoutEventsForHourGrid([tev('a', 20, 9, 10)], day1, [7, 19]);
+    expect(out.timedBlocks).toHaveLength(1);
+    expect(out.timedBlocks[0]).toMatchObject({
+      dayIndex: 0,
+      startMinutes: 120, // (9 - 7) * 60
+      endMinutes: 180,
+      lane: 0,
+      laneCount: 1,
+    });
+  });
+
+  it('places two non-overlapping events on the same lane', () => {
+    const out = layoutEventsForHourGrid([tev('a', 20, 9, 10), tev('b', 20, 11, 12)], day1, [7, 19]);
+    expect(out.timedBlocks).toHaveLength(2);
+    expect(out.timedBlocks[0].lane).toBe(0);
+    expect(out.timedBlocks[1].lane).toBe(0);
+    // Same lane but different collision groups → laneCount 1 each
+    expect(out.timedBlocks[0].laneCount).toBe(1);
+    expect(out.timedBlocks[1].laneCount).toBe(1);
+  });
+
+  it('places two overlapping events on lanes 0 and 1, both laneCount=2', () => {
+    const out = layoutEventsForHourGrid([tev('a', 20, 9, 11), tev('b', 20, 10, 12)], day1, [7, 19]);
+    expect(out.timedBlocks).toHaveLength(2);
+    const byId = new Map(out.timedBlocks.map((b) => [b.event.id, b]));
+    expect(byId.get('a')!.lane).toBe(0);
+    expect(byId.get('b')!.lane).toBe(1);
+    expect(byId.get('a')!.laneCount).toBe(2);
+    expect(byId.get('b')!.laneCount).toBe(2);
+  });
+
+  it('places three mutually overlapping events with laneCount=3', () => {
+    const out = layoutEventsForHourGrid(
+      [tev('a', 20, 9, 11), tev('b', 20, 9, 11), tev('c', 20, 9, 11)],
+      day1,
+      [7, 19],
+    );
+    expect(out.timedBlocks).toHaveLength(3);
+    out.timedBlocks.forEach((b) => expect(b.laneCount).toBe(3));
+    const lanes = out.timedBlocks.map((b) => b.lane).sort();
+    expect(lanes).toEqual([0, 1, 2]);
+  });
+
+  it('groups by transitive overlap (chain A-B, B-C → all laneCount=3 even if A and C disjoint)', () => {
+    // A: 9-10:30, B: 10-11, C: 10:45-12 → all in one group
+    const out = layoutEventsForHourGrid(
+      [
+        {
+          id: 'a',
+          title: 'a',
+          startsAt: new Date(2026, 4, 20, 9, 0),
+          endsAt: new Date(2026, 4, 20, 10, 30),
+        },
+        {
+          id: 'b',
+          title: 'b',
+          startsAt: new Date(2026, 4, 20, 10, 0),
+          endsAt: new Date(2026, 4, 20, 11, 0),
+        },
+        {
+          id: 'c',
+          title: 'c',
+          startsAt: new Date(2026, 4, 20, 10, 45),
+          endsAt: new Date(2026, 4, 20, 12, 0),
+        },
+      ],
+      day1,
+      [7, 19],
+    );
+    out.timedBlocks.forEach((b) => expect(b.laneCount).toBe(3));
+  });
+
+  it('puts a multi-day event into allDayBars when allDay is true', () => {
+    const out = layoutEventsForHourGrid(
+      [
+        {
+          id: 'conf',
+          title: 'Conference',
+          startsAt: new Date(2026, 4, 18),
+          endsAt: new Date(2026, 4, 22),
+          allDay: true,
+        },
+      ],
+      week7,
+      [7, 19],
+    );
+    expect(out.timedBlocks).toEqual([]);
+    expect(out.allDayBars).toHaveLength(1);
+    expect(out.allDayBars[0]).toMatchObject({
+      startCol: 1, // Mon May 18 = column 1 in Sun-start week (May 17 = col 0)
+      endCol: 5, // Fri May 22 = column 5
+      lane: 0,
+      continuesLeft: false,
+      continuesRight: false,
+    });
+  });
+
+  it('clips an allDay event extending before the view to startCol=0 with continuesLeft', () => {
+    const out = layoutEventsForHourGrid(
+      [
+        {
+          id: 'conf',
+          title: 'Conference',
+          startsAt: new Date(2026, 4, 15),
+          endsAt: new Date(2026, 4, 20),
+          allDay: true,
+        },
+      ],
+      week7,
+      [7, 19],
+    );
+    expect(out.allDayBars).toHaveLength(1);
+    expect(out.allDayBars[0]).toMatchObject({
+      startCol: 0,
+      endCol: 3,
+      continuesLeft: true,
+      continuesRight: false,
+    });
+  });
+
+  it('clips an allDay event extending past the view with continuesRight', () => {
+    const out = layoutEventsForHourGrid(
+      [
+        {
+          id: 'conf',
+          title: 'Conference',
+          startsAt: new Date(2026, 4, 22),
+          endsAt: new Date(2026, 4, 28),
+          allDay: true,
+        },
+      ],
+      week7,
+      [7, 19],
+    );
+    expect(out.allDayBars[0]).toMatchObject({
+      startCol: 5,
+      endCol: 6,
+      continuesLeft: false,
+      continuesRight: true,
+    });
+  });
+
+  it('drops events entirely outside the view', () => {
+    const out = layoutEventsForHourGrid([tev('a', 25, 9, 10)], day1, [7, 19]);
+    expect(out.timedBlocks).toEqual([]);
+  });
+
+  it('places events at the correct dayIndex within a week', () => {
+    const out = layoutEventsForHourGrid([tev('a', 20, 9, 10)], week7, [7, 19]);
+    expect(out.timedBlocks).toHaveLength(1);
+    expect(out.timedBlocks[0].dayIndex).toBe(3); // May 20 = col 3 in Sun-start week (17, 18, 19, 20)
+  });
+
+  it('keeps events starting before hourRange (negative startMinutes) so the renderer can clip', () => {
+    const out = layoutEventsForHourGrid([tev('a', 20, 6, 8)], day1, [7, 19]);
+    expect(out.timedBlocks).toHaveLength(1);
+    expect(out.timedBlocks[0].startMinutes).toBe(-60); // 6am = -60 minutes from 7am
+    expect(out.timedBlocks[0].endMinutes).toBe(60); // 8am = +60 minutes
+  });
+});
+```
+
+You'll need to add `import type { CalendarEvent } from './types';` at the top of the test file if it isn't already imported.
+
+- [ ] **Step 2: Run, confirm fail**
+
+```bash
+cd packages/design-system && npx vitest run src/components/Calendar/utils.test.tsx
+```
+
+Expected: `layoutEventsForHourGrid is not a function` errors.
+
+- [ ] **Step 3: Implement in `utils.ts`**
+
+Append to `packages/design-system/src/components/Calendar/utils.ts`:
+
+```ts
+import { isSameMonth } from '../../calendar/dateMath';
+// (keep existing imports — `startOfDay`, `toDateKey` are already imported)
+
+interface DayRef {
+  date: Date;
+  key: string;
+}
+
+interface NormalizedTimed {
+  event: CalendarEvent;
+  dayIndex: number;
+  startMinutes: number;
+  endMinutes: number;
+}
+
+/**
+ * Lay out events for a Week or Day view's hour grid.
+ *
+ * - `allDay` events become bars in the AllDayBand (multi-day spans flatten
+ *   edges, like the month bars).
+ * - Timed events get positioned in their day column with greedy lane
+ *   assignment; each block's `laneCount` equals the size of its transitive
+ *   collision group (so siblings render at uniform width within the group).
+ * - Events outside the day range are dropped; events partially outside the
+ *   hour range keep their natural `startMinutes`/`endMinutes` (may be
+ *   negative or past the range) so the renderer can clip visually.
+ */
+export function layoutEventsForHourGrid(
+  events: readonly CalendarEvent[],
+  days: readonly DayRef[],
+  hourRange: readonly [number, number],
+): HourGridLayout {
+  if (events.length === 0 || days.length === 0) {
+    return { timedBlocks: [], allDayBars: [] };
+  }
+
+  const viewStart = startOfDay(days[0].date).getTime();
+  const viewEnd = startOfDay(days[days.length - 1].date).getTime() + MS_PER_DAY;
+  const baseHourMinutes = hourRange[0] * 60;
+
+  const timedNormalized: NormalizedTimed[] = [];
+  const allDayInput: CalendarEvent[] = [];
+
+  for (const ev of events) {
+    const start = ev.startsAt;
+    const end = ev.endsAt ?? ev.startsAt;
+    // Drop events entirely outside the view's day range
+    if (end.getTime() < viewStart || start.getTime() >= viewEnd) continue;
+    if (ev.allDay === true) {
+      allDayInput.push(ev);
+      continue;
+    }
+    // Place timed event in its (clamped) start-day column
+    const eventStartDay = startOfDay(start).getTime();
+    const dayIndex = days.findIndex((d) => startOfDay(d.date).getTime() === eventStartDay);
+    if (dayIndex === -1) continue; // multi-day timed events: only place on their start day (out of scope for v1)
+    const startMinutes = start.getHours() * 60 + start.getMinutes() - baseHourMinutes;
+    const endMinutes = end.getHours() * 60 + end.getMinutes() - baseHourMinutes;
+    timedNormalized.push({ event: ev, dayIndex, startMinutes, endMinutes });
+  }
+
+  // Per-day lane assignment + collision-group laneCount
+  const timedBlocks: TimedEventBlock[] = [];
+  for (let d = 0; d < days.length; d++) {
+    const dayEvents = timedNormalized
+      .filter((n) => n.dayIndex === d)
+      .sort((a, b) => a.startMinutes - b.startMinutes || b.endMinutes - a.endMinutes);
+
+    interface LaneState {
+      endMinutes: number;
+    }
+    const lanes: LaneState[] = [];
+    const placed: { ne: NormalizedTimed; lane: number }[] = [];
+
+    for (const ne of dayEvents) {
+      let assigned = -1;
+      for (let l = 0; l < lanes.length; l++) {
+        if (lanes[l].endMinutes <= ne.startMinutes) {
+          assigned = l;
+          lanes[l].endMinutes = ne.endMinutes;
+          break;
+        }
+      }
+      if (assigned === -1) {
+        assigned = lanes.length;
+        lanes.push({ endMinutes: ne.endMinutes });
+      }
+      placed.push({ ne, lane: assigned });
+    }
+
+    // Sweep into transitive collision groups; assign laneCount per group.
+    interface Group {
+      members: { ne: NormalizedTimed; lane: number }[];
+      maxLane: number;
+    }
+    const groups: Group[] = [];
+    let currentGroup: Group | null = null;
+    let currentEndMax = -Infinity;
+    const sortedByStart = [...placed].sort((a, b) => a.ne.startMinutes - b.ne.startMinutes);
+    for (const p of sortedByStart) {
+      if (p.ne.startMinutes >= currentEndMax) {
+        if (currentGroup) groups.push(currentGroup);
+        currentGroup = { members: [p], maxLane: p.lane };
+        currentEndMax = p.ne.endMinutes;
+      } else {
+        currentGroup!.members.push(p);
+        currentGroup!.maxLane = Math.max(currentGroup!.maxLane, p.lane);
+        currentEndMax = Math.max(currentEndMax, p.ne.endMinutes);
+      }
+    }
+    if (currentGroup) groups.push(currentGroup);
+
+    for (const g of groups) {
+      const laneCount = g.maxLane + 1;
+      for (const { ne, lane } of g.members) {
+        timedBlocks.push({
+          event: ne.event,
+          dayIndex: ne.dayIndex,
+          startMinutes: ne.startMinutes,
+          endMinutes: ne.endMinutes,
+          lane,
+          laneCount,
+        });
+      }
+    }
+  }
+
+  // All-day bars — same continuation-flag logic as the month bars, but over
+  // the visible day range (not a 7-cell week).
+  const allDayBars = layoutAllDayBars(allDayInput, days);
+
+  return { timedBlocks, allDayBars };
+}
+
+function layoutAllDayBars(
+  events: readonly CalendarEvent[],
+  days: readonly DayRef[],
+): readonly AllDayBar[] {
+  if (events.length === 0) return [];
+  const viewStartMs = startOfDay(days[0].date).getTime();
+  const viewEndMs = startOfDay(days[days.length - 1].date).getTime();
+
+  interface NormalizedAllDay {
+    event: CalendarEvent;
+    startMs: number;
+    endMs: number;
+    duration: number;
+  }
+  const normalized: NormalizedAllDay[] = [];
+  for (const ev of events) {
+    let startMs = startOfDay(ev.startsAt).getTime();
+    let endMs = startOfDay(ev.endsAt ?? ev.startsAt).getTime();
+    if (endMs < startMs) [startMs, endMs] = [endMs, startMs];
+    if (endMs < viewStartMs || startMs > viewEndMs) continue;
+    normalized.push({ event: ev, startMs, endMs, duration: (endMs - startMs) / MS_PER_DAY });
+  }
+  normalized.sort((a, b) => a.startMs - b.startMs || b.duration - a.duration);
+
+  // Greedy lane assignment per bar (one lane per row of the band)
+  interface LaneSegment {
+    startCol: number;
+    endCol: number;
+  }
+  const lanes: LaneSegment[][] = [];
+  const bars: AllDayBar[] = [];
+
+  for (const n of normalized) {
+    const segStartMs = Math.max(n.startMs, viewStartMs);
+    const segEndMs = Math.min(n.endMs, viewEndMs);
+    const startCol = Math.round((segStartMs - viewStartMs) / MS_PER_DAY);
+    const endCol = Math.round((segEndMs - viewStartMs) / MS_PER_DAY);
+
+    let assigned = -1;
+    for (let l = 0; l < lanes.length; l++) {
+      const conflicts = lanes[l].some((s) => !(s.endCol < startCol || s.startCol > endCol));
+      if (!conflicts) {
+        assigned = l;
+        break;
+      }
+    }
+    if (assigned === -1) {
+      assigned = lanes.length;
+      lanes.push([]);
+    }
+    lanes[assigned].push({ startCol, endCol });
+
+    bars.push({
+      event: n.event,
+      startCol,
+      endCol,
+      lane: assigned,
+      continuesLeft: n.startMs < viewStartMs,
+      continuesRight: n.endMs > viewEndMs,
+    });
+  }
+  return bars;
+}
+```
+
+You'll need to add `import type { AllDayBar, HourGridLayout, TimedEventBlock } from './types';` at the top of `utils.ts` if not already present (the existing imports cover `CalendarEvent`, `EventBar`, `MonthLayout`).
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```bash
+cd packages/design-system && npx vitest run src/components/Calendar/utils.test.tsx
+```
+
+Expected: all tests in `utils.test.tsx` pass (existing month tests + new 12 hour-grid tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/dpws/projects/design-system && git add packages/design-system/src/components/Calendar/utils.ts packages/design-system/src/components/Calendar/utils.test.tsx && git commit -m "calendar/week-day: layoutEventsForHourGrid — lane + collision-group laneCount"
+```
+
+---
+
+## Task 4: `<HourGrid>`, `<TimedEvent>`, `<AllDayBand>` (internal components)
+
+These are the foundational rendering pieces. They're tested indirectly through `WeekView.test.tsx` / `DayView.test.tsx`.
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Calendar/HourGrid.tsx`
+- Create: `packages/design-system/src/components/Calendar/HourGrid.module.scss`
+- Create: `packages/design-system/src/components/Calendar/TimedEvent.tsx`
+- Create: `packages/design-system/src/components/Calendar/TimedEvent.module.scss`
+- Create: `packages/design-system/src/components/Calendar/AllDayBand.tsx`
+- Create: `packages/design-system/src/components/Calendar/AllDayBand.module.scss`
+
+- [ ] **Step 1: `TimedEvent.tsx`**
+
+```tsx
+import { useMemo, type MouseEvent } from 'react';
+import clsx from 'clsx';
+import { useLocale } from '../../i18n/useLocale';
+import { formatTime } from '../../calendar';
+import { Tooltip } from '../Tooltip';
+import type { CalendarEvent, CalendarEventTone, TimedEventBlock } from './types';
+import styles from './TimedEvent.module.scss';
+
+export interface TimedEventProps {
+  /** The placed block produced by `layoutEventsForHourGrid`. */
+  block: TimedEventBlock;
+  /** Pixel height per hour row. */
+  hourRowHeight: number;
+  onClick?: (event: CalendarEvent) => void;
+}
+
+/**
+ * Internal: a single timed-event block, absolutely positioned inside an
+ * hour-grid day column. Tone-styled, wrapped in a Tooltip so the full
+ * "time range + title" is reachable.
+ */
+export function TimedEvent({ block, hourRowHeight, onClick }: TimedEventProps) {
+  const locale = useLocale();
+  const tone: CalendarEventTone = block.event.tone ?? 'neutral';
+
+  const top = (block.startMinutes / 60) * hourRowHeight;
+  const height = ((block.endMinutes - block.startMinutes) / 60) * hourRowHeight;
+  const width = `${100 / block.laneCount}%`;
+  const left = `${(100 / block.laneCount) * block.lane}%`;
+
+  const timeLabel = useMemo(
+    () =>
+      `${formatTime(block.event.startsAt, locale)} – ${formatTime(block.event.endsAt ?? block.event.startsAt, locale)}`,
+    [block.event.startsAt, block.event.endsAt, locale],
+  );
+
+  const tooltipContent = (
+    <span className={styles.tooltipBody}>
+      <span className={styles.tooltipTime}>{timeLabel}</span>
+      <span className={styles.tooltipTitle}>{block.event.title}</span>
+    </span>
+  );
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onClick?.(block.event);
+  };
+
+  // For short events (<30 min visible height), only show the title.
+  const isShort = height < 30;
+
+  return (
+    <Tooltip content={tooltipContent}>
+      <button
+        type="button"
+        className={clsx(styles.block, styles[tone])}
+        style={{ top, height, width, left }}
+        onClick={handleClick}
+      >
+        {!isShort && <span className={styles.time}>{timeLabel}</span>}
+        <span className={styles.title}>{block.event.title}</span>
+      </button>
+    </Tooltip>
+  );
+}
+```
+
+- [ ] **Step 2: `TimedEvent.module.scss`**
+
+```scss
+@use '../../styles/mixins' as *;
+
+.block {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border: var(--border-width) solid transparent;
+  border-radius: var(--radius-sm);
+  font-family: inherit;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.2;
+  text-align: left;
+  overflow: hidden;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    filter var(--transition-fast),
+    background var(--transition-fast);
+
+  &:hover:not(:disabled) {
+    filter: brightness(0.95);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+  }
+}
+
+.time {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-regular);
+  opacity: var(--opacity-muted);
+  flex-shrink: 0;
+}
+
+.title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tooltipBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.tooltipTime {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-regular);
+  color: var(--color-bg-subtle);
+}
+
+.tooltipTitle {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-bg);
+}
+
+.neutral {
+  background: var(--color-bg-subtle);
+  color: var(--color-fg);
+}
+
+.accent {
+  background: var(--color-accent-bg-subtle);
+  color: var(--color-accent);
+}
+
+.success {
+  background: var(--color-success-bg-subtle);
+  color: var(--color-success);
+}
+
+.warning {
+  background: var(--color-warning-bg-subtle);
+  color: var(--color-warning);
+}
+
+.danger {
+  background: var(--color-danger-bg-subtle);
+  color: var(--color-danger);
+}
+```
+
+- [ ] **Step 3: `AllDayBand.tsx`**
+
+```tsx
+import clsx from 'clsx';
+import { EventChip } from './EventChip';
+import type { AllDayBar, CalendarEvent } from './types';
+import styles from './AllDayBand.module.scss';
+
+export interface AllDayBandProps {
+  /** Bars produced by `layoutEventsForHourGrid`. */
+  bars: readonly AllDayBar[];
+  /** Number of day columns the band spans (1 or 7). */
+  columnCount: number;
+  /** Pixel width of the hour-gutter on the left (so the band aligns with the hour grid below). */
+  gutterWidth: number;
+  onEventClick?: (event: CalendarEvent) => void;
+}
+
+/**
+ * Internal: the all-day event band above the hour grid. Multi-day events
+ * render as continuous bars across day columns; the gutter on the left is
+ * empty (matches the hour-grid's gutter so columns line up).
+ */
+export function AllDayBand({ bars, columnCount, gutterWidth, onEventClick }: AllDayBandProps) {
+  if (bars.length === 0) return null;
+  const maxLane = bars.reduce((m, b) => Math.max(m, b.lane), 0);
+
+  return (
+    <div
+      className={styles.band}
+      style={{
+        gridTemplateColumns: `${gutterWidth}px repeat(${columnCount}, 1fr)`,
+      }}
+    >
+      {/* Empty gutter cell */}
+      <div className={styles.gutter} />
+      {/* Bars are positioned via grid-column inside the body */}
+      <div
+        className={styles.body}
+        style={{
+          gridTemplateColumns: `repeat(${columnCount}, 1fr)`,
+          gridTemplateRows: `repeat(${maxLane + 1}, auto)`,
+        }}
+      >
+        {bars.map((bar) => (
+          <div
+            key={bar.event.id}
+            className={clsx(
+              styles.barSlot,
+              bar.continuesLeft && styles.continuesLeft,
+              bar.continuesRight && styles.continuesRight,
+            )}
+            style={{
+              gridColumn: `${bar.startCol + 1} / ${bar.endCol + 2}`,
+              gridRow: bar.lane + 1,
+            }}
+          >
+            <EventChip
+              event={bar.event}
+              continuesLeft={bar.continuesLeft}
+              continuesRight={bar.continuesRight}
+              onClick={(ev) => onEventClick?.(ev)}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: `AllDayBand.module.scss`**
+
+```scss
+.band {
+  display: grid;
+  border-bottom: var(--border-width) solid var(--color-border);
+  background: var(--color-bg);
+}
+
+.gutter {
+  border-right: var(--border-width) solid var(--color-border);
+}
+
+.body {
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-1);
+  align-items: start;
+}
+
+.barSlot {
+  min-width: 0;
+}
+
+.continuesLeft,
+.continuesRight {
+  // Visual cues on the chip itself; nothing to do at the wrapper level
+}
+```
+
+- [ ] **Step 5: `HourGrid.tsx`**
+
+```tsx
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { useLocale } from '../../i18n/useLocale';
+import { formatHour } from '../../calendar';
+import { isSameDay } from '../../calendar/dateMath';
+import { TimedEvent } from './TimedEvent';
+import type { CalendarEvent, TimedEventBlock } from './types';
+import styles from './HourGrid.module.scss';
+
+/** Default gutter width in pixels. */
+export const HOUR_GUTTER_WIDTH = 60;
+
+export interface HourGridProps {
+  /** One date per column (1 for DayView, 7 for WeekView). */
+  days: readonly { date: Date; key: string; isWeekend?: boolean }[];
+  /** Localized column header content (one per day). */
+  columnHeaders: readonly ReactNode[];
+  /** Inclusive start, exclusive end. */
+  hourRange: readonly [number, number];
+  /** Pixel height per hour row. */
+  hourRowHeight: number;
+  /** Timed events positioned within columns. */
+  timedBlocks: readonly TimedEventBlock[];
+  /** Today's date (injected for testability). Defaults to `new Date()`. */
+  now?: Date;
+  onEventClick?: (event: CalendarEvent) => void;
+}
+
+/**
+ * Internal: hour-grid scaffold for Week and Day views. Renders the column
+ * headers, hour gutter labels, the column bodies (with timed events
+ * positioned absolutely inside), and a horizontal "now" line in today's
+ * column when today is in the rendered range.
+ */
+export function HourGrid({
+  days,
+  columnHeaders,
+  hourRange,
+  hourRowHeight,
+  timedBlocks,
+  now,
+  onEventClick,
+}: HourGridProps) {
+  const locale = useLocale();
+  const [tick, setTick] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Re-render every minute so the "now" line moves.
+  useEffect(() => {
+    const id = window.setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const currentTime = now ?? new Date();
+  // Suppress unused-variable warning when `tick` is only there to invalidate memos
+  void tick;
+
+  const hourLabels = useMemo(() => {
+    const labels: string[] = [];
+    for (let h = hourRange[0]; h < hourRange[1]; h++) {
+      labels.push(formatHour(h, locale));
+    }
+    return labels;
+  }, [hourRange, locale]);
+
+  const columnCount = days.length;
+  const blocksByDay = useMemo(() => {
+    const m = new Map<number, TimedEventBlock[]>();
+    for (const b of timedBlocks) {
+      const list = m.get(b.dayIndex) ?? [];
+      list.push(b);
+      m.set(b.dayIndex, list);
+    }
+    return m;
+  }, [timedBlocks]);
+
+  const totalHours = hourRange[1] - hourRange[0];
+  const nowMinutesFromStart =
+    (currentTime.getHours() - hourRange[0]) * 60 + currentTime.getMinutes();
+  const nowVisible = nowMinutesFromStart >= 0 && nowMinutesFromStart <= totalHours * 60;
+  const todayColumnIndex = days.findIndex((d) => isSameDay(d.date, currentTime));
+
+  return (
+    <div ref={containerRef} className={styles.scroll}>
+      <div
+        className={styles.grid}
+        style={{
+          gridTemplateColumns: `${HOUR_GUTTER_WIDTH}px repeat(${columnCount}, 1fr)`,
+          gridTemplateRows: `auto repeat(${totalHours}, ${hourRowHeight}px)`,
+        }}
+      >
+        {/* Top-left corner cell */}
+        <div className={styles.cornerCell} aria-hidden="true" />
+        {/* Column headers */}
+        {columnHeaders.map((header, i) => (
+          <div
+            key={`header-${days[i].key}`}
+            role="columnheader"
+            className={clsx(
+              styles.columnHeader,
+              days[i].isWeekend && styles.weekendHeader,
+              todayColumnIndex === i && styles.todayHeader,
+            )}
+          >
+            {header}
+          </div>
+        ))}
+        {/* Hour gutter labels */}
+        {hourLabels.map((label, h) => (
+          <div
+            key={`hour-${h}`}
+            className={styles.hourLabel}
+            style={{ gridColumn: 1, gridRow: h + 2 }}
+          >
+            {label}
+          </div>
+        ))}
+        {/* Day columns (one per day) — each is `position: relative` so
+            TimedEvent blocks position absolutely inside. */}
+        {days.map((day, i) => {
+          const blocks = blocksByDay.get(i) ?? [];
+          return (
+            <div
+              key={day.key}
+              className={clsx(
+                styles.dayColumn,
+                day.isWeekend && styles.weekendColumn,
+                todayColumnIndex === i && styles.todayColumn,
+              )}
+              style={{ gridColumn: i + 2, gridRow: `2 / span ${totalHours}` }}
+            >
+              {/* Hour-row separators */}
+              {Array.from({ length: totalHours }).map((_, h) => (
+                <div
+                  key={`sep-${h}`}
+                  className={styles.hourSeparator}
+                  style={{ top: h * hourRowHeight }}
+                  aria-hidden="true"
+                />
+              ))}
+              {/* Now line */}
+              {nowVisible && todayColumnIndex === i && (
+                <div
+                  className={styles.nowLine}
+                  style={{ top: (nowMinutesFromStart / 60) * hourRowHeight }}
+                  aria-hidden="true"
+                />
+              )}
+              {/* Timed event blocks */}
+              {blocks.map((b) => (
+                <TimedEvent
+                  key={b.event.id}
+                  block={b}
+                  hourRowHeight={hourRowHeight}
+                  onClick={onEventClick}
+                />
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: `HourGrid.module.scss`**
+
+```scss
+.scroll {
+  overflow: auto;
+  max-height: 70vh;
+}
+
+.grid {
+  display: grid;
+  background: var(--color-bg);
+  position: relative;
+}
+
+.cornerCell {
+  border-right: var(--border-width) solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
+  background: var(--color-bg-subtle);
+}
+
+.columnHeader {
+  padding: var(--space-2);
+  background: var(--color-bg-subtle);
+  border-right: var(--border-width) solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg);
+  text-align: center;
+}
+
+.weekendHeader {
+  background: var(--color-bg-muted);
+}
+
+.todayHeader {
+  background: var(--color-accent-bg-subtle);
+  color: var(--color-accent);
+}
+
+.hourLabel {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+  text-align: right;
+  border-right: var(--border-width) solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
+  background: var(--color-bg-subtle);
+}
+
+.dayColumn {
+  position: relative;
+  border-right: var(--border-width) solid var(--color-border);
+}
+
+.weekendColumn {
+  background: var(--color-bg-muted);
+}
+
+.todayColumn {
+  background: var(--color-accent-bg-subtle);
+}
+
+.hourSeparator {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: var(--border-width);
+  background: var(--color-border);
+}
+
+.nowLine {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--color-danger);
+  z-index: 1;
+}
+```
+
+- [ ] **Step 7: Token availability check**
+
+```bash
+grep -E "color-fg-muted|color-bg-muted|opacity-muted|color-accent-bg-subtle" packages/design-system/src/styles/tokens.scss
+```
+
+If any are missing, add them (they should already exist from PR 2's tone work — verify all four).
+
+- [ ] **Step 8: Lint + typecheck**
+
+```bash
+npm run lint:css && npm run typecheck
+```
+
+Both exit 0.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/design-system/src/components/Calendar/TimedEvent.tsx packages/design-system/src/components/Calendar/TimedEvent.module.scss packages/design-system/src/components/Calendar/AllDayBand.tsx packages/design-system/src/components/Calendar/AllDayBand.module.scss packages/design-system/src/components/Calendar/HourGrid.tsx packages/design-system/src/components/Calendar/HourGrid.module.scss
+git commit -m "calendar/week-day: HourGrid + TimedEvent + AllDayBand primitives"
+```
+
+---
+
+## Task 5: `<WeekView>` + `<DayView>` + tests
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Calendar/WeekView.tsx`
+- Create: `packages/design-system/src/components/Calendar/WeekView.module.scss`
+- Create: `packages/design-system/src/components/Calendar/WeekView.test.tsx`
+- Create: `packages/design-system/src/components/Calendar/DayView.tsx`
+- Create: `packages/design-system/src/components/Calendar/DayView.module.scss`
+- Create: `packages/design-system/src/components/Calendar/DayView.test.tsx`
+
+- [ ] **Step 1: `WeekView.tsx`**
+
+```tsx
+import { useMemo } from 'react';
+import { useWeek } from '../../calendar/useWeek';
+import { useLocale } from '../../i18n/useLocale';
+import { formatWeekdayShort } from '../../calendar/formatters';
+import { AllDayBand } from './AllDayBand';
+import { HourGrid, HOUR_GUTTER_WIDTH } from './HourGrid';
+import { layoutEventsForHourGrid } from './utils';
+import type { CalendarEvent } from './types';
+import styles from './WeekView.module.scss';
+
+export interface WeekViewProps {
+  cursor: Date;
+  events: readonly CalendarEvent[];
+  hourRange: readonly [number, number];
+  hourRowHeight: number;
+  locale?: string;
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  onEventClick?: (event: CalendarEvent) => void;
+}
+
+/**
+ * Internal: 7-day hour grid. Shows the week containing `cursor`, with an
+ * AllDayBand above and an HourGrid below.
+ */
+export function WeekView({
+  cursor,
+  events,
+  hourRange,
+  hourRowHeight,
+  locale: localeOverride,
+  weekStartsOn,
+  onEventClick,
+}: WeekViewProps) {
+  const contextLocale = useLocale();
+  const locale = localeOverride ?? contextLocale;
+  const week = useWeek(cursor, { locale, weekStartsOn });
+
+  const layout = useMemo(
+    () =>
+      layoutEventsForHourGrid(
+        events,
+        week.days.map((d) => ({ date: d.date, key: d.key })),
+        hourRange,
+      ),
+    [events, week.days, hourRange],
+  );
+
+  const headers = week.days.map((d) => (
+    <span>
+      {formatWeekdayShort(d.date, locale)} <strong>{d.dayOfMonth}</strong>
+    </span>
+  ));
+
+  const dayRefs = week.days.map((d) => ({
+    date: d.date,
+    key: d.key,
+    isWeekend: d.isWeekend,
+  }));
+
+  return (
+    <div className={styles.weekView}>
+      <AllDayBand
+        bars={layout.allDayBars}
+        columnCount={7}
+        gutterWidth={HOUR_GUTTER_WIDTH}
+        onEventClick={onEventClick}
+      />
+      <HourGrid
+        days={dayRefs}
+        columnHeaders={headers}
+        hourRange={hourRange}
+        hourRowHeight={hourRowHeight}
+        timedBlocks={layout.timedBlocks}
+        onEventClick={onEventClick}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: `WeekView.module.scss`**
+
+```scss
+.weekView {
+  display: flex;
+  flex-direction: column;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-bg);
+}
+```
+
+- [ ] **Step 3: `DayView.tsx`**
+
+```tsx
+import { useMemo } from 'react';
+import { useDay } from '../../calendar/useDay';
+import { useLocale } from '../../i18n/useLocale';
+import { AllDayBand } from './AllDayBand';
+import { HourGrid, HOUR_GUTTER_WIDTH } from './HourGrid';
+import { layoutEventsForHourGrid } from './utils';
+import type { CalendarEvent } from './types';
+import styles from './DayView.module.scss';
+
+export interface DayViewProps {
+  cursor: Date;
+  events: readonly CalendarEvent[];
+  hourRange: readonly [number, number];
+  hourRowHeight: number;
+  locale?: string;
+  onEventClick?: (event: CalendarEvent) => void;
+}
+
+/**
+ * Internal: single-day hour grid. Shows the day at `cursor` with an
+ * AllDayBand above and an HourGrid below.
+ */
+export function DayView({
+  cursor,
+  events,
+  hourRange,
+  hourRowHeight,
+  locale: localeOverride,
+  onEventClick,
+}: DayViewProps) {
+  const contextLocale = useLocale();
+  const locale = localeOverride ?? contextLocale;
+  const day = useDay(cursor, { locale });
+
+  const layout = useMemo(
+    () => layoutEventsForHourGrid(events, [{ date: day.day.date, key: day.day.key }], hourRange),
+    [events, day.day.date, day.day.key, hourRange],
+  );
+
+  const dayRefs = [
+    {
+      date: day.day.date,
+      key: day.day.key,
+      isWeekend: day.day.isWeekend,
+    },
+  ];
+
+  return (
+    <div className={styles.dayView}>
+      <AllDayBand
+        bars={layout.allDayBars}
+        columnCount={1}
+        gutterWidth={HOUR_GUTTER_WIDTH}
+        onEventClick={onEventClick}
+      />
+      <HourGrid
+        days={dayRefs}
+        columnHeaders={[<span>{day.dayLabel}</span>]}
+        hourRange={hourRange}
+        hourRowHeight={hourRowHeight}
+        timedBlocks={layout.timedBlocks}
+        onEventClick={onEventClick}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: `DayView.module.scss`**
+
+```scss
+.dayView {
+  display: flex;
+  flex-direction: column;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-bg);
+}
+```
+
+- [ ] **Step 5: `WeekView.test.tsx`**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { LocaleProvider } from '../../i18n/LocaleProvider';
+import { WeekView } from './WeekView';
+import type { CalendarEvent } from './types';
+
+function wrap(locale = 'en-US') {
+  return ({ children }: { children: ReactNode }) => (
+    <LocaleProvider locale={locale}>{children}</LocaleProvider>
+  );
+}
+
+describe('WeekView', () => {
+  const cursor = new Date(2026, 4, 20); // Wed May 20
+
+  it('renders 7 column headers', () => {
+    render(<WeekView cursor={cursor} events={[]} hourRange={[7, 19]} hourRowHeight={48} />, {
+      wrapper: wrap(),
+    });
+    expect(screen.getAllByRole('columnheader').length).toBe(7);
+  });
+
+  it('renders 12 hour labels for the default 7–19 range', () => {
+    const { container } = render(
+      <WeekView cursor={cursor} events={[]} hourRange={[7, 19]} hourRowHeight={48} />,
+      { wrapper: wrap() },
+    );
+    // Hour labels live in the gutter; count entries with the hourLabel class
+    expect(container.querySelectorAll('[class*="hourLabel"]').length).toBe(12);
+  });
+
+  it('renders a timed event block', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 10),
+      },
+    ];
+    render(<WeekView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />, {
+      wrapper: wrap(),
+    });
+    expect(screen.getByRole('button', { name: /Standup/ })).toBeInTheDocument();
+  });
+
+  it('fires onEventClick when a timed event is clicked', async () => {
+    const onEventClick = vi.fn();
+    const user = userEvent.setup();
+    const events: CalendarEvent[] = [
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 10),
+      },
+    ];
+    render(
+      <WeekView
+        cursor={cursor}
+        events={events}
+        hourRange={[7, 19]}
+        hourRowHeight={48}
+        onEventClick={onEventClick}
+      />,
+      { wrapper: wrap() },
+    );
+    await user.click(screen.getByRole('button', { name: /Standup/ }));
+    expect(onEventClick).toHaveBeenCalledWith(events[0]);
+  });
+
+  it('renders an allDay event in the AllDayBand', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 'conf',
+        title: 'Conference',
+        startsAt: new Date(2026, 4, 18),
+        endsAt: new Date(2026, 4, 22),
+        allDay: true,
+      },
+    ];
+    render(<WeekView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />, {
+      wrapper: wrap(),
+    });
+    expect(screen.getByRole('button', { name: /Conference/ })).toBeInTheDocument();
+  });
+
+  it('respects custom hourRange', () => {
+    const { container } = render(
+      <WeekView cursor={cursor} events={[]} hourRange={[9, 17]} hourRowHeight={48} />,
+      { wrapper: wrap() },
+    );
+    expect(container.querySelectorAll('[class*="hourLabel"]').length).toBe(8);
+  });
+
+  it('places overlapping events side-by-side (each laneCount = 2)', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 10, 30),
+      },
+      {
+        id: 'b',
+        title: '1:1',
+        startsAt: new Date(2026, 4, 20, 10),
+        endsAt: new Date(2026, 4, 20, 11),
+      },
+    ];
+    render(<WeekView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />, {
+      wrapper: wrap(),
+    });
+    const a = screen.getByRole('button', { name: /Standup/ });
+    const b = screen.getByRole('button', { name: /1:1/ });
+    expect(a).toHaveStyle({ width: '50%' });
+    expect(b).toHaveStyle({ width: '50%' });
+  });
+
+  it('uses locale-aware column headers (ru-RU has Cyrillic)', () => {
+    render(
+      <WeekView
+        cursor={cursor}
+        events={[]}
+        hourRange={[7, 19]}
+        hourRowHeight={48}
+        locale="ru-RU"
+      />,
+      { wrapper: wrap('ru-RU') },
+    );
+    const headers = screen.getAllByRole('columnheader');
+    const text = headers.map((h) => h.textContent ?? '').join(' ');
+    expect(text).toMatch(/[Ѐ-ӿ]/);
+  });
+});
+```
+
+- [ ] **Step 6: `DayView.test.tsx`**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { LocaleProvider } from '../../i18n/LocaleProvider';
+import { DayView } from './DayView';
+import type { CalendarEvent } from './types';
+
+function wrap(locale = 'en-US') {
+  return ({ children }: { children: ReactNode }) => (
+    <LocaleProvider locale={locale}>{children}</LocaleProvider>
+  );
+}
+
+describe('DayView', () => {
+  const cursor = new Date(2026, 4, 20);
+
+  it('renders 1 column header', () => {
+    render(<DayView cursor={cursor} events={[]} hourRange={[7, 19]} hourRowHeight={48} />, {
+      wrapper: wrap(),
+    });
+    expect(screen.getAllByRole('columnheader').length).toBe(1);
+  });
+
+  it('places a timed event in the single column', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 10),
+      },
+    ];
+    render(<DayView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />, {
+      wrapper: wrap(),
+    });
+    expect(screen.getByRole('button', { name: /Standup/ })).toBeInTheDocument();
+  });
+
+  it('fires onEventClick', async () => {
+    const onEventClick = vi.fn();
+    const user = userEvent.setup();
+    const events: CalendarEvent[] = [
+      {
+        id: 'a',
+        title: 'Call',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 10),
+      },
+    ];
+    render(
+      <DayView
+        cursor={cursor}
+        events={events}
+        hourRange={[7, 19]}
+        hourRowHeight={48}
+        onEventClick={onEventClick}
+      />,
+      { wrapper: wrap() },
+    );
+    await user.click(screen.getByRole('button', { name: /Call/ }));
+    expect(onEventClick).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 7: Run tests + gates**
+
+```bash
+cd packages/design-system && npx vitest run src/components/Calendar/
+cd /home/dpws/projects/design-system && npm run typecheck && npm run lint:css
+```
+
+All exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/design-system/src/components/Calendar/WeekView.tsx packages/design-system/src/components/Calendar/WeekView.module.scss packages/design-system/src/components/Calendar/WeekView.test.tsx packages/design-system/src/components/Calendar/DayView.tsx packages/design-system/src/components/Calendar/DayView.module.scss packages/design-system/src/components/Calendar/DayView.test.tsx
+git commit -m "calendar/week-day: WeekView + DayView composing HourGrid"
+```
+
+---
+
+## Task 6: `<ViewSwitcher>` + Calendar shell wiring
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Calendar/ViewSwitcher.tsx`
+- Create: `packages/design-system/src/components/Calendar/ViewSwitcher.module.scss`
+- Modify: `packages/design-system/src/components/Calendar/Calendar.tsx`
+- Modify: `packages/design-system/src/components/Calendar/Calendar.test.tsx`
+
+- [ ] **Step 1: `ViewSwitcher.tsx`**
+
+A small segmented control using the Tabs component. (If Tabs styling doesn't fit visually after the demo, we can swap to a custom Cluster of Buttons.)
+
+```tsx
+import { Tabs } from '../Tabs';
+import type { CalendarView } from './types';
+import styles from './ViewSwitcher.module.scss';
+
+export interface ViewSwitcherProps {
+  view: CalendarView;
+  onViewChange: (view: CalendarView) => void;
+  monthLabel: string;
+  weekLabel: string;
+  dayLabel: string;
+}
+
+/**
+ * Internal: segmented control for switching between month/week/day views.
+ * Uses the design system's `<Tabs>` for keyboard nav + ARIA.
+ */
+export function ViewSwitcher({
+  view,
+  onViewChange,
+  monthLabel,
+  weekLabel,
+  dayLabel,
+}: ViewSwitcherProps) {
+  return (
+    <div className={styles.switcher}>
+      <Tabs
+        value={view}
+        onValueChange={(v) => onViewChange(v as CalendarView)}
+        items={[
+          { value: 'month', label: monthLabel },
+          { value: 'week', label: weekLabel },
+          { value: 'day', label: dayLabel },
+        ]}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: `ViewSwitcher.module.scss`**
+
+```scss
+.switcher {
+  display: flex;
+}
+```
+
+- [ ] **Step 3: Update `Calendar.tsx`**
+
+The full updated `Calendar.tsx`:
+
+```tsx
+import { forwardRef, useCallback, useState, type HTMLAttributes, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '../Button';
+import { Cluster } from '../Cluster';
+import { addMonths } from '../../calendar/dateMath';
+import { useMonth } from '../../calendar/useMonth';
+import { LocaleProvider } from '../../i18n/LocaleProvider';
+import { MonthView } from './MonthView';
+import { WeekView } from './WeekView';
+import { DayView } from './DayView';
+import { ViewSwitcher } from './ViewSwitcher';
+import type { CalendarEvent, CalendarView } from './types';
+import styles from './Calendar.module.scss';
+
+/**
+ * UI strings consumed by `<Calendar>`.
+ */
+export interface CalendarLabels {
+  today?: string;
+  previousMonth?: string;
+  nextMonth?: string;
+  moreEvents?: (count: number) => string;
+  viewMonth?: string;
+  viewWeek?: string;
+  viewDay?: string;
+}
+
+export interface CalendarProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'defaultValue'
+> {
+  events?: readonly CalendarEvent[];
+  /** Active view (controlled). Pair with `onViewChange`. */
+  view?: CalendarView;
+  /** Initial view (uncontrolled). Defaults to `'month'`. */
+  defaultView?: CalendarView;
+  /** Fires when the user clicks the view switcher. */
+  onViewChange?: (view: CalendarView) => void;
+
+  value?: Date;
+  defaultValue?: Date;
+  onChange?: (date: Date) => void;
+
+  onDayClick?: (date: Date) => void;
+  onEventClick?: (event: CalendarEvent) => void;
+
+  locale?: string;
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  maxLanesPerWeek?: number;
+
+  /** Hour range for week/day views (inclusive start, exclusive end). Default `[7, 19]`. */
+  hourRange?: [number, number];
+  /** Pixel height per hour row in week/day views. Default 48. */
+  hourRowHeight?: number;
+
+  labels?: CalendarLabels;
+}
+
+const DEFAULT_LABELS: Required<CalendarLabels> = {
+  today: 'Today',
+  previousMonth: 'Previous month',
+  nextMonth: 'Next month',
+  moreEvents: (n) => `${n} more events`,
+  viewMonth: 'Month',
+  viewWeek: 'Week',
+  viewDay: 'Day',
+};
+
+/**
+ * Month / Week / Day calendar.
+ *
+ * - Controlled via `value` / `onChange`, or uncontrolled via `defaultValue`.
+ * - View is controlled via `view` / `onViewChange`, or uncontrolled via
+ *   `defaultView`.
+ * - Events are `CalendarEvent` objects; multi-day events render as
+ *   continuous bars in both month and week/day all-day bands.
+ *
+ * @example
+ * <Calendar events={events} defaultView="week" />
+ */
+export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calendar(
+  {
+    events = [],
+    view: viewProp,
+    defaultView,
+    onViewChange,
+    value,
+    defaultValue,
+    onChange,
+    onDayClick,
+    onEventClick,
+    locale,
+    weekStartsOn,
+    maxLanesPerWeek = 3,
+    hourRange = [7, 19],
+    hourRowHeight = 48,
+    labels,
+    className,
+    ...rest
+  },
+  ref,
+) {
+  const [uncontrolled, setUncontrolled] = useState<Date>(() => defaultValue ?? new Date());
+  const cursor = value ?? uncontrolled;
+  const [uncontrolledView, setUncontrolledView] = useState<CalendarView>(
+    () => defaultView ?? 'month',
+  );
+  const view = viewProp ?? uncontrolledView;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+
+  const handleChange = useCallback(
+    (next: Date) => {
+      if (value === undefined) setUncontrolled(next);
+      onChange?.(next);
+    },
+    [value, onChange],
+  );
+
+  const handleViewChange = useCallback(
+    (next: CalendarView) => {
+      if (viewProp === undefined) setUncontrolledView(next);
+      onViewChange?.(next);
+    },
+    [viewProp, onViewChange],
+  );
+
+  const grid = useMonth(cursor, { locale, weekStartsOn });
+
+  const goPrev = () => handleChange(addMonths(cursor, -1));
+  const goNext = () => handleChange(addMonths(cursor, 1));
+  const goToday = () => handleChange(new Date());
+
+  const body: ReactNode = (
+    <div ref={ref} className={clsx(styles.calendar, className)} {...rest}>
+      <header className={styles.header}>
+        <h2 className={styles.title}>{grid.monthLabel}</h2>
+        <Cluster gap="sm" align="center">
+          <Cluster gap="xs" align="center">
+            <Button
+              size="xs"
+              variant="ghost"
+              iconOnly
+              aria-label={resolvedLabels.previousMonth}
+              onClick={goPrev}
+            >
+              <ChevronLeft size={14} />
+            </Button>
+            <Button size="sm" variant="secondary" onClick={goToday}>
+              {resolvedLabels.today}
+            </Button>
+            <Button
+              size="xs"
+              variant="ghost"
+              iconOnly
+              aria-label={resolvedLabels.nextMonth}
+              onClick={goNext}
+            >
+              <ChevronRight size={14} />
+            </Button>
+          </Cluster>
+          <ViewSwitcher
+            view={view}
+            onViewChange={handleViewChange}
+            monthLabel={resolvedLabels.viewMonth}
+            weekLabel={resolvedLabels.viewWeek}
+            dayLabel={resolvedLabels.viewDay}
+          />
+        </Cluster>
+      </header>
+      {view === 'month' && (
+        <MonthView
+          grid={grid}
+          events={events}
+          maxLanesPerWeek={maxLanesPerWeek}
+          cursor={cursor}
+          onChange={handleChange}
+          onDayClick={onDayClick}
+          onEventClick={onEventClick}
+          moreEventsLabel={resolvedLabels.moreEvents}
+        />
+      )}
+      {view === 'week' && (
+        <WeekView
+          cursor={cursor}
+          events={events}
+          hourRange={hourRange}
+          hourRowHeight={hourRowHeight}
+          locale={locale}
+          weekStartsOn={weekStartsOn}
+          onEventClick={onEventClick}
+        />
+      )}
+      {view === 'day' && (
+        <DayView
+          cursor={cursor}
+          events={events}
+          hourRange={hourRange}
+          hourRowHeight={hourRowHeight}
+          locale={locale}
+          onEventClick={onEventClick}
+        />
+      )}
+    </div>
+  );
+
+  return locale !== undefined ? <LocaleProvider locale={locale}>{body}</LocaleProvider> : body;
+});
+```
+
+- [ ] **Step 4: Add view-switching tests to `Calendar.test.tsx`**
+
+Append before the closing `});` of the existing `describe('Calendar', ...)` block:
+
+```tsx
+it('switches to WeekView when defaultView="week"', () => {
+  render(<Calendar defaultValue={new Date(2026, 4, 20)} defaultView="week" />, { wrapper: wrap() });
+  // Week view has a HourGrid; look for hour labels
+  const hourLabels = document.querySelectorAll('[class*="hourLabel"]');
+  expect(hourLabels.length).toBeGreaterThan(0);
+});
+
+it('switches to DayView when defaultView="day"', () => {
+  render(<Calendar defaultValue={new Date(2026, 4, 20)} defaultView="day" />, { wrapper: wrap() });
+  expect(document.querySelectorAll('[role="columnheader"]').length).toBe(1);
+});
+
+it('controlled view: clicking Week tab fires onViewChange', async () => {
+  const user = userEvent.setup();
+  const onViewChange = vi.fn();
+  render(
+    <Calendar
+      defaultValue={new Date(2026, 4, 20)}
+      view="month"
+      onViewChange={onViewChange}
+      labels={{ viewMonth: 'Month', viewWeek: 'Week', viewDay: 'Day' }}
+    />,
+    { wrapper: wrap() },
+  );
+  await user.click(screen.getByRole('tab', { name: 'Week' }));
+  expect(onViewChange).toHaveBeenCalledWith('week');
+});
+```
+
+- [ ] **Step 5: Run tests + gates**
+
+```bash
+cd packages/design-system && npx vitest run src/components/Calendar/
+cd /home/dpws/projects/design-system && npm run typecheck && npm run lint:css
+```
+
+All exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Calendar/ViewSwitcher.tsx packages/design-system/src/components/Calendar/ViewSwitcher.module.scss packages/design-system/src/components/Calendar/Calendar.tsx packages/design-system/src/components/Calendar/Calendar.test.tsx
+git commit -m "calendar/week-day: ViewSwitcher + Calendar shell view dispatch"
+```
+
+---
+
+## Task 7: AGENTS.md update
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Update the Calendar TL;DR section**
+
+Find the existing `### <Calendar>` block (it's just before `### Calendar primitives`). Replace it with:
+
+````markdown
+### `<Calendar>` — month / week / day views
+
+```tsx
+const [cursor, setCursor] = useState(new Date());
+const [view, setView] = useState<'month' | 'week' | 'day'>('month');
+<Calendar
+  value={cursor}
+  onChange={setCursor}
+  view={view}
+  onViewChange={setView}
+  events={events}
+  onEventClick={(e) => openDetail(e)}
+/>;
+```
+
+- Three views in v3: `'month'` (continuous event bars across the grid),
+  `'week'` (7 columns × hour rows + all-day band), `'day'` (single column).
+  Agenda view comes in PR 4.
+- Events are `{ id, title, startsAt, endsAt?, tone?, allDay? }`.
+- Tones: `neutral` (default) / `accent` / `success` / `warning` / `danger`.
+- View is controlled via `view`/`onViewChange` or uncontrolled via `defaultView`.
+- `hourRange` (default `[7, 19]`) controls week/day visible hour range.
+  Hours outside the range stay scroll-reachable.
+- `hourRowHeight` (default 48) controls the pixel height of each hour row.
+- Overlapping timed events split into equal-width lanes side-by-side.
+- All-day & multi-day events render in the band above the hour grid.
+- A horizontal "now" line marks the current time in today's column.
+- Read-mostly: `onDayClick` and `onEventClick` callbacks; consumers wire
+  their own detail UI.
+- Locale-aware via `useLocale()`; override with `locale` prop. UI strings
+  (`today`, `viewMonth`, etc.) are the consumer's responsibility via
+  `labels`.
+````
+
+- [ ] **Step 2: Verify formatting + commit**
+
+```bash
+npx prettier --check packages/design-system/AGENTS.md
+git add packages/design-system/AGENTS.md
+git commit -m "AGENTS.md: document Calendar week + day views"
+```
+
+---
+
+## Task 8: Playground demo update
+
+**Files:**
+
+- Modify: `packages/playground/src/pages/components/CalendarDemo.tsx`
+
+- [ ] **Step 1: Add Week + Day examples**
+
+Find the existing `<Example title="Controlled navigation">` block. Just before it, insert two new Examples:
+
+```tsx
+      <Example
+        title="Week view"
+        description="7 columns × hour rows. Timed events position by hour; overlapping events split into equal-width lanes side-by-side. All-day and multi-day events render in the band above the hour grid."
+        code={`<Calendar
+  defaultValue={new Date()}
+  defaultView="week"
+  events={SAMPLE_EVENTS}
+/>`}
+      >
+        <Calendar defaultValue={TODAY} defaultView="week" events={SAMPLE_EVENTS} />
+      </Example>
+
+      <Example
+        title="Day view"
+        description="Single-day hour grid. Useful for focused day planning. Custom hourRange shrinks the visible range to business hours."
+        code={`<Calendar
+  defaultValue={new Date()}
+  defaultView="day"
+  events={SAMPLE_EVENTS}
+  hourRange={[8, 18]}
+/>`}
+      >
+        <Calendar
+          defaultValue={TODAY}
+          defaultView="day"
+          events={SAMPLE_EVENTS}
+          hourRange={[8, 18]}
+        />
+      </Example>
+
+      <Example
+        title="View switching (controlled)"
+        description="Consumer owns the view state. Useful for URL-sync of the current view."
+        code={`function ViewSwitcherDemo() {
+  const [view, setView] = useState<'month' | 'week' | 'day'>('week');
+  return (
+    <Calendar
+      defaultValue={new Date()}
+      view={view}
+      onViewChange={setView}
+      events={SAMPLE_EVENTS}
+    />
+  );
+}`}
+      >
+        <ViewSwitcherDemo />
+      </Example>
+```
+
+- [ ] **Step 2: Add the `ViewSwitcherDemo` helper component**
+
+Just below `ControlledCalendarDemo` (in the file's helper-components area), add:
+
+```tsx
+function ViewSwitcherDemo() {
+  const [view, setView] = useState<'month' | 'week' | 'day'>('week');
+  return (
+    <Calendar defaultValue={TODAY} view={view} onViewChange={setView} events={SAMPLE_EVENTS} />
+  );
+}
+```
+
+- [ ] **Step 3: Update the ru-RU example to include view labels**
+
+Find the existing `<Example title="ru-RU locale">` block. Update the `labels` prop in BOTH the `code={`...`}` snippet and the live `<Calendar>` to include the view labels:
+
+```tsx
+labels={{
+  today: 'Сегодня',
+  previousMonth: 'Предыдущий месяц',
+  nextMonth: 'Следующий месяц',
+  moreEvents: (n) => `ещё ${n} событий`,
+  viewMonth: 'Месяц',
+  viewWeek: 'Неделя',
+  viewDay: 'День',
+}}
+```
+
+For the code-snippet version (with template-literal escaping), use the existing template-literal-escape pattern (`\`ещё ${'${n}'} событий\``).
+
+- [ ] **Step 4: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add packages/playground/src/pages/components/CalendarDemo.tsx
+git commit -m "playground: CalendarDemo — week, day, and view-switcher examples"
+```
+
+---
+
+## Task 9: Run all quality gates
+
+**Files:** (verification only)
+
+- [ ] **Step 1: Tests**
+
+```bash
+npm test
+```
+
+Expected: all suites pass. Test count up significantly from the PR 2 baseline (587).
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Exit 0.
+
+- [ ] **Step 3: Stylelint**
+
+```bash
+npm run lint:css
+```
+
+Exit 0.
+
+- [ ] **Step 4: Build**
+
+```bash
+npm run build
+```
+
+Exit 0 (warnings about chunk size are pre-existing).
+
+- [ ] **Step 5: Tarball**
+
+```bash
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -E "(test|Calendar/|i18n|calendar)" | head -30
+```
+
+Verify: new Calendar source files (HourGrid, WeekView, etc.) included; no `*.test.*` in the tarball.
+
+If any gate fails, fix and re-run before Task 10.
+
+---
+
+## Task 10: Hard Rule 8 review-fix cycle
+
+- [ ] **Step 1: Spawn a fresh-context reviewer** (general-purpose, opus). Brief on the 10 review categories; explicitly mention:
+  - The `layoutEventsForHourGrid` algorithm (lane assignment + collision-group laneCount)
+  - `position: absolute` use on TimedEvent (allowed via relative-anchor exception in Rule 4)
+  - View dispatch in Calendar shell
+  - Locale propagation via the existing `<LocaleProvider>` wrap
+
+- [ ] **Step 2: Fix every Critical and Important finding.** Focused commits per finding; document explicit skips.
+
+- [ ] **Step 3: Re-run gates.**
+
+- [ ] **Step 4: Re-spawn reviewer until verdict is `clean enough to stop`.**
+
+---
+
+## Task 11: Push, open PR, watch CI
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feat/calendar-week-day-views
+```
+
+Pre-push hook runs prettier/stylelint/typecheck.
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "Calendar PR 3: Week + Day views with hour grid" --body "$(cat <<'EOF'
+## Summary
+
+- New `<WeekView>` (7 columns × hour rows) and `<DayView>` (1 column × hour rows).
+- Shared `<HourGrid>` primitive — CSS grid scaffold with hour labels, day columns, and a "now" line on today's column.
+- `<TimedEvent>` blocks position absolutely inside their day column with collision-group lane width.
+- `<AllDayBand>` renders multi-day and `allDay` events above the hour grid with continuation flags.
+- `<ViewSwitcher>` segmented control wired to the Calendar shell.
+- `layoutEventsForHourGrid` in `utils.ts` — greedy lane assignment + sweep-based collision-group `laneCount`.
+- `CalendarView` extended to `'month' | 'week' | 'day'`.
+- New props on `<Calendar>`: `view`, `defaultView`, `onViewChange`, `hourRange` (default `[7, 19]`), `hourRowHeight` (default 48). `CalendarLabels` gains `viewMonth/viewWeek/viewDay`.
+
+## Test plan
+
+- [ ] CI \`Quality / check\` green
+- [ ] \`npm test\` — all suites pass
+- [ ] \`npm run typecheck\` — clean
+- [ ] \`npm run lint:css\` — clean
+- [ ] \`npm run build\` — clean
+- [ ] \`npm pack --dry-run -w @eocrm/design-system\` — Calendar source included; no test files
+- [ ] Hard Rule 8 review-fix cycle reached \`clean enough to stop\`
+- [ ] Visual check at \`/components/calendar\` — week + day + switcher examples render correctly; overlapping events split into lanes; now line appears in today's column; ru-RU labels show Cyrillic.
+
+## Non-goals (deferred)
+
+- Agenda view — PR 4.
+- DatePicker — separate PR.
+- Drag-create / drag-reschedule.
+- Time zones.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Watch CI**
+
+```bash
+gh pr checks --watch
+```
+
+- [ ] **Step 4: Report PR URL.**
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+- `CalendarView` union → Task 2
+- `TimedEventBlock` / `AllDayBar` / `HourGridLayout` types → Task 2
+- `layoutEventsForHourGrid` algorithm → Task 3
+- `<HourGrid>` / `<TimedEvent>` / `<AllDayBand>` primitives → Task 4
+- `<WeekView>` / `<DayView>` → Task 5
+- `<ViewSwitcher>` + Calendar shell + new props → Task 6
+- `CalendarLabels` extension → Task 6
+- Now-line indicator → inside Task 4 (`HourGrid`)
+- Locale propagation → existing pattern from PR 2, reused in Task 6
+- AGENTS.md → Task 7
+- Demo → Task 8
+- Verification → Tasks 9 + 10
+- Push → Task 11
+
+**Type consistency:** `TimedEventBlock`/`AllDayBar`/`HourGridLayout` defined Task 2, consumed in Tasks 3-6 with matching shapes. `CalendarLabels` extended in Task 6; defaults match the spec.
+
+**Placeholder scan:** No TBD/TODO. All code blocks complete.

--- a/docs/superpowers/specs/2026-05-20-calendar-week-day-views-design.md
+++ b/docs/superpowers/specs/2026-05-20-calendar-week-day-views-design.md
@@ -1,0 +1,356 @@
+# Calendar — PR 3: Week + Day views
+
+**Date:** 2026-05-20
+**Status:** Spec — proceeding to plan
+**Scope:** Add `<WeekView>` (7 cols × hour rows) and `<DayView>` (1 col × hour rows) to the Calendar surface, plus a view switcher in the Calendar shell. Consumes existing primitives from PRs 1–2.
+
+## Goal
+
+Ship the time-based views of the Calendar — week and day grids with positioned event blocks, an all-day band, a "now" indicator, and a view switcher that lets the consumer toggle between month/week/day.
+
+## Non-goals
+
+- Agenda view — PR 4.
+- DatePicker — separate PR, reuses `useMonth`.
+- Drag-to-create / drag-to-reschedule / drag-to-resize event blocks.
+- Event creation popovers.
+- Recurring-event expansion.
+- Time-zone-aware event math — all events use local-time `Date`.
+- Snap-to-grid editing.
+- Print stylesheet.
+
+## File layout
+
+New files under `packages/design-system/src/components/Calendar/`:
+
+```
+HourGrid.tsx              # Shared primitive: hour-row scaffold + column grid + "now" line
+HourGrid.module.scss
+WeekView.tsx              # 7-day hour grid using HourGrid + AllDayBand
+WeekView.module.scss
+WeekView.test.tsx
+DayView.tsx               # Single-day hour grid using HourGrid + AllDayBand
+DayView.module.scss
+DayView.test.tsx
+TimedEvent.tsx            # One positioned timed-event block inside an hour grid column
+TimedEvent.module.scss
+AllDayBand.tsx            # Multi-column band above the hour grid for allDay + multi-day events
+AllDayBand.module.scss
+ViewSwitcher.tsx          # Segmented control for the Calendar shell (Month/Week/Day)
+ViewSwitcher.module.scss
+```
+
+Modified files:
+
+```
+Calendar.tsx                  # View dispatch (month/week/day), view switcher chrome
+Calendar.test.tsx             # Tests for view switching
+types.ts                      # CalendarView union extends; TimedEventBlock, AllDayBar types
+utils.ts                      # Add layoutEventsForHourGrid + layoutAllDayEvents
+utils.test.tsx                # Algorithm tests
+AGENTS.md                     # Updated <Calendar> TL;DR for the new views
+```
+
+Internal helpers (`HourGrid`, `TimedEvent`, `AllDayBand`, `ViewSwitcher`) are file siblings of `Calendar.tsx`, tested indirectly through `WeekView.test.tsx` and `DayView.test.tsx`. The structure test only requires `<Name>.tsx`/`<Name>.test.tsx`/`<Name>.module.scss`/`index.ts` on the `Calendar` component directory itself — siblings are unconstrained.
+
+## Public API additions
+
+### `types.ts`
+
+```ts
+/** Calendar views. Previously `'month'`. */
+export type CalendarView = 'month' | 'week' | 'day';
+
+/** One positioned timed-event block inside an `<HourGrid>` column. */
+export interface TimedEventBlock {
+  event: CalendarEvent;
+  /** Day index within the rendered view. 0..6 for WeekView, always 0 for DayView. */
+  dayIndex: number;
+  /** Vertical position (minutes from `hourRange[0] * 60`). Can be negative if the event started before `hourRange[0]`. */
+  startMinutes: number;
+  /** Vertical end (minutes from `hourRange[0] * 60`). */
+  endMinutes: number;
+  /** 0..laneCount-1 — horizontal lane within the day's collision group. */
+  lane: number;
+  /** Total lanes in this block's collision group (siblings overlapping this event in time). */
+  laneCount: number;
+}
+
+/** One bar in the AllDayBand. Multi-day events span columns. */
+export interface AllDayBar {
+  event: CalendarEvent;
+  /** First column the bar covers (inclusive, 0-indexed within the view). */
+  startCol: number;
+  /** Last column the bar covers (inclusive). */
+  endCol: number;
+  /** 0..laneCount-1 — row position within the band stack. */
+  lane: number;
+  /** True when the event begins before the view's first day. */
+  continuesLeft: boolean;
+  /** True when the event continues past the view's last day. */
+  continuesRight: boolean;
+}
+```
+
+### `CalendarProps`
+
+```ts
+export interface CalendarProps {
+  // ... existing props ...
+
+  /** Active view. Defaults to `'month'`. */
+  view?: CalendarView;
+  /** Fires when the consumer interacts with the view switcher. Controlled when paired with `view`. */
+  onViewChange?: (view: CalendarView) => void;
+  /**
+   * Hour range shown in week/day views (inclusive start, exclusive end).
+   * Defaults to `[7, 19]` (7am–7pm). Hours outside the range are reachable
+   * by scrolling the view container.
+   */
+  hourRange?: [number, number];
+  /** Pixel height per hour row. Default 48. */
+  hourRowHeight?: number;
+}
+```
+
+The view switcher is internally rendered by the Calendar shell. When `onViewChange` is omitted, view defaults to `'month'` (uncontrolled-style — no internal state for view, just initial render). Document: for switching to work, consumers must control via `view`/`onViewChange`.
+
+Actually — simpler: keep `view` uncontrolled by default (internal `useState`), fall back to controlled when consumer passes the prop. Same pattern as `value`/`defaultValue`.
+
+```ts
+export interface CalendarProps {
+  // ...
+  view?: CalendarView;
+  defaultView?: CalendarView; // initial value when uncontrolled
+  onViewChange?: (view: CalendarView) => void;
+  hourRange?: [number, number];
+  hourRowHeight?: number;
+}
+```
+
+### `CalendarLabels`
+
+```ts
+export interface CalendarLabels {
+  // ... existing fields ...
+  /** Segmented control labels. Defaults: 'Month' / 'Week' / 'Day'. */
+  viewMonth?: string;
+  viewWeek?: string;
+  viewDay?: string;
+}
+```
+
+## Behavior
+
+### `<ViewSwitcher>`
+
+Wraps the design system's `<Tabs>` component as a segmented control. Activates on click; calls Calendar's `onViewChange`. Labels come from `labels.viewMonth/viewWeek/viewDay`.
+
+Renders to the right of the prev/next/today buttons in the Calendar header:
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  May 2026          [<] [Today] [>]   [Month][Week][Day]            │
+├────────────────────────────────────────────────────────────────────┤
+│  ...view content...                                                │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### `<HourGrid>` — internal primitive
+
+Renders a scrollable container with:
+
+- A column header row (sticky top) — day labels for WeekView, single day label for DayView.
+- An hour gutter on the left — labels like `9 AM`, `10 AM`, etc.
+- Hour-row backgrounds (horizontal lines every `hourRowHeight` px).
+- N day columns (1 or 7) with `position: relative` so timed-event blocks can position absolutely inside.
+- A "now" indicator (horizontal line) when today is within the rendered range.
+
+Layout via CSS grid:
+
+```scss
+.hourGrid {
+  display: grid;
+  grid-template-columns: var(--hour-gutter-width) repeat(var(--column-count), 1fr);
+  /* Header row + N hour rows */
+  grid-template-rows: auto repeat(var(--hour-count), var(--hour-row-height));
+}
+```
+
+Each timed event block is `position: absolute` inside its day column (which is `position: relative`). `top` = `(startMinutes / 60) * hourRowHeight` px; `height` = `((endMinutes - startMinutes) / 60) * hourRowHeight` px; `width` = `100% / laneCount`; `left` = `lane * (100% / laneCount)`.
+
+Rule 4 allows `position: relative` for child anchors. `position: absolute` on the timed-event blocks is internal layout — they're positioning themselves within their parent column, not consuming parent space. This is the same `relative + absolute` anchor pattern Tooltip/Popover use.
+
+### `<WeekView>`
+
+- Consumes `useWeek(cursor, { locale, weekStartsOn })` from PR 1.
+- Renders an `AllDayBand` above the `HourGrid`.
+- `HourGrid` with 7 columns; column headers are weekday labels + day numbers (e.g., "Mon 11").
+- Today's column gets the same background tint as today in Month view.
+- Weekend columns get a muted background.
+- Scroll position on mount: scroll to `hourRange[0]` (top of the visible range — already the top).
+
+### `<DayView>`
+
+- Consumes `useDay(cursor, { locale })`.
+- Same structure but with 1 column.
+- Column header shows the long day label (`Wednesday, May 20`).
+- Otherwise identical to WeekView's column behavior.
+
+### `<TimedEvent>`
+
+- Renders an `EventChip`-like button positioned absolutely inside its column.
+- Wrapped in `<Tooltip>` so the full "time range + title" is reachable.
+- Tone colors match `EventChip` (tinted background, strong-color text).
+- Click → `onEventClick(event)`.
+- Shows event title + a small time-range prefix (e.g., "9–10:30").
+- If `endMinutes - startMinutes < 30`, hide the time prefix and show only the title (or just an icon if even tighter).
+
+### `<AllDayBand>`
+
+- Same continuous-bar approach as MonthView's bars: events spanning multiple columns render as a single bar across them, with `continuesLeft`/`continuesRight` flags flattening edges when the event extends beyond the visible range.
+- Lane stacking: events sorted by `(startsAt asc, durationDesc)`, greedy lane assignment.
+- Cap on visible lanes (default 2 in week/day views — narrower band than month). Overflow shows `+N more` (no popover; calls `onDayClick` like in MonthView).
+
+### Now indicator
+
+- A 1px horizontal line in `--color-danger` across today's column at the current time.
+- Positioned absolutely inside the day column. `top = (nowMinutesFromHourRangeStart / 60) * hourRowHeight`.
+- Updated every minute via `setInterval(60_000)` (cleared on unmount).
+- Hidden when today is not in the rendered week or when the current time is outside `hourRange`.
+
+### Collision layout (`layoutEventsForHourGrid`)
+
+Algorithm — produces `TimedEventBlock[]`:
+
+1. Filter events to those overlapping the visible date range, excluding `allDay` (those go to `AllDayBand`).
+2. For each day in the range, collect events that touch that day.
+3. Sort by `(startsAt asc, endsAt desc)` so longer events get earlier lanes.
+4. Greedy lane assignment: walk events in order, assign to the lowest lane index where no existing event in that lane overlaps in time (`a.end > b.start && a.start < b.end`).
+5. Compute `laneCount` per collision group: events that mutually overlap share a lane count. Two events with no time overlap can both be in lane 0 with laneCount=1.
+
+The trickiest part: `laneCount` is the **maximum lane count seen across the event's collision group**, not just the global max. E.g., morning has 3 overlapping events (laneCount=3 for all of them), afternoon has 2 overlapping (laneCount=2 for those, NOT 3).
+
+Detail: walk events in time order. Maintain "active set" = events whose interval contains the current time. For each event, its `laneCount` is `max(activeSet size at any moment during its interval)`.
+
+```ts
+export function layoutEventsForHourGrid(
+  events: readonly CalendarEvent[],
+  days: readonly Day[],
+  hourRange: readonly [number, number],
+): {
+  timedBlocks: readonly TimedEventBlock[];
+  allDayBars: readonly AllDayBar[];
+};
+```
+
+Returns both the timed blocks (positioned within hour rows) and the all-day bars (positioned in the band).
+
+## Visual details
+
+- **Hour gutter width**: 60px (enough for `12:00 PM` / `09:00`).
+- **Hour row height**: 48px default (configurable via `hourRowHeight`).
+- **Column header height**: 40px.
+- **All-day band height**: `auto` based on lane count, max ~3 lanes × 24px + padding.
+- **Hour labels**: top-aligned to their row, in the gutter only (not repeated per column).
+- **Hour row separator**: 1px line on `--color-border` between rows.
+- **Half-hour separator**: optional, dashed line at 30-minute mark — defer unless visual demands it.
+- **Today's column**: subtle `--color-accent-bg-subtle` tint.
+- **Weekend columns**: subtle `--color-bg-muted` tint.
+
+## Keyboard / ARIA
+
+- View switcher: standard `<Tabs>` keyboard handling (already implemented in Tabs).
+- HourGrid container: `role="grid"`, `aria-label="<weekLabel>"` or day label.
+- Column headers: `role="columnheader"`.
+- Each hour-cell intersection (not user-visible as a cell but ARIA-mapped) can be `role="gridcell"`, OR we treat each timed event as a `role="gridcell"`. **Simpler approach for v1**: only the timed event blocks are gridcells; intersection cells are presentational. Future enhancement could add click-empty-slot-to-create.
+- Keyboard navigation for events: Tab from view switcher → AllDayBand events → timed events. Standard sequential focus, no roving tab index across the grid (would be confusing with absolute-positioned events).
+- "Now" line: `aria-hidden="true"` — purely visual.
+
+## Locale
+
+- Same `<LocaleProvider>` wrapping pattern from PR 2 — Calendar wraps subtree in LocaleProvider when `locale` prop is provided, so HourGrid and TimedEvent's `formatTime` calls pick up the override.
+- Hour labels formatted via `formatHour(hour, locale)` — already in the codebase from PR 1.
+
+## Demo updates
+
+`packages/playground/src/pages/components/CalendarDemo.tsx`:
+
+- Add a new "Week view" Example showing the same `SAMPLE_EVENTS` with `view='week'` and `defaultView='week'`.
+- Add a "Day view" Example.
+- Add a "View switching (controlled)" Example demonstrating `view`/`onViewChange`.
+- Update the existing ru-RU Example to pass `viewMonth`/`viewWeek`/`viewDay` labels.
+
+The relative-date helpers (`fromToday`, `mondaysOfThisMonth`) stay — events shift to today's month.
+
+## Testing strategy
+
+### `utils.test.tsx` — extend with hour-grid algorithm tests
+
+- Single timed event → 1 block, lane 0, laneCount 1.
+- Two non-overlapping events same day → 2 blocks, both lane 0, each laneCount 1.
+- Two overlapping events same day → 2 blocks, lanes 0 and 1, both laneCount 2.
+- Three overlapping events → 3 blocks, lanes 0/1/2, all laneCount 3.
+- Morning has 3 overlapping, afternoon has 2 different overlapping → morning blocks laneCount=3, afternoon blocks laneCount=2.
+- Multi-day event → renders only in AllDayBand (excluded from timed blocks).
+- Event starting before hour range → block clipped at top (`startMinutes` negative in input; clamped at 0 when rendered).
+- Event ending after hour range → block clipped at bottom.
+- `allDay` events → only in AllDayBand.
+
+### `WeekView.test.tsx`
+
+- Renders 7 column headers with locale-aware weekday labels.
+- Renders the hour gutter with `hourRange` labels (default 7am–7pm = 12 labels).
+- Custom `hourRange={[9, 17]}` → 8 hour rows.
+- Custom `hourRowHeight={64}` → CSS variable / inline style updated.
+- Timed event renders at correct vertical position.
+- Two overlapping events → both visible at 50% width side-by-side.
+- Today's column has the today class.
+- Now indicator renders when today is in the week.
+- All-day band renders multi-day spans.
+- `onEventClick` fires from a timed event block.
+
+### `DayView.test.tsx`
+
+- Renders 1 column header.
+- Single timed event positioned correctly.
+- All-day band renders for that day only.
+- Now indicator renders when the day === today.
+
+### `Calendar.test.tsx`
+
+- View switcher renders 3 buttons (Month/Week/Day).
+- Clicking Week fires `onViewChange('week')` and renders WeekView.
+- Clicking Day renders DayView.
+- Uncontrolled (`defaultView='week'`) renders WeekView on mount.
+- ru-RU label override changes the segmented control labels.
+
+## SCSS / tokens
+
+- Reuse all existing tokens.
+- New SCSS module exports `--hour-row-height` and `--hour-count` as CSS custom properties — set inline from the JSX based on `hourRowHeight` and `hourRange` props.
+- Hour gutter: `--hour-gutter-width: 60px` (could become a token if reused; for now inline).
+- Rule 4: no `margin`, no `position: absolute` on the **outer** wrapper; absolute positioning on internal children (timed event blocks, now-line) is the explicit relative-anchor pattern.
+
+## Risks / open items
+
+- **Collision algorithm correctness.** Lane-count-per-event is the tricky bit. Extensive `utils.test.tsx` coverage.
+- **Scroll behavior across view changes.** Switching views resets scroll. Acceptable for v1; could add scroll-restore later.
+- **Now indicator re-renders.** `setInterval(60_000)` on every mounted `<WeekView>`/`<DayView>` is fine — only one is mounted at a time. Cleared on unmount.
+- **Tabs as segmented control.** The design system's `<Tabs>` is full-fledged for tab navigation. Using it for a 3-option segmented control may be heavy. Alternative: a small custom segmented `<Cluster>` of buttons. Decision: **use `<Tabs>` for consistency** with the rest of the design system; if the styling feels off in the visual review, swap to a custom segmented Button group then.
+- **All-day band visual density.** Default lane cap of 2 may be too few for busy weeks. Make `maxLanesPerWeek` apply to both Month and the all-day band, or add a separate `allDayMaxLanes` option. Defer — see how it looks first.
+- **DayView is mostly WeekView with N=1.** Worth keeping as a separate component for ergonomics (`<Calendar view="day">` reads better than `<Calendar view="week" columnCount={1}>`), but the internal shared primitive is `HourGrid`.
+
+## Verification (post-implementation)
+
+Hard rule 8 review-fix cycle applies. Gates: `npm test`, `npm run typecheck`, `npm run lint:css`, `npm run build`, `npm pack --dry-run -w @eocrm/design-system`. Then fresh-context reviewer until verdict is `clean enough to stop`.
+
+Manual visual check at `/components/calendar`:
+
+- Switch between Month/Week/Day — view changes without flicker.
+- Week view shows a continuous "Web Summit" all-day band across the week.
+- Timed events in the week match their hour positions.
+- Overlapping events split into side-by-side lanes.
+- Now indicator appears in today's column.
+- Custom `hourRange={[9, 17]}` shows only 8 hour rows.
+- ru-RU shows Russian month label + Russian segmented-control labels (when passed).

--- a/docs/superpowers/specs/2026-05-20-calendar-week-day-views-design.md
+++ b/docs/superpowers/specs/2026-05-20-calendar-week-day-views-design.md
@@ -98,9 +98,11 @@ export interface AllDayBar {
 export interface CalendarProps {
   // ... existing props ...
 
-  /** Active view. Defaults to `'month'`. */
+  /** Active view (controlled). When provided, pair with `onViewChange`. */
   view?: CalendarView;
-  /** Fires when the consumer interacts with the view switcher. Controlled when paired with `view`. */
+  /** Initial view (uncontrolled). Defaults to `'month'`. */
+  defaultView?: CalendarView;
+  /** Fires when the user clicks the view switcher. */
   onViewChange?: (view: CalendarView) => void;
   /**
    * Hour range shown in week/day views (inclusive start, exclusive end).
@@ -113,20 +115,7 @@ export interface CalendarProps {
 }
 ```
 
-The view switcher is internally rendered by the Calendar shell. When `onViewChange` is omitted, view defaults to `'month'` (uncontrolled-style — no internal state for view, just initial render). Document: for switching to work, consumers must control via `view`/`onViewChange`.
-
-Actually — simpler: keep `view` uncontrolled by default (internal `useState`), fall back to controlled when consumer passes the prop. Same pattern as `value`/`defaultValue`.
-
-```ts
-export interface CalendarProps {
-  // ...
-  view?: CalendarView;
-  defaultView?: CalendarView; // initial value when uncontrolled
-  onViewChange?: (view: CalendarView) => void;
-  hourRange?: [number, number];
-  hourRowHeight?: number;
-}
-```
+`view` follows the same controlled/uncontrolled pattern as `value`/`defaultValue`: pass `view`+`onViewChange` for controlled, or `defaultView` for uncontrolled internal state. The view switcher renders inside the Calendar shell header.
 
 ### `CalendarLabels`
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -418,26 +418,31 @@ const locale = useLocale(); // 'ru-RU', or navigator.language fallback
 - No `<LocaleProvider>` mounted? `useLocale()` falls back to `navigator.language` (or `'en-US'` in SSR / Node).
 - Stateless. To switch locale at runtime, re-render the Provider with a new `locale` prop. Nested Providers override outer ones.
 
-### `<Calendar>` — month view with continuous event bars
+### `<Calendar>` — month / week / day views
 
 ```tsx
 const [cursor, setCursor] = useState(new Date());
+const [view, setView] = useState<'month' | 'week' | 'day'>('month');
 <Calendar
   value={cursor}
   onChange={setCursor}
+  view={view}
+  onViewChange={setView}
   events={events}
   onEventClick={(e) => openDetail(e)}
 />;
 ```
 
-- Month view only in v1; Week / Day / Agenda views ship in follow-up PRs.
-- Events are `{ id, title, startsAt, endsAt?, tone?, allDay? }`. Multi-day events render as continuous bars across days; week boundaries split into separate bars with flattened edges.
+- Three views in v3: `'month'` (continuous event bars across the grid), `'week'` (7 columns × hour rows + all-day band), `'day'` (single column × hour rows). Agenda view comes in PR 4.
+- Events are `{ id, title, startsAt, endsAt?, tone?, allDay? }`. Multi-day events render as continuous bars in both the month grid and the week/day all-day band.
 - Tones: `neutral` (default) / `accent` / `success` / `warning` / `danger`. `allDay: true` renders as a tone-filled band (no time prefix).
-- Controlled (`value` / `onChange`) or uncontrolled (`defaultValue`).
-- Locale-aware via `useLocale()`; override with `locale` prop. `weekStartsOn` overrides the locale-derived first day.
-- `maxLanesPerWeek` (default 3) caps event lanes per week. Events beyond the cap collapse into a `+N more` chip in affected cells; click fires `onDayClick(date)` so you can open your own popover/modal with the full list.
+- Controlled cursor via `value` / `onChange`, or uncontrolled via `defaultValue`. Controlled view via `view` / `onViewChange`, or uncontrolled via `defaultView`.
+- `hourRange` (default `[7, 19]`) sets the visible hour window in week/day views; hours outside the range stay scroll-reachable. `hourRowHeight` (default 48) is the pixel height per hour row.
+- Overlapping timed events in week/day views split into equal-width lanes side-by-side. A horizontal "now" line marks the current time in today's column.
+- Locale-aware via `useLocale()`; override with `locale` prop. UI strings (`today`, `viewMonth`, etc.) are the consumer's responsibility via `labels`.
+- `maxLanesPerWeek` (default 3) caps event lanes per week in the month view. Events beyond the cap collapse into a `+N more` chip; click fires `onDayClick(date)`.
 - Read-mostly: `onDayClick` and `onEventClick` callbacks only. No built-in popover or modal — wire your own detail UI.
-- ARIA: `role="grid" aria-readonly="true"`; arrow keys move focus, PageUp/PageDown navigates months, Enter/Space calls `onDayClick`.
+- ARIA: month view is `role="grid" aria-readonly="true"`; arrow keys move focus, PageUp/PageDown navigates months, Enter/Space calls `onDayClick`. Week/day views use `role="columnheader"` on day headers and standard sequential tab order for event blocks.
 
 ### Calendar primitives — `useMonth`, `useWeek`, `useDay`, `useAgenda`
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -442,7 +442,7 @@ const [view, setView] = useState<'month' | 'week' | 'day'>('month');
 - Locale-aware via `useLocale()`; override with `locale` prop. UI strings (`today`, `viewMonth`, etc.) are the consumer's responsibility via `labels`.
 - `maxLanesPerWeek` (default 3) caps event lanes per week in the month view. Events beyond the cap collapse into a `+N more` chip; click fires `onDayClick(date)`.
 - Read-mostly: `onDayClick` and `onEventClick` callbacks only. `onDayClick` fires across all views — month-cell click, "+N more" chip, keyboard activation (Enter/Space) on a focused cell, and (in week/day views) clicks on the empty hour-grid space of a day column. No built-in popover or modal — wire your own detail UI.
-- ARIA: month view is `role="grid" aria-readonly="true"`; arrow keys move focus, PageUp/PageDown navigates months, Enter/Space calls `onDayClick`. Week/day views use `role="columnheader"` on day headers and standard sequential tab order for event blocks.
+- ARIA: month view is `role="grid" aria-readonly="true"`; arrow keys move focus, PageUp/PageDown navigates months, Enter/Space calls `onDayClick`. Week/day views are also `role="grid" aria-readonly="true"` with `role="row"` + `role="columnheader"` headers and standard sequential tab order for event blocks. **Known v3 gap:** in week/day views, `onDayClick` on empty hour-grid space is **mouse-only** (no keyboard equivalent). Consumers needing keyboard activation should drive their detail UI through the focusable event chips via `onEventClick`.
 
 ### Calendar primitives — `useMonth`, `useWeek`, `useDay`, `useAgenda`
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -438,10 +438,10 @@ const [view, setView] = useState<'month' | 'week' | 'day'>('month');
 - Tones: `neutral` (default) / `accent` / `success` / `warning` / `danger`. `allDay: true` renders as a tone-filled band (no time prefix).
 - Controlled cursor via `value` / `onChange`, or uncontrolled via `defaultValue`. Controlled view via `view` / `onViewChange`, or uncontrolled via `defaultView`.
 - `hourRange` (default `[7, 19]`) sets the visible hour window in week/day views. Hours outside the range are not rendered. `hourRowHeight` (default 48) is the pixel height per hour row.
-- Overlapping timed events in week/day views split into equal-width lanes side-by-side. A horizontal "now" line marks the current time in today's column.
+- Overlapping timed events in week/day views render as a Google-Calendar-style cascade: each lane is offset to the right by a small constant step but every block extends to the column's right edge, with later lanes overlaying earlier ones via `z-index`. Hovering or keyboard-focusing a block lifts it to full width on top of all neighbours. A horizontal "now" line marks the current time in today's column.
 - Locale-aware via `useLocale()`; override with `locale` prop. UI strings (`today`, `viewMonth`, etc.) are the consumer's responsibility via `labels`.
 - `maxLanesPerWeek` (default 3) caps event lanes per week in the month view. Events beyond the cap collapse into a `+N more` chip; click fires `onDayClick(date)`.
-- Read-mostly: `onDayClick` and `onEventClick` callbacks only. No built-in popover or modal — wire your own detail UI.
+- Read-mostly: `onDayClick` and `onEventClick` callbacks only. `onDayClick` fires across all views — month-cell click, "+N more" chip, keyboard activation (Enter/Space) on a focused cell, and (in week/day views) clicks on the empty hour-grid space of a day column. No built-in popover or modal — wire your own detail UI.
 - ARIA: month view is `role="grid" aria-readonly="true"`; arrow keys move focus, PageUp/PageDown navigates months, Enter/Space calls `onDayClick`. Week/day views use `role="columnheader"` on day headers and standard sequential tab order for event blocks.
 
 ### Calendar primitives — `useMonth`, `useWeek`, `useDay`, `useAgenda`

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -437,7 +437,7 @@ const [view, setView] = useState<'month' | 'week' | 'day'>('month');
 - Events are `{ id, title, startsAt, endsAt?, tone?, allDay? }`. Multi-day events render as continuous bars in both the month grid and the week/day all-day band.
 - Tones: `neutral` (default) / `accent` / `success` / `warning` / `danger`. `allDay: true` renders as a tone-filled band (no time prefix).
 - Controlled cursor via `value` / `onChange`, or uncontrolled via `defaultValue`. Controlled view via `view` / `onViewChange`, or uncontrolled via `defaultView`.
-- `hourRange` (default `[7, 19]`) sets the visible hour window in week/day views; hours outside the range stay scroll-reachable. `hourRowHeight` (default 48) is the pixel height per hour row.
+- `hourRange` (default `[7, 19]`) sets the visible hour window in week/day views. Hours outside the range are not rendered. `hourRowHeight` (default 48) is the pixel height per hour row.
 - Overlapping timed events in week/day views split into equal-width lanes side-by-side. A horizontal "now" line marks the current time in today's column.
 - Locale-aware via `useLocale()`; override with `locale` prop. UI strings (`today`, `viewMonth`, etc.) are the consumer's responsibility via `labels`.
 - `maxLanesPerWeek` (default 3) caps event lanes per week in the month view. Events beyond the cap collapse into a `+N more` chip; click fires `onDayClick(date)`.

--- a/packages/design-system/src/components/Calendar/AllDayBand.module.scss
+++ b/packages/design-system/src/components/Calendar/AllDayBand.module.scss
@@ -1,5 +1,7 @@
 .band {
   display: grid;
+  gap: var(--space-1);
+  padding: var(--space-1) 0;
   border-bottom: var(--border-width) solid var(--color-border);
   background: var(--color-bg);
 }
@@ -8,18 +10,12 @@
   border-right: var(--border-width) solid var(--color-border);
 }
 
-.body {
-  display: grid;
-  gap: var(--space-1);
-  padding: var(--space-1);
-  align-items: start;
-}
-
 .barSlot {
   min-width: 0;
+  padding: 0 var(--space-1);
 }
 
 .continuesLeft,
 .continuesRight {
-  // Visual cues are on the EventChip itself; wrapper has no styling.
+  // Visual cues on the EventChip; no wrapper styling needed.
 }

--- a/packages/design-system/src/components/Calendar/AllDayBand.module.scss
+++ b/packages/design-system/src/components/Calendar/AllDayBand.module.scss
@@ -14,8 +14,3 @@
   min-width: 0;
   padding: 0 var(--space-1);
 }
-
-.continuesLeft,
-.continuesRight {
-  // Visual cues on the EventChip; no wrapper styling needed.
-}

--- a/packages/design-system/src/components/Calendar/AllDayBand.module.scss
+++ b/packages/design-system/src/components/Calendar/AllDayBand.module.scss
@@ -1,0 +1,25 @@
+.band {
+  display: grid;
+  border-bottom: var(--border-width) solid var(--color-border);
+  background: var(--color-bg);
+}
+
+.gutter {
+  border-right: var(--border-width) solid var(--color-border);
+}
+
+.body {
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-1);
+  align-items: start;
+}
+
+.barSlot {
+  min-width: 0;
+}
+
+.continuesLeft,
+.continuesRight {
+  // Visual cues are on the EventChip itself; wrapper has no styling.
+}

--- a/packages/design-system/src/components/Calendar/AllDayBand.tsx
+++ b/packages/design-system/src/components/Calendar/AllDayBand.tsx
@@ -10,6 +10,7 @@ export interface AllDayBandProps {
   columnCount: number;
   /** Pixel width of the hour-gutter on the left (band aligns with the hour-grid columns). */
   gutterWidth: number;
+  /** Fires when an all-day chip is clicked; receives the `CalendarEvent`. */
   onEventClick?: (event: CalendarEvent) => void;
 }
 

--- a/packages/design-system/src/components/Calendar/AllDayBand.tsx
+++ b/packages/design-system/src/components/Calendar/AllDayBand.tsx
@@ -1,0 +1,69 @@
+import clsx from 'clsx';
+import { EventChip } from './EventChip';
+import type { AllDayBar, CalendarEvent } from './types';
+import styles from './AllDayBand.module.scss';
+
+export interface AllDayBandProps {
+  /** Bars produced by `layoutEventsForHourGrid`. */
+  bars: readonly AllDayBar[];
+  /** Number of day columns the band spans (1 or 7). */
+  columnCount: number;
+  /** Pixel width of the hour-gutter on the left (band aligns with the hour-grid columns). */
+  gutterWidth: number;
+  onEventClick?: (event: CalendarEvent) => void;
+}
+
+/**
+ * Internal: the all-day event band rendered above the hour grid. Multi-day
+ * events span columns as continuous bars; the left gutter is empty so the
+ * band aligns visually with the hour-grid columns below.
+ *
+ * @remarks
+ * **When NOT to use:** Do not render `AllDayBand` directly in application code —
+ * it is an internal building block consumed by `WeekView`/`DayView`. Use `Calendar`
+ * from the design system and pass events via the `events` prop.
+ */
+export function AllDayBand({ bars, columnCount, gutterWidth, onEventClick }: AllDayBandProps) {
+  if (bars.length === 0) return null;
+  const maxLane = bars.reduce((m, b) => Math.max(m, b.lane), 0);
+
+  return (
+    <div
+      className={styles.band}
+      style={{
+        gridTemplateColumns: `${gutterWidth}px repeat(${columnCount}, 1fr)`,
+      }}
+    >
+      <div className={styles.gutter} />
+      <div
+        className={styles.body}
+        style={{
+          gridTemplateColumns: `repeat(${columnCount}, 1fr)`,
+          gridTemplateRows: `repeat(${maxLane + 1}, auto)`,
+        }}
+      >
+        {bars.map((bar) => (
+          <div
+            key={bar.event.id}
+            className={clsx(
+              styles.barSlot,
+              bar.continuesLeft && styles.continuesLeft,
+              bar.continuesRight && styles.continuesRight,
+            )}
+            style={{
+              gridColumn: `${bar.startCol + 1} / ${bar.endCol + 2}`,
+              gridRow: bar.lane + 1,
+            }}
+          >
+            <EventChip
+              event={bar.event}
+              continuesLeft={bar.continuesLeft}
+              continuesRight={bar.continuesRight}
+              onClick={(ev) => onEventClick?.(ev)}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/Calendar/AllDayBand.tsx
+++ b/packages/design-system/src/components/Calendar/AllDayBand.tsx
@@ -33,38 +33,35 @@ export function AllDayBand({ bars, columnCount, gutterWidth, onEventClick }: All
       className={styles.band}
       style={{
         gridTemplateColumns: `${gutterWidth}px repeat(${columnCount}, 1fr)`,
+        gridTemplateRows: `repeat(${maxLane + 1}, auto)`,
       }}
     >
-      <div className={styles.gutter} />
       <div
-        className={styles.body}
-        style={{
-          gridTemplateColumns: `repeat(${columnCount}, 1fr)`,
-          gridTemplateRows: `repeat(${maxLane + 1}, auto)`,
-        }}
-      >
-        {bars.map((bar) => (
-          <div
-            key={bar.event.id}
-            className={clsx(
-              styles.barSlot,
-              bar.continuesLeft && styles.continuesLeft,
-              bar.continuesRight && styles.continuesRight,
-            )}
-            style={{
-              gridColumn: `${bar.startCol + 1} / ${bar.endCol + 2}`,
-              gridRow: bar.lane + 1,
-            }}
-          >
-            <EventChip
-              event={bar.event}
-              continuesLeft={bar.continuesLeft}
-              continuesRight={bar.continuesRight}
-              onClick={(ev) => onEventClick?.(ev)}
-            />
-          </div>
-        ))}
-      </div>
+        className={styles.gutter}
+        style={{ gridColumn: 1, gridRow: `1 / span ${maxLane + 1}` }}
+      />
+      {bars.map((bar) => (
+        <div
+          key={bar.event.id}
+          className={clsx(
+            styles.barSlot,
+            bar.continuesLeft && styles.continuesLeft,
+            bar.continuesRight && styles.continuesRight,
+          )}
+          style={{
+            // +2 because column 1 is the gutter; day index 0 → outer column 2
+            gridColumn: `${bar.startCol + 2} / ${bar.endCol + 3}`,
+            gridRow: bar.lane + 1,
+          }}
+        >
+          <EventChip
+            event={bar.event}
+            continuesLeft={bar.continuesLeft}
+            continuesRight={bar.continuesRight}
+            onClick={(ev) => onEventClick?.(ev)}
+          />
+        </div>
+      ))}
     </div>
   );
 }

--- a/packages/design-system/src/components/Calendar/AllDayBand.tsx
+++ b/packages/design-system/src/components/Calendar/AllDayBand.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx';
 import { EventChip } from './EventChip';
 import type { AllDayBar, CalendarEvent, CalendarView, RenderEvent } from './types';
 import styles from './AllDayBand.module.scss';
@@ -54,11 +53,7 @@ export function AllDayBand({
       {bars.map((bar) => (
         <div
           key={bar.event.id}
-          className={clsx(
-            styles.barSlot,
-            bar.continuesLeft && styles.continuesLeft,
-            bar.continuesRight && styles.continuesRight,
-          )}
+          className={styles.barSlot}
           style={{
             // +2 because column 1 is the gutter; day index 0 → outer column 2
             gridColumn: `${bar.startCol + 2} / ${bar.endCol + 3}`,

--- a/packages/design-system/src/components/Calendar/AllDayBand.tsx
+++ b/packages/design-system/src/components/Calendar/AllDayBand.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { EventChip } from './EventChip';
-import type { AllDayBar, CalendarEvent } from './types';
+import type { AllDayBar, CalendarEvent, CalendarView, RenderEvent } from './types';
 import styles from './AllDayBand.module.scss';
 
 export interface AllDayBandProps {
@@ -10,6 +10,10 @@ export interface AllDayBandProps {
   columnCount: number;
   /** Pixel width of the hour-gutter on the left (band aligns with the hour-grid columns). */
   gutterWidth: number;
+  /** Which view contains this band — passed to `renderEvent` (`'week'` or `'day'`). */
+  view?: CalendarView;
+  /** Optional custom event renderer (replaces the chip's default inner content). */
+  renderEvent?: RenderEvent;
   /** Fires when an all-day chip is clicked; receives the `CalendarEvent`. */
   onEventClick?: (event: CalendarEvent) => void;
 }
@@ -24,7 +28,14 @@ export interface AllDayBandProps {
  * it is an internal building block consumed by `WeekView`/`DayView`. Use `Calendar`
  * from the design system and pass events via the `events` prop.
  */
-export function AllDayBand({ bars, columnCount, gutterWidth, onEventClick }: AllDayBandProps) {
+export function AllDayBand({
+  bars,
+  columnCount,
+  gutterWidth,
+  view = 'week',
+  renderEvent,
+  onEventClick,
+}: AllDayBandProps) {
   if (bars.length === 0) return null;
   const maxLane = bars.reduce((m, b) => Math.max(m, b.lane), 0);
 
@@ -58,6 +69,8 @@ export function AllDayBand({ bars, columnCount, gutterWidth, onEventClick }: All
             event={bar.event}
             continuesLeft={bar.continuesLeft}
             continuesRight={bar.continuesRight}
+            view={view}
+            renderEvent={renderEvent}
             onClick={(ev) => onEventClick?.(ev)}
           />
         </div>

--- a/packages/design-system/src/components/Calendar/Calendar.test.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.test.tsx
@@ -97,4 +97,30 @@ describe('Calendar', () => {
     const focusable = cells.filter((c) => c.getAttribute('tabindex') === '0');
     expect(focusable.length).toBe(1);
   });
+
+  it('switches to WeekView when defaultView="week"', () => {
+    render(<Calendar defaultValue={new Date(2026, 4, 20)} defaultView="week" />, {
+      wrapper: wrap(),
+    });
+    const hourLabels = document.querySelectorAll('[class*="hourLabel"]');
+    expect(hourLabels.length).toBeGreaterThan(0);
+  });
+
+  it('switches to DayView when defaultView="day"', () => {
+    render(<Calendar defaultValue={new Date(2026, 4, 20)} defaultView="day" />, {
+      wrapper: wrap(),
+    });
+    expect(document.querySelectorAll('[role="columnheader"]').length).toBe(1);
+  });
+
+  it('controlled view: clicking Week tab fires onViewChange', async () => {
+    const user = userEvent.setup();
+    const onViewChange = vi.fn();
+    render(
+      <Calendar defaultValue={new Date(2026, 4, 20)} view="month" onViewChange={onViewChange} />,
+      { wrapper: wrap() },
+    );
+    await user.click(screen.getByRole('tab', { name: 'Week' }));
+    expect(onViewChange).toHaveBeenCalledWith('week');
+  });
 });

--- a/packages/design-system/src/components/Calendar/Calendar.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.tsx
@@ -10,7 +10,7 @@ import { MonthView } from './MonthView';
 import { WeekView } from './WeekView';
 import { DayView } from './DayView';
 import { ViewSwitcher } from './ViewSwitcher';
-import type { CalendarEvent, CalendarView } from './types';
+import type { CalendarEvent, CalendarView, RenderEvent } from './types';
 import styles from './Calendar.module.scss';
 
 /**
@@ -70,6 +70,20 @@ export interface CalendarProps extends Omit<
   hourRange?: [number, number];
   /** Pixel height per hour row in week/day views. Default 48. */
   hourRowHeight?: number;
+  /**
+   * Optional custom renderer for the inner content of every event chip
+   * across views (month chips, week/day timed blocks, all-day band chips).
+   * The returned ReactNode replaces the default `<time> · <title>` markup
+   * inside the chip's button wrapper — the wrapper still handles tone
+   * background, click, tooltip, and (for timed blocks) absolute positioning.
+   *
+   * To override colors, return content with inline styling that fills the
+   * wrapper (e.g., `position: absolute; inset: 0; background: <color>`).
+   *
+   * The `ctx` argument carries view-aware metadata: `view`, `asAllDay`,
+   * `continuesLeft`/`continuesRight` (multi-day), `timeLabel`, `duration`.
+   */
+  renderEvent?: RenderEvent;
   /** Localized UI strings. */
   labels?: CalendarLabels;
 }
@@ -147,6 +161,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
     maxLanesPerWeek = 3,
     hourRange = [7, 19],
     hourRowHeight = 48,
+    renderEvent,
     labels,
     className,
     ...rest
@@ -240,6 +255,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
           onDayClick={onDayClick}
           onEventClick={onEventClick}
           moreEventsLabel={resolvedLabels.moreEvents}
+          renderEvent={renderEvent}
         />
       )}
       {view === 'week' && (
@@ -251,6 +267,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
           locale={locale}
           weekStartsOn={weekStartsOn}
           onEventClick={onEventClick}
+          renderEvent={renderEvent}
         />
       )}
       {view === 'day' && (
@@ -261,6 +278,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
           hourRowHeight={hourRowHeight}
           locale={locale}
           onEventClick={onEventClick}
+          renderEvent={renderEvent}
         />
       )}
     </div>

--- a/packages/design-system/src/components/Calendar/Calendar.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '../Button';
 import { Cluster } from '../Cluster';
-import { addMonths } from '../../calendar/dateMath';
+import { addDays, addMonths, addWeeks } from '../../calendar/dateMath';
 import { useMonth } from '../../calendar/useMonth';
 import { LocaleProvider } from '../../i18n/LocaleProvider';
 import { MonthView } from './MonthView';
@@ -179,8 +179,18 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
 
   const grid = useMonth(cursor, { locale, weekStartsOn });
 
-  const goPrev = () => handleChange(addMonths(cursor, -1));
-  const goNext = () => handleChange(addMonths(cursor, 1));
+  // Prev/Next step matches the active view: a month in month view, a week in
+  // week view, a day in day view. Without this, multi-day events that span
+  // several weeks aren't reachable when in week/day view — each click would
+  // skip over them.
+  const stepBy =
+    view === 'month'
+      ? (d: Date, n: number) => addMonths(d, n)
+      : view === 'week'
+        ? (d: Date, n: number) => addWeeks(d, n)
+        : (d: Date, n: number) => addDays(d, n);
+  const goPrev = () => handleChange(stepBy(cursor, -1));
+  const goNext = () => handleChange(stepBy(cursor, 1));
   const goToday = () => handleChange(new Date());
 
   const body: ReactNode = (

--- a/packages/design-system/src/components/Calendar/Calendar.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, useCallback, useState, type HTMLAttributes, type ReactNode } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
 import clsx from 'clsx';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '../Button';
@@ -7,34 +13,44 @@ import { addMonths } from '../../calendar/dateMath';
 import { useMonth } from '../../calendar/useMonth';
 import { LocaleProvider } from '../../i18n/LocaleProvider';
 import { MonthView } from './MonthView';
+import { WeekView } from './WeekView';
+import { DayView } from './DayView';
+import { ViewSwitcher } from './ViewSwitcher';
 import type { CalendarEvent, CalendarView } from './types';
 import styles from './Calendar.module.scss';
 
 /**
- * UI strings consumed by `<Calendar>`. The design system ships locale-aware
- * month/weekday names via `Intl`, but UI strings like "Today" are the
- * consumer's responsibility — pass localized values via `labels`.
+ * UI strings consumed by `<Calendar>`. Each key has an English default;
+ * pass localized values via the `labels` prop.
  */
 export interface CalendarLabels {
-  /** Text on the "Today" button. Default: `"Today"`. */
+  /** Text on the "Today" button. */
   today?: string;
-  /** ARIA label on the previous-month chevron. Default: `"Previous month"`. */
+  /** ARIA label on the prev chevron. */
   previousMonth?: string;
-  /** ARIA label on the next-month chevron. Default: `"Next month"`. */
+  /** ARIA label on the next chevron. */
   nextMonth?: string;
-  /** Template for the "+N more events" `aria-label`. Receives the hidden count. Default: `(n) => `${n} more events``. */
+  /** Template for the "+N more events" aria-label. */
   moreEvents?: (count: number) => string;
+  /** Segmented-control label for the month view. */
+  viewMonth?: string;
+  /** Segmented-control label for the week view. */
+  viewWeek?: string;
+  /** Segmented-control label for the day view. */
+  viewDay?: string;
 }
 
-export interface CalendarProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  'onChange' | 'defaultValue'
-> {
-  /** Events to display. Calendar groups them internally; no pre-bucketing. */
+export interface CalendarProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue'> {
+  /** Events to display. */
   events?: readonly CalendarEvent[];
-  /** Active view. Only `'month'` ships in this PR. */
+  /** Active view (controlled). Pair with `onViewChange`. */
   view?: CalendarView;
-  /** Navigation cursor (controlled). Any date within the target month works. */
+  /** Initial view (uncontrolled). Defaults to `'month'`. */
+  defaultView?: CalendarView;
+  /** Fires when the user clicks the view switcher. */
+  onViewChange?: (view: CalendarView) => void;
+  /** Navigation cursor (controlled). */
   value?: Date;
   /** Initial cursor (uncontrolled). Defaults to `new Date()`. */
   defaultValue?: Date;
@@ -48,9 +64,13 @@ export interface CalendarProps extends Omit<
   locale?: string;
   /** Override locale-derived first day of week. */
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-  /** Lane cap per week before "+N more" appears in affected cells. Default 3. */
+  /** Lane cap per week before "+N more" appears in affected cells (month view). Default 3. */
   maxLanesPerWeek?: number;
-  /** Localized UI strings. Each key has a sensible English default. */
+  /** Hour range for week/day views (inclusive start, exclusive end). Default `[7, 19]`. */
+  hourRange?: [number, number];
+  /** Pixel height per hour row in week/day views. Default 48. */
+  hourRowHeight?: number;
+  /** Localized UI strings. */
   labels?: CalendarLabels;
 }
 
@@ -59,45 +79,64 @@ const DEFAULT_LABELS: Required<CalendarLabels> = {
   previousMonth: 'Previous month',
   nextMonth: 'Next month',
   moreEvents: (n) => `${n} more events`,
+  viewMonth: 'Month',
+  viewWeek: 'Week',
+  viewDay: 'Day',
 };
 
 /**
- * Month calendar with continuous event bars (Google-Calendar style).
+ * Month / week / day calendar.
  *
- * - Controlled via `value` / `onChange`, or uncontrolled via `defaultValue`.
- * - Events are arbitrary `CalendarEvent` objects; multi-day events render as
- *   continuous bars across days (and as separate bars across week boundaries).
- * - Locale-aware via `useLocale()` from `<LocaleProvider>`; override with the
- *   `locale` prop.
- * - Read-mostly: `onDayClick` / `onEventClick` callbacks fire; no built-in
- *   popover or modal. Wire your own detail UI on top.
+ * - Controlled cursor via `value` / `onChange`, or uncontrolled via
+ *   `defaultValue`.
+ * - Controlled view via `view` / `onViewChange`, or uncontrolled via
+ *   `defaultView`.
+ * - Events as `CalendarEvent` objects; multi-day events render as continuous
+ *   bars across the month grid and in the all-day band of week/day views.
+ * - Locale-aware via `useLocale()`; override with `locale` prop. UI strings
+ *   (`today`, `viewMonth`, etc.) are the consumer's responsibility via
+ *   `labels`.
+ * - Read-mostly: `onDayClick` and `onEventClick` callbacks; no built-in
+ *   popover or modal.
  *
  * @example
- * <Calendar events={events} onEventClick={(e) => openDetail(e)} />
+ * <Calendar events={events} defaultView="week" />
  *
  * @example
- * // Controlled cursor:
+ * // Controlled cursor + view + locale labels:
  * const [cursor, setCursor] = useState(new Date());
- * <Calendar value={cursor} onChange={(d) => setCursor(d)} events={events} />
+ * const [view, setView] = useState<'month' | 'week' | 'day'>('month');
+ * <Calendar
+ *   value={cursor}
+ *   onChange={setCursor}
+ *   view={view}
+ *   onViewChange={setView}
+ *   events={events}
+ *   locale="ru-RU"
+ *   labels={{
+ *     today: 'Сегодня',
+ *     viewMonth: 'Месяц',
+ *     viewWeek: 'Неделя',
+ *     viewDay: 'День',
+ *   }}
+ * />;
  *
  * @remarks When NOT to use
- * - Single-date or date-range selection → use the future `<DatePicker>`.
- * - Hour-grid event scheduling → wait for `<WeekView>` / `<DayView>` in PR 3.
- * - Inline-edit calendars (drag-create, drag-reschedule) — out of scope; this
- *   component is read-mostly.
+ * - Single-date or date-range selection → use a future `<DatePicker>`.
+ * - Inline-edit calendars (drag-create, drag-reschedule) — out of scope.
  *
  * @remarks Anti-patterns
- * - ❌ Mounting `<Calendar>` with no `events` prop AND no `onDayClick` — the
- *   grid is fully inert. Either provide events to display or a click handler.
- * - ❌ Wrapping `<Calendar>` in another component that strips the controlled
- *   `value` cursor — the cursor must travel with the consumer's state.
+ * - ❌ Mounting `<Calendar>` with no `events` AND no `onDayClick` — the grid
+ *   is fully inert. Provide events or a click handler.
  * - ❌ Pre-grouping events by day in the consumer. Pass the flat array; the
- *   layout algorithm groups + lanes internally.
+ *   layout algorithms group + lane internally.
  */
 export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calendar(
   {
     events = [],
-    view = 'month',
+    view: viewProp,
+    defaultView,
+    onViewChange,
     value,
     defaultValue,
     onChange,
@@ -106,6 +145,8 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
     locale,
     weekStartsOn,
     maxLanesPerWeek = 3,
+    hourRange = [7, 19],
+    hourRowHeight = 48,
     labels,
     className,
     ...rest
@@ -114,6 +155,10 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
 ) {
   const [uncontrolled, setUncontrolled] = useState<Date>(() => defaultValue ?? new Date());
   const cursor = value ?? uncontrolled;
+  const [uncontrolledView, setUncontrolledView] = useState<CalendarView>(
+    () => defaultView ?? 'month',
+  );
+  const view = viewProp ?? uncontrolledView;
   const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
 
   const handleChange = useCallback(
@@ -122,6 +167,14 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
       onChange?.(next);
     },
     [value, onChange],
+  );
+
+  const handleViewChange = useCallback(
+    (next: CalendarView) => {
+      if (viewProp === undefined) setUncontrolledView(next);
+      onViewChange?.(next);
+    },
+    [viewProp, onViewChange],
   );
 
   const grid = useMonth(cursor, { locale, weekStartsOn });
@@ -134,28 +187,37 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
     <div ref={ref} className={clsx(styles.calendar, className)} {...rest}>
       <header className={styles.header}>
         <h2 className={styles.title}>{grid.monthLabel}</h2>
-        <Cluster gap="xs" align="center">
-          <Button
-            size="xs"
-            variant="ghost"
-            iconOnly
-            aria-label={resolvedLabels.previousMonth}
-            onClick={goPrev}
-          >
-            <ChevronLeft size={14} />
-          </Button>
-          <Button size="sm" variant="secondary" onClick={goToday}>
-            {resolvedLabels.today}
-          </Button>
-          <Button
-            size="xs"
-            variant="ghost"
-            iconOnly
-            aria-label={resolvedLabels.nextMonth}
-            onClick={goNext}
-          >
-            <ChevronRight size={14} />
-          </Button>
+        <Cluster gap="sm" align="center">
+          <Cluster gap="xs" align="center">
+            <Button
+              size="xs"
+              variant="ghost"
+              iconOnly
+              aria-label={resolvedLabels.previousMonth}
+              onClick={goPrev}
+            >
+              <ChevronLeft size={14} />
+            </Button>
+            <Button size="sm" variant="secondary" onClick={goToday}>
+              {resolvedLabels.today}
+            </Button>
+            <Button
+              size="xs"
+              variant="ghost"
+              iconOnly
+              aria-label={resolvedLabels.nextMonth}
+              onClick={goNext}
+            >
+              <ChevronRight size={14} />
+            </Button>
+          </Cluster>
+          <ViewSwitcher
+            view={view}
+            onViewChange={handleViewChange}
+            monthLabel={resolvedLabels.viewMonth}
+            weekLabel={resolvedLabels.viewWeek}
+            dayLabel={resolvedLabels.viewDay}
+          />
         </Cluster>
       </header>
       {view === 'month' && (
@@ -170,11 +232,29 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
           moreEventsLabel={resolvedLabels.moreEvents}
         />
       )}
+      {view === 'week' && (
+        <WeekView
+          cursor={cursor}
+          events={events}
+          hourRange={hourRange}
+          hourRowHeight={hourRowHeight}
+          locale={locale}
+          weekStartsOn={weekStartsOn}
+          onEventClick={onEventClick}
+        />
+      )}
+      {view === 'day' && (
+        <DayView
+          cursor={cursor}
+          events={events}
+          hourRange={hourRange}
+          hourRowHeight={hourRowHeight}
+          locale={locale}
+          onEventClick={onEventClick}
+        />
+      )}
     </div>
   );
 
-  // When an explicit `locale` prop is provided, wrap the subtree so internal
-  // descendants (EventChip's `formatHour`, etc.) read the override via
-  // `useLocale()` rather than the ambient Context.
   return locale !== undefined ? <LocaleProvider locale={locale}>{body}</LocaleProvider> : body;
 });

--- a/packages/design-system/src/components/Calendar/Calendar.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.tsx
@@ -56,7 +56,10 @@ export interface CalendarProps extends Omit<
    * Fires when the user clicks a day cell's empty space.
    * - Month view: empty space in a day cell, the "+N more" overflow chip, or
    *   keyboard activation (Enter/Space) on a focused cell.
-   * - Week/Day view: empty hour-grid space inside that day's column.
+   * - Week/Day view: empty hour-grid space inside that day's column —
+   *   **mouse click only**. There is no keyboard equivalent in v3; consumers
+   *   needing keyboard activation in week/day should surface their detail UI
+   *   through the focusable event chips (which fire `onEventClick`).
    */
   onDayClick?: (date: Date) => void;
   /** Fires when the user clicks an event chip. */

--- a/packages/design-system/src/components/Calendar/Calendar.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.tsx
@@ -66,7 +66,11 @@ export interface CalendarProps
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   /** Lane cap per week before "+N more" appears in affected cells (month view). Default 3. */
   maxLanesPerWeek?: number;
-  /** Hour range for week/day views (inclusive start, exclusive end). Default `[7, 19]`. */
+  /**
+   * Hour range shown in week/day views (inclusive start, exclusive end).
+   * Defaults to `[7, 19]` (7am–7pm). Hours outside this range are NOT
+   * rendered (no row in the grid).
+   */
   hourRange?: [number, number];
   /** Pixel height per hour row in week/day views. Default 48. */
   hourRowHeight?: number;

--- a/packages/design-system/src/components/Calendar/Calendar.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.tsx
@@ -52,7 +52,12 @@ export interface CalendarProps extends Omit<
   defaultValue?: Date;
   /** Fires on prev/next/today/keyboard navigation. */
   onChange?: (date: Date) => void;
-  /** Fires when the user clicks empty space in a day cell. */
+  /**
+   * Fires when the user clicks a day cell's empty space.
+   * - Month view: empty space in a day cell, the "+N more" overflow chip, or
+   *   keyboard activation (Enter/Space) on a focused cell.
+   * - Week/Day view: empty hour-grid space inside that day's column.
+   */
   onDayClick?: (date: Date) => void;
   /** Fires when the user clicks an event chip. */
   onEventClick?: (event: CalendarEvent) => void;
@@ -267,6 +272,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
           locale={locale}
           weekStartsOn={weekStartsOn}
           onEventClick={onEventClick}
+          onDayClick={onDayClick}
           renderEvent={renderEvent}
         />
       )}
@@ -278,6 +284,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
           hourRowHeight={hourRowHeight}
           locale={locale}
           onEventClick={onEventClick}
+          onDayClick={onDayClick}
           renderEvent={renderEvent}
         />
       )}

--- a/packages/design-system/src/components/Calendar/Calendar.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.tsx
@@ -1,10 +1,4 @@
-import {
-  forwardRef,
-  useCallback,
-  useState,
-  type HTMLAttributes,
-  type ReactNode,
-} from 'react';
+import { forwardRef, useCallback, useState, type HTMLAttributes, type ReactNode } from 'react';
 import clsx from 'clsx';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '../Button';
@@ -40,8 +34,10 @@ export interface CalendarLabels {
   viewDay?: string;
 }
 
-export interface CalendarProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue'> {
+export interface CalendarProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'defaultValue'
+> {
   /** Events to display. */
   events?: readonly CalendarEvent[];
   /** Active view (controlled). Pair with `onViewChange`. */

--- a/packages/design-system/src/components/Calendar/DayView.module.scss
+++ b/packages/design-system/src/components/Calendar/DayView.module.scss
@@ -1,0 +1,8 @@
+.dayView {
+  display: flex;
+  flex-direction: column;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-bg);
+}

--- a/packages/design-system/src/components/Calendar/DayView.test.tsx
+++ b/packages/design-system/src/components/Calendar/DayView.test.tsx
@@ -23,7 +23,12 @@ describe('DayView', () => {
 
   it('places a timed event in the single column', () => {
     const events: CalendarEvent[] = [
-      { id: 'a', title: 'Standup', startsAt: new Date(2026, 4, 20, 9), endsAt: new Date(2026, 4, 20, 10) },
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 10),
+      },
     ];
     render(<DayView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />, {
       wrapper: wrap(),
@@ -35,7 +40,12 @@ describe('DayView', () => {
     const onEventClick = vi.fn();
     const user = userEvent.setup();
     const events: CalendarEvent[] = [
-      { id: 'a', title: 'Call', startsAt: new Date(2026, 4, 20, 9), endsAt: new Date(2026, 4, 20, 10) },
+      {
+        id: 'a',
+        title: 'Call',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 10),
+      },
     ];
     render(
       <DayView

--- a/packages/design-system/src/components/Calendar/DayView.test.tsx
+++ b/packages/design-system/src/components/Calendar/DayView.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { LocaleProvider } from '../../i18n/LocaleProvider';
+import { DayView } from './DayView';
+import type { CalendarEvent } from './types';
+
+function wrap(locale = 'en-US') {
+  return ({ children }: { children: ReactNode }) => (
+    <LocaleProvider locale={locale}>{children}</LocaleProvider>
+  );
+}
+
+describe('DayView', () => {
+  const cursor = new Date(2026, 4, 20);
+
+  it('renders 1 column header', () => {
+    render(<DayView cursor={cursor} events={[]} hourRange={[7, 19]} hourRowHeight={48} />, {
+      wrapper: wrap(),
+    });
+    expect(screen.getAllByRole('columnheader').length).toBe(1);
+  });
+
+  it('places a timed event in the single column', () => {
+    const events: CalendarEvent[] = [
+      { id: 'a', title: 'Standup', startsAt: new Date(2026, 4, 20, 9), endsAt: new Date(2026, 4, 20, 10) },
+    ];
+    render(<DayView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />, {
+      wrapper: wrap(),
+    });
+    expect(screen.getByRole('button', { name: /Standup/ })).toBeInTheDocument();
+  });
+
+  it('fires onEventClick', async () => {
+    const onEventClick = vi.fn();
+    const user = userEvent.setup();
+    const events: CalendarEvent[] = [
+      { id: 'a', title: 'Call', startsAt: new Date(2026, 4, 20, 9), endsAt: new Date(2026, 4, 20, 10) },
+    ];
+    render(
+      <DayView
+        cursor={cursor}
+        events={events}
+        hourRange={[7, 19]}
+        hourRowHeight={48}
+        onEventClick={onEventClick}
+      />,
+      { wrapper: wrap() },
+    );
+    await user.click(screen.getByRole('button', { name: /Call/ }));
+    expect(onEventClick).toHaveBeenCalled();
+  });
+});

--- a/packages/design-system/src/components/Calendar/DayView.tsx
+++ b/packages/design-system/src/components/Calendar/DayView.tsx
@@ -4,7 +4,7 @@ import { useLocale } from '../../i18n/useLocale';
 import { AllDayBand } from './AllDayBand';
 import { HourGrid, HOUR_GUTTER_WIDTH } from './HourGrid';
 import { layoutEventsForHourGrid } from './utils';
-import type { CalendarEvent } from './types';
+import type { CalendarEvent, RenderEvent } from './types';
 import styles from './DayView.module.scss';
 
 export interface DayViewProps {
@@ -20,6 +20,8 @@ export interface DayViewProps {
   locale?: string;
   /** Fires when a timed-event block or all-day chip is clicked. */
   onEventClick?: (event: CalendarEvent) => void;
+  /** Optional custom event renderer (see `RenderEvent`). */
+  renderEvent?: RenderEvent;
 }
 
 /**
@@ -37,6 +39,7 @@ export function DayView({
   hourRowHeight,
   locale: localeOverride,
   onEventClick,
+  renderEvent,
 }: DayViewProps) {
   const contextLocale = useLocale();
   const locale = localeOverride ?? contextLocale;
@@ -61,6 +64,8 @@ export function DayView({
         bars={layout.allDayBars}
         columnCount={1}
         gutterWidth={HOUR_GUTTER_WIDTH}
+        view="day"
+        renderEvent={renderEvent}
         onEventClick={onEventClick}
       />
       <HourGrid
@@ -69,6 +74,8 @@ export function DayView({
         hourRange={hourRange}
         hourRowHeight={hourRowHeight}
         timedBlocks={layout.timedBlocks}
+        view="day"
+        renderEvent={renderEvent}
         onEventClick={onEventClick}
       />
     </div>

--- a/packages/design-system/src/components/Calendar/DayView.tsx
+++ b/packages/design-system/src/components/Calendar/DayView.tsx
@@ -1,0 +1,81 @@
+import { useMemo } from 'react';
+import { useDay } from '../../calendar/useDay';
+import { useLocale } from '../../i18n/useLocale';
+import { AllDayBand } from './AllDayBand';
+import { HourGrid, HOUR_GUTTER_WIDTH } from './HourGrid';
+import { layoutEventsForHourGrid } from './utils';
+import type { CalendarEvent } from './types';
+import styles from './DayView.module.scss';
+
+export interface DayViewProps {
+  /** The date to display. */
+  cursor: Date;
+  /** Events to display for the day. */
+  events: readonly CalendarEvent[];
+  /** Inclusive start, exclusive end of the visible hour range. */
+  hourRange: readonly [number, number];
+  /** Pixel height per hour row. */
+  hourRowHeight: number;
+  /** Override locale. */
+  locale?: string;
+  /** Fires when a timed-event block or all-day chip is clicked. */
+  onEventClick?: (event: CalendarEvent) => void;
+}
+
+/**
+ * Internal: single-day hour grid. Shows the day at `cursor` with an
+ * AllDayBand above and an HourGrid below.
+ *
+ * @remarks
+ * **When NOT to use:** Do not render `DayView` directly — use the `Calendar`
+ * shell with `view='day'`.
+ */
+export function DayView({
+  cursor,
+  events,
+  hourRange,
+  hourRowHeight,
+  locale: localeOverride,
+  onEventClick,
+}: DayViewProps) {
+  const contextLocale = useLocale();
+  const locale = localeOverride ?? contextLocale;
+  const day = useDay(cursor, { locale });
+
+  const layout = useMemo(
+    () =>
+      layoutEventsForHourGrid(
+        events,
+        [{ date: day.day.date, key: day.day.key }],
+        hourRange,
+      ),
+    [events, day.day.date, day.day.key, hourRange],
+  );
+
+  const dayRefs = [
+    {
+      date: day.day.date,
+      key: day.day.key,
+      isWeekend: day.day.isWeekend,
+    },
+  ];
+
+  return (
+    <div className={styles.dayView}>
+      <AllDayBand
+        bars={layout.allDayBars}
+        columnCount={1}
+        gutterWidth={HOUR_GUTTER_WIDTH}
+        onEventClick={onEventClick}
+      />
+      <HourGrid
+        days={dayRefs}
+        columnHeaders={[<span>{day.dayLabel}</span>]}
+        hourRange={hourRange}
+        hourRowHeight={hourRowHeight}
+        timedBlocks={layout.timedBlocks}
+        onEventClick={onEventClick}
+      />
+    </div>
+  );
+}

--- a/packages/design-system/src/components/Calendar/DayView.tsx
+++ b/packages/design-system/src/components/Calendar/DayView.tsx
@@ -43,12 +43,7 @@ export function DayView({
   const day = useDay(cursor, { locale });
 
   const layout = useMemo(
-    () =>
-      layoutEventsForHourGrid(
-        events,
-        [{ date: day.day.date, key: day.day.key }],
-        hourRange,
-      ),
+    () => layoutEventsForHourGrid(events, [{ date: day.day.date, key: day.day.key }], hourRange),
     [events, day.day.date, day.day.key, hourRange],
   );
 

--- a/packages/design-system/src/components/Calendar/DayView.tsx
+++ b/packages/design-system/src/components/Calendar/DayView.tsx
@@ -20,6 +20,8 @@ export interface DayViewProps {
   locale?: string;
   /** Fires when a timed-event block or all-day chip is clicked. */
   onEventClick?: (event: CalendarEvent) => void;
+  /** Fires when empty hour-grid space is clicked, with the day's date. */
+  onDayClick?: (date: Date) => void;
   /** Optional custom event renderer (see `RenderEvent`). */
   renderEvent?: RenderEvent;
 }
@@ -39,6 +41,7 @@ export function DayView({
   hourRowHeight,
   locale: localeOverride,
   onEventClick,
+  onDayClick,
   renderEvent,
 }: DayViewProps) {
   const contextLocale = useLocale();
@@ -77,6 +80,7 @@ export function DayView({
         view="day"
         renderEvent={renderEvent}
         onEventClick={onEventClick}
+        onDayClick={onDayClick}
       />
     </div>
   );

--- a/packages/design-system/src/components/Calendar/DayView.tsx
+++ b/packages/design-system/src/components/Calendar/DayView.tsx
@@ -81,6 +81,7 @@ export function DayView({
         renderEvent={renderEvent}
         onEventClick={onEventClick}
         onDayClick={onDayClick}
+        ariaLabel={day.dayLabel}
       />
     </div>
   );

--- a/packages/design-system/src/components/Calendar/EventChip.module.scss
+++ b/packages/design-system/src/components/Calendar/EventChip.module.scss
@@ -7,7 +7,11 @@
   width: 100%;
   padding: 0 var(--space-2);
   height: var(--space-5);
-  border: var(--border-width) solid transparent;
+
+  // Border is set per-tone (see below) so neutral chips stay visible on
+  // tinted backgrounds (today column, weekend columns). Tone chips get a
+  // border matching their accent color for the same reason.
+  border: var(--border-width) solid currentColor;
   border-radius: var(--radius-sm);
   font-family: inherit;
   font-size: var(--font-size-xs);
@@ -78,6 +82,7 @@
 .neutral {
   background: var(--color-bg-subtle);
   color: var(--color-fg);
+  border-color: var(--color-border-strong);
 }
 
 .accent {

--- a/packages/design-system/src/components/Calendar/EventChip.tsx
+++ b/packages/design-system/src/components/Calendar/EventChip.tsx
@@ -4,7 +4,7 @@ import { formatTime } from '../../calendar';
 import { useLocale } from '../../i18n/useLocale';
 import { Tooltip } from '../Tooltip';
 import { formatEventDuration } from './utils';
-import type { CalendarEvent, CalendarEventTone } from './types';
+import type { CalendarEvent, CalendarEventTone, CalendarView, RenderEvent } from './types';
 import styles from './EventChip.module.scss';
 
 export interface EventChipProps {
@@ -16,6 +16,10 @@ export interface EventChipProps {
   continuesRight?: boolean;
   /** Called when the chip is clicked; receives the event and the native mouse event. */
   onClick?: (event: CalendarEvent, mouseEvent: MouseEvent<HTMLButtonElement>) => void;
+  /** Which view is rendering this chip (passed to `renderEvent` for branching). Defaults to `'month'`. */
+  view?: CalendarView;
+  /** Optional custom inner content. When set, replaces the default time + title spans. */
+  renderEvent?: RenderEvent;
 }
 
 /**
@@ -40,12 +44,14 @@ export function EventChip({
   continuesLeft = false,
   continuesRight = false,
   onClick,
+  view = 'month',
+  renderEvent,
 }: EventChipProps) {
   const locale = useLocale();
   const tone: CalendarEventTone = event.tone ?? 'neutral';
   const isAllDay = event.allDay === true;
   const time = isAllDay ? '' : formatTime(event.startsAt, locale);
-  const duration = formatEventDuration(event.startsAt, event.endsAt);
+  const duration = formatEventDuration(event.startsAt, event.endsAt, isAllDay);
   const tooltipContent = isAllDay ? (
     <span className={styles.tooltipBody}>
       <span className={styles.tooltipTime}>{duration}</span>
@@ -65,6 +71,17 @@ export function EventChip({
     onClick?.(event, e);
   };
 
+  const customContent = renderEvent
+    ? renderEvent(event, {
+        view,
+        asAllDay: isAllDay,
+        continuesLeft,
+        continuesRight,
+        timeLabel: isAllDay ? undefined : time,
+        duration,
+      })
+    : null;
+
   return (
     <Tooltip content={tooltipContent}>
       <button
@@ -78,8 +95,14 @@ export function EventChip({
         )}
         onClick={handleClick}
       >
-        {!isAllDay && <span className={styles.time}>{time}</span>}
-        <span className={styles.title}>{event.title}</span>
+        {customContent !== null ? (
+          customContent
+        ) : (
+          <>
+            {!isAllDay && <span className={styles.time}>{time}</span>}
+            <span className={styles.title}>{event.title}</span>
+          </>
+        )}
       </button>
     </Tooltip>
   );

--- a/packages/design-system/src/components/Calendar/EventChip.tsx
+++ b/packages/design-system/src/components/Calendar/EventChip.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { formatTime } from '../../calendar';
 import { useLocale } from '../../i18n/useLocale';
 import { Tooltip } from '../Tooltip';
+import { formatEventDuration } from './utils';
 import type { CalendarEvent, CalendarEventTone } from './types';
 import styles from './EventChip.module.scss';
 
@@ -44,11 +45,17 @@ export function EventChip({
   const tone: CalendarEventTone = event.tone ?? 'neutral';
   const isAllDay = event.allDay === true;
   const time = isAllDay ? '' : formatTime(event.startsAt, locale);
+  const duration = formatEventDuration(event.startsAt, event.endsAt);
   const tooltipContent = isAllDay ? (
-    <span className={styles.tooltipTitle}>{event.title}</span>
+    <span className={styles.tooltipBody}>
+      <span className={styles.tooltipTime}>{duration}</span>
+      <span className={styles.tooltipTitle}>{event.title}</span>
+    </span>
   ) : (
     <span className={styles.tooltipBody}>
-      <span className={styles.tooltipTime}>{time}</span>
+      <span className={styles.tooltipTime}>
+        {time} · {duration}
+      </span>
       <span className={styles.tooltipTitle}>{event.title}</span>
     </span>
   );

--- a/packages/design-system/src/components/Calendar/HourGrid.module.scss
+++ b/packages/design-system/src/components/Calendar/HourGrid.module.scss
@@ -53,8 +53,11 @@
   background: var(--color-bg-muted);
 }
 
+// Today's column body intentionally has NO tint — only the column header
+// carries the accent color. A tinted body makes events with the `accent`
+// tone vanish into the background.
 .todayColumn {
-  background: var(--color-accent-bg-subtle);
+  // no background — header alone signals "today"
 }
 
 .hourSeparator {

--- a/packages/design-system/src/components/Calendar/HourGrid.module.scss
+++ b/packages/design-system/src/components/Calendar/HourGrid.module.scss
@@ -8,6 +8,13 @@
   background: var(--color-bg);
 }
 
+// ARIA-row wrapper: `display: contents` keeps the corner cell + column
+// headers as direct grid children of `.grid` while satisfying the
+// WAI-ARIA contract that `columnheader` live inside `row`.
+.headerRow {
+  display: contents;
+}
+
 .cornerCell {
   border-right: var(--border-width) solid var(--color-border);
   border-bottom: var(--border-width) solid var(--color-border);
@@ -54,11 +61,8 @@
 }
 
 // Today's column body intentionally has NO tint — only the column header
-// carries the accent color. A tinted body makes events with the `accent`
-// tone vanish into the background.
-.todayColumn {
-  // no background — header alone signals "today"
-}
+// (`.todayHeader`) carries the accent color. A tinted body would make
+// events with the `accent` tone vanish into the background.
 
 .hourSeparator {
   position: absolute;
@@ -72,7 +76,7 @@
   position: absolute;
   left: 0;
   right: 0;
-  height: 2px;
+  height: var(--border-width-emphasis);
   background: var(--color-danger);
   z-index: 1;
 }

--- a/packages/design-system/src/components/Calendar/HourGrid.module.scss
+++ b/packages/design-system/src/components/Calendar/HourGrid.module.scss
@@ -1,0 +1,75 @@
+.scroll {
+  overflow: auto;
+  max-height: 70vh;
+}
+
+.grid {
+  display: grid;
+  background: var(--color-bg);
+}
+
+.cornerCell {
+  border-right: var(--border-width) solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
+  background: var(--color-bg-subtle);
+}
+
+.columnHeader {
+  padding: var(--space-2);
+  background: var(--color-bg-subtle);
+  border-right: var(--border-width) solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg);
+  text-align: center;
+}
+
+.weekendHeader {
+  background: var(--color-bg-muted);
+}
+
+.todayHeader {
+  background: var(--color-accent-bg-subtle);
+  color: var(--color-accent);
+}
+
+.hourLabel {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+  text-align: right;
+  border-right: var(--border-width) solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
+  background: var(--color-bg-subtle);
+}
+
+.dayColumn {
+  position: relative;
+  border-right: var(--border-width) solid var(--color-border);
+}
+
+.weekendColumn {
+  background: var(--color-bg-muted);
+}
+
+.todayColumn {
+  background: var(--color-accent-bg-subtle);
+}
+
+.hourSeparator {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: var(--border-width);
+  background: var(--color-border);
+}
+
+.nowLine {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--color-danger);
+  z-index: 1;
+}

--- a/packages/design-system/src/components/Calendar/HourGrid.module.scss
+++ b/packages/design-system/src/components/Calendar/HourGrid.module.scss
@@ -72,11 +72,15 @@
   background: var(--color-border);
 }
 
+// The now-line sits above lane-stacked event blocks (z-index = lane + 1,
+// max ~10) but below the hover-lifted block (z-index 100), so it stays
+// visible across resting events and yields when a consumer is focused on
+// reading a specific block.
 .nowLine {
   position: absolute;
   left: 0;
   right: 0;
   height: var(--border-width-emphasis);
   background: var(--color-danger);
-  z-index: 1;
+  z-index: 50;
 }

--- a/packages/design-system/src/components/Calendar/HourGrid.tsx
+++ b/packages/design-system/src/components/Calendar/HourGrid.tsx
@@ -4,7 +4,7 @@ import { useLocale } from '../../i18n/useLocale';
 import { formatHour } from '../../calendar';
 import { isSameDay } from '../../calendar/dateMath';
 import { TimedEvent } from './TimedEvent';
-import type { CalendarEvent, TimedEventBlock } from './types';
+import type { CalendarEvent, CalendarView, RenderEvent, TimedEventBlock } from './types';
 import styles from './HourGrid.module.scss';
 
 /** Default hour-gutter width in pixels. */
@@ -23,6 +23,10 @@ export interface HourGridProps {
   timedBlocks: readonly TimedEventBlock[];
   /** Today's date (injected for testability). Defaults to `new Date()`. */
   now?: Date;
+  /** Which view is rendering this grid (`'week'` or `'day'`). Passed to `renderEvent`. */
+  view?: CalendarView;
+  /** Optional custom event renderer (replaces the inner chip content). */
+  renderEvent?: RenderEvent;
   /** Fires when a timed-event block in a day column is clicked. */
   onEventClick?: (event: CalendarEvent) => void;
 }
@@ -46,6 +50,8 @@ export function HourGrid({
   hourRowHeight,
   timedBlocks,
   now,
+  view = 'week',
+  renderEvent,
   onEventClick,
 }: HourGridProps) {
   const locale = useLocale();
@@ -82,7 +88,9 @@ export function HourGrid({
   const totalHours = hourRange[1] - hourRange[0];
   const nowMinutesFromStart =
     (currentTime.getHours() - hourRange[0]) * 60 + currentTime.getMinutes();
-  const nowVisible = nowMinutesFromStart >= 0 && nowMinutesFromStart <= totalHours * 60;
+  // Strict inequality on the upper bound so the now-line doesn't render
+  // on top of the bottom border when current time hits the end of hourRange.
+  const nowVisible = nowMinutesFromStart >= 0 && nowMinutesFromStart < totalHours * 60;
   const todayColumnIndex = days.findIndex((d) => isSameDay(d.date, currentTime));
 
   return (
@@ -149,6 +157,8 @@ export function HourGrid({
                   key={b.event.id}
                   block={b}
                   hourRowHeight={hourRowHeight}
+                  view={view}
+                  renderEvent={renderEvent}
                   onClick={onEventClick}
                 />
               ))}

--- a/packages/design-system/src/components/Calendar/HourGrid.tsx
+++ b/packages/design-system/src/components/Calendar/HourGrid.tsx
@@ -23,6 +23,7 @@ export interface HourGridProps {
   timedBlocks: readonly TimedEventBlock[];
   /** Today's date (injected for testability). Defaults to `new Date()`. */
   now?: Date;
+  /** Fires when a timed-event block in a day column is clicked. */
   onEventClick?: (event: CalendarEvent) => void;
 }
 

--- a/packages/design-system/src/components/Calendar/HourGrid.tsx
+++ b/packages/design-system/src/components/Calendar/HourGrid.tsx
@@ -31,6 +31,8 @@ export interface HourGridProps {
   onEventClick?: (event: CalendarEvent) => void;
   /** Fires when empty space inside a day column is clicked, with that column's date. */
   onDayClick?: (date: Date) => void;
+  /** ARIA label for the outer `role="grid"` container (e.g., week range or day label). */
+  ariaLabel: string;
 }
 
 /**
@@ -56,6 +58,7 @@ export function HourGrid({
   renderEvent,
   onEventClick,
   onDayClick,
+  ariaLabel,
 }: HourGridProps) {
   const locale = useLocale();
   const [tick, setTick] = useState(0);
@@ -99,6 +102,9 @@ export function HourGrid({
   return (
     <div className={styles.scroll}>
       <div
+        role="grid"
+        aria-readonly="true"
+        aria-label={ariaLabel}
         className={styles.grid}
         style={{
           gridTemplateColumns: `${HOUR_GUTTER_WIDTH}px repeat(${columnCount}, 1fr)`,

--- a/packages/design-system/src/components/Calendar/HourGrid.tsx
+++ b/packages/design-system/src/components/Calendar/HourGrid.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { useLocale } from '../../i18n/useLocale';
+import { formatHour } from '../../calendar';
+import { isSameDay } from '../../calendar/dateMath';
+import { TimedEvent } from './TimedEvent';
+import type { CalendarEvent, TimedEventBlock } from './types';
+import styles from './HourGrid.module.scss';
+
+/** Default hour-gutter width in pixels. */
+export const HOUR_GUTTER_WIDTH = 60;
+
+export interface HourGridProps {
+  /** One date per column (1 for DayView, 7 for WeekView). */
+  days: readonly { date: Date; key: string; isWeekend?: boolean }[];
+  /** Localized column header content (one per day). */
+  columnHeaders: readonly ReactNode[];
+  /** Inclusive start, exclusive end. */
+  hourRange: readonly [number, number];
+  /** Pixel height per hour row. */
+  hourRowHeight: number;
+  /** Timed events positioned within columns. */
+  timedBlocks: readonly TimedEventBlock[];
+  /** Today's date (injected for testability). Defaults to `new Date()`. */
+  now?: Date;
+  onEventClick?: (event: CalendarEvent) => void;
+}
+
+/**
+ * Internal: hour-grid scaffold for Week and Day views. Renders the column
+ * headers, hour gutter labels, the column bodies (with timed events
+ * positioned absolutely inside), and a horizontal "now" line in today's
+ * column when today is in the rendered range. Re-renders every minute so
+ * the now-line stays accurate.
+ *
+ * @remarks
+ * **When NOT to use:** Do not render `HourGrid` directly in application code —
+ * it is an internal building block consumed by `WeekView`/`DayView`. Use `Calendar`
+ * from the design system and pass events via the `events` prop.
+ */
+export function HourGrid({
+  days,
+  columnHeaders,
+  hourRange,
+  hourRowHeight,
+  timedBlocks,
+  now,
+  onEventClick,
+}: HourGridProps) {
+  const locale = useLocale();
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const id = window.setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+  // `tick` only exists to invalidate the time-derived memos
+  void tick;
+
+  const currentTime = now ?? new Date();
+
+  const hourLabels = useMemo(() => {
+    const labels: string[] = [];
+    for (let h = hourRange[0]; h < hourRange[1]; h++) {
+      labels.push(formatHour(h, locale));
+    }
+    return labels;
+  }, [hourRange, locale]);
+
+  const columnCount = days.length;
+  const blocksByDay = useMemo(() => {
+    const m = new Map<number, TimedEventBlock[]>();
+    for (const b of timedBlocks) {
+      const list = m.get(b.dayIndex) ?? [];
+      list.push(b);
+      m.set(b.dayIndex, list);
+    }
+    return m;
+  }, [timedBlocks]);
+
+  const totalHours = hourRange[1] - hourRange[0];
+  const nowMinutesFromStart =
+    (currentTime.getHours() - hourRange[0]) * 60 + currentTime.getMinutes();
+  const nowVisible = nowMinutesFromStart >= 0 && nowMinutesFromStart <= totalHours * 60;
+  const todayColumnIndex = days.findIndex((d) => isSameDay(d.date, currentTime));
+
+  return (
+    <div className={styles.scroll}>
+      <div
+        className={styles.grid}
+        style={{
+          gridTemplateColumns: `${HOUR_GUTTER_WIDTH}px repeat(${columnCount}, 1fr)`,
+          gridTemplateRows: `auto repeat(${totalHours}, ${hourRowHeight}px)`,
+        }}
+      >
+        <div className={styles.cornerCell} aria-hidden="true" />
+        {columnHeaders.map((header, i) => (
+          <div
+            key={`header-${days[i].key}`}
+            role="columnheader"
+            className={clsx(
+              styles.columnHeader,
+              days[i].isWeekend && styles.weekendHeader,
+              todayColumnIndex === i && styles.todayHeader,
+            )}
+          >
+            {header}
+          </div>
+        ))}
+        {hourLabels.map((label, h) => (
+          <div
+            key={`hour-${h}`}
+            className={styles.hourLabel}
+            style={{ gridColumn: 1, gridRow: h + 2 }}
+          >
+            {label}
+          </div>
+        ))}
+        {days.map((day, i) => {
+          const blocks = blocksByDay.get(i) ?? [];
+          return (
+            <div
+              key={day.key}
+              className={clsx(
+                styles.dayColumn,
+                day.isWeekend && styles.weekendColumn,
+                todayColumnIndex === i && styles.todayColumn,
+              )}
+              style={{ gridColumn: i + 2, gridRow: `2 / span ${totalHours}` }}
+            >
+              {Array.from({ length: totalHours }).map((_, h) => (
+                <div
+                  key={`sep-${h}`}
+                  className={styles.hourSeparator}
+                  style={{ top: h * hourRowHeight }}
+                  aria-hidden="true"
+                />
+              ))}
+              {nowVisible && todayColumnIndex === i && (
+                <div
+                  className={styles.nowLine}
+                  style={{ top: (nowMinutesFromStart / 60) * hourRowHeight }}
+                  aria-hidden="true"
+                />
+              )}
+              {blocks.map((b) => (
+                <TimedEvent
+                  key={b.event.id}
+                  block={b}
+                  hourRowHeight={hourRowHeight}
+                  onClick={onEventClick}
+                />
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/Calendar/HourGrid.tsx
+++ b/packages/design-system/src/components/Calendar/HourGrid.tsx
@@ -29,6 +29,8 @@ export interface HourGridProps {
   renderEvent?: RenderEvent;
   /** Fires when a timed-event block in a day column is clicked. */
   onEventClick?: (event: CalendarEvent) => void;
+  /** Fires when empty space inside a day column is clicked, with that column's date. */
+  onDayClick?: (date: Date) => void;
 }
 
 /**
@@ -53,6 +55,7 @@ export function HourGrid({
   view = 'week',
   renderEvent,
   onEventClick,
+  onDayClick,
 }: HourGridProps) {
   const locale = useLocale();
   const [tick, setTick] = useState(0);
@@ -102,20 +105,25 @@ export function HourGrid({
           gridTemplateRows: `auto repeat(${totalHours}, ${hourRowHeight}px)`,
         }}
       >
-        <div className={styles.cornerCell} aria-hidden="true" />
-        {columnHeaders.map((header, i) => (
-          <div
-            key={`header-${days[i].key}`}
-            role="columnheader"
-            className={clsx(
-              styles.columnHeader,
-              days[i].isWeekend && styles.weekendHeader,
-              todayColumnIndex === i && styles.todayHeader,
-            )}
-          >
-            {header}
-          </div>
-        ))}
+        {/* `display: contents` flattens this ARIA-row wrapper so each header
+           is a direct grid child of `.grid` while still satisfying the
+           WAI-ARIA grid contract (columnheader must live inside a row). */}
+        <div role="row" className={styles.headerRow}>
+          <div className={styles.cornerCell} aria-hidden="true" />
+          {columnHeaders.map((header, i) => (
+            <div
+              key={`header-${days[i].key}`}
+              role="columnheader"
+              className={clsx(
+                styles.columnHeader,
+                days[i].isWeekend && styles.weekendHeader,
+                todayColumnIndex === i && styles.todayHeader,
+              )}
+            >
+              {header}
+            </div>
+          ))}
+        </div>
         {hourLabels.map((label, h) => (
           <div
             key={`hour-${h}`}
@@ -127,15 +135,16 @@ export function HourGrid({
         ))}
         {days.map((day, i) => {
           const blocks = blocksByDay.get(i) ?? [];
+          // Background clicks on the day column fire `onDayClick`; clicks on
+          // a TimedEvent button stopPropagation in TimedEvent so they don't
+          // also fire this handler.
+          const handleColumnClick = onDayClick ? () => onDayClick(day.date) : undefined;
           return (
             <div
               key={day.key}
-              className={clsx(
-                styles.dayColumn,
-                day.isWeekend && styles.weekendColumn,
-                todayColumnIndex === i && styles.todayColumn,
-              )}
+              className={clsx(styles.dayColumn, day.isWeekend && styles.weekendColumn)}
               style={{ gridColumn: i + 2, gridRow: `2 / span ${totalHours}` }}
+              onClick={handleColumnClick}
             >
               {Array.from({ length: totalHours }).map((_, h) => (
                 <div

--- a/packages/design-system/src/components/Calendar/MonthView.module.scss
+++ b/packages/design-system/src/components/Calendar/MonthView.module.scss
@@ -55,8 +55,10 @@
   border-bottom: var(--border-width) solid var(--color-border);
 }
 
+// Today's cell uses a 2px accent border-top instead of a tinted background,
+// so events with the `accent` tone don't visually blend into the cell.
 .dayColumnToday {
-  background: var(--color-accent-bg-subtle);
+  box-shadow: inset 0 2px 0 var(--color-accent);
 }
 
 .dayColumnWeekend {

--- a/packages/design-system/src/components/Calendar/MonthView.module.scss
+++ b/packages/design-system/src/components/Calendar/MonthView.module.scss
@@ -55,10 +55,11 @@
   border-bottom: var(--border-width) solid var(--color-border);
 }
 
-// Today's cell uses a 2px accent border-top instead of a tinted background,
-// so events with the `accent` tone don't visually blend into the cell.
+// Today's cell uses an accent border-top (emphasis-weight) instead of a
+// tinted background, so events with the `accent` tone don't visually blend
+// into the cell.
 .dayColumnToday {
-  box-shadow: inset 0 2px 0 var(--color-accent);
+  box-shadow: inset 0 var(--border-width-emphasis) 0 var(--color-accent);
 }
 
 .dayColumnWeekend {

--- a/packages/design-system/src/components/Calendar/MonthView.module.scss
+++ b/packages/design-system/src/components/Calendar/MonthView.module.scss
@@ -50,7 +50,7 @@
    `min-height` makes empty weeks still look like cells without inflating
    the day-number row (events sit immediately below the day number). */
 .dayColumn {
-  min-height: 6.5rem;
+  min-height: var(--size-calendar-day-cell-min-height);
   border-right: var(--border-width) solid var(--color-border);
   border-bottom: var(--border-width) solid var(--color-border);
 }

--- a/packages/design-system/src/components/Calendar/MonthView.tsx
+++ b/packages/design-system/src/components/Calendar/MonthView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState, type KeyboardEvent } from 'r
 import clsx from 'clsx';
 import type { MonthGrid } from '../../calendar/types';
 import { addDays, addMonths, isSameDay, startOfWeek } from '../../calendar/dateMath';
-import type { CalendarEvent, EventBar } from './types';
+import type { CalendarEvent, EventBar, RenderEvent } from './types';
 import { layoutEventsForMonth } from './utils';
 import { DayCell } from './DayCell';
 import { EventChip } from './EventChip';
@@ -41,6 +41,8 @@ export interface MonthViewProps {
   onEventClick?: (event: CalendarEvent) => void;
   /** Localizable formatter for the "+N more" `aria-label`. */
   moreEventsLabel?: (count: number) => string;
+  /** Optional custom event renderer. See `RenderEvent` in `types.ts`. */
+  renderEvent?: RenderEvent;
 }
 
 /**
@@ -79,6 +81,7 @@ export function MonthView({
   onDayClick,
   onEventClick,
   moreEventsLabel = (n) => `${n} more events`,
+  renderEvent,
 }: MonthViewProps) {
   const layout = useMemo(
     () => layoutEventsForMonth(events, grid.weeks, maxLanesPerWeek),
@@ -250,6 +253,8 @@ export function MonthView({
                     event={bar.event}
                     continuesLeft={bar.continuesLeft}
                     continuesRight={bar.continuesRight}
+                    view="month"
+                    renderEvent={renderEvent}
                     onClick={(ev) => onEventClick?.(ev)}
                   />
                 </div>

--- a/packages/design-system/src/components/Calendar/TimedEvent.module.scss
+++ b/packages/design-system/src/components/Calendar/TimedEvent.module.scss
@@ -1,7 +1,13 @@
 @use '../../styles/mixins' as *;
 
 .block {
+  // Per-block cascade geometry is passed as CSS custom properties from
+  // TimedEvent.tsx so that :hover / :focus-visible can override left, width,
+  // and z-index without specificity fights with inline style.
   position: absolute;
+  left: var(--cal-block-left);
+  width: var(--cal-block-width);
+  z-index: var(--cal-block-z);
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -22,10 +28,18 @@
   cursor: pointer;
   user-select: none;
   transition:
+    left var(--transition-base),
+    width var(--transition-base),
     filter var(--transition-fast),
     background var(--transition-fast);
 
-  &:hover:not(:disabled) {
+  // Hover (and keyboard-focus) lifts the block to full column width and on
+  // top of any cascade neighbours. Animated via the transition above.
+  &:hover:not(:disabled),
+  &:focus-visible {
+    left: 0;
+    width: 100%;
+    z-index: var(--cal-block-z-hover);
     filter: brightness(0.95);
   }
 
@@ -46,6 +60,7 @@
   font-weight: var(--font-weight-regular);
   opacity: var(--opacity-muted);
   flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .title {

--- a/packages/design-system/src/components/Calendar/TimedEvent.module.scss
+++ b/packages/design-system/src/components/Calendar/TimedEvent.module.scss
@@ -1,0 +1,87 @@
+@use '../../styles/mixins' as *;
+
+.block {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border: var(--border-width) solid transparent;
+  border-radius: var(--radius-sm);
+  font-family: inherit;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.2;
+  text-align: left;
+  overflow: hidden;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    filter var(--transition-fast),
+    background var(--transition-fast);
+
+  &:hover:not(:disabled) {
+    filter: brightness(0.95);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+  }
+}
+
+.time {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-regular);
+  opacity: var(--opacity-muted);
+  flex-shrink: 0;
+}
+
+.title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tooltipBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.tooltipTime {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-regular);
+  color: var(--color-bg-subtle);
+}
+
+.tooltipTitle {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-bg);
+}
+
+.neutral {
+  background: var(--color-bg-subtle);
+  color: var(--color-fg);
+}
+
+.accent {
+  background: var(--color-accent-bg-subtle);
+  color: var(--color-accent);
+}
+
+.success {
+  background: var(--color-success-bg-subtle);
+  color: var(--color-success);
+}
+
+.warning {
+  background: var(--color-warning-bg-subtle);
+  color: var(--color-warning);
+}
+
+.danger {
+  background: var(--color-danger-bg-subtle);
+  color: var(--color-danger);
+}

--- a/packages/design-system/src/components/Calendar/TimedEvent.module.scss
+++ b/packages/design-system/src/components/Calendar/TimedEvent.module.scss
@@ -4,6 +4,7 @@
   position: absolute;
   display: flex;
   flex-direction: column;
+  align-items: stretch;
   gap: var(--space-1);
   padding: var(--space-1) var(--space-2);
   border: var(--border-width) solid transparent;
@@ -27,6 +28,13 @@
   &:focus-visible {
     @include focus-ring;
   }
+}
+
+// Short blocks (at min-height) use a single-line row layout so the start
+// time stays visible alongside the title in the limited vertical space.
+.short {
+  flex-direction: row;
+  align-items: center;
 }
 
 .time {

--- a/packages/design-system/src/components/Calendar/TimedEvent.module.scss
+++ b/packages/design-system/src/components/Calendar/TimedEvent.module.scss
@@ -7,7 +7,11 @@
   align-items: stretch;
   gap: var(--space-1);
   padding: var(--space-1) var(--space-2);
-  border: var(--border-width) solid transparent;
+
+  // Border is set per-tone (see rules below) so neutral blocks stay visible
+  // on the tinted today / weekend column backgrounds. Tone blocks get a
+  // border matching their accent color for the same reason.
+  border: var(--border-width) solid currentColor;
   border-radius: var(--radius-sm);
   font-family: inherit;
   font-size: var(--font-size-xs);
@@ -72,6 +76,7 @@
 .neutral {
   background: var(--color-bg-subtle);
   color: var(--color-fg);
+  border-color: var(--color-border-strong);
 }
 
 .accent {

--- a/packages/design-system/src/components/Calendar/TimedEvent.tsx
+++ b/packages/design-system/src/components/Calendar/TimedEvent.tsx
@@ -4,7 +4,13 @@ import { useLocale } from '../../i18n/useLocale';
 import { formatTime } from '../../calendar';
 import { Tooltip } from '../Tooltip';
 import { formatEventDuration } from './utils';
-import type { CalendarEvent, CalendarEventTone, TimedEventBlock } from './types';
+import type {
+  CalendarEvent,
+  CalendarEventTone,
+  CalendarView,
+  RenderEvent,
+  TimedEventBlock,
+} from './types';
 import styles from './TimedEvent.module.scss';
 
 export interface TimedEventProps {
@@ -12,6 +18,10 @@ export interface TimedEventProps {
   block: TimedEventBlock;
   /** Pixel height per hour row (matches the hour-grid scaffold). */
   hourRowHeight: number;
+  /** Which view is rendering this chip (`'week'` or `'day'`). Passed to `renderEvent` for branching. */
+  view?: CalendarView;
+  /** Optional custom inner content. When set, replaces the default time + title spans. */
+  renderEvent?: RenderEvent;
   /** Fires when the chip is clicked; receives the `CalendarEvent`. */
   onClick?: (event: CalendarEvent) => void;
 }
@@ -28,7 +38,13 @@ export interface TimedEventProps {
  */
 const MIN_BLOCK_HEIGHT_PX = 20;
 
-export function TimedEvent({ block, hourRowHeight, onClick }: TimedEventProps) {
+export function TimedEvent({
+  block,
+  hourRowHeight,
+  view = 'week',
+  renderEvent,
+  onClick,
+}: TimedEventProps) {
   const locale = useLocale();
   const tone: CalendarEventTone = block.event.tone ?? 'neutral';
 
@@ -66,6 +82,15 @@ export function TimedEvent({ block, hourRowHeight, onClick }: TimedEventProps) {
   // stack time above title in a column for more breathing room.
   const isShort = height < MIN_BLOCK_HEIGHT_PX + 10;
 
+  const customContent = renderEvent
+    ? renderEvent(block.event, {
+        view,
+        asAllDay: false,
+        timeLabel,
+        duration,
+      })
+    : null;
+
   return (
     <Tooltip content={tooltipContent}>
       <button
@@ -74,8 +99,14 @@ export function TimedEvent({ block, hourRowHeight, onClick }: TimedEventProps) {
         style={{ top, height, width, left }}
         onClick={handleClick}
       >
-        <span className={styles.time}>{timeLabel}</span>
-        <span className={styles.title}>{block.event.title}</span>
+        {customContent !== null ? (
+          customContent
+        ) : (
+          <>
+            <span className={styles.time}>{timeLabel}</span>
+            <span className={styles.title}>{block.event.title}</span>
+          </>
+        )}
       </button>
     </Tooltip>
   );

--- a/packages/design-system/src/components/Calendar/TimedEvent.tsx
+++ b/packages/design-system/src/components/Calendar/TimedEvent.tsx
@@ -1,0 +1,73 @@
+import { useMemo, type MouseEvent } from 'react';
+import clsx from 'clsx';
+import { useLocale } from '../../i18n/useLocale';
+import { formatTime } from '../../calendar';
+import { Tooltip } from '../Tooltip';
+import type { CalendarEvent, CalendarEventTone, TimedEventBlock } from './types';
+import styles from './TimedEvent.module.scss';
+
+export interface TimedEventProps {
+  /** Placed block produced by `layoutEventsForHourGrid`. */
+  block: TimedEventBlock;
+  /** Pixel height per hour row (matches the hour-grid scaffold). */
+  hourRowHeight: number;
+  onClick?: (event: CalendarEvent) => void;
+}
+
+/**
+ * Internal: a single timed-event block, absolutely positioned inside an
+ * hour-grid day column. Tone-styled, wrapped in a Tooltip so the full
+ * "time range + title" is reachable even when the chip is short.
+ *
+ * @remarks
+ * **When NOT to use:** Do not render `TimedEvent` directly in application code —
+ * it is an internal building block consumed by `HourGrid`. Use `Calendar` (or
+ * `WeekView`/`DayView`) from the design system and pass events via the `events` prop.
+ */
+export function TimedEvent({ block, hourRowHeight, onClick }: TimedEventProps) {
+  const locale = useLocale();
+  const tone: CalendarEventTone = block.event.tone ?? 'neutral';
+
+  const top = (block.startMinutes / 60) * hourRowHeight;
+  const height = ((block.endMinutes - block.startMinutes) / 60) * hourRowHeight;
+  const width = `${100 / block.laneCount}%`;
+  const left = `${(100 / block.laneCount) * block.lane}%`;
+
+  const timeLabel = useMemo(
+    () =>
+      `${formatTime(block.event.startsAt, locale)} – ${formatTime(
+        block.event.endsAt ?? block.event.startsAt,
+        locale,
+      )}`,
+    [block.event.startsAt, block.event.endsAt, locale],
+  );
+
+  const tooltipContent = (
+    <span className={styles.tooltipBody}>
+      <span className={styles.tooltipTime}>{timeLabel}</span>
+      <span className={styles.tooltipTitle}>{block.event.title}</span>
+    </span>
+  );
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onClick?.(block.event);
+  };
+
+  // Short events (<30 visible px) drop the time prefix and show title only.
+  const isShort = height < 30;
+
+  return (
+    <Tooltip content={tooltipContent}>
+      <button
+        type="button"
+        className={clsx(styles.block, styles[tone])}
+        style={{ top, height, width, left }}
+        onClick={handleClick}
+      >
+        {!isShort && <span className={styles.time}>{timeLabel}</span>}
+        <span className={styles.title}>{block.event.title}</span>
+      </button>
+    </Tooltip>
+  );
+}

--- a/packages/design-system/src/components/Calendar/TimedEvent.tsx
+++ b/packages/design-system/src/components/Calendar/TimedEvent.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { useLocale } from '../../i18n/useLocale';
 import { formatTime } from '../../calendar';
 import { Tooltip } from '../Tooltip';
+import { formatEventDuration } from './utils';
 import type { CalendarEvent, CalendarEventTone, TimedEventBlock } from './types';
 import styles from './TimedEvent.module.scss';
 
@@ -25,12 +26,15 @@ export interface TimedEventProps {
  * it is an internal building block consumed by `HourGrid`. Use `Calendar` (or
  * `WeekView`/`DayView`) from the design system and pass events via the `events` prop.
  */
+const MIN_BLOCK_HEIGHT_PX = 20;
+
 export function TimedEvent({ block, hourRowHeight, onClick }: TimedEventProps) {
   const locale = useLocale();
   const tone: CalendarEventTone = block.event.tone ?? 'neutral';
 
   const top = (block.startMinutes / 60) * hourRowHeight;
-  const height = ((block.endMinutes - block.startMinutes) / 60) * hourRowHeight;
+  const rawHeight = ((block.endMinutes - block.startMinutes) / 60) * hourRowHeight;
+  const height = Math.max(rawHeight, MIN_BLOCK_HEIGHT_PX);
   const width = `${100 / block.laneCount}%`;
   const left = `${(100 / block.laneCount) * block.lane}%`;
 
@@ -43,9 +47,12 @@ export function TimedEvent({ block, hourRowHeight, onClick }: TimedEventProps) {
     [block.event.startsAt, block.event.endsAt, locale],
   );
 
+  const duration = formatEventDuration(block.event.startsAt, block.event.endsAt);
   const tooltipContent = (
     <span className={styles.tooltipBody}>
-      <span className={styles.tooltipTime}>{timeLabel}</span>
+      <span className={styles.tooltipTime}>
+        {timeLabel} · {duration}
+      </span>
       <span className={styles.tooltipTitle}>{block.event.title}</span>
     </span>
   );
@@ -55,8 +62,8 @@ export function TimedEvent({ block, hourRowHeight, onClick }: TimedEventProps) {
     onClick?.(block.event);
   };
 
-  // Short events (<30 visible px) drop the time prefix and show title only.
-  const isShort = height < 30;
+  // Short events (at or near min-height) drop the time prefix and show title only.
+  const isShort = height < MIN_BLOCK_HEIGHT_PX + 10;
 
   return (
     <Tooltip content={tooltipContent}>

--- a/packages/design-system/src/components/Calendar/TimedEvent.tsx
+++ b/packages/design-system/src/components/Calendar/TimedEvent.tsx
@@ -11,6 +11,7 @@ export interface TimedEventProps {
   block: TimedEventBlock;
   /** Pixel height per hour row (matches the hour-grid scaffold). */
   hourRowHeight: number;
+  /** Fires when the chip is clicked; receives the `CalendarEvent`. */
   onClick?: (event: CalendarEvent) => void;
 }
 

--- a/packages/design-system/src/components/Calendar/TimedEvent.tsx
+++ b/packages/design-system/src/components/Calendar/TimedEvent.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type MouseEvent } from 'react';
+import { type MouseEvent } from 'react';
 import clsx from 'clsx';
 import { useLocale } from '../../i18n/useLocale';
 import { formatTime } from '../../calendar';
@@ -38,14 +38,13 @@ export function TimedEvent({ block, hourRowHeight, onClick }: TimedEventProps) {
   const width = `${100 / block.laneCount}%`;
   const left = `${(100 / block.laneCount) * block.lane}%`;
 
-  const timeLabel = useMemo(
-    () =>
-      `${formatTime(block.event.startsAt, locale)} – ${formatTime(
-        block.event.endsAt ?? block.event.startsAt,
-        locale,
-      )}`,
-    [block.event.startsAt, block.event.endsAt, locale],
-  );
+  const startLabel = formatTime(block.event.startsAt, locale);
+  const endLabel = block.event.endsAt ? formatTime(block.event.endsAt, locale) : null;
+
+  // For zero-duration events the start and end times are the same (or there's
+  // no endsAt) — collapse to a single time label rather than "9:30 AM – 9:30 AM".
+  const isZeroDuration = !endLabel || endLabel === startLabel;
+  const timeLabel = isZeroDuration ? startLabel : `${startLabel} – ${endLabel}`;
 
   const duration = formatEventDuration(block.event.startsAt, block.event.endsAt);
   const tooltipContent = (
@@ -62,18 +61,20 @@ export function TimedEvent({ block, hourRowHeight, onClick }: TimedEventProps) {
     onClick?.(block.event);
   };
 
-  // Short events (at or near min-height) drop the time prefix and show title only.
+  // Short events use a single-line row layout (time + title side-by-side)
+  // so the start time stays visible even on min-height blocks. Tall events
+  // stack time above title in a column for more breathing room.
   const isShort = height < MIN_BLOCK_HEIGHT_PX + 10;
 
   return (
     <Tooltip content={tooltipContent}>
       <button
         type="button"
-        className={clsx(styles.block, styles[tone])}
+        className={clsx(styles.block, styles[tone], isShort && styles.short)}
         style={{ top, height, width, left }}
         onClick={handleClick}
       >
-        {!isShort && <span className={styles.time}>{timeLabel}</span>}
+        <span className={styles.time}>{timeLabel}</span>
         <span className={styles.title}>{block.event.title}</span>
       </button>
     </Tooltip>

--- a/packages/design-system/src/components/Calendar/TimedEvent.tsx
+++ b/packages/design-system/src/components/Calendar/TimedEvent.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent } from 'react';
+import { type CSSProperties, type MouseEvent } from 'react';
 import clsx from 'clsx';
 import { useLocale } from '../../i18n/useLocale';
 import { formatTime } from '../../calendar';
@@ -37,6 +37,10 @@ export interface TimedEventProps {
  * `WeekView`/`DayView`) from the design system and pass events via the `events` prop.
  */
 const MIN_BLOCK_HEIGHT_PX = 20;
+/** Percent of the day column each cascade lane is offset to the right. */
+const LANE_OFFSET_PERCENT = 10;
+/** Z-index used for the hovered / focused block — sits above any lane. */
+const HOVER_Z_INDEX = 100;
 
 export function TimedEvent({
   block,
@@ -51,8 +55,14 @@ export function TimedEvent({
   const top = (block.startMinutes / 60) * hourRowHeight;
   const rawHeight = ((block.endMinutes - block.startMinutes) / 60) * hourRowHeight;
   const height = Math.max(rawHeight, MIN_BLOCK_HEIGHT_PX);
-  const width = `${100 / block.laneCount}%`;
-  const left = `${(100 / block.laneCount) * block.lane}%`;
+  // Google-Calendar-style cascade: each lane shifts right by a small,
+  // constant step but every block still extends to the column's right edge.
+  // Higher lanes overlay earlier ones via z-index, so later events
+  // partially cover the one beneath them while keeping the predecessor's
+  // left edge visible. On hover, the block lifts to full width and on top
+  // — see `:hover` rules in TimedEvent.module.scss.
+  const leftPercent = LANE_OFFSET_PERCENT * block.lane;
+  const zIndex = block.lane + 1;
 
   const startLabel = formatTime(block.event.startsAt, locale);
   const endLabel = block.event.endsAt ? formatTime(block.event.endsAt, locale) : null;
@@ -96,7 +106,16 @@ export function TimedEvent({
       <button
         type="button"
         className={clsx(styles.block, styles[tone], isShort && styles.short)}
-        style={{ top, height, width, left }}
+        style={
+          {
+            top,
+            height,
+            '--cal-block-left': `${leftPercent}%`,
+            '--cal-block-width': `${100 - leftPercent}%`,
+            '--cal-block-z': zIndex,
+            '--cal-block-z-hover': HOVER_Z_INDEX,
+          } as CSSProperties
+        }
         onClick={handleClick}
       >
         {customContent !== null ? (

--- a/packages/design-system/src/components/Calendar/ViewSwitcher.module.scss
+++ b/packages/design-system/src/components/Calendar/ViewSwitcher.module.scss
@@ -1,0 +1,3 @@
+.switcher {
+  display: flex;
+}

--- a/packages/design-system/src/components/Calendar/ViewSwitcher.tsx
+++ b/packages/design-system/src/components/Calendar/ViewSwitcher.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Tabs } from '../Tabs';
 import type { CalendarView } from './types';
 import styles from './ViewSwitcher.module.scss';
@@ -9,12 +10,6 @@ export interface ViewSwitcherProps {
   weekLabel: string;
   dayLabel: string;
 }
-
-const ITEMS = (monthLabel: string, weekLabel: string, dayLabel: string) => [
-  { id: 'month', label: monthLabel },
-  { id: 'week', label: weekLabel },
-  { id: 'day', label: dayLabel },
-];
 
 /**
  * Internal: segmented control for switching between month / week / day views.
@@ -31,12 +26,21 @@ export function ViewSwitcher({
   weekLabel,
   dayLabel,
 }: ViewSwitcherProps) {
+  const items = useMemo(
+    () => [
+      { id: 'month', label: monthLabel },
+      { id: 'week', label: weekLabel },
+      { id: 'day', label: dayLabel },
+    ],
+    [monthLabel, weekLabel, dayLabel],
+  );
+
   return (
     <div className={styles.switcher}>
       <Tabs
         activeId={view}
         onChange={(id) => onViewChange(id as CalendarView)}
-        items={ITEMS(monthLabel, weekLabel, dayLabel)}
+        items={items}
       />
     </div>
   );

--- a/packages/design-system/src/components/Calendar/ViewSwitcher.tsx
+++ b/packages/design-system/src/components/Calendar/ViewSwitcher.tsx
@@ -37,11 +37,7 @@ export function ViewSwitcher({
 
   return (
     <div className={styles.switcher}>
-      <Tabs
-        activeId={view}
-        onChange={(id) => onViewChange(id as CalendarView)}
-        items={items}
-      />
+      <Tabs activeId={view} onChange={(id) => onViewChange(id as CalendarView)} items={items} />
     </div>
   );
 }

--- a/packages/design-system/src/components/Calendar/ViewSwitcher.tsx
+++ b/packages/design-system/src/components/Calendar/ViewSwitcher.tsx
@@ -1,0 +1,43 @@
+import { Tabs } from '../Tabs';
+import type { CalendarView } from './types';
+import styles from './ViewSwitcher.module.scss';
+
+export interface ViewSwitcherProps {
+  view: CalendarView;
+  onViewChange: (view: CalendarView) => void;
+  monthLabel: string;
+  weekLabel: string;
+  dayLabel: string;
+}
+
+const ITEMS = (monthLabel: string, weekLabel: string, dayLabel: string) => [
+  { id: 'month', label: monthLabel },
+  { id: 'week', label: weekLabel },
+  { id: 'day', label: dayLabel },
+];
+
+/**
+ * Internal: segmented control for switching between month / week / day views.
+ * Uses the design system's `<Tabs>` for ARIA + keyboard navigation.
+ *
+ * @remarks
+ * **When NOT to use:** Do not render `ViewSwitcher` directly. It is composed
+ * by the `Calendar` shell. Use `<Calendar view ... onViewChange ...>`.
+ */
+export function ViewSwitcher({
+  view,
+  onViewChange,
+  monthLabel,
+  weekLabel,
+  dayLabel,
+}: ViewSwitcherProps) {
+  return (
+    <div className={styles.switcher}>
+      <Tabs
+        activeId={view}
+        onChange={(id) => onViewChange(id as CalendarView)}
+        items={ITEMS(monthLabel, weekLabel, dayLabel)}
+      />
+    </div>
+  );
+}

--- a/packages/design-system/src/components/Calendar/WeekView.module.scss
+++ b/packages/design-system/src/components/Calendar/WeekView.module.scss
@@ -1,0 +1,8 @@
+.weekView {
+  display: flex;
+  flex-direction: column;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-bg);
+}

--- a/packages/design-system/src/components/Calendar/WeekView.test.tsx
+++ b/packages/design-system/src/components/Calendar/WeekView.test.tsx
@@ -93,7 +93,11 @@ describe('WeekView', () => {
     expect(container.querySelectorAll('[class*="hourLabel"]').length).toBe(8);
   });
 
-  it('places overlapping events side-by-side (each width 50%)', () => {
+  it('renders overlapping events as a Google-style cascade (full width, small lane offset)', () => {
+    // Cascade: each lane shifts right by LANE_OFFSET_PERCENT (10%); every
+    // block still extends to the column's right edge. Later lanes overlay
+    // earlier ones via z-index, so the second event covers the first's
+    // right portion while leaving the predecessor's left edge visible.
     const events: CalendarEvent[] = [
       {
         id: 'a',
@@ -113,8 +117,12 @@ describe('WeekView', () => {
     });
     const a = screen.getByRole('button', { name: /Standup/ });
     const b = screen.getByRole('button', { name: /1:1/ });
-    expect(a).toHaveStyle({ width: '50%' });
-    expect(b).toHaveStyle({ width: '50%' });
+    expect(a.style.getPropertyValue('--cal-block-left')).toBe('0%');
+    expect(a.style.getPropertyValue('--cal-block-width')).toBe('100%');
+    expect(a.style.getPropertyValue('--cal-block-z')).toBe('1');
+    expect(b.style.getPropertyValue('--cal-block-left')).toBe('10%');
+    expect(b.style.getPropertyValue('--cal-block-width')).toBe('90%');
+    expect(b.style.getPropertyValue('--cal-block-z')).toBe('2');
   });
 
   it('uses locale-aware column headers (ru-RU has Cyrillic)', () => {

--- a/packages/design-system/src/components/Calendar/WeekView.test.tsx
+++ b/packages/design-system/src/components/Calendar/WeekView.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { LocaleProvider } from '../../i18n/LocaleProvider';
+import { WeekView } from './WeekView';
+import type { CalendarEvent } from './types';
+
+function wrap(locale = 'en-US') {
+  return ({ children }: { children: ReactNode }) => (
+    <LocaleProvider locale={locale}>{children}</LocaleProvider>
+  );
+}
+
+describe('WeekView', () => {
+  const cursor = new Date(2026, 4, 20); // Wed May 20
+
+  it('renders 7 column headers', () => {
+    render(
+      <WeekView cursor={cursor} events={[]} hourRange={[7, 19]} hourRowHeight={48} />,
+      { wrapper: wrap() },
+    );
+    expect(screen.getAllByRole('columnheader').length).toBe(7);
+  });
+
+  it('renders 12 hour labels for the default 7-19 range', () => {
+    const { container } = render(
+      <WeekView cursor={cursor} events={[]} hourRange={[7, 19]} hourRowHeight={48} />,
+      { wrapper: wrap() },
+    );
+    expect(container.querySelectorAll('[class*="hourLabel"]').length).toBe(12);
+  });
+
+  it('renders a timed event block', () => {
+    const events: CalendarEvent[] = [
+      { id: 'a', title: 'Standup', startsAt: new Date(2026, 4, 20, 9), endsAt: new Date(2026, 4, 20, 10) },
+    ];
+    render(
+      <WeekView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />,
+      { wrapper: wrap() },
+    );
+    expect(screen.getByRole('button', { name: /Standup/ })).toBeInTheDocument();
+  });
+
+  it('fires onEventClick when a timed event is clicked', async () => {
+    const onEventClick = vi.fn();
+    const user = userEvent.setup();
+    const events: CalendarEvent[] = [
+      { id: 'a', title: 'Standup', startsAt: new Date(2026, 4, 20, 9), endsAt: new Date(2026, 4, 20, 10) },
+    ];
+    render(
+      <WeekView
+        cursor={cursor}
+        events={events}
+        hourRange={[7, 19]}
+        hourRowHeight={48}
+        onEventClick={onEventClick}
+      />,
+      { wrapper: wrap() },
+    );
+    await user.click(screen.getByRole('button', { name: /Standup/ }));
+    expect(onEventClick).toHaveBeenCalledWith(events[0]);
+  });
+
+  it('renders an allDay event in the AllDayBand', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 'conf',
+        title: 'Conference',
+        startsAt: new Date(2026, 4, 18),
+        endsAt: new Date(2026, 4, 22),
+        allDay: true,
+      },
+    ];
+    render(
+      <WeekView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />,
+      { wrapper: wrap() },
+    );
+    expect(screen.getByRole('button', { name: /Conference/ })).toBeInTheDocument();
+  });
+
+  it('respects custom hourRange', () => {
+    const { container } = render(
+      <WeekView cursor={cursor} events={[]} hourRange={[9, 17]} hourRowHeight={48} />,
+      { wrapper: wrap() },
+    );
+    expect(container.querySelectorAll('[class*="hourLabel"]').length).toBe(8);
+  });
+
+  it('places overlapping events side-by-side (each width 50%)', () => {
+    const events: CalendarEvent[] = [
+      { id: 'a', title: 'Standup', startsAt: new Date(2026, 4, 20, 9), endsAt: new Date(2026, 4, 20, 10, 30) },
+      { id: 'b', title: '1:1', startsAt: new Date(2026, 4, 20, 10), endsAt: new Date(2026, 4, 20, 11) },
+    ];
+    render(
+      <WeekView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />,
+      { wrapper: wrap() },
+    );
+    const a = screen.getByRole('button', { name: /Standup/ });
+    const b = screen.getByRole('button', { name: /1:1/ });
+    expect(a).toHaveStyle({ width: '50%' });
+    expect(b).toHaveStyle({ width: '50%' });
+  });
+
+  it('uses locale-aware column headers (ru-RU has Cyrillic)', () => {
+    render(
+      <WeekView cursor={cursor} events={[]} hourRange={[7, 19]} hourRowHeight={48} locale="ru-RU" />,
+      { wrapper: wrap('ru-RU') },
+    );
+    const headers = screen.getAllByRole('columnheader');
+    const text = headers.map((h) => h.textContent ?? '').join(' ');
+    expect(text).toMatch(/[Ѐ-ӿ]/);
+  });
+});

--- a/packages/design-system/src/components/Calendar/WeekView.test.tsx
+++ b/packages/design-system/src/components/Calendar/WeekView.test.tsx
@@ -15,10 +15,9 @@ describe('WeekView', () => {
   const cursor = new Date(2026, 4, 20); // Wed May 20
 
   it('renders 7 column headers', () => {
-    render(
-      <WeekView cursor={cursor} events={[]} hourRange={[7, 19]} hourRowHeight={48} />,
-      { wrapper: wrap() },
-    );
+    render(<WeekView cursor={cursor} events={[]} hourRange={[7, 19]} hourRowHeight={48} />, {
+      wrapper: wrap(),
+    });
     expect(screen.getAllByRole('columnheader').length).toBe(7);
   });
 
@@ -32,12 +31,16 @@ describe('WeekView', () => {
 
   it('renders a timed event block', () => {
     const events: CalendarEvent[] = [
-      { id: 'a', title: 'Standup', startsAt: new Date(2026, 4, 20, 9), endsAt: new Date(2026, 4, 20, 10) },
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 10),
+      },
     ];
-    render(
-      <WeekView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />,
-      { wrapper: wrap() },
-    );
+    render(<WeekView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />, {
+      wrapper: wrap(),
+    });
     expect(screen.getByRole('button', { name: /Standup/ })).toBeInTheDocument();
   });
 
@@ -45,7 +48,12 @@ describe('WeekView', () => {
     const onEventClick = vi.fn();
     const user = userEvent.setup();
     const events: CalendarEvent[] = [
-      { id: 'a', title: 'Standup', startsAt: new Date(2026, 4, 20, 9), endsAt: new Date(2026, 4, 20, 10) },
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 10),
+      },
     ];
     render(
       <WeekView
@@ -71,10 +79,9 @@ describe('WeekView', () => {
         allDay: true,
       },
     ];
-    render(
-      <WeekView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />,
-      { wrapper: wrap() },
-    );
+    render(<WeekView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />, {
+      wrapper: wrap(),
+    });
     expect(screen.getByRole('button', { name: /Conference/ })).toBeInTheDocument();
   });
 
@@ -88,13 +95,22 @@ describe('WeekView', () => {
 
   it('places overlapping events side-by-side (each width 50%)', () => {
     const events: CalendarEvent[] = [
-      { id: 'a', title: 'Standup', startsAt: new Date(2026, 4, 20, 9), endsAt: new Date(2026, 4, 20, 10, 30) },
-      { id: 'b', title: '1:1', startsAt: new Date(2026, 4, 20, 10), endsAt: new Date(2026, 4, 20, 11) },
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 10, 30),
+      },
+      {
+        id: 'b',
+        title: '1:1',
+        startsAt: new Date(2026, 4, 20, 10),
+        endsAt: new Date(2026, 4, 20, 11),
+      },
     ];
-    render(
-      <WeekView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />,
-      { wrapper: wrap() },
-    );
+    render(<WeekView cursor={cursor} events={events} hourRange={[7, 19]} hourRowHeight={48} />, {
+      wrapper: wrap(),
+    });
     const a = screen.getByRole('button', { name: /Standup/ });
     const b = screen.getByRole('button', { name: /1:1/ });
     expect(a).toHaveStyle({ width: '50%' });
@@ -103,7 +119,13 @@ describe('WeekView', () => {
 
   it('uses locale-aware column headers (ru-RU has Cyrillic)', () => {
     render(
-      <WeekView cursor={cursor} events={[]} hourRange={[7, 19]} hourRowHeight={48} locale="ru-RU" />,
+      <WeekView
+        cursor={cursor}
+        events={[]}
+        hourRange={[7, 19]}
+        hourRowHeight={48}
+        locale="ru-RU"
+      />,
       { wrapper: wrap('ru-RU') },
     );
     const headers = screen.getAllByRole('columnheader');

--- a/packages/design-system/src/components/Calendar/WeekView.test.tsx
+++ b/packages/design-system/src/components/Calendar/WeekView.test.tsx
@@ -125,6 +125,143 @@ describe('WeekView', () => {
     expect(b.style.getPropertyValue('--cal-block-z')).toBe('2');
   });
 
+  it('fires onDayClick when empty hour-grid space is clicked', async () => {
+    const onDayClick = vi.fn<(d: Date) => void>();
+    const events: CalendarEvent[] = [
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 10),
+      },
+    ];
+    const { container } = render(
+      <WeekView
+        cursor={cursor}
+        events={events}
+        hourRange={[7, 19]}
+        hourRowHeight={48}
+        onDayClick={onDayClick}
+      />,
+      { wrapper: wrap() },
+    );
+    // Click the empty hour-grid column for Wed May 20 (column index 3 when
+    // week starts on Sunday in en-US).
+    const columns = container.querySelectorAll<HTMLDivElement>('[class*="dayColumn"]');
+    await userEvent.click(columns[3]);
+    expect(onDayClick).toHaveBeenCalledTimes(1);
+    expect(onDayClick.mock.calls[0][0].getDate()).toBe(20);
+  });
+
+  it('clicking a timed event does NOT also fire onDayClick (stopPropagation)', async () => {
+    const onDayClick = vi.fn();
+    const events: CalendarEvent[] = [
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 10),
+      },
+    ];
+    render(
+      <WeekView
+        cursor={cursor}
+        events={events}
+        hourRange={[7, 19]}
+        hourRowHeight={48}
+        onDayClick={onDayClick}
+      />,
+      { wrapper: wrap() },
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Standup/ }));
+    expect(onDayClick).not.toHaveBeenCalled();
+  });
+
+  it('renderEvent receives view-aware context for timed and all-day events', () => {
+    const calls: Array<{ id: string; view: string; asAllDay: boolean; duration: string }> = [];
+    const events: CalendarEvent[] = [
+      {
+        id: 'timed',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9),
+        endsAt: new Date(2026, 4, 20, 9, 30),
+      },
+      {
+        id: 'all',
+        title: 'Conference',
+        startsAt: new Date(2026, 4, 20),
+        endsAt: new Date(2026, 4, 21),
+        allDay: true,
+      },
+    ];
+    render(
+      <WeekView
+        cursor={cursor}
+        events={events}
+        hourRange={[7, 19]}
+        hourRowHeight={48}
+        renderEvent={(event, ctx) => {
+          calls.push({
+            id: event.id,
+            view: ctx.view,
+            asAllDay: ctx.asAllDay,
+            duration: ctx.duration,
+          });
+          return <span>{event.title}</span>;
+        }}
+      />,
+      { wrapper: wrap() },
+    );
+    const timed = calls.find((c) => c.id === 'timed');
+    const all = calls.find((c) => c.id === 'all');
+    expect(timed).toMatchObject({ view: 'week', asAllDay: false, duration: '30m' });
+    expect(all).toMatchObject({ view: 'week', asAllDay: true });
+  });
+
+  it('renders the now-line only when the current time falls inside hourRange and inside today’s column', () => {
+    // Set "now" to noon on cursor day (Wed May 20) — inside the 7-19 range.
+    const insideNow = new Date(2026, 4, 20, 12, 0);
+    const { container, rerender } = render(
+      <WeekView
+        cursor={cursor}
+        events={[]}
+        hourRange={[7, 19]}
+        hourRowHeight={48}
+        now={insideNow}
+      />,
+      { wrapper: wrap() },
+    );
+    const nowLines = container.querySelectorAll('[class*="nowLine"]');
+    expect(nowLines).toHaveLength(1);
+    // Sits in today's column — the one with the todayColumn class on its parent.
+    const todayColumn = nowLines[0].parentElement!;
+    expect(todayColumn.className).toMatch(/dayColumn/);
+
+    // Re-render with `now` BEFORE the hourRange start — no line.
+    rerender(
+      <WeekView
+        cursor={cursor}
+        events={[]}
+        hourRange={[7, 19]}
+        hourRowHeight={48}
+        now={new Date(2026, 4, 20, 5, 0)}
+      />,
+    );
+    expect(container.querySelectorAll('[class*="nowLine"]')).toHaveLength(0);
+
+    // Re-render with `now` AT the hourRange end (exclusive upper bound) — no line.
+    rerender(
+      <WeekView
+        cursor={cursor}
+        events={[]}
+        hourRange={[7, 19]}
+        hourRowHeight={48}
+        now={new Date(2026, 4, 20, 19, 0)}
+      />,
+    );
+    expect(container.querySelectorAll('[class*="nowLine"]')).toHaveLength(0);
+  });
+
   it('uses locale-aware column headers (ru-RU has Cyrillic)', () => {
     render(
       <WeekView

--- a/packages/design-system/src/components/Calendar/WeekView.tsx
+++ b/packages/design-system/src/components/Calendar/WeekView.tsx
@@ -23,8 +23,12 @@ export interface WeekViewProps {
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   /** Fires when a timed-event block or all-day chip is clicked. */
   onEventClick?: (event: CalendarEvent) => void;
+  /** Fires when empty hour-grid space inside a day column is clicked, with that column's date. */
+  onDayClick?: (date: Date) => void;
   /** Optional custom event renderer (see `RenderEvent`). */
   renderEvent?: RenderEvent;
+  /** Override the "now" clock for the now-line. For tests; defaults to `new Date()`. */
+  now?: Date;
 }
 
 /**
@@ -44,7 +48,9 @@ export function WeekView({
   locale: localeOverride,
   weekStartsOn,
   onEventClick,
+  onDayClick,
   renderEvent,
+  now,
 }: WeekViewProps) {
   const contextLocale = useLocale();
   const locale = localeOverride ?? contextLocale;
@@ -91,6 +97,8 @@ export function WeekView({
         view="week"
         renderEvent={renderEvent}
         onEventClick={onEventClick}
+        onDayClick={onDayClick}
+        now={now}
       />
     </div>
   );

--- a/packages/design-system/src/components/Calendar/WeekView.tsx
+++ b/packages/design-system/src/components/Calendar/WeekView.tsx
@@ -1,0 +1,90 @@
+import { useMemo } from 'react';
+import { useWeek } from '../../calendar/useWeek';
+import { useLocale } from '../../i18n/useLocale';
+import { formatWeekdayShort } from '../../calendar/formatters';
+import { AllDayBand } from './AllDayBand';
+import { HourGrid, HOUR_GUTTER_WIDTH } from './HourGrid';
+import { layoutEventsForHourGrid } from './utils';
+import type { CalendarEvent } from './types';
+import styles from './WeekView.module.scss';
+
+export interface WeekViewProps {
+  /** Navigation cursor — any date in the target week works. */
+  cursor: Date;
+  /** Events to display across the week. */
+  events: readonly CalendarEvent[];
+  /** Inclusive start, exclusive end of the visible hour range. */
+  hourRange: readonly [number, number];
+  /** Pixel height per hour row. */
+  hourRowHeight: number;
+  /** Override locale (otherwise reads `useLocale()`). */
+  locale?: string;
+  /** Override locale-derived first day of week (0=Sun..6=Sat). */
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  /** Fires when a timed-event block or all-day chip is clicked. */
+  onEventClick?: (event: CalendarEvent) => void;
+}
+
+/**
+ * Internal: 7-day hour grid. Shows the week containing `cursor`, with an
+ * AllDayBand above and an HourGrid below.
+ *
+ * @remarks
+ * **When NOT to use:** Do not render `WeekView` directly in application code —
+ * use the `Calendar` shell component, which owns view state and navigation
+ * and dispatches into `WeekView` when `view === 'week'`.
+ */
+export function WeekView({
+  cursor,
+  events,
+  hourRange,
+  hourRowHeight,
+  locale: localeOverride,
+  weekStartsOn,
+  onEventClick,
+}: WeekViewProps) {
+  const contextLocale = useLocale();
+  const locale = localeOverride ?? contextLocale;
+  const week = useWeek(cursor, { locale, weekStartsOn });
+
+  const layout = useMemo(
+    () =>
+      layoutEventsForHourGrid(
+        events,
+        week.days.map((d) => ({ date: d.date, key: d.key })),
+        hourRange,
+      ),
+    [events, week.days, hourRange],
+  );
+
+  const headers = week.days.map((d) => (
+    <span>
+      {formatWeekdayShort(d.date, locale)} <strong>{d.dayOfMonth}</strong>
+    </span>
+  ));
+
+  const dayRefs = week.days.map((d) => ({
+    date: d.date,
+    key: d.key,
+    isWeekend: d.isWeekend,
+  }));
+
+  return (
+    <div className={styles.weekView}>
+      <AllDayBand
+        bars={layout.allDayBars}
+        columnCount={7}
+        gutterWidth={HOUR_GUTTER_WIDTH}
+        onEventClick={onEventClick}
+      />
+      <HourGrid
+        days={dayRefs}
+        columnHeaders={headers}
+        hourRange={hourRange}
+        hourRowHeight={hourRowHeight}
+        timedBlocks={layout.timedBlocks}
+        onEventClick={onEventClick}
+      />
+    </div>
+  );
+}

--- a/packages/design-system/src/components/Calendar/WeekView.tsx
+++ b/packages/design-system/src/components/Calendar/WeekView.tsx
@@ -5,7 +5,7 @@ import { formatWeekdayShort } from '../../calendar/formatters';
 import { AllDayBand } from './AllDayBand';
 import { HourGrid, HOUR_GUTTER_WIDTH } from './HourGrid';
 import { layoutEventsForHourGrid } from './utils';
-import type { CalendarEvent } from './types';
+import type { CalendarEvent, RenderEvent } from './types';
 import styles from './WeekView.module.scss';
 
 export interface WeekViewProps {
@@ -23,6 +23,8 @@ export interface WeekViewProps {
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   /** Fires when a timed-event block or all-day chip is clicked. */
   onEventClick?: (event: CalendarEvent) => void;
+  /** Optional custom event renderer (see `RenderEvent`). */
+  renderEvent?: RenderEvent;
 }
 
 /**
@@ -42,6 +44,7 @@ export function WeekView({
   locale: localeOverride,
   weekStartsOn,
   onEventClick,
+  renderEvent,
 }: WeekViewProps) {
   const contextLocale = useLocale();
   const locale = localeOverride ?? contextLocale;
@@ -75,6 +78,8 @@ export function WeekView({
         bars={layout.allDayBars}
         columnCount={7}
         gutterWidth={HOUR_GUTTER_WIDTH}
+        view="week"
+        renderEvent={renderEvent}
         onEventClick={onEventClick}
       />
       <HourGrid
@@ -83,6 +88,8 @@ export function WeekView({
         hourRange={hourRange}
         hourRowHeight={hourRowHeight}
         timedBlocks={layout.timedBlocks}
+        view="week"
+        renderEvent={renderEvent}
         onEventClick={onEventClick}
       />
     </div>

--- a/packages/design-system/src/components/Calendar/WeekView.tsx
+++ b/packages/design-system/src/components/Calendar/WeekView.tsx
@@ -99,6 +99,7 @@ export function WeekView({
         onEventClick={onEventClick}
         onDayClick={onDayClick}
         now={now}
+        ariaLabel={week.weekLabel}
       />
     </div>
   );

--- a/packages/design-system/src/components/Calendar/index.ts
+++ b/packages/design-system/src/components/Calendar/index.ts
@@ -6,4 +6,6 @@ export type {
   CalendarView,
   EventBar,
   MonthLayout,
+  RenderEvent,
+  RenderEventContext,
 } from './types';

--- a/packages/design-system/src/components/Calendar/types.ts
+++ b/packages/design-system/src/components/Calendar/types.ts
@@ -136,4 +136,7 @@ export interface RenderEventContext {
  * tooltip, and tone background — return content with inline `background` /
  * `style` to override colors.
  */
-export type RenderEvent = (event: CalendarEvent, ctx: RenderEventContext) => import('react').ReactNode;
+export type RenderEvent = (
+  event: CalendarEvent,
+  ctx: RenderEventContext,
+) => import('react').ReactNode;

--- a/packages/design-system/src/components/Calendar/types.ts
+++ b/packages/design-system/src/components/Calendar/types.ts
@@ -84,10 +84,8 @@ export interface TimedEventBlock {
   startMinutes: number;
   /** Minutes from `hourRange[0] * 60`. May exceed `(hourRange[1] - hourRange[0]) * 60`. */
   endMinutes: number;
-  /** 0..laneCount-1 — horizontal lane within the collision group. */
+  /** Cascade lane within the collision group (0..N). Drives both left offset and z-index. */
   lane: number;
-  /** Lane count for this block's collision group. */
-  laneCount: number;
 }
 
 /**

--- a/packages/design-system/src/components/Calendar/types.ts
+++ b/packages/design-system/src/components/Calendar/types.ts
@@ -27,10 +27,9 @@ export interface CalendarEvent {
 }
 
 /**
- * Active Calendar view. Only `'month'` ships in this PR; the union extends in
- * later PRs to `'week' | 'day' | 'agenda'`.
+ * Active Calendar view. Month + week + day in v3. Agenda lands in PR 4.
  */
-export type CalendarView = 'month';
+export type CalendarView = 'month' | 'week' | 'day';
 
 /**
  * One placed event bar inside the month grid. Produced by
@@ -61,4 +60,48 @@ export interface MonthLayout {
    * Keyed by `toDateKey(day)`. Used by `DayCell` to render "+N more".
    */
   hiddenCounts: ReadonlyMap<string, number>;
+}
+
+/**
+ * One positioned timed-event block inside an `<HourGrid>` column. Produced
+ * by `layoutEventsForHourGrid` and consumed by `WeekView`/`DayView`.
+ */
+export interface TimedEventBlock {
+  event: CalendarEvent;
+  /** Column index within the rendered view (0..N-1; always 0 for DayView). */
+  dayIndex: number;
+  /** Minutes from `hourRange[0] * 60`. May be negative if the event started earlier. */
+  startMinutes: number;
+  /** Minutes from `hourRange[0] * 60`. May exceed `(hourRange[1] - hourRange[0]) * 60`. */
+  endMinutes: number;
+  /** 0..laneCount-1 — horizontal lane within the day's collision group. */
+  lane: number;
+  /** Lane count for this block's collision group; bar width = `100% / laneCount`. */
+  laneCount: number;
+}
+
+/**
+ * One bar in the AllDayBand (above the hour grid in WeekView/DayView).
+ * Multi-day events span columns as a single visual element.
+ */
+export interface AllDayBar {
+  event: CalendarEvent;
+  /** First column the bar covers (inclusive, 0-indexed within the view). */
+  startCol: number;
+  /** Last column the bar covers (inclusive). */
+  endCol: number;
+  /** 0..N — row position within the band stack. */
+  lane: number;
+  /** True when the event begins before the view's first day. */
+  continuesLeft: boolean;
+  /** True when the event continues past the view's last day. */
+  continuesRight: boolean;
+}
+
+/** Result of `layoutEventsForHourGrid`. */
+export interface HourGridLayout {
+  /** Positioned timed-event blocks, one per non-allDay event placed in the view. */
+  timedBlocks: readonly TimedEventBlock[];
+  /** Continuous bars in the all-day band above the hour grid. */
+  allDayBars: readonly AllDayBar[];
 }

--- a/packages/design-system/src/components/Calendar/types.ts
+++ b/packages/design-system/src/components/Calendar/types.ts
@@ -105,3 +105,35 @@ export interface HourGridLayout {
   /** Continuous bars in the all-day band above the hour grid. */
   allDayBars: readonly AllDayBar[];
 }
+
+/**
+ * Context passed to a `renderEvent` callback. The chip wrapper (button +
+ * tone background + tooltip + click handler + positioning) stays default;
+ * the consumer's returned ReactNode replaces the inner content (time + title
+ * labels). To override the chip's background fully, wrap your content in an
+ * element with `position: absolute; inset: 0; background: ...` so it covers
+ * the default tone fill.
+ */
+export interface RenderEventContext {
+  /** Which view is rendering this chip. */
+  view: CalendarView;
+  /** True when the chip is in the all-day band (week/day) or `event.allDay` (month). */
+  asAllDay: boolean;
+  /** True when the bar continues from a previous week (multi-day events). */
+  continuesLeft?: boolean;
+  /** True when the bar continues into a next week (multi-day events). */
+  continuesRight?: boolean;
+  /** Pre-formatted time label. Single time (e.g., "9:00 AM") for zero-duration; range otherwise. Absent for all-day. */
+  timeLabel?: string;
+  /** Pre-formatted human duration ("30m" / "1h 30m" / "2d 5h"). */
+  duration: string;
+}
+
+/**
+ * Custom event renderer. When provided on `<Calendar>`, it's called for every
+ * event chip across views; the returned ReactNode replaces the inner content
+ * of the default chip. The chip wrapper still handles positioning, click,
+ * tooltip, and tone background — return content with inline `background` /
+ * `style` to override colors.
+ */
+export type RenderEvent = (event: CalendarEvent, ctx: RenderEventContext) => import('react').ReactNode;

--- a/packages/design-system/src/components/Calendar/types.ts
+++ b/packages/design-system/src/components/Calendar/types.ts
@@ -65,6 +65,17 @@ export interface MonthLayout {
 /**
  * One positioned timed-event block inside an `<HourGrid>` column. Produced
  * by `layoutEventsForHourGrid` and consumed by `WeekView`/`DayView`.
+ *
+ * Horizontal placement (Google-Calendar-style cascade):
+ * - Lanes are offset to the right by a fixed step rather than partitioning
+ *   the column. Higher lanes overlay earlier ones (z-index = lane index),
+ *   so a later/right-side event partially covers the one beneath it.
+ * - With `step = 100 / (laneCount + 1)` percent, a singleton in any lane is
+ *   `2 * step` wide. For 2 overlapping events the geometry comes out to
+ *   ~67% each with a ~33% offset; for 3, ~50% each with ~25% offset.
+ * - `widthInLanes` lets a block expand further right when no higher-lane
+ *   neighbour overlaps it in time. Render with
+ *   `left = lane * step` and `width = (widthInLanes + 1) * step`.
  */
 export interface TimedEventBlock {
   event: CalendarEvent;
@@ -74,9 +85,9 @@ export interface TimedEventBlock {
   startMinutes: number;
   /** Minutes from `hourRange[0] * 60`. May exceed `(hourRange[1] - hourRange[0]) * 60`. */
   endMinutes: number;
-  /** 0..laneCount-1 — horizontal lane within the day's collision group. */
+  /** 0..laneCount-1 — horizontal lane within the collision group. */
   lane: number;
-  /** Lane count for this block's collision group; bar width = `100% / laneCount`. */
+  /** Lane count for this block's collision group. */
   laneCount: number;
 }
 

--- a/packages/design-system/src/components/Calendar/types.ts
+++ b/packages/design-system/src/components/Calendar/types.ts
@@ -67,15 +67,14 @@ export interface MonthLayout {
  * by `layoutEventsForHourGrid` and consumed by `WeekView`/`DayView`.
  *
  * Horizontal placement (Google-Calendar-style cascade):
- * - Lanes are offset to the right by a fixed step rather than partitioning
- *   the column. Higher lanes overlay earlier ones (z-index = lane index),
- *   so a later/right-side event partially covers the one beneath it.
- * - With `step = 100 / (laneCount + 1)` percent, a singleton in any lane is
- *   `2 * step` wide. For 2 overlapping events the geometry comes out to
- *   ~67% each with a ~33% offset; for 3, ~50% each with ~25% offset.
- * - `widthInLanes` lets a block expand further right when no higher-lane
- *   neighbour overlaps it in time. Render with
- *   `left = lane * step` and `width = (widthInLanes + 1) * step`.
+ * - Lanes are offset to the right by a small constant step per lane
+ *   (`LANE_OFFSET_PERCENT` in TimedEvent.tsx — currently 10% of the column
+ *   width). Every block still extends to the column's right edge.
+ * - Higher lanes overlay earlier ones via `z-index = lane + 1`, so the
+ *   later/right-side event partially covers the one beneath while keeping
+ *   the predecessor's left edge visible.
+ * - On hover or keyboard focus, a block lifts to `left: 0; width: 100%`
+ *   above all neighbours — see TimedEvent.module.scss.
  */
 export interface TimedEventBlock {
   event: CalendarEvent;
@@ -146,6 +145,12 @@ export interface RenderEventContext {
  * of the default chip. The chip wrapper still handles positioning, click,
  * tooltip, and tone background — return content with inline `background` /
  * `style` to override colors.
+ *
+ * Note on layout: for hour-grid blocks shorter than ~30px tall (`isShort`),
+ * the wrapping `<button>` switches from `flex-direction: column` to `row`
+ * to keep the start time visible alongside the title. Author your inner
+ * content so it works in both layouts (e.g., let text shrink with
+ * `min-width: 0; overflow: hidden` instead of pinning a fixed width).
  */
 export type RenderEvent = (
   event: CalendarEvent,

--- a/packages/design-system/src/components/Calendar/utils.test.tsx
+++ b/packages/design-system/src/components/Calendar/utils.test.tsx
@@ -469,15 +469,11 @@ describe('formatEventDuration', () => {
   });
 
   it('counts allDay events inclusively (May 20 → May 22 reads as "3d")', () => {
-    expect(
-      formatEventDuration(new Date(2026, 4, 20), new Date(2026, 4, 22), true),
-    ).toBe('3d');
+    expect(formatEventDuration(new Date(2026, 4, 20), new Date(2026, 4, 22), true)).toBe('3d');
   });
 
   it('counts single-day allDay events as "1d"', () => {
-    expect(
-      formatEventDuration(new Date(2026, 4, 20), new Date(2026, 4, 20), true),
-    ).toBe('1d');
+    expect(formatEventDuration(new Date(2026, 4, 20), new Date(2026, 4, 20), true)).toBe('1d');
   });
 
   it('counts allDay event with no endsAt as "1d"', () => {

--- a/packages/design-system/src/components/Calendar/utils.test.tsx
+++ b/packages/design-system/src/components/Calendar/utils.test.tsx
@@ -253,7 +253,7 @@ describe('layoutEventsForHourGrid', () => {
     expect(out.allDayBars).toEqual([]);
   });
 
-  it('places a single timed event in column 0 with lane=0, laneCount=1', () => {
+  it('places a single timed event in column 0 with lane=0', () => {
     const out = layoutEventsForHourGrid([tev('a', 20, 9, 10)], day1, [7, 19]);
     expect(out.timedBlocks).toHaveLength(1);
     expect(out.timedBlocks[0]).toMatchObject({
@@ -261,7 +261,6 @@ describe('layoutEventsForHourGrid', () => {
       startMinutes: 120,
       endMinutes: 180,
       lane: 0,
-      laneCount: 1,
     });
   });
 
@@ -270,37 +269,30 @@ describe('layoutEventsForHourGrid', () => {
     expect(out.timedBlocks).toHaveLength(2);
     expect(out.timedBlocks[0].lane).toBe(0);
     expect(out.timedBlocks[1].lane).toBe(0);
-    expect(out.timedBlocks[0].laneCount).toBe(1);
-    expect(out.timedBlocks[1].laneCount).toBe(1);
   });
 
-  it('places two overlapping events on lanes 0 and 1, both laneCount=2', () => {
+  it('places two overlapping events on lanes 0 and 1', () => {
     const out = layoutEventsForHourGrid([tev('a', 20, 9, 11), tev('b', 20, 10, 12)], day1, [7, 19]);
     expect(out.timedBlocks).toHaveLength(2);
     const byId = new Map(out.timedBlocks.map((b) => [b.event.id, b]));
     expect(byId.get('a')!.lane).toBe(0);
     expect(byId.get('b')!.lane).toBe(1);
-    expect(byId.get('a')!.laneCount).toBe(2);
-    expect(byId.get('b')!.laneCount).toBe(2);
   });
 
-  it('places three mutually overlapping events with laneCount=3', () => {
+  it('places three mutually overlapping events on lanes 0, 1, 2', () => {
     const out = layoutEventsForHourGrid(
       [tev('a', 20, 9, 11), tev('b', 20, 9, 11), tev('c', 20, 9, 11)],
       day1,
       [7, 19],
     );
     expect(out.timedBlocks).toHaveLength(3);
-    out.timedBlocks.forEach((b) => expect(b.laneCount).toBe(3));
     const lanes = out.timedBlocks.map((b) => b.lane).sort();
     expect(lanes).toEqual([0, 1, 2]);
   });
 
-  it('chain A-B-C: recycles A’s lane for C; laneCount=2 across the transitive group', () => {
+  it('chain A-B-C: recycles A’s lane for C (lanes 0, 1, 0 in transitive group)', () => {
     // A (9:00-10:30) and B (10:00-11:00) overlap → A=lane0, B=lane1.
     // C (10:45-12:00) starts after A ends → reuses lane 0.
-    // Group has 3 transitive members but only 2 lanes are ever active at once,
-    // so the cascade renders with laneCount=2 (10% offset for lane 1).
     const out = layoutEventsForHourGrid(
       [
         {
@@ -325,7 +317,6 @@ describe('layoutEventsForHourGrid', () => {
       day1,
       [7, 19],
     );
-    out.timedBlocks.forEach((b) => expect(b.laneCount).toBe(2));
     const byId = new Map(out.timedBlocks.map((b) => [b.event.id, b]));
     expect(byId.get('a')!.lane).toBe(0);
     expect(byId.get('b')!.lane).toBe(1);

--- a/packages/design-system/src/components/Calendar/utils.test.tsx
+++ b/packages/design-system/src/components/Calendar/utils.test.tsx
@@ -404,4 +404,26 @@ describe('layoutEventsForHourGrid', () => {
     expect(out.timedBlocks[0].startMinutes).toBe(-60);
     expect(out.timedBlocks[0].endMinutes).toBe(60);
   });
+
+  it('clamps endMinutes to end-of-day when a timed event spans multiple days', () => {
+    // Event: May 19 14:00 → May 21 09:00 (spans 3 days)
+    // In a [7, 19] view rendered for the week of May 17..23, this event
+    // should appear on May 19 (dayIndex=2 in Sun-start week)
+    // with endMinutes clamped to 24*60 - 7*60 = 1020 (= end of day past
+    // the visible range; TimedEvent will render as a block extending past
+    // the bottom of the column).
+    const ev: CalendarEvent = {
+      id: 'multi',
+      title: 'Conference call',
+      startsAt: new Date(2026, 4, 19, 14, 0),
+      endsAt: new Date(2026, 4, 21, 9, 0),
+    };
+    const out = layoutEventsForHourGrid([ev], week7, [7, 19]);
+    expect(out.timedBlocks).toHaveLength(1);
+    expect(out.timedBlocks[0].dayIndex).toBe(2); // May 19 in Sun-start week 17..23
+    expect(out.timedBlocks[0].startMinutes).toBe(7 * 60); // 14:00 - 7:00 = 7h = 420min
+    // 24:00 (end-of-day) − 7:00 (hour-range base) = 17h = 1020min
+    expect(out.timedBlocks[0].endMinutes).toBe(1020);
+    expect(out.timedBlocks[0].endMinutes).toBeGreaterThan(out.timedBlocks[0].startMinutes);
+  });
 });

--- a/packages/design-system/src/components/Calendar/utils.test.tsx
+++ b/packages/design-system/src/components/Calendar/utils.test.tsx
@@ -296,7 +296,11 @@ describe('layoutEventsForHourGrid', () => {
     expect(lanes).toEqual([0, 1, 2]);
   });
 
-  it('groups by transitive overlap (chain A-B, B-C → all laneCount=3 even if A and C disjoint)', () => {
+  it('chain A-B-C: recycles A’s lane for C; laneCount=2 across the transitive group', () => {
+    // A (9:00-10:30) and B (10:00-11:00) overlap → A=lane0, B=lane1.
+    // C (10:45-12:00) starts after A ends → reuses lane 0.
+    // Group has 3 transitive members but only 2 lanes are ever active at once,
+    // so the cascade renders with laneCount=2 (10% offset for lane 1).
     const out = layoutEventsForHourGrid(
       [
         {
@@ -321,7 +325,11 @@ describe('layoutEventsForHourGrid', () => {
       day1,
       [7, 19],
     );
-    out.timedBlocks.forEach((b) => expect(b.laneCount).toBe(3));
+    out.timedBlocks.forEach((b) => expect(b.laneCount).toBe(2));
+    const byId = new Map(out.timedBlocks.map((b) => [b.event.id, b]));
+    expect(byId.get('a')!.lane).toBe(0);
+    expect(byId.get('b')!.lane).toBe(1);
+    expect(byId.get('c')!.lane).toBe(0);
   });
 
   it('puts a multi-day event into allDayBars when allDay is true', () => {

--- a/packages/design-system/src/components/Calendar/utils.test.tsx
+++ b/packages/design-system/src/components/Calendar/utils.test.tsx
@@ -266,11 +266,7 @@ describe('layoutEventsForHourGrid', () => {
   });
 
   it('places two non-overlapping events on the same lane', () => {
-    const out = layoutEventsForHourGrid(
-      [tev('a', 20, 9, 10), tev('b', 20, 11, 12)],
-      day1,
-      [7, 19],
-    );
+    const out = layoutEventsForHourGrid([tev('a', 20, 9, 10), tev('b', 20, 11, 12)], day1, [7, 19]);
     expect(out.timedBlocks).toHaveLength(2);
     expect(out.timedBlocks[0].lane).toBe(0);
     expect(out.timedBlocks[1].lane).toBe(0);
@@ -279,11 +275,7 @@ describe('layoutEventsForHourGrid', () => {
   });
 
   it('places two overlapping events on lanes 0 and 1, both laneCount=2', () => {
-    const out = layoutEventsForHourGrid(
-      [tev('a', 20, 9, 11), tev('b', 20, 10, 12)],
-      day1,
-      [7, 19],
-    );
+    const out = layoutEventsForHourGrid([tev('a', 20, 9, 11), tev('b', 20, 10, 12)], day1, [7, 19]);
     expect(out.timedBlocks).toHaveLength(2);
     const byId = new Map(out.timedBlocks.map((b) => [b.event.id, b]));
     expect(byId.get('a')!.lane).toBe(0);
@@ -307,9 +299,24 @@ describe('layoutEventsForHourGrid', () => {
   it('groups by transitive overlap (chain A-B, B-C → all laneCount=3 even if A and C disjoint)', () => {
     const out = layoutEventsForHourGrid(
       [
-        { id: 'a', title: 'a', startsAt: new Date(2026, 4, 20, 9, 0), endsAt: new Date(2026, 4, 20, 10, 30) },
-        { id: 'b', title: 'b', startsAt: new Date(2026, 4, 20, 10, 0), endsAt: new Date(2026, 4, 20, 11, 0) },
-        { id: 'c', title: 'c', startsAt: new Date(2026, 4, 20, 10, 45), endsAt: new Date(2026, 4, 20, 12, 0) },
+        {
+          id: 'a',
+          title: 'a',
+          startsAt: new Date(2026, 4, 20, 9, 0),
+          endsAt: new Date(2026, 4, 20, 10, 30),
+        },
+        {
+          id: 'b',
+          title: 'b',
+          startsAt: new Date(2026, 4, 20, 10, 0),
+          endsAt: new Date(2026, 4, 20, 11, 0),
+        },
+        {
+          id: 'c',
+          title: 'c',
+          startsAt: new Date(2026, 4, 20, 10, 45),
+          endsAt: new Date(2026, 4, 20, 12, 0),
+        },
       ],
       day1,
       [7, 19],

--- a/packages/design-system/src/components/Calendar/utils.test.tsx
+++ b/packages/design-system/src/components/Calendar/utils.test.tsx
@@ -467,4 +467,20 @@ describe('formatEventDuration', () => {
       '2d 5h',
     );
   });
+
+  it('counts allDay events inclusively (May 20 → May 22 reads as "3d")', () => {
+    expect(
+      formatEventDuration(new Date(2026, 4, 20), new Date(2026, 4, 22), true),
+    ).toBe('3d');
+  });
+
+  it('counts single-day allDay events as "1d"', () => {
+    expect(
+      formatEventDuration(new Date(2026, 4, 20), new Date(2026, 4, 20), true),
+    ).toBe('1d');
+  });
+
+  it('counts allDay event with no endsAt as "1d"', () => {
+    expect(formatEventDuration(new Date(2026, 4, 20), undefined, true)).toBe('1d');
+  });
 });

--- a/packages/design-system/src/components/Calendar/utils.test.tsx
+++ b/packages/design-system/src/components/Calendar/utils.test.tsx
@@ -441,21 +441,21 @@ describe('formatEventDuration', () => {
   });
 
   it('returns "30m" for sub-hour events', () => {
-    expect(
-      formatEventDuration(new Date(2026, 4, 20, 9, 0), new Date(2026, 4, 20, 9, 30)),
-    ).toBe('30m');
+    expect(formatEventDuration(new Date(2026, 4, 20, 9, 0), new Date(2026, 4, 20, 9, 30))).toBe(
+      '30m',
+    );
   });
 
   it('returns "1h" for exact-hour events', () => {
-    expect(
-      formatEventDuration(new Date(2026, 4, 20, 9, 0), new Date(2026, 4, 20, 10, 0)),
-    ).toBe('1h');
+    expect(formatEventDuration(new Date(2026, 4, 20, 9, 0), new Date(2026, 4, 20, 10, 0))).toBe(
+      '1h',
+    );
   });
 
   it('returns "1h 30m" for one-and-a-half hours', () => {
-    expect(
-      formatEventDuration(new Date(2026, 4, 20, 9, 0), new Date(2026, 4, 20, 10, 30)),
-    ).toBe('1h 30m');
+    expect(formatEventDuration(new Date(2026, 4, 20, 9, 0), new Date(2026, 4, 20, 10, 30))).toBe(
+      '1h 30m',
+    );
   });
 
   it('returns "2d" for exact two-day events', () => {
@@ -463,8 +463,8 @@ describe('formatEventDuration', () => {
   });
 
   it('returns "2d 5h" for two-day five-hour events', () => {
-    expect(
-      formatEventDuration(new Date(2026, 4, 20, 9, 0), new Date(2026, 4, 22, 14, 0)),
-    ).toBe('2d 5h');
+    expect(formatEventDuration(new Date(2026, 4, 20, 9, 0), new Date(2026, 4, 22, 14, 0))).toBe(
+      '2d 5h',
+    );
   });
 });

--- a/packages/design-system/src/components/Calendar/utils.test.tsx
+++ b/packages/design-system/src/components/Calendar/utils.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { useMonth } from '../../calendar/useMonth';
 import { LocaleProvider } from '../../i18n/LocaleProvider';
 import type { CalendarEvent } from './types';
-import { layoutEventsForMonth } from './utils';
+import { layoutEventsForMonth, layoutEventsForHourGrid } from './utils';
 import type { ReactNode } from 'react';
 
 function wrapEnUS({ children }: { children: ReactNode }) {
@@ -225,5 +225,183 @@ describe('layoutEventsForMonth', () => {
     expect(out.hiddenCounts.get('2026-05-12')).toBe(1);
     expect(out.hiddenCounts.get('2026-05-13')).toBe(1);
     expect(out.hiddenCounts.get('2026-05-14')).toBe(1);
+  });
+});
+
+describe('layoutEventsForHourGrid', () => {
+  // Helper: a list of 1 day = May 20 2026 (Wed)
+  const day1 = [{ date: new Date(2026, 4, 20), key: '2026-05-20' }];
+
+  // Helper: a list of 7 days = May 17..23 (Sun-Sat)
+  const week7 = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(2026, 4, 17 + i);
+    return { date: d, key: `2026-05-${String(17 + i).padStart(2, '0')}` };
+  });
+
+  function tev(id: string, day: number, startHour: number, endHour: number): CalendarEvent {
+    return {
+      id,
+      title: id,
+      startsAt: new Date(2026, 4, day, startHour, 0),
+      endsAt: new Date(2026, 4, day, endHour, 0),
+    };
+  }
+
+  it('returns empty layout for no events', () => {
+    const out = layoutEventsForHourGrid([], day1, [7, 19]);
+    expect(out.timedBlocks).toEqual([]);
+    expect(out.allDayBars).toEqual([]);
+  });
+
+  it('places a single timed event in column 0 with lane=0, laneCount=1', () => {
+    const out = layoutEventsForHourGrid([tev('a', 20, 9, 10)], day1, [7, 19]);
+    expect(out.timedBlocks).toHaveLength(1);
+    expect(out.timedBlocks[0]).toMatchObject({
+      dayIndex: 0,
+      startMinutes: 120,
+      endMinutes: 180,
+      lane: 0,
+      laneCount: 1,
+    });
+  });
+
+  it('places two non-overlapping events on the same lane', () => {
+    const out = layoutEventsForHourGrid(
+      [tev('a', 20, 9, 10), tev('b', 20, 11, 12)],
+      day1,
+      [7, 19],
+    );
+    expect(out.timedBlocks).toHaveLength(2);
+    expect(out.timedBlocks[0].lane).toBe(0);
+    expect(out.timedBlocks[1].lane).toBe(0);
+    expect(out.timedBlocks[0].laneCount).toBe(1);
+    expect(out.timedBlocks[1].laneCount).toBe(1);
+  });
+
+  it('places two overlapping events on lanes 0 and 1, both laneCount=2', () => {
+    const out = layoutEventsForHourGrid(
+      [tev('a', 20, 9, 11), tev('b', 20, 10, 12)],
+      day1,
+      [7, 19],
+    );
+    expect(out.timedBlocks).toHaveLength(2);
+    const byId = new Map(out.timedBlocks.map((b) => [b.event.id, b]));
+    expect(byId.get('a')!.lane).toBe(0);
+    expect(byId.get('b')!.lane).toBe(1);
+    expect(byId.get('a')!.laneCount).toBe(2);
+    expect(byId.get('b')!.laneCount).toBe(2);
+  });
+
+  it('places three mutually overlapping events with laneCount=3', () => {
+    const out = layoutEventsForHourGrid(
+      [tev('a', 20, 9, 11), tev('b', 20, 9, 11), tev('c', 20, 9, 11)],
+      day1,
+      [7, 19],
+    );
+    expect(out.timedBlocks).toHaveLength(3);
+    out.timedBlocks.forEach((b) => expect(b.laneCount).toBe(3));
+    const lanes = out.timedBlocks.map((b) => b.lane).sort();
+    expect(lanes).toEqual([0, 1, 2]);
+  });
+
+  it('groups by transitive overlap (chain A-B, B-C → all laneCount=3 even if A and C disjoint)', () => {
+    const out = layoutEventsForHourGrid(
+      [
+        { id: 'a', title: 'a', startsAt: new Date(2026, 4, 20, 9, 0), endsAt: new Date(2026, 4, 20, 10, 30) },
+        { id: 'b', title: 'b', startsAt: new Date(2026, 4, 20, 10, 0), endsAt: new Date(2026, 4, 20, 11, 0) },
+        { id: 'c', title: 'c', startsAt: new Date(2026, 4, 20, 10, 45), endsAt: new Date(2026, 4, 20, 12, 0) },
+      ],
+      day1,
+      [7, 19],
+    );
+    out.timedBlocks.forEach((b) => expect(b.laneCount).toBe(3));
+  });
+
+  it('puts a multi-day event into allDayBars when allDay is true', () => {
+    const out = layoutEventsForHourGrid(
+      [
+        {
+          id: 'conf',
+          title: 'Conference',
+          startsAt: new Date(2026, 4, 18),
+          endsAt: new Date(2026, 4, 22),
+          allDay: true,
+        },
+      ],
+      week7,
+      [7, 19],
+    );
+    expect(out.timedBlocks).toEqual([]);
+    expect(out.allDayBars).toHaveLength(1);
+    expect(out.allDayBars[0]).toMatchObject({
+      startCol: 1,
+      endCol: 5,
+      lane: 0,
+      continuesLeft: false,
+      continuesRight: false,
+    });
+  });
+
+  it('clips an allDay event extending before the view to startCol=0 with continuesLeft', () => {
+    const out = layoutEventsForHourGrid(
+      [
+        {
+          id: 'conf',
+          title: 'Conference',
+          startsAt: new Date(2026, 4, 15),
+          endsAt: new Date(2026, 4, 20),
+          allDay: true,
+        },
+      ],
+      week7,
+      [7, 19],
+    );
+    expect(out.allDayBars).toHaveLength(1);
+    expect(out.allDayBars[0]).toMatchObject({
+      startCol: 0,
+      endCol: 3,
+      continuesLeft: true,
+      continuesRight: false,
+    });
+  });
+
+  it('clips an allDay event extending past the view with continuesRight', () => {
+    const out = layoutEventsForHourGrid(
+      [
+        {
+          id: 'conf',
+          title: 'Conference',
+          startsAt: new Date(2026, 4, 22),
+          endsAt: new Date(2026, 4, 28),
+          allDay: true,
+        },
+      ],
+      week7,
+      [7, 19],
+    );
+    expect(out.allDayBars[0]).toMatchObject({
+      startCol: 5,
+      endCol: 6,
+      continuesLeft: false,
+      continuesRight: true,
+    });
+  });
+
+  it('drops events entirely outside the view', () => {
+    const out = layoutEventsForHourGrid([tev('a', 25, 9, 10)], day1, [7, 19]);
+    expect(out.timedBlocks).toEqual([]);
+  });
+
+  it('places events at the correct dayIndex within a week', () => {
+    const out = layoutEventsForHourGrid([tev('a', 20, 9, 10)], week7, [7, 19]);
+    expect(out.timedBlocks).toHaveLength(1);
+    expect(out.timedBlocks[0].dayIndex).toBe(3);
+  });
+
+  it('keeps events starting before hourRange (negative startMinutes) so the renderer can clip', () => {
+    const out = layoutEventsForHourGrid([tev('a', 20, 6, 8)], day1, [7, 19]);
+    expect(out.timedBlocks).toHaveLength(1);
+    expect(out.timedBlocks[0].startMinutes).toBe(-60);
+    expect(out.timedBlocks[0].endMinutes).toBe(60);
   });
 });

--- a/packages/design-system/src/components/Calendar/utils.test.tsx
+++ b/packages/design-system/src/components/Calendar/utils.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { useMonth } from '../../calendar/useMonth';
 import { LocaleProvider } from '../../i18n/LocaleProvider';
 import type { CalendarEvent } from './types';
-import { layoutEventsForMonth, layoutEventsForHourGrid } from './utils';
+import { layoutEventsForMonth, layoutEventsForHourGrid, formatEventDuration } from './utils';
 import type { ReactNode } from 'react';
 
 function wrapEnUS({ children }: { children: ReactNode }) {
@@ -432,5 +432,39 @@ describe('layoutEventsForHourGrid', () => {
     // 24:00 (end-of-day) − 7:00 (hour-range base) = 17h = 1020min
     expect(out.timedBlocks[0].endMinutes).toBe(1020);
     expect(out.timedBlocks[0].endMinutes).toBeGreaterThan(out.timedBlocks[0].startMinutes);
+  });
+});
+
+describe('formatEventDuration', () => {
+  it('returns "0m" for zero-duration events (no endsAt)', () => {
+    expect(formatEventDuration(new Date(2026, 4, 20, 9, 0), undefined)).toBe('0m');
+  });
+
+  it('returns "30m" for sub-hour events', () => {
+    expect(
+      formatEventDuration(new Date(2026, 4, 20, 9, 0), new Date(2026, 4, 20, 9, 30)),
+    ).toBe('30m');
+  });
+
+  it('returns "1h" for exact-hour events', () => {
+    expect(
+      formatEventDuration(new Date(2026, 4, 20, 9, 0), new Date(2026, 4, 20, 10, 0)),
+    ).toBe('1h');
+  });
+
+  it('returns "1h 30m" for one-and-a-half hours', () => {
+    expect(
+      formatEventDuration(new Date(2026, 4, 20, 9, 0), new Date(2026, 4, 20, 10, 30)),
+    ).toBe('1h 30m');
+  });
+
+  it('returns "2d" for exact two-day events', () => {
+    expect(formatEventDuration(new Date(2026, 4, 20), new Date(2026, 4, 22))).toBe('2d');
+  });
+
+  it('returns "2d 5h" for two-day five-hour events', () => {
+    expect(
+      formatEventDuration(new Date(2026, 4, 20, 9, 0), new Date(2026, 4, 22, 14, 0)),
+    ).toBe('2d 5h');
   });
 });

--- a/packages/design-system/src/components/Calendar/utils.ts
+++ b/packages/design-system/src/components/Calendar/utils.ts
@@ -1,6 +1,13 @@
 import { startOfDay, toDateKey } from '../../calendar/dateMath';
 import type { Week } from '../../calendar/types';
-import type { AllDayBar, CalendarEvent, EventBar, HourGridLayout, MonthLayout, TimedEventBlock } from './types';
+import type {
+  AllDayBar,
+  CalendarEvent,
+  EventBar,
+  HourGridLayout,
+  MonthLayout,
+  TimedEventBlock,
+} from './types';
 
 const MS_PER_DAY = 86_400_000;
 

--- a/packages/design-system/src/components/Calendar/utils.ts
+++ b/packages/design-system/src/components/Calendar/utils.ts
@@ -326,8 +326,25 @@ function layoutAllDayBars(
 /**
  * Human-readable event duration: "0m" / "30m" / "1h" / "1h 30m" / "2d" /
  * "2d 5h". For tooltip / display contexts where a compact label is wanted.
+ *
+ * When `allDay` is true, the count is inclusive of both the start and end
+ * day — so an event from `May 11` to `May 27` reads as `17d`, matching the
+ * visual span of the bar across the calendar grid (the user sees 17 days
+ * highlighted). Otherwise (timed events), it's a raw `end - start` diff:
+ * `9:00 → 9:30` reads as `30m`.
  */
-export function formatEventDuration(startsAt: Date, endsAt: Date | undefined): string {
+export function formatEventDuration(
+  startsAt: Date,
+  endsAt: Date | undefined,
+  allDay = false,
+): string {
+  if (allDay) {
+    const startDayMs = startOfDay(startsAt).getTime();
+    const endDayMs = startOfDay(endsAt ?? startsAt).getTime();
+    const dayDiff = Math.round((endDayMs - startDayMs) / 86_400_000);
+    const days = Math.max(1, dayDiff + 1);
+    return `${days}d`;
+  }
   const start = startsAt.getTime();
   const end = (endsAt ?? startsAt).getTime();
   const minutes = Math.max(0, Math.round((end - start) / 60_000));

--- a/packages/design-system/src/components/Calendar/utils.ts
+++ b/packages/design-system/src/components/Calendar/utils.ts
@@ -222,15 +222,20 @@ export function layoutEventsForHourGrid(
     }
     if (currentGroup) groups.push(currentGroup);
 
-    // Step 2: within each group, assign a unique lane per event (greedy, no
-    // recycling within the group) so that laneCount = group.members.length
-    // and no two same-lane events ever share screen space.
+    // Step 2: within each group, assign a leftmost-available lane to each
+    // event greedily — lanes are recycled once an earlier event ends.
+    // `laneCount` is the highest lane index ever assigned, so the cascade
+    // renderer in TimedEvent.tsx knows how many lanes share the column.
     for (const g of groups) {
-      const laneCount = g.members.length;
       interface LaneState {
         endMinutes: number;
       }
       const laneBuckets: LaneState[] = [];
+      interface Placed {
+        ne: NormalizedTimed;
+        lane: number;
+      }
+      const placed: Placed[] = [];
       for (const ne of g.members) {
         let assigned = -1;
         for (let l = 0; l < laneBuckets.length; l++) {
@@ -244,12 +249,17 @@ export function layoutEventsForHourGrid(
           assigned = laneBuckets.length;
           laneBuckets.push({ endMinutes: ne.endMinutes });
         }
+        placed.push({ ne, lane: assigned });
+      }
+
+      const laneCount = laneBuckets.length;
+      for (const p of placed) {
         timedBlocks.push({
-          event: ne.event,
-          dayIndex: ne.dayIndex,
-          startMinutes: ne.startMinutes,
-          endMinutes: ne.endMinutes,
-          lane: assigned,
+          event: p.ne.event,
+          dayIndex: p.ne.dayIndex,
+          startMinutes: p.ne.startMinutes,
+          endMinutes: p.ne.endMinutes,
+          lane: p.lane,
           laneCount,
         });
       }

--- a/packages/design-system/src/components/Calendar/utils.ts
+++ b/packages/design-system/src/components/Calendar/utils.ts
@@ -182,7 +182,11 @@ export function layoutEventsForHourGrid(
     const dayIndex = days.findIndex((d) => startOfDay(d.date).getTime() === eventStartDay);
     if (dayIndex === -1) continue;
     const startMinutes = start.getHours() * 60 + start.getMinutes() - baseHourMinutes;
-    const endMinutes = end.getHours() * 60 + end.getMinutes() - baseHourMinutes;
+    // If the event ends on a later day, clamp to end-of-day so the block extends
+    // to the bottom of the visible column rather than collapsing to negative height.
+    const endsOnSameDay = startOfDay(end).getTime() === eventStartDay;
+    const rawEndMinutes = end.getHours() * 60 + end.getMinutes() - baseHourMinutes;
+    const endMinutes = endsOnSameDay ? rawEndMinutes : 24 * 60 - baseHourMinutes;
     timedNormalized.push({ event: ev, dayIndex, startMinutes, endMinutes });
   }
 

--- a/packages/design-system/src/components/Calendar/utils.ts
+++ b/packages/design-system/src/components/Calendar/utils.ts
@@ -322,3 +322,21 @@ function layoutAllDayBars(
   }
   return bars;
 }
+
+/**
+ * Human-readable event duration: "0m" / "30m" / "1h" / "1h 30m" / "2d" /
+ * "2d 5h". For tooltip / display contexts where a compact label is wanted.
+ */
+export function formatEventDuration(startsAt: Date, endsAt: Date | undefined): string {
+  const start = startsAt.getTime();
+  const end = (endsAt ?? startsAt).getTime();
+  const minutes = Math.max(0, Math.round((end - start) / 60_000));
+  if (minutes === 0) return '0m';
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remMin = minutes % 60;
+  if (hours < 24) return remMin === 0 ? `${hours}h` : `${hours}h ${remMin}m`;
+  const days = Math.floor(hours / 24);
+  const remHours = hours % 24;
+  return remHours === 0 ? `${days}d` : `${days}d ${remHours}h`;
+}

--- a/packages/design-system/src/components/Calendar/utils.ts
+++ b/packages/design-system/src/components/Calendar/utils.ts
@@ -1,6 +1,6 @@
 import { startOfDay, toDateKey } from '../../calendar/dateMath';
 import type { Week } from '../../calendar/types';
-import type { CalendarEvent, EventBar, MonthLayout } from './types';
+import type { AllDayBar, CalendarEvent, EventBar, HourGridLayout, MonthLayout, TimedEventBlock } from './types';
 
 const MS_PER_DAY = 86_400_000;
 
@@ -128,4 +128,186 @@ export function layoutEventsForMonth(
   }
 
   return { bars, hiddenCounts };
+}
+
+interface DayRef {
+  date: Date;
+  key: string;
+}
+
+interface NormalizedTimed {
+  event: CalendarEvent;
+  dayIndex: number;
+  startMinutes: number;
+  endMinutes: number;
+}
+
+/**
+ * Lay out events for a Week or Day view's hour grid.
+ *
+ * - `allDay` events become bars in the AllDayBand (multi-day spans flatten
+ *   edges, like the month bars).
+ * - Timed events get positioned in their day column with greedy lane
+ *   assignment; each block's `laneCount` equals the size of its transitive
+ *   collision group (so siblings render at uniform width within the group).
+ * - Events outside the day range are dropped; events partially outside the
+ *   hour range keep their natural `startMinutes`/`endMinutes` (may be
+ *   negative or past the range) so the renderer can clip visually.
+ */
+export function layoutEventsForHourGrid(
+  events: readonly CalendarEvent[],
+  days: readonly DayRef[],
+  hourRange: readonly [number, number],
+): HourGridLayout {
+  if (events.length === 0 || days.length === 0) {
+    return { timedBlocks: [], allDayBars: [] };
+  }
+
+  const viewStart = startOfDay(days[0].date).getTime();
+  const viewEnd = startOfDay(days[days.length - 1].date).getTime() + MS_PER_DAY;
+  const baseHourMinutes = hourRange[0] * 60;
+
+  const timedNormalized: NormalizedTimed[] = [];
+  const allDayInput: CalendarEvent[] = [];
+
+  for (const ev of events) {
+    const start = ev.startsAt;
+    const end = ev.endsAt ?? ev.startsAt;
+    if (end.getTime() < viewStart || start.getTime() >= viewEnd) continue;
+    if (ev.allDay === true) {
+      allDayInput.push(ev);
+      continue;
+    }
+    const eventStartDay = startOfDay(start).getTime();
+    const dayIndex = days.findIndex((d) => startOfDay(d.date).getTime() === eventStartDay);
+    if (dayIndex === -1) continue;
+    const startMinutes = start.getHours() * 60 + start.getMinutes() - baseHourMinutes;
+    const endMinutes = end.getHours() * 60 + end.getMinutes() - baseHourMinutes;
+    timedNormalized.push({ event: ev, dayIndex, startMinutes, endMinutes });
+  }
+
+  const timedBlocks: TimedEventBlock[] = [];
+  for (let d = 0; d < days.length; d++) {
+    const dayEvents = timedNormalized
+      .filter((n) => n.dayIndex === d)
+      .sort((a, b) => a.startMinutes - b.startMinutes || b.endMinutes - a.endMinutes);
+
+    // Step 1: sweep sorted events into transitive collision groups.
+    interface Group {
+      members: NormalizedTimed[];
+    }
+    const groups: Group[] = [];
+    let currentGroup: Group | null = null;
+    let currentEndMax = -Infinity;
+    for (const ne of dayEvents) {
+      if (ne.startMinutes >= currentEndMax) {
+        if (currentGroup) groups.push(currentGroup);
+        currentGroup = { members: [ne] };
+        currentEndMax = ne.endMinutes;
+      } else {
+        currentGroup!.members.push(ne);
+        currentEndMax = Math.max(currentEndMax, ne.endMinutes);
+      }
+    }
+    if (currentGroup) groups.push(currentGroup);
+
+    // Step 2: within each group, assign a unique lane per event (greedy, no
+    // recycling within the group) so that laneCount = group.members.length
+    // and no two same-lane events ever share screen space.
+    for (const g of groups) {
+      const laneCount = g.members.length;
+      interface LaneState {
+        endMinutes: number;
+      }
+      const laneBuckets: LaneState[] = [];
+      for (const ne of g.members) {
+        let assigned = -1;
+        for (let l = 0; l < laneBuckets.length; l++) {
+          if (laneBuckets[l].endMinutes <= ne.startMinutes) {
+            assigned = l;
+            laneBuckets[l].endMinutes = ne.endMinutes;
+            break;
+          }
+        }
+        if (assigned === -1) {
+          assigned = laneBuckets.length;
+          laneBuckets.push({ endMinutes: ne.endMinutes });
+        }
+        timedBlocks.push({
+          event: ne.event,
+          dayIndex: ne.dayIndex,
+          startMinutes: ne.startMinutes,
+          endMinutes: ne.endMinutes,
+          lane: assigned,
+          laneCount,
+        });
+      }
+    }
+  }
+
+  const allDayBars = layoutAllDayBars(allDayInput, days);
+  return { timedBlocks, allDayBars };
+}
+
+function layoutAllDayBars(
+  events: readonly CalendarEvent[],
+  days: readonly DayRef[],
+): readonly AllDayBar[] {
+  if (events.length === 0) return [];
+  const viewStartMs = startOfDay(days[0].date).getTime();
+  const viewEndMs = startOfDay(days[days.length - 1].date).getTime();
+
+  interface NormalizedAllDay {
+    event: CalendarEvent;
+    startMs: number;
+    endMs: number;
+    duration: number;
+  }
+  const normalized: NormalizedAllDay[] = [];
+  for (const ev of events) {
+    let startMs = startOfDay(ev.startsAt).getTime();
+    let endMs = startOfDay(ev.endsAt ?? ev.startsAt).getTime();
+    if (endMs < startMs) [startMs, endMs] = [endMs, startMs];
+    if (endMs < viewStartMs || startMs > viewEndMs) continue;
+    normalized.push({ event: ev, startMs, endMs, duration: (endMs - startMs) / MS_PER_DAY });
+  }
+  normalized.sort((a, b) => a.startMs - b.startMs || b.duration - a.duration);
+
+  interface LaneSegment {
+    startCol: number;
+    endCol: number;
+  }
+  const lanes: LaneSegment[][] = [];
+  const bars: AllDayBar[] = [];
+
+  for (const n of normalized) {
+    const segStartMs = Math.max(n.startMs, viewStartMs);
+    const segEndMs = Math.min(n.endMs, viewEndMs);
+    const startCol = Math.round((segStartMs - viewStartMs) / MS_PER_DAY);
+    const endCol = Math.round((segEndMs - viewStartMs) / MS_PER_DAY);
+
+    let assigned = -1;
+    for (let l = 0; l < lanes.length; l++) {
+      const conflicts = lanes[l].some((s) => !(s.endCol < startCol || s.startCol > endCol));
+      if (!conflicts) {
+        assigned = l;
+        break;
+      }
+    }
+    if (assigned === -1) {
+      assigned = lanes.length;
+      lanes.push([]);
+    }
+    lanes[assigned].push({ startCol, endCol });
+
+    bars.push({
+      event: n.event,
+      startCol,
+      endCol,
+      lane: assigned,
+      continuesLeft: n.startMs < viewStartMs,
+      continuesRight: n.endMs > viewEndMs,
+    });
+  }
+  return bars;
 }

--- a/packages/design-system/src/components/Calendar/utils.ts
+++ b/packages/design-system/src/components/Calendar/utils.ts
@@ -155,8 +155,9 @@ interface NormalizedTimed {
  * - `allDay` events become bars in the AllDayBand (multi-day spans flatten
  *   edges, like the month bars).
  * - Timed events get positioned in their day column with greedy lane
- *   assignment; each block's `laneCount` equals the size of its transitive
- *   collision group (so siblings render at uniform width within the group).
+ *   assignment (lanes recycle once an earlier event ends). The cascade
+ *   renderer in TimedEvent.tsx uses `lane` for both left-offset and z-index
+ *   stacking; every block extends to the column's right edge.
  * - Events outside the day range are dropped; events partially outside the
  *   hour range keep their natural `startMinutes`/`endMinutes` (may be
  *   negative or past the range) so the renderer can clip visually.
@@ -224,18 +225,11 @@ export function layoutEventsForHourGrid(
 
     // Step 2: within each group, assign a leftmost-available lane to each
     // event greedily — lanes are recycled once an earlier event ends.
-    // `laneCount` is the highest lane index ever assigned, so the cascade
-    // renderer in TimedEvent.tsx knows how many lanes share the column.
     for (const g of groups) {
       interface LaneState {
         endMinutes: number;
       }
       const laneBuckets: LaneState[] = [];
-      interface Placed {
-        ne: NormalizedTimed;
-        lane: number;
-      }
-      const placed: Placed[] = [];
       for (const ne of g.members) {
         let assigned = -1;
         for (let l = 0; l < laneBuckets.length; l++) {
@@ -249,18 +243,12 @@ export function layoutEventsForHourGrid(
           assigned = laneBuckets.length;
           laneBuckets.push({ endMinutes: ne.endMinutes });
         }
-        placed.push({ ne, lane: assigned });
-      }
-
-      const laneCount = laneBuckets.length;
-      for (const p of placed) {
         timedBlocks.push({
-          event: p.ne.event,
-          dayIndex: p.ne.dayIndex,
-          startMinutes: p.ne.startMinutes,
-          endMinutes: p.ne.endMinutes,
-          lane: p.lane,
-          laneCount,
+          event: ne.event,
+          dayIndex: ne.dayIndex,
+          startMinutes: ne.startMinutes,
+          endMinutes: ne.endMinutes,
+          lane: assigned,
         });
       }
     }

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -133,4 +133,6 @@ export type {
   CalendarView,
   EventBar,
   MonthLayout,
+  RenderEvent,
+  RenderEventContext,
 } from './components/Calendar';

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -133,6 +133,10 @@
   // Width/height of the leading indicator slot in DropdownMenu checkbox/radio items.
   --size-dropdown-indicator: 16px;
 
+  // Calendar — minimum height for a month-grid day cell so empty weeks
+  // still look like cells without inflating the day-number row.
+  --size-calendar-day-cell-min-height: 6.5rem;
+
   // Border weights — emphasis = tab underline/focus rings; strong = accent
   // stripes on cards or other "this stands out" visuals.
   --border-width: 1px;

--- a/packages/playground/src/pages/components/CalendarDemo.tsx
+++ b/packages/playground/src/pages/components/CalendarDemo.tsx
@@ -84,9 +84,9 @@ const SAMPLE_EVENTS: CalendarEvent[] = [
     endsAt: fromToday(6, 14, 0),
     tone: 'neutral',
   },
-  // Overlapping events on the same day — demonstrate the collision-lane
-  // layout in week / day views (events at the same time share a column
-  // with equal-width lanes).
+  // Overlapping events on the same day — demonstrate the cascade layout in
+  // week / day views (each lane offset right by a small step; later lanes
+  // overlay earlier ones; hover lifts a block to full width on top).
   {
     id: 'overlap-a',
     title: 'Design review',
@@ -108,7 +108,8 @@ const SAMPLE_EVENTS: CalendarEvent[] = [
     endsAt: fromToday(1, 12, 30),
     tone: 'warning',
   },
-  // Two simultaneously-starting events same day → 50/50 split.
+  // Two simultaneously-starting events same day → cascade with the second
+  // event offset right and layered on top of the first.
   {
     id: 'concurrent-a',
     title: 'Interview: Sarah',
@@ -262,7 +263,7 @@ export function CalendarDemo() {
 
       <Example
         title="Week view"
-        description="7 columns × hour rows. Timed events position by hour; overlapping events split into equal-width lanes side-by-side. All-day and multi-day events render in the band above the hour grid. A horizontal line marks the current time in today's column."
+        description="7 columns × hour rows. Timed events position by hour; overlapping events cascade — each lane offset right by a small step, later lanes overlay earlier ones, and hover lifts a block to full width on top. All-day and multi-day events render in the band above the hour grid. A horizontal line marks the current time in today's column."
         code={`<Calendar
   defaultValue={new Date()}
   defaultView="week"

--- a/packages/playground/src/pages/components/CalendarDemo.tsx
+++ b/packages/playground/src/pages/components/CalendarDemo.tsx
@@ -115,6 +115,13 @@ function ControlledCalendarDemo() {
   return <Calendar value={cursor} onChange={setCursor} events={SAMPLE_EVENTS} />;
 }
 
+function ViewSwitcherDemo() {
+  const [view, setView] = useState<'month' | 'week' | 'day'>('week');
+  return (
+    <Calendar defaultValue={TODAY} view={view} onViewChange={setView} events={SAMPLE_EVENTS} />
+  );
+}
+
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export function CalendarDemo() {
@@ -182,7 +189,7 @@ export function CalendarDemo() {
 
       <Example
         title="ru-RU locale"
-        description="Russian locale — Monday-start grid, Cyrillic month/weekday labels. UI strings like the Today button are the consumer's responsibility; pass them via the labels prop."
+        description="Russian locale — Monday-start grid, Cyrillic month/weekday labels. UI strings like the Today button and view-switcher labels are the consumer's responsibility; pass them via the labels prop."
         code={`<Calendar
   defaultValue={new Date(2026, 4, 15)}
   events={SAMPLE_EVENTS}
@@ -192,6 +199,9 @@ export function CalendarDemo() {
     previousMonth: 'Предыдущий месяц',
     nextMonth: 'Следующий месяц',
     moreEvents: (n) => \`ещё ${'${n}'} событий\`,
+    viewMonth: 'Месяц',
+    viewWeek: 'Неделя',
+    viewDay: 'День',
   }}
 />`}
       >
@@ -204,8 +214,59 @@ export function CalendarDemo() {
             previousMonth: 'Предыдущий месяц',
             nextMonth: 'Следующий месяц',
             moreEvents: (n) => `ещё ${n} событий`,
+            viewMonth: 'Месяц',
+            viewWeek: 'Неделя',
+            viewDay: 'День',
           }}
         />
+      </Example>
+
+      <Example
+        title="Week view"
+        description="7 columns × hour rows. Timed events position by hour; overlapping events split into equal-width lanes side-by-side. All-day and multi-day events render in the band above the hour grid. A horizontal line marks the current time in today's column."
+        code={`<Calendar
+  defaultValue={new Date()}
+  defaultView="week"
+  events={SAMPLE_EVENTS}
+/>`}
+      >
+        <Calendar defaultValue={TODAY} defaultView="week" events={SAMPLE_EVENTS} />
+      </Example>
+
+      <Example
+        title="Day view"
+        description="Single-day hour grid for focused planning. Custom hourRange tightens the visible range to business hours."
+        code={`<Calendar
+  defaultValue={new Date()}
+  defaultView="day"
+  events={SAMPLE_EVENTS}
+  hourRange={[8, 18]}
+/>`}
+      >
+        <Calendar
+          defaultValue={TODAY}
+          defaultView="day"
+          events={SAMPLE_EVENTS}
+          hourRange={[8, 18]}
+        />
+      </Example>
+
+      <Example
+        title="View switching (controlled)"
+        description="Consumer owns the active view via `view` / `onViewChange`. Useful for URL-syncing the current view."
+        code={`function ViewSwitcherDemo() {
+  const [view, setView] = useState<'month' | 'week' | 'day'>('week');
+  return (
+    <Calendar
+      defaultValue={new Date()}
+      view={view}
+      onViewChange={setView}
+      events={SAMPLE_EVENTS}
+    />
+  );
+}`}
+      >
+        <ViewSwitcherDemo />
       </Example>
 
       <Example

--- a/packages/playground/src/pages/components/CalendarDemo.tsx
+++ b/packages/playground/src/pages/components/CalendarDemo.tsx
@@ -84,6 +84,45 @@ const SAMPLE_EVENTS: CalendarEvent[] = [
     endsAt: fromToday(6, 14, 0),
     tone: 'neutral',
   },
+  // Overlapping events on the same day — demonstrate the collision-lane
+  // layout in week / day views (events at the same time share a column
+  // with equal-width lanes).
+  {
+    id: 'overlap-a',
+    title: 'Design review',
+    startsAt: fromToday(1, 10, 0),
+    endsAt: fromToday(1, 11, 30),
+    tone: 'accent',
+  },
+  {
+    id: 'overlap-b',
+    title: 'Sync: Engineering',
+    startsAt: fromToday(1, 10, 30),
+    endsAt: fromToday(1, 12, 0),
+    tone: 'success',
+  },
+  {
+    id: 'overlap-c',
+    title: 'Sales handoff',
+    startsAt: fromToday(1, 11, 0),
+    endsAt: fromToday(1, 12, 30),
+    tone: 'warning',
+  },
+  // Two simultaneously-starting events same day → 50/50 split.
+  {
+    id: 'concurrent-a',
+    title: 'Interview: Sarah',
+    startsAt: fromToday(3, 15, 0),
+    endsAt: fromToday(3, 16, 0),
+    tone: 'accent',
+  },
+  {
+    id: 'concurrent-b',
+    title: 'Vendor demo',
+    startsAt: fromToday(3, 15, 0),
+    endsAt: fromToday(3, 16, 0),
+    tone: 'neutral',
+  },
 ];
 
 const OVERFLOW_EVENTS: CalendarEvent[] = [


### PR DESCRIPTION
## Summary

- New `<WeekView>` (7 columns × hour rows) and `<DayView>` (1 column × hour rows).
- Shared `<HourGrid>` primitive — CSS grid scaffold with hour labels, day columns, today/weekend tints, and a "now" line that updates every minute.
- `<TimedEvent>` blocks position absolutely inside their day column with collision-group lane width (overlapping events split equal-width side-by-side).
- `<AllDayBand>` renders multi-day and `allDay` events above the hour grid with continuation flags.
- `<ViewSwitcher>` segmented control wired to the Calendar shell.
- `layoutEventsForHourGrid` in `utils.ts` — per-day greedy lane assignment within transitive collision groups; multi-day timed events clamp to end-of-day so they don't collapse to negative height.
- `CalendarView` extended to `'month' | 'week' | 'day'`.
- New props on `<Calendar>`: `view`, `defaultView`, `onViewChange`, `hourRange` (default `[7, 19]`), `hourRowHeight` (default 48). `CalendarLabels` gains `viewMonth/viewWeek/viewDay`.
- Playground demo: new Week / Day / view-switcher examples; ru-RU labels for the switcher.

## Test plan

- [ ] CI \`Quality / check\` green
- [ ] \`npm test\` — 614 tests across 31 files
- [ ] \`npm run typecheck\` — clean
- [ ] \`npm run lint:css\` — clean
- [ ] \`npm run build\` — clean
- [ ] \`npm pack --dry-run -w @eocrm/design-system\` — Calendar source included; no test files
- [ ] Hard Rule 8 review-fix cycle reached \`clean enough to stop\` (pass 1 caught a real bug: multi-day timed events produced negative-height blocks; fixed with a clamp + regression test)
- [ ] Visual check at \`/components/calendar\`: week + day examples render correctly; overlapping events split into lanes; now-line visible in today's column; ru-RU view labels show Cyrillic.

## Non-goals (deferred)

- Agenda view — PR 4.
- DatePicker — separate PR.
- Drag-create / drag-reschedule.
- Time zones.
- Multi-day **timed** events: only placed on their start day (clamped to end-of-day visually). Future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)