### PR TITLE
Checkbox: native input + custom paint, sm/md/lg, indeterminate, label, invalid

### DIFF
--- a/docs/superpowers/plans/2026-05-21-checkbox.md
+++ b/docs/superpowers/plans/2026-05-21-checkbox.md
@@ -1,0 +1,1043 @@
+# Checkbox — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Checkbox>` — native `<input type="checkbox">` visually hidden + custom-painted box. Supports `size` (sm/md/lg), `checked` (controlled + uncontrolled), `indeterminate`, `label`, `invalid`, `disabled`, native HTML attr pass-through.
+
+**Architecture:** `<label class="checkbox size-md">` wraps a visually-hidden `<input>` + a `<span class="box">` painted via SCSS + an optional `<span class="labelText">`. Indeterminate flagged via `useEffect(() => { ref.current.indeterminate = … }, [indeterminate])`. Three new tokens: `--size-checkbox-{sm,md,lg}`.
+
+**Tech Stack:** React, SCSS modules, Vitest + RTL.
+
+**Branch:** `feat/checkbox`. Off fresh main.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-checkbox-design.md`.
+
+---
+
+## Task 1: Verify branch + hooks
+
+- [ ] **Step 1: Verify**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # → feat/checkbox
+git config --get core.hooksPath   # → .husky/_
+test -x .husky/pre-push           # exit 0
+```
+
+---
+
+## Task 2: Add `--size-checkbox-{sm,md,lg}` tokens
+
+**Files:**
+
+- Modify: `packages/design-system/src/styles/tokens.scss`
+
+- [ ] **Step 1: Insert near `--size-spinner` / `--size-chip`**
+
+Find the block that defines `--size-spinner`. Add directly above or below it:
+
+```scss
+// Checkbox box diameter per size. Pairs with the Input scale so a
+// checkbox labelled next to a `<Input size="sm">` lines up visually.
+--size-checkbox-sm: 14px;
+--size-checkbox-md: 16px;
+--size-checkbox-lg: 20px;
+```
+
+- [ ] **Step 2: Gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm run lint:css 2>&1 | tail -3
+npm run build 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/styles/tokens.scss
+git commit -m "tokens: add --size-checkbox-{sm,md,lg}"
+```
+
+---
+
+## Task 3: `Checkbox.tsx` + `Checkbox.module.scss`
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Checkbox/Checkbox.tsx`
+- Create: `packages/design-system/src/components/Checkbox/Checkbox.module.scss`
+
+- [ ] **Step 1: Write `Checkbox.tsx`**
+
+```tsx
+import {
+  forwardRef,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import { Check, Minus } from 'lucide-react';
+import { mergeRefs } from '../_internal/refs';
+import styles from './Checkbox.module.scss';
+
+/** Box diameter + label type scale. */
+export type CheckboxSize = 'sm' | 'md' | 'lg';
+
+export interface CheckboxProps
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
+  > {
+  /**
+   * Box diameter + label type scale. Defaults to `'md'`.
+   * - `'sm'` — 14px box, font-size-sm label. Dense tables, inline filters.
+   * - `'md'` — 16px box, font-size-md label. Default.
+   * - `'lg'` — 20px box, font-size-lg label. Hero forms, mobile-friendly.
+   *
+   * Note: shadows the native HTML `<input size>` attribute (which on
+   * checkboxes is meaningless anyway).
+   */
+  size?: CheckboxSize;
+
+  /**
+   * Controlled checked state. Pair with `onChange`. Omit (with optional
+   * `defaultChecked`) for uncontrolled use.
+   */
+  checked?: boolean;
+
+  /** Initial checked state for uncontrolled use. Defaults to `false`. */
+  defaultChecked?: boolean;
+
+  /**
+   * Indeterminate (mixed) visual + a11y state. Independent of `checked` —
+   * the box paints with a dash icon and `input.indeterminate = true` so AT
+   * announces "mixed". Consumer drives this based on partial selection
+   * (e.g., a "select all" header where some-but-not-all rows are selected).
+   *
+   * When the user clicks an indeterminate checkbox, the native change event
+   * fires with the next `checked` value (`true` if it was `false`). The
+   * consumer typically responds by clearing `indeterminate`.
+   */
+  indeterminate?: boolean;
+
+  /**
+   * Optional label rendered next to the box. The whole `<label>` is the
+   * click target. Omit for icon-only checkboxes (e.g., a DataTable row
+   * selector) — pass `aria-label` instead.
+   */
+  label?: ReactNode;
+
+  /** Toggles the error visual + sets `aria-invalid="true"`. */
+  invalid?: boolean;
+
+  /**
+   * Fires on every change. Receives the next checked state AND the native
+   * event so consumers can do `event.preventDefault()`, read modifier keys,
+   * etc.
+   */
+  onChange?: (checked: boolean, event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+const iconSize: Record<CheckboxSize, number> = {
+  sm: 10,
+  md: 12,
+  lg: 14,
+};
+
+/**
+ * Checkbox — native `<input type="checkbox">` visually hidden + custom-painted
+ * box. Supports checked / unchecked / indeterminate / disabled / invalid
+ * states. The native input owns all a11y (keyboard, screen reader, form
+ * submission, RHF/Zod integration); the custom paint owns the look.
+ *
+ * @example
+ * <Checkbox label="I agree to the terms" />
+ *
+ * @example
+ * // Controlled:
+ * <Checkbox checked={agreed} onChange={(next) => setAgreed(next)} label="I agree" />
+ *
+ * @example
+ * // Indeterminate ("select all" pattern):
+ * <Checkbox
+ *   checked={allSelected}
+ *   indeterminate={someSelected && !allSelected}
+ *   onChange={(next) => (next ? selectAll() : selectNone())}
+ *   aria-label="Select all rows"
+ * />
+ *
+ * @example
+ * // Icon-only (no visible label):
+ * <Checkbox aria-label="Select row" checked={isSelected} onChange={setIsSelected} />
+ *
+ * @remarks When NOT to use
+ * - Single binary on/off setting that toggles immediately and visually
+ *   communicates "on" vs "off" — use a `Switch` (not yet shipped).
+ * - One-of-many choice from a fixed set — use `Radio` (not yet shipped).
+ * - Multi-select from a long list — use `<Select multi>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Treating `indeterminate` as a third value. It's a display flag for
+ *   "partial selection"; `checked` is still the underlying boolean. Clicking
+ *   an indeterminate checkbox emits `onChange(nextChecked)` based on the
+ *   current `checked` state, not on `indeterminate`.
+ * - ❌ Wrapping the checkbox in your own `<label>`. We already wrap it; an
+ *   outer `<label>` nests two and breaks the click contract.
+ * - ❌ Omitting `label` AND `aria-label`. Screen readers will announce just
+ *   "checkbox" with no context.
+ */
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  {
+    size = 'md',
+    checked,
+    defaultChecked,
+    indeterminate,
+    label,
+    invalid,
+    onChange,
+    className,
+    disabled,
+    ...props
+  },
+  ref,
+) {
+  const isControlled = checked !== undefined;
+  const [internalChecked, setInternalChecked] = useState(defaultChecked ?? false);
+  const currentChecked = isControlled ? checked : internalChecked;
+
+  // Native `indeterminate` is a DOM property, not an attribute. React doesn't
+  // surface it as a prop, so we set it via ref in an effect that fires after
+  // each render — covers both initial mount and prop changes.
+  const inputRef = useRef<HTMLInputElement>(null);
+  const mergedRef = mergeRefs(ref, inputRef);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate ?? false;
+    }
+  }, [indeterminate]);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const next = event.target.checked;
+    if (!isControlled) setInternalChecked(next);
+    onChange?.(next, event);
+  };
+
+  return (
+    <label
+      className={clsx(
+        styles.checkbox,
+        styles[`size-${size}`],
+        disabled && styles.disabled,
+        invalid && styles.invalid,
+        className,
+      )}
+    >
+      <input
+        {...props}
+        ref={mergedRef}
+        type="checkbox"
+        checked={currentChecked}
+        disabled={disabled}
+        aria-invalid={invalid || undefined}
+        onChange={handleChange}
+        className={styles.input}
+      />
+      <span aria-hidden="true" className={styles.box}>
+        {indeterminate ? (
+          <Minus size={iconSize[size]} strokeWidth={3} />
+        ) : currentChecked ? (
+          <Check size={iconSize[size]} strokeWidth={3} />
+        ) : null}
+      </span>
+      {label != null && <span className={styles.labelText}>{label}</span>}
+    </label>
+  );
+});
+```
+
+- [ ] **Step 2: Write `Checkbox.module.scss`**
+
+```scss
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+  user-select: none;
+
+  &.disabled {
+    cursor: not-allowed;
+  }
+}
+
+// Visually-hidden native input — stays in tab order + AT tree.
+.input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// The painted box.
+.box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border: var(--border-width) solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  color: var(--color-accent-fg);
+  transition:
+    border-color var(--transition-fast),
+    background var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+// Size modifiers — box diameter + label font.
+.size-sm .box {
+  width: var(--size-checkbox-sm);
+  height: var(--size-checkbox-sm);
+}
+
+.size-md .box {
+  width: var(--size-checkbox-md);
+  height: var(--size-checkbox-md);
+}
+
+.size-lg .box {
+  width: var(--size-checkbox-lg);
+  height: var(--size-checkbox-lg);
+}
+
+.size-sm .labelText {
+  font-size: var(--font-size-sm);
+}
+
+.size-md .labelText {
+  font-size: var(--font-size-md);
+}
+
+.size-lg .labelText {
+  font-size: var(--font-size-lg);
+}
+
+// Hover preview — border only, no fill (Atlassian-style restraint).
+.checkbox:not(.disabled):hover .box {
+  border-color: var(--color-accent);
+}
+
+// Checked + indeterminate share the filled-accent visual.
+.input:checked + .box,
+.input:indeterminate + .box {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+// Focus ring on the box (sibling selector picks up native input focus).
+.input:focus-visible + .box {
+  box-shadow: 0 0 0 var(--ring-width) var(--ring-accent);
+}
+
+// Disabled — muted bg + border. The input still receives `disabled`
+// natively which gates pointer events on the label.
+.disabled .box {
+  background: var(--color-bg-subtle);
+  border-color: var(--color-border);
+  color: var(--color-fg-disabled);
+}
+
+.disabled .input:checked + .box,
+.disabled .input:indeterminate + .box {
+  background: var(--color-border);
+  border-color: var(--color-border);
+}
+
+.disabled .labelText {
+  color: var(--color-fg-disabled);
+}
+
+// Invalid — danger border + danger focus ring. Wins over the unchecked
+// hover preview.
+.invalid .box {
+  border-color: var(--color-danger);
+}
+
+.invalid .input:focus-visible + .box {
+  box-shadow: 0 0 0 var(--ring-width) var(--ring-danger);
+}
+
+.invalid .input:checked + .box,
+.invalid .input:indeterminate + .box {
+  background: var(--color-danger);
+  border-color: var(--color-danger);
+}
+
+.labelText {
+  line-height: var(--line-height-normal);
+}
+```
+
+- [ ] **Step 3: Gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm run typecheck 2>&1 | tail -5
+npm run lint:css 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+If stylelint flags any rules, address inline (likely none — the SCSS uses only tokens and standard selectors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Checkbox/Checkbox.tsx \
+        packages/design-system/src/components/Checkbox/Checkbox.module.scss
+git commit -m "Checkbox: new component — native input + custom paint, sm/md/lg, indeterminate"
+```
+
+---
+
+## Task 4: `Checkbox.test.tsx`
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Checkbox/Checkbox.test.tsx`
+
+- [ ] **Step 1: Write the tests**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { Checkbox } from './Checkbox';
+
+describe('Checkbox', () => {
+  it('renders unchecked by default', () => {
+    render(<Checkbox label="Agree" />);
+    const input = screen.getByRole('checkbox', { name: 'Agree' });
+    expect(input).not.toBeChecked();
+  });
+
+  it('uses defaultChecked for uncontrolled initial state', () => {
+    render(<Checkbox label="Agree" defaultChecked />);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('reflects controlled `checked`', () => {
+    const { rerender } = render(<Checkbox label="Agree" checked={false} onChange={() => {}} />);
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    rerender(<Checkbox label="Agree" checked onChange={() => {}} />);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('fires onChange with (nextChecked, event) on click', async () => {
+    const user = userEvent.setup();
+    const handle = vi.fn();
+    render(<Checkbox label="Agree" onChange={handle} />);
+    await user.click(screen.getByRole('checkbox'));
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle.mock.calls[0][0]).toBe(true);
+    expect(handle.mock.calls[0][1]).toBeDefined();
+    expect(handle.mock.calls[0][1].target).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it('toggling the label text also fires onChange', async () => {
+    const user = userEvent.setup();
+    const handle = vi.fn();
+    render(<Checkbox label="Click my text" onChange={handle} />);
+    await user.click(screen.getByText('Click my text'));
+    expect(handle).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets indeterminate on the DOM input and renders the dash icon', () => {
+    const { container, rerender } = render(<Checkbox label="Mixed" indeterminate />);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(input.indeterminate).toBe(true);
+    // Dash icon visible (lucide renders an <svg>).
+    expect(container.querySelector('svg')).toBeInTheDocument();
+
+    // Toggle off — indeterminate cleared, no icon when also unchecked.
+    rerender(<Checkbox label="Mixed" indeterminate={false} />);
+    expect(input.indeterminate).toBe(false);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('disabled propagates and blocks click', async () => {
+    const user = userEvent.setup();
+    const handle = vi.fn();
+    render(<Checkbox label="Locked" disabled onChange={handle} />);
+    const input = screen.getByRole('checkbox');
+    expect(input).toBeDisabled();
+    await user.click(input);
+    expect(handle).not.toHaveBeenCalled();
+  });
+
+  it('invalid sets aria-invalid + invalid class', () => {
+    const { container } = render(<Checkbox label="Required" invalid />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-invalid', 'true');
+    expect(container.querySelector('label')!.className).toMatch(/invalid/);
+  });
+
+  it('renders without label when only aria-label is provided', () => {
+    const { container } = render(<Checkbox aria-label="Select row" />);
+    expect(screen.getByRole('checkbox', { name: 'Select row' })).toBeInTheDocument();
+    // No .labelText span — the label prop is unset.
+    expect(container.querySelector('span[class*="labelText"]')).toBeNull();
+  });
+
+  it('applies size class names for sm / md / lg', () => {
+    const { container, rerender } = render(<Checkbox label="X" size="sm" />);
+    expect(container.querySelector('label')!.className).toMatch(/size-sm/);
+    rerender(<Checkbox label="X" size="md" />);
+    expect(container.querySelector('label')!.className).toMatch(/size-md/);
+    rerender(<Checkbox label="X" size="lg" />);
+    expect(container.querySelector('label')!.className).toMatch(/size-lg/);
+  });
+
+  it('defaults to size="md"', () => {
+    const { container } = render(<Checkbox label="X" />);
+    expect(container.querySelector('label')!.className).toMatch(/size-md/);
+  });
+
+  it('does NOT pass component size prop through to the DOM size attribute', () => {
+    render(<Checkbox label="X" size="sm" />);
+    expect(screen.getByRole('checkbox')).not.toHaveAttribute('size');
+  });
+
+  it('forwards ref to the native input', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<Checkbox label="X" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    expect(ref.current?.type).toBe('checkbox');
+  });
+
+  it('merges className on the outer label', () => {
+    const { container } = render(<Checkbox label="X" className="my-cls" />);
+    expect(container.querySelector('label.my-cls')).not.toBeNull();
+  });
+
+  it('name + value flow through for FormData', () => {
+    render(
+      <form data-testid="form">
+        <Checkbox name="agree" value="yes" defaultChecked />
+      </form>,
+    );
+    const form = screen.getByTestId('form') as HTMLFormElement;
+    const fd = new FormData(form);
+    expect(fd.get('agree')).toBe('yes');
+  });
+});
+```
+
+- [ ] **Step 2: Gates**
+
+```bash
+npm test --workspace=@eocrm/design-system --run -- src/components/Checkbox 2>&1 | tail -8
+```
+
+All 14 tests must pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/Checkbox/Checkbox.test.tsx
+git commit -m "Checkbox: unit tests for controlled/uncontrolled, indeterminate, sizes, a11y, form"
+```
+
+---
+
+## Task 5: Barrel + re-export from `src/index.ts`
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Checkbox/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+- [ ] **Step 1: Write `index.ts`**
+
+```ts
+export { Checkbox } from './Checkbox';
+export type { CheckboxProps, CheckboxSize } from './Checkbox';
+```
+
+- [ ] **Step 2: Re-export from `src/index.ts`**
+
+Read the file first. Slot alphabetically (after `Card`, before `Cluster`):
+
+```ts
+export { Checkbox } from './components/Checkbox';
+export type { CheckboxProps, CheckboxSize } from './components/Checkbox';
+```
+
+- [ ] **Step 3: Gates**
+
+```bash
+npm run typecheck 2>&1 | tail -3
+npm run build 2>&1 | tail -3
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Checkbox/index.ts \
+        packages/design-system/src/index.ts
+git commit -m "Checkbox: re-export from barrel + src/index.ts (Rule 5)"
+```
+
+---
+
+## Task 6: Playground demo + wiring
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/CheckboxDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Write `CheckboxDemo.tsx`**
+
+```tsx
+import { useMemo, useState } from 'react';
+import { Button, Checkbox, Cluster, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import { InputExample } from './InputExample';
+import tsxSource from '@lib-source/components/Checkbox/Checkbox.tsx?raw';
+import scssSource from '@lib-source/components/Checkbox/Checkbox.module.scss?raw';
+
+const TEAM = ['Alex', 'Priya', 'Tom', 'Sara', 'Jaden'];
+
+function ControlledDemo() {
+  const [agreed, setAgreed] = useState(false);
+  return (
+    <Stack gap="xs">
+      <Checkbox checked={agreed} onChange={setAgreed} label="I agree to the terms" />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        agreed = {String(agreed)}
+      </code>
+    </Stack>
+  );
+}
+
+function IndeterminateDemo() {
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+  const selectedCount = useMemo(() => Object.values(selected).filter(Boolean).length, [selected]);
+  const allChecked = selectedCount === TEAM.length;
+  const someChecked = selectedCount > 0 && !allChecked;
+
+  function toggleAll(next: boolean) {
+    const map: Record<string, boolean> = {};
+    if (next) for (const name of TEAM) map[name] = true;
+    setSelected(map);
+  }
+
+  function toggleOne(name: string, next: boolean) {
+    setSelected((prev) => ({ ...prev, [name]: next }));
+  }
+
+  return (
+    <Stack gap="sm">
+      <Checkbox
+        checked={allChecked}
+        indeterminate={someChecked}
+        onChange={toggleAll}
+        label={
+          <strong>
+            Select all ({selectedCount} of {TEAM.length})
+          </strong>
+        }
+      />
+      <Stack gap="xs" style={{ paddingLeft: 'var(--space-5)' }}>
+        {TEAM.map((name) => (
+          <Checkbox
+            key={name}
+            checked={!!selected[name]}
+            onChange={(next) => toggleOne(name, next)}
+            label={name}
+          />
+        ))}
+      </Stack>
+    </Stack>
+  );
+}
+
+function FormDemo() {
+  const [submitted, setSubmitted] = useState<string | null>(null);
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const fd = new FormData(e.currentTarget);
+        const values = fd.getAll('notify');
+        setSubmitted(values.length ? values.join(', ') : '(none)');
+      }}
+    >
+      <Stack gap="xs">
+        <Checkbox name="notify" value="email" defaultChecked label="Email" />
+        <Checkbox name="notify" value="sms" label="SMS" />
+        <Checkbox name="notify" value="push" label="Push" />
+        <Button type="submit" size="sm">
+          Submit
+        </Button>
+        {submitted !== null && (
+          <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+            notify = {submitted}
+          </code>
+        )}
+      </Stack>
+    </form>
+  );
+}
+
+export function CheckboxDemo() {
+  return (
+    <DemoLayout
+      name="Checkbox"
+      componentName="Checkbox"
+      description="Native `<input type='checkbox'>` visually hidden + custom-painted box. Supports controlled / uncontrolled state, indeterminate (mixed) state, sizes, label, disabled, invalid, and full native form integration."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Checkbox.tsx"
+      scssFilename="Checkbox.module.scss"
+    >
+      <Example
+        title="Default"
+        description="Uncontrolled, with a label. The whole label is the click target."
+        code={`<Checkbox label="I agree to the terms" />`}
+      >
+        <InputExample>
+          <Checkbox label="I agree to the terms" />
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Sizes"
+        description="Three sizes — sm (14px box / font-size-sm) / md (16px / font-size-md, default) / lg (20px / font-size-lg). Same scale as <Input>."
+        code={`<Checkbox size="sm" label="Small" />
+<Checkbox size="md" label="Medium" />
+<Checkbox size="lg" label="Large" />`}
+      >
+        <InputExample>
+          <Stack gap="sm">
+            <Checkbox size="sm" label="Small" defaultChecked />
+            <Checkbox size="md" label="Medium" defaultChecked />
+            <Checkbox size="lg" label="Large" defaultChecked />
+          </Stack>
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Controlled"
+        description="Provide `checked` + `onChange`. The handler receives `(nextChecked, event)`."
+        code={`const [agreed, setAgreed] = useState(false);
+<Checkbox checked={agreed} onChange={setAgreed} label="I agree" />`}
+      >
+        <InputExample>
+          <ControlledDemo />
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Indeterminate (select-all pattern)"
+        description="When some-but-not-all child checkboxes are selected, the parent renders an indeterminate dash. Clicking the parent in indeterminate state toggles to checked → consumer responds by selecting all."
+        code={`<Checkbox
+  checked={allChecked}
+  indeterminate={someChecked}
+  onChange={(next) => toggleAll(next)}
+  label="Select all"
+/>`}
+      >
+        <InputExample>
+          <IndeterminateDemo />
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Disabled"
+        description="The native `disabled` attribute is forwarded — click is blocked and the box mutes."
+        code={`<Checkbox disabled defaultChecked label="Locked (checked)" />
+<Checkbox disabled label="Locked (unchecked)" />`}
+      >
+        <InputExample>
+          <Stack gap="xs">
+            <Checkbox disabled defaultChecked label="Locked (checked)" />
+            <Checkbox disabled label="Locked (unchecked)" />
+          </Stack>
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Invalid"
+        description="`invalid` adds the danger border + sets `aria-invalid='true'`. Pair with a visible error message and `aria-describedby`."
+        code={`<Checkbox invalid required aria-describedby="terms-error" label="Accept terms" />
+<p id="terms-error">You must accept to continue.</p>`}
+      >
+        <InputExample>
+          <Stack gap="xs">
+            <Checkbox invalid required aria-describedby="terms-error" label="Accept terms" />
+            <p
+              id="terms-error"
+              style={{ color: 'var(--color-danger)', fontSize: 'var(--font-size-xs)' }}
+            >
+              You must accept to continue.
+            </p>
+          </Stack>
+        </InputExample>
+      </Example>
+
+      <Example
+        title="No label (icon-only)"
+        description="Omit `label` for icon-only checkboxes (e.g., a DataTable row selector). Always pair with `aria-label`."
+        code={`<Checkbox aria-label="Select row" />`}
+      >
+        <InputExample>
+          <Checkbox aria-label="Select row" />
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Form integration"
+        description="`name` + `value` round-trip through native FormData. Same-`name` checkboxes group via `FormData.getAll(name)`."
+        code={`<form>
+  <Checkbox name="notify" value="email" defaultChecked label="Email" />
+  <Checkbox name="notify" value="sms" label="SMS" />
+  <Checkbox name="notify" value="push" label="Push" />
+  <button type="submit">Submit</button>
+</form>
+
+// On submit: const values = new FormData(form).getAll('notify');`}
+      >
+        <InputExample>
+          <FormDemo />
+        </InputExample>
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+- [ ] **Step 2: Wire `App.tsx`**
+
+Add import (alphabetical, after `Card`, before `Cluster`) and route:
+
+```tsx
+import { CheckboxDemo } from './pages/components/CheckboxDemo';
+// …
+<Route path="/components/checkbox" element={<CheckboxDemo />} />
+```
+
+- [ ] **Step 3: Wire `AppShell.tsx`**
+
+Add a Forms-group entry alphabetically (between Button and "Date pickers" most likely):
+
+```tsx
+import { CheckSquare } from 'lucide-react';
+// …
+{ to: '/components/checkbox', label: 'Checkbox', icon: CheckSquare, end: false },
+```
+
+- [ ] **Step 4: Wire `ComponentsIndex.tsx`**
+
+Add `Checkbox` to the `@eocrm/design-system` import and a card alphabetically:
+
+```tsx
+{
+  to: '/components/checkbox',
+  name: 'Checkbox',
+  description: 'Native-input-backed checkbox with custom paint — sizes, indeterminate, label, invalid, full form integration.',
+  preview: (
+    <Stack gap="xs">
+      <Checkbox defaultChecked label="Checked" />
+      <Checkbox indeterminate label="Indeterminate" />
+      <Checkbox label="Unchecked" />
+    </Stack>
+  ),
+},
+```
+
+- [ ] **Step 5: Wire `registry.ts`**
+
+Add `'Checkbox'` to the `ComponentName` union alphabetically.
+
+- [ ] **Step 6: Gates**
+
+```bash
+npm run typecheck 2>&1 | tail -3
+npm run build 2>&1 | tail -3
+```
+
+- [ ] **Step 7: Smoke test**
+
+Browse `/components/checkbox` in dev server. Verify all 8 examples render, indeterminate dash shows, hover shifts border, focus ring appears on keyboard tab, sizes look right.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/playground/src/
+git commit -m "CheckboxDemo: examples + sidebar + index + registry wiring"
+```
+
+---
+
+## Task 7: AGENTS.md section
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Insert after `<Input>`**
+
+```bash
+grep -n "^### \`<Card>\`\|^### \`<Input>\`" packages/design-system/AGENTS.md
+```
+
+After the `<Input>` section, before the next section (likely `<Card>`):
+
+```markdown
+### `<Checkbox>` — checkbox with native input + custom paint
+
+```tsx
+<Checkbox label="I agree" />
+<Checkbox checked={agreed} onChange={setAgreed} label="Subscribe" />
+<Checkbox indeterminate checked={allSelected} onChange={selectAll} aria-label="Select all" />
+```
+
+- Native `<input type='checkbox'>` is visually hidden but stays in tab order + AT tree — keyboard, screen reader, form submission, RHF/Zod, autofill all work.
+- `size`: `sm` (14px) / `md` (16px, default) / `lg` (20px). Same scale as `<Input>`.
+- `checked` + `onChange(next, event)` for controlled; `defaultChecked` for uncontrolled.
+- `indeterminate` is a display flag, NOT a third value. Pairs with `checked` for the "select all where some-but-not-all are picked" pattern. Clicking an indeterminate checkbox emits `onChange(nextChecked)` based on the current `checked`; consumer typically clears `indeterminate` in response.
+- `label` (ReactNode) renders next to the box; the whole `<label>` is the click target. Omit `label` for icon-only checkboxes (e.g., DataTable row selectors) and pass `aria-label` instead.
+- `invalid` adds the danger border + sets `aria-invalid='true'`. Pair with a visible error + `aria-describedby`.
+- Native HTML attrs flow through (`name`, `value`, `required`, `form`, `autoFocus`, etc.) — `FormData.getAll(name)` returns the array of checked values for same-`name` checkboxes.
+- forwardRef points at the native `<input>` so consumers can `.focus()` or programmatically set `.indeterminate`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/design-system/AGENTS.md
+git commit -m "AGENTS.md: document new <Checkbox> component"
+```
+
+---
+
+## Task 8: Final gates + Hard Rule 8 + PR
+
+- [ ] **Step 1: Prettier write**
+
+```bash
+npx prettier --write "packages/**/src/**/*.{ts,tsx,scss}" "docs/**/*.md" "packages/design-system/AGENTS.md"
+git add -A packages/ docs/
+git diff --cached --stat
+git commit -m "Prettier: format Checkbox changes" || echo "no formatting changes"
+```
+
+- [ ] **Step 2: Full gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test --workspace=@eocrm/design-system --run 2>&1 | tail -5
+npm run typecheck 2>&1 | tail -5
+npm run lint:css 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+npx prettier --check "packages/**/src/**/*.{ts,tsx,scss}" "docs/**/*.md" "packages/design-system/AGENTS.md" 2>&1 | tail -3
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -cE "\.test\."
+```
+
+All green; npm pack count = 0.
+
+- [ ] **Step 3: Push**
+
+```bash
+git push -u origin feat/checkbox
+```
+
+- [ ] **Step 4: Hard Rule 8 review cycle**
+
+Dispatch a fresh-context review agent. Specifics to look at hard:
+
+- `mergeRefs` import path — does `_internal/refs` export it? (Tooltip imports it, so yes — verify the import.)
+- The `Omit<…, 'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'>` — `onChange` is added to the Omit because we re-type the signature. Verify the spec's earlier listing said `'size' | 'type' | 'checked' | 'defaultChecked'` only — the addition of `'onChange'` is correct but worth noting.
+- The visually-hidden recipe — does it preserve tab order? (Yes — `position: absolute; opacity unspecified; clip; width 1px` — still focusable.)
+- Indeterminate-via-ref effect — does it correctly clear when `indeterminate` becomes false? (Yes, the effect runs on every change with `indeterminate ?? false`.)
+- Disabled + label — clicking the label of a disabled checkbox should NOT toggle. Native `<input disabled>` handles this for click events fired on the input directly, but a click on the label still tries to forward to the input — verify Vitest test passes.
+- Same-`name` form behaviour — `FormData.getAll('notify')` returns the array of `value` strings for checked checkboxes. Verify the test asserts this correctly.
+- Hover border shift on disabled — `.checkbox:not(.disabled):hover .box` correctly skips disabled. Verify.
+
+- [ ] **Step 5: Fix Critical + Important findings; re-push; re-review until clean.**
+
+- [ ] **Step 6: Open PR**
+
+```bash
+gh pr create --title "Checkbox: native-input + custom paint, sm/md/lg, indeterminate, label, invalid" --body "$(cat <<'EOF'
+## Summary
+
+- New `<Checkbox>` component — native `<input type='checkbox'>` visually hidden + custom-painted box. The native input owns all a11y (keyboard, screen reader, form submission, RHF/Zod); the paint owns the look.
+- `size`: `'sm' | 'md' | 'lg'` (default `'md'`). Three new tokens: `--size-checkbox-{sm,md,lg}` (14 / 16 / 20px).
+- `checked` + `onChange(next, event)` for controlled; `defaultChecked` for uncontrolled.
+- `indeterminate` is a display flag (not a third value) — sets `input.indeterminate = true` via ref + paints the dash icon. Models the "select all where some-but-not-all are picked" pattern DataTable will use.
+- `label` renders next to the box inside the `<label>` wrapper; omit + pass `aria-label` for icon-only checkboxes.
+- `invalid` adds danger border + `aria-invalid='true'`. Hover preview is border-only (no fill tint).
+- Native HTML attrs flow through (`name`, `value`, `required`, `form`); `FormData.getAll(name)` returns the array of checked values for same-`name` groups.
+
+Unblocks DataTable v1 row selection (next PR).
+
+## Test plan
+
+- [x] `npm test --run` — all green, including 14 new Checkbox tests.
+- [x] `npm run typecheck` clean
+- [x] `npm run lint:css` clean
+- [x] `npm run build` clean
+- [x] `npx prettier --check` clean
+- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files in tarball
+- [x] Manual smoke (Playwright): all 8 demo examples render; indeterminate dash visible; hover/focus rings correct; sizes align to Input scale
+- [x] Hard Rule 8 review cycle — final verdict: clean enough to stop
+
+## Design spec / plan
+
+- Spec: \`docs/superpowers/specs/2026-05-21-checkbox-design.md\`
+- Plan: \`docs/superpowers/plans/2026-05-21-checkbox.md\`
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+Spec coverage:
+
+- §Public API → Task 3 (Checkbox.tsx).
+- §Visual / tokens → Task 2 (3 new tokens) + Task 3 SCSS.
+- §States covered → Task 3 + Task 4 (tests).
+- §A11y → Task 3 (native input + label wrap + aria-invalid + aria-label).
+- §Implementation notes → Task 3 (mergeRefs + visually-hidden + indeterminate effect).
+- §Tests → Task 4.
+- §Playground demo → Task 6 (8 examples).
+- §AGENTS.md → Task 7.
+- §Hard Rule 8 + PR → Task 8.
+
+Type consistency:
+
+- `CheckboxSize = 'sm' | 'md' | 'lg'` — matches Input / Select / DatePicker.
+- Re-exported from both barrels.
+- `onChange: (checked: boolean, event)` — matches Tabs `onChange(id)` pattern + Select's value-first signature.
+
+No placeholders. All paths absolute. All commits scoped.

--- a/docs/superpowers/plans/2026-05-21-checkbox.md
+++ b/docs/superpowers/plans/2026-05-21-checkbox.md
@@ -88,11 +88,10 @@ import styles from './Checkbox.module.scss';
 /** Box diameter + label type scale. */
 export type CheckboxSize = 'sm' | 'md' | 'lg';
 
-export interface CheckboxProps
-  extends Omit<
-    InputHTMLAttributes<HTMLInputElement>,
-    'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
-  > {
+export interface CheckboxProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
+> {
   /**
    * Box diameter + label type scale. Defaults to `'md'`.
    * - `'sm'` — 14px box, font-size-sm label. Dense tables, inline filters.
@@ -838,7 +837,7 @@ Add import (alphabetical, after `Card`, before `Cluster`) and route:
 ```tsx
 import { CheckboxDemo } from './pages/components/CheckboxDemo';
 // …
-<Route path="/components/checkbox" element={<CheckboxDemo />} />
+<Route path="/components/checkbox" element={<CheckboxDemo />} />;
 ```
 
 - [ ] **Step 3: Wire `AppShell.tsx`**
@@ -908,7 +907,7 @@ grep -n "^### \`<Card>\`\|^### \`<Input>\`" packages/design-system/AGENTS.md
 
 After the `<Input>` section, before the next section (likely `<Card>`):
 
-```markdown
+````markdown
 ### `<Checkbox>` — checkbox with native input + custom paint
 
 ```tsx
@@ -916,6 +915,7 @@ After the `<Input>` section, before the next section (likely `<Card>`):
 <Checkbox checked={agreed} onChange={setAgreed} label="Subscribe" />
 <Checkbox indeterminate checked={allSelected} onChange={selectAll} aria-label="Select all" />
 ```
+````
 
 - Native `<input type='checkbox'>` is visually hidden but stays in tab order + AT tree — keyboard, screen reader, form submission, RHF/Zod, autofill all work.
 - `size`: `sm` (14px) / `md` (16px, default) / `lg` (20px). Same scale as `<Input>`.
@@ -925,14 +925,15 @@ After the `<Input>` section, before the next section (likely `<Card>`):
 - `invalid` adds the danger border + sets `aria-invalid='true'`. Pair with a visible error + `aria-describedby`.
 - Native HTML attrs flow through (`name`, `value`, `required`, `form`, `autoFocus`, etc.) — `FormData.getAll(name)` returns the array of checked values for same-`name` checkboxes.
 - forwardRef points at the native `<input>` so consumers can `.focus()` or programmatically set `.indeterminate`.
-```
+
+````
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add packages/design-system/AGENTS.md
 git commit -m "AGENTS.md: document new <Checkbox> component"
-```
+````
 
 ---
 

--- a/docs/superpowers/specs/2026-05-21-checkbox-design.md
+++ b/docs/superpowers/specs/2026-05-21-checkbox-design.md
@@ -16,8 +16,10 @@ DataTable v1 (next PR) needs row-selection checkboxes. The library's `CLAUDE.md`
 
 ```tsx
 <label>
-  <input type="checkbox" class="visually-hidden" />   ← native input owns all a11y
-  <span class="box" aria-hidden>                       ← custom-painted box
+  <input type="checkbox" class="visually-hidden" /> ← native input owns all a11y
+  <span class="box" aria-hidden>
+    {' '}
+    ← custom-painted box
     {checked && <CheckIcon />}
     {indeterminate && <MinusIcon />}
   </span>
@@ -35,8 +37,10 @@ DataTable v1 (next PR) needs row-selection checkboxes. The library's `CLAUDE.md`
 ```ts
 export type CheckboxSize = 'sm' | 'md' | 'lg';
 
-export interface CheckboxProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'type' | 'checked' | 'defaultChecked'> {
+export interface CheckboxProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'size' | 'type' | 'checked' | 'defaultChecked'
+> {
   /**
    * Box diameter + label type scale. Defaults to `'md'`. Same scale as
    * `<Input>` so a checkbox paired with a labelled input lines up.
@@ -88,26 +92,26 @@ Native `<input>` attributes pass through except `size` (shadowed by the componen
 
 ## Visual / tokens
 
-| Visual                              | Token                                            |
-| ----------------------------------- | ------------------------------------------------ |
-| Box size (sm)                       | `--size-checkbox-sm` (NEW: `14px`)               |
-| Box size (md)                       | `--size-checkbox-md` (NEW: `16px`)               |
-| Box size (lg)                       | `--size-checkbox-lg` (NEW: `20px`)               |
-| Check / dash icon size              | 10px (sm) / 12px (md) / 14px (lg), `<Icon size>` literals |
-| Label font (sm)                     | `--font-size-sm`                                 |
-| Label font (md)                     | `--font-size-md`                                 |
-| Label font (lg)                     | `--font-size-lg`                                 |
-| Box border (unchecked)              | `--color-border-strong`                          |
-| Box border (hover, unchecked)       | `--color-accent` — **border only**, no fill preview |
-| Box bg (checked / indeterminate)    | `--color-accent`                                 |
-| Box border (checked / indeterminate)| `--color-accent`                                 |
-| Check / dash icon color             | `--color-accent-fg` (white)                      |
-| Box bg (disabled)                   | `--color-bg-subtle`                              |
-| Box border (disabled)               | `--color-border`                                 |
-| Box border (invalid)                | `--color-danger`                                 |
-| Focus ring                          | `--ring-accent` (or `--ring-danger` when invalid)|
-| Label gap                           | `--space-2` (all sizes)                          |
-| Box radius                          | `--radius-sm`                                    |
+| Visual                               | Token                                                     |
+| ------------------------------------ | --------------------------------------------------------- |
+| Box size (sm)                        | `--size-checkbox-sm` (NEW: `14px`)                        |
+| Box size (md)                        | `--size-checkbox-md` (NEW: `16px`)                        |
+| Box size (lg)                        | `--size-checkbox-lg` (NEW: `20px`)                        |
+| Check / dash icon size               | 10px (sm) / 12px (md) / 14px (lg), `<Icon size>` literals |
+| Label font (sm)                      | `--font-size-sm`                                          |
+| Label font (md)                      | `--font-size-md`                                          |
+| Label font (lg)                      | `--font-size-lg`                                          |
+| Box border (unchecked)               | `--color-border-strong`                                   |
+| Box border (hover, unchecked)        | `--color-accent` — **border only**, no fill preview       |
+| Box bg (checked / indeterminate)     | `--color-accent`                                          |
+| Box border (checked / indeterminate) | `--color-accent`                                          |
+| Check / dash icon color              | `--color-accent-fg` (white)                               |
+| Box bg (disabled)                    | `--color-bg-subtle`                                       |
+| Box border (disabled)                | `--color-border`                                          |
+| Box border (invalid)                 | `--color-danger`                                          |
+| Focus ring                           | `--ring-accent` (or `--ring-danger` when invalid)         |
+| Label gap                            | `--space-2` (all sizes)                                   |
+| Box radius                           | `--radius-sm`                                             |
 
 Three new tokens: `--size-checkbox-sm: 14px`, `--size-checkbox-md: 16px`, `--size-checkbox-lg: 20px`. Slot near the other component-specific sizes (`--size-spinner`, `--size-chip`).
 

--- a/docs/superpowers/specs/2026-05-21-checkbox-design.md
+++ b/docs/superpowers/specs/2026-05-21-checkbox-design.md
@@ -1,0 +1,228 @@
+# Checkbox — design spec
+
+**Date:** 2026-05-21
+**Branch:** `feat/checkbox`
+**Scope:** New `<Checkbox>` component. Standalone in v1. Will unblock DataTable row-selection (next PR).
+
+## Goal
+
+A native-input-backed checkbox with custom paint — full visual control, full a11y, supports indeterminate state, ergonomic label, form-integratable.
+
+## Why now
+
+DataTable v1 (next PR) needs row-selection checkboxes. The library's `CLAUDE.md` wishlist already flags Checkbox as missing. Shipping it standalone first means DataTable can compose it cleanly instead of inlining a one-off native input.
+
+## Architecture
+
+```tsx
+<label>
+  <input type="checkbox" class="visually-hidden" />   ← native input owns all a11y
+  <span class="box" aria-hidden>                       ← custom-painted box
+    {checked && <CheckIcon />}
+    {indeterminate && <MinusIcon />}
+  </span>
+  {label && <span class="labelText">{label}</span>}
+</label>
+```
+
+- Native `<input type="checkbox">` is visually hidden but stays in tab order and the AT tree — keyboard, screen reader, form submission, autofill, RHF/Zod integration all work for free.
+- Custom `<span class="box">` paints the visible affordance.
+- The `<label>` wraps everything; clicking the box, the icon, or the text all toggle the input via native label semantics.
+- When no `label` prop is passed, only the box renders (still inside the `<label>` element — `aria-label` on the native input drives the accessible name).
+
+## Public API
+
+```ts
+export interface CheckboxProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'type' | 'checked' | 'defaultChecked'> {
+  /**
+   * Controlled checked state. Pair with `onChange`. Omit (with optional
+   * `defaultChecked`) for uncontrolled use.
+   */
+  checked?: boolean;
+
+  /** Initial checked state for uncontrolled use. Defaults to `false`. */
+  defaultChecked?: boolean;
+
+  /**
+   * Indeterminate (mixed) visual + a11y state. Independent of `checked` —
+   * an indeterminate checkbox is rendered with the muted dash icon and
+   * `input.indeterminate = true` so AT announces "mixed". Consumer drives
+   * this based on partial selection (e.g., "some of N items selected").
+   * When the user clicks an indeterminate checkbox, the native event fires
+   * with the next checked state (`true` from current `checked`); the
+   * consumer typically responds by clearing indeterminate.
+   */
+  indeterminate?: boolean;
+
+  /**
+   * Optional label rendered next to the box. The whole `<label>` is the
+   * click target. Omit for icon-only checkboxes (e.g., a DataTable row
+   * selector) — pass `aria-label` instead.
+   */
+  label?: ReactNode;
+
+  /** Toggles the error visual + sets `aria-invalid="true"`. */
+  invalid?: boolean;
+
+  /**
+   * Fires on every change. Receives the next checked state AND the
+   * native event so consumers can do `event.preventDefault()` etc.
+   */
+  onChange?: (checked: boolean, event: ChangeEvent<HTMLInputElement>) => void;
+}
+```
+
+Native `<input>` attributes pass through. `size` is shadowed (no component-level size in v1 — single 16px box; if a future screen wants sm/md/lg, extend the same way Input did). `type` is hardcoded `"checkbox"`. `checked` and `defaultChecked` are re-typed because our `onChange` signature differs from native.
+
+## Visual / tokens
+
+| Visual                         | Token                                       |
+| ------------------------------ | ------------------------------------------- |
+| Box size                       | `--size-checkbox` (NEW: `16px`)             |
+| Box border (unchecked)         | `--color-border-strong`                     |
+| Box border (hover)             | `--color-accent` (uses accent for hover preview) |
+| Box bg (checked / indeterminate)| `--color-accent`                            |
+| Box border (checked / indeterminate)| `--color-accent`                       |
+| Check / dash icon color        | `--color-accent-fg` (white)                 |
+| Box bg (disabled)              | `--color-bg-subtle`                         |
+| Box border (disabled)          | `--color-border`                            |
+| Box border (invalid)           | `--color-danger`                            |
+| Focus ring                     | `--ring-accent` (or `--ring-danger` when invalid) |
+| Label gap                      | `--space-2`                                 |
+| Box radius                     | `--radius-sm`                               |
+
+One new token: `--size-checkbox: 16px`. Slots near the other component-specific sizes (`--size-spinner`, `--size-chip`).
+
+## States covered
+
+- **Unchecked, enabled** — empty box with strong border.
+- **Checked, enabled** — accent-filled box with white `Check` icon.
+- **Indeterminate, enabled** — accent-filled box with white `Minus` icon. Visual takes priority over `checked` (an "indeterminate + checked" combo renders as indeterminate; `checked` is the value, indeterminate is the display).
+- **Hover (any enabled)** — border shifts to `--color-accent`. Cursor pointer on the whole `<label>`.
+- **Focus-visible** — accent ring around the box (or danger ring if invalid).
+- **Disabled** — muted bg + border, cursor not-allowed, `aria-disabled` via native `disabled` attr.
+- **Invalid** — danger-color border + danger focus ring. Sets `aria-invalid="true"`.
+
+## A11y
+
+- Native `<input type="checkbox">` handles role, tab order, keyboard (Space toggles), screen-reader announcement.
+- `aria-checked` is set by the browser based on the input's `checked` state.
+- Indeterminate handled via `input.indeterminate = true` (set in a `useEffect` on the ref since React doesn't expose it as a prop).
+- Label is associated via `<label>` wrap — no `for`/`id` plumbing needed.
+- For icon-only (no `label` prop), consumer passes `aria-label`. We don't auto-generate one because the visual provides no context.
+- Invalid state sets `aria-invalid="true"` on the native input.
+- Focus stays on the native input (visually-hidden but `position: absolute; opacity: 0` keeps it tab-focusable). The custom `.box` paints the focus ring via `:has(input:focus-visible)` on the box, OR via a sibling selector — see SCSS section.
+
+## File layout
+
+```
+packages/design-system/src/components/Checkbox/
+  Checkbox.tsx
+  Checkbox.module.scss
+  Checkbox.test.tsx
+  index.ts
+```
+
+Top-level `src/index.ts` re-exports `Checkbox` + `CheckboxProps`.
+
+## Implementation notes
+
+### Indeterminate
+
+```tsx
+const inputRef = useRef<HTMLInputElement>(null);
+const mergedRef = mergeRefs(ref, inputRef);
+
+useEffect(() => {
+  if (inputRef.current) {
+    inputRef.current.indeterminate = indeterminate ?? false;
+  }
+}, [indeterminate]);
+```
+
+Use the existing `mergeRefs` helper from `_internal/refs` (used by Tooltip).
+
+### Visually-hidden native input
+
+```scss
+.input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+```
+
+Standard `.visually-hidden` recipe. The input is invisible but tab-focusable and click-targetable via the parent `<label>`.
+
+### Focus ring on the box
+
+Sibling selector — `.input:focus-visible + .box`:
+
+```scss
+.input:focus-visible + .box {
+  box-shadow: 0 0 0 var(--ring-width) var(--ring-accent);
+}
+.input:focus-visible + .box.invalid {
+  box-shadow: 0 0 0 var(--ring-width) var(--ring-danger);
+}
+```
+
+### Controlled vs uncontrolled
+
+Same pattern as `<Input>`: when `checked` is provided, controlled; otherwise uncontrolled with `defaultChecked`. Internal state uses `useState(defaultChecked ?? false)`.
+
+The `onChange` callback signature is `(checked: boolean, event)` — first arg the next state for ergonomics. Standard React pattern for value-emitting components.
+
+## Tests
+
+- Renders unchecked by default.
+- `defaultChecked` initializes uncontrolled state.
+- `checked` (controlled) reflects in the DOM input.
+- Clicking the label/box toggles checked.
+- `onChange` fires with `(nextChecked, event)`.
+- `indeterminate` sets `input.indeterminate` on the DOM node AND renders the dash icon.
+- `disabled` propagates + blocks click.
+- `invalid` sets `aria-invalid="true"` + adds the invalid class.
+- `label` prop renders as text + the entire label is click-targetable.
+- Without `label`, just the box renders (test by querying for the `.labelText` span — should be absent).
+- `aria-label` (when no `label`) is the accessible name.
+- `name` + `value` flow through (FormData round-trip).
+- `ref` forwards to the native input element.
+- `className` is merged on the outer `<label>`, not replaced.
+- Box focus-visible adds the focus ring class (assert via class, not computed style).
+
+## Playground demo
+
+`CheckboxDemo.tsx` with examples:
+
+1. **Default** — `<Checkbox label="I agree" />`
+2. **Controlled** — checked + onChange with a debug echo
+3. **Indeterminate** — boolean state that flips: 0 selected → unchecked, all selected → checked, partial → indeterminate
+4. **Disabled** — `<Checkbox disabled label="Locked" defaultChecked />` and `<Checkbox disabled label="Locked, unchecked" />`
+5. **Invalid** — paired with `aria-describedby` and a visible error message
+6. **No label** — `<Checkbox aria-label="Select row" />`
+7. **Form integration** — `<Checkbox name="agree" required>` inside a form, log FormData on submit
+
+## AGENTS.md
+
+Add a `<Checkbox>` section right after `<Input>` (Forms group). Document the API + the indeterminate-is-display-not-value semantic + the icon-only `aria-label` pattern.
+
+## Non-goals
+
+- **Sizes (sm/md/lg)**. One 16px size in v1. Extend if a CRM screen demands it.
+- **Checkbox groups / Fieldset wrapper**. Consumer wraps in `<fieldset>` themselves; we don't ship a `<Checkbox.Group>` yet.
+- **Switch / Toggle**. Different component (single binary state with motion). Wishlist entry separate from Checkbox.
+- **Tri-state value** — `indeterminate` here is a display flag, not a third boolean. If a use case for a real `'unchecked' | 'checked' | 'partial'` value union emerges, that's a separate prop.
+
+## Risks / open questions
+
+- **`<label>` wrap creates click target on the entire row** — if the consumer puts the checkbox in a wider flex container, the parent layout may absorb clicks the consumer didn't intend. Standard, well-understood; no mitigation needed.
+- **Visually-hidden + focus ring on sibling** — works in all evergreen browsers; relies on `:focus-visible` + `+` adjacent-sibling combinator. Mature.
+- **Indeterminate + click semantics** — when the user clicks an indeterminate checkbox, the native event fires with the input's CURRENT `checked` value flipped. If `checked` was `false` and `indeterminate` was `true`, click moves to `checked=true`. Consumer must respond by clearing `indeterminate` (typical "select all" UI: indeterminate → click → check all → indeterminate cleared).

--- a/docs/superpowers/specs/2026-05-21-checkbox-design.md
+++ b/docs/superpowers/specs/2026-05-21-checkbox-design.md
@@ -33,8 +33,19 @@ DataTable v1 (next PR) needs row-selection checkboxes. The library's `CLAUDE.md`
 ## Public API
 
 ```ts
+export type CheckboxSize = 'sm' | 'md' | 'lg';
+
 export interface CheckboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'type' | 'checked' | 'defaultChecked'> {
+  /**
+   * Box diameter + label type scale. Defaults to `'md'`. Same scale as
+   * `<Input>` so a checkbox paired with a labelled input lines up.
+   * - `'sm'` — 14px box, font-size-sm label. Dense tables, inline filters.
+   * - `'md'` — 16px box, font-size-md label. Default.
+   * - `'lg'` — 20px box, font-size-lg label. Hero forms, mobile-friendly.
+   */
+  size?: CheckboxSize;
+
   /**
    * Controlled checked state. Pair with `onChange`. Omit (with optional
    * `defaultChecked`) for uncontrolled use.
@@ -73,26 +84,32 @@ export interface CheckboxProps
 }
 ```
 
-Native `<input>` attributes pass through. `size` is shadowed (no component-level size in v1 — single 16px box; if a future screen wants sm/md/lg, extend the same way Input did). `type` is hardcoded `"checkbox"`. `checked` and `defaultChecked` are re-typed because our `onChange` signature differs from native.
+Native `<input>` attributes pass through except `size` (shadowed by the component-level `size` prop, same Omit pattern as Input/DatePicker/DRP), `type` (hardcoded `"checkbox"`), and `checked` / `defaultChecked` (re-typed because our `onChange` signature differs from native).
 
 ## Visual / tokens
 
-| Visual                         | Token                                       |
-| ------------------------------ | ------------------------------------------- |
-| Box size                       | `--size-checkbox` (NEW: `16px`)             |
-| Box border (unchecked)         | `--color-border-strong`                     |
-| Box border (hover)             | `--color-accent` (uses accent for hover preview) |
-| Box bg (checked / indeterminate)| `--color-accent`                            |
-| Box border (checked / indeterminate)| `--color-accent`                       |
-| Check / dash icon color        | `--color-accent-fg` (white)                 |
-| Box bg (disabled)              | `--color-bg-subtle`                         |
-| Box border (disabled)          | `--color-border`                            |
-| Box border (invalid)           | `--color-danger`                            |
-| Focus ring                     | `--ring-accent` (or `--ring-danger` when invalid) |
-| Label gap                      | `--space-2`                                 |
-| Box radius                     | `--radius-sm`                               |
+| Visual                              | Token                                            |
+| ----------------------------------- | ------------------------------------------------ |
+| Box size (sm)                       | `--size-checkbox-sm` (NEW: `14px`)               |
+| Box size (md)                       | `--size-checkbox-md` (NEW: `16px`)               |
+| Box size (lg)                       | `--size-checkbox-lg` (NEW: `20px`)               |
+| Check / dash icon size              | 10px (sm) / 12px (md) / 14px (lg), `<Icon size>` literals |
+| Label font (sm)                     | `--font-size-sm`                                 |
+| Label font (md)                     | `--font-size-md`                                 |
+| Label font (lg)                     | `--font-size-lg`                                 |
+| Box border (unchecked)              | `--color-border-strong`                          |
+| Box border (hover, unchecked)       | `--color-accent` — **border only**, no fill preview |
+| Box bg (checked / indeterminate)    | `--color-accent`                                 |
+| Box border (checked / indeterminate)| `--color-accent`                                 |
+| Check / dash icon color             | `--color-accent-fg` (white)                      |
+| Box bg (disabled)                   | `--color-bg-subtle`                              |
+| Box border (disabled)               | `--color-border`                                 |
+| Box border (invalid)                | `--color-danger`                                 |
+| Focus ring                          | `--ring-accent` (or `--ring-danger` when invalid)|
+| Label gap                           | `--space-2` (all sizes)                          |
+| Box radius                          | `--radius-sm`                                    |
 
-One new token: `--size-checkbox: 16px`. Slots near the other component-specific sizes (`--size-spinner`, `--size-chip`).
+Three new tokens: `--size-checkbox-sm: 14px`, `--size-checkbox-md: 16px`, `--size-checkbox-lg: 20px`. Slot near the other component-specific sizes (`--size-spinner`, `--size-chip`).
 
 ## States covered
 
@@ -196,19 +213,21 @@ The `onChange` callback signature is `(checked: boolean, event)` — first arg t
 - `name` + `value` flow through (FormData round-trip).
 - `ref` forwards to the native input element.
 - `className` is merged on the outer `<label>`, not replaced.
-- Box focus-visible adds the focus ring class (assert via class, not computed style).
+- `size` applies the right class name (sm / md / lg) and defaults to `'md'`.
+- Component-level `size` does NOT propagate to the DOM `size` attribute (Omit regression check, matches Input precedent).
 
 ## Playground demo
 
 `CheckboxDemo.tsx` with examples:
 
 1. **Default** — `<Checkbox label="I agree" />`
-2. **Controlled** — checked + onChange with a debug echo
-3. **Indeterminate** — boolean state that flips: 0 selected → unchecked, all selected → checked, partial → indeterminate
-4. **Disabled** — `<Checkbox disabled label="Locked" defaultChecked />` and `<Checkbox disabled label="Locked, unchecked" />`
-5. **Invalid** — paired with `aria-describedby` and a visible error message
-6. **No label** — `<Checkbox aria-label="Select row" />`
-7. **Form integration** — `<Checkbox name="agree" required>` inside a form, log FormData on submit
+2. **Sizes** — three checkboxes (sm / md / lg) side by side with labels.
+3. **Controlled** — checked + onChange with a debug echo.
+4. **Indeterminate** — boolean state that flips: 0 selected → unchecked, all selected → checked, partial → indeterminate. Models the "select all" header pattern DataTable will use.
+5. **Disabled** — `<Checkbox disabled label="Locked" defaultChecked />` and `<Checkbox disabled label="Locked, unchecked" />`.
+6. **Invalid** — paired with `aria-describedby` and a visible error message.
+7. **No label** — `<Checkbox aria-label="Select row" />`.
+8. **Form integration** — `<Checkbox name="agree" required>` inside a form, log FormData on submit.
 
 ## AGENTS.md
 
@@ -216,10 +235,10 @@ Add a `<Checkbox>` section right after `<Input>` (Forms group). Document the API
 
 ## Non-goals
 
-- **Sizes (sm/md/lg)**. One 16px size in v1. Extend if a CRM screen demands it.
 - **Checkbox groups / Fieldset wrapper**. Consumer wraps in `<fieldset>` themselves; we don't ship a `<Checkbox.Group>` yet.
 - **Switch / Toggle**. Different component (single binary state with motion). Wishlist entry separate from Checkbox.
 - **Tri-state value** — `indeterminate` here is a display flag, not a third boolean. If a use case for a real `'unchecked' | 'checked' | 'partial'` value union emerges, that's a separate prop.
+- **Hover fill preview**. Hover only shifts the box border to accent — no fill preview of the eventual checked state. (Less aggressive than some DSes; aligns with Atlassian.)
 
 ## Risks / open questions
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -77,6 +77,23 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 - Sizes: `sm` (24px) / `md` (32px, default) / `lg` (40px). Same scale as `<Select>`. (`<Button>` exposes `xs/sm/md/lg`; fields don't ship `xs` yet.)
 - Validation logic lives in your form layer (React Hook Form + Zod recommended), not in the component.
 
+### `<Checkbox>` — checkbox with native input + custom paint
+
+```tsx
+<Checkbox label="I agree" />
+<Checkbox checked={agreed} onChange={setAgreed} label="Subscribe" />
+<Checkbox indeterminate checked={allSelected} onChange={selectAll} aria-label="Select all" />
+```
+
+- Native `<input type='checkbox'>` is visually hidden but stays in tab order + AT tree — keyboard, screen reader, form submission, RHF/Zod, autofill all work for free.
+- `size`: `sm` (14px) / `md` (16px, default) / `lg` (20px). Same scale as `<Input>`.
+- `checked` + `onChange(next, event)` for controlled; `defaultChecked` for uncontrolled.
+- `indeterminate` is a **display flag, not a third value**. Pairs with `checked` for the "select all where some-but-not-all are picked" pattern. Clicking an indeterminate checkbox emits `onChange(nextChecked)` based on the current `checked`; consumer typically clears `indeterminate` in response.
+- `label` (ReactNode) renders next to the box; the whole `<label>` is the click target. Omit `label` for icon-only checkboxes (e.g., DataTable row selectors) and pass `aria-label` instead.
+- `invalid` adds the danger border + sets `aria-invalid='true'`. Pair with a visible error + `aria-describedby`. Hover preview is border-only (no fill tint).
+- Native HTML attrs flow through (`name`, `value`, `required`, `form`, `autoFocus`, etc.). `FormData.getAll(name)` returns the array of checked values for same-`name` checkboxes.
+- forwardRef points at the native `<input>` so consumers can `.focus()` or programmatically set `.indeterminate`.
+
 ### `<Card>` — bordered container
 
 ```tsx

--- a/packages/design-system/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/design-system/src/components/Checkbox/Checkbox.module.scss
@@ -1,0 +1,124 @@
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+  user-select: none;
+
+  &.disabled {
+    cursor: not-allowed;
+  }
+}
+
+// Visually-hidden native input — stays in tab order + AT tree.
+.input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  /* stylelint-disable-next-line property-disallowed-list -- margin: -1px is the standard visually-hidden recipe; it offsets the 1px width/height so the element doesn't affect flow. Not a layout concern on the component boundary. */
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// The painted box.
+.box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border: var(--border-width) solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  color: var(--color-accent-fg);
+  transition:
+    border-color var(--transition-fast),
+    background var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+// Size modifiers — box diameter + label font.
+.size-sm .box {
+  width: var(--size-checkbox-sm);
+  height: var(--size-checkbox-sm);
+}
+
+.size-md .box {
+  width: var(--size-checkbox-md);
+  height: var(--size-checkbox-md);
+}
+
+.size-lg .box {
+  width: var(--size-checkbox-lg);
+  height: var(--size-checkbox-lg);
+}
+
+.size-sm .labelText {
+  font-size: var(--font-size-sm);
+}
+
+.size-md .labelText {
+  font-size: var(--font-size-md);
+}
+
+.size-lg .labelText {
+  font-size: var(--font-size-lg);
+}
+
+// Hover preview — border only, no fill (Atlassian-style restraint).
+.checkbox:not(.disabled):hover .box {
+  border-color: var(--color-accent);
+}
+
+// Checked + indeterminate share the filled-accent visual.
+.input:checked + .box,
+.input:indeterminate + .box {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+// Focus ring on the box (sibling selector picks up native input focus).
+.input:focus-visible + .box {
+  box-shadow: 0 0 0 var(--ring-width) var(--ring-accent);
+}
+
+// Disabled — muted bg + border. The input still receives `disabled`
+// natively which gates pointer events on the label.
+.disabled .box {
+  background: var(--color-bg-subtle);
+  border-color: var(--color-border);
+  color: var(--color-fg-disabled);
+}
+
+.disabled .input:checked + .box,
+.disabled .input:indeterminate + .box {
+  background: var(--color-border);
+  border-color: var(--color-border);
+}
+
+.disabled .labelText {
+  color: var(--color-fg-disabled);
+}
+
+// Invalid — danger border + danger focus ring. Wins over the unchecked
+// hover preview.
+.invalid .box {
+  border-color: var(--color-danger);
+}
+
+.invalid .input:focus-visible + .box {
+  box-shadow: 0 0 0 var(--ring-width) var(--ring-danger);
+}
+
+.invalid .input:checked + .box,
+.invalid .input:indeterminate + .box {
+  background: var(--color-danger);
+  border-color: var(--color-danger);
+}
+
+.labelText {
+  line-height: var(--line-height-normal);
+}

--- a/packages/design-system/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/design-system/src/components/Checkbox/Checkbox.module.scss
@@ -30,6 +30,13 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  box-sizing: border-box;
+
+  // line-height: 1 keeps the box's intrinsic height constant whether it
+  // contains an SVG (checked / indeterminate) or nothing (unchecked).
+  // Without this the inline-box height jumps between states because the
+  // child SVG's baseline contributes to the line-box.
+  line-height: 1;
   border: var(--border-width) solid var(--color-border-strong);
   border-radius: var(--radius-sm);
   background: var(--color-bg);

--- a/packages/design-system/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/design-system/src/components/Checkbox/Checkbox.module.scss
@@ -5,6 +5,12 @@
   cursor: pointer;
   user-select: none;
 
+  // Pin the label's baseline contribution to its middle so the surrounding
+  // line-box stays the same height whether the box is checked (SVG inside)
+  // or unchecked (empty). Without this, an inline-flex element's baseline
+  // shifts based on inner content and the parent line-box grows/shrinks ~2px.
+  vertical-align: middle;
+
   &.disabled {
     cursor: not-allowed;
   }

--- a/packages/design-system/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/design-system/src/components/Checkbox/Checkbox.module.scss
@@ -82,7 +82,9 @@
 }
 
 // Hover preview — border only, no fill (Atlassian-style restraint).
-.checkbox:not(.disabled):hover .box {
+// Excludes .invalid so the danger border stays visible on hover instead
+// of flipping to accent and hiding the error signal.
+.checkbox:not(.disabled, .invalid):hover .box {
   border-color: var(--color-accent);
 }
 

--- a/packages/design-system/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { Checkbox } from './Checkbox';
+
+describe('Checkbox', () => {
+  it('renders unchecked by default', () => {
+    render(<Checkbox label="Agree" />);
+    const input = screen.getByRole('checkbox', { name: 'Agree' });
+    expect(input).not.toBeChecked();
+  });
+
+  it('uses defaultChecked for uncontrolled initial state', () => {
+    render(<Checkbox label="Agree" defaultChecked />);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('reflects controlled `checked`', () => {
+    const { rerender } = render(<Checkbox label="Agree" checked={false} onChange={() => {}} />);
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    rerender(<Checkbox label="Agree" checked onChange={() => {}} />);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('fires onChange with (nextChecked, event) on click', async () => {
+    const user = userEvent.setup();
+    const handle = vi.fn();
+    render(<Checkbox label="Agree" onChange={handle} />);
+    await user.click(screen.getByRole('checkbox'));
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle.mock.calls[0][0]).toBe(true);
+    expect(handle.mock.calls[0][1]).toBeDefined();
+    expect(handle.mock.calls[0][1].target).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it('toggling the label text also fires onChange', async () => {
+    const user = userEvent.setup();
+    const handle = vi.fn();
+    render(<Checkbox label="Click my text" onChange={handle} />);
+    await user.click(screen.getByText('Click my text'));
+    expect(handle).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets indeterminate on the DOM input and renders the dash icon', () => {
+    const { container, rerender } = render(<Checkbox label="Mixed" indeterminate />);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(input.indeterminate).toBe(true);
+    // Dash icon visible (lucide renders an <svg>).
+    expect(container.querySelector('svg')).toBeInTheDocument();
+
+    // Toggle off — indeterminate cleared, no icon when also unchecked.
+    rerender(<Checkbox label="Mixed" indeterminate={false} />);
+    expect(input.indeterminate).toBe(false);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('disabled propagates and blocks click', async () => {
+    const user = userEvent.setup();
+    const handle = vi.fn();
+    render(<Checkbox label="Locked" disabled onChange={handle} />);
+    const input = screen.getByRole('checkbox');
+    expect(input).toBeDisabled();
+    await user.click(input);
+    expect(handle).not.toHaveBeenCalled();
+  });
+
+  it('invalid sets aria-invalid + invalid class', () => {
+    const { container } = render(<Checkbox label="Required" invalid />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-invalid', 'true');
+    expect(container.querySelector('label')!.className).toMatch(/invalid/);
+  });
+
+  it('renders without label when only aria-label is provided', () => {
+    const { container } = render(<Checkbox aria-label="Select row" />);
+    expect(screen.getByRole('checkbox', { name: 'Select row' })).toBeInTheDocument();
+    // No .labelText span — the label prop is unset.
+    expect(container.querySelector('span[class*="labelText"]')).toBeNull();
+  });
+
+  it('applies size class names for sm / md / lg', () => {
+    const { container, rerender } = render(<Checkbox label="X" size="sm" />);
+    expect(container.querySelector('label')!.className).toMatch(/size-sm/);
+    rerender(<Checkbox label="X" size="md" />);
+    expect(container.querySelector('label')!.className).toMatch(/size-md/);
+    rerender(<Checkbox label="X" size="lg" />);
+    expect(container.querySelector('label')!.className).toMatch(/size-lg/);
+  });
+
+  it('defaults to size="md"', () => {
+    const { container } = render(<Checkbox label="X" />);
+    expect(container.querySelector('label')!.className).toMatch(/size-md/);
+  });
+
+  it('does NOT pass component size prop through to the DOM size attribute', () => {
+    render(<Checkbox label="X" size="sm" />);
+    expect(screen.getByRole('checkbox')).not.toHaveAttribute('size');
+  });
+
+  it('forwards ref to the native input', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<Checkbox label="X" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    expect(ref.current?.type).toBe('checkbox');
+  });
+
+  it('merges className on the outer label', () => {
+    const { container } = render(<Checkbox label="X" className="my-cls" />);
+    expect(container.querySelector('label.my-cls')).not.toBeNull();
+  });
+
+  it('name + value flow through for FormData', () => {
+    render(
+      <form data-testid="form">
+        <Checkbox name="agree" value="yes" defaultChecked />
+      </form>,
+    );
+    const form = screen.getByTestId('form') as HTMLFormElement;
+    const fd = new FormData(form);
+    expect(fd.get('agree')).toBe('yes');
+  });
+});

--- a/packages/design-system/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.test.tsx
@@ -54,13 +54,19 @@ describe('Checkbox', () => {
     expect(container.querySelector('svg')).toBeNull();
   });
 
-  it('disabled propagates and blocks click', async () => {
+  it('disabled propagates and blocks click on both input and label text', async () => {
     const user = userEvent.setup();
     const handle = vi.fn();
     render(<Checkbox label="Locked" disabled onChange={handle} />);
     const input = screen.getByRole('checkbox');
     expect(input).toBeDisabled();
+    // Click on the native input directly.
     await user.click(input);
+    expect(handle).not.toHaveBeenCalled();
+    // Click on the label text — native <input disabled> inside <label> blocks
+    // label-forwarded clicks too. Important: a consumer can't accidentally
+    // toggle a disabled checkbox by clicking the surrounding label area.
+    await user.click(screen.getByText('Locked'));
     expect(handle).not.toHaveBeenCalled();
   });
 

--- a/packages/design-system/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,188 @@
+import {
+  forwardRef,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import { Check, Minus } from 'lucide-react';
+import { mergeRefs } from '../_internal/refs';
+import styles from './Checkbox.module.scss';
+
+/** Box diameter + label type scale. */
+export type CheckboxSize = 'sm' | 'md' | 'lg';
+
+export interface CheckboxProps
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
+  > {
+  /**
+   * Box diameter + label type scale. Defaults to `'md'`.
+   * - `'sm'` — 14px box, font-size-sm label. Dense tables, inline filters.
+   * - `'md'` — 16px box, font-size-md label. Default.
+   * - `'lg'` — 20px box, font-size-lg label. Hero forms, mobile-friendly.
+   *
+   * Note: shadows the native HTML `<input size>` attribute (which on
+   * checkboxes is meaningless anyway).
+   */
+  size?: CheckboxSize;
+
+  /**
+   * Controlled checked state. Pair with `onChange`. Omit (with optional
+   * `defaultChecked`) for uncontrolled use.
+   */
+  checked?: boolean;
+
+  /** Initial checked state for uncontrolled use. Defaults to `false`. */
+  defaultChecked?: boolean;
+
+  /**
+   * Indeterminate (mixed) visual + a11y state. Independent of `checked` —
+   * the box paints with a dash icon and `input.indeterminate = true` so AT
+   * announces "mixed". Consumer drives this based on partial selection
+   * (e.g., a "select all" header where some-but-not-all rows are selected).
+   *
+   * When the user clicks an indeterminate checkbox, the native change event
+   * fires with the next `checked` value (`true` if it was `false`). The
+   * consumer typically responds by clearing `indeterminate`.
+   */
+  indeterminate?: boolean;
+
+  /**
+   * Optional label rendered next to the box. The whole `<label>` is the
+   * click target. Omit for icon-only checkboxes (e.g., a DataTable row
+   * selector) — pass `aria-label` instead.
+   */
+  label?: ReactNode;
+
+  /** Toggles the error visual + sets `aria-invalid="true"`. */
+  invalid?: boolean;
+
+  /**
+   * Fires on every change. Receives the next checked state AND the native
+   * event so consumers can do `event.preventDefault()`, read modifier keys,
+   * etc.
+   */
+  onChange?: (checked: boolean, event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+const iconSize: Record<CheckboxSize, number> = {
+  sm: 10,
+  md: 12,
+  lg: 14,
+};
+
+/**
+ * Checkbox — native `<input type="checkbox">` visually hidden + custom-painted
+ * box. Supports checked / unchecked / indeterminate / disabled / invalid
+ * states. The native input owns all a11y (keyboard, screen reader, form
+ * submission, RHF/Zod integration); the custom paint owns the look.
+ *
+ * @example
+ * <Checkbox label="I agree to the terms" />
+ *
+ * @example
+ * // Controlled:
+ * <Checkbox checked={agreed} onChange={(next) => setAgreed(next)} label="I agree" />
+ *
+ * @example
+ * // Indeterminate ("select all" pattern):
+ * <Checkbox
+ *   checked={allSelected}
+ *   indeterminate={someSelected && !allSelected}
+ *   onChange={(next) => (next ? selectAll() : selectNone())}
+ *   aria-label="Select all rows"
+ * />
+ *
+ * @example
+ * // Icon-only (no visible label):
+ * <Checkbox aria-label="Select row" checked={isSelected} onChange={setIsSelected} />
+ *
+ * @remarks When NOT to use
+ * - Single binary on/off setting that toggles immediately and visually
+ *   communicates "on" vs "off" — use a `Switch` (not yet shipped).
+ * - One-of-many choice from a fixed set — use `Radio` (not yet shipped).
+ * - Multi-select from a long list — use `<Select multi>`.
+ *
+ * @remarks Anti-patterns
+ * - Treating `indeterminate` as a third value. It's a display flag for
+ *   "partial selection"; `checked` is still the underlying boolean. Clicking
+ *   an indeterminate checkbox emits `onChange(nextChecked)` based on the
+ *   current `checked` state, not on `indeterminate`.
+ * - Wrapping the checkbox in your own `<label>`. We already wrap it; an
+ *   outer `<label>` nests two and breaks the click contract.
+ * - Omitting `label` AND `aria-label`. Screen readers will announce just
+ *   "checkbox" with no context.
+ */
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  {
+    size = 'md',
+    checked,
+    defaultChecked,
+    indeterminate,
+    label,
+    invalid,
+    onChange,
+    className,
+    disabled,
+    ...props
+  },
+  ref,
+) {
+  const isControlled = checked !== undefined;
+  const [internalChecked, setInternalChecked] = useState(defaultChecked ?? false);
+  const currentChecked = isControlled ? checked : internalChecked;
+
+  // Native `indeterminate` is a DOM property, not an attribute. React doesn't
+  // surface it as a prop, so we set it via ref in an effect that fires after
+  // each render — covers both initial mount and prop changes.
+  const inputRef = useRef<HTMLInputElement>(null);
+  const mergedRef = mergeRefs(ref, inputRef);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate ?? false;
+    }
+  }, [indeterminate]);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const next = event.target.checked;
+    if (!isControlled) setInternalChecked(next);
+    onChange?.(next, event);
+  };
+
+  return (
+    <label
+      className={clsx(
+        styles.checkbox,
+        styles[`size-${size}`],
+        disabled && styles.disabled,
+        invalid && styles.invalid,
+        className,
+      )}
+    >
+      <input
+        {...props}
+        ref={mergedRef}
+        type="checkbox"
+        checked={currentChecked}
+        disabled={disabled}
+        aria-invalid={invalid || undefined}
+        onChange={handleChange}
+        className={styles.input}
+      />
+      <span aria-hidden="true" className={styles.box}>
+        {indeterminate ? (
+          <Minus size={iconSize[size]} strokeWidth={3} />
+        ) : currentChecked ? (
+          <Check size={iconSize[size]} strokeWidth={3} />
+        ) : null}
+      </span>
+      {label != null && <span className={styles.labelText}>{label}</span>}
+    </label>
+  );
+});

--- a/packages/design-system/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.tsx
@@ -15,11 +15,10 @@ import styles from './Checkbox.module.scss';
 /** Box diameter + label type scale. */
 export type CheckboxSize = 'sm' | 'md' | 'lg';
 
-export interface CheckboxProps
-  extends Omit<
-    InputHTMLAttributes<HTMLInputElement>,
-    'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
-  > {
+export interface CheckboxProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
+> {
   /**
    * Box diameter + label type scale. Defaults to `'md'`.
    * - `'sm'` — 14px box, font-size-sm label. Dense tables, inline filters.

--- a/packages/design-system/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.tsx
@@ -164,6 +164,10 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
         className,
       )}
     >
+      {/* Pattern B — props first so the component-owned attrs below
+          (type, checked, disabled, aria-invalid, onChange, className) win.
+          The semantic contract is that a Checkbox is always type=checkbox,
+          uses our checked/onChange machinery, and styles via styles.input. */}
       <input
         {...props}
         ref={mergedRef}

--- a/packages/design-system/src/components/Checkbox/index.ts
+++ b/packages/design-system/src/components/Checkbox/index.ts
@@ -1,0 +1,2 @@
+export { Checkbox } from './Checkbox';
+export type { CheckboxProps, CheckboxSize } from './Checkbox';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -8,6 +8,9 @@ export type { InputProps, InputSize } from './components/Input';
 export { Card } from './components/Card';
 export type { CardProps, CardPadding } from './components/Card';
 
+export { Checkbox } from './components/Checkbox';
+export type { CheckboxProps, CheckboxSize } from './components/Checkbox';
+
 export { Stack } from './components/Stack';
 export type { StackProps, StackGap, StackAlign } from './components/Stack';
 

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -120,6 +120,12 @@
   --size-badge-dot: 6px;
   --size-chip: 18px;
 
+  // Checkbox box diameter per size. Pairs with the Input scale so a
+  // checkbox labelled next to a `<Input size="sm">` lines up visually.
+  --size-checkbox-sm: 14px;
+  --size-checkbox-md: 16px;
+  --size-checkbox-lg: 20px;
+
   // Indeterminate loading spinner (Select listbox loading row). Small
   // enough to fit inline next to the "Loading…" label without dominating
   // the row.

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -13,6 +13,7 @@ import { InputDemo } from './pages/components/InputDemo';
 import { SelectDemo } from './pages/components/SelectDemo';
 import { TableDemo } from './pages/components/TableDemo';
 import { CardDemo } from './pages/components/CardDemo';
+import { CheckboxDemo } from './pages/components/CheckboxDemo';
 import { StackDemo } from './pages/components/StackDemo';
 import { ClusterDemo } from './pages/components/ClusterDemo';
 import { AvatarDemo } from './pages/components/AvatarDemo';
@@ -45,6 +46,7 @@ export default function App() {
           <Route path="/components/select" element={<SelectDemo />} />
           <Route path="/components/table" element={<TableDemo />} />
           <Route path="/components/card" element={<CardDemo />} />
+          <Route path="/components/checkbox" element={<CheckboxDemo />} />
           <Route path="/components/stack" element={<StackDemo />} />
           <Route path="/components/cluster" element={<ClusterDemo />} />
           <Route path="/components/avatar" element={<AvatarDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -10,6 +10,7 @@ import {
   Plus,
   Component,
   MousePointer2,
+  CheckSquare,
   TextCursorInput,
   ChevronsUpDown,
   CalendarRange,
@@ -61,6 +62,7 @@ const componentGroups = [
     heading: 'Forms',
     items: [
       { to: '/components/button', label: 'Button', icon: MousePointer2, end: false },
+      { to: '/components/checkbox', label: 'Checkbox', icon: CheckSquare, end: false },
       { to: '/components/datepickers', label: 'Date pickers', icon: CalendarRange, end: false },
       { to: '/components/input', label: 'Input', icon: TextCursorInput, end: false },
       { to: '/components/select', label: 'Select', icon: ChevronsUpDown, end: false },

--- a/packages/playground/src/pages/components/CheckboxDemo.tsx
+++ b/packages/playground/src/pages/components/CheckboxDemo.tsx
@@ -1,0 +1,217 @@
+import { useMemo, useState } from 'react';
+import { Button, Checkbox, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import { InputExample } from './InputExample';
+import tsxSource from '@lib-source/components/Checkbox/Checkbox.tsx?raw';
+import scssSource from '@lib-source/components/Checkbox/Checkbox.module.scss?raw';
+
+const TEAM = ['Alex', 'Priya', 'Tom', 'Sara', 'Jaden'];
+
+function ControlledDemo() {
+  const [agreed, setAgreed] = useState(false);
+  return (
+    <Stack gap="xs">
+      <Checkbox checked={agreed} onChange={setAgreed} label="I agree to the terms" />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        agreed = {String(agreed)}
+      </code>
+    </Stack>
+  );
+}
+
+function IndeterminateDemo() {
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+  const selectedCount = useMemo(() => Object.values(selected).filter(Boolean).length, [selected]);
+  const allChecked = selectedCount === TEAM.length;
+  const someChecked = selectedCount > 0 && !allChecked;
+
+  function toggleAll(next: boolean) {
+    const map: Record<string, boolean> = {};
+    if (next) for (const name of TEAM) map[name] = true;
+    setSelected(map);
+  }
+
+  function toggleOne(name: string, next: boolean) {
+    setSelected((prev) => ({ ...prev, [name]: next }));
+  }
+
+  return (
+    <Stack gap="sm">
+      <Checkbox
+        checked={allChecked}
+        indeterminate={someChecked}
+        onChange={toggleAll}
+        label={
+          <strong>
+            Select all ({selectedCount} of {TEAM.length})
+          </strong>
+        }
+      />
+      <Stack gap="xs" style={{ paddingLeft: 'var(--space-5)' }}>
+        {TEAM.map((name) => (
+          <Checkbox
+            key={name}
+            checked={!!selected[name]}
+            onChange={(next) => toggleOne(name, next)}
+            label={name}
+          />
+        ))}
+      </Stack>
+    </Stack>
+  );
+}
+
+function FormDemo() {
+  const [submitted, setSubmitted] = useState<string | null>(null);
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const fd = new FormData(e.currentTarget);
+        const values = fd.getAll('notify');
+        setSubmitted(values.length ? values.join(', ') : '(none)');
+      }}
+    >
+      <Stack gap="xs">
+        <Checkbox name="notify" value="email" defaultChecked label="Email" />
+        <Checkbox name="notify" value="sms" label="SMS" />
+        <Checkbox name="notify" value="push" label="Push" />
+        <Button type="submit" size="sm">
+          Submit
+        </Button>
+        {submitted !== null && (
+          <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+            notify = {submitted}
+          </code>
+        )}
+      </Stack>
+    </form>
+  );
+}
+
+export function CheckboxDemo() {
+  return (
+    <DemoLayout
+      name="Checkbox"
+      componentName="Checkbox"
+      description="Native `<input type='checkbox'>` visually hidden + custom-painted box. Supports controlled / uncontrolled state, indeterminate (mixed) state, sizes, label, disabled, invalid, and full native form integration."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Checkbox.tsx"
+      scssFilename="Checkbox.module.scss"
+    >
+      <Example
+        title="Default"
+        description="Uncontrolled, with a label. The whole label is the click target."
+        code={`<Checkbox label="I agree to the terms" />`}
+      >
+        <InputExample>
+          <Checkbox label="I agree to the terms" />
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Sizes"
+        description="Three sizes — sm (14px box / font-size-sm) / md (16px / font-size-md, default) / lg (20px / font-size-lg). Same scale as <Input>."
+        code={`<Checkbox size="sm" label="Small" />
+<Checkbox size="md" label="Medium" />
+<Checkbox size="lg" label="Large" />`}
+      >
+        <InputExample>
+          <Stack gap="sm">
+            <Checkbox size="sm" label="Small" defaultChecked />
+            <Checkbox size="md" label="Medium" defaultChecked />
+            <Checkbox size="lg" label="Large" defaultChecked />
+          </Stack>
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Controlled"
+        description="Provide `checked` + `onChange`. The handler receives `(nextChecked, event)`."
+        code={`const [agreed, setAgreed] = useState(false);
+<Checkbox checked={agreed} onChange={setAgreed} label="I agree" />`}
+      >
+        <InputExample>
+          <ControlledDemo />
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Indeterminate (select-all pattern)"
+        description="When some-but-not-all child checkboxes are selected, the parent renders an indeterminate dash. Clicking the parent in indeterminate state toggles to checked → consumer responds by selecting all."
+        code={`<Checkbox
+  checked={allChecked}
+  indeterminate={someChecked}
+  onChange={(next) => toggleAll(next)}
+  label="Select all"
+/>`}
+      >
+        <InputExample>
+          <IndeterminateDemo />
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Disabled"
+        description="The native `disabled` attribute is forwarded — click is blocked and the box mutes."
+        code={`<Checkbox disabled defaultChecked label="Locked (checked)" />
+<Checkbox disabled label="Locked (unchecked)" />`}
+      >
+        <InputExample>
+          <Stack gap="xs">
+            <Checkbox disabled defaultChecked label="Locked (checked)" />
+            <Checkbox disabled label="Locked (unchecked)" />
+          </Stack>
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Invalid"
+        description="`invalid` adds the danger border + sets `aria-invalid='true'`. Pair with a visible error message and `aria-describedby`."
+        code={`<Checkbox invalid required aria-describedby="terms-error" label="Accept terms" />
+<p id="terms-error">You must accept to continue.</p>`}
+      >
+        <InputExample>
+          <Stack gap="xs">
+            <Checkbox invalid required aria-describedby="terms-error" label="Accept terms" />
+            <p
+              id="terms-error"
+              style={{ color: 'var(--color-danger)', fontSize: 'var(--font-size-xs)' }}
+            >
+              You must accept to continue.
+            </p>
+          </Stack>
+        </InputExample>
+      </Example>
+
+      <Example
+        title="No label (icon-only)"
+        description="Omit `label` for icon-only checkboxes (e.g., a DataTable row selector). Always pair with `aria-label`."
+        code={`<Checkbox aria-label="Select row" />`}
+      >
+        <InputExample>
+          <Checkbox aria-label="Select row" />
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Form integration"
+        description="`name` + `value` round-trip through native FormData. Same-`name` checkboxes group via `FormData.getAll(name)`."
+        code={`<form>
+  <Checkbox name="notify" value="email" defaultChecked label="Email" />
+  <Checkbox name="notify" value="sms" label="SMS" />
+  <Checkbox name="notify" value="push" label="Push" />
+  <button type="submit">Submit</button>
+</form>
+
+// On submit: const values = new FormData(form).getAll('notify');`}
+      >
+        <InputExample>
+          <FormDemo />
+        </InputExample>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -4,6 +4,7 @@ import { Avatar } from '@eocrm/design-system';
 import { Badge } from '@eocrm/design-system';
 import { Button } from '@eocrm/design-system';
 import { Card } from '@eocrm/design-system';
+import { Checkbox } from '@eocrm/design-system';
 import { Cluster } from '@eocrm/design-system';
 import { Input } from '@eocrm/design-system';
 import { Select } from '@eocrm/design-system';
@@ -110,6 +111,19 @@ const items: { to: string; name: string; description: string; preview: React.Rea
           <div className={styles.skeleton} style={{ width: '80%' }} />
         </Stack>
       </Card>
+    ),
+  },
+  {
+    to: '/components/checkbox',
+    name: 'Checkbox',
+    description:
+      'Native-input-backed checkbox with custom paint — sizes, indeterminate, label, invalid, full form integration.',
+    preview: (
+      <Stack gap="xs">
+        <Checkbox defaultChecked label="Checked" />
+        <Checkbox indeterminate label="Indeterminate" />
+        <Checkbox label="Unchecked" />
+      </Stack>
     ),
   },
   {

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -10,6 +10,7 @@ export type ComponentName =
   | 'Select'
   | 'Table'
   | 'Card'
+  | 'Checkbox'
   | 'Stack'
   | 'Cluster'
   | 'Avatar'


### PR DESCRIPTION
## Summary

- New `<Checkbox>` component — native `<input type='checkbox'>` visually hidden + custom-painted box. Native input owns all a11y (keyboard, screen reader, form submission, autofill, RHF/Zod); the paint owns the look.
- **`size`**: `'sm' | 'md' | 'lg'` (default `'md'`). Three new tokens: `--size-checkbox-{sm,md,lg}` (14 / 16 / 20px). Matches the `<Input>` scale.
- **`checked` + `onChange(next, event)`** for controlled; **`defaultChecked`** for uncontrolled.
- **`indeterminate`** is a display flag (not a third value) — sets `input.indeterminate = true` via ref + paints the `Minus` icon. Models the "select all where some-but-not-all are picked" pattern DataTable will use next.
- **`label`** (ReactNode) renders next to the box inside the `<label>` wrapper; the whole label is the click target. Omit `label` + pass `aria-label` for icon-only checkboxes.
- **`invalid`** adds danger border + sets `aria-invalid='true'`. The danger border survives hover (excluded from the hover-preview rule).
- Native HTML attrs flow through (`name`, `value`, `required`, `form`, `autoFocus`). `FormData.getAll(name)` returns the array of checked values for same-`name` checkboxes.
- `Omit<…, 'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'>` on props because the component re-types those (size: string union vs native number; type: locked to checkbox; checked/defaultChecked re-shaped; onChange returns `(next, event)` instead of just `event`).
- Stable height across toggle states (verified via Playwright measurement — line-box jitter from baseline-shift was a real cycle-0 bug, fixed with `vertical-align: middle` on the outer `<label>` + `line-height: 1` on the box).

Unblocks DataTable v1 row selection (next PR).

## Test plan

- [x] `npm test --run` — 834/834 (15 new Checkbox tests; full suite green)
- [x] `npm run typecheck` clean
- [x] `npm run lint:css` clean
- [x] `npm run build` clean
- [x] `npx prettier --check` clean
- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files in tarball
- [x] Manual smoke (Playwright): all 8 demo examples render; indeterminate dash visible; height stable across toggles (measured DOM; box stays 16px, parent line-box stable); focus ring on Tab; invalid border survives hover
- [x] Hard Rule 8 review cycle 1 — final verdict: clean enough to stop; 3 small cycle-1 follow-ups (invalid-on-hover, label-click disabled test, spread-order comment) folded back in

## Design spec / plan

- Spec: \`docs/superpowers/specs/2026-05-21-checkbox-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-21-checkbox.md\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>