### PR TITLE
DataTable Phase 1: hook + component + column visibility companion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ dist-ssr
 .vscode/*
 !.vscode/extensions.json
 .idea
+
+# Superpowers brainstorm session artefacts (visual companion mockups, server state)
+.superpowers/

--- a/docs/superpowers/plans/2026-05-22-datatable-phase-1.md
+++ b/docs/superpowers/plans/2026-05-22-datatable-phase-1.md
@@ -1,0 +1,3407 @@
+# DataTable Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first phase of `<DataTable>` — the `useDataTable` hook, `<DataTable>` component, and `<DataTable.ColumnVisibilityTrigger>` companion — covering column ordering / sizing / visibility, row selection, row click, sticky header, sort interaction, and loading/empty states. **Column pinning rendering and expandable rows are deferred to phases 2 and 3** (state plumbing for those is included here but their rendering effects are not).
+
+**Architecture:** Config-driven column model (`ColumnDef<T>[]`). State managed by `useDataTable` hook with Radix-style controlled/uncontrolled pattern per piece. `<DataTable>` accepts an `instance` from the hook and renders via the existing `<Table>` compound primitive. Drag-to-reorder uses `@dnd-kit/sortable`. Resize handle is hand-rolled with pointer events. Server-driven sort/search/pagination — no client-side data transforms.
+
+**Tech Stack:** React 18 + TypeScript (source-distributed). `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` (new deps). Composes existing `<Table>`, `<DropdownMenu>`, `<Checkbox>`, `<EmptyState>`, `<Skeleton>`, `<Button>`. Vitest + RTL for tests. CSS Modules + SCSS tokens.
+
+**Source of truth:** `docs/superpowers/specs/2026-05-22-datatable-design.md` (commit `de95398`). Read it for any requirement not explicit in a task.
+
+**Branch:** `feat/datatable`. Commit per-task. Open a PR at the end of the plan (after the Hard-Rule-8 review-fix cycle passes).
+
+---
+
+## File Structure
+
+```
+packages/design-system/src/components/DataTable/
+  types.ts                          ← ColumnDef<T>, state types, instance type, options type
+  useControllableState.ts           ← local hook: Radix-style controlled-or-default state
+  useControllableState.test.ts
+  useDataTable.ts                   ← the hook: state machine + derived view models
+  useDataTable.test.ts              ← pure-logic unit tests
+  useResizeHandle.ts                ← pointer-based resize-handle hook
+  useResizeHandle.test.ts
+  HeaderCell.tsx                    ← sortable header (label + sort + hover grip + resize handle)
+  HeaderCell.module.scss
+  BodyRow.tsx                       ← row renderer (selection cell + data cells + row-click)
+  DataTable.tsx                     ← <DataTable> component (wires DndContext + renders Table)
+  DataTable.module.scss
+  DataTable.test.tsx                ← integration tests via RTL
+  ColumnVisibilityTrigger.tsx       ← companion: Button → DropdownMenu of CheckboxItems
+  ColumnVisibilityTrigger.module.scss
+  ColumnVisibilityTrigger.test.tsx
+  index.ts                          ← public re-exports
+
+packages/design-system/src/styles/tokens.scss   ← MODIFIED: add any new tokens
+packages/design-system/src/index.ts             ← MODIFIED: re-export DataTable surface
+packages/design-system/AGENTS.md                ← MODIFIED: add DataTable TL;DR
+packages/playground/src/pages/components/DataTableDemo.tsx   ← NEW
+packages/playground/src/App.tsx                              ← MODIFIED: route
+packages/playground/src/layout/AppShell/AppShell.tsx         ← MODIFIED: nav item
+packages/playground/src/pages/components/ComponentsIndex.tsx ← MODIFIED: grid card
+```
+
+**Decomposition rationale:**
+
+- `types.ts` is the type-only contract; consumed by every other file. Keeps re-export surface flat.
+- `useControllableState` is a tiny local utility (12 lines). Lives next to `useDataTable` rather than `_internal/` because no other component uses it today; promote later if reused.
+- `useDataTable` is the heart of the design — pure state machine + memoized derived models. Tested in isolation without DOM.
+- `HeaderCell` and `BodyRow` are split out so neither file becomes too large to reason about. Each is a focused responsibility: header = sort/grip/resize; body = selection/click/cells.
+- `useResizeHandle` is its own hook + test so the pointer-event logic can be tested without mounting a full table.
+- `<DataTable>` is the orchestrator — sets up `DndContext`, renders `<Table>` with `colgroup` + header + body.
+- `ColumnVisibilityTrigger` is a standalone companion component; lives in the same folder so it can directly use internal types but exports cleanly.
+
+---
+
+## Task 1 — Install dnd-kit dependencies
+
+**Files:**
+- Modify: `packages/design-system/package.json`
+
+- [ ] **Step 1: Verify clean working tree on `feat/datatable`**
+
+```bash
+cd /home/dpws/projects/design-system
+git status
+git branch --show-current
+```
+
+Expected: `On branch feat/datatable`, working tree clean (the spec commit `de95398` is already in place).
+
+- [ ] **Step 2: Add dnd-kit deps to the library workspace**
+
+```bash
+npm install --workspace @eocrm/design-system \
+  @dnd-kit/core@^6.1.0 \
+  @dnd-kit/sortable@^8.0.0 \
+  @dnd-kit/utilities@^3.2.2
+```
+
+Expected: `package.json` updated under `packages/design-system/`. Root `package-lock.json` updated.
+
+- [ ] **Step 3: Verify install + typecheck still passes**
+
+```bash
+make build-lib
+```
+
+Expected: typecheck passes (no DataTable code yet, so no usage of dnd-kit yet — just verifying nothing broke).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/package.json package-lock.json
+git commit -m "DataTable: add @dnd-kit deps (core, sortable, utilities)
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2 — Create folder + types.ts
+
+**Files:**
+- Create: `packages/design-system/src/components/DataTable/types.ts`
+- Create: `packages/design-system/src/components/DataTable/index.ts` (placeholder, will be populated)
+
+- [ ] **Step 1: Create folder + index placeholder**
+
+```bash
+mkdir -p packages/design-system/src/components/DataTable
+```
+
+- [ ] **Step 2: Write `types.ts` with the full type contract**
+
+Create `packages/design-system/src/components/DataTable/types.ts`:
+
+```ts
+import type { ReactNode, MouseEvent as ReactMouseEvent } from 'react';
+
+/** Cell / header text alignment. */
+export type ColumnAlign = 'start' | 'center' | 'end';
+
+/** Single-column sort state. v1 is single-column only; multi-column is a future extension. */
+export interface SortState {
+  columnId: string;
+  direction: 'asc' | 'desc';
+}
+
+/** Ordered list of column ids (includes hidden columns at their absolute positions). */
+export type ColumnOrderState = string[];
+
+/** Map column id → resolved width in px. Missing entries fall back to `ColumnDef.size` or the default (120). */
+export type ColumnSizingState = Record<string, number>;
+
+/** Map column id → visible flag. Missing entries are treated as `true` (visible). */
+export type ColumnVisibilityState = Record<string, boolean>;
+
+/**
+ * Ordered pin lists per side. Phase 1 plumbs this state but does not render
+ * the sticky CSS — rendering effects ship in Phase 2.
+ */
+export interface ColumnPinningState {
+  left: string[];
+  right: string[];
+}
+
+/** Map row id → selected flag. Missing entries treated as `false`. */
+export type RowSelectionState = Record<string, boolean>;
+
+/** Map row id → expanded flag. Phase 1 plumbs state; rendering ships in Phase 3. */
+export type ExpandedRowsState = Record<string, boolean>;
+
+/** setState-style updater: either the next value, or a function (prev) => next. */
+export type Updater<S> = S | ((prev: S) => S);
+
+/** Header render-prop context. */
+export interface HeaderContext<T = unknown> {
+  column: ColumnDef<T>;
+  instance: DataTableInstance<T>;
+}
+
+/** Cell render-prop context. */
+export interface CellContext<T> {
+  row: T;
+  rowId: string;
+  column: ColumnDef<T>;
+  instance: DataTableInstance<T>;
+}
+
+/** Descriptor for one column. Keyed by `id` — used as the key for all per-column state. */
+export interface ColumnDef<T> {
+  /** Stable id. Used as key for column order, sizing, visibility, pinning state. */
+  id: string;
+  /** Header content. String, node, or a render-prop receiving HeaderContext. */
+  header: ReactNode | ((ctx: HeaderContext<T>) => ReactNode);
+  /** Cell content for a row. */
+  cell: (row: T, ctx: CellContext<T>) => ReactNode;
+  /** Cell text alignment. Defaults to 'start'. */
+  align?: ColumnAlign;
+  /** Default width in px when no entry in ColumnSizingState. Defaults to 120. */
+  size?: number;
+  /** Min width during resize (px). Defaults to 40. */
+  minSize?: number;
+  /** Max width during resize (px). Defaults to undefined (no max). */
+  maxSize?: number;
+  /** Whether the column can be reordered via drag. Defaults true. */
+  enableReorder?: boolean;
+  /** Whether the column can be resized via the handle. Defaults true. */
+  enableResize?: boolean;
+  /** Whether the column can be hidden via the visibility menu. Defaults true. */
+  enableHide?: boolean;
+  /** Whether the column can be pinned. Defaults true. (Phase 2 will use this.) */
+  enablePin?: boolean;
+  /**
+   * Server-side sortable. When true, the header label is clickable and
+   * keyboard-actionable; toggling fires onSortChange. DataTable does
+   * not perform client-side sorting.
+   */
+  sortable?: boolean;
+  /** Label shown in the column visibility menu. Falls back to `header` if string. */
+  visibilityLabel?: string;
+}
+
+/** Public options to `useDataTable<T>(...)`. */
+export interface UseDataTableOptions<T> {
+  // pure data
+  data: T[];
+  pinnedRows?: T[];
+  columns: ColumnDef<T>[];
+  /** Required. Stable id per row — used by selection, expansion, and `getRowId`. */
+  getRowId: (row: T) => string;
+  /** Total server-side row count. Surfaced as `aria-rowcount` for screen readers. */
+  rowCount?: number;
+  /** Opt-in to the selection auto-column. Defaults false. */
+  enableRowSelection?: boolean;
+
+  // each state piece: controlled / default / onChange (Radix pattern)
+  columnOrder?: ColumnOrderState;
+  defaultColumnOrder?: ColumnOrderState;
+  onColumnOrderChange?: (next: ColumnOrderState) => void;
+
+  columnSizing?: ColumnSizingState;
+  defaultColumnSizing?: ColumnSizingState;
+  onColumnSizingChange?: (next: ColumnSizingState) => void;
+
+  columnVisibility?: ColumnVisibilityState;
+  defaultColumnVisibility?: ColumnVisibilityState;
+  onColumnVisibilityChange?: (next: ColumnVisibilityState) => void;
+
+  columnPinning?: ColumnPinningState;
+  defaultColumnPinning?: ColumnPinningState;
+  onColumnPinningChange?: (next: ColumnPinningState) => void;
+
+  rowSelection?: RowSelectionState;
+  defaultRowSelection?: RowSelectionState;
+  onRowSelectionChange?: (next: RowSelectionState) => void;
+
+  expandedRows?: ExpandedRowsState;
+  defaultExpandedRows?: ExpandedRowsState;
+  onExpandedRowsChange?: (next: ExpandedRowsState) => void;
+
+  sort?: SortState | null;
+  defaultSort?: SortState | null;
+  onSortChange?: (next: SortState | null) => void;
+
+  // interactivity
+  onRowClick?: (row: T, event: ReactMouseEvent<HTMLTableRowElement>) => void;
+  /** Phase 1 plumbs this prop but does not render expansion. Rendering ships in Phase 3. */
+  renderExpandedRow?: (row: T) => ReactNode;
+}
+
+/** Returned by `useDataTable<T>(...)`. Passed into `<DataTable instance={...} />`. */
+export interface DataTableInstance<T> {
+  // echoed inputs
+  data: T[];
+  pinnedRows: T[];
+  columns: ColumnDef<T>[];
+  getRowId: (row: T) => string;
+  rowCount?: number;
+  enableRowSelection: boolean;
+  hasExpansion: boolean;
+  onRowClick?: UseDataTableOptions<T>['onRowClick'];
+  renderExpandedRow?: UseDataTableOptions<T>['renderExpandedRow'];
+
+  // resolved current state
+  columnOrder: ColumnOrderState;
+  columnSizing: ColumnSizingState;
+  columnVisibility: ColumnVisibilityState;
+  columnPinning: ColumnPinningState;
+  rowSelection: RowSelectionState;
+  expandedRows: ExpandedRowsState;
+  sort: SortState | null;
+
+  // derived view-models (memoized)
+  visibleColumns: ColumnDef<T>[];
+  leftPinnedColumns: ColumnDef<T>[];
+  rightPinnedColumns: ColumnDef<T>[];
+  unpinnedColumns: ColumnDef<T>[];
+  columnSizesPx: Record<string, number>;
+  leftPinOffsets: Record<string, number>;
+  rightPinOffsets: Record<string, number>;
+
+  // setState-style mutators
+  setColumnOrder: (updater: Updater<ColumnOrderState>) => void;
+  setColumnSizing: (updater: Updater<ColumnSizingState>) => void;
+  setColumnVisibility: (updater: Updater<ColumnVisibilityState>) => void;
+  setColumnPinning: (updater: Updater<ColumnPinningState>) => void;
+  setRowSelection: (updater: Updater<RowSelectionState>) => void;
+  setExpandedRows: (updater: Updater<ExpandedRowsState>) => void;
+  setSort: (updater: Updater<SortState | null>) => void;
+
+  // higher-level helpers
+  toggleRowSelection: (rowId: string) => void;
+  toggleAllOnPage: () => void;
+  isAllOnPageSelected: () => boolean;
+  isSomeOnPageSelected: () => boolean;
+  toggleRowExpanded: (rowId: string) => void;
+  toggleColumnVisibility: (columnId: string) => void;
+  pinColumn: (columnId: string, side: 'left' | 'right' | false) => void;
+  toggleSort: (columnId: string) => void;
+}
+```
+
+- [ ] **Step 3: Stub `index.ts`**
+
+Create `packages/design-system/src/components/DataTable/index.ts`:
+
+```ts
+export type * from './types';
+```
+
+- [ ] **Step 4: Verify typecheck**
+
+```bash
+make build-lib
+```
+
+Expected: passes. No runtime code yet, just types being exported.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/DataTable/
+git commit -m "DataTable: type-only contract (ColumnDef, state types, instance type)
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 — `useControllableState` hook
+
+A tiny local utility that resolves the Radix `value`/`defaultValue`/`onChange` pattern. Used by `useDataTable` for every state piece.
+
+**Files:**
+- Create: `packages/design-system/src/components/DataTable/useControllableState.ts`
+- Test: `packages/design-system/src/components/DataTable/useControllableState.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/design-system/src/components/DataTable/useControllableState.test.ts`:
+
+```ts
+import { renderHook, act } from '@testing-library/react';
+import { useControllableState } from './useControllableState';
+
+describe('useControllableState', () => {
+  it('uses defaultValue when uncontrolled', () => {
+    const { result } = renderHook(() => useControllableState({ defaultValue: 5 }));
+    expect(result.current[0]).toBe(5);
+  });
+
+  it('uses value when controlled (ignores default)', () => {
+    const { result } = renderHook(() =>
+      useControllableState({ value: 10, defaultValue: 5 }),
+    );
+    expect(result.current[0]).toBe(10);
+  });
+
+  it('updates internal state when uncontrolled', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useControllableState({ defaultValue: 0, onChange }),
+    );
+    act(() => result.current[1](42));
+    expect(result.current[0]).toBe(42);
+    expect(onChange).toHaveBeenCalledWith(42);
+  });
+
+  it('does NOT update internal state when controlled — only fires onChange', () => {
+    const onChange = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ v }) => useControllableState({ value: v, onChange }),
+      { initialProps: { v: 10 } },
+    );
+    act(() => result.current[1](99));
+    // value prop didn't change, so resolved stays 10
+    expect(result.current[0]).toBe(10);
+    expect(onChange).toHaveBeenCalledWith(99);
+
+    rerender({ v: 99 });
+    expect(result.current[0]).toBe(99);
+  });
+
+  it('accepts an updater function', () => {
+    const { result } = renderHook(() => useControllableState({ defaultValue: 5 }));
+    act(() => result.current[1]((prev) => prev + 1));
+    expect(result.current[0]).toBe(6);
+  });
+
+  it('updater function receives current value when controlled', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useControllableState({ value: 10, onChange }),
+    );
+    act(() => result.current[1]((prev) => prev + 5));
+    expect(onChange).toHaveBeenCalledWith(15);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — expect failure**
+
+```bash
+make test -- useControllableState.test.ts
+```
+
+Expected: fails with `Cannot find module './useControllableState'`.
+
+- [ ] **Step 3: Implement `useControllableState`**
+
+Create `packages/design-system/src/components/DataTable/useControllableState.ts`:
+
+```ts
+import { useCallback, useRef, useState } from 'react';
+import type { Updater } from './types';
+
+/**
+ * Radix-style controlled/uncontrolled state hook.
+ *
+ * - If `value` is defined → controlled. Resolved value tracks `value`. Setter
+ *   does NOT update internal state; only fires `onChange` so the consumer can
+ *   update their own state.
+ * - If `value` is undefined → uncontrolled. Resolved value comes from internal
+ *   state seeded with `defaultValue`. Setter updates internal state AND fires
+ *   `onChange`.
+ *
+ * Switching between controlled and uncontrolled across renders is not supported
+ * (matches Radix / React behavior — produces a warning in dev only on first
+ * such switch in React, but otherwise no-op).
+ */
+export function useControllableState<T>(options: {
+  value?: T;
+  defaultValue?: T;
+  onChange?: (next: T) => void;
+}): [T, (updater: Updater<T>) => void] {
+  const { value, defaultValue, onChange } = options;
+  const isControlled = value !== undefined;
+
+  const [internal, setInternal] = useState<T | undefined>(defaultValue);
+  const resolved = (isControlled ? value : internal) as T;
+
+  // Keep a ref to the most recent resolved value so updater functions
+  // always operate on the latest state even if callers debounce or batch.
+  const resolvedRef = useRef(resolved);
+  resolvedRef.current = resolved;
+
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  const setValue = useCallback(
+    (updater: Updater<T>) => {
+      const prev = resolvedRef.current;
+      const next =
+        typeof updater === 'function' ? (updater as (p: T) => T)(prev) : updater;
+      if (!isControlled) setInternal(next);
+      onChangeRef.current?.(next);
+    },
+    [isControlled],
+  );
+
+  return [resolved, setValue];
+}
+```
+
+- [ ] **Step 4: Run the test — expect pass**
+
+```bash
+make test -- useControllableState.test.ts
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/DataTable/useControllableState.ts \
+        packages/design-system/src/components/DataTable/useControllableState.test.ts
+git commit -m "DataTable: useControllableState hook (Radix-style controlled/uncontrolled)
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 — `useDataTable` skeleton + controlled-state resolution
+
+Build the hook in slices. This first slice: state plumbing for every piece, no derived view-models yet, no helper methods yet.
+
+**Files:**
+- Create: `packages/design-system/src/components/DataTable/useDataTable.ts`
+- Test: `packages/design-system/src/components/DataTable/useDataTable.test.ts`
+
+- [ ] **Step 1: Write the failing tests for skeleton + state resolution**
+
+Create `packages/design-system/src/components/DataTable/useDataTable.test.ts`:
+
+```ts
+import { renderHook, act } from '@testing-library/react';
+import { useDataTable } from './useDataTable';
+import type { ColumnDef } from './types';
+
+type Row = { id: string; name: string; amount: number };
+
+const cols: ColumnDef<Row>[] = [
+  { id: 'name', header: 'Name', cell: (r) => r.name },
+  { id: 'amount', header: 'Amount', cell: (r) => r.amount, sortable: true },
+];
+
+const rows: Row[] = [
+  { id: 'r1', name: 'Alpha', amount: 10 },
+  { id: 'r2', name: 'Bravo', amount: 20 },
+];
+
+const getRowId = (r: Row) => r.id;
+
+describe('useDataTable — state resolution', () => {
+  it('echoes data, columns, getRowId', () => {
+    const { result } = renderHook(() =>
+      useDataTable({ data: rows, columns: cols, getRowId }),
+    );
+    expect(result.current.data).toBe(rows);
+    expect(result.current.columns).toBe(cols);
+    expect(result.current.getRowId).toBe(getRowId);
+    expect(result.current.pinnedRows).toEqual([]);
+  });
+
+  it('defaults enableRowSelection to false and hasExpansion to false', () => {
+    const { result } = renderHook(() =>
+      useDataTable({ data: rows, columns: cols, getRowId }),
+    );
+    expect(result.current.enableRowSelection).toBe(false);
+    expect(result.current.hasExpansion).toBe(false);
+  });
+
+  it('reports hasExpansion=true when renderExpandedRow is provided', () => {
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        renderExpandedRow: () => null,
+      }),
+    );
+    expect(result.current.hasExpansion).toBe(true);
+  });
+
+  it('initialises columnOrder from defaultColumnOrder', () => {
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        defaultColumnOrder: ['amount', 'name'],
+      }),
+    );
+    expect(result.current.columnOrder).toEqual(['amount', 'name']);
+  });
+
+  it('falls back to columns order when no default given', () => {
+    const { result } = renderHook(() =>
+      useDataTable({ data: rows, columns: cols, getRowId }),
+    );
+    expect(result.current.columnOrder).toEqual(['name', 'amount']);
+  });
+
+  it('controlled columnOrder overrides default', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        columnOrder: ['amount', 'name'],
+        onColumnOrderChange: onChange,
+      }),
+    );
+    expect(result.current.columnOrder).toEqual(['amount', 'name']);
+    act(() => result.current.setColumnOrder(['name', 'amount']));
+    expect(onChange).toHaveBeenCalledWith(['name', 'amount']);
+  });
+
+  it('initialises all other state pieces with sensible defaults', () => {
+    const { result } = renderHook(() =>
+      useDataTable({ data: rows, columns: cols, getRowId }),
+    );
+    expect(result.current.columnSizing).toEqual({});
+    expect(result.current.columnVisibility).toEqual({});
+    expect(result.current.columnPinning).toEqual({ left: [], right: [] });
+    expect(result.current.rowSelection).toEqual({});
+    expect(result.current.expandedRows).toEqual({});
+    expect(result.current.sort).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — expect failure**
+
+```bash
+make test -- useDataTable.test.ts
+```
+
+Expected: fails with `Cannot find module './useDataTable'`.
+
+- [ ] **Step 3: Implement skeleton of `useDataTable`**
+
+Create `packages/design-system/src/components/DataTable/useDataTable.ts`:
+
+```ts
+import { useMemo } from 'react';
+import { useControllableState } from './useControllableState';
+import type {
+  ColumnOrderState,
+  ColumnPinningState,
+  ColumnSizingState,
+  ColumnVisibilityState,
+  DataTableInstance,
+  ExpandedRowsState,
+  RowSelectionState,
+  SortState,
+  UseDataTableOptions,
+} from './types';
+
+const EMPTY_PINNING: ColumnPinningState = { left: [], right: [] };
+
+/**
+ * Headless state machine for `<DataTable>`. Implements the Radix-style
+ * controlled/uncontrolled pattern for every state piece. Returns an
+ * `instance` object passed into `<DataTable instance={...} />` and any
+ * companion components (e.g. `<DataTable.ColumnVisibilityTrigger>`).
+ *
+ * Pure logic — no DOM, no refs to elements, no side effects beyond firing
+ * the consumer's onChange callbacks.
+ */
+export function useDataTable<T>(options: UseDataTableOptions<T>): DataTableInstance<T> {
+  const {
+    data,
+    pinnedRows = [],
+    columns,
+    getRowId,
+    rowCount,
+    enableRowSelection = false,
+    onRowClick,
+    renderExpandedRow,
+  } = options;
+
+  const defaultColumnOrder = useMemo(
+    () => options.defaultColumnOrder ?? columns.map((c) => c.id),
+    // Intentionally not depending on `columns` — defaultColumnOrder is a
+    // one-time initial value. If columns change identity, consumer must
+    // pass a controlled columnOrder.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const [columnOrder, setColumnOrder] = useControllableState<ColumnOrderState>({
+    value: options.columnOrder,
+    defaultValue: defaultColumnOrder,
+    onChange: options.onColumnOrderChange,
+  });
+
+  const [columnSizing, setColumnSizing] = useControllableState<ColumnSizingState>({
+    value: options.columnSizing,
+    defaultValue: options.defaultColumnSizing ?? {},
+    onChange: options.onColumnSizingChange,
+  });
+
+  const [columnVisibility, setColumnVisibility] = useControllableState<ColumnVisibilityState>({
+    value: options.columnVisibility,
+    defaultValue: options.defaultColumnVisibility ?? {},
+    onChange: options.onColumnVisibilityChange,
+  });
+
+  const [columnPinning, setColumnPinning] = useControllableState<ColumnPinningState>({
+    value: options.columnPinning,
+    defaultValue: options.defaultColumnPinning ?? EMPTY_PINNING,
+    onChange: options.onColumnPinningChange,
+  });
+
+  const [rowSelection, setRowSelection] = useControllableState<RowSelectionState>({
+    value: options.rowSelection,
+    defaultValue: options.defaultRowSelection ?? {},
+    onChange: options.onRowSelectionChange,
+  });
+
+  const [expandedRows, setExpandedRows] = useControllableState<ExpandedRowsState>({
+    value: options.expandedRows,
+    defaultValue: options.defaultExpandedRows ?? {},
+    onChange: options.onExpandedRowsChange,
+  });
+
+  const [sort, setSort] = useControllableState<SortState | null>({
+    value: options.sort,
+    defaultValue: options.defaultSort ?? null,
+    onChange: options.onSortChange,
+  });
+
+  // Derived view-models and helper methods land in subsequent tasks.
+  // For now, stubs that satisfy the interface; tasks 5–10 will replace them.
+  const visibleColumns = columns;
+  const leftPinnedColumns: typeof columns = [];
+  const rightPinnedColumns: typeof columns = [];
+  const unpinnedColumns = columns;
+  const columnSizesPx: Record<string, number> = {};
+  const leftPinOffsets: Record<string, number> = {};
+  const rightPinOffsets: Record<string, number> = {};
+
+  const noop = () => {};
+
+  return {
+    data,
+    pinnedRows,
+    columns,
+    getRowId,
+    rowCount,
+    enableRowSelection,
+    hasExpansion: renderExpandedRow != null,
+    onRowClick,
+    renderExpandedRow,
+
+    columnOrder,
+    columnSizing,
+    columnVisibility,
+    columnPinning,
+    rowSelection,
+    expandedRows,
+    sort,
+
+    visibleColumns,
+    leftPinnedColumns,
+    rightPinnedColumns,
+    unpinnedColumns,
+    columnSizesPx,
+    leftPinOffsets,
+    rightPinOffsets,
+
+    setColumnOrder,
+    setColumnSizing,
+    setColumnVisibility,
+    setColumnPinning,
+    setRowSelection,
+    setExpandedRows,
+    setSort,
+
+    toggleRowSelection: noop,
+    toggleAllOnPage: noop,
+    isAllOnPageSelected: () => false,
+    isSomeOnPageSelected: () => false,
+    toggleRowExpanded: noop,
+    toggleColumnVisibility: noop,
+    pinColumn: noop,
+    toggleSort: noop,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test — expect pass**
+
+```bash
+make test -- useDataTable.test.ts
+```
+
+Expected: all 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/DataTable/useDataTable.ts \
+        packages/design-system/src/components/DataTable/useDataTable.test.ts
+git commit -m "DataTable: useDataTable skeleton + controlled-state resolution
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 — Derived view-models (visibleColumns, pin grouping, columnSizesPx)
+
+Replace the stubs in `useDataTable` with memoized derivations.
+
+**Files:**
+- Modify: `packages/design-system/src/components/DataTable/useDataTable.ts`
+- Modify: `packages/design-system/src/components/DataTable/useDataTable.test.ts`
+
+- [ ] **Step 1: Append derived view-model tests**
+
+Append to `packages/design-system/src/components/DataTable/useDataTable.test.ts`:
+
+```ts
+describe('useDataTable — derived view-models', () => {
+  it('visibleColumns excludes columns where columnVisibility[id] === false', () => {
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        defaultColumnVisibility: { amount: false },
+      }),
+    );
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(['name']);
+  });
+
+  it('visibleColumns honours columnOrder', () => {
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        defaultColumnOrder: ['amount', 'name'],
+      }),
+    );
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(['amount', 'name']);
+  });
+
+  it('columnSizesPx resolves: sizing state > ColumnDef.size > default 120', () => {
+    const colsWithSize: ColumnDef<Row>[] = [
+      { id: 'name', header: 'Name', cell: (r) => r.name },
+      { id: 'amount', header: 'Amount', cell: (r) => r.amount, size: 80 },
+    ];
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: colsWithSize,
+        getRowId,
+        defaultColumnSizing: { name: 200 },
+      }),
+    );
+    expect(result.current.columnSizesPx).toEqual({ name: 200, amount: 80 });
+  });
+
+  it('groups columns by pinning side', () => {
+    const threeCols: ColumnDef<Row>[] = [
+      { id: 'a', header: 'A', cell: (r) => r.id },
+      { id: 'b', header: 'B', cell: (r) => r.id },
+      { id: 'c', header: 'C', cell: (r) => r.id },
+    ];
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: threeCols,
+        getRowId,
+        defaultColumnPinning: { left: ['a'], right: ['c'] },
+      }),
+    );
+    expect(result.current.leftPinnedColumns.map((c) => c.id)).toEqual(['a']);
+    expect(result.current.rightPinnedColumns.map((c) => c.id)).toEqual(['c']);
+    expect(result.current.unpinnedColumns.map((c) => c.id)).toEqual(['b']);
+  });
+
+  it('leftPinOffsets accumulates widths in pin order', () => {
+    const threeCols: ColumnDef<Row>[] = [
+      { id: 'a', header: 'A', cell: (r) => r.id, size: 50 },
+      { id: 'b', header: 'B', cell: (r) => r.id, size: 80 },
+      { id: 'c', header: 'C', cell: (r) => r.id },
+    ];
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: threeCols,
+        getRowId,
+        defaultColumnPinning: { left: ['a', 'b'], right: [] },
+      }),
+    );
+    expect(result.current.leftPinOffsets).toEqual({ a: 0, b: 50 });
+  });
+
+  it('rightPinOffsets accumulates widths from the right side inward', () => {
+    const threeCols: ColumnDef<Row>[] = [
+      { id: 'a', header: 'A', cell: (r) => r.id, size: 50 },
+      { id: 'b', header: 'B', cell: (r) => r.id, size: 80 },
+      { id: 'c', header: 'C', cell: (r) => r.id, size: 60 },
+    ];
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: threeCols,
+        getRowId,
+        defaultColumnPinning: { left: [], right: ['b', 'c'] },
+      }),
+    );
+    // right pinning: rightmost column gets right: 0, next inward stacks past it
+    expect(result.current.rightPinOffsets).toEqual({ c: 0, b: 60 });
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failures**
+
+```bash
+make test -- useDataTable.test.ts
+```
+
+Expected: the 6 new tests fail (stubs return empty).
+
+- [ ] **Step 3: Replace stubs in `useDataTable.ts` with memoized derivations**
+
+In `packages/design-system/src/components/DataTable/useDataTable.ts`, replace the section starting with `// Derived view-models and helper methods land in subsequent tasks.` through the end of the stubs (just before `const noop = () => {};`) with:
+
+```ts
+  const DEFAULT_COL_WIDTH = 120;
+
+  const columnsById = useMemo(() => {
+    const m = new Map<string, (typeof columns)[number]>();
+    for (const c of columns) m.set(c.id, c);
+    return m;
+  }, [columns]);
+
+  // columnSizesPx: id → resolved width (sizing state > ColumnDef.size > default)
+  const columnSizesPx = useMemo<Record<string, number>>(() => {
+    const out: Record<string, number> = {};
+    for (const c of columns) {
+      out[c.id] = columnSizing[c.id] ?? c.size ?? DEFAULT_COL_WIDTH;
+    }
+    return out;
+  }, [columns, columnSizing]);
+
+  // visibleColumns: ordered (per columnOrder) and filtered (visibility !== false)
+  const visibleColumns = useMemo(() => {
+    const isVisible = (id: string) => columnVisibility[id] !== false;
+    const ordered: typeof columns = [];
+    for (const id of columnOrder) {
+      const col = columnsById.get(id);
+      if (col && isVisible(id)) ordered.push(col);
+    }
+    // Any column not in columnOrder (e.g. added after init) goes to the end.
+    for (const c of columns) {
+      if (!columnOrder.includes(c.id) && isVisible(c.id)) ordered.push(c);
+    }
+    return ordered;
+  }, [columns, columnsById, columnOrder, columnVisibility]);
+
+  // Pin grouping. Pinning order within a side is given by columnPinning.left/right.
+  const leftPinnedColumns = useMemo(
+    () =>
+      columnPinning.left
+        .map((id) => columnsById.get(id))
+        .filter((c): c is (typeof columns)[number] => !!c && columnVisibility[c.id] !== false),
+    [columnPinning.left, columnsById, columnVisibility],
+  );
+
+  const rightPinnedColumns = useMemo(
+    () =>
+      columnPinning.right
+        .map((id) => columnsById.get(id))
+        .filter((c): c is (typeof columns)[number] => !!c && columnVisibility[c.id] !== false),
+    [columnPinning.right, columnsById, columnVisibility],
+  );
+
+  const unpinnedColumns = useMemo(() => {
+    const pinned = new Set([...columnPinning.left, ...columnPinning.right]);
+    return visibleColumns.filter((c) => !pinned.has(c.id));
+  }, [visibleColumns, columnPinning.left, columnPinning.right]);
+
+  // Pin offsets — cumulative widths from the pinned edge inward.
+  const leftPinOffsets = useMemo<Record<string, number>>(() => {
+    const out: Record<string, number> = {};
+    let acc = 0;
+    for (const col of leftPinnedColumns) {
+      out[col.id] = acc;
+      acc += columnSizesPx[col.id] ?? DEFAULT_COL_WIDTH;
+    }
+    return out;
+  }, [leftPinnedColumns, columnSizesPx]);
+
+  const rightPinOffsets = useMemo<Record<string, number>>(() => {
+    const out: Record<string, number> = {};
+    let acc = 0;
+    // Rightmost pinned column has offset 0; walk right-to-left accumulating.
+    for (let i = rightPinnedColumns.length - 1; i >= 0; i--) {
+      const col = rightPinnedColumns[i]!;
+      out[col.id] = acc;
+      acc += columnSizesPx[col.id] ?? DEFAULT_COL_WIDTH;
+    }
+    return out;
+  }, [rightPinnedColumns, columnSizesPx]);
+```
+
+Then replace the corresponding stub fields in the returned object:
+
+```ts
+    visibleColumns,
+    leftPinnedColumns,
+    rightPinnedColumns,
+    unpinnedColumns,
+    columnSizesPx,
+    leftPinOffsets,
+    rightPinOffsets,
+```
+
+(They were already named correctly in the stub — confirm the references now resolve to the new memoized values, and remove the now-unused stub declarations above.)
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+make test -- useDataTable.test.ts
+```
+
+Expected: all tests pass (state + derived view-models).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/DataTable/useDataTable.ts \
+        packages/design-system/src/components/DataTable/useDataTable.test.ts
+git commit -m "DataTable: derived view-models (visibleColumns, pin grouping, columnSizesPx, pin offsets)
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6 — Selection helpers + sort cycling
+
+Replace the helper-method stubs.
+
+**Files:**
+- Modify: `packages/design-system/src/components/DataTable/useDataTable.ts`
+- Modify: `packages/design-system/src/components/DataTable/useDataTable.test.ts`
+
+- [ ] **Step 1: Append helper tests**
+
+Append to `packages/design-system/src/components/DataTable/useDataTable.test.ts`:
+
+```ts
+describe('useDataTable — selection helpers', () => {
+  it('toggleRowSelection toggles a single row', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        enableRowSelection: true,
+        onRowSelectionChange: onChange,
+      }),
+    );
+    act(() => result.current.toggleRowSelection('r1'));
+    expect(onChange).toHaveBeenCalledWith({ r1: true });
+    act(() => result.current.toggleRowSelection('r1'));
+    expect(onChange).toHaveBeenLastCalledWith({});
+  });
+
+  it('toggleAllOnPage selects all rows in data (ignoring pinnedRows)', () => {
+    const onChange = vi.fn();
+    const pinned: Row[] = [{ id: 'p1', name: 'Pin', amount: 1 }];
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        pinnedRows: pinned,
+        columns: cols,
+        getRowId,
+        enableRowSelection: true,
+        onRowSelectionChange: onChange,
+      }),
+    );
+    act(() => result.current.toggleAllOnPage());
+    expect(onChange).toHaveBeenCalledWith({ r1: true, r2: true });
+  });
+
+  it('toggleAllOnPage deselects when all are selected', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        enableRowSelection: true,
+        defaultRowSelection: { r1: true, r2: true },
+        onRowSelectionChange: onChange,
+      }),
+    );
+    act(() => result.current.toggleAllOnPage());
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  it('isAllOnPageSelected / isSomeOnPageSelected reflect data only', () => {
+    const { result, rerender } = renderHook(
+      (sel: { r1?: boolean; r2?: boolean }) =>
+        useDataTable({
+          data: rows,
+          columns: cols,
+          getRowId,
+          enableRowSelection: true,
+          rowSelection: sel,
+          onRowSelectionChange: () => {},
+        }),
+      { initialProps: {} },
+    );
+    expect(result.current.isAllOnPageSelected()).toBe(false);
+    expect(result.current.isSomeOnPageSelected()).toBe(false);
+
+    rerender({ r1: true });
+    expect(result.current.isAllOnPageSelected()).toBe(false);
+    expect(result.current.isSomeOnPageSelected()).toBe(true);
+
+    rerender({ r1: true, r2: true });
+    expect(result.current.isAllOnPageSelected()).toBe(true);
+    expect(result.current.isSomeOnPageSelected()).toBe(false); // "some but not all" semantics
+  });
+});
+
+describe('useDataTable — sort helpers', () => {
+  it('toggleSort cycles null → asc → desc → null', () => {
+    const onChange = vi.fn();
+    const { result, rerender } = renderHook(
+      (sort: any) =>
+        useDataTable({
+          data: rows,
+          columns: cols,
+          getRowId,
+          sort,
+          onSortChange: onChange,
+        }),
+      { initialProps: null as any },
+    );
+    act(() => result.current.toggleSort('amount'));
+    expect(onChange).toHaveBeenLastCalledWith({ columnId: 'amount', direction: 'asc' });
+
+    rerender({ columnId: 'amount', direction: 'asc' });
+    act(() => result.current.toggleSort('amount'));
+    expect(onChange).toHaveBeenLastCalledWith({ columnId: 'amount', direction: 'desc' });
+
+    rerender({ columnId: 'amount', direction: 'desc' });
+    act(() => result.current.toggleSort('amount'));
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('toggleSort on a different column starts asc from scratch', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        sort: { columnId: 'amount', direction: 'desc' },
+        onSortChange: onChange,
+      }),
+    );
+    act(() => result.current.toggleSort('name'));
+    expect(onChange).toHaveBeenLastCalledWith({ columnId: 'name', direction: 'asc' });
+  });
+});
+
+describe('useDataTable — column helpers', () => {
+  it('toggleColumnVisibility flips visibility for an id', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        onColumnVisibilityChange: onChange,
+      }),
+    );
+    act(() => result.current.toggleColumnVisibility('amount'));
+    expect(onChange).toHaveBeenCalledWith({ amount: false });
+    act(() => result.current.toggleColumnVisibility('amount'));
+    expect(onChange).toHaveBeenLastCalledWith({ amount: true });
+  });
+
+  it('pinColumn moves a column to left, right, or unpins it', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        onColumnPinningChange: onChange,
+      }),
+    );
+    act(() => result.current.pinColumn('name', 'left'));
+    expect(onChange).toHaveBeenLastCalledWith({ left: ['name'], right: [] });
+    act(() => result.current.pinColumn('amount', 'right'));
+    expect(onChange).toHaveBeenLastCalledWith({ left: ['name'], right: ['amount'] });
+    act(() => result.current.pinColumn('name', false));
+    expect(onChange).toHaveBeenLastCalledWith({ left: [], right: ['amount'] });
+  });
+
+  it('toggleRowExpanded flips expansion for a row id', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        renderExpandedRow: () => null,
+        onExpandedRowsChange: onChange,
+      }),
+    );
+    act(() => result.current.toggleRowExpanded('r1'));
+    expect(onChange).toHaveBeenCalledWith({ r1: true });
+    act(() => result.current.toggleRowExpanded('r1'));
+    expect(onChange).toHaveBeenLastCalledWith({});
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failures**
+
+```bash
+make test -- useDataTable.test.ts
+```
+
+Expected: the new tests fail (helpers are still no-ops).
+
+- [ ] **Step 3: Implement helpers**
+
+In `useDataTable.ts`, replace the helper stubs (the lines from `const noop = () => {};` through the `pinColumn: noop` line in the returned object) with real implementations.
+
+Add these `useCallback` definitions above the `return` statement (after the derived view-models):
+
+```ts
+  const toggleRowSelection = useCallback(
+    (rowId: string) => {
+      setRowSelection((prev) => {
+        const next = { ...prev };
+        if (next[rowId]) delete next[rowId];
+        else next[rowId] = true;
+        return next;
+      });
+    },
+    [setRowSelection],
+  );
+
+  const toggleAllOnPage = useCallback(() => {
+    setRowSelection((prev) => {
+      const pageIds = data.map(getRowId);
+      const allSelected = pageIds.every((id) => prev[id]);
+      if (allSelected) {
+        const next = { ...prev };
+        for (const id of pageIds) delete next[id];
+        return next;
+      }
+      const next = { ...prev };
+      for (const id of pageIds) next[id] = true;
+      return next;
+    });
+  }, [data, getRowId, setRowSelection]);
+
+  const isAllOnPageSelected = useCallback(() => {
+    if (data.length === 0) return false;
+    return data.every((row) => rowSelection[getRowId(row)] === true);
+  }, [data, getRowId, rowSelection]);
+
+  const isSomeOnPageSelected = useCallback(() => {
+    if (data.length === 0) return false;
+    let some = false;
+    let all = true;
+    for (const row of data) {
+      if (rowSelection[getRowId(row)]) some = true;
+      else all = false;
+    }
+    return some && !all;
+  }, [data, getRowId, rowSelection]);
+
+  const toggleRowExpanded = useCallback(
+    (rowId: string) => {
+      setExpandedRows((prev) => {
+        const next = { ...prev };
+        if (next[rowId]) delete next[rowId];
+        else next[rowId] = true;
+        return next;
+      });
+    },
+    [setExpandedRows],
+  );
+
+  const toggleColumnVisibility = useCallback(
+    (columnId: string) => {
+      setColumnVisibility((prev) => ({
+        ...prev,
+        [columnId]: prev[columnId] === false ? true : false,
+      }));
+    },
+    [setColumnVisibility],
+  );
+
+  const pinColumn = useCallback(
+    (columnId: string, side: 'left' | 'right' | false) => {
+      setColumnPinning((prev) => {
+        const left = prev.left.filter((id) => id !== columnId);
+        const right = prev.right.filter((id) => id !== columnId);
+        if (side === 'left') left.push(columnId);
+        else if (side === 'right') right.push(columnId);
+        return { left, right };
+      });
+    },
+    [setColumnPinning],
+  );
+
+  const toggleSort = useCallback(
+    (columnId: string) => {
+      setSort((prev) => {
+        if (!prev || prev.columnId !== columnId) {
+          return { columnId, direction: 'asc' };
+        }
+        if (prev.direction === 'asc') return { columnId, direction: 'desc' };
+        return null;
+      });
+    },
+    [setSort],
+  );
+```
+
+Also add `useCallback` to the imports at the top of the file:
+
+```ts
+import { useCallback, useMemo } from 'react';
+```
+
+Update the returned object's helper fields:
+
+```ts
+    toggleRowSelection,
+    toggleAllOnPage,
+    isAllOnPageSelected,
+    isSomeOnPageSelected,
+    toggleRowExpanded,
+    toggleColumnVisibility,
+    pinColumn,
+    toggleSort,
+```
+
+Delete the `const noop = () => {};` line.
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+make test -- useDataTable.test.ts
+```
+
+Expected: all useDataTable tests pass (~20+ total now).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/DataTable/useDataTable.ts \
+        packages/design-system/src/components/DataTable/useDataTable.test.ts
+git commit -m "DataTable: helper methods (selection, sort cycle, pin, expand, visibility toggle)
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7 — `useResizeHandle` hook
+
+Pointer-based resize handle. Pure hook returning event handlers + drag state.
+
+**Files:**
+- Create: `packages/design-system/src/components/DataTable/useResizeHandle.ts`
+- Test: `packages/design-system/src/components/DataTable/useResizeHandle.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/design-system/src/components/DataTable/useResizeHandle.test.ts`:
+
+```ts
+import { renderHook, act } from '@testing-library/react';
+import { useResizeHandle } from './useResizeHandle';
+
+function pointer(type: string, clientX: number, pointerId = 1): PointerEvent {
+  return new PointerEvent(type, { clientX, pointerId, bubbles: true });
+}
+
+describe('useResizeHandle', () => {
+  it('returns initial isResizing=false', () => {
+    const { result } = renderHook(() =>
+      useResizeHandle({ initialWidth: 100, minWidth: 40, onResize: () => {} }),
+    );
+    expect(result.current.isResizing).toBe(false);
+  });
+
+  it('pointerdown → pointermove → pointerup fires onResize with delta-clamped width', () => {
+    const onResize = vi.fn();
+    const { result } = renderHook(() =>
+      useResizeHandle({ initialWidth: 100, minWidth: 40, onResize }),
+    );
+
+    const target = document.createElement('div');
+    // jsdom's setPointerCapture is a no-op; that's fine.
+    target.setPointerCapture = vi.fn();
+    target.releasePointerCapture = vi.fn();
+
+    act(() => {
+      result.current.onPointerDown({
+        ...pointer('pointerdown', 50),
+        currentTarget: target,
+        clientX: 50,
+        pointerId: 1,
+      } as any);
+    });
+    expect(result.current.isResizing).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(pointer('pointermove', 75)); // +25px
+    });
+    expect(onResize).toHaveBeenCalledWith(125);
+
+    act(() => {
+      window.dispatchEvent(pointer('pointerup', 75));
+    });
+    expect(result.current.isResizing).toBe(false);
+  });
+
+  it('clamps width below minWidth', () => {
+    const onResize = vi.fn();
+    const { result } = renderHook(() =>
+      useResizeHandle({ initialWidth: 100, minWidth: 40, onResize }),
+    );
+
+    const target = document.createElement('div');
+    target.setPointerCapture = vi.fn();
+    target.releasePointerCapture = vi.fn();
+
+    act(() => {
+      result.current.onPointerDown({
+        ...pointer('pointerdown', 50),
+        currentTarget: target,
+        clientX: 50,
+        pointerId: 1,
+      } as any);
+    });
+
+    act(() => {
+      window.dispatchEvent(pointer('pointermove', -100)); // -150px would be width=-50
+    });
+    expect(onResize).toHaveBeenLastCalledWith(40); // clamped to minWidth
+  });
+
+  it('clamps to maxWidth when provided', () => {
+    const onResize = vi.fn();
+    const { result } = renderHook(() =>
+      useResizeHandle({ initialWidth: 100, minWidth: 40, maxWidth: 200, onResize }),
+    );
+
+    const target = document.createElement('div');
+    target.setPointerCapture = vi.fn();
+    target.releasePointerCapture = vi.fn();
+
+    act(() => {
+      result.current.onPointerDown({
+        ...pointer('pointerdown', 50),
+        currentTarget: target,
+        clientX: 50,
+        pointerId: 1,
+      } as any);
+    });
+
+    act(() => {
+      window.dispatchEvent(pointer('pointermove', 500));
+    });
+    expect(onResize).toHaveBeenLastCalledWith(200);
+  });
+
+  it('pointercancel ends the drag', () => {
+    const onResize = vi.fn();
+    const { result } = renderHook(() =>
+      useResizeHandle({ initialWidth: 100, minWidth: 40, onResize }),
+    );
+
+    const target = document.createElement('div');
+    target.setPointerCapture = vi.fn();
+    target.releasePointerCapture = vi.fn();
+
+    act(() => {
+      result.current.onPointerDown({
+        ...pointer('pointerdown', 50),
+        currentTarget: target,
+        clientX: 50,
+        pointerId: 1,
+      } as any);
+    });
+    expect(result.current.isResizing).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(pointer('pointercancel', 60));
+    });
+    expect(result.current.isResizing).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure (module missing)**
+
+```bash
+make test -- useResizeHandle.test.ts
+```
+
+- [ ] **Step 3: Implement the hook**
+
+Create `packages/design-system/src/components/DataTable/useResizeHandle.ts`:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+
+interface UseResizeHandleOptions {
+  initialWidth: number;
+  minWidth: number;
+  maxWidth?: number;
+  onResize: (nextWidth: number) => void;
+}
+
+interface ResizeHandleApi {
+  isResizing: boolean;
+  onPointerDown: (e: ReactPointerEvent<HTMLElement>) => void;
+}
+
+/**
+ * Pointer-based resize-handle hook. Attach `onPointerDown` to the handle
+ * element. While dragging, `pointermove` on window fires `onResize` with
+ * the clamped width; `pointerup` / `pointercancel` ends the drag.
+ *
+ * `initialWidth` is captured at pointerdown — callers don't need to keep
+ * it in sync between events (the hook holds the start width internally).
+ */
+export function useResizeHandle(options: UseResizeHandleOptions): ResizeHandleApi {
+  const { minWidth, maxWidth, onResize } = options;
+  const [isResizing, setIsResizing] = useState(false);
+
+  // Held in refs so handlers attached to window don't go stale.
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+  const onResizeRef = useRef(onResize);
+  onResizeRef.current = onResize;
+  const minRef = useRef(minWidth);
+  minRef.current = minWidth;
+  const maxRef = useRef(maxWidth);
+  maxRef.current = maxWidth;
+
+  const onPointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLElement>) => {
+      e.stopPropagation();
+      startXRef.current = e.clientX;
+      startWidthRef.current = options.initialWidth;
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        // No-op for older browsers / jsdom.
+      }
+      setIsResizing(true);
+    },
+    [options.initialWidth],
+  );
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    function clamp(n: number) {
+      const min = minRef.current;
+      const max = maxRef.current;
+      let v = Math.max(min, n);
+      if (max != null) v = Math.min(max, v);
+      return v;
+    }
+
+    function onMove(e: PointerEvent) {
+      const delta = e.clientX - startXRef.current;
+      const next = clamp(startWidthRef.current + delta);
+      onResizeRef.current(next);
+    }
+    function onEnd() {
+      setIsResizing(false);
+    }
+
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onEnd);
+    window.addEventListener('pointercancel', onEnd);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onEnd);
+      window.removeEventListener('pointercancel', onEnd);
+    };
+  }, [isResizing]);
+
+  return { isResizing, onPointerDown };
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+make test -- useResizeHandle.test.ts
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/DataTable/useResizeHandle.ts \
+        packages/design-system/src/components/DataTable/useResizeHandle.test.ts
+git commit -m "DataTable: useResizeHandle hook (pointer-based, clamped)
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8 — `HeaderCell` component
+
+The sortable header cell. Renders the label, sort indicator, hover-revealed drag grip (with `useSortable` from dnd-kit), and resize handle.
+
+**Files:**
+- Create: `packages/design-system/src/components/DataTable/HeaderCell.tsx`
+- Create: `packages/design-system/src/components/DataTable/HeaderCell.module.scss`
+
+This file is rendering-only — the behavior it composes is tested at the `DataTable.test.tsx` integration level (Task 12). No separate unit test for `HeaderCell.tsx`.
+
+- [ ] **Step 1: Write the SCSS module**
+
+Create `packages/design-system/src/components/DataTable/HeaderCell.module.scss`:
+
+```scss
+.headerCell {
+  position: relative;
+  // Layout for inner content — using `:global` to avoid leaking
+  // any layout property out of this scope per Rule 4.
+}
+
+.inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0 var(--space-2);
+  height: 100%;
+}
+
+.label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex: 1 1 auto;
+  min-width: 0;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-fg-default);
+  cursor: default;
+  user-select: none;
+
+  &.sortable {
+    cursor: pointer;
+  }
+
+  &.sortable:focus-visible {
+    outline: var(--focus-ring);
+    outline-offset: -2px;
+    border-radius: var(--radius-sm);
+  }
+}
+
+.grip {
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-fg-muted);
+  opacity: 0;
+  cursor: grab;
+  padding: 0 var(--space-05);
+  transition: opacity 0.1s ease;
+
+  // Reveal on header hover OR when grip itself is focused.
+  .headerCell:hover &,
+  &:focus-visible {
+    opacity: 1;
+  }
+
+  &:focus-visible {
+    outline: var(--focus-ring);
+    outline-offset: -2px;
+    border-radius: var(--radius-sm);
+  }
+}
+
+.resizeHandle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 6px;
+  cursor: col-resize;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  user-select: none;
+}
+
+.resizeBar {
+  width: 1px;
+  height: 60%;
+  background: transparent;
+  transition: background 0.1s ease, width 0.1s ease;
+}
+
+.resizeHandle:hover .resizeBar,
+.resizeBar.active {
+  background: var(--color-accent);
+  width: 2px;
+}
+
+.dragging {
+  opacity: 0.4;
+}
+```
+
+Note on tokens used: `--color-fg-default`, `--color-fg-muted`, `--color-accent`, `--space-05`, `--space-1`, `--space-2`, `--font-weight-semibold`, `--radius-sm`, `--focus-ring`. **If any of these don't exist** in `src/styles/tokens.scss`, add them in the smallest possible way before committing this file — they're standard.
+
+- [ ] **Step 2: Write the component**
+
+Create `packages/design-system/src/components/DataTable/HeaderCell.tsx`:
+
+```tsx
+import { forwardRef, type KeyboardEvent } from 'react';
+import clsx from 'clsx';
+import { GripVertical } from 'lucide-react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Table } from '../Table';
+import type { TableSortDirection } from '../Table';
+import { useResizeHandle } from './useResizeHandle';
+import type { ColumnDef, DataTableInstance } from './types';
+import styles from './HeaderCell.module.scss';
+
+export interface HeaderCellProps<T> {
+  column: ColumnDef<T>;
+  instance: DataTableInstance<T>;
+}
+
+/**
+ * Sortable header cell with a hover-revealed drag grip and a resize handle.
+ *
+ * - **Label area** is the sort click-target when `column.sortable === true`.
+ * - **Grip** appears on hover or keyboard focus; it's the drag handle wired
+ *   to `@dnd-kit/sortable`'s `useSortable`. The grip is the ONLY draggable
+ *   target — listeners are not attached to the cell or label, so clicking
+ *   the label never starts a drag.
+ * - **Resize handle** is a 6px hit-zone on the right edge. Disabled when
+ *   `column.enableResize === false`.
+ */
+export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
+  const sortable = column.sortable === true;
+  const sortDir: TableSortDirection | undefined =
+    instance.sort?.columnId === column.id
+      ? instance.sort.direction
+      : sortable
+      ? 'none'
+      : undefined;
+
+  // dnd-kit sortable — column is its own sortable item.
+  const reorderable = column.enableReorder !== false;
+  const sortableResult = useSortable({ id: column.id, disabled: !reorderable });
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = sortableResult;
+
+  const width = instance.columnSizesPx[column.id] ?? 120;
+  const resize = useResizeHandle({
+    initialWidth: width,
+    minWidth: column.minSize ?? 40,
+    maxWidth: column.maxSize,
+    onResize: (next) => {
+      instance.setColumnSizing((prev) => ({ ...prev, [column.id]: next }));
+    },
+  });
+
+  const onLabelKeyDown = (e: KeyboardEvent<HTMLSpanElement>) => {
+    // Sort cycle on Enter / Space (when sortable)
+    if (sortable && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault();
+      instance.toggleSort(column.id);
+      return;
+    }
+    // Keyboard resize: ← / → for ±8px; Shift+← / Shift+→ for ±32px.
+    if (column.enableResize === false) return;
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+      e.preventDefault();
+      const step = (e.shiftKey ? 32 : 8) * (e.key === 'ArrowRight' ? 1 : -1);
+      const current = instance.columnSizesPx[column.id] ?? 120;
+      const minW = column.minSize ?? 40;
+      const maxW = column.maxSize;
+      let next = current + step;
+      if (next < minW) next = minW;
+      if (maxW != null && next > maxW) next = maxW;
+      instance.setColumnSizing((prev) => ({ ...prev, [column.id]: next }));
+    }
+  };
+
+  const headerContent =
+    typeof column.header === 'function'
+      ? column.header({ column, instance })
+      : column.header;
+
+  const dragStyle = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  } as const;
+
+  return (
+    <Table.HeaderCell
+      align={column.align ?? 'start'}
+      sortDirection={sortDir}
+      onClick={sortable ? () => instance.toggleSort(column.id) : undefined}
+      className={clsx(styles.headerCell, isDragging && styles.dragging)}
+      ref={setNodeRef as any}
+      style={dragStyle}
+    >
+      <div className={styles.inner}>
+        {reorderable && (
+          <span
+            className={styles.grip}
+            ref={(el) => {
+              // dnd-kit's listeners are spread on the grip
+            }}
+            // Spread BOTH attributes (aria/role) and listeners (pointerdown etc.)
+            {...attributes}
+            {...listeners}
+            aria-label={`Drag to reorder ${typeof column.header === 'string' ? column.header : column.id}`}
+            // tabIndex so keyboard users can focus to reveal grip + activate drag
+            tabIndex={0}
+          >
+            <GripVertical size={14} aria-hidden="true" />
+          </span>
+        )}
+        <span
+          className={clsx(styles.label, sortable && styles.sortable)}
+          tabIndex={sortable ? 0 : undefined}
+          role={sortable ? 'button' : undefined}
+          onKeyDown={onLabelKeyDown}
+        >
+          {headerContent}
+        </span>
+        {column.enableResize !== false && (
+          <span
+            className={styles.resizeHandle}
+            onPointerDown={resize.onPointerDown}
+            // Stop sort click when interacting with resize.
+            onClick={(e) => e.stopPropagation()}
+            aria-hidden="true"
+          >
+            <span className={clsx(styles.resizeBar, resize.isResizing && styles.active)} />
+          </span>
+        )}
+      </div>
+    </Table.HeaderCell>
+  );
+}
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+make build-lib
+```
+
+Expected: passes. No tests run yet — this file is exercised by `DataTable.test.tsx` in Task 12.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/DataTable/HeaderCell.tsx \
+        packages/design-system/src/components/DataTable/HeaderCell.module.scss
+git commit -m "DataTable: HeaderCell (sort label + hover grip + resize handle)
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9 — `BodyRow` component
+
+Row renderer with the optional selection auto-cell, data cells, and row-click handler.
+
+**Files:**
+- Create: `packages/design-system/src/components/DataTable/BodyRow.tsx`
+
+`BodyRow.tsx` uses styles from `DataTable.module.scss` (created in Task 11). For now it imports from a module that will exist.
+
+- [ ] **Step 1: Write the component**
+
+Create `packages/design-system/src/components/DataTable/BodyRow.tsx`:
+
+```tsx
+import { type MouseEvent, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import clsx from 'clsx';
+import { Table } from '../Table';
+import { Checkbox } from '../Checkbox';
+import type { DataTableInstance } from './types';
+import styles from './DataTable.module.scss';
+
+export interface BodyRowProps<T> {
+  row: T;
+  instance: DataTableInstance<T>;
+}
+
+/**
+ * One row of the body. Handles:
+ *  - selection auto-cell (when `instance.enableRowSelection`)
+ *  - row click (when `instance.onRowClick`) — ignored if the click target
+ *    was an interactive child (button, input, a) so checkbox/button clicks
+ *    don't bubble into a navigation.
+ *  - data cells from `instance.visibleColumns` (pinning rendering is in
+ *    Phase 2 — this phase renders unpinned order only).
+ */
+export function BodyRow<T>({ row, instance }: BodyRowProps<T>) {
+  const rowId = instance.getRowId(row);
+  const selected = instance.rowSelection[rowId] === true;
+
+  const onRowClick = (e: MouseEvent<HTMLTableRowElement>) => {
+    if (!instance.onRowClick) return;
+    // Ignore clicks that originated on an interactive child.
+    const target = e.target as HTMLElement;
+    if (target.closest('button, input, a, [role="button"], [role="checkbox"]')) {
+      return;
+    }
+    instance.onRowClick(row, e);
+  };
+
+  const onRowKeyDown = (e: ReactKeyboardEvent<HTMLTableRowElement>) => {
+    if (!instance.onRowClick) return;
+    if (e.key !== 'Enter') return;
+    const target = e.target as HTMLElement;
+    // Ignore Enter coming from an interactive child (it should drive that child).
+    if (target !== e.currentTarget && target.closest('button, input, a, [role="button"], [role="checkbox"]')) {
+      return;
+    }
+    e.preventDefault();
+    instance.onRowClick(row, e as unknown as MouseEvent<HTMLTableRowElement>);
+  };
+
+  return (
+    <Table.Row
+      selected={selected || undefined}
+      onClick={instance.onRowClick ? onRowClick : undefined}
+      onKeyDown={instance.onRowClick ? onRowKeyDown : undefined}
+      tabIndex={instance.onRowClick ? 0 : undefined}
+      className={clsx(instance.onRowClick && styles.clickableRow)}
+    >
+      {instance.enableRowSelection && (
+        <Table.Cell className={styles.autoCell} align="center">
+          <Checkbox
+            checked={selected}
+            onChange={() => instance.toggleRowSelection(rowId)}
+            aria-label={`Select row ${rowId}`}
+          />
+        </Table.Cell>
+      )}
+      {instance.visibleColumns.map((col) => (
+        <Table.Cell key={col.id} align={col.align ?? 'start'}>
+          {col.cell(row, { row, rowId, column: col, instance })}
+        </Table.Cell>
+      ))}
+    </Table.Row>
+  );
+}
+```
+
+- [ ] **Step 2: Verify typecheck (will fail until Task 11 creates DataTable.module.scss; we'll proceed and let it pass after Task 11)**
+
+For now, skip the build verification — `DataTable.module.scss` doesn't exist yet. Continue to Task 10.
+
+- [ ] **Step 3: Commit (deferred — bundle with Task 11)**
+
+Do not commit until `DataTable.module.scss` is in place. Stage this file but commit at the end of Task 11.
+
+---
+
+## Task 10 — `DataTable` component test scaffolding
+
+Write the integration test file first (TDD), focusing on the rendering paths that exist in Phase 1.
+
+**Files:**
+- Create: `packages/design-system/src/components/DataTable/DataTable.test.tsx`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `packages/design-system/src/components/DataTable/DataTable.test.tsx`:
+
+```tsx
+/**
+ * Integration tests for <DataTable> (Phase 1).
+ *
+ * NOTE on drag-and-drop coverage: column reorder via @dnd-kit's PointerSensor
+ * is genuinely hard to test in jsdom. The playground demo serves as the smoke
+ * test for reorder. A future Playwright e2e test is the recommended remedy
+ * if reorder regresses in practice.
+ */
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRef } from 'react';
+import { DataTable } from './DataTable';
+import { useDataTable } from './useDataTable';
+import type { ColumnDef } from './types';
+
+type Row = { id: string; name: string; amount: number };
+
+const cols: ColumnDef<Row>[] = [
+  { id: 'name', header: 'Name', cell: (r) => r.name, sortable: true },
+  { id: 'amount', header: 'Amount', cell: (r) => r.amount },
+];
+
+const rows: Row[] = [
+  { id: 'r1', name: 'Alpha', amount: 10 },
+  { id: 'r2', name: 'Bravo', amount: 20 },
+];
+
+const getRowId = (r: Row) => r.id;
+
+function Harness(props: Partial<Parameters<typeof useDataTable<Row>>[0]>) {
+  const instance = useDataTable<Row>({
+    data: rows,
+    columns: cols,
+    getRowId,
+    ...props,
+  });
+  return <DataTable instance={instance} aria-label="Test" />;
+}
+
+describe('<DataTable>', () => {
+  it('renders header + body rows', () => {
+    render(<Harness />);
+    expect(screen.getByRole('columnheader', { name: /name/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /amount/i })).toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Bravo')).toBeInTheDocument();
+  });
+
+  it('respects aria-label on the table', () => {
+    render(<Harness />);
+    expect(screen.getByRole('table')).toHaveAttribute('aria-label', 'Test');
+  });
+
+  it('sortable column header click cycles sort and fires onSortChange', async () => {
+    const onSortChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onSortChange={onSortChange} />);
+    await user.click(screen.getByRole('columnheader', { name: /name/i }));
+    expect(onSortChange).toHaveBeenLastCalledWith({ columnId: 'name', direction: 'asc' });
+  });
+
+  it('renders an empty state when data is empty', () => {
+    render(<Harness data={[]} />);
+    expect(screen.getByText(/no data/i)).toBeInTheDocument();
+  });
+
+  it('renders a custom emptyState when provided', () => {
+    function CustomHarness() {
+      const instance = useDataTable<Row>({ data: [], columns: cols, getRowId });
+      return <DataTable instance={instance} aria-label="t" emptyState={<div>NOTHING HERE</div>} />;
+    }
+    render(<CustomHarness />);
+    expect(screen.getByText('NOTHING HERE')).toBeInTheDocument();
+  });
+
+  it('renders skeleton rows when loading', () => {
+    function LoadingHarness() {
+      const instance = useDataTable<Row>({ data: [], columns: cols, getRowId });
+      return <DataTable instance={instance} aria-label="t" loading loadingRowCount={3} />;
+    }
+    const { container } = render(<LoadingHarness />);
+    // Skeleton renders a span with role="status" or a known className from the Skeleton component.
+    // We check by tbody row count instead — most robust.
+    const bodyRows = container.querySelectorAll('tbody tr');
+    expect(bodyRows.length).toBe(3);
+  });
+
+  it('renders selection auto-column when enableRowSelection is true', () => {
+    render(<Harness enableRowSelection />);
+    const headerRow = screen.getAllByRole('row')[0]!;
+    // Select-all + 2 data column headers = 3 cells
+    expect(within(headerRow).getAllByRole('columnheader').length).toBe(2);
+    expect(within(headerRow).getAllByRole('checkbox').length).toBe(1);
+  });
+
+  it('toggleRowSelection toggles a row via per-row checkbox', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness enableRowSelection onRowSelectionChange={onChange} defaultRowSelection={{}} />,
+    );
+    const rowCheckboxes = screen.getAllByRole('checkbox', { name: /select row/i });
+    expect(rowCheckboxes).toHaveLength(2);
+    await user.click(rowCheckboxes[0]!);
+    expect(onChange).toHaveBeenCalledWith({ r1: true });
+  });
+
+  it('header select-all checkbox toggles all rows on page', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness enableRowSelection onRowSelectionChange={onChange} defaultRowSelection={{}} />,
+    );
+    const headerCheckbox = screen.getAllByRole('checkbox')[0]!;
+    await user.click(headerCheckbox);
+    expect(onChange).toHaveBeenCalledWith({ r1: true, r2: true });
+  });
+
+  it('row click fires onRowClick when target is not interactive', async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onRowClick={onRowClick} />);
+    await user.click(screen.getByText('Alpha'));
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick.mock.calls[0]![0]).toEqual(rows[0]);
+  });
+
+  it('row Enter keypress fires onRowClick when onRowClick is provided', async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onRowClick={onRowClick} />);
+    const firstRow = screen.getAllByRole('row')[1]!; // [0] is the header row
+    firstRow.focus();
+    await user.keyboard('{Enter}');
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('rows are NOT focusable when onRowClick is not provided', () => {
+    render(<Harness />);
+    const firstBodyRow = screen.getAllByRole('row')[1]!;
+    expect(firstBodyRow).not.toHaveAttribute('tabindex');
+  });
+
+  it('row click does NOT fire onRowClick when target is the selection checkbox', async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        enableRowSelection
+        onRowClick={onRowClick}
+        defaultRowSelection={{}}
+        onRowSelectionChange={() => {}}
+      />,
+    );
+    const rowCheckboxes = screen.getAllByRole('checkbox', { name: /select row/i });
+    await user.click(rowCheckboxes[0]!);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('hidden columns do not render cells', () => {
+    render(<Harness defaultColumnVisibility={{ amount: false }} />);
+    expect(screen.queryByText('10')).toBeNull();
+    expect(screen.queryByText('20')).toBeNull();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+  });
+
+  it('respects columnOrder ordering in header + body', () => {
+    render(<Harness defaultColumnOrder={['amount', 'name']} />);
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers[0]!.textContent).toMatch(/amount/i);
+    expect(headers[1]!.textContent).toMatch(/name/i);
+  });
+
+  it('forwards ref to the underlying <table>', () => {
+    function RefHarness() {
+      const ref = useRef<HTMLTableElement>(null);
+      const instance = useDataTable<Row>({ data: rows, columns: cols, getRowId });
+      return <DataTable instance={instance} ref={ref} aria-label="t" data-testid="dt" />;
+    }
+    const { container } = render(<RefHarness />);
+    expect(container.querySelector('table')).toBeInstanceOf(HTMLTableElement);
+  });
+
+  it('merges className with the underlying <table>', () => {
+    function ClassHarness() {
+      const instance = useDataTable<Row>({ data: rows, columns: cols, getRowId });
+      return <DataTable instance={instance} className="my-class" aria-label="t" />;
+    }
+    const { container } = render(<ClassHarness />);
+    expect(container.querySelector('table.my-class')).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure (`DataTable` module missing)**
+
+```bash
+make test -- DataTable.test.tsx
+```
+
+Expected: fails — DataTable not implemented yet.
+
+(The implementation comes in Task 11; this task only stages the test file. Do not commit until Task 11.)
+
+---
+
+## Task 11 — `DataTable` component + SCSS
+
+Implement the orchestrator component and its styles. This is the largest single task in the plan.
+
+**Files:**
+- Create: `packages/design-system/src/components/DataTable/DataTable.tsx`
+- Create: `packages/design-system/src/components/DataTable/DataTable.module.scss`
+
+- [ ] **Step 1: Write the SCSS module**
+
+Create `packages/design-system/src/components/DataTable/DataTable.module.scss`:
+
+```scss
+// Visual / behavior modifiers ONLY. No layout (Rule 4).
+
+.root {
+  // composes the Table primitive's scroll wrapper — nothing to add here yet
+}
+
+// Selection auto-column — fixed narrow width is set via inline <col width> in colgroup.
+.autoCell {
+  // text-align center is set by <Table.Cell align="center" />
+}
+
+.clickableRow {
+  cursor: pointer;
+}
+
+// Empty state row — single colspan cell with centered content.
+.emptyCell {
+  text-align: center;
+  padding: var(--space-6) var(--space-4);
+  color: var(--color-fg-muted);
+}
+
+// Skeleton row cells — just give some visual breathing room.
+.skeletonCell {
+  // padding inherits from Table.Cell
+}
+```
+
+- [ ] **Step 2: Write the component**
+
+Create `packages/design-system/src/components/DataTable/DataTable.tsx`:
+
+```tsx
+import {
+  forwardRef,
+  useMemo,
+  type ReactNode,
+  type Ref,
+} from 'react';
+import clsx from 'clsx';
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
+import { Table } from '../Table';
+import type { TableDensity } from '../Table';
+import { Checkbox } from '../Checkbox';
+import { Skeleton } from '../Skeleton';
+import { EmptyState } from '../EmptyState';
+import { HeaderCell } from './HeaderCell';
+import { BodyRow } from './BodyRow';
+import { ColumnVisibilityTrigger } from './ColumnVisibilityTrigger';
+import type { DataTableInstance } from './types';
+import styles from './DataTable.module.scss';
+
+export interface DataTableProps<T> {
+  instance: DataTableInstance<T>;
+  density?: TableDensity;
+  striped?: boolean;
+  /** Hover highlight on body rows. Defaults TRUE (DataTable rows are usually interactive). */
+  hover?: boolean;
+  bordered?: boolean;
+  loading?: boolean;
+  /** Number of skeleton rows when `loading`. Defaults 10. */
+  loadingRowCount?: number;
+  /** Element shown when `data` is empty and not loading. Defaults to a stock <EmptyState>. */
+  emptyState?: ReactNode;
+  /** Required for a11y when no caption is provided. */
+  'aria-label'?: string;
+  caption?: ReactNode;
+  className?: string;
+}
+
+const AUTO_CELL_WIDTH = 44;
+
+/**
+ * Tabular data component built on the `<Table>` primitive. Owns the column-axis
+ * state machine (order / sizing / visibility / pinning) and row-axis state
+ * (selection, expansion). Sort/search/pagination are server-driven — DataTable
+ * fires `onSortChange` and exposes selection state for the consumer to act on.
+ *
+ * Accepts a `DataTableInstance<T>` from `useDataTable` (the only state-owning
+ * surface). Pass companion components like `<DataTable.ColumnVisibilityTrigger>`
+ * the same `instance`.
+ *
+ * @example
+ * function Example() {
+ *   const instance = useDataTable<Row>({
+ *     data, columns, getRowId,
+ *     enableRowSelection: true,
+ *     onSortChange: setSort,
+ *     sort,
+ *   });
+ *   return (
+ *     <>
+ *       <DataTable.ColumnVisibilityTrigger instance={instance} />
+ *       <DataTable instance={instance} aria-label="Deals" />
+ *     </>
+ *   );
+ * }
+ *
+ * @remarks When NOT to use
+ * - For a static read-only table without column features — use `<Table>` directly.
+ * - For huge datasets (10k+ rows on screen at once) — Phase 1 doesn't virtualize;
+ *   this'll get slow. Future phase will add a virtualization escape hatch.
+ * - For Excel-like cell editing or cell selection — out of scope; consumer composes.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Pre-sorting / pre-filtering `data` client-side then ALSO passing `sort`.
+ *   DataTable assumes `data` is the server's pre-paginated, pre-sorted slice.
+ *   Mixing creates ghost rows.
+ * - ❌ Mutating `columns` identity across renders. The hook captures
+ *   `defaultColumnOrder` from `columns` once; later identity changes won't
+ *   trigger a re-derive. Pass a stable reference (e.g. defined outside render
+ *   or memoized).
+ */
+function DataTableInner<T>(
+  {
+    instance,
+    density = 'comfortable',
+    striped,
+    hover = true,
+    bordered,
+    loading = false,
+    loadingRowCount = 10,
+    emptyState,
+    caption,
+    className,
+    ...rest
+  }: DataTableProps<T>,
+  ref: Ref<HTMLTableElement>,
+) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const visibleIds = useMemo(
+    () => instance.visibleColumns.map((c) => c.id),
+    [instance.visibleColumns],
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const activeId = String(active.id);
+    const overId = String(over.id);
+
+    instance.setColumnOrder((prev) => {
+      // Map dnd-kit's visible-list-result back into the full columnOrder array
+      // by replacing visible-column slots one-by-one in their absolute positions.
+      const visible = prev.filter((id) => visibleIds.includes(id));
+      const fromIdx = visible.indexOf(activeId);
+      const toIdx = visible.indexOf(overId);
+      if (fromIdx === -1 || toIdx === -1) return prev;
+      const reorderedVisible = [...visible];
+      const [moved] = reorderedVisible.splice(fromIdx, 1);
+      reorderedVisible.splice(toIdx, 0, moved!);
+
+      // Splice reorderedVisible back into prev at the same absolute positions.
+      let cursor = 0;
+      return prev.map((id) => {
+        if (visibleIds.includes(id)) {
+          return reorderedVisible[cursor++]!;
+        }
+        return id;
+      });
+    });
+  };
+
+  const totalColCount = instance.visibleColumns.length + (instance.enableRowSelection ? 1 : 0);
+  const dataIsEmpty = !loading && instance.data.length === 0 && instance.pinnedRows.length === 0;
+
+  return (
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+      <SortableContext items={visibleIds} strategy={horizontalListSortingStrategy}>
+        <Table
+          ref={ref}
+          stickyHeader
+          hover={hover}
+          density={density}
+          striped={striped}
+          bordered={bordered}
+          aria-rowcount={instance.rowCount}
+          className={clsx(styles.root, className)}
+          {...rest}
+        >
+          {caption && <Table.Caption>{caption}</Table.Caption>}
+
+          <colgroup>
+            {instance.enableRowSelection && <col style={{ width: AUTO_CELL_WIDTH }} />}
+            {instance.visibleColumns.map((col) => (
+              <col key={col.id} style={{ width: instance.columnSizesPx[col.id] ?? 120 }} />
+            ))}
+          </colgroup>
+
+          <Table.Header>
+            <Table.Row>
+              {instance.enableRowSelection && (
+                <Table.HeaderCell align="center" className={styles.autoCell}>
+                  <Checkbox
+                    checked={instance.isAllOnPageSelected()}
+                    indeterminate={instance.isSomeOnPageSelected()}
+                    onChange={() => instance.toggleAllOnPage()}
+                    aria-label="Select all rows on page"
+                  />
+                </Table.HeaderCell>
+              )}
+              {instance.visibleColumns.map((col) => (
+                <HeaderCell key={col.id} column={col} instance={instance} />
+              ))}
+            </Table.Row>
+          </Table.Header>
+
+          <Table.Body>
+            {loading ? (
+              <SkeletonRows count={loadingRowCount} totalColCount={totalColCount} />
+            ) : dataIsEmpty ? (
+              <EmptyRow totalColCount={totalColCount} content={emptyState} />
+            ) : (
+              instance.data.map((row) => (
+                <BodyRow key={instance.getRowId(row)} row={row} instance={instance} />
+              ))
+            )}
+          </Table.Body>
+        </Table>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+function SkeletonRows({ count, totalColCount }: { count: number; totalColCount: number }) {
+  return (
+    <>
+      {Array.from({ length: count }, (_, i) => (
+        <Table.Row key={`sk-${i}`}>
+          {Array.from({ length: totalColCount }, (_, j) => (
+            <Table.Cell key={j}>
+              <Skeleton variant="text" />
+            </Table.Cell>
+          ))}
+        </Table.Row>
+      ))}
+    </>
+  );
+}
+
+function EmptyRow({ totalColCount, content }: { totalColCount: number; content?: ReactNode }) {
+  return (
+    <Table.Row>
+      <Table.Cell colSpan={totalColCount} className={styles.emptyCell}>
+        {content ?? <EmptyState title="No data" />}
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+/**
+ * Generic forwardRef wrapper — TypeScript erases the `T` generic in a normal
+ * forwardRef so we re-type via assertion. This is the standard pattern for
+ * generic forwardRef components.
+ */
+export const DataTable = forwardRef(DataTableInner) as <T>(
+  props: DataTableProps<T> & { ref?: Ref<HTMLTableElement> },
+) => ReturnType<typeof DataTableInner>;
+
+// Attach companion components like Radix-style compound APIs.
+(DataTable as any).ColumnVisibilityTrigger = ColumnVisibilityTrigger;
+
+// Re-export the companion as a named member of the union below for type purposes.
+// (Consumers can also import ColumnVisibilityTrigger directly from the package root.)
+```
+
+- [ ] **Step 3: Run the integration tests — expect mostly-passing**
+
+```bash
+make test -- DataTable.test.tsx
+```
+
+Expected: all tests in `DataTable.test.tsx` pass (~15 tests). Some specific tests may need tweaks:
+- If `aria-rowcount` doesn't appear when `rowCount` is undefined, that's fine (the spec uses `?` on the prop).
+- If `<Skeleton variant="text">` doesn't render with a `role`, the tbody-row-count check is the right shape.
+
+Fix any test failures by adjusting the component (preferred) or the test (only when the test asserts something the spec doesn't require).
+
+- [ ] **Step 4: Commit DataTable + BodyRow + SCSS together**
+
+```bash
+git add packages/design-system/src/components/DataTable/DataTable.tsx \
+        packages/design-system/src/components/DataTable/DataTable.module.scss \
+        packages/design-system/src/components/DataTable/DataTable.test.tsx \
+        packages/design-system/src/components/DataTable/BodyRow.tsx
+git commit -m "DataTable: component + BodyRow + integration tests
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12 — `ColumnVisibilityTrigger` companion
+
+**Files:**
+- Create: `packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx`
+- Create: `packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.module.scss`
+- Test: `packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ColumnVisibilityTrigger } from './ColumnVisibilityTrigger';
+import { useDataTable } from './useDataTable';
+import type { ColumnDef } from './types';
+
+type Row = { id: string };
+
+const cols: ColumnDef<Row>[] = [
+  { id: 'a', header: 'A', cell: (r) => r.id },
+  { id: 'b', header: 'B', cell: (r) => r.id },
+  { id: 'c', header: 'C', cell: (r) => r.id, enableHide: false }, // always visible — not in menu
+];
+
+function Harness(props: { onChange?: (v: any) => void; visibility?: Record<string, boolean> }) {
+  const instance = useDataTable<Row>({
+    data: [],
+    columns: cols,
+    getRowId: (r) => r.id,
+    columnVisibility: props.visibility ?? {},
+    onColumnVisibilityChange: props.onChange,
+  });
+  return <ColumnVisibilityTrigger instance={instance} />;
+}
+
+describe('<ColumnVisibilityTrigger>', () => {
+  it('renders one menu item per hidable column', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', { name: /columns/i }));
+    expect(screen.getByRole('menuitemcheckbox', { name: 'A' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemcheckbox', { name: 'B' })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitemcheckbox', { name: 'C' })).toBeNull();
+  });
+
+  it('toggle fires onColumnVisibilityChange', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onChange={onChange} />);
+    await user.click(screen.getByRole('button', { name: /columns/i }));
+    await user.click(screen.getByRole('menuitemcheckbox', { name: 'A' }));
+    expect(onChange).toHaveBeenCalledWith({ a: false });
+  });
+
+  it('disables the toggle for the last visible hidable column', async () => {
+    const user = userEvent.setup();
+    // a is the only visible hidable column (b is hidden, c is non-hidable).
+    render(<Harness visibility={{ b: false }} />);
+    await user.click(screen.getByRole('button', { name: /columns/i }));
+    const aItem = screen.getByRole('menuitemcheckbox', { name: 'A' });
+    expect(aItem).toHaveAttribute('aria-disabled', 'true');
+    // b is hidden but still toggleable to show.
+    const bItem = screen.getByRole('menuitemcheckbox', { name: 'B' });
+    expect(bItem).not.toHaveAttribute('aria-disabled', 'true');
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure (module missing)**
+
+```bash
+make test -- ColumnVisibilityTrigger.test.tsx
+```
+
+- [ ] **Step 3: Write the SCSS module**
+
+Create `packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.module.scss`:
+
+```scss
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+```
+
+- [ ] **Step 4: Write the component**
+
+Create `packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx`:
+
+```tsx
+import type { ReactNode } from 'react';
+import { Columns3 } from 'lucide-react';
+import { Button } from '../Button';
+import { DropdownMenu } from '../DropdownMenu';
+import type {
+  DropdownMenuAlign,
+  DropdownMenuSide,
+} from '../DropdownMenu';
+import type { DataTableInstance } from './types';
+
+export interface ColumnVisibilityTriggerProps<T = unknown> {
+  instance: DataTableInstance<T>;
+  /** Trigger button label. Defaults to "Columns". */
+  label?: ReactNode;
+  /** Trigger icon. Defaults to a `Columns3` lucide icon. */
+  icon?: ReactNode;
+  side?: DropdownMenuSide;
+  align?: DropdownMenuAlign;
+}
+
+/**
+ * Built-in companion for `<DataTable>`. Renders a Button trigger + DropdownMenu
+ * of CheckboxItems — one per column where `enableHide !== false`.
+ *
+ * Guards against hiding the last visible hidable column: when only one
+ * hidable column is currently visible, its menu item renders as disabled.
+ *
+ * @example
+ * const instance = useDataTable<Row>({ ... });
+ * <Cluster>
+ *   <ColumnVisibilityTrigger instance={instance} />
+ * </Cluster>
+ * <DataTable instance={instance} />
+ *
+ * @remarks When NOT to use
+ * - When the consumer wants a different visibility UI (e.g. a settings drawer).
+ *   Build it directly against `instance.columns`, `instance.columnVisibility`,
+ *   and `instance.toggleColumnVisibility`.
+ */
+export function ColumnVisibilityTrigger<T>({
+  instance,
+  label = 'Columns',
+  icon = <Columns3 size={14} aria-hidden="true" />,
+  side,
+  align,
+}: ColumnVisibilityTriggerProps<T>) {
+  const hidableCols = instance.columns.filter((c) => c.enableHide !== false);
+  const visibleHidableCount = hidableCols.reduce(
+    (n, c) => n + (instance.columnVisibility[c.id] === false ? 0 : 1),
+    0,
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="ghost" size="sm">
+          {icon}
+          {label}
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content side={side} align={align}>
+        {hidableCols.map((col) => {
+          const visible = instance.columnVisibility[col.id] !== false;
+          const isLastVisible = visible && visibleHidableCount === 1;
+          const itemLabel =
+            col.visibilityLabel ?? (typeof col.header === 'string' ? col.header : col.id);
+          return (
+            <DropdownMenu.CheckboxItem
+              key={col.id}
+              checked={visible}
+              disabled={isLastVisible}
+              onCheckedChange={() => instance.toggleColumnVisibility(col.id)}
+            >
+              {itemLabel}
+            </DropdownMenu.CheckboxItem>
+          );
+        })}
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+}
+```
+
+- [ ] **Step 5: Run — expect pass**
+
+```bash
+make test -- ColumnVisibilityTrigger.test.tsx
+```
+
+Expected: all 3 tests pass.
+
+If the test for `aria-disabled` fails because the project's `DropdownMenu.CheckboxItem` doesn't surface that attribute when `disabled`, fix the test to query by another marker (e.g. `data-disabled`) — match what the project's existing menu items produce. Verify by inspecting one of the existing demo tests for `DropdownMenu`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx \
+        packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.module.scss \
+        packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.test.tsx
+git commit -m "DataTable: ColumnVisibilityTrigger companion + last-visible guard
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13 — Public exports + library `index.ts`
+
+**Files:**
+- Modify: `packages/design-system/src/components/DataTable/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+- [ ] **Step 1: Update the DataTable folder's `index.ts`**
+
+Replace the contents of `packages/design-system/src/components/DataTable/index.ts`:
+
+```ts
+export { DataTable } from './DataTable';
+export type { DataTableProps } from './DataTable';
+
+export { useDataTable } from './useDataTable';
+export { ColumnVisibilityTrigger } from './ColumnVisibilityTrigger';
+export type { ColumnVisibilityTriggerProps } from './ColumnVisibilityTrigger';
+
+export type {
+  ColumnDef,
+  ColumnAlign,
+  ColumnOrderState,
+  ColumnSizingState,
+  ColumnVisibilityState,
+  ColumnPinningState,
+  RowSelectionState,
+  ExpandedRowsState,
+  SortState,
+  Updater,
+  HeaderContext,
+  CellContext,
+  UseDataTableOptions,
+  DataTableInstance,
+} from './types';
+```
+
+- [ ] **Step 2: Re-export from library root**
+
+Append to `packages/design-system/src/index.ts` (right after the existing `export { CursorPagination }` block):
+
+```ts
+export { DataTable, useDataTable, ColumnVisibilityTrigger } from './components/DataTable';
+export type {
+  DataTableProps,
+  ColumnVisibilityTriggerProps,
+  DataTableInstance,
+  UseDataTableOptions,
+  ColumnDef,
+  ColumnAlign,
+  ColumnOrderState,
+  ColumnSizingState,
+  ColumnVisibilityState,
+  ColumnPinningState,
+  RowSelectionState,
+  ExpandedRowsState,
+  SortState,
+  HeaderContext,
+  CellContext,
+} from './components/DataTable';
+```
+
+- [ ] **Step 3: Verify build + tests**
+
+```bash
+make build-lib && make test
+```
+
+Expected: both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/DataTable/index.ts \
+        packages/design-system/src/index.ts
+git commit -m "DataTable: public exports (DataTable, useDataTable, ColumnVisibilityTrigger + types)
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14 — Playground demo
+
+**Files:**
+- Create: `packages/playground/src/pages/components/DataTableDemo.tsx`
+
+- [ ] **Step 1: Write the demo**
+
+Create `packages/playground/src/pages/components/DataTableDemo.tsx`:
+
+```tsx
+import { useState } from 'react';
+import {
+  Badge,
+  Cluster,
+  DataTable,
+  Stack,
+  useDataTable,
+  type ColumnDef,
+  type SortState,
+} from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/DataTable/DataTable.tsx?raw';
+import scssSource from '@lib-source/components/DataTable/DataTable.module.scss?raw';
+
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
+
+const deals: Deal[] = [
+  { id: 'd1', name: 'Acme renewal',     stage: 'Negotiation', amount: 12000, owner: 'Sara' },
+  { id: 'd2', name: 'Globex expansion', stage: 'Lead',         amount: 4500,  owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won',        amount: 8800,  owner: 'Sara' },
+  { id: 'd4', name: 'Hooli pilot',      stage: 'Lost',         amount: 0,     owner: 'Jin' },
+];
+
+const dealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name, sortable: true, size: 200 },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>, size: 140 },
+  { id: 'amount', header: 'Amount', cell: (r) => `$${r.amount.toLocaleString()}`, align: 'end', sortable: true, size: 120 },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner, size: 120 },
+];
+
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won': return 'success' as const;
+    case 'Lost': return 'danger' as const;
+    case 'Negotiation': return 'warning' as const;
+    default: return 'info' as const;
+  }
+}
+
+export function DataTableDemo() {
+  return (
+    <DemoLayout
+      name="DataTable"
+      componentName="DataTable"
+      description="Composition over the Table primitive with column ordering / sizing / visibility, row selection, row click, sortable headers, and loading/empty states. Phase 1 — column pinning and expandable rows ship in later phases."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="DataTable.tsx"
+      scssFilename="DataTable.module.scss"
+    >
+      <BasicExample />
+      <SortableExample />
+      <SelectableExample />
+      <VisibilityExample />
+      <LoadingExample />
+      <EmptyExample />
+    </DemoLayout>
+  );
+}
+
+function BasicExample() {
+  return (
+    <Example
+      title="Basic"
+      description="Default DataTable with sticky header, hover rows, and resizable + reorderable columns. Click any header label to sort. Hover over a header to reveal the drag grip."
+      code={`const instance = useDataTable<Deal>({ data, columns, getRowId: (r) => r.id });
+return <DataTable instance={instance} aria-label="Deals" />;`}
+    >
+      <BasicTable />
+    </Example>
+  );
+}
+
+function BasicTable() {
+  const instance = useDataTable<Deal>({
+    data: deals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+  });
+  return <DataTable instance={instance} aria-label="Deals (basic)" />;
+}
+
+function SortableExample() {
+  const [sort, setSort] = useState<SortState | null>(null);
+  const sortedDeals = sort
+    ? [...deals].sort((a, b) => {
+        const va = (a as any)[sort.columnId];
+        const vb = (b as any)[sort.columnId];
+        const cmp = va < vb ? -1 : va > vb ? 1 : 0;
+        return sort.direction === 'asc' ? cmp : -cmp;
+      })
+    : deals;
+
+  const instance = useDataTable<Deal>({
+    data: sortedDeals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    sort,
+    onSortChange: setSort,
+  });
+
+  return (
+    <Example
+      title="Server-driven sort (simulated)"
+      description="The demo sorts on the client for illustration, but in real code your onSortChange callback would refetch from the server with the new sort. DataTable does not transform data — it only manages and emits sort state."
+      code={`const [sort, setSort] = useState<SortState | null>(null);
+const instance = useDataTable({ data, columns, getRowId, sort, onSortChange: setSort });`}
+    >
+      <DataTable instance={instance} aria-label="Deals (sortable)" />
+    </Example>
+  );
+}
+
+function SelectableExample() {
+  const [selection, setSelection] = useState({});
+  const selectedCount = Object.keys(selection).length;
+
+  const instance = useDataTable<Deal>({
+    data: deals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    enableRowSelection: true,
+    rowSelection: selection,
+    onRowSelectionChange: setSelection,
+    onRowClick: (row) => alert(`Row clicked: ${row.name}`),
+  });
+
+  return (
+    <Example
+      title="Selection + row click"
+      description="enableRowSelection adds a checkbox column. The header checkbox toggles all rows on the current page (indeterminate when partially selected). Clicking elsewhere on a row fires onRowClick — but clicking the checkbox does not."
+      code={`const [selection, setSelection] = useState({});
+const instance = useDataTable({
+  data, columns, getRowId,
+  enableRowSelection: true,
+  rowSelection: selection,
+  onRowSelectionChange: setSelection,
+  onRowClick: (row) => navigate(\`/deals/\${row.id}\`),
+});`}
+    >
+      <Stack gap="sm">
+        <Cluster gap="sm">
+          <span>{selectedCount} selected</span>
+        </Cluster>
+        <DataTable instance={instance} aria-label="Deals (selectable)" />
+      </Stack>
+    </Example>
+  );
+}
+
+function VisibilityExample() {
+  const instance = useDataTable<Deal>({
+    data: deals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    defaultColumnVisibility: { owner: false },
+  });
+
+  return (
+    <Example
+      title="Column visibility"
+      description="ColumnVisibilityTrigger renders a Button → DropdownMenu of CheckboxItems for every column where enableHide is not false. The last visible hidable column is disabled — DataTable always shows at least one data column."
+      code={`<Cluster><DataTable.ColumnVisibilityTrigger instance={instance} /></Cluster>
+<DataTable instance={instance} />`}
+    >
+      <Stack gap="sm">
+        <Cluster gap="sm">
+          <DataTable.ColumnVisibilityTrigger instance={instance} />
+        </Cluster>
+        <DataTable instance={instance} aria-label="Deals (visibility)" />
+      </Stack>
+    </Example>
+  );
+}
+
+function LoadingExample() {
+  const instance = useDataTable<Deal>({
+    data: [],
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+  });
+  return (
+    <Example
+      title="Loading"
+      description="Pass loading to render skeleton rows. loadingRowCount controls how many (default 10)."
+      code={`<DataTable instance={instance} loading loadingRowCount={4} />`}
+    >
+      <DataTable instance={instance} loading loadingRowCount={4} aria-label="Loading" />
+    </Example>
+  );
+}
+
+function EmptyExample() {
+  const instance = useDataTable<Deal>({
+    data: [],
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+  });
+  return (
+    <Example
+      title="Empty"
+      description="When data is empty (and not loading), DataTable shows a default EmptyState. Pass emptyState for a custom one."
+      code={`<DataTable instance={instance} aria-label="Deals" />`}
+    >
+      <DataTable instance={instance} aria-label="Deals (empty)" />
+    </Example>
+  );
+}
+```
+
+If `Badge` doesn't expose the exact tones used (`success`, `danger`, `warning`, `info`), inspect `Badge`'s types via `grep -rn "BadgeTone" packages/design-system/src` and use the available ones. Don't invent new tones.
+
+- [ ] **Step 2: Verify the demo builds**
+
+```bash
+make build-lib  # smoke-tests both packages
+```
+
+If the build fails on a missing Badge tone or a Cluster prop, fix the demo's usage to match available exports (don't change the library).
+
+- [ ] **Step 3: Commit (will wire into nav in next task)**
+
+```bash
+git add packages/playground/src/pages/components/DataTableDemo.tsx
+git commit -m "playground: DataTableDemo (basic / sortable / selectable / visibility / loading / empty)
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15 — Wire demo into navigation (4 places)
+
+Per playground `CLAUDE.md` Hard Rule 4.
+
+**Files:**
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts` (only if any mockup uses DataTable)
+
+- [ ] **Step 1: Add the route in `App.tsx`**
+
+In `packages/playground/src/App.tsx`:
+
+1. Add the import alongside the others:
+```ts
+import { DataTableDemo } from './pages/components/DataTableDemo';
+```
+2. Add the route inside `<Routes>` (alphabetical with siblings is fine):
+```tsx
+<Route path="/components/datatable" element={<DataTableDemo />} />
+```
+
+- [ ] **Step 2: Add the sidebar item in `AppShell.tsx`**
+
+Open `packages/playground/src/layout/AppShell/AppShell.tsx`. Find the `componentGroups` array. DataTable goes in the `Display` group (alongside `Table`, `Skeleton`, etc.). Add:
+
+```ts
+{ to: '/components/datatable', label: 'DataTable' }
+```
+
+Match the exact shape and ordering used for other items in that group.
+
+- [ ] **Step 3: Add the card in `ComponentsIndex.tsx`**
+
+In `packages/playground/src/pages/components/ComponentsIndex.tsx`, find the grid (likely a `<Stack>` or `<div>` rendering one card per component) and add a tile for DataTable with a brief description ("Tabular data with sortable / resizable / reorderable columns and row selection.") and a small live preview (a 2x2 mini-table or just the name).
+
+Match the visual shape of adjacent tiles (e.g. `Table`, `Pagination`). When in doubt copy the `Table` tile's structure verbatim and swap the label/description.
+
+- [ ] **Step 4: Check `mockups/registry.ts`**
+
+Inspect `packages/playground/src/pages/mockups/registry.ts`. Phase 1 does not modify any mockup to use DataTable (that lands in later work). So **no change required** here. However, if you find any mockup file that already uses DataTable (it shouldn't yet), add `'DataTable'` to the relevant `usesComponents` list AND to the `ComponentName` union at the top of the file.
+
+- [ ] **Step 5: Smoke-test in the playground**
+
+```bash
+make dev
+```
+
+Open http://localhost:8080/components/datatable in a browser. Verify:
+- Header renders with the four columns (Deal, Stage, Amount, Owner)
+- Body shows the four deals
+- Hovering a header reveals the drag grip
+- Clicking the "Deal" header label adds a sort indicator and cycles asc → desc → off
+- The Selectable example toggles row selection; clicking elsewhere on a row alerts
+- The Column visibility example's "Columns" button opens a dropdown menu
+- The Loading example shows 4 skeleton rows
+- The Empty example shows the default empty state
+
+Stop dev (`Ctrl+C`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/playground/src/App.tsx \
+        packages/playground/src/layout/AppShell/AppShell.tsx \
+        packages/playground/src/pages/components/ComponentsIndex.tsx
+git commit -m "playground: wire DataTableDemo into App route + sidebar + components grid
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16 — `AGENTS.md` TL;DR + final JSDoc audit
+
+**Files:**
+- Modify: `packages/design-system/AGENTS.md`
+- Verify (no edit unless missing): JSDoc on `<DataTable>`, `useDataTable`, `<ColumnVisibilityTrigger>` includes `@example`, `@remarks When NOT to use`, `@remarks Anti-patterns`.
+
+- [ ] **Step 1: Add the `<DataTable>` TL;DR section to AGENTS.md**
+
+Find the "Components — TL;DR" section in `packages/design-system/AGENTS.md`. Add a new subsection after `<Table>` (since DataTable composes Table):
+
+````markdown
+### `<DataTable>` — server-driven data table with column features
+
+```tsx
+const instance = useDataTable<Deal>({
+  data,
+  columns,
+  getRowId: (r) => r.id,
+  enableRowSelection: true,
+  sort,
+  onSortChange: setSort,
+});
+
+<Cluster>
+  <DataTable.ColumnVisibilityTrigger instance={instance} />
+</Cluster>
+<DataTable instance={instance} aria-label="Deals" />
+```
+
+- Config-driven via `columns: ColumnDef<T>[]`. Each column has a stable `id` used as the key for all per-column state.
+- All state pieces (column order/sizing/visibility/pinning, row selection/expansion, sort) follow the Radix controlled/uncontrolled pattern: `value` + `onValueChange`, OR `defaultValue` only, OR neither.
+- Server-driven sort/search/pagination. DataTable does NOT transform data — `data` must be the server's pre-sorted, pre-paginated slice. `onSortChange` is your trigger to refetch.
+- `enableRowSelection: true` adds a leading checkbox column with select-all (indeterminate when partial). `toggleAllOnPage` ignores `pinnedRows`.
+- Drag-to-reorder is keyboard-accessible (Tab to grip → Space to pick up → ←/→ to move → Space/Enter to drop → Esc to cancel). The grip is hover-revealed on desktop.
+- Resize via the right-edge handle. Keyboard: focused header label, `←`/`→` for −/+8px; Shift+`←`/`→` for ±32px.
+- `ColumnVisibilityTrigger` is the only built-in companion. For column pinning UI (Phase 2 ships state, no built-in UI), wire your own using `instance.pinColumn(id, side)`.
+- **Phase 1 only**: column pinning is plumbed (`columnPinning` state + `pinColumn` helper) but the sticky CSS does NOT render yet — it lands in Phase 2 along with `pinnedRows` rendering. Expandable rows (`renderExpandedRow`) lands in Phase 3. The state plumbing is forward-compatible — code you write now keeps working when those phases ship.
+
+**Anti-patterns:**
+
+- ❌ Mutating `columns` array identity on every render. `useDataTable` captures `defaultColumnOrder` from `columns` once at mount — later identity changes don't trigger a re-derive of the default order. Use a stable reference (`useMemo` or module-level).
+- ❌ Client-sorting `data` AND passing `sort` controlled. Pick one — server is the canonical source. Spinning both means rows reorder twice and ghost-rows appear during fetches.
+- ❌ Rolling your own column visibility UI when `ColumnVisibilityTrigger` does the job. The built-in handles the "last column" guard for you.
+- ❌ Using `<Table>` directly when you want any of: ordering, sizing, visibility, selection, sort indicator wiring. Compose `<DataTable>` instead — the primitive `<Table>` is for static read-only views.
+````
+
+- [ ] **Step 2: Audit JSDoc on the three public surfaces**
+
+Verify each of these has the required JSDoc shape (per Hard rule 7 in `packages/design-system/CLAUDE.md`). Use this checklist:
+
+```bash
+grep -n "@example\|@remarks" packages/design-system/src/components/DataTable/DataTable.tsx
+grep -n "@example\|@remarks" packages/design-system/src/components/DataTable/useDataTable.ts
+grep -n "@example\|@remarks" packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx
+```
+
+Expected output: each file has at least one `@example` block and `@remarks` "When NOT to use" + "Anti-patterns" blocks.
+
+If `useDataTable.ts` is missing JSDoc, add a function-level doc comment with:
+
+```ts
+/**
+ * Headless state machine for `<DataTable>`. ...
+ *
+ * @example
+ * const instance = useDataTable<Deal>({
+ *   data,
+ *   columns,
+ *   getRowId: (r) => r.id,
+ *   sort,
+ *   onSortChange: setSort,
+ * });
+ * <DataTable instance={instance} aria-label="Deals" />
+ *
+ * @remarks When NOT to use
+ * - For a read-only static table — use `<Table>` directly.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Passing both `value` and `defaultValue` for the same state piece — `value`
+ *   wins and `defaultValue` is silently ignored. Pick one.
+ * - ❌ Mutating `columns` identity across renders. See `<DataTable>` JSDoc.
+ */
+```
+
+- [ ] **Step 3: Verify tests + build still pass**
+
+```bash
+make test && make build-lib && make lint
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/AGENTS.md \
+        packages/design-system/src/components/DataTable/
+git commit -m "DataTable: AGENTS.md TL;DR + JSDoc audit pass
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17 — Pre-push review-fix cycle (Hard rule 8)
+
+This is **non-optional** per `packages/design-system/CLAUDE.md` Rule 8 — and the user has a memory entry explicitly flagging it as mandatory.
+
+**Files:** none directly — this task drives subagent-based review of the library work in this branch.
+
+- [ ] **Step 1: Run all gates locally**
+
+```bash
+make test
+make build-lib
+make build
+make lint
+npm pack --dry-run --workspace @eocrm/design-system
+```
+
+Each must exit 0. If any fail, fix before proceeding to review.
+
+- [ ] **Step 2: Spawn a fresh-context review subagent**
+
+Use the `Agent` tool with `subagent_type: "general-purpose"`. Prompt template:
+
+```
+Review the DataTable Phase 1 work on this branch.
+
+Scope: packages/design-system/src/components/DataTable/ and its exports.
+Also touch: packages/design-system/src/index.ts, AGENTS.md, playground demo.
+
+REQUIRED READING FIRST (in order):
+1. packages/design-system/CLAUDE.md — the 10 hard rules
+2. packages/design-system/AGENTS.md — component contract & anti-patterns
+3. packages/design-system/README.md — consumer install / build context
+4. docs/superpowers/specs/2026-05-22-datatable-design.md — the design source of truth
+
+Then review the diff vs main against the 10 categories:
+1. Bugs / correctness
+2. Accessibility (keyboard, ARIA, focus management, screen reader)
+3. API inconsistencies (prop naming, default values, type shape)
+4. Type safety (no `any` without justification, exhaustive unions, generics)
+5. Rule violations (Rules 1-7 in packages/design-system/CLAUDE.md)
+6. Test coverage (controlled/uncontrolled, derived models, helpers, all integration paths)
+7. Token discipline (Rule 3) — no raw colors / spacing / radii in .module.scss
+8. SCSS quality (Rule 4 — no layout props on components, focus-visible per 3a)
+9. Cross-package leakage (playground deps not used in library; lib doesn't import playground)
+10. Package / distribution: anything new under src/ is whitelisted by files in package.json
+
+Phase 2 (column pinning rendering, pinned rows) and Phase 3 (expandable row rendering)
+are deferred — do NOT flag missing pinning sticky CSS or chevron rendering as bugs.
+Phase 1 ships state plumbing for those, no render effects.
+
+Output format: Critical / Important / Nice-to-have / Regression-watch.
+End with verdict: "clean enough to stop" or "keep iterating".
+```
+
+- [ ] **Step 3: Fix every Critical + Important finding**
+
+For each Critical or Important finding, fix in the codebase. For each deliberate skip (Nice-to-have or contested Important), leave a one-line note in your follow-up.
+
+- [ ] **Step 4: Re-run gates**
+
+```bash
+make test && make build-lib && make build && make lint
+```
+
+- [ ] **Step 5: Spawn a second review subagent with the same prompt**
+
+If verdict is "clean enough to stop", proceed. Otherwise repeat Step 3.
+
+- [ ] **Step 6: Commit any fixes from the review loop**
+
+Use a single commit for each round of fixes (do not amend earlier commits):
+
+```bash
+git add -A
+git commit -m "DataTable: review-cycle fixes (round N)
+
+$(cat <<'EOF'
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 7: Push the branch**
+
+The Husky pre-push hook runs prettier, stylelint, and typecheck. If it blocks, fix the underlying issue — never use `--no-verify` without explicit user authorization.
+
+```bash
+git push -u origin feat/datatable
+```
+
+---
+
+## Task 18 — Open PR
+
+**Files:** none — uses `gh`.
+
+- [ ] **Step 1: Open the PR**
+
+Per root `CLAUDE.md`: code/config/workflow changes go through PRs. Wait for the `Quality / check` status check.
+
+```bash
+gh pr create --title "DataTable Phase 1: hook + component + column visibility companion" --body "$(cat <<'EOF'
+## Summary
+
+- New `<DataTable>` component composing the `<Table>` primitive
+- `useDataTable<T>` hook owns column-axis state (order / sizing / visibility / pinning) and row-axis state (selection / expansion / sort)
+- `<DataTable.ColumnVisibilityTrigger>` built-in companion for show/hide menu
+- Drag-to-reorder columns via `@dnd-kit/sortable` (with keyboard a11y)
+- Hand-rolled pointer-based resize handle (keyboard ± resize via header label)
+- Sticky header default-on; loading / empty / sortable / selectable states; row click handler
+
+**Phase 1 of 3.** Column pinning rendering and expandable rows ship in phases 2 and 3 — state plumbing for both is included here so the API surface is forward-compatible.
+
+Spec: `docs/superpowers/specs/2026-05-22-datatable-design.md`.
+
+## Test plan
+
+- [x] `useDataTable` pure-logic unit tests (controlled/uncontrolled resolution, all helpers, derived view-models including pin offsets)
+- [x] `useResizeHandle` pointer + clamping tests
+- [x] `useControllableState` controlled vs uncontrolled tests
+- [x] `<DataTable>` integration tests (sort click, selection, row click, hidden columns, column order, loading, empty, ref forwarding, className merge)
+- [x] `<ColumnVisibilityTrigger>` last-visible-guard + toggle tests
+- [x] Playground demo manually exercised at /components/datatable
+- [x] Hard-rule-8 pre-push review-fix cycle completed
+
+Known gap: column drag-and-drop reorder is not unit-tested (jsdom limitation with `@dnd-kit`'s PointerSensor). Documented in the test file header. Playground demo is the smoke test; a Playwright e2e is the planned remedy.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for CI**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: `Quality / check` passes.
+
+- [ ] **Step 3: Return PR URL to user**
+
+```bash
+gh pr view --json url --jq .url
+```
+
+Report the URL back to the user so they can review and merge.
+
+---
+
+## Plan Complete
+
+After Task 18, Phase 1 is shipped. Phase 2 (column pinning rendering + pinned rows) and Phase 3 (expandable rows) each get their own plan via the `superpowers:writing-plans` skill, sourced from the same spec.

--- a/docs/superpowers/plans/2026-05-22-datatable-phase-1.md
+++ b/docs/superpowers/plans/2026-05-22-datatable-phase-1.md
@@ -60,6 +60,7 @@ packages/playground/src/pages/components/ComponentsIndex.tsx ← MODIFIED: grid 
 ## Task 1 — Install dnd-kit dependencies
 
 **Files:**
+
 - Modify: `packages/design-system/package.json`
 
 - [ ] **Step 1: Verify clean working tree on `feat/datatable`**
@@ -108,6 +109,7 @@ EOF
 ## Task 2 — Create folder + types.ts
 
 **Files:**
+
 - Create: `packages/design-system/src/components/DataTable/types.ts`
 - Create: `packages/design-system/src/components/DataTable/index.ts` (placeholder, will be populated)
 
@@ -343,6 +345,7 @@ EOF
 A tiny local utility that resolves the Radix `value`/`defaultValue`/`onChange` pattern. Used by `useDataTable` for every state piece.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/DataTable/useControllableState.ts`
 - Test: `packages/design-system/src/components/DataTable/useControllableState.test.ts`
 
@@ -361,17 +364,13 @@ describe('useControllableState', () => {
   });
 
   it('uses value when controlled (ignores default)', () => {
-    const { result } = renderHook(() =>
-      useControllableState({ value: 10, defaultValue: 5 }),
-    );
+    const { result } = renderHook(() => useControllableState({ value: 10, defaultValue: 5 }));
     expect(result.current[0]).toBe(10);
   });
 
   it('updates internal state when uncontrolled', () => {
     const onChange = vi.fn();
-    const { result } = renderHook(() =>
-      useControllableState({ defaultValue: 0, onChange }),
-    );
+    const { result } = renderHook(() => useControllableState({ defaultValue: 0, onChange }));
     act(() => result.current[1](42));
     expect(result.current[0]).toBe(42);
     expect(onChange).toHaveBeenCalledWith(42);
@@ -400,9 +399,7 @@ describe('useControllableState', () => {
 
   it('updater function receives current value when controlled', () => {
     const onChange = vi.fn();
-    const { result } = renderHook(() =>
-      useControllableState({ value: 10, onChange }),
-    );
+    const { result } = renderHook(() => useControllableState({ value: 10, onChange }));
     act(() => result.current[1]((prev) => prev + 5));
     expect(onChange).toHaveBeenCalledWith(15);
   });
@@ -461,8 +458,7 @@ export function useControllableState<T>(options: {
   const setValue = useCallback(
     (updater: Updater<T>) => {
       const prev = resolvedRef.current;
-      const next =
-        typeof updater === 'function' ? (updater as (p: T) => T)(prev) : updater;
+      const next = typeof updater === 'function' ? (updater as (p: T) => T)(prev) : updater;
       if (!isControlled) setInternal(next);
       onChangeRef.current?.(next);
     },
@@ -501,6 +497,7 @@ EOF
 Build the hook in slices. This first slice: state plumbing for every piece, no derived view-models yet, no helper methods yet.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/DataTable/useDataTable.ts`
 - Test: `packages/design-system/src/components/DataTable/useDataTable.test.ts`
 
@@ -529,9 +526,7 @@ const getRowId = (r: Row) => r.id;
 
 describe('useDataTable — state resolution', () => {
   it('echoes data, columns, getRowId', () => {
-    const { result } = renderHook(() =>
-      useDataTable({ data: rows, columns: cols, getRowId }),
-    );
+    const { result } = renderHook(() => useDataTable({ data: rows, columns: cols, getRowId }));
     expect(result.current.data).toBe(rows);
     expect(result.current.columns).toBe(cols);
     expect(result.current.getRowId).toBe(getRowId);
@@ -539,9 +534,7 @@ describe('useDataTable — state resolution', () => {
   });
 
   it('defaults enableRowSelection to false and hasExpansion to false', () => {
-    const { result } = renderHook(() =>
-      useDataTable({ data: rows, columns: cols, getRowId }),
-    );
+    const { result } = renderHook(() => useDataTable({ data: rows, columns: cols, getRowId }));
     expect(result.current.enableRowSelection).toBe(false);
     expect(result.current.hasExpansion).toBe(false);
   });
@@ -571,9 +564,7 @@ describe('useDataTable — state resolution', () => {
   });
 
   it('falls back to columns order when no default given', () => {
-    const { result } = renderHook(() =>
-      useDataTable({ data: rows, columns: cols, getRowId }),
-    );
+    const { result } = renderHook(() => useDataTable({ data: rows, columns: cols, getRowId }));
     expect(result.current.columnOrder).toEqual(['name', 'amount']);
   });
 
@@ -594,9 +585,7 @@ describe('useDataTable — state resolution', () => {
   });
 
   it('initialises all other state pieces with sensible defaults', () => {
-    const { result } = renderHook(() =>
-      useDataTable({ data: rows, columns: cols, getRowId }),
-    );
+    const { result } = renderHook(() => useDataTable({ data: rows, columns: cols, getRowId }));
     expect(result.current.columnSizing).toEqual({});
     expect(result.current.columnVisibility).toEqual({});
     expect(result.current.columnPinning).toEqual({ left: [], right: [] });
@@ -795,6 +784,7 @@ EOF
 Replace the stubs in `useDataTable` with memoized derivations.
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/DataTable/useDataTable.ts`
 - Modify: `packages/design-system/src/components/DataTable/useDataTable.test.ts`
 
@@ -913,82 +903,82 @@ Expected: the 6 new tests fail (stubs return empty).
 In `packages/design-system/src/components/DataTable/useDataTable.ts`, replace the section starting with `// Derived view-models and helper methods land in subsequent tasks.` through the end of the stubs (just before `const noop = () => {};`) with:
 
 ```ts
-  const DEFAULT_COL_WIDTH = 120;
+const DEFAULT_COL_WIDTH = 120;
 
-  const columnsById = useMemo(() => {
-    const m = new Map<string, (typeof columns)[number]>();
-    for (const c of columns) m.set(c.id, c);
-    return m;
-  }, [columns]);
+const columnsById = useMemo(() => {
+  const m = new Map<string, (typeof columns)[number]>();
+  for (const c of columns) m.set(c.id, c);
+  return m;
+}, [columns]);
 
-  // columnSizesPx: id → resolved width (sizing state > ColumnDef.size > default)
-  const columnSizesPx = useMemo<Record<string, number>>(() => {
-    const out: Record<string, number> = {};
-    for (const c of columns) {
-      out[c.id] = columnSizing[c.id] ?? c.size ?? DEFAULT_COL_WIDTH;
-    }
-    return out;
-  }, [columns, columnSizing]);
+// columnSizesPx: id → resolved width (sizing state > ColumnDef.size > default)
+const columnSizesPx = useMemo<Record<string, number>>(() => {
+  const out: Record<string, number> = {};
+  for (const c of columns) {
+    out[c.id] = columnSizing[c.id] ?? c.size ?? DEFAULT_COL_WIDTH;
+  }
+  return out;
+}, [columns, columnSizing]);
 
-  // visibleColumns: ordered (per columnOrder) and filtered (visibility !== false)
-  const visibleColumns = useMemo(() => {
-    const isVisible = (id: string) => columnVisibility[id] !== false;
-    const ordered: typeof columns = [];
-    for (const id of columnOrder) {
-      const col = columnsById.get(id);
-      if (col && isVisible(id)) ordered.push(col);
-    }
-    // Any column not in columnOrder (e.g. added after init) goes to the end.
-    for (const c of columns) {
-      if (!columnOrder.includes(c.id) && isVisible(c.id)) ordered.push(c);
-    }
-    return ordered;
-  }, [columns, columnsById, columnOrder, columnVisibility]);
+// visibleColumns: ordered (per columnOrder) and filtered (visibility !== false)
+const visibleColumns = useMemo(() => {
+  const isVisible = (id: string) => columnVisibility[id] !== false;
+  const ordered: typeof columns = [];
+  for (const id of columnOrder) {
+    const col = columnsById.get(id);
+    if (col && isVisible(id)) ordered.push(col);
+  }
+  // Any column not in columnOrder (e.g. added after init) goes to the end.
+  for (const c of columns) {
+    if (!columnOrder.includes(c.id) && isVisible(c.id)) ordered.push(c);
+  }
+  return ordered;
+}, [columns, columnsById, columnOrder, columnVisibility]);
 
-  // Pin grouping. Pinning order within a side is given by columnPinning.left/right.
-  const leftPinnedColumns = useMemo(
-    () =>
-      columnPinning.left
-        .map((id) => columnsById.get(id))
-        .filter((c): c is (typeof columns)[number] => !!c && columnVisibility[c.id] !== false),
-    [columnPinning.left, columnsById, columnVisibility],
-  );
+// Pin grouping. Pinning order within a side is given by columnPinning.left/right.
+const leftPinnedColumns = useMemo(
+  () =>
+    columnPinning.left
+      .map((id) => columnsById.get(id))
+      .filter((c): c is (typeof columns)[number] => !!c && columnVisibility[c.id] !== false),
+  [columnPinning.left, columnsById, columnVisibility],
+);
 
-  const rightPinnedColumns = useMemo(
-    () =>
-      columnPinning.right
-        .map((id) => columnsById.get(id))
-        .filter((c): c is (typeof columns)[number] => !!c && columnVisibility[c.id] !== false),
-    [columnPinning.right, columnsById, columnVisibility],
-  );
+const rightPinnedColumns = useMemo(
+  () =>
+    columnPinning.right
+      .map((id) => columnsById.get(id))
+      .filter((c): c is (typeof columns)[number] => !!c && columnVisibility[c.id] !== false),
+  [columnPinning.right, columnsById, columnVisibility],
+);
 
-  const unpinnedColumns = useMemo(() => {
-    const pinned = new Set([...columnPinning.left, ...columnPinning.right]);
-    return visibleColumns.filter((c) => !pinned.has(c.id));
-  }, [visibleColumns, columnPinning.left, columnPinning.right]);
+const unpinnedColumns = useMemo(() => {
+  const pinned = new Set([...columnPinning.left, ...columnPinning.right]);
+  return visibleColumns.filter((c) => !pinned.has(c.id));
+}, [visibleColumns, columnPinning.left, columnPinning.right]);
 
-  // Pin offsets — cumulative widths from the pinned edge inward.
-  const leftPinOffsets = useMemo<Record<string, number>>(() => {
-    const out: Record<string, number> = {};
-    let acc = 0;
-    for (const col of leftPinnedColumns) {
-      out[col.id] = acc;
-      acc += columnSizesPx[col.id] ?? DEFAULT_COL_WIDTH;
-    }
-    return out;
-  }, [leftPinnedColumns, columnSizesPx]);
+// Pin offsets — cumulative widths from the pinned edge inward.
+const leftPinOffsets = useMemo<Record<string, number>>(() => {
+  const out: Record<string, number> = {};
+  let acc = 0;
+  for (const col of leftPinnedColumns) {
+    out[col.id] = acc;
+    acc += columnSizesPx[col.id] ?? DEFAULT_COL_WIDTH;
+  }
+  return out;
+}, [leftPinnedColumns, columnSizesPx]);
 
-  const rightPinOffsets = useMemo<Record<string, number>>(() => {
-    const out: Record<string, number> = {};
-    let acc = 0;
-    // Rightmost pinned column has offset 0; walk right-to-left accumulating.
-    for (let i = rightPinnedColumns.length - 1; i >= 0; i--) {
-      const col = rightPinnedColumns[i]!;
-      out[col.id] = acc;
-      acc += columnSizesPx[col.id] ?? DEFAULT_COL_WIDTH;
-    }
-    return out;
-  }, [rightPinnedColumns, columnSizesPx]);
+const rightPinOffsets = useMemo<Record<string, number>>(() => {
+  const out: Record<string, number> = {};
+  let acc = 0;
+  // Rightmost pinned column has offset 0; walk right-to-left accumulating.
+  for (let i = rightPinnedColumns.length - 1; i >= 0; i--) {
+    const col = rightPinnedColumns[i]!;
+    out[col.id] = acc;
+    acc += columnSizesPx[col.id] ?? DEFAULT_COL_WIDTH;
+  }
+  return out;
+}, [rightPinnedColumns, columnSizesPx]);
 ```
 
 Then replace the corresponding stub fields in the returned object:
@@ -1033,6 +1023,7 @@ EOF
 Replace the helper-method stubs.
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/DataTable/useDataTable.ts`
 - Modify: `packages/design-system/src/components/DataTable/useDataTable.test.ts`
 
@@ -1229,96 +1220,96 @@ In `useDataTable.ts`, replace the helper stubs (the lines from `const noop = () 
 Add these `useCallback` definitions above the `return` statement (after the derived view-models):
 
 ```ts
-  const toggleRowSelection = useCallback(
-    (rowId: string) => {
-      setRowSelection((prev) => {
-        const next = { ...prev };
-        if (next[rowId]) delete next[rowId];
-        else next[rowId] = true;
-        return next;
-      });
-    },
-    [setRowSelection],
-  );
-
-  const toggleAllOnPage = useCallback(() => {
+const toggleRowSelection = useCallback(
+  (rowId: string) => {
     setRowSelection((prev) => {
-      const pageIds = data.map(getRowId);
-      const allSelected = pageIds.every((id) => prev[id]);
-      if (allSelected) {
-        const next = { ...prev };
-        for (const id of pageIds) delete next[id];
-        return next;
-      }
       const next = { ...prev };
-      for (const id of pageIds) next[id] = true;
+      if (next[rowId]) delete next[rowId];
+      else next[rowId] = true;
       return next;
     });
-  }, [data, getRowId, setRowSelection]);
+  },
+  [setRowSelection],
+);
 
-  const isAllOnPageSelected = useCallback(() => {
-    if (data.length === 0) return false;
-    return data.every((row) => rowSelection[getRowId(row)] === true);
-  }, [data, getRowId, rowSelection]);
-
-  const isSomeOnPageSelected = useCallback(() => {
-    if (data.length === 0) return false;
-    let some = false;
-    let all = true;
-    for (const row of data) {
-      if (rowSelection[getRowId(row)]) some = true;
-      else all = false;
+const toggleAllOnPage = useCallback(() => {
+  setRowSelection((prev) => {
+    const pageIds = data.map(getRowId);
+    const allSelected = pageIds.every((id) => prev[id]);
+    if (allSelected) {
+      const next = { ...prev };
+      for (const id of pageIds) delete next[id];
+      return next;
     }
-    return some && !all;
-  }, [data, getRowId, rowSelection]);
+    const next = { ...prev };
+    for (const id of pageIds) next[id] = true;
+    return next;
+  });
+}, [data, getRowId, setRowSelection]);
 
-  const toggleRowExpanded = useCallback(
-    (rowId: string) => {
-      setExpandedRows((prev) => {
-        const next = { ...prev };
-        if (next[rowId]) delete next[rowId];
-        else next[rowId] = true;
-        return next;
-      });
-    },
-    [setExpandedRows],
-  );
+const isAllOnPageSelected = useCallback(() => {
+  if (data.length === 0) return false;
+  return data.every((row) => rowSelection[getRowId(row)] === true);
+}, [data, getRowId, rowSelection]);
 
-  const toggleColumnVisibility = useCallback(
-    (columnId: string) => {
-      setColumnVisibility((prev) => ({
-        ...prev,
-        [columnId]: prev[columnId] === false ? true : false,
-      }));
-    },
-    [setColumnVisibility],
-  );
+const isSomeOnPageSelected = useCallback(() => {
+  if (data.length === 0) return false;
+  let some = false;
+  let all = true;
+  for (const row of data) {
+    if (rowSelection[getRowId(row)]) some = true;
+    else all = false;
+  }
+  return some && !all;
+}, [data, getRowId, rowSelection]);
 
-  const pinColumn = useCallback(
-    (columnId: string, side: 'left' | 'right' | false) => {
-      setColumnPinning((prev) => {
-        const left = prev.left.filter((id) => id !== columnId);
-        const right = prev.right.filter((id) => id !== columnId);
-        if (side === 'left') left.push(columnId);
-        else if (side === 'right') right.push(columnId);
-        return { left, right };
-      });
-    },
-    [setColumnPinning],
-  );
+const toggleRowExpanded = useCallback(
+  (rowId: string) => {
+    setExpandedRows((prev) => {
+      const next = { ...prev };
+      if (next[rowId]) delete next[rowId];
+      else next[rowId] = true;
+      return next;
+    });
+  },
+  [setExpandedRows],
+);
 
-  const toggleSort = useCallback(
-    (columnId: string) => {
-      setSort((prev) => {
-        if (!prev || prev.columnId !== columnId) {
-          return { columnId, direction: 'asc' };
-        }
-        if (prev.direction === 'asc') return { columnId, direction: 'desc' };
-        return null;
-      });
-    },
-    [setSort],
-  );
+const toggleColumnVisibility = useCallback(
+  (columnId: string) => {
+    setColumnVisibility((prev) => ({
+      ...prev,
+      [columnId]: prev[columnId] === false ? true : false,
+    }));
+  },
+  [setColumnVisibility],
+);
+
+const pinColumn = useCallback(
+  (columnId: string, side: 'left' | 'right' | false) => {
+    setColumnPinning((prev) => {
+      const left = prev.left.filter((id) => id !== columnId);
+      const right = prev.right.filter((id) => id !== columnId);
+      if (side === 'left') left.push(columnId);
+      else if (side === 'right') right.push(columnId);
+      return { left, right };
+    });
+  },
+  [setColumnPinning],
+);
+
+const toggleSort = useCallback(
+  (columnId: string) => {
+    setSort((prev) => {
+      if (!prev || prev.columnId !== columnId) {
+        return { columnId, direction: 'asc' };
+      }
+      if (prev.direction === 'asc') return { columnId, direction: 'desc' };
+      return null;
+    });
+  },
+  [setSort],
+);
 ```
 
 Also add `useCallback` to the imports at the top of the file:
@@ -1370,6 +1361,7 @@ EOF
 Pointer-based resize handle. Pure hook returning event handlers + drag state.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/DataTable/useResizeHandle.ts`
 - Test: `packages/design-system/src/components/DataTable/useResizeHandle.test.ts`
 
@@ -1628,6 +1620,7 @@ EOF
 The sortable header cell. Renders the label, sort indicator, hover-revealed drag grip (with `useSortable` from dnd-kit), and resize handle.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/DataTable/HeaderCell.tsx`
 - Create: `packages/design-system/src/components/DataTable/HeaderCell.module.scss`
 
@@ -1713,7 +1706,9 @@ Create `packages/design-system/src/components/DataTable/HeaderCell.module.scss`:
   width: 1px;
   height: 60%;
   background: transparent;
-  transition: background 0.1s ease, width 0.1s ease;
+  transition:
+    background 0.1s ease,
+    width 0.1s ease;
 }
 
 .resizeHandle:hover .resizeBar,
@@ -1764,11 +1759,7 @@ export interface HeaderCellProps<T> {
 export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
   const sortable = column.sortable === true;
   const sortDir: TableSortDirection | undefined =
-    instance.sort?.columnId === column.id
-      ? instance.sort.direction
-      : sortable
-      ? 'none'
-      : undefined;
+    instance.sort?.columnId === column.id ? instance.sort.direction : sortable ? 'none' : undefined;
 
   // dnd-kit sortable — column is its own sortable item.
   const reorderable = column.enableReorder !== false;
@@ -1808,9 +1799,7 @@ export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
   };
 
   const headerContent =
-    typeof column.header === 'function'
-      ? column.header({ column, instance })
-      : column.header;
+    typeof column.header === 'function' ? column.header({ column, instance }) : column.header;
 
   const dragStyle = {
     transform: CSS.Transform.toString(transform),
@@ -1896,6 +1885,7 @@ EOF
 Row renderer with the optional selection auto-cell, data cells, and row-click handler.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/DataTable/BodyRow.tsx`
 
 `BodyRow.tsx` uses styles from `DataTable.module.scss` (created in Task 11). For now it imports from a module that will exist.
@@ -1945,7 +1935,10 @@ export function BodyRow<T>({ row, instance }: BodyRowProps<T>) {
     if (e.key !== 'Enter') return;
     const target = e.target as HTMLElement;
     // Ignore Enter coming from an interactive child (it should drive that child).
-    if (target !== e.currentTarget && target.closest('button, input, a, [role="button"], [role="checkbox"]')) {
+    if (
+      target !== e.currentTarget &&
+      target.closest('button, input, a, [role="button"], [role="checkbox"]')
+    ) {
       return;
     }
     e.preventDefault();
@@ -1994,6 +1987,7 @@ Do not commit until `DataTable.module.scss` is in place. Stage this file but com
 Write the integration test file first (TDD), focusing on the rendering paths that exist in Phase 1.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/DataTable/DataTable.test.tsx`
 
 - [ ] **Step 1: Write the failing test file**
@@ -2099,9 +2093,7 @@ describe('<DataTable>', () => {
   it('toggleRowSelection toggles a row via per-row checkbox', async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
-    render(
-      <Harness enableRowSelection onRowSelectionChange={onChange} defaultRowSelection={{}} />,
-    );
+    render(<Harness enableRowSelection onRowSelectionChange={onChange} defaultRowSelection={{}} />);
     const rowCheckboxes = screen.getAllByRole('checkbox', { name: /select row/i });
     expect(rowCheckboxes).toHaveLength(2);
     await user.click(rowCheckboxes[0]!);
@@ -2111,9 +2103,7 @@ describe('<DataTable>', () => {
   it('header select-all checkbox toggles all rows on page', async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
-    render(
-      <Harness enableRowSelection onRowSelectionChange={onChange} defaultRowSelection={{}} />,
-    );
+    render(<Harness enableRowSelection onRowSelectionChange={onChange} defaultRowSelection={{}} />);
     const headerCheckbox = screen.getAllByRole('checkbox')[0]!;
     await user.click(headerCheckbox);
     expect(onChange).toHaveBeenCalledWith({ r1: true, r2: true });
@@ -2212,6 +2202,7 @@ Expected: fails — DataTable not implemented yet.
 Implement the orchestrator component and its styles. This is the largest single task in the plan.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/DataTable/DataTable.tsx`
 - Create: `packages/design-system/src/components/DataTable/DataTable.module.scss`
 
@@ -2253,12 +2244,7 @@ Create `packages/design-system/src/components/DataTable/DataTable.module.scss`:
 Create `packages/design-system/src/components/DataTable/DataTable.tsx`:
 
 ```tsx
-import {
-  forwardRef,
-  useMemo,
-  type ReactNode,
-  type Ref,
-} from 'react';
+import { forwardRef, useMemo, type ReactNode, type Ref } from 'react';
 import clsx from 'clsx';
 import {
   DndContext,
@@ -2509,6 +2495,7 @@ make test -- DataTable.test.tsx
 ```
 
 Expected: all tests in `DataTable.test.tsx` pass (~15 tests). Some specific tests may need tweaks:
+
 - If `aria-rowcount` doesn't appear when `rowCount` is undefined, that's fine (the spec uses `?` on the prop).
 - If `<Skeleton variant="text">` doesn't render with a `role`, the tbody-row-count check is the right shape.
 
@@ -2534,6 +2521,7 @@ EOF
 ## Task 12 — `ColumnVisibilityTrigger` companion
 
 **Files:**
+
 - Create: `packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx`
 - Create: `packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.module.scss`
 - Test: `packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.test.tsx`
@@ -2628,10 +2616,7 @@ import type { ReactNode } from 'react';
 import { Columns3 } from 'lucide-react';
 import { Button } from '../Button';
 import { DropdownMenu } from '../DropdownMenu';
-import type {
-  DropdownMenuAlign,
-  DropdownMenuSide,
-} from '../DropdownMenu';
+import type { DropdownMenuAlign, DropdownMenuSide } from '../DropdownMenu';
 import type { DataTableInstance } from './types';
 
 export interface ColumnVisibilityTriggerProps<T = unknown> {
@@ -2736,6 +2721,7 @@ EOF
 ## Task 13 — Public exports + library `index.ts`
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/DataTable/index.ts`
 - Modify: `packages/design-system/src/index.ts`
 
@@ -2820,6 +2806,7 @@ EOF
 ## Task 14 — Playground demo
 
 **Files:**
+
 - Create: `packages/playground/src/pages/components/DataTableDemo.tsx`
 
 - [ ] **Step 1: Write the demo**
@@ -2851,25 +2838,41 @@ type Deal = {
 };
 
 const deals: Deal[] = [
-  { id: 'd1', name: 'Acme renewal',     stage: 'Negotiation', amount: 12000, owner: 'Sara' },
-  { id: 'd2', name: 'Globex expansion', stage: 'Lead',         amount: 4500,  owner: 'Marcus' },
-  { id: 'd3', name: 'Initech onboarding', stage: 'Won',        amount: 8800,  owner: 'Sara' },
-  { id: 'd4', name: 'Hooli pilot',      stage: 'Lost',         amount: 0,     owner: 'Jin' },
+  { id: 'd1', name: 'Acme renewal', stage: 'Negotiation', amount: 12000, owner: 'Sara' },
+  { id: 'd2', name: 'Globex expansion', stage: 'Lead', amount: 4500, owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won', amount: 8800, owner: 'Sara' },
+  { id: 'd4', name: 'Hooli pilot', stage: 'Lost', amount: 0, owner: 'Jin' },
 ];
 
 const dealColumns: ColumnDef<Deal>[] = [
-  { id: 'name',   header: 'Deal',   cell: (r) => r.name, sortable: true, size: 200 },
-  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>, size: 140 },
-  { id: 'amount', header: 'Amount', cell: (r) => `$${r.amount.toLocaleString()}`, align: 'end', sortable: true, size: 120 },
-  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner, size: 120 },
+  { id: 'name', header: 'Deal', cell: (r) => r.name, sortable: true, size: 200 },
+  {
+    id: 'stage',
+    header: 'Stage',
+    cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,
+    size: 140,
+  },
+  {
+    id: 'amount',
+    header: 'Amount',
+    cell: (r) => `$${r.amount.toLocaleString()}`,
+    align: 'end',
+    sortable: true,
+    size: 120,
+  },
+  { id: 'owner', header: 'Owner', cell: (r) => r.owner, size: 120 },
 ];
 
 function stageTone(stage: Deal['stage']) {
   switch (stage) {
-    case 'Won': return 'success' as const;
-    case 'Lost': return 'danger' as const;
-    case 'Negotiation': return 'warning' as const;
-    default: return 'info' as const;
+    case 'Won':
+      return 'success' as const;
+    case 'Lost':
+      return 'danger' as const;
+    case 'Negotiation':
+      return 'warning' as const;
+    default:
+      return 'info' as const;
   }
 }
 
@@ -3073,6 +3076,7 @@ EOF
 Per playground `CLAUDE.md` Hard Rule 4.
 
 **Files:**
+
 - Modify: `packages/playground/src/App.tsx`
 - Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
 - Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
@@ -3083,10 +3087,13 @@ Per playground `CLAUDE.md` Hard Rule 4.
 In `packages/playground/src/App.tsx`:
 
 1. Add the import alongside the others:
+
 ```ts
 import { DataTableDemo } from './pages/components/DataTableDemo';
 ```
+
 2. Add the route inside `<Routes>` (alphabetical with siblings is fine):
+
 ```tsx
 <Route path="/components/datatable" element={<DataTableDemo />} />
 ```
@@ -3118,6 +3125,7 @@ make dev
 ```
 
 Open http://localhost:8080/components/datatable in a browser. Verify:
+
 - Header renders with the four columns (Deal, Stage, Amount, Owner)
 - Body shows the four deals
 - Hovering a header reveals the drag grip
@@ -3148,6 +3156,7 @@ EOF
 ## Task 16 — `AGENTS.md` TL;DR + final JSDoc audit
 
 **Files:**
+
 - Modify: `packages/design-system/AGENTS.md`
 - Verify (no edit unless missing): JSDoc on `<DataTable>`, `useDataTable`, `<ColumnVisibilityTrigger>` includes `@example`, `@remarks When NOT to use`, `@remarks Anti-patterns`.
 

--- a/docs/superpowers/specs/2026-05-22-datatable-design.md
+++ b/docs/superpowers/specs/2026-05-22-datatable-design.md
@@ -161,13 +161,13 @@ No `accessor` shortcut — `cell: (row) => row.foo` is one extra character and a
 ### State types
 
 ```ts
-export type ColumnOrderState = string[];                    // ordered ids (includes hidden)
-export type ColumnSizingState = Record<string, number>;     // id → width px
-export type ColumnVisibilityState = Record<string, boolean>;// id → visible (missing = visible)
+export type ColumnOrderState = string[]; // ordered ids (includes hidden)
+export type ColumnSizingState = Record<string, number>; // id → width px
+export type ColumnVisibilityState = Record<string, boolean>; // id → visible (missing = visible)
 export type ColumnPinningState = { left: string[]; right: string[] }; // ordered per side
 
-export type RowSelectionState = Record<string, boolean>;    // rowId → selected (missing = false)
-export type ExpandedRowsState = Record<string, boolean>;    // rowId → expanded
+export type RowSelectionState = Record<string, boolean>; // rowId → selected (missing = false)
+export type ExpandedRowsState = Record<string, boolean>; // rowId → expanded
 
 export interface SortState {
   columnId: string;
@@ -187,11 +187,11 @@ export interface UseDataTableOptions<T> {
   data: T[];
   pinnedRows?: T[];
   columns: ColumnDef<T>[];
-  getRowId: (row: T) => string;   // required
-  rowCount?: number;              // total server-side count (a11y metadata)
+  getRowId: (row: T) => string; // required
+  rowCount?: number; // total server-side count (a11y metadata)
 
   // Feature toggles
-  enableRowSelection?: boolean;   // default false — must opt in
+  enableRowSelection?: boolean; // default false — must opt in
   // expansion is implicitly enabled when renderExpandedRow is passed
 
   // Controlled / uncontrolled state (one trio per piece)
@@ -235,7 +235,7 @@ export interface DataTableInstance<T> {
   columns: ColumnDef<T>[];
   getRowId: (row: T) => string;
   enableRowSelection: boolean;
-  hasExpansion: boolean;          // true when renderExpandedRow was provided
+  hasExpansion: boolean; // true when renderExpandedRow was provided
   onRowClick?: UseDataTableOptions<T>['onRowClick'];
   renderExpandedRow?: UseDataTableOptions<T>['renderExpandedRow'];
 
@@ -249,12 +249,12 @@ export interface DataTableInstance<T> {
   sort: SortState | null;
 
   // Derived view-models (memoized)
-  visibleColumns: ColumnDef<T>[];        // filtered by visibility, sorted by order
+  visibleColumns: ColumnDef<T>[]; // filtered by visibility, sorted by order
   leftPinnedColumns: ColumnDef<T>[];
   rightPinnedColumns: ColumnDef<T>[];
   unpinnedColumns: ColumnDef<T>[];
   columnSizesPx: Record<string, number>; // id → resolved px width
-  leftPinOffsets: Record<string, number>;  // id → cumulative left px
+  leftPinOffsets: Record<string, number>; // id → cumulative left px
   rightPinOffsets: Record<string, number>; // id → cumulative right px
 
   // setState-style mutators (always route through onChange or internal setState)
@@ -268,9 +268,9 @@ export interface DataTableInstance<T> {
 
   // Higher-level helpers
   toggleRowSelection(rowId: string): void;
-  toggleAllOnPage(): void;            // toggles select-state of all rows in `data` (ignores pinnedRows)
+  toggleAllOnPage(): void; // toggles select-state of all rows in `data` (ignores pinnedRows)
   isAllOnPageSelected(): boolean;
-  isSomeOnPageSelected(): boolean;    // → indeterminate for header checkbox
+  isSomeOnPageSelected(): boolean; // → indeterminate for header checkbox
   toggleRowExpanded(rowId: string): void;
   toggleColumnVisibility(columnId: string): void;
   pinColumn(columnId: string, side: 'left' | 'right' | false): void;
@@ -285,19 +285,19 @@ export interface DataTableProps<T> {
   instance: DataTableInstance<T>;
 
   // Passthrough to underlying <Table>
-  density?: TableDensity;             // default 'comfortable'
+  density?: TableDensity; // default 'comfortable'
   striped?: boolean;
-  hover?: boolean;                    // default TRUE (DataTable rows are usually interactive)
+  hover?: boolean; // default TRUE (DataTable rows are usually interactive)
   bordered?: boolean;
 
   // State decorations
   loading?: boolean;
-  loadingRowCount?: number;           // default 10
-  emptyState?: ReactNode;             // default: a sensible <EmptyState>
+  loadingRowCount?: number; // default 10
+  emptyState?: ReactNode; // default: a sensible <EmptyState>
 
   // a11y
-  'aria-label'?: string;              // required when no <caption>
-  caption?: ReactNode;                // alternative — renders as <Table.Caption>
+  'aria-label'?: string; // required when no <caption>
+  caption?: ReactNode; // alternative — renders as <Table.Caption>
 
   // Passthrough
   className?: string;
@@ -309,8 +309,8 @@ export interface DataTableProps<T> {
 ```ts
 export interface ColumnVisibilityTriggerProps {
   instance: DataTableInstance<any>;
-  label?: ReactNode;                  // default "Columns"
-  icon?: ReactNode;                   // default Columns icon from lucide
+  label?: ReactNode; // default "Columns"
+  icon?: ReactNode; // default Columns icon from lucide
   side?: DropdownMenuSide;
   align?: DropdownMenuAlign;
 }
@@ -423,20 +423,20 @@ Expand chevron button lives in the auto-expand cell. Fires `instance.toggleRowEx
 
 ### Keyboard a11y matrix
 
-| Element | Key | Action |
-|---|---|---|
-| Header label (sortable) | Enter / Space | Toggle sort (cycles null → asc → desc) |
-| Header label | ← / → | Resize column −/+ 8px |
-| Header label | Shift+← / Shift+→ | Resize column −/+ 32px |
-| Drag grip | Tab to focus | Reveals grip (focus = hover equivalent) |
-| Drag grip | Space | Pick up column (dnd-kit `KeyboardSensor`) |
-| Drag grip (active) | ← / → | Move column |
-| Drag grip (active) | Space / Enter | Drop |
-| Drag grip (active) | Escape | Cancel reorder |
-| Selection checkbox (per-row) | Space | Toggle row selection |
-| Selection checkbox (header) | Space | Toggle all on page |
-| Expand chevron | Enter / Space | Toggle expansion |
-| Row (when `onRowClick` set) | Enter | Fire onRowClick |
+| Element                      | Key               | Action                                    |
+| ---------------------------- | ----------------- | ----------------------------------------- |
+| Header label (sortable)      | Enter / Space     | Toggle sort (cycles null → asc → desc)    |
+| Header label                 | ← / →             | Resize column −/+ 8px                     |
+| Header label                 | Shift+← / Shift+→ | Resize column −/+ 32px                    |
+| Drag grip                    | Tab to focus      | Reveals grip (focus = hover equivalent)   |
+| Drag grip                    | Space             | Pick up column (dnd-kit `KeyboardSensor`) |
+| Drag grip (active)           | ← / →             | Move column                               |
+| Drag grip (active)           | Space / Enter     | Drop                                      |
+| Drag grip (active)           | Escape            | Cancel reorder                            |
+| Selection checkbox (per-row) | Space             | Toggle row selection                      |
+| Selection checkbox (header)  | Space             | Toggle all on page                        |
+| Expand chevron               | Enter / Space     | Toggle expansion                          |
+| Row (when `onRowClick` set)  | Enter             | Fire onRowClick                           |
 
 dnd-kit's `KeyboardSensor` provides screen-reader announcements (`"Status column picked up at position 3 of 7"`) via a live region appended by `<DndContext>`.
 
@@ -457,9 +457,15 @@ No built-in UI in v1. Consumer wires using `instance.pinColumn(id, side)`. Recom
 <DropdownMenu>
   <DropdownMenu.Trigger>⋯</DropdownMenu.Trigger>
   <DropdownMenu.Content>
-    <DropdownMenu.Item onSelect={() => instance.pinColumn(column.id, 'left')}>Pin left</DropdownMenu.Item>
-    <DropdownMenu.Item onSelect={() => instance.pinColumn(column.id, 'right')}>Pin right</DropdownMenu.Item>
-    <DropdownMenu.Item onSelect={() => instance.pinColumn(column.id, false)}>Unpin</DropdownMenu.Item>
+    <DropdownMenu.Item onSelect={() => instance.pinColumn(column.id, 'left')}>
+      Pin left
+    </DropdownMenu.Item>
+    <DropdownMenu.Item onSelect={() => instance.pinColumn(column.id, 'right')}>
+      Pin right
+    </DropdownMenu.Item>
+    <DropdownMenu.Item onSelect={() => instance.pinColumn(column.id, false)}>
+      Unpin
+    </DropdownMenu.Item>
   </DropdownMenu.Content>
 </DropdownMenu>
 ```
@@ -484,6 +490,7 @@ SCSS structure inside the DataTable folder follows Rule 4 (no layout properties)
 Three phases, each its own PR shipping independently:
 
 **Phase 1 — Core + columns + selection** (largest):
+
 - `useDataTable` hook with state plumbing for column order / sizing / visibility / selection / sort. `columnPinning` and `expandedRows` state plumbing is included but their rendering effects (sticky CSS, chevron, detail row) are deferred to phases 2 and 3 respectively.
 - `<DataTable>` component (all rendering except column pinning, pinned rows, and expansion)
 - Column ordering via `@dnd-kit/sortable`, sizing via hand-rolled handle, visibility
@@ -495,6 +502,7 @@ Three phases, each its own PR shipping independently:
 - Sort interaction
 
 **Phase 2 — Column & row pinning:**
+
 - `columnPinning` state rendering: sticky CSS, offset math (`useColumnPinningOffsets`), edge shadow, z-index stacking
 - Cross-pin-boundary drag rejection at the drop-target level
 - Selection auto-column becomes sticky-left at this point (contributes to the offset stack)
@@ -503,6 +511,7 @@ Three phases, each its own PR shipping independently:
 - Tests + demo + AGENTS.md update
 
 **Phase 3 — Expandable rows:**
+
 - `renderExpandedRow` prop becomes operational
 - Expand auto-column (chevron button, 44px, fixed left position, sticky-left from this phase forward)
 - Detail row rendering (`colSpan` across all visible + auto columns)

--- a/docs/superpowers/specs/2026-05-22-datatable-design.md
+++ b/docs/superpowers/specs/2026-05-22-datatable-design.md
@@ -1,0 +1,559 @@
+# DataTable — design spec
+
+**Date:** 2026-05-22
+**Branch:** `feat/datatable`
+**Scope:** `<DataTable>` component + `useDataTable` hook + `<DataTable.ColumnVisibilityTrigger>` companion. Server-driven sort/search/pagination. Features: column ordering, sizing, visibility, pinning; row selection, row click, expandable rows, row pinning; sticky header.
+
+## Goal
+
+A composition over the existing `<Table>` primitive that owns the column-axis state machine (order, sizing, visibility, pinning) and row-axis state machine (selection, expansion). Consumer remains responsible for fetching data, paginating, and sorting via the server.
+
+The component is config-driven on the column axis (`columns: ColumnDef<T>[]`) because column-state features cannot work with JSX children — columns are an array, not a tree.
+
+## Why now
+
+- The CRM has several pages where a sortable, resizable, user-customizable table is the dominant UI. Each one rolling its own causes drift and bugs.
+- All the prerequisite primitives are in place: `<Table>`, `<DropdownMenu>` (with `CheckboxItem`), `<Popover>`, `<Checkbox>`, `<EmptyState>`, `<Skeleton>`, `<Pagination>`.
+- `@floating-ui/react-dom` already in the dep graph (used by `DropdownMenu` and `Popover`).
+
+## Non-goals (v1)
+
+- **No TanStack Table.** The project's `packages/design-system/CLAUDE.md` explicitly carves out TanStack as acceptable for this case ("behavioral hook, not a UI library"). User has overridden that policy for this build — own state machine instead.
+- **No multi-column sort.** Single-column only. Sort state shape kept extensible: `SortState | null` today, could become `SortState[]` later.
+- **No client-side sort / filter / search.** Server is the source of truth. DataTable emits change events; consumer fetches.
+- **No virtualized rendering.** Hundreds of rows per page is fine; 10k+ rows on one page will hit perf limits — defer to a future phase using `react-window` or equivalent.
+- **No cell editing, no cell selection.** Display only.
+- **No column groups / multi-level headers.** Single header row.
+- **No drag-to-reorder rows, no drag-to-pin rows.** Programmatic only via consumer-provided UI.
+- **No export-to-CSV / clipboard.** Not a DataTable concern.
+- **No persistence helpers** (localStorage / URL state). Consumer wires using controlled-state callbacks.
+- **No built-in pagination UI.** Existing `<Pagination>` composes outside DataTable. Same for bulk-action toolbar.
+- **No built-in column-pin UI in v1.** Consumer wires using `instance.pinColumn(id, side)`. Recommended recipe documented in JSDoc.
+
+## Architecture
+
+### Dependencies
+
+Three new packages (all behavioral, no UI):
+
+- `@dnd-kit/core` (~10KB) — DnD primitives + `KeyboardSensor` (a11y) + `<DragOverlay>`
+- `@dnd-kit/sortable` (~5KB) — `useSortable`, `SortableContext`, `horizontalListSortingStrategy`
+- `@dnd-kit/utilities` (~1KB) — `CSS.Transform.toString` helper
+
+Total ~16KB gzipped added. Justified by the same rationale as `@floating-ui/react-dom`: behavioral hook, not a UI library. Hand-rolling DnD with keyboard a11y + screen-reader announcements + autoscroll would cost ~500 LoC of well-tested-elsewhere logic.
+
+### File layout
+
+```
+packages/design-system/src/components/DataTable/
+  DataTable.tsx                       ← <DataTable> component
+  DataTable.module.scss
+  DataTable.test.tsx
+  useDataTable.ts                     ← hook (state machine)
+  useDataTable.test.ts                ← pure-logic unit tests
+  ColumnVisibilityTrigger.tsx
+  ColumnVisibilityTrigger.module.scss
+  ColumnVisibilityTrigger.test.tsx
+  types.ts                            ← ColumnDef<T>, state types, instance type
+  _internal/
+    HeaderCell.tsx                    ← sortable header cell (drag handle, resize, sort)
+    HeaderCell.module.scss
+    BodyRow.tsx                       ← row renderer (select cell, expand cell, data cells)
+    PinnedRowsSection.tsx             ← separate <tbody> for pinned rows
+    DragOverlay.tsx                   ← drop indicator portal during column drag
+    useColumnPinningOffsets.ts        ← pure: column widths → sticky left/right offsets
+    useResizeHandle.ts                ← pointer-based resize handle hook
+  index.ts                            ← public re-exports
+```
+
+### Exports (added to `src/index.ts`)
+
+```ts
+export { DataTable, useDataTable } from './components/DataTable';
+export type {
+  DataTableProps,
+  DataTableInstance,
+  UseDataTableOptions,
+  ColumnDef,
+  ColumnAlign,
+  ColumnOrderState,
+  ColumnSizingState,
+  ColumnVisibilityState,
+  ColumnPinningState,
+  ExpandedRowsState,
+  RowSelectionState,
+  SortState,
+  HeaderContext,
+  CellContext,
+} from './components/DataTable';
+```
+
+### Composition
+
+- `<Table>` compound for table markup (uses its `scroll`, `stickyHeader`, `hover`, `density`, `striped`, `bordered` modifiers)
+- `<DropdownMenu>` + `<DropdownMenu.CheckboxItem>` for column visibility menu
+- `<Checkbox>` for selection cells (indeterminate via existing prop)
+- `<EmptyState>` for empty-data state
+- `<Skeleton variant="text">` for loading rows
+- `<Pagination>` is **not** composed — consumer renders it outside
+
+## Public API
+
+### `ColumnDef<T>`
+
+```ts
+export type ColumnAlign = 'start' | 'center' | 'end';
+
+export interface HeaderContext<T = unknown> {
+  column: ColumnDef<T>;
+  instance: DataTableInstance<T>;
+}
+
+export interface CellContext<T> {
+  row: T;
+  rowId: string;
+  column: ColumnDef<T>;
+  instance: DataTableInstance<T>;
+}
+
+export interface ColumnDef<T> {
+  /** Stable id — keys all per-column state (order, size, visibility, pin). */
+  id: string;
+
+  /** Header content. String, ReactNode, or render-prop. */
+  header: ReactNode | ((ctx: HeaderContext<T>) => ReactNode);
+
+  /** Cell content for a row. */
+  cell: (row: T, ctx: CellContext<T>) => ReactNode;
+
+  /** Cell text alignment. Defaults to 'start'. */
+  align?: ColumnAlign;
+
+  /** Default width in px. Defaults to 120. */
+  size?: number;
+  /** Min width during resize (px). Defaults to 40. */
+  minSize?: number;
+  /** Max width during resize (px). Defaults to undefined (no max). */
+  maxSize?: number;
+
+  /** Per-column opt-outs (all default true). */
+  enableReorder?: boolean;
+  enableResize?: boolean;
+  enableHide?: boolean;
+  enablePin?: boolean;
+
+  /**
+   * Mark column as server-sortable. When true, header is clickable and
+   * keyboard-actionable, and toggling fires onSortChange. DataTable
+   * never performs client-side sorting.
+   */
+  sortable?: boolean;
+
+  /** Label for the column visibility menu. Falls back to `header` if string. */
+  visibilityLabel?: string;
+}
+```
+
+No `accessor` shortcut — `cell: (row) => row.foo` is one extra character and avoids `keyof T` complexity. Wait until a consumer asks.
+
+`getRowId` lives on `UseDataTableOptions<T>` (the hook), not on `DataTableProps` or `ColumnDef`. It's required — no implicit `row.id` fallback. Keeps the row type unconstrained.
+
+### State types
+
+```ts
+export type ColumnOrderState = string[];                    // ordered ids (includes hidden)
+export type ColumnSizingState = Record<string, number>;     // id → width px
+export type ColumnVisibilityState = Record<string, boolean>;// id → visible (missing = visible)
+export type ColumnPinningState = { left: string[]; right: string[] }; // ordered per side
+
+export type RowSelectionState = Record<string, boolean>;    // rowId → selected (missing = false)
+export type ExpandedRowsState = Record<string, boolean>;    // rowId → expanded
+
+export interface SortState {
+  columnId: string;
+  direction: 'asc' | 'desc';
+}
+```
+
+`SortState | null` for the sort prop — `null` = unsorted.
+
+### `useDataTable<T>(options)`
+
+```ts
+export type Updater<S> = S | ((prev: S) => S);
+
+export interface UseDataTableOptions<T> {
+  // Pure data
+  data: T[];
+  pinnedRows?: T[];
+  columns: ColumnDef<T>[];
+  getRowId: (row: T) => string;   // required
+  rowCount?: number;              // total server-side count (a11y metadata)
+
+  // Feature toggles
+  enableRowSelection?: boolean;   // default false — must opt in
+  // expansion is implicitly enabled when renderExpandedRow is passed
+
+  // Controlled / uncontrolled state (one trio per piece)
+  columnOrder?: ColumnOrderState;
+  defaultColumnOrder?: ColumnOrderState;
+  onColumnOrderChange?: (next: ColumnOrderState) => void;
+
+  columnSizing?: ColumnSizingState;
+  defaultColumnSizing?: ColumnSizingState;
+  onColumnSizingChange?: (next: ColumnSizingState) => void;
+
+  columnVisibility?: ColumnVisibilityState;
+  defaultColumnVisibility?: ColumnVisibilityState;
+  onColumnVisibilityChange?: (next: ColumnVisibilityState) => void;
+
+  columnPinning?: ColumnPinningState;
+  defaultColumnPinning?: ColumnPinningState;
+  onColumnPinningChange?: (next: ColumnPinningState) => void;
+
+  rowSelection?: RowSelectionState;
+  defaultRowSelection?: RowSelectionState;
+  onRowSelectionChange?: (next: RowSelectionState) => void;
+
+  expandedRows?: ExpandedRowsState;
+  defaultExpandedRows?: ExpandedRowsState;
+  onExpandedRowsChange?: (next: ExpandedRowsState) => void;
+
+  sort?: SortState | null;
+  defaultSort?: SortState | null;
+  onSortChange?: (next: SortState | null) => void;
+
+  // Interactivity
+  onRowClick?: (row: T, event: React.MouseEvent<HTMLTableRowElement>) => void;
+  renderExpandedRow?: (row: T) => ReactNode;
+}
+
+export interface DataTableInstance<T> {
+  // Echoed inputs
+  data: T[];
+  pinnedRows: T[];
+  columns: ColumnDef<T>[];
+  getRowId: (row: T) => string;
+  enableRowSelection: boolean;
+  hasExpansion: boolean;          // true when renderExpandedRow was provided
+  onRowClick?: UseDataTableOptions<T>['onRowClick'];
+  renderExpandedRow?: UseDataTableOptions<T>['renderExpandedRow'];
+
+  // Resolved current state
+  columnOrder: ColumnOrderState;
+  columnSizing: ColumnSizingState;
+  columnVisibility: ColumnVisibilityState;
+  columnPinning: ColumnPinningState;
+  rowSelection: RowSelectionState;
+  expandedRows: ExpandedRowsState;
+  sort: SortState | null;
+
+  // Derived view-models (memoized)
+  visibleColumns: ColumnDef<T>[];        // filtered by visibility, sorted by order
+  leftPinnedColumns: ColumnDef<T>[];
+  rightPinnedColumns: ColumnDef<T>[];
+  unpinnedColumns: ColumnDef<T>[];
+  columnSizesPx: Record<string, number>; // id → resolved px width
+  leftPinOffsets: Record<string, number>;  // id → cumulative left px
+  rightPinOffsets: Record<string, number>; // id → cumulative right px
+
+  // setState-style mutators (always route through onChange or internal setState)
+  setColumnOrder(updater: Updater<ColumnOrderState>): void;
+  setColumnSizing(updater: Updater<ColumnSizingState>): void;
+  setColumnVisibility(updater: Updater<ColumnVisibilityState>): void;
+  setColumnPinning(updater: Updater<ColumnPinningState>): void;
+  setRowSelection(updater: Updater<RowSelectionState>): void;
+  setExpandedRows(updater: Updater<ExpandedRowsState>): void;
+  setSort(updater: Updater<SortState | null>): void;
+
+  // Higher-level helpers
+  toggleRowSelection(rowId: string): void;
+  toggleAllOnPage(): void;            // toggles select-state of all rows in `data` (ignores pinnedRows)
+  isAllOnPageSelected(): boolean;
+  isSomeOnPageSelected(): boolean;    // → indeterminate for header checkbox
+  toggleRowExpanded(rowId: string): void;
+  toggleColumnVisibility(columnId: string): void;
+  pinColumn(columnId: string, side: 'left' | 'right' | false): void;
+  toggleSort(columnId: string): void; // cycles: null → asc → desc → null
+}
+```
+
+### `<DataTable>` component
+
+```ts
+export interface DataTableProps<T> {
+  instance: DataTableInstance<T>;
+
+  // Passthrough to underlying <Table>
+  density?: TableDensity;             // default 'comfortable'
+  striped?: boolean;
+  hover?: boolean;                    // default TRUE (DataTable rows are usually interactive)
+  bordered?: boolean;
+
+  // State decorations
+  loading?: boolean;
+  loadingRowCount?: number;           // default 10
+  emptyState?: ReactNode;             // default: a sensible <EmptyState>
+
+  // a11y
+  'aria-label'?: string;              // required when no <caption>
+  caption?: ReactNode;                // alternative — renders as <Table.Caption>
+
+  // Passthrough
+  className?: string;
+}
+```
+
+### `<DataTable.ColumnVisibilityTrigger>`
+
+```ts
+export interface ColumnVisibilityTriggerProps {
+  instance: DataTableInstance<any>;
+  label?: ReactNode;                  // default "Columns"
+  icon?: ReactNode;                   // default Columns icon from lucide
+  side?: DropdownMenuSide;
+  align?: DropdownMenuAlign;
+}
+```
+
+Renders `<Button variant="ghost">` → `<DropdownMenu>` with one `<DropdownMenu.CheckboxItem>` per column where `enableHide !== false`. Toggling fires `instance.toggleColumnVisibility(id)`.
+
+**Last-visible-column guard**: the checkbox item for the currently-only-visible-hidable column is rendered with `disabled` to prevent hiding every data column. Columns with `enableHide: false` (always visible by config) are not counted in this guard and are absent from the menu.
+
+## Rendering pipeline
+
+### DOM structure
+
+```
+<Table scroll stickyHeader hover>
+  <colgroup>
+    [<col width=44 />]    ← auto: select column (if enableRowSelection)
+    [<col width=44 />]    ← auto: expand column (if hasExpansion)
+    <col width={size} />  ← per visible data column, in resolved order
+    ...
+  </colgroup>
+
+  <Table.Header>
+    <Table.Row>
+      [select-all header cell]  ← <Checkbox> with indeterminate
+      [expand header cell]      ← empty, fixed width
+      [<HeaderCell column={c} /> per visible column, in resolved order]
+    </Table.Row>
+  </Table.Header>
+
+  [<Table.Body className={styles.pinnedRowsTbody}>  ← only when pinnedRows.length > 0
+    [<BodyRow row={r} pinned /> per pinned row]
+  </Table.Body>]
+
+  <Table.Body className={styles.mainTbody}>
+    {loading
+      ? skeletonRows
+      : isEmpty
+      ? emptyRow
+      : data.flatMap(row => [
+          <BodyRow row={row} />,
+          row is expanded && <ExpandedDetailRow row={row} />,
+        ])}
+  </Table.Body>
+</Table>
+```
+
+### Auto-prepended leading cells
+
+- **Selection cell**: appears iff `enableRowSelection === true`. 44px fixed width. Always at the leftmost position (before any left-pinned data column). Locked: not in `columnOrder`, not reorderable / resizable / hidable / pinnable. From Phase 2 onward, auto-left-pinned (contributes to left-pin offset stack); in Phase 1 it just sits at the left without sticky positioning.
+- **Expand cell**: appears iff `renderExpandedRow` is provided. 44px fixed width. Same locking rules and sticky behavior as the selection cell. Always rendered to the right of the selection cell, to the left of all data columns. Introduced in Phase 3 along with the rest of the expansion feature.
+
+Mental model: `[ table-affordances ][ left-pinned data ][ scrollable data ][ right-pinned data ]`.
+
+### Column pinning
+
+CSS `position: sticky` with computed `left` or `right` offsets. Offsets computed in `useColumnPinningOffsets.ts` from current `columnSizesPx`.
+
+Edge shadow is **always-on**, not scroll-aware (4px shadow on inside edge of pinned section). Scroll-aware shadows would require per-column `IntersectionObserver` and add complexity for marginal UX win.
+
+**Z-index stacking** at the sticky-header / pinned-column intersection: pinned-column body cells `z-index: 1` (above unpinned body), sticky header `z-index: 2` (above body), pinned-column header cells `z-index: 3` (top-left/top-right corners win over everything). Pinned-rows section sits above main `<tbody>` in DOM order but its cells get `z-index: 1` to stay above unpinned scrolling content.
+
+Cross-pin-boundary drag drops are **rejected** (drop target invalidated). Consumer can override via `instance.pinColumn(id, side)` after a drop if a different policy is wanted.
+
+### Pinned rows
+
+Separate `<Table.Body>` rendered before the main body. No vertical-sticky positioning (rendering above the body is sufficient given the "always-visible across pagination/sort" semantics). Each pinned row respects column pinning + sizing exactly like main rows. Subtle background tint via `--color-bg-row-pinned`.
+
+`toggleAllOnPage` does **not** affect pinned rows — they're conceptually a different "page" (their own server query). Pinned-row selection toggles per-row via the row checkbox.
+
+**Duplicate row handling**: if a row appears in both `data` and `pinnedRows` (same `getRowId` value), it renders in **both** places — once in the pinned section, once in its natural place in the main body. To dedupe, consumer filters `data` to exclude pinned ids before passing. DataTable does not auto-dedupe because the "starred row also visible inline" UX is sometimes desired.
+
+### Expanded row
+
+When `expandedRows[rowId]` is true, render an extra `<Table.Row>` immediately after the data row, with a single `<Table.Cell colSpan={totalColumnsIncludingAuto}>` containing `renderExpandedRow(row)`.
+
+Expand chevron button lives in the auto-expand cell. Fires `instance.toggleRowExpanded(rowId)`. Sets `aria-expanded` on chevron; sets `aria-controls={detailRowId}` linking chevron to the detail row.
+
+### Empty + loading states
+
+- **Loading** (`loading: true`): render `loadingRowCount` (default 10) skeleton rows. Each data cell wraps a `<Skeleton variant="text">`. Header renders normally. Pinned rows render normally (they're separate data — consumer holds them back if not ready).
+- **Empty** (`!loading && data.length === 0 && pinnedRows.length === 0`): render one `<Table.Row><Table.Cell colSpan={...}>` containing the `emptyState` prop, or a default `<EmptyState title="No data" />`.
+
+## Interactions & a11y
+
+### Header cell anatomy (hover-revealed grip)
+
+- **Default state**: label + sort indicator only. Clean.
+- **Hover/focus state**: grip icon (⋮⋮) fades in on the left. Cursor over grip = `grab`.
+- **Click on label area**: toggles sort (when `sortable: true`). Cycles `null → asc → desc → null`.
+- **Resize handle**: 6px-wide pointer hit zone on the right edge. Hover shows a 2px accent-color bar. `pointerdown` + drag adjusts width clamped to `[minSize, maxSize]`.
+
+### Drag-to-reorder (using `@dnd-kit/sortable`)
+
+- **Sensors**: `PointerSensor` with `activationConstraint: { distance: 6 }` + `KeyboardSensor` from `@dnd-kit/sortable/sortable-keyboard-coordinates`. The 6px distance is a tolerance against misreading a grip click as a drag — drag listeners are attached **only** to the grip element, not the header label, so label clicks (sort) never compete with drag activation.
+- **Strategy**: `horizontalListSortingStrategy` — adjacent columns animate to their new positions in real time as the drag moves.
+- **Hidden columns during reorder**: `columnOrder` contains all column ids (visible + hidden). dnd-kit only sees visible columns. When a reorder happens, the new visible-only order is spliced back into `columnOrder` by replacing the visible-column slots one-by-one in place. Hidden columns retain their absolute positions in `columnOrder`.
+- **Drag overlay**: portal-mounted semi-transparent copy of the dragged header via `<DragOverlay>`. Receives `cursor: grabbing` + a subtle elevation shadow.
+- **Autoscroll during drag**: dnd-kit's built-in modifier.
+- **Cross-pin-boundary drops**: rejected. Dragging a left-pinned column over an unpinned column → drop is canceled; column returns to origin. Dragging an unpinned column into the left-pinned region → same.
+- **Non-reorderable columns** (`enableReorder: false`): no `useSortable` attached. Cannot be dragged. Other columns cannot be dragged past them — they're fixed positions in the order.
+
+### Resize handle (hand-rolled, ~80 LoC)
+
+- `pointerdown` → capture pointer, record initial X + initial width.
+- `pointermove` → update `columnSizing` via `instance.setColumnSizing(prev => ({ ...prev, [id]: clamp(initial + delta, minSize, maxSize) }))`.
+- `pointerup` / `pointercancel` → release capture.
+- Keyboard alternative: focused header `←` / `→` resize by 8px; Shift+`←` / Shift+`→` by 32px.
+- Resizing a pinned column re-flows the pin offsets in the same render.
+
+### Keyboard a11y matrix
+
+| Element | Key | Action |
+|---|---|---|
+| Header label (sortable) | Enter / Space | Toggle sort (cycles null → asc → desc) |
+| Header label | ← / → | Resize column −/+ 8px |
+| Header label | Shift+← / Shift+→ | Resize column −/+ 32px |
+| Drag grip | Tab to focus | Reveals grip (focus = hover equivalent) |
+| Drag grip | Space | Pick up column (dnd-kit `KeyboardSensor`) |
+| Drag grip (active) | ← / → | Move column |
+| Drag grip (active) | Space / Enter | Drop |
+| Drag grip (active) | Escape | Cancel reorder |
+| Selection checkbox (per-row) | Space | Toggle row selection |
+| Selection checkbox (header) | Space | Toggle all on page |
+| Expand chevron | Enter / Space | Toggle expansion |
+| Row (when `onRowClick` set) | Enter | Fire onRowClick |
+
+dnd-kit's `KeyboardSensor` provides screen-reader announcements (`"Status column picked up at position 3 of 7"`) via a live region appended by `<DndContext>`.
+
+### ARIA
+
+- `<table>` gets `aria-rowcount={rowCount}` when provided (helps screen readers when paginated).
+- Sortable headers get `aria-sort` via the existing `Table.HeaderCell` `sortDirection` prop.
+- Expand chevron gets `aria-expanded` + `aria-controls={detailRowId}`.
+- Selection checkbox gets `aria-label` referencing the row (consumer-provided via the row data or fallback to "Select row N").
+- Pinned section gets `aria-label="Pinned rows"`.
+
+### Pin/unpin UX
+
+No built-in UI in v1. Consumer wires using `instance.pinColumn(id, side)`. Recommended recipe documented in JSDoc:
+
+```tsx
+// In the header cell or a row action menu:
+<DropdownMenu>
+  <DropdownMenu.Trigger>⋯</DropdownMenu.Trigger>
+  <DropdownMenu.Content>
+    <DropdownMenu.Item onSelect={() => instance.pinColumn(column.id, 'left')}>Pin left</DropdownMenu.Item>
+    <DropdownMenu.Item onSelect={() => instance.pinColumn(column.id, 'right')}>Pin right</DropdownMenu.Item>
+    <DropdownMenu.Item onSelect={() => instance.pinColumn(column.id, false)}>Unpin</DropdownMenu.Item>
+  </DropdownMenu.Content>
+</DropdownMenu>
+```
+
+## Tokens & styling
+
+Likely new tokens (added to `src/styles/tokens.scss` per Rule 3):
+
+- `--color-bg-row-pinned` — subtle tint for the pinned rows section background
+- `--shadow-table-pinned-edge` — soft shadow on the inside edge of sticky columns (e.g. `0 0 8px -2px rgba(0,0,0,0.15)`)
+
+Reused (no new tokens needed):
+
+- `--color-fg-muted` — drag grip icon color
+- `--color-accent` — resize handle hover bar
+- Existing radii / spacing / typography tokens
+
+SCSS structure inside the DataTable folder follows Rule 4 (no layout properties): widths via `<col>` style attribute (column-level), no `margin` / `position`-absolute / `flex: 1` etc. in `.module.scss`.
+
+## Phasing
+
+Three phases, each its own PR shipping independently:
+
+**Phase 1 — Core + columns + selection** (largest):
+- `useDataTable` hook with state plumbing for column order / sizing / visibility / selection / sort. `columnPinning` and `expandedRows` state plumbing is included but their rendering effects (sticky CSS, chevron, detail row) are deferred to phases 2 and 3 respectively.
+- `<DataTable>` component (all rendering except column pinning, pinned rows, and expansion)
+- Column ordering via `@dnd-kit/sortable`, sizing via hand-rolled handle, visibility
+- `<DataTable.ColumnVisibilityTrigger>` companion
+- Selection (checkbox column at the leftmost position; select-all with indeterminate)
+- Row click handler
+- Sticky header default-on
+- Loading + empty states
+- Sort interaction
+
+**Phase 2 — Column & row pinning:**
+- `columnPinning` state rendering: sticky CSS, offset math (`useColumnPinningOffsets`), edge shadow, z-index stacking
+- Cross-pin-boundary drag rejection at the drop-target level
+- Selection auto-column becomes sticky-left at this point (contributes to the offset stack)
+- `pinnedRows` prop rendering (separate `<tbody>` above main)
+- New tokens: `--color-bg-row-pinned`, `--shadow-table-pinned-edge`
+- Tests + demo + AGENTS.md update
+
+**Phase 3 — Expandable rows:**
+- `renderExpandedRow` prop becomes operational
+- Expand auto-column (chevron button, 44px, fixed left position, sticky-left from this phase forward)
+- Detail row rendering (`colSpan` across all visible + auto columns)
+- `aria-expanded`, `aria-controls` wiring
+- Tests + demo + AGENTS.md update
+
+## Testing strategy
+
+### `useDataTable.test.ts` (pure logic, no DOM)
+
+- Controlled/uncontrolled resolution per state piece (controlled wins; uncontrolled uses default + internal)
+- Mutations: each `set*` and helper method round-trips through `onChange` correctly
+- Derived view models: `visibleColumns`, `leftPinnedColumns` / `rightPinnedColumns` / `unpinnedColumns`, `columnSizesPx`, `leftPinOffsets` / `rightPinOffsets` (offset math edge cases)
+- Sort cycling: `null → asc → desc → null`
+- Selection helpers: `toggleAllOnPage` excludes `pinnedRows`; `isSomeOnPageSelected` indeterminate
+- Reorder rejects cross-pin-boundary moves at the hook level
+
+### `DataTable.test.tsx` (integration via React Testing Library)
+
+- Renders without crashing with default props
+- Controlled state round-trip (consumer state reflects mutations)
+- Header sort click fires `onSortChange` with correct direction
+- Selection: per-row checkbox toggles; header checkbox indeterminate when partial
+- Expansion: chevron toggles, detail row renders with correct `colSpan`, `aria-expanded` set
+- Pinned columns: sticky CSS class + correct `left`/`right` style per offset
+- Pinned rows: separate `<tbody>` renders above main body when `pinnedRows.length > 0`
+- Loading: `loadingRowCount` skeleton rows render
+- Empty: `<EmptyState>` renders when `data` + `pinnedRows` both empty
+- Hidden columns: cells don't render
+- Ref forwarding to underlying `<table>`
+- `className` merged (Rule 7)
+- ARIA: `aria-rowcount`, `aria-sort`, `aria-expanded`, `aria-controls`, `aria-label="Pinned rows"`
+
+### `ColumnVisibilityTrigger.test.tsx`
+
+- Renders one `<DropdownMenu.CheckboxItem>` per column with `enableHide !== false`
+- Toggle fires `onColumnVisibilityChange` with correct payload
+- Columns with `enableHide: false` are absent from the menu
+
+### Gap: drag-and-drop reorder is not unit-tested
+
+dnd-kit's pointer-based DnD is genuinely hard to test in JSDOM. The playground demo serves as the smoke test. A future Playwright e2e test is the recommended remediation if reorder regresses in practice. This gap is documented in a comment at the top of `DataTable.test.tsx`.
+
+## Hard-rule compliance checklist
+
+The "component is complete" criteria from root `CLAUDE.md`:
+
+1. `DataTable.test.tsx`, `useDataTable.test.ts`, `ColumnVisibilityTrigger.test.tsx` colocated with their source.
+2. `DataTableDemo.tsx` added to `packages/playground/src/pages/demo/` showing every feature: columns, ordering, sizing, visibility menu, pinning (col + row), selection, click, expansion, sort, loading, empty.
+3. Demo wired into `App.tsx` (route), `AppShell.tsx` (sidebar), `DemoIndex.tsx` (tile).
+4. `DataTable`, `useDataTable`, `ColumnVisibilityTrigger` re-exported from `packages/design-system/src/index.ts`.
+5. "When NOT to use / anti-patterns" prose in JSDoc `@remarks` blocks for each public component / hook. One-section TL;DR in `packages/design-system/AGENTS.md`.
+
+The phasing above splits these across three PRs — each PR satisfies the hard rules for its slice (its own tests, demo updates, JSDoc, AGENTS.md additions).

--- a/package-lock.json
+++ b/package-lock.json
@@ -643,6 +643,59 @@
         "postcss-selector-parser": "^7.0.0"
       }
     },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@dual-bundle/import-meta-resolve": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
@@ -5114,7 +5167,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/typescript": {
@@ -5523,6 +5575,9 @@
       "version": "0.0.0",
       "license": "UNLICENSED",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@floating-ui/react-dom": "^2.1.8",
         "clsx": "^2.1.1"
       },

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -575,6 +575,40 @@ const [tab, setTab] = useState('overview');
 - The native HTML `align` attribute on `<th>` / `<td>` is shadowed by the component-level `align` prop (logical) — `Omit<…, 'align'>` on both `*Props`.
 - **Use `<DataTable>` instead** when you need sorting / filtering / pagination state. Table is the paint primitive; DataTable will be the opinionated wrapper.
 
+### `<DataTable>` — server-driven data table with column features
+
+```tsx
+const instance = useDataTable<Deal>({
+  data,
+  columns,
+  getRowId: (r) => r.id,
+  enableRowSelection: true,
+  sort,
+  onSortChange: setSort,
+});
+
+<Cluster>
+  <ColumnVisibilityTrigger instance={instance} />
+</Cluster>
+<DataTable instance={instance} aria-label="Deals" />
+```
+
+- Config-driven via `columns: ColumnDef<T>[]`. Each column has a stable `id` used as the key for all per-column state.
+- All state pieces (column order/sizing/visibility/pinning, row selection/expansion, sort) follow the Radix controlled/uncontrolled pattern: `value` + `onValueChange`, OR `defaultValue` only, OR neither.
+- Server-driven sort/search/pagination. DataTable does NOT transform data — `data` must be the server's pre-sorted, pre-paginated slice. `onSortChange` is your trigger to refetch.
+- `enableRowSelection: true` adds a leading checkbox column with select-all (indeterminate when partial). `toggleAllOnPage` ignores `pinnedRows`.
+- Drag-to-reorder is keyboard-accessible (Tab to grip → Space to pick up → ←/→ to move → Space/Enter to drop → Esc to cancel). The grip is hover-revealed on desktop.
+- Resize via the right-edge handle. Keyboard: focused header label, `←`/`→` for −/+8px; Shift+`←`/`→` for ±32px.
+- `ColumnVisibilityTrigger` is the only built-in companion. For column pinning UI (Phase 2 ships state, no built-in UI), wire your own using `instance.pinColumn(id, side)`.
+- **Phase 1 only**: column pinning is plumbed (`columnPinning` state + `pinColumn` helper) but the sticky CSS does NOT render yet — it lands in Phase 2 along with `pinnedRows` rendering. Expandable rows (`renderExpandedRow`) lands in Phase 3. The state plumbing is forward-compatible — code you write now keeps working when those phases ship.
+
+**Anti-patterns:**
+
+- ❌ Mutating `columns` array identity on every render. `useDataTable` captures `defaultColumnOrder` from `columns` once at mount — later identity changes don't trigger a re-derive of the default order. Use a stable reference (`useMemo` or module-level).
+- ❌ Client-sorting `data` AND passing `sort` controlled. Pick one — server is the canonical source. Spinning both means rows reorder twice and ghost-rows appear during fetches.
+- ❌ Rolling your own column visibility UI when `ColumnVisibilityTrigger` does the job. The built-in handles the "last column" guard for you.
+- ❌ Using `<Table>` directly when you want any of: ordering, sizing, visibility, selection, sort indicator wiring. Compose `<DataTable>` instead — the primitive `<Table>` is for static read-only views.
+
 ### `<Pagination>` — numbered nav with windowing
 
 ```tsx

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -44,6 +44,9 @@
     "react-dom": "^19.0.0"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@floating-ui/react-dom": "^2.1.8",
     "clsx": "^2.1.1"
   },

--- a/packages/design-system/src/components/DataTable/BodyRow.tsx
+++ b/packages/design-system/src/components/DataTable/BodyRow.tsx
@@ -1,0 +1,73 @@
+import { type MouseEvent, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import clsx from 'clsx';
+import { Table } from '../Table';
+import { Checkbox } from '../Checkbox';
+import type { DataTableInstance } from './types';
+import styles from './DataTable.module.scss';
+
+export interface BodyRowProps<T> {
+  row: T;
+  instance: DataTableInstance<T>;
+}
+
+/**
+ * One row of the body. Handles:
+ *  - selection auto-cell (when `instance.enableRowSelection`)
+ *  - row click (when `instance.onRowClick`) — ignored if the click target
+ *    was an interactive child (button, input, a) so checkbox/button clicks
+ *    don't bubble into a navigation.
+ *  - row Enter keypress fires onRowClick when row is focusable.
+ *  - data cells from `instance.visibleColumns` (pinning rendering is in
+ *    Phase 2 — this phase renders unpinned order only).
+ */
+export function BodyRow<T>({ row, instance }: BodyRowProps<T>) {
+  const rowId = instance.getRowId(row);
+  const selected = instance.rowSelection[rowId] === true;
+
+  const onRowClick = (e: MouseEvent<HTMLTableRowElement>) => {
+    if (!instance.onRowClick) return;
+    // Ignore clicks that originated on an interactive child.
+    const target = e.target as HTMLElement;
+    if (target.closest('button, input, a, [role="button"], [role="checkbox"]')) {
+      return;
+    }
+    instance.onRowClick(row, e);
+  };
+
+  const onRowKeyDown = (e: ReactKeyboardEvent<HTMLTableRowElement>) => {
+    if (!instance.onRowClick) return;
+    if (e.key !== 'Enter') return;
+    const target = e.target as HTMLElement;
+    // Ignore Enter coming from an interactive child (it should drive that child).
+    if (target !== e.currentTarget && target.closest('button, input, a, [role="button"], [role="checkbox"]')) {
+      return;
+    }
+    e.preventDefault();
+    instance.onRowClick(row, e as unknown as MouseEvent<HTMLTableRowElement>);
+  };
+
+  return (
+    <Table.Row
+      selected={selected || undefined}
+      onClick={instance.onRowClick ? onRowClick : undefined}
+      onKeyDown={instance.onRowClick ? onRowKeyDown : undefined}
+      tabIndex={instance.onRowClick ? 0 : undefined}
+      className={clsx(instance.onRowClick && styles.clickableRow)}
+    >
+      {instance.enableRowSelection && (
+        <Table.Cell className={styles.autoCell} align="center">
+          <Checkbox
+            checked={selected}
+            onChange={() => instance.toggleRowSelection(rowId)}
+            aria-label={`Select row ${rowId}`}
+          />
+        </Table.Cell>
+      )}
+      {instance.visibleColumns.map((col) => (
+        <Table.Cell key={col.id} align={col.align ?? 'start'}>
+          {col.cell(row, { row, rowId, column: col, instance })}
+        </Table.Cell>
+      ))}
+    </Table.Row>
+  );
+}

--- a/packages/design-system/src/components/DataTable/BodyRow.tsx
+++ b/packages/design-system/src/components/DataTable/BodyRow.tsx
@@ -55,7 +55,14 @@ export function BodyRow<T>({ row, instance }: BodyRowProps<T>) {
       className={clsx(instance.onRowClick && styles.clickableRow)}
     >
       {instance.enableRowSelection && (
-        <Table.Cell className={styles.autoCell} align="center">
+        <Table.Cell
+          className={styles.autoCell}
+          align="center"
+          // Stop clicks anywhere in the selection cell from bubbling to the row's
+          // onRowClick handler. The closest('input,...') filter in onRowClick catches
+          // the input element itself but misses the styled visual-checkbox span sibling.
+          onClick={(e) => e.stopPropagation()}
+        >
           <Checkbox
             checked={selected}
             onChange={() => instance.toggleRowSelection(rowId)}

--- a/packages/design-system/src/components/DataTable/BodyRow.tsx
+++ b/packages/design-system/src/components/DataTable/BodyRow.tsx
@@ -39,7 +39,10 @@ export function BodyRow<T>({ row, instance }: BodyRowProps<T>) {
     if (e.key !== 'Enter') return;
     const target = e.target as HTMLElement;
     // Ignore Enter coming from an interactive child (it should drive that child).
-    if (target !== e.currentTarget && target.closest('button, input, a, [role="button"], [role="checkbox"]')) {
+    if (
+      target !== e.currentTarget &&
+      target.closest('button, input, a, [role="button"], [role="checkbox"]')
+    ) {
       return;
     }
     e.preventDefault();

--- a/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.module.scss
+++ b/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.module.scss
@@ -1,0 +1,5 @@
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}

--- a/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.test.tsx
+++ b/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ColumnVisibilityTrigger } from './ColumnVisibilityTrigger';
+import { useDataTable } from './useDataTable';
+import type { ColumnDef } from './types';
+
+type Row = { id: string };
+
+const cols: ColumnDef<Row>[] = [
+  { id: 'a', header: 'A', cell: (r) => r.id },
+  { id: 'b', header: 'B', cell: (r) => r.id },
+  { id: 'c', header: 'C', cell: (r) => r.id, enableHide: false }, // always visible — not in menu
+];
+
+function Harness(props: { onChange?: (v: Record<string, boolean>) => void; visibility?: Record<string, boolean> }) {
+  const instance = useDataTable<Row>({
+    data: [],
+    columns: cols,
+    getRowId: (r) => r.id,
+    columnVisibility: props.visibility ?? {},
+    onColumnVisibilityChange: props.onChange,
+  });
+  return <ColumnVisibilityTrigger instance={instance} />;
+}
+
+describe('<ColumnVisibilityTrigger>', () => {
+  it('renders one menu item per hidable column', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', { name: /columns/i }));
+    expect(screen.getByRole('menuitemcheckbox', { name: 'A' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemcheckbox', { name: 'B' })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitemcheckbox', { name: 'C' })).toBeNull();
+  });
+
+  it('toggle fires onColumnVisibilityChange', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onChange={onChange} />);
+    await user.click(screen.getByRole('button', { name: /columns/i }));
+    await user.click(screen.getByRole('menuitemcheckbox', { name: 'A' }));
+    expect(onChange).toHaveBeenCalledWith({ a: false });
+  });
+
+  it('disables the toggle for the last visible hidable column', async () => {
+    const user = userEvent.setup();
+    // a is the only visible hidable column (b is hidden, c is non-hidable).
+    render(<Harness visibility={{ b: false }} />);
+    await user.click(screen.getByRole('button', { name: /columns/i }));
+    const aItem = screen.getByRole('menuitemcheckbox', { name: 'A' });
+    expect(aItem).toHaveAttribute('aria-disabled', 'true');
+    // b is hidden but still toggleable to show.
+    const bItem = screen.getByRole('menuitemcheckbox', { name: 'B' });
+    expect(bItem).not.toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.test.tsx
+++ b/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.test.tsx
@@ -12,7 +12,10 @@ const cols: ColumnDef<Row>[] = [
   { id: 'c', header: 'C', cell: (r) => r.id, enableHide: false }, // always visible — not in menu
 ];
 
-function Harness(props: { onChange?: (v: Record<string, boolean>) => void; visibility?: Record<string, boolean> }) {
+function Harness(props: {
+  onChange?: (v: Record<string, boolean>) => void;
+  visibility?: Record<string, boolean>;
+}) {
   const instance = useDataTable<Row>({
     data: [],
     columns: cols,

--- a/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx
+++ b/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx
@@ -66,6 +66,15 @@ export interface ColumnVisibilityTriggerProps<T = unknown> {
  *   convenience wrapper, not the only way to drive visibility state.
  * - When all columns have `enableHide: false`. The menu will be empty; don't
  *   render this component at all in that case.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Passing a different `instance` to `<ColumnVisibilityTrigger>` than to
+ *   `<DataTable>`. Both must receive the same instance reference; split instances
+ *   means visibility changes in the trigger won't reflect in the table (and
+ *   vice versa).
+ * - ❌ Rendering `<ColumnVisibilityTrigger>` when every column has
+ *   `enableHide: false`. The dropdown will be empty — check `instance.columns`
+ *   first and conditionally suppress the trigger.
  */
 export function ColumnVisibilityTrigger<T>({
   instance,

--- a/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx
+++ b/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode, type Ref } from 'react';
 import { Columns3 } from 'lucide-react';
 import { Button } from '../Button';
 import { DropdownMenu } from '../DropdownMenu';
@@ -8,7 +8,8 @@ import type {
 } from '../DropdownMenu';
 import type { DataTableInstance } from './types';
 
-export interface ColumnVisibilityTriggerProps<T = unknown> {
+export interface ColumnVisibilityTriggerProps<T = unknown>
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children' | 'onChange'> {
   /** The `useDataTable` instance to read column state from and dispatch visibility changes to. */
   instance: DataTableInstance<T>;
   /**
@@ -76,13 +77,17 @@ export interface ColumnVisibilityTriggerProps<T = unknown> {
  *   `enableHide: false`. The dropdown will be empty — check `instance.columns`
  *   first and conditionally suppress the trigger.
  */
-export function ColumnVisibilityTrigger<T>({
-  instance,
-  label = 'Columns',
-  icon = <Columns3 size={14} aria-hidden="true" />,
-  side,
-  align,
-}: ColumnVisibilityTriggerProps<T>) {
+function ColumnVisibilityTriggerInner<T>(
+  {
+    instance,
+    label = 'Columns',
+    icon = <Columns3 size={14} aria-hidden="true" />,
+    side,
+    align,
+    ...rest
+  }: ColumnVisibilityTriggerProps<T>,
+  ref: Ref<HTMLButtonElement>,
+) {
   const hidableCols = instance.columns.filter((c) => c.enableHide !== false);
 
   // Count visible hidable columns so we can disable the last one.
@@ -93,9 +98,11 @@ export function ColumnVisibilityTrigger<T>({
 
   return (
     <DropdownMenu>
-      {/* DropdownMenu.Trigger clones its child — no asChild prop needed. */}
+      {/* DropdownMenu.Trigger clones its child and merges refs — the forwarded ref
+          will be preserved alongside the trigger's internal positioning ref. */}
       <DropdownMenu.Trigger>
-        <Button variant="ghost" size="sm">
+        {/* {...rest} last so consumer overrides win (Pattern A). */}
+        <Button ref={ref} variant="ghost" size="sm" {...rest}>
           {icon}
           {label}
         </Button>
@@ -121,3 +128,7 @@ export function ColumnVisibilityTrigger<T>({
     </DropdownMenu>
   );
 }
+
+export const ColumnVisibilityTrigger = forwardRef(ColumnVisibilityTriggerInner) as <T>(
+  props: ColumnVisibilityTriggerProps<T> & { ref?: Ref<HTMLButtonElement> },
+) => ReturnType<typeof ColumnVisibilityTriggerInner>;

--- a/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx
+++ b/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx
@@ -2,14 +2,13 @@ import { forwardRef, type ButtonHTMLAttributes, type ReactNode, type Ref } from 
 import { Columns3 } from 'lucide-react';
 import { Button } from '../Button';
 import { DropdownMenu } from '../DropdownMenu';
-import type {
-  DropdownMenuAlign,
-  DropdownMenuSide,
-} from '../DropdownMenu';
+import type { DropdownMenuAlign, DropdownMenuSide } from '../DropdownMenu';
 import type { DataTableInstance } from './types';
 
-export interface ColumnVisibilityTriggerProps<T = unknown>
-  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children' | 'onChange'> {
+export interface ColumnVisibilityTriggerProps<T = unknown> extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children' | 'onChange'
+> {
   /** The `useDataTable` instance to read column state from and dispatch visibility changes to. */
   instance: DataTableInstance<T>;
   /**

--- a/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx
+++ b/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx
@@ -1,14 +1,114 @@
+import type { ReactNode } from 'react';
+import { Columns3 } from 'lucide-react';
+import { Button } from '../Button';
+import { DropdownMenu } from '../DropdownMenu';
+import type {
+  DropdownMenuAlign,
+  DropdownMenuSide,
+} from '../DropdownMenu';
 import type { DataTableInstance } from './types';
 
 export interface ColumnVisibilityTriggerProps<T = unknown> {
+  /** The `useDataTable` instance to read column state from and dispatch visibility changes to. */
   instance: DataTableInstance<T>;
+  /**
+   * Trigger button label. Defaults to `"Columns"`.
+   * Pass a node to use a custom label or icon+label combination.
+   */
+  label?: ReactNode;
+  /**
+   * Trigger icon rendered to the left of the label. Defaults to a `Columns3`
+   * lucide icon (14px). Pass `null` to suppress the icon.
+   */
+  icon?: ReactNode;
+  /** Preferred side of the trigger for the menu. Defaults to `'bottom'`. Auto-flips on collision. */
+  side?: DropdownMenuSide;
+  /** Edge alignment of the menu relative to the trigger. Defaults to `'start'`. */
+  align?: DropdownMenuAlign;
 }
 
 /**
- * Trigger button that opens a menu to toggle column visibility.
- * Stub — real implementation arrives in Task 12.
+ * Built-in companion for `<DataTable>`. Renders a ghost Button trigger + DropdownMenu
+ * of CheckboxItems — one per column where `enableHide !== false`.
+ *
+ * Guards against hiding the last visible hidable column: when only one
+ * hidable column is currently visible, its menu item renders as disabled so
+ * the table can never reach a zero-column state.
+ *
+ * Pair with `useDataTable` — pass the same `instance` to both `<DataTable>` and
+ * `<ColumnVisibilityTrigger>` so visibility state stays in sync.
+ *
+ * @example
+ * const instance = useDataTable<Row>({ columns, data, getRowId });
+ * // Render the trigger somewhere above or beside the table.
+ * <Cluster justify="end">
+ *   <ColumnVisibilityTrigger instance={instance} />
+ * </Cluster>
+ * <DataTable instance={instance} />
+ *
+ * @example
+ * // Custom label + right-aligned menu:
+ * <ColumnVisibilityTrigger
+ *   instance={instance}
+ *   label="Manage columns"
+ *   align="end"
+ * />
+ *
+ * @example
+ * // Icon-only trigger:
+ * <ColumnVisibilityTrigger instance={instance} label={null} />
+ *
+ * @remarks When NOT to use
+ * - When the consumer wants a different visibility UI (e.g. a settings drawer,
+ *   a multi-select combobox, or a Popover with column grouping). Build it
+ *   directly against `instance.columns`, `instance.columnVisibility`, and
+ *   `instance.toggleColumnVisibility` — `ColumnVisibilityTrigger` is a
+ *   convenience wrapper, not the only way to drive visibility state.
+ * - When all columns have `enableHide: false`. The menu will be empty; don't
+ *   render this component at all in that case.
  */
-export function ColumnVisibilityTrigger<T>(_props: ColumnVisibilityTriggerProps<T>) {
-  // Real implementation comes in Task 12.
-  return null;
+export function ColumnVisibilityTrigger<T>({
+  instance,
+  label = 'Columns',
+  icon = <Columns3 size={14} aria-hidden="true" />,
+  side,
+  align,
+}: ColumnVisibilityTriggerProps<T>) {
+  const hidableCols = instance.columns.filter((c) => c.enableHide !== false);
+
+  // Count visible hidable columns so we can disable the last one.
+  const visibleHidableCount = hidableCols.reduce(
+    (n, c) => n + (instance.columnVisibility[c.id] === false ? 0 : 1),
+    0,
+  );
+
+  return (
+    <DropdownMenu>
+      {/* DropdownMenu.Trigger clones its child — no asChild prop needed. */}
+      <DropdownMenu.Trigger>
+        <Button variant="ghost" size="sm">
+          {icon}
+          {label}
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content side={side} align={align}>
+        {hidableCols.map((col) => {
+          const visible = instance.columnVisibility[col.id] !== false;
+          const isLastVisible = visible && visibleHidableCount === 1;
+          const itemLabel =
+            col.visibilityLabel ?? (typeof col.header === 'string' ? col.header : col.id);
+          return (
+            <DropdownMenu.CheckboxItem
+              key={col.id}
+              checked={visible}
+              disabled={isLastVisible}
+              onCheckedChange={() => instance.toggleColumnVisibility(col.id)}
+            >
+              {itemLabel}
+            </DropdownMenu.CheckboxItem>
+          );
+        })}
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
 }

--- a/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx
+++ b/packages/design-system/src/components/DataTable/ColumnVisibilityTrigger.tsx
@@ -1,0 +1,14 @@
+import type { DataTableInstance } from './types';
+
+export interface ColumnVisibilityTriggerProps<T = unknown> {
+  instance: DataTableInstance<T>;
+}
+
+/**
+ * Trigger button that opens a menu to toggle column visibility.
+ * Stub — real implementation arrives in Task 12.
+ */
+export function ColumnVisibilityTrigger<T>(_props: ColumnVisibilityTriggerProps<T>) {
+  // Real implementation comes in Task 12.
+  return null;
+}

--- a/packages/design-system/src/components/DataTable/DataTable.module.scss
+++ b/packages/design-system/src/components/DataTable/DataTable.module.scss
@@ -2,7 +2,6 @@
 
 .root {
   // composes the Table primitive's scroll wrapper — nothing to add here yet
-  display: contents;
 }
 
 // Selection auto-column — fixed narrow width is set via inline <col width> in colgroup.

--- a/packages/design-system/src/components/DataTable/DataTable.module.scss
+++ b/packages/design-system/src/components/DataTable/DataTable.module.scss
@@ -1,0 +1,28 @@
+// Visual / behavior modifiers ONLY. No layout (Rule 4).
+
+.root {
+  // composes the Table primitive's scroll wrapper — nothing to add here yet
+  display: contents;
+}
+
+// Selection auto-column — fixed narrow width is set via inline <col width> in colgroup.
+.autoCell {
+  // text-align center is set by <Table.Cell align="center" />
+  vertical-align: middle;
+}
+
+.clickableRow {
+  cursor: pointer;
+}
+
+// Empty state row — single colspan cell with centered content.
+.emptyCell {
+  text-align: center;
+  padding: var(--space-6) var(--space-4);
+  color: var(--color-fg-muted);
+}
+
+// Skeleton row cells — give some visual breathing room.
+.skeletonCell {
+  vertical-align: middle;
+}

--- a/packages/design-system/src/components/DataTable/DataTable.module.scss
+++ b/packages/design-system/src/components/DataTable/DataTable.module.scss
@@ -1,3 +1,5 @@
+@use '../../styles/mixins' as *;
+
 // Visual / behavior modifiers ONLY. No layout (Rule 4).
 
 .root {
@@ -12,6 +14,14 @@
 
 .clickableRow {
   cursor: pointer;
+
+  &:focus-visible {
+    @include focus-ring;
+
+    outline: none;
+    outline-offset: -2px;
+    border-radius: var(--radius-sm);
+  }
 }
 
 // Empty state row — single colspan cell with centered content.

--- a/packages/design-system/src/components/DataTable/DataTable.test.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Integration tests for <DataTable> (Phase 1).
+ *
+ * NOTE on drag-and-drop coverage: column reorder via @dnd-kit's PointerSensor
+ * is genuinely hard to test in jsdom. The playground demo serves as the smoke
+ * test for reorder. A future Playwright e2e test is the recommended remedy
+ * if reorder regresses in practice.
+ */
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRef } from 'react';
+import { DataTable } from './DataTable';
+import { useDataTable } from './useDataTable';
+import type { ColumnDef } from './types';
+
+type Row = { id: string; name: string; amount: number };
+
+const cols: ColumnDef<Row>[] = [
+  { id: 'name', header: 'Name', cell: (r) => r.name, sortable: true },
+  { id: 'amount', header: 'Amount', cell: (r) => r.amount },
+];
+
+const rows: Row[] = [
+  { id: 'r1', name: 'Alpha', amount: 10 },
+  { id: 'r2', name: 'Bravo', amount: 20 },
+];
+
+const getRowId = (r: Row) => r.id;
+
+function Harness(props: Partial<Parameters<typeof useDataTable<Row>>[0]>) {
+  const instance = useDataTable<Row>({
+    data: rows,
+    columns: cols,
+    getRowId,
+    ...props,
+  });
+  return <DataTable instance={instance} aria-label="Test" />;
+}
+
+describe('<DataTable>', () => {
+  it('renders header + body rows', () => {
+    render(<Harness />);
+    expect(screen.getByRole('columnheader', { name: /name/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /amount/i })).toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Bravo')).toBeInTheDocument();
+  });
+
+  it('respects aria-label on the table', () => {
+    render(<Harness />);
+    expect(screen.getByRole('table')).toHaveAttribute('aria-label', 'Test');
+  });
+
+  it('sortable column header click cycles sort and fires onSortChange', async () => {
+    const onSortChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onSortChange={onSortChange} />);
+    await user.click(screen.getByRole('columnheader', { name: /name/i }));
+    expect(onSortChange).toHaveBeenLastCalledWith({ columnId: 'name', direction: 'asc' });
+  });
+
+  it('renders an empty state when data is empty', () => {
+    render(<Harness data={[]} />);
+    expect(screen.getByText(/no data/i)).toBeInTheDocument();
+  });
+
+  it('renders a custom emptyState when provided', () => {
+    function CustomHarness() {
+      const instance = useDataTable<Row>({ data: [], columns: cols, getRowId });
+      return <DataTable instance={instance} aria-label="t" emptyState={<div>NOTHING HERE</div>} />;
+    }
+    render(<CustomHarness />);
+    expect(screen.getByText('NOTHING HERE')).toBeInTheDocument();
+  });
+
+  it('renders skeleton rows when loading', () => {
+    function LoadingHarness() {
+      const instance = useDataTable<Row>({ data: [], columns: cols, getRowId });
+      return <DataTable instance={instance} aria-label="t" loading loadingRowCount={3} />;
+    }
+    const { container } = render(<LoadingHarness />);
+    // Skeleton renders a span with role="status" or a known className from the Skeleton component.
+    // We check by tbody row count instead — most robust.
+    const bodyRows = container.querySelectorAll('tbody tr');
+    expect(bodyRows.length).toBe(3);
+  });
+
+  it('renders selection auto-column when enableRowSelection is true', () => {
+    render(<Harness enableRowSelection />);
+    const headerRow = screen.getAllByRole('row')[0]!;
+    // Select-all + 2 data column headers = 3 cells
+    expect(within(headerRow).getAllByRole('columnheader').length).toBe(2);
+    expect(within(headerRow).getAllByRole('checkbox').length).toBe(1);
+  });
+
+  it('toggleRowSelection toggles a row via per-row checkbox', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness enableRowSelection onRowSelectionChange={onChange} defaultRowSelection={{}} />,
+    );
+    const rowCheckboxes = screen.getAllByRole('checkbox', { name: /select row/i });
+    expect(rowCheckboxes).toHaveLength(2);
+    await user.click(rowCheckboxes[0]!);
+    expect(onChange).toHaveBeenCalledWith({ r1: true });
+  });
+
+  it('header select-all checkbox toggles all rows on page', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness enableRowSelection onRowSelectionChange={onChange} defaultRowSelection={{}} />,
+    );
+    const headerCheckbox = screen.getAllByRole('checkbox')[0]!;
+    await user.click(headerCheckbox);
+    expect(onChange).toHaveBeenCalledWith({ r1: true, r2: true });
+  });
+
+  it('row click fires onRowClick when target is not interactive', async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onRowClick={onRowClick} />);
+    await user.click(screen.getByText('Alpha'));
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick.mock.calls[0]![0]).toEqual(rows[0]);
+  });
+
+  it('row Enter keypress fires onRowClick when onRowClick is provided', async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onRowClick={onRowClick} />);
+    const firstRow = screen.getAllByRole('row')[1]!; // [0] is the header row
+    firstRow.focus();
+    await user.keyboard('{Enter}');
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('rows are NOT focusable when onRowClick is not provided', () => {
+    render(<Harness />);
+    const firstBodyRow = screen.getAllByRole('row')[1]!;
+    expect(firstBodyRow).not.toHaveAttribute('tabindex');
+  });
+
+  it('row click does NOT fire onRowClick when target is the selection checkbox', async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        enableRowSelection
+        onRowClick={onRowClick}
+        defaultRowSelection={{}}
+        onRowSelectionChange={() => {}}
+      />,
+    );
+    const rowCheckboxes = screen.getAllByRole('checkbox', { name: /select row/i });
+    await user.click(rowCheckboxes[0]!);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('hidden columns do not render cells', () => {
+    render(<Harness defaultColumnVisibility={{ amount: false }} />);
+    expect(screen.queryByText('10')).toBeNull();
+    expect(screen.queryByText('20')).toBeNull();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+  });
+
+  it('respects columnOrder ordering in header + body', () => {
+    render(<Harness defaultColumnOrder={['amount', 'name']} />);
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers[0]!.textContent).toMatch(/amount/i);
+    expect(headers[1]!.textContent).toMatch(/name/i);
+  });
+
+  it('forwards ref to the underlying <table>', () => {
+    function RefHarness() {
+      const ref = useRef<HTMLTableElement>(null);
+      const instance = useDataTable<Row>({ data: rows, columns: cols, getRowId });
+      return <DataTable instance={instance} ref={ref} aria-label="t" data-testid="dt" />;
+    }
+    const { container } = render(<RefHarness />);
+    expect(container.querySelector('table')).toBeInstanceOf(HTMLTableElement);
+  });
+
+  it('merges className with the underlying <table>', () => {
+    function ClassHarness() {
+      const instance = useDataTable<Row>({ data: rows, columns: cols, getRowId });
+      return <DataTable instance={instance} className="my-class" aria-label="t" />;
+    }
+    const { container } = render(<ClassHarness />);
+    expect(container.querySelector('table.my-class')).not.toBeNull();
+  });
+});

--- a/packages/design-system/src/components/DataTable/DataTable.test.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.test.tsx
@@ -88,8 +88,8 @@ describe('<DataTable>', () => {
   it('renders selection auto-column when enableRowSelection is true', () => {
     render(<Harness enableRowSelection />);
     const headerRow = screen.getAllByRole('row')[0]!;
-    // Select-all + 2 data column headers = 3 cells
-    expect(within(headerRow).getAllByRole('columnheader').length).toBe(2);
+    // Select-all <th> + 2 data column headers = 3 columnheaders
+    expect(within(headerRow).getAllByRole('columnheader').length).toBe(3);
     expect(within(headerRow).getAllByRole('checkbox').length).toBe(1);
   });
 

--- a/packages/design-system/src/components/DataTable/DataTable.test.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.test.tsx
@@ -96,9 +96,7 @@ describe('<DataTable>', () => {
   it('toggleRowSelection toggles a row via per-row checkbox', async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
-    render(
-      <Harness enableRowSelection onRowSelectionChange={onChange} defaultRowSelection={{}} />,
-    );
+    render(<Harness enableRowSelection onRowSelectionChange={onChange} defaultRowSelection={{}} />);
     const rowCheckboxes = screen.getAllByRole('checkbox', { name: /select row/i });
     expect(rowCheckboxes).toHaveLength(2);
     await user.click(rowCheckboxes[0]!);
@@ -108,9 +106,7 @@ describe('<DataTable>', () => {
   it('header select-all checkbox toggles all rows on page', async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
-    render(
-      <Harness enableRowSelection onRowSelectionChange={onChange} defaultRowSelection={{}} />,
-    );
+    render(<Harness enableRowSelection onRowSelectionChange={onChange} defaultRowSelection={{}} />);
     const headerCheckbox = screen.getAllByRole('checkbox')[0]!;
     await user.click(headerCheckbox);
     expect(onChange).toHaveBeenCalledWith({ r1: true, r2: true });

--- a/packages/design-system/src/components/DataTable/DataTable.test.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.test.tsx
@@ -157,6 +157,25 @@ describe('<DataTable>', () => {
     expect(onRowClick).not.toHaveBeenCalled();
   });
 
+  it('row click does NOT fire onRowClick when origin is in the selection cell (any descendant)', async () => {
+    const onRowClick = vi.fn();
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        enableRowSelection
+        onRowClick={onRowClick}
+        defaultRowSelection={{}}
+        onRowSelectionChange={onChange}
+      />,
+    );
+    // Click the auto-cell <td> itself — the selection cell is the first cell of each body row.
+    const firstRow = screen.getAllByRole('row')[1]!;
+    const cells = within(firstRow).getAllByRole('cell');
+    await user.click(cells[0]!); // selection cell is the first <td>
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
   it('hidden columns do not render cells', () => {
     render(<Harness defaultColumnVisibility={{ amount: false }} />);
     expect(screen.queryByText('10')).toBeNull();

--- a/packages/design-system/src/components/DataTable/DataTable.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.tsx
@@ -237,7 +237,7 @@ function SkeletonRows({
         <Table.Row key={`sk-${i}`}>
           {Array.from({ length: totalColCount }, (_, j) => (
             <Table.Cell key={j} className={styles.skeletonCell}>
-              <Skeleton variant="text" />
+              <Skeleton variant="text" width="80%" />
             </Table.Cell>
           ))}
         </Table.Row>

--- a/packages/design-system/src/components/DataTable/DataTable.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.tsx
@@ -1,9 +1,4 @@
-import {
-  forwardRef,
-  useMemo,
-  type ReactNode,
-  type Ref,
-} from 'react';
+import { forwardRef, useMemo, type ReactNode, type Ref } from 'react';
 import clsx from 'clsx';
 import {
   DndContext,
@@ -143,10 +138,8 @@ function DataTableInner<T>(
     });
   };
 
-  const totalColCount =
-    instance.visibleColumns.length + (instance.enableRowSelection ? 1 : 0);
-  const dataIsEmpty =
-    !loading && instance.data.length === 0 && instance.pinnedRows.length === 0;
+  const totalColCount = instance.visibleColumns.length + (instance.enableRowSelection ? 1 : 0);
+  const dataIsEmpty = !loading && instance.data.length === 0 && instance.pinnedRows.length === 0;
 
   return (
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
@@ -166,25 +159,16 @@ function DataTableInner<T>(
           {caption && <Table.Caption>{caption}</Table.Caption>}
 
           <colgroup>
-            {instance.enableRowSelection && (
-              <col style={{ width: AUTO_CELL_WIDTH }} />
-            )}
+            {instance.enableRowSelection && <col style={{ width: AUTO_CELL_WIDTH }} />}
             {instance.visibleColumns.map((col) => (
-              <col
-                key={col.id}
-                style={{ width: instance.columnSizesPx[col.id] ?? 120 }}
-              />
+              <col key={col.id} style={{ width: instance.columnSizesPx[col.id] ?? 120 }} />
             ))}
           </colgroup>
 
           <Table.Header>
             <Table.Row>
               {instance.enableRowSelection && (
-                <Table.HeaderCell
-                  align="center"
-                  scope="col"
-                  className={styles.autoCell}
-                >
+                <Table.HeaderCell align="center" scope="col" className={styles.autoCell}>
                   <Checkbox
                     checked={instance.isAllOnPageSelected()}
                     indeterminate={instance.isSomeOnPageSelected()}
@@ -201,19 +185,12 @@ function DataTableInner<T>(
 
           <Table.Body>
             {loading ? (
-              <SkeletonRows
-                count={loadingRowCount}
-                totalColCount={totalColCount}
-              />
+              <SkeletonRows count={loadingRowCount} totalColCount={totalColCount} />
             ) : dataIsEmpty ? (
               <EmptyRow totalColCount={totalColCount} content={emptyState} />
             ) : (
               instance.data.map((row) => (
-                <BodyRow
-                  key={instance.getRowId(row)}
-                  row={row}
-                  instance={instance}
-                />
+                <BodyRow key={instance.getRowId(row)} row={row} instance={instance} />
               ))
             )}
           </Table.Body>
@@ -223,13 +200,7 @@ function DataTableInner<T>(
   );
 }
 
-function SkeletonRows({
-  count,
-  totalColCount,
-}: {
-  count: number;
-  totalColCount: number;
-}) {
+function SkeletonRows({ count, totalColCount }: { count: number; totalColCount: number }) {
   return (
     <>
       {Array.from({ length: count }, (_, i) => (
@@ -245,13 +216,7 @@ function SkeletonRows({
   );
 }
 
-function EmptyRow({
-  totalColCount,
-  content,
-}: {
-  totalColCount: number;
-  content?: ReactNode;
-}) {
+function EmptyRow({ totalColCount, content }: { totalColCount: number; content?: ReactNode }) {
   return (
     <Table.Row>
       <Table.Cell colSpan={totalColCount} className={styles.emptyCell}>
@@ -269,4 +234,3 @@ function EmptyRow({
 export const DataTable = forwardRef(DataTableInner) as <T>(
   props: DataTableProps<T> & { ref?: Ref<HTMLTableElement> },
 ) => ReturnType<typeof DataTableInner>;
-

--- a/packages/design-system/src/components/DataTable/DataTable.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.tsx
@@ -1,0 +1,275 @@
+import {
+  forwardRef,
+  useMemo,
+  type ReactNode,
+  type Ref,
+} from 'react';
+import clsx from 'clsx';
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
+import { Table } from '../Table';
+import type { TableDensity } from '../Table';
+import { Checkbox } from '../Checkbox';
+import { Skeleton } from '../Skeleton';
+import { EmptyState } from '../EmptyState';
+import { HeaderCell } from './HeaderCell';
+import { BodyRow } from './BodyRow';
+import { ColumnVisibilityTrigger } from './ColumnVisibilityTrigger';
+import type { DataTableInstance } from './types';
+import styles from './DataTable.module.scss';
+
+export interface DataTableProps<T> {
+  instance: DataTableInstance<T>;
+  density?: TableDensity;
+  striped?: boolean;
+  /** Hover highlight on body rows. Defaults TRUE (DataTable rows are usually interactive). */
+  hover?: boolean;
+  bordered?: boolean;
+  loading?: boolean;
+  /** Number of skeleton rows when `loading`. Defaults 10. */
+  loadingRowCount?: number;
+  /** Element shown when `data` is empty and not loading. Defaults to a stock <EmptyState>. */
+  emptyState?: ReactNode;
+  /** Required for a11y when no caption is provided. */
+  'aria-label'?: string;
+  caption?: ReactNode;
+  className?: string;
+}
+
+const AUTO_CELL_WIDTH = 44;
+
+/**
+ * Tabular data component built on the `<Table>` primitive. Owns the column-axis
+ * state machine (order / sizing / visibility / pinning) and row-axis state
+ * (selection, expansion). Sort/search/pagination are server-driven — DataTable
+ * fires `onSortChange` and exposes selection state for the consumer to act on.
+ *
+ * Accepts a `DataTableInstance<T>` from `useDataTable` (the only state-owning
+ * surface). Pass companion components like `<DataTable.ColumnVisibilityTrigger>`
+ * the same `instance`.
+ *
+ * @example
+ * function Example() {
+ *   const instance = useDataTable<Row>({
+ *     data, columns, getRowId,
+ *     enableRowSelection: true,
+ *     onSortChange: setSort,
+ *     sort,
+ *   });
+ *   return (
+ *     <>
+ *       <DataTable.ColumnVisibilityTrigger instance={instance} />
+ *       <DataTable instance={instance} aria-label="Deals" />
+ *     </>
+ *   );
+ * }
+ *
+ * @remarks When NOT to use
+ * - For a static read-only table without column features — use `<Table>` directly.
+ * - For huge datasets (10k+ rows on screen at once) — Phase 1 doesn't virtualize;
+ *   this'll get slow. Future phase will add a virtualization escape hatch.
+ * - For Excel-like cell editing or cell selection — out of scope; consumer composes.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Pre-sorting / pre-filtering `data` client-side then ALSO passing `sort`.
+ *   DataTable assumes `data` is the server's pre-paginated, pre-sorted slice.
+ *   Mixing creates ghost rows.
+ * - ❌ Mutating `columns` identity across renders. The hook captures
+ *   `defaultColumnOrder` from `columns` once; later identity changes won't
+ *   trigger a re-derive. Pass a stable reference (e.g. defined outside render
+ *   or memoized).
+ */
+function DataTableInner<T>(
+  {
+    instance,
+    density = 'comfortable',
+    striped,
+    hover = true,
+    bordered,
+    loading = false,
+    loadingRowCount = 10,
+    emptyState,
+    caption,
+    className,
+    ...rest
+  }: DataTableProps<T>,
+  ref: Ref<HTMLTableElement>,
+) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const visibleIds = useMemo(
+    () => instance.visibleColumns.map((c) => c.id),
+    [instance.visibleColumns],
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const activeId = String(active.id);
+    const overId = String(over.id);
+
+    instance.setColumnOrder((prev) => {
+      // Map dnd-kit's visible-list-result back into the full columnOrder array
+      // by replacing visible-column slots one-by-one in their absolute positions.
+      const visible = prev.filter((id) => visibleIds.includes(id));
+      const fromIdx = visible.indexOf(activeId);
+      const toIdx = visible.indexOf(overId);
+      if (fromIdx === -1 || toIdx === -1) return prev;
+      const reorderedVisible = [...visible];
+      const [moved] = reorderedVisible.splice(fromIdx, 1);
+      reorderedVisible.splice(toIdx, 0, moved!);
+
+      // Splice reorderedVisible back into prev at the same absolute positions.
+      let cursor = 0;
+      return prev.map((id) => {
+        if (visibleIds.includes(id)) {
+          return reorderedVisible[cursor++]!;
+        }
+        return id;
+      });
+    });
+  };
+
+  const totalColCount =
+    instance.visibleColumns.length + (instance.enableRowSelection ? 1 : 0);
+  const dataIsEmpty =
+    !loading && instance.data.length === 0 && instance.pinnedRows.length === 0;
+
+  return (
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+      <SortableContext items={visibleIds} strategy={horizontalListSortingStrategy}>
+        {/* {...rest} last so consumer overrides win (Pattern A). */}
+        <Table
+          ref={ref}
+          stickyHeader
+          hover={hover}
+          density={density}
+          striped={striped}
+          bordered={bordered}
+          aria-rowcount={instance.rowCount}
+          className={clsx(styles.root, className)}
+          {...rest}
+        >
+          {caption && <Table.Caption>{caption}</Table.Caption>}
+
+          <colgroup>
+            {instance.enableRowSelection && (
+              <col style={{ width: AUTO_CELL_WIDTH }} />
+            )}
+            {instance.visibleColumns.map((col) => (
+              <col
+                key={col.id}
+                style={{ width: instance.columnSizesPx[col.id] ?? 120 }}
+              />
+            ))}
+          </colgroup>
+
+          <Table.Header>
+            <Table.Row>
+              {instance.enableRowSelection && (
+                <Table.Cell
+                  align="center"
+                  className={styles.autoCell}
+                >
+                  <Checkbox
+                    checked={instance.isAllOnPageSelected()}
+                    indeterminate={instance.isSomeOnPageSelected()}
+                    onChange={() => instance.toggleAllOnPage()}
+                    aria-label="Select all rows on page"
+                  />
+                </Table.Cell>
+              )}
+              {instance.visibleColumns.map((col) => (
+                <HeaderCell key={col.id} column={col} instance={instance} />
+              ))}
+            </Table.Row>
+          </Table.Header>
+
+          <Table.Body>
+            {loading ? (
+              <SkeletonRows
+                count={loadingRowCount}
+                totalColCount={totalColCount}
+              />
+            ) : dataIsEmpty ? (
+              <EmptyRow totalColCount={totalColCount} content={emptyState} />
+            ) : (
+              instance.data.map((row) => (
+                <BodyRow
+                  key={instance.getRowId(row)}
+                  row={row}
+                  instance={instance}
+                />
+              ))
+            )}
+          </Table.Body>
+        </Table>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+function SkeletonRows({
+  count,
+  totalColCount,
+}: {
+  count: number;
+  totalColCount: number;
+}) {
+  return (
+    <>
+      {Array.from({ length: count }, (_, i) => (
+        <Table.Row key={`sk-${i}`}>
+          {Array.from({ length: totalColCount }, (_, j) => (
+            <Table.Cell key={j} className={styles.skeletonCell}>
+              <Skeleton variant="text" />
+            </Table.Cell>
+          ))}
+        </Table.Row>
+      ))}
+    </>
+  );
+}
+
+function EmptyRow({
+  totalColCount,
+  content,
+}: {
+  totalColCount: number;
+  content?: ReactNode;
+}) {
+  return (
+    <Table.Row>
+      <Table.Cell colSpan={totalColCount} className={styles.emptyCell}>
+        {content ?? <EmptyState title="No data" />}
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+/**
+ * Generic forwardRef wrapper — TypeScript erases the `T` generic in a normal
+ * forwardRef so we re-type via assertion. This is the standard pattern for
+ * generic forwardRef components.
+ */
+export const DataTable = forwardRef(DataTableInner) as <T>(
+  props: DataTableProps<T> & { ref?: Ref<HTMLTableElement> },
+) => ReturnType<typeof DataTableInner>;
+
+// Attach companion components as a Radix-style compound API.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(DataTable as any).ColumnVisibilityTrigger = ColumnVisibilityTrigger;

--- a/packages/design-system/src/components/DataTable/DataTable.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.tsx
@@ -181,8 +181,9 @@ function DataTableInner<T>(
           <Table.Header>
             <Table.Row>
               {instance.enableRowSelection && (
-                <Table.Cell
+                <Table.HeaderCell
                   align="center"
+                  scope="col"
                   className={styles.autoCell}
                 >
                   <Checkbox
@@ -191,7 +192,7 @@ function DataTableInner<T>(
                     onChange={() => instance.toggleAllOnPage()}
                     aria-label="Select all rows on page"
                   />
-                </Table.Cell>
+                </Table.HeaderCell>
               )}
               {instance.visibleColumns.map((col) => (
                 <HeaderCell key={col.id} column={col} instance={instance} />

--- a/packages/design-system/src/components/DataTable/DataTable.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.tsx
@@ -25,7 +25,6 @@ import { Skeleton } from '../Skeleton';
 import { EmptyState } from '../EmptyState';
 import { HeaderCell } from './HeaderCell';
 import { BodyRow } from './BodyRow';
-import { ColumnVisibilityTrigger } from './ColumnVisibilityTrigger';
 import type { DataTableInstance } from './types';
 import styles from './DataTable.module.scss';
 
@@ -56,8 +55,8 @@ const AUTO_CELL_WIDTH = 44;
  * fires `onSortChange` and exposes selection state for the consumer to act on.
  *
  * Accepts a `DataTableInstance<T>` from `useDataTable` (the only state-owning
- * surface). Pass companion components like `<DataTable.ColumnVisibilityTrigger>`
- * the same `instance`.
+ * surface). Pass companion components like `<ColumnVisibilityTrigger>` the same
+ * `instance`.
  *
  * @example
  * function Example() {
@@ -69,7 +68,7 @@ const AUTO_CELL_WIDTH = 44;
  *   });
  *   return (
  *     <>
- *       <DataTable.ColumnVisibilityTrigger instance={instance} />
+ *       <ColumnVisibilityTrigger instance={instance} />
  *       <DataTable instance={instance} aria-label="Deals" />
  *     </>
  *   );
@@ -271,6 +270,3 @@ export const DataTable = forwardRef(DataTableInner) as <T>(
   props: DataTableProps<T> & { ref?: Ref<HTMLTableElement> },
 ) => ReturnType<typeof DataTableInner>;
 
-// Attach companion components as a Radix-style compound API.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(DataTable as any).ColumnVisibilityTrigger = ColumnVisibilityTrigger;

--- a/packages/design-system/src/components/DataTable/HeaderCell.module.scss
+++ b/packages/design-system/src/components/DataTable/HeaderCell.module.scss
@@ -85,5 +85,5 @@
 }
 
 .dragging {
-  opacity: var(--opacity-muted);
+  opacity: var(--opacity-dragging);
 }

--- a/packages/design-system/src/components/DataTable/HeaderCell.module.scss
+++ b/packages/design-system/src/components/DataTable/HeaderCell.module.scss
@@ -1,0 +1,89 @@
+@use '../../styles/mixins' as *;
+
+.headerCell {
+  position: relative;
+}
+
+.inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0 var(--space-2);
+  height: 100%;
+}
+
+.label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex: 1 1 auto;
+  min-width: 0;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-fg);
+  cursor: default;
+  user-select: none;
+
+  &.sortable {
+    cursor: pointer;
+  }
+
+  &.sortable:focus-visible {
+    @include focus-ring;
+
+    outline-offset: -2px;
+    border-radius: var(--radius-sm);
+  }
+}
+
+.grip {
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-fg-muted);
+  opacity: var(--opacity-hidden);
+  cursor: grab;
+  padding: 0 var(--space-05);
+  transition: opacity var(--transition-fast);
+
+  // Reveal on header hover OR when grip itself is focused.
+  .headerCell:hover &,
+  &:focus-visible {
+    opacity: var(--opacity-visible);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+
+    outline-offset: -2px;
+    border-radius: var(--radius-sm);
+  }
+}
+
+.resizeHandle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 6px;
+  cursor: col-resize;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  user-select: none;
+}
+
+.resizeBar {
+  width: 1px;
+  height: 60%;
+  background: transparent;
+  transition: background var(--transition-fast), width var(--transition-fast);
+}
+
+.resizeHandle:hover .resizeBar,
+.resizeBar.active {
+  background: var(--color-accent);
+  width: 2px;
+}
+
+.dragging {
+  opacity: var(--opacity-muted);
+}

--- a/packages/design-system/src/components/DataTable/HeaderCell.module.scss
+++ b/packages/design-system/src/components/DataTable/HeaderCell.module.scss
@@ -2,6 +2,10 @@
 
 .headerCell {
   position: relative;
+
+  // overflow:hidden ensures dnd-kit's CSS transform doesn't cause the cell
+  // content to appear wider than the column's <col> width during drag.
+  overflow: hidden;
 }
 
 .inner {
@@ -10,6 +14,9 @@
   gap: var(--space-1);
   padding: 0 var(--space-2);
   height: 100%;
+
+  // Prevent content overflow from expanding the measured cell width.
+  min-width: 0;
 }
 
 .label {
@@ -18,6 +25,9 @@
   gap: var(--space-1);
   flex: 1 1 auto;
   min-width: 0;
+
+  // Clip overflowing text instead of stretching the cell.
+  overflow: hidden;
   font-weight: var(--font-weight-semibold);
   color: var(--color-fg);
   cursor: default;
@@ -38,10 +48,13 @@
 .grip {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   color: var(--color-fg-muted);
   opacity: var(--opacity-hidden);
   cursor: grab;
-  padding: 0 var(--space-05);
+
+  // No horizontal padding — let flex centering handle alignment so the
+  // icon sits visually centred in its slot.
   transition: opacity var(--transition-fast);
 
   // Reveal on header hover OR when grip itself is focused.
@@ -78,10 +91,22 @@
   transition: background var(--transition-fast), width var(--transition-fast);
 }
 
-.resizeHandle:hover .resizeBar,
+// Show the resize bar whenever the user hovers anywhere on the header cell,
+// not just when they hover directly over the 6 px handle zone.
+.headerCell:hover .resizeHandle .resizeBar,
 .resizeBar.active {
   background: var(--color-accent);
   width: 2px;
+}
+
+// Sort chevron — sits at the end of .inner, between label and resize handle.
+.sortIcon {
+  flex-shrink: 0;
+  color: var(--color-fg-muted);
+}
+
+.sortIconActive {
+  color: var(--color-fg);
 }
 
 .dragging {

--- a/packages/design-system/src/components/DataTable/HeaderCell.module.scss
+++ b/packages/design-system/src/components/DataTable/HeaderCell.module.scss
@@ -125,7 +125,9 @@
   height: 60%;
   background: var(--color-fg-muted);
   flex-shrink: 0;
-  transition: background var(--transition-fast), width var(--transition-fast);
+  transition:
+    background var(--transition-fast),
+    width var(--transition-fast);
 }
 
 // Accent-colour the bar and chevrons when hovered or actively resizing.

--- a/packages/design-system/src/components/DataTable/HeaderCell.module.scss
+++ b/packages/design-system/src/components/DataTable/HeaderCell.module.scss
@@ -8,15 +8,48 @@
   overflow: hidden;
 }
 
+// Drag grip — absolutely positioned at the left edge of the cell so it never
+// shifts the content area regardless of label length.
+.grip {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-fg-muted);
+  opacity: var(--opacity-hidden);
+  cursor: grab;
+  transition: opacity var(--transition-fast);
+
+  // Reveal on header hover OR when grip itself is focused.
+  .headerCell:hover &,
+  &:focus-visible {
+    opacity: var(--opacity-visible);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+
+    outline-offset: -2px;
+    border-radius: var(--radius-sm);
+  }
+}
+
 .inner {
   display: flex;
   align-items: center;
   gap: var(--space-1);
-  padding: 0 var(--space-2);
   height: 100%;
 
   // Prevent content overflow from expanding the measured cell width.
   min-width: 0;
+
+  // Reserve space for absolute-positioned grip (left, ~20px) and resize
+  // handle (right, ~24px — wider because it contains chevrons + bar).
+  padding: 0 24px 0 20px;
 }
 
 .label {
@@ -28,6 +61,8 @@
 
   // Clip overflowing text instead of stretching the cell.
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-weight: var(--font-weight-semibold);
   color: var(--color-fg);
   cursor: default;
@@ -45,61 +80,7 @@
   }
 }
 
-.grip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-fg-muted);
-  opacity: var(--opacity-hidden);
-  cursor: grab;
-
-  // No horizontal padding — let flex centering handle alignment so the
-  // icon sits visually centred in its slot.
-  transition: opacity var(--transition-fast);
-
-  // Reveal on header hover OR when grip itself is focused.
-  .headerCell:hover &,
-  &:focus-visible {
-    opacity: var(--opacity-visible);
-  }
-
-  &:focus-visible {
-    @include focus-ring;
-
-    outline-offset: -2px;
-    border-radius: var(--radius-sm);
-  }
-}
-
-.resizeHandle {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  width: 6px;
-  cursor: col-resize;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  user-select: none;
-}
-
-.resizeBar {
-  width: 1px;
-  height: 60%;
-  background: transparent;
-  transition: background var(--transition-fast), width var(--transition-fast);
-}
-
-// Show the resize bar whenever the user hovers anywhere on the header cell,
-// not just when they hover directly over the 6 px handle zone.
-.headerCell:hover .resizeHandle .resizeBar,
-.resizeBar.active {
-  background: var(--color-accent);
-  width: 2px;
-}
-
-// Sort chevron — sits at the end of .inner, between label and resize handle.
+// Sort chevron — sits at the end of .inner, after the label.
 .sortIcon {
   flex-shrink: 0;
   color: var(--color-fg-muted);
@@ -107,6 +88,56 @@
 
 .sortIconActive {
   color: var(--color-fg);
+}
+
+// Resize handle — absolutely positioned at the right edge of the cell so it
+// never occupies flex space and is always at the exact cell boundary.
+.resizeHandle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 24px;
+  cursor: col-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+  opacity: var(--opacity-hidden);
+  transition: opacity var(--transition-fast);
+
+  // Reveal when hovering anywhere on the header cell.
+  .headerCell:hover & {
+    opacity: var(--opacity-visible);
+  }
+}
+
+.resizeChevron {
+  width: 8px;
+  height: 8px;
+  color: var(--color-fg-muted);
+  flex-shrink: 0;
+  transition: color var(--transition-fast);
+}
+
+.resizeBar {
+  width: 1px;
+  height: 60%;
+  background: var(--color-fg-muted);
+  flex-shrink: 0;
+  transition: background var(--transition-fast), width var(--transition-fast);
+}
+
+// Accent-colour the bar and chevrons when hovered or actively resizing.
+.resizeHandle:hover .resizeBar,
+.resizeBar.active {
+  background: var(--color-accent);
+  width: 2px;
+}
+
+.resizeHandle:hover .resizeChevron,
+.resizeHandle:has(.resizeBar.active) .resizeChevron {
+  color: var(--color-accent);
 }
 
 .dragging {

--- a/packages/design-system/src/components/DataTable/HeaderCell.tsx
+++ b/packages/design-system/src/components/DataTable/HeaderCell.tsx
@@ -88,6 +88,7 @@ export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
       sortDirection={sortDir}
       onClick={sortable ? () => instance.toggleSort(column.id) : undefined}
       className={clsx(styles.headerCell, isDragging && styles.dragging)}
+      // HTMLTableCellElement extends HTMLElement; dnd-kit only reads DOM geometry from the ref.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ref={setNodeRef as any}
       style={dragStyle}

--- a/packages/design-system/src/components/DataTable/HeaderCell.tsx
+++ b/packages/design-system/src/components/DataTable/HeaderCell.tsx
@@ -121,6 +121,8 @@ export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
             aria-label={`Drag to reorder ${typeof column.header === 'string' ? column.header : column.id}`}
             // tabIndex so keyboard users can focus to reveal grip + activate drag
             tabIndex={0}
+            // Stop sort click from misfiring when the user clicks the grip without moving.
+            onClick={(e) => e.stopPropagation()}
           >
             <GripVertical size={14} aria-hidden="true" />
           </span>

--- a/packages/design-system/src/components/DataTable/HeaderCell.tsx
+++ b/packages/design-system/src/components/DataTable/HeaderCell.tsx
@@ -1,6 +1,6 @@
 import { type KeyboardEvent } from 'react';
 import clsx from 'clsx';
-import { GripVertical, ChevronUp, ChevronDown, ChevronsUpDown } from 'lucide-react';
+import { GripVertical, ChevronUp, ChevronDown, ChevronsUpDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Table } from '../Table';
@@ -111,22 +111,27 @@ export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
       ref={setNodeRef as any}
       style={dragStyle}
     >
+      {/* Grip pinned to absolute left — kept outside .inner so it doesn't
+          shift the content area. Only rendered when column is reorderable. */}
+      {reorderable && (
+        <span
+          className={styles.grip}
+          // Spread BOTH attributes (aria/role) and listeners (pointerdown etc.)
+          {...attributes}
+          {...listeners}
+          aria-label={`Drag to reorder ${typeof column.header === 'string' ? column.header : column.id}`}
+          // tabIndex so keyboard users can focus to reveal grip + activate drag
+          tabIndex={0}
+          // Stop sort click from misfiring when the user clicks the grip without moving.
+          onClick={(e) => e.stopPropagation()}
+        >
+          <GripVertical size={14} aria-hidden="true" />
+        </span>
+      )}
+
+      {/* Content area: label (flex:1) + sort icon pinned to end of content.
+          Left/right padding reserves space for the absolute grip and resize handle. */}
       <div className={styles.inner}>
-        {reorderable && (
-          <span
-            className={styles.grip}
-            // Spread BOTH attributes (aria/role) and listeners (pointerdown etc.)
-            {...attributes}
-            {...listeners}
-            aria-label={`Drag to reorder ${typeof column.header === 'string' ? column.header : column.id}`}
-            // tabIndex so keyboard users can focus to reveal grip + activate drag
-            tabIndex={0}
-            // Stop sort click from misfiring when the user clicks the grip without moving.
-            onClick={(e) => e.stopPropagation()}
-          >
-            <GripVertical size={14} aria-hidden="true" />
-          </span>
-        )}
         <span
           className={clsx(styles.label, sortable && styles.sortable)}
           tabIndex={sortable ? 0 : undefined}
@@ -135,9 +140,8 @@ export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
         >
           {headerContent}
         </span>
-        {/* Sort chevron sits between label and resize handle — at the end of
-            the content area. aria-hidden: purely decorative; aria-sort on the
-            <th> carries the semantic signal. */}
+        {/* Sort chevron always at end of content area — aria-hidden because
+            aria-sort on the <th> carries the semantic signal. */}
         {sortDir != null && (
           <SortIcon
             size={12}
@@ -145,18 +149,23 @@ export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
             className={clsx(styles.sortIcon, sortDir !== 'none' && styles.sortIconActive)}
           />
         )}
-        {column.enableResize !== false && (
-          <span
-            className={styles.resizeHandle}
-            onPointerDown={resize.onPointerDown}
-            // Stop sort click when interacting with resize.
-            onClick={(e) => e.stopPropagation()}
-            aria-hidden="true"
-          >
-            <span className={clsx(styles.resizeBar, resize.isResizing && styles.active)} />
-          </span>
-        )}
       </div>
+
+      {/* Resize handle pinned to absolute right — outside .inner so it
+          doesn't consume flex space and stays at the exact cell edge. */}
+      {column.enableResize !== false && (
+        <span
+          className={styles.resizeHandle}
+          onPointerDown={resize.onPointerDown}
+          // Stop sort click when interacting with resize.
+          onClick={(e) => e.stopPropagation()}
+          aria-hidden="true"
+        >
+          <ChevronLeft className={styles.resizeChevron} aria-hidden="true" />
+          <span className={clsx(styles.resizeBar, resize.isResizing && styles.active)} />
+          <ChevronRight className={styles.resizeChevron} aria-hidden="true" />
+        </span>
+      )}
     </Table.HeaderCell>
   );
 }

--- a/packages/design-system/src/components/DataTable/HeaderCell.tsx
+++ b/packages/design-system/src/components/DataTable/HeaderCell.tsx
@@ -1,6 +1,13 @@
 import { type KeyboardEvent } from 'react';
 import clsx from 'clsx';
-import { GripVertical, ChevronUp, ChevronDown, ChevronsUpDown, ChevronLeft, ChevronRight } from 'lucide-react';
+import {
+  GripVertical,
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Table } from '../Table';
@@ -35,11 +42,7 @@ const sortAriaMap: Record<TableSortDirection, 'ascending' | 'descending' | 'none
 export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
   const sortable = column.sortable === true;
   const sortDir: TableSortDirection | undefined =
-    instance.sort?.columnId === column.id
-      ? instance.sort.direction
-      : sortable
-        ? 'none'
-        : undefined;
+    instance.sort?.columnId === column.id ? instance.sort.direction : sortable ? 'none' : undefined;
 
   // Derive the visual sort icon to render in our own .inner layout (approach
   // a): we do NOT pass sortDirection to Table.HeaderCell (to suppress its
@@ -87,9 +90,7 @@ export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
   };
 
   const headerContent =
-    typeof column.header === 'function'
-      ? column.header({ column, instance })
-      : column.header;
+    typeof column.header === 'function' ? column.header({ column, instance }) : column.header;
 
   const dragStyle = {
     transform: CSS.Transform.toString(transform),

--- a/packages/design-system/src/components/DataTable/HeaderCell.tsx
+++ b/packages/design-system/src/components/DataTable/HeaderCell.tsx
@@ -1,0 +1,131 @@
+import { type KeyboardEvent } from 'react';
+import clsx from 'clsx';
+import { GripVertical } from 'lucide-react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Table } from '../Table';
+import type { TableSortDirection } from '../Table';
+import { useResizeHandle } from './useResizeHandle';
+import type { ColumnDef, DataTableInstance } from './types';
+import styles from './HeaderCell.module.scss';
+
+export interface HeaderCellProps<T> {
+  column: ColumnDef<T>;
+  instance: DataTableInstance<T>;
+}
+
+/**
+ * Sortable header cell with a hover-revealed drag grip and a resize handle.
+ *
+ * - **Label area** is the sort click-target when `column.sortable === true`.
+ * - **Grip** appears on hover or keyboard focus; it's the drag handle wired
+ *   to `@dnd-kit/sortable`'s `useSortable`. The grip is the ONLY draggable
+ *   target — listeners are not attached to the cell or label, so clicking
+ *   the label never starts a drag.
+ * - **Resize handle** is a 6px hit-zone on the right edge. Disabled when
+ *   `column.enableResize === false`. Also supports keyboard resize: arrow
+ *   keys ±8px; Shift+arrow keys ±32px (when the label is focused).
+ */
+export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
+  const sortable = column.sortable === true;
+  const sortDir: TableSortDirection | undefined =
+    instance.sort?.columnId === column.id
+      ? instance.sort.direction
+      : sortable
+        ? 'none'
+        : undefined;
+
+  // dnd-kit sortable — column is its own sortable item.
+  const reorderable = column.enableReorder !== false;
+  const sortableResult = useSortable({ id: column.id, disabled: !reorderable });
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = sortableResult;
+
+  const width = instance.columnSizesPx[column.id] ?? 120;
+  const resize = useResizeHandle({
+    initialWidth: width,
+    minWidth: column.minSize ?? 40,
+    maxWidth: column.maxSize,
+    onResize: (next) => {
+      instance.setColumnSizing((prev) => ({ ...prev, [column.id]: next }));
+    },
+  });
+
+  const onLabelKeyDown = (e: KeyboardEvent<HTMLSpanElement>) => {
+    // Sort cycle on Enter / Space (when sortable)
+    if (sortable && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault();
+      instance.toggleSort(column.id);
+      return;
+    }
+    // Keyboard resize: ← / → for ±8px; Shift+← / Shift+→ for ±32px.
+    if (column.enableResize === false) return;
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+      e.preventDefault();
+      const step = (e.shiftKey ? 32 : 8) * (e.key === 'ArrowRight' ? 1 : -1);
+      const current = instance.columnSizesPx[column.id] ?? 120;
+      const minW = column.minSize ?? 40;
+      const maxW = column.maxSize;
+      let next = current + step;
+      if (next < minW) next = minW;
+      if (maxW != null && next > maxW) next = maxW;
+      instance.setColumnSizing((prev) => ({ ...prev, [column.id]: next }));
+    }
+  };
+
+  const headerContent =
+    typeof column.header === 'function'
+      ? column.header({ column, instance })
+      : column.header;
+
+  const dragStyle = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  } as const;
+
+  return (
+    <Table.HeaderCell
+      align={column.align ?? 'start'}
+      sortDirection={sortDir}
+      onClick={sortable ? () => instance.toggleSort(column.id) : undefined}
+      className={clsx(styles.headerCell, isDragging && styles.dragging)}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ref={setNodeRef as any}
+      style={dragStyle}
+    >
+      <div className={styles.inner}>
+        {reorderable && (
+          <span
+            className={styles.grip}
+            // Spread BOTH attributes (aria/role) and listeners (pointerdown etc.)
+            {...attributes}
+            {...listeners}
+            aria-label={`Drag to reorder ${typeof column.header === 'string' ? column.header : column.id}`}
+            // tabIndex so keyboard users can focus to reveal grip + activate drag
+            tabIndex={0}
+          >
+            <GripVertical size={14} aria-hidden="true" />
+          </span>
+        )}
+        <span
+          className={clsx(styles.label, sortable && styles.sortable)}
+          tabIndex={sortable ? 0 : undefined}
+          role={sortable ? 'button' : undefined}
+          onKeyDown={onLabelKeyDown}
+        >
+          {headerContent}
+        </span>
+        {column.enableResize !== false && (
+          <span
+            className={styles.resizeHandle}
+            onPointerDown={resize.onPointerDown}
+            // Stop sort click when interacting with resize.
+            onClick={(e) => e.stopPropagation()}
+            aria-hidden="true"
+          >
+            <span className={clsx(styles.resizeBar, resize.isResizing && styles.active)} />
+          </span>
+        )}
+      </div>
+    </Table.HeaderCell>
+  );
+}

--- a/packages/design-system/src/components/DataTable/HeaderCell.tsx
+++ b/packages/design-system/src/components/DataTable/HeaderCell.tsx
@@ -1,6 +1,6 @@
 import { type KeyboardEvent } from 'react';
 import clsx from 'clsx';
-import { GripVertical } from 'lucide-react';
+import { GripVertical, ChevronUp, ChevronDown, ChevronsUpDown } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Table } from '../Table';
@@ -26,6 +26,12 @@ export interface HeaderCellProps<T> {
  *   `column.enableResize === false`. Also supports keyboard resize: arrow
  *   keys ±8px; Shift+arrow keys ±32px (when the label is focused).
  */
+const sortAriaMap: Record<TableSortDirection, 'ascending' | 'descending' | 'none'> = {
+  asc: 'ascending',
+  desc: 'descending',
+  none: 'none',
+};
+
 export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
   const sortable = column.sortable === true;
   const sortDir: TableSortDirection | undefined =
@@ -34,6 +40,14 @@ export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
       : sortable
         ? 'none'
         : undefined;
+
+  // Derive the visual sort icon to render in our own .inner layout (approach
+  // a): we do NOT pass sortDirection to Table.HeaderCell (to suppress its
+  // built-in inline icon). Instead we pass aria-sort directly and render the
+  // chevron ourselves at the end of the label area, just before the resize
+  // handle.
+  const SortIcon =
+    sortDir === 'asc' ? ChevronUp : sortDir === 'desc' ? ChevronDown : ChevronsUpDown;
 
   // dnd-kit sortable — column is its own sortable item.
   const reorderable = column.enableReorder !== false;
@@ -83,9 +97,13 @@ export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
   } as const;
 
   return (
+    // sortDirection is intentionally NOT passed to Table.HeaderCell — we suppress
+    // its built-in inline chevron and render our own at the end of .inner (between
+    // label and resize handle). aria-sort is set directly so the ARIA contract is
+    // preserved without the visual side-effect.
     <Table.HeaderCell
       align={column.align ?? 'start'}
-      sortDirection={sortDir}
+      aria-sort={sortDir != null ? sortAriaMap[sortDir] : undefined}
       onClick={sortable ? () => instance.toggleSort(column.id) : undefined}
       className={clsx(styles.headerCell, isDragging && styles.dragging)}
       // HTMLTableCellElement extends HTMLElement; dnd-kit only reads DOM geometry from the ref.
@@ -115,6 +133,16 @@ export function HeaderCell<T>({ column, instance }: HeaderCellProps<T>) {
         >
           {headerContent}
         </span>
+        {/* Sort chevron sits between label and resize handle — at the end of
+            the content area. aria-hidden: purely decorative; aria-sort on the
+            <th> carries the semantic signal. */}
+        {sortDir != null && (
+          <SortIcon
+            size={12}
+            aria-hidden="true"
+            className={clsx(styles.sortIcon, sortDir !== 'none' && styles.sortIconActive)}
+          />
+        )}
         {column.enableResize !== false && (
           <span
             className={styles.resizeHandle}

--- a/packages/design-system/src/components/DataTable/index.ts
+++ b/packages/design-system/src/components/DataTable/index.ts
@@ -1,0 +1,1 @@
+export type * from './types';

--- a/packages/design-system/src/components/DataTable/index.ts
+++ b/packages/design-system/src/components/DataTable/index.ts
@@ -1,4 +1,23 @@
 export { DataTable } from './DataTable';
 export type { DataTableProps } from './DataTable';
+
 export { useDataTable } from './useDataTable';
-export type * from './types';
+export { ColumnVisibilityTrigger } from './ColumnVisibilityTrigger';
+export type { ColumnVisibilityTriggerProps } from './ColumnVisibilityTrigger';
+
+export type {
+  ColumnDef,
+  ColumnAlign,
+  ColumnOrderState,
+  ColumnSizingState,
+  ColumnVisibilityState,
+  ColumnPinningState,
+  RowSelectionState,
+  ExpandedRowsState,
+  SortState,
+  Updater,
+  HeaderContext,
+  CellContext,
+  UseDataTableOptions,
+  DataTableInstance,
+} from './types';

--- a/packages/design-system/src/components/DataTable/index.ts
+++ b/packages/design-system/src/components/DataTable/index.ts
@@ -1,1 +1,4 @@
+export { DataTable } from './DataTable';
+export type { DataTableProps } from './DataTable';
+export { useDataTable } from './useDataTable';
 export type * from './types';

--- a/packages/design-system/src/components/DataTable/types.ts
+++ b/packages/design-system/src/components/DataTable/types.ts
@@ -98,32 +98,66 @@ export interface UseDataTableOptions<T> {
   enableRowSelection?: boolean;
 
   // each state piece: controlled / default / onChange (Radix pattern)
+
+  /** Controlled column order. Pass with `onColumnOrderChange` to manage state externally. */
   columnOrder?: ColumnOrderState;
+  /** Initial column order when uncontrolled. Defaults to `columns.map(c => c.id)`. */
   defaultColumnOrder?: ColumnOrderState;
+  /** Fires when the order changes (drag-reorder or programmatic set). */
   onColumnOrderChange?: (next: ColumnOrderState) => void;
 
+  /** Controlled column sizing map (column id → width in px). Pass with `onColumnSizingChange`. */
   columnSizing?: ColumnSizingState;
+  /** Initial column sizing when uncontrolled. Missing entries fall back to `ColumnDef.size` or 120px. */
   defaultColumnSizing?: ColumnSizingState;
+  /** Fires when any column is resized. */
   onColumnSizingChange?: (next: ColumnSizingState) => void;
 
+  /** Controlled column visibility map (column id → visible flag). Pass with `onColumnVisibilityChange`. */
   columnVisibility?: ColumnVisibilityState;
+  /** Initial column visibility when uncontrolled. Missing entries are treated as visible. */
   defaultColumnVisibility?: ColumnVisibilityState;
+  /** Fires when column visibility toggles (e.g. via `<ColumnVisibilityTrigger>`). */
   onColumnVisibilityChange?: (next: ColumnVisibilityState) => void;
 
+  /**
+   * Controlled column pinning state. Pass with `onColumnPinningChange`.
+   * Note: Phase 1 plumbs this state — sticky rendering ships in Phase 2.
+   */
   columnPinning?: ColumnPinningState;
+  /**
+   * Initial column pinning when uncontrolled. Defaults to `{ left: [], right: [] }`.
+   * Note: Phase 1 plumbs this state — sticky rendering ships in Phase 2.
+   */
   defaultColumnPinning?: ColumnPinningState;
+  /** Fires when a column is pinned or unpinned. */
   onColumnPinningChange?: (next: ColumnPinningState) => void;
 
+  /** Controlled row selection map (row id → selected flag). Pass with `onRowSelectionChange`. */
   rowSelection?: RowSelectionState;
+  /** Initial row selection when uncontrolled. Defaults to `{}` (nothing selected). */
   defaultRowSelection?: RowSelectionState;
+  /** Fires when any row selection changes (per-row toggle or select-all). */
   onRowSelectionChange?: (next: RowSelectionState) => void;
 
+  /**
+   * Controlled expanded-rows map (row id → expanded flag). Pass with `onExpandedRowsChange`.
+   * Note: Phase 1 plumbs this state — expansion rendering ships in Phase 3.
+   */
   expandedRows?: ExpandedRowsState;
+  /**
+   * Initial expanded rows when uncontrolled. Defaults to `{}` (all collapsed).
+   * Note: Phase 1 plumbs this state — expansion rendering ships in Phase 3.
+   */
   defaultExpandedRows?: ExpandedRowsState;
+  /** Fires when a row is expanded or collapsed. */
   onExpandedRowsChange?: (next: ExpandedRowsState) => void;
 
+  /** Controlled single-column sort state. Pass with `onSortChange` for server-driven sorting. */
   sort?: SortState | null;
+  /** Initial sort when uncontrolled. Defaults to `null` (unsorted). */
   defaultSort?: SortState | null;
+  /** Fires when the sort state changes (column header click cycles null → asc → desc → null). */
   onSortChange?: (next: SortState | null) => void;
 
   // interactivity
@@ -173,12 +207,20 @@ export interface DataTableInstance<T> {
   setSort: (updater: Updater<SortState | null>) => void;
 
   // higher-level helpers
+  /** Toggle selection of a single row by id. */
   toggleRowSelection: (rowId: string) => void;
+  /** Toggle selection of all rows in `data` (does not affect `pinnedRows`). */
   toggleAllOnPage: () => void;
+  /** All rows in `data` are selected (excludes `pinnedRows`). */
   isAllOnPageSelected: () => boolean;
+  /** Some but not all rows in `data` are selected — drives the header checkbox indeterminate state. */
   isSomeOnPageSelected: () => boolean;
+  /** Toggle expansion of a single row by id. */
   toggleRowExpanded: (rowId: string) => void;
+  /** Toggle visibility of a column by id. Guarded against hiding the last visible hidable column when called via `<ColumnVisibilityTrigger>`. */
   toggleColumnVisibility: (columnId: string) => void;
+  /** Pin a column to `left`, `right`, or `false` to unpin. Pinning order within a side is append-on-pin. */
   pinColumn: (columnId: string, side: 'left' | 'right' | false) => void;
+  /** Cycle sort state for a column: null → asc → desc → null. */
   toggleSort: (columnId: string) => void;
 }

--- a/packages/design-system/src/components/DataTable/types.ts
+++ b/packages/design-system/src/components/DataTable/types.ts
@@ -1,0 +1,184 @@
+import type { ReactNode, MouseEvent as ReactMouseEvent } from 'react';
+
+/** Cell / header text alignment. */
+export type ColumnAlign = 'start' | 'center' | 'end';
+
+/** Single-column sort state. v1 is single-column only; multi-column is a future extension. */
+export interface SortState {
+  columnId: string;
+  direction: 'asc' | 'desc';
+}
+
+/** Ordered list of column ids (includes hidden columns at their absolute positions). */
+export type ColumnOrderState = string[];
+
+/** Map column id → resolved width in px. Missing entries fall back to `ColumnDef.size` or the default (120). */
+export type ColumnSizingState = Record<string, number>;
+
+/** Map column id → visible flag. Missing entries are treated as `true` (visible). */
+export type ColumnVisibilityState = Record<string, boolean>;
+
+/**
+ * Ordered pin lists per side. Phase 1 plumbs this state but does not render
+ * the sticky CSS — rendering effects ship in Phase 2.
+ */
+export interface ColumnPinningState {
+  left: string[];
+  right: string[];
+}
+
+/** Map row id → selected flag. Missing entries treated as `false`. */
+export type RowSelectionState = Record<string, boolean>;
+
+/** Map row id → expanded flag. Phase 1 plumbs state; rendering ships in Phase 3. */
+export type ExpandedRowsState = Record<string, boolean>;
+
+/** setState-style updater: either the next value, or a function (prev) => next. */
+export type Updater<S> = S | ((prev: S) => S);
+
+/** Header render-prop context. */
+export interface HeaderContext<T = unknown> {
+  column: ColumnDef<T>;
+  instance: DataTableInstance<T>;
+}
+
+/** Cell render-prop context. */
+export interface CellContext<T> {
+  row: T;
+  rowId: string;
+  column: ColumnDef<T>;
+  instance: DataTableInstance<T>;
+}
+
+/** Descriptor for one column. Keyed by `id` — used as the key for all per-column state. */
+export interface ColumnDef<T> {
+  /** Stable id. Used as key for column order, sizing, visibility, pinning state. */
+  id: string;
+  /** Header content. String, node, or a render-prop receiving HeaderContext. */
+  header: ReactNode | ((ctx: HeaderContext<T>) => ReactNode);
+  /** Cell content for a row. */
+  cell: (row: T, ctx: CellContext<T>) => ReactNode;
+  /** Cell text alignment. Defaults to 'start'. */
+  align?: ColumnAlign;
+  /** Default width in px when no entry in ColumnSizingState. Defaults to 120. */
+  size?: number;
+  /** Min width during resize (px). Defaults to 40. */
+  minSize?: number;
+  /** Max width during resize (px). Defaults to undefined (no max). */
+  maxSize?: number;
+  /** Whether the column can be reordered via drag. Defaults true. */
+  enableReorder?: boolean;
+  /** Whether the column can be resized via the handle. Defaults true. */
+  enableResize?: boolean;
+  /** Whether the column can be hidden via the visibility menu. Defaults true. */
+  enableHide?: boolean;
+  /** Whether the column can be pinned. Defaults true. (Phase 2 will use this.) */
+  enablePin?: boolean;
+  /**
+   * Server-side sortable. When true, the header label is clickable and
+   * keyboard-actionable; toggling fires onSortChange. DataTable does
+   * not perform client-side sorting.
+   */
+  sortable?: boolean;
+  /** Label shown in the column visibility menu. Falls back to `header` if string. */
+  visibilityLabel?: string;
+}
+
+/** Public options to `useDataTable<T>(...)`. */
+export interface UseDataTableOptions<T> {
+  // pure data
+  data: T[];
+  pinnedRows?: T[];
+  columns: ColumnDef<T>[];
+  /** Required. Stable id per row — used by selection, expansion, and `getRowId`. */
+  getRowId: (row: T) => string;
+  /** Total server-side row count. Surfaced as `aria-rowcount` for screen readers. */
+  rowCount?: number;
+  /** Opt-in to the selection auto-column. Defaults false. */
+  enableRowSelection?: boolean;
+
+  // each state piece: controlled / default / onChange (Radix pattern)
+  columnOrder?: ColumnOrderState;
+  defaultColumnOrder?: ColumnOrderState;
+  onColumnOrderChange?: (next: ColumnOrderState) => void;
+
+  columnSizing?: ColumnSizingState;
+  defaultColumnSizing?: ColumnSizingState;
+  onColumnSizingChange?: (next: ColumnSizingState) => void;
+
+  columnVisibility?: ColumnVisibilityState;
+  defaultColumnVisibility?: ColumnVisibilityState;
+  onColumnVisibilityChange?: (next: ColumnVisibilityState) => void;
+
+  columnPinning?: ColumnPinningState;
+  defaultColumnPinning?: ColumnPinningState;
+  onColumnPinningChange?: (next: ColumnPinningState) => void;
+
+  rowSelection?: RowSelectionState;
+  defaultRowSelection?: RowSelectionState;
+  onRowSelectionChange?: (next: RowSelectionState) => void;
+
+  expandedRows?: ExpandedRowsState;
+  defaultExpandedRows?: ExpandedRowsState;
+  onExpandedRowsChange?: (next: ExpandedRowsState) => void;
+
+  sort?: SortState | null;
+  defaultSort?: SortState | null;
+  onSortChange?: (next: SortState | null) => void;
+
+  // interactivity
+  onRowClick?: (row: T, event: ReactMouseEvent<HTMLTableRowElement>) => void;
+  /** Phase 1 plumbs this prop but does not render expansion. Rendering ships in Phase 3. */
+  renderExpandedRow?: (row: T) => ReactNode;
+}
+
+/** Returned by `useDataTable<T>(...)`. Passed into `<DataTable instance={...} />`. */
+export interface DataTableInstance<T> {
+  // echoed inputs
+  data: T[];
+  pinnedRows: T[];
+  columns: ColumnDef<T>[];
+  getRowId: (row: T) => string;
+  rowCount?: number;
+  enableRowSelection: boolean;
+  hasExpansion: boolean;
+  onRowClick?: UseDataTableOptions<T>['onRowClick'];
+  renderExpandedRow?: UseDataTableOptions<T>['renderExpandedRow'];
+
+  // resolved current state
+  columnOrder: ColumnOrderState;
+  columnSizing: ColumnSizingState;
+  columnVisibility: ColumnVisibilityState;
+  columnPinning: ColumnPinningState;
+  rowSelection: RowSelectionState;
+  expandedRows: ExpandedRowsState;
+  sort: SortState | null;
+
+  // derived view-models (memoized)
+  visibleColumns: ColumnDef<T>[];
+  leftPinnedColumns: ColumnDef<T>[];
+  rightPinnedColumns: ColumnDef<T>[];
+  unpinnedColumns: ColumnDef<T>[];
+  columnSizesPx: Record<string, number>;
+  leftPinOffsets: Record<string, number>;
+  rightPinOffsets: Record<string, number>;
+
+  // setState-style mutators
+  setColumnOrder: (updater: Updater<ColumnOrderState>) => void;
+  setColumnSizing: (updater: Updater<ColumnSizingState>) => void;
+  setColumnVisibility: (updater: Updater<ColumnVisibilityState>) => void;
+  setColumnPinning: (updater: Updater<ColumnPinningState>) => void;
+  setRowSelection: (updater: Updater<RowSelectionState>) => void;
+  setExpandedRows: (updater: Updater<ExpandedRowsState>) => void;
+  setSort: (updater: Updater<SortState | null>) => void;
+
+  // higher-level helpers
+  toggleRowSelection: (rowId: string) => void;
+  toggleAllOnPage: () => void;
+  isAllOnPageSelected: () => boolean;
+  isSomeOnPageSelected: () => boolean;
+  toggleRowExpanded: (rowId: string) => void;
+  toggleColumnVisibility: (columnId: string) => void;
+  pinColumn: (columnId: string, side: 'left' | 'right' | false) => void;
+  toggleSort: (columnId: string) => void;
+}

--- a/packages/design-system/src/components/DataTable/useControllableState.test.ts
+++ b/packages/design-system/src/components/DataTable/useControllableState.test.ts
@@ -8,17 +8,13 @@ describe('useControllableState', () => {
   });
 
   it('uses value when controlled (ignores default)', () => {
-    const { result } = renderHook(() =>
-      useControllableState({ value: 10, defaultValue: 5 }),
-    );
+    const { result } = renderHook(() => useControllableState({ value: 10, defaultValue: 5 }));
     expect(result.current[0]).toBe(10);
   });
 
   it('updates internal state when uncontrolled', () => {
     const onChange = vi.fn();
-    const { result } = renderHook(() =>
-      useControllableState({ defaultValue: 0, onChange }),
-    );
+    const { result } = renderHook(() => useControllableState({ defaultValue: 0, onChange }));
     act(() => result.current[1](42));
     expect(result.current[0]).toBe(42);
     expect(onChange).toHaveBeenCalledWith(42);
@@ -47,9 +43,7 @@ describe('useControllableState', () => {
 
   it('updater function receives current value when controlled', () => {
     const onChange = vi.fn();
-    const { result } = renderHook(() =>
-      useControllableState({ value: 10, onChange }),
-    );
+    const { result } = renderHook(() => useControllableState({ value: 10, onChange }));
     act(() => result.current[1]((prev) => prev + 5));
     expect(onChange).toHaveBeenCalledWith(15);
   });

--- a/packages/design-system/src/components/DataTable/useControllableState.test.ts
+++ b/packages/design-system/src/components/DataTable/useControllableState.test.ts
@@ -1,0 +1,56 @@
+import { renderHook, act } from '@testing-library/react';
+import { useControllableState } from './useControllableState';
+
+describe('useControllableState', () => {
+  it('uses defaultValue when uncontrolled', () => {
+    const { result } = renderHook(() => useControllableState({ defaultValue: 5 }));
+    expect(result.current[0]).toBe(5);
+  });
+
+  it('uses value when controlled (ignores default)', () => {
+    const { result } = renderHook(() =>
+      useControllableState({ value: 10, defaultValue: 5 }),
+    );
+    expect(result.current[0]).toBe(10);
+  });
+
+  it('updates internal state when uncontrolled', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useControllableState({ defaultValue: 0, onChange }),
+    );
+    act(() => result.current[1](42));
+    expect(result.current[0]).toBe(42);
+    expect(onChange).toHaveBeenCalledWith(42);
+  });
+
+  it('does NOT update internal state when controlled — only fires onChange', () => {
+    const onChange = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ v }) => useControllableState({ value: v, onChange }),
+      { initialProps: { v: 10 } },
+    );
+    act(() => result.current[1](99));
+    // value prop didn't change, so resolved stays 10
+    expect(result.current[0]).toBe(10);
+    expect(onChange).toHaveBeenCalledWith(99);
+
+    rerender({ v: 99 });
+    expect(result.current[0]).toBe(99);
+  });
+
+  it('accepts an updater function', () => {
+    const { result } = renderHook(() => useControllableState({ defaultValue: 5 }));
+    act(() => result.current[1]((prev) => prev + 1));
+    expect(result.current[0]).toBe(6);
+  });
+
+  it('updater function receives current value when controlled', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useControllableState({ value: 10, onChange }),
+    );
+    act(() => result.current[1]((prev) => prev + 5));
+    expect(onChange).toHaveBeenCalledWith(15);
+  });
+});

--- a/packages/design-system/src/components/DataTable/useControllableState.ts
+++ b/packages/design-system/src/components/DataTable/useControllableState.ts
@@ -37,8 +37,7 @@ export function useControllableState<T>(options: {
   const setValue = useCallback(
     (updater: Updater<T>) => {
       const prev = resolvedRef.current;
-      const next =
-        typeof updater === 'function' ? (updater as (p: T) => T)(prev) : updater;
+      const next = typeof updater === 'function' ? (updater as (p: T) => T)(prev) : updater;
       if (!isControlled) setInternal(next);
       onChangeRef.current?.(next);
     },

--- a/packages/design-system/src/components/DataTable/useControllableState.ts
+++ b/packages/design-system/src/components/DataTable/useControllableState.ts
@@ -1,0 +1,49 @@
+import { useCallback, useRef, useState } from 'react';
+import type { Updater } from './types';
+
+/**
+ * Radix-style controlled/uncontrolled state hook.
+ *
+ * - If `value` is defined → controlled. Resolved value tracks `value`. Setter
+ *   does NOT update internal state; only fires `onChange` so the consumer can
+ *   update their own state.
+ * - If `value` is undefined → uncontrolled. Resolved value comes from internal
+ *   state seeded with `defaultValue`. Setter updates internal state AND fires
+ *   `onChange`.
+ *
+ * Switching between controlled and uncontrolled across renders is not supported
+ * (matches Radix / React behavior — produces a warning in dev only on first
+ * such switch in React, but otherwise no-op).
+ */
+export function useControllableState<T>(options: {
+  value?: T;
+  defaultValue?: T;
+  onChange?: (next: T) => void;
+}): [T, (updater: Updater<T>) => void] {
+  const { value, defaultValue, onChange } = options;
+  const isControlled = value !== undefined;
+
+  const [internal, setInternal] = useState<T | undefined>(defaultValue);
+  const resolved = (isControlled ? value : internal) as T;
+
+  // Keep a ref to the most recent resolved value so updater functions
+  // always operate on the latest state even if callers debounce or batch.
+  const resolvedRef = useRef(resolved);
+  resolvedRef.current = resolved;
+
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  const setValue = useCallback(
+    (updater: Updater<T>) => {
+      const prev = resolvedRef.current;
+      const next =
+        typeof updater === 'function' ? (updater as (p: T) => T)(prev) : updater;
+      if (!isControlled) setInternal(next);
+      onChangeRef.current?.(next);
+    },
+    [isControlled],
+  );
+
+  return [resolved, setValue];
+}

--- a/packages/design-system/src/components/DataTable/useDataTable.test.ts
+++ b/packages/design-system/src/components/DataTable/useDataTable.test.ts
@@ -1,0 +1,96 @@
+import { renderHook, act } from '@testing-library/react';
+import { useDataTable } from './useDataTable';
+import type { ColumnDef } from './types';
+
+type Row = { id: string; name: string; amount: number };
+
+const cols: ColumnDef<Row>[] = [
+  { id: 'name', header: 'Name', cell: (r) => r.name },
+  { id: 'amount', header: 'Amount', cell: (r) => r.amount, sortable: true },
+];
+
+const rows: Row[] = [
+  { id: 'r1', name: 'Alpha', amount: 10 },
+  { id: 'r2', name: 'Bravo', amount: 20 },
+];
+
+const getRowId = (r: Row) => r.id;
+
+describe('useDataTable — state resolution', () => {
+  it('echoes data, columns, getRowId', () => {
+    const { result } = renderHook(() =>
+      useDataTable({ data: rows, columns: cols, getRowId }),
+    );
+    expect(result.current.data).toBe(rows);
+    expect(result.current.columns).toBe(cols);
+    expect(result.current.getRowId).toBe(getRowId);
+    expect(result.current.pinnedRows).toEqual([]);
+  });
+
+  it('defaults enableRowSelection to false and hasExpansion to false', () => {
+    const { result } = renderHook(() =>
+      useDataTable({ data: rows, columns: cols, getRowId }),
+    );
+    expect(result.current.enableRowSelection).toBe(false);
+    expect(result.current.hasExpansion).toBe(false);
+  });
+
+  it('reports hasExpansion=true when renderExpandedRow is provided', () => {
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        renderExpandedRow: () => null,
+      }),
+    );
+    expect(result.current.hasExpansion).toBe(true);
+  });
+
+  it('initialises columnOrder from defaultColumnOrder', () => {
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        defaultColumnOrder: ['amount', 'name'],
+      }),
+    );
+    expect(result.current.columnOrder).toEqual(['amount', 'name']);
+  });
+
+  it('falls back to columns order when no default given', () => {
+    const { result } = renderHook(() =>
+      useDataTable({ data: rows, columns: cols, getRowId }),
+    );
+    expect(result.current.columnOrder).toEqual(['name', 'amount']);
+  });
+
+  it('controlled columnOrder overrides default', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        columnOrder: ['amount', 'name'],
+        onColumnOrderChange: onChange,
+      }),
+    );
+    expect(result.current.columnOrder).toEqual(['amount', 'name']);
+    act(() => result.current.setColumnOrder(['name', 'amount']));
+    expect(onChange).toHaveBeenCalledWith(['name', 'amount']);
+  });
+
+  it('initialises all other state pieces with sensible defaults', () => {
+    const { result } = renderHook(() =>
+      useDataTable({ data: rows, columns: cols, getRowId }),
+    );
+    expect(result.current.columnSizing).toEqual({});
+    expect(result.current.columnVisibility).toEqual({});
+    expect(result.current.columnPinning).toEqual({ left: [], right: [] });
+    expect(result.current.rowSelection).toEqual({});
+    expect(result.current.expandedRows).toEqual({});
+    expect(result.current.sort).toBeNull();
+  });
+});

--- a/packages/design-system/src/components/DataTable/useDataTable.test.ts
+++ b/packages/design-system/src/components/DataTable/useDataTable.test.ts
@@ -190,3 +190,175 @@ describe('useDataTable — derived view-models', () => {
     expect(result.current.rightPinOffsets).toEqual({ c: 0, b: 60 });
   });
 });
+
+describe('useDataTable — selection helpers', () => {
+  it('toggleRowSelection toggles a single row', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        enableRowSelection: true,
+        onRowSelectionChange: onChange,
+      }),
+    );
+    act(() => result.current.toggleRowSelection('r1'));
+    expect(onChange).toHaveBeenCalledWith({ r1: true });
+    act(() => result.current.toggleRowSelection('r1'));
+    expect(onChange).toHaveBeenLastCalledWith({});
+  });
+
+  it('toggleAllOnPage selects all rows in data (ignoring pinnedRows)', () => {
+    const onChange = vi.fn();
+    const pinned: Row[] = [{ id: 'p1', name: 'Pin', amount: 1 }];
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        pinnedRows: pinned,
+        columns: cols,
+        getRowId,
+        enableRowSelection: true,
+        onRowSelectionChange: onChange,
+      }),
+    );
+    act(() => result.current.toggleAllOnPage());
+    expect(onChange).toHaveBeenCalledWith({ r1: true, r2: true });
+  });
+
+  it('toggleAllOnPage deselects when all are selected', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        enableRowSelection: true,
+        defaultRowSelection: { r1: true, r2: true },
+        onRowSelectionChange: onChange,
+      }),
+    );
+    act(() => result.current.toggleAllOnPage());
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  it('isAllOnPageSelected / isSomeOnPageSelected reflect data only', () => {
+    const { result, rerender } = renderHook(
+      (sel: { r1?: boolean; r2?: boolean }) =>
+        useDataTable({
+          data: rows,
+          columns: cols,
+          getRowId,
+          enableRowSelection: true,
+          rowSelection: sel,
+          onRowSelectionChange: () => {},
+        }),
+      { initialProps: {} },
+    );
+    expect(result.current.isAllOnPageSelected()).toBe(false);
+    expect(result.current.isSomeOnPageSelected()).toBe(false);
+
+    rerender({ r1: true });
+    expect(result.current.isAllOnPageSelected()).toBe(false);
+    expect(result.current.isSomeOnPageSelected()).toBe(true);
+
+    rerender({ r1: true, r2: true });
+    expect(result.current.isAllOnPageSelected()).toBe(true);
+    expect(result.current.isSomeOnPageSelected()).toBe(false); // "some but not all" semantics
+  });
+});
+
+describe('useDataTable — sort helpers', () => {
+  it('toggleSort cycles null → asc → desc → null', () => {
+    const onChange = vi.fn();
+    const { result, rerender } = renderHook(
+      (sort: any) =>
+        useDataTable({
+          data: rows,
+          columns: cols,
+          getRowId,
+          sort,
+          onSortChange: onChange,
+        }),
+      { initialProps: null as any },
+    );
+    act(() => result.current.toggleSort('amount'));
+    expect(onChange).toHaveBeenLastCalledWith({ columnId: 'amount', direction: 'asc' });
+
+    rerender({ columnId: 'amount', direction: 'asc' });
+    act(() => result.current.toggleSort('amount'));
+    expect(onChange).toHaveBeenLastCalledWith({ columnId: 'amount', direction: 'desc' });
+
+    rerender({ columnId: 'amount', direction: 'desc' });
+    act(() => result.current.toggleSort('amount'));
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('toggleSort on a different column starts asc from scratch', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        sort: { columnId: 'amount', direction: 'desc' },
+        onSortChange: onChange,
+      }),
+    );
+    act(() => result.current.toggleSort('name'));
+    expect(onChange).toHaveBeenLastCalledWith({ columnId: 'name', direction: 'asc' });
+  });
+});
+
+describe('useDataTable — column helpers', () => {
+  it('toggleColumnVisibility flips visibility for an id', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        onColumnVisibilityChange: onChange,
+      }),
+    );
+    act(() => result.current.toggleColumnVisibility('amount'));
+    expect(onChange).toHaveBeenCalledWith({ amount: false });
+    act(() => result.current.toggleColumnVisibility('amount'));
+    expect(onChange).toHaveBeenLastCalledWith({ amount: true });
+  });
+
+  it('pinColumn moves a column to left, right, or unpins it', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        onColumnPinningChange: onChange,
+      }),
+    );
+    act(() => result.current.pinColumn('name', 'left'));
+    expect(onChange).toHaveBeenLastCalledWith({ left: ['name'], right: [] });
+    act(() => result.current.pinColumn('amount', 'right'));
+    expect(onChange).toHaveBeenLastCalledWith({ left: ['name'], right: ['amount'] });
+    act(() => result.current.pinColumn('name', false));
+    expect(onChange).toHaveBeenLastCalledWith({ left: [], right: ['amount'] });
+  });
+
+  it('toggleRowExpanded flips expansion for a row id', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        renderExpandedRow: () => null,
+        onExpandedRowsChange: onChange,
+      }),
+    );
+    act(() => result.current.toggleRowExpanded('r1'));
+    expect(onChange).toHaveBeenCalledWith({ r1: true });
+    act(() => result.current.toggleRowExpanded('r1'));
+    expect(onChange).toHaveBeenLastCalledWith({});
+  });
+});

--- a/packages/design-system/src/components/DataTable/useDataTable.test.ts
+++ b/packages/design-system/src/components/DataTable/useDataTable.test.ts
@@ -94,3 +94,99 @@ describe('useDataTable — state resolution', () => {
     expect(result.current.sort).toBeNull();
   });
 });
+
+describe('useDataTable — derived view-models', () => {
+  it('visibleColumns excludes columns where columnVisibility[id] === false', () => {
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        defaultColumnVisibility: { amount: false },
+      }),
+    );
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(['name']);
+  });
+
+  it('visibleColumns honours columnOrder', () => {
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: cols,
+        getRowId,
+        defaultColumnOrder: ['amount', 'name'],
+      }),
+    );
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(['amount', 'name']);
+  });
+
+  it('columnSizesPx resolves: sizing state > ColumnDef.size > default 120', () => {
+    const colsWithSize: ColumnDef<Row>[] = [
+      { id: 'name', header: 'Name', cell: (r) => r.name },
+      { id: 'amount', header: 'Amount', cell: (r) => r.amount, size: 80 },
+    ];
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: colsWithSize,
+        getRowId,
+        defaultColumnSizing: { name: 200 },
+      }),
+    );
+    expect(result.current.columnSizesPx).toEqual({ name: 200, amount: 80 });
+  });
+
+  it('groups columns by pinning side', () => {
+    const threeCols: ColumnDef<Row>[] = [
+      { id: 'a', header: 'A', cell: (r) => r.id },
+      { id: 'b', header: 'B', cell: (r) => r.id },
+      { id: 'c', header: 'C', cell: (r) => r.id },
+    ];
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: threeCols,
+        getRowId,
+        defaultColumnPinning: { left: ['a'], right: ['c'] },
+      }),
+    );
+    expect(result.current.leftPinnedColumns.map((c) => c.id)).toEqual(['a']);
+    expect(result.current.rightPinnedColumns.map((c) => c.id)).toEqual(['c']);
+    expect(result.current.unpinnedColumns.map((c) => c.id)).toEqual(['b']);
+  });
+
+  it('leftPinOffsets accumulates widths in pin order', () => {
+    const threeCols: ColumnDef<Row>[] = [
+      { id: 'a', header: 'A', cell: (r) => r.id, size: 50 },
+      { id: 'b', header: 'B', cell: (r) => r.id, size: 80 },
+      { id: 'c', header: 'C', cell: (r) => r.id },
+    ];
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: threeCols,
+        getRowId,
+        defaultColumnPinning: { left: ['a', 'b'], right: [] },
+      }),
+    );
+    expect(result.current.leftPinOffsets).toEqual({ a: 0, b: 50 });
+  });
+
+  it('rightPinOffsets accumulates widths from the right side inward', () => {
+    const threeCols: ColumnDef<Row>[] = [
+      { id: 'a', header: 'A', cell: (r) => r.id, size: 50 },
+      { id: 'b', header: 'B', cell: (r) => r.id, size: 80 },
+      { id: 'c', header: 'C', cell: (r) => r.id, size: 60 },
+    ];
+    const { result } = renderHook(() =>
+      useDataTable({
+        data: rows,
+        columns: threeCols,
+        getRowId,
+        defaultColumnPinning: { left: [], right: ['b', 'c'] },
+      }),
+    );
+    // right pinning: rightmost column gets right: 0, next inward stacks past it
+    expect(result.current.rightPinOffsets).toEqual({ c: 0, b: 60 });
+  });
+});

--- a/packages/design-system/src/components/DataTable/useDataTable.test.ts
+++ b/packages/design-system/src/components/DataTable/useDataTable.test.ts
@@ -18,9 +18,7 @@ const getRowId = (r: Row) => r.id;
 
 describe('useDataTable — state resolution', () => {
   it('echoes data, columns, getRowId', () => {
-    const { result } = renderHook(() =>
-      useDataTable({ data: rows, columns: cols, getRowId }),
-    );
+    const { result } = renderHook(() => useDataTable({ data: rows, columns: cols, getRowId }));
     expect(result.current.data).toBe(rows);
     expect(result.current.columns).toBe(cols);
     expect(result.current.getRowId).toBe(getRowId);
@@ -28,9 +26,7 @@ describe('useDataTable — state resolution', () => {
   });
 
   it('defaults enableRowSelection to false and hasExpansion to false', () => {
-    const { result } = renderHook(() =>
-      useDataTable({ data: rows, columns: cols, getRowId }),
-    );
+    const { result } = renderHook(() => useDataTable({ data: rows, columns: cols, getRowId }));
     expect(result.current.enableRowSelection).toBe(false);
     expect(result.current.hasExpansion).toBe(false);
   });
@@ -60,9 +56,7 @@ describe('useDataTable — state resolution', () => {
   });
 
   it('falls back to columns order when no default given', () => {
-    const { result } = renderHook(() =>
-      useDataTable({ data: rows, columns: cols, getRowId }),
-    );
+    const { result } = renderHook(() => useDataTable({ data: rows, columns: cols, getRowId }));
     expect(result.current.columnOrder).toEqual(['name', 'amount']);
   });
 
@@ -83,9 +77,7 @@ describe('useDataTable — state resolution', () => {
   });
 
   it('initialises all other state pieces with sensible defaults', () => {
-    const { result } = renderHook(() =>
-      useDataTable({ data: rows, columns: cols, getRowId }),
-    );
+    const { result } = renderHook(() => useDataTable({ data: rows, columns: cols, getRowId }));
     expect(result.current.columnSizing).toEqual({});
     expect(result.current.columnVisibility).toEqual({});
     expect(result.current.columnPinning).toEqual({ left: [], right: [] });

--- a/packages/design-system/src/components/DataTable/useDataTable.ts
+++ b/packages/design-system/src/components/DataTable/useDataTable.ts
@@ -1,0 +1,145 @@
+import { useMemo } from 'react';
+import { useControllableState } from './useControllableState';
+import type {
+  ColumnOrderState,
+  ColumnPinningState,
+  ColumnSizingState,
+  ColumnVisibilityState,
+  DataTableInstance,
+  ExpandedRowsState,
+  RowSelectionState,
+  SortState,
+  UseDataTableOptions,
+} from './types';
+
+const EMPTY_PINNING: ColumnPinningState = { left: [], right: [] };
+
+/**
+ * Headless state machine for `<DataTable>`. Implements the Radix-style
+ * controlled/uncontrolled pattern for every state piece. Returns an
+ * `instance` object passed into `<DataTable instance={...} />` and any
+ * companion components (e.g. `<DataTable.ColumnVisibilityTrigger>`).
+ *
+ * Pure logic — no DOM, no refs to elements, no side effects beyond firing
+ * the consumer's onChange callbacks.
+ */
+export function useDataTable<T>(options: UseDataTableOptions<T>): DataTableInstance<T> {
+  const {
+    data,
+    pinnedRows = [],
+    columns,
+    getRowId,
+    rowCount,
+    enableRowSelection = false,
+    onRowClick,
+    renderExpandedRow,
+  } = options;
+
+  const defaultColumnOrder = useMemo(
+    () => options.defaultColumnOrder ?? columns.map((c) => c.id),
+    // Intentionally not depending on `columns` — defaultColumnOrder is a
+    // one-time initial value. If columns change identity, consumer must
+    // pass a controlled columnOrder.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const [columnOrder, setColumnOrder] = useControllableState<ColumnOrderState>({
+    value: options.columnOrder,
+    defaultValue: defaultColumnOrder,
+    onChange: options.onColumnOrderChange,
+  });
+
+  const [columnSizing, setColumnSizing] = useControllableState<ColumnSizingState>({
+    value: options.columnSizing,
+    defaultValue: options.defaultColumnSizing ?? {},
+    onChange: options.onColumnSizingChange,
+  });
+
+  const [columnVisibility, setColumnVisibility] = useControllableState<ColumnVisibilityState>({
+    value: options.columnVisibility,
+    defaultValue: options.defaultColumnVisibility ?? {},
+    onChange: options.onColumnVisibilityChange,
+  });
+
+  const [columnPinning, setColumnPinning] = useControllableState<ColumnPinningState>({
+    value: options.columnPinning,
+    defaultValue: options.defaultColumnPinning ?? EMPTY_PINNING,
+    onChange: options.onColumnPinningChange,
+  });
+
+  const [rowSelection, setRowSelection] = useControllableState<RowSelectionState>({
+    value: options.rowSelection,
+    defaultValue: options.defaultRowSelection ?? {},
+    onChange: options.onRowSelectionChange,
+  });
+
+  const [expandedRows, setExpandedRows] = useControllableState<ExpandedRowsState>({
+    value: options.expandedRows,
+    defaultValue: options.defaultExpandedRows ?? {},
+    onChange: options.onExpandedRowsChange,
+  });
+
+  const [sort, setSort] = useControllableState<SortState | null>({
+    value: options.sort,
+    defaultValue: options.defaultSort ?? null,
+    onChange: options.onSortChange,
+  });
+
+  // Derived view-models and helper methods land in subsequent tasks (5 & 6).
+  // For now, stubs that satisfy the interface.
+  const visibleColumns = columns;
+  const leftPinnedColumns: typeof columns = [];
+  const rightPinnedColumns: typeof columns = [];
+  const unpinnedColumns = columns;
+  const columnSizesPx: Record<string, number> = {};
+  const leftPinOffsets: Record<string, number> = {};
+  const rightPinOffsets: Record<string, number> = {};
+
+  const noop = () => {};
+
+  return {
+    data,
+    pinnedRows,
+    columns,
+    getRowId,
+    rowCount,
+    enableRowSelection,
+    hasExpansion: renderExpandedRow != null,
+    onRowClick,
+    renderExpandedRow,
+
+    columnOrder,
+    columnSizing,
+    columnVisibility,
+    columnPinning,
+    rowSelection,
+    expandedRows,
+    sort,
+
+    visibleColumns,
+    leftPinnedColumns,
+    rightPinnedColumns,
+    unpinnedColumns,
+    columnSizesPx,
+    leftPinOffsets,
+    rightPinOffsets,
+
+    setColumnOrder,
+    setColumnSizing,
+    setColumnVisibility,
+    setColumnPinning,
+    setRowSelection,
+    setExpandedRows,
+    setSort,
+
+    toggleRowSelection: noop,
+    toggleAllOnPage: noop,
+    isAllOnPageSelected: () => false,
+    isSomeOnPageSelected: () => false,
+    toggleRowExpanded: noop,
+    toggleColumnVisibility: noop,
+    pinColumn: noop,
+    toggleSort: noop,
+  };
+}

--- a/packages/design-system/src/components/DataTable/useDataTable.ts
+++ b/packages/design-system/src/components/DataTable/useDataTable.ts
@@ -22,6 +22,55 @@ const EMPTY_PINNING: ColumnPinningState = { left: [], right: [] };
  *
  * Pure logic — no DOM, no refs to elements, no side effects beyond firing
  * the consumer's onChange callbacks.
+ *
+ * @example
+ * const instance = useDataTable<Deal>({
+ *   data,
+ *   columns,
+ *   getRowId: (r) => r.id,
+ *   sort,
+ *   onSortChange: setSort,
+ * });
+ * <DataTable instance={instance} aria-label="Deals" />
+ *
+ * @example
+ * // With row selection and column visibility:
+ * const instance = useDataTable<Deal>({
+ *   data,
+ *   columns,
+ *   getRowId: (r) => r.id,
+ *   enableRowSelection: true,
+ *   onRowSelectionChange: setRowSelection,
+ * });
+ * <Cluster justify="end">
+ *   <ColumnVisibilityTrigger instance={instance} />
+ * </Cluster>
+ * <DataTable instance={instance} aria-label="Deals" />
+ *
+ * @example
+ * // Fully controlled column order + sizing (e.g. persisted to localStorage):
+ * const instance = useDataTable<Deal>({
+ *   data,
+ *   columns,
+ *   getRowId: (r) => r.id,
+ *   columnOrder: savedOrder,
+ *   onColumnOrderChange: setSavedOrder,
+ *   columnSizing: savedSizing,
+ *   onColumnSizingChange: setSavedSizing,
+ * });
+ *
+ * @remarks When NOT to use
+ * - For a read-only static table — use `<Table>` directly. `useDataTable`
+ *   adds overhead you don't need when there's no column or row interactivity.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Passing both `value` and `defaultValue` for the same state piece — `value`
+ *   wins and `defaultValue` is silently ignored. Pick one.
+ * - ❌ Mutating `columns` identity across renders. The hook captures
+ *   `defaultColumnOrder` from `columns` once at mount; later identity changes
+ *   don't trigger a re-derive. Pass a stable reference (`useMemo` or module-level).
+ * - ❌ Client-sorting `data` AND passing controlled `sort`. DataTable is
+ *   server-driven — `data` must be the pre-sorted slice the server returned.
  */
 export function useDataTable<T>(options: UseDataTableOptions<T>): DataTableInstance<T> {
   const {

--- a/packages/design-system/src/components/DataTable/useDataTable.ts
+++ b/packages/design-system/src/components/DataTable/useDataTable.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useControllableState } from './useControllableState';
 import type {
   ColumnOrderState,
@@ -163,7 +163,96 @@ export function useDataTable<T>(options: UseDataTableOptions<T>): DataTableInsta
     return out;
   }, [rightPinnedColumns, columnSizesPx]);
 
-  const noop = () => {};
+  const toggleRowSelection = useCallback(
+    (rowId: string) => {
+      setRowSelection((prev) => {
+        const next = { ...prev };
+        if (next[rowId]) delete next[rowId];
+        else next[rowId] = true;
+        return next;
+      });
+    },
+    [setRowSelection],
+  );
+
+  const toggleAllOnPage = useCallback(() => {
+    setRowSelection((prev) => {
+      const pageIds = data.map(getRowId);
+      const allSelected = pageIds.every((id) => prev[id]);
+      if (allSelected) {
+        const next = { ...prev };
+        for (const id of pageIds) delete next[id];
+        return next;
+      }
+      const next = { ...prev };
+      for (const id of pageIds) next[id] = true;
+      return next;
+    });
+  }, [data, getRowId, setRowSelection]);
+
+  const isAllOnPageSelected = useCallback(() => {
+    if (data.length === 0) return false;
+    return data.every((row) => rowSelection[getRowId(row)] === true);
+  }, [data, getRowId, rowSelection]);
+
+  const isSomeOnPageSelected = useCallback(() => {
+    if (data.length === 0) return false;
+    let some = false;
+    let all = true;
+    for (const row of data) {
+      if (rowSelection[getRowId(row)]) some = true;
+      else all = false;
+    }
+    return some && !all;
+  }, [data, getRowId, rowSelection]);
+
+  const toggleRowExpanded = useCallback(
+    (rowId: string) => {
+      setExpandedRows((prev) => {
+        const next = { ...prev };
+        if (next[rowId]) delete next[rowId];
+        else next[rowId] = true;
+        return next;
+      });
+    },
+    [setExpandedRows],
+  );
+
+  const toggleColumnVisibility = useCallback(
+    (columnId: string) => {
+      setColumnVisibility((prev) => ({
+        ...prev,
+        [columnId]: prev[columnId] === false ? true : false,
+      }));
+    },
+    [setColumnVisibility],
+  );
+
+  const pinColumn = useCallback(
+    (columnId: string, side: 'left' | 'right' | false) => {
+      setColumnPinning((prev) => {
+        const left = prev.left.filter((id) => id !== columnId);
+        const right = prev.right.filter((id) => id !== columnId);
+        if (side === 'left') left.push(columnId);
+        else if (side === 'right') right.push(columnId);
+        return { left, right };
+      });
+    },
+    [setColumnPinning],
+  );
+
+  const toggleSort = useCallback(
+    (columnId: string) => {
+      setSort((prev) => {
+        if (!prev || prev.columnId !== columnId) {
+          return { columnId, direction: 'asc' };
+        }
+        if (prev.direction === 'asc') return { columnId, direction: 'desc' };
+        return null;
+      });
+    },
+    [setSort],
+  );
 
   return {
     data,
@@ -200,13 +289,13 @@ export function useDataTable<T>(options: UseDataTableOptions<T>): DataTableInsta
     setExpandedRows,
     setSort,
 
-    toggleRowSelection: noop,
-    toggleAllOnPage: noop,
-    isAllOnPageSelected: () => false,
-    isSomeOnPageSelected: () => false,
-    toggleRowExpanded: noop,
-    toggleColumnVisibility: noop,
-    pinColumn: noop,
-    toggleSort: noop,
+    toggleRowSelection,
+    toggleAllOnPage,
+    isAllOnPageSelected,
+    isSomeOnPageSelected,
+    toggleRowExpanded,
+    toggleColumnVisibility,
+    pinColumn,
+    toggleSort,
   };
 }

--- a/packages/design-system/src/components/DataTable/useDataTable.ts
+++ b/packages/design-system/src/components/DataTable/useDataTable.ts
@@ -86,15 +86,82 @@ export function useDataTable<T>(options: UseDataTableOptions<T>): DataTableInsta
     onChange: options.onSortChange,
   });
 
-  // Derived view-models and helper methods land in subsequent tasks (5 & 6).
-  // For now, stubs that satisfy the interface.
-  const visibleColumns = columns;
-  const leftPinnedColumns: typeof columns = [];
-  const rightPinnedColumns: typeof columns = [];
-  const unpinnedColumns = columns;
-  const columnSizesPx: Record<string, number> = {};
-  const leftPinOffsets: Record<string, number> = {};
-  const rightPinOffsets: Record<string, number> = {};
+  const DEFAULT_COL_WIDTH = 120;
+
+  const columnsById = useMemo(() => {
+    const m = new Map<string, (typeof columns)[number]>();
+    for (const c of columns) m.set(c.id, c);
+    return m;
+  }, [columns]);
+
+  // columnSizesPx: id → resolved width (sizing state > ColumnDef.size > default)
+  const columnSizesPx = useMemo<Record<string, number>>(() => {
+    const out: Record<string, number> = {};
+    for (const c of columns) {
+      out[c.id] = columnSizing[c.id] ?? c.size ?? DEFAULT_COL_WIDTH;
+    }
+    return out;
+  }, [columns, columnSizing]);
+
+  // visibleColumns: ordered (per columnOrder) and filtered (visibility !== false)
+  const visibleColumns = useMemo(() => {
+    const isVisible = (id: string) => columnVisibility[id] !== false;
+    const ordered: typeof columns = [];
+    for (const id of columnOrder) {
+      const col = columnsById.get(id);
+      if (col && isVisible(id)) ordered.push(col);
+    }
+    // Any column not in columnOrder (e.g. added after init) goes to the end.
+    for (const c of columns) {
+      if (!columnOrder.includes(c.id) && isVisible(c.id)) ordered.push(c);
+    }
+    return ordered;
+  }, [columns, columnsById, columnOrder, columnVisibility]);
+
+  // Pin grouping. Pinning order within a side is given by columnPinning.left/right.
+  const leftPinnedColumns = useMemo(
+    () =>
+      columnPinning.left
+        .map((id) => columnsById.get(id))
+        .filter((c): c is (typeof columns)[number] => !!c && columnVisibility[c.id] !== false),
+    [columnPinning.left, columnsById, columnVisibility],
+  );
+
+  const rightPinnedColumns = useMemo(
+    () =>
+      columnPinning.right
+        .map((id) => columnsById.get(id))
+        .filter((c): c is (typeof columns)[number] => !!c && columnVisibility[c.id] !== false),
+    [columnPinning.right, columnsById, columnVisibility],
+  );
+
+  const unpinnedColumns = useMemo(() => {
+    const pinned = new Set([...columnPinning.left, ...columnPinning.right]);
+    return visibleColumns.filter((c) => !pinned.has(c.id));
+  }, [visibleColumns, columnPinning.left, columnPinning.right]);
+
+  // Pin offsets — cumulative widths from the pinned edge inward.
+  const leftPinOffsets = useMemo<Record<string, number>>(() => {
+    const out: Record<string, number> = {};
+    let acc = 0;
+    for (const col of leftPinnedColumns) {
+      out[col.id] = acc;
+      acc += columnSizesPx[col.id] ?? DEFAULT_COL_WIDTH;
+    }
+    return out;
+  }, [leftPinnedColumns, columnSizesPx]);
+
+  const rightPinOffsets = useMemo<Record<string, number>>(() => {
+    const out: Record<string, number> = {};
+    let acc = 0;
+    // Rightmost pinned column has offset 0; walk right-to-left accumulating.
+    for (let i = rightPinnedColumns.length - 1; i >= 0; i--) {
+      const col = rightPinnedColumns[i]!;
+      out[col.id] = acc;
+      acc += columnSizesPx[col.id] ?? DEFAULT_COL_WIDTH;
+    }
+    return out;
+  }, [rightPinnedColumns, columnSizesPx]);
 
   const noop = () => {};
 

--- a/packages/design-system/src/components/DataTable/useResizeHandle.test.ts
+++ b/packages/design-system/src/components/DataTable/useResizeHandle.test.ts
@@ -1,0 +1,123 @@
+import { renderHook, act } from '@testing-library/react';
+import { useResizeHandle } from './useResizeHandle';
+
+function pointer(type: string, clientX: number, pointerId = 1): PointerEvent {
+  return new PointerEvent(type, { clientX, pointerId, bubbles: true });
+}
+
+describe('useResizeHandle', () => {
+  it('returns initial isResizing=false', () => {
+    const { result } = renderHook(() =>
+      useResizeHandle({ initialWidth: 100, minWidth: 40, onResize: () => {} }),
+    );
+    expect(result.current.isResizing).toBe(false);
+  });
+
+  it('pointerdown → pointermove → pointerup fires onResize with delta-clamped width', () => {
+    const onResize = vi.fn();
+    const { result } = renderHook(() =>
+      useResizeHandle({ initialWidth: 100, minWidth: 40, onResize }),
+    );
+
+    const target = document.createElement('div');
+    // jsdom's setPointerCapture is a no-op; that's fine.
+    target.setPointerCapture = vi.fn();
+    target.releasePointerCapture = vi.fn();
+
+    act(() => {
+      result.current.onPointerDown({
+        ...pointer('pointerdown', 50),
+        currentTarget: target,
+        clientX: 50,
+        pointerId: 1,
+      } as any);
+    });
+    expect(result.current.isResizing).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(pointer('pointermove', 75)); // +25px
+    });
+    expect(onResize).toHaveBeenCalledWith(125);
+
+    act(() => {
+      window.dispatchEvent(pointer('pointerup', 75));
+    });
+    expect(result.current.isResizing).toBe(false);
+  });
+
+  it('clamps width below minWidth', () => {
+    const onResize = vi.fn();
+    const { result } = renderHook(() =>
+      useResizeHandle({ initialWidth: 100, minWidth: 40, onResize }),
+    );
+
+    const target = document.createElement('div');
+    target.setPointerCapture = vi.fn();
+    target.releasePointerCapture = vi.fn();
+
+    act(() => {
+      result.current.onPointerDown({
+        ...pointer('pointerdown', 50),
+        currentTarget: target,
+        clientX: 50,
+        pointerId: 1,
+      } as any);
+    });
+
+    act(() => {
+      window.dispatchEvent(pointer('pointermove', -100)); // -150px would be width=-50
+    });
+    expect(onResize).toHaveBeenLastCalledWith(40); // clamped to minWidth
+  });
+
+  it('clamps to maxWidth when provided', () => {
+    const onResize = vi.fn();
+    const { result } = renderHook(() =>
+      useResizeHandle({ initialWidth: 100, minWidth: 40, maxWidth: 200, onResize }),
+    );
+
+    const target = document.createElement('div');
+    target.setPointerCapture = vi.fn();
+    target.releasePointerCapture = vi.fn();
+
+    act(() => {
+      result.current.onPointerDown({
+        ...pointer('pointerdown', 50),
+        currentTarget: target,
+        clientX: 50,
+        pointerId: 1,
+      } as any);
+    });
+
+    act(() => {
+      window.dispatchEvent(pointer('pointermove', 500));
+    });
+    expect(onResize).toHaveBeenLastCalledWith(200);
+  });
+
+  it('pointercancel ends the drag', () => {
+    const onResize = vi.fn();
+    const { result } = renderHook(() =>
+      useResizeHandle({ initialWidth: 100, minWidth: 40, onResize }),
+    );
+
+    const target = document.createElement('div');
+    target.setPointerCapture = vi.fn();
+    target.releasePointerCapture = vi.fn();
+
+    act(() => {
+      result.current.onPointerDown({
+        ...pointer('pointerdown', 50),
+        currentTarget: target,
+        clientX: 50,
+        pointerId: 1,
+      } as any);
+    });
+    expect(result.current.isResizing).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(pointer('pointercancel', 60));
+    });
+    expect(result.current.isResizing).toBe(false);
+  });
+});

--- a/packages/design-system/src/components/DataTable/useResizeHandle.ts
+++ b/packages/design-system/src/components/DataTable/useResizeHandle.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+
+interface UseResizeHandleOptions {
+  initialWidth: number;
+  minWidth: number;
+  maxWidth?: number;
+  onResize: (nextWidth: number) => void;
+}
+
+interface ResizeHandleApi {
+  isResizing: boolean;
+  onPointerDown: (e: ReactPointerEvent<HTMLElement>) => void;
+}
+
+/**
+ * Pointer-based resize-handle hook. Attach `onPointerDown` to the handle
+ * element. While dragging, `pointermove` on window fires `onResize` with
+ * the clamped width; `pointerup` / `pointercancel` ends the drag.
+ *
+ * `initialWidth` is captured at pointerdown — callers don't need to keep
+ * it in sync between events (the hook holds the start width internally).
+ *
+ * @remarks
+ * **When NOT to use / anti-patterns**
+ *
+ * - Do not use this hook outside of a column-resize context. It is
+ *   purpose-built for DataTable header cells and assumes a horizontal
+ *   drag interaction with a fixed start width.
+ * - Do not wire `onPointerDown` to a full cell — only the narrow resize
+ *   handle element. Attaching it to the whole header cell will intercept
+ *   sort clicks and other cell interactions.
+ * - Do not rely on `setPointerCapture` being functional in all
+ *   environments (it is best-effort / no-op in jsdom). The hook falls
+ *   back to window-level listeners for cross-browser reliability.
+ */
+export function useResizeHandle(options: UseResizeHandleOptions): ResizeHandleApi {
+  const { minWidth, maxWidth, onResize } = options;
+  const [isResizing, setIsResizing] = useState(false);
+
+  // Held in refs so handlers attached to window don't go stale.
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+  const onResizeRef = useRef(onResize);
+  onResizeRef.current = onResize;
+  const minRef = useRef(minWidth);
+  minRef.current = minWidth;
+  const maxRef = useRef(maxWidth);
+  maxRef.current = maxWidth;
+
+  const onPointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLElement>) => {
+      e.stopPropagation?.();
+      startXRef.current = e.clientX;
+      startWidthRef.current = options.initialWidth;
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        // No-op for older browsers / jsdom.
+      }
+      setIsResizing(true);
+    },
+    [options.initialWidth],
+  );
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    function clamp(n: number) {
+      const min = minRef.current;
+      const max = maxRef.current;
+      let v = Math.max(min, n);
+      if (max != null) v = Math.min(max, v);
+      return v;
+    }
+
+    function onMove(e: PointerEvent) {
+      const delta = e.clientX - startXRef.current;
+      const next = clamp(startWidthRef.current + delta);
+      onResizeRef.current(next);
+    }
+    function onEnd() {
+      setIsResizing(false);
+    }
+
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onEnd);
+    window.addEventListener('pointercancel', onEnd);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onEnd);
+      window.removeEventListener('pointercancel', onEnd);
+    };
+  }, [isResizing]);
+
+  return { isResizing, onPointerDown };
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -129,8 +129,24 @@ export type { PaginationProps, PaginationSize, PaginationItem } from './componen
 export { CursorPagination } from './components/CursorPagination';
 export type { CursorPaginationProps } from './components/CursorPagination';
 
-export { DataTable, useDataTable } from './components/DataTable';
-export type { DataTableProps } from './components/DataTable';
+export { DataTable, useDataTable, ColumnVisibilityTrigger } from './components/DataTable';
+export type {
+  DataTableProps,
+  ColumnVisibilityTriggerProps,
+  DataTableInstance,
+  UseDataTableOptions,
+  ColumnDef,
+  ColumnAlign,
+  ColumnOrderState,
+  ColumnSizingState,
+  ColumnVisibilityState,
+  ColumnPinningState,
+  RowSelectionState,
+  ExpandedRowsState,
+  SortState,
+  HeaderContext,
+  CellContext,
+} from './components/DataTable';
 
 // i18n
 export { LocaleProvider, useLocale } from './i18n';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -129,6 +129,9 @@ export type { PaginationProps, PaginationSize, PaginationItem } from './componen
 export { CursorPagination } from './components/CursorPagination';
 export type { CursorPaginationProps } from './components/CursorPagination';
 
+export { DataTable, useDataTable } from './components/DataTable';
+export type { DataTableProps } from './components/DataTable';
+
 // i18n
 export { LocaleProvider, useLocale } from './i18n';
 export type { LocaleProviderProps } from './i18n';

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -71,8 +71,9 @@
   --ring-success: rgb(0 135 90 / 40%);
   --ring-width: 2px;
 
-  // Spacing — 4px scale
+  // Spacing — 4px scale (--space-05 is a half-step at 2px for tight internal padding)
   --space-0: 0;
+  --space-05: 2px;
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -236,6 +236,7 @@
   --opacity-disabled: 0.5;
   --opacity-muted: 0.75; // de-emphasised secondary text (e.g. event time prefix)
   --opacity-subtle: 0.6; // skeleton pulse dim; slightly stronger fade than muted
+  --opacity-dragging: 0.4; // drag-in-progress source element fade
   --opacity-hidden: 0;
   --opacity-visible: 1;
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -29,6 +29,7 @@ import { PopoverDemo } from './pages/components/PopoverDemo';
 import { RadioDemo } from './pages/components/RadioDemo';
 import { CalendarDemo } from './pages/components/CalendarDemo';
 import { ConfirmationPopoverDemo } from './pages/components/ConfirmationPopoverDemo';
+import { DataTableDemo } from './pages/components/DataTableDemo';
 import { EmptyStateDemo } from './pages/components/EmptyStateDemo';
 
 export default function App() {
@@ -71,6 +72,7 @@ export default function App() {
           <Route path="/components/radio" element={<RadioDemo />} />
           <Route path="/components/calendar" element={<CalendarDemo />} />
           <Route path="/components/confirmation-popover" element={<ConfirmationPopoverDemo />} />
+          <Route path="/components/datatable" element={<DataTableDemo />} />
           <Route path="/components/empty-state" element={<EmptyStateDemo />} />
         </Routes>
       </AppShell>

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -32,6 +32,7 @@ import {
   Inbox,
   Square,
   Table as TableIcon,
+  TableProperties,
   ListOrdered,
   type LucideIcon,
 } from 'lucide-react';
@@ -91,6 +92,7 @@ const componentGroups = [
       { to: '/components/pagination', label: 'Pagination', icon: ListOrdered, end: false },
       { to: '/components/skeleton', label: 'Skeleton', icon: Square, end: false },
       { to: '/components/table', label: 'Table', icon: TableIcon, end: false },
+      { to: '/components/datatable', label: 'DataTable', icon: TableProperties, end: false },
     ],
   },
   {

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -19,10 +19,34 @@ import { Tooltip } from '@eocrm/design-system';
 import { Calendar } from '@eocrm/design-system';
 import { DatePicker } from '@eocrm/design-system';
 import { ConfirmationPopover, Popover } from '@eocrm/design-system';
+import { DataTable, useDataTable, type ColumnDef } from '@eocrm/design-system';
 import { EmptyState } from '@eocrm/design-system';
 import { Pagination } from '@eocrm/design-system';
 import { Radio, RadioGroup } from '@eocrm/design-system';
 import styles from './ComponentsIndex.module.scss';
+
+type _PreviewRow = { id: string; name: string; stage: string; amount: string };
+const _previewCols: ColumnDef<_PreviewRow>[] = [
+  { id: 'name', header: 'Deal', cell: (r) => r.name, size: 120 },
+  { id: 'stage', header: 'Stage', cell: (r) => r.stage, size: 90 },
+  { id: 'amount', header: 'Amount', cell: (r) => r.amount, align: 'end', size: 80 },
+];
+const _previewData: _PreviewRow[] = [
+  { id: '1', name: 'Acme', stage: 'Won', amount: '$12k' },
+  { id: '2', name: 'Globex', stage: 'Lead', amount: '$4.5k' },
+];
+function DataTablePreview() {
+  const instance = useDataTable<_PreviewRow>({
+    data: _previewData,
+    columns: _previewCols,
+    getRowId: (r) => r.id,
+  });
+  return (
+    <div style={{ width: 220, pointerEvents: 'none' }}>
+      <DataTable instance={instance} aria-label="Preview" />
+    </div>
+  );
+}
 
 const items: { to: string; name: string; description: string; preview: React.ReactNode }[] = [
   {
@@ -144,6 +168,13 @@ const items: { to: string; name: string; description: string; preview: React.Rea
         <Skeleton width="40%" />
       </Stack>
     ),
+  },
+  {
+    to: '/components/datatable',
+    name: 'DataTable',
+    description:
+      'Tabular data with sortable / resizable / reorderable columns and row selection.',
+    preview: <DataTablePreview />,
   },
   {
     to: '/components/table',

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -172,8 +172,7 @@ const items: { to: string; name: string; description: string; preview: React.Rea
   {
     to: '/components/datatable',
     name: 'DataTable',
-    description:
-      'Tabular data with sortable / resizable / reorderable columns and row selection.',
+    description: 'Tabular data with sortable / resizable / reorderable columns and row selection.',
     preview: <DataTablePreview />,
   },
   {

--- a/packages/playground/src/pages/components/DataTableDemo.tsx
+++ b/packages/playground/src/pages/components/DataTableDemo.tsx
@@ -23,25 +23,41 @@ type Deal = {
 };
 
 const deals: Deal[] = [
-  { id: 'd1', name: 'Acme renewal',       stage: 'Negotiation', amount: 12000, owner: 'Sara' },
-  { id: 'd2', name: 'Globex expansion',   stage: 'Lead',        amount: 4500,  owner: 'Marcus' },
-  { id: 'd3', name: 'Initech onboarding', stage: 'Won',         amount: 8800,  owner: 'Sara' },
-  { id: 'd4', name: 'Hooli pilot',        stage: 'Lost',        amount: 0,     owner: 'Jin' },
+  { id: 'd1', name: 'Acme renewal', stage: 'Negotiation', amount: 12000, owner: 'Sara' },
+  { id: 'd2', name: 'Globex expansion', stage: 'Lead', amount: 4500, owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won', amount: 8800, owner: 'Sara' },
+  { id: 'd4', name: 'Hooli pilot', stage: 'Lost', amount: 0, owner: 'Jin' },
 ];
 
 const dealColumns: ColumnDef<Deal>[] = [
-  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                                         sortable: true, size: 200 },
-  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,              size: 140 },
-  { id: 'amount', header: 'Amount', cell: (r) => `$${r.amount.toLocaleString()}`, align: 'end', sortable: true,   size: 120 },
-  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                         size: 120 },
+  { id: 'name', header: 'Deal', cell: (r) => r.name, sortable: true, size: 200 },
+  {
+    id: 'stage',
+    header: 'Stage',
+    cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,
+    size: 140,
+  },
+  {
+    id: 'amount',
+    header: 'Amount',
+    cell: (r) => `$${r.amount.toLocaleString()}`,
+    align: 'end',
+    sortable: true,
+    size: 120,
+  },
+  { id: 'owner', header: 'Owner', cell: (r) => r.owner, size: 120 },
 ];
 
 function stageTone(stage: Deal['stage']) {
   switch (stage) {
-    case 'Won':         return 'success' as const;
-    case 'Lost':        return 'danger' as const;
-    case 'Negotiation': return 'warning' as const;
-    default:            return 'info' as const;
+    case 'Won':
+      return 'success' as const;
+    case 'Lost':
+      return 'danger' as const;
+    case 'Negotiation':
+      return 'warning' as const;
+    default:
+      return 'info' as const;
   }
 }
 

--- a/packages/playground/src/pages/components/DataTableDemo.tsx
+++ b/packages/playground/src/pages/components/DataTableDemo.tsx
@@ -1,0 +1,215 @@
+import { useState } from 'react';
+import {
+  Badge,
+  Cluster,
+  ColumnVisibilityTrigger,
+  DataTable,
+  Stack,
+  useDataTable,
+  type ColumnDef,
+  type SortState,
+} from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/DataTable/DataTable.tsx?raw';
+import scssSource from '@lib-source/components/DataTable/DataTable.module.scss?raw';
+
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
+
+const deals: Deal[] = [
+  { id: 'd1', name: 'Acme renewal',       stage: 'Negotiation', amount: 12000, owner: 'Sara' },
+  { id: 'd2', name: 'Globex expansion',   stage: 'Lead',        amount: 4500,  owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won',         amount: 8800,  owner: 'Sara' },
+  { id: 'd4', name: 'Hooli pilot',        stage: 'Lost',        amount: 0,     owner: 'Jin' },
+];
+
+const dealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                                         sortable: true, size: 200 },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,              size: 140 },
+  { id: 'amount', header: 'Amount', cell: (r) => `$${r.amount.toLocaleString()}`, align: 'end', sortable: true,   size: 120 },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                         size: 120 },
+];
+
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger' as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info' as const;
+  }
+}
+
+export function DataTableDemo() {
+  return (
+    <DemoLayout
+      name="DataTable"
+      description="Composition over the Table primitive with column ordering / sizing / visibility, row selection, row click, sortable headers, and loading/empty states. Phase 1 — column pinning and expandable rows ship in later phases."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="DataTable.tsx"
+      scssFilename="DataTable.module.scss"
+    >
+      <BasicExample />
+      <SortableExample />
+      <SelectableExample />
+      <VisibilityExample />
+      <LoadingExample />
+      <EmptyExample />
+    </DemoLayout>
+  );
+}
+
+function BasicExample() {
+  return (
+    <Example
+      title="Basic"
+      description="Default DataTable with sticky header, hover rows, and resizable + reorderable columns. Click any header label to sort. Hover over a header to reveal the drag grip."
+      code={`const instance = useDataTable<Deal>({ data, columns, getRowId: (r) => r.id });
+return <DataTable instance={instance} aria-label="Deals" />;`}
+    >
+      <BasicTable />
+    </Example>
+  );
+}
+
+function BasicTable() {
+  const instance = useDataTable<Deal>({
+    data: deals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+  });
+  return <DataTable instance={instance} aria-label="Deals (basic)" />;
+}
+
+function SortableExample() {
+  const [sort, setSort] = useState<SortState | null>(null);
+  const sortedDeals = sort
+    ? [...deals].sort((a, b) => {
+        const va = (a as Record<string, unknown>)[sort.columnId] as string | number;
+        const vb = (b as Record<string, unknown>)[sort.columnId] as string | number;
+        const cmp = va < vb ? -1 : va > vb ? 1 : 0;
+        return sort.direction === 'asc' ? cmp : -cmp;
+      })
+    : deals;
+
+  const instance = useDataTable<Deal>({
+    data: sortedDeals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    sort,
+    onSortChange: setSort,
+  });
+
+  return (
+    <Example
+      title="Server-driven sort (simulated)"
+      description="The demo sorts on the client for illustration, but in real code your onSortChange callback would refetch from the server with the new sort. DataTable does not transform data — it only manages and emits sort state."
+      code={`const [sort, setSort] = useState<SortState | null>(null);
+const instance = useDataTable({ data, columns, getRowId, sort, onSortChange: setSort });`}
+    >
+      <DataTable instance={instance} aria-label="Deals (sortable)" />
+    </Example>
+  );
+}
+
+function SelectableExample() {
+  const [selection, setSelection] = useState<Record<string, boolean>>({});
+  const selectedCount = Object.keys(selection).length;
+
+  const instance = useDataTable<Deal>({
+    data: deals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    enableRowSelection: true,
+    rowSelection: selection,
+    onRowSelectionChange: setSelection,
+    onRowClick: (row) => alert(`Row clicked: ${row.name}`),
+  });
+
+  return (
+    <Example
+      title="Selection + row click"
+      description="enableRowSelection adds a checkbox column. The header checkbox toggles all rows on the current page (indeterminate when partially selected). Clicking elsewhere on a row fires onRowClick — but clicking the checkbox does not."
+      code={`const [selection, setSelection] = useState({});
+const instance = useDataTable({
+  data, columns, getRowId,
+  enableRowSelection: true,
+  rowSelection: selection,
+  onRowSelectionChange: setSelection,
+  onRowClick: (row) => navigate(\`/deals/\${row.id}\`),
+});`}
+    >
+      <Stack gap="sm">
+        <Cluster gap="sm">
+          <span>{selectedCount} selected</span>
+        </Cluster>
+        <DataTable instance={instance} aria-label="Deals (selectable)" />
+      </Stack>
+    </Example>
+  );
+}
+
+function VisibilityExample() {
+  const instance = useDataTable<Deal>({
+    data: deals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    defaultColumnVisibility: { owner: false },
+  });
+
+  return (
+    <Example
+      title="Column visibility"
+      description="ColumnVisibilityTrigger renders a Button → DropdownMenu of CheckboxItems for every column where enableHide is not false. The last visible hidable column is disabled — DataTable always shows at least one data column."
+      code={`<Cluster><ColumnVisibilityTrigger instance={instance} /></Cluster>
+<DataTable instance={instance} />`}
+    >
+      <Stack gap="sm">
+        <Cluster gap="sm">
+          <ColumnVisibilityTrigger instance={instance} />
+        </Cluster>
+        <DataTable instance={instance} aria-label="Deals (visibility)" />
+      </Stack>
+    </Example>
+  );
+}
+
+function LoadingExample() {
+  const instance = useDataTable<Deal>({
+    data: [],
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+  });
+  return (
+    <Example
+      title="Loading"
+      description="Pass loading to render skeleton rows. loadingRowCount controls how many (default 10)."
+      code={`<DataTable instance={instance} loading loadingRowCount={4} />`}
+    >
+      <DataTable instance={instance} loading loadingRowCount={4} aria-label="Loading" />
+    </Example>
+  );
+}
+
+function EmptyExample() {
+  const instance = useDataTable<Deal>({
+    data: [],
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+  });
+  return (
+    <Example
+      title="Empty"
+      description="When data is empty (and not loading), DataTable shows a default EmptyState. Pass emptyState for a custom one."
+      code={`<DataTable instance={instance} aria-label="Deals" />`}
+    >
+      <DataTable instance={instance} aria-label="Deals (empty)" />
+    </Example>
+  );
+}

--- a/packages/playground/src/pages/components/DataTableDemo.tsx
+++ b/packages/playground/src/pages/components/DataTableDemo.tsx
@@ -49,6 +49,7 @@ export function DataTableDemo() {
   return (
     <DemoLayout
       name="DataTable"
+      componentName="DataTable"
       description="Composition over the Table primitive with column ordering / sizing / visibility, row selection, row click, sortable headers, and loading/empty states. Phase 1 — column pinning and expandable rows ship in later phases."
       tsxSource={tsxSource}
       scssSource={scssSource}

--- a/packages/playground/src/pages/components/DataTableDemo.tsx
+++ b/packages/playground/src/pages/components/DataTableDemo.tsx
@@ -57,6 +57,8 @@ export function DataTableDemo() {
       scssFilename="DataTable.module.scss"
     >
       <BasicExample />
+      <BorderedExample />
+      <DenseExample />
       <SortableExample />
       <SelectableExample />
       <VisibilityExample />
@@ -86,6 +88,40 @@ function BasicTable() {
     getRowId: (r) => r.id,
   });
   return <DataTable instance={instance} aria-label="Deals (basic)" />;
+}
+
+function BorderedExample() {
+  const instance = useDataTable<Deal>({
+    data: deals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+  });
+  return (
+    <Example
+      title="Bordered"
+      description="Pass bordered for a full grid of cell borders. Useful when the table contains many numeric columns or when rendered on a white background without zebra striping."
+      code={`<DataTable instance={instance} bordered aria-label="Deals (bordered)" />`}
+    >
+      <DataTable instance={instance} bordered aria-label="Deals (bordered)" />
+    </Example>
+  );
+}
+
+function DenseExample() {
+  const instance = useDataTable<Deal>({
+    data: deals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+  });
+  return (
+    <Example
+      title="Dense"
+      description="density='dense' reduces row height and padding — useful for data-heavy screens where vertical space is at a premium."
+      code={`<DataTable instance={instance} density="dense" aria-label="Deals (dense)" />`}
+    >
+      <DataTable instance={instance} density="dense" aria-label="Deals (dense)" />
+    </Example>
+  );
 }
 
 function SortableExample() {

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -10,6 +10,7 @@ export type ComponentName =
   | 'Cluster'
   | 'ConfirmationPopover'
   | 'CursorPagination'
+  | 'DataTable'
   | 'DatePicker'
   | 'DateRangePicker'
   | 'DropdownMenu'


### PR DESCRIPTION
## Summary

- New `<DataTable>` component composing the `<Table>` primitive
- `useDataTable<T>` hook owns column-axis state (order / sizing / visibility / pinning) and row-axis state (selection / expansion / sort)
- `<ColumnVisibilityTrigger>` built-in companion for show/hide menu
- Drag-to-reorder columns via `@dnd-kit/sortable` (with keyboard a11y)
- Hand-rolled pointer-based resize handle (keyboard ± resize via header label)
- Sticky header default-on; loading / empty / sortable / selectable states; row click + Enter handler

**Phase 1 of 3.** Column pinning rendering and expandable rows ship in phases 2 and 3 — state plumbing for both is included here so the API surface is forward-compatible.

Spec: `docs/superpowers/specs/2026-05-22-datatable-design.md`
Plan: `docs/superpowers/plans/2026-05-22-datatable-phase-1.md`

## What's in the diff

- New deps: `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` (~16KB gzipped, behavioral hooks — same rationale as `@floating-ui/react-dom`)
- New tokens: `--opacity-dragging`, `--space-05`
- New library files: `useDataTable`, `useControllableState`, `useResizeHandle`, `HeaderCell`, `BodyRow`, `DataTable`, `ColumnVisibilityTrigger`, types
- Playground demo with 8 examples (basic / sortable / selectable / visibility / loading / empty / bordered / dense)
- AGENTS.md TL;DR + per-field JSDoc on all public types

## Test plan

- [x] `useDataTable` pure-logic unit tests (controlled/uncontrolled resolution, all helpers, derived view-models including pin offsets)
- [x] `useResizeHandle` pointer + clamping tests
- [x] `useControllableState` controlled vs uncontrolled tests
- [x] `<DataTable>` integration tests (sort click, selection, row click, hidden columns, column order, loading, empty, ref forwarding, className merge, keyboard activation)
- [x] `<ColumnVisibilityTrigger>` last-visible-guard + toggle tests
- [x] Playground demo manually exercised at `/components/datatable`
- [x] Hard-rule-8 pre-push review-fix cycle completed (Critical + Important findings fixed)

**Known gap:** column drag-and-drop reorder is not unit-tested (jsdom limitation with `@dnd-kit`'s PointerSensor). Documented in the test file header. Playground demo is the smoke test; a Playwright e2e is the planned remedy.

## Header anatomy

- Drag grip absolute-positioned at the cell's left edge (hover-revealed)
- Sort indicator pinned to the right end of the cell content
- Resize handle absolute-positioned at the cell's right edge, with `‹|›` chevrons + central bar (visible on cell hover, accent color on active drag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)