### PR TITLE
Calendar PR 4: agenda view + per-view nav labels

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -418,7 +418,7 @@ const locale = useLocale(); // 'ru-RU', or navigator.language fallback
 - No `<LocaleProvider>` mounted? `useLocale()` falls back to `navigator.language` (or `'en-US'` in SSR / Node).
 - Stateless. To switch locale at runtime, re-render the Provider with a new `locale` prop. Nested Providers override outer ones.
 
-### `<Calendar>` — month / week / day views
+### `<Calendar>` — month / week / day / agenda views
 
 ```tsx
 const [cursor, setCursor] = useState(new Date());
@@ -433,7 +433,7 @@ const [view, setView] = useState<'month' | 'week' | 'day'>('month');
 />;
 ```
 
-- Three views in v3: `'month'` (continuous event bars across the grid), `'week'` (7 columns × hour rows + all-day band), `'day'` (single column × hour rows). Agenda view comes in PR 4.
+- Four views: `'month'` (continuous event bars across the grid), `'week'` (7 columns × hour rows + all-day band), `'day'` (single column × hour rows), `'agenda'` (chronological list of the cursor's current week, grouped by day with empty days hidden).
 - Events are `{ id, title, startsAt, endsAt?, tone?, allDay? }`. Multi-day events render as continuous bars in both the month grid and the week/day all-day band.
 - Tones: `neutral` (default) / `accent` / `success` / `warning` / `danger`. `allDay: true` renders as a tone-filled band (no time prefix).
 - Controlled cursor via `value` / `onChange`, or uncontrolled via `defaultValue`. Controlled view via `view` / `onViewChange`, or uncontrolled via `defaultView`.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -422,7 +422,7 @@ const locale = useLocale(); // 'ru-RU', or navigator.language fallback
 
 ```tsx
 const [cursor, setCursor] = useState(new Date());
-const [view, setView] = useState<'month' | 'week' | 'day'>('month');
+const [view, setView] = useState<CalendarView>('month');
 <Calendar
   value={cursor}
   onChange={setCursor}
@@ -442,7 +442,7 @@ const [view, setView] = useState<'month' | 'week' | 'day'>('month');
 - Locale-aware via `useLocale()`; override with `locale` prop. UI strings (`today`, `viewMonth`, etc.) are the consumer's responsibility via `labels`.
 - `maxLanesPerWeek` (default 3) caps event lanes per week in the month view. Events beyond the cap collapse into a `+N more` chip; click fires `onDayClick(date)`.
 - Read-mostly: `onDayClick` and `onEventClick` callbacks only. `onDayClick` fires across all views — month-cell click, "+N more" chip, keyboard activation (Enter/Space) on a focused cell, and (in week/day views) clicks on the empty hour-grid space of a day column. No built-in popover or modal — wire your own detail UI.
-- ARIA: month view is `role="grid" aria-readonly="true"`; arrow keys move focus, PageUp/PageDown navigates months, Enter/Space calls `onDayClick`. Week/day views are also `role="grid" aria-readonly="true"` with `role="row"` + `role="columnheader"` headers and standard sequential tab order for event blocks. **Known v3 gap:** in week/day views, `onDayClick` on empty hour-grid space is **mouse-only** (no keyboard equivalent). Consumers needing keyboard activation should drive their detail UI through the focusable event chips via `onEventClick`.
+- ARIA: month view is `role="grid" aria-readonly="true"`; arrow keys move focus, PageUp/PageDown navigates months, Enter/Space calls `onDayClick`. Week/day views are also `role="grid" aria-readonly="true"` with `role="row"` + `role="columnheader"` headers and standard sequential tab order for event blocks. Agenda view exposes the visible week as `role="list"` with each day group as a `role="listitem"` and the day label as an `<h3>` heading inside — screen readers announce the date grouping before reading each event row. **Known v3 gap:** in week/day views, `onDayClick` on empty hour-grid space is **mouse-only** (no keyboard equivalent). Consumers needing keyboard activation should drive their detail UI through the focusable event chips via `onEventClick`.
 
 ### Calendar primitives — `useMonth`, `useWeek`, `useDay`, `useAgenda`
 
@@ -458,7 +458,7 @@ const { day, dayLabel, dayShortLabel } = useDay(date);
 const { days, rangeLabel } = useAgenda(rangeStart, rangeEnd);
 ```
 
-- Headless. These hooks return data shapes — no rendering. The Calendar UI components (Month/Week/Day/Agenda views) consume them and ship in follow-up PRs.
+- Headless. These hooks return data shapes — no rendering. The Calendar UI components (Month/Week/Day/Agenda views) consume them.
 - Each hook accepts an optional `options.locale` to override the Context value. `useMonth`, `useWeek`, and `useAgenda` accept `options.weekStartsOn` to override the locale-derived first day (used by `useAgenda` to compute the locale-aware column index for each `Day.weekday`).
 - `Day.key` is `'YYYY-MM-DD'` in local time — safe React key, comparison handle, and event-lookup index.
 - Pure date math + `Intl` formatters live alongside as utility exports: `addDays`, `startOfWeek`, `formatMonth`, `getFirstDayOfWeek`, etc. Use them if you need to derive labels or do date math outside a component.

--- a/packages/design-system/src/calendar/useAgenda.ts
+++ b/packages/design-system/src/calendar/useAgenda.ts
@@ -34,7 +34,7 @@ export interface AgendaResult {
  * ends). When `from > to` the result is a single-day agenda for `from` — pass
  * `from <= to` to the hook to get the intended range.
  *
- * Used by the future `<AgendaView>` to group events by day.
+ * Used by `<AgendaView>` (via the `<Calendar>` shell) to group events by day.
  */
 export function useAgenda(from: Date, to: Date, options: UseAgendaOptions = {}): AgendaResult {
   const contextLocale = useLocale();

--- a/packages/design-system/src/components/Calendar/AgendaView.module.scss
+++ b/packages/design-system/src/components/Calendar/AgendaView.module.scss
@@ -16,13 +16,23 @@
 // Each dayGroup carries its own bottom padding (in place of `gap` on
 // `.agenda`) so the today-group's accent borders extend down through the
 // spacing area, all the way to the next day-header's top border.
+// `gap` provides the breathing room between the dayHeader and the rows.
+// `padding-bottom` matches that gap so the space below the last row
+// equals the space above the first row.
 .dayGroup {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  padding-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
   border-left: var(--border-width) solid var(--color-border);
   border-right: var(--border-width) solid var(--color-border);
+}
+
+// The last day-group has no "next" header to provide its closing
+// horizontal line — add an explicit bottom border so the list reads as
+// closed at the bottom edge.
+.dayGroup:last-child {
+  border-bottom: var(--border-width) solid var(--color-border);
 }
 
 // Today's group swaps its grey side borders for the accent color so the

--- a/packages/design-system/src/components/Calendar/AgendaView.module.scss
+++ b/packages/design-system/src/components/Calendar/AgendaView.module.scss
@@ -44,7 +44,7 @@
 
 .rowButton {
   display: grid;
-  grid-template-columns: 8rem auto 1fr;
+  grid-template-columns: var(--size-calendar-agenda-gutter) auto 1fr;
   align-items: center;
   gap: var(--space-2);
   width: 100%;

--- a/packages/design-system/src/components/Calendar/AgendaView.module.scss
+++ b/packages/design-system/src/components/Calendar/AgendaView.module.scss
@@ -3,7 +3,6 @@
 .agenda {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
   padding: var(--space-3) 0;
 }
 
@@ -14,22 +13,49 @@
   color: var(--color-fg-muted);
 }
 
+// Each dayGroup carries its own bottom padding (in place of `gap` on
+// `.agenda`) so the today-group's accent border-left extends down through
+// the spacing area, all the way to the next day-header's top border.
 .dayGroup {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  padding-left: var(--space-3);
+  padding-bottom: var(--space-4);
   border-left: var(--border-width-emphasis) solid transparent;
 }
 
 // Today's group draws an accent border on its left edge — same emphasis
-// language as month view's today cell, no background tint to compete with
-// tone dots on event rows.
+// language as month view's today cell, no background tint on the rows
+// area so tone dots stay legible.
 .todayGroup {
   border-left-color: var(--color-accent);
 }
 
+// Today's day-header band gets an accent tint + accent border so the
+// current day is instantly findable when the agenda list is long. The
+// rows area stays untinted so event tone dots keep their contrast.
+.todayGroup .dayHeader {
+  background: var(--color-accent-bg-subtle);
+  border-top-color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+// The next day-group's top border continues the today accent so the
+// vertical left-border line lands cleanly on a matching horizontal one,
+// instead of meeting a plain grey rule.
+.todayGroup + .dayGroup .dayHeader {
+  border-top-color: var(--color-accent);
+}
+
+// Day-header reads as a full-width banded row. Top + bottom borders frame
+// the band so it doesn't float against an empty row gap; subtle fill
+// reinforces the day-group boundary visually.
 .dayHeader {
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-subtle);
+  border-top: var(--border-width) solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-medium);
   color: var(--color-fg);
@@ -40,6 +66,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
+  padding-left: var(--space-3);
 }
 
 .rowButton {
@@ -108,24 +135,6 @@
   white-space: nowrap;
   font-weight: var(--font-weight-medium);
   color: var(--color-fg);
-}
-
-.tooltipBody {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-.tooltipTime {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-regular);
-  color: var(--color-bg-subtle);
-}
-
-.tooltipTitle {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-bg);
 }
 
 // Tone -> color of the dot (via currentColor inheritance).

--- a/packages/design-system/src/components/Calendar/AgendaView.module.scss
+++ b/packages/design-system/src/components/Calendar/AgendaView.module.scss
@@ -1,0 +1,150 @@
+@use '../../styles/mixins' as *;
+
+.agenda {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-3) 0;
+}
+
+.empty {
+  padding: var(--space-6);
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+}
+
+.dayGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-left: var(--space-3);
+  border-left: var(--border-width-emphasis) solid transparent;
+}
+
+// Today's group draws an accent border on its left edge — same emphasis
+// language as month view's today cell, no background tint to compete with
+// tone dots on event rows.
+.todayGroup {
+  border-left-color: var(--color-accent);
+}
+
+.dayHeader {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg);
+  font-variant-numeric: tabular-nums;
+}
+
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.rowButton {
+  display: grid;
+  grid-template-columns: 8rem auto 1fr;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  color: var(--color-fg);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+
+  &:hover:not(:disabled) {
+    background: var(--color-bg-subtle);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+  }
+}
+
+.timeGutter {
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.allDay {
+  font-style: normal;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg);
+}
+
+// The tone dot sits between gutter and body to color-code the event
+// without tinting the whole row (which would clash with the today-group
+// accent and the hover background).
+.toneDot {
+  width: var(--space-2);
+  height: var(--space-2);
+  border-radius: var(--radius-full);
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.body {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg);
+}
+
+.tooltipBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.tooltipTime {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-regular);
+  color: var(--color-bg-subtle);
+}
+
+.tooltipTitle {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-bg);
+}
+
+// Tone -> color of the dot (via currentColor inheritance).
+.neutral {
+  color: var(--color-border-strong);
+}
+
+.accent {
+  color: var(--color-accent);
+}
+
+.success {
+  color: var(--color-success);
+}
+
+.warning {
+  color: var(--color-warning);
+}
+
+.danger {
+  color: var(--color-danger);
+}

--- a/packages/design-system/src/components/Calendar/AgendaView.module.scss
+++ b/packages/design-system/src/components/Calendar/AgendaView.module.scss
@@ -14,21 +14,39 @@
 }
 
 // Each dayGroup carries its own bottom padding (in place of `gap` on
-// `.agenda`) so the today-group's accent border-left extends down through
-// the spacing area, all the way to the next day-header's top border.
+// `.agenda`) so the today-group's accent borders extend down through the
+// spacing area, all the way to the next day-header's top border.
 .dayGroup {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
   padding-bottom: var(--space-4);
-  border-left: var(--border-width-emphasis) solid transparent;
+  border-left: var(--border-width) solid var(--color-border);
+  border-right: var(--border-width) solid var(--color-border);
 }
 
-// Today's group draws an accent border on its left edge — same emphasis
-// language as month view's today cell, no background tint on the rows
-// area so tone dots stay legible.
+// Today's group swaps its grey side borders for the accent color so the
+// current day is framed in blue on all four edges (together with the
+// accent top/bottom on `.dayHeader`).
 .todayGroup {
+  position: relative;
   border-left-color: var(--color-accent);
+  border-right-color: var(--color-accent);
+}
+
+// Today's side borders end exactly at the next day-header's accent top
+// border. This pseudo-element draws a 1px accent strip spanning the full
+// width of the today-group just below it, so the bottom-left and
+// bottom-right corners both meet the next header's horizontal line
+// cleanly instead of stopping a pixel short.
+.todayGroup::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(var(--border-width) * -1);
+  height: var(--border-width);
+  background: var(--color-accent);
 }
 
 // Today's day-header band gets an accent tint + accent border so the

--- a/packages/design-system/src/components/Calendar/AgendaView.test.tsx
+++ b/packages/design-system/src/components/Calendar/AgendaView.test.tsx
@@ -250,6 +250,83 @@ describe('AgendaView', () => {
     expect(all).toMatchObject({ view: 'agenda', asAllDay: true });
   });
 
+  it('today’s day group carries the todayGroup accent class', () => {
+    // Build a 1-day window where the only day is flagged isToday=true.
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const todayDay: Day = {
+      date: today,
+      dayOfMonth: today.getDate(),
+      isCurrentMonth: true,
+      isToday: true,
+      isWeekend: false,
+      weekday: 0,
+      key: toDateKey(today),
+    };
+    const events: CalendarEvent[] = [
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 0),
+        endsAt: new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 30),
+      },
+    ];
+    render(
+      <AgendaView days={[todayDay]} rangeLabel="Today" events={events} emptyLabel="No events" />,
+      { wrapper: wrap() },
+    );
+    const group = screen.getByRole('listitem');
+    expect(group.className).toMatch(/todayGroup/);
+  });
+
+  it('renders a single-time gutter for events without endsAt', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 'point',
+        title: 'Doorbell',
+        startsAt: new Date(2026, 4, 20, 9, 0),
+      },
+    ];
+    render(
+      <AgendaView
+        days={WEEK_DAYS}
+        rangeLabel="May 18 – 24, 2026"
+        events={events}
+        emptyLabel="No events"
+      />,
+      { wrapper: wrap() },
+    );
+    const button = screen.getByRole('button', { name: /Doorbell/ });
+    expect(button.textContent).toMatch(/9:00\s*(AM|am)/);
+    // No range en-dash — start only.
+    expect(button.textContent).not.toMatch(/–|—/);
+  });
+
+  it('exposes day groups as role="listitem" with an h3 day heading', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9, 0),
+        endsAt: new Date(2026, 4, 20, 9, 30),
+      },
+    ];
+    render(
+      <AgendaView
+        days={WEEK_DAYS}
+        rangeLabel="May 18 – 24, 2026"
+        events={events}
+        emptyLabel="No events"
+      />,
+      { wrapper: wrap() },
+    );
+    expect(screen.getByRole('list', { name: 'May 18 – 24, 2026' })).toBeInTheDocument();
+    expect(screen.getByRole('listitem')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 3, name: /Wednesday, May 20/ }),
+    ).toBeInTheDocument();
+  });
+
   it('uses locale-aware day headers (ru-RU has Cyrillic)', () => {
     const events: CalendarEvent[] = [
       {

--- a/packages/design-system/src/components/Calendar/AgendaView.test.tsx
+++ b/packages/design-system/src/components/Calendar/AgendaView.test.tsx
@@ -1,0 +1,275 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { LocaleProvider } from '../../i18n/LocaleProvider';
+import { AgendaView } from './AgendaView';
+import type { CalendarEvent } from './types';
+import type { Day } from '../../calendar/types';
+import { toDateKey } from '../../calendar/dateMath';
+
+function wrap(locale = 'en-US') {
+  return ({ children }: { children: ReactNode }) => (
+    <LocaleProvider locale={locale}>{children}</LocaleProvider>
+  );
+}
+
+function makeDay(year: number, monthIndex: number, dayOfMonth: number): Day {
+  const date = new Date(year, monthIndex, dayOfMonth);
+  return {
+    date,
+    dayOfMonth: date.getDate(),
+    isCurrentMonth: true,
+    isToday: false,
+    isWeekend: false,
+    weekday: 0,
+    key: toDateKey(date),
+  };
+}
+
+// Mon May 18 → Sun May 24, 2026
+const WEEK_DAYS: readonly Day[] = [
+  makeDay(2026, 4, 18),
+  makeDay(2026, 4, 19),
+  makeDay(2026, 4, 20),
+  makeDay(2026, 4, 21),
+  makeDay(2026, 4, 22),
+  makeDay(2026, 4, 23),
+  makeDay(2026, 4, 24),
+];
+
+describe('AgendaView', () => {
+  it('renders the empty-state when no events fall in the visible window', () => {
+    render(
+      <AgendaView
+        days={WEEK_DAYS}
+        rangeLabel="May 18 – 24, 2026"
+        events={[]}
+        emptyLabel="No events"
+      />,
+      { wrapper: wrap() },
+    );
+    expect(screen.getByText('No events')).toBeInTheDocument();
+  });
+
+  it('groups events under the day they occur on and hides days with no events', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 'standup',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9, 0),
+        endsAt: new Date(2026, 4, 20, 9, 30),
+      },
+      {
+        id: 'planning',
+        title: 'Planning',
+        startsAt: new Date(2026, 4, 22, 14, 0),
+        endsAt: new Date(2026, 4, 22, 15, 30),
+      },
+    ];
+    render(
+      <AgendaView
+        days={WEEK_DAYS}
+        rangeLabel="May 18 – 24, 2026"
+        events={events}
+        emptyLabel="No events"
+      />,
+      { wrapper: wrap() },
+    );
+    // Only two day headers — Wednesday May 20 and Friday May 22.
+    const headers = screen.getAllByRole('button').map((b) => b.textContent ?? '');
+    expect(headers.some((t) => /Standup/.test(t))).toBe(true);
+    expect(headers.some((t) => /Planning/.test(t))).toBe(true);
+    expect(screen.getByText(/Wednesday, May 20/)).toBeInTheDocument();
+    expect(screen.getByText(/Friday, May 22/)).toBeInTheDocument();
+    expect(screen.queryByText(/Monday, May 18/)).not.toBeInTheDocument();
+  });
+
+  it('shows the start time in the gutter for single-day timed events', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 's',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9, 0),
+        endsAt: new Date(2026, 4, 20, 9, 30),
+      },
+    ];
+    render(
+      <AgendaView
+        days={WEEK_DAYS}
+        rangeLabel="May 18 – 24, 2026"
+        events={events}
+        emptyLabel="No events"
+      />,
+      { wrapper: wrap() },
+    );
+    const button = screen.getByRole('button', { name: /Standup/ });
+    expect(button.textContent).toMatch(/9:00\s*(AM|am)/);
+    // Range form: "9:00 AM – 9:30 AM"
+    expect(button.textContent).toMatch(/9:30/);
+  });
+
+  it('shows "All day" for allDay events', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 'bd',
+        title: 'Birthday',
+        startsAt: new Date(2026, 4, 20),
+        endsAt: new Date(2026, 4, 20),
+        allDay: true,
+      },
+    ];
+    render(
+      <AgendaView
+        days={WEEK_DAYS}
+        rangeLabel="May 18 – 24, 2026"
+        events={events}
+        emptyLabel="No events"
+      />,
+      { wrapper: wrap() },
+    );
+    expect(screen.getByText('All day')).toBeInTheDocument();
+  });
+
+  it('multi-day events appear under every day they span', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 'conf',
+        title: 'Conference',
+        startsAt: new Date(2026, 4, 19),
+        endsAt: new Date(2026, 4, 21),
+        allDay: true,
+      },
+    ];
+    render(
+      <AgendaView
+        days={WEEK_DAYS}
+        rangeLabel="May 18 – 24, 2026"
+        events={events}
+        emptyLabel="No events"
+      />,
+      { wrapper: wrap() },
+    );
+    const conferenceButtons = screen.getAllByRole('button', { name: /Conference/ });
+    expect(conferenceButtons).toHaveLength(3); // Tue, Wed, Thu
+  });
+
+  it('sorts all-day events before timed events within a day', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 'timed',
+        title: 'Timed event',
+        startsAt: new Date(2026, 4, 20, 9, 0),
+        endsAt: new Date(2026, 4, 20, 10, 0),
+      },
+      {
+        id: 'allday',
+        title: 'All-day event',
+        startsAt: new Date(2026, 4, 20),
+        endsAt: new Date(2026, 4, 20),
+        allDay: true,
+      },
+    ];
+    render(
+      <AgendaView
+        days={WEEK_DAYS}
+        rangeLabel="May 18 – 24, 2026"
+        events={events}
+        emptyLabel="No events"
+      />,
+      { wrapper: wrap() },
+    );
+    const buttons = screen.getAllByRole('button');
+    const allDayIdx = buttons.findIndex((b) => /All-day event/.test(b.textContent ?? ''));
+    const timedIdx = buttons.findIndex((b) => /Timed event/.test(b.textContent ?? ''));
+    expect(allDayIdx).toBeLessThan(timedIdx);
+  });
+
+  it('fires onEventClick when a row is clicked', async () => {
+    const onEventClick = vi.fn<(event: CalendarEvent) => void>();
+    const events: CalendarEvent[] = [
+      {
+        id: 'a',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9, 0),
+        endsAt: new Date(2026, 4, 20, 9, 30),
+      },
+    ];
+    render(
+      <AgendaView
+        days={WEEK_DAYS}
+        rangeLabel="May 18 – 24, 2026"
+        events={events}
+        emptyLabel="No events"
+        onEventClick={onEventClick}
+      />,
+      { wrapper: wrap() },
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Standup/ }));
+    expect(onEventClick).toHaveBeenCalledTimes(1);
+    expect(onEventClick.mock.calls[0][0].id).toBe('a');
+  });
+
+  it('renderEvent receives view-aware context for agenda rows', () => {
+    const calls: Array<{ id: string; view: string; asAllDay: boolean; duration: string }> = [];
+    const events: CalendarEvent[] = [
+      {
+        id: 'timed',
+        title: 'Standup',
+        startsAt: new Date(2026, 4, 20, 9, 0),
+        endsAt: new Date(2026, 4, 20, 9, 30),
+      },
+      {
+        id: 'all',
+        title: 'Birthday',
+        startsAt: new Date(2026, 4, 20),
+        endsAt: new Date(2026, 4, 20),
+        allDay: true,
+      },
+    ];
+    render(
+      <AgendaView
+        days={WEEK_DAYS}
+        rangeLabel="May 18 – 24, 2026"
+        events={events}
+        emptyLabel="No events"
+        renderEvent={(event, ctx) => {
+          calls.push({
+            id: event.id,
+            view: ctx.view,
+            asAllDay: ctx.asAllDay,
+            duration: ctx.duration,
+          });
+          return <span>{event.title}</span>;
+        }}
+      />,
+      { wrapper: wrap() },
+    );
+    const timed = calls.find((c) => c.id === 'timed');
+    const all = calls.find((c) => c.id === 'all');
+    expect(timed).toMatchObject({ view: 'agenda', asAllDay: false, duration: '30m' });
+    expect(all).toMatchObject({ view: 'agenda', asAllDay: true });
+  });
+
+  it('uses locale-aware day headers (ru-RU has Cyrillic)', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: 'a',
+        title: 'Стендап',
+        startsAt: new Date(2026, 4, 20, 9, 0),
+        endsAt: new Date(2026, 4, 20, 9, 30),
+      },
+    ];
+    render(
+      <AgendaView
+        days={WEEK_DAYS}
+        rangeLabel="May 18 – 24, 2026"
+        events={events}
+        emptyLabel="No events"
+        locale="ru-RU"
+      />,
+      { wrapper: wrap('ru-RU') },
+    );
+    const headers = document.body.textContent ?? '';
+    expect(headers).toMatch(/[Ѐ-ӿ]/);
+  });
+});

--- a/packages/design-system/src/components/Calendar/AgendaView.tsx
+++ b/packages/design-system/src/components/Calendar/AgendaView.tsx
@@ -4,7 +4,6 @@ import { useLocale } from '../../i18n/useLocale';
 import { formatDayLong, formatTime } from '../../calendar';
 import { startOfDay } from '../../calendar/dateMath';
 import type { Day } from '../../calendar/types';
-import { Tooltip } from '../Tooltip';
 import { formatEventDuration } from './utils';
 import type { CalendarEvent, CalendarEventTone, RenderEvent } from './types';
 import styles from './AgendaView.module.scss';
@@ -117,15 +116,6 @@ function AgendaRowItem({ row, locale, onClick, renderEvent }: AgendaRowItemProps
   const timeLabel =
     !isAllDay && endLabel && endLabel !== startLabel ? `${startLabel} – ${endLabel}` : startLabel;
 
-  const tooltipBody = (
-    <span className={styles.tooltipBody}>
-      <span className={styles.tooltipTime}>
-        {isAllDay ? duration : `${startLabel} · ${duration}`}
-      </span>
-      <span className={styles.tooltipTitle}>{event.title}</span>
-    </span>
-  );
-
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     onClick?.(event);
@@ -141,21 +131,19 @@ function AgendaRowItem({ row, locale, onClick, renderEvent }: AgendaRowItemProps
     : null;
 
   return (
-    <Tooltip content={tooltipBody}>
-      <button type="button" className={clsx(styles.rowButton, styles[tone])} onClick={handleClick}>
-        <span className={styles.timeGutter}>
-          {isAllDay ? <em className={styles.allDay}>All day</em> : timeLabel}
-        </span>
-        <span className={styles.toneDot} aria-hidden="true" />
-        <span className={styles.body}>
-          {customContent !== null ? (
-            customContent
-          ) : (
-            <span className={styles.title}>{event.title}</span>
-          )}
-        </span>
-      </button>
-    </Tooltip>
+    <button type="button" className={clsx(styles.rowButton, styles[tone])} onClick={handleClick}>
+      <span className={styles.timeGutter}>
+        {isAllDay ? <em className={styles.allDay}>All day</em> : timeLabel}
+      </span>
+      <span className={styles.toneDot} aria-hidden="true" />
+      <span className={styles.body}>
+        {customContent !== null ? (
+          customContent
+        ) : (
+          <span className={styles.title}>{event.title}</span>
+        )}
+      </span>
+    </button>
   );
 }
 

--- a/packages/design-system/src/components/Calendar/AgendaView.tsx
+++ b/packages/design-system/src/components/Calendar/AgendaView.tsx
@@ -15,11 +15,11 @@ export interface AgendaViewProps {
   /** Localized range label for the agenda window (e.g., "May 18 – 24, 2026"). */
   rangeLabel: string;
   /** Events to project into the window. Multi-day events appear under every day they span. */
-  events?: readonly CalendarEvent[];
+  events: readonly CalendarEvent[];
   /** Override locale (otherwise reads `useLocale()`). */
   locale?: string;
-  /** Empty-state message shown when no events fall inside the window. */
-  emptyLabel: string;
+  /** Empty-state message shown when no events fall inside the window. Defaults to "No events". */
+  emptyLabel?: string;
   /** Fires when the user clicks an event row. */
   onEventClick?: (event: CalendarEvent) => void;
   /** Optional custom event renderer (see `RenderEvent`). */
@@ -59,28 +59,32 @@ export function AgendaView({
   rangeLabel,
   events,
   locale: localeOverride,
-  emptyLabel,
+  emptyLabel = 'No events',
   onEventClick,
   renderEvent,
 }: AgendaViewProps) {
   const contextLocale = useLocale();
   const locale = localeOverride ?? contextLocale;
 
-  const groups = useMemo(() => buildDayGroups(days, events ?? []), [days, events]);
+  const groups = useMemo(() => buildDayGroups(days, events), [days, events]);
 
   if (groups.length === 0) {
     return (
-      <div className={styles.agenda} aria-label={rangeLabel}>
+      <div className={styles.agenda} role="list" aria-label={rangeLabel}>
         <p className={styles.empty}>{emptyLabel}</p>
       </div>
     );
   }
 
   return (
-    <div className={styles.agenda} aria-label={rangeLabel}>
+    <div className={styles.agenda} role="list" aria-label={rangeLabel}>
       {groups.map(({ day, rows }) => (
-        <section key={day.key} className={clsx(styles.dayGroup, day.isToday && styles.todayGroup)}>
-          <header className={styles.dayHeader}>{formatDayLong(day.date, locale)}</header>
+        <div
+          key={day.key}
+          role="listitem"
+          className={clsx(styles.dayGroup, day.isToday && styles.todayGroup)}
+        >
+          <h3 className={styles.dayHeader}>{formatDayLong(day.date, locale)}</h3>
           <div className={styles.rows}>
             {rows.map((row) => (
               <AgendaRowItem
@@ -92,7 +96,7 @@ export function AgendaView({
               />
             ))}
           </div>
-        </section>
+        </div>
       ))}
     </div>
   );

--- a/packages/design-system/src/components/Calendar/AgendaView.tsx
+++ b/packages/design-system/src/components/Calendar/AgendaView.tsx
@@ -1,0 +1,210 @@
+import { useMemo, type MouseEvent } from 'react';
+import clsx from 'clsx';
+import { useLocale } from '../../i18n/useLocale';
+import { formatDayLong, formatTime } from '../../calendar';
+import { startOfDay } from '../../calendar/dateMath';
+import type { Day } from '../../calendar/types';
+import { Tooltip } from '../Tooltip';
+import { formatEventDuration } from './utils';
+import type { CalendarEvent, CalendarEventTone, RenderEvent } from './types';
+import styles from './AgendaView.module.scss';
+
+export interface AgendaViewProps {
+  /** One `Day` per calendar day in the agenda window (inclusive at both ends). */
+  days: readonly Day[];
+  /** Localized range label for the agenda window (e.g., "May 18 – 24, 2026"). */
+  rangeLabel: string;
+  /** Events to project into the window. Multi-day events appear under every day they span. */
+  events?: readonly CalendarEvent[];
+  /** Override locale (otherwise reads `useLocale()`). */
+  locale?: string;
+  /** Empty-state message shown when no events fall inside the window. */
+  emptyLabel: string;
+  /** Fires when the user clicks an event row. */
+  onEventClick?: (event: CalendarEvent) => void;
+  /** Optional custom event renderer (see `RenderEvent`). */
+  renderEvent?: RenderEvent;
+}
+
+interface AgendaRow {
+  event: CalendarEvent;
+  /** True when this row represents an `allDay` or multi-day event. */
+  isAllDay: boolean;
+  /** Pre-formatted duration ("30m", "1h", "3d") — locale-independent. */
+  duration: string;
+}
+
+interface DayGroup {
+  day: Day;
+  rows: AgendaRow[];
+}
+
+/**
+ * Internal: agenda (list) view for `<Calendar view='agenda'>`. Projects the
+ * cursor's current-week event window into a chronological list grouped by
+ * day. Days without events are hidden so the list stays scannable.
+ *
+ * - Multi-day events appear under every day they span, each row marked
+ *   `asAllDay` so the time gutter shows "All day" instead of a clock time.
+ * - Single-day timed events show the start time in the gutter.
+ * - Within a day: all-day events first, then timed events by start time.
+ *
+ * @remarks
+ * **When NOT to use:** Do not render `AgendaView` directly — use the
+ * `Calendar` shell with `view='agenda'` (or `defaultView='agenda'`). The
+ * shell owns cursor / locale / labels and dispatches into this component.
+ */
+export function AgendaView({
+  days,
+  rangeLabel,
+  events,
+  locale: localeOverride,
+  emptyLabel,
+  onEventClick,
+  renderEvent,
+}: AgendaViewProps) {
+  const contextLocale = useLocale();
+  const locale = localeOverride ?? contextLocale;
+
+  const groups = useMemo(() => buildDayGroups(days, events ?? []), [days, events]);
+
+  if (groups.length === 0) {
+    return (
+      <div className={styles.agenda} aria-label={rangeLabel}>
+        <p className={styles.empty}>{emptyLabel}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.agenda} aria-label={rangeLabel}>
+      {groups.map(({ day, rows }) => (
+        <section key={day.key} className={clsx(styles.dayGroup, day.isToday && styles.todayGroup)}>
+          <header className={styles.dayHeader}>{formatDayLong(day.date, locale)}</header>
+          <div className={styles.rows}>
+            {rows.map((row) => (
+              <AgendaRowItem
+                key={`${day.key}-${row.event.id}`}
+                row={row}
+                locale={locale}
+                onClick={onEventClick}
+                renderEvent={renderEvent}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+interface AgendaRowItemProps {
+  row: AgendaRow;
+  locale: string;
+  onClick?: (event: CalendarEvent) => void;
+  renderEvent?: RenderEvent;
+}
+
+function AgendaRowItem({ row, locale, onClick, renderEvent }: AgendaRowItemProps) {
+  const { event, isAllDay, duration } = row;
+  const tone: CalendarEventTone = event.tone ?? 'neutral';
+  const startLabel = isAllDay ? undefined : formatTime(event.startsAt, locale);
+  const endLabel = !isAllDay && event.endsAt ? formatTime(event.endsAt, locale) : undefined;
+  const timeLabel =
+    !isAllDay && endLabel && endLabel !== startLabel ? `${startLabel} – ${endLabel}` : startLabel;
+
+  const tooltipBody = (
+    <span className={styles.tooltipBody}>
+      <span className={styles.tooltipTime}>
+        {isAllDay ? duration : `${startLabel} · ${duration}`}
+      </span>
+      <span className={styles.tooltipTitle}>{event.title}</span>
+    </span>
+  );
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onClick?.(event);
+  };
+
+  const customContent = renderEvent
+    ? renderEvent(event, {
+        view: 'agenda',
+        asAllDay: isAllDay,
+        timeLabel: isAllDay ? undefined : timeLabel,
+        duration,
+      })
+    : null;
+
+  return (
+    <Tooltip content={tooltipBody}>
+      <button type="button" className={clsx(styles.rowButton, styles[tone])} onClick={handleClick}>
+        <span className={styles.timeGutter}>
+          {isAllDay ? <em className={styles.allDay}>All day</em> : timeLabel}
+        </span>
+        <span className={styles.toneDot} aria-hidden="true" />
+        <span className={styles.body}>
+          {customContent !== null ? (
+            customContent
+          ) : (
+            <span className={styles.title}>{event.title}</span>
+          )}
+        </span>
+      </button>
+    </Tooltip>
+  );
+}
+
+/**
+ * Group events by day across the agenda window. Multi-day events appear
+ * under every day they span. Empty days are dropped. Within a day rows
+ * are sorted: all-day first (by startsAt), then timed events by startsAt.
+ */
+function buildDayGroups(days: readonly Day[], events: readonly CalendarEvent[]): DayGroup[] {
+  if (days.length === 0 || events.length === 0) return [];
+
+  // Pre-normalize each event into row data once.
+  interface Normalized {
+    event: CalendarEvent;
+    startDayMs: number;
+    endDayMs: number;
+    isAllDay: boolean;
+    isMultiDay: boolean;
+  }
+  const normalized: Normalized[] = events.map((ev) => {
+    const startDayMs = startOfDay(ev.startsAt).getTime();
+    const endDayMs = ev.endsAt ? startOfDay(ev.endsAt).getTime() : startDayMs;
+    const isAllDayProp = ev.allDay === true;
+    const isMultiDay = endDayMs > startDayMs;
+    // Multi-day events render with an "All day" gutter regardless of allDay
+    // flag — there's no single time that's meaningful across the span.
+    return {
+      event: ev,
+      startDayMs,
+      endDayMs,
+      isAllDay: isAllDayProp || isMultiDay,
+      isMultiDay,
+    };
+  });
+
+  const groups: DayGroup[] = [];
+  for (const day of days) {
+    const dayMs = startOfDay(day.date).getTime();
+    const dayEvents = normalized.filter((n) => n.startDayMs <= dayMs && dayMs <= n.endDayMs);
+    if (dayEvents.length === 0) continue;
+
+    // Sort: allDay/multi-day first by startsAt, then timed by startsAt.
+    dayEvents.sort((a, b) => {
+      if (a.isAllDay !== b.isAllDay) return a.isAllDay ? -1 : 1;
+      return a.event.startsAt.getTime() - b.event.startsAt.getTime();
+    });
+
+    const rows: AgendaRow[] = dayEvents.map((n) => ({
+      event: n.event,
+      isAllDay: n.isAllDay,
+      duration: formatEventDuration(n.event.startsAt, n.event.endsAt, n.isAllDay),
+    }));
+    groups.push({ day, rows });
+  }
+  return groups;
+}

--- a/packages/design-system/src/components/Calendar/Calendar.test.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.test.tsx
@@ -141,6 +141,9 @@ describe('Calendar', () => {
       { wrapper: wrap() },
     );
     expect(screen.getByRole('button', { name: /Standup/ })).toBeInTheDocument();
+    // Agenda exposes a labelled list region (cycle-1 a11y fix).
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getByRole('listitem')).toBeInTheDocument();
   });
 
   it('prev/next aria-labels reflect the active view (per-view labels)', async () => {

--- a/packages/design-system/src/components/Calendar/Calendar.test.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.test.tsx
@@ -123,4 +123,66 @@ describe('Calendar', () => {
     await user.click(screen.getByRole('tab', { name: 'Week' }));
     expect(onViewChange).toHaveBeenCalledWith('week');
   });
+
+  it('switches to AgendaView when defaultView="agenda"', () => {
+    render(
+      <Calendar
+        defaultValue={new Date(2026, 4, 20)}
+        defaultView="agenda"
+        events={[
+          {
+            id: 'a',
+            title: 'Standup',
+            startsAt: new Date(2026, 4, 20, 9),
+            endsAt: new Date(2026, 4, 20, 9, 30),
+          },
+        ]}
+      />,
+      { wrapper: wrap() },
+    );
+    expect(screen.getByRole('button', { name: /Standup/ })).toBeInTheDocument();
+  });
+
+  it('prev/next aria-labels reflect the active view (per-view labels)', async () => {
+    const user = userEvent.setup();
+    const cases: Array<{
+      defaultView: 'month' | 'week' | 'day' | 'agenda';
+      prev: string;
+      next: string;
+    }> = [
+      { defaultView: 'month', prev: 'Previous month', next: 'Next month' },
+      { defaultView: 'week', prev: 'Previous week', next: 'Next week' },
+      { defaultView: 'day', prev: 'Previous day', next: 'Next day' },
+      { defaultView: 'agenda', prev: 'Previous week', next: 'Next week' },
+    ];
+    for (const { defaultView, prev, next } of cases) {
+      const { unmount } = render(
+        <Calendar defaultValue={new Date(2026, 4, 20)} defaultView={defaultView} />,
+        { wrapper: wrap() },
+      );
+      expect(screen.getByRole('button', { name: prev })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: next })).toBeInTheDocument();
+      unmount();
+    }
+    // Prove the user can step through views and see the labels swap.
+    render(<Calendar defaultValue={new Date(2026, 4, 20)} defaultView="month" />, {
+      wrapper: wrap(),
+    });
+    expect(screen.getByRole('button', { name: 'Previous month' })).toBeInTheDocument();
+    await user.click(screen.getByRole('tab', { name: 'Day' }));
+    expect(screen.getByRole('button', { name: 'Previous day' })).toBeInTheDocument();
+  });
+
+  it('prev/next steps by week in agenda view', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn<(d: Date) => void>();
+    render(
+      <Calendar defaultValue={new Date(2026, 4, 20)} defaultView="agenda" onChange={onChange} />,
+      { wrapper: wrap() },
+    );
+    await user.click(screen.getByRole('button', { name: /Next week/ }));
+    const next = onChange.mock.calls[0][0];
+    // May 20 + 7 days = May 27
+    expect(next.getDate()).toBe(27);
+  });
 });

--- a/packages/design-system/src/components/Calendar/Calendar.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.tsx
@@ -157,7 +157,7 @@ const DEFAULT_LABELS: Required<CalendarLabels> = {
  * @example
  * // Controlled cursor + view + locale labels:
  * const [cursor, setCursor] = useState(new Date());
- * const [view, setView] = useState<'month' | 'week' | 'day'>('month');
+ * const [view, setView] = useState<CalendarView>('month');
  * <Calendar
  *   value={cursor}
  *   onChange={setCursor}
@@ -170,6 +170,7 @@ const DEFAULT_LABELS: Required<CalendarLabels> = {
  *     viewMonth: 'Месяц',
  *     viewWeek: 'Неделя',
  *     viewDay: 'День',
+ *     viewAgenda: 'Повестка',
  *   }}
  * />;
  *

--- a/packages/design-system/src/components/Calendar/Calendar.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.tsx
@@ -3,12 +3,18 @@ import clsx from 'clsx';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '../Button';
 import { Cluster } from '../Cluster';
-import { addDays, addMonths, addWeeks } from '../../calendar/dateMath';
+import { addDays, addMonths, addWeeks, startOfWeek } from '../../calendar/dateMath';
 import { useMonth } from '../../calendar/useMonth';
+import { useWeek } from '../../calendar/useWeek';
+import { useDay } from '../../calendar/useDay';
+import { useAgenda } from '../../calendar/useAgenda';
+import { useLocale } from '../../i18n/useLocale';
 import { LocaleProvider } from '../../i18n/LocaleProvider';
+import { getFirstDayOfWeek } from '../../calendar/weekInfo';
 import { MonthView } from './MonthView';
 import { WeekView } from './WeekView';
 import { DayView } from './DayView';
+import { AgendaView } from './AgendaView';
 import { ViewSwitcher } from './ViewSwitcher';
 import type { CalendarEvent, CalendarView, RenderEvent } from './types';
 import styles from './Calendar.module.scss';
@@ -20,10 +26,22 @@ import styles from './Calendar.module.scss';
 export interface CalendarLabels {
   /** Text on the "Today" button. */
   today?: string;
-  /** ARIA label on the prev chevron. */
+  /** ARIA label on the prev chevron when month view is active (steps a month). */
   previousMonth?: string;
-  /** ARIA label on the next chevron. */
+  /** ARIA label on the next chevron when month view is active (steps a month). */
   nextMonth?: string;
+  /** ARIA label on the prev chevron when week view is active (steps a week). */
+  previousWeek?: string;
+  /** ARIA label on the next chevron when week view is active (steps a week). */
+  nextWeek?: string;
+  /** ARIA label on the prev chevron when day view is active (steps a day). */
+  previousDay?: string;
+  /** ARIA label on the next chevron when day view is active (steps a day). */
+  nextDay?: string;
+  /** ARIA label on the prev chevron when agenda view is active (steps a week). */
+  previousAgenda?: string;
+  /** ARIA label on the next chevron when agenda view is active (steps a week). */
+  nextAgenda?: string;
   /** Template for the "+N more events" aria-label. */
   moreEvents?: (count: number) => string;
   /** Segmented-control label for the month view. */
@@ -32,6 +50,10 @@ export interface CalendarLabels {
   viewWeek?: string;
   /** Segmented-control label for the day view. */
   viewDay?: string;
+  /** Segmented-control label for the agenda view. */
+  viewAgenda?: string;
+  /** Empty-state message in agenda view when no events fall in the visible week. */
+  agendaEmpty?: string;
 }
 
 export interface CalendarProps extends Omit<
@@ -100,14 +122,22 @@ const DEFAULT_LABELS: Required<CalendarLabels> = {
   today: 'Today',
   previousMonth: 'Previous month',
   nextMonth: 'Next month',
+  previousWeek: 'Previous week',
+  nextWeek: 'Next week',
+  previousDay: 'Previous day',
+  nextDay: 'Next day',
+  previousAgenda: 'Previous week',
+  nextAgenda: 'Next week',
   moreEvents: (n) => `${n} more events`,
   viewMonth: 'Month',
   viewWeek: 'Week',
   viewDay: 'Day',
+  viewAgenda: 'Agenda',
+  agendaEmpty: 'No events',
 };
 
 /**
- * Month / week / day calendar.
+ * Month / week / day / agenda calendar.
  *
  * - Controlled cursor via `value` / `onChange`, or uncontrolled via
  *   `defaultValue`.
@@ -200,47 +230,72 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
     [viewProp, onViewChange],
   );
 
+  const contextLocale = useLocale();
+  const resolvedWeekStartsOn = weekStartsOn ?? getFirstDayOfWeek(locale ?? contextLocale);
+
   const grid = useMonth(cursor, { locale, weekStartsOn });
+  const week = useWeek(cursor, { locale, weekStartsOn });
+  const day = useDay(cursor, { locale });
+  // Agenda window mirrors the cursor's current week (Sun-Sat or Mon-Sun
+  // depending on locale). Prev/Next on agenda steps a week, same as week view.
+  const agendaFrom = startOfWeek(cursor, resolvedWeekStartsOn);
+  const agendaTo = addDays(agendaFrom, 6);
+  const agenda = useAgenda(agendaFrom, agendaTo, { locale, weekStartsOn });
 
   // Prev/Next step matches the active view: a month in month view, a week in
-  // week view, a day in day view. Without this, multi-day events that span
-  // several weeks aren't reachable when in week/day view — each click would
-  // skip over them.
+  // week or agenda view, a day in day view. Without this, multi-day events
+  // that span several weeks aren't reachable in week/day view — each click
+  // would skip over them.
   const stepBy =
     view === 'month'
       ? (d: Date, n: number) => addMonths(d, n)
-      : view === 'week'
-        ? (d: Date, n: number) => addWeeks(d, n)
-        : (d: Date, n: number) => addDays(d, n);
+      : view === 'day'
+        ? (d: Date, n: number) => addDays(d, n)
+        : (d: Date, n: number) => addWeeks(d, n);
   const goPrev = () => handleChange(stepBy(cursor, -1));
   const goNext = () => handleChange(stepBy(cursor, 1));
   const goToday = () => handleChange(new Date());
 
+  // View-aware title + prev/next aria-labels. Each view's label/range
+  // formatter is locale-aware (Intl-driven inside the hooks).
+  const titleLabel =
+    view === 'month'
+      ? grid.monthLabel
+      : view === 'week'
+        ? week.weekLabel
+        : view === 'day'
+          ? day.dayLabel
+          : agenda.rangeLabel;
+  const prevLabel =
+    view === 'month'
+      ? resolvedLabels.previousMonth
+      : view === 'week'
+        ? resolvedLabels.previousWeek
+        : view === 'day'
+          ? resolvedLabels.previousDay
+          : resolvedLabels.previousAgenda;
+  const nextLabel =
+    view === 'month'
+      ? resolvedLabels.nextMonth
+      : view === 'week'
+        ? resolvedLabels.nextWeek
+        : view === 'day'
+          ? resolvedLabels.nextDay
+          : resolvedLabels.nextAgenda;
+
   const body: ReactNode = (
     <div ref={ref} className={clsx(styles.calendar, className)} {...rest}>
       <header className={styles.header}>
-        <h2 className={styles.title}>{grid.monthLabel}</h2>
+        <h2 className={styles.title}>{titleLabel}</h2>
         <Cluster gap="sm" align="center">
           <Cluster gap="xs" align="center">
-            <Button
-              size="xs"
-              variant="ghost"
-              iconOnly
-              aria-label={resolvedLabels.previousMonth}
-              onClick={goPrev}
-            >
+            <Button size="xs" variant="ghost" iconOnly aria-label={prevLabel} onClick={goPrev}>
               <ChevronLeft size={14} />
             </Button>
             <Button size="sm" variant="secondary" onClick={goToday}>
               {resolvedLabels.today}
             </Button>
-            <Button
-              size="xs"
-              variant="ghost"
-              iconOnly
-              aria-label={resolvedLabels.nextMonth}
-              onClick={goNext}
-            >
+            <Button size="xs" variant="ghost" iconOnly aria-label={nextLabel} onClick={goNext}>
               <ChevronRight size={14} />
             </Button>
           </Cluster>
@@ -250,6 +305,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
             monthLabel={resolvedLabels.viewMonth}
             weekLabel={resolvedLabels.viewWeek}
             dayLabel={resolvedLabels.viewDay}
+            agendaLabel={resolvedLabels.viewAgenda}
           />
         </Cluster>
       </header>
@@ -288,6 +344,17 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
           locale={locale}
           onEventClick={onEventClick}
           onDayClick={onDayClick}
+          renderEvent={renderEvent}
+        />
+      )}
+      {view === 'agenda' && (
+        <AgendaView
+          days={agenda.days}
+          rangeLabel={agenda.rangeLabel}
+          events={events}
+          locale={locale}
+          emptyLabel={resolvedLabels.agendaEmpty}
+          onEventClick={onEventClick}
           renderEvent={renderEvent}
         />
       )}

--- a/packages/design-system/src/components/Calendar/ViewSwitcher.tsx
+++ b/packages/design-system/src/components/Calendar/ViewSwitcher.tsx
@@ -9,11 +9,13 @@ export interface ViewSwitcherProps {
   monthLabel: string;
   weekLabel: string;
   dayLabel: string;
+  agendaLabel: string;
 }
 
 /**
- * Internal: segmented control for switching between month / week / day views.
- * Uses the design system's `<Tabs>` for ARIA + keyboard navigation.
+ * Internal: segmented control for switching between month / week / day /
+ * agenda views. Uses the design system's `<Tabs>` for ARIA + keyboard
+ * navigation.
  *
  * @remarks
  * **When NOT to use:** Do not render `ViewSwitcher` directly. It is composed
@@ -25,14 +27,16 @@ export function ViewSwitcher({
   monthLabel,
   weekLabel,
   dayLabel,
+  agendaLabel,
 }: ViewSwitcherProps) {
   const items = useMemo(
     () => [
       { id: 'month', label: monthLabel },
       { id: 'week', label: weekLabel },
       { id: 'day', label: dayLabel },
+      { id: 'agenda', label: agendaLabel },
     ],
-    [monthLabel, weekLabel, dayLabel],
+    [monthLabel, weekLabel, dayLabel, agendaLabel],
   );
 
   return (

--- a/packages/design-system/src/components/Calendar/types.ts
+++ b/packages/design-system/src/components/Calendar/types.ts
@@ -27,9 +27,10 @@ export interface CalendarEvent {
 }
 
 /**
- * Active Calendar view. Month + week + day in v3. Agenda lands in PR 4.
+ * Active Calendar view. Month / week / day render a grid; agenda is a
+ * scannable list of events grouped by day for the cursor's current week.
  */
-export type CalendarView = 'month' | 'week' | 'day';
+export type CalendarView = 'month' | 'week' | 'day' | 'agenda';
 
 /**
  * One placed event bar inside the month grid. Produced by

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -79,8 +79,8 @@ export { LocaleProvider, useLocale } from './i18n';
 export type { LocaleProviderProps } from './i18n';
 
 // Calendar primitives (hooks + date math + Intl formatters + locale week info).
-// The Calendar UI components ship in a follow-up PR; these primitives are the
-// substrate they (and a future DatePicker) compose against.
+// The Calendar UI components below and a future DatePicker compose against
+// these — use them directly when you need date math without the UI.
 export {
   useMonth,
   useWeek,

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -137,6 +137,11 @@
   // still look like cells without inflating the day-number row.
   --size-calendar-day-cell-min-height: 6.5rem;
 
+  // Calendar — fixed gutter width for the agenda-row time label column.
+  // Wide enough to fit "12:00 PM – 12:30 PM" without clipping at default
+  // font size while keeping titles readable.
+  --size-calendar-agenda-gutter: 8rem;
+
   // Border weights — emphasis = tab underline/focus rings; strong = accent
   // stripes on cards or other "this stands out" visuals.
   --border-width: 1px;

--- a/packages/playground/src/pages/components/CalendarDemo.tsx
+++ b/packages/playground/src/pages/components/CalendarDemo.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Calendar, type CalendarEvent } from '@eocrm/design-system';
+import { Calendar, type CalendarEvent, type CalendarView } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import tsxSource from '@lib-source/components/Calendar/Calendar.tsx?raw';
@@ -156,7 +156,7 @@ function ControlledCalendarDemo() {
 }
 
 function ViewSwitcherDemo() {
-  const [view, setView] = useState<'month' | 'week' | 'day'>('week');
+  const [view, setView] = useState<CalendarView>('week');
   return (
     <Calendar defaultValue={TODAY} view={view} onViewChange={setView} events={SAMPLE_EVENTS} />
   );
@@ -289,6 +289,18 @@ export function CalendarDemo() {
           events={SAMPLE_EVENTS}
           hourRange={[8, 18]}
         />
+      </Example>
+
+      <Example
+        title="Agenda view"
+        description="Chronological list of the cursor's current week, grouped by day. Days without events are hidden so the list stays scannable. Multi-day events appear under every day they span. Prev/next steps a week at a time."
+        code={`<Calendar
+  defaultValue={new Date()}
+  defaultView="agenda"
+  events={SAMPLE_EVENTS}
+/>`}
+      >
+        <Calendar defaultValue={TODAY} defaultView="agenda" events={SAMPLE_EVENTS} />
       </Example>
 
       <Example

--- a/packages/playground/src/pages/components/CalendarDemo.tsx
+++ b/packages/playground/src/pages/components/CalendarDemo.tsx
@@ -238,10 +238,18 @@ export function CalendarDemo() {
     today: 'Сегодня',
     previousMonth: 'Предыдущий месяц',
     nextMonth: 'Следующий месяц',
+    previousWeek: 'Предыдущая неделя',
+    nextWeek: 'Следующая неделя',
+    previousDay: 'Предыдущий день',
+    nextDay: 'Следующий день',
+    previousAgenda: 'Предыдущая неделя',
+    nextAgenda: 'Следующая неделя',
     moreEvents: (n) => \`ещё ${'${n}'} событий\`,
     viewMonth: 'Месяц',
     viewWeek: 'Неделя',
     viewDay: 'День',
+    viewAgenda: 'Повестка',
+    agendaEmpty: 'Нет событий',
   }}
 />`}
       >
@@ -253,10 +261,18 @@ export function CalendarDemo() {
             today: 'Сегодня',
             previousMonth: 'Предыдущий месяц',
             nextMonth: 'Следующий месяц',
+            previousWeek: 'Предыдущая неделя',
+            nextWeek: 'Следующая неделя',
+            previousDay: 'Предыдущий день',
+            nextDay: 'Следующий день',
+            previousAgenda: 'Предыдущая неделя',
+            nextAgenda: 'Следующая неделя',
             moreEvents: (n) => `ещё ${n} событий`,
             viewMonth: 'Месяц',
             viewWeek: 'Неделя',
             viewDay: 'День',
+            viewAgenda: 'Повестка',
+            agendaEmpty: 'Нет событий',
           }}
         />
       </Example>
@@ -307,7 +323,7 @@ export function CalendarDemo() {
         title="View switching (controlled)"
         description="Consumer owns the active view via `view` / `onViewChange`. Useful for URL-syncing the current view."
         code={`function ViewSwitcherDemo() {
-  const [view, setView] = useState<'month' | 'week' | 'day'>('week');
+  const [view, setView] = useState<CalendarView>('week');
   return (
     <Calendar
       defaultValue={new Date()}


### PR DESCRIPTION
## Summary

- New `'agenda'` value on `CalendarView`. The Calendar shell branches into a new `<AgendaView>` that shows a chronological list of the cursor's current week, grouped by day with empty days hidden. Multi-day events appear under every day they span.
- Title is now view-aware (month label / week range / day label / agenda range) instead of always showing the month label.
- Prev/Next aria-labels are now per-view (`previousMonth`/`previousWeek`/`previousDay`/`previousAgenda` and their `next*` counterparts). Fixes the long-standing "Previous month" leak in week/day/agenda views — flagged in PR #21's final review cycle.
- ViewSwitcher gets an "Agenda" segment.
- Playground demo gets an Agenda example.

## Test plan

- [x] `make test` — 639 passing (9 new for AgendaView + 3 new on Calendar.test.tsx)
- [x] `make build` clean
- [x] `npm run typecheck` clean (both workspaces)
- [x] `npm run lint:css` clean
- [x] Prettier clean
- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files leak

## Review cycles

Pre-push review-fix cycle from `packages/design-system/CLAUDE.md` Rule 8 will run after this PR is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)