### PR TITLE
Table: colSpan / rowSpan support (docs + demos + tests)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -452,6 +452,7 @@ const [tab, setTab] = useState('overview');
 - `<Table.HeaderCell sortDirection>` is a visual hook: renders an up / down / unsorted chevron + sets `aria-sort`. Wire `onClick` to your own sort state. `<DataTable>` (not yet shipped) will compose this seam.
 - `<Table.Cell align>` / `<Table.HeaderCell align>`: `'start' | 'center' | 'end'` (CSS logical, RTL-friendly). Right-aligned headers auto-flip the sort chevron to the start side.
 - `<Table.Cell truncate>` ellipses overflow text on one line. Requires a constrained cell width (`style={{ maxWidth }}` or `<col>`).
+- **`colSpan` / `rowSpan`** flow through to the native `<th>` / `<td>` via spread. Use for multi-row grouped headers (`rowSpan` on a corner cell + `colSpan` on group cells over a second `<Table.Row>`), category-grouped body rows (`rowSpan` on a leftmost cell), and footer total rows (`<Table.Cell colSpan={n}>Total</Table.Cell>`). Use `<Table.HeaderCell scope="row">` (instead of `<Table.Cell>`) for the leftmost cell when it labels its row to AT.
 - The native HTML `align` attribute on `<th>` / `<td>` is shadowed by the component-level `align` prop (logical) — `Omit<…, 'align'>` on both `*Props`.
 - **Use `<DataTable>` instead** when you need sorting / filtering / pagination state. Table is the paint primitive; DataTable will be the opinionated wrapper.
 

--- a/packages/design-system/src/components/Table/Table.test.tsx
+++ b/packages/design-system/src/components/Table/Table.test.tsx
@@ -357,4 +357,62 @@ describe('Table', () => {
     expect(thRef.current).toBeInstanceOf(HTMLTableCellElement);
     expect(tdRef.current).toBeInstanceOf(HTMLTableCellElement);
   });
+
+  it('passes colSpan / rowSpan through to native <th> and <td>', () => {
+    const { container } = render(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell colSpan={3}>Group header</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell rowSpan={2}>Spanning two rows</Table.Cell>
+            <Table.Cell>A</Table.Cell>
+            <Table.Cell colSpan={2}>Spanning two cols</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>B</Table.Cell>
+            <Table.Cell>C</Table.Cell>
+            <Table.Cell>D</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+    // colSpan on header — rendered DOM exposes the property as `colSpan`.
+    const th = container.querySelector('th')!;
+    expect(th.colSpan).toBe(3);
+    // rowSpan + colSpan on body cells.
+    const tds = container.querySelectorAll('tbody td');
+    expect((tds[0] as HTMLTableCellElement).rowSpan).toBe(2);
+    expect((tds[2] as HTMLTableCellElement).colSpan).toBe(2);
+  });
+
+  it('supports multi-row grouped header (colSpan on parent row + matching child cells)', () => {
+    const { container } = render(
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell rowSpan={2}>Region</Table.HeaderCell>
+            <Table.HeaderCell colSpan={2}>Q1</Table.HeaderCell>
+            <Table.HeaderCell colSpan={2}>Q2</Table.HeaderCell>
+          </Table.Row>
+          <Table.Row>
+            <Table.HeaderCell>Plan</Table.HeaderCell>
+            <Table.HeaderCell>Actual</Table.HeaderCell>
+            <Table.HeaderCell>Plan</Table.HeaderCell>
+            <Table.HeaderCell>Actual</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>,
+    );
+    const headerRows = container.querySelectorAll('thead tr');
+    expect(headerRows).toHaveLength(2);
+    const firstRowCells = headerRows[0].querySelectorAll('th');
+    expect((firstRowCells[0] as HTMLTableCellElement).rowSpan).toBe(2);
+    expect((firstRowCells[1] as HTMLTableCellElement).colSpan).toBe(2);
+    expect((firstRowCells[2] as HTMLTableCellElement).colSpan).toBe(2);
+    expect(headerRows[1].querySelectorAll('th')).toHaveLength(4);
+  });
 });

--- a/packages/playground/src/pages/components/TableDemo.tsx
+++ b/packages/playground/src/pages/components/TableDemo.tsx
@@ -341,15 +341,139 @@ export function TableDemo() {
           </Table.Body>
           <Table.Footer>
             <Table.Row>
-              <Table.Cell>
+              <Table.Cell colSpan={2}>
                 <strong>Total</strong>
               </Table.Cell>
-              <Table.Cell />
               <Table.Cell align="end">
                 <strong>${ROWS.reduce((sum, r) => sum + r.amount, 0).toLocaleString()}</strong>
               </Table.Cell>
             </Table.Row>
           </Table.Footer>
+        </Table>
+      </Example>
+
+      <Example
+        title="Grouped header (multi-row, colSpan + rowSpan)"
+        description="Native `colSpan` / `rowSpan` work straight through on `<Table.HeaderCell>` and `<Table.Cell>`. Bordered + multi-row header is the typical 'plan vs actual per quarter' shape."
+        code={`<Table bordered>
+  <Table.Header>
+    <Table.Row>
+      <Table.HeaderCell rowSpan={2}>Region</Table.HeaderCell>
+      <Table.HeaderCell colSpan={2} align="center">Q1</Table.HeaderCell>
+      <Table.HeaderCell colSpan={2} align="center">Q2</Table.HeaderCell>
+    </Table.Row>
+    <Table.Row>
+      <Table.HeaderCell align="end">Plan</Table.HeaderCell>
+      <Table.HeaderCell align="end">Actual</Table.HeaderCell>
+      <Table.HeaderCell align="end">Plan</Table.HeaderCell>
+      <Table.HeaderCell align="end">Actual</Table.HeaderCell>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>...</Table.Body>
+</Table>`}
+      >
+        <Table bordered>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell rowSpan={2}>Region</Table.HeaderCell>
+              <Table.HeaderCell colSpan={2} align="center">
+                Q1
+              </Table.HeaderCell>
+              <Table.HeaderCell colSpan={2} align="center">
+                Q2
+              </Table.HeaderCell>
+            </Table.Row>
+            <Table.Row>
+              <Table.HeaderCell align="end">Plan</Table.HeaderCell>
+              <Table.HeaderCell align="end">Actual</Table.HeaderCell>
+              <Table.HeaderCell align="end">Plan</Table.HeaderCell>
+              <Table.HeaderCell align="end">Actual</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>North</Table.Cell>
+              <Table.Cell align="end">100</Table.Cell>
+              <Table.Cell align="end">95</Table.Cell>
+              <Table.Cell align="end">120</Table.Cell>
+              <Table.Cell align="end">130</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>South</Table.Cell>
+              <Table.Cell align="end">80</Table.Cell>
+              <Table.Cell align="end">88</Table.Cell>
+              <Table.Cell align="end">90</Table.Cell>
+              <Table.Cell align="end">92</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>West</Table.Cell>
+              <Table.Cell align="end">60</Table.Cell>
+              <Table.Cell align="end">71</Table.Cell>
+              <Table.Cell align="end">75</Table.Cell>
+              <Table.Cell align="end">68</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </Example>
+
+      <Example
+        title="Row grouping (rowSpan in body)"
+        description="Use `rowSpan` on a body cell to label a category that owns several rows. Combine with `<th scope='row'>` on the spanning cell if it should be read as a row-header by AT."
+        code={`<Table bordered>
+  <Table.Header>...</Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.HeaderCell rowSpan={3} scope="row">Active</Table.HeaderCell>
+      <Table.Cell>Acme Corp</Table.Cell>
+      <Table.Cell align="end">$12,500</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>Cobalt Studios</Table.Cell>
+      <Table.Cell align="end">$28,400</Table.Cell>
+    </Table.Row>
+    {/* ... */}
+  </Table.Body>
+</Table>`}
+      >
+        <Table bordered>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Status</Table.HeaderCell>
+              <Table.HeaderCell>Company</Table.HeaderCell>
+              <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.HeaderCell rowSpan={3} scope="row">
+                <Badge tone="success">Active</Badge>
+              </Table.HeaderCell>
+              <Table.Cell>Acme Corp</Table.Cell>
+              <Table.Cell align="end">$12,500</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Cobalt Studios</Table.Cell>
+              <Table.Cell align="end">$28,400</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Echo Logistics</Table.Cell>
+              <Table.Cell align="end">$7,900</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.HeaderCell scope="row">
+                <Badge tone="warning">Pending</Badge>
+              </Table.HeaderCell>
+              <Table.Cell>Beanstalk Ltd</Table.Cell>
+              <Table.Cell align="end">$4,200</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.HeaderCell scope="row">
+                <Badge tone="neutral">Archived</Badge>
+              </Table.HeaderCell>
+              <Table.Cell>Delta Mfg</Table.Cell>
+              <Table.Cell align="end">$800</Table.Cell>
+            </Table.Row>
+          </Table.Body>
         </Table>
       </Example>
 


### PR DESCRIPTION
## Summary

colSpan and rowSpan **already work** on the Table primitive today — `<Table.HeaderCell>` and `<Table.Cell>` extend the native HTML attribute interfaces (`ThHTMLAttributes` / `TdHTMLAttributes`) and spread `{...props}` onto the underlying `<th>` / `<td>`. This PR closes the discoverability gap that made it look like a missing feature:

- **2 new tests** pin the contract:
  - colSpan/rowSpan reach the DOM on header + body cells
  - The multi-row grouped-header pattern (rowSpan on corner + colSpan on quarter groups + second row of leaf cells) renders the expected structure
- **3 new / updated demo examples**:
  1. "Footer with totals" — `colSpan={2}` on the Total label (was 3 separate cells before)
  2. **Grouped header (multi-row, colSpan + rowSpan)** — region × quarter × plan/actual shape
  3. **Row grouping (rowSpan in body)** — category-grouped rows using `<Table.HeaderCell rowSpan={N} scope="row">` for AT compatibility
- **AGENTS.md note** documenting the three idiomatic patterns + the `scope="row"` guidance

No library production code changed. The component already supports this — we just hadn't shown it.

## Test plan

- [x] `npm test --run` — 817/817 (was 815; +2 span tests)
- [x] `npm run typecheck` clean
- [x] `npm run lint:css` clean
- [x] `npm run build` clean
- [x] `npx prettier --check` clean
- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files in tarball

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>