### PR TITLE
Table: compound primitive (density / hover / striped / sticky / sort-indicator)

### DIFF
--- a/docs/superpowers/plans/2026-05-21-table-primitive.md
+++ b/docs/superpowers/plans/2026-05-21-table-primitive.md
@@ -1,0 +1,1405 @@
+# Table primitive — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Table>` compound primitive — `Table`, `Table.Caption`, `Table.Header`, `Table.Body`, `Table.Footer`, `Table.Row`, `Table.HeaderCell`, `Table.Cell`. Visual modifiers (density, hover, striped, sticky header, scroll wrapper). Sortable header is visual hook only — consumer wires onClick.
+
+**Architecture:** Single-file component family at `packages/design-system/src/components/Table/Table.tsx`. Native HTML elements throughout (`<table>`, `<thead>`, `<tbody>`, `<tr>`, `<th>`, `<td>`, `<tfoot>`, `<caption>`). `Object.assign(Root, { Caption, Header, … })` for compound API — matches existing `DropdownMenu` pattern.
+
+**Tech Stack:** React, SCSS modules, Vitest + RTL.
+
+**Branch:** `feat/table-primitive` (already created, off fresh main).
+
+**Spec:** `docs/superpowers/specs/2026-05-21-table-primitive-design.md`.
+
+---
+
+## Task 1: Verify branch + hooks
+
+- [ ] **Step 1: Verify**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # → feat/table-primitive
+git config --get core.hooksPath   # → .husky/_
+test -x .husky/pre-push           # exit 0
+```
+
+---
+
+## Task 2: `Table.tsx` + `Table.module.scss`
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Table/Table.tsx`
+- Create: `packages/design-system/src/components/Table/Table.module.scss`
+
+- [ ] **Step 1: Write `Table.tsx`**
+
+Use EXACTLY this content:
+
+```tsx
+import {
+  forwardRef,
+  type HTMLAttributes,
+  type ReactNode,
+  type TdHTMLAttributes,
+  type ThHTMLAttributes,
+} from 'react';
+import clsx from 'clsx';
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
+import styles from './Table.module.scss';
+
+/** Row height + cell padding scale. */
+export type TableDensity = 'comfortable' | 'dense';
+
+/** Header-cell text alignment. */
+export type TableCellAlign = 'start' | 'center' | 'end';
+
+/** Sort state for a header cell. */
+export type TableSortDirection = 'asc' | 'desc' | 'none';
+
+export interface TableProps extends Omit<HTMLAttributes<HTMLTableElement>, 'children'> {
+  /**
+   * Row height + cell padding scale. Defaults to `'comfortable'`.
+   * - `'comfortable'` — 32px row, 12px horiz padding, font-size-md.
+   * - `'dense'`       — 24px row, 8px horiz padding, font-size-sm.
+   */
+  density?: TableDensity;
+  /** Zebra-striped body rows (even rows tinted). Defaults to `false`. */
+  striped?: boolean;
+  /** Hover highlight on body rows. Defaults to `true`. */
+  hover?: boolean;
+  /**
+   * `position: sticky` on the header so it stays visible while body
+   * scrolls. Requires a scrollable ancestor — the default `scroll`
+   * wrapper provides one. Defaults to `false`.
+   */
+  stickyHeader?: boolean;
+  /**
+   * When `true` (default), the `<table>` is wrapped in a `<div>` with
+   * `overflow-x: auto` so wide tables scroll horizontally inside their
+   * container. Set to `false` to render a bare `<table>` — the consumer
+   * manages their own scroll context.
+   */
+  scroll?: boolean;
+  /** Compound-subcomponent children. */
+  children: ReactNode;
+}
+
+export interface TableCaptionProps extends HTMLAttributes<HTMLTableCaptionElement> {
+  children: ReactNode;
+}
+
+export interface TableSectionProps extends HTMLAttributes<HTMLTableSectionElement> {
+  children: ReactNode;
+}
+
+export interface TableRowProps extends HTMLAttributes<HTMLTableRowElement> {
+  /**
+   * Visual selected state. Pair with the consumer's own selection logic.
+   * Adds `aria-selected="true"` and a subtle accent tint that wins over
+   * hover/striped.
+   */
+  selected?: boolean;
+  children: ReactNode;
+}
+
+export interface TableHeaderCellProps extends ThHTMLAttributes<HTMLTableCellElement> {
+  /** Text alignment. Defaults to `'start'`. */
+  align?: TableCellAlign;
+  /**
+   * When set, the cell renders a sort indicator (up/down/unsorted chevron)
+   * and sets `aria-sort`. The consumer drives interactivity via `onClick`;
+   * this primitive only paints the indicator.
+   * - `'asc'`  → up chevron + `aria-sort="ascending"`.
+   * - `'desc'` → down chevron + `aria-sort="descending"`.
+   * - `'none'` → muted up/down chevron + `aria-sort="none"`.
+   * Omit to render a non-sortable header (no chevron, no `aria-sort`).
+   */
+  sortDirection?: TableSortDirection;
+  children?: ReactNode;
+}
+
+export interface TableCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
+  /** Text alignment. Defaults to `'start'`. */
+  align?: TableCellAlign;
+  /**
+   * Suppress wrapping and ellipsize on overflow. Requires a constrained
+   * cell width (column-level CSS or `style={{ maxWidth: … }}`).
+   */
+  truncate?: boolean;
+  children?: ReactNode;
+}
+
+const sortAriaFor: Record<TableSortDirection, 'ascending' | 'descending' | 'none'> = {
+  asc: 'ascending',
+  desc: 'descending',
+  none: 'none',
+};
+
+/**
+ * Tabular data primitive. Compound API:
+ * `Table`, `Table.Caption`, `Table.Header`, `Table.Body`, `Table.Footer`,
+ * `Table.Row`, `Table.HeaderCell`, `Table.Cell`.
+ *
+ * Native HTML elements throughout — no ARIA-on-divs. Density, hover,
+ * striped, sticky header, and horizontal-scroll wrapper are visual
+ * modifiers on the root. Sortable header is a visual hook — the consumer
+ * wires `onClick` on `Table.HeaderCell` to drive their own sort state.
+ *
+ * @example
+ * <Table>
+ *   <Table.Caption>Recent activity</Table.Caption>
+ *   <Table.Header>
+ *     <Table.Row>
+ *       <Table.HeaderCell>Name</Table.HeaderCell>
+ *       <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+ *     </Table.Row>
+ *   </Table.Header>
+ *   <Table.Body>
+ *     {rows.map((r) => (
+ *       <Table.Row key={r.id}>
+ *         <Table.Cell>{r.name}</Table.Cell>
+ *         <Table.Cell align="end">{r.amount}</Table.Cell>
+ *       </Table.Row>
+ *     ))}
+ *   </Table.Body>
+ * </Table>
+ *
+ * @example
+ * // Sortable column — consumer owns the state machine; the primitive
+ * // only paints the indicator and sets aria-sort.
+ * <Table.HeaderCell
+ *   sortDirection={sortKey === 'amount' ? sortDir : 'none'}
+ *   onClick={() => toggleSort('amount')}
+ * >
+ *   Amount
+ * </Table.HeaderCell>
+ *
+ * @remarks When NOT to use
+ * - For data that needs sorting / filtering / pagination state — wait for
+ *   `<DataTable>` (not yet shipped). DataTable composes this primitive +
+ *   TanStack Table headless.
+ * - For non-tabular content (cards, lists). Use `<Stack>` / `<Cluster>` /
+ *   `<Card>` instead.
+ * - For dashboards with editable cells. The primitive doesn't ship inline
+ *   editing; consumer adds inputs inside cells as needed.
+ *
+ * @remarks Anti-patterns
+ * - ❌ `<Table>` without `<Table.Body>` for non-header rows. Native
+ *   semantics require `<tbody>` for data rows.
+ * - ❌ Putting `<Table.HeaderCell>` inside `<Table.Body>` for the leftmost
+ *   row-header column. Use a `<th scope="row">` instead — pass `scope` via
+ *   spread on `<Table.Cell>` is not supported (it would silently render as
+ *   `<td scope="row">` which is invalid). If you need row headers, file a
+ *   follow-up to add a `rowHeader` prop.
+ */
+const TableRoot = forwardRef<HTMLTableElement, TableProps>(function TableRoot(
+  { density = 'comfortable', striped, hover = true, stickyHeader, scroll = true, className, children, ...props },
+  ref,
+) {
+  const table = (
+    <table
+      ref={ref}
+      className={clsx(
+        styles.table,
+        styles[`density-${density}`],
+        striped && styles.striped,
+        hover && styles.hover,
+        stickyHeader && styles.stickyHeader,
+        className,
+      )}
+      // {...props} last so consumer overrides win (Pattern A).
+      {...props}
+    >
+      {children}
+    </table>
+  );
+
+  if (!scroll) return table;
+  return <div className={styles.scrollWrap}>{table}</div>;
+});
+
+const TableCaption = forwardRef<HTMLTableCaptionElement, TableCaptionProps>(function TableCaption(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <caption ref={ref} className={clsx(styles.caption, className)} {...props}>
+      {children}
+    </caption>
+  );
+});
+
+const TableHeader = forwardRef<HTMLTableSectionElement, TableSectionProps>(function TableHeader(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <thead ref={ref} className={clsx(styles.thead, className)} {...props}>
+      {children}
+    </thead>
+  );
+});
+
+const TableBody = forwardRef<HTMLTableSectionElement, TableSectionProps>(function TableBody(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <tbody ref={ref} className={clsx(styles.tbody, className)} {...props}>
+      {children}
+    </tbody>
+  );
+});
+
+const TableFooter = forwardRef<HTMLTableSectionElement, TableSectionProps>(function TableFooter(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <tfoot ref={ref} className={clsx(styles.tfoot, className)} {...props}>
+      {children}
+    </tfoot>
+  );
+});
+
+const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(function TableRow(
+  { selected, className, children, ...props },
+  ref,
+) {
+  return (
+    <tr
+      ref={ref}
+      aria-selected={selected || undefined}
+      className={clsx(styles.tr, selected && styles.selected, className)}
+      {...props}
+    >
+      {children}
+    </tr>
+  );
+});
+
+const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellProps>(function TableHeaderCell(
+  { align = 'start', sortDirection, scope = 'col', className, children, ...props },
+  ref,
+) {
+  const sortable = sortDirection != null;
+  const SortIcon =
+    sortDirection === 'asc' ? ChevronUp : sortDirection === 'desc' ? ChevronDown : ChevronsUpDown;
+
+  return (
+    <th
+      ref={ref}
+      scope={scope}
+      aria-sort={sortable ? sortAriaFor[sortDirection] : undefined}
+      className={clsx(
+        styles.th,
+        styles[`align-${align}`],
+        sortable && styles.sortable,
+        sortable && sortDirection === 'none' && styles.sortableInactive,
+        className,
+      )}
+      {...props}
+    >
+      <span className={styles.thInner}>
+        <span>{children}</span>
+        {sortable && <SortIcon size={12} aria-hidden="true" className={styles.sortIcon} />}
+      </span>
+    </th>
+  );
+});
+
+const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(function TableCell(
+  { align = 'start', truncate, className, children, ...props },
+  ref,
+) {
+  return (
+    <td
+      ref={ref}
+      className={clsx(
+        styles.td,
+        styles[`align-${align}`],
+        truncate && styles.truncate,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </td>
+  );
+});
+
+/**
+ * Compound `<Table>` family. Attach subcomponents via Object.assign so
+ * consumers write `<Table.Body>` etc., not separate imports.
+ */
+export const Table = Object.assign(TableRoot, {
+  Caption: TableCaption,
+  Header: TableHeader,
+  Body: TableBody,
+  Footer: TableFooter,
+  Row: TableRow,
+  HeaderCell: TableHeaderCell,
+  Cell: TableCell,
+});
+```
+
+- [ ] **Step 2: Write `Table.module.scss`**
+
+Use EXACTLY this content:
+
+```scss
+// Scroll wrapper — horizontal overflow context for wide tables AND the
+// scroll container for sticky headers.
+.scrollWrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: inherit;
+  color: var(--color-fg);
+}
+
+// ─── Density ───────────────────────────────────────────────────────────────
+
+.density-comfortable .td,
+.density-comfortable .th {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-md);
+}
+
+.density-comfortable .tr {
+  min-height: var(--size-md);
+}
+
+.density-dense .td,
+.density-dense .th {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+}
+
+.density-dense .tr {
+  min-height: var(--size-sm);
+}
+
+// ─── Sections ──────────────────────────────────────────────────────────────
+
+.caption {
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-fg-muted);
+  font-size: var(--font-size-sm);
+  text-align: start;
+}
+
+.thead .tr {
+  background: var(--color-bg-subtle);
+}
+
+.tbody .tr {
+  background: var(--color-bg);
+}
+
+.tfoot .tr {
+  background: var(--color-bg-subtle);
+}
+
+// ─── Rows ──────────────────────────────────────────────────────────────────
+
+.tr {
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.hover .tbody .tr:hover {
+  background: var(--color-bg-subtle);
+}
+
+.striped .tbody .tr:nth-of-type(even) {
+  background: var(--color-bg-subtle);
+}
+
+// Selected wins over hover + striped (later declaration, equal specificity).
+.tbody .tr.selected,
+.tbody .tr.selected:hover {
+  background: var(--color-accent-bg-subtle);
+  color: var(--color-fg);
+}
+
+// ─── Cells ─────────────────────────────────────────────────────────────────
+
+.th {
+  color: var(--color-fg-muted);
+  font-weight: var(--font-weight-semibold);
+  text-transform: none;
+  vertical-align: middle;
+}
+
+.td {
+  vertical-align: middle;
+}
+
+// Inner flex container for header cells so sort chevron sits beside text.
+.thInner {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+// Alignment — applied via CSS logical properties (RTL-friendly).
+.align-start {
+  text-align: start;
+}
+
+.align-center {
+  text-align: center;
+}
+
+.align-end {
+  text-align: end;
+}
+
+// Right-aligned headers need the chevron on the start side of the label,
+// not the end — flip the inner flex direction.
+.align-end .thInner {
+  flex-direction: row-reverse;
+}
+
+// ─── Sortable header ───────────────────────────────────────────────────────
+
+.sortable {
+  cursor: pointer;
+  user-select: none;
+
+  &:hover {
+    background: var(--color-bg-muted);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 var(--ring-width) var(--ring-accent);
+  }
+}
+
+.sortIcon {
+  flex-shrink: 0;
+  color: var(--color-fg-muted);
+}
+
+.sortable:not(.sortableInactive) .sortIcon {
+  color: var(--color-fg);
+}
+
+// ─── Sticky header ─────────────────────────────────────────────────────────
+
+.stickyHeader .thead .th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  // Repeat the header bg here — `tr` bg paints below the th's sticky
+  // layer in some browsers, leaving body rows visible through it.
+  background: var(--color-bg-subtle);
+}
+
+// ─── Cell modifiers ────────────────────────────────────────────────────────
+
+.truncate {
+  max-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+```
+
+NOTE on the SCSS: stylelint's `property-disallowed-list` may flag `position: sticky`, `top: 0`, `min-width`, etc. The Table primitive is the public component — its outer box is `<table>`, but the inner `<th>` sticky behavior is internal layout (scrolls inside the scrollWrap). This is the documented Rule 4 escape hatch ("`position` when not `relative` for an internal child anchor" — sticky is for an internal-child anchor too, just to the scroll container). If stylelint complains, wrap the rule in `stylelint-disable property-disallowed-list` with a documented justification matching the AvatarGroup `margin-left` precedent.
+
+Same for `max-width: 0` on `.truncate` — it's a flex-container trick to force ellipsis-respecting widths and is the standard CSS pattern (see CSS-Tricks article on flex-truncate). Document if stylelint flags.
+
+- [ ] **Step 3: Gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm run typecheck 2>&1 | tail -5
+npm run lint:css 2>&1 | tail -10
+npm run build 2>&1 | tail -5
+```
+
+Fix any stylelint findings inline with `stylelint-disable` + documented justification if the rule is the Rule 4 escape hatch.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Table/Table.tsx \
+        packages/design-system/src/components/Table/Table.module.scss
+git commit -m "Table: new compound primitive (density / hover / striped / sticky / sort-indicator)"
+```
+
+---
+
+## Task 3: `Table.test.tsx`
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Table/Table.test.tsx`
+
+- [ ] **Step 1: Write the tests**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { Table } from './Table';
+
+describe('Table', () => {
+  it('renders a native <table> with the default structure', () => {
+    const { container } = render(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Name</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>Alex</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    expect(container.querySelector('table')).toBeInTheDocument();
+    expect(container.querySelector('thead')).toBeInTheDocument();
+    expect(container.querySelector('tbody')).toBeInTheDocument();
+    expect(container.querySelector('th')).toHaveAttribute('scope', 'col');
+  });
+
+  it('wraps the table in a scroll <div> by default; scroll={false} renders bare', () => {
+    const { container, rerender } = render(
+      <Table>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    // Bydefault, the <table> sits inside an outer <div>.
+    expect(container.querySelector('div > table')).not.toBeNull();
+
+    rerender(
+      <Table scroll={false}>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    // The first child is now the <table> itself.
+    expect(container.firstChild?.nodeName).toBe('TABLE');
+  });
+
+  it('applies density / hover / striped / stickyHeader class names', () => {
+    const { container, rerender } = render(<Table density="dense" striped hover={false} stickyHeader />);
+    const table = container.querySelector('table')!;
+    expect(table.className).toMatch(/density-dense/);
+    expect(table.className).toMatch(/striped/);
+    expect(table.className).not.toMatch(/hover/);
+    expect(table.className).toMatch(/stickyHeader/);
+
+    rerender(<Table />);
+    const table2 = container.querySelector('table')!;
+    expect(table2.className).toMatch(/density-comfortable/);
+    expect(table2.className).toMatch(/hover/);
+    expect(table2.className).not.toMatch(/striped/);
+    expect(table2.className).not.toMatch(/stickyHeader/);
+  });
+
+  it('Table.Row selected adds aria-selected and the selected class', () => {
+    const { container } = render(
+      <Table>
+        <Table.Body>
+          <Table.Row selected>
+            <Table.Cell>X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    const tr = container.querySelector('tr');
+    expect(tr).toHaveAttribute('aria-selected', 'true');
+    expect(tr?.className).toMatch(/selected/);
+  });
+
+  it('Table.HeaderCell sortDirection renders chevron + aria-sort', () => {
+    const { container, rerender } = render(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell sortDirection="asc">Amount</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    expect(container.querySelector('th')).toHaveAttribute('aria-sort', 'ascending');
+    expect(container.querySelector('th svg')).toBeInTheDocument();
+
+    rerender(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell sortDirection="desc">Amount</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    expect(container.querySelector('th')).toHaveAttribute('aria-sort', 'descending');
+
+    rerender(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell sortDirection="none">Amount</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    expect(container.querySelector('th')).toHaveAttribute('aria-sort', 'none');
+  });
+
+  it('Table.HeaderCell without sortDirection has no chevron and no aria-sort', () => {
+    const { container } = render(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Amount</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    expect(container.querySelector('th')).not.toHaveAttribute('aria-sort');
+    expect(container.querySelector('th svg')).toBeNull();
+  });
+
+  it('Table.Cell align applies the right class', () => {
+    const { container } = render(
+      <Table>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell align="end">42</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    expect(container.querySelector('td')?.className).toMatch(/align-end/);
+  });
+
+  it('Table.Cell truncate applies the truncate class', () => {
+    const { container } = render(
+      <Table>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell truncate>Long long long</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    expect(container.querySelector('td')?.className).toMatch(/truncate/);
+  });
+
+  it('forwards ref on Table to the <table> element', () => {
+    const ref = createRef<HTMLTableElement>();
+    render(
+      <Table ref={ref}>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLTableElement);
+  });
+
+  it('merges className on every subcomponent', () => {
+    const { container } = render(
+      <Table className="root-cls">
+        <Table.Caption className="cap-cls">Cap</Table.Caption>
+        <Table.Header className="thead-cls">
+          <Table.Row className="tr-cls">
+            <Table.HeaderCell className="th-cls">H</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body className="tbody-cls">
+          <Table.Row>
+            <Table.Cell className="td-cls">X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+        <Table.Footer className="tfoot-cls">
+          <Table.Row>
+            <Table.Cell>F</Table.Cell>
+          </Table.Row>
+        </Table.Footer>
+      </Table>,
+    );
+    expect(container.querySelector('table.root-cls')).not.toBeNull();
+    expect(container.querySelector('caption.cap-cls')).not.toBeNull();
+    expect(container.querySelector('thead.thead-cls')).not.toBeNull();
+    expect(container.querySelector('tr.tr-cls')).not.toBeNull();
+    expect(container.querySelector('th.th-cls')).not.toBeNull();
+    expect(container.querySelector('tbody.tbody-cls')).not.toBeNull();
+    expect(container.querySelector('td.td-cls')).not.toBeNull();
+    expect(container.querySelector('tfoot.tfoot-cls')).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Gates**
+
+```bash
+npm test --workspace=@eocrm/design-system --run -- src/components/Table 2>&1 | tail -8
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/Table/Table.test.tsx
+git commit -m "Table: unit tests for compound subcomponents, modifiers, ref, className merge"
+```
+
+---
+
+## Task 4: Barrel + re-export from `src/index.ts`
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Table/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+- [ ] **Step 1: Write `index.ts`**
+
+```ts
+export { Table } from './Table';
+export type {
+  TableProps,
+  TableCaptionProps,
+  TableSectionProps,
+  TableRowProps,
+  TableHeaderCellProps,
+  TableCellProps,
+  TableDensity,
+  TableCellAlign,
+  TableSortDirection,
+} from './Table';
+```
+
+- [ ] **Step 2: Re-export from `src/index.ts`**
+
+Read the file first; locate the alphabetical position (Table should slot after `Select` and before `Tabs`). Add:
+
+```ts
+export { Table } from './components/Table';
+export type {
+  TableProps,
+  TableCaptionProps,
+  TableSectionProps,
+  TableRowProps,
+  TableHeaderCellProps,
+  TableCellProps,
+  TableDensity,
+  TableCellAlign,
+  TableSortDirection,
+} from './components/Table';
+```
+
+- [ ] **Step 3: Gates**
+
+```bash
+npm run typecheck 2>&1 | tail -3
+npm run build 2>&1 | tail -3
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Table/index.ts \
+        packages/design-system/src/index.ts
+git commit -m "Table: re-export from barrel + src/index.ts (Rule 5)"
+```
+
+---
+
+## Task 5: Playground demo + wiring
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/TableDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Write `TableDemo.tsx`**
+
+```tsx
+import { useState } from 'react';
+import { Table, Badge, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Table/Table.tsx?raw';
+import scssSource from '@lib-source/components/Table/Table.module.scss?raw';
+
+interface Row {
+  id: string;
+  name: string;
+  status: 'Active' | 'Pending' | 'Archived';
+  amount: number;
+}
+
+const ROWS: Row[] = [
+  { id: 'a', name: 'Acme Corp', status: 'Active', amount: 12_500 },
+  { id: 'b', name: 'Beanstalk Ltd', status: 'Pending', amount: 4_200 },
+  { id: 'c', name: 'Cobalt Studios', status: 'Active', amount: 28_400 },
+  { id: 'd', name: 'Delta Mfg', status: 'Archived', amount: 800 },
+  { id: 'e', name: 'Echo Logistics', status: 'Active', amount: 7_900 },
+];
+
+const STATUS_TONE: Record<Row['status'], 'success' | 'warning' | 'neutral'> = {
+  Active: 'success',
+  Pending: 'warning',
+  Archived: 'neutral',
+};
+
+function StaticTable() {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Company</Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {ROWS.map((row) => (
+          <Table.Row key={row.id}>
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell>
+              <Badge tone={STATUS_TONE[row.status]}>{row.status}</Badge>
+            </Table.Cell>
+            <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}
+
+function SortableTable() {
+  const [sortKey, setSortKey] = useState<'name' | 'amount'>('name');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  const sorted = [...ROWS].sort((a, b) => {
+    const dir = sortDir === 'asc' ? 1 : -1;
+    if (sortKey === 'amount') return (a.amount - b.amount) * dir;
+    return a.name.localeCompare(b.name) * dir;
+  });
+
+  function dirFor(key: 'name' | 'amount') {
+    if (sortKey !== key) return 'none' as const;
+    return sortDir;
+  }
+
+  function toggle(key: 'name' | 'amount') {
+    if (sortKey === key) setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  }
+
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell sortDirection={dirFor('name')} onClick={() => toggle('name')}>
+            Company
+          </Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell
+            align="end"
+            sortDirection={dirFor('amount')}
+            onClick={() => toggle('amount')}
+          >
+            Amount
+          </Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {sorted.map((row) => (
+          <Table.Row key={row.id}>
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell>
+              <Badge tone={STATUS_TONE[row.status]}>{row.status}</Badge>
+            </Table.Cell>
+            <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}
+
+function SelectableTable() {
+  const [selectedId, setSelectedId] = useState<string | null>('c');
+
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Company</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {ROWS.map((row) => (
+          <Table.Row
+            key={row.id}
+            selected={selectedId === row.id}
+            onClick={() => setSelectedId(row.id)}
+            style={{ cursor: 'pointer' }}
+          >
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}
+
+export function TableDemo() {
+  return (
+    <DemoLayout
+      name="Table"
+      componentName="Table"
+      description="Tabular data primitive — compound subcomponents (Table.Header, Table.Body, Table.Row, Table.Cell, Table.HeaderCell, Table.Caption, Table.Footer) over native HTML semantics. Density, hover, striped, sticky-header, and sort-indicator visuals; data behavior (sort/filter/pagination) is the consumer's job."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Table.tsx"
+      scssFilename="Table.module.scss"
+    >
+      <Example
+        title="Default"
+        description="Comfortable density, hover on, no stripes. Native `<table>` semantics throughout."
+        code={`<Table>
+  <Table.Header>
+    <Table.Row>
+      <Table.HeaderCell>Company</Table.HeaderCell>
+      <Table.HeaderCell>Status</Table.HeaderCell>
+      <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    {rows.map((r) => (
+      <Table.Row key={r.id}>
+        <Table.Cell>{r.name}</Table.Cell>
+        <Table.Cell><Badge tone={...}>{r.status}</Badge></Table.Cell>
+        <Table.Cell align="end">\${r.amount.toLocaleString()}</Table.Cell>
+      </Table.Row>
+    ))}
+  </Table.Body>
+</Table>`}
+      >
+        <StaticTable />
+      </Example>
+
+      <Example
+        title="Dense"
+        description="24px row, 8px cell padding, `font-size-sm`. Useful for inline tables inside cards or narrow side panels."
+        code={`<Table density="dense">{...}</Table>`}
+      >
+        <Table density="dense">
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Company</Table.HeaderCell>
+              <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {ROWS.slice(0, 3).map((row) => (
+              <Table.Row key={row.id}>
+                <Table.Cell>{row.name}</Table.Cell>
+                <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      </Example>
+
+      <Example
+        title="Striped + hover"
+        description="Zebra stripes on even body rows. Hover is on by default; pass `hover={false}` to disable."
+        code={`<Table striped>{...}</Table>`}
+      >
+        <Table striped>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Company</Table.HeaderCell>
+              <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {ROWS.map((row) => (
+              <Table.Row key={row.id}>
+                <Table.Cell>{row.name}</Table.Cell>
+                <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      </Example>
+
+      <Example
+        title="Sortable headers"
+        description="`<Table.HeaderCell sortDirection>` renders a chevron + sets `aria-sort`. The primitive only paints the indicator — wire `onClick` to your own sort state. (DataTable will compose this seam.)"
+        code={`<Table.HeaderCell
+  sortDirection={sortKey === 'amount' ? sortDir : 'none'}
+  onClick={() => toggleSort('amount')}
+>
+  Amount
+</Table.HeaderCell>`}
+      >
+        <SortableTable />
+      </Example>
+
+      <Example
+        title="Selected row"
+        description="`<Table.Row selected>` paints a tinted bg + sets `aria-selected`. Click any row to select it (consumer-owned state)."
+        code={`<Table.Row selected={isSelected(row.id)} onClick={() => select(row.id)}>
+  {...}
+</Table.Row>`}
+      >
+        <SelectableTable />
+      </Example>
+
+      <Example
+        title="Sticky header"
+        description="`stickyHeader` keeps the header row visible while body rows scroll. Requires a scrollable ancestor — the default outer wrapper provides one."
+        code={`<div style={{ maxHeight: 200, overflow: 'auto' }}>
+  <Table stickyHeader scroll={false}>{...}</Table>
+</div>`}
+      >
+        <div style={{ maxHeight: 200, overflow: 'auto', border: 'var(--border-width) solid var(--color-border)', borderRadius: 'var(--radius-md)' }}>
+          <Table stickyHeader scroll={false}>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Company</Table.HeaderCell>
+                <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {[...ROWS, ...ROWS, ...ROWS].map((row, i) => (
+                <Table.Row key={`${row.id}-${i}`}>
+                  <Table.Cell>{row.name}</Table.Cell>
+                  <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </div>
+      </Example>
+
+      <Example
+        title="Truncated cell"
+        description="`<Table.Cell truncate>` ellipsizes overflow text. Requires a constrained cell width — set `style={{ maxWidth }}` on the cell or `<col>` width on the column."
+        code={`<Table.Cell truncate style={{ maxWidth: 180 }}>{longString}</Table.Cell>`}
+      >
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell style={{ width: 180 }}>Subject</Table.HeaderCell>
+              <Table.HeaderCell>Status</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell truncate style={{ maxWidth: 180 }}>
+                Q4 strategy: revisit the long-tail growth bets and align with platform launches
+              </Table.Cell>
+              <Table.Cell>
+                <Badge tone="warning">Pending</Badge>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell truncate style={{ maxWidth: 180 }}>
+                Short subject
+              </Table.Cell>
+              <Table.Cell>
+                <Badge tone="success">Active</Badge>
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+- [ ] **Step 2: Wire `App.tsx`**
+
+Add the import + route in the alphabetical position (after `Select` and before `Tabs` or wherever the existing pattern slots Table).
+
+```tsx
+import { TableDemo } from './pages/components/TableDemo';
+// …
+<Route path="/components/table" element={<TableDemo />} />
+```
+
+- [ ] **Step 3: Wire `AppShell.tsx`**
+
+Add a `Table` entry to the Display group (Table is a Display component, not Forms). Match the existing pattern with an icon — use `Table` icon from lucide-react if not already imported:
+
+```tsx
+import { Table as TableIcon } from 'lucide-react';
+// …
+// In the Display group:
+{ to: '/components/table', label: 'Table', icon: TableIcon, end: false },
+```
+
+Place it alphabetically (between `Calendar` and any next Display item, or wherever it fits).
+
+- [ ] **Step 4: Wire `ComponentsIndex.tsx`**
+
+Add a card for Table:
+
+```tsx
+{
+  to: '/components/table',
+  name: 'Table',
+  description: 'Tabular data primitive — compound subcomponents over native HTML semantics with density, hover, striped, and sortable-header visuals.',
+  preview: (
+    <div style={{ width: 220 }}>
+      <Table density="dense" scroll={false}>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Name</Table.HeaderCell>
+            <Table.HeaderCell align="end">Total</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>Acme</Table.Cell>
+            <Table.Cell align="end">12.5K</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Beanstalk</Table.Cell>
+            <Table.Cell align="end">4.2K</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </div>
+  ),
+},
+```
+
+Don't forget to extend the import line at the top of `ComponentsIndex.tsx` with `Table`.
+
+- [ ] **Step 5: Wire `registry.ts`**
+
+Add `'Table'` to the `ComponentName` union (alphabetical).
+
+- [ ] **Step 6: Gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm run typecheck 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 7: Smoke test in dev server**
+
+```bash
+make dev  # or assume already running on :8080
+```
+
+Visit `http://localhost:8080/components/table`. Verify:
+- All 7 Examples render.
+- Sortable headers toggle on click and the chevron flips.
+- Selected row tints on click.
+- Sticky header stays pinned while the inner content scrolls.
+- Truncated cell ellipses long text.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/playground/src/
+git commit -m "TableDemo: examples + sidebar + index + registry wiring"
+```
+
+---
+
+## Task 6: AGENTS.md section
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Find the right slot**
+
+```bash
+grep -n "^### " packages/design-system/AGENTS.md
+```
+
+Table is a Display/Data component. Slot it between `<Select>` (last Forms entry) and `<LocaleProvider>` (i18n), OR right before `<DropdownMenu>` (Overlays). Pick what matches the existing groupings — likely between `<Select>` and `<LocaleProvider>` since Table doesn't fit Forms cleanly and AGENTS.md groups roughly by category.
+
+- [ ] **Step 2: Insert this section**
+
+```markdown
+### `<Table>` — tabular data primitive
+
+```tsx
+<Table>
+  <Table.Header>
+    <Table.Row>
+      <Table.HeaderCell>Name</Table.HeaderCell>
+      <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    {rows.map((r) => (
+      <Table.Row key={r.id}>
+        <Table.Cell>{r.name}</Table.Cell>
+        <Table.Cell align="end">{r.amount}</Table.Cell>
+      </Table.Row>
+    ))}
+  </Table.Body>
+</Table>
+```
+
+- Compound subcomponents: `Table`, `Table.Caption`, `Table.Header`, `Table.Body`, `Table.Footer`, `Table.Row`, `Table.HeaderCell`, `Table.Cell`. Renders native `<table>`/`<thead>`/`<tbody>`/`<tr>`/`<th>`/`<td>`/`<tfoot>`/`<caption>` — no ARIA-on-divs.
+- Visual modifiers on root: `density` (`'comfortable'` (default, 32px row) / `'dense'` (24px)), `hover` (default `true`), `striped`, `stickyHeader`, `scroll` (default `true` — wraps in `overflow-x: auto`).
+- `<Table.Row selected>` paints a tinted bg + `aria-selected="true"`. Selection state itself is the consumer's job.
+- `<Table.HeaderCell sortDirection>` is a visual hook: renders a chevron + sets `aria-sort`. Wire `onClick` to your own sort state. `<DataTable>` (not yet shipped) will compose this seam.
+- `<Table.Cell align>` / `<Table.HeaderCell align>`: `'start' | 'center' | 'end'` (CSS logical, RTL-friendly). Right-aligned for numbers / amounts; the sort chevron auto-flips to the start side.
+- `<Table.Cell truncate>` ellipses overflow text on one line. Requires a constrained cell width.
+- **Use `<DataTable>` instead** when you need sorting / filtering / pagination state. Table is the paint primitive; DataTable will be the opinionated wrapper.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/AGENTS.md
+git commit -m "AGENTS.md: document new <Table> compound primitive"
+```
+
+---
+
+## Task 7: Final gates + Hard Rule 8 + PR
+
+- [ ] **Step 1: Prettier write**
+
+```bash
+npx prettier --write "packages/**/src/**/*.{ts,tsx,scss}" "docs/**/*.md" "packages/design-system/AGENTS.md"
+git add -A packages/ docs/
+git diff --cached --stat
+git commit -m "Prettier: format Table primitive changes" || echo "no formatting changes"
+```
+
+- [ ] **Step 2: Full gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test --workspace=@eocrm/design-system --run 2>&1 | tail -5
+npm run typecheck 2>&1 | tail -5
+npm run lint:css 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+npx prettier --check "packages/**/src/**/*.{ts,tsx,scss}" "docs/**/*.md" "packages/design-system/AGENTS.md" 2>&1 | tail -3
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -cE "\\.test\\."
+```
+
+All green; npm-pack count = 0.
+
+- [ ] **Step 3: Push**
+
+```bash
+git push -u origin feat/table-primitive
+```
+
+- [ ] **Step 4: Hard Rule 8 review cycle 1**
+
+Dispatch a fresh `general-purpose` review agent. Brief:
+
+- Required reading: repo `CLAUDE.md`, package `CLAUDE.md`, `AGENTS.md`, the spec `docs/superpowers/specs/2026-05-21-table-primitive-design.md`, full diff `git diff main..HEAD -- packages/`.
+- 10-category review (bugs, a11y, API consistency, type safety, Rules 1–7, test coverage, token discipline, SCSS, cross-package leakage, package/distribution).
+- Specifics to look at hard:
+  - `Object.assign(TableRoot, { ... })` — does TypeScript correctly type the subcomponents on `Table.Header` etc.? `Table.Body` should be a forwardRef component accepting `TableSectionProps`.
+  - Native HTML semantics — `<th>` `scope="col"` by default; `<td>` with no scope; verify the sort chevron does NOT consume the cell's click event independently (it's a sibling span inside `.thInner`, click bubbles to `<th>`).
+  - Rule 4 escape hatches: `position: sticky` on `<th>` (internal layout for sticky scrolling) — documented? `max-width: 0` on `.truncate` — flex-truncate idiom, documented? The outer `.scrollWrap` `<div>` introduces a width:100% + overflow-x:auto box that's not the Table itself but its wrapper — acceptable internal helper, no Rule 4 violation.
+  - Token discipline: no raw hex / px outside `tokens.scss`.
+  - `aria-sort` values are `"ascending" | "descending" | "none"` (strings, not booleans).
+  - `<Table.Row selected>` `aria-selected="true"` is set on `<tr>` — does AT actually use this attribute on table rows? It's valid HTML but not commonly used. Worth noting in the review but not a blocker.
+
+- [ ] **Step 5: Fix Critical + Important findings; re-push; re-review until verdict is `clean enough to stop`.**
+
+- [ ] **Step 6: Open PR**
+
+```bash
+gh pr create --title "Table: compound primitive (density / hover / striped / sticky / sort-indicator)" --body "$(cat <<'EOF'
+## Summary
+
+- New `<Table>` compound primitive — `Table`, `Table.Caption`, `Table.Header`, `Table.Body`, `Table.Footer`, `Table.Row`, `Table.HeaderCell`, `Table.Cell`. Native HTML semantics throughout (`<table>`/`<thead>`/`<tbody>`/`<tr>`/`<th>`/`<td>`/`<tfoot>`/`<caption>`); no ARIA-on-divs.
+- Visual modifiers on root: `density` (`'comfortable' | 'dense'`), `hover` (default on), `striped`, `stickyHeader`, `scroll` (default on — wraps in horizontal-scroll `<div>`).
+- `<Table.Row selected>` paints a tinted bg + `aria-selected="true"`.
+- `<Table.HeaderCell sortDirection>` renders an up/down/unsorted chevron + sets `aria-sort`. The primitive only paints the indicator — wire `onClick` to your own sort state. This is the seam `<DataTable>` will compose against.
+- `<Table.Cell align>` / `<Table.HeaderCell align>` — `'start' | 'center' | 'end'` (CSS logical). Right-aligned headers auto-flip the sort chevron to the start side.
+- `<Table.Cell truncate>` ellipses overflow text on a single line.
+- No data behavior (sort logic, pagination, filtering, selection state machinery, empty/loading states) — those live in the future `<DataTable>`, not in the primitive.
+
+## Test plan
+
+- [x] `npm test --run` — all green, including new Table tests (subcomponents render, modifiers apply, ref forwards, className merges, sort visuals + aria-sort, truncate / align classes).
+- [x] `npm run typecheck` clean
+- [x] `npm run lint:css` clean
+- [x] `npm run build` clean
+- [x] `npx prettier --check` clean
+- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files in tarball
+- [x] Manual smoke (Playwright) — Default, Dense, Striped, Sortable, Selected, Sticky, Truncated examples all render correctly; sort chevron flips on click.
+- [x] Hard Rule 8 review cycle — final verdict: clean enough to stop.
+
+## Design spec / plan
+
+- Spec: \`docs/superpowers/specs/2026-05-21-table-primitive-design.md\`
+- Plan: \`docs/superpowers/plans/2026-05-21-table-primitive.md\`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+Spec coverage:
+
+- §Compound API + native HTML semantics → Task 2.
+- §Visual modifiers (density, hover, striped, sticky, scroll) → Task 2.
+- §Sortable header visual hook → Task 2 + Task 5 (SortableTable demo).
+- §`selected` row paint → Task 2 + Task 5 (SelectableTable demo).
+- §`truncate` cell → Task 2 + Task 5 (Truncated cell demo).
+- §Tokens (all existing) → Task 2 SCSS.
+- §Tests → Task 3.
+- §Re-exports → Task 4.
+- §Playground demo → Task 5.
+- §AGENTS.md section → Task 6.
+- §Hard Rule 8 + PR → Task 7.
+
+Type consistency:
+
+- `TableDensity = 'comfortable' | 'dense'`
+- `TableCellAlign = 'start' | 'center' | 'end'`
+- `TableSortDirection = 'asc' | 'desc' | 'none'`
+- All re-exported from both barrels.
+
+No placeholders. All paths absolute. All commits scoped.

--- a/docs/superpowers/plans/2026-05-21-table-primitive.md
+++ b/docs/superpowers/plans/2026-05-21-table-primitive.md
@@ -195,7 +195,16 @@ const sortAriaFor: Record<TableSortDirection, 'ascending' | 'descending' | 'none
  *   follow-up to add a `rowHeader` prop.
  */
 const TableRoot = forwardRef<HTMLTableElement, TableProps>(function TableRoot(
-  { density = 'comfortable', striped, hover = true, stickyHeader, scroll = true, className, children, ...props },
+  {
+    density = 'comfortable',
+    striped,
+    hover = true,
+    stickyHeader,
+    scroll = true,
+    className,
+    children,
+    ...props
+  },
   ref,
 ) {
   const table = (
@@ -280,35 +289,37 @@ const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(function TableRo
   );
 });
 
-const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellProps>(function TableHeaderCell(
-  { align = 'start', sortDirection, scope = 'col', className, children, ...props },
-  ref,
-) {
-  const sortable = sortDirection != null;
-  const SortIcon =
-    sortDirection === 'asc' ? ChevronUp : sortDirection === 'desc' ? ChevronDown : ChevronsUpDown;
+const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellProps>(
+  function TableHeaderCell(
+    { align = 'start', sortDirection, scope = 'col', className, children, ...props },
+    ref,
+  ) {
+    const sortable = sortDirection != null;
+    const SortIcon =
+      sortDirection === 'asc' ? ChevronUp : sortDirection === 'desc' ? ChevronDown : ChevronsUpDown;
 
-  return (
-    <th
-      ref={ref}
-      scope={scope}
-      aria-sort={sortable ? sortAriaFor[sortDirection] : undefined}
-      className={clsx(
-        styles.th,
-        styles[`align-${align}`],
-        sortable && styles.sortable,
-        sortable && sortDirection === 'none' && styles.sortableInactive,
-        className,
-      )}
-      {...props}
-    >
-      <span className={styles.thInner}>
-        <span>{children}</span>
-        {sortable && <SortIcon size={12} aria-hidden="true" className={styles.sortIcon} />}
-      </span>
-    </th>
-  );
-});
+    return (
+      <th
+        ref={ref}
+        scope={scope}
+        aria-sort={sortable ? sortAriaFor[sortDirection] : undefined}
+        className={clsx(
+          styles.th,
+          styles[`align-${align}`],
+          sortable && styles.sortable,
+          sortable && sortDirection === 'none' && styles.sortableInactive,
+          className,
+        )}
+        {...props}
+      >
+        <span className={styles.thInner}>
+          <span>{children}</span>
+          {sortable && <SortIcon size={12} aria-hidden="true" className={styles.sortIcon} />}
+        </span>
+      </th>
+    );
+  },
+);
 
 const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(function TableCell(
   { align = 'start', truncate, className, children, ...props },
@@ -317,12 +328,7 @@ const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(function Tabl
   return (
     <td
       ref={ref}
-      className={clsx(
-        styles.td,
-        styles[`align-${align}`],
-        truncate && styles.truncate,
-        className,
-      )}
+      className={clsx(styles.td, styles[`align-${align}`], truncate && styles.truncate, className)}
       {...props}
     >
       {children}
@@ -600,7 +606,9 @@ describe('Table', () => {
   });
 
   it('applies density / hover / striped / stickyHeader class names', () => {
-    const { container, rerender } = render(<Table density="dense" striped hover={false} stickyHeader />);
+    const { container, rerender } = render(
+      <Table density="dense" striped hover={false} stickyHeader />,
+    );
     const table = container.querySelector('table')!;
     expect(table.className).toMatch(/density-dense/);
     expect(table.className).toMatch(/striped/);
@@ -1089,7 +1097,14 @@ export function TableDemo() {
   <Table stickyHeader scroll={false}>{...}</Table>
 </div>`}
       >
-        <div style={{ maxHeight: 200, overflow: 'auto', border: 'var(--border-width) solid var(--color-border)', borderRadius: 'var(--radius-md)' }}>
+        <div
+          style={{
+            maxHeight: 200,
+            overflow: 'auto',
+            border: 'var(--border-width) solid var(--color-border)',
+            borderRadius: 'var(--radius-md)',
+          }}
+        >
           <Table stickyHeader scroll={false}>
             <Table.Header>
               <Table.Row>
@@ -1153,7 +1168,7 @@ Add the import + route in the alphabetical position (after `Select` and before `
 ```tsx
 import { TableDemo } from './pages/components/TableDemo';
 // …
-<Route path="/components/table" element={<TableDemo />} />
+<Route path="/components/table" element={<TableDemo />} />;
 ```
 
 - [ ] **Step 3: Wire `AppShell.tsx`**
@@ -1224,6 +1239,7 @@ make dev  # or assume already running on :8080
 ```
 
 Visit `http://localhost:8080/components/table`. Verify:
+
 - All 7 Examples render.
 - Sortable headers toggle on click and the chevron flips.
 - Selected row tints on click.
@@ -1255,7 +1271,7 @@ Table is a Display/Data component. Slot it between `<Select>` (last Forms entry)
 
 - [ ] **Step 2: Insert this section**
 
-```markdown
+````markdown
 ### `<Table>` — tabular data primitive
 
 ```tsx
@@ -1276,6 +1292,7 @@ Table is a Display/Data component. Slot it between `<Select>` (last Forms entry)
   </Table.Body>
 </Table>
 ```
+````
 
 - Compound subcomponents: `Table`, `Table.Caption`, `Table.Header`, `Table.Body`, `Table.Footer`, `Table.Row`, `Table.HeaderCell`, `Table.Cell`. Renders native `<table>`/`<thead>`/`<tbody>`/`<tr>`/`<th>`/`<td>`/`<tfoot>`/`<caption>` — no ARIA-on-divs.
 - Visual modifiers on root: `density` (`'comfortable'` (default, 32px row) / `'dense'` (24px)), `hover` (default `true`), `striped`, `stickyHeader`, `scroll` (default `true` — wraps in `overflow-x: auto`).
@@ -1284,14 +1301,15 @@ Table is a Display/Data component. Slot it between `<Select>` (last Forms entry)
 - `<Table.Cell align>` / `<Table.HeaderCell align>`: `'start' | 'center' | 'end'` (CSS logical, RTL-friendly). Right-aligned for numbers / amounts; the sort chevron auto-flips to the start side.
 - `<Table.Cell truncate>` ellipses overflow text on one line. Requires a constrained cell width.
 - **Use `<DataTable>` instead** when you need sorting / filtering / pagination state. Table is the paint primitive; DataTable will be the opinionated wrapper.
-```
+
+````
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add packages/design-system/AGENTS.md
 git commit -m "AGENTS.md: document new <Table> compound primitive"
-```
+````
 
 ---
 

--- a/docs/superpowers/specs/2026-05-21-table-primitive-design.md
+++ b/docs/superpowers/specs/2026-05-21-table-primitive-design.md
@@ -1,0 +1,256 @@
+# Table primitive — design spec
+
+**Date:** 2026-05-21
+**Branch:** `feat/table-primitive`
+**Scope:** New `<Table>` compound component. Purely visual primitive — no data behavior. DataTable (sort / filter / pagination / selection) is a separate future PR composing this primitive + TanStack Table headless.
+
+## Goal
+
+Ship the building blocks every CRM screen needs to render tabular data: a token-correct, accessible, native-HTML-based `<table>` with controlled density, opt-in hover/striped/sticky-header visuals, and a sort-indicator hook on header cells. Consumers wire their own data; this primitive just paints.
+
+## Why a primitive first
+
+- Lots of CRM screens render fixed-row tables (settings panels, summary lists, form-embedded data) that don't need column-defs / sort state. Forcing those through a heavyweight DataTable would be wrong.
+- DataTable (the next PR) will compose this primitive — so the styling work has to happen here first or DataTable will end up rebuilding it.
+- Aligns with established design-system convention: Mantine, Chakra, MUI all ship a primitive Table + an opinionated data wrapper.
+
+## Architecture
+
+Compound component using `Object.assign`-attached subcomponents (matches existing `DropdownMenu` pattern in this repo):
+
+```tsx
+<Table>
+  <Table.Caption>Recent activity</Table.Caption>
+  <Table.Header>
+    <Table.Row>
+      <Table.HeaderCell>Name</Table.HeaderCell>
+      <Table.HeaderCell>Status</Table.HeaderCell>
+      <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    {rows.map((row) => (
+      <Table.Row key={row.id}>
+        <Table.Cell>{row.name}</Table.Cell>
+        <Table.Cell>{row.status}</Table.Cell>
+        <Table.Cell align="end">{row.amount}</Table.Cell>
+      </Table.Row>
+    ))}
+  </Table.Body>
+</Table>
+```
+
+Native HTML elements throughout (`<table>`, `<thead>`, `<tbody>`, `<tr>`, `<th>`, `<td>`, `<tfoot>`, `<caption>`). No ARIA-roles-on-divs — native semantics are AT-friendly out of the box.
+
+### Subcomponents
+
+| Subcomponent          | Renders          | Purpose                                                 |
+| --------------------- | ---------------- | ------------------------------------------------------- |
+| `<Table>`             | `<table>`        | Root. Owns density + visual variants.                   |
+| `<Table.Caption>`     | `<caption>`      | Accessible title for the table.                         |
+| `<Table.Header>`      | `<thead>`        | Header row(s).                                          |
+| `<Table.Body>`        | `<tbody>`        | Data rows.                                              |
+| `<Table.Footer>`      | `<tfoot>`        | Footer row(s) — totals, summary, etc.                   |
+| `<Table.Row>`         | `<tr>`           | A row. Carries hover/striped/selected visual.           |
+| `<Table.HeaderCell>`  | `<th>`           | Column header. `scope="col"` by default.                |
+| `<Table.Cell>`        | `<td>`           | Body / footer cell.                                     |
+
+### Root `<Table>` props
+
+```ts
+export type TableDensity = 'comfortable' | 'dense';
+
+export interface TableProps extends Omit<HTMLAttributes<HTMLTableElement>, 'children'> {
+  /**
+   * Row height + cell padding scale. Defaults to `'comfortable'`.
+   * - `'comfortable'` — 32px row, --space-3 cell padding, --font-size-md.
+   * - `'dense'`       — 24px row, --space-2 cell padding, --font-size-sm.
+   */
+  density?: TableDensity;
+  /** Zebra-striped body rows. Defaults to `false`. */
+  striped?: boolean;
+  /** Hover highlight on body rows. Defaults to `true`. */
+  hover?: boolean;
+  /**
+   * `position: sticky` on the header so it stays visible while body scrolls.
+   * Requires a scrollable ancestor (the default `scroll` wrapper provides
+   * one). Defaults to `false`.
+   */
+  stickyHeader?: boolean;
+  /**
+   * When `true` (default), the `<table>` is wrapped in a `<div>` with
+   * `overflow-x: auto` so wide tables scroll horizontally inside their
+   * container. Set to `false` to render a bare `<table>` (the consumer
+   * manages their own scroll context).
+   */
+  scroll?: boolean;
+  children: ReactNode;
+}
+```
+
+### `<Table.Row>` props
+
+```ts
+export interface TableRowProps extends HTMLAttributes<HTMLTableRowElement> {
+  /**
+   * Visual selected state. Pair with a checkbox cell + the consumer's own
+   * selection state. Adds `aria-selected="true"` and a subtle accent tint.
+   */
+  selected?: boolean;
+}
+```
+
+No `hover` / `striped` per-row — those are table-wide visual modifiers.
+
+### `<Table.HeaderCell>` props
+
+```ts
+export type TableSortDirection = 'asc' | 'desc' | 'none';
+export type TableCellAlign = 'start' | 'center' | 'end';
+
+export interface TableHeaderCellProps extends ThHTMLAttributes<HTMLTableCellElement> {
+  /** Text alignment inside the header cell. Defaults to `'start'`. */
+  align?: TableCellAlign;
+  /**
+   * When set, the cell renders a sort indicator (up/down chevron) and
+   * sets `aria-sort`. The consumer drives interactivity by passing an
+   * `onClick` — the primitive only paints the indicator.
+   * - `'asc'`  → up chevron + `aria-sort="ascending"`.
+   * - `'desc'` → down chevron + `aria-sort="descending"`.
+   * - `'none'` → muted "unsorted" chevron + `aria-sort="none"`.
+   * Omit to render a non-sortable header (no chevron, no `aria-sort`).
+   */
+  sortDirection?: TableSortDirection;
+}
+```
+
+When `sortDirection` is set, the cell becomes a clickable button visually (cursor pointer, hover bg). The consumer wires the onClick — this is the DataTable composition seam.
+
+### `<Table.Cell>` props
+
+```ts
+export interface TableCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
+  /** Text alignment inside the cell. Defaults to `'start'`. */
+  align?: TableCellAlign;
+  /**
+   * Suppress text-wrapping. When true, the cell content stays on one line
+   * and truncates with ellipsis if it overflows. Useful for IDs, dates,
+   * status badges.
+   */
+  truncate?: boolean;
+}
+```
+
+`truncate` is the one consumer-facing convenience worth bundling because text-wrap behavior is the #1 thing every Table consumer asks for. Sets `white-space: nowrap; text-overflow: ellipsis; overflow: hidden;` on the cell — requires a constrained width from the column (a CSS variable or `<col width>` if the consumer cares).
+
+## Visual reference (tokens used)
+
+All values come from existing tokens. No new tokens added.
+
+| Visual                        | Token                                  |
+| ----------------------------- | -------------------------------------- |
+| Header bg                     | `--color-bg-subtle`                    |
+| Header fg                     | `--color-fg-muted`                     |
+| Header underline              | `--color-border` (bottom 1px)          |
+| Row divider                   | `--color-border` (bottom 1px)          |
+| Row hover bg                  | `--color-bg-subtle`                    |
+| Row striped bg (even)         | `--color-bg-subtle`                    |
+| Row selected bg               | `--color-accent-bg-subtle`             |
+| Row selected fg               | `--color-fg`                           |
+| Cell padding (comfortable)    | `--space-3` (12px) horiz, `--space-2` vert |
+| Cell padding (dense)          | `--space-2` (8px) horiz, `--space-1` vert  |
+| Row height (comfortable)      | `--size-md` (32px) min-height          |
+| Row height (dense)            | `--size-sm` (24px) min-height          |
+| Font size (comfortable)       | `--font-size-md`                       |
+| Font size (dense)             | `--font-size-sm`                       |
+| Sort chevron icon size        | 12px (matches existing 14px / 12px lucide convention; tight to header text) |
+
+Sticky-header background must be opaque (`--color-bg-subtle`) so scrolling body rows don't show through.
+
+## Behavior
+
+- **Hover**: when `hover` is true (default), rows in `<Table.Body>` get a subtle bg on `:hover`. Header / footer rows do not hover-highlight.
+- **Striped**: when `striped` is true, even-numbered body rows (1-indexed: 2nd, 4th, …) get `--color-bg-subtle`. Combines cleanly with hover (hover wins via CSS specificity).
+- **Selected**: a row with `selected` gets a tinted bg + `aria-selected="true"`. Selected ALWAYS wins over hover/striped.
+- **Sticky header**: header cells get `position: sticky; top: 0;` + a z-index above body rows. The default `scroll` wrapper provides the scroll context. If `scroll={false}`, the consumer must provide one.
+- **Scroll wrapper**: `<div>` with `overflow-x: auto`. Renders an automatic horizontal scrollbar when the table is wider than its container.
+- **Sortable header cell**: renders the cell's children + a chevron icon inline-end. Cursor pointer + hover bg signal interactivity. `aria-sort` set correctly.
+- **Captions**: `<caption>` defaults to `caption-side: top` in HTML; we keep that.
+
+## Accessibility
+
+- Native HTML semantics throughout. No ARIA spoofing.
+- `<th>` with `scope="col"` by default — handled inside `<Table.HeaderCell>`.
+- `aria-sort` on sortable header cells.
+- `aria-selected` on selected rows.
+- Caption read by AT as the table's accessible name.
+- Sticky header doesn't break AT (sticky is a paint-only optimization).
+
+## File layout
+
+```
+packages/design-system/src/components/Table/
+  Table.tsx              ← root + Object.assign-attached subcomponents
+  Table.module.scss
+  Table.test.tsx
+  index.ts               ← re-exports
+```
+
+Single file for the entire component family — matches `DropdownMenu`'s pattern. Internal subcomponent functions live in `Table.tsx`; the `Table` export is the `Object.assign(Root, { Caption, Header, Body, Footer, Row, HeaderCell, Cell })` value.
+
+## Tests
+
+Standard Rule 1 coverage:
+
+- Default render — `<Table><Table.Body><Table.Row><Table.Cell>…</Table.Cell></Table.Row></Table.Body></Table>` renders the expected DOM.
+- Density modifier applies the right class.
+- `hover` / `striped` / `stickyHeader` apply their classes.
+- `<Table.Row selected>` carries `aria-selected="true"`.
+- `<Table.HeaderCell sortDirection="asc">` renders the up chevron + `aria-sort="ascending"`.
+- `<Table.HeaderCell>` without `sortDirection` does NOT render a chevron and does NOT set `aria-sort`.
+- `<Table.Cell align="end">` applies the right alignment class.
+- `<Table.Cell truncate>` applies the truncate class.
+- `scroll={false}` does NOT wrap in the outer `<div>`.
+- ForwardRef on `<Table>` reaches the `<table>` element.
+- `className` on every subcomponent is merged, not replaced.
+
+## Playground demo
+
+`TableDemo.tsx` with examples:
+
+1. **Default** — small static table (3 rows, 3 columns). Density=comfortable, hover on, no stripes.
+2. **Dense** — same data, density=dense.
+3. **Striped + hover** — striped rows.
+4. **Selected row** — one row with `selected`.
+5. **Sortable headers** — clickable header cells that toggle a local sort state and re-render with the right `sortDirection` chevron. Demonstrates the DataTable composition seam without actually shipping DataTable.
+6. **Sticky header** — table in a fixed-height container that scrolls; header stays pinned.
+7. **Truncated cell** — a column with `<Table.Cell truncate>` containing a long string that ellipses.
+
+## AGENTS.md
+
+Add a `<Table>` section right before `<DropdownMenu>` (or wherever Display alphabetically lands). Document:
+
+- Compound subcomponents list.
+- Density + visual modifiers.
+- Sortable header is a visual hook — DataTable composes it.
+- "Use `<DataTable>` (not yet shipped) when you need sorting / filtering / pagination state."
+
+## Non-goals
+
+- **Selection state machinery**. Visual `selected` prop only; selection logic lives in DataTable / consumer.
+- **Empty / loading / error states**. DataTable concern. Consumer renders their own `<Table.Cell colSpan={n}>Empty</Table.Cell>` if needed.
+- **Pagination footer**. DataTable concern.
+- **Virtualization**. DataTable v2 maybe.
+- **Column resizing / reordering**. DataTable v2 maybe.
+- **Row expansion / nested rows**. Out of scope; future spec if a CRM screen needs it.
+- **Row as link**. Consumer wraps cells in `<Link>`. We don't need an `asChild` pattern here yet.
+- **Bordered variant**. Skip in v1; Atlassian-style minimal borders (header underline + row dividers) is the default. Add later if a CRM screen needs full borders.
+- **xs / lg density**. Two densities is enough. Extend if a CRM screen demands it.
+
+## Risks / open questions
+
+- **`Object.assign` attached subcomponents + TypeScript ref inference**: each subcomponent uses `forwardRef`, so `Table.Body` etc. should accept refs typed to their respective HTML element. Verify in tests.
+- **Sticky header z-index**: needs to sit above selected/hover row backgrounds. Use a small positive z-index (e.g., `z-index: 1`) on the `<th>` — not a global token because this is a table-internal stacking context.
+- **Scroll wrapper Rule 4 compliance**: the outer `<div>` introduces a layout-impacting box (`overflow-x: auto`). Rule 4 forbids layout properties on the *component* box; this is on the WRAPPER (a sibling helper) and is the documented scroll-container pattern (matches how Calendar, Select, DatePicker handle their own internal wrappers). Acceptable.
+- **`align` prop semantics**: `start | center | end` (CSS logical) vs `left | right | center` (physical). Going with logical — matches RTL future and the existing Cluster/Stack `justify`/`align` props.
+- **Caption position**: HTML default is `caption-side: top`. Atlassian uses caption-top. Keep default.

--- a/docs/superpowers/specs/2026-05-21-table-primitive-design.md
+++ b/docs/superpowers/specs/2026-05-21-table-primitive-design.md
@@ -44,16 +44,16 @@ Native HTML elements throughout (`<table>`, `<thead>`, `<tbody>`, `<tr>`, `<th>`
 
 ### Subcomponents
 
-| Subcomponent          | Renders          | Purpose                                                 |
-| --------------------- | ---------------- | ------------------------------------------------------- |
-| `<Table>`             | `<table>`        | Root. Owns density + visual variants.                   |
-| `<Table.Caption>`     | `<caption>`      | Accessible title for the table.                         |
-| `<Table.Header>`      | `<thead>`        | Header row(s).                                          |
-| `<Table.Body>`        | `<tbody>`        | Data rows.                                              |
-| `<Table.Footer>`      | `<tfoot>`        | Footer row(s) — totals, summary, etc.                   |
-| `<Table.Row>`         | `<tr>`           | A row. Carries hover/striped/selected visual.           |
-| `<Table.HeaderCell>`  | `<th>`           | Column header. `scope="col"` by default.                |
-| `<Table.Cell>`        | `<td>`           | Body / footer cell.                                     |
+| Subcomponent         | Renders     | Purpose                                       |
+| -------------------- | ----------- | --------------------------------------------- |
+| `<Table>`            | `<table>`   | Root. Owns density + visual variants.         |
+| `<Table.Caption>`    | `<caption>` | Accessible title for the table.               |
+| `<Table.Header>`     | `<thead>`   | Header row(s).                                |
+| `<Table.Body>`       | `<tbody>`   | Data rows.                                    |
+| `<Table.Footer>`     | `<tfoot>`   | Footer row(s) — totals, summary, etc.         |
+| `<Table.Row>`        | `<tr>`      | A row. Carries hover/striped/selected visual. |
+| `<Table.HeaderCell>` | `<th>`      | Column header. `scope="col"` by default.      |
+| `<Table.Cell>`       | `<td>`      | Body / footer cell.                           |
 
 ### Root `<Table>` props
 
@@ -147,23 +147,23 @@ export interface TableCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
 
 All values come from existing tokens. No new tokens added.
 
-| Visual                        | Token                                  |
-| ----------------------------- | -------------------------------------- |
-| Header bg                     | `--color-bg-subtle`                    |
-| Header fg                     | `--color-fg-muted`                     |
-| Header underline              | `--color-border` (bottom 1px)          |
-| Row divider                   | `--color-border` (bottom 1px)          |
-| Row hover bg                  | `--color-bg-subtle`                    |
-| Row striped bg (even)         | `--color-bg-subtle`                    |
-| Row selected bg               | `--color-accent-bg-subtle`             |
-| Row selected fg               | `--color-fg`                           |
-| Cell padding (comfortable)    | `--space-3` (12px) horiz, `--space-2` vert |
-| Cell padding (dense)          | `--space-2` (8px) horiz, `--space-1` vert  |
-| Row height (comfortable)      | `--size-md` (32px) min-height          |
-| Row height (dense)            | `--size-sm` (24px) min-height          |
-| Font size (comfortable)       | `--font-size-md`                       |
-| Font size (dense)             | `--font-size-sm`                       |
-| Sort chevron icon size        | 12px (matches existing 14px / 12px lucide convention; tight to header text) |
+| Visual                     | Token                                                                       |
+| -------------------------- | --------------------------------------------------------------------------- |
+| Header bg                  | `--color-bg-subtle`                                                         |
+| Header fg                  | `--color-fg-muted`                                                          |
+| Header underline           | `--color-border` (bottom 1px)                                               |
+| Row divider                | `--color-border` (bottom 1px)                                               |
+| Row hover bg               | `--color-bg-subtle`                                                         |
+| Row striped bg (even)      | `--color-bg-subtle`                                                         |
+| Row selected bg            | `--color-accent-bg-subtle`                                                  |
+| Row selected fg            | `--color-fg`                                                                |
+| Cell padding (comfortable) | `--space-3` (12px) horiz, `--space-2` vert                                  |
+| Cell padding (dense)       | `--space-2` (8px) horiz, `--space-1` vert                                   |
+| Row height (comfortable)   | `--size-md` (32px) min-height                                               |
+| Row height (dense)         | `--size-sm` (24px) min-height                                               |
+| Font size (comfortable)    | `--font-size-md`                                                            |
+| Font size (dense)          | `--font-size-sm`                                                            |
+| Sort chevron icon size     | 12px (matches existing 14px / 12px lucide convention; tight to header text) |
 
 Sticky-header background must be opaque (`--color-bg-subtle`) so scrolling body rows don't show through.
 
@@ -251,6 +251,6 @@ Add a `<Table>` section right before `<DropdownMenu>` (or wherever Display alpha
 
 - **`Object.assign` attached subcomponents + TypeScript ref inference**: each subcomponent uses `forwardRef`, so `Table.Body` etc. should accept refs typed to their respective HTML element. Verify in tests.
 - **Sticky header z-index**: needs to sit above selected/hover row backgrounds. Use a small positive z-index (e.g., `z-index: 1`) on the `<th>` — not a global token because this is a table-internal stacking context.
-- **Scroll wrapper Rule 4 compliance**: the outer `<div>` introduces a layout-impacting box (`overflow-x: auto`). Rule 4 forbids layout properties on the *component* box; this is on the WRAPPER (a sibling helper) and is the documented scroll-container pattern (matches how Calendar, Select, DatePicker handle their own internal wrappers). Acceptable.
+- **Scroll wrapper Rule 4 compliance**: the outer `<div>` introduces a layout-impacting box (`overflow-x: auto`). Rule 4 forbids layout properties on the _component_ box; this is on the WRAPPER (a sibling helper) and is the documented scroll-container pattern (matches how Calendar, Select, DatePicker handle their own internal wrappers). Acceptable.
 - **`align` prop semantics**: `start | center | end` (CSS logical) vs `left | right | center` (physical). Going with logical — matches RTL future and the existing Cluster/Stack `justify`/`align` props.
 - **Caption position**: HTML default is `caption-side: top`. Atlassian uses caption-top. Keep default.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -425,6 +425,36 @@ const [tab, setTab] = useState('overview');
 - Don't reach for `triggerDisplay='summary'` for tag input — chips communicate the active filter set at a glance.
 - `creatable` requires `searchable` (throws in dev). Passing both `options` and `loadOptions` is also flagged (loadOptions wins).
 
+### `<Table>` — tabular data primitive
+
+```tsx
+<Table>
+  <Table.Header>
+    <Table.Row>
+      <Table.HeaderCell>Name</Table.HeaderCell>
+      <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    {rows.map((r) => (
+      <Table.Row key={r.id}>
+        <Table.Cell>{r.name}</Table.Cell>
+        <Table.Cell align="end">{r.amount}</Table.Cell>
+      </Table.Row>
+    ))}
+  </Table.Body>
+</Table>
+```
+
+- Compound subcomponents: `Table`, `Table.Caption`, `Table.Header`, `Table.Body`, `Table.Footer`, `Table.Row`, `Table.HeaderCell`, `Table.Cell`. Renders native `<table>` / `<thead>` / `<tbody>` / `<tr>` / `<th>` / `<td>` / `<tfoot>` / `<caption>` — no ARIA-on-divs.
+- Visual modifiers on root: `density` (`'comfortable'` (default, 32px row) / `'dense'` (24px)), `hover` (default `true`), `striped`, `stickyHeader`, `scroll` (default `true` — wraps in `overflow-x: auto`).
+- `<Table.Row selected>` paints a tinted bg + `aria-selected="true"`. Selection state itself is the consumer's job.
+- `<Table.HeaderCell sortDirection>` is a visual hook: renders an up / down / unsorted chevron + sets `aria-sort`. Wire `onClick` to your own sort state. `<DataTable>` (not yet shipped) will compose this seam.
+- `<Table.Cell align>` / `<Table.HeaderCell align>`: `'start' | 'center' | 'end'` (CSS logical, RTL-friendly). Right-aligned headers auto-flip the sort chevron to the start side.
+- `<Table.Cell truncate>` ellipses overflow text on one line. Requires a constrained cell width (`style={{ maxWidth }}` or `<col>`).
+- The native HTML `align` attribute on `<th>` / `<td>` is shadowed by the component-level `align` prop (logical) — `Omit<…, 'align'>` on both `*Props`.
+- **Use `<DataTable>` instead** when you need sorting / filtering / pagination state. Table is the paint primitive; DataTable will be the opinionated wrapper.
+
 ### `<LocaleProvider>` + `useLocale` — locale Context
 
 ```tsx

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -447,7 +447,7 @@ const [tab, setTab] = useState('overview');
 ```
 
 - Compound subcomponents: `Table`, `Table.Caption`, `Table.Header`, `Table.Body`, `Table.Footer`, `Table.Row`, `Table.HeaderCell`, `Table.Cell`. Renders native `<table>` / `<thead>` / `<tbody>` / `<tr>` / `<th>` / `<td>` / `<tfoot>` / `<caption>` — no ARIA-on-divs.
-- Visual modifiers on root: `density` (`'comfortable'` (default, 32px row) / `'dense'` (24px)), `hover` (default `true`), `striped`, `stickyHeader`, `scroll` (default `true` — wraps in `overflow-x: auto`).
+- Visual modifiers on root: `density` (`'comfortable'` (default, 32px row) / `'dense'` (24px)), `hover` (default `true`), `striped`, `bordered` (full-grid borders; default off — Atlassian-minimal style is just row dividers + header underline), `stickyHeader`, `scroll` (default `true` — wraps in `overflow-x: auto`).
 - `<Table.Row selected>` paints a tinted bg + `aria-selected="true"`. Selection state itself is the consumer's job.
 - `<Table.HeaderCell sortDirection>` is a visual hook: renders an up / down / unsorted chevron + sets `aria-sort`. Wire `onClick` to your own sort state. `<DataTable>` (not yet shipped) will compose this seam.
 - `<Table.Cell align>` / `<Table.HeaderCell align>`: `'start' | 'center' | 'end'` (CSS logical, RTL-friendly). Right-aligned headers auto-flip the sort chevron to the start side.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -447,7 +447,7 @@ const [tab, setTab] = useState('overview');
 ```
 
 - Compound subcomponents: `Table`, `Table.Caption`, `Table.Header`, `Table.Body`, `Table.Footer`, `Table.Row`, `Table.HeaderCell`, `Table.Cell`. Renders native `<table>` / `<thead>` / `<tbody>` / `<tr>` / `<th>` / `<td>` / `<tfoot>` / `<caption>` — no ARIA-on-divs.
-- Visual modifiers on root: `density` (`'comfortable'` (default, 32px row) / `'dense'` (24px)), `hover` (default `true`), `striped`, `bordered` (full-grid borders; default off — Atlassian-minimal style is just row dividers + header underline), `stickyHeader`, `scroll` (default `true` — wraps in `overflow-x: auto`).
+- Visual modifiers on root: `density` (`'comfortable'` (default, 32px row) / `'dense'` (24px)), `hover` (default off — opt in for clickable / selectable row lists), `striped`, `bordered` (full-grid borders; default off — Atlassian-minimal style is just row dividers + header underline), `stickyHeader`, `scroll` (default `true` — wraps in `overflow-x: auto`).
 - `<Table.Row selected>` paints a tinted bg + `aria-selected="true"`. Selection state itself is the consumer's job.
 - `<Table.HeaderCell sortDirection>` is a visual hook: renders an up / down / unsorted chevron + sets `aria-sort`. Wire `onClick` to your own sort state. `<DataTable>` (not yet shipped) will compose this seam.
 - `<Table.Cell align>` / `<Table.HeaderCell align>`: `'start' | 'center' | 'end'` (CSS logical, RTL-friendly). Right-aligned headers auto-flip the sort chevron to the start side.

--- a/packages/design-system/src/components/Table/Table.module.scss
+++ b/packages/design-system/src/components/Table/Table.module.scss
@@ -35,30 +35,50 @@
   text-align: start;
 }
 
+// Three distinct background tones in a hierarchy:
+//   header / footer  → --color-bg-muted   (#f4f5f7)  — visibly chrome-y
+//   striped (even)   → --color-bg-subtle  (#fafbfc)  — faintest zebra
+//   hover            → --color-bg-sunken  (#ebecf0)  — strongest, signals
+//                                                       active interaction
+// Each visually distinguishable from the others and from the white body row.
 .thead .tr {
-  background: var(--color-bg-subtle);
+  background: var(--color-bg-muted);
 }
 
 .tbody .tr {
+  // Body row bg + bottom-border divider. The last body row's bottom
+  // border also serves as the divider between body and footer via
+  // `border-collapse: collapse`.
   background: var(--color-bg);
+  border-bottom: var(--border-width) solid var(--color-border);
 }
 
 .tfoot .tr {
-  background: var(--color-bg-subtle);
+  background: var(--color-bg-muted);
 }
 
 // ─── Rows ──────────────────────────────────────────────────────────────────
 
-.tr {
+// The header's bottom border lives on the .th itself (NOT on a generic
+// `.tr { border-bottom }`) so it stays pinned with sticky headers — a
+// border on `<tr>` scrolls away because only the inner `<th>`s are sticky.
+.thead .th {
   border-bottom: var(--border-width) solid var(--color-border);
 }
 
-.hover .tbody .tr:hover {
+// Background cascade (all four rules same-ish specificity — source order
+// resolves ties):
+//   .striped .tbody .tr:nth-of-type(even)  (0,4,0)
+//   .hover   .tbody .tr:hover              (0,4,0)  — must be declared AFTER
+//                                                    striped so hover wins on
+//                                                    striped+even rows
+//   Selected variants below — declared even later AND higher specificity.
+.striped .tbody .tr:nth-of-type(even) {
   background: var(--color-bg-subtle);
 }
 
-.striped .tbody .tr:nth-of-type(even) {
-  background: var(--color-bg-subtle);
+.hover .tbody .tr:hover {
+  background: var(--color-bg-sunken);
 }
 
 // Bordered — full grid. With `border-collapse: collapse` already on the
@@ -71,16 +91,16 @@
   border: var(--border-width) solid var(--color-border);
 }
 
-// Selected wins over hover + striped. The `.striped .tbody .tr.selected`
-// arm matches the same specificity as `.striped .tbody .tr:nth-of-type(even)`
-// (both four-class selectors) — source order then wins because selected is
-// declared AFTER striped. Without this extra arm, striped would beat selected
-// on even rows due to the `:nth-of-type(even)` pseudo-class bumping
-// specificity above the plain `.tbody .tr.selected` selector.
+// Selected wins over striped + hover.
+//   .tbody .tr.selected               (0,3,0) — base, beats .tbody .tr (0,2,1)
+//   .striped .tbody .tr.selected      (0,4,0) — beats .striped+nth-of-type
+//                                                via source order
+//   .hover .tbody .tr.selected:hover  (0,5,0) — beats .hover .tr:hover (0,4,0)
+//                                                via specificity, covers both
+//                                                striped and non-striped tables
 .tbody .tr.selected,
-.tbody .tr.selected:hover,
 .striped .tbody .tr.selected,
-.striped .tbody .tr.selected:hover {
+.hover .tbody .tr.selected:hover {
   background: var(--color-accent-bg-subtle);
   color: var(--color-fg);
 }
@@ -158,8 +178,9 @@
   z-index: 1;
 
   // Repeat the header bg here — `tr` bg paints below the th's sticky
-  // layer in some browsers, leaving body rows visible through it.
-  background: var(--color-bg-subtle);
+  // layer in some browsers, leaving body rows visible through it. Must
+  // match the .thead .tr background above.
+  background: var(--color-bg-muted);
 }
 // stylelint-enable property-disallowed-list
 

--- a/packages/design-system/src/components/Table/Table.module.scss
+++ b/packages/design-system/src/components/Table/Table.module.scss
@@ -61,6 +61,16 @@
   background: var(--color-bg-subtle);
 }
 
+// Bordered — full grid. With `border-collapse: collapse` already on the
+// .table, putting a 1px border on every cell collapses adjacent cell
+// borders into a single line AND produces the outer table border
+// automatically. The existing row-divider `tr { border-bottom }` stays
+// fine — it collapses against the cell borders without doubling.
+.bordered .th,
+.bordered .td {
+  border: var(--border-width) solid var(--color-border);
+}
+
 // Selected wins over hover + striped. The `.striped .tbody .tr.selected`
 // arm matches the same specificity as `.striped .tbody .tr:nth-of-type(even)`
 // (both four-class selectors) — source order then wins because selected is

--- a/packages/design-system/src/components/Table/Table.module.scss
+++ b/packages/design-system/src/components/Table/Table.module.scss
@@ -9,7 +9,8 @@
   width: 100%;
   border-collapse: collapse;
   font-family: inherit;
-  color: var(--color-fg);
+  color: var(--color-table-fg);
+  background: var(--color-table-bg);
 }
 
 // ─── Density ───────────────────────────────────────────────────────────────
@@ -30,31 +31,31 @@
 
 .caption {
   padding: var(--space-2) var(--space-3);
-  color: var(--color-fg-muted);
+  color: var(--color-table-caption-fg);
   font-size: var(--font-size-sm);
   text-align: start;
 }
 
-// Three distinct background tones in a hierarchy:
-//   header / footer  → --color-bg-muted   (#f4f5f7)  — visibly chrome-y
-//   striped (even)   → --color-bg-subtle  (#fafbfc)  — faintest zebra
-//   hover            → --color-bg-sunken  (#ebecf0)  — strongest, signals
-//                                                       active interaction
-// Each visually distinguishable from the others and from the white body row.
+// Four distinct row background tones, in increasing visual weight:
+//   body row      → --color-table-bg                  (white)
+//   striped even  → --color-table-row-bg-striped      (faintest gray)
+//   header/footer → --color-table-header-bg           (muted gray, chrome)
+//   hover         → --color-table-row-bg-hover        (light info blue)
+//   selected      → --color-table-row-bg-selected     (stronger info blue)
 .thead .tr {
-  background: var(--color-bg-muted);
+  background: var(--color-table-header-bg);
 }
 
 .tbody .tr {
   // Body row bg + bottom-border divider. The last body row's bottom
   // border also serves as the divider between body and footer via
   // `border-collapse: collapse`.
-  background: var(--color-bg);
-  border-bottom: var(--border-width) solid var(--color-border);
+  background: var(--color-table-bg);
+  border-bottom: var(--border-width) solid var(--color-table-border);
 }
 
 .tfoot .tr {
-  background: var(--color-bg-muted);
+  background: var(--color-table-header-bg);
 }
 
 // ─── Rows ──────────────────────────────────────────────────────────────────
@@ -63,7 +64,7 @@
 // `.tr { border-bottom }`) so it stays pinned with sticky headers — a
 // border on `<tr>` scrolls away because only the inner `<th>`s are sticky.
 .thead .th {
-  border-bottom: var(--border-width) solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-table-border);
 }
 
 // Background cascade (all four rules same-ish specificity — source order
@@ -74,11 +75,11 @@
 //                                                    striped+even rows
 //   Selected variants below — declared even later AND higher specificity.
 .striped .tbody .tr:nth-of-type(even) {
-  background: var(--color-bg-subtle);
+  background: var(--color-table-row-bg-striped);
 }
 
 .hover .tbody .tr:hover {
-  background: var(--color-bg-sunken);
+  background: var(--color-table-row-bg-hover);
 }
 
 // Bordered — full grid. With `border-collapse: collapse` already on the
@@ -88,7 +89,7 @@
 // fine — it collapses against the cell borders without doubling.
 .bordered .th,
 .bordered .td {
-  border: var(--border-width) solid var(--color-border);
+  border: var(--border-width) solid var(--color-table-border);
 }
 
 // Selected wins over striped + hover.
@@ -101,14 +102,14 @@
 .tbody .tr.selected,
 .striped .tbody .tr.selected,
 .hover .tbody .tr.selected:hover {
-  background: var(--color-accent-bg-subtle);
-  color: var(--color-fg);
+  background: var(--color-table-row-bg-selected);
+  color: var(--color-table-row-fg-selected);
 }
 
 // ─── Cells ─────────────────────────────────────────────────────────────────
 
 .th {
-  color: var(--color-fg-muted);
+  color: var(--color-table-header-fg);
   font-weight: var(--font-weight-semibold);
   text-transform: none;
   vertical-align: middle;
@@ -151,7 +152,7 @@
   user-select: none;
 
   &:hover {
-    background: var(--color-bg-muted);
+    background: var(--color-table-header-bg-hover);
   }
 
   &:focus-visible {
@@ -162,11 +163,11 @@
 
 .sortIcon {
   flex-shrink: 0;
-  color: var(--color-fg-muted);
+  color: var(--color-table-header-fg);
 }
 
 .sortable:not(.sortableInactive) .sortIcon {
-  color: var(--color-fg);
+  color: var(--color-table-fg);
 }
 
 // ─── Sticky header ─────────────────────────────────────────────────────────
@@ -180,7 +181,7 @@
   // Repeat the header bg here — `tr` bg paints below the th's sticky
   // layer in some browsers, leaving body rows visible through it. Must
   // match the .thead .tr background above.
-  background: var(--color-bg-muted);
+  background: var(--color-table-header-bg);
 }
 // stylelint-enable property-disallowed-list
 

--- a/packages/design-system/src/components/Table/Table.module.scss
+++ b/packages/design-system/src/components/Table/Table.module.scss
@@ -61,9 +61,16 @@
   background: var(--color-bg-subtle);
 }
 
-// Selected wins over hover + striped (later declaration, equal specificity).
+// Selected wins over hover + striped. The `.striped .tbody .tr.selected`
+// arm matches the same specificity as `.striped .tbody .tr:nth-of-type(even)`
+// (both four-class selectors) — source order then wins because selected is
+// declared AFTER striped. Without this extra arm, striped would beat selected
+// on even rows due to the `:nth-of-type(even)` pseudo-class bumping
+// specificity above the plain `.tbody .tr.selected` selector.
 .tbody .tr.selected,
-.tbody .tr.selected:hover {
+.tbody .tr.selected:hover,
+.striped .tbody .tr.selected,
+.striped .tbody .tr.selected:hover {
   background: var(--color-accent-bg-subtle);
   color: var(--color-fg);
 }

--- a/packages/design-system/src/components/Table/Table.module.scss
+++ b/packages/design-system/src/components/Table/Table.module.scss
@@ -1,0 +1,158 @@
+// Scroll wrapper — horizontal overflow context for wide tables AND the
+// scroll container for sticky headers.
+.scrollWrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: inherit;
+  color: var(--color-fg);
+}
+
+// ─── Density ───────────────────────────────────────────────────────────────
+
+.density-comfortable .td,
+.density-comfortable .th {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-md);
+}
+
+.density-dense .td,
+.density-dense .th {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+}
+
+// ─── Sections ──────────────────────────────────────────────────────────────
+
+.caption {
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-fg-muted);
+  font-size: var(--font-size-sm);
+  text-align: start;
+}
+
+.thead .tr {
+  background: var(--color-bg-subtle);
+}
+
+.tbody .tr {
+  background: var(--color-bg);
+}
+
+.tfoot .tr {
+  background: var(--color-bg-subtle);
+}
+
+// ─── Rows ──────────────────────────────────────────────────────────────────
+
+.tr {
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.hover .tbody .tr:hover {
+  background: var(--color-bg-subtle);
+}
+
+.striped .tbody .tr:nth-of-type(even) {
+  background: var(--color-bg-subtle);
+}
+
+// Selected wins over hover + striped (later declaration, equal specificity).
+.tbody .tr.selected,
+.tbody .tr.selected:hover {
+  background: var(--color-accent-bg-subtle);
+  color: var(--color-fg);
+}
+
+// ─── Cells ─────────────────────────────────────────────────────────────────
+
+.th {
+  color: var(--color-fg-muted);
+  font-weight: var(--font-weight-semibold);
+  text-transform: none;
+  vertical-align: middle;
+}
+
+.td {
+  vertical-align: middle;
+}
+
+// Inner flex container for header cells so sort chevron sits beside text.
+.thInner {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+// Alignment — applied via CSS logical properties (RTL-friendly).
+.align-start {
+  text-align: start;
+}
+
+.align-center {
+  text-align: center;
+}
+
+.align-end {
+  text-align: end;
+}
+
+// Right-aligned headers need the chevron on the start side of the label,
+// not the end — flip the inner flex direction.
+.align-end .thInner {
+  flex-direction: row-reverse;
+}
+
+// ─── Sortable header ───────────────────────────────────────────────────────
+
+.sortable {
+  cursor: pointer;
+  user-select: none;
+
+  &:hover {
+    background: var(--color-bg-muted);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 var(--ring-width) var(--ring-accent);
+  }
+}
+
+.sortIcon {
+  flex-shrink: 0;
+  color: var(--color-fg-muted);
+}
+
+.sortable:not(.sortableInactive) .sortIcon {
+  color: var(--color-fg);
+}
+
+// ─── Sticky header ─────────────────────────────────────────────────────────
+
+// stylelint-disable property-disallowed-list -- Rule 4 escape hatch: position:sticky here is internal layout (anchors the header to the .scrollWrap scroll context), not a public-component layout property. Same precedent as AvatarGroup .item z-index.
+.stickyHeader .thead .th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+
+  // Repeat the header bg here — `tr` bg paints below the th's sticky
+  // layer in some browsers, leaving body rows visible through it.
+  background: var(--color-bg-subtle);
+}
+// stylelint-enable property-disallowed-list
+
+// ─── Cell modifiers ────────────────────────────────────────────────────────
+
+// stylelint-disable property-disallowed-list -- max-width: 0 is the standard flex/table-cell ellipsis trick (forces the cell to honour text-overflow). This is an internal-child modifier, not a public layout constraint on the component boundary.
+.truncate {
+  max-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+// stylelint-enable property-disallowed-list

--- a/packages/design-system/src/components/Table/Table.test.tsx
+++ b/packages/design-system/src/components/Table/Table.test.tsx
@@ -53,19 +53,19 @@ describe('Table', () => {
 
   it('applies density / hover / striped / bordered / stickyHeader class names', () => {
     const { container, rerender } = render(
-      <Table density="dense" striped bordered hover={false} stickyHeader />,
+      <Table density="dense" striped bordered hover stickyHeader />,
     );
     const table = container.querySelector('table')!;
     expect(table.className).toMatch(/density-dense/);
     expect(table.className).toMatch(/striped/);
     expect(table.className).toMatch(/bordered/);
-    expect(table.className).not.toMatch(/hover/);
+    expect(table.className).toMatch(/hover/);
     expect(table.className).toMatch(/stickyHeader/);
 
     rerender(<Table />);
     const table2 = container.querySelector('table')!;
     expect(table2.className).toMatch(/density-comfortable/);
-    expect(table2.className).toMatch(/hover/);
+    expect(table2.className).not.toMatch(/hover/);
     expect(table2.className).not.toMatch(/striped/);
     expect(table2.className).not.toMatch(/bordered/);
     expect(table2.className).not.toMatch(/stickyHeader/);

--- a/packages/design-system/src/components/Table/Table.test.tsx
+++ b/packages/design-system/src/components/Table/Table.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { createRef } from 'react';
 import { Table } from './Table';
 

--- a/packages/design-system/src/components/Table/Table.test.tsx
+++ b/packages/design-system/src/components/Table/Table.test.tsx
@@ -1,0 +1,204 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { Table } from './Table';
+
+describe('Table', () => {
+  it('renders a native <table> with the default structure', () => {
+    const { container } = render(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Name</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>Alex</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    expect(container.querySelector('table')).toBeInTheDocument();
+    expect(container.querySelector('thead')).toBeInTheDocument();
+    expect(container.querySelector('tbody')).toBeInTheDocument();
+    expect(container.querySelector('th')).toHaveAttribute('scope', 'col');
+  });
+
+  it('wraps the table in a scroll <div> by default; scroll={false} renders bare', () => {
+    const { container, rerender } = render(
+      <Table>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    // Bydefault, the <table> sits inside an outer <div>.
+    expect(container.querySelector('div > table')).not.toBeNull();
+
+    rerender(
+      <Table scroll={false}>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    // The first child is now the <table> itself.
+    expect(container.firstChild?.nodeName).toBe('TABLE');
+  });
+
+  it('applies density / hover / striped / stickyHeader class names', () => {
+    const { container, rerender } = render(<Table density="dense" striped hover={false} stickyHeader />);
+    const table = container.querySelector('table')!;
+    expect(table.className).toMatch(/density-dense/);
+    expect(table.className).toMatch(/striped/);
+    expect(table.className).not.toMatch(/hover/);
+    expect(table.className).toMatch(/stickyHeader/);
+
+    rerender(<Table />);
+    const table2 = container.querySelector('table')!;
+    expect(table2.className).toMatch(/density-comfortable/);
+    expect(table2.className).toMatch(/hover/);
+    expect(table2.className).not.toMatch(/striped/);
+    expect(table2.className).not.toMatch(/stickyHeader/);
+  });
+
+  it('Table.Row selected adds aria-selected and the selected class', () => {
+    const { container } = render(
+      <Table>
+        <Table.Body>
+          <Table.Row selected>
+            <Table.Cell>X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    const tr = container.querySelector('tr');
+    expect(tr).toHaveAttribute('aria-selected', 'true');
+    expect(tr?.className).toMatch(/selected/);
+  });
+
+  it('Table.HeaderCell sortDirection renders chevron + aria-sort', () => {
+    const { container, rerender } = render(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell sortDirection="asc">Amount</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    expect(container.querySelector('th')).toHaveAttribute('aria-sort', 'ascending');
+    expect(container.querySelector('th svg')).toBeInTheDocument();
+
+    rerender(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell sortDirection="desc">Amount</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    expect(container.querySelector('th')).toHaveAttribute('aria-sort', 'descending');
+
+    rerender(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell sortDirection="none">Amount</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    expect(container.querySelector('th')).toHaveAttribute('aria-sort', 'none');
+  });
+
+  it('Table.HeaderCell without sortDirection has no chevron and no aria-sort', () => {
+    const { container } = render(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Amount</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    expect(container.querySelector('th')).not.toHaveAttribute('aria-sort');
+    expect(container.querySelector('th svg')).toBeNull();
+  });
+
+  it('Table.Cell align applies the right class', () => {
+    const { container } = render(
+      <Table>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell align="end">42</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    expect(container.querySelector('td')?.className).toMatch(/align-end/);
+  });
+
+  it('Table.Cell truncate applies the truncate class', () => {
+    const { container } = render(
+      <Table>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell truncate>Long long long</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    expect(container.querySelector('td')?.className).toMatch(/truncate/);
+  });
+
+  it('forwards ref on Table to the <table> element', () => {
+    const ref = createRef<HTMLTableElement>();
+    render(
+      <Table ref={ref}>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLTableElement);
+  });
+
+  it('merges className on every subcomponent', () => {
+    const { container } = render(
+      <Table className="root-cls">
+        <Table.Caption className="cap-cls">Cap</Table.Caption>
+        <Table.Header className="thead-cls">
+          <Table.Row className="tr-cls">
+            <Table.HeaderCell className="th-cls">H</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body className="tbody-cls">
+          <Table.Row>
+            <Table.Cell className="td-cls">X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+        <Table.Footer className="tfoot-cls">
+          <Table.Row>
+            <Table.Cell>F</Table.Cell>
+          </Table.Row>
+        </Table.Footer>
+      </Table>,
+    );
+    expect(container.querySelector('table.root-cls')).not.toBeNull();
+    expect(container.querySelector('caption.cap-cls')).not.toBeNull();
+    expect(container.querySelector('thead.thead-cls')).not.toBeNull();
+    expect(container.querySelector('tr.tr-cls')).not.toBeNull();
+    expect(container.querySelector('th.th-cls')).not.toBeNull();
+    expect(container.querySelector('tbody.tbody-cls')).not.toBeNull();
+    expect(container.querySelector('td.td-cls')).not.toBeNull();
+    expect(container.querySelector('tfoot.tfoot-cls')).not.toBeNull();
+  });
+});

--- a/packages/design-system/src/components/Table/Table.test.tsx
+++ b/packages/design-system/src/components/Table/Table.test.tsx
@@ -1,4 +1,5 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import { Table } from './Table';
 
@@ -202,5 +203,156 @@ describe('Table', () => {
     expect(container.querySelector('tbody.tbody-cls')).not.toBeNull();
     expect(container.querySelector('td.td-cls')).not.toBeNull();
     expect(container.querySelector('tfoot.tfoot-cls')).not.toBeNull();
+  });
+
+  it('renders <caption> as the first child of <table>', () => {
+    const { container } = render(
+      <Table>
+        <Table.Caption>Recent activity</Table.Caption>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    const table = container.querySelector('table')!;
+    expect(table.firstChild?.nodeName).toBe('CAPTION');
+    expect(table.querySelector('caption')).toHaveTextContent('Recent activity');
+  });
+
+  it('Table.HeaderCell scope defaults to "col" but is overridable', () => {
+    const { container, rerender } = render(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>H</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    expect(container.querySelector('th')).toHaveAttribute('scope', 'col');
+
+    rerender(
+      <Table>
+        <Table.Body>
+          <Table.Row>
+            <Table.HeaderCell scope="row">RowHeader</Table.HeaderCell>
+            <Table.Cell>X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    expect(container.querySelector('th')).toHaveAttribute('scope', 'row');
+  });
+
+  it('sortable Table.HeaderCell is keyboard-reachable (tabIndex=0, Enter/Space fires onClick)', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell sortDirection="none" onClick={onClick}>
+              Amount
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    const th = screen.getByText('Amount').closest('th')!;
+    expect(th).toHaveAttribute('tabIndex', '0');
+    th.focus();
+    expect(document.activeElement).toBe(th);
+    await user.keyboard('{Enter}');
+    expect(onClick).toHaveBeenCalledTimes(1);
+    await user.keyboard(' ');
+    expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('non-sortable Table.HeaderCell is NOT focusable by default (no tabIndex injected)', () => {
+    const { container } = render(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Plain header</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    expect(container.querySelector('th')).not.toHaveAttribute('tabIndex');
+  });
+
+  it('selected row wins over striped (even row in striped table stays selected)', () => {
+    const { container } = render(
+      <Table striped scroll={false}>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>row 1 (odd)</Table.Cell>
+          </Table.Row>
+          <Table.Row selected>
+            <Table.Cell>row 2 (even, selected)</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    // Specificity cascade test — selected styles must beat striped's
+    // :nth-of-type(even). Assert via class application; the visual
+    // assertion is the SCSS rule's job.
+    const rows = container.querySelectorAll('tbody tr');
+    expect(rows[1].className).toMatch(/selected/);
+  });
+
+  it('sortable header with no children renders only the chevron, no empty span', () => {
+    const { container } = render(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell sortDirection="asc" aria-label="Sort by amount" />
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    // Only one inner span (.thInner) — the children-wrap span should be omitted.
+    const innerSpans = container.querySelectorAll('th > span');
+    expect(innerSpans.length).toBe(1);
+    expect(container.querySelector('th svg')).toBeInTheDocument();
+  });
+
+  it('forwards ref on every subcomponent', () => {
+    const captionRef = createRef<HTMLTableCaptionElement>();
+    const theadRef = createRef<HTMLTableSectionElement>();
+    const tbodyRef = createRef<HTMLTableSectionElement>();
+    const tfootRef = createRef<HTMLTableSectionElement>();
+    const trRef = createRef<HTMLTableRowElement>();
+    const thRef = createRef<HTMLTableCellElement>();
+    const tdRef = createRef<HTMLTableCellElement>();
+    render(
+      <Table>
+        <Table.Caption ref={captionRef}>Cap</Table.Caption>
+        <Table.Header ref={theadRef}>
+          <Table.Row ref={trRef}>
+            <Table.HeaderCell ref={thRef}>H</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body ref={tbodyRef}>
+          <Table.Row>
+            <Table.Cell ref={tdRef}>X</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+        <Table.Footer ref={tfootRef}>
+          <Table.Row>
+            <Table.Cell>F</Table.Cell>
+          </Table.Row>
+        </Table.Footer>
+      </Table>,
+    );
+    expect(captionRef.current).toBeInstanceOf(HTMLTableCaptionElement);
+    expect(theadRef.current).toBeInstanceOf(HTMLTableSectionElement);
+    expect(tbodyRef.current).toBeInstanceOf(HTMLTableSectionElement);
+    expect(tfootRef.current).toBeInstanceOf(HTMLTableSectionElement);
+    expect(trRef.current).toBeInstanceOf(HTMLTableRowElement);
+    expect(thRef.current).toBeInstanceOf(HTMLTableCellElement);
+    expect(tdRef.current).toBeInstanceOf(HTMLTableCellElement);
   });
 });

--- a/packages/design-system/src/components/Table/Table.test.tsx
+++ b/packages/design-system/src/components/Table/Table.test.tsx
@@ -51,13 +51,14 @@ describe('Table', () => {
     expect(container.firstChild?.nodeName).toBe('TABLE');
   });
 
-  it('applies density / hover / striped / stickyHeader class names', () => {
+  it('applies density / hover / striped / bordered / stickyHeader class names', () => {
     const { container, rerender } = render(
-      <Table density="dense" striped hover={false} stickyHeader />,
+      <Table density="dense" striped bordered hover={false} stickyHeader />,
     );
     const table = container.querySelector('table')!;
     expect(table.className).toMatch(/density-dense/);
     expect(table.className).toMatch(/striped/);
+    expect(table.className).toMatch(/bordered/);
     expect(table.className).not.toMatch(/hover/);
     expect(table.className).toMatch(/stickyHeader/);
 
@@ -66,6 +67,7 @@ describe('Table', () => {
     expect(table2.className).toMatch(/density-comfortable/);
     expect(table2.className).toMatch(/hover/);
     expect(table2.className).not.toMatch(/striped/);
+    expect(table2.className).not.toMatch(/bordered/);
     expect(table2.className).not.toMatch(/stickyHeader/);
   });
 

--- a/packages/design-system/src/components/Table/Table.test.tsx
+++ b/packages/design-system/src/components/Table/Table.test.tsx
@@ -51,7 +51,9 @@ describe('Table', () => {
   });
 
   it('applies density / hover / striped / stickyHeader class names', () => {
-    const { container, rerender } = render(<Table density="dense" striped hover={false} stickyHeader />);
+    const { container, rerender } = render(
+      <Table density="dense" striped hover={false} stickyHeader />,
+    );
     const table = container.querySelector('table')!;
     expect(table.className).toMatch(/density-dense/);
     expect(table.className).toMatch(/striped/);

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -1,6 +1,7 @@
 import {
   forwardRef,
   type HTMLAttributes,
+  type KeyboardEvent,
   type ReactNode,
   type TdHTMLAttributes,
   type ThHTMLAttributes,
@@ -254,18 +255,42 @@ const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(function TableRo
 
 const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellProps>(
   function TableHeaderCell(
-    { align = 'start', sortDirection, scope = 'col', className, children, ...props },
+    {
+      align = 'start',
+      sortDirection,
+      scope = 'col',
+      className,
+      children,
+      onKeyDown,
+      tabIndex,
+      ...props
+    },
     ref,
   ) {
     const sortable = sortDirection != null;
     const SortIcon =
       sortDirection === 'asc' ? ChevronUp : sortDirection === 'desc' ? ChevronDown : ChevronsUpDown;
 
+    // Sortable headers are keyboard-reachable: `<th>` is not natively
+    // focusable, so we add `tabIndex={0}` when sortable and forward
+    // Enter/Space to a synthetic click so the consumer's `onClick`
+    // handler fires. Consumer-supplied tabIndex/onKeyDown still win.
+    const handleKeyDown = (e: KeyboardEvent<HTMLTableCellElement>) => {
+      onKeyDown?.(e);
+      if (!sortable || e.defaultPrevented) return;
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.currentTarget.click();
+      }
+    };
+
     return (
       <th
         ref={ref}
         scope={scope}
         aria-sort={sortable ? sortAriaFor[sortDirection] : undefined}
+        tabIndex={sortable ? (tabIndex ?? 0) : tabIndex}
+        onKeyDown={sortable ? handleKeyDown : onKeyDown}
         className={clsx(
           styles.th,
           styles[`align-${align}`],
@@ -276,7 +301,7 @@ const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellProps>(
         {...props}
       >
         <span className={styles.thInner}>
-          <span>{children}</span>
+          {children != null && <span>{children}</span>}
           {sortable && <SortIcon size={12} aria-hidden="true" className={styles.sortIcon} />}
         </span>
       </th>

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -1,0 +1,305 @@
+import {
+  forwardRef,
+  type HTMLAttributes,
+  type ReactNode,
+  type TdHTMLAttributes,
+  type ThHTMLAttributes,
+} from 'react';
+import clsx from 'clsx';
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
+import styles from './Table.module.scss';
+
+/** Row height + cell padding scale. */
+export type TableDensity = 'comfortable' | 'dense';
+
+/** Header-cell text alignment. */
+export type TableCellAlign = 'start' | 'center' | 'end';
+
+/** Sort state for a header cell. */
+export type TableSortDirection = 'asc' | 'desc' | 'none';
+
+export interface TableProps extends Omit<HTMLAttributes<HTMLTableElement>, 'children'> {
+  /**
+   * Row height + cell padding scale. Defaults to `'comfortable'`.
+   * - `'comfortable'` — 32px row, 12px horiz padding, font-size-md.
+   * - `'dense'`       — 24px row, 8px horiz padding, font-size-sm.
+   */
+  density?: TableDensity;
+  /** Zebra-striped body rows (even rows tinted). Defaults to `false`. */
+  striped?: boolean;
+  /** Hover highlight on body rows. Defaults to `true`. */
+  hover?: boolean;
+  /**
+   * `position: sticky` on the header so it stays visible while body
+   * scrolls. Requires a scrollable ancestor — the default `scroll`
+   * wrapper provides one. Defaults to `false`.
+   */
+  stickyHeader?: boolean;
+  /**
+   * When `true` (default), the `<table>` is wrapped in a `<div>` with
+   * `overflow-x: auto` so wide tables scroll horizontally inside their
+   * container. Set to `false` to render a bare `<table>` — the consumer
+   * manages their own scroll context.
+   */
+  scroll?: boolean;
+  /** Compound-subcomponent children. */
+  children: ReactNode;
+}
+
+export interface TableCaptionProps extends HTMLAttributes<HTMLTableCaptionElement> {
+  children: ReactNode;
+}
+
+export interface TableSectionProps extends HTMLAttributes<HTMLTableSectionElement> {
+  children: ReactNode;
+}
+
+export interface TableRowProps extends HTMLAttributes<HTMLTableRowElement> {
+  /**
+   * Visual selected state. Pair with the consumer's own selection logic.
+   * Adds `aria-selected="true"` and a subtle accent tint that wins over
+   * hover/striped.
+   */
+  selected?: boolean;
+  children: ReactNode;
+}
+
+export interface TableHeaderCellProps extends ThHTMLAttributes<HTMLTableCellElement> {
+  /** Text alignment. Defaults to `'start'`. */
+  align?: TableCellAlign;
+  /**
+   * When set, the cell renders a sort indicator (up/down/unsorted chevron)
+   * and sets `aria-sort`. The consumer drives interactivity via `onClick`;
+   * this primitive only paints the indicator.
+   * - `'asc'`  → up chevron + `aria-sort="ascending"`.
+   * - `'desc'` → down chevron + `aria-sort="descending"`.
+   * - `'none'` → muted up/down chevron + `aria-sort="none"`.
+   * Omit to render a non-sortable header (no chevron, no `aria-sort`).
+   */
+  sortDirection?: TableSortDirection;
+  children?: ReactNode;
+}
+
+export interface TableCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
+  /** Text alignment. Defaults to `'start'`. */
+  align?: TableCellAlign;
+  /**
+   * Suppress wrapping and ellipsize on overflow. Requires a constrained
+   * cell width (column-level CSS or `style={{ maxWidth: … }}`).
+   */
+  truncate?: boolean;
+  children?: ReactNode;
+}
+
+const sortAriaFor: Record<TableSortDirection, 'ascending' | 'descending' | 'none'> = {
+  asc: 'ascending',
+  desc: 'descending',
+  none: 'none',
+};
+
+/**
+ * Tabular data primitive. Compound API:
+ * `Table`, `Table.Caption`, `Table.Header`, `Table.Body`, `Table.Footer`,
+ * `Table.Row`, `Table.HeaderCell`, `Table.Cell`.
+ *
+ * Native HTML elements throughout — no ARIA-on-divs. Density, hover,
+ * striped, sticky header, and horizontal-scroll wrapper are visual
+ * modifiers on the root. Sortable header is a visual hook — the consumer
+ * wires `onClick` on `Table.HeaderCell` to drive their own sort state.
+ *
+ * @example
+ * <Table>
+ *   <Table.Caption>Recent activity</Table.Caption>
+ *   <Table.Header>
+ *     <Table.Row>
+ *       <Table.HeaderCell>Name</Table.HeaderCell>
+ *       <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+ *     </Table.Row>
+ *   </Table.Header>
+ *   <Table.Body>
+ *     {rows.map((r) => (
+ *       <Table.Row key={r.id}>
+ *         <Table.Cell>{r.name}</Table.Cell>
+ *         <Table.Cell align="end">{r.amount}</Table.Cell>
+ *       </Table.Row>
+ *     ))}
+ *   </Table.Body>
+ * </Table>
+ *
+ * @example
+ * // Sortable column — consumer owns the state machine; the primitive
+ * // only paints the indicator and sets aria-sort.
+ * <Table.HeaderCell
+ *   sortDirection={sortKey === 'amount' ? sortDir : 'none'}
+ *   onClick={() => toggleSort('amount')}
+ * >
+ *   Amount
+ * </Table.HeaderCell>
+ *
+ * @remarks When NOT to use
+ * - For data that needs sorting / filtering / pagination state — wait for
+ *   `<DataTable>` (not yet shipped). DataTable composes this primitive +
+ *   TanStack Table headless.
+ * - For non-tabular content (cards, lists). Use `<Stack>` / `<Cluster>` /
+ *   `<Card>` instead.
+ * - For dashboards with editable cells. The primitive doesn't ship inline
+ *   editing; consumer adds inputs inside cells as needed.
+ *
+ * @remarks Anti-patterns
+ * - ❌ `<Table>` without `<Table.Body>` for non-header rows. Native
+ *   semantics require `<tbody>` for data rows.
+ * - ❌ Putting `<Table.HeaderCell>` inside `<Table.Body>` for the leftmost
+ *   row-header column. Use a `<th scope="row">` instead — pass `scope` via
+ *   spread on `<Table.Cell>` is not supported (it would silently render as
+ *   `<td scope="row">` which is invalid). If you need row headers, file a
+ *   follow-up to add a `rowHeader` prop.
+ */
+const TableRoot = forwardRef<HTMLTableElement, TableProps>(function TableRoot(
+  { density = 'comfortable', striped, hover = true, stickyHeader, scroll = true, className, children, ...props },
+  ref,
+) {
+  const table = (
+    <table
+      ref={ref}
+      className={clsx(
+        styles.table,
+        styles[`density-${density}`],
+        striped && styles.striped,
+        hover && styles.hover,
+        stickyHeader && styles.stickyHeader,
+        className,
+      )}
+      // {...props} last so consumer overrides win (Pattern A).
+      {...props}
+    >
+      {children}
+    </table>
+  );
+
+  if (!scroll) return table;
+  return <div className={styles.scrollWrap}>{table}</div>;
+});
+
+const TableCaption = forwardRef<HTMLTableCaptionElement, TableCaptionProps>(function TableCaption(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <caption ref={ref} className={clsx(styles.caption, className)} {...props}>
+      {children}
+    </caption>
+  );
+});
+
+const TableHeader = forwardRef<HTMLTableSectionElement, TableSectionProps>(function TableHeader(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <thead ref={ref} className={clsx(styles.thead, className)} {...props}>
+      {children}
+    </thead>
+  );
+});
+
+const TableBody = forwardRef<HTMLTableSectionElement, TableSectionProps>(function TableBody(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <tbody ref={ref} className={clsx(styles.tbody, className)} {...props}>
+      {children}
+    </tbody>
+  );
+});
+
+const TableFooter = forwardRef<HTMLTableSectionElement, TableSectionProps>(function TableFooter(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <tfoot ref={ref} className={clsx(styles.tfoot, className)} {...props}>
+      {children}
+    </tfoot>
+  );
+});
+
+const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(function TableRow(
+  { selected, className, children, ...props },
+  ref,
+) {
+  return (
+    <tr
+      ref={ref}
+      aria-selected={selected || undefined}
+      className={clsx(styles.tr, selected && styles.selected, className)}
+      {...props}
+    >
+      {children}
+    </tr>
+  );
+});
+
+const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellProps>(function TableHeaderCell(
+  { align = 'start', sortDirection, scope = 'col', className, children, ...props },
+  ref,
+) {
+  const sortable = sortDirection != null;
+  const SortIcon =
+    sortDirection === 'asc' ? ChevronUp : sortDirection === 'desc' ? ChevronDown : ChevronsUpDown;
+
+  return (
+    <th
+      ref={ref}
+      scope={scope}
+      aria-sort={sortable ? sortAriaFor[sortDirection] : undefined}
+      className={clsx(
+        styles.th,
+        styles[`align-${align}`],
+        sortable && styles.sortable,
+        sortable && sortDirection === 'none' && styles.sortableInactive,
+        className,
+      )}
+      {...props}
+    >
+      <span className={styles.thInner}>
+        <span>{children}</span>
+        {sortable && <SortIcon size={12} aria-hidden="true" className={styles.sortIcon} />}
+      </span>
+    </th>
+  );
+});
+
+const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(function TableCell(
+  { align = 'start', truncate, className, children, ...props },
+  ref,
+) {
+  return (
+    <td
+      ref={ref}
+      className={clsx(
+        styles.td,
+        styles[`align-${align}`],
+        truncate && styles.truncate,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </td>
+  );
+});
+
+/**
+ * Compound `<Table>` family. Attach subcomponents via Object.assign so
+ * consumers write `<Table.Body>` etc., not separate imports.
+ */
+export const Table = Object.assign(TableRoot, {
+  Caption: TableCaption,
+  Header: TableHeader,
+  Body: TableBody,
+  Footer: TableFooter,
+  Row: TableRow,
+  HeaderCell: TableHeaderCell,
+  Cell: TableCell,
+});

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -65,16 +65,22 @@ export interface TableRowProps extends HTMLAttributes<HTMLTableRowElement> {
   children: ReactNode;
 }
 
-export interface TableHeaderCellProps extends Omit<
-  ThHTMLAttributes<HTMLTableCellElement>,
-  'align'
-> {
+export interface TableHeaderCellProps
+  extends Omit<ThHTMLAttributes<HTMLTableCellElement>, 'align' | 'scope'> {
   /** Text alignment. Defaults to `'start'`. */
   align?: TableCellAlign;
   /**
+   * Native HTML `<th scope>` attribute. Defaults to `'col'` (the cell labels
+   * its column). Use `'row'` for the leftmost cell that labels its row when
+   * rendering row-headers inside `<Table.Body>`. `'colgroup'` / `'rowgroup'`
+   * are valid HTML but rarely needed in practice.
+   */
+  scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
+  /**
    * When set, the cell renders a sort indicator (up/down/unsorted chevron)
    * and sets `aria-sort`. The consumer drives interactivity via `onClick`;
-   * this primitive only paints the indicator.
+   * this primitive only paints the indicator. Sortable headers also become
+   * keyboard-reachable (`tabIndex={0}` + Enter/Space → `onClick`).
    * - `'asc'`  → up chevron + `aria-sort="ascending"`.
    * - `'desc'` → down chevron + `aria-sort="descending"`.
    * - `'none'` → muted up/down chevron + `aria-sort="none"`.

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -64,7 +64,10 @@ export interface TableRowProps extends HTMLAttributes<HTMLTableRowElement> {
   children: ReactNode;
 }
 
-export interface TableHeaderCellProps extends Omit<ThHTMLAttributes<HTMLTableCellElement>, 'align'> {
+export interface TableHeaderCellProps extends Omit<
+  ThHTMLAttributes<HTMLTableCellElement>,
+  'align'
+> {
   /** Text alignment. Defaults to `'start'`. */
   align?: TableCellAlign;
   /**
@@ -155,7 +158,16 @@ const sortAriaFor: Record<TableSortDirection, 'ascending' | 'descending' | 'none
  *   follow-up to add a `rowHeader` prop.
  */
 const TableRoot = forwardRef<HTMLTableElement, TableProps>(function TableRoot(
-  { density = 'comfortable', striped, hover = true, stickyHeader, scroll = true, className, children, ...props },
+  {
+    density = 'comfortable',
+    striped,
+    hover = true,
+    stickyHeader,
+    scroll = true,
+    className,
+    children,
+    ...props
+  },
   ref,
 ) {
   const table = (
@@ -240,35 +252,37 @@ const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(function TableRo
   );
 });
 
-const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellProps>(function TableHeaderCell(
-  { align = 'start', sortDirection, scope = 'col', className, children, ...props },
-  ref,
-) {
-  const sortable = sortDirection != null;
-  const SortIcon =
-    sortDirection === 'asc' ? ChevronUp : sortDirection === 'desc' ? ChevronDown : ChevronsUpDown;
+const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellProps>(
+  function TableHeaderCell(
+    { align = 'start', sortDirection, scope = 'col', className, children, ...props },
+    ref,
+  ) {
+    const sortable = sortDirection != null;
+    const SortIcon =
+      sortDirection === 'asc' ? ChevronUp : sortDirection === 'desc' ? ChevronDown : ChevronsUpDown;
 
-  return (
-    <th
-      ref={ref}
-      scope={scope}
-      aria-sort={sortable ? sortAriaFor[sortDirection] : undefined}
-      className={clsx(
-        styles.th,
-        styles[`align-${align}`],
-        sortable && styles.sortable,
-        sortable && sortDirection === 'none' && styles.sortableInactive,
-        className,
-      )}
-      {...props}
-    >
-      <span className={styles.thInner}>
-        <span>{children}</span>
-        {sortable && <SortIcon size={12} aria-hidden="true" className={styles.sortIcon} />}
-      </span>
-    </th>
-  );
-});
+    return (
+      <th
+        ref={ref}
+        scope={scope}
+        aria-sort={sortable ? sortAriaFor[sortDirection] : undefined}
+        className={clsx(
+          styles.th,
+          styles[`align-${align}`],
+          sortable && styles.sortable,
+          sortable && sortDirection === 'none' && styles.sortableInactive,
+          className,
+        )}
+        {...props}
+      >
+        <span className={styles.thInner}>
+          <span>{children}</span>
+          {sortable && <SortIcon size={12} aria-hidden="true" className={styles.sortIcon} />}
+        </span>
+      </th>
+    );
+  },
+);
 
 const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(function TableCell(
   { align = 'start', truncate, className, children, ...props },
@@ -277,12 +291,7 @@ const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(function Tabl
   return (
     <td
       ref={ref}
-      className={clsx(
-        styles.td,
-        styles[`align-${align}`],
-        truncate && styles.truncate,
-        className,
-      )}
+      className={clsx(styles.td, styles[`align-${align}`], truncate && styles.truncate, className)}
       {...props}
     >
       {children}

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -34,7 +34,12 @@ export interface TableProps extends Omit<HTMLAttributes<HTMLTableElement>, 'chil
    * (Atlassian-style minimal: header underline + row dividers only).
    */
   bordered?: boolean;
-  /** Hover highlight on body rows. Defaults to `true`. */
+  /**
+   * Hover highlight on body rows. Defaults to `false` — turn on when the
+   * table represents a list of clickable / selectable items (a row a user
+   * is likely to act on). Leave off for read-only data displays where the
+   * hover affordance would suggest interactivity that isn't there.
+   */
   hover?: boolean;
   /**
    * `position: sticky` on the header so it stays visible while body
@@ -177,7 +182,7 @@ const TableRoot = forwardRef<HTMLTableElement, TableProps>(function TableRoot(
     density = 'comfortable',
     striped,
     bordered,
-    hover = true,
+    hover = false,
     stickyHeader,
     scroll = true,
     className,

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -28,6 +28,12 @@ export interface TableProps extends Omit<HTMLAttributes<HTMLTableElement>, 'chil
   density?: TableDensity;
   /** Zebra-striped body rows (even rows tinted). Defaults to `false`. */
   striped?: boolean;
+  /**
+   * Full-grid borders — outer border + vertical borders between every cell
+   * on top of the existing horizontal row dividers. Defaults to `false`
+   * (Atlassian-style minimal: header underline + row dividers only).
+   */
+  bordered?: boolean;
   /** Hover highlight on body rows. Defaults to `true`. */
   hover?: boolean;
   /**
@@ -170,6 +176,7 @@ const TableRoot = forwardRef<HTMLTableElement, TableProps>(function TableRoot(
   {
     density = 'comfortable',
     striped,
+    bordered,
     hover = true,
     stickyHeader,
     scroll = true,
@@ -186,6 +193,7 @@ const TableRoot = forwardRef<HTMLTableElement, TableProps>(function TableRoot(
         styles.table,
         styles[`density-${density}`],
         striped && styles.striped,
+        bordered && styles.bordered,
         hover && styles.hover,
         stickyHeader && styles.stickyHeader,
         className,

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -43,7 +43,7 @@ export interface TableProps extends Omit<HTMLAttributes<HTMLTableElement>, 'chil
    */
   scroll?: boolean;
   /** Compound-subcomponent children. */
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 export interface TableCaptionProps extends HTMLAttributes<HTMLTableCaptionElement> {
@@ -64,7 +64,7 @@ export interface TableRowProps extends HTMLAttributes<HTMLTableRowElement> {
   children: ReactNode;
 }
 
-export interface TableHeaderCellProps extends ThHTMLAttributes<HTMLTableCellElement> {
+export interface TableHeaderCellProps extends Omit<ThHTMLAttributes<HTMLTableCellElement>, 'align'> {
   /** Text alignment. Defaults to `'start'`. */
   align?: TableCellAlign;
   /**
@@ -80,7 +80,7 @@ export interface TableHeaderCellProps extends ThHTMLAttributes<HTMLTableCellElem
   children?: ReactNode;
 }
 
-export interface TableCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
+export interface TableCellProps extends Omit<TdHTMLAttributes<HTMLTableCellElement>, 'align'> {
   /** Text alignment. Defaults to `'start'`. */
   align?: TableCellAlign;
   /**

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -65,8 +65,10 @@ export interface TableRowProps extends HTMLAttributes<HTMLTableRowElement> {
   children: ReactNode;
 }
 
-export interface TableHeaderCellProps
-  extends Omit<ThHTMLAttributes<HTMLTableCellElement>, 'align' | 'scope'> {
+export interface TableHeaderCellProps extends Omit<
+  ThHTMLAttributes<HTMLTableCellElement>,
+  'align' | 'scope'
+> {
   /** Text alignment. Defaults to `'start'`. */
   align?: TableCellAlign;
   /**

--- a/packages/design-system/src/components/Table/index.ts
+++ b/packages/design-system/src/components/Table/index.ts
@@ -1,0 +1,12 @@
+export { Table } from './Table';
+export type {
+  TableProps,
+  TableCaptionProps,
+  TableSectionProps,
+  TableRowProps,
+  TableHeaderCellProps,
+  TableCellProps,
+  TableDensity,
+  TableCellAlign,
+  TableSortDirection,
+} from './Table';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -74,6 +74,19 @@ export type {
   SelectTriggerDisplay,
 } from './components/Select';
 
+export { Table } from './components/Table';
+export type {
+  TableProps,
+  TableCaptionProps,
+  TableSectionProps,
+  TableRowProps,
+  TableHeaderCellProps,
+  TableCellProps,
+  TableDensity,
+  TableCellAlign,
+  TableSortDirection,
+} from './components/Table';
+
 // i18n
 export { LocaleProvider, useLocale } from './i18n';
 export type { LocaleProviderProps } from './i18n';

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -38,6 +38,7 @@
   --color-warning-fg: #ffffff;
   --color-warning-bg-subtle: #fff7ed; // tinted surface for event chips / highlights
   --color-info: #0052cc;
+  --color-info-bg-subtle: #ebf3ff; // very light blue tint — between white and --color-accent-bg-subtle (#deebff); used for soft "hint" surfaces like table row hover
 
   // Badge palette — subtle bg + readable fg pairs
   --color-badge-neutral-bg: #f4f5f7;
@@ -170,6 +171,23 @@
 
   // Special line-heights
   --line-height-none: 1;
+
+  // Table — component-namespaced aliases over the base palette so a future
+  // theme can shift Table colors independently. Edit the right-hand side
+  // here, not the consumers in Table.module.scss.
+  --color-table-bg: var(--color-bg);
+  --color-table-fg: var(--color-fg);
+  --color-table-border: var(--color-border);
+  --color-table-header-bg: var(--color-bg-muted); // <thead> + <tfoot> rows
+  --color-table-header-bg-hover: var(--color-bg-sunken); // sortable <th>:hover
+  --color-table-header-fg: var(--color-fg-muted);
+  --color-table-caption-fg: var(--color-fg-muted);
+  --color-table-row-bg-striped: var(--color-bg-subtle);
+  --color-table-row-bg-hover: var(
+    --color-info-bg-subtle
+  ); // light blue — distinct from striped (gray) and selected (stronger blue)
+  --color-table-row-bg-selected: var(--color-accent-bg-subtle);
+  --color-table-row-fg-selected: var(--color-fg);
 
   // Presence dots (Avatar status). Aliases over the existing semantic
   // palette — theme changes propagate.

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -11,6 +11,7 @@ import { ButtonDemo } from './pages/components/ButtonDemo';
 import { DatePickersDemo } from './pages/components/DatePickersDemo';
 import { InputDemo } from './pages/components/InputDemo';
 import { SelectDemo } from './pages/components/SelectDemo';
+import { TableDemo } from './pages/components/TableDemo';
 import { CardDemo } from './pages/components/CardDemo';
 import { StackDemo } from './pages/components/StackDemo';
 import { ClusterDemo } from './pages/components/ClusterDemo';
@@ -42,6 +43,7 @@ export default function App() {
           <Route path="/components/datepickers" element={<DatePickersDemo />} />
           <Route path="/components/input" element={<InputDemo />} />
           <Route path="/components/select" element={<SelectDemo />} />
+          <Route path="/components/table" element={<TableDemo />} />
           <Route path="/components/card" element={<CardDemo />} />
           <Route path="/components/stack" element={<StackDemo />} />
           <Route path="/components/cluster" element={<ClusterDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -26,6 +26,7 @@ import {
   PanelLeft,
   ShieldCheck,
   CalendarDays,
+  Table as TableIcon,
   type LucideIcon,
 } from 'lucide-react';
 import { Avatar } from '@eocrm/design-system';
@@ -71,6 +72,7 @@ const componentGroups = [
       { to: '/components/avatar', label: 'Avatar', icon: CircleUser, end: false },
       { to: '/components/badge', label: 'Badge', icon: Tag, end: false },
       { to: '/components/calendar', label: 'Calendar', icon: CalendarDays, end: false },
+      { to: '/components/table', label: 'Table', icon: TableIcon, end: false },
     ],
   },
   {

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -8,6 +8,7 @@ import { Cluster } from '@eocrm/design-system';
 import { Input } from '@eocrm/design-system';
 import { Select } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
+import { Table } from '@eocrm/design-system';
 import { Tabs } from '@eocrm/design-system';
 import { DropdownMenu } from '@eocrm/design-system';
 import { Tooltip } from '@eocrm/design-system';
@@ -66,6 +67,34 @@ const items: { to: string; name: string; description: string; preview: React.Rea
           ]}
           placeholder="Pick a status"
         />
+      </div>
+    ),
+  },
+  {
+    to: '/components/table',
+    name: 'Table',
+    description:
+      'Tabular data primitive — compound subcomponents over native HTML semantics with density, hover, striped, and sortable-header visuals.',
+    preview: (
+      <div style={{ width: 220 }}>
+        <Table density="dense" scroll={false}>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Name</Table.HeaderCell>
+              <Table.HeaderCell align="end">Total</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Acme</Table.Cell>
+              <Table.Cell align="end">12.5K</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Beanstalk</Table.Cell>
+              <Table.Cell align="end">4.2K</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
       </div>
     ),
   },

--- a/packages/playground/src/pages/components/TableDemo.tsx
+++ b/packages/playground/src/pages/components/TableDemo.tsx
@@ -1,0 +1,310 @@
+import { useState } from 'react';
+import { Table, Badge } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Table/Table.tsx?raw';
+import scssSource from '@lib-source/components/Table/Table.module.scss?raw';
+
+interface Row {
+  id: string;
+  name: string;
+  status: 'Active' | 'Pending' | 'Archived';
+  amount: number;
+}
+
+const ROWS: Row[] = [
+  { id: 'a', name: 'Acme Corp', status: 'Active', amount: 12_500 },
+  { id: 'b', name: 'Beanstalk Ltd', status: 'Pending', amount: 4_200 },
+  { id: 'c', name: 'Cobalt Studios', status: 'Active', amount: 28_400 },
+  { id: 'd', name: 'Delta Mfg', status: 'Archived', amount: 800 },
+  { id: 'e', name: 'Echo Logistics', status: 'Active', amount: 7_900 },
+];
+
+const STATUS_TONE: Record<Row['status'], 'success' | 'warning' | 'neutral'> = {
+  Active: 'success',
+  Pending: 'warning',
+  Archived: 'neutral',
+};
+
+function StaticTable() {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Company</Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {ROWS.map((row) => (
+          <Table.Row key={row.id}>
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell>
+              <Badge tone={STATUS_TONE[row.status]}>{row.status}</Badge>
+            </Table.Cell>
+            <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}
+
+function SortableTable() {
+  const [sortKey, setSortKey] = useState<'name' | 'amount'>('name');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  const sorted = [...ROWS].sort((a, b) => {
+    const dir = sortDir === 'asc' ? 1 : -1;
+    if (sortKey === 'amount') return (a.amount - b.amount) * dir;
+    return a.name.localeCompare(b.name) * dir;
+  });
+
+  function dirFor(key: 'name' | 'amount') {
+    if (sortKey !== key) return 'none' as const;
+    return sortDir;
+  }
+
+  function toggle(key: 'name' | 'amount') {
+    if (sortKey === key) setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  }
+
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell sortDirection={dirFor('name')} onClick={() => toggle('name')}>
+            Company
+          </Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell
+            align="end"
+            sortDirection={dirFor('amount')}
+            onClick={() => toggle('amount')}
+          >
+            Amount
+          </Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {sorted.map((row) => (
+          <Table.Row key={row.id}>
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell>
+              <Badge tone={STATUS_TONE[row.status]}>{row.status}</Badge>
+            </Table.Cell>
+            <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}
+
+function SelectableTable() {
+  const [selectedId, setSelectedId] = useState<string | null>('c');
+
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Company</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {ROWS.map((row) => (
+          <Table.Row
+            key={row.id}
+            selected={selectedId === row.id}
+            onClick={() => setSelectedId(row.id)}
+            style={{ cursor: 'pointer' }}
+          >
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}
+
+export function TableDemo() {
+  return (
+    <DemoLayout
+      name="Table"
+      componentName="Table"
+      description="Tabular data primitive — compound subcomponents (Table.Header, Table.Body, Table.Row, Table.Cell, Table.HeaderCell, Table.Caption, Table.Footer) over native HTML semantics. Density, hover, striped, sticky-header, and sort-indicator visuals; data behavior (sort/filter/pagination) is the consumer's job."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Table.tsx"
+      scssFilename="Table.module.scss"
+    >
+      <Example
+        title="Default"
+        description="Comfortable density, hover on, no stripes. Native `<table>` semantics throughout."
+        code={`<Table>
+  <Table.Header>
+    <Table.Row>
+      <Table.HeaderCell>Company</Table.HeaderCell>
+      <Table.HeaderCell>Status</Table.HeaderCell>
+      <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    {rows.map((r) => (
+      <Table.Row key={r.id}>
+        <Table.Cell>{r.name}</Table.Cell>
+        <Table.Cell><Badge tone={...}>{r.status}</Badge></Table.Cell>
+        <Table.Cell align="end">\${r.amount.toLocaleString()}</Table.Cell>
+      </Table.Row>
+    ))}
+  </Table.Body>
+</Table>`}
+      >
+        <StaticTable />
+      </Example>
+
+      <Example
+        title="Dense"
+        description="24px row, 8px cell padding, `font-size-sm`. Useful for inline tables inside cards or narrow side panels."
+        code={`<Table density="dense">{...}</Table>`}
+      >
+        <Table density="dense">
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Company</Table.HeaderCell>
+              <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {ROWS.slice(0, 3).map((row) => (
+              <Table.Row key={row.id}>
+                <Table.Cell>{row.name}</Table.Cell>
+                <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      </Example>
+
+      <Example
+        title="Striped + hover"
+        description="Zebra stripes on even body rows. Hover is on by default; pass `hover={false}` to disable."
+        code={`<Table striped>{...}</Table>`}
+      >
+        <Table striped>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Company</Table.HeaderCell>
+              <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {ROWS.map((row) => (
+              <Table.Row key={row.id}>
+                <Table.Cell>{row.name}</Table.Cell>
+                <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      </Example>
+
+      <Example
+        title="Sortable headers"
+        description="`<Table.HeaderCell sortDirection>` renders a chevron + sets `aria-sort`. The primitive only paints the indicator — wire `onClick` to your own sort state. (DataTable will compose this seam.)"
+        code={`<Table.HeaderCell
+  sortDirection={sortKey === 'amount' ? sortDir : 'none'}
+  onClick={() => toggleSort('amount')}
+>
+  Amount
+</Table.HeaderCell>`}
+      >
+        <SortableTable />
+      </Example>
+
+      <Example
+        title="Selected row"
+        description="`<Table.Row selected>` paints a tinted bg + sets `aria-selected`. Click any row to select it (consumer-owned state)."
+        code={`<Table.Row selected={isSelected(row.id)} onClick={() => select(row.id)}>
+  {...}
+</Table.Row>`}
+      >
+        <SelectableTable />
+      </Example>
+
+      <Example
+        title="Sticky header"
+        description="`stickyHeader` keeps the header row visible while body rows scroll. Requires a scrollable ancestor — the default outer wrapper provides one."
+        code={`<div style={{ maxHeight: 200, overflow: 'auto' }}>
+  <Table stickyHeader scroll={false}>{...}</Table>
+</div>`}
+      >
+        <div
+          style={{
+            maxHeight: 200,
+            overflow: 'auto',
+            border: 'var(--border-width) solid var(--color-border)',
+            borderRadius: 'var(--radius-md)',
+          }}
+        >
+          <Table stickyHeader scroll={false}>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Company</Table.HeaderCell>
+                <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {[...ROWS, ...ROWS, ...ROWS].map((row, i) => (
+                <Table.Row key={`${row.id}-${i}`}>
+                  <Table.Cell>{row.name}</Table.Cell>
+                  <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </div>
+      </Example>
+
+      <Example
+        title="Truncated cell"
+        description="`<Table.Cell truncate>` ellipsizes overflow text. Requires a constrained cell width — set `style={{ maxWidth }}` on the cell or `<col>` width on the column."
+        code={`<Table.Cell truncate style={{ maxWidth: 180 }}>{longString}</Table.Cell>`}
+      >
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell style={{ width: 180 }}>Subject</Table.HeaderCell>
+              <Table.HeaderCell>Status</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell truncate style={{ maxWidth: 180 }}>
+                Q4 strategy: revisit the long-tail growth bets and align with platform launches
+              </Table.Cell>
+              <Table.Cell>
+                <Badge tone="warning">Pending</Badge>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell truncate style={{ maxWidth: 180 }}>
+                Short subject
+              </Table.Cell>
+              <Table.Cell>
+                <Badge tone="success">Active</Badge>
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/components/TableDemo.tsx
+++ b/packages/playground/src/pages/components/TableDemo.tsx
@@ -51,27 +51,32 @@ function StaticTable() {
   );
 }
 
+type SortKey = 'name' | 'amount';
+type SortState = { key: SortKey; dir: 'asc' | 'desc' } | null;
+
 function SortableTable() {
-  const [sortKey, setSortKey] = useState<'name' | 'amount'>('name');
-  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+  const [sort, setSort] = useState<SortState>(null);
 
-  const sorted = [...ROWS].sort((a, b) => {
-    const dir = sortDir === 'asc' ? 1 : -1;
-    if (sortKey === 'amount') return (a.amount - b.amount) * dir;
-    return a.name.localeCompare(b.name) * dir;
-  });
+  const sorted = sort
+    ? [...ROWS].sort((a, b) => {
+        const factor = sort.dir === 'asc' ? 1 : -1;
+        if (sort.key === 'amount') return (a.amount - b.amount) * factor;
+        return a.name.localeCompare(b.name) * factor;
+      })
+    : ROWS;
 
-  function dirFor(key: 'name' | 'amount') {
-    if (sortKey !== key) return 'none' as const;
-    return sortDir;
+  function dirFor(key: SortKey) {
+    if (sort?.key !== key) return 'none' as const;
+    return sort.dir;
   }
 
-  function toggle(key: 'name' | 'amount') {
-    if (sortKey === key) setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
-    else {
-      setSortKey(key);
-      setSortDir('asc');
-    }
+  // 3-state toggle: unsorted → asc → desc → unsorted → …
+  function toggle(key: SortKey) {
+    setSort((prev) => {
+      if (prev?.key !== key) return { key, dir: 'asc' };
+      if (prev.dir === 'asc') return { key, dir: 'desc' };
+      return null;
+    });
   }
 
   return (
@@ -245,7 +250,7 @@ export function TableDemo() {
 
       <Example
         title="Sortable headers"
-        description="`<Table.HeaderCell sortDirection>` renders a chevron + sets `aria-sort`. The primitive only paints the indicator — wire `onClick` to your own sort state. (DataTable will compose this seam.)"
+        description="`<Table.HeaderCell sortDirection>` renders the right chevron + sets `aria-sort`. The primitive only paints — wire `onClick` to your own state. Demo uses the typical 3-state cycle (unsorted → asc → desc → unsorted), but consumers can use any cycle. DataTable will compose this seam."
         code={`<Table.HeaderCell
   sortDirection={sortKey === 'amount' ? sortDir : 'none'}
   onClick={() => toggleSort('amount')}

--- a/packages/playground/src/pages/components/TableDemo.tsx
+++ b/packages/playground/src/pages/components/TableDemo.tsx
@@ -217,6 +217,33 @@ export function TableDemo() {
       </Example>
 
       <Example
+        title="Bordered"
+        description="Full-grid borders (outer + vertical between cells). Default is Atlassian-minimal (just row dividers + header underline); pass `bordered` for the heavier admin-screen look."
+        code={`<Table bordered>{...}</Table>`}
+      >
+        <Table bordered>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Company</Table.HeaderCell>
+              <Table.HeaderCell>Status</Table.HeaderCell>
+              <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {ROWS.map((row) => (
+              <Table.Row key={row.id}>
+                <Table.Cell>{row.name}</Table.Cell>
+                <Table.Cell>
+                  <Badge tone={STATUS_TONE[row.status]}>{row.status}</Badge>
+                </Table.Cell>
+                <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      </Example>
+
+      <Example
         title="Sortable headers"
         description="`<Table.HeaderCell sortDirection>` renders a chevron + sets `aria-sort`. The primitive only paints the indicator — wire `onClick` to your own sort state. (DataTable will compose this seam.)"
         code={`<Table.HeaderCell

--- a/packages/playground/src/pages/components/TableDemo.tsx
+++ b/packages/playground/src/pages/components/TableDemo.tsx
@@ -110,7 +110,7 @@ function SelectableTable() {
   const [selectedId, setSelectedId] = useState<string | null>('c');
 
   return (
-    <Table>
+    <Table hover>
       <Table.Header>
         <Table.Row>
           <Table.HeaderCell>Company</Table.HeaderCell>
@@ -195,10 +195,10 @@ export function TableDemo() {
 
       <Example
         title="Striped + hover"
-        description="Zebra stripes on even body rows. Hover is on by default; pass `hover={false}` to disable."
-        code={`<Table striped>{...}</Table>`}
+        description="Zebra stripes on even body rows + opt-in hover affordance. Both default off — use them together when the table represents a list of selectable rows."
+        code={`<Table striped hover>{...}</Table>`}
       >
-        <Table striped>
+        <Table striped hover>
           <Table.Header>
             <Table.Row>
               <Table.HeaderCell>Company</Table.HeaderCell>

--- a/packages/playground/src/pages/components/TableDemo.tsx
+++ b/packages/playground/src/pages/components/TableDemo.tsx
@@ -301,6 +301,54 @@ export function TableDemo() {
       </Example>
 
       <Example
+        title="Footer with totals"
+        description="`<Table.Footer>` (renders `<tfoot>`) is the spot for totals, summary, or pagination chrome. Same `--color-bg-muted` background as the header; doesn't participate in hover/striped."
+        code={`<Table>
+  <Table.Header>...</Table.Header>
+  <Table.Body>...</Table.Body>
+  <Table.Footer>
+    <Table.Row>
+      <Table.Cell>Total</Table.Cell>
+      <Table.Cell />
+      <Table.Cell align="end">{total}</Table.Cell>
+    </Table.Row>
+  </Table.Footer>
+</Table>`}
+      >
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Company</Table.HeaderCell>
+              <Table.HeaderCell>Status</Table.HeaderCell>
+              <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {ROWS.map((row) => (
+              <Table.Row key={row.id}>
+                <Table.Cell>{row.name}</Table.Cell>
+                <Table.Cell>
+                  <Badge tone={STATUS_TONE[row.status]}>{row.status}</Badge>
+                </Table.Cell>
+                <Table.Cell align="end">${row.amount.toLocaleString()}</Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+          <Table.Footer>
+            <Table.Row>
+              <Table.Cell>
+                <strong>Total</strong>
+              </Table.Cell>
+              <Table.Cell />
+              <Table.Cell align="end">
+                <strong>${ROWS.reduce((sum, r) => sum + r.amount, 0).toLocaleString()}</strong>
+              </Table.Cell>
+            </Table.Row>
+          </Table.Footer>
+        </Table>
+      </Example>
+
+      <Example
         title="Truncated cell"
         description="`<Table.Cell truncate>` ellipsizes overflow text. Requires a constrained cell width — set `style={{ maxWidth }}` on the cell or `<col>` width on the column."
         code={`<Table.Cell truncate style={{ maxWidth: 180 }}>{longString}</Table.Cell>`}

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -8,6 +8,7 @@ export type ComponentName =
   | 'InlineDateRangePicker'
   | 'Input'
   | 'Select'
+  | 'Table'
   | 'Card'
   | 'Stack'
   | 'Cluster'


### PR DESCRIPTION
## Summary

- New `<Table>` compound primitive — `Table`, `Table.Caption`, `Table.Header`, `Table.Body`, `Table.Footer`, `Table.Row`, `Table.HeaderCell`, `Table.Cell`. Subcomponents attached via `Object.assign` (matches existing `DropdownMenu` pattern). Native HTML elements throughout — no ARIA-on-divs.
- **Visual modifiers on root**: `density` (`'comfortable' | 'dense'`, default comfortable), `hover` (default true), `striped`, `stickyHeader`, `scroll` (default true — wraps `<table>` in `<div>` with `overflow-x: auto`).
- **`<Table.Row selected>`** — paints a tinted bg + `aria-selected="true"`. Selection logic itself is the consumer's job.
- **`<Table.HeaderCell sortDirection>`** — visual hook for the composition seam DataTable will use. Renders an up/down/unsorted chevron + sets `aria-sort`. Auto-adds `tabIndex={0}` + Enter/Space → click so the cell is keyboard-reachable (WCAG 2.1.1). Consumer-supplied `tabIndex` / `onKeyDown` still win.
- **`<Table.Cell align>`** / **`<Table.HeaderCell align>`** — `'start' | 'center' | 'end'` (CSS logical, RTL-friendly). Right-aligned headers auto-flip the sort chevron to the start side.
- **`<Table.Cell truncate>`** — ellipses overflow text on one line (requires constrained cell width).
- **No new tokens** — reuses `--color-bg-subtle`, `--color-border`, `--color-accent-bg-subtle`, etc.
- **No data behavior** — sort logic, pagination, filtering, selection state, empty/loading states all live in the future `<DataTable>`, not the primitive.

## Test plan

- [x] `npm test --run` — 815/815 (17 new Table tests, including ref-on-every-subcomponent, sortable keyboard a11y, striped-vs-selected cascade, caption-first-child, scope override, no-empty-span sortable)
- [x] `npm run typecheck` clean
- [x] `npm run lint:css` clean
- [x] `npm run build` clean
- [x] `npx prettier --check` clean
- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files in tarball
- [x] Manual smoke: 7 examples render (default, dense, striped, sortable, selected, sticky, truncated); sort chevron flips; selected row tints over striped; sticky header pins
- [x] Hard Rule 8 review cycles (2) — final verdict: clean enough to stop

## Notable Hard Rule 8 cycle-1 fixes

1. **Selection cascade bug** — `striped` was beating `selected` on even rows because `:nth-of-type(even)` bumped specificity. Fixed by adding `.striped .tbody .tr.selected` arm to match parity; later source-order then wins.
2. **WCAG 2.1.1 violation on sortable headers** — `<th>` is not natively focusable; consumers wiring `sortDirection` + `onClick` had no keyboard path. Fixed by auto-adding `tabIndex={0}` and Enter/Space → click handler. Consumer chains still win.

## Design spec / plan

- Spec: \`docs/superpowers/specs/2026-05-21-table-primitive-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-21-table-primitive.md\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>