### PR TITLE
Avatar: status dot + name tooltip + AvatarGroup (Slack-style stacked row)

### DIFF
--- a/docs/superpowers/plans/2026-05-21-avatar-group-status.md
+++ b/docs/superpowers/plans/2026-05-21-avatar-group-status.md
@@ -37,24 +37,24 @@ test -x .husky/pre-push           # exit 0
 Find the existing `// States` section (around `--opacity-disabled`) and INSERT this block just above it:
 
 ```scss
-  // Presence dots (Avatar status). Aliases over the existing semantic
-  // palette — theme changes propagate.
-  --color-presence-online: var(--color-success);
-  --color-presence-busy: var(--color-danger);
-  --color-presence-away: var(--color-warning);
-  --color-presence-offline: var(--color-fg-disabled);
+// Presence dots (Avatar status). Aliases over the existing semantic
+// palette — theme changes propagate.
+--color-presence-online: var(--color-success);
+--color-presence-busy: var(--color-danger);
+--color-presence-away: var(--color-warning);
+--color-presence-offline: var(--color-fg-disabled);
 
-  // Presence-dot dimensions per avatar size.
-  --size-presence-sm: 8px;
-  --size-presence-md: 10px;
-  --size-presence-lg: 12px;
+// Presence-dot dimensions per avatar size.
+--size-presence-sm: 8px;
+--size-presence-md: 10px;
+--size-presence-lg: 12px;
 
-  // Avatar overlap when stacked in a group. Each child after the first
-  // slides left by this amount (negative margin-left). 30% of diameter
-  // looks like Slack at every supported size.
-  --avatar-overlap-sm: calc(var(--size-sm) * -0.3);
-  --avatar-overlap-md: calc(var(--size-md) * -0.3);
-  --avatar-overlap-lg: calc(var(--size-lg) * -0.3);
+// Avatar overlap when stacked in a group. Each child after the first
+// slides left by this amount (negative margin-left). 30% of diameter
+// looks like Slack at every supported size.
+--avatar-overlap-sm: calc(var(--size-sm) * -0.3);
+--avatar-overlap-md: calc(var(--size-md) * -0.3);
+--avatar-overlap-lg: calc(var(--size-lg) * -0.3);
 ```
 
 - [ ] **Step 2: Gates**
@@ -606,11 +606,7 @@ export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(function
           +{hiddenCount}
         </button>
       ) : (
-        <span
-          className={overflowClass}
-          role="img"
-          aria-label={`${hiddenCount} more avatars`}
-        >
+        <span className={overflowClass} role="img" aria-label={`${hiddenCount} more avatars`}>
           +{hiddenCount}
         </span>
       )
@@ -986,11 +982,7 @@ function GroupDemo() {
   const [clicked, setClicked] = useState<number | null>(null);
   return (
     <Stack gap="xs">
-      <AvatarGroup
-        max={4}
-        size="md"
-        onOverflowClick={(_e, count) => setClicked(count)}
-      >
+      <AvatarGroup max={4} size="md" onOverflowClick={(_e, count) => setClicked(count)}>
         {TEAM.map((n) => (
           <Avatar key={n} name={n} />
         ))}
@@ -1031,13 +1023,19 @@ Then in the demo JSX:
 >
   <Stack gap="md">
     <AvatarGroup size="sm" max={5}>
-      {TEAM.slice(0, 6).map((n) => <Avatar key={n} name={n} />)}
+      {TEAM.slice(0, 6).map((n) => (
+        <Avatar key={n} name={n} />
+      ))}
     </AvatarGroup>
     <AvatarGroup size="md" max={5}>
-      {TEAM.slice(0, 6).map((n) => <Avatar key={n} name={n} />)}
+      {TEAM.slice(0, 6).map((n) => (
+        <Avatar key={n} name={n} />
+      ))}
     </AvatarGroup>
     <AvatarGroup size="lg" max={5}>
-      {TEAM.slice(0, 6).map((n) => <Avatar key={n} name={n} />)}
+      {TEAM.slice(0, 6).map((n) => (
+        <Avatar key={n} name={n} />
+      ))}
     </AvatarGroup>
   </Stack>
 </Example>
@@ -1056,6 +1054,7 @@ npm run build 2>&1 | tail -5
 - [ ] **Step 4: Smoke test**
 
 Browse `/components/avatar` in the dev server (use Playwright MCP or local browser). Verify:
+
 - Status dots render in the right corner with the right colors.
 - Tooltip appears on hover/focus.
 - Group with overflow shows 4 visible + a "+3" button. Clicking it logs to the debug `<code>`.
@@ -1093,14 +1092,17 @@ After the existing bullets, add:
 
 - [ ] **Step 3: Add a new `<AvatarGroup>` section RIGHT AFTER the `<Avatar>` section**
 
-```markdown
+````markdown
 ### `<AvatarGroup>` — Slack-style stacked row of avatars
 
 ```tsx
 <AvatarGroup max={4} size="md" onOverflowClick={(_e, n) => openMembersPopover(n)}>
-  {team.map((m) => <Avatar key={m.id} name={m.name} src={m.avatarUrl} status={m.presence} />)}
+  {team.map((m) => (
+    <Avatar key={m.id} name={m.name} src={m.avatarUrl} status={m.presence} />
+  ))}
 </AvatarGroup>
 ```
+````
 
 - Horizontal row of overlapping `<Avatar>`s with a `+N` overflow control when the child count exceeds `max` (default `4`).
 - `size` is set on the group, NOT per child. The group's size overrides any per-child `size`. Three sizes: `'sm' | 'md' | 'lg'`.
@@ -1108,14 +1110,15 @@ After the existing bullets, add:
 - `onOverflowClick(event, hiddenCount)` — the library does NOT render its own popover. When the user clicks `+N`, the app decides what happens (open a `<Popover>` with a list of all members, navigate to a page, open a modal, etc.). When the handler is omitted, the `+N` renders as a non-interactive `<span>`.
 - The group wrapper is `role="list"` and each visible avatar is wrapped in `role="listitem"`. The +N (button or span) is the last list item.
 - forwardRef to the outer `<div>`. `className` is merged, not replaced.
-```
+
+````
 
 - [ ] **Step 4: Commit**
 
 ```bash
 git add packages/design-system/AGENTS.md
 git commit -m "AGENTS.md: document AvatarGroup + Avatar status/tooltip"
-```
+````
 
 ---
 

--- a/docs/superpowers/plans/2026-05-21-avatar-group-status.md
+++ b/docs/superpowers/plans/2026-05-21-avatar-group-status.md
@@ -1,0 +1,1219 @@
+# Avatar group + status + tooltip — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<AvatarGroup>` (Slack-style stacked row with `+N` overflow callback), add `status` (presence dot) + `tooltip` (name on hover) props to `<Avatar>`.
+
+**Architecture:** New `AvatarGroupContext` lets group propagate `size` and `tooltip` defaults to descendant `<Avatar>`s. Group renders visible children + a `+N` button (or non-interactive span when `onOverflowClick` is omitted). Avatar gains an absolutely-positioned presence dot child + a conditional `<Tooltip>` wrapper. New presence-color + dot-size + overlap tokens in `tokens.scss`.
+
+**Tech Stack:** React, SCSS modules, Vitest + RTL.
+
+**Branch:** `feat/avatar-group-status`.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-avatar-group-status-design.md`.
+
+---
+
+## Task 1: Verify branch + hooks
+
+- [ ] **Step 1: Verify**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # → feat/avatar-group-status
+git config --get core.hooksPath   # → .husky/_
+test -x .husky/pre-push           # exit 0
+```
+
+---
+
+## Task 2: Add presence + overlap tokens
+
+**Files:**
+
+- Modify: `packages/design-system/src/styles/tokens.scss`
+
+- [ ] **Step 1: Add the new tokens**
+
+Find the existing `// States` section (around `--opacity-disabled`) and INSERT this block just above it:
+
+```scss
+  // Presence dots (Avatar status). Aliases over the existing semantic
+  // palette — theme changes propagate.
+  --color-presence-online: var(--color-success);
+  --color-presence-busy: var(--color-danger);
+  --color-presence-away: var(--color-warning);
+  --color-presence-offline: var(--color-fg-disabled);
+
+  // Presence-dot dimensions per avatar size.
+  --size-presence-sm: 8px;
+  --size-presence-md: 10px;
+  --size-presence-lg: 12px;
+
+  // Avatar overlap when stacked in a group. Each child after the first
+  // slides left by this amount (negative margin-left). 30% of diameter
+  // looks like Slack at every supported size.
+  --avatar-overlap-sm: calc(var(--size-sm) * -0.3);
+  --avatar-overlap-md: calc(var(--size-md) * -0.3);
+  --avatar-overlap-lg: calc(var(--size-lg) * -0.3);
+```
+
+- [ ] **Step 2: Gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm run lint:css 2>&1 | tail -3
+npm run build 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/styles/tokens.scss
+git commit -m "tokens: add presence colors + dot sizes + avatar-overlap"
+```
+
+---
+
+## Task 3: `AvatarGroupContext.tsx`
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Avatar/AvatarGroupContext.tsx`
+
+- [ ] **Step 1: Create the file**
+
+```tsx
+import { createContext, useContext } from 'react';
+import type { AvatarSize } from './Avatar';
+
+export interface AvatarGroupContextValue {
+  /** Uniform size for every avatar in the group. */
+  size: AvatarSize;
+  /** Default tooltip behavior for child avatars. */
+  tooltip: boolean;
+}
+
+/**
+ * Internal context shared by `<AvatarGroup>` with its descendant `<Avatar>`s.
+ * `null` means the avatar is standalone (not inside a group).
+ */
+export const AvatarGroupContext = createContext<AvatarGroupContextValue | null>(null);
+
+/** Read the surrounding group context; `null` when standalone. */
+export function useAvatarGroup(): AvatarGroupContextValue | null {
+  return useContext(AvatarGroupContext);
+}
+```
+
+- [ ] **Step 2: Gates**
+
+```bash
+npm run typecheck 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/Avatar/AvatarGroupContext.tsx
+git commit -m "Avatar: add internal AvatarGroupContext for size + tooltip propagation"
+```
+
+---
+
+## Task 4: Extend `<Avatar>` with `status` + `tooltip` + group awareness
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Avatar/Avatar.tsx`
+- Modify: `packages/design-system/src/components/Avatar/Avatar.module.scss`
+
+- [ ] **Step 1: Read current `Avatar.tsx`**
+
+The file's at `/home/dpws/projects/design-system/packages/design-system/src/components/Avatar/Avatar.tsx`. Note the existing prop shape, the `hasImage` branch, and where `<img>` / initials wrapper render.
+
+- [ ] **Step 2: Replace the file body**
+
+```tsx
+import { forwardRef, useEffect, useState, type CSSProperties, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import { Tooltip } from '../Tooltip';
+import { useAvatarGroup } from './AvatarGroupContext';
+import styles from './Avatar.module.scss';
+
+/** Diameter. Matches the shared `--size-*` scale so a Button next to an Avatar lines up. */
+export type AvatarSize = 'sm' | 'md' | 'lg';
+
+/** Presence dot rendered in the bottom-right corner. Omit to render no dot. */
+export type AvatarStatus = 'online' | 'busy' | 'away' | 'offline';
+
+export interface AvatarProps extends HTMLAttributes<HTMLSpanElement> {
+  /**
+   * The person's name. Required — used as the `alt`/`aria-label`, as the
+   * source of the initials, and as the seed for the deterministic fallback
+   * color. The same name always renders the same color. When `tooltip` is
+   * true, also used as the tooltip body.
+   */
+  name: string;
+  /**
+   * Image URL. When provided, the `<img>` is rendered with `alt={name}`.
+   * Empty/whitespace strings are treated as missing. If the image fails to
+   * load (404, network), the component automatically falls back to initials.
+   */
+  src?: string;
+  /**
+   * Diameter.
+   * - `sm` (24px) — table rows, dense lists.
+   * - `md` (32px, default) — most uses.
+   * - `lg` (40px) — detail-page headers.
+   *
+   * Inside `<AvatarGroup>`, the group's `size` overrides this.
+   */
+  size?: AvatarSize;
+  /**
+   * Presence dot in the bottom-right.
+   * - `'online'`  — green.
+   * - `'busy'`    — red.
+   * - `'away'`    — amber.
+   * - `'offline'` — gray.
+   * Omit to render no dot at all.
+   */
+  status?: AvatarStatus;
+  /**
+   * When true, wraps the avatar in a `<Tooltip>` showing `name`. Defaults
+   * to `false`. Inside `<AvatarGroup>` the default flips to the group's
+   * `tooltip` prop (default `true`).
+   */
+  tooltip?: boolean;
+}
+
+const sizeClass: Record<AvatarSize, string> = {
+  sm: styles.sm,
+  md: styles.md,
+  lg: styles.lg,
+};
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).slice(0, 2);
+  return parts.map((p) => p[0]?.toUpperCase() ?? '').join('') || '?';
+}
+
+/**
+ * Returns the avatar color slot (1-6) for a given name. The mapping is stable:
+ * the same name always returns the same slot. Useful for matching avatar
+ * colors elsewhere (e.g. a "ghost" item or a chart segment representing the
+ * same user).
+ *
+ * Each slot corresponds to a `--color-avatar-N` CSS custom property.
+ */
+export function avatarColorIndex(name: string): number {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  return (Math.abs(hash) % 6) + 1;
+}
+
+type StyleWithVars = CSSProperties & { [key: `--${string}`]: string | number };
+
+function hasOwnProps(obj: object | undefined): obj is object {
+  return obj !== undefined && Object.keys(obj).length > 0;
+}
+
+/**
+ * Profile circle. Renders an `<img>` when `src` is set; otherwise renders the
+ * person's initials on a deterministic color (same name → same color, always —
+ * so a given user keeps their color across every page).
+ *
+ * On image load failure, the component automatically falls back to initials.
+ *
+ * Inside `<AvatarGroup>`, the group's `size` and `tooltip` defaults take over —
+ * individual `size` / `tooltip` props still win per-child.
+ *
+ * @example
+ * <Avatar name="Alex Rivera" />
+ *
+ * @example
+ * <Avatar name="Alex Rivera" src="https://example.com/alex.jpg" size="lg" status="online" />
+ *
+ * @example
+ * // Hover-discoverable name:
+ * <Avatar name="Alex Rivera" tooltip />
+ *
+ * @example
+ * // In a table row:
+ * <Cluster gap="sm" align="center">
+ *   <Avatar name={contact.name} size="sm" />
+ *   <span>{contact.name}</span>
+ * </Cluster>
+ *
+ * @remarks When NOT to use
+ * - For company logos — Avatars are for people. Use a `Logo` component (not
+ *   yet shipped) or an `<img>` with rounded corners.
+ * - As a clickable button. If clicking opens a profile, wrap the Avatar in
+ *   a `<button>` or `<Link>` — don't make the Avatar itself interactive.
+ *
+ * @remarks Anti-patterns
+ * - ❌ `<Avatar name="" />` — `name` is required and is the accessible label.
+ * - ❌ Using Avatar to show a non-person icon. Use an icon component instead.
+ * - ❌ Wrapping the result with `role="img"` again. The component already
+ *   handles ARIA: with `src` set, the inner `<img>` is the labeled image;
+ *   without `src`, the wrapper has `role="img" aria-label={name}`.
+ */
+export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(function Avatar(
+  { name, src, size, status, tooltip, className, style, ...props },
+  ref,
+) {
+  const group = useAvatarGroup();
+  const resolvedSize: AvatarSize = size ?? group?.size ?? 'md';
+  const resolvedTooltip: boolean = tooltip ?? group?.tooltip ?? false;
+
+  const [imageBroken, setImageBroken] = useState(false);
+  useEffect(() => {
+    setImageBroken(false);
+  }, [src]);
+
+  const hasImage = typeof src === 'string' && src.trim() !== '' && !imageBroken;
+  const trimmedName = name.trim();
+  const accessibleName = trimmedName === '' ? '?' : trimmedName;
+
+  const fallbackStyle: StyleWithVars | undefined = hasImage
+    ? undefined
+    : { '--avatar-bg': `var(--color-avatar-${avatarColorIndex(accessibleName)})` };
+
+  const mergedStyle: StyleWithVars | undefined =
+    hasOwnProps(fallbackStyle) || hasOwnProps(style) ? { ...fallbackStyle, ...style } : undefined;
+
+  const wrapperClass = clsx(
+    styles.avatar,
+    sizeClass[resolvedSize],
+    group != null && styles.inGroup,
+    className,
+  );
+
+  // Presence dot is an absolutely-positioned child. Rendered only when
+  // `status` is set. Carries `data-status` for SCSS selector + test query.
+  const presenceDot = status ? (
+    <span aria-hidden="true" className={styles.presence} data-status={status} />
+  ) : null;
+
+  const inner = hasImage ? (
+    <span {...props} ref={ref} className={wrapperClass} style={mergedStyle}>
+      <img src={src} alt={accessibleName} onError={() => setImageBroken(true)} />
+      {presenceDot}
+    </span>
+  ) : (
+    <span
+      {...props}
+      ref={ref}
+      role="img"
+      aria-label={accessibleName}
+      className={wrapperClass}
+      style={mergedStyle}
+    >
+      <span aria-hidden="true">{initials(name)}</span>
+      {presenceDot}
+    </span>
+  );
+
+  if (resolvedTooltip && accessibleName !== '?') {
+    return <Tooltip content={accessibleName}>{inner}</Tooltip>;
+  }
+
+  return inner;
+});
+```
+
+- [ ] **Step 3: Update `Avatar.module.scss`**
+
+Find the existing `.avatar` block. ADD `position: relative;` to it (Rule 4 escape hatch — internal child anchor; document with a SCSS comment).
+
+ADD at the end of the file:
+
+```scss
+// Presence dot (Avatar status). Anchored to the bottom-right of the
+// avatar via the parent's `position: relative`. Carries a 2px ring of
+// --color-bg so the dot stays visible on tinted ancestors.
+.presence {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  border-radius: var(--radius-full);
+  box-shadow: 0 0 0 2px var(--color-bg);
+
+  &[data-status='online'] {
+    background: var(--color-presence-online);
+  }
+  &[data-status='busy'] {
+    background: var(--color-presence-busy);
+  }
+  &[data-status='away'] {
+    background: var(--color-presence-away);
+  }
+  &[data-status='offline'] {
+    background: var(--color-presence-offline);
+  }
+}
+
+// Per-size dot dimensions. The `.sm .presence` selector relies on the size
+// class living on the avatar wrapper (which is also `.presence`'s parent).
+.sm .presence {
+  width: var(--size-presence-sm);
+  height: var(--size-presence-sm);
+}
+.md .presence {
+  width: var(--size-presence-md);
+  height: var(--size-presence-md);
+}
+.lg .presence {
+  width: var(--size-presence-lg);
+  height: var(--size-presence-lg);
+}
+
+// When inside an AvatarGroup, each avatar picks up a --color-bg ring so
+// stacked siblings read as distinct. The ring uses box-shadow (no layout
+// impact) — pure visual separator.
+.inGroup {
+  box-shadow: 0 0 0 2px var(--color-bg);
+}
+```
+
+ADD `position: relative;` to `.avatar`:
+
+```scss
+.avatar {
+  position: relative; // Rule 4 escape hatch — anchors the .presence dot child.
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  // … existing rules stay …
+}
+```
+
+- [ ] **Step 4: Gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test --workspace=@eocrm/design-system --run -- src/components/Avatar 2>&1 | tail -8
+npm run typecheck 2>&1 | tail -5
+npm run lint:css 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+Existing tests should still pass (status/tooltip default false → no behavior change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Avatar/Avatar.tsx \
+        packages/design-system/src/components/Avatar/Avatar.module.scss
+git commit -m "Avatar: add status (presence dot) + tooltip props + group awareness"
+```
+
+---
+
+## Task 5: Avatar tests
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Avatar/Avatar.test.tsx`
+
+- [ ] **Step 1: Read current test file**
+
+```bash
+cat packages/design-system/src/components/Avatar/Avatar.test.tsx
+```
+
+- [ ] **Step 2: Add tests at the end of the existing `describe`**
+
+```tsx
+it('renders presence dot when status is set', () => {
+  const { container } = render(<Avatar name="Alex" status="online" />);
+  const dot = container.querySelector('[data-status="online"]');
+  expect(dot).not.toBeNull();
+  expect(dot).toHaveAttribute('aria-hidden', 'true');
+});
+
+it('omits presence dot when status is undefined', () => {
+  const { container } = render(<Avatar name="Alex" />);
+  expect(container.querySelector('[data-status]')).toBeNull();
+});
+
+it('switches presence color when status changes', () => {
+  const { container, rerender } = render(<Avatar name="Alex" status="online" />);
+  expect(container.querySelector('[data-status="online"]')).not.toBeNull();
+  rerender(<Avatar name="Alex" status="busy" />);
+  expect(container.querySelector('[data-status="online"]')).toBeNull();
+  expect(container.querySelector('[data-status="busy"]')).not.toBeNull();
+});
+
+it('does NOT wrap in Tooltip when tooltip is false / unset', () => {
+  // Without the Tooltip wrapper, focus on the avatar should not announce
+  // a tooltip. We verify by ensuring no `role="tooltip"` is reachable.
+  render(<Avatar name="Alex" />);
+  expect(screen.queryByRole('tooltip')).toBeNull();
+});
+
+it('wraps in Tooltip when tooltip prop is true', async () => {
+  const user = userEvent.setup();
+  render(<Avatar name="Alex" tooltip />);
+  // Focus the avatar — Tooltip opens immediately on keyboard focus.
+  const avatar = screen.getByRole('img', { name: 'Alex' });
+  avatar.focus();
+  // Tooltip is portaled into document.body; query via findByRole.
+  const tip = await screen.findByRole('tooltip');
+  expect(tip).toHaveTextContent('Alex');
+});
+```
+
+Note: the existing Avatar isn't focusable by default (`<span>` without tabIndex). The Tooltip component handles this — it wraps the trigger element and the Tooltip component itself adds the appropriate event listeners. Verify by reading `Tooltip.tsx` if the keyboard-focus path requires the trigger to be focusable. If it does (e.g., Tooltip uses focus-trap or requires tabIndex), the test may need `<Avatar name="Alex" tooltip tabIndex={0} />` OR may need to use `userEvent.hover()` instead. Match whatever the Tooltip's existing tests do for non-focusable triggers.
+
+- [ ] **Step 3: Gates**
+
+```bash
+npm test --workspace=@eocrm/design-system --run -- src/components/Avatar 2>&1 | tail -8
+```
+
+If the tooltip-focus test fails because of focusability, swap to `user.hover(avatar)` and add an `await screen.findByRole('tooltip')` with a small wait — Tooltip defaults to a 400ms open delay.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Avatar/Avatar.test.tsx
+git commit -m "Avatar: tests for new status + tooltip props"
+```
+
+---
+
+## Task 6: `<AvatarGroup>` component + SCSS + barrel
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Avatar/AvatarGroup.tsx`
+- Create: `packages/design-system/src/components/Avatar/AvatarGroup.module.scss`
+- Modify: `packages/design-system/src/components/Avatar/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+- [ ] **Step 1: Create `AvatarGroup.tsx`**
+
+```tsx
+import {
+  Children,
+  forwardRef,
+  isValidElement,
+  useMemo,
+  type HTMLAttributes,
+  type MouseEvent,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import type { AvatarSize } from './Avatar';
+import { AvatarGroupContext, type AvatarGroupContextValue } from './AvatarGroupContext';
+import styles from './AvatarGroup.module.scss';
+
+export interface AvatarGroupProps extends HTMLAttributes<HTMLDivElement> {
+  /** Avatar children. */
+  children: ReactNode;
+
+  /**
+   * Uniform diameter for every avatar in the group. Defaults to `'md'`.
+   * Overrides any `size` set on individual children.
+   */
+  size?: AvatarSize;
+
+  /**
+   * Maximum number of visible avatars. Children beyond this count collapse
+   * into a single `+N` button at the tail. Defaults to `4`. The `+N` only
+   * appears when there are STRICTLY more children than `max`.
+   */
+  max?: number;
+
+  /**
+   * Whether to render a name tooltip on each child avatar. Defaults to `true`
+   * inside the group; overridable per-child by setting `tooltip` on the Avatar.
+   */
+  tooltip?: boolean;
+
+  /**
+   * Fires when the user clicks the `+N` overflow button. The library does
+   * NOT render a popover — apps decide what happens (open a modal, navigate,
+   * etc.). When omitted, the `+N` is rendered as a non-interactive `<span>`.
+   *
+   * @param event The native click event.
+   * @param hiddenCount The number of children not visible in the strip.
+   */
+  onOverflowClick?: (event: MouseEvent<HTMLButtonElement>, hiddenCount: number) => void;
+}
+
+/**
+ * Horizontal stack of `<Avatar>`s with `+N` overflow when count exceeds `max`.
+ *
+ * The group propagates `size` and `tooltip` to descendant `<Avatar>`s via
+ * context. The first `max` children render; any remainder collapses to a
+ * single overflow button.
+ *
+ * @example
+ * // Static — non-interactive +N:
+ * <AvatarGroup max={3}>
+ *   <Avatar name="Alex Rivera" />
+ *   <Avatar name="Priya Patel" />
+ *   <Avatar name="Tom Kim" />
+ *   <Avatar name="Sara Chen" />
+ *   <Avatar name="Jaden Lee" />
+ * </AvatarGroup>
+ *
+ * @example
+ * // With overflow handler — app composes whatever popover/modal it wants:
+ * <AvatarGroup
+ *   max={4}
+ *   size="lg"
+ *   onOverflowClick={(_e, hiddenCount) => openMembersPopover(hiddenCount)}
+ * >
+ *   {members.map((m) => <Avatar key={m.id} name={m.name} src={m.avatarUrl} status={m.presence} />)}
+ * </AvatarGroup>
+ *
+ * @remarks When NOT to use
+ * - For a single avatar — use `<Avatar>` directly.
+ * - When you want to show member counts but not faces — use a `Badge` next to a label.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Wrapping `<AvatarGroup>` in a `<button>` and treating it as one click target.
+ *   The +N is the click affordance; the visible avatars are deliberately not interactive
+ *   in the library — wrap individual avatars in `<button>` / `<Link>` if needed.
+ * - ❌ Mixing avatar sizes inside one group. The group's `size` overrides per-child sizes.
+ */
+export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(function AvatarGroup(
+  { children, size = 'md', max = 4, tooltip = true, onOverflowClick, className, ...props },
+  ref,
+) {
+  // Convert children to a stable array so we can slice deterministically.
+  // React.Children.toArray strips out falsy values + assigns keys defensively.
+  const items = Children.toArray(children).filter(isValidElement);
+  const visible = items.slice(0, max);
+  const hiddenCount = Math.max(0, items.length - max);
+
+  const ctx: AvatarGroupContextValue = useMemo(() => ({ size, tooltip }), [size, tooltip]);
+
+  const overflowClass = clsx(styles.overflow, styles[`size-${size}`]);
+
+  const overflowNode =
+    hiddenCount > 0 ? (
+      onOverflowClick ? (
+        <button
+          type="button"
+          className={overflowClass}
+          aria-label={`${hiddenCount} more avatars`}
+          onClick={(e) => onOverflowClick(e, hiddenCount)}
+        >
+          +{hiddenCount}
+        </button>
+      ) : (
+        <span
+          className={overflowClass}
+          role="img"
+          aria-label={`${hiddenCount} more avatars`}
+        >
+          +{hiddenCount}
+        </span>
+      )
+    ) : null;
+
+  return (
+    // Pattern A — props last so consumer overrides win.
+    <AvatarGroupContext.Provider value={ctx}>
+      <div ref={ref} role="list" className={clsx(styles.group, className)} {...props}>
+        {visible.map((child, i) => (
+          <div key={i} role="listitem" className={styles.item}>
+            {child}
+          </div>
+        ))}
+        {overflowNode && (
+          <div role="listitem" className={styles.item}>
+            {overflowNode}
+          </div>
+        )}
+      </div>
+    </AvatarGroupContext.Provider>
+  );
+});
+```
+
+- [ ] **Step 2: Create `AvatarGroup.module.scss`**
+
+```scss
+// AvatarGroup — horizontal row of stacked Avatars with optional +N overflow.
+// Rule 4 note: `.item:not(:first-child)` uses `margin-left` to overlap
+// siblings — this is intentional internal layout, not a Rule-4 violation
+// because the public component IS the wrapper; consumers don't see the
+// inner items.
+.group {
+  display: inline-flex;
+  align-items: center;
+}
+
+.item {
+  display: inline-flex;
+  // First item: no offset. Every subsequent item slides left to overlap the
+  // preceding one. Per-size overlap tokens live in tokens.scss.
+  &:not(:first-child) {
+    margin-left: var(--avatar-overlap-md);
+  }
+}
+
+// Per-size overlap — applied to the group wrapper so all children inherit.
+.group:has(.item:not(:first-child)) {
+  // No-op; specificity helper.
+}
+
+// +N overflow chip — same circular surface as Avatar, muted background.
+.overflow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: var(--color-bg-muted);
+  color: var(--color-fg-muted);
+  border: none;
+  border-radius: var(--radius-full);
+  font-family: inherit;
+  font-weight: var(--font-weight-semibold);
+  // The 2px ring matches the .inGroup ring on Avatar so the +N sits flush.
+  box-shadow: 0 0 0 2px var(--color-bg);
+  cursor: default;
+  user-select: none;
+
+  &:is(button) {
+    cursor: pointer;
+  }
+
+  &:is(button):hover {
+    background: var(--color-bg-sunken);
+    color: var(--color-fg);
+  }
+
+  &:is(button):focus-visible {
+    outline: none;
+    box-shadow:
+      0 0 0 2px var(--color-bg),
+      0 0 0 calc(2px + var(--ring-width)) var(--ring-accent);
+  }
+}
+
+.size-sm {
+  width: var(--size-sm);
+  height: var(--size-sm);
+  font-size: var(--font-size-xs);
+}
+.size-md {
+  width: var(--size-md);
+  height: var(--size-md);
+  font-size: var(--font-size-sm);
+}
+.size-lg {
+  width: var(--size-lg);
+  height: var(--size-lg);
+  font-size: var(--font-size-md);
+}
+
+// Per-size overlap override on items — applied via the parent group's size
+// modifier. We need to know the group's size to pick the right overlap,
+// which means wiring per-size classes onto the group wrapper.
+:global(.size-sm) > .item:not(:first-child) {
+  margin-left: var(--avatar-overlap-sm);
+}
+:global(.size-md) > .item:not(:first-child) {
+  margin-left: var(--avatar-overlap-md);
+}
+:global(.size-lg) > .item:not(:first-child) {
+  margin-left: var(--avatar-overlap-lg);
+}
+```
+
+NOTE: the `:global()` selectors above are a foot-gun; they'll match ANY ancestor with those class names. CSS modules hash class names so this would normally work only with locally-scoped classes. The cleaner approach: tag the group wrapper with `styles[`groupSize-${size}`]` and target `.groupSize-sm > .item`, etc. REWRITE the SCSS bottom block as:
+
+```scss
+.groupSize-sm > .item:not(:first-child) {
+  margin-left: var(--avatar-overlap-sm);
+}
+.groupSize-md > .item:not(:first-child) {
+  margin-left: var(--avatar-overlap-md);
+}
+.groupSize-lg > .item:not(:first-child) {
+  margin-left: var(--avatar-overlap-lg);
+}
+```
+
+And update the JSX wrapper to:
+
+```tsx
+<div ref={ref} role="list" className={clsx(styles.group, styles[`groupSize-${size}`], className)} {...props}>
+```
+
+Also REMOVE the `.item:not(:first-child) { margin-left: var(--avatar-overlap-md); }` rule from `.item` (replaced by the per-size selectors above) and the empty `.group:has(...)` block.
+
+- [ ] **Step 3: Update barrels**
+
+In `packages/design-system/src/components/Avatar/index.ts`:
+
+```ts
+export { Avatar, avatarColorIndex } from './Avatar';
+export type { AvatarProps, AvatarSize, AvatarStatus } from './Avatar';
+export { AvatarGroup } from './AvatarGroup';
+export type { AvatarGroupProps } from './AvatarGroup';
+```
+
+In `packages/design-system/src/index.ts`, find:
+
+```ts
+export { Avatar } from './components/Avatar';
+export type { AvatarProps, AvatarSize } from './components/Avatar';
+```
+
+Replace with:
+
+```ts
+export { Avatar, AvatarGroup, avatarColorIndex } from './components/Avatar';
+export type { AvatarProps, AvatarSize, AvatarStatus, AvatarGroupProps } from './components/Avatar';
+```
+
+(If `avatarColorIndex` was already re-exported via Avatar's barrel, the top-level may or may not need it; check current state.)
+
+- [ ] **Step 4: Gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test --workspace=@eocrm/design-system --run -- src/components/Avatar 2>&1 | tail -8
+npm run typecheck 2>&1 | tail -5
+npm run lint:css 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Avatar/AvatarGroup.tsx \
+        packages/design-system/src/components/Avatar/AvatarGroup.module.scss \
+        packages/design-system/src/components/Avatar/index.ts \
+        packages/design-system/src/index.ts
+git commit -m "AvatarGroup: new component with size + max + overflow callback"
+```
+
+---
+
+## Task 7: AvatarGroup tests
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Avatar/AvatarGroup.test.tsx`
+
+- [ ] **Step 1: Write the file**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Avatar } from './Avatar';
+import { AvatarGroup } from './AvatarGroup';
+
+describe('AvatarGroup', () => {
+  it('renders all children when count <= max', () => {
+    render(
+      <AvatarGroup max={4}>
+        <Avatar name="A" />
+        <Avatar name="B" />
+        <Avatar name="C" />
+      </AvatarGroup>,
+    );
+    expect(screen.getByRole('img', { name: 'A' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'B' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'C' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /more avatars/ })).toBeNull();
+    expect(screen.queryByRole('img', { name: /more avatars/ })).toBeNull();
+  });
+
+  it('collapses to +N when count > max', () => {
+    render(
+      <AvatarGroup max={2}>
+        <Avatar name="A" />
+        <Avatar name="B" />
+        <Avatar name="C" />
+        <Avatar name="D" />
+      </AvatarGroup>,
+    );
+    expect(screen.getByRole('img', { name: 'A' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'B' })).toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: 'C' })).toBeNull();
+    expect(screen.queryByRole('img', { name: 'D' })).toBeNull();
+    // No handler → non-interactive span with role="img" + aria-label
+    expect(screen.getByRole('img', { name: '2 more avatars' })).toBeInTheDocument();
+  });
+
+  it('renders +N as a button when onOverflowClick is provided, and fires the handler', async () => {
+    const user = userEvent.setup();
+    const handler = vi.fn();
+    render(
+      <AvatarGroup max={1} onOverflowClick={handler}>
+        <Avatar name="A" />
+        <Avatar name="B" />
+        <Avatar name="C" />
+      </AvatarGroup>,
+    );
+    const btn = screen.getByRole('button', { name: '2 more avatars' });
+    await user.click(btn);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][1]).toBe(2);
+  });
+
+  it('propagates size to descendant Avatars via context', () => {
+    const { container } = render(
+      <AvatarGroup size="lg">
+        <Avatar name="A" size="sm" />
+      </AvatarGroup>,
+    );
+    // Group's size wins — Avatar should render with the lg size class.
+    const avatar = container.querySelector('[role="img"]');
+    expect(avatar?.className).toMatch(/lg/);
+  });
+
+  it('forwards ref to the outer div', () => {
+    const ref = { current: null as HTMLDivElement | null };
+    render(
+      <AvatarGroup ref={ref}>
+        <Avatar name="A" />
+      </AvatarGroup>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('merges className', () => {
+    const { container } = render(
+      <AvatarGroup className="my-class">
+        <Avatar name="A" />
+      </AvatarGroup>,
+    );
+    expect(container.querySelector('div.my-class')).not.toBeNull();
+  });
+
+  it('renders the role="list" wrapper with role="listitem" children', () => {
+    render(
+      <AvatarGroup>
+        <Avatar name="A" />
+        <Avatar name="B" />
+      </AvatarGroup>,
+    );
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Gates**
+
+```bash
+npm test --workspace=@eocrm/design-system --run -- src/components/Avatar/AvatarGroup 2>&1 | tail -8
+```
+
+If any test fails on the role/text-matching, inspect the rendered DOM via a `screen.debug()` call to confirm the actual structure.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/Avatar/AvatarGroup.test.tsx
+git commit -m "AvatarGroup: tests for size propagation, overflow, ref + role wiring"
+```
+
+---
+
+## Task 8: Playground demo
+
+**Files:**
+
+- Modify: `packages/playground/src/pages/components/AvatarDemo.tsx`
+
+- [ ] **Step 1: Read current demo**
+
+```bash
+cat packages/playground/src/pages/components/AvatarDemo.tsx
+```
+
+- [ ] **Step 2: Add four new Examples**
+
+After whatever the current LAST example is, insert (in order):
+
+1. Status example:
+
+```tsx
+<Example
+  title="Status indicator"
+  description="Presence dot in the bottom-right. Four states: online / busy / away / offline."
+  code={`<Avatar name="Online Olivia" status="online" />
+<Avatar name="Busy Beatrice" status="busy" />
+<Avatar name="Away Adrien" status="away" />
+<Avatar name="Offline Otto" status="offline" />`}
+>
+  <Cluster gap="md" align="center">
+    <Avatar name="Online Olivia" status="online" />
+    <Avatar name="Busy Beatrice" status="busy" />
+    <Avatar name="Away Adrien" status="away" />
+    <Avatar name="Offline Otto" status="offline" />
+  </Cluster>
+</Example>
+```
+
+2. Tooltip example:
+
+```tsx
+<Example
+  title="Name tooltip"
+  description="Set `tooltip` to surface the name on hover / keyboard focus."
+  code={`<Avatar name="Alex Rivera" tooltip />`}
+>
+  <Avatar name="Alex Rivera" tooltip />
+</Example>
+```
+
+3. AvatarGroup with overflow:
+
+```tsx
+const TEAM = [
+  'Alex Rivera',
+  'Priya Patel',
+  'Tom Kim',
+  'Sara Chen',
+  'Jaden Lee',
+  'Mei Tanaka',
+  'Diego Ortiz',
+];
+
+function GroupDemo() {
+  const [clicked, setClicked] = useState<number | null>(null);
+  return (
+    <Stack gap="xs">
+      <AvatarGroup
+        max={4}
+        size="md"
+        onOverflowClick={(_e, count) => setClicked(count)}
+      >
+        {TEAM.map((n) => (
+          <Avatar key={n} name={n} />
+        ))}
+      </AvatarGroup>
+      {clicked !== null && (
+        <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+          onOverflowClick fired with hiddenCount = {clicked}
+        </code>
+      )}
+    </Stack>
+  );
+}
+```
+
+Then in the demo JSX:
+
+```tsx
+<Example
+  title="Avatar group with overflow handler"
+  description="Up to `max` avatars render in flow; the rest collapse into a +N button. The library does not render a popover — the app's `onOverflowClick` decides what happens."
+  code={`<AvatarGroup max={4} onOverflowClick={(_e, count) => openMembersPopover(count)}>
+  {team.map((m) => <Avatar key={m.id} name={m.name} />)}
+</AvatarGroup>`}
+>
+  <GroupDemo />
+</Example>
+```
+
+4. AvatarGroup sizes:
+
+```tsx
+<Example
+  title="Group sizes"
+  description="Three sizes — sm / md (default) / lg. The group size overrides any per-child size."
+  code={`<AvatarGroup size="sm">{...}</AvatarGroup>
+<AvatarGroup size="md">{...}</AvatarGroup>
+<AvatarGroup size="lg">{...}</AvatarGroup>`}
+>
+  <Stack gap="md">
+    <AvatarGroup size="sm" max={5}>
+      {TEAM.slice(0, 6).map((n) => <Avatar key={n} name={n} />)}
+    </AvatarGroup>
+    <AvatarGroup size="md" max={5}>
+      {TEAM.slice(0, 6).map((n) => <Avatar key={n} name={n} />)}
+    </AvatarGroup>
+    <AvatarGroup size="lg" max={5}>
+      {TEAM.slice(0, 6).map((n) => <Avatar key={n} name={n} />)}
+    </AvatarGroup>
+  </Stack>
+</Example>
+```
+
+Imports at the top of the file: add `AvatarGroup`, `Cluster`, `Stack`, `useState` if not present.
+
+- [ ] **Step 3: Gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm run typecheck 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Smoke test**
+
+Browse `/components/avatar` in the dev server (use Playwright MCP or local browser). Verify:
+- Status dots render in the right corner with the right colors.
+- Tooltip appears on hover/focus.
+- Group with overflow shows 4 visible + a "+3" button. Clicking it logs to the debug `<code>`.
+- Three group sizes render at the right diameters.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/playground/src/pages/components/AvatarDemo.tsx
+git commit -m "AvatarDemo: examples for status / tooltip / AvatarGroup"
+```
+
+---
+
+## Task 9: AGENTS.md sweep
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Find the `<Avatar>` section**
+
+```bash
+grep -n "^### \`<Avatar>\`" packages/design-system/AGENTS.md
+```
+
+- [ ] **Step 2: Extend the `<Avatar>` section bullets**
+
+After the existing bullets, add:
+
+```
+- `status?` — presence dot in the bottom-right corner. `'online' | 'busy' | 'away' | 'offline'`. Omit to render no dot.
+- `tooltip?` — when true, wraps the avatar in `<Tooltip>` with `content={name}`. Default `false` standalone; defaults to `true` inside `<AvatarGroup>` (per-child override still wins).
+```
+
+- [ ] **Step 3: Add a new `<AvatarGroup>` section RIGHT AFTER the `<Avatar>` section**
+
+```markdown
+### `<AvatarGroup>` — Slack-style stacked row of avatars
+
+```tsx
+<AvatarGroup max={4} size="md" onOverflowClick={(_e, n) => openMembersPopover(n)}>
+  {team.map((m) => <Avatar key={m.id} name={m.name} src={m.avatarUrl} status={m.presence} />)}
+</AvatarGroup>
+```
+
+- Horizontal row of overlapping `<Avatar>`s with a `+N` overflow control when the child count exceeds `max` (default `4`).
+- `size` is set on the group, NOT per child. The group's size overrides any per-child `size`. Three sizes: `'sm' | 'md' | 'lg'`.
+- `tooltip` defaults to `true` inside a group — each visible avatar shows its `name` on hover / focus. Override per-child via `tooltip={false}` on a specific `<Avatar>`.
+- `onOverflowClick(event, hiddenCount)` — the library does NOT render its own popover. When the user clicks `+N`, the app decides what happens (open a `<Popover>` with a list of all members, navigate to a page, open a modal, etc.). When the handler is omitted, the `+N` renders as a non-interactive `<span>`.
+- The group wrapper is `role="list"` and each visible avatar is wrapped in `role="listitem"`. The +N (button or span) is the last list item.
+- forwardRef to the outer `<div>`. `className` is merged, not replaced.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/AGENTS.md
+git commit -m "AGENTS.md: document AvatarGroup + Avatar status/tooltip"
+```
+
+---
+
+## Task 10: Final gates + Hard Rule 8 cycle + PR
+
+- [ ] **Step 1: Prettier --write**
+
+```bash
+npx prettier --write "packages/**/src/**/*.{ts,tsx,scss}" "docs/**/*.md" "packages/design-system/AGENTS.md"
+```
+
+Commit drift:
+
+```bash
+git add -A packages/ docs/
+git diff --cached --stat
+git commit -m "Prettier: format avatar-group changes" || echo "no formatting changes"
+```
+
+- [ ] **Step 2: Full gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test --workspace=@eocrm/design-system --run 2>&1 | tail -5
+npm run typecheck 2>&1 | tail -5
+npm run lint:css 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+npx prettier --check "packages/**/src/**/*.{ts,tsx,scss}" "docs/**/*.md" "packages/design-system/AGENTS.md" 2>&1 | tail -3
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -cE "\.test\."
+```
+
+- [ ] **Step 3: Push**
+
+```bash
+git push -u origin feat/avatar-group-status
+```
+
+- [ ] **Step 4: Hard Rule 8 review cycle 1**
+
+Dispatch a fresh-context `general-purpose` review agent with the standard 10-category brief. Specifics to look at hard:
+
+- The `Tooltip` wrapping inside `Avatar`: does `screen.getByRole('img', { name: '...' })` still find the Avatar through the Tooltip wrapper? (Tooltip wraps but doesn't break role-mapping since it portals the tooltip itself, not the trigger.)
+- The `:has()` SCSS selector if used — browser support. (If used, the implementer should have replaced it with the explicit `.groupSize-*` class pattern per the plan's correction in Task 6.)
+- `Children.toArray + isValidElement` filter on AvatarGroup — does it correctly handle `null` / `false` / fragments inside the children? Add a test case if missing.
+- Token discipline on the new tokens (presence + overlap) — all values reference existing tokens, no raw hex / px outside `tokens.scss`.
+- Box-shadow ring stacking: when a presence dot AND `.inGroup` ring both apply, the `box-shadow` of `.presence` and the wrapper's `.inGroup` ring don't visually conflict (different elements, different layers).
+
+- [ ] **Step 5: Fix findings; re-push; re-review until verdict is `clean enough to stop`.**
+
+- [ ] **Step 6: Open PR**
+
+```bash
+gh pr create --title "Avatar: status dot + name tooltip + AvatarGroup (Slack-style stacked row)" --body "$(cat <<'EOF'
+## Summary
+
+- New `<AvatarGroup>` component — horizontal stack of `<Avatar>`s with `+N` overflow when count exceeds `max` (default 4). Group's `size` propagates to all children via context. `onOverflowClick(event, hiddenCount)` is the only overflow hook — the library does NOT render its own popover; consumer composes whatever popover / modal / route fits.
+- `<Avatar>` gains `status?: 'online' | 'busy' | 'away' | 'offline'` (presence dot bottom-right) and `tooltip?: boolean` (wraps in `<Tooltip>` with `content={name}`).
+- Inside an `<AvatarGroup>`, the group's `size` and `tooltip` defaults take over for each child (per-child override still wins).
+- Eight new tokens: four presence colors (aliases over existing semantic palette), three presence-dot sizes, three avatar-overlap amounts.
+
+## Test plan
+
+- [x] `npm test --run` — all green, including new Avatar + AvatarGroup tests.
+- [x] `npm run typecheck` clean
+- [x] `npm run lint:css` clean
+- [x] `npm run build` clean
+- [x] `npx prettier --check` clean
+- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files in tarball
+- [x] Manual smoke (Playwright) — status colors, tooltip on hover, overflow handler fires, three group sizes render correctly.
+- [x] Hard Rule 8 review cycle — final verdict: clean enough to stop.
+
+## Design spec / plan
+
+- Spec: `docs/superpowers/specs/2026-05-21-avatar-group-status-design.md`
+- Plan: `docs/superpowers/plans/2026-05-21-avatar-group-status.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+Spec coverage:
+
+- §Avatar status → Tasks 4, 5.
+- §Avatar tooltip → Tasks 4, 5.
+- §AvatarGroup → Tasks 3, 6, 7.
+- §Tokens → Task 2.
+- §Playground demo → Task 8.
+- §AGENTS.md → Task 9.
+
+Type consistency:
+
+- `AvatarStatus` exported and re-exported from both barrels.
+- `AvatarGroupProps` exported and re-exported from both barrels.
+- `AvatarGroupContext` + `useAvatarGroup` are internal (NOT re-exported from `src/index.ts`; only used inside the Avatar folder).
+
+No placeholders. Each task includes the complete code. The Task 6 SCSS correction inline (`.groupSize-*` instead of `:global`) is the version to implement.

--- a/docs/superpowers/specs/2026-05-21-avatar-group-status-design.md
+++ b/docs/superpowers/specs/2026-05-21-avatar-group-status-design.md
@@ -147,7 +147,7 @@ Add to `tokens.scss`:
 --avatar-overlap-lg: calc(var(--size-lg) * -0.3);
 ```
 
-Eight new tokens, all aliases or arithmetic from existing tokens. Adopting the convention "presence-*" instead of "status-*" since "status" is overloaded in the library (DatePicker has invalid status, Button has loading status, etc.).
+Eight new tokens, all aliases or arithmetic from existing tokens. Adopting the convention "presence-_" instead of "status-_" since "status" is overloaded in the library (DatePicker has invalid status, Button has loading status, etc.).
 
 ## File layout
 

--- a/docs/superpowers/specs/2026-05-21-avatar-group-status-design.md
+++ b/docs/superpowers/specs/2026-05-21-avatar-group-status-design.md
@@ -1,0 +1,213 @@
+# Avatar group + status indicator + name tooltip
+
+**Date:** 2026-05-21
+**Branch:** `feat/avatar-group-status`
+**Scope:** `<Avatar>` (extend) + `<AvatarGroup>` (new). No other components touched.
+
+## Goals
+
+1. New `<AvatarGroup>` — Slack-style stacked, overlapping row of avatars with a `+N` overflow button when the group exceeds `max`.
+2. New `status` prop on `<Avatar>` — presence dot in the bottom-right (`online | busy | away | offline`).
+3. New `tooltip` prop on `<Avatar>` — when true, wraps the avatar in the existing `<Tooltip>` with `content={name}`.
+
+## Non-goals
+
+- No new Avatar sizes. The existing `'sm' | 'md' | 'lg'` scale stays. If a future Slack-fidelity screen wants `xs` (20px) or `xl` (56px), add them as a separate change.
+- No built-in popover for the overflow button — the library exposes an `onOverflowClick(event, hiddenAvatars)` callback; the consuming app composes whatever popover / modal / route it wants on top.
+- No async / loading states. Avatars and AvatarGroups render synchronously from props.
+- No "stacked vertical" / "wrapping" variant. The group is always a single horizontal row.
+
+## Components
+
+### Updated `<Avatar>`
+
+**New props:**
+
+```ts
+/** Presence dot rendered in the bottom-right corner. Omit to render no dot. */
+export type AvatarStatus = 'online' | 'busy' | 'away' | 'offline';
+
+export interface AvatarProps extends HTMLAttributes<HTMLSpanElement> {
+  // ... existing name / src / size ...
+
+  /**
+   * Presence dot. Renders a small colored circle anchored to the avatar's
+   * bottom-right corner.
+   * - `'online'`  — green (`--color-presence-online`)
+   * - `'busy'`    — red   (`--color-presence-busy`)
+   * - `'away'`    — amber (`--color-presence-away`)
+   * - `'offline'` — gray  (`--color-presence-offline`)
+   * Omit (the default) to render no dot at all.
+   */
+  status?: AvatarStatus;
+
+  /**
+   * When `true`, wraps the avatar in a `<Tooltip>` showing `name`. Defaults
+   * to `false` for backwards-compatibility — every existing render keeps
+   * its current behavior. Inside `<AvatarGroup>` the default flips to
+   * `true` via context so grouped avatars are name-discoverable on hover.
+   */
+  tooltip?: boolean;
+}
+```
+
+**Behavior:**
+
+- The presence dot is a positioned `<span>` child of the avatar wrapper. The wrapper picks up `position: relative` (Rule 4 escape hatch — internal child anchor). The dot is `position: absolute; bottom: 0; right: 0;` with a 2px `--color-bg`-colored ring so it stays visible on textured / colored ancestors.
+- Dot size scales with avatar size: `sm` → 8px, `md` → 10px, `lg` → 12px. Sizes come from tokens, not magic numbers (added below).
+- When `tooltip` is true AND `name` is non-empty, the rendered avatar is wrapped in `<Tooltip content={name}>`. Per `<Tooltip>`'s contract, the tooltip is keyboard-accessible (focus opens it immediately).
+- When `tooltip` is true but the consumer also passed an explicit `aria-label`, the avatar's accessible name from `aria-label` wins; the tooltip is a visual affordance, not an a11y replacement.
+
+**Context awareness:**
+
+A new `useAvatarGroup()` hook reads `AvatarGroupContext`. When an `<Avatar>` is rendered inside an `<AvatarGroup>`:
+
+- The group's `size` overrides the Avatar's own `size` (so the group renders uniformly even if a consumer-pasted child specified its own size).
+- The group's `tooltip` flag becomes the default for `tooltip` (still overridable on each child).
+- A SCSS modifier `.inGroup` is added so the avatar picks up the white ring used to visually separate stacked siblings.
+
+If `useAvatarGroup()` returns `null` (the common standalone case), Avatar behaves exactly as it does today.
+
+### New `<AvatarGroup>`
+
+```tsx
+export interface AvatarGroupProps extends HTMLAttributes<HTMLDivElement> {
+  /** Avatar children. */
+  children: ReactNode;
+
+  /**
+   * Uniform diameter for every avatar in the group. Defaults to `'md'`.
+   * Overrides any `size` set on individual children.
+   */
+  size?: AvatarSize;
+
+  /**
+   * Maximum number of visible avatars. Children beyond this count collapse
+   * into a single `+N` button at the tail. Defaults to `4`.
+   *
+   * When the total number of children is `max + 1`, the +1 child renders as
+   * itself (no `+N` button needed — same total count). The +N button only
+   * appears when there are STRICTLY more children than `max`.
+   */
+  max?: number;
+
+  /**
+   * Whether to render a name tooltip on each child avatar. Defaults to
+   * `true` inside the group (overridable per-child). Set to `false` at the
+   * group level to suppress all tooltips, or pass `tooltip={false}` on a
+   * specific child to opt that one out.
+   */
+  tooltip?: boolean;
+
+  /**
+   * Fires when the user clicks the `+N` overflow button. The library does
+   * not render a popover — apps decide what happens (open a modal listing
+   * the rest, navigate to a member-list page, etc.).
+   *
+   * `hiddenCount` is the number of children NOT visible in the strip.
+   * `event` is the native click event so apps can do e.g. `event.preventDefault()`.
+   */
+  onOverflowClick?: (event: MouseEvent<HTMLButtonElement>, hiddenCount: number) => void;
+}
+```
+
+**Behavior:**
+
+- Renders a horizontal row of children. Each visible avatar overlaps its left neighbor by ~30% of avatar diameter (`margin-left: calc(var(--avatar-overlap) * -1)` where `--avatar-overlap` is a per-size token; `0` on the first child).
+- Each rendered avatar has the `.inGroup` class so its wrapper picks up a 2px `--color-bg`-colored ring (separates stacked siblings).
+- DOM order: first child renders leftmost; later children stack on top via flex order or via SCSS `z-index` so the right edge of each later avatar overlays earlier ones (matches Slack — newest on top). The stacking choice is a SCSS detail; either works as long as it's consistent.
+- Overflow: when `children.length > max`, only the first `max` children render. The (`max + 1`)-th slot is replaced by a `<button>` rendered with the same circle shape, showing `+N` text where `N = children.length - max`. The button has the same `.inGroup` ring; `aria-label="N more avatars"` (so screen readers say "5 more avatars" not "+5").
+- When `onOverflowClick` is omitted, the +N is rendered as a non-interactive `<span>` (visually identical but not focusable / not a button). When set, it's a `<button type="button">` with focus styling and the click handler.
+- The group's wrapper itself is `<div>` (`role="list"` ARIA) and each visible avatar gets `role="listitem"` via the AvatarGroupContext (cleanest place to set it without forcing consumers to write `role` per child). The +N button stays a `<button>` — buttons inside lists are valid.
+- `forwardRef` to the outer `<div>`. Spread order: Pattern A (props last) — group-owned `role="list"` and className get overridden by consumer attrs if explicitly passed.
+
+### Tokens
+
+Add to `tokens.scss`:
+
+```scss
+// Presence dots (Avatar status indicator). Aliases over the existing
+// semantic palette — these are aliases, not new hex values, so future
+// theme changes propagate.
+--color-presence-online: var(--color-success);
+--color-presence-busy: var(--color-danger);
+--color-presence-away: var(--color-warning);
+--color-presence-offline: var(--color-fg-disabled);
+
+// Presence-dot dimensions per avatar size.
+--size-presence-sm: 8px;
+--size-presence-md: 10px;
+--size-presence-lg: 12px;
+
+// Avatar overlap when stacked in a group — fraction of avatar diameter.
+// Each child after the first slides left by this amount.
+--avatar-overlap-sm: calc(var(--size-sm) * -0.3);
+--avatar-overlap-md: calc(var(--size-md) * -0.3);
+--avatar-overlap-lg: calc(var(--size-lg) * -0.3);
+```
+
+Eight new tokens, all aliases or arithmetic from existing tokens. Adopting the convention "presence-*" instead of "status-*" since "status" is overloaded in the library (DatePicker has invalid status, Button has loading status, etc.).
+
+## File layout
+
+```
+packages/design-system/src/components/Avatar/
+  Avatar.tsx              ← extend with status, tooltip, group-context awareness
+  Avatar.module.scss      ← add .presence + .inGroup styles
+  Avatar.test.tsx         ← extend with status, tooltip, in-group tests
+  AvatarGroup.tsx         ← NEW
+  AvatarGroup.module.scss ← NEW
+  AvatarGroup.test.tsx    ← NEW
+  AvatarGroupContext.tsx  ← NEW (small context + provider + useAvatarGroup hook)
+  index.ts                ← re-export AvatarGroup, AvatarStatus, AvatarGroupProps
+```
+
+Top-level `src/index.ts` gets the corresponding `export { AvatarGroup }` + `export type { AvatarGroupProps, AvatarStatus }`.
+
+## Test surface
+
+- **`<Avatar>`**:
+  - `'renders presence dot when status is set'` — assert `.presence` class + the `data-status` attribute matches the prop (test via `[class*="presence"]` selector).
+  - `'omits presence dot when status is undefined'`.
+  - `'wraps in Tooltip when tooltip prop is true'` — assert `role="tooltip"` shows up after focus (or the tooltip's `aria-describedby` wiring on the avatar).
+  - `'does not wrap in Tooltip when tooltip is false / unset'`.
+  - `'inside AvatarGroup, picks up group size'` — render `<AvatarGroup size="lg"><Avatar name="X" size="sm" /></AvatarGroup>` and assert the avatar renders at `lg`.
+
+- **`<AvatarGroup>`**:
+  - `'renders all children when count <= max'`.
+  - `'collapses to +N button when count > max'` — assert the +N button has `aria-label="3 more avatars"` (for 3 hidden).
+  - `'renders +N as non-interactive span when onOverflowClick is omitted'`.
+  - `'fires onOverflowClick with the hidden count'`.
+  - `'forwards ref to outer div'`.
+  - `'applies the group size class to every child (and the +N button)'`.
+  - `'merges className without replacing'`.
+
+## Playground demo
+
+`AvatarDemo.tsx` gains examples:
+
+1. **Status indicator** — 4 avatars showing online / busy / away / offline.
+2. **Name tooltip** — one Avatar with `tooltip` true; hover to see the tooltip.
+3. **Avatar Group** — a `<AvatarGroup>` with 6 children + `max={4}` so the +N button appears. Three of them have a status. The +N click logs to a `<code>` debug line for proof.
+4. **Avatar Group sizes** — three `<AvatarGroup>`s side-by-side at `sm` / `md` / `lg`.
+
+## AGENTS.md
+
+- Extend `<Avatar>` section with bullets on `status` and `tooltip`.
+- Add a new `<AvatarGroup>` section right after `<Avatar>` with a canonical snippet, max default, and a callout that `onOverflowClick` is the only overflow hook (the consumer composes the popover).
+
+## Risks / open questions
+
+- **Tooltip composition** (`<Tooltip>` wraps `<Avatar>`): Tooltip requires a child that accepts a ref and is a single ReactElement. Avatar uses `forwardRef` → fine. Inside an `<AvatarGroup>`, each child Avatar is wrapped → the group sees `<Tooltip><Avatar /></Tooltip>` not `<Avatar />`, so `React.Children.toArray` / slicing the children array still works (we slice BEFORE wrapping). The wrap happens inside Avatar itself based on the `tooltip` prop.
+- **Ring color theming**: `.inGroup` ring uses `box-shadow: 0 0 0 2px var(--color-bg)`. If a consumer renders an AvatarGroup on a colored card (e.g., a Card with `padding="md"` on a tinted background), the ring becomes visually wrong. Acceptable v1 limitation — consumers wanting card-bg-matching rings can pass a `className` that overrides the ring color, or we add an `avatarRing` token later.
+- **Overflow button semantics when `onOverflowClick` is omitted**: rendering as a `<span>` (non-interactive) is the right call — a button without a handler is a UX hazard (Slack does the same: their +N is non-interactive if there's nothing to expand to).
+- **Group children stability**: the order of avatars in DOM matches the order in props. If the consumer reorders, the visual reorders with no animation. v1 doesn't animate; this is fine.
+- **`role="list"` on the group wrapper**: ensures AT can navigate the group. Could be opt-out if it confuses some screen-reader workflows, but defaulting on matches WAI-ARIA APG guidance for groups of items.
+
+## Out of scope
+
+- Avatar size additions (`xs` / `xl`). Defer.
+- Built-in popover for overflow. Consumer composes it via `onOverflowClick`.
+- Animated entry / reorder.
+- Avatar selected / focused states beyond what `<Tooltip>` already adds.
+- Group-level click handler (clicking the row itself). Wrap in `<button>` if needed.

--- a/docs/superpowers/specs/2026-05-21-avatar-group-status-design.md
+++ b/docs/superpowers/specs/2026-05-21-avatar-group-status-design.md
@@ -62,9 +62,9 @@ export interface AvatarProps extends HTMLAttributes<HTMLSpanElement> {
 
 A new `useAvatarGroup()` hook reads `AvatarGroupContext`. When an `<Avatar>` is rendered inside an `<AvatarGroup>`:
 
-- The group's `size` overrides the Avatar's own `size` (so the group renders uniformly even if a consumer-pasted child specified its own size).
-- The group's `tooltip` flag becomes the default for `tooltip` (still overridable on each child).
-- A SCSS modifier `.inGroup` is added so the avatar picks up the white ring used to visually separate stacked siblings.
+- The group's `size` becomes the **default** for each child — explicit per-child `size` prop still wins (idiomatic React composition: explicit prop beats context). The common "uniform group" case works by simply not setting per-child sizes.
+- The group's `tooltip` flag also becomes the default; explicit per-child `tooltip` wins.
+- A SCSS modifier `.inGroup` is added so the avatar picks up the `--color-bg` ring used to visually separate stacked siblings.
 
 If `useAvatarGroup()` returns `null` (the common standalone case), Avatar behaves exactly as it does today.
 
@@ -76,8 +76,9 @@ export interface AvatarGroupProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
 
   /**
-   * Uniform diameter for every avatar in the group. Defaults to `'md'`.
-   * Overrides any `size` set on individual children.
+   * Diameter default for child avatars (each child can override via its own
+   * `size` prop). Defaults to `'md'`. To get a strictly uniform group, simply
+   * don't set `size` on individual children.
    */
   size?: AvatarSize;
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -156,7 +156,7 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 
 - Horizontal row of overlapping `<Avatar>`s with a `+N` overflow control when child count exceeds `max` (default `4`).
 - `size` is the default for child avatars (per-child explicit `size` still wins). Three sizes: `'sm' | 'md' | 'lg'`. For a strictly uniform group, just don't set per-child sizes.
-- `tooltip` defaults to `true` (same as standalone `<Avatar>`). Set `tooltip={false}` at the group level to suppress all tooltips, or per-child to opt out one.
+- `tooltip` defaults to `true` (group context flips the per-Avatar default — standalone `<Avatar tooltip>` is opt-in, but inside a group each visible face shows its name on hover by default). Set `tooltip={false}` at the group level to suppress all tooltips, or per-child to opt out one.
 - `onOverflowClick(event, hiddenCount)` — the library does NOT render its own popover. The app decides what happens (open a `<Popover>` listing all members, navigate to a page, open a modal). When omitted, `+N` renders as a non-interactive `<span>` (still labelled for AT).
 - The group wrapper is `role="list"` and each visible avatar is wrapped in a `role="listitem"` div; the +N (button or span) is the last list item.
 - forwardRef to the outer `<div>`. `className` is merged.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -140,7 +140,7 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 - `src` — image URL. Empty/whitespace = no image. Falls back to initials on load failure.
 - `size`: `sm` (24) / `md` (32, default) / `lg` (40)
 - `status?` — presence dot in the bottom-right corner. `'online' | 'busy' | 'away' | 'offline'`. Omit to render no dot.
-- `tooltip?` — when true, wraps the avatar in `<Tooltip>` with `content={name}`. Default `false` standalone; defaults to `true` inside `<AvatarGroup>` (explicit per-child still wins).
+- `tooltip?` — wraps the avatar in `<Tooltip>` with `content={name}`. **Defaults to `true`** — every Avatar shows its name on hover / keyboard focus out of the box. Pass `tooltip={false}` to opt out (e.g., when the name is already visible adjacent to the avatar). Inside `<AvatarGroup>`, the group's `tooltip` becomes the default; explicit per-child still wins.
 - Inside `<AvatarGroup>`, the group's `size` and `tooltip` become defaults — explicit per-child props still win. The avatar also picks up a `--color-bg` ring so stacked siblings read as distinct.
 - Use `avatarColorIndex(name)` if you need to match an avatar's color elsewhere (e.g. a chart segment).
 
@@ -156,7 +156,7 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 
 - Horizontal row of overlapping `<Avatar>`s with a `+N` overflow control when child count exceeds `max` (default `4`).
 - `size` is the default for child avatars (per-child explicit `size` still wins). Three sizes: `'sm' | 'md' | 'lg'`. For a strictly uniform group, just don't set per-child sizes.
-- `tooltip` defaults to `true` inside a group — each visible avatar shows its `name` on hover / focus. Override per-child via `tooltip={false}` on a specific `<Avatar>`.
+- `tooltip` defaults to `true` (same as standalone `<Avatar>`). Set `tooltip={false}` at the group level to suppress all tooltips, or per-child to opt out one.
 - `onOverflowClick(event, hiddenCount)` — the library does NOT render its own popover. The app decides what happens (open a `<Popover>` listing all members, navigate to a page, open a modal). When omitted, `+N` renders as a non-interactive `<span>` (still labelled for AT).
 - The group wrapper is `role="list"` and each visible avatar is wrapped in a `role="listitem"` div; the +N (button or span) is the last list item.
 - forwardRef to the outer `<div>`. `className` is merged.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -140,7 +140,7 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 - `src` — image URL. Empty/whitespace = no image. Falls back to initials on load failure.
 - `size`: `sm` (24) / `md` (32, default) / `lg` (40)
 - `status?` — presence dot in the bottom-right corner. `'online' | 'busy' | 'away' | 'offline'`. Omit to render no dot.
-- `tooltip?` — wraps the avatar in `<Tooltip>` with `content={name}`. **Defaults to `true`** — every Avatar shows its name on hover / keyboard focus out of the box. Pass `tooltip={false}` to opt out (e.g., when the name is already visible adjacent to the avatar). Inside `<AvatarGroup>`, the group's `tooltip` becomes the default; explicit per-child still wins.
+- `tooltip?` — wraps the avatar in `<Tooltip>` with `content={name}`. Defaults to `false` standalone (back-compat). Inside `<AvatarGroup>`, the group's `tooltip` becomes the default (which itself defaults to `true`); explicit per-child still wins.
 - Inside `<AvatarGroup>`, the group's `size` and `tooltip` become defaults — explicit per-child props still win. The avatar also picks up a `--color-bg` ring so stacked siblings read as distinct.
 - Use `avatarColorIndex(name)` if you need to match an avatar's color elsewhere (e.g. a chart segment).
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -139,7 +139,27 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 - `name` (required) — alt/aria-label, initials source, and color seed. Same name → same color, always.
 - `src` — image URL. Empty/whitespace = no image. Falls back to initials on load failure.
 - `size`: `sm` (24) / `md` (32, default) / `lg` (40)
+- `status?` — presence dot in the bottom-right corner. `'online' | 'busy' | 'away' | 'offline'`. Omit to render no dot.
+- `tooltip?` — when true, wraps the avatar in `<Tooltip>` with `content={name}`. Default `false` standalone; defaults to `true` inside `<AvatarGroup>` (explicit per-child still wins).
+- Inside `<AvatarGroup>`, the group's `size` and `tooltip` become defaults — explicit per-child props still win. The avatar also picks up a `--color-bg` ring so stacked siblings read as distinct.
 - Use `avatarColorIndex(name)` if you need to match an avatar's color elsewhere (e.g. a chart segment).
+
+### `<AvatarGroup>` — Slack-style stacked row of avatars
+
+```tsx
+<AvatarGroup max={4} size="md" onOverflowClick={(_e, n) => openMembersPopover(n)}>
+  {team.map((m) => (
+    <Avatar key={m.id} name={m.name} src={m.avatarUrl} status={m.presence} />
+  ))}
+</AvatarGroup>
+```
+
+- Horizontal row of overlapping `<Avatar>`s with a `+N` overflow control when child count exceeds `max` (default `4`).
+- `size` is the default for child avatars (per-child explicit `size` still wins). Three sizes: `'sm' | 'md' | 'lg'`. For a strictly uniform group, just don't set per-child sizes.
+- `tooltip` defaults to `true` inside a group — each visible avatar shows its `name` on hover / focus. Override per-child via `tooltip={false}` on a specific `<Avatar>`.
+- `onOverflowClick(event, hiddenCount)` — the library does NOT render its own popover. The app decides what happens (open a `<Popover>` listing all members, navigate to a page, open a modal). When omitted, `+N` renders as a non-interactive `<span>` (still labelled for AT).
+- The group wrapper is `role="list"` and each visible avatar is wrapped in a `role="listitem"` div; the +N (button or span) is the last list item.
+- forwardRef to the outer `<div>`. `className` is merged.
 
 ### `<Badge>` — status / category pill
 

--- a/packages/design-system/src/components/Avatar/Avatar.module.scss
+++ b/packages/design-system/src/components/Avatar/Avatar.module.scss
@@ -1,21 +1,37 @@
+// Outer wrapper — position:relative anchors the .presence dot (Rule 4 escape
+// hatch for an internal child). No overflow:hidden here — that lives on .crop
+// so the presence dot sibling is never clipped.
 .avatar {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
   border-radius: var(--radius-full);
-  background: var(--avatar-bg, var(--color-bg-sunken));
   color: var(--color-avatar-fg);
   font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
-  overflow: hidden;
   user-select: none;
+}
 
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
+// Inner crop — clips the image or initials into a circle. Inherits the
+// background color CSS variable set on the outer wrapper.
+.crop {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: inherit;
+  overflow: hidden;
+  background: var(--avatar-bg, var(--color-bg-sunken));
+}
+
+.crop img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .sm {
@@ -34,4 +50,54 @@
   width: var(--size-lg);
   height: var(--size-lg);
   font-size: var(--font-size-md);
+}
+
+// Presence dot (Avatar status). Anchored to the bottom-right via the
+// parent's position:relative. Carries a 2px ring of --color-bg so the dot
+// stays visible on tinted ancestors.
+.presence {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  border-radius: var(--radius-full);
+  box-shadow: 0 0 0 2px var(--color-bg);
+
+  &[data-status='online'] {
+    background: var(--color-presence-online);
+  }
+
+  &[data-status='busy'] {
+    background: var(--color-presence-busy);
+  }
+
+  &[data-status='away'] {
+    background: var(--color-presence-away);
+  }
+
+  &[data-status='offline'] {
+    background: var(--color-presence-offline);
+  }
+}
+
+// Per-size dot dimensions. The size class lives on the avatar wrapper (the
+// .presence child's parent), so a descendant selector picks the right size.
+.sm .presence {
+  width: var(--size-presence-sm);
+  height: var(--size-presence-sm);
+}
+
+.md .presence {
+  width: var(--size-presence-md);
+  height: var(--size-presence-md);
+}
+
+.lg .presence {
+  width: var(--size-presence-lg);
+  height: var(--size-presence-lg);
+}
+
+// When inside an AvatarGroup, each avatar picks up a --color-bg ring so
+// stacked siblings read as distinct.
+.inGroup {
+  box-shadow: 0 0 0 2px var(--color-bg);
 }

--- a/packages/design-system/src/components/Avatar/Avatar.module.scss
+++ b/packages/design-system/src/components/Avatar/Avatar.module.scss
@@ -60,7 +60,7 @@
   right: 0;
   bottom: 0;
   border-radius: var(--radius-full);
-  box-shadow: 0 0 0 2px var(--color-bg);
+  box-shadow: 0 0 0 var(--border-width-emphasis) var(--color-bg);
 
   &[data-status='online'] {
     background: var(--color-presence-online);
@@ -99,5 +99,5 @@
 // When inside an AvatarGroup, each avatar picks up a --color-bg ring so
 // stacked siblings read as distinct.
 .inGroup {
-  box-shadow: 0 0 0 2px var(--color-bg);
+  box-shadow: 0 0 0 var(--border-width-emphasis) var(--color-bg);
 }

--- a/packages/design-system/src/components/Avatar/Avatar.test.tsx
+++ b/packages/design-system/src/components/Avatar/Avatar.test.tsx
@@ -164,17 +164,22 @@ describe('Avatar', () => {
     expect(container.querySelector('[data-status="busy"]')).not.toBeNull();
   });
 
-  it('does NOT wrap in Tooltip when tooltip is false / unset', () => {
-    render(<Avatar name="Alex" />);
-    expect(screen.queryByRole('tooltip')).toBeNull();
-  });
-
-  it('wraps in Tooltip when tooltip prop is true (visible on hover)', async () => {
+  it('wraps in Tooltip by default and shows the name on hover', async () => {
     const user = userEvent.setup();
-    render(<Avatar name="Alex" tooltip />);
+    render(<Avatar name="Alex" />);
     const avatar = screen.getByRole('img', { name: 'Alex' });
     await user.hover(avatar);
     const tip = await screen.findByRole('tooltip', {}, { timeout: 2000 });
     expect(tip).toHaveTextContent('Alex');
+  });
+
+  it('does NOT wrap in Tooltip when tooltip is false', async () => {
+    const user = userEvent.setup();
+    render(<Avatar name="Alex" tooltip={false} />);
+    const avatar = screen.getByRole('img', { name: 'Alex' });
+    await user.hover(avatar);
+    // Wait briefly past the default tooltip delay (400ms) to confirm no tooltip appears.
+    await new Promise((r) => setTimeout(r, 500));
+    expect(screen.queryByRole('tooltip')).toBeNull();
   });
 });

--- a/packages/design-system/src/components/Avatar/Avatar.test.tsx
+++ b/packages/design-system/src/components/Avatar/Avatar.test.tsx
@@ -164,22 +164,17 @@ describe('Avatar', () => {
     expect(container.querySelector('[data-status="busy"]')).not.toBeNull();
   });
 
-  it('wraps in Tooltip by default and shows the name on hover', async () => {
-    const user = userEvent.setup();
+  it('does NOT wrap in Tooltip by default (tooltip is opt-in)', () => {
     render(<Avatar name="Alex" />);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('wraps in Tooltip when tooltip prop is true (visible on hover)', async () => {
+    const user = userEvent.setup();
+    render(<Avatar name="Alex" tooltip />);
     const avatar = screen.getByRole('img', { name: 'Alex' });
     await user.hover(avatar);
     const tip = await screen.findByRole('tooltip', {}, { timeout: 2000 });
     expect(tip).toHaveTextContent('Alex');
-  });
-
-  it('does NOT wrap in Tooltip when tooltip is false', async () => {
-    const user = userEvent.setup();
-    render(<Avatar name="Alex" tooltip={false} />);
-    const avatar = screen.getByRole('img', { name: 'Alex' });
-    await user.hover(avatar);
-    // Wait briefly past the default tooltip delay (400ms) to confirm no tooltip appears.
-    await new Promise((r) => setTimeout(r, 500));
-    expect(screen.queryByRole('tooltip')).toBeNull();
   });
 });

--- a/packages/design-system/src/components/Avatar/Avatar.test.tsx
+++ b/packages/design-system/src/components/Avatar/Avatar.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import { Avatar, avatarColorIndex } from './Avatar';
 
@@ -141,5 +142,39 @@ describe('Avatar', () => {
   it('does not emit an empty style attribute when the consumer passes style={{}}', () => {
     const { container } = render(<Avatar name="Alex" src="https://example.com/a.jpg" style={{}} />);
     expect(container.firstChild).not.toHaveAttribute('style');
+  });
+
+  it('renders presence dot when status is set', () => {
+    const { container } = render(<Avatar name="Alex" status="online" />);
+    const dot = container.querySelector('[data-status="online"]');
+    expect(dot).not.toBeNull();
+    expect(dot).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('omits presence dot when status is undefined', () => {
+    const { container } = render(<Avatar name="Alex" />);
+    expect(container.querySelector('[data-status]')).toBeNull();
+  });
+
+  it('switches presence color when status changes', () => {
+    const { container, rerender } = render(<Avatar name="Alex" status="online" />);
+    expect(container.querySelector('[data-status="online"]')).not.toBeNull();
+    rerender(<Avatar name="Alex" status="busy" />);
+    expect(container.querySelector('[data-status="online"]')).toBeNull();
+    expect(container.querySelector('[data-status="busy"]')).not.toBeNull();
+  });
+
+  it('does NOT wrap in Tooltip when tooltip is false / unset', () => {
+    render(<Avatar name="Alex" />);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('wraps in Tooltip when tooltip prop is true (visible on hover)', async () => {
+    const user = userEvent.setup();
+    render(<Avatar name="Alex" tooltip />);
+    const avatar = screen.getByRole('img', { name: 'Alex' });
+    await user.hover(avatar);
+    const tip = await screen.findByRole('tooltip', {}, { timeout: 2000 });
+    expect(tip).toHaveTextContent('Alex');
   });
 });

--- a/packages/design-system/src/components/Avatar/Avatar.tsx
+++ b/packages/design-system/src/components/Avatar/Avatar.tsx
@@ -1,15 +1,21 @@
 import { forwardRef, useEffect, useState, type CSSProperties, type HTMLAttributes } from 'react';
 import clsx from 'clsx';
+import { Tooltip } from '../Tooltip';
+import { useAvatarGroup } from './AvatarGroupContext';
 import styles from './Avatar.module.scss';
 
 /** Diameter. Matches the shared `--size-*` scale so a Button next to an Avatar lines up. */
 export type AvatarSize = 'sm' | 'md' | 'lg';
 
+/** Presence dot rendered in the bottom-right corner. Omit to render no dot. */
+export type AvatarStatus = 'online' | 'busy' | 'away' | 'offline';
+
 export interface AvatarProps extends HTMLAttributes<HTMLSpanElement> {
   /**
    * The person's name. Required — used as the `alt`/`aria-label`, as the
    * source of the initials, and as the seed for the deterministic fallback
-   * color. The same name always renders the same color.
+   * color. The same name always renders the same color. When `tooltip` is
+   * true, also used as the tooltip body.
    */
   name: string;
   /**
@@ -23,8 +29,25 @@ export interface AvatarProps extends HTMLAttributes<HTMLSpanElement> {
    * - `sm` (24px) — table rows, dense lists.
    * - `md` (32px, default) — most uses.
    * - `lg` (40px) — detail-page headers.
+   *
+   * Inside `<AvatarGroup>`, the group's `size` overrides this.
    */
   size?: AvatarSize;
+  /**
+   * Presence dot in the bottom-right.
+   * - `'online'`  — green.
+   * - `'busy'`    — red.
+   * - `'away'`    — amber.
+   * - `'offline'` — gray.
+   * Omit to render no dot at all.
+   */
+  status?: AvatarStatus;
+  /**
+   * When true, wraps the avatar in a `<Tooltip>` showing `name`. Defaults
+   * to `false`. Inside `<AvatarGroup>` the default flips to the group's
+   * `tooltip` prop (default `true`).
+   */
+  tooltip?: boolean;
 }
 
 const sizeClass: Record<AvatarSize, string> = {
@@ -52,9 +75,6 @@ export function avatarColorIndex(name: string): number {
   return (Math.abs(hash) % 6) + 1;
 }
 
-// CSS custom properties (--foo) aren't part of CSSProperties' typed keys, so
-// we intersect with a template-literal-key map for `--*` entries. Avoids the
-// `as never` + `as React.CSSProperties` double-cast.
 type StyleWithVars = CSSProperties & { [key: `--${string}`]: string | number };
 
 function hasOwnProps(obj: object | undefined): obj is object {
@@ -68,11 +88,18 @@ function hasOwnProps(obj: object | undefined): obj is object {
  *
  * On image load failure, the component automatically falls back to initials.
  *
+ * Inside `<AvatarGroup>`, the group's `size` and `tooltip` defaults take over —
+ * individual `size` / `tooltip` props still win per-child.
+ *
  * @example
  * <Avatar name="Alex Rivera" />
  *
  * @example
- * <Avatar name="Alex Rivera" src="https://example.com/alex.jpg" size="lg" />
+ * <Avatar name="Alex Rivera" src="https://example.com/alex.jpg" size="lg" status="online" />
+ *
+ * @example
+ * // Hover-discoverable name:
+ * <Avatar name="Alex Rivera" tooltip />
  *
  * @example
  * // In a table row:
@@ -95,22 +122,19 @@ function hasOwnProps(obj: object | undefined): obj is object {
  *   without `src`, the wrapper has `role="img" aria-label={name}`.
  */
 export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(function Avatar(
-  { name, src, size = 'md', className, style, ...props },
+  { name, src, size, status, tooltip, className, style, ...props },
   ref,
 ) {
-  // Reset the broken-image flag whenever `src` changes — a new URL deserves
-  // a fresh attempt to load.
+  const group = useAvatarGroup();
+  const resolvedSize: AvatarSize = size ?? group?.size ?? 'md';
+  const resolvedTooltip: boolean = tooltip ?? group?.tooltip ?? false;
+
   const [imageBroken, setImageBroken] = useState(false);
   useEffect(() => {
     setImageBroken(false);
   }, [src]);
 
-  // Treat empty/whitespace `src` as "no image" so we don't render <img src="">.
-  // Same effect when the image fails to load — fall back to initials.
   const hasImage = typeof src === 'string' && src.trim() !== '' && !imageBroken;
-
-  // Always derive a safe label/alt — even if the consumer passes a whitespace
-  // name with an image, we want a meaningful accessible name.
   const trimmedName = name.trim();
   const accessibleName = trimmedName === '' ? '?' : trimmedName;
 
@@ -118,40 +142,55 @@ export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(function Avatar(
     ? undefined
     : { '--avatar-bg': `var(--color-avatar-${avatarColorIndex(accessibleName)})` };
 
-  // Only emit a style attribute when we actually have something to set —
-  // checking truthiness alone would let an empty `style={{}}` prop emit `style=""`.
   const mergedStyle: StyleWithVars | undefined =
     hasOwnProps(fallbackStyle) || hasOwnProps(style) ? { ...fallbackStyle, ...style } : undefined;
 
-  if (hasImage) {
-    // When showing a real image, the <img> itself carries the image role
-    // (with `name` as its alt). The wrapper is just a circular crop — no
-    // need to also be role="img".
-    //
-    // {...props} is spread FIRST so component-owned attributes (className/style)
-    // win against any consumer override.
-    return (
-      <span
-        {...props}
-        ref={ref}
-        className={clsx(styles.avatar, sizeClass[size], className)}
-        style={mergedStyle}
-      >
-        <img src={src} alt={accessibleName} onError={() => setImageBroken(true)} />
-      </span>
-    );
-  }
+  const wrapperClass = clsx(
+    styles.avatar,
+    sizeClass[resolvedSize],
+    group != null && styles.inGroup,
+    className,
+  );
 
-  return (
+  // .crop clips the image/initials into a circle without clipping the
+  // .presence dot, which lives as a sibling outside .crop.
+  const cropInner = hasImage ? (
+    <span className={styles.crop}>
+      <img src={src} alt={accessibleName} onError={() => setImageBroken(true)} />
+    </span>
+  ) : (
+    <span className={styles.crop}>
+      <span aria-hidden="true">{initials(name)}</span>
+    </span>
+  );
+
+  const presenceDot = status ? (
+    <span aria-hidden="true" className={styles.presence} data-status={status} />
+  ) : null;
+
+  // {...props} first so component-owned ARIA attributes (role, aria-label) win.
+  const inner = hasImage ? (
+    <span {...props} ref={ref} className={wrapperClass} style={mergedStyle}>
+      {cropInner}
+      {presenceDot}
+    </span>
+  ) : (
     <span
       {...props}
       ref={ref}
       role="img"
       aria-label={accessibleName}
-      className={clsx(styles.avatar, sizeClass[size], className)}
+      className={wrapperClass}
       style={mergedStyle}
     >
-      <span aria-hidden="true">{initials(name)}</span>
+      {cropInner}
+      {presenceDot}
     </span>
   );
+
+  if (resolvedTooltip && accessibleName !== '?') {
+    return <Tooltip content={accessibleName}>{inner}</Tooltip>;
+  }
+
+  return inner;
 });

--- a/packages/design-system/src/components/Avatar/Avatar.tsx
+++ b/packages/design-system/src/components/Avatar/Avatar.tsx
@@ -127,7 +127,7 @@ export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(function Avatar(
 ) {
   const group = useAvatarGroup();
   const resolvedSize: AvatarSize = size ?? group?.size ?? 'md';
-  const resolvedTooltip: boolean = tooltip ?? group?.tooltip ?? false;
+  const resolvedTooltip: boolean = tooltip ?? group?.tooltip ?? true;
 
   const [imageBroken, setImageBroken] = useState(false);
   useEffect(() => {

--- a/packages/design-system/src/components/Avatar/Avatar.tsx
+++ b/packages/design-system/src/components/Avatar/Avatar.tsx
@@ -43,9 +43,11 @@ export interface AvatarProps extends HTMLAttributes<HTMLSpanElement> {
    */
   status?: AvatarStatus;
   /**
-   * When true, wraps the avatar in a `<Tooltip>` showing `name`. Defaults
-   * to `false`. Inside `<AvatarGroup>` the default flips to the group's
-   * `tooltip` prop (default `true`).
+   * Whether to wrap the avatar in a `<Tooltip>` showing `name`. Defaults to
+   * `false` (back-compat — existing renders don't gain a hover affordance).
+   * Inside `<AvatarGroup>`, the group's `tooltip` prop becomes the default
+   * (which itself defaults to `true` for grouped avatars); explicit
+   * per-child still wins.
    */
   tooltip?: boolean;
 }
@@ -98,7 +100,7 @@ function hasOwnProps(obj: object | undefined): obj is object {
  * <Avatar name="Alex Rivera" src="https://example.com/alex.jpg" size="lg" status="online" />
  *
  * @example
- * // Hover-discoverable name:
+ * // Hover-discoverable name (off by default; opt in).
  * <Avatar name="Alex Rivera" tooltip />
  *
  * @example
@@ -127,7 +129,7 @@ export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(function Avatar(
 ) {
   const group = useAvatarGroup();
   const resolvedSize: AvatarSize = size ?? group?.size ?? 'md';
-  const resolvedTooltip: boolean = tooltip ?? group?.tooltip ?? true;
+  const resolvedTooltip: boolean = tooltip ?? group?.tooltip ?? false;
 
   const [imageBroken, setImageBroken] = useState(false);
   useEffect(() => {
@@ -188,7 +190,12 @@ export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(function Avatar(
     </span>
   );
 
-  if (resolvedTooltip && accessibleName !== '?') {
+  // Suppress the tooltip when we don't have a real name to show — the
+  // `?` fallback is for unnamed avatars and saying "?" in a tooltip
+  // would be noise. (Comparing trimmedName, not accessibleName, so a
+  // person legitimately named `?` still gets a tooltip.)
+  const hasRealName = trimmedName !== '';
+  if (resolvedTooltip && hasRealName) {
     return <Tooltip content={accessibleName}>{inner}</Tooltip>;
   }
 

--- a/packages/design-system/src/components/Avatar/AvatarGroup.module.scss
+++ b/packages/design-system/src/components/Avatar/AvatarGroup.module.scss
@@ -8,7 +8,16 @@
 }
 
 .item {
+  position: relative;
   display: inline-flex;
+}
+
+// Hovered (or keyboard-focused) item rises to the top of the stack so the
+// reader can see the full circle of the avatar they're inspecting. Without
+// this, deeper-in-the-stack avatars are clipped by their right neighbour.
+.item:hover,
+.item:focus-within {
+  z-index: 1;
 }
 
 // Per-size overlap. The group wrapper picks up a .groupSize-* class so
@@ -17,16 +26,26 @@
 // internal layout: .item divs are internal implementation detail, not exposed to
 // consumers. Negative margin is the only CSS mechanism that both overlaps elements
 // and reclaims space in the flow; gap and translate cannot produce negative spacing.
-.groupSize-sm > .item:not(:first-child) {
+.groupSize-sm > .item:not(:first-child, .overflowItem) {
   margin-left: var(--avatar-overlap-sm);
 }
 
-.groupSize-md > .item:not(:first-child) {
+.groupSize-md > .item:not(:first-child, .overflowItem) {
   margin-left: var(--avatar-overlap-md);
 }
 
-.groupSize-lg > .item:not(:first-child) {
+.groupSize-lg > .item:not(:first-child, .overflowItem) {
   margin-left: var(--avatar-overlap-lg);
+}
+
+// The +N item gets a small positive gap from its preceding sibling instead
+// of the negative overlap used between avatars. It's metadata, not a face,
+// so it should not pretend to be another stacked avatar — plus longer
+// counts (+33, +99) deserve breathing room.
+.groupSize-sm > .overflowItem,
+.groupSize-md > .overflowItem,
+.groupSize-lg > .overflowItem {
+  margin-left: var(--space-1);
 }
 // stylelint-enable property-disallowed-list
 
@@ -37,6 +56,11 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+
+  // Height is fixed per size; width stretches for multi-digit counts (+33,
+  // +99) via min-width + horizontal padding. The pill keeps full radius so
+  // a single-digit +N still reads as a perfect circle.
+  padding: 0 var(--space-2);
   background: var(--color-bg-muted);
   color: var(--color-fg-muted);
   border: none;
@@ -65,19 +89,19 @@
 }
 
 .overflowSize-sm {
-  width: var(--size-sm);
+  min-width: var(--size-sm);
   height: var(--size-sm);
   font-size: var(--font-size-xs);
 }
 
 .overflowSize-md {
-  width: var(--size-md);
+  min-width: var(--size-md);
   height: var(--size-md);
   font-size: var(--font-size-sm);
 }
 
 .overflowSize-lg {
-  width: var(--size-lg);
+  min-width: var(--size-lg);
   height: var(--size-lg);
   font-size: var(--font-size-md);
 }

--- a/packages/design-system/src/components/Avatar/AvatarGroup.module.scss
+++ b/packages/design-system/src/components/Avatar/AvatarGroup.module.scss
@@ -1,0 +1,83 @@
+// AvatarGroup — horizontal row of stacked Avatars with optional +N overflow.
+// Rule 4 note: `.item:not(:first-child)` uses `margin-left` to overlap
+// siblings — intentional internal layout. The public component IS the
+// wrapper; consumers don't see the inner `.item` divs.
+.group {
+  display: inline-flex;
+  align-items: center;
+}
+
+.item {
+  display: inline-flex;
+}
+
+// Per-size overlap. The group wrapper picks up a .groupSize-* class so
+// every direct .item child after the first slides left by the right amount.
+// stylelint-disable property-disallowed-list -- margin-left here is intentional
+// internal layout: .item divs are internal implementation detail, not exposed to
+// consumers. Negative margin is the only CSS mechanism that both overlaps elements
+// and reclaims space in the flow; gap and translate cannot produce negative spacing.
+.groupSize-sm > .item:not(:first-child) {
+  margin-left: var(--avatar-overlap-sm);
+}
+
+.groupSize-md > .item:not(:first-child) {
+  margin-left: var(--avatar-overlap-md);
+}
+
+.groupSize-lg > .item:not(:first-child) {
+  margin-left: var(--avatar-overlap-lg);
+}
+// stylelint-enable property-disallowed-list
+
+// +N overflow chip — same circular surface as Avatar, muted background.
+// The 2px ring matches the .inGroup ring on Avatar so the +N sits flush.
+.overflow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: var(--color-bg-muted);
+  color: var(--color-fg-muted);
+  border: none;
+  border-radius: var(--radius-full);
+  font-family: inherit;
+  font-weight: var(--font-weight-semibold);
+  box-shadow: 0 0 0 2px var(--color-bg);
+  cursor: default;
+  user-select: none;
+
+  &:is(button) {
+    cursor: pointer;
+  }
+
+  &:is(button):hover {
+    background: var(--color-bg-sunken);
+    color: var(--color-fg);
+  }
+
+  &:is(button):focus-visible {
+    outline: none;
+    box-shadow:
+      0 0 0 2px var(--color-bg),
+      0 0 0 calc(2px + var(--ring-width)) var(--ring-accent);
+  }
+}
+
+.overflowSize-sm {
+  width: var(--size-sm);
+  height: var(--size-sm);
+  font-size: var(--font-size-xs);
+}
+
+.overflowSize-md {
+  width: var(--size-md);
+  height: var(--size-md);
+  font-size: var(--font-size-sm);
+}
+
+.overflowSize-lg {
+  width: var(--size-lg);
+  height: var(--size-lg);
+  font-size: var(--font-size-md);
+}

--- a/packages/design-system/src/components/Avatar/AvatarGroup.module.scss
+++ b/packages/design-system/src/components/Avatar/AvatarGroup.module.scss
@@ -67,7 +67,7 @@
   border-radius: var(--radius-full);
   font-family: inherit;
   font-weight: var(--font-weight-semibold);
-  box-shadow: 0 0 0 2px var(--color-bg);
+  box-shadow: 0 0 0 var(--border-width-emphasis) var(--color-bg);
   cursor: default;
   user-select: none;
 
@@ -83,8 +83,8 @@
   &:is(button):focus-visible {
     outline: none;
     box-shadow:
-      0 0 0 2px var(--color-bg),
-      0 0 0 calc(2px + var(--ring-width)) var(--ring-accent);
+      0 0 0 var(--border-width-emphasis) var(--color-bg),
+      0 0 0 calc(var(--border-width-emphasis) + var(--ring-width)) var(--ring-accent);
   }
 }
 

--- a/packages/design-system/src/components/Avatar/AvatarGroup.test.tsx
+++ b/packages/design-system/src/components/Avatar/AvatarGroup.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Avatar } from './Avatar';
+import { AvatarGroup } from './AvatarGroup';
+
+describe('AvatarGroup', () => {
+  it('renders all children when count <= max', () => {
+    render(
+      <AvatarGroup max={4}>
+        <Avatar name="A" />
+        <Avatar name="B" />
+        <Avatar name="C" />
+      </AvatarGroup>,
+    );
+    expect(screen.getByRole('img', { name: 'A' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'B' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'C' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /more avatars/ })).toBeNull();
+    expect(screen.queryByRole('img', { name: /more avatars/ })).toBeNull();
+  });
+
+  it('collapses to +N when count > max', () => {
+    render(
+      <AvatarGroup max={2}>
+        <Avatar name="A" />
+        <Avatar name="B" />
+        <Avatar name="C" />
+        <Avatar name="D" />
+      </AvatarGroup>,
+    );
+    expect(screen.getByRole('img', { name: 'A' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'B' })).toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: 'C' })).toBeNull();
+    expect(screen.queryByRole('img', { name: 'D' })).toBeNull();
+    // No handler → non-interactive span with role="img" + aria-label
+    expect(screen.getByRole('img', { name: '2 more avatars' })).toBeInTheDocument();
+  });
+
+  it('renders +N as a button when onOverflowClick is provided, and fires the handler', async () => {
+    const user = userEvent.setup();
+    const handler = vi.fn();
+    render(
+      <AvatarGroup max={1} onOverflowClick={handler}>
+        <Avatar name="A" />
+        <Avatar name="B" />
+        <Avatar name="C" />
+      </AvatarGroup>,
+    );
+    const btn = screen.getByRole('button', { name: '2 more avatars' });
+    await user.click(btn);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][1]).toBe(2);
+  });
+
+  it('propagates size to descendant Avatars via context', () => {
+    const { container } = render(
+      <AvatarGroup size="lg">
+        <Avatar name="A" />
+      </AvatarGroup>,
+    );
+    // No per-child size set — group context size ("lg") should apply.
+    const avatar = container.querySelector('[role="img"]');
+    expect(avatar?.className).toMatch(/lg/);
+  });
+
+  it('forwards ref to the outer div', () => {
+    const ref = { current: null as HTMLDivElement | null };
+    render(
+      <AvatarGroup ref={ref}>
+        <Avatar name="A" />
+      </AvatarGroup>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('merges className without replacing', () => {
+    const { container } = render(
+      <AvatarGroup className="my-class">
+        <Avatar name="A" />
+      </AvatarGroup>,
+    );
+    expect(container.querySelector('div.my-class')).not.toBeNull();
+  });
+
+  it('renders role="list" wrapper with role="listitem" children', () => {
+    render(
+      <AvatarGroup>
+        <Avatar name="A" />
+        <Avatar name="B" />
+      </AvatarGroup>,
+    );
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  it('handles count exactly equal to max — no +N appears', () => {
+    render(
+      <AvatarGroup max={3}>
+        <Avatar name="A" />
+        <Avatar name="B" />
+        <Avatar name="C" />
+      </AvatarGroup>,
+    );
+    expect(screen.queryByRole('img', { name: /more avatars/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /more avatars/ })).toBeNull();
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+  });
+});

--- a/packages/design-system/src/components/Avatar/AvatarGroup.tsx
+++ b/packages/design-system/src/components/Avatar/AvatarGroup.tsx
@@ -17,8 +17,10 @@ export interface AvatarGroupProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
 
   /**
-   * Uniform diameter for every avatar in the group. Defaults to `'md'`.
-   * Overrides any `size` set on individual children.
+   * Diameter default for child avatars. Defaults to `'md'`. Each child can
+   * still override via its own `size` prop (idiomatic React composition —
+   * explicit prop wins). For a strictly uniform group, don't set `size` on
+   * individual children.
    */
   size?: AvatarSize;
 
@@ -82,8 +84,9 @@ export interface AvatarGroupProps extends HTMLAttributes<HTMLDivElement> {
  *   The `+N` is the click affordance; the visible avatars are deliberately not
  *   interactive in the library — wrap individual avatars in `<button>` / `<Link>`
  *   if needed.
- * - ❌ Mixing avatar sizes inside one group. The group's `size` overrides
- *   per-child sizes.
+ * - ❌ Mixing avatar sizes inside one group on purpose. The group's `size`
+ *   is the default; per-child explicit `size` wins, which is useful for
+ *   emphasising a specific member but visually noisy if used carelessly.
  */
 export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(function AvatarGroup(
   { children, size = 'md', max = 4, tooltip = true, onOverflowClick, className, ...props },

--- a/packages/design-system/src/components/Avatar/AvatarGroup.tsx
+++ b/packages/design-system/src/components/Avatar/AvatarGroup.tsx
@@ -133,7 +133,7 @@ export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(function
           </div>
         ))}
         {overflowNode && (
-          <div role="listitem" className={styles.item}>
+          <div role="listitem" className={clsx(styles.item, styles.overflowItem)}>
             {overflowNode}
           </div>
         )}

--- a/packages/design-system/src/components/Avatar/AvatarGroup.tsx
+++ b/packages/design-system/src/components/Avatar/AvatarGroup.tsx
@@ -1,0 +1,140 @@
+import {
+  Children,
+  forwardRef,
+  isValidElement,
+  useMemo,
+  type HTMLAttributes,
+  type MouseEvent,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import type { AvatarSize } from './Avatar';
+import { AvatarGroupContext, type AvatarGroupContextValue } from './AvatarGroupContext';
+import styles from './AvatarGroup.module.scss';
+
+export interface AvatarGroupProps extends HTMLAttributes<HTMLDivElement> {
+  /** Avatar children. */
+  children: ReactNode;
+
+  /**
+   * Uniform diameter for every avatar in the group. Defaults to `'md'`.
+   * Overrides any `size` set on individual children.
+   */
+  size?: AvatarSize;
+
+  /**
+   * Maximum number of visible avatars. Children beyond this count collapse
+   * into a single `+N` button at the tail. Defaults to `4`. The `+N` only
+   * appears when there are STRICTLY more children than `max`.
+   */
+  max?: number;
+
+  /**
+   * Whether to render a name tooltip on each child avatar. Defaults to `true`
+   * inside the group; overridable per-child by setting `tooltip` on the Avatar.
+   */
+  tooltip?: boolean;
+
+  /**
+   * Fires when the user clicks the `+N` overflow button. The library does
+   * NOT render a popover — apps decide what happens (open a modal, navigate,
+   * etc.). When omitted, the `+N` is rendered as a non-interactive `<span>`.
+   *
+   * @param event The native click event.
+   * @param hiddenCount The number of children not visible in the strip.
+   */
+  onOverflowClick?: (event: MouseEvent<HTMLButtonElement>, hiddenCount: number) => void;
+}
+
+/**
+ * Horizontal stack of `<Avatar>`s with `+N` overflow when count exceeds `max`.
+ *
+ * The group propagates `size` and `tooltip` to descendant `<Avatar>`s via
+ * context. The first `max` children render; any remainder collapses to a
+ * single overflow control.
+ *
+ * @example
+ * // Static — non-interactive +N:
+ * <AvatarGroup max={3}>
+ *   <Avatar name="Alex Rivera" />
+ *   <Avatar name="Priya Patel" />
+ *   <Avatar name="Tom Kim" />
+ *   <Avatar name="Sara Chen" />
+ *   <Avatar name="Jaden Lee" />
+ * </AvatarGroup>
+ *
+ * @example
+ * // With overflow handler — app composes whatever popover/modal it wants:
+ * <AvatarGroup
+ *   max={4}
+ *   size="lg"
+ *   onOverflowClick={(_e, hiddenCount) => openMembersPopover(hiddenCount)}
+ * >
+ *   {members.map((m) => <Avatar key={m.id} name={m.name} src={m.avatarUrl} status={m.presence} />)}
+ * </AvatarGroup>
+ *
+ * @remarks When NOT to use
+ * - For a single avatar — use `<Avatar>` directly.
+ * - When you want to show member counts but not faces — use a `Badge` next to a label.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Wrapping `<AvatarGroup>` in a `<button>` and treating it as one click target.
+ *   The `+N` is the click affordance; the visible avatars are deliberately not
+ *   interactive in the library — wrap individual avatars in `<button>` / `<Link>`
+ *   if needed.
+ * - ❌ Mixing avatar sizes inside one group. The group's `size` overrides
+ *   per-child sizes.
+ */
+export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(function AvatarGroup(
+  { children, size = 'md', max = 4, tooltip = true, onOverflowClick, className, ...props },
+  ref,
+) {
+  const items = Children.toArray(children).filter(isValidElement);
+  const visible = items.slice(0, max);
+  const hiddenCount = Math.max(0, items.length - max);
+
+  const ctx: AvatarGroupContextValue = useMemo(() => ({ size, tooltip }), [size, tooltip]);
+
+  const overflowClass = clsx(styles.overflow, styles[`overflowSize-${size}`]);
+
+  const overflowNode =
+    hiddenCount > 0 ? (
+      onOverflowClick ? (
+        <button
+          type="button"
+          className={overflowClass}
+          aria-label={`${hiddenCount} more avatars`}
+          onClick={(e) => onOverflowClick(e, hiddenCount)}
+        >
+          +{hiddenCount}
+        </button>
+      ) : (
+        <span className={overflowClass} role="img" aria-label={`${hiddenCount} more avatars`}>
+          +{hiddenCount}
+        </span>
+      )
+    ) : null;
+
+  return (
+    // Pattern A — props last so consumer overrides win.
+    <AvatarGroupContext.Provider value={ctx}>
+      <div
+        ref={ref}
+        role="list"
+        className={clsx(styles.group, styles[`groupSize-${size}`], className)}
+        {...props}
+      >
+        {visible.map((child, i) => (
+          <div key={i} role="listitem" className={styles.item}>
+            {child}
+          </div>
+        ))}
+        {overflowNode && (
+          <div role="listitem" className={styles.item}>
+            {overflowNode}
+          </div>
+        )}
+      </div>
+    </AvatarGroupContext.Provider>
+  );
+});

--- a/packages/design-system/src/components/Avatar/AvatarGroupContext.tsx
+++ b/packages/design-system/src/components/Avatar/AvatarGroupContext.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+import type { AvatarSize } from './Avatar';
+
+export interface AvatarGroupContextValue {
+  /** Uniform size for every avatar in the group. */
+  size: AvatarSize;
+  /** Default tooltip behavior for child avatars. */
+  tooltip: boolean;
+}
+
+/**
+ * Internal context shared by `<AvatarGroup>` with its descendant `<Avatar>`s.
+ * `null` means the avatar is standalone (not inside a group).
+ */
+export const AvatarGroupContext = createContext<AvatarGroupContextValue | null>(null);
+
+/** Read the surrounding group context; `null` when standalone. */
+export function useAvatarGroup(): AvatarGroupContextValue | null {
+  return useContext(AvatarGroupContext);
+}

--- a/packages/design-system/src/components/Avatar/index.ts
+++ b/packages/design-system/src/components/Avatar/index.ts
@@ -1,2 +1,4 @@
-export { Avatar } from './Avatar';
-export type { AvatarProps, AvatarSize } from './Avatar';
+export { Avatar, avatarColorIndex } from './Avatar';
+export type { AvatarProps, AvatarSize, AvatarStatus } from './Avatar';
+export { AvatarGroup } from './AvatarGroup';
+export type { AvatarGroupProps } from './AvatarGroup';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -14,8 +14,8 @@ export type { StackProps, StackGap, StackAlign } from './components/Stack';
 export { Cluster } from './components/Cluster';
 export type { ClusterProps, ClusterGap, ClusterJustify, ClusterAlign } from './components/Cluster';
 
-export { Avatar } from './components/Avatar';
-export type { AvatarProps, AvatarSize } from './components/Avatar';
+export { Avatar, AvatarGroup, avatarColorIndex } from './components/Avatar';
+export type { AvatarProps, AvatarSize, AvatarStatus, AvatarGroupProps } from './components/Avatar';
 
 export { Badge } from './components/Badge';
 export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot } from './components/Badge';

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -171,6 +171,25 @@
   // Special line-heights
   --line-height-none: 1;
 
+  // Presence dots (Avatar status). Aliases over the existing semantic
+  // palette — theme changes propagate.
+  --color-presence-online: var(--color-success);
+  --color-presence-busy: var(--color-danger);
+  --color-presence-away: var(--color-warning);
+  --color-presence-offline: var(--color-fg-disabled);
+
+  // Presence-dot dimensions per avatar size.
+  --size-presence-sm: 8px;
+  --size-presence-md: 10px;
+  --size-presence-lg: 12px;
+
+  // Avatar overlap when stacked in a group. Each child after the first
+  // slides left by this amount (negative margin-left). 30% of diameter
+  // looks like Slack at every supported size.
+  --avatar-overlap-sm: calc(var(--size-sm) * -0.3);
+  --avatar-overlap-md: calc(var(--size-md) * -0.3);
+  --avatar-overlap-lg: calc(var(--size-lg) * -0.3);
+
   // States
   --opacity-disabled: 0.5;
   --opacity-muted: 0.75; // de-emphasised secondary text (e.g. event time prefix)

--- a/packages/playground/src/pages/components/AvatarDemo.tsx
+++ b/packages/playground/src/pages/components/AvatarDemo.tsx
@@ -116,11 +116,18 @@ export function AvatarDemo() {
       </Example>
 
       <Example
-        title="Name tooltip"
-        description="Set `tooltip` to surface the name on hover / keyboard focus."
-        code={`<Avatar name="Alex Rivera" tooltip />`}
+        title="Name tooltip (default on)"
+        description="Every Avatar shows its name on hover / keyboard focus by default. Pass `tooltip={false}` to opt out — useful when the name is already visible next to the avatar."
+        code={`// Default — tooltip on hover.
+<Avatar name="Alex Rivera" />
+
+// Opt out (e.g., when the name is visible adjacent to the avatar).
+<Avatar name="Alex Rivera" tooltip={false} />`}
       >
-        <Avatar name="Alex Rivera" tooltip />
+        <Cluster gap="md" align="center">
+          <Avatar name="Alex Rivera" />
+          <Avatar name="Alex Rivera" tooltip={false} />
+        </Cluster>
       </Example>
 
       <Example

--- a/packages/playground/src/pages/components/AvatarDemo.tsx
+++ b/packages/playground/src/pages/components/AvatarDemo.tsx
@@ -116,18 +116,11 @@ export function AvatarDemo() {
       </Example>
 
       <Example
-        title="Name tooltip (default on)"
-        description="Every Avatar shows its name on hover / keyboard focus by default. Pass `tooltip={false}` to opt out — useful when the name is already visible next to the avatar."
-        code={`// Default — tooltip on hover.
-<Avatar name="Alex Rivera" />
-
-// Opt out (e.g., when the name is visible adjacent to the avatar).
-<Avatar name="Alex Rivera" tooltip={false} />`}
+        title="Name tooltip"
+        description="Opt in with `tooltip` to surface the name on hover / keyboard focus. Defaults to off standalone; inside an `<AvatarGroup>` it defaults to on."
+        code={`<Avatar name="Alex Rivera" tooltip />`}
       >
-        <Cluster gap="md" align="center">
-          <Avatar name="Alex Rivera" />
-          <Avatar name="Alex Rivera" tooltip={false} />
-        </Cluster>
+        <Avatar name="Alex Rivera" tooltip />
       </Example>
 
       <Example

--- a/packages/playground/src/pages/components/AvatarDemo.tsx
+++ b/packages/playground/src/pages/components/AvatarDemo.tsx
@@ -1,10 +1,37 @@
-import { Avatar } from '@eocrm/design-system';
-import { Cluster } from '@eocrm/design-system';
-import { Stack } from '@eocrm/design-system';
+import { useState } from 'react';
+import { Avatar, AvatarGroup, Cluster, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import tsxSource from '@lib-source/components/Avatar/Avatar.tsx?raw';
 import scssSource from '@lib-source/components/Avatar/Avatar.module.scss?raw';
+
+const TEAM = [
+  'Alex Rivera',
+  'Priya Patel',
+  'Tom Kim',
+  'Sara Chen',
+  'Jaden Lee',
+  'Mei Tanaka',
+  'Diego Ortiz',
+];
+
+function GroupDemo() {
+  const [clicked, setClicked] = useState<number | null>(null);
+  return (
+    <Stack gap="xs">
+      <AvatarGroup max={4} size="md" onOverflowClick={(_e, count) => setClicked(count)}>
+        {TEAM.map((n) => (
+          <Avatar key={n} name={n} />
+        ))}
+      </AvatarGroup>
+      {clicked !== null && (
+        <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+          onOverflowClick fired with hiddenCount = {clicked}
+        </code>
+      )}
+    </Stack>
+  );
+}
 
 export function AvatarDemo() {
   return (
@@ -70,6 +97,66 @@ export function AvatarDemo() {
           <Avatar name="Maya Owens" src="https://i.pravatar.cc/96?u=maya" size="md" />
           <Avatar name="Sam Chen" src="https://i.pravatar.cc/120?u=sam" size="lg" />
         </Cluster>
+      </Example>
+
+      <Example
+        title="Status indicator"
+        description="Presence dot in the bottom-right. Four states: online / busy / away / offline."
+        code={`<Avatar name="Online Olivia" status="online" />
+<Avatar name="Busy Beatrice" status="busy" />
+<Avatar name="Away Adrien" status="away" />
+<Avatar name="Offline Otto" status="offline" />`}
+      >
+        <Cluster gap="md" align="center">
+          <Avatar name="Online Olivia" status="online" />
+          <Avatar name="Busy Beatrice" status="busy" />
+          <Avatar name="Away Adrien" status="away" />
+          <Avatar name="Offline Otto" status="offline" />
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Name tooltip"
+        description="Set `tooltip` to surface the name on hover / keyboard focus."
+        code={`<Avatar name="Alex Rivera" tooltip />`}
+      >
+        <Avatar name="Alex Rivera" tooltip />
+      </Example>
+
+      <Example
+        title="Avatar group with overflow handler"
+        description="Up to `max` avatars render in flow; the rest collapse into a +N button. The library does not render a popover — the app's `onOverflowClick` decides what happens."
+        code={`<AvatarGroup max={4} onOverflowClick={(_e, count) => openMembersPopover(count)}>
+  {team.map((m) => <Avatar key={m.id} name={m.name} />)}
+</AvatarGroup>`}
+      >
+        <GroupDemo />
+      </Example>
+
+      <Example
+        title="Group sizes"
+        description="Three sizes — sm / md (default) / lg. The group's size is the default for child avatars; per-child override still wins."
+        code={`<AvatarGroup size="sm">{...}</AvatarGroup>
+<AvatarGroup size="md">{...}</AvatarGroup>
+<AvatarGroup size="lg">{...}</AvatarGroup>`}
+      >
+        <Stack gap="md">
+          <AvatarGroup size="sm" max={5}>
+            {TEAM.slice(0, 6).map((n) => (
+              <Avatar key={n} name={n} />
+            ))}
+          </AvatarGroup>
+          <AvatarGroup size="md" max={5}>
+            {TEAM.slice(0, 6).map((n) => (
+              <Avatar key={n} name={n} />
+            ))}
+          </AvatarGroup>
+          <AvatarGroup size="lg" max={5}>
+            {TEAM.slice(0, 6).map((n) => (
+              <Avatar key={n} name={n} />
+            ))}
+          </AvatarGroup>
+        </Stack>
       </Example>
     </DemoLayout>
   );


### PR DESCRIPTION
## Summary

- **New `<AvatarGroup>`** — horizontal stack of `<Avatar>`s with `+N` overflow when count exceeds `max` (default `4`). Group's `size` + `tooltip` propagate to children via context. The library does NOT render a popover for `+N` — it exposes `onOverflowClick(event, hiddenCount)`. Consumer composes whatever popover/modal/route fits.
- **`<Avatar status>`** — presence dot in the bottom-right. Four states: `'online' | 'busy' | 'away' | 'offline'`. Anchored via `position: relative` (Rule 4 escape hatch for internal child anchor); a 2px `--color-bg` ring keeps the dot visible on tinted ancestors. `overflow: hidden` moved off the outer wrapper onto an inner `.crop` span so the dot isn't clipped.
- **`<Avatar tooltip>`** — wraps the avatar in `<Tooltip content={name}>`. Defaults to `false` standalone (back-compat); inside `<AvatarGroup>` the default flips to `true` so grouped faces are name-discoverable on hover.
- **Hover z-index in AvatarGroup** — `.item:hover, .item:focus-within { z-index: 1 }` so the hovered avatar rises to the top of the overlap stack.
- **`+N` pill** — detaches from the last avatar (small positive `margin-left: var(--space-1)`) AND becomes a stretchable pill (`min-width` per size + horizontal padding) so multi-digit counts (+33, +99) don't get squashed.
- **Tokens** — 8 new tokens in `tokens.scss`: 4 presence-color aliases over the existing semantic palette, 3 presence-dot sizes, 3 avatar-overlap amounts.

## Test plan

- [x] `npm test --run` — 796/796 (Avatar 23 + new AvatarGroup 8 added)
- [x] `npm run typecheck` clean
- [x] `npm run lint:css` clean
- [x] `npm run build` clean
- [x] `npx prettier --check` clean
- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files in tarball
- [x] Manual Playwright smoke — status dots render in the right corner with the right colors; +N stretches correctly; tooltip appears on hover when opted in; hover bumps the avatar to the top of the stack
- [x] Hard Rule 8 review cycles (3) — final verdict: clean enough to stop

## Design spec / plan

- Spec: \`docs/superpowers/specs/2026-05-21-avatar-group-status-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-21-avatar-group-status.md\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>