### PR TITLE
Skeleton: loading placeholder primitive (text / circular / rectangular)

### DIFF
--- a/docs/superpowers/plans/2026-05-22-skeleton.md
+++ b/docs/superpowers/plans/2026-05-22-skeleton.md
@@ -412,6 +412,7 @@ git commit -m "Skeleton: re-export from barrel + src/index.ts (Rule 5)"
 7. **Inside a Table** — `<Table>` with 5 body rows, each cell containing a `<Skeleton>` (DataTable preview)
 
 Match the existing `DemoLayout` + `Example` conventions. Source-display via:
+
 - `@lib-source/components/Skeleton/Skeleton.tsx?raw`
 - `@lib-source/components/Skeleton/Skeleton.module.scss?raw`
 
@@ -422,7 +423,7 @@ Add import + route alphabetically.
 ```tsx
 import { SkeletonDemo } from './pages/components/SkeletonDemo';
 // …
-<Route path="/components/skeleton" element={<SkeletonDemo />} />
+<Route path="/components/skeleton" element={<SkeletonDemo />} />;
 ```
 
 - [ ] **Step 3: Wire `AppShell.tsx`**
@@ -487,7 +488,7 @@ git commit -m "SkeletonDemo: examples + sidebar + index + registry wiring"
 
 Place between `Calendar` and `Table` (alphabetically). One-section TL;DR + canonical snippet.
 
-```markdown
+````markdown
 ### `<Skeleton>` — loading placeholder
 
 ```tsx
@@ -495,6 +496,7 @@ Place between `Calendar` and `Table` (alphabetically). One-section TL;DR + canon
 <Skeleton variant="circular" width={32} />                   // avatar
 <Skeleton variant="rectangular" width="100%" height={120} /> // image
 ```
+````
 
 - Three variants: `text` (default, inline, height=1em), `circular` (avatar/icon, square when only one dim set), `rectangular` (image/card/button, block).
 - `width` / `height` flow to inline style — `number` becomes `px`, `string` passes through (`'60%'`, `'12rem'`).
@@ -503,14 +505,15 @@ Place between `Calendar` and `Table` (alphabetically). One-section TL;DR + canon
 - `aria-hidden='true'` by default — Skeleton is decorative. Communicate "loading" from a parent live region (e.g., `aria-busy='true'` on the section being filled).
 - Composes — for a list-row placeholder, render `<Skeleton variant='circular' />` + 2-3 text skeletons + a button-shaped rectangular in a Cluster.
 - Use `<EmptyState>` (not yet shipped) for "nothing here yet" — Skeleton implies "loading," not "empty."
-```
+
+````
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add packages/design-system/AGENTS.md
 git commit -m "AGENTS.md: document new <Skeleton>"
-```
+````
 
 ---
 

--- a/docs/superpowers/plans/2026-05-22-skeleton.md
+++ b/docs/superpowers/plans/2026-05-22-skeleton.md
@@ -1,0 +1,616 @@
+# Skeleton — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Skeleton>` — single dumb primitive with `text | circular | rectangular` variants and a `pulse | none` animation, respecting `prefers-reduced-motion`. No new tokens.
+
+**Architecture:** One `<span>` (or `<div>` for rectangular block use) with token-colored background and an inline `@keyframes pulse` animation. `width` / `height` flow to inline style.
+
+**Tech Stack:** React, SCSS modules, Vitest + RTL.
+
+**Branch:** `feat/skeleton`. Off fresh main.
+
+**Spec:** `docs/superpowers/specs/2026-05-22-skeleton-design.md`.
+
+---
+
+## Task 1: Verify branch + hooks
+
+- [ ] **Step 1: Verify**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # → feat/skeleton
+git config --get core.hooksPath   # → .husky/_
+test -x .husky/pre-push           # exit 0
+```
+
+---
+
+## Task 2: `Skeleton.tsx` + `Skeleton.module.scss`
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Skeleton/Skeleton.tsx`
+- Create: `packages/design-system/src/components/Skeleton/Skeleton.module.scss`
+
+- [ ] **Step 1: Write `Skeleton.tsx`**
+
+```tsx
+import { forwardRef, type CSSProperties, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './Skeleton.module.scss';
+
+/** Shape preset. */
+export type SkeletonVariant = 'text' | 'circular' | 'rectangular';
+
+/** Animation style. */
+export type SkeletonAnimation = 'pulse' | 'none';
+
+export interface SkeletonProps extends HTMLAttributes<HTMLSpanElement> {
+  /**
+   * Shape preset. Defaults to `'text'`.
+   * - `'text'` — inline-block; `height` defaults to `1em` so it sits on text
+   *   baselines. Use inside paragraphs / labels for word-shaped placeholders.
+   * - `'circular'` — `border-radius: 50%`; when only one of `width`/`height`
+   *   is set, the other matches (square). Avatar / icon placeholder.
+   * - `'rectangular'` — block, small radius. Image / card / button placeholder.
+   */
+  variant?: SkeletonVariant;
+
+  /** Explicit width. Number → px, string → as-is (e.g., `'60%'`, `'12rem'`). */
+  width?: number | string;
+
+  /**
+   * Explicit height. Number → px, string → as-is.
+   * Defaults: `text` → `1em`, `circular` → matches `width` (square),
+   * `rectangular` → no default (consumer must size).
+   */
+  height?: number | string;
+
+  /**
+   * Animation. Defaults to `'pulse'`.
+   * - `'pulse'` — opacity 1 → 0.6 → 1, 1.5s ease-in-out infinite.
+   * - `'none'` — static. Use when stacking many skeletons to avoid motion
+   *   overload.
+   *
+   * Regardless of this prop, animation is suppressed when the user has
+   * `prefers-reduced-motion: reduce`.
+   */
+  animation?: SkeletonAnimation;
+}
+
+function toCssSize(value: number | string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === 'number' ? `${value}px` : value;
+}
+
+/**
+ * Placeholder rectangle for loading states. Consumers compose multiple
+ * `<Skeleton>`s in any layout to mimic the eventual content shape.
+ *
+ * @example
+ * // Single text line (inline with surrounding text):
+ * <Skeleton width={120} />
+ *
+ * @example
+ * // Avatar + two text lines + button (the canonical "list row loading"):
+ * <Cluster gap="md" align="center">
+ *   <Skeleton variant="circular" width={32} />
+ *   <Stack gap="xs" style={{ flex: 1 }}>
+ *     <Skeleton width="60%" />
+ *     <Skeleton width="40%" />
+ *   </Stack>
+ *   <Skeleton variant="rectangular" width={80} height={32} />
+ * </Cluster>
+ *
+ * @example
+ * // Many rows — disable animation to avoid motion overload:
+ * {Array.from({ length: 20 }).map((_, i) => (
+ *   <Skeleton key={i} variant="rectangular" height={32} animation="none" />
+ * ))}
+ *
+ * @remarks When NOT to use
+ * - When loading takes < 200ms — flashing a skeleton then content jitters
+ *   the layout. Render the real content directly.
+ * - For empty states ("No contacts yet"). Use `<EmptyState>` (not yet
+ *   shipped) — a skeleton implies "loading," not "nothing here."
+ *
+ * @remarks Anti-patterns
+ * - ❌ Wrapping real content in a Skeleton ("just hide everything"). The
+ *   primitive is a leaf — don't pass children.
+ * - ❌ Omitting all dimensions on `rectangular`. With no `width`/`height`,
+ *   the box has zero size and renders invisibly. Always size it.
+ */
+export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(function Skeleton(
+  { variant = 'text', width, height, animation = 'pulse', className, style, ...props },
+  ref,
+) {
+  // Default height: text → 1em (sits on baseline), circular → matches width
+  // (square), rectangular → undefined (consumer must size).
+  let resolvedHeight: string | undefined = toCssSize(height);
+  if (resolvedHeight === undefined) {
+    if (variant === 'text') resolvedHeight = '1em';
+    else if (variant === 'circular' && width !== undefined) resolvedHeight = toCssSize(width);
+  }
+
+  // Default width: circular with only height set → matches height (square).
+  let resolvedWidth: string | undefined = toCssSize(width);
+  if (resolvedWidth === undefined && variant === 'circular' && height !== undefined) {
+    resolvedWidth = toCssSize(height);
+  }
+
+  const mergedStyle: CSSProperties = {
+    width: resolvedWidth,
+    height: resolvedHeight,
+    ...style,
+  };
+
+  return (
+    <span
+      ref={ref}
+      aria-hidden="true"
+      {...props}
+      className={clsx(
+        styles.skeleton,
+        styles[`variant-${variant}`],
+        animation === 'pulse' && styles.pulse,
+        className,
+      )}
+      style={mergedStyle}
+    />
+  );
+});
+```
+
+- [ ] **Step 2: Write `Skeleton.module.scss`**
+
+```scss
+.skeleton {
+  display: inline-block;
+  background: var(--color-bg-muted);
+  // Prevent text selection — skeletons are decorative.
+  user-select: none;
+  // Ensures the inline-block lays out cleanly inside text flow.
+  vertical-align: middle;
+}
+
+.variant-text {
+  border-radius: var(--radius-sm);
+}
+
+.variant-circular {
+  border-radius: var(--radius-full);
+}
+
+.variant-rectangular {
+  display: block;
+  border-radius: var(--radius-md);
+}
+
+// Pulse — opacity cycle. Hardware-accelerated (opacity is a compositor
+// property). 1.5s read as "alive" without being distracting.
+.pulse {
+  animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes skeleton-pulse {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+// Respect reduced-motion. Wins over the .pulse class above because of
+// source order + the !important on the animation property (which is
+// the standard pattern for reduced-motion suppression — without it,
+// the more-specific .pulse rule would override).
+@media (prefers-reduced-motion: reduce) {
+  .pulse {
+    animation: none;
+  }
+}
+```
+
+NOTE on stylelint: `keyframes` and `animation` are not in `property-disallowed-list`. The `display: block` on rectangular shouldn't trip Rule 4 because the public component box IS the skeleton itself (it's a leaf with no children). If stylelint flags anything, fix inline.
+
+- [ ] **Step 3: Gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm run typecheck 2>&1 | tail -5
+npm run lint:css 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Skeleton/Skeleton.tsx \
+        packages/design-system/src/components/Skeleton/Skeleton.module.scss
+git commit -m "Skeleton: new primitive — text / circular / rectangular variants, pulse animation"
+```
+
+---
+
+## Task 3: `Skeleton.test.tsx`
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Skeleton/Skeleton.test.tsx`
+
+- [ ] **Step 1: Write tests**
+
+```tsx
+import { render } from '@testing-library/react';
+import { createRef } from 'react';
+import { Skeleton } from './Skeleton';
+
+describe('Skeleton', () => {
+  it('renders a span by default', () => {
+    const { container } = render(<Skeleton />);
+    expect(container.firstChild?.nodeName).toBe('SPAN');
+  });
+
+  it('default variant is text — applies the text class + height defaults to 1em', () => {
+    const { container } = render(<Skeleton />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toMatch(/variant-text/);
+    expect(el.style.height).toBe('1em');
+  });
+
+  it('variant="circular" — when only width is set, height matches (square)', () => {
+    const { container } = render(<Skeleton variant="circular" width={32} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toMatch(/variant-circular/);
+    expect(el.style.width).toBe('32px');
+    expect(el.style.height).toBe('32px');
+  });
+
+  it('variant="circular" — when only height is set, width matches (square)', () => {
+    const { container } = render(<Skeleton variant="circular" height={40} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe('40px');
+    expect(el.style.height).toBe('40px');
+  });
+
+  it('variant="rectangular" — applies the rectangular class, no default height', () => {
+    const { container } = render(<Skeleton variant="rectangular" width={120} height={32} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toMatch(/variant-rectangular/);
+    expect(el.style.width).toBe('120px');
+    expect(el.style.height).toBe('32px');
+  });
+
+  it('numeric dimensions become `px`; string dimensions pass through as-is', () => {
+    const { container } = render(<Skeleton width={50} height="60%" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe('50px');
+    expect(el.style.height).toBe('60%');
+  });
+
+  it('animation="pulse" (default) applies the pulse class', () => {
+    const { container } = render(<Skeleton />);
+    expect((container.firstChild as HTMLElement).className).toMatch(/pulse/);
+  });
+
+  it('animation="none" — no pulse class', () => {
+    const { container } = render(<Skeleton animation="none" />);
+    expect((container.firstChild as HTMLElement).className).not.toMatch(/pulse/);
+  });
+
+  it('aria-hidden="true" by default; consumer can override', () => {
+    const { container, rerender } = render(<Skeleton />);
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true');
+    rerender(<Skeleton aria-hidden="false" />);
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('forwards ref to the root element', () => {
+    const ref = createRef<HTMLSpanElement>();
+    render(<Skeleton ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+
+  it('merges className without replacing', () => {
+    const { container } = render(<Skeleton className="my-cls" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toMatch(/my-cls/);
+    expect(el.className).toMatch(/skeleton/);
+  });
+
+  it('consumer style is merged into inline style', () => {
+    const { container } = render(<Skeleton width={100} style={{ marginTop: 4 }} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe('100px');
+    expect(el.style.marginTop).toBe('4px');
+  });
+});
+```
+
+- [ ] **Step 2: Gates**
+
+```bash
+npm test --workspace=@eocrm/design-system --run -- src/components/Skeleton 2>&1 | tail -8
+```
+
+All 12 tests must pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/Skeleton/Skeleton.test.tsx
+git commit -m "Skeleton: unit tests — variants, dimensions, animation, a11y, ref"
+```
+
+---
+
+## Task 4: Barrel + src/index.ts re-export
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Skeleton/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+- [ ] **Step 1: Write the component barrel**
+
+```ts
+export { Skeleton } from './Skeleton';
+export type { SkeletonProps, SkeletonVariant, SkeletonAnimation } from './Skeleton';
+```
+
+- [ ] **Step 2: Re-export from `src/index.ts`**
+
+Read the file. Slot alphabetically — `Skeleton` sits between `Select` and `Stack`.
+
+```ts
+export { Skeleton } from './components/Skeleton';
+export type { SkeletonProps, SkeletonVariant, SkeletonAnimation } from './components/Skeleton';
+```
+
+- [ ] **Step 3: Gates**
+
+```bash
+npm run typecheck 2>&1 | tail -3
+npm run build 2>&1 | tail -3
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Skeleton/index.ts \
+        packages/design-system/src/index.ts
+git commit -m "Skeleton: re-export from barrel + src/index.ts (Rule 5)"
+```
+
+---
+
+## Task 5: Playground demo + wiring
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/SkeletonDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Write `SkeletonDemo.tsx`**
+
+7 examples per the spec:
+
+1. **Text** — single inline skeleton at width=120
+2. **Multi-line text** — three text skeletons stacked at 80% / 60% / 40%
+3. **Circular** — 32px and 40px avatars side-by-side
+4. **Rectangular** — image (200×120), button (80×32), card (full×180)
+5. **List-row composition** — Circular(32) + Stack(text@60%, text@40%) + Rectangular(80×32) in a Cluster, inside a Card
+6. **No animation** — five rectangular skeletons stacked, `animation="none"`
+7. **Inside a Table** — `<Table>` with 5 body rows, each cell containing a `<Skeleton>` (DataTable preview)
+
+Match the existing `DemoLayout` + `Example` conventions. Source-display via:
+- `@lib-source/components/Skeleton/Skeleton.tsx?raw`
+- `@lib-source/components/Skeleton/Skeleton.module.scss?raw`
+
+- [ ] **Step 2: Wire `App.tsx`**
+
+Add import + route alphabetically.
+
+```tsx
+import { SkeletonDemo } from './pages/components/SkeletonDemo';
+// …
+<Route path="/components/skeleton" element={<SkeletonDemo />} />
+```
+
+- [ ] **Step 3: Wire `AppShell.tsx`**
+
+Add to the Display group alphabetically (between `Calendar` and `Table`). Use the `Square` lucide icon (or `Loader` if it reads better). Going with `Square`:
+
+```tsx
+import { Square } from 'lucide-react';
+// …
+{ to: '/components/skeleton', label: 'Skeleton', icon: Square, end: false },
+```
+
+- [ ] **Step 4: Wire `ComponentsIndex.tsx`**
+
+Add `Skeleton` to the `@eocrm/design-system` import. Add a card:
+
+```tsx
+{
+  to: '/components/skeleton',
+  name: 'Skeleton',
+  description:
+    'Placeholder rectangle for loading states. Three variants (text / circular / rectangular), pulse animation respects prefers-reduced-motion.',
+  preview: (
+    <Stack gap="xs" style={{ width: 200 }}>
+      <Skeleton width="80%" />
+      <Skeleton width="60%" />
+      <Skeleton width="40%" />
+    </Stack>
+  ),
+},
+```
+
+- [ ] **Step 5: Wire `registry.ts`**
+
+Add `'Skeleton'` to the `ComponentName` union alphabetically.
+
+- [ ] **Step 6: Gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm run typecheck 2>&1 | tail -5
+npm run build 2>&1 | tail -5
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/components/skeleton
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/playground/src/
+git commit -m "SkeletonDemo: examples + sidebar + index + registry wiring"
+```
+
+---
+
+## Task 6: AGENTS.md section
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Insert in the Display group**
+
+Place between `Calendar` and `Table` (alphabetically). One-section TL;DR + canonical snippet.
+
+```markdown
+### `<Skeleton>` — loading placeholder
+
+```tsx
+<Skeleton width={120} />                                    // text line
+<Skeleton variant="circular" width={32} />                   // avatar
+<Skeleton variant="rectangular" width="100%" height={120} /> // image
+```
+
+- Three variants: `text` (default, inline, height=1em), `circular` (avatar/icon, square when only one dim set), `rectangular` (image/card/button, block).
+- `width` / `height` flow to inline style — `number` becomes `px`, `string` passes through (`'60%'`, `'12rem'`).
+- `animation`: `'pulse'` (default, opacity 1→0.6 cycle) / `'none'` (static).
+- Animation is automatically suppressed when the user has `prefers-reduced-motion: reduce`.
+- `aria-hidden='true'` by default — Skeleton is decorative. Communicate "loading" from a parent live region (e.g., `aria-busy='true'` on the section being filled).
+- Composes — for a list-row placeholder, render `<Skeleton variant='circular' />` + 2-3 text skeletons + a button-shaped rectangular in a Cluster.
+- Use `<EmptyState>` (not yet shipped) for "nothing here yet" — Skeleton implies "loading," not "empty."
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/design-system/AGENTS.md
+git commit -m "AGENTS.md: document new <Skeleton>"
+```
+
+---
+
+## Task 7: Final gates + Hard Rule 8 + PR
+
+- [ ] **Step 1: Prettier write**
+
+```bash
+npx prettier --write "packages/**/src/**/*.{ts,tsx,scss}" "docs/**/*.md" "packages/design-system/AGENTS.md"
+git add -A packages/ docs/
+git commit -m "Prettier: format Skeleton changes" || echo "no formatting changes"
+```
+
+- [ ] **Step 2: Full gates**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test --workspace=@eocrm/design-system --run 2>&1 | tail -5
+npm run typecheck 2>&1 | tail -3
+npm run lint:css 2>&1 | tail -3
+npm run build 2>&1 | tail -3
+npx prettier --check "packages/**/src/**/*.{ts,tsx,scss}" "docs/**/*.md" "packages/design-system/AGENTS.md" 2>&1 | tail -3
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -cE "\.test\."
+```
+
+All green; npm pack count = 0.
+
+- [ ] **Step 3: Push**
+
+```bash
+git push -u origin feat/skeleton
+```
+
+- [ ] **Step 4: Hard Rule 8 review cycle**
+
+Dispatch a fresh-context review agent. Specifics to look at hard:
+
+- The default `height: 1em` for text variant — does that actually render as text-line height inside a `<p>`? Test via `style.height === '1em'` is fine; visual smoke test happens in the playground.
+- `prefers-reduced-motion` suppression — the SCSS uses `@media (prefers-reduced-motion: reduce) { .pulse { animation: none } }`. Verify the source order means this beats the base `.pulse` declaration without `!important`.
+- `aria-hidden` default vs override — confirm consumer can pass `aria-hidden="false"` and it makes it to the DOM.
+- The `display: block` on `.variant-rectangular` overrides `display: inline-block` from `.skeleton`. Verify the class composition order in `clsx` puts rectangular AFTER skeleton so source-order beats specificity (or specificity ties and source order wins).
+- The `width`/`height` inline-style logic — `toCssSize(undefined)` returns `undefined`, which means React won't emit the property at all. Verify the rectangular case with no dims renders an invisible (0×0) element rather than throwing.
+
+- [ ] **Step 5: Fix Critical + Important findings; re-push; re-review until clean.**
+
+- [ ] **Step 6: Open PR**
+
+```bash
+gh pr create --title "Skeleton: loading placeholder primitive (text / circular / rectangular)" --body "$(cat <<'EOF'
+## Summary
+
+- New `<Skeleton>` primitive — single dumb leaf component that paints a token-colored placeholder rectangle. Consumers compose multiple in any layout to mimic the eventual content shape while it loads.
+- **3 variants**: `text` (default, inline, height=1em), `circular` (avatar/icon, auto-square), `rectangular` (image/card/button, block).
+- **2 animations**: `pulse` (default, opacity 1→0.6 cycle, 1.5s ease-in-out) / `none`. Pulse is automatically suppressed when the user has `prefers-reduced-motion: reduce`.
+- **No new tokens** — reuses `--color-bg-muted`, existing radius tokens. Inline `@keyframes` in the SCSS module.
+- **`aria-hidden='true'` by default** — Skeleton is decorative; AT users hear "Loading…" from a parent live region.
+- 12 unit tests covering all variants, dimension handling (number → px, string → as-is), animation toggle, aria-hidden override, ref, className merge.
+
+Unblocks the DataTable v1 loading state. Will be paired with `<EmptyState>` (next PR) and DataTable thereafter.
+
+## Test plan
+
+- [x] `npm test --run` — all green, 12 new Skeleton tests
+- [x] `npm run typecheck` clean
+- [x] `npm run lint:css` clean
+- [x] `npm run build` clean
+- [x] `npx prettier --check` clean
+- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files in tarball
+- [x] Manual smoke: 7 demo examples render; pulse visible; `prefers-reduced-motion` suppresses animation; list-row composition + table-rows preview look like DataTable's eventual loading state
+- [x] Hard Rule 8 review cycle — verdict: clean enough to stop
+
+## Design spec / plan
+
+- Spec: \`docs/superpowers/specs/2026-05-22-skeleton-design.md\`
+- Plan: \`docs/superpowers/plans/2026-05-22-skeleton.md\`
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+Spec coverage:
+
+- §Public API → Task 2 (TSX).
+- §Visual / tokens → Task 2 (SCSS).
+- §Animation + reduced-motion → Task 2 SCSS.
+- §A11y (aria-hidden default) → Task 2 + Task 3 (test).
+- §Tests → Task 3 (12 tests).
+- §Demo → Task 5 (7 examples).
+- §AGENTS.md → Task 6.
+- §Hard Rule 8 + PR → Task 7.
+
+Type consistency:
+
+- `SkeletonVariant = 'text' | 'circular' | 'rectangular'`.
+- `SkeletonAnimation = 'pulse' | 'none'`.
+- Both re-exported from both barrels.
+
+No placeholders. All paths absolute. Each commit scoped.

--- a/docs/superpowers/specs/2026-05-22-skeleton-design.md
+++ b/docs/superpowers/specs/2026-05-22-skeleton-design.md
@@ -53,14 +53,14 @@ export interface SkeletonProps extends HTMLAttributes<HTMLSpanElement> {
 
 ## Visual
 
-| Visual                    | Token                              |
-| ------------------------- | ---------------------------------- |
-| Background                | `--color-bg-muted` (`#f4f5f7`)     |
-| Pulse opacity range       | 1 → 0.6 → 1                        |
-| Pulse duration            | 1.5s ease-in-out infinite          |
-| Border radius (text)      | `--radius-sm`                      |
-| Border radius (circular)  | `--radius-full`                    |
-| Border radius (rectangular)| `--radius-md`                     |
+| Visual                      | Token                          |
+| --------------------------- | ------------------------------ |
+| Background                  | `--color-bg-muted` (`#f4f5f7`) |
+| Pulse opacity range         | 1 → 0.6 → 1                    |
+| Pulse duration              | 1.5s ease-in-out infinite      |
+| Border radius (text)        | `--radius-sm`                  |
+| Border radius (circular)    | `--radius-full`                |
+| Border radius (rectangular) | `--radius-md`                  |
 
 No new tokens. Inline `@keyframes pulse` defined in the SCSS module.
 

--- a/docs/superpowers/specs/2026-05-22-skeleton-design.md
+++ b/docs/superpowers/specs/2026-05-22-skeleton-design.md
@@ -1,0 +1,131 @@
+# Skeleton — design spec
+
+**Date:** 2026-05-22
+**Branch:** `feat/skeleton`
+**Scope:** New `<Skeleton>` primitive — shimmer/pulse placeholder block for loading states.
+
+## Goal
+
+A single, dumb primitive that paints a token-colored placeholder rectangle, optionally animated. Consumers compose multiple `<Skeleton>`s in any layout to mimic the eventual content shape while it loads.
+
+## Why now
+
+DataTable v1 needs a loading state. So does every other "data-fetched-from-server" screen in the CRM. Shipping Skeleton first unblocks DataTable AND gives every consumer a primitive to use everywhere else (card placeholders, list rows, mockup data slots).
+
+## Architecture
+
+```tsx
+<Skeleton variant="text" />
+<Skeleton variant="circular" width={32} height={32} />
+<Skeleton variant="rectangular" width="100%" height={120} />
+```
+
+- Single `<span>` (or `<div>` for rectangular) with a token-colored background.
+- Optional CSS animation cycles opacity to suggest "loading" without being distracting.
+- No children. Skeleton is a leaf — consumers compose multiple in a `<Stack>` / `<Cluster>` to build complex placeholders.
+
+## Public API
+
+```ts
+export type SkeletonVariant = 'text' | 'circular' | 'rectangular';
+export type SkeletonAnimation = 'pulse' | 'none';
+
+export interface SkeletonProps extends HTMLAttributes<HTMLSpanElement> {
+  /**
+   * Shape preset. Defaults to `'text'`.
+   * - `'text'` — inline-block, height defaults to `1em` so it sits on text baselines. Use inside paragraphs / labels for word-shaped placeholders.
+   * - `'circular'` — `border-radius: 50%`; width = height when only one is set. Avatar / icon placeholder.
+   * - `'rectangular'` — block, small radius. Image / card / button placeholder.
+   */
+  variant?: SkeletonVariant;
+  /** Explicit width. Number → px, string → as-is (e.g., `'60%'`, `'12rem'`). */
+  width?: number | string;
+  /** Explicit height. Number → px, string → as-is. Variant defaults: text=1em, circular=`width` (square), rectangular=no default. */
+  height?: number | string;
+  /**
+   * Animation. Defaults to `'pulse'`.
+   * - `'pulse'` — opacity 1 → 0.6 → 1, 1.5s ease-in-out infinite. Low-cost, hardware-accelerated.
+   * - `'none'` — static (no animation). Use when stacking many skeletons to avoid motion overload, or when `prefers-reduced-motion` is set (we also respect that at the CSS level).
+   */
+  animation?: SkeletonAnimation;
+}
+```
+
+## Visual
+
+| Visual                    | Token                              |
+| ------------------------- | ---------------------------------- |
+| Background                | `--color-bg-muted` (`#f4f5f7`)     |
+| Pulse opacity range       | 1 → 0.6 → 1                        |
+| Pulse duration            | 1.5s ease-in-out infinite          |
+| Border radius (text)      | `--radius-sm`                      |
+| Border radius (circular)  | `--radius-full`                    |
+| Border radius (rectangular)| `--radius-md`                     |
+
+No new tokens. Inline `@keyframes pulse` defined in the SCSS module.
+
+`@media (prefers-reduced-motion: reduce)`: animation is suppressed regardless of the `animation` prop.
+
+## States
+
+- **Default (pulse)** — token-muted bg with the opacity cycle.
+- **`animation="none"`** — same bg, no animation. Used when N skeletons would create distracting motion (e.g., a long table loading 50 rows).
+- **Reduced motion** — pulse suppressed via media query; bg stays static.
+
+## A11y
+
+- Skeleton is purely visual. Renders with `aria-hidden="true"` by default — AT users get nothing from the placeholder shape itself; they should hear "loading…" from a parent live region.
+- Consumer can override `aria-hidden` (e.g., a top-level loading region that wants its own `aria-busy="true"` + label).
+
+## File layout
+
+```
+packages/design-system/src/components/Skeleton/
+  Skeleton.tsx
+  Skeleton.module.scss
+  Skeleton.test.tsx
+  index.ts
+```
+
+Top-level `src/index.ts` re-exports `Skeleton`, `SkeletonProps`, `SkeletonVariant`, `SkeletonAnimation`.
+
+## Tests
+
+- Renders a span by default.
+- `variant="text"` (default) applies the text class + height defaults to `1em`.
+- `variant="circular"` applies the circular class + when only `width` is set, `height` matches.
+- `variant="rectangular"` applies the rectangular class.
+- `width` / `height` flow through to inline `style` (number → `px`, string → as-is).
+- `animation="none"` does NOT apply the pulse class; default applies it.
+- `aria-hidden="true"` by default; consumer can override.
+- `ref` forwards to the root element.
+- `className` merges, does not replace.
+
+## Playground demo
+
+`SkeletonDemo.tsx` — 7 examples:
+
+1. **Text** — single text-line skeleton inline with real text ("Loading…")
+2. **Multi-line text** — three text skeletons stacked, varied widths (`80%`, `60%`, `40%`) to mimic a paragraph
+3. **Circular** — 32px and 40px circles (avatar placeholders)
+4. **Rectangular** — image / button / card placeholders at different sizes
+5. **Card composition** — Circle + 2 text lines + rectangle in a Card; the canonical "list row loading" shape
+6. **Animation none** — five rectangles stacked, no animation
+7. **Inside a Table** — placeholder rows (DataTable preview): a real `<Table>` with 5 body rows containing `<Skeleton>` cells
+
+## AGENTS.md
+
+Add `<Skeleton>` section in the Display group, right before `<Avatar>` alphabetically — or wherever it fits the existing groupings.
+
+## Non-goals
+
+- **Skeleton.Group / preset compounds** (e.g., `<Skeleton.Avatar>`, `<Skeleton.Card>`). YAGNI for v1; consumers compose what they need.
+- **Shimmer animation** (gradient sweep). More expensive, more flashy; defer to v2 if a screen demands it.
+- **Variant-specific defaults that change at different sizes** (e.g., text height tracking parent font). The `height: 1em` default handles the text case; consumer passes explicit `height` for the rectangular case.
+
+## Risks / open questions
+
+- **`aria-hidden="true"` by default** — correct for the common case (parent communicates loading). If a consumer renders a lone Skeleton with no parent loading indicator, AT users see nothing. Acceptable; documented in JSDoc.
+- **Reduced-motion suppression at the CSS level** — applied unconditionally via `@media (prefers-reduced-motion: reduce)`. Means even `animation="pulse"` falls back to static when the user has reduced-motion on. No way to opt out (which is the right call).
+- **No "shimmer" variant** — pulse is cheap and unintrusive. If a brand-y consumer wants gradient shimmer, that's a separate prop later.
+- **Tokens chosen for the bg are NEUTRAL gray, not consumer-themed.** A future theme that recolors `--color-bg-muted` will recolor the skeleton automatically. No further theming hooks needed in v1.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -508,6 +508,22 @@ const [tab, setTab] = useState('overview');
 - Don't reach for `triggerDisplay='summary'` for tag input — chips communicate the active filter set at a glance.
 - `creatable` requires `searchable` (throws in dev). Passing both `options` and `loadOptions` is also flagged (loadOptions wins).
 
+### `<Skeleton>` — loading placeholder
+
+```tsx
+<Skeleton width={120} />                                    // text line
+<Skeleton variant="circular" width={32} />                  // avatar
+<Skeleton variant="rectangular" width="100%" height={120} /> // image
+```
+
+- Three variants: `text` (default, inline, `height=1em`), `circular` (avatar / icon, square when only one dim set), `rectangular` (image / card / button, block).
+- `width` / `height` flow to inline style — `number` becomes `px`, `string` passes through (`'60%'`, `'12rem'`).
+- `animation`: `'pulse'` (default, opacity cycle) / `'none'` (static).
+- Pulse is **automatically suppressed** when the user has `prefers-reduced-motion: reduce`.
+- `aria-hidden='true'` by default — Skeleton is decorative. Communicate "loading" from a parent live region (e.g., `aria-busy='true'` on the section being filled).
+- Composes — for a list-row placeholder, render `<Skeleton variant='circular' />` + 2–3 text skeletons + a button-shaped rectangular in a Cluster.
+- Use `<EmptyState>` (not yet shipped) for "nothing here yet" — Skeleton implies "loading," not "empty."
+
 ### `<Table>` — tabular data primitive
 
 ```tsx

--- a/packages/design-system/src/components/Skeleton/Skeleton.module.scss
+++ b/packages/design-system/src/components/Skeleton/Skeleton.module.scss
@@ -1,0 +1,53 @@
+.skeleton {
+  display: inline-block;
+  background: var(--color-bg-muted);
+
+  // Prevent text selection — skeletons are decorative.
+  user-select: none;
+
+  // Ensures the inline-block lays out cleanly inside text flow.
+  vertical-align: middle;
+}
+
+.variant-text {
+  border-radius: var(--radius-sm);
+}
+
+.variant-circular {
+  border-radius: var(--radius-full);
+}
+
+.variant-rectangular {
+  display: block;
+  border-radius: var(--radius-md);
+}
+
+// Pulse — opacity cycle. Hardware-accelerated (opacity is a compositor
+// property). 1.5s read as "alive" without being distracting.
+.pulse {
+  animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes skeleton-pulse {
+  0% {
+    opacity: var(--opacity-visible);
+  }
+
+  50% {
+    opacity: var(--opacity-subtle);
+  }
+
+  100% {
+    opacity: var(--opacity-visible);
+  }
+}
+
+// Respect reduced-motion. Wins over the .pulse class above because of
+// source order + the !important on the animation property (which is
+// the standard pattern for reduced-motion suppression — without it,
+// the more-specific .pulse rule would override).
+@media (prefers-reduced-motion: reduce) {
+  .pulse {
+    animation: none;
+  }
+}

--- a/packages/design-system/src/components/Skeleton/Skeleton.module.scss
+++ b/packages/design-system/src/components/Skeleton/Skeleton.module.scss
@@ -42,10 +42,10 @@
   }
 }
 
-// Respect reduced-motion. Wins over the .pulse class above because of
-// source order + the !important on the animation property (which is
-// the standard pattern for reduced-motion suppression — without it,
-// the more-specific .pulse rule would override).
+// Respect reduced-motion. Wins over the .pulse rule above purely via
+// source order — both selectors are class-specificity (0,1,0), so the
+// later declaration takes precedence in the cascade. No !important
+// needed.
 @media (prefers-reduced-motion: reduce) {
   .pulse {
     animation: none;

--- a/packages/design-system/src/components/Skeleton/Skeleton.test.tsx
+++ b/packages/design-system/src/components/Skeleton/Skeleton.test.tsx
@@ -1,0 +1,84 @@
+import { render } from '@testing-library/react';
+import { createRef } from 'react';
+import { Skeleton } from './Skeleton';
+
+describe('Skeleton', () => {
+  it('renders a span by default', () => {
+    const { container } = render(<Skeleton />);
+    expect(container.firstChild?.nodeName).toBe('SPAN');
+  });
+
+  it('default variant is text — applies the text class + height defaults to 1em', () => {
+    const { container } = render(<Skeleton />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toMatch(/variant-text/);
+    expect(el.style.height).toBe('1em');
+  });
+
+  it('variant="circular" — when only width is set, height matches (square)', () => {
+    const { container } = render(<Skeleton variant="circular" width={32} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toMatch(/variant-circular/);
+    expect(el.style.width).toBe('32px');
+    expect(el.style.height).toBe('32px');
+  });
+
+  it('variant="circular" — when only height is set, width matches (square)', () => {
+    const { container } = render(<Skeleton variant="circular" height={40} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe('40px');
+    expect(el.style.height).toBe('40px');
+  });
+
+  it('variant="rectangular" — applies the rectangular class, no default height', () => {
+    const { container } = render(<Skeleton variant="rectangular" width={120} height={32} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toMatch(/variant-rectangular/);
+    expect(el.style.width).toBe('120px');
+    expect(el.style.height).toBe('32px');
+  });
+
+  it('numeric dimensions become `px`; string dimensions pass through as-is', () => {
+    const { container } = render(<Skeleton width={50} height="60%" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe('50px');
+    expect(el.style.height).toBe('60%');
+  });
+
+  it('animation="pulse" (default) applies the pulse class', () => {
+    const { container } = render(<Skeleton />);
+    expect((container.firstChild as HTMLElement).className).toMatch(/pulse/);
+  });
+
+  it('animation="none" — no pulse class', () => {
+    const { container } = render(<Skeleton animation="none" />);
+    expect((container.firstChild as HTMLElement).className).not.toMatch(/pulse/);
+  });
+
+  it('aria-hidden="true" by default; consumer can override', () => {
+    const { container, rerender } = render(<Skeleton />);
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true');
+    rerender(<Skeleton aria-hidden="false" />);
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('forwards ref to the root element', () => {
+    const ref = createRef<HTMLSpanElement>();
+    render(<Skeleton ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+
+  it('merges className without replacing', () => {
+    const { container } = render(<Skeleton className="my-cls" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toMatch(/my-cls/);
+    expect(el.className).toMatch(/skeleton/);
+  });
+
+  it('consumer style is merged into inline style', () => {
+    const { container } = render(<Skeleton width={100} style={{ marginTop: 4 }} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe('100px');
+    expect(el.style.marginTop).toBe('4px');
+  });
+});

--- a/packages/design-system/src/components/Skeleton/Skeleton.test.tsx
+++ b/packages/design-system/src/components/Skeleton/Skeleton.test.tsx
@@ -8,12 +8,21 @@ describe('Skeleton', () => {
     expect(container.firstChild?.nodeName).toBe('SPAN');
   });
 
-  it('default variant is text — applies the text class + height defaults to 1em', () => {
+  it('default variant is text — applies the text class + height defaults to 1em + no inline width', () => {
     const { container } = render(<Skeleton />);
     const el = container.firstChild as HTMLElement;
     expect(el.className).toMatch(/variant-text/);
     expect(el.style.height).toBe('1em');
+    // No width prop → no inline width style emitted; the element flows
+    // inline within its parent text container.
+    expect(el.style.width).toBe('');
   });
+
+  // Note: `prefers-reduced-motion: reduce` animation suppression is
+  // verified at the CSS layer (Skeleton.module.scss line 45+). jsdom's
+  // matchMedia is unreliable for media-query reactivity, so we don't
+  // attempt to assert on it here — the cascade rule sits at equal
+  // specificity with the .pulse declaration and wins via source order.
 
   it('variant="circular" — when only width is set, height matches (square)', () => {
     const { container } = render(<Skeleton variant="circular" width={32} />);

--- a/packages/design-system/src/components/Skeleton/Skeleton.tsx
+++ b/packages/design-system/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,124 @@
+import { forwardRef, type CSSProperties, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './Skeleton.module.scss';
+
+/** Shape preset. */
+export type SkeletonVariant = 'text' | 'circular' | 'rectangular';
+
+/** Animation style. */
+export type SkeletonAnimation = 'pulse' | 'none';
+
+export interface SkeletonProps extends HTMLAttributes<HTMLSpanElement> {
+  /**
+   * Shape preset. Defaults to `'text'`.
+   * - `'text'` — inline-block; `height` defaults to `1em` so it sits on text
+   *   baselines. Use inside paragraphs / labels for word-shaped placeholders.
+   * - `'circular'` — `border-radius: 50%`; when only one of `width`/`height`
+   *   is set, the other matches (square). Avatar / icon placeholder.
+   * - `'rectangular'` — block, small radius. Image / card / button placeholder.
+   */
+  variant?: SkeletonVariant;
+
+  /** Explicit width. Number → px, string → as-is (e.g., `'60%'`, `'12rem'`). */
+  width?: number | string;
+
+  /**
+   * Explicit height. Number → px, string → as-is.
+   * Defaults: `text` → `1em`, `circular` → matches `width` (square),
+   * `rectangular` → no default (consumer must size).
+   */
+  height?: number | string;
+
+  /**
+   * Animation. Defaults to `'pulse'`.
+   * - `'pulse'` — opacity 1 → 0.6 → 1, 1.5s ease-in-out infinite.
+   * - `'none'` — static. Use when stacking many skeletons to avoid motion
+   *   overload.
+   *
+   * Regardless of this prop, animation is suppressed when the user has
+   * `prefers-reduced-motion: reduce`.
+   */
+  animation?: SkeletonAnimation;
+}
+
+function toCssSize(value: number | string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === 'number' ? `${value}px` : value;
+}
+
+/**
+ * Placeholder rectangle for loading states. Consumers compose multiple
+ * `<Skeleton>`s in any layout to mimic the eventual content shape.
+ *
+ * @example
+ * // Single text line (inline with surrounding text):
+ * <Skeleton width={120} />
+ *
+ * @example
+ * // Avatar + two text lines + button (the canonical "list row loading"):
+ * <Cluster gap="md" align="center">
+ *   <Skeleton variant="circular" width={32} />
+ *   <Stack gap="xs" style={{ flex: 1 }}>
+ *     <Skeleton width="60%" />
+ *     <Skeleton width="40%" />
+ *   </Stack>
+ *   <Skeleton variant="rectangular" width={80} height={32} />
+ * </Cluster>
+ *
+ * @example
+ * // Many rows — disable animation to avoid motion overload:
+ * {Array.from({ length: 20 }).map((_, i) => (
+ *   <Skeleton key={i} variant="rectangular" height={32} animation="none" />
+ * ))}
+ *
+ * @remarks When NOT to use
+ * - When loading takes < 200ms — flashing a skeleton then content jitters
+ *   the layout. Render the real content directly.
+ * - For empty states ("No contacts yet"). Use `<EmptyState>` (not yet
+ *   shipped) — a skeleton implies "loading," not "nothing here."
+ *
+ * @remarks Anti-patterns
+ * - ❌ Wrapping real content in a Skeleton ("just hide everything"). The
+ *   primitive is a leaf — don't pass children.
+ * - ❌ Omitting all dimensions on `rectangular`. With no `width`/`height`,
+ *   the box has zero size and renders invisibly. Always size it.
+ */
+export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(function Skeleton(
+  { variant = 'text', width, height, animation = 'pulse', className, style, ...props },
+  ref,
+) {
+  // Default height: text → 1em (sits on baseline), circular → matches width
+  // (square), rectangular → undefined (consumer must size).
+  let resolvedHeight: string | undefined = toCssSize(height);
+  if (resolvedHeight === undefined) {
+    if (variant === 'text') resolvedHeight = '1em';
+    else if (variant === 'circular' && width !== undefined) resolvedHeight = toCssSize(width);
+  }
+
+  // Default width: circular with only height set → matches height (square).
+  let resolvedWidth: string | undefined = toCssSize(width);
+  if (resolvedWidth === undefined && variant === 'circular' && height !== undefined) {
+    resolvedWidth = toCssSize(height);
+  }
+
+  const mergedStyle: CSSProperties = {
+    width: resolvedWidth,
+    height: resolvedHeight,
+    ...style,
+  };
+
+  return (
+    <span
+      ref={ref}
+      aria-hidden="true"
+      {...props}
+      className={clsx(
+        styles.skeleton,
+        styles[`variant-${variant}`],
+        animation === 'pulse' && styles.pulse,
+        className,
+      )}
+      style={mergedStyle}
+    />
+  );
+});

--- a/packages/design-system/src/components/Skeleton/Skeleton.tsx
+++ b/packages/design-system/src/components/Skeleton/Skeleton.tsx
@@ -107,6 +107,12 @@ export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(function Skel
     ...style,
   };
 
+  // Spread order: ref + aria-hidden BEFORE {...props} so a consumer can
+  // override aria-hidden (e.g., for a Skeleton that IS the loading
+  // announcement on a page with no parent live region). className and
+  // style live AFTER {...props} so the component's class composition +
+  // dimension style win over any consumer-supplied raw className / style
+  // (consumer composes via the prop, not by replacing).
   return (
     <span
       ref={ref}

--- a/packages/design-system/src/components/Skeleton/index.ts
+++ b/packages/design-system/src/components/Skeleton/index.ts
@@ -1,0 +1,2 @@
+export { Skeleton } from './Skeleton';
+export type { SkeletonProps, SkeletonVariant, SkeletonAnimation } from './Skeleton';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -99,6 +99,9 @@ export type {
   SelectTriggerDisplay,
 } from './components/Select';
 
+export { Skeleton } from './components/Skeleton';
+export type { SkeletonProps, SkeletonVariant, SkeletonAnimation } from './components/Skeleton';
+
 export { Table } from './components/Table';
 export type {
   TableProps,

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -234,6 +234,7 @@
   // States
   --opacity-disabled: 0.5;
   --opacity-muted: 0.75; // de-emphasised secondary text (e.g. event time prefix)
+  --opacity-subtle: 0.6; // skeleton pulse dim; slightly stronger fade than muted
   --opacity-hidden: 0;
   --opacity-visible: 1;
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -13,6 +13,7 @@ import { InputDemo } from './pages/components/InputDemo';
 import { PasswordInputDemo } from './pages/components/PasswordInputDemo';
 import { PasswordStrengthMeterDemo } from './pages/components/PasswordStrengthMeterDemo';
 import { SelectDemo } from './pages/components/SelectDemo';
+import { SkeletonDemo } from './pages/components/SkeletonDemo';
 import { TableDemo } from './pages/components/TableDemo';
 import { CardDemo } from './pages/components/CardDemo';
 import { CheckboxDemo } from './pages/components/CheckboxDemo';
@@ -52,6 +53,7 @@ export default function App() {
             element={<PasswordStrengthMeterDemo />}
           />
           <Route path="/components/select" element={<SelectDemo />} />
+          <Route path="/components/skeleton" element={<SkeletonDemo />} />
           <Route path="/components/table" element={<TableDemo />} />
           <Route path="/components/card" element={<CardDemo />} />
           <Route path="/components/checkbox" element={<CheckboxDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -29,6 +29,7 @@ import {
   PanelLeft,
   ShieldCheck,
   CalendarDays,
+  Square,
   Table as TableIcon,
   type LucideIcon,
 } from 'lucide-react';
@@ -84,6 +85,7 @@ const componentGroups = [
       { to: '/components/avatar', label: 'Avatar', icon: CircleUser, end: false },
       { to: '/components/badge', label: 'Badge', icon: Tag, end: false },
       { to: '/components/calendar', label: 'Calendar', icon: CalendarDays, end: false },
+      { to: '/components/skeleton', label: 'Skeleton', icon: Square, end: false },
       { to: '/components/table', label: 'Table', icon: TableIcon, end: false },
     ],
   },

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -10,6 +10,7 @@ import { Input } from '@eocrm/design-system';
 import { PasswordInput } from '@eocrm/design-system';
 import { PasswordStrengthMeter } from '@eocrm/design-system';
 import { Select } from '@eocrm/design-system';
+import { Skeleton } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { Table } from '@eocrm/design-system';
 import { Tabs } from '@eocrm/design-system';
@@ -106,6 +107,19 @@ const items: { to: string; name: string; description: string; preview: React.Rea
           placeholder="Pick a status"
         />
       </div>
+    ),
+  },
+  {
+    to: '/components/skeleton',
+    name: 'Skeleton',
+    description:
+      'Placeholder rectangle for loading states. Three variants (text / circular / rectangular), pulse animation respects prefers-reduced-motion.',
+    preview: (
+      <Stack gap="xs" style={{ width: 200 }}>
+        <Skeleton width="80%" />
+        <Skeleton width="60%" />
+        <Skeleton width="40%" />
+      </Stack>
     ),
   },
   {

--- a/packages/playground/src/pages/components/SkeletonDemo.tsx
+++ b/packages/playground/src/pages/components/SkeletonDemo.tsx
@@ -1,0 +1,167 @@
+import { Card, Cluster, Skeleton, Stack, Table } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Skeleton/Skeleton.tsx?raw';
+import scssSource from '@lib-source/components/Skeleton/Skeleton.module.scss?raw';
+
+export function SkeletonDemo() {
+  return (
+    <DemoLayout
+      name="Skeleton"
+      componentName="Skeleton"
+      description="Placeholder rectangle for loading states. Three variants (text / circular / rectangular), pulse animation respects prefers-reduced-motion."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Skeleton.tsx"
+      scssFilename="Skeleton.module.scss"
+    >
+      <Example
+        title="Text — inline placeholder"
+        description="Default variant sits on the text baseline. Use directly inside a paragraph or label while the real value loads."
+        code={`<p style={{ margin: 0 }}>
+  Loading user name: <Skeleton width={120} />
+</p>`}
+      >
+        <p style={{ margin: 0 }}>
+          Loading user name: <Skeleton width={120} />
+        </p>
+      </Example>
+
+      <Example
+        title="Multi-line text"
+        description="Stack several text skeletons at varied widths to mimic a paragraph or list-item copy block."
+        code={`<Stack gap="xs" style={{ width: 240 }}>
+  <Skeleton width="80%" />
+  <Skeleton width="60%" />
+  <Skeleton width="40%" />
+</Stack>`}
+      >
+        <Stack gap="xs" style={{ width: 240 }}>
+          <Skeleton width="80%" />
+          <Skeleton width="60%" />
+          <Skeleton width="40%" />
+        </Stack>
+      </Example>
+
+      <Example
+        title="Circular — avatar placeholders"
+        description='`variant="circular"` forces border-radius 50%. When only `width` is set the height matches automatically — no need to supply both.'
+        code={`<Cluster gap="md" align="center">
+  <Skeleton variant="circular" width={32} />
+  <Skeleton variant="circular" width={40} />
+</Cluster>`}
+      >
+        <Cluster gap="md" align="center">
+          <Skeleton variant="circular" width={32} />
+          <Skeleton variant="circular" width={40} />
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Rectangular — image / button / card"
+        description='`variant="rectangular"` gives a small border-radius. Always supply explicit dimensions — with no width/height the box has zero size and renders invisibly.'
+        code={`<Stack gap="sm">
+  <Skeleton variant="rectangular" width={200} height={120} />
+  <Skeleton variant="rectangular" width={80} height={32} />
+  <Skeleton variant="rectangular" width="100%" height={60} />
+</Stack>`}
+      >
+        <Stack gap="sm">
+          <Skeleton variant="rectangular" width={200} height={120} />
+          <Skeleton variant="rectangular" width={80} height={32} />
+          <Skeleton variant="rectangular" width="100%" height={60} />
+        </Stack>
+      </Example>
+
+      <Example
+        title="List-row composition"
+        description="Compose circular + text + rectangular skeletons inside your normal layout primitives to match the shape of the real content."
+        code={`<Card padding="md">
+  <Cluster gap="md" align="center">
+    <Skeleton variant="circular" width={32} />
+    <Stack gap="xs" style={{ flex: 1 }}>
+      <Skeleton width="60%" />
+      <Skeleton width="40%" />
+    </Stack>
+    <Skeleton variant="rectangular" width={80} height={32} />
+  </Cluster>
+</Card>`}
+      >
+        <Card padding="md">
+          <Cluster gap="md" align="center">
+            <Skeleton variant="circular" width={32} />
+            <Stack gap="xs" style={{ flex: 1 }}>
+              <Skeleton width="60%" />
+              <Skeleton width="40%" />
+            </Stack>
+            <Skeleton variant="rectangular" width={80} height={32} />
+          </Cluster>
+        </Card>
+      </Example>
+
+      <Example
+        title='No animation — animation="none"'
+        description='Pass `animation="none"` when rendering many skeletons at once. Simultaneous pulsing on 10+ elements is visually noisy; a static state reads more cleanly.'
+        code={`<Stack gap="xs" style={{ width: 240 }}>
+  {Array.from({ length: 5 }).map((_, i) => (
+    <Skeleton key={i} variant="rectangular" height={32} animation="none" />
+  ))}
+</Stack>`}
+      >
+        <Stack gap="xs" style={{ width: 240 }}>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} variant="rectangular" height={32} animation="none" />
+          ))}
+        </Stack>
+      </Example>
+
+      <Example
+        title="Inside a Table — DataTable preview"
+        description="Drop skeletons directly into Table cells to render a realistic table loading state before data arrives."
+        code={`<Table>
+  <Table.Header>
+    <Table.Row>
+      <Table.HeaderCell>Name</Table.HeaderCell>
+      <Table.HeaderCell>Status</Table.HeaderCell>
+      <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    {Array.from({ length: 5 }).map((_, i) => (
+      <Table.Row key={i}>
+        <Table.Cell><Skeleton width="80%" /></Table.Cell>
+        <Table.Cell><Skeleton width={60} /></Table.Cell>
+        <Table.Cell align="end"><Skeleton width={50} /></Table.Cell>
+      </Table.Row>
+    ))}
+  </Table.Body>
+</Table>`}
+      >
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Name</Table.HeaderCell>
+              <Table.HeaderCell>Status</Table.HeaderCell>
+              <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Table.Row key={i}>
+                <Table.Cell>
+                  <Skeleton width="80%" />
+                </Table.Cell>
+                <Table.Cell>
+                  <Skeleton width={60} />
+                </Table.Cell>
+                <Table.Cell align="end">
+                  <Skeleton width={50} />
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -10,6 +10,7 @@ export type ComponentName =
   | 'PasswordInput'
   | 'PasswordStrengthMeter'
   | 'Select'
+  | 'Skeleton'
   | 'Table'
   | 'Card'
   | 'Checkbox'


### PR DESCRIPTION
## Summary

New `<Skeleton>` primitive — single dumb leaf that paints a token-colored placeholder rectangle. Consumers compose multiple in any layout to mimic the eventual content shape while it loads.

- **3 variants**: `text` (default — inline, `height=1em`), `circular` (avatar/icon, auto-square when only one dim set), `rectangular` (image/card/button — block, no default dims).
- **2 animations**: `pulse` (default — opacity 1 → 0.6 → 1 cycle, 1.5s ease-in-out) / `none`. Pulse is automatically suppressed when the user has `prefers-reduced-motion: reduce`.
- `width` / `height`: `number | string`. Numbers become px; strings pass through.
- **`aria-hidden="true"` by default** — Skeleton is decorative. AT users should hear "loading" from a parent live region. Consumer can override.
- **One new token**: `--opacity-subtle: 0.6` (used by the pulse keyframes; stylelint requires CSS variables for opacity values). Sits alongside the existing `--opacity-disabled` / `--opacity-muted` / `--opacity-visible` / `--opacity-hidden` scale.

Unblocks DataTable v1 loading state. Next up: `<EmptyState>` (for "no rows"), then `<Pagination>` (inline in DataTable), then DataTable itself.

## Test plan

- [x] `npm test --run` — 921/921 (12 new Skeleton tests)
- [x] `npm run typecheck` clean
- [x] `npm run lint:css` clean
- [x] `npm run build` clean
- [x] `npx prettier --check` clean
- [x] `npm pack --dry-run -w @eocrm/design-system` — no test files in tarball
- [x] Manual smoke: 7 demo examples render — text inline, multi-line stacked, circular pair, rectangular grid, list-row composition (Cluster + Stack inside a Card), no-animation stack, table-rows preview
- [x] Hard Rule 8 review cycle 1 — verdict: clean enough to stop after one cycle-1 fix (misleading SCSS comment about a non-existent `!important`)

## Design spec / plan

- Spec: `docs/superpowers/specs/2026-05-22-skeleton-design.md`
- Plan: `docs/superpowers/plans/2026-05-22-skeleton.md`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>