### PR TITLE
Input / DatePicker / DateRangePicker: add size prop (sm | md | lg)

### DIFF
--- a/docs/superpowers/plans/2026-05-21-input-sizes-sm-lg.md
+++ b/docs/superpowers/plans/2026-05-21-input-sizes-sm-lg.md
@@ -1,0 +1,750 @@
+# Input field sizes `sm` + `lg` — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `size: 'sm' | 'md' | 'lg'` prop to `<Input>`, `<DatePicker>`, `<DateRangePicker>`. `<Select>` already has the same scale and needs no library code changes. `md` stays the default — no behavior change for existing consumers.
+
+**Architecture:** Token-based SCSS modifier classes (`.size-sm`, `.size-md`, `.size-lg`) per component. Composite components (DP/DRP) also scale their inner clear ✕ and open-calendar button slots + the lucide icon size via a small per-size lookup constant.
+
+**Tech Stack:** React, SCSS modules, Vitest + RTL.
+
+**Branch:** `feat/input-sizes-xs-lg` (retained for continuity; `xs` deferred per the spec).
+
+**Spec:** `docs/superpowers/specs/2026-05-21-input-sizes-xs-lg-design.md`.
+
+---
+
+## Task 1: Verify branch + hooks
+
+- [ ] **Step 1: Verify branch + hooks installed**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # → feat/input-sizes-xs-lg
+git config --get core.hooksPath   # → .husky/_
+test -x .husky/pre-push           # exit 0
+```
+
+Expected: branch matches, hooks path is `.husky/_`, pre-push exists.
+
+---
+
+## Task 2: `<Input>` — add `size` prop + SCSS
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Input/Input.tsx`
+- Modify: `packages/design-system/src/components/Input/Input.module.scss`
+
+- [ ] **Step 1: Update `Input.tsx`**
+
+Replace the file body with:
+
+```tsx
+import { forwardRef, type InputHTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './Input.module.scss';
+
+/**
+ * Field height + type scale. Pairs with `<Button>` and `<Select>` sizes.
+ */
+export type InputSize = 'sm' | 'md' | 'lg';
+
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  /**
+   * Toggles the error visual (red border + focus ring) and sets `aria-invalid="true"`.
+   * Pair with a visible error message and `aria-describedby` pointing at the message id.
+   */
+  invalid?: boolean;
+  /**
+   * Visual size. Defaults to `'md'`.
+   * - `'sm'` — 24px tall; toolbars, secondary forms.
+   * - `'md'` — 32px tall (default); most form contexts.
+   * - `'lg'` — 40px tall; hero search, mobile-friendly forms.
+   *
+   * Note: this shadows the native HTML `<input size>` attribute (visible
+   * character count). If you need that legacy attribute, set width via
+   * `style` or a parent container.
+   */
+  size?: InputSize;
+}
+
+/**
+ * Single-line text input. Forwards all native `<input>` attributes — `type`,
+ * `placeholder`, `value`/`onChange`, `disabled`, `readOnly`, `pattern`,
+ * `autoComplete`, `inputMode`, etc. (The native HTML `size` attribute is
+ * shadowed by the component-level `size` prop — see `InputProps.size`.)
+ *
+ * The component is intentionally dumb. Validation logic lives in your form
+ * layer (React Hook Form + Zod recommended); pass the result down via `invalid`.
+ *
+ * @example
+ * // Controlled, with a real label:
+ * <label>
+ *   Email
+ *   <Input
+ *     type="email"
+ *     autoComplete="email"
+ *     value={email}
+ *     onChange={(e) => setEmail(e.target.value)}
+ *   />
+ * </label>
+ *
+ * @example
+ * // Sized:
+ * <Input size="sm" placeholder="Filter…" />
+ * <Input size="lg" type="search" placeholder="Search the workspace" />
+ *
+ * @example
+ * // Error state:
+ * <Input invalid value={value} aria-describedby="email-error" />
+ * <p id="email-error">Enter a valid email.</p>
+ *
+ * @remarks When NOT to use
+ * - Multi-line → use `Textarea` (not yet shipped).
+ * - Choosing from a fixed list → use `Select`.
+ * - Date/time → use `DatePicker` / `DateRangePicker`.
+ * - Password reveal/toggle → use `PasswordInput` (not yet shipped).
+ *
+ * @remarks Anti-patterns
+ * - ❌ Putting validation logic *inside* the component. The Input is dumb on
+ *   purpose — validation lives in your form layer.
+ * - ❌ Using `placeholder` as a label. Placeholders disappear on focus. Use a
+ *   real `<label>` and pair the Input with it.
+ * - ❌ `type="number"` for things like phone numbers or zip codes — strips
+ *   leading zeros and breaks formatting. Use `inputMode="numeric"` instead.
+ */
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { invalid, size = 'md', className, ...props },
+  ref,
+) {
+  return (
+    <input
+      ref={ref}
+      // Default aria-invalid to the `invalid` prop, then spread {...props} so
+      // a consumer who explicitly passes aria-invalid (e.g. aria-invalid="false"
+      // for a screen-reader workflow that distinguishes empty from invalid)
+      // wins.
+      aria-invalid={invalid || undefined}
+      {...props}
+      className={clsx(
+        styles.input,
+        styles[`size-${size}`],
+        invalid && styles.invalid,
+        className,
+      )}
+    />
+  );
+});
+```
+
+- [ ] **Step 2: Update `Input.module.scss`**
+
+Replace the file body with:
+
+```scss
+.input {
+  display: block;
+  width: 100%;
+  border: var(--border-width) solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font-family: inherit;
+  line-height: var(--line-height-normal);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+
+  &::placeholder {
+    color: var(--color-fg-subtle);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 var(--ring-width) var(--ring-accent);
+  }
+
+  &:disabled {
+    background: var(--color-bg-subtle);
+    border-color: var(--color-border);
+    color: var(--color-fg-subtle);
+    cursor: not-allowed;
+  }
+}
+
+// Size modifiers. md is the default — match the previous hard-coded values.
+.size-sm {
+  height: var(--size-sm);
+  padding: 0 var(--space-2);
+  font-size: var(--font-size-sm);
+}
+
+.size-md {
+  height: var(--size-md);
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-md);
+}
+
+.size-lg {
+  height: var(--size-lg);
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-lg);
+}
+
+.invalid {
+  border-color: var(--color-danger);
+
+  &:focus-visible {
+    border-color: var(--color-danger);
+    box-shadow: 0 0 0 var(--ring-width) var(--ring-danger);
+  }
+}
+```
+
+- [ ] **Step 3: Run gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test --workspace=@eocrm/design-system --run -- src/components/Input 2>&1 | tail -8
+npm run typecheck 2>&1 | tail -5
+npm run lint:css 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+Tests will likely still pass with default md behavior, but verify.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Input/Input.tsx \
+        packages/design-system/src/components/Input/Input.module.scss
+git commit -m "Input: add size prop (sm | md | lg, default md)"
+```
+
+---
+
+## Task 3: `<Input>` — tests + playground demo
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Input/Input.test.tsx`
+- Modify: `packages/playground/src/pages/components/InputDemo.tsx`
+
+- [ ] **Step 1: Update `Input.test.tsx` — add size tests**
+
+Locate the existing test file. Find the closest analog to "applies className correctly" or the existing tests at the end of the file (after the rendering / variant / ref / className / invalid tests). Add these two tests at the end of the existing `describe`:
+
+```tsx
+it('applies size class names for sm / md / lg', () => {
+  const { rerender, container } = render(<Input size="sm" />);
+  expect(container.querySelector('input')!.className).toMatch(/size-sm/);
+  rerender(<Input size="md" />);
+  expect(container.querySelector('input')!.className).toMatch(/size-md/);
+  rerender(<Input size="lg" />);
+  expect(container.querySelector('input')!.className).toMatch(/size-lg/);
+});
+
+it('defaults to size="md" when no size prop is passed', () => {
+  const { container } = render(<Input />);
+  expect(container.querySelector('input')!.className).toMatch(/size-md/);
+});
+
+it('does NOT pass component size prop through to the DOM size attribute', () => {
+  const { container } = render(<Input size="sm" />);
+  expect(container.querySelector('input')).not.toHaveAttribute('size');
+});
+```
+
+The third test enforces the `Omit<…, 'size'>` discipline. If anyone removes the Omit in a future refactor, the component's string `size` ("sm" / "md" / "lg") would propagate to the DOM `size` attribute. The native `size` only accepts numbers and the browser would coerce / drop the string, but it's still a DOM-attr leak; this test catches the regression.
+
+- [ ] **Step 2: Update `InputDemo.tsx` — add a Sizes example**
+
+After the existing "Default" example block (or wherever sizes naturally slot — match the file's existing order convention), add:
+
+```tsx
+<Example
+  title="Sizes"
+  description="Three sizes — sm (24px), md (32px, default), lg (40px). Use sm for dense toolbars, lg for hero / mobile-friendly forms."
+  code={`<Input size="sm" placeholder="Filter…" />
+<Input size="md" placeholder="Default" />
+<Input size="lg" type="search" placeholder="Search the workspace" />`}
+>
+  <InputExample>
+    <Stack gap="sm">
+      <Input size="sm" placeholder="Filter…" aria-label="Small input" />
+      <Input size="md" placeholder="Default" aria-label="Medium input" />
+      <Input size="lg" type="search" placeholder="Search the workspace" aria-label="Large input" />
+    </Stack>
+  </InputExample>
+</Example>
+```
+
+(`Stack` is already imported in `InputDemo.tsx`; no new imports needed.)
+
+- [ ] **Step 3: Run gates**
+
+```bash
+npm test --workspace=@eocrm/design-system --run -- src/components/Input 2>&1 | tail -8
+npm run typecheck 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Input/Input.test.tsx \
+        packages/playground/src/pages/components/InputDemo.tsx
+git commit -m "Input: tests + demo for new size prop"
+```
+
+---
+
+## Task 4: `<DatePicker>` — add `size` prop + SCSS
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/DatePicker/DatePicker.tsx`
+- Modify: `packages/design-system/src/components/DatePicker/DatePicker.module.scss`
+
+- [ ] **Step 1: Read current `DatePicker.tsx`**
+
+Spot where `DatePickerProps` is defined and where the wrapper `<div>` className gets composed. Note the `<input>` JSX, the `<button>` clear/open elements, and the `<CalendarIcon size={…} />` + `<X size={…} />` icon-size literals.
+
+- [ ] **Step 2: Add `DatePickerSize` type + `size` prop**
+
+Above `DatePickerLabels`:
+
+```ts
+/** Field height + type scale. Pairs with `<Input>` and `<Select>`. */
+export type DatePickerSize = 'sm' | 'md' | 'lg';
+```
+
+In `DatePickerProps`:
+
+- Add `'size'` to the existing `Omit<…>` (the type currently omits `'value' | 'defaultValue' | 'onChange' | 'type' | 'min' | 'max'` — append `| 'size'`).
+- Add the new prop with JSDoc:
+
+```ts
+/**
+ * Field height + type scale. Same scale as `<Input>`. Defaults to `'md'`.
+ * Affects only the trigger row; the popover month grid is fixed-size.
+ */
+size?: DatePickerSize;
+```
+
+- [ ] **Step 3: Add the icon-size lookup constant**
+
+Just below the `DEFAULT_LABELS` constant near the top of the file:
+
+```ts
+const ICON_SIZE_FOR: Record<DatePickerSize, number> = {
+  sm: 14,
+  md: 14,
+  lg: 16,
+};
+```
+
+- [ ] **Step 4: Destructure `size = 'md'` in the component**
+
+Find the destructuring (currently destructures `value`, `defaultValue`, `onChange`, `min`, `max`, `clearable`, etc.). Add `size = 'md'` to the destructuring.
+
+- [ ] **Step 5: Apply the size class on the wrapper**
+
+The wrapper className currently composes something like `clsx(styles.wrapper, invalid && styles.invalid, disabled && styles.disabled, className)`. Extend it to:
+
+```tsx
+className={clsx(
+  styles.wrapper,
+  styles[`size-${size}`],
+  invalid && styles.invalid,
+  disabled && styles.disabled,
+  className,
+)}
+```
+
+- [ ] **Step 6: Use the icon-size lookup**
+
+Replace the literal `size={14}` (or whatever the current value is) on `<CalendarIcon />` and `<X />` with `size={ICON_SIZE_FOR[size]}`. Verify those two icons are the ONLY lucide icons in this file that should scale; the chevrons inside the popover grid do NOT scale (they belong to `DatePickerGrid`).
+
+- [ ] **Step 7: Update `DatePicker.module.scss`**
+
+The existing `.input` block has hard-coded `height: var(--size-md)` and `font-size: var(--font-size-md)`. The existing `.clearButton, .openButton` block has hard-coded `width: var(--space-5)` and `height: var(--space-5)` (20px). Move these into size modifiers.
+
+```scss
+// Add to the END of the file, after the existing .popover block.
+
+.size-sm {
+  padding: 0 var(--space-2);
+
+  .input {
+    height: var(--size-sm);
+    font-size: var(--font-size-sm);
+  }
+  .clearButton,
+  .openButton {
+    width: var(--space-5);
+    height: var(--space-5);
+  }
+}
+
+.size-md {
+  padding: 0 var(--space-2);
+
+  .input {
+    height: var(--size-md);
+    font-size: var(--font-size-md);
+  }
+  .clearButton,
+  .openButton {
+    width: var(--space-5);
+    height: var(--space-5);
+  }
+}
+
+.size-lg {
+  padding: 0 var(--space-3);
+
+  .input {
+    height: var(--size-lg);
+    font-size: var(--font-size-lg);
+  }
+  .clearButton,
+  .openButton {
+    width: var(--space-6); // 24px
+    height: var(--space-6);
+  }
+}
+```
+
+Remove the hard-coded `height: var(--size-md)` + `font-size: var(--font-size-md)` from `.input` (those values now live in `.size-md .input`).
+
+Remove the hard-coded `width: var(--space-5)` + `height: var(--space-5)` from `.clearButton, .openButton` (those values now live in each `.size-* .clearButton` / `.size-* .openButton`).
+
+Also remove the wrapper's hard-coded `padding: 0 var(--space-2)` — that moves into the per-size modifiers above so `lg` can use `--space-3`.
+
+- [ ] **Step 8: Run gates**
+
+```bash
+npm test --workspace=@eocrm/design-system --run -- src/components/DatePicker 2>&1 | tail -8
+npm run typecheck 2>&1 | tail -5
+npm run lint:css 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+Tests should still pass — the default behavior at `size="md"` mirrors the previous hard-coded values.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/design-system/src/components/DatePicker/DatePicker.tsx \
+        packages/design-system/src/components/DatePicker/DatePicker.module.scss
+git commit -m "DatePicker: add size prop (sm | md | lg, default md)"
+```
+
+---
+
+## Task 5: `<DatePicker>` — tests + playground demo
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/DatePicker/DatePicker.test.tsx`
+- Modify: `packages/playground/src/pages/components/DatePickerDemo.tsx`
+
+- [ ] **Step 1: Add size tests**
+
+At the end of the existing `describe`:
+
+```tsx
+it('applies size class names for sm / md / lg', () => {
+  const { rerender, container } = render(<DatePicker size="sm" aria-label="Sized" />);
+  // The wrapper div carries the size-* class.
+  expect(container.querySelector('div')!.className).toMatch(/size-sm/);
+  rerender(<DatePicker size="md" aria-label="Sized" />);
+  expect(container.querySelector('div')!.className).toMatch(/size-md/);
+  rerender(<DatePicker size="lg" aria-label="Sized" />);
+  expect(container.querySelector('div')!.className).toMatch(/size-lg/);
+});
+
+it('defaults to size="md" when no size prop is passed', () => {
+  const { container } = render(<DatePicker aria-label="Default" />);
+  expect(container.querySelector('div')!.className).toMatch(/size-md/);
+});
+```
+
+If the existing test file imports `render` from a specific testing library wrapper, use the same import. Don't introduce a new import.
+
+- [ ] **Step 2: Update `DatePickerPanel` (the `<XDemoPanel>` exported by DatePickerDemo.tsx)**
+
+Add this Example block before `Form integration`:
+
+```tsx
+<Example
+  title="Sizes"
+  description="Three sizes — sm (24px), md (32px, default), lg (40px). The popover month grid is fixed-size; only the trigger row scales."
+  code={`<DatePicker size="sm" defaultValue={new Date()} />
+<DatePicker size="md" defaultValue={new Date()} />
+<DatePicker size="lg" defaultValue={new Date()} />`}
+>
+  <InputExample>
+    <Stack gap="sm">
+      <DatePicker size="sm" defaultValue={TODAY} aria-label="Small date" />
+      <DatePicker size="md" defaultValue={TODAY} aria-label="Medium date" />
+      <DatePicker size="lg" defaultValue={TODAY} aria-label="Large date" />
+    </Stack>
+  </InputExample>
+</Example>
+```
+
+(`Stack` and `TODAY` are already in scope per the unified DatePickersDemo conversion.)
+
+- [ ] **Step 3: Run gates**
+
+```bash
+npm test --workspace=@eocrm/design-system --run -- src/components/DatePicker 2>&1 | tail -8
+npm run typecheck 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/DatePicker/DatePicker.test.tsx \
+        packages/playground/src/pages/components/DatePickerDemo.tsx
+git commit -m "DatePicker: tests + demo for new size prop"
+```
+
+---
+
+## Task 6: `<DateRangePicker>` — add `size` prop + SCSS
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/DateRangePicker/DateRangePicker.tsx`
+- Modify: `packages/design-system/src/components/DateRangePicker/DateRangePicker.module.scss`
+
+- [ ] **Step 1: Mirror Task 4 exactly**
+
+The DRP file structure is parallel to DatePicker: `DateRangePickerProps` `Omit`-list, wrapper className composition, clear/open buttons, CalendarIcon + X icons in those buttons. Apply the same edits:
+
+- Add `export type DateRangePickerSize = 'sm' | 'md' | 'lg';`
+- Add `'size'` to the `Omit<…>` in `DateRangePickerProps`.
+- Add the `size?: DateRangePickerSize` prop with the same JSDoc as DatePicker.
+- Add `const ICON_SIZE_FOR: Record<DateRangePickerSize, number> = { sm: 14, md: 14, lg: 16 };`.
+- Destructure `size = 'md'` in the component.
+- Add `styles[`size-${size}`]` to the wrapper className.
+- Use `size={ICON_SIZE_FOR[size]}` on `<CalendarIcon />` and `<X />` inside the trigger (the chevrons inside the popover grids stay at their existing literal values).
+
+- [ ] **Step 2: Mirror Task 4's SCSS changes**
+
+`DateRangePicker.module.scss` has the same shape as DatePicker's. Move the hard-coded `.input` height + font + the hard-coded `.clearButton/.openButton` dimensions + the hard-coded wrapper `padding` into the same three `.size-sm / .size-md / .size-lg` modifier blocks.
+
+- [ ] **Step 3: Gates**
+
+```bash
+npm test --workspace=@eocrm/design-system --run -- src/components/DateRangePicker 2>&1 | tail -8
+npm run typecheck 2>&1 | tail -5
+npm run lint:css 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/DateRangePicker/DateRangePicker.tsx \
+        packages/design-system/src/components/DateRangePicker/DateRangePicker.module.scss
+git commit -m "DateRangePicker: add size prop (sm | md | lg, default md)"
+```
+
+---
+
+## Task 7: `<DateRangePicker>` — tests + playground demo
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/DateRangePicker/DateRangePicker.test.tsx`
+- Modify: `packages/playground/src/pages/components/DateRangePickerDemo.tsx`
+
+- [ ] **Step 1: Add size tests**
+
+Same shape as Task 5 Step 1, swapped for DateRangePicker. Use the test file's existing render-helper conventions.
+
+- [ ] **Step 2: Add a Sizes Example to `DateRangePickerDemoPanel`**
+
+```tsx
+<Example
+  title="Sizes"
+  description="Three sizes — sm (24px), md (32px, default), lg (40px). The two-month popover grid is fixed-size; only the trigger row scales."
+  code={`<DateRangePicker size="sm" defaultValue={{ start: today, end: in14 }} />
+<DateRangePicker size="md" defaultValue={{ start: today, end: in14 }} />
+<DateRangePicker size="lg" defaultValue={{ start: today, end: in14 }} />`}
+>
+  <InputExample>
+    <Stack gap="sm">
+      <DateRangePicker size="sm" defaultValue={{ start: TODAY, end: IN_14 }} aria-label="Small range" />
+      <DateRangePicker size="md" defaultValue={{ start: TODAY, end: IN_14 }} aria-label="Medium range" />
+      <DateRangePicker size="lg" defaultValue={{ start: TODAY, end: IN_14 }} aria-label="Large range" />
+    </Stack>
+  </InputExample>
+</Example>
+```
+
+- [ ] **Step 3: Gates**
+
+```bash
+npm test --workspace=@eocrm/design-system --run -- src/components/DateRangePicker 2>&1 | tail -8
+npm run typecheck 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/DateRangePicker/DateRangePicker.test.tsx \
+        packages/playground/src/pages/components/DateRangePickerDemo.tsx
+git commit -m "DateRangePicker: tests + demo for new size prop"
+```
+
+---
+
+## Task 8: AGENTS.md sweep
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Update the `<Input>` section**
+
+Add this bullet at the appropriate position:
+
+```
+- Sizes: `sm` (24px) / `md` (32px, default) / `lg` (40px). Mirrors `<Button>` and `<Select>`.
+```
+
+- [ ] **Step 2: Update the `<DatePicker>` section**
+
+Same bullet:
+
+```
+- Sizes: `sm` / `md` (default) / `lg`. Same scale as `<Input>`; affects the trigger row only — popover grid stays fixed.
+```
+
+- [ ] **Step 3: Update the `<DateRangePicker>` section**
+
+```
+- Sizes: `sm` / `md` (default) / `lg`. Same scale as `<DatePicker>`; popover (two-month grid) stays fixed.
+```
+
+- [ ] **Step 4: No change to `<Select>` section** — it already documents the three sizes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/AGENTS.md
+git commit -m "AGENTS.md: document new size prop on Input / DatePicker / DateRangePicker"
+```
+
+---
+
+## Task 9: Final gates + Hard Rule 8 review cycle + PR
+
+- [ ] **Step 1: Prettier --write everything**
+
+```bash
+npx prettier --write "packages/**/src/**/*.{ts,tsx,scss}" "docs/**/*.md" "packages/design-system/AGENTS.md"
+```
+
+Commit any drift:
+
+```bash
+git add -A packages/ docs/
+git diff --cached --stat
+git commit -m "Prettier: format size-prop changes" || echo "no formatting changes"
+```
+
+- [ ] **Step 2: Full gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test --workspace=@eocrm/design-system --run 2>&1 | tail -5
+npm run typecheck 2>&1 | tail -5
+npm run lint:css 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+npx prettier --check "packages/**/src/**/*.{ts,tsx,scss}" "docs/**/*.md" "packages/design-system/AGENTS.md" 2>&1 | tail -3
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -cE "\.test\."
+```
+
+Expected: all green; npm-pack count = 0.
+
+- [ ] **Step 3: Push branch**
+
+```bash
+git push -u origin feat/input-sizes-xs-lg
+```
+
+- [ ] **Step 4: Hard Rule 8 review cycle 1**
+
+Dispatch a fresh-context `general-purpose` review agent. Brief:
+
+- Required reading: repo `CLAUDE.md`, package `CLAUDE.md`, `AGENTS.md`, the spec `docs/superpowers/specs/2026-05-21-input-sizes-xs-lg-design.md`, full branch diff `git diff main..HEAD -- packages/`.
+- 10-category review (bugs, a11y, API consistency, type safety, Rules 1–7, test coverage, token discipline, SCSS, cross-package leakage, package/distribution).
+- Specific things to look hard at:
+  - The `Omit<…, 'size'>` in InputProps + DatePickerProps + DateRangePickerProps. Did anyone forget one? Does the test for "native size attr is omitted from DOM" actually catch a regression if the Omit is removed?
+  - DatePicker / DRP `lg` button slots use `--space-6` (24px). Is that token meaningful for "control inline-button size" or is it spacing-only? (Acceptable either way; flag if a reviewer would dislike spacing→sizing reuse.)
+  - The chevrons inside the popover grids (`DatePickerGrid.tsx`) MUST NOT scale — they live in fixed-size grid cells. Verify by checking the SCSS — no `.size-*` selectors should target `.navButton` or the popover.
+  - Token discipline: all values come from `tokens.scss`; no `width: 16px` raw literals etc.
+- Output: Critical / Important / Nice-to-have / Regression-watch + verdict (`clean enough to stop` or `keep iterating`).
+
+- [ ] **Step 5: Fix critical + important findings, re-push, re-review until clean.**
+
+- [ ] **Step 6: Open PR**
+
+```bash
+gh pr create --title "Input / DatePicker / DateRangePicker: add size prop (sm | md | lg)" --body "$(cat <<'EOF'
+## Summary
+
+- Added a `size: 'sm' | 'md' | 'lg'` prop to `<Input>`, `<DatePicker>`, and `<DateRangePicker>`. `md` stays the default — no behavior change for existing consumers.
+- `<Select>` already exposes the same three sizes; no library changes there.
+- Composite pickers (`DatePicker` / `DateRangePicker`) scale the trigger row, the inline clear ✕ and open-calendar button slots, and their lucide icon sizes. The popover month grid is intentionally NOT scaled.
+- `Omit<…, 'size'>` added to the three components' props interfaces to shadow the native HTML `<input size>` attribute. A regression test enforces that the component-level `size` prop does NOT leak to the DOM `size` attribute.
+- `xs` (20px) variant explicitly deferred — to be added when a real CRM screen demands it.
+
+## Test plan
+
+- [x] All tests pass — added size-class assertions to Input, DatePicker, DateRangePicker tests.
+- [x] Regression test: `Input` does NOT propagate component `size` prop to the DOM `size` attribute.
+- [x] Hard Rule 8 review cycles passed; final verdict: clean enough to stop.
+
+## Design spec / plan
+
+- Spec: `docs/superpowers/specs/2026-05-21-input-sizes-xs-lg-design.md`
+- Plan: `docs/superpowers/plans/2026-05-21-input-sizes-sm-lg.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+Spec coverage:
+
+- §The shared size scale → Tasks 2, 4, 6 (SCSS modifier classes per component).
+- §`<Input>` → Tasks 2, 3.
+- §`<Select>` (no change) → Task 8 (AGENTS.md unchanged) + no test/demo updates.
+- §`<DatePicker>` → Tasks 4, 5.
+- §`<DateRangePicker>` → Tasks 6, 7.
+- §Test surface → Tasks 3, 5, 7 (size-class tests + Input Omit regression).
+- §Playground demos → Tasks 3, 5, 7 (Sizes Example in each demo).
+- §AGENTS.md → Task 8.
+- §Risks (Omit discipline) → enforced by the Input "does NOT pass to DOM" test (Task 3).
+
+Type consistency:
+
+- `InputSize`, `DatePickerSize`, `DateRangePickerSize` — same string union shape (`'sm' | 'md' | 'lg'`), kept as separate exports so each component's prop docs read naturally.
+- `Omit<…, 'size'>` appears on all three component props interfaces.
+- `ICON_SIZE_FOR` constant — separate per component but identical shape.
+
+No placeholders. All file paths absolute. All commit messages present. All TDD steps include test code AND implementation code.

--- a/docs/superpowers/plans/2026-05-21-input-sizes-sm-lg.md
+++ b/docs/superpowers/plans/2026-05-21-input-sizes-sm-lg.md
@@ -126,12 +126,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
       // wins.
       aria-invalid={invalid || undefined}
       {...props}
-      className={clsx(
-        styles.input,
-        styles[`size-${size}`],
-        invalid && styles.invalid,
-        className,
-      )}
+      className={clsx(styles.input, styles[`size-${size}`], invalid && styles.invalid, className)}
     />
   );
 });
@@ -581,9 +576,21 @@ Same shape as Task 5 Step 1, swapped for DateRangePicker. Use the test file's ex
 >
   <InputExample>
     <Stack gap="sm">
-      <DateRangePicker size="sm" defaultValue={{ start: TODAY, end: IN_14 }} aria-label="Small range" />
-      <DateRangePicker size="md" defaultValue={{ start: TODAY, end: IN_14 }} aria-label="Medium range" />
-      <DateRangePicker size="lg" defaultValue={{ start: TODAY, end: IN_14 }} aria-label="Large range" />
+      <DateRangePicker
+        size="sm"
+        defaultValue={{ start: TODAY, end: IN_14 }}
+        aria-label="Small range"
+      />
+      <DateRangePicker
+        size="md"
+        defaultValue={{ start: TODAY, end: IN_14 }}
+        aria-label="Medium range"
+      />
+      <DateRangePicker
+        size="lg"
+        defaultValue={{ start: TODAY, end: IN_14 }}
+        aria-label="Large range"
+      />
     </Stack>
   </InputExample>
 </Example>

--- a/docs/superpowers/specs/2026-05-21-input-sizes-xs-lg-design.md
+++ b/docs/superpowers/specs/2026-05-21-input-sizes-xs-lg-design.md
@@ -96,11 +96,10 @@ Component composes: `clsx(styles.input, styles[`size-${size}`], invalid && style
 ```ts
 export type DatePickerSize = 'sm' | 'md' | 'lg';
 
-export interface DatePickerProps
-  extends Omit<
-    InputHTMLAttributes<HTMLInputElement>,
-    'value' | 'defaultValue' | 'onChange' | 'type' | 'min' | 'max' | 'size'
-  > {
+export interface DatePickerProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'value' | 'defaultValue' | 'onChange' | 'type' | 'min' | 'max' | 'size'
+> {
   // … existing props …
   /** Field height + type scale. Same scale as `<Input>`. Defaults to `'md'`. */
   size?: DatePickerSize;

--- a/docs/superpowers/specs/2026-05-21-input-sizes-xs-lg-design.md
+++ b/docs/superpowers/specs/2026-05-21-input-sizes-xs-lg-design.md
@@ -1,42 +1,43 @@
-# Input field sizes — `xs` + `lg` across all field controls
+# Input field sizes — `sm` + `lg` across all field controls
 
 **Date:** 2026-05-21
-**Branch:** `feat/input-sizes-xs-lg`
+**Branch:** `feat/input-sizes-xs-lg` (branch name retained for continuity even though `xs` was dropped before implementation)
 **Scope:** `Input`, `Select`, `DatePicker`, `DateRangePicker`. Inline calendar variants intentionally excluded (they're grids, not fields).
 
 ## Goal
 
-Bring the four field-style components onto a consistent four-step size scale (`xs | sm | md | lg`) matching the one `Button` already uses. `md` stays the default — adding the prop introduces no behavior change for existing consumers.
+Bring the four field-style components onto a consistent three-step size scale (`sm | md | lg`) matching what `<Select>` already uses. `md` stays the default — adding the prop introduces no behavior change for existing consumers.
 
 ## Why
 
-- Dense CRM screens (filter rows, inline-edit tables) need a 20px-tall field that visually pairs with `Button size="xs"`.
+- Dense CRM screens (toolbars, secondary forms) want a 24px-tall field that visually pairs with `Button size="sm"`.
 - Marketing-style and mobile-friendly screens want a roomier 40px `lg` for hero search / primary form fields.
 - Today's `Select` already exposes `sm | md | lg`. `Input`, `DatePicker`, `DateRangePicker` ship a single hard-coded 32px height. The asymmetry is the bug; aligning all four on the same union is the fix.
+- `xs` (20px) was considered and explicitly dropped — the AA touch-target risk and the icon-clipping work on DatePicker/DRP outweigh its narrow density use case. If a future CRM screen genuinely needs 20px field rows, add `xs` as a follow-up extension of the same prop.
 
 ## Non-goals
 
 - Inline calendar variants (`InlineDatePicker`, `InlineDateRangePicker`) — their density is a separate `cellSize`-style question and not coupled to field height.
 - Future controls (`Textarea`, `Checkbox`, `Radio`, `Switch`) — they'll opt in when shipped.
 - Auto-sized "responsive" fields. Consumer picks one size per field; no media-query magic.
-- Library-wide token rename. The existing `--size-{xs,sm,md,lg}` and `--font-size-{xs,sm,md,lg}` tokens are reused as-is.
+- Library-wide token rename. The existing `--size-{sm,md,lg}` and `--font-size-{sm,md,lg}` tokens are reused as-is.
+- An `xs` (20px) variant. Out of scope per the explicit dropdown above.
 
 ## The shared size scale
 
-| Step | Height            | Font                  | Inline-button slot | Icon |
-| ---- | ----------------- | --------------------- | ------------------ | ---- |
-| `xs` | `--size-xs` 20px  | `--font-size-xs` 11px | 16×16              | 12px |
-| `sm` | `--size-sm` 24px  | `--font-size-sm` 12px | 20×20              | 14px |
-| `md` | `--size-md` 32px  | `--font-size-md` 14px | 20×20              | 14px |
-| `lg` | `--size-lg` 40px  | `--font-size-lg` 16px | 24×24              | 16px |
+| Step | Height           | Font                  | Inline-button slot | Icon |
+| ---- | ---------------- | --------------------- | ------------------ | ---- |
+| `sm` | `--size-sm` 24px | `--font-size-sm` 12px | 20×20              | 14px |
+| `md` | `--size-md` 32px | `--font-size-md` 14px | 20×20              | 14px |
+| `lg` | `--size-lg` 40px | `--font-size-lg` 16px | 24×24              | 16px |
 
-The inline-button slot column applies to DatePicker / DateRangePicker (clear ✕ + open-calendar buttons). At `xs` the slot shrinks to 16×16 so the 12px icon stays centered with breathing room; at `lg` it bumps to 24×24 so the icon doesn't look orphaned. `sm` and `md` deliberately share 20×20 — that's where the current 32px field already sits and there's no UX win in scaling each step independently.
+The inline-button slot column applies to DatePicker / DateRangePicker (clear ✕ + open-calendar buttons). `sm` and `md` deliberately share 20×20 — that's where the current 32px field already sits and there's no UX win in scaling each step independently when only two pixels separate them. At `lg` the slot bumps to 24×24 so the icon doesn't look orphaned next to a 16px font.
 
-These four targets are CSS custom-property reuses, not new tokens. Nothing gets added to `tokens.scss`.
+These three targets are CSS custom-property reuses, not new tokens. Nothing gets added to `tokens.scss`.
 
-### Why these exact icon-slot dimensions
+### Why these exact icon-slot dimensions at `lg`
 
-At `xs` (20px row), padding is `0 var(--space-2)` (8px) → inner row height is 20px. A 16×16 button at the right edge of a 20px row reads as a flush trailing affordance; 20×20 would touch the border. At `lg` (40px row, padding `0 var(--space-3)` = 12px), 20×20 is too small relative to the row — 24×24 reads correctly. The slot sizes here are the result of paint-time intuition, not arbitrary scaling math; if a reviewer prefers different exact numbers, change them.
+At `lg` (40px row, padding `0 var(--space-3)` = 12px), 20×20 buttons read as too small relative to the row — 24×24 reads correctly. The slot sizes here are the result of paint-time intuition, not arbitrary scaling math; if a reviewer prefers different exact numbers, change them.
 
 ## Per-component changes
 
@@ -45,15 +46,13 @@ At `xs` (20px row), padding is `0 var(--space-2)` (8px) → inner row height is 
 **TSX:**
 
 ```ts
-export type InputSize = 'xs' | 'sm' | 'md' | 'lg';
+export type InputSize = 'sm' | 'md' | 'lg';
 
-export interface InputProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
   /** Toggles the error visual + sets `aria-invalid="true"`. */
   invalid?: boolean;
   /**
    * Field height + type scale. Defaults to `'md'`.
-   * - `xs` (20px / 11px) — dense filter rows, inline table edits.
    * - `sm` (24px / 12px) — toolbars, secondary forms.
    * - `md` (32px / 14px) — default form fields.
    * - `lg` (40px / 16px) — hero search, mobile-friendly forms.
@@ -64,14 +63,9 @@ export interface InputProps
 
 `Omit<…, 'size'>` is necessary because the native HTML `<input>` has its own `size` attribute (visible-character count) typed as `number`. Our string-union prop shadows it. The native attribute is rarely used and consumers who genuinely need it can pass `style={{ width: '…' }}` or wrap in a sized parent — matches what `<Input>` already documents about width.
 
-**SCSS:** the existing base `.input` block keeps its non-size-dependent rules (border, color, transitions, placeholder). The hard-coded `height: var(--size-md)`, `padding: 0 var(--space-3)`, `font-size: var(--font-size-md)` move into a `.size-md` modifier. Add `.size-xs`, `.size-sm`, `.size-lg` siblings.
+**SCSS:** the existing base `.input` block keeps its non-size-dependent rules (border, color, transitions, placeholder). The hard-coded `height: var(--size-md)`, `padding: 0 var(--space-3)`, `font-size: var(--font-size-md)` move into a `.size-md` modifier. Add `.size-sm` and `.size-lg` siblings.
 
 ```scss
-.size-xs {
-  height: var(--size-xs);
-  padding: 0 var(--space-2);
-  font-size: var(--font-size-xs);
-}
 .size-sm {
   height: var(--size-sm);
   padding: 0 var(--space-2);
@@ -93,38 +87,20 @@ Component composes: `clsx(styles.input, styles[`size-${size}`], invalid && style
 
 ### `<Select>`
 
-**TSX:** extend the existing union and update the JSDoc to list `xs`.
-
-```ts
-export type SelectSize = 'xs' | 'sm' | 'md' | 'lg';
-```
-
-**SCSS:** add a `.size-xs .trigger` block that mirrors the existing `.size-sm` / `.size-md` / `.size-lg` siblings already in `Select.module.scss`:
-
-```scss
-.size-xs .trigger {
-  min-height: var(--size-xs);
-  font-size: var(--font-size-xs);
-
-  &:not(.triggerChips) {
-    padding: 0 var(--space-2);
-  }
-}
-```
-
-Chip-bearing triggers (multi-select with `triggerDisplay='chips'`) at `xs` — the chips are already sized off `--size-chip` (18px) which doesn't fit inside a 20px row. Decision: `xs` + chips falls back to a higher effective height; the chip wrap rule (Y-padding `--space-1`) means the row will visually grow past 20px when a chip is present. Documented as "xs is for single-select Select; multi+chips at xs visually behaves like sm because the chip floor wins." We don't try to make 18px chips fit in 20px; that's a YAGNI fight.
+**No code changes required.** Select already exposes `sm | md | lg` with the right SCSS modifiers and JSDoc. The unified scale described in this spec matches Select's existing API exactly. The Select section here exists only so the AGENTS.md sweep and the playground "Sizes" example sweep cover all four components consistently.
 
 ### `<DatePicker>`
 
 **TSX:**
 
 ```ts
-export type DatePickerSize = 'xs' | 'sm' | 'md' | 'lg';
+export type DatePickerSize = 'sm' | 'md' | 'lg';
 
-export interface DatePickerProps extends Omit<
-  InputHTMLAttributes<HTMLInputElement>,
-  'value' | 'defaultValue' | 'onChange' | 'type' | 'min' | 'max' | 'size'
-> {
+export interface DatePickerProps
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    'value' | 'defaultValue' | 'onChange' | 'type' | 'min' | 'max' | 'size'
+  > {
   // … existing props …
   /** Field height + type scale. Same scale as `<Input>`. Defaults to `'md'`. */
   size?: DatePickerSize;
@@ -136,28 +112,20 @@ The popover content (month grid) is **not** affected by `size`. Cells stay `--si
 **SCSS:** add size modifier classes that target the wrapper, the inner input, AND the clear/open buttons:
 
 ```scss
-.size-xs {
-  padding: 0 var(--space-1);
-
-  .input {
-    height: var(--size-xs);
-    font-size: var(--font-size-xs);
-  }
-  .clearButton,
-  .openButton {
-    width: 16px;
-    height: 16px;
-  }
+.size-sm {
+  /* 24px row, 20×20 buttons, sm font */
 }
-
-.size-sm { /* 24px row, 20×20 buttons, sm font */ }
-.size-md { /* 32px row, 20×20 buttons, md font — the current defaults */ }
-.size-lg { /* 40px row, 24×24 buttons, lg font */ }
+.size-md {
+  /* 32px row, 20×20 buttons, md font — the current defaults */
+}
+.size-lg {
+  /* 40px row, 24×24 buttons, lg font */
+}
 ```
 
 Component composes `clsx(styles.wrapper, styles[`size-${size}`], invalid && styles.invalid, disabled && styles.disabled, className)`.
 
-**Lucide icon sizes**: the `<CalendarIcon />` and `<X />` inside the buttons receive `size={ICON_SIZE_FOR[size]}` where the lookup is `{ xs: 12, sm: 14, md: 14, lg: 16 }`.
+**Lucide icon sizes**: the `<CalendarIcon />` and `<X />` inside the buttons receive `size={ICON_SIZE_FOR[size]}` where the lookup is `{ sm: 14, md: 14, lg: 16 }`.
 
 ### `<DateRangePicker>`
 
@@ -167,29 +135,25 @@ Same shape as DatePicker — `size` prop, SCSS modifiers, icon-size lookup. Popo
 
 Each component picks up tests that mirror the existing `'applies the variant and size class names'` style.
 
-- **Input**: new test `'applies size class names for xs / sm / md / lg'`. Also a regression test `'native size attr is omitted from rendered DOM'` to confirm the Omit works (i.e., passing `size="md"` does NOT propagate as the HTML `size` attribute, which would otherwise truncate visible character width).
-- **Select**: extend the existing size test to include `xs` and assert the trigger gets `min-height: var(--size-xs)` via class application (not computed style).
-- **DatePicker** + **DateRangePicker**: new tests `'applies size class names for xs / sm / md / lg'` and `'size xs scales the clear and open buttons'` (assert classnames; visual proof lives in the playground demo).
+- **Input**: new test `'applies size class names for sm / md / lg'`. Also a regression test `'native size attr is omitted from rendered DOM'` to confirm the Omit works (i.e., passing `size="md"` does NOT propagate as the HTML `size` attribute, which would otherwise truncate visible character width).
+- **Select**: no new tests — the size scale is unchanged.
+- **DatePicker** + **DateRangePicker**: new tests `'applies size class names for sm / md / lg'` and `'size lg scales the clear and open buttons'` (assert classnames; visual proof lives in the playground demo).
 
 ## Playground demos
 
-Each of the four demos gains one new "Sizes" `<Example>` block showing all four variants in a `Stack gap="sm"`. The existing "Default" example continues to render at `md`. The Select demo's existing sizes example extends to include `xs` (4 items, not 3).
+The Input, DatePicker, and DateRangePicker demos each gain one new "Sizes" `<Example>` block showing all three variants in a `Stack gap="sm"`. The existing "Default" example continues to render at `md`. The Select demo's existing sizes example needs no changes.
 
 ## AGENTS.md
 
-Each component's section in `packages/design-system/AGENTS.md` is updated:
-
-- The `<Input>` section grows a bullet listing the four sizes.
-- The `<Select>` section already lists `sm | md | lg`; replace with `xs | sm | md | lg`.
-- The `<DatePicker>` and `<DateRangePicker>` sections gain a "Sizes: xs / sm / md / lg (default md)" bullet.
+- The `<Input>` section gains a "Sizes: sm / md / lg (default md)" bullet.
+- The `<Select>` section is unchanged (it already documents the three sizes).
+- The `<DatePicker>` and `<DateRangePicker>` sections gain a "Sizes: sm / md / lg (default md)" bullet.
 
 ## Risks / open questions
 
-- **`xs` row height (20px) vs WCAG 2.5.5 Level AAA (24×24 minimum target size)**: same trade-off `Button size="xs"` already documented. This codebase is desktop-first; the `xs` JSDoc on each component lists the touch-target caveat verbatim.
-- **DatePicker `xs` row + two-button slot (clear + open) + chevron-free input**: the two 16×16 buttons consume 32px of the row width. On narrow columns (e.g., a `<200px` filter dropdown) the typed-date placeholder ("01/02/2000" at 11px) is borderline. Accept it as a documented limitation; consumers picking `xs` on a narrow column should hide the clear button or use `<Select>` instead.
-- **Select `xs` + multi-chips**: as noted, chip floor wins at 18px → the row visually grows past 20px. Documented, not fought.
 - **Existing consumers**: no behavior change. Default `'md'` matches every current implicit hard-coded `--size-md`.
 - **Spread-order discipline**: `Omit<…, 'size'>` is a hard requirement on Input and DatePicker / DateRangePicker. If anyone removes the Omit in a future refactor, the component's `size` prop silently propagates as the native HTML `size` attribute and breaks layouts. Spread comment in each file should call this out explicitly.
+- **DatePicker / DRP `lg`**: scaling the inline clear / open buttons from 20×20 to 24×24 nudges the visual balance away from the existing `md` look. Consumers who mix `lg` and `md` fields on one screen should keep an eye on the vertical rhythm — but that's true of any size mix and not specific to this change.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-05-21-input-sizes-xs-lg-design.md
+++ b/docs/superpowers/specs/2026-05-21-input-sizes-xs-lg-design.md
@@ -1,0 +1,199 @@
+# Input field sizes — `xs` + `lg` across all field controls
+
+**Date:** 2026-05-21
+**Branch:** `feat/input-sizes-xs-lg`
+**Scope:** `Input`, `Select`, `DatePicker`, `DateRangePicker`. Inline calendar variants intentionally excluded (they're grids, not fields).
+
+## Goal
+
+Bring the four field-style components onto a consistent four-step size scale (`xs | sm | md | lg`) matching the one `Button` already uses. `md` stays the default — adding the prop introduces no behavior change for existing consumers.
+
+## Why
+
+- Dense CRM screens (filter rows, inline-edit tables) need a 20px-tall field that visually pairs with `Button size="xs"`.
+- Marketing-style and mobile-friendly screens want a roomier 40px `lg` for hero search / primary form fields.
+- Today's `Select` already exposes `sm | md | lg`. `Input`, `DatePicker`, `DateRangePicker` ship a single hard-coded 32px height. The asymmetry is the bug; aligning all four on the same union is the fix.
+
+## Non-goals
+
+- Inline calendar variants (`InlineDatePicker`, `InlineDateRangePicker`) — their density is a separate `cellSize`-style question and not coupled to field height.
+- Future controls (`Textarea`, `Checkbox`, `Radio`, `Switch`) — they'll opt in when shipped.
+- Auto-sized "responsive" fields. Consumer picks one size per field; no media-query magic.
+- Library-wide token rename. The existing `--size-{xs,sm,md,lg}` and `--font-size-{xs,sm,md,lg}` tokens are reused as-is.
+
+## The shared size scale
+
+| Step | Height            | Font                  | Inline-button slot | Icon |
+| ---- | ----------------- | --------------------- | ------------------ | ---- |
+| `xs` | `--size-xs` 20px  | `--font-size-xs` 11px | 16×16              | 12px |
+| `sm` | `--size-sm` 24px  | `--font-size-sm` 12px | 20×20              | 14px |
+| `md` | `--size-md` 32px  | `--font-size-md` 14px | 20×20              | 14px |
+| `lg` | `--size-lg` 40px  | `--font-size-lg` 16px | 24×24              | 16px |
+
+The inline-button slot column applies to DatePicker / DateRangePicker (clear ✕ + open-calendar buttons). At `xs` the slot shrinks to 16×16 so the 12px icon stays centered with breathing room; at `lg` it bumps to 24×24 so the icon doesn't look orphaned. `sm` and `md` deliberately share 20×20 — that's where the current 32px field already sits and there's no UX win in scaling each step independently.
+
+These four targets are CSS custom-property reuses, not new tokens. Nothing gets added to `tokens.scss`.
+
+### Why these exact icon-slot dimensions
+
+At `xs` (20px row), padding is `0 var(--space-2)` (8px) → inner row height is 20px. A 16×16 button at the right edge of a 20px row reads as a flush trailing affordance; 20×20 would touch the border. At `lg` (40px row, padding `0 var(--space-3)` = 12px), 20×20 is too small relative to the row — 24×24 reads correctly. The slot sizes here are the result of paint-time intuition, not arbitrary scaling math; if a reviewer prefers different exact numbers, change them.
+
+## Per-component changes
+
+### `<Input>`
+
+**TSX:**
+
+```ts
+export type InputSize = 'xs' | 'sm' | 'md' | 'lg';
+
+export interface InputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  /** Toggles the error visual + sets `aria-invalid="true"`. */
+  invalid?: boolean;
+  /**
+   * Field height + type scale. Defaults to `'md'`.
+   * - `xs` (20px / 11px) — dense filter rows, inline table edits.
+   * - `sm` (24px / 12px) — toolbars, secondary forms.
+   * - `md` (32px / 14px) — default form fields.
+   * - `lg` (40px / 16px) — hero search, mobile-friendly forms.
+   */
+  size?: InputSize;
+}
+```
+
+`Omit<…, 'size'>` is necessary because the native HTML `<input>` has its own `size` attribute (visible-character count) typed as `number`. Our string-union prop shadows it. The native attribute is rarely used and consumers who genuinely need it can pass `style={{ width: '…' }}` or wrap in a sized parent — matches what `<Input>` already documents about width.
+
+**SCSS:** the existing base `.input` block keeps its non-size-dependent rules (border, color, transitions, placeholder). The hard-coded `height: var(--size-md)`, `padding: 0 var(--space-3)`, `font-size: var(--font-size-md)` move into a `.size-md` modifier. Add `.size-xs`, `.size-sm`, `.size-lg` siblings.
+
+```scss
+.size-xs {
+  height: var(--size-xs);
+  padding: 0 var(--space-2);
+  font-size: var(--font-size-xs);
+}
+.size-sm {
+  height: var(--size-sm);
+  padding: 0 var(--space-2);
+  font-size: var(--font-size-sm);
+}
+.size-md {
+  height: var(--size-md);
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-md);
+}
+.size-lg {
+  height: var(--size-lg);
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-lg);
+}
+```
+
+Component composes: `clsx(styles.input, styles[`size-${size}`], invalid && styles.invalid, className)`.
+
+### `<Select>`
+
+**TSX:** extend the existing union and update the JSDoc to list `xs`.
+
+```ts
+export type SelectSize = 'xs' | 'sm' | 'md' | 'lg';
+```
+
+**SCSS:** add a `.size-xs .trigger` block that mirrors the existing `.size-sm` / `.size-md` / `.size-lg` siblings already in `Select.module.scss`:
+
+```scss
+.size-xs .trigger {
+  min-height: var(--size-xs);
+  font-size: var(--font-size-xs);
+
+  &:not(.triggerChips) {
+    padding: 0 var(--space-2);
+  }
+}
+```
+
+Chip-bearing triggers (multi-select with `triggerDisplay='chips'`) at `xs` — the chips are already sized off `--size-chip` (18px) which doesn't fit inside a 20px row. Decision: `xs` + chips falls back to a higher effective height; the chip wrap rule (Y-padding `--space-1`) means the row will visually grow past 20px when a chip is present. Documented as "xs is for single-select Select; multi+chips at xs visually behaves like sm because the chip floor wins." We don't try to make 18px chips fit in 20px; that's a YAGNI fight.
+
+### `<DatePicker>`
+
+**TSX:**
+
+```ts
+export type DatePickerSize = 'xs' | 'sm' | 'md' | 'lg';
+
+export interface DatePickerProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'value' | 'defaultValue' | 'onChange' | 'type' | 'min' | 'max' | 'size'
+> {
+  // … existing props …
+  /** Field height + type scale. Same scale as `<Input>`. Defaults to `'md'`. */
+  size?: DatePickerSize;
+}
+```
+
+The popover content (month grid) is **not** affected by `size`. Cells stay `--size-datepicker-cell`; chevrons stay their existing size. Only the trigger row changes.
+
+**SCSS:** add size modifier classes that target the wrapper, the inner input, AND the clear/open buttons:
+
+```scss
+.size-xs {
+  padding: 0 var(--space-1);
+
+  .input {
+    height: var(--size-xs);
+    font-size: var(--font-size-xs);
+  }
+  .clearButton,
+  .openButton {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.size-sm { /* 24px row, 20×20 buttons, sm font */ }
+.size-md { /* 32px row, 20×20 buttons, md font — the current defaults */ }
+.size-lg { /* 40px row, 24×24 buttons, lg font */ }
+```
+
+Component composes `clsx(styles.wrapper, styles[`size-${size}`], invalid && styles.invalid, disabled && styles.disabled, className)`.
+
+**Lucide icon sizes**: the `<CalendarIcon />` and `<X />` inside the buttons receive `size={ICON_SIZE_FOR[size]}` where the lookup is `{ xs: 12, sm: 14, md: 14, lg: 16 }`.
+
+### `<DateRangePicker>`
+
+Same shape as DatePicker — `size` prop, SCSS modifiers, icon-size lookup. Popover (two month grids side-by-side) does NOT scale with the trigger size.
+
+## Test surface
+
+Each component picks up tests that mirror the existing `'applies the variant and size class names'` style.
+
+- **Input**: new test `'applies size class names for xs / sm / md / lg'`. Also a regression test `'native size attr is omitted from rendered DOM'` to confirm the Omit works (i.e., passing `size="md"` does NOT propagate as the HTML `size` attribute, which would otherwise truncate visible character width).
+- **Select**: extend the existing size test to include `xs` and assert the trigger gets `min-height: var(--size-xs)` via class application (not computed style).
+- **DatePicker** + **DateRangePicker**: new tests `'applies size class names for xs / sm / md / lg'` and `'size xs scales the clear and open buttons'` (assert classnames; visual proof lives in the playground demo).
+
+## Playground demos
+
+Each of the four demos gains one new "Sizes" `<Example>` block showing all four variants in a `Stack gap="sm"`. The existing "Default" example continues to render at `md`. The Select demo's existing sizes example extends to include `xs` (4 items, not 3).
+
+## AGENTS.md
+
+Each component's section in `packages/design-system/AGENTS.md` is updated:
+
+- The `<Input>` section grows a bullet listing the four sizes.
+- The `<Select>` section already lists `sm | md | lg`; replace with `xs | sm | md | lg`.
+- The `<DatePicker>` and `<DateRangePicker>` sections gain a "Sizes: xs / sm / md / lg (default md)" bullet.
+
+## Risks / open questions
+
+- **`xs` row height (20px) vs WCAG 2.5.5 Level AAA (24×24 minimum target size)**: same trade-off `Button size="xs"` already documented. This codebase is desktop-first; the `xs` JSDoc on each component lists the touch-target caveat verbatim.
+- **DatePicker `xs` row + two-button slot (clear + open) + chevron-free input**: the two 16×16 buttons consume 32px of the row width. On narrow columns (e.g., a `<200px` filter dropdown) the typed-date placeholder ("01/02/2000" at 11px) is borderline. Accept it as a documented limitation; consumers picking `xs` on a narrow column should hide the clear button or use `<Select>` instead.
+- **Select `xs` + multi-chips**: as noted, chip floor wins at 18px → the row visually grows past 20px. Documented, not fought.
+- **Existing consumers**: no behavior change. Default `'md'` matches every current implicit hard-coded `--size-md`.
+- **Spread-order discipline**: `Omit<…, 'size'>` is a hard requirement on Input and DatePicker / DateRangePicker. If anyone removes the Omit in a future refactor, the component's `size` prop silently propagates as the native HTML `size` attribute and breaks layouts. Spread comment in each file should call this out explicitly.
+
+## Out of scope
+
+- Inline calendar variants. They have no field row to size.
+- Visual rhythm enforcement. Mixing sizes on one screen is the consumer's job.
+- Token additions. The existing scale is sufficient.
+- README components-table update (already pre-existing gap; not part of this change).

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -72,8 +72,9 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 <Input invalid value={email} aria-describedby="email-error" />
 ```
 
-- All native `<input>` attributes pass through.
+- All native `<input>` attributes pass through, except `size` — that's been replaced by the component-level `size` prop (the native HTML `size` attribute, visible-character count, is shadowed).
 - `invalid` toggles the error visual + sets `aria-invalid="true"`. Pair with an error message and `aria-describedby`.
+- Sizes: `sm` (24px) / `md` (32px, default) / `lg` (40px). Mirrors `<Button>` and `<Select>`.
 - Validation logic lives in your form layer (React Hook Form + Zod recommended), not in the component.
 
 ### `<Card>` — bordered container
@@ -457,6 +458,7 @@ const [value, setValue] = useState<Date | null>(null);
 - `min` / `max` (inclusive, day-granular) gate both the grid and typed input. `isDateDisabled(date) => boolean` is per-cell + per-parsed-input.
 - `clearable` (default `true`) shows the ✕ button when a value is set. `name` renders a hidden mirror `<input type="hidden">` with the ISO date so native `<form>` submission works.
 - `invalid` toggles the red border + `aria-invalid="true"`. Pair with a visible error and `aria-describedby`.
+- Sizes: `sm` / `md` (default) / `lg`. Same scale as `<Input>`; affects the trigger row only — the popover month grid stays fixed.
 - Locale-aware via `useLocale()`; override with `locale` prop. `labels` overrides the five hard-coded strings: `previousMonth`, `nextMonth`, `openCalendar`, `clear`, `dialogLabel`.
 - ARIA: typed input has `aria-haspopup="dialog"` + `aria-expanded`. Popover wrapper is `role="dialog"` (labelled by `labels.dialogLabel`); the grid inside is `role="grid"` with `role="gridcell"` buttons that carry `aria-selected` / `aria-disabled` as appropriate.
 - Keyboard inside the grid: ←→↑↓ move focus by 1 day, Home/End to start/end of week, PageUp/PageDown step a month, Enter/Space selects, Escape closes and returns focus to the input. Tab leaves the grid.
@@ -475,6 +477,7 @@ const [range, setRange] = useState<DateRange | null>(null);
 - `min` / `max` (inclusive) + `isDateDisabled(date) => boolean` gate both the popover grid AND typed-input parsing.
 - `clearable` (default `true`) shows the ✕ when a range is set. `nameStart` / `nameEnd` render two hidden mirror `<input>`s with ISO dates so native `<form>` submission works (post both keys, or just one — caller's choice).
 - `invalid` toggles the red border + `aria-invalid="true"`. Pair with a visible error and `aria-describedby`.
+- Sizes: `sm` / `md` (default) / `lg`. Same scale as `<DatePicker>`; affects the trigger row only — the two-month popover grid stays fixed.
 - ARIA: typed input has `aria-haspopup="dialog"` + `aria-expanded`. Popover wrapper is `role="dialog"` (labelled by `labels.dialogLabel`); each grid inside is `role="grid"` with `gridcell` buttons. The range-start and range-end cells (and the live hover end during selection) carry `aria-selected="true"`.
 - Keyboard inside a grid: ←→↑↓ move focus by 1 day, Home/End to start/end of week, PageUp/PageDown step a month, Enter/Space drives the same first-click → second-click flow, Escape closes and returns focus to the input. With selection-start set, the focused cell acts as the hover end so the preview range follows arrow keys.
 - Reuses `<DatePickerGrid>` via `selectionMode='range'` + `rangeStart`/`rangeEnd`/`hoverDate`/`onHoverDate` + `chevrons={false}`. The two grids share the same cursor; the picker renders its own prev/next chevrons outside them.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -74,7 +74,7 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 
 - All native `<input>` attributes pass through, except `size` — that's been replaced by the component-level `size` prop (the native HTML `size` attribute, visible-character count, is shadowed).
 - `invalid` toggles the error visual + sets `aria-invalid="true"`. Pair with an error message and `aria-describedby`.
-- Sizes: `sm` (24px) / `md` (32px, default) / `lg` (40px). Mirrors `<Button>` and `<Select>`.
+- Sizes: `sm` (24px) / `md` (32px, default) / `lg` (40px). Same scale as `<Select>`. (`<Button>` exposes `xs/sm/md/lg`; fields don't ship `xs` yet.)
 - Validation logic lives in your form layer (React Hook Form + Zod recommended), not in the component.
 
 ### `<Card>` — bordered container

--- a/packages/design-system/src/components/DatePicker/DatePicker.module.scss
+++ b/packages/design-system/src/components/DatePicker/DatePicker.module.scss
@@ -10,7 +10,6 @@
   width: 100%;
   align-items: center;
   gap: var(--space-1);
-  padding: 0 var(--space-2);
   background: var(--color-bg);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-md);
@@ -47,13 +46,11 @@
 .input {
   flex: 1 1 auto;
   min-width: 0;
-  height: var(--size-md);
   padding: 0;
   background: transparent;
   border: none;
   outline: none;
   font-family: inherit;
-  font-size: var(--font-size-md);
   color: var(--color-fg);
 
   &::placeholder {
@@ -67,8 +64,6 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: var(--space-5);
-  height: var(--space-5);
   padding: 0;
   background: transparent;
   border: none;
@@ -93,4 +88,52 @@
 
 .popover {
   z-index: var(--z-popover);
+}
+
+// Size modifiers — drive wrapper padding, inner input height + font, and
+// clear/open button slot dimensions. The chevrons inside the popover grid
+// are NOT controlled here; they belong to DatePickerGrid.
+.size-sm {
+  padding: 0 var(--space-2);
+
+  .input {
+    height: var(--size-sm);
+    font-size: var(--font-size-sm);
+  }
+
+  .clearButton,
+  .openButton {
+    width: var(--space-5);
+    height: var(--space-5);
+  }
+}
+
+.size-md {
+  padding: 0 var(--space-2);
+
+  .input {
+    height: var(--size-md);
+    font-size: var(--font-size-md);
+  }
+
+  .clearButton,
+  .openButton {
+    width: var(--space-5);
+    height: var(--space-5);
+  }
+}
+
+.size-lg {
+  padding: 0 var(--space-3);
+
+  .input {
+    height: var(--size-lg);
+    font-size: var(--font-size-lg);
+  }
+
+  .clearButton,
+  .openButton {
+    width: var(--space-6);
+    height: var(--space-6);
+  }
 }

--- a/packages/design-system/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/design-system/src/components/DatePicker/DatePicker.test.tsx
@@ -217,4 +217,20 @@ describe('DatePicker', () => {
     expect(committed.getMonth()).toBe(4);
     expect(committed.getDate()).toBe(21);
   });
+
+  it('applies size class names for sm / md / lg', () => {
+    const { rerender, container } = render(<DatePicker size="sm" aria-label="Sized" />, {
+      wrapper: wrap(),
+    });
+    expect(container.querySelector('[class*="size-sm"]')).not.toBeNull();
+    rerender(<DatePicker size="md" aria-label="Sized" />);
+    expect(container.querySelector('[class*="size-md"]')).not.toBeNull();
+    rerender(<DatePicker size="lg" aria-label="Sized" />);
+    expect(container.querySelector('[class*="size-lg"]')).not.toBeNull();
+  });
+
+  it('defaults to size="md" when no size prop is passed', () => {
+    const { container } = render(<DatePicker aria-label="Default" />, { wrapper: wrap() });
+    expect(container.querySelector('[class*="size-md"]')).not.toBeNull();
+  });
 });

--- a/packages/design-system/src/components/DatePicker/DatePicker.tsx
+++ b/packages/design-system/src/components/DatePicker/DatePicker.tsx
@@ -20,6 +20,9 @@ import { DatePickerGrid } from './DatePickerGrid';
 import { formatDate, parseDate, toIsoDate, isDateOutOfRange } from './utils';
 import styles from './DatePicker.module.scss';
 
+/** Field height + type scale. Pairs with `<Input>` and `<Select>`. */
+export type DatePickerSize = 'sm' | 'md' | 'lg';
+
 export interface DatePickerLabels {
   /** aria-label for the previous-month chevron. */
   previousMonth?: string;
@@ -35,7 +38,7 @@ export interface DatePickerLabels {
 
 export interface DatePickerProps extends Omit<
   InputHTMLAttributes<HTMLInputElement>,
-  'value' | 'defaultValue' | 'onChange' | 'type' | 'min' | 'max'
+  'value' | 'defaultValue' | 'onChange' | 'type' | 'min' | 'max' | 'size'
 > {
   /** Selected date. `null` = no value. Pair with `onChange` for controlled use. */
   value?: Date | null;
@@ -61,6 +64,16 @@ export interface DatePickerProps extends Omit<
   /** Form name. When set, renders a hidden mirror `<input>` with the ISO date. */
   name?: string;
 
+  /**
+   * Field height + type scale. Same scale as `<Input>`. Defaults to `'md'`.
+   * Affects only the trigger row; the popover month grid is fixed-size.
+   *
+   * - `'sm'` — 24px tall.
+   * - `'md'` — 32px tall (default).
+   * - `'lg'` — 40px tall.
+   */
+  size?: DatePickerSize;
+
   /** Localized strings. */
   labels?: DatePickerLabels;
 }
@@ -71,6 +84,12 @@ const DEFAULT_LABELS: Required<DatePickerLabels> = {
   openCalendar: 'Open calendar',
   clear: 'Clear date',
   dialogLabel: 'Choose date',
+};
+
+const ICON_SIZE_FOR: Record<DatePickerSize, number> = {
+  sm: 14,
+  md: 14,
+  lg: 16,
 };
 
 /**
@@ -123,6 +142,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(function
     clearable = true,
     invalid = false,
     disabled = false,
+    size = 'md',
     name,
     labels,
     placeholder,
@@ -323,6 +343,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(function
       ref={setWrapperRef}
       className={clsx(
         styles.wrapper,
+        styles[`size-${size}`],
         invalid && styles.invalid,
         disabled && styles.disabled,
         className,
@@ -356,7 +377,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(function
           aria-label={resolvedLabels.clear}
           onClick={handleClear}
         >
-          <X size={14} />
+          <X size={ICON_SIZE_FOR[size]} />
         </button>
       )}
       <button
@@ -366,7 +387,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(function
         onClick={handleToggle}
         disabled={disabled}
       >
-        <CalendarIcon size={14} />
+        <CalendarIcon size={ICON_SIZE_FOR[size]} />
       </button>
       {name && <input type="hidden" name={name} value={value ? toIsoDate(value) : ''} />}
       {open &&

--- a/packages/design-system/src/components/DatePicker/index.ts
+++ b/packages/design-system/src/components/DatePicker/index.ts
@@ -1,4 +1,4 @@
 export { DatePicker } from './DatePicker';
-export type { DatePickerProps, DatePickerLabels } from './DatePicker';
+export type { DatePickerProps, DatePickerLabels, DatePickerSize } from './DatePicker';
 export { InlineDatePicker } from './InlineDatePicker';
 export type { InlineDatePickerProps, InlineDatePickerLabels } from './InlineDatePicker';

--- a/packages/design-system/src/components/DateRangePicker/DateRangePicker.module.scss
+++ b/packages/design-system/src/components/DateRangePicker/DateRangePicker.module.scss
@@ -12,7 +12,6 @@
   width: 100%;
   align-items: center;
   gap: var(--space-1);
-  padding: 0 var(--space-2);
   background: var(--color-bg);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-md);
@@ -48,13 +47,11 @@
 .input {
   flex: 1;
   min-width: 0;
-  height: var(--size-md);
   padding: 0;
   background: transparent;
   border: none;
   outline: none;
   font-family: inherit;
-  font-size: var(--font-size-md);
   color: var(--color-fg);
 
   &::placeholder {
@@ -68,8 +65,6 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: var(--space-5);
-  height: var(--space-5);
   padding: 0;
   background: transparent;
   border: none;
@@ -145,4 +140,52 @@
 .grids {
   display: flex;
   gap: var(--space-3);
+}
+
+// Size modifiers — drive wrapper padding, inner input height + font, and
+// clear/open button slot dimensions. The chevrons inside the popover grids
+// are NOT controlled here; they belong to DatePickerGrid.
+.size-sm {
+  padding: 0 var(--space-2);
+
+  .input {
+    height: var(--size-sm);
+    font-size: var(--font-size-sm);
+  }
+
+  .clearButton,
+  .openButton {
+    width: var(--space-5);
+    height: var(--space-5);
+  }
+}
+
+.size-md {
+  padding: 0 var(--space-2);
+
+  .input {
+    height: var(--size-md);
+    font-size: var(--font-size-md);
+  }
+
+  .clearButton,
+  .openButton {
+    width: var(--space-5);
+    height: var(--space-5);
+  }
+}
+
+.size-lg {
+  padding: 0 var(--space-3);
+
+  .input {
+    height: var(--size-lg);
+    font-size: var(--font-size-lg);
+  }
+
+  .clearButton,
+  .openButton {
+    width: var(--space-6);
+    height: var(--space-6);
+  }
 }

--- a/packages/design-system/src/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/design-system/src/components/DateRangePicker/DateRangePicker.test.tsx
@@ -327,6 +327,20 @@ describe('DateRangePicker', () => {
     expect((document.activeElement as HTMLElement)?.textContent).toBe('1');
   });
 
+  it('applies size class names for sm / md / lg', () => {
+    const { rerender, container } = render(<DateRangePicker size="sm" aria-label="Sized" />, { wrapper: wrap() });
+    expect(container.querySelector('[class*="size-sm"]')).not.toBeNull();
+    rerender(<DateRangePicker size="md" aria-label="Sized" />);
+    expect(container.querySelector('[class*="size-md"]')).not.toBeNull();
+    rerender(<DateRangePicker size="lg" aria-label="Sized" />);
+    expect(container.querySelector('[class*="size-lg"]')).not.toBeNull();
+  });
+
+  it('defaults to size="md" when no size prop is passed', () => {
+    const { container } = render(<DateRangePicker aria-label="Default" />, { wrapper: wrap() });
+    expect(container.querySelector('[class*="size-md"]')).not.toBeNull();
+  });
+
   it('keyboard ArrowLeft from a right-grid cell shifts cursor backward and focuses the left side (exercises handleRightGridCursorChange)', async () => {
     const user = userEvent.setup();
     // defaultValue spans April→May:

--- a/packages/design-system/src/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/design-system/src/components/DateRangePicker/DateRangePicker.test.tsx
@@ -328,7 +328,9 @@ describe('DateRangePicker', () => {
   });
 
   it('applies size class names for sm / md / lg', () => {
-    const { rerender, container } = render(<DateRangePicker size="sm" aria-label="Sized" />, { wrapper: wrap() });
+    const { rerender, container } = render(<DateRangePicker size="sm" aria-label="Sized" />, {
+      wrapper: wrap(),
+    });
     expect(container.querySelector('[class*="size-sm"]')).not.toBeNull();
     rerender(<DateRangePicker size="md" aria-label="Sized" />);
     expect(container.querySelector('[class*="size-md"]')).not.toBeNull();

--- a/packages/design-system/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/design-system/src/components/DateRangePicker/DateRangePicker.tsx
@@ -22,6 +22,9 @@ import { toIsoDate, isDateOutOfRange, formatDate } from '../DatePicker/utils';
 import { type DateRange, autoSwapRange, formatDateRange, parseDateRange } from './utils';
 import styles from './DateRangePicker.module.scss';
 
+/** Field height + type scale. Pairs with `<Input>`, `<Select>`, and `<DatePicker>`. */
+export type DateRangePickerSize = 'sm' | 'md' | 'lg';
+
 export interface DateRangePickerLabels {
   /** aria-label for the previous-month chevron. */
   previousMonth?: string;
@@ -37,7 +40,7 @@ export interface DateRangePickerLabels {
 
 export interface DateRangePickerProps extends Omit<
   InputHTMLAttributes<HTMLInputElement>,
-  'value' | 'defaultValue' | 'onChange' | 'type' | 'min' | 'max' | 'name'
+  'value' | 'defaultValue' | 'onChange' | 'type' | 'min' | 'max' | 'name' | 'size'
 > {
   /** Selected range. `null` = no range. Pair with `onChange` for controlled use. */
   value?: DateRange | null;
@@ -54,6 +57,16 @@ export interface DateRangePickerProps extends Omit<
   max?: Date;
   /** Per-date disable predicate. */
   isDateDisabled?: (date: Date) => boolean;
+
+  /**
+   * Field height + type scale. Same scale as `<DatePicker>`. Defaults to `'md'`.
+   * Affects only the trigger row; the two-month popover grid is fixed-size.
+   *
+   * - `'sm'` — 24px tall.
+   * - `'md'` — 32px tall (default).
+   * - `'lg'` — 40px tall.
+   */
+  size?: DateRangePickerSize;
 
   /** Show the ✕ clear button when a range is set. Defaults to `true`. */
   clearable?: boolean;
@@ -75,6 +88,12 @@ const DEFAULT_LABELS: Required<DateRangePickerLabels> = {
   openCalendar: 'Open calendar',
   clear: 'Clear range',
   dialogLabel: 'Choose date range',
+};
+
+const ICON_SIZE_FOR: Record<DateRangePickerSize, number> = {
+  sm: 14,
+  md: 14,
+  lg: 16,
 };
 
 /**
@@ -126,6 +145,7 @@ export const DateRangePicker = forwardRef<HTMLInputElement, DateRangePickerProps
       clearable = true,
       invalid = false,
       disabled = false,
+      size = 'md',
       nameStart,
       nameEnd,
       labels,
@@ -391,6 +411,7 @@ export const DateRangePicker = forwardRef<HTMLInputElement, DateRangePickerProps
         ref={setWrapperRef}
         className={clsx(
           styles.wrapper,
+          styles[`size-${size}`],
           invalid && styles.invalid,
           disabled && styles.disabled,
           className,
@@ -427,7 +448,7 @@ export const DateRangePicker = forwardRef<HTMLInputElement, DateRangePickerProps
             aria-label={resolvedLabels.clear}
             onClick={handleClear}
           >
-            <X size={14} />
+            <X size={ICON_SIZE_FOR[size]} />
           </button>
         )}
         <button
@@ -437,7 +458,7 @@ export const DateRangePicker = forwardRef<HTMLInputElement, DateRangePickerProps
           onClick={handleToggle}
           disabled={disabled}
         >
-          <CalendarIcon size={14} />
+          <CalendarIcon size={ICON_SIZE_FOR[size]} />
         </button>
         {nameStart && (
           <input type="hidden" name={nameStart} value={value ? toIsoDate(value.start) : ''} />

--- a/packages/design-system/src/components/DateRangePicker/index.ts
+++ b/packages/design-system/src/components/DateRangePicker/index.ts
@@ -1,5 +1,9 @@
 export { DateRangePicker } from './DateRangePicker';
-export type { DateRangePickerProps, DateRangePickerLabels, DateRangePickerSize } from './DateRangePicker';
+export type {
+  DateRangePickerProps,
+  DateRangePickerLabels,
+  DateRangePickerSize,
+} from './DateRangePicker';
 export type { DateRange } from './utils';
 export { InlineDateRangePicker } from './InlineDateRangePicker';
 export type {

--- a/packages/design-system/src/components/DateRangePicker/index.ts
+++ b/packages/design-system/src/components/DateRangePicker/index.ts
@@ -1,5 +1,5 @@
 export { DateRangePicker } from './DateRangePicker';
-export type { DateRangePickerProps, DateRangePickerLabels } from './DateRangePicker';
+export type { DateRangePickerProps, DateRangePickerLabels, DateRangePickerSize } from './DateRangePicker';
 export type { DateRange } from './utils';
 export { InlineDateRangePicker } from './InlineDateRangePicker';
 export type {

--- a/packages/design-system/src/components/Input/Input.module.scss
+++ b/packages/design-system/src/components/Input/Input.module.scss
@@ -1,14 +1,11 @@
 .input {
   display: block;
   width: 100%;
-  height: var(--size-md);
-  padding: 0 var(--space-3);
   border: var(--border-width) solid var(--color-border-strong);
   border-radius: var(--radius-md);
   background: var(--color-bg);
   color: var(--color-fg);
   font-family: inherit;
-  font-size: var(--font-size-md);
   line-height: var(--line-height-normal);
   transition:
     border-color var(--transition-fast),
@@ -30,6 +27,25 @@
     color: var(--color-fg-subtle);
     cursor: not-allowed;
   }
+}
+
+// Size modifiers. md is the default — match the previous hard-coded values.
+.size-sm {
+  height: var(--size-sm);
+  padding: 0 var(--space-2);
+  font-size: var(--font-size-sm);
+}
+
+.size-md {
+  height: var(--size-md);
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-md);
+}
+
+.size-lg {
+  height: var(--size-lg);
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-lg);
 }
 
 .invalid {

--- a/packages/design-system/src/components/Input/Input.test.tsx
+++ b/packages/design-system/src/components/Input/Input.test.tsx
@@ -85,4 +85,23 @@ describe('Input', () => {
     expect(input.value).toBe('locked');
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('applies size class names for sm / md / lg', () => {
+    const { rerender, container } = render(<Input size="sm" />);
+    expect(container.querySelector('input')!.className).toMatch(/size-sm/);
+    rerender(<Input size="md" />);
+    expect(container.querySelector('input')!.className).toMatch(/size-md/);
+    rerender(<Input size="lg" />);
+    expect(container.querySelector('input')!.className).toMatch(/size-lg/);
+  });
+
+  it('defaults to size="md" when no size prop is passed', () => {
+    const { container } = render(<Input />);
+    expect(container.querySelector('input')!.className).toMatch(/size-md/);
+  });
+
+  it('does NOT pass component size prop through to the DOM size attribute', () => {
+    const { container } = render(<Input size="sm" />);
+    expect(container.querySelector('input')).not.toHaveAttribute('size');
+  });
 });

--- a/packages/design-system/src/components/Input/Input.tsx
+++ b/packages/design-system/src/components/Input/Input.tsx
@@ -84,12 +84,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
       // wins.
       aria-invalid={invalid || undefined}
       {...props}
-      className={clsx(
-        styles.input,
-        styles[`size-${size}`],
-        invalid && styles.invalid,
-        className,
-      )}
+      className={clsx(styles.input, styles[`size-${size}`], invalid && styles.invalid, className)}
     />
   );
 });

--- a/packages/design-system/src/components/Input/Input.tsx
+++ b/packages/design-system/src/components/Input/Input.tsx
@@ -2,18 +2,35 @@ import { forwardRef, type InputHTMLAttributes } from 'react';
 import clsx from 'clsx';
 import styles from './Input.module.scss';
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+/**
+ * Field height + type scale. Pairs with `<Button>` and `<Select>` sizes.
+ */
+export type InputSize = 'sm' | 'md' | 'lg';
+
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
   /**
    * Toggles the error visual (red border + focus ring) and sets `aria-invalid="true"`.
    * Pair with a visible error message and `aria-describedby` pointing at the message id.
    */
   invalid?: boolean;
+  /**
+   * Visual size. Defaults to `'md'`.
+   * - `'sm'` — 24px tall; toolbars, secondary forms.
+   * - `'md'` — 32px tall (default); most form contexts.
+   * - `'lg'` — 40px tall; hero search, mobile-friendly forms.
+   *
+   * Note: this shadows the native HTML `<input size>` attribute (visible
+   * character count). If you need that legacy attribute, set width via
+   * `style` or a parent container.
+   */
+  size?: InputSize;
 }
 
 /**
  * Single-line text input. Forwards all native `<input>` attributes — `type`,
  * `placeholder`, `value`/`onChange`, `disabled`, `readOnly`, `pattern`,
- * `autoComplete`, `inputMode`, etc.
+ * `autoComplete`, `inputMode`, etc. (The native HTML `size` attribute is
+ * shadowed by the component-level `size` prop — see `InputProps.size`.)
  *
  * The component is intentionally dumb. Validation logic lives in your form
  * layer (React Hook Form + Zod recommended); pass the result down via `invalid`.
@@ -31,14 +48,19 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
  * </label>
  *
  * @example
+ * // Sized:
+ * <Input size="sm" placeholder="Filter…" />
+ * <Input size="lg" type="search" placeholder="Search the workspace" />
+ *
+ * @example
  * // Error state:
  * <Input invalid value={value} aria-describedby="email-error" />
  * <p id="email-error">Enter a valid email.</p>
  *
  * @remarks When NOT to use
  * - Multi-line → use `Textarea` (not yet shipped).
- * - Choosing from a fixed list → use `Select` (not yet shipped).
- * - Date/time → use `DatePicker` (not yet shipped, plan: `react-day-picker`).
+ * - Choosing from a fixed list → use `Select`.
+ * - Date/time → use `DatePicker` / `DateRangePicker`.
  * - Password reveal/toggle → use `PasswordInput` (not yet shipped).
  *
  * @remarks Anti-patterns
@@ -50,7 +72,7 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
  *   leading zeros and breaks formatting. Use `inputMode="numeric"` instead.
  */
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { invalid, className, ...props },
+  { invalid, size = 'md', className, ...props },
   ref,
 ) {
   return (
@@ -62,7 +84,12 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
       // wins.
       aria-invalid={invalid || undefined}
       {...props}
-      className={clsx(styles.input, invalid && styles.invalid, className)}
+      className={clsx(
+        styles.input,
+        styles[`size-${size}`],
+        invalid && styles.invalid,
+        className,
+      )}
     />
   );
 });

--- a/packages/design-system/src/components/Input/index.ts
+++ b/packages/design-system/src/components/Input/index.ts
@@ -1,2 +1,2 @@
 export { Input } from './Input';
-export type { InputProps } from './Input';
+export type { InputProps, InputSize } from './Input';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -138,7 +138,7 @@ export type {
 } from './components/Calendar';
 
 export { DatePicker } from './components/DatePicker';
-export type { DatePickerProps, DatePickerLabels } from './components/DatePicker';
+export type { DatePickerProps, DatePickerLabels, DatePickerSize } from './components/DatePicker';
 
 export { DateRangePicker } from './components/DateRangePicker';
 export type {

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -144,6 +144,7 @@ export { DateRangePicker } from './components/DateRangePicker';
 export type {
   DateRangePickerProps,
   DateRangePickerLabels,
+  DateRangePickerSize,
   DateRange,
 } from './components/DateRangePicker';
 

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -3,7 +3,7 @@ export { Button } from './components/Button';
 export type { ButtonProps, ButtonVariant, ButtonSize } from './components/Button';
 
 export { Input } from './components/Input';
-export type { InputProps } from './components/Input';
+export type { InputProps, InputSize } from './components/Input';
 
 export { Card } from './components/Card';
 export type { CardProps, CardPadding } from './components/Card';

--- a/packages/playground/src/pages/components/DatePickerDemo.tsx
+++ b/packages/playground/src/pages/components/DatePickerDemo.tsx
@@ -113,6 +113,22 @@ const in90Days = new Date(today.getFullYear(), today.getMonth(), today.getDate()
       </Example>
 
       <Example
+        title="Sizes"
+        description="Three sizes — sm (24px), md (32px, default), lg (40px). The popover month grid is fixed-size; only the trigger row scales."
+        code={`<DatePicker size="sm" defaultValue={new Date()} />
+<DatePicker size="md" defaultValue={new Date()} />
+<DatePicker size="lg" defaultValue={new Date()} />`}
+      >
+        <InputExample>
+          <Stack gap="sm">
+            <DatePicker size="sm" defaultValue={TODAY} aria-label="Small date" />
+            <DatePicker size="md" defaultValue={TODAY} aria-label="Medium date" />
+            <DatePicker size="lg" defaultValue={TODAY} aria-label="Large date" />
+          </Stack>
+        </InputExample>
+      </Example>
+
+      <Example
         title="Disabled"
         description="Use `disabled` when the field is unavailable in the current context (e.g., read-only stage of a workflow). The clear button is hidden when disabled."
         code={`<DatePicker disabled defaultValue={new Date()} />`}

--- a/packages/playground/src/pages/components/DateRangePickerDemo.tsx
+++ b/packages/playground/src/pages/components/DateRangePickerDemo.tsx
@@ -146,9 +146,21 @@ const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1
       >
         <InputExample>
           <Stack gap="sm">
-            <DateRangePicker size="sm" defaultValue={{ start: TODAY, end: IN_14 }} aria-label="Small range" />
-            <DateRangePicker size="md" defaultValue={{ start: TODAY, end: IN_14 }} aria-label="Medium range" />
-            <DateRangePicker size="lg" defaultValue={{ start: TODAY, end: IN_14 }} aria-label="Large range" />
+            <DateRangePicker
+              size="sm"
+              defaultValue={{ start: TODAY, end: IN_14 }}
+              aria-label="Small range"
+            />
+            <DateRangePicker
+              size="md"
+              defaultValue={{ start: TODAY, end: IN_14 }}
+              aria-label="Medium range"
+            />
+            <DateRangePicker
+              size="lg"
+              defaultValue={{ start: TODAY, end: IN_14 }}
+              aria-label="Large range"
+            />
           </Stack>
         </InputExample>
       </Example>

--- a/packages/playground/src/pages/components/DateRangePickerDemo.tsx
+++ b/packages/playground/src/pages/components/DateRangePickerDemo.tsx
@@ -135,6 +135,25 @@ const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 9
       </Example>
 
       <Example
+        title="Sizes"
+        description="Three sizes — sm (24px), md (32px, default), lg (40px). The two-month popover grid is fixed-size; only the trigger row scales."
+        code={`const today = new Date();
+const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
+
+<DateRangePicker size="sm" defaultValue={{ start: today, end: in14 }} />
+<DateRangePicker size="md" defaultValue={{ start: today, end: in14 }} />
+<DateRangePicker size="lg" defaultValue={{ start: today, end: in14 }} />`}
+      >
+        <InputExample>
+          <Stack gap="sm">
+            <DateRangePicker size="sm" defaultValue={{ start: TODAY, end: IN_14 }} aria-label="Small range" />
+            <DateRangePicker size="md" defaultValue={{ start: TODAY, end: IN_14 }} aria-label="Medium range" />
+            <DateRangePicker size="lg" defaultValue={{ start: TODAY, end: IN_14 }} aria-label="Large range" />
+          </Stack>
+        </InputExample>
+      </Example>
+
+      <Example
         title="Disabled"
         description="Use `disabled` when the range is unavailable in the current context. The clear button is hidden when disabled."
         code={`const today = new Date();

--- a/packages/playground/src/pages/components/InputDemo.tsx
+++ b/packages/playground/src/pages/components/InputDemo.tsx
@@ -52,7 +52,12 @@ export function InputDemo() {
           <Stack gap="sm">
             <Input size="sm" placeholder="Filter…" aria-label="Small input" />
             <Input size="md" placeholder="Default" aria-label="Medium input" />
-            <Input size="lg" type="search" placeholder="Search the workspace" aria-label="Large input" />
+            <Input
+              size="lg"
+              type="search"
+              placeholder="Search the workspace"
+              aria-label="Large input"
+            />
           </Stack>
         </InputExample>
       </Example>

--- a/packages/playground/src/pages/components/InputDemo.tsx
+++ b/packages/playground/src/pages/components/InputDemo.tsx
@@ -42,6 +42,22 @@ export function InputDemo() {
       </Example>
 
       <Example
+        title="Sizes"
+        description="Three sizes — sm (24px), md (32px, default), lg (40px). Use sm for dense toolbars, lg for hero / mobile-friendly forms."
+        code={`<Input size="sm" placeholder="Filter…" />
+<Input size="md" placeholder="Default" />
+<Input size="lg" type="search" placeholder="Search the workspace" />`}
+      >
+        <InputExample>
+          <Stack gap="sm">
+            <Input size="sm" placeholder="Filter…" aria-label="Small input" />
+            <Input size="md" placeholder="Default" aria-label="Medium input" />
+            <Input size="lg" type="search" placeholder="Search the workspace" aria-label="Large input" />
+          </Stack>
+        </InputExample>
+      </Example>
+
+      <Example
         title="Invalid state"
         description="Pass invalid to toggle the error visual. Pair with an external error message and aria-describedby."
         code={`<Input


### PR DESCRIPTION
## Summary

- Added a `size: 'sm' | 'md' | 'lg'` prop to `<Input>`, `<DatePicker>`, and `<DateRangePicker>`. `md` stays the default — no behavior change for existing consumers.
- `<Select>` already exposes the same three sizes; no library changes there.
- Composite pickers (`DatePicker` / `DateRangePicker`) scale the trigger row, the inline clear ✕ and open-calendar button slots, and the lucide icons inside those buttons. The popover month grid is intentionally NOT scaled.
- `Omit<…, 'size'>` added to the three components' props interfaces to shadow the native HTML `<input size>` attribute. A regression test enforces that the component-level `size` prop does NOT leak to the DOM `size` attribute.
- `xs` (20px) variant explicitly deferred — to be added when a real CRM screen demands it.

## Test plan

- [x] `npm test --run` — 783/783 (existing + 3 Input + 2 DatePicker + 2 DateRangePicker)
- [x] `npm run typecheck` clean
- [x] `npm run lint:css` clean
- [x] `npm run build` clean
- [x] `npx prettier --check` clean
- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files in tarball
- [x] Hard Rule 8 review cycle — final verdict: clean enough to stop

## Design spec / plan

- Spec: \`docs/superpowers/specs/2026-05-21-input-sizes-xs-lg-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-21-input-sizes-sm-lg.md\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>