### PR TITLE
Modal: focus-locked compound dialog (sm/md/lg, solid+blur overlay, stacked, fullscreen mobile)

### DIFF
--- a/docs/superpowers/plans/2026-05-22-modal.md
+++ b/docs/superpowers/plans/2026-05-22-modal.md
@@ -14,6 +14,16 @@
 
 ---
 
+## AMENDMENT (2026-05-22, mid-execution)
+
+Two requirements added after Task 3 was complete. The implementation controller will weave these into the per-task prompts for Tasks 5, 6, 9, 12. The verbatim code blocks below should be treated as a base; the controller's prompts will note the exact deltas.
+
+**A — Overlay variant prop.** Add `overlay?: 'solid' | 'blur'` to `ModalProps` (default `'solid'`). Thread through `ModalContextValue`. `Overlay.tsx` writes `data-variant={ctx.overlay}` on the portal root. SCSS adds a `.overlay[data-variant='blur']` rule using the new `--color-bg-overlay-blur` token (`rgb(255 255 255 / 30%)`) and `backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);`. Token already added to `tokens.scss` (follow-up commit).
+
+**B — Stack display model: only top is visible.** Stacked modals reuse a single visible overlay layer — the topmost. Lower modals stay mounted (React state preserved) but are hidden via `display: none`. Implementation: `Overlay.tsx` writes `data-stack-position={ctx.isTop ? 'top' : 'hidden'}` on the portal root; SCSS adds `.overlay[data-stack-position='hidden'] { display: none; }`. Re-show on pop is instant (no fade). Z-index calc stays in the SCSS for safety but is effectively a no-op since at most one overlay is `display: block`.
+
+---
+
 ## File Structure
 
 ```

--- a/docs/superpowers/plans/2026-05-22-modal.md
+++ b/docs/superpowers/plans/2026-05-22-modal.md
@@ -69,6 +69,7 @@ packages/playground/src/pages/mockups/registry.ts        ← MODIFY: 'Modal' in 
 ## Task 1 — New tokens
 
 **Files:**
+
 - Modify: `packages/design-system/src/styles/tokens.scss`
 
 - [ ] **Step 1: Verify branch + clean tree**
@@ -81,6 +82,7 @@ git log --oneline -3
 ```
 
 Expected:
+
 - Branch: `feat/modal`
 - Working tree clean
 - Most recent commit: this plan + `63716f7 Modal: design spec — compound API …`
@@ -127,6 +129,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 Pure hook. Attach `keydown` to cycle Tab within a container ref + `focusin` to redirect any focus escape back into the container. Stack-aware: when the modal isn't top of the stack, the focusin redirect is a no-op (the topmost modal owns focus).
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Modal/useFocusTrap.ts`
 - Test: `packages/design-system/src/components/Modal/useFocusTrap.test.ts`
 
@@ -299,10 +302,7 @@ function getFocusables(container: HTMLElement): HTMLElement[] {
  * const contentRef = useRef<HTMLDivElement | null>(null);
  * useFocusTrap(contentRef, open);
  */
-export function useFocusTrap(
-  containerRef: RefObject<HTMLElement | null>,
-  active: boolean,
-): void {
+export function useFocusTrap(containerRef: RefObject<HTMLElement | null>, active: boolean): void {
   useEffect(() => {
     if (!active) return;
     const container = containerRef.current;
@@ -372,6 +372,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 Ref-counted body-scroll suppression. The first modal to mount sets `body.style.overflow = 'hidden'` (and adds `padding-right` equal to the scrollbar width to prevent layout shift); the last modal to unmount restores both. Module-level counter so nested modals all see the same lock.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Modal/useScrollLock.ts`
 - Test: `packages/design-system/src/components/Modal/useScrollLock.test.ts`
 
@@ -513,6 +514,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 Module-level singleton tracking which modal ids are currently open. Exposes `register(id) -> depth`, `unregister(id)`, `isTop(id) -> boolean`, `topDepth() -> number`. Used for routing Escape and assigning per-modal z-index via the `--modal-depth` CSS custom prop.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Modal/useModalStack.ts`
 - Test: `packages/design-system/src/components/Modal/useModalStack.test.ts`
 
@@ -727,6 +729,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 Provider component owning state, refs, and the cross-cutting lifecycle (capture/restore focus, scroll lock, stack register, heading id registration). `ModalRoot` renders nothing visible — just provides context. The Overlay/Content render conditionally on `open`.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Modal/context.ts`
 - Create: `packages/design-system/src/components/Modal/ModalRoot.tsx`
 
@@ -1012,6 +1015,7 @@ Expected: fails because `./Overlay` and `./Content` don't exist yet. That's OK �
 The portaled backdrop + dialog container. Handles dismissal (Escape, overlay click), focus restoration, inert background, focus trap activation, and the z-index custom-prop wiring.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Modal/Overlay.tsx`
 - Create: `packages/design-system/src/components/Modal/Content.tsx`
 
@@ -1202,6 +1206,7 @@ The component still needs `Header/Body/Footer/Close` (Task 7), the assembled `Mo
 Compound members. Each is a small forwardRef component.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Modal/Header.tsx`
 - Create: `packages/design-system/src/components/Modal/Body.tsx`
 - Create: `packages/design-system/src/components/Modal/Footer.tsx`
@@ -1399,6 +1404,7 @@ Expected: passes. (SCSS classes referenced — `header`, `headerTitle`, `headerC
 ## Task 8 — `Modal.tsx` compound assembly + folder `index.ts`
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Modal/Modal.tsx`
 - Create: `packages/design-system/src/components/Modal/index.ts`
 
@@ -1463,6 +1469,7 @@ Expected: passes.
 The full stylesheet: overlay backdrop + dialog container with three size presets + Header/Body/Footer + animations + mobile fullscreen + reduced-motion.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Modal/Modal.module.scss`
 
 - [ ] **Step 1: Create the SCSS module**
@@ -1534,9 +1541,15 @@ The full stylesheet: overlay backdrop + dialog container with three size presets
 // Size presets — each one sets --modal-width which `.content` consumes via
 // the `min(100% - 32px, var(--modal-width, …))` clamp above. Using a custom
 // prop keeps the size logic in one place.
-.size-sm { --modal-width: var(--size-modal-sm); }
-.size-md { --modal-width: var(--size-modal-md); }
-.size-lg { --modal-width: var(--size-modal-lg); }
+.size-sm {
+  --modal-width: var(--size-modal-sm);
+}
+.size-md {
+  --modal-width: var(--size-modal-md);
+}
+.size-lg {
+  --modal-width: var(--size-modal-lg);
+}
 
 // ─── Header ─────────────────────────────────────────────────────────────
 
@@ -1606,9 +1619,15 @@ The full stylesheet: overlay backdrop + dialog container with three size presets
   border-top: var(--border-width) solid var(--color-border);
 }
 
-.footerAlign-start { justify-content: flex-start; }
-.footerAlign-end { justify-content: flex-end; }
-.footerAlign-space-between { justify-content: space-between; }
+.footerAlign-start {
+  justify-content: flex-start;
+}
+.footerAlign-end {
+  justify-content: flex-end;
+}
+.footerAlign-space-between {
+  justify-content: space-between;
+}
 
 // ─── Mobile fullscreen breakpoint ───────────────────────────────────────
 
@@ -1688,6 +1707,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 End-to-end behavior tests via React Testing Library. Verifies the full compound assembly works correctly.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Modal/Modal.test.tsx`
 
 - [ ] **Step 1: Write the integration tests**
@@ -2066,6 +2086,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ## Task 11 — Public exports + AGENTS.md TL;DR + JSDoc final pass
 
 **Files:**
+
 - Modify: `packages/design-system/src/index.ts`
 - Modify: `packages/design-system/AGENTS.md`
 
@@ -2167,6 +2188,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ## Task 12 — Playground demo + nav wiring
 
 **Files:**
+
 - Create: `packages/playground/src/pages/components/ModalDemo.tsx`
 - Modify: `packages/playground/src/App.tsx`
 - Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
@@ -2179,14 +2201,7 @@ Create `packages/playground/src/pages/components/ModalDemo.tsx`:
 
 ```tsx
 import { useRef, useState } from 'react';
-import {
-  Badge,
-  Button,
-  Cluster,
-  Input,
-  Modal,
-  Stack,
-} from '@eocrm/design-system';
+import { Badge, Button, Cluster, Input, Modal, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import tsxSource from '@lib-source/components/Modal/ModalRoot.tsx?raw';
@@ -2362,7 +2377,9 @@ function ForcedStepExample() {
         aria-label="Session expired"
       >
         <Modal.Header closeButton={false}>Session expired</Modal.Header>
-        <Modal.Body>This modal can&apos;t be dismissed via Esc or overlay click. Use the button below.</Modal.Body>
+        <Modal.Body>
+          This modal can&apos;t be dismissed via Esc or overlay click. Use the button below.
+        </Modal.Body>
         <Modal.Footer>
           <Button onClick={() => setOpen(false)}>Sign in again</Button>
         </Modal.Footer>
@@ -2484,19 +2501,23 @@ function NoHeaderInline() {
 In `packages/playground/src/App.tsx`:
 
 1. Add the import:
+
 ```ts
 import { ModalDemo } from './pages/components/ModalDemo';
 ```
 
 2. Add the route inside `<Routes>` (alphabetical placement is fine):
+
 ```tsx
 <Route path="/components/modal" element={<ModalDemo />} />
 ```
 
 In `packages/playground/src/layout/AppShell/AppShell.tsx`, find the `componentGroups` array. Modal goes in the **Overlays** group (alongside Popover, DropdownMenu, Tooltip) — or **Display** if no Overlays group exists. Add:
+
 ```ts
 { to: '/components/modal', label: 'Modal' }
 ```
+
 matching the existing entry shape.
 
 In `packages/playground/src/pages/components/ComponentsIndex.tsx`, add a tile for Modal — copy the shape of an adjacent component tile (e.g. Popover's) and swap the label/description. Description: "Focus-locked dialog with header / body / footer slots."
@@ -2556,6 +2577,7 @@ All exit 0.
 Use the `Agent` tool with `subagent_type: "general-purpose"`, model `opus`. Brief it explicitly on the 10 review categories, point it at `packages/design-system/CLAUDE.md`, `AGENTS.md`, `README.md`, and the spec at `docs/superpowers/specs/2026-05-22-modal-design.md`. Ask for output as Critical / Important / Nice-to-have / Regression-watch + a final verdict.
 
 Key things the reviewer must check:
+
 - Focus trap correctness on stacked modals (only top has active trap)
 - Escape routes through `modalStack.isTop` so inner modals close first
 - `useScrollLock` ref-count is correct across stack open/close orders

--- a/docs/superpowers/plans/2026-05-22-modal.md
+++ b/docs/superpowers/plans/2026-05-22-modal.md
@@ -1,0 +1,2660 @@
+# Modal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Modal>` — a compound, controlled-only modal dialog primitive with three sizes (sm/md/lg), fullscreen on narrow viewports, stacked-modal support, focus trap, scroll lock, and `@starting-style` animations.
+
+**Architecture:** Compound API (`<Modal>` root + `<Modal.Header>` / `<Modal.Body>` / `<Modal.Footer>` / `<Modal.Close>` subcomponents). Context provider holds `open` + `onOpenChange` + a captured `previouslyFocused` element + a heading id for `aria-labelledby` wiring. The content is portaled to `document.body`. Three module-level hooks back the cross-component behavior: `useFocusTrap` (Tab cycle + focusin recapture), `useScrollLock` (ref-counted body scroll suppression), `useModalStack` (depth registry routing Escape to the topmost modal and assigning z-index via a `--modal-depth` CSS custom prop). Animations reuse Popover's `@starting-style` pattern, plus a `prefers-reduced-motion` opt-out.
+
+**Tech Stack:** React 18 + TypeScript (source-distributed). No new packages. Composes existing `Stack` / `Cluster` / `Button` (Button only in JSDoc / demo, not imported by Modal itself). Vitest + RTL for tests. CSS Modules + SCSS tokens.
+
+**Source of truth:** `docs/superpowers/specs/2026-05-22-modal-design.md` (commit `63716f7`). Read it for any requirement not explicit in a task.
+
+**Branch:** `feat/modal`. Commit per task. Open the PR after the Hard-Rule-8 cycle (Task 13).
+
+---
+
+## File Structure
+
+```
+packages/design-system/src/components/Modal/
+  Modal.tsx                   ← Object.assign({ Header, Body, Footer, Close }) on ModalRoot
+  ModalRoot.tsx               ← Owns context: state, refs, captured previouslyFocused, scroll/stack lifecycle
+  Overlay.tsx                 ← Portaled backdrop; click-to-dismiss when dismissOnOverlayClick=true
+  Content.tsx                 ← role="dialog" container; focus trap; sized via data-size
+  Header.tsx                  ← Title bar + auto-registered heading id + optional × close button
+  Body.tsx                    ← Scrollable content area; padding 'default' | 'none'
+  Footer.tsx                  ← role="group" action bar; align 'start' | 'end' | 'space-between'
+  Close.tsx                   ← cloneElement wrapper firing onOpenChange(false)
+  context.ts                  ← ModalContext + useModalContext('ComponentName') guard
+  useFocusTrap.ts             ← Hook: Tab cycle + focusin recapture
+  useFocusTrap.test.ts        ← Pure-logic unit tests
+  useScrollLock.ts            ← Hook: ref-counted body scroll lock
+  useScrollLock.test.ts
+  useModalStack.ts            ← Module-level singleton: depth registry + isTop + Esc routing
+  useModalStack.test.ts
+  Modal.module.scss
+  Modal.test.tsx              ← Integration tests via React Testing Library
+  index.ts                    ← Folder-level public re-exports
+
+packages/design-system/src/styles/tokens.scss     ← MODIFY: add --size-modal-sm/md/lg + --color-bg-overlay
+packages/design-system/src/index.ts               ← MODIFY: re-export Modal + types from the library root
+packages/design-system/AGENTS.md                  ← MODIFY: add Modal TL;DR section
+packages/playground/src/pages/components/ModalDemo.tsx   ← NEW: demo with all the examples
+packages/playground/src/App.tsx                          ← MODIFY: route
+packages/playground/src/layout/AppShell/AppShell.tsx     ← MODIFY: sidebar nav item
+packages/playground/src/pages/components/ComponentsIndex.tsx ← MODIFY: grid tile
+packages/playground/src/pages/mockups/registry.ts        ← MODIFY: 'Modal' in ComponentName union
+```
+
+**Decomposition rationale:**
+
+- Three hooks (`useFocusTrap`, `useScrollLock`, `useModalStack`) are pure logic with no DOM rendering — perfect for TDD, easy to unit-test without mounting the full component.
+- `ModalRoot` owns context + cross-cutting lifecycle (scroll lock acquire/release, stack register/unregister, focus restore). Keeps `Overlay` / `Content` rendering-focused.
+- `Header` / `Body` / `Footer` / `Close` mirror Popover's compound idiom — small focused files, one responsibility each.
+- The SCSS is its own task because it's a sizeable chunk (overlay, three size presets, animations, mobile breakpoint, reduced-motion) and easier to review as one diff.
+
+---
+
+## Task 1 — New tokens
+
+**Files:**
+- Modify: `packages/design-system/src/styles/tokens.scss`
+
+- [ ] **Step 1: Verify branch + clean tree**
+
+```bash
+cd /home/dpws/projects/design-system
+git status
+git branch --show-current
+git log --oneline -3
+```
+
+Expected:
+- Branch: `feat/modal`
+- Working tree clean
+- Most recent commit: this plan + `63716f7 Modal: design spec — compound API …`
+
+- [ ] **Step 2: Add the two new tokens**
+
+Open `packages/design-system/src/styles/tokens.scss`. Find the `--size-*` token block. Add:
+
+```scss
+--size-modal-sm: 400px;
+--size-modal-md: 560px;
+--size-modal-lg: 800px;
+```
+
+Find the `--color-bg-*` token block (near `--color-bg-row-pinned` added in DataTable Phase 2). Add:
+
+```scss
+--color-bg-overlay: rgb(15 23 42 / 50%); /* dimming backdrop behind modal */
+```
+
+(The `--z-modal: 1100` token is already present from an earlier ladder — do NOT re-add it. Verify with `grep -n "z-modal" packages/design-system/src/styles/tokens.scss` if you want.)
+
+- [ ] **Step 3: Verify lint**
+
+```bash
+make lint
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/styles/tokens.scss
+git commit -m "Modal: tokens — --size-modal-sm/md/lg, --color-bg-overlay
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2 — `useFocusTrap` hook
+
+Pure hook. Attach `keydown` to cycle Tab within a container ref + `focusin` to redirect any focus escape back into the container. Stack-aware: when the modal isn't top of the stack, the focusin redirect is a no-op (the topmost modal owns focus).
+
+**Files:**
+- Create: `packages/design-system/src/components/Modal/useFocusTrap.ts`
+- Test: `packages/design-system/src/components/Modal/useFocusTrap.test.ts`
+
+- [ ] **Step 1: Create the folder + write failing tests**
+
+```bash
+mkdir -p packages/design-system/src/components/Modal
+```
+
+Create `packages/design-system/src/components/Modal/useFocusTrap.test.ts`:
+
+```ts
+import { renderHook } from '@testing-library/react';
+import { useRef, type RefObject } from 'react';
+import { useFocusTrap } from './useFocusTrap';
+
+function makeContainer(html: string): HTMLDivElement {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  document.body.appendChild(div);
+  return div;
+}
+
+function trapHook(container: HTMLElement | null, options?: { active?: boolean }) {
+  return renderHook(() => {
+    const ref = useRef<HTMLElement | null>(container);
+    useFocusTrap(ref as RefObject<HTMLElement | null>, options?.active ?? true);
+    return ref;
+  });
+}
+
+describe('useFocusTrap', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('Tab from the last focusable wraps to the first', () => {
+    const container = makeContainer(`
+      <button id="a">A</button>
+      <button id="b">B</button>
+      <button id="c">C</button>
+    `);
+    trapHook(container);
+    const c = container.querySelector<HTMLButtonElement>('#c')!;
+    c.focus();
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    c.dispatchEvent(event);
+    expect(document.activeElement?.id).toBe('a');
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('Shift+Tab from the first focusable wraps to the last', () => {
+    const container = makeContainer(`
+      <button id="a">A</button>
+      <button id="b">B</button>
+      <button id="c">C</button>
+    `);
+    trapHook(container);
+    const a = container.querySelector<HTMLButtonElement>('#a')!;
+    a.focus();
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    a.dispatchEvent(event);
+    expect(document.activeElement?.id).toBe('c');
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('Tab in the middle of the focusables is left to the browser', () => {
+    const container = makeContainer(`
+      <button id="a">A</button>
+      <button id="b">B</button>
+      <button id="c">C</button>
+    `);
+    trapHook(container);
+    const b = container.querySelector<HTMLButtonElement>('#b')!;
+    b.focus();
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    b.dispatchEvent(event);
+    // Hook does not intercept the middle of the cycle.
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('redirects focus back to the container when focus escapes', () => {
+    const container = makeContainer(`<button id="a">A</button>`);
+    container.tabIndex = -1;
+    const outside = document.createElement('button');
+    outside.id = 'outside';
+    document.body.appendChild(outside);
+    trapHook(container);
+
+    outside.focus();
+    // focusin is async via the listener; trigger a dispatch.
+    outside.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(document.activeElement).toBe(container);
+  });
+
+  it('does nothing when container ref is null', () => {
+    expect(() => trapHook(null)).not.toThrow();
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
+    outside.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(document.activeElement).toBe(outside);
+  });
+
+  it('does nothing when active is false', () => {
+    const container = makeContainer(`<button id="a">A</button>`);
+    container.tabIndex = -1;
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    trapHook(container, { active: false });
+    outside.focus();
+    outside.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(document.activeElement).toBe(outside);
+  });
+
+  it('zero focusables: focus stays on container, Tab is preventDefault-ed without movement', () => {
+    const container = makeContainer(`<p>read-only</p>`);
+    container.tabIndex = -1;
+    trapHook(container);
+    container.focus();
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    container.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(container);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure (module missing)**
+
+```bash
+make test -- useFocusTrap.test.ts
+```
+
+- [ ] **Step 3: Implement the hook**
+
+Create `packages/design-system/src/components/Modal/useFocusTrap.ts`:
+
+```ts
+import { useEffect, type RefObject } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'button:not([disabled])',
+  '[href]',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function getFocusables(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+/**
+ * Focus trap: keeps Tab focus cycling inside `containerRef`. Attaches a
+ * `keydown` listener to detect Tab at the first/last focusable and wrap, plus
+ * a `focusin` listener at document level to redirect any focus that escapes
+ * the container back to it.
+ *
+ * `active = false` no-ops the trap (used by Modal when not top of stack — the
+ * inner modal mounts but only the topmost modal owns focus).
+ *
+ * @example
+ * const contentRef = useRef<HTMLDivElement | null>(null);
+ * useFocusTrap(contentRef, open);
+ */
+export function useFocusTrap(
+  containerRef: RefObject<HTMLElement | null>,
+  active: boolean,
+): void {
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Tab') return;
+      const focusables = getFocusables(container!);
+      if (focusables.length === 0) {
+        // Zero focusables: prevent Tab from escaping the container.
+        e.preventDefault();
+        container!.focus();
+        return;
+      }
+      const first = focusables[0]!;
+      const last = focusables[focusables.length - 1]!;
+      if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      } else if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+      // Middle of the cycle: browser handles it natively.
+    }
+
+    function onFocusIn(e: FocusEvent) {
+      const target = e.target as Node | null;
+      if (!target || !container) return;
+      if (container.contains(target)) return;
+      // Focus escaped — redirect to the container.
+      container.focus();
+    }
+
+    container.addEventListener('keydown', onKeyDown);
+    document.addEventListener('focusin', onFocusIn);
+    return () => {
+      container.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('focusin', onFocusIn);
+    };
+  }, [containerRef, active]);
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+make test -- useFocusTrap.test.ts
+```
+
+Expected: all 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Modal/useFocusTrap.ts \
+        packages/design-system/src/components/Modal/useFocusTrap.test.ts
+git commit -m "Modal: useFocusTrap hook (Tab cycle + focusin recapture)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3 — `useScrollLock` hook
+
+Ref-counted body-scroll suppression. The first modal to mount sets `body.style.overflow = 'hidden'` (and adds `padding-right` equal to the scrollbar width to prevent layout shift); the last modal to unmount restores both. Module-level counter so nested modals all see the same lock.
+
+**Files:**
+- Create: `packages/design-system/src/components/Modal/useScrollLock.ts`
+- Test: `packages/design-system/src/components/Modal/useScrollLock.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/design-system/src/components/Modal/useScrollLock.test.ts`:
+
+```ts
+import { renderHook } from '@testing-library/react';
+import { useScrollLock } from './useScrollLock';
+
+describe('useScrollLock', () => {
+  beforeEach(() => {
+    document.body.style.overflow = '';
+    document.body.style.paddingRight = '';
+  });
+
+  it('locks body scroll on first acquire', () => {
+    const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+  });
+
+  it('restores body scroll when refcount drops to zero', () => {
+    const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('second acquire while locked is a no-op (refcount only)', () => {
+    const a = renderHook(() => useScrollLock(true));
+    document.body.style.overflow = 'hidden'; // sanity
+    const b = renderHook(() => useScrollLock(true));
+    // Still locked.
+    expect(document.body.style.overflow).toBe('hidden');
+    b.unmount();
+    // First lock still active.
+    expect(document.body.style.overflow).toBe('hidden');
+    a.unmount();
+    // Now released.
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('restores ORIGINAL overflow value, not blank', () => {
+    document.body.style.overflow = 'scroll';
+    const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('scroll');
+  });
+
+  it('active=false is a no-op', () => {
+    renderHook(() => useScrollLock(false));
+    expect(document.body.style.overflow).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+```bash
+make test -- useScrollLock.test.ts
+```
+
+- [ ] **Step 3: Implement the hook**
+
+Create `packages/design-system/src/components/Modal/useScrollLock.ts`:
+
+```ts
+import { useLayoutEffect } from 'react';
+
+// Module-level state shared across all useScrollLock callers.
+let count = 0;
+let originalOverflow: string | null = null;
+let originalPaddingRight: string | null = null;
+
+function lock() {
+  if (count === 0) {
+    originalOverflow = document.body.style.overflow;
+    originalPaddingRight = document.body.style.paddingRight;
+    // Compensate for the disappearing scrollbar to avoid horizontal layout shift.
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
+    }
+    document.body.style.overflow = 'hidden';
+  }
+  count += 1;
+}
+
+function unlock() {
+  count = Math.max(0, count - 1);
+  if (count === 0) {
+    document.body.style.overflow = originalOverflow ?? '';
+    document.body.style.paddingRight = originalPaddingRight ?? '';
+    originalOverflow = null;
+    originalPaddingRight = null;
+  }
+}
+
+/**
+ * Body scroll lock. Ref-counted across all callers so nested modals share
+ * the same lock — the first acquire suppresses scrolling, the last release
+ * restores it. The original `overflow` value is captured on first acquire
+ * and restored on final release (so non-default values are preserved).
+ */
+export function useScrollLock(active: boolean): void {
+  useLayoutEffect(() => {
+    if (!active) return;
+    lock();
+    return unlock;
+  }, [active]);
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+make test -- useScrollLock.test.ts
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Modal/useScrollLock.ts \
+        packages/design-system/src/components/Modal/useScrollLock.test.ts
+git commit -m "Modal: useScrollLock hook (ref-counted body scroll suppression)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4 — `useModalStack` hook + module
+
+Module-level singleton tracking which modal ids are currently open. Exposes `register(id) -> depth`, `unregister(id)`, `isTop(id) -> boolean`, `topDepth() -> number`. Used for routing Escape and assigning per-modal z-index via the `--modal-depth` CSS custom prop.
+
+**Files:**
+- Create: `packages/design-system/src/components/Modal/useModalStack.ts`
+- Test: `packages/design-system/src/components/Modal/useModalStack.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/design-system/src/components/Modal/useModalStack.test.ts`:
+
+```ts
+import { renderHook, act } from '@testing-library/react';
+import { useModalStack, modalStack } from './useModalStack';
+
+describe('modalStack singleton', () => {
+  afterEach(() => {
+    // Reset the stack between tests.
+    modalStack._reset();
+  });
+
+  it('register returns 0 for the first modal, 1 for the second', () => {
+    expect(modalStack.register('a')).toBe(0);
+    expect(modalStack.register('b')).toBe(1);
+  });
+
+  it('unregister removes a modal from the stack', () => {
+    modalStack.register('a');
+    modalStack.register('b');
+    modalStack.unregister('a');
+    expect(modalStack.isTop('b')).toBe(true);
+    expect(modalStack.depthOf('b')).toBe(0);
+  });
+
+  it('isTop returns true for the most-recently-registered modal', () => {
+    modalStack.register('a');
+    modalStack.register('b');
+    expect(modalStack.isTop('b')).toBe(true);
+    expect(modalStack.isTop('a')).toBe(false);
+  });
+
+  it('topDepth returns the current stack height', () => {
+    expect(modalStack.topDepth()).toBe(0);
+    modalStack.register('a');
+    expect(modalStack.topDepth()).toBe(1);
+    modalStack.register('b');
+    expect(modalStack.topDepth()).toBe(2);
+    modalStack.unregister('a');
+    // 'b' is still open; topDepth reflects open count.
+    expect(modalStack.topDepth()).toBe(1);
+  });
+
+  it('depthOf compacts indexes after a mid-stack unregister', () => {
+    modalStack.register('a');
+    modalStack.register('b');
+    modalStack.register('c');
+    modalStack.unregister('a');
+    expect(modalStack.depthOf('b')).toBe(0);
+    expect(modalStack.depthOf('c')).toBe(1);
+  });
+});
+
+describe('useModalStack', () => {
+  afterEach(() => {
+    modalStack._reset();
+  });
+
+  it('returns null depth when active=false', () => {
+    const { result } = renderHook(() => useModalStack('a', false));
+    expect(result.current.depth).toBeNull();
+  });
+
+  it('registers when active goes true and returns depth', () => {
+    const { result, rerender } = renderHook(({ active }) => useModalStack('a', active), {
+      initialProps: { active: false },
+    });
+    expect(result.current.depth).toBeNull();
+    rerender({ active: true });
+    expect(result.current.depth).toBe(0);
+  });
+
+  it('isTop reflects current top state', () => {
+    renderHook(() => useModalStack('a', true));
+    const { result } = renderHook(() => useModalStack('b', true));
+    // b registered second, so b is top.
+    expect(result.current.isTop).toBe(true);
+  });
+
+  it('unregisters on unmount', () => {
+    const { unmount } = renderHook(() => useModalStack('a', true));
+    expect(modalStack.depthOf('a')).toBe(0);
+    unmount();
+    expect(modalStack.depthOf('a')).toBe(-1);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+```bash
+make test -- useModalStack.test.ts
+```
+
+- [ ] **Step 3: Implement the module + hook**
+
+Create `packages/design-system/src/components/Modal/useModalStack.ts`:
+
+```ts
+import { useEffect, useState } from 'react';
+
+// Internal ordered list of open modal ids, most-recently-registered last.
+const stack: string[] = [];
+
+function depthOf(id: string): number {
+  return stack.indexOf(id);
+}
+
+function topId(): string | null {
+  return stack.length === 0 ? null : stack[stack.length - 1]!;
+}
+
+/**
+ * Module-level singleton tracking open modal ids in registration order.
+ * Each modal calls `register` on open and `unregister` on close. Depth is
+ * the modal's index in the open-stack (0 = bottom, length-1 = top).
+ */
+export const modalStack = {
+  register(id: string): number {
+    if (!stack.includes(id)) stack.push(id);
+    return depthOf(id);
+  },
+  unregister(id: string): void {
+    const idx = stack.indexOf(id);
+    if (idx >= 0) stack.splice(idx, 1);
+  },
+  isTop(id: string): boolean {
+    return topId() === id;
+  },
+  topDepth(): number {
+    return stack.length;
+  },
+  depthOf,
+  /** Test-only escape hatch. */
+  _reset(): void {
+    stack.length = 0;
+  },
+};
+
+export interface ModalStackState {
+  /** Current depth in the stack, or null if not registered. */
+  depth: number | null;
+  /** True iff this modal is the topmost open modal. */
+  isTop: boolean;
+}
+
+/**
+ * Register/unregister this modal in the singleton stack while `active` is
+ * true. Returns the current depth + whether this modal is on top, so
+ * callers can route Escape, focus, and z-index correctly.
+ *
+ * Re-renders on stack changes elsewhere (e.g. a sibling modal opens) so
+ * `isTop` stays accurate. The state is cheap (one number + one boolean).
+ */
+export function useModalStack(id: string, active: boolean): ModalStackState {
+  const [state, setState] = useState<ModalStackState>({ depth: null, isTop: false });
+
+  useEffect(() => {
+    if (!active) {
+      setState({ depth: null, isTop: false });
+      return;
+    }
+    modalStack.register(id);
+    setState({ depth: modalStack.depthOf(id), isTop: modalStack.isTop(id) });
+    return () => {
+      modalStack.unregister(id);
+    };
+  }, [id, active]);
+
+  // Re-sync whenever the stack might have changed elsewhere. This effect
+  // runs on every render and reads the singleton; cheap, no setState if
+  // nothing changed.
+  useEffect(() => {
+    if (!active) return;
+    const next = { depth: modalStack.depthOf(id), isTop: modalStack.isTop(id) };
+    if (next.depth !== state.depth || next.isTop !== state.isTop) {
+      setState(next);
+    }
+  });
+
+  return state;
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+make test -- useModalStack.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Modal/useModalStack.ts \
+        packages/design-system/src/components/Modal/useModalStack.test.ts
+git commit -m "Modal: useModalStack hook + singleton (depth registry + isTop)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5 — `context.ts` + `ModalRoot`
+
+Provider component owning state, refs, and the cross-cutting lifecycle (capture/restore focus, scroll lock, stack register, heading id registration). `ModalRoot` renders nothing visible — just provides context. The Overlay/Content render conditionally on `open`.
+
+**Files:**
+- Create: `packages/design-system/src/components/Modal/context.ts`
+- Create: `packages/design-system/src/components/Modal/ModalRoot.tsx`
+
+- [ ] **Step 1: Create the context module**
+
+Create `packages/design-system/src/components/Modal/context.ts`:
+
+```ts
+import { createContext, useContext, type RefObject } from 'react';
+
+export type ModalSize = 'sm' | 'md' | 'lg';
+
+export interface ModalContextValue {
+  open: boolean;
+  setOpen: (next: boolean) => void;
+  /** Stable modal id, used by the stack registry + aria-controls bindings. */
+  modalId: string;
+  /** Ref to the dialog container, populated by <Content>. Used for focus trap + outside-click. */
+  contentRef: RefObject<HTMLDivElement | null>;
+  /** Stable id for the heading registered by <Header>, used for aria-labelledby. */
+  headingId: string | null;
+  /** Called by <Header> to register its heading id. */
+  setHeadingId: (id: string | null) => void;
+  /** Size preset; drives the content's --modal-size CSS class. */
+  size: ModalSize;
+  /** Forwarded from props for the Esc handler in Content. */
+  disableEscapeClose: boolean;
+  /** Forwarded for the overlay click handler. */
+  dismissOnOverlayClick: boolean;
+  /** Forwarded so Content can override initial focus. */
+  initialFocusRef: RefObject<HTMLElement | null> | undefined;
+  /** From Modal props; used by Content for aria-label when no heading is registered. */
+  ariaLabel: string | undefined;
+  ariaDescribedBy: string | undefined;
+  /** Current stack depth (for the --modal-depth custom prop on the overlay). */
+  depth: number;
+  /** Whether this modal is currently the topmost open modal. Drives Escape/focus-trap activity. */
+  isTop: boolean;
+}
+
+export const ModalContext = createContext<ModalContextValue | null>(null);
+
+export function useModalContext(componentName: string): ModalContextValue {
+  const ctx = useContext(ModalContext);
+  if (!ctx) {
+    throw new Error(`<Modal.${componentName}> must be used inside <Modal>.`);
+  }
+  return ctx;
+}
+```
+
+- [ ] **Step 2: Create `ModalRoot.tsx`**
+
+Create `packages/design-system/src/components/Modal/ModalRoot.tsx`:
+
+```tsx
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  type RefObject,
+} from 'react';
+import { ModalContext, type ModalContextValue, type ModalSize } from './context';
+import { useModalStack } from './useModalStack';
+import { useScrollLock } from './useScrollLock';
+import { Overlay } from './Overlay';
+import { Content } from './Content';
+import { sanitizeId } from '../_internal/refs';
+
+export interface ModalProps {
+  /** Controlled open state. Required. */
+  open: boolean;
+  /** Fired when Modal wants to change open state — Esc, overlay click, Close button, programmatic. */
+  onOpenChange: (open: boolean) => void;
+
+  /** Size preset. Defaults to 'md'. */
+  size?: ModalSize;
+
+  /**
+   * Disable Escape-to-close. Default false. Combined with `dismissOnOverlayClick: false`
+   * and omitting `<Modal.Close>` produces a fully forced step.
+   */
+  disableEscapeClose?: boolean;
+  /**
+   * When false, clicking the overlay backdrop does NOT close the modal. Default true.
+   */
+  dismissOnOverlayClick?: boolean;
+
+  /**
+   * Initial focus target on open. Default: the dialog container itself.
+   * Pass a ref to override (e.g. focus the first input in a form).
+   */
+  initialFocusRef?: RefObject<HTMLElement | null>;
+
+  /** Compound children: Header / Body / Footer / Close + any consumer JSX. */
+  children: ReactNode;
+
+  /** className passes through to the dialog container. */
+  className?: string;
+  /** style passes through to the dialog container. */
+  style?: CSSProperties;
+
+  /**
+   * Required for a11y when no Modal.Header is rendered. When Header IS rendered,
+   * aria-labelledby auto-binds to the heading id; this prop is then ignored.
+   */
+  'aria-label'?: string;
+  /** Optional id of an external descriptor element; sets aria-describedby on the dialog. */
+  'aria-describedby'?: string;
+}
+
+/**
+ * Modal dialog: focus-locked, scroll-locked, ARIA-correct overlay panel.
+ *
+ * Compound API:
+ * - `<Modal.Header>` renders the title bar (auto-wires aria-labelledby).
+ * - `<Modal.Body>` is the scrollable content area.
+ * - `<Modal.Footer>` is the pinned action bar.
+ * - `<Modal.Close>` wraps a clickable child to dismiss the modal.
+ *
+ * Controlled-only — Modal has no uncontrolled mode. Consumer holds `open`
+ * state and passes `open` + `onOpenChange`.
+ *
+ * @example
+ * const [open, setOpen] = useState(false);
+ * <Button onClick={() => setOpen(true)}>Edit contact</Button>
+ * <Modal open={open} onOpenChange={setOpen} size="md">
+ *   <Modal.Header>Edit contact</Modal.Header>
+ *   <Modal.Body>
+ *     <Stack gap="md">
+ *       <Input label="Name" value={name} onChange={...} />
+ *     </Stack>
+ *   </Modal.Body>
+ *   <Modal.Footer>
+ *     <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
+ *     <Button onClick={save}>Save</Button>
+ *   </Modal.Footer>
+ * </Modal>
+ *
+ * @example
+ * // Forced step — no Esc, no overlay-click dismiss, no built-in close button:
+ * <Modal
+ *   open
+ *   onOpenChange={() => {}}
+ *   size="sm"
+ *   disableEscapeClose
+ *   dismissOnOverlayClick={false}
+ *   aria-label="Session expired"
+ * >
+ *   <Modal.Header closeButton={false}>Session expired</Modal.Header>
+ *   <Modal.Body>Please sign in again to continue.</Modal.Body>
+ *   <Modal.Footer><Button onClick={reauth}>Sign in</Button></Modal.Footer>
+ * </Modal>
+ *
+ * @remarks When NOT to use
+ * - For lightweight popovers anchored to a trigger — use `<Popover>` or `<DropdownMenu>`.
+ * - For non-blocking notifications — use `<Toast>` (not yet shipped).
+ * - For inline confirms attached to a button — use `<ConfirmationPopover>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Rendering long, scrollable forms with sticky footers that contain
+ *   additional sticky elements inside Body — flexbox + sticky compose badly.
+ *   Either use `<Modal.Footer>` for the actions and let Body scroll, or
+ *   render outside Modal.
+ * - ❌ Opening a modal from inside another modal without using `<Modal>` itself
+ *   (e.g. a custom div with `position: fixed`). Skipping the stack registry
+ *   breaks Esc routing and z-index ordering.
+ * - ❌ Passing neither a `<Modal.Header>` nor an `aria-label` — Modal will
+ *   warn in development. Screen-reader users get no announcement on open.
+ */
+export function ModalRoot({
+  open,
+  onOpenChange,
+  size = 'md',
+  disableEscapeClose = false,
+  dismissOnOverlayClick = true,
+  initialFocusRef,
+  children,
+  className,
+  style,
+  'aria-label': ariaLabel,
+  'aria-describedby': ariaDescribedBy,
+}: ModalProps) {
+  const rawId = useId();
+  const modalId = `modal-${sanitizeId(rawId)}`;
+
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [headingId, setHeadingId] = useState<string | null>(null);
+
+  // previouslyFocused: capture when transitioning false → true; restore on
+  // close. Captured on the SAME render that flipped `open` to true (via a
+  // ref + effect pattern).
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  const prevOpenRef = useRef<boolean>(open);
+  useEffect(() => {
+    if (open && !prevOpenRef.current) {
+      previouslyFocusedRef.current = (document.activeElement as HTMLElement | null) ?? null;
+    }
+    if (!open && prevOpenRef.current) {
+      const target = previouslyFocusedRef.current;
+      if (target && document.contains(target)) {
+        target.focus({ preventScroll: true });
+      }
+      previouslyFocusedRef.current = null;
+    }
+    prevOpenRef.current = open;
+  }, [open]);
+
+  // Stack registration + scroll lock are driven by `open`.
+  const { depth, isTop } = useModalStack(modalId, open);
+  useScrollLock(open);
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      onOpenChange(next);
+    },
+    [onOpenChange],
+  );
+
+  // Dev warning: must have either a Header (sets headingId in context) OR aria-label.
+  useEffect(() => {
+    if (!open) return;
+    if (process.env.NODE_ENV !== 'production') {
+      if (!headingId && !ariaLabel) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '<Modal> must be labelled. Either render <Modal.Header> or pass an `aria-label` prop. Screen-reader users get no announcement otherwise.',
+        );
+      }
+    }
+  }, [open, headingId, ariaLabel]);
+
+  const value: ModalContextValue = {
+    open,
+    setOpen,
+    modalId,
+    contentRef,
+    headingId,
+    setHeadingId,
+    size,
+    disableEscapeClose,
+    dismissOnOverlayClick,
+    initialFocusRef,
+    ariaLabel,
+    ariaDescribedBy,
+    depth: depth ?? 0,
+    isTop,
+  };
+
+  return (
+    <ModalContext.Provider value={value}>
+      {children}
+      {open && (
+        <Overlay>
+          <Content className={className} style={style} />
+        </Overlay>
+      )}
+    </ModalContext.Provider>
+  );
+}
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+make build-lib
+```
+
+Expected: fails because `./Overlay` and `./Content` don't exist yet. That's OK — those land in Task 6.
+
+- [ ] **Step 4: Do NOT commit yet — bundle with Task 6**
+
+`git status` should show `context.ts` and `ModalRoot.tsx` as untracked. Leave them for the Task 6 commit.
+
+---
+
+## Task 6 — `Overlay` + `Content` (the heart of the component)
+
+The portaled backdrop + dialog container. Handles dismissal (Escape, overlay click), focus restoration, inert background, focus trap activation, and the z-index custom-prop wiring.
+
+**Files:**
+- Create: `packages/design-system/src/components/Modal/Overlay.tsx`
+- Create: `packages/design-system/src/components/Modal/Content.tsx`
+
+- [ ] **Step 1: Create `Overlay.tsx`**
+
+Create `packages/design-system/src/components/Modal/Overlay.tsx`:
+
+```tsx
+import { useEffect, type CSSProperties, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { useModalContext } from './context';
+import styles from './Modal.module.scss';
+
+export interface OverlayProps {
+  children: ReactNode;
+}
+
+/**
+ * Portaled dimming backdrop rendered behind the dialog. Owns the
+ * inert-background attribute on body children + the overlay-click
+ * dismissal (only fires when click target is the overlay itself,
+ * not bubbled from the content).
+ */
+export function Overlay({ children }: OverlayProps) {
+  const ctx = useModalContext('Overlay');
+
+  // Inert background — applied to all body children EXCEPT the portal root
+  // (created here on demand). Only the topmost modal sets it; nested modals
+  // are already inside the portal so they're inherently exempt.
+  useEffect(() => {
+    if (!ctx.isTop) return;
+    const portalRoot = document.querySelector('[data-modal-portal-root]') as HTMLElement | null;
+    const bodyChildren = Array.from(document.body.children) as HTMLElement[];
+    const toRestore: Array<{ el: HTMLElement; had: boolean }> = [];
+    for (const el of bodyChildren) {
+      if (el === portalRoot) continue;
+      const had = el.hasAttribute('inert');
+      if (!had) el.setAttribute('inert', '');
+      toRestore.push({ el, had });
+    }
+    return () => {
+      for (const { el, had } of toRestore) {
+        if (!had) el.removeAttribute('inert');
+      }
+    };
+  }, [ctx.isTop]);
+
+  const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    // Only dismiss when the click is on the backdrop itself.
+    if (e.target !== e.currentTarget) return;
+    if (!ctx.dismissOnOverlayClick) return;
+    ctx.setOpen(false);
+  };
+
+  // Custom prop carries depth to SCSS so z-index can be computed via calc().
+  const style = { ['--modal-depth' as string]: String(ctx.depth) } as CSSProperties;
+
+  return createPortal(
+    <div
+      data-modal-portal-root=""
+      data-state={ctx.open ? 'open' : 'closed'}
+      className={styles.overlay}
+      style={style}
+      onClick={onClick}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}
+```
+
+- [ ] **Step 2: Create `Content.tsx` (renders the compound children inside the dialog)**
+
+Create `packages/design-system/src/components/Modal/Content.tsx`:
+
+```tsx
+import { useEffect, useLayoutEffect, type CSSProperties, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { useModalContext } from './context';
+import { useFocusTrap } from './useFocusTrap';
+import { modalStack } from './useModalStack';
+import styles from './Modal.module.scss';
+
+export interface ContentProps {
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * Dialog container. `role="dialog"`, `aria-modal="true"`, tabIndex=-1 so
+ * the focus trap can take over. Owns:
+ * - Initial focus on open (either initialFocusRef or the container itself).
+ * - Focus trap (active only when this modal is top of the stack).
+ * - Escape capture-phase listener (also gated by isTop).
+ * - Renders the compound children (Header/Body/Footer/Close) inside the dialog.
+ */
+export function Content({ children, className, style }: ContentProps) {
+  const ctx = useModalContext('Content');
+
+  // Initial focus on open. Try the ref first; if it points to a non-focusable
+  // node, the browser .focus() no-ops and the focusin recapture in
+  // useFocusTrap will bring focus back to the container.
+  useLayoutEffect(() => {
+    if (!ctx.open) return;
+    queueMicrotask(() => {
+      const target = ctx.initialFocusRef?.current ?? ctx.contentRef.current;
+      target?.focus({ preventScroll: true });
+    });
+  }, [ctx.open, ctx.initialFocusRef, ctx.contentRef]);
+
+  // Escape closes the topmost modal only. Capture-phase to beat focused
+  // widgets that stopPropagation on Esc (matches Popover).
+  useEffect(() => {
+    if (!ctx.open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      // Only the topmost modal handles Escape.
+      if (!modalStack.isTop(ctx.modalId)) return;
+      if (ctx.disableEscapeClose) return;
+      e.preventDefault();
+      ctx.setOpen(false);
+    }
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [ctx.open, ctx.modalId, ctx.disableEscapeClose, ctx.setOpen]);
+
+  // Focus trap — active only when this modal is on top of the stack.
+  useFocusTrap(ctx.contentRef, ctx.open && ctx.isTop);
+
+  return (
+    <div
+      ref={ctx.contentRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={ctx.headingId ?? undefined}
+      aria-label={!ctx.headingId ? ctx.ariaLabel : undefined}
+      aria-describedby={ctx.ariaDescribedBy}
+      tabIndex={-1}
+      data-state={ctx.open ? 'open' : 'closed'}
+      data-size={ctx.size}
+      className={clsx(styles.content, styles[`size-${ctx.size}`], className)}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Update `ModalRoot.tsx` to pass children into `<Content>`**
+
+The compound `children` (Header/Body/Footer/Close) need to render INSIDE `<Content>`, not as a sibling of `<Overlay>`. Update the JSX return at the bottom of `ModalRoot.tsx` from Task 5:
+
+```tsx
+return (
+  <ModalContext.Provider value={value}>
+    {open && (
+      <Overlay>
+        <Content className={className} style={style}>
+          {children}
+        </Content>
+      </Overlay>
+    )}
+  </ModalContext.Provider>
+);
+```
+
+(Drop the standalone `{children}` rendering above the `open && (...)` block — children only render inside the portal when `open` is true. When closed, nothing renders.)
+
+- [ ] **Step 4: Verify typecheck**
+
+```bash
+make build-lib
+```
+
+Expected: typecheck passes. (The SCSS file isn't created yet, but CSS Modules' ambient `Record<string, string>` type makes class references compile.)
+
+- [ ] **Step 5: Do NOT commit yet — bundle with Task 9 (SCSS) and the rest of the compound**
+
+The component still needs `Header/Body/Footer/Close` (Task 7), the assembled `Modal.tsx` (Task 8), and the SCSS (Task 9) before it can actually run. Bundle the Modal commits there.
+
+---
+
+## Task 7 — `Header` / `Body` / `Footer` / `Close` subcomponents
+
+Compound members. Each is a small forwardRef component.
+
+**Files:**
+- Create: `packages/design-system/src/components/Modal/Header.tsx`
+- Create: `packages/design-system/src/components/Modal/Body.tsx`
+- Create: `packages/design-system/src/components/Modal/Footer.tsx`
+- Create: `packages/design-system/src/components/Modal/Close.tsx`
+
+- [ ] **Step 1: Create `Header.tsx`**
+
+```tsx
+import { forwardRef, useEffect, useId, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import { X } from 'lucide-react';
+import { useModalContext } from './context';
+import { sanitizeId } from '../_internal/refs';
+import styles from './Modal.module.scss';
+
+export interface ModalHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  /** Show the built-in × close button on the right edge. Default true. */
+  closeButton?: boolean;
+}
+
+/**
+ * Title bar at the top of the modal. Auto-registers its heading id with
+ * the modal's context so `<Content>` can wire `aria-labelledby`. Renders
+ * a built-in × close button at the right edge unless `closeButton={false}`
+ * (used for forced-step modals).
+ */
+export const Header = forwardRef<HTMLDivElement, ModalHeaderProps>(function Header(
+  { closeButton = true, className, children, ...rest },
+  ref,
+) {
+  const ctx = useModalContext('Header');
+  const rawId = useId();
+  const headingId = `modal-heading-${sanitizeId(rawId)}`;
+
+  useEffect(() => {
+    ctx.setHeadingId(headingId);
+    return () => ctx.setHeadingId(null);
+  }, [ctx, headingId]);
+
+  return (
+    <div ref={ref} className={clsx(styles.header, className)} {...rest}>
+      <h2 id={headingId} className={styles.headerTitle}>
+        {children}
+      </h2>
+      {closeButton && (
+        <button
+          type="button"
+          aria-label="Close dialog"
+          className={styles.headerCloseButton}
+          onClick={() => ctx.setOpen(false)}
+        >
+          <X size={16} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+});
+```
+
+- [ ] **Step 2: Create `Body.tsx`**
+
+```tsx
+import { forwardRef, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './Modal.module.scss';
+
+export interface ModalBodyProps extends HTMLAttributes<HTMLDivElement> {
+  /** Override body's padding. Default 'default' (--space-4). 'none' for edge-to-edge content. */
+  padding?: 'default' | 'none';
+}
+
+/**
+ * Scrollable content area between the Header and Footer. Default padding is
+ * `var(--space-4)`. Pass `padding="none"` for edge-to-edge layouts (e.g. a
+ * full-bleed Tabs strip).
+ */
+export const Body = forwardRef<HTMLDivElement, ModalBodyProps>(function Body(
+  { padding = 'default', className, children, ...rest },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      className={clsx(styles.body, padding === 'none' && styles.bodyPaddingNone, className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+});
+```
+
+- [ ] **Step 3: Create `Footer.tsx`**
+
+```tsx
+import { forwardRef, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './Modal.module.scss';
+
+export interface ModalFooterProps extends HTMLAttributes<HTMLDivElement> {
+  /** Horizontal action alignment. Default 'end'. */
+  align?: 'start' | 'end' | 'space-between';
+}
+
+/**
+ * Pinned action bar at the bottom of the modal. `role="group"` so screen
+ * readers announce the action set as a unit. `align='end'` (default)
+ * right-aligns the actions; `'space-between'` splits primary actions to
+ * opposite ends (e.g. a danger action on the left, save/cancel on the right).
+ */
+export const Footer = forwardRef<HTMLDivElement, ModalFooterProps>(function Footer(
+  { align = 'end', className, children, ...rest },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      role="group"
+      className={clsx(styles.footer, styles[`footerAlign-${align}`], className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+});
+```
+
+- [ ] **Step 4: Create `Close.tsx`**
+
+```tsx
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  type MouseEvent as ReactMouseEvent,
+  type ReactElement,
+} from 'react';
+import { useModalContext } from './context';
+import { chain } from '../_internal/refs';
+
+export interface ModalCloseProps {
+  /**
+   * Exactly one React element. Close clones this element to inject an
+   * `onClick` that closes the modal, chained with the child's existing
+   * `onClick` (consumer runs first).
+   */
+  children: ReactElement;
+}
+
+/**
+ * Wraps any single element with an onClick that closes the modal.
+ * Useful for Cancel buttons inside `<Modal.Footer>`.
+ *
+ * @example
+ * <Modal.Close>
+ *   <Button variant="secondary">Cancel</Button>
+ * </Modal.Close>
+ */
+export function Close({ children }: ModalCloseProps) {
+  const ctx = useModalContext('Close');
+
+  if (!isValidElement(children)) {
+    throw new Error('<Modal.Close> requires exactly one React element child.');
+  }
+
+  const childProps = children.props as {
+    onClick?: (e: ReactMouseEvent<HTMLElement>) => void;
+  };
+
+  const handleClick = useCallback(
+    (_e: ReactMouseEvent<HTMLElement>) => {
+      ctx.setOpen(false);
+    },
+    [ctx],
+  );
+
+  return cloneElement(children, {
+    onClick: chain(childProps.onClick, handleClick),
+  } as object);
+}
+```
+
+- [ ] **Step 5: Verify typecheck**
+
+```bash
+make build-lib
+```
+
+Expected: passes. (SCSS classes referenced — `header`, `headerTitle`, `headerCloseButton`, `body`, `bodyPaddingNone`, `footer`, `footerAlign-start/end/space-between`, `overlay`, `content`, `size-sm/md/lg` — will land in Task 9. CSS Modules' ambient type makes any class reference compile.)
+
+- [ ] **Step 6: Do NOT commit yet** — bundle with Modal.tsx assembly (Task 8) and SCSS (Task 9).
+
+---
+
+## Task 8 — `Modal.tsx` compound assembly + folder `index.ts`
+
+**Files:**
+- Create: `packages/design-system/src/components/Modal/Modal.tsx`
+- Create: `packages/design-system/src/components/Modal/index.ts`
+
+- [ ] **Step 1: Create `Modal.tsx`**
+
+```tsx
+import { ModalRoot } from './ModalRoot';
+import { Header } from './Header';
+import { Body } from './Body';
+import { Footer } from './Footer';
+import { Close } from './Close';
+
+/**
+ * Compound `<Modal>` family. Subcomponents attached via Object.assign so
+ * consumers write `<Modal.Header>` etc., not separate imports.
+ */
+export const Modal = Object.assign(ModalRoot, {
+  Header,
+  Body,
+  Footer,
+  Close,
+});
+
+export type { ModalProps } from './ModalRoot';
+export type { ModalSize } from './context';
+export type { ModalHeaderProps } from './Header';
+export type { ModalBodyProps } from './Body';
+export type { ModalFooterProps } from './Footer';
+export type { ModalCloseProps } from './Close';
+```
+
+(`ModalProps` lives in `ModalRoot.tsx` next to the component; `ModalSize` lives in `context.ts` because it's read by `ModalContextValue`.)
+
+- [ ] **Step 2: Create folder `index.ts`**
+
+```ts
+export { Modal } from './Modal';
+export type {
+  ModalProps,
+  ModalSize,
+  ModalHeaderProps,
+  ModalBodyProps,
+  ModalFooterProps,
+  ModalCloseProps,
+} from './Modal';
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+make build-lib
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Do NOT commit yet** — bundle with the SCSS (Task 9) so the bundle compiles to runnable output.
+
+---
+
+## Task 9 — `Modal.module.scss`
+
+The full stylesheet: overlay backdrop + dialog container with three size presets + Header/Body/Footer + animations + mobile fullscreen + reduced-motion.
+
+**Files:**
+- Create: `packages/design-system/src/components/Modal/Modal.module.scss`
+
+- [ ] **Step 1: Create the SCSS module**
+
+```scss
+@use '../../styles/mixins' as *;
+
+// ─── Overlay ────────────────────────────────────────────────────────────
+// Dimming backdrop. Portaled directly inside <body>. Fills the viewport,
+// centers the content via flex. The --modal-depth custom prop (set by
+// Overlay.tsx) drives z-index for stacked modals.
+
+// stylelint-disable property-disallowed-list -- internal positioning, not consumer layout
+.overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-overlay);
+  z-index: calc(var(--z-modal) + var(--modal-depth, 0) * 2);
+  opacity: 1;
+  transition: opacity var(--transition-base);
+
+  @starting-style {
+    opacity: 0;
+  }
+}
+
+.overlay[data-state='closed'] {
+  opacity: 0;
+}
+// stylelint-enable property-disallowed-list
+
+// ─── Content (dialog) ───────────────────────────────────────────────────
+// The dialog box itself. Flex column so Header/Body/Footer stack with the
+// Body taking remaining height (scrollable when overflowing).
+
+// stylelint-disable property-disallowed-list -- internal positioning, not consumer layout
+.content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  z-index: calc(var(--z-modal) + var(--modal-depth, 0) * 2 + 1);
+  max-height: calc(100vh - 64px);
+  width: min(100% - 32px, var(--modal-width, var(--size-modal-md)));
+
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base);
+
+  @starting-style {
+    opacity: 0;
+    transform: translateY(8px) scale(0.96);
+  }
+}
+
+.content[data-state='closed'] {
+  opacity: 0;
+  transform: translateY(8px) scale(0.96);
+}
+// stylelint-enable property-disallowed-list
+
+// Size presets — each one sets --modal-width which `.content` consumes via
+// the `min(100% - 32px, var(--modal-width, …))` clamp above. Using a custom
+// prop keeps the size logic in one place.
+.size-sm { --modal-width: var(--size-modal-sm); }
+.size-md { --modal-width: var(--size-modal-md); }
+.size-lg { --modal-width: var(--size-modal-lg); }
+
+// ─── Header ─────────────────────────────────────────────────────────────
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.headerTitle {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-fg);
+}
+
+.headerCloseButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+
+  &:hover {
+    background: var(--color-bg-muted);
+    color: var(--color-fg);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+
+    outline: none;
+  }
+}
+
+// ─── Body ───────────────────────────────────────────────────────────────
+
+.body {
+  padding: var(--space-4);
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.bodyPaddingNone {
+  padding: 0;
+}
+
+// ─── Footer ─────────────────────────────────────────────────────────────
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border-top: var(--border-width) solid var(--color-border);
+}
+
+.footerAlign-start { justify-content: flex-start; }
+.footerAlign-end { justify-content: flex-end; }
+.footerAlign-space-between { justify-content: space-between; }
+
+// ─── Mobile fullscreen breakpoint ───────────────────────────────────────
+
+// stylelint-disable property-disallowed-list -- internal layout for narrow viewports
+@media (max-width: 640px) {
+  .content {
+    width: 100vw;
+    height: 100vh;
+    max-width: 100vw;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+}
+// stylelint-enable property-disallowed-list
+
+// ─── Reduced motion ─────────────────────────────────────────────────────
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay,
+  .content {
+    transition: none;
+
+    @starting-style {
+      opacity: 1;
+      transform: none;
+    }
+  }
+}
+```
+
+**Token check before committing:** verify these tokens exist in `packages/design-system/src/styles/tokens.scss`. If any are missing, use the closest equivalent:
+
+- `--color-bg-surface` — for the dialog body
+- `--color-bg-overlay` — added in Task 1
+- `--color-bg-muted` — for header close button hover
+- `--color-fg`, `--color-fg-muted`
+- `--color-border` — for header/footer divider lines
+- `--radius-lg`, `--radius-sm`
+- `--shadow-lg`
+- `--size-modal-sm/md/lg` — added in Task 1
+- `--z-modal` — already exists (1100)
+- `--space-2`, `--space-3`, `--space-4`
+- `--font-size-lg`, `--font-weight-semibold`
+- `--border-width`
+- `--transition-base`, `--transition-fast`
+
+Most are common precedent (used in DataTable, Popover, etc.). If anything's missing, pick the closest existing alternative and document the substitution in the commit message.
+
+- [ ] **Step 2: Verify build + lint**
+
+```bash
+make build-lib
+make lint
+```
+
+Expected: both clean.
+
+- [ ] **Step 3: Commit Modal source files together (Tasks 5–9 bundle)**
+
+```bash
+git add packages/design-system/src/components/Modal/
+git commit -m "Modal: ModalRoot + Overlay + Content + Header/Body/Footer/Close + SCSS
+
+Compound API with controlled-only state. Hand-rolled focus trap via
+useFocusTrap, ref-counted body scroll lock via useScrollLock, depth
+registry via useModalStack. Three size presets (sm/md/lg), full-screen
+below 640px, @starting-style animations matching Popover. Inert
+background on body children while topmost modal is open.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10 — `Modal.test.tsx` integration tests
+
+End-to-end behavior tests via React Testing Library. Verifies the full compound assembly works correctly.
+
+**Files:**
+- Create: `packages/design-system/src/components/Modal/Modal.test.tsx`
+
+- [ ] **Step 1: Write the integration tests**
+
+```tsx
+/**
+ * Integration tests for <Modal>. The three hooks (useFocusTrap, useScrollLock,
+ * useModalStack) have their own unit tests; these tests exercise the
+ * assembled component behavior.
+ */
+import { useRef, useState, type RefObject } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Modal } from './Modal';
+import { modalStack } from './useModalStack';
+
+function Harness(props: Partial<React.ComponentProps<typeof Modal>>) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open</button>
+      <Modal open={open} onOpenChange={setOpen} {...props}>
+        {props.children ?? (
+          <>
+            <Modal.Header>Title</Modal.Header>
+            <Modal.Body>
+              <button>Inner button</button>
+            </Modal.Body>
+            <Modal.Footer>
+              <Modal.Close>
+                <button>Cancel</button>
+              </Modal.Close>
+            </Modal.Footer>
+          </>
+        )}
+      </Modal>
+    </>
+  );
+}
+
+describe('<Modal>', () => {
+  afterEach(() => {
+    modalStack._reset();
+    document.body.style.overflow = '';
+    document.body.style.paddingRight = '';
+  });
+
+  it('renders nothing when closed', () => {
+    render(<Harness />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders dialog with role="dialog" and aria-modal when open', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByText('Open'));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('wires aria-labelledby to Modal.Header heading', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByText('Open'));
+    const dialog = screen.getByRole('dialog');
+    const labelledBy = dialog.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    const heading = document.getElementById(labelledBy!);
+    expect(heading?.textContent).toBe('Title');
+  });
+
+  it('uses aria-label fallback when no Header is rendered', async () => {
+    const user = userEvent.setup();
+    function NoHeaderHarness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open</button>
+          <Modal open={open} onOpenChange={setOpen} aria-label="Confirm action">
+            <Modal.Body>Body</Modal.Body>
+          </Modal>
+        </>
+      );
+    }
+    render(<NoHeaderHarness />);
+    await user.click(screen.getByText('Open'));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-label', 'Confirm action');
+    expect(dialog).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('Escape fires onOpenChange(false) by default', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    function Ctrl() {
+      const [open, setOpen] = useState(true);
+      return (
+        <Modal
+          open={open}
+          onOpenChange={(next) => {
+            setOpen(next);
+            onOpenChange(next);
+          }}
+        >
+          <Modal.Header>Title</Modal.Header>
+          <Modal.Body>x</Modal.Body>
+        </Modal>
+      );
+    }
+    render(<Ctrl />);
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('Escape is ignored when disableEscapeClose is true', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Modal open onOpenChange={onOpenChange} disableEscapeClose aria-label="x">
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('overlay click fires onOpenChange(false) by default', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <Modal open onOpenChange={onOpenChange} aria-label="x">
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    // The portal root has data-modal-portal-root="" — click it directly.
+    const overlay = container.ownerDocument.querySelector(
+      '[data-modal-portal-root]',
+    ) as HTMLElement;
+    await user.click(overlay);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('overlay click is ignored when dismissOnOverlayClick is false', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <Modal open onOpenChange={onOpenChange} dismissOnOverlayClick={false} aria-label="x">
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    const overlay = container.ownerDocument.querySelector(
+      '[data-modal-portal-root]',
+    ) as HTMLElement;
+    await user.click(overlay);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('clicking inside Content does NOT fire onOpenChange', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Modal open onOpenChange={onOpenChange} aria-label="x">
+        <Modal.Body>
+          <p>click me</p>
+        </Modal.Body>
+      </Modal>,
+    );
+    await user.click(screen.getByText('click me'));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('Modal.Close click fires onOpenChange(false)', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Modal open onOpenChange={onOpenChange} aria-label="x">
+        <Modal.Body>x</Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <button>Cancel</button>
+          </Modal.Close>
+        </Modal.Footer>
+      </Modal>,
+    );
+    await user.click(screen.getByText('Cancel'));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('Header × close button fires onOpenChange(false) by default', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Modal open onOpenChange={onOpenChange}>
+        <Modal.Header>Title</Modal.Header>
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    await user.click(screen.getByRole('button', { name: /close dialog/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('Header with closeButton={false} does NOT render the × button', () => {
+    render(
+      <Modal open onOpenChange={() => {}}>
+        <Modal.Header closeButton={false}>Title</Modal.Header>
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    expect(screen.queryByRole('button', { name: /close dialog/i })).toBeNull();
+  });
+
+  it('initialFocusRef receives focus on open', async () => {
+    const user = userEvent.setup();
+    function FocusHarness() {
+      const [open, setOpen] = useState(false);
+      const inputRef = useRef<HTMLInputElement | null>(null);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open</button>
+          <Modal
+            open={open}
+            onOpenChange={setOpen}
+            initialFocusRef={inputRef as RefObject<HTMLElement | null>}
+          >
+            <Modal.Header>Title</Modal.Header>
+            <Modal.Body>
+              <input ref={inputRef} aria-label="Name" />
+            </Modal.Body>
+          </Modal>
+        </>
+      );
+    }
+    render(<FocusHarness />);
+    await user.click(screen.getByText('Open'));
+    // queueMicrotask delays the focus call — wait a tick.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(document.activeElement).toBe(screen.getByLabelText('Name'));
+  });
+
+  it('locks body scroll while open', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    expect(document.body.style.overflow).toBe('');
+    await user.click(screen.getByText('Open'));
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('releases body scroll after close', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByText('Open'));
+    expect(document.body.style.overflow).toBe('hidden');
+    await user.keyboard('{Escape}');
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('data-size reflects size prop', async () => {
+    const user = userEvent.setup();
+    render(<Harness size="lg" />);
+    await user.click(screen.getByText('Open'));
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-size', 'lg');
+  });
+
+  it('warns in dev when neither Header nor aria-label is provided', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <Modal open onOpenChange={() => {}}>
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('Footer applies align prop class', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Modal open onOpenChange={() => {}} aria-label="x">
+        <Modal.Body>x</Modal.Body>
+        <Modal.Footer align="space-between">
+          <button>Left</button>
+          <button>Right</button>
+        </Modal.Footer>
+      </Modal>,
+    );
+    const footer = container.ownerDocument.querySelector('[role="group"]');
+    expect(footer?.className).toMatch(/footerAlign-space-between/);
+  });
+
+  it('stacked modals: Esc only closes topmost', async () => {
+    const user = userEvent.setup();
+    const onOuter = vi.fn();
+    const onInner = vi.fn();
+    function Stacked() {
+      const [outer, setOuter] = useState(true);
+      const [inner, setInner] = useState(true);
+      return (
+        <>
+          <Modal
+            open={outer}
+            onOpenChange={(next) => {
+              setOuter(next);
+              onOuter(next);
+            }}
+            aria-label="Outer"
+          >
+            <Modal.Body>outer</Modal.Body>
+          </Modal>
+          <Modal
+            open={inner}
+            onOpenChange={(next) => {
+              setInner(next);
+              onInner(next);
+            }}
+            aria-label="Inner"
+          >
+            <Modal.Body>inner</Modal.Body>
+          </Modal>
+        </>
+      );
+    }
+    render(<Stacked />);
+    await user.keyboard('{Escape}');
+    expect(onInner).toHaveBeenCalledWith(false);
+    expect(onOuter).not.toHaveBeenCalled();
+  });
+
+  it('forces step combo: open + disableEscapeClose + dismissOnOverlayClick=false + no Close', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <Modal
+        open
+        onOpenChange={onOpenChange}
+        disableEscapeClose
+        dismissOnOverlayClick={false}
+        aria-label="Forced"
+      >
+        <Modal.Header closeButton={false}>Forced</Modal.Header>
+        <Modal.Body>Cannot escape.</Modal.Body>
+      </Modal>,
+    );
+    await user.keyboard('{Escape}');
+    const overlay = container.ownerDocument.querySelector(
+      '[data-modal-portal-root]',
+    ) as HTMLElement;
+    await user.click(overlay);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect pass**
+
+```bash
+make test
+```
+
+Expected: all tests pass (existing project tests + 17 new Modal tests + 6 new hook tests already passing from Tasks 2–4).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/Modal/Modal.test.tsx
+git commit -m "Modal: integration tests (17 cases)
+
+ARIA wiring, Esc + overlay-click + Modal.Close dismissal, initial focus,
+scroll lock acquire/release, data-size, stacked Esc routing, forced-step
+combo, dev warning when unlabelled.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11 — Public exports + AGENTS.md TL;DR + JSDoc final pass
+
+**Files:**
+- Modify: `packages/design-system/src/index.ts`
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Add Modal exports to the library root**
+
+In `packages/design-system/src/index.ts`, append (after the DataTable export block):
+
+```ts
+export { Modal } from './components/Modal';
+export type {
+  ModalProps,
+  ModalSize,
+  ModalHeaderProps,
+  ModalBodyProps,
+  ModalFooterProps,
+  ModalCloseProps,
+} from './components/Modal';
+```
+
+- [ ] **Step 2: Add the Modal TL;DR section to AGENTS.md**
+
+Open `packages/design-system/AGENTS.md`. Find the "Components — TL;DR" section. Add a new subsection (logical place: after `<DropdownMenu>` or `<Popover>`, near the other dismissable surfaces):
+
+````markdown
+### `<Modal>` — focus-locked dialog
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<Button onClick={() => setOpen(true)}>Edit contact</Button>
+
+<Modal open={open} onOpenChange={setOpen} size="md">
+  <Modal.Header>Edit contact</Modal.Header>
+  <Modal.Body>
+    <Stack gap="md">
+      <Input label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+    </Stack>
+  </Modal.Body>
+  <Modal.Footer>
+    <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
+    <Button onClick={save}>Save</Button>
+  </Modal.Footer>
+</Modal>
+```
+
+- **Controlled-only.** Pass `open` + `onOpenChange` always. There is no `<Modal.Trigger>` — wire your own button(s).
+- **Three sizes:** `sm` (400px), `md` (560px, default), `lg` (800px). Below 640px the modal goes fullscreen.
+- **`<Modal.Header>` auto-wires `aria-labelledby`.** Pass `closeButton={false}` to hide the built-in × button (e.g. forced-step modals). The Header's children become the dialog title.
+- **`<Modal.Body>` scrolls** when content overflows. `padding="none"` for edge-to-edge children (e.g. a tabs strip).
+- **`<Modal.Footer>` defaults to right-aligned actions.** Use `align="space-between"` to split a danger action away from save/cancel.
+- **`<Modal.Close>`** wraps a clickable child and fires `onOpenChange(false)` on click. Chains with the child's existing `onClick`.
+- **Forced step:** combine `disableEscapeClose`, `dismissOnOverlayClick={false}`, omit `<Modal.Close>`, and pass `<Modal.Header closeButton={false}>` to lock the user into the modal until they resolve it programmatically.
+- **Stacked modals supported.** Opening a modal from inside an open modal stacks correctly: z-index is computed per depth, Escape closes only the topmost, body scroll stays locked across the whole stack.
+- **Initial focus:** pass `initialFocusRef` to focus a specific element (e.g. the first input). Otherwise the dialog container receives focus and the focus trap takes over.
+
+**Anti-patterns:**
+
+- ❌ Rendering a Modal as a child of another component that itself uses `position: fixed` — the portal escapes that container anyway, so the fixed positioning is dead code. Just render `<Modal>` at any level; it portals to `document.body`.
+- ❌ Calling `onOpenChange={() => {}}` AND providing `<Modal.Close>` — the Close button calls `onOpenChange(false)` which then no-ops. Use `disableEscapeClose + dismissOnOverlayClick={false}` + omit Close for forced steps.
+- ❌ Mutating an `initialFocusRef.current` value after open — Modal reads the ref ONCE on the open transition. Re-reads on subsequent renders are ignored.
+- ❌ Using `<Modal>` for popovers or non-blocking notifications. Use `<Popover>`, `<DropdownMenu>`, or wait for `<Toast>`.
+````
+
+- [ ] **Step 3: JSDoc final pass — verify the three required blocks on the public surface**
+
+Run these greps to confirm each public surface has `@example`, `@remarks When NOT to use`, `@remarks Anti-patterns`:
+
+```bash
+grep -n "@example\|@remarks" packages/design-system/src/components/Modal/ModalRoot.tsx
+grep -n "@example\|@remarks" packages/design-system/src/components/Modal/Header.tsx
+grep -n "@example\|@remarks" packages/design-system/src/components/Modal/Body.tsx
+grep -n "@example\|@remarks" packages/design-system/src/components/Modal/Footer.tsx
+grep -n "@example\|@remarks" packages/design-system/src/components/Modal/Close.tsx
+```
+
+Expected: `ModalRoot.tsx` has all three (the function-level JSDoc from Task 5 already includes them). Smaller subcomponents (`Header`, `Body`, `Footer`, `Close`) only need a concise function-level JSDoc with at least one `@example` (already added in Task 7). No additional sweeps needed unless something is missing.
+
+- [ ] **Step 4: Run all gates**
+
+```bash
+make test
+make build-lib
+make lint
+```
+
+All green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/index.ts packages/design-system/AGENTS.md
+git commit -m "Modal: public exports + AGENTS.md TL;DR
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12 — Playground demo + nav wiring
+
+**Files:**
+- Create: `packages/playground/src/pages/components/ModalDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Write the demo**
+
+Create `packages/playground/src/pages/components/ModalDemo.tsx`:
+
+```tsx
+import { useRef, useState } from 'react';
+import {
+  Badge,
+  Button,
+  Cluster,
+  Input,
+  Modal,
+  Stack,
+} from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Modal/ModalRoot.tsx?raw';
+import scssSource from '@lib-source/components/Modal/Modal.module.scss?raw';
+
+export function ModalDemo() {
+  return (
+    <DemoLayout
+      name="Modal"
+      componentName="Modal"
+      description="Focus-locked, scroll-locked dialog with a compound API (Header / Body / Footer / Close). Three size presets, fullscreen on mobile, stacked-modal support."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="ModalRoot.tsx"
+      scssFilename="Modal.module.scss"
+    >
+      <BasicExample />
+      <SizesExample />
+      <FormExample />
+      <ForcedStepExample />
+      <StackedExample />
+      <CustomInitialFocusExample />
+    </DemoLayout>
+  );
+}
+
+function BasicExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Example
+      title="Basic"
+      description="Controlled open state. Header wires aria-labelledby automatically. Built-in × close button + Esc + overlay click all dismiss."
+      code={`const [open, setOpen] = useState(false);
+<Button onClick={() => setOpen(true)}>Open modal</Button>
+<Modal open={open} onOpenChange={setOpen}>
+  <Modal.Header>Hello</Modal.Header>
+  <Modal.Body>This is a modal.</Modal.Body>
+  <Modal.Footer>
+    <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
+    <Button onClick={() => setOpen(false)}>OK</Button>
+  </Modal.Footer>
+</Modal>`}
+    >
+      <Cluster>
+        <Button onClick={() => setOpen(true)}>Open modal</Button>
+      </Cluster>
+      <Modal open={open} onOpenChange={setOpen}>
+        <Modal.Header>Hello</Modal.Header>
+        <Modal.Body>This is a modal. Click outside, press Esc, or use the × to close.</Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button onClick={() => setOpen(false)}>OK</Button>
+        </Modal.Footer>
+      </Modal>
+    </Example>
+  );
+}
+
+function SizesExample() {
+  const [openSize, setOpenSize] = useState<'sm' | 'md' | 'lg' | null>(null);
+  return (
+    <Example
+      title="Sizes"
+      description='`size="sm"` (400px) / `"md"` (560px, default) / `"lg"` (800px). Below 640px viewport width the modal goes fullscreen regardless.'
+      code={`<Modal size="sm" open={open} onOpenChange={setOpen}>...</Modal>`}
+    >
+      <Cluster gap="sm">
+        <Button variant="secondary" size="sm" onClick={() => setOpenSize('sm')}>
+          Small
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setOpenSize('md')}>
+          Medium
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setOpenSize('lg')}>
+          Large
+        </Button>
+      </Cluster>
+      <Modal
+        open={openSize !== null}
+        onOpenChange={(next) => !next && setOpenSize(null)}
+        size={openSize ?? 'md'}
+      >
+        <Modal.Header>Size: {openSize ?? 'md'}</Modal.Header>
+        <Modal.Body>The width is determined by the `size` prop.</Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button>Close</Button>
+          </Modal.Close>
+        </Modal.Footer>
+      </Modal>
+    </Example>
+  );
+}
+
+function FormExample() {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('Acme Inc.');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  return (
+    <Example
+      title="Form modal with initial focus"
+      description="Use `initialFocusRef` to focus the first input on open. Body content stays in a Stack."
+      code={`const inputRef = useRef<HTMLInputElement>(null);
+<Modal open={open} onOpenChange={setOpen} initialFocusRef={inputRef}>
+  <Modal.Header>Edit contact</Modal.Header>
+  <Modal.Body>
+    <Input ref={inputRef} label="Name" value={name} onChange={...} />
+  </Modal.Body>
+  <Modal.Footer>...</Modal.Footer>
+</Modal>`}
+    >
+      <Cluster>
+        <Button onClick={() => setOpen(true)}>Edit contact</Button>
+      </Cluster>
+      <Modal open={open} onOpenChange={setOpen} initialFocusRef={inputRef}>
+        <Modal.Header>Edit contact</Modal.Header>
+        <Modal.Body>
+          <Stack gap="md">
+            <Input
+              ref={inputRef}
+              label="Company name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <Input label="Owner" placeholder="Sara" />
+          </Stack>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button onClick={() => setOpen(false)}>Save</Button>
+        </Modal.Footer>
+      </Modal>
+    </Example>
+  );
+}
+
+function ForcedStepExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Example
+      title="Forced step (non-dismissible)"
+      description="`disableEscapeClose` + `dismissOnOverlayClick={false}` + `<Modal.Header closeButton={false}>` + no `<Modal.Close>` = the user can only resolve via the in-modal action."
+      code={`<Modal
+  open
+  onOpenChange={() => {}}
+  size="sm"
+  disableEscapeClose
+  dismissOnOverlayClick={false}
+  aria-label="Session expired"
+>
+  <Modal.Header closeButton={false}>Session expired</Modal.Header>
+  <Modal.Body>Please sign in again.</Modal.Body>
+  <Modal.Footer>
+    <Button onClick={reauth}>Sign in</Button>
+  </Modal.Footer>
+</Modal>`}
+    >
+      <Cluster>
+        <Button variant="danger" onClick={() => setOpen(true)}>
+          Trigger forced step
+        </Button>
+      </Cluster>
+      <Modal
+        open={open}
+        onOpenChange={() => {}}
+        size="sm"
+        disableEscapeClose
+        dismissOnOverlayClick={false}
+        aria-label="Session expired"
+      >
+        <Modal.Header closeButton={false}>Session expired</Modal.Header>
+        <Modal.Body>This modal can&apos;t be dismissed via Esc or overlay click. Use the button below.</Modal.Body>
+        <Modal.Footer>
+          <Button onClick={() => setOpen(false)}>Sign in again</Button>
+        </Modal.Footer>
+      </Modal>
+    </Example>
+  );
+}
+
+function StackedExample() {
+  const [editOpen, setEditOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  return (
+    <Example
+      title="Stacked modals"
+      description="Opening a modal from inside another modal stacks. Escape closes only the topmost; body scroll stays locked across the whole stack."
+      code={`<Modal open={editOpen} ...>
+  <Modal.Footer align="space-between">
+    <Button variant="danger" onClick={() => setConfirmOpen(true)}>Delete</Button>
+    ...
+  </Modal.Footer>
+</Modal>
+<Modal open={confirmOpen} ...>
+  <Modal.Header>Delete contact?</Modal.Header>
+  <Modal.Footer>
+    <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
+    <Button variant="danger" onClick={confirmDelete}>Delete</Button>
+  </Modal.Footer>
+</Modal>`}
+    >
+      <Cluster>
+        <Button onClick={() => setEditOpen(true)}>Edit (with delete inside)</Button>
+      </Cluster>
+      <Modal open={editOpen} onOpenChange={setEditOpen} size="md">
+        <Modal.Header>Edit contact</Modal.Header>
+        <Modal.Body>
+          <Stack gap="md">
+            <Input label="Company" defaultValue="Acme Inc." />
+            <Cluster gap="sm" align="center">
+              <Badge tone="success">Active</Badge>
+            </Cluster>
+          </Stack>
+        </Modal.Body>
+        <Modal.Footer align="space-between">
+          <Button variant="danger" onClick={() => setConfirmOpen(true)}>
+            Delete
+          </Button>
+          <Cluster gap="sm">
+            <Modal.Close>
+              <Button variant="secondary">Cancel</Button>
+            </Modal.Close>
+            <Button onClick={() => setEditOpen(false)}>Save</Button>
+          </Cluster>
+        </Modal.Footer>
+      </Modal>
+      <Modal open={confirmOpen} onOpenChange={setConfirmOpen} size="sm">
+        <Modal.Header>Delete contact?</Modal.Header>
+        <Modal.Body>This cannot be undone.</Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button
+            variant="danger"
+            onClick={() => {
+              setConfirmOpen(false);
+              setEditOpen(false);
+            }}
+          >
+            Delete
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </Example>
+  );
+}
+
+function CustomInitialFocusExample() {
+  return (
+    <Example
+      title="No Header (aria-label fallback)"
+      description="Omit `<Modal.Header>` and pass `aria-label` for the dialog's accessible name."
+      code={`<Modal open={open} onOpenChange={setOpen} aria-label="Confirm action">
+  <Modal.Body>Are you sure?</Modal.Body>
+  <Modal.Footer>...</Modal.Footer>
+</Modal>`}
+    >
+      <NoHeaderInline />
+    </Example>
+  );
+}
+
+function NoHeaderInline() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Cluster>
+        <Button variant="secondary" onClick={() => setOpen(true)}>
+          Open (no Header)
+        </Button>
+      </Cluster>
+      <Modal open={open} onOpenChange={setOpen} aria-label="Confirm action">
+        <Modal.Body>
+          <p style={{ margin: 0 }}>Are you sure you want to continue?</p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button onClick={() => setOpen(false)}>Continue</Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Wire the demo into the four playground integration points**
+
+In `packages/playground/src/App.tsx`:
+
+1. Add the import:
+```ts
+import { ModalDemo } from './pages/components/ModalDemo';
+```
+
+2. Add the route inside `<Routes>` (alphabetical placement is fine):
+```tsx
+<Route path="/components/modal" element={<ModalDemo />} />
+```
+
+In `packages/playground/src/layout/AppShell/AppShell.tsx`, find the `componentGroups` array. Modal goes in the **Overlays** group (alongside Popover, DropdownMenu, Tooltip) — or **Display** if no Overlays group exists. Add:
+```ts
+{ to: '/components/modal', label: 'Modal' }
+```
+matching the existing entry shape.
+
+In `packages/playground/src/pages/components/ComponentsIndex.tsx`, add a tile for Modal — copy the shape of an adjacent component tile (e.g. Popover's) and swap the label/description. Description: "Focus-locked dialog with header / body / footer slots."
+
+In `packages/playground/src/pages/mockups/registry.ts`, add `'Modal'` to the `ComponentName` union (keep it alphabetical). No mockup uses Modal yet, so no `usesComponents` list needs updating.
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+make build
+```
+
+Both library and playground build cleanly.
+
+Optional manual smoke:
+
+```bash
+make dev &
+sleep 5
+# Visit http://localhost:8080/components/modal — click Open, Esc, overlay click, etc.
+kill %1 2>/dev/null || pkill -f vite || true
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/playground/src/pages/components/ModalDemo.tsx \
+        packages/playground/src/App.tsx \
+        packages/playground/src/layout/AppShell/AppShell.tsx \
+        packages/playground/src/pages/components/ComponentsIndex.tsx \
+        packages/playground/src/pages/mockups/registry.ts
+git commit -m "playground: ModalDemo + nav wiring (4 places)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13 — Hard-rule-8 review-fix cycle + push + PR
+
+**Files:** none directly; runs the standard cycle.
+
+- [ ] **Step 1: Run all gates**
+
+```bash
+make test
+make build-lib
+make build
+make lint
+npm pack --dry-run --workspace @eocrm/design-system
+```
+
+All exit 0.
+
+- [ ] **Step 2: Spawn a fresh-context reviewer (`opus`)**
+
+Use the `Agent` tool with `subagent_type: "general-purpose"`, model `opus`. Brief it explicitly on the 10 review categories, point it at `packages/design-system/CLAUDE.md`, `AGENTS.md`, `README.md`, and the spec at `docs/superpowers/specs/2026-05-22-modal-design.md`. Ask for output as Critical / Important / Nice-to-have / Regression-watch + a final verdict.
+
+Key things the reviewer must check:
+- Focus trap correctness on stacked modals (only top has active trap)
+- Escape routes through `modalStack.isTop` so inner modals close first
+- `useScrollLock` ref-count is correct across stack open/close orders
+- `inert` is added/removed correctly on body children, excluding the portal root
+- `previouslyFocused` capture/restore happens on the OPEN transition (not every render)
+- Dev warning fires only when truly unlabelled
+- `<Modal.Close>` chains onto consumer's existing onClick (doesn't replace it)
+- Reduced-motion media query catches both overlay + content
+- Mobile fullscreen breakpoint at 640px doesn't conflict with Header/Body/Footer flex layout
+- All tokens used exist in `tokens.scss` (no raw values per Rule 3)
+- `position: fixed`, `position: relative` etc. in Modal.module.scss have stylelint-disable comments matching the precedent from Phase 2/3 of DataTable
+- Tests cover all the documented behaviors
+
+- [ ] **Step 3: Fix every Critical + Important finding**
+
+For each, fix in code and re-run gates.
+
+- [ ] **Step 4: Spawn second reviewer with the same prompt**
+
+Loop until verdict is "clean enough to stop".
+
+- [ ] **Step 5: Commit review-cycle fixes (if any)**
+
+```bash
+git add -A
+git commit -m "Modal: review-cycle fixes (round N)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 6: Push the branch**
+
+```bash
+git push -u origin feat/modal
+```
+
+If Husky pre-push blocks on prettier:
+
+```bash
+npx prettier --write \
+  docs/superpowers/plans/2026-05-22-modal.md \
+  packages/design-system/src/components/Modal/ \
+  packages/design-system/src/index.ts \
+  packages/design-system/AGENTS.md \
+  packages/playground/src/pages/components/ModalDemo.tsx
+git add -A
+git commit -m "Modal: prettier --write
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push
+```
+
+- [ ] **Step 7: Open the PR**
+
+```bash
+gh pr create --title "Modal: focus-locked compound dialog (sm/md/lg, stacked, fullscreen mobile)" --body "$(cat <<'EOF'
+## Summary
+
+- New `<Modal>` compound component closing the wishlist gap in
+  `packages/design-system/CLAUDE.md` ("Modal/Dialog — hand-roll, needs
+  focus trap + scroll lock").
+- Compound API: `<Modal.Header>` / `<Modal.Body>` / `<Modal.Footer>` /
+  `<Modal.Close>`. Controlled-only (`open` + `onOpenChange` always required).
+- Three size presets (`sm` 400px / `md` 560px / `lg` 800px) + fullscreen
+  below 640px viewport. Stacked modals supported (z-index per depth via
+  `--modal-depth` CSS custom prop; Escape closes only the topmost).
+- Three hand-rolled hooks: `useFocusTrap` (Tab cycle + focusin recapture),
+  `useScrollLock` (ref-counted body scroll suppression), `useModalStack`
+  (singleton depth registry).
+- `inert` attribute on background body children while open. `@starting-style`
+  animations matching Popover, with `prefers-reduced-motion` opt-out.
+- Tokens added: `--size-modal-sm/md/lg`, `--color-bg-overlay`. The
+  `--z-modal: 1100` token was already in the ladder.
+
+## Test plan
+
+- [x] `useFocusTrap` unit tests (7)
+- [x] `useScrollLock` unit tests (5)
+- [x] `useModalStack` unit tests (9)
+- [x] `<Modal>` integration tests (17) — ARIA wiring, dismissal paths,
+      initial focus, scroll lock, stacked Esc, forced-step combo, dev warning
+- [x] Playground demo with 6 examples — basic, sizes, form with initial focus,
+      forced step, stacked, no-header (aria-label fallback)
+- [x] Hard-rule-8 pre-push review-fix cycle completed
+
+Spec: `docs/superpowers/specs/2026-05-22-modal-design.md`
+Plan: `docs/superpowers/plans/2026-05-22-modal.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 8: Watch CI**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: `Quality / check` passes.
+
+- [ ] **Step 9: Report PR URL**
+
+```bash
+gh pr view --json url --jq .url
+```
+
+---
+
+## Plan complete
+
+After Task 13, Modal ships and closes the wishlist item from `packages/design-system/CLAUDE.md`. Next on the wishlist (per the same CLAUDE.md): Toast (no Floating UI), Textarea, Switch, Breadcrumb, Link, IconButton. Pick one and brainstorm when ready.

--- a/docs/superpowers/specs/2026-05-22-modal-design.md
+++ b/docs/superpowers/specs/2026-05-22-modal-design.md
@@ -74,7 +74,8 @@ Add to `packages/design-system/src/styles/tokens.scss`:
 --size-modal-lg: 800px;
 
 /* Dimming backdrop. rgb-modern notation matching existing shadow tokens. */
---color-bg-overlay: rgb(15 23 42 / 50%);
+--color-bg-overlay: rgb(15 23 42 / 50%);              /* solid variant */
+--color-bg-overlay-blur: rgb(255 255 255 / 30%);      /* blur variant: light frosted-glass tint paired with backdrop-filter: blur(8px) */
 ```
 
 ## Public API
@@ -92,6 +93,14 @@ export interface ModalProps {
 
   /** Size preset → maps to `--size-modal-sm/md/lg` width. Defaults to 'md'. */
   size?: ModalSize;
+
+  /**
+   * Overlay variant. 'solid' (default) paints a dark dimming layer. 'blur' uses a
+   * light tinted background plus `backdrop-filter: blur(8px)` for a frosted-glass
+   * effect. 'blur' costs an extra compositor layer — fine for normal use; avoid
+   * stacking three blurred modals on the same screen.
+   */
+  overlay?: 'solid' | 'blur';
 
   /**
    * Disable Escape-to-close. Default false. Combined with `dismissOnOverlayClick: false`
@@ -313,21 +322,19 @@ Overlay and content are sibling stacking layers within the portal. The content i
 
 ### Stacking math
 
-`useModalStack` is a module-level singleton (a `Set<string> + ordered array`). Each Modal calls `register(id)` and gets back its depth. Renders with:
+`useModalStack` is a module-level singleton (a `Set<string> + ordered array`). Each Modal calls `register(id)` and gets back its depth.
 
-- `overlay z-index = var(--z-modal) + depth * 2`
-- `content z-index = var(--z-modal) + depth * 2 + 1`
+**Display model — only the topmost modal is visible.** When two modals are open, the outer one is hidden via `display: none` while the inner is on top. React state of the hidden modal is preserved (controlled inputs keep their values, refs stay populated). When the inner closes, the outer's `isTop` flips back to `true` and it re-appears instantly. The user sees one overlay at a time, never stacked dimming layers.
 
-Why step of 2: leaves a slot between modals for future use (e.g. between-modal connector or shared decoration). Not strictly required.
+Implementation:
 
-Implementation note: the depth value is passed to CSS via a custom prop (`--modal-depth: <n>` on the overlay's `style`) so SCSS can compute both z-indexes in one place:
+- `<Overlay>` reads `ctx.isTop` and writes `data-stack-position={isTop ? 'top' : 'hidden'}` on the portal root.
+- SCSS: `.overlay[data-stack-position='hidden'] { display: none; }` hides both the overlay and its `<Content>` child (the content is rendered inside the overlay element).
+- Z-index stays simple because at most one overlay is `display: block` at a time. We still emit `--modal-depth` for any future decoration that wants to read it, but the `calc()` collapses to a no-op for a single visible layer.
 
-```scss
-.overlay  { z-index: calc(var(--z-modal) + var(--modal-depth) * 2); }
-.content  { z-index: calc(var(--z-modal) + var(--modal-depth) * 2 + 1); }
-```
+Re-show after popping is **instant** (no fade-in). `display: none → display: flex` is not transitionable; making it animatable would require `visibility + opacity` instead, which is fine but adds machinery we don't need yet.
 
-Escape listener on each modal checks `if (!stack.isTop(id)) return;` so only the topmost modal handles Esc. Outside-click is similarly guarded — but in practice the nested modal's overlay covers the parent's overlay entirely, so outside-click on the nested overlay can only resolve to that overlay anyway.
+Escape listener on each modal checks `if (!stack.isTop(id)) return;` so only the topmost modal handles Esc. Overlay-click dismissal: same guard via `data-stack-position='hidden'` making the lower overlays non-interactive (zero hit area).
 
 Scroll lock is acquired ONCE across the stack (refcount stays >= 1 while any modal is open).
 
@@ -361,6 +368,14 @@ Edge case: zero focusables in the modal (rare — a Modal.Header with `closeButt
   transition: opacity var(--transition-base);
 
   @starting-style { opacity: 0; }
+}
+
+/* Blur variant — opt-in via overlay="blur". Light tinted background +
+   backdrop-filter for a frosted-glass effect. -webkit prefix for Safari. */
+.overlay[data-variant='blur'] {
+  background: var(--color-bg-overlay-blur);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 }
 
 .content {

--- a/docs/superpowers/specs/2026-05-22-modal-design.md
+++ b/docs/superpowers/specs/2026-05-22-modal-design.md
@@ -74,8 +74,10 @@ Add to `packages/design-system/src/styles/tokens.scss`:
 --size-modal-lg: 800px;
 
 /* Dimming backdrop. rgb-modern notation matching existing shadow tokens. */
---color-bg-overlay: rgb(15 23 42 / 50%);              /* solid variant */
---color-bg-overlay-blur: rgb(255 255 255 / 30%);      /* blur variant: light frosted-glass tint paired with backdrop-filter: blur(4px) */
+--color-bg-overlay: rgb(15 23 42 / 50%); /* solid variant */
+--color-bg-overlay-blur: rgb(
+  255 255 255 / 30%
+); /* blur variant: light frosted-glass tint paired with backdrop-filter: blur(4px) */
 ```
 
 ## Public API
@@ -367,7 +369,9 @@ Edge case: zero focusables in the modal (rare — a Modal.Header with `closeButt
   opacity: 1;
   transition: opacity var(--transition-base);
 
-  @starting-style { opacity: 0; }
+  @starting-style {
+    opacity: 0;
+  }
 }
 
 /* Blur variant — opt-in via overlay="blur". Light tinted background +
@@ -391,7 +395,9 @@ Edge case: zero focusables in the modal (rare — a Modal.Header with `closeButt
   }
 }
 
-.overlay[data-state='closed'] { opacity: 0; }
+.overlay[data-state='closed'] {
+  opacity: 0;
+}
 .content[data-state='closed'] {
   opacity: 0;
   transform: translateY(8px) scale(0.96);
@@ -418,28 +424,29 @@ Header + Body + Footer remain a flex column inside; Body fills the gap and scrol
 
 ### ARIA contract
 
-| Element | Attributes |
-|---|---|
-| Overlay | (no role — clickable backdrop only) |
-| Content | `role="dialog"`, `aria-modal="true"`, `tabIndex={-1}`, plus EITHER `aria-labelledby={headingId}` (Header rendered) OR `aria-label={prop}` (no Header), plus optional `aria-describedby` |
-| Header inner `<h2>` | Auto-assigned id via `useId()` + `sanitizeId`; stored in context, consumed by Content for `aria-labelledby` |
-| Header × button | `aria-label="Close dialog"` |
-| Body | Plain `<div>`; if `aria-describedby` matches a child id, consumer wires it themselves |
-| Footer | `<div role="group">` so AT announces the action set as a group |
-| Modal.Close wrapper | No ARIA — cloned child's native semantics carry the contract |
+| Element             | Attributes                                                                                                                                                                              |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Overlay             | (no role — clickable backdrop only)                                                                                                                                                     |
+| Content             | `role="dialog"`, `aria-modal="true"`, `tabIndex={-1}`, plus EITHER `aria-labelledby={headingId}` (Header rendered) OR `aria-label={prop}` (no Header), plus optional `aria-describedby` |
+| Header inner `<h2>` | Auto-assigned id via `useId()` + `sanitizeId`; stored in context, consumed by Content for `aria-labelledby`                                                                             |
+| Header × button     | `aria-label="Close dialog"`                                                                                                                                                             |
+| Body                | Plain `<div>`; if `aria-describedby` matches a child id, consumer wires it themselves                                                                                                   |
+| Footer              | `<div role="group">` so AT announces the action set as a group                                                                                                                          |
+| Modal.Close wrapper | No ARIA — cloned child's native semantics carry the contract                                                                                                                            |
 
 **Dev warning:** if neither `aria-labelledby` (Header rendered) nor `aria-label` is set, console.warn in development only. Same precedent as Popover.
 
 ### Keyboard
 
-| Key | Action |
-|---|---|
-| Tab | Cycle focus forward within modal; from last focusable wraps to first |
-| Shift+Tab | Cycle focus backward; from first wraps to last |
-| Escape | Close the **topmost** modal only; ignored when `disableEscapeClose: true` |
-| Enter / Space | Native — activates focused control |
+| Key           | Action                                                                    |
+| ------------- | ------------------------------------------------------------------------- |
+| Tab           | Cycle focus forward within modal; from last focusable wraps to first      |
+| Shift+Tab     | Cycle focus backward; from first wraps to last                            |
+| Escape        | Close the **topmost** modal only; ignored when `disableEscapeClose: true` |
+| Enter / Space | Native — activates focused control                                        |
 
 Auto-focus on open:
+
 1. `initialFocusRef.current` if provided and focusable
 2. Else the dialog container (`tabIndex=-1`)
 
@@ -452,7 +459,10 @@ Focus restore on close: `previouslyFocused.focus({ preventScroll: true })` if st
   .overlay,
   .content {
     transition: none;
-    @starting-style { opacity: 1; transform: none; }
+    @starting-style {
+      opacity: 1;
+      transform: none;
+    }
   }
 }
 ```

--- a/docs/superpowers/specs/2026-05-22-modal-design.md
+++ b/docs/superpowers/specs/2026-05-22-modal-design.md
@@ -75,7 +75,7 @@ Add to `packages/design-system/src/styles/tokens.scss`:
 
 /* Dimming backdrop. rgb-modern notation matching existing shadow tokens. */
 --color-bg-overlay: rgb(15 23 42 / 50%);              /* solid variant */
---color-bg-overlay-blur: rgb(255 255 255 / 30%);      /* blur variant: light frosted-glass tint paired with backdrop-filter: blur(8px) */
+--color-bg-overlay-blur: rgb(255 255 255 / 30%);      /* blur variant: light frosted-glass tint paired with backdrop-filter: blur(4px) */
 ```
 
 ## Public API
@@ -96,7 +96,7 @@ export interface ModalProps {
 
   /**
    * Overlay variant. 'solid' (default) paints a dark dimming layer. 'blur' uses a
-   * light tinted background plus `backdrop-filter: blur(8px)` for a frosted-glass
+   * light tinted background plus `backdrop-filter: blur(4px)` for a frosted-glass
    * effect. 'blur' costs an extra compositor layer — fine for normal use; avoid
    * stacking three blurred modals on the same screen.
    */
@@ -374,8 +374,8 @@ Edge case: zero focusables in the modal (rare — a Modal.Header with `closeButt
    backdrop-filter for a frosted-glass effect. -webkit prefix for Safari. */
 .overlay[data-variant='blur'] {
   background: var(--color-bg-overlay-blur);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
 }
 
 .content {

--- a/docs/superpowers/specs/2026-05-22-modal-design.md
+++ b/docs/superpowers/specs/2026-05-22-modal-design.md
@@ -326,13 +326,19 @@ Overlay and content are sibling stacking layers within the portal. The content i
 
 `useModalStack` is a module-level singleton (a `Set<string> + ordered array`). Each Modal calls `register(id)` and gets back its depth.
 
-**Display model — only the topmost modal is visible.** When two modals are open, the outer one is hidden via `display: none` while the inner is on top. React state of the hidden modal is preserved (controlled inputs keep their values, refs stay populated). When the inner closes, the outer's `isTop` flips back to `true` and it re-appears instantly. The user sees one overlay at a time, never stacked dimming layers.
+**Display model — controlled by the new `stackMode` prop (`'overlay'` default, `'replace'` opt-in).** When two modals are open, the behavior depends on the top modal's `stackMode`:
 
-Implementation:
+- **`stackMode="overlay"` (default):** the parent modal stays visible underneath. The inner modal's overlay paints transparent (no dim, no blur) so the parent's dim shows through. Only the bottom modal (depth 0) paints the actual overlay background. The user sees one consistent dim layer with the parent context visible behind the active modal.
+- **`stackMode="replace"`:** the prior default. The outer modal hides via `display: none` (React state preserved); the inner modal paints its own overlay normally. Re-show on pop is instant.
 
-- `<Overlay>` reads `ctx.isTop` and writes `data-stack-position={isTop ? 'top' : 'hidden'}` on the portal root.
-- SCSS: `.overlay[data-stack-position='hidden'] { display: none; }` hides both the overlay and its `<Content>` child (the content is rendered inside the overlay element).
-- Z-index stays simple because at most one overlay is `display: block` at a time. We still emit `--modal-depth` for any future decoration that wants to read it, but the `calc()` collapses to a no-op for a single visible layer.
+Two data-attributes on each portal root drive the SCSS:
+
+- `data-stack-position`: `'top'` | `'underneath'` (overlay mode, lower modal) | `'hidden'` (replace mode, lower modal)
+- `data-overlay-paint`: `'yes'` | `'no'` — only the ground-level modal paints (`depth === 0` in overlay mode; the top modal in replace mode)
+
+`useModalStack` was extended to track per-modal `mode` and expose `topMode()`. `ModalRoot` reads `topMode` from the hook and threads it through context. `Overlay` computes both attributes from `ctx.isTop`, `ctx.topMode`, and `ctx.depth`.
+
+Z-index stays simple — the `--modal-depth` custom prop is still emitted for any future per-depth decoration, but with the stacking model the overlay paint logic is attribute-driven rather than z-index-driven.
 
 Re-show after popping is **instant** (no fade-in). `display: none → display: flex` is not transitionable; making it animatable would require `visibility + opacity` instead, which is fine but adds machinery we don't need yet.
 

--- a/docs/superpowers/specs/2026-05-22-modal-design.md
+++ b/docs/superpowers/specs/2026-05-22-modal-design.md
@@ -1,0 +1,519 @@
+# Modal — design spec
+
+**Date:** 2026-05-22
+**Branch:** `feat/modal`
+**Scope:** Single `<Modal>` compound component covering confirm/alert, form/edit, detail/preview, and forced-step use cases. Three size variants (`sm` / `md` / `lg`), fullscreen on narrow viewports, supports stacked modals.
+
+## Goal
+
+A modal dialog primitive that handles the patterns the CRM actually needs — focused confirmations, form editors, detail panels, and forced-step interrupts. Hand-rolled per the project's "no UI libraries" policy. Closes the explicit gap noted in `packages/design-system/CLAUDE.md`'s wishlist: "Modal/Dialog (hand-roll, no positioning needed; needs focus trap + scroll lock)."
+
+## Why now
+
+- Popover (already shipped) explicitly defers focus-trap + inert-background behavior to "once `<Modal>` lands" via a reserved `modal: boolean` prop note in its source. The seam exists; the component doesn't.
+- DataTable, EditContact-style forms, and destructive-confirmation flows all need a focus-locked, scroll-locked dialog. Today these compose Popover + workarounds, which is the wrong primitive for full-attention interactions.
+- Existing primitives cover everything Modal will compose with: Stack/Cluster for layout, Button for actions, the full token system for sizing and theming, `_internal/refs.ts` for `mergeRefs` + `sanitizeId`.
+
+## Non-goals (v1)
+
+- **No bottom-sheet variant.** Drag-to-dismiss + snap-points is its own component category. Phase 2 if real demand surfaces.
+- **No imperative manager (`modal.open() => Promise`).** v1 is JSX-based, controlled-only. Promise-based opener is a 30-line wrapper consumers can build if they want it.
+- **No built-in confirm/alert convenience component.** Consumers compose `<Modal>` + `<Modal.Header>` + body + `<Button>` for confirms. `ConfirmationPopover` already exists for the lightweight inline-confirm case.
+- **No drag-to-position or resize.** Modals are centered. Period.
+- **No multi-modal coordination beyond stacking.** No "queued modals" or "modal manager". Consumers manage their own state.
+- **No `<dialog>` element semantics.** Browsers' native `<dialog>` lacks consistent focus-trap behavior across the project's support range. Use a `role="dialog"` div with explicit focus management.
+- **No persistence helpers.** Modal doesn't remember it was open across navigations. Consumer-owned `open` state means consumers can persist if they want.
+
+## Architecture
+
+### Dependencies
+
+No new packages. Hand-rolled per project policy.
+
+### File layout
+
+```
+packages/design-system/src/components/Modal/
+  ModalRoot.tsx         ← <Modal> — context, controlled state, scroll lock, focus restore
+  Overlay.tsx           ← Dimming backdrop; click-to-dismiss
+  Content.tsx           ← Dialog container; portaled; focus-trapped; role="dialog"
+  Header.tsx            ← Title bar + optional close button; auto-registers aria-labelledby id
+  Body.tsx              ← Scrollable content area
+  Footer.tsx            ← Pinned action bar (role="group")
+  Close.tsx             ← cloneElement wrapper that calls onOpenChange(false)
+  Modal.tsx             ← Object.assign attaches subcomponents
+  Modal.module.scss
+  Modal.test.tsx
+  context.ts            ← ModalContext + useModalContext("ComponentName") guard
+  useFocusTrap.ts       ← Tab cycle within container + focusin recapture
+  useFocusTrap.test.ts
+  useScrollLock.ts      ← Ref-counted body scroll lock with scrollbar-gutter padding
+  useScrollLock.test.ts
+  useModalStack.ts      ← Module-level stack registry; depth indexing for z-index + Esc routing
+  useModalStack.test.ts
+  index.ts
+```
+
+### Composition
+
+- `<Stack>` / `<Cluster>` used internally by `Header` / `Footer` for layout primitives
+- `<Button>` referenced in JSDoc examples and the playground demo, not imported by Modal itself
+- Existing tokens for color/spacing/shadow/radius
+- Pattern reuse from Popover: compound context, portal mount, escape capture-phase listener, `cloneElement` for `Modal.Close`, focus return via captured `previouslyFocused`
+
+### New tokens
+
+`--z-modal: 1100` already exists in `tokens.scss` (part of the layered ladder: dropdown 1000, popover 1050, modal 1100, toast 1200, tooltip 1300). Reuse as the base for the stacking math.
+
+Add to `packages/design-system/src/styles/tokens.scss`:
+
+```scss
+/* Modal width presets. Match the size= prop on <Modal>. */
+--size-modal-sm: 400px;
+--size-modal-md: 560px;
+--size-modal-lg: 800px;
+
+/* Dimming backdrop. rgb-modern notation matching existing shadow tokens. */
+--color-bg-overlay: rgb(15 23 42 / 50%);
+```
+
+## Public API
+
+### `<Modal>` root
+
+```ts
+export type ModalSize = 'sm' | 'md' | 'lg';
+
+export interface ModalProps {
+  /** Controlled open state. Required — Modal has no uncontrolled mode. */
+  open: boolean;
+  /** Fired when Modal wants to change open state — Esc, overlay click, Close button, programmatic. */
+  onOpenChange: (open: boolean) => void;
+
+  /** Size preset → maps to `--size-modal-sm/md/lg` width. Defaults to 'md'. */
+  size?: ModalSize;
+
+  /**
+   * Disable Escape-to-close. Default false. Combined with `dismissOnOverlayClick: false`
+   * and omitting `<Modal.Close>` produces a fully forced step.
+   */
+  disableEscapeClose?: boolean;
+  /**
+   * When false, clicking the overlay backdrop does NOT close the modal. Default true.
+   * Use for forms with unsaved-data guards.
+   */
+  dismissOnOverlayClick?: boolean;
+
+  /**
+   * Initial focus target on open. Default: the dialog container itself (tabIndex=-1).
+   * Pass a ref to override (e.g. focus the first input in a form).
+   */
+  initialFocusRef?: React.RefObject<HTMLElement | null>;
+
+  /** Compound children: Header / Body / Footer / Close + any consumer JSX. */
+  children: ReactNode;
+
+  /** className passes through to the dialog container. */
+  className?: string;
+  /** style passes through to the dialog container. */
+  style?: CSSProperties;
+
+  /**
+   * Required for a11y when no Modal.Header is rendered. When Header IS rendered,
+   * aria-labelledby auto-binds to the heading id; this prop is then ignored.
+   * Throws a dev-only warning if neither this nor a Header is provided.
+   */
+  'aria-label'?: string;
+  /** Optional id of an external descriptor element; sets aria-describedby on the dialog. */
+  'aria-describedby'?: string;
+}
+```
+
+### Sub-component props (all `forwardRef`)
+
+```ts
+export interface ModalHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  /** Show the built-in × close button on the right edge. Default true. */
+  closeButton?: boolean;
+}
+
+export interface ModalBodyProps extends HTMLAttributes<HTMLDivElement> {
+  /** Override body's padding. Default 'default' (--space-4). 'none' for edge-to-edge content. */
+  padding?: 'default' | 'none';
+}
+
+export interface ModalFooterProps extends HTMLAttributes<HTMLDivElement> {
+  /** Horizontal action alignment. Default 'end'. */
+  align?: 'start' | 'end' | 'space-between';
+}
+
+export interface ModalCloseProps {
+  /**
+   * Single clickable child. Click anywhere on it triggers onOpenChange(false).
+   * Uses cloneElement to chain the existing onClick (matches Popover.Close pattern).
+   */
+  children: ReactElement;
+}
+```
+
+### Exports
+
+From `packages/design-system/src/components/Modal/index.ts`:
+
+```ts
+export { Modal } from './Modal';
+export type {
+  ModalProps,
+  ModalSize,
+  ModalHeaderProps,
+  ModalBodyProps,
+  ModalFooterProps,
+  ModalCloseProps,
+} from './Modal';
+```
+
+From the library root `src/index.ts`:
+
+```ts
+export { Modal } from './components/Modal';
+export type {
+  ModalProps,
+  ModalSize,
+  ModalHeaderProps,
+  ModalBodyProps,
+  ModalFooterProps,
+  ModalCloseProps,
+} from './components/Modal';
+```
+
+### Canonical usage
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<Button onClick={() => setOpen(true)}>Edit contact</Button>
+
+<Modal open={open} onOpenChange={setOpen} size="md">
+  <Modal.Header>Edit contact</Modal.Header>
+  <Modal.Body>
+    <Stack gap="md">
+      <Input label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+      <Input label="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+    </Stack>
+  </Modal.Body>
+  <Modal.Footer>
+    <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
+    <Button onClick={save}>Save</Button>
+  </Modal.Footer>
+</Modal>
+```
+
+### Forced-step variant
+
+```tsx
+<Modal
+  open
+  onOpenChange={() => {}}
+  size="sm"
+  disableEscapeClose
+  dismissOnOverlayClick={false}
+  aria-label="Session expired"
+>
+  <Modal.Header closeButton={false}>Session expired</Modal.Header>
+  <Modal.Body>Please sign in again to continue.</Modal.Body>
+  <Modal.Footer>
+    <Button onClick={reauth}>Sign in</Button>
+  </Modal.Footer>
+</Modal>
+```
+
+### Stacked usage (Edit → Confirm Delete)
+
+```tsx
+const [editOpen, setEditOpen] = useState(false);
+const [confirmOpen, setConfirmOpen] = useState(false);
+
+<Modal open={editOpen} onOpenChange={setEditOpen} size="md">
+  <Modal.Header>Edit contact</Modal.Header>
+  <Modal.Body>{/* form */}</Modal.Body>
+  <Modal.Footer align="space-between">
+    <Button variant="danger" onClick={() => setConfirmOpen(true)}>Delete</Button>
+    <Cluster gap="sm">
+      <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
+      <Button onClick={save}>Save</Button>
+    </Cluster>
+  </Modal.Footer>
+</Modal>
+
+<Modal open={confirmOpen} onOpenChange={setConfirmOpen} size="sm">
+  <Modal.Header>Delete contact?</Modal.Header>
+  <Modal.Body>This cannot be undone.</Modal.Body>
+  <Modal.Footer>
+    <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
+    <Button variant="danger" onClick={confirmDelete}>Delete</Button>
+  </Modal.Footer>
+</Modal>
+```
+
+Both modals are open simultaneously. Confirm modal's overlay paints over the Edit modal. Esc closes Confirm only; Edit remains open. Body scroll stays locked.
+
+## Rendering pipeline
+
+### DOM structure (when open)
+
+```
+[react-dom portal → document.body]
+  <div
+    class="overlay"
+    data-state="open|closed"
+    style={{ '--modal-depth': depth }}    ← CSS reads depth via calc(var(--z-modal) + ...)
+    onClick={handleOverlayClick}    ← dispatches only when e.target === e.currentTarget
+  >
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={headingId ?? undefined}
+      aria-label={!headingId ? props['aria-label'] : undefined}
+      aria-describedby={props['aria-describedby']}
+      tabIndex={-1}
+      data-state="open|closed"
+      data-size={size}
+      class="content content-{size}"
+      style={{ ...props.style }}
+      ref={contentRef}
+    >
+      {children}
+    </div>
+  </div>
+```
+
+Overlay and content are sibling stacking layers within the portal. The content is positioned inside the overlay region via flex (overlay = `display: flex; align-items: center; justify-content: center`), not absolutely positioned, so click events on the overlay area resolve to the overlay element (not the content) and `e.target === e.currentTarget` cleanly detects backdrop clicks.
+
+### Mount / unmount flow
+
+**Open transition (`open: false → true`):**
+
+1. `useModalStack.register(modalId)` — returns depth index. First modal: 0. Nested: 1, 2, etc.
+2. `useScrollLock.acquire()` — ref-counted; on first acquire, sets `body { overflow: hidden; padding-right: <scrollbar-width>px }` to lock scroll without layout shift.
+3. `previouslyFocused = document.activeElement` captured before portal mounts.
+4. Portal mounts overlay + content.
+5. `useLayoutEffect`: if `initialFocusRef.current` is set, call `.focus({ preventScroll: true })` on it. Otherwise focus the dialog container (which has `tabIndex={-1}`). If the ref points to a non-focusable element, the browser's `.focus()` no-ops; the subsequent focus-trap `focusin` recapture will then route focus back to the container.
+6. `useFocusTrap(contentRef)` attaches `keydown` (Tab cycling) + `focusin` (escape recapture) listeners.
+7. Animations: overlay fades via `@starting-style { opacity: 0 }`. Content scales in via `@starting-style { opacity: 0; transform: translateY(8px) scale(0.96) }`.
+8. `inert` attribute applied to all `document.body.children` EXCEPT the portal root (for AT background suppression + extra focus-trap insurance).
+
+**Close transition (`open: true → false`):**
+
+1. `data-state="closed"` set before unmount to play exit animation (matches Popover convention).
+2. After `--transition-base` (animationend listener), portal unmounts.
+3. Focus restores via `previouslyFocused.focus({ preventScroll: true })` if element is still in the DOM. Otherwise focus falls through to `document.body`.
+4. `useScrollLock.release()` — when refcount drops to 0, restore `body { overflow }` + remove the scrollbar-gutter padding.
+5. `useModalStack.unregister(modalId)` — depth indexes of remaining open modals compact down.
+6. `inert` removed from `body.children` if no modals remain.
+
+### Stacking math
+
+`useModalStack` is a module-level singleton (a `Set<string> + ordered array`). Each Modal calls `register(id)` and gets back its depth. Renders with:
+
+- `overlay z-index = var(--z-modal) + depth * 2`
+- `content z-index = var(--z-modal) + depth * 2 + 1`
+
+Why step of 2: leaves a slot between modals for future use (e.g. between-modal connector or shared decoration). Not strictly required.
+
+Implementation note: the depth value is passed to CSS via a custom prop (`--modal-depth: <n>` on the overlay's `style`) so SCSS can compute both z-indexes in one place:
+
+```scss
+.overlay  { z-index: calc(var(--z-modal) + var(--modal-depth) * 2); }
+.content  { z-index: calc(var(--z-modal) + var(--modal-depth) * 2 + 1); }
+```
+
+Escape listener on each modal checks `if (!stack.isTop(id)) return;` so only the topmost modal handles Esc. Outside-click is similarly guarded — but in practice the nested modal's overlay covers the parent's overlay entirely, so outside-click on the nested overlay can only resolve to that overlay anyway.
+
+Scroll lock is acquired ONCE across the stack (refcount stays >= 1 while any modal is open).
+
+### Focus trap
+
+`useFocusTrap(contentRef)`:
+
+- Queries focusable descendants on each `keydown` invocation (no caching — DOM may have changed):
+  ```
+  button:not([disabled]),
+  [href],
+  input:not([disabled]),
+  select:not([disabled]),
+  textarea:not([disabled]),
+  [tabindex]:not([tabindex="-1"])
+  ```
+- `Tab` from last focusable → first; `Shift+Tab` from first → last.
+- `focusin` document-level listener: if focus moves to an element NOT inside `contentRef.current` AND this modal is top of stack, redirect to dialog container.
+- Returns cleanup that removes both listeners on unmount.
+
+For stacked modals, only the topmost has an ACTIVE trap. Inner modals' traps remain mounted but the `focusin` handler checks `stack.isTop(id)` and no-ops if false.
+
+Edge case: zero focusables in the modal (rare — a Modal.Header with `closeButton: false` + read-only Body + empty Footer). The dialog container itself is `tabIndex=-1`, so focus stays on it; Tab does nothing.
+
+### Animation
+
+```scss
+.overlay {
+  background: var(--color-bg-overlay);
+  opacity: 1;
+  transition: opacity var(--transition-base);
+
+  @starting-style { opacity: 0; }
+}
+
+.content {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base);
+
+  @starting-style {
+    opacity: 0;
+    transform: translateY(8px) scale(0.96);
+  }
+}
+
+.overlay[data-state='closed'] { opacity: 0; }
+.content[data-state='closed'] {
+  opacity: 0;
+  transform: translateY(8px) scale(0.96);
+}
+```
+
+### Mobile fullscreen
+
+```scss
+@media (max-width: 640px) {
+  .content {
+    width: 100vw;
+    height: 100vh;
+    max-width: 100vw;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+}
+```
+
+Header + Body + Footer remain a flex column inside; Body fills the gap and scrolls. Overlay still painted (preserves click-to-dismiss consistency even though it's largely hidden behind the fullscreen content).
+
+## Accessibility
+
+### ARIA contract
+
+| Element | Attributes |
+|---|---|
+| Overlay | (no role — clickable backdrop only) |
+| Content | `role="dialog"`, `aria-modal="true"`, `tabIndex={-1}`, plus EITHER `aria-labelledby={headingId}` (Header rendered) OR `aria-label={prop}` (no Header), plus optional `aria-describedby` |
+| Header inner `<h2>` | Auto-assigned id via `useId()` + `sanitizeId`; stored in context, consumed by Content for `aria-labelledby` |
+| Header × button | `aria-label="Close dialog"` |
+| Body | Plain `<div>`; if `aria-describedby` matches a child id, consumer wires it themselves |
+| Footer | `<div role="group">` so AT announces the action set as a group |
+| Modal.Close wrapper | No ARIA — cloned child's native semantics carry the contract |
+
+**Dev warning:** if neither `aria-labelledby` (Header rendered) nor `aria-label` is set, console.warn in development only. Same precedent as Popover.
+
+### Keyboard
+
+| Key | Action |
+|---|---|
+| Tab | Cycle focus forward within modal; from last focusable wraps to first |
+| Shift+Tab | Cycle focus backward; from first wraps to last |
+| Escape | Close the **topmost** modal only; ignored when `disableEscapeClose: true` |
+| Enter / Space | Native — activates focused control |
+
+Auto-focus on open:
+1. `initialFocusRef.current` if provided and focusable
+2. Else the dialog container (`tabIndex=-1`)
+
+Focus restore on close: `previouslyFocused.focus({ preventScroll: true })` if still in the document; otherwise falls through to `document.body`.
+
+### Reduced motion
+
+```scss
+@media (prefers-reduced-motion: reduce) {
+  .overlay,
+  .content {
+    transition: none;
+    @starting-style { opacity: 1; transform: none; }
+  }
+}
+```
+
+Open/close becomes instantaneous. Eliminates motion-related discomfort.
+
+### Inert background
+
+When any modal is open, set `inert` attribute on every direct child of `<body>` EXCEPT the portal root. This:
+
+- Hides background content from AT cursor navigation
+- Blocks all focus into background (belt-and-suspenders with the focus trap)
+- Disables pointer events on background
+
+Removed on last modal close. No polyfill — modern browsers only (the project's support range allows native `inert`).
+
+## Testing strategy
+
+### `useFocusTrap.test.ts` (pure hook)
+
+- Tab from last focusable → first
+- Shift+Tab from first → last
+- Programmatic focus escape outside the container → redirected back
+- Cleanup on unmount removes listeners
+- Zero focusables → focus stays on container, Tab no-ops
+- Stack-aware: when not top of stack, focusin doesn't redirect
+
+### `useScrollLock.test.ts` (pure hook)
+
+- First `acquire()` sets `body.style.overflow = 'hidden'` + scrollbar-gutter padding
+- Second `acquire()` increments refcount; body style unchanged
+- `release()` decrements; only when count = 0 restores original `overflow` + removes padding
+- Captures original `overflow` value pre-lock (so non-default values are restored, not blanked)
+
+### `useModalStack.test.ts` (pure hook)
+
+- `register()` returns 0 for first, 1 for second
+- `unregister()` compacts indexes — closing modal #0 with #1 still open → #1 becomes index 0
+- `isTop(id)` reflects most-recently-registered open modal
+- `topDepth()` returns current stack height (number of open modals)
+- Cleanup on unmount calls `unregister` exactly once
+
+### `Modal.test.tsx` (integration via React Testing Library)
+
+- Renders only when `open={true}`; nothing in DOM when `open={false}`
+- `aria-labelledby` set when Header rendered; falls back to `aria-label` prop when Header omitted
+- Dev warning when neither labelledby nor aria-label set
+- Escape fires `onOpenChange(false)` by default; ignored when `disableEscapeClose: true`
+- Overlay click fires `onOpenChange(false)` by default; ignored when `dismissOnOverlayClick: false`
+- Overlay click on content (not the overlay edge) does NOT fire close (e.target === currentTarget guard)
+- `Modal.Close` click fires `onOpenChange(false)`
+- `initialFocusRef` focused on open; else dialog container has focus
+- Focus restores to previously-focused element on close
+- `Modal.Header closeButton={false}` doesn't render the X
+- `data-size` reflects `size` prop
+- Body scroll lock applied while open; released on close
+- Stacked modals: Esc only closes topmost; nested z-index higher
+- Forced-step combo: `open + disableEscapeClose + dismissOnOverlayClick=false + no Modal.Close` → modal cannot be dismissed via the four normal paths (test asserts onOpenChange is NOT called)
+- Ref forwarding to content div
+- `className` merged with internal classes
+- `style` passed through to content div
+- Footer `align` prop applies the right CSS class (test by checking data attr or computed style)
+
+### Manual / playground smoke tests
+
+- Focus-trap with screen reader (manual)
+- Mobile fullscreen breakpoint (resize browser)
+- Reduced-motion via DevTools
+
+## Hard-rule compliance checklist
+
+Per root `CLAUDE.md`:
+
+1. `Modal.test.tsx`, `useFocusTrap.test.ts`, `useScrollLock.test.ts`, `useModalStack.test.ts` colocated with source
+2. `ModalDemo.tsx` added to `packages/playground/src/pages/components/` showing: basic, three sizes, forced step, stacked, header-without-close, custom initial focus
+3. Demo wired into `App.tsx` (route), `AppShell.tsx` (sidebar — Display or Navigation group), `ComponentsIndex.tsx` (tile). `mockups/registry.ts` updated if any mockup uses it (none in v1).
+4. `Modal` re-exported from `packages/design-system/src/index.ts` with all sub-component prop types
+5. JSDoc with `@example` blocks + `@remarks When NOT to use` + `@remarks Anti-patterns` on the `Modal` root and on each prop in `ModalProps`. AGENTS.md TL;DR section added.
+6. Pre-push review-fix cycle (Hard rule 8) before push

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -418,7 +418,7 @@ const [tab, setTab] = useState('overview');
 - Opens with a short scale-fade from the trigger side (140ms). Closes instantly. Respects `prefers-reduced-motion: reduce`.
 - **From a DropdownMenu item.** Wrap a `<DropdownMenu.Item closeOnSelect={false}>` as the `<Popover.Trigger>` child — the Item itself becomes the trigger, so the full highlighted row opens the popover. `closeOnSelect={false}` keeps the menu open while the popover is shown.
 - Z-layer `--z-popover: 1050` — above dropdown, below modal/toast/tooltip.
-- For passive hover/focus hints → `<Tooltip>`. For lists of actions → `<DropdownMenu>`. For focus-locked dialogs → `<Modal>` (not yet shipped).
+- For passive hover/focus hints → `<Tooltip>`. For lists of actions → `<DropdownMenu>`. For focus-locked dialogs → `<Modal>`.
 
 ### `<ConfirmationPopover>` — opinionated "Are you sure?" preset
 
@@ -467,7 +467,7 @@ const [open, setOpen] = useState(false);
 
 - **Controlled-only.** Pass `open` + `onOpenChange` always. There is no `<Modal.Trigger>` — wire your own button(s).
 - **Three sizes:** `sm` (400px), `md` (560px, default), `lg` (800px). Below 640px the modal goes fullscreen.
-- **Overlay variant:** `overlay="solid"` (default, dark dim) or `overlay="blur"` (frosted-glass effect — light tint + `backdrop-filter: blur(8px)`). Avoid stacking three blurred modals — extra compositor cost per layer.
+- **Overlay variant:** `overlay="solid"` (default, dark dim) or `overlay="blur"` (frosted-glass effect — light tint + `backdrop-filter: blur(4px)`). Avoid stacking three blurred modals — extra compositor cost per layer.
 - **`<Modal.Header>` auto-wires `aria-labelledby`.** Pass `closeButton={false}` to hide the built-in × button (e.g. forced-step modals). The Header's children become the dialog title.
 - **`<Modal.Body>` scrolls** when content overflows. `padding="none"` for edge-to-edge children (e.g. a tabs strip).
 - **`<Modal.Footer>` defaults to right-aligned actions.** Use `align="space-between"` to split a danger action away from save/cancel.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -473,7 +473,7 @@ const [open, setOpen] = useState(false);
 - **`<Modal.Footer>` defaults to right-aligned actions.** Use `align="space-between"` to split a danger action away from save/cancel.
 - **`<Modal.Close>`** wraps a clickable child and fires `onOpenChange(false)` on click. Chains with the child's existing `onClick`.
 - **Forced step:** combine `disableEscapeClose`, `dismissOnOverlayClick={false}`, omit `<Modal.Close>`, and pass `<Modal.Header closeButton={false}>` to lock the user into the modal until they resolve it programmatically.
-- **Stacked modals — only the topmost is visible.** Opening a modal from inside an open modal hides the outer via `display: none` (React state preserved); when the inner closes, the outer reappears instantly. Escape only closes the topmost, body scroll stays locked across the whole stack.
+- **Stacked modals.** Default `stackMode="overlay"`: the parent stays visible underneath and the inner overlay paints transparent so the parent's dim shows through (one effective dim layer for the stack). Use `stackMode="replace"` to hide the parent via `display: none` (React state preserved) — best for forced steps where the parent context is irrelevant. Escape still closes only the topmost; body scroll stays locked across the whole stack.
 - **Initial focus:** pass `initialFocusRef` to focus a specific element (e.g. the first input). Otherwise the dialog container receives focus and the focus trap takes over.
 
 **Anti-patterns:**

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -480,7 +480,7 @@ const [open, setOpen] = useState(false);
 
 - ❌ Rendering a Modal as a child of another component that itself uses `position: fixed` — the portal escapes that container anyway, so the fixed positioning is dead code. Just render `<Modal>` at any level; it portals to `document.body`.
 - ❌ Calling `onOpenChange={() => {}}` AND providing `<Modal.Close>` — the Close button calls `onOpenChange(false)` which then no-ops. Use `disableEscapeClose + dismissOnOverlayClick={false}` + omit Close for forced steps.
-- ❌ Mutating an `initialFocusRef.current` value after open — Modal reads the ref ONCE on the open transition. Re-reads on subsequent renders are ignored.
+- ❌ Mutating an `initialFocusRef.current` value after open — Modal reads the ref when the modal opens AND whenever it becomes the top of the stack again (e.g., after a nested modal closes). Don't rely on a specific number of reads; instead, ensure the ref points at a stable element while the modal is open.
 - ❌ Using `<Modal>` for popovers or non-blocking notifications. Use `<Popover>`, `<DropdownMenu>`, or wait for `<Toast>`.
 
 ### `<Select>` — value picker (single, multi, searchable, async, creatable)

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -444,6 +444,45 @@ const [tab, setTab] = useState('overview');
 - Anchors above the trigger by default (`side="top"`).
 - **From a DropdownMenu item (kebab Delete pattern).** Wrap a `<DropdownMenu.Item closeOnSelect={false}>` as the trigger — clicking anywhere on the row opens the confirmation. The menu stays open until the user dismisses it (Escape or click outside). To close the menu after the action resolves, drive `DropdownMenu`'s `open` state externally and call `setMenuOpen(false)` inside `onConfirm`.
 
+### `<Modal>` — focus-locked dialog
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<Button onClick={() => setOpen(true)}>Edit contact</Button>
+
+<Modal open={open} onOpenChange={setOpen} size="md">
+  <Modal.Header>Edit contact</Modal.Header>
+  <Modal.Body>
+    <Stack gap="md">
+      <Input label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+    </Stack>
+  </Modal.Body>
+  <Modal.Footer>
+    <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
+    <Button onClick={save}>Save</Button>
+  </Modal.Footer>
+</Modal>
+```
+
+- **Controlled-only.** Pass `open` + `onOpenChange` always. There is no `<Modal.Trigger>` — wire your own button(s).
+- **Three sizes:** `sm` (400px), `md` (560px, default), `lg` (800px). Below 640px the modal goes fullscreen.
+- **Overlay variant:** `overlay="solid"` (default, dark dim) or `overlay="blur"` (frosted-glass effect — light tint + `backdrop-filter: blur(8px)`). Avoid stacking three blurred modals — extra compositor cost per layer.
+- **`<Modal.Header>` auto-wires `aria-labelledby`.** Pass `closeButton={false}` to hide the built-in × button (e.g. forced-step modals). The Header's children become the dialog title.
+- **`<Modal.Body>` scrolls** when content overflows. `padding="none"` for edge-to-edge children (e.g. a tabs strip).
+- **`<Modal.Footer>` defaults to right-aligned actions.** Use `align="space-between"` to split a danger action away from save/cancel.
+- **`<Modal.Close>`** wraps a clickable child and fires `onOpenChange(false)` on click. Chains with the child's existing `onClick`.
+- **Forced step:** combine `disableEscapeClose`, `dismissOnOverlayClick={false}`, omit `<Modal.Close>`, and pass `<Modal.Header closeButton={false}>` to lock the user into the modal until they resolve it programmatically.
+- **Stacked modals — only the topmost is visible.** Opening a modal from inside an open modal hides the outer via `display: none` (React state preserved); when the inner closes, the outer reappears instantly. Escape only closes the topmost, body scroll stays locked across the whole stack.
+- **Initial focus:** pass `initialFocusRef` to focus a specific element (e.g. the first input). Otherwise the dialog container receives focus and the focus trap takes over.
+
+**Anti-patterns:**
+
+- ❌ Rendering a Modal as a child of another component that itself uses `position: fixed` — the portal escapes that container anyway, so the fixed positioning is dead code. Just render `<Modal>` at any level; it portals to `document.body`.
+- ❌ Calling `onOpenChange={() => {}}` AND providing `<Modal.Close>` — the Close button calls `onOpenChange(false)` which then no-ops. Use `disableEscapeClose + dismissOnOverlayClick={false}` + omit Close for forced steps.
+- ❌ Mutating an `initialFocusRef.current` value after open — Modal reads the ref ONCE on the open transition. Re-reads on subsequent renders are ignored.
+- ❌ Using `<Modal>` for popovers or non-blocking notifications. Use `<Popover>`, `<DropdownMenu>`, or wait for `<Toast>`.
+
 ### `<Select>` — value picker (single, multi, searchable, async, creatable)
 
 ```tsx

--- a/packages/design-system/src/components/Modal/Body.tsx
+++ b/packages/design-system/src/components/Modal/Body.tsx
@@ -1,0 +1,28 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './Modal.module.scss';
+
+export interface ModalBodyProps extends HTMLAttributes<HTMLDivElement> {
+  /** Override body's padding. Default 'default' (--space-4). 'none' for edge-to-edge content. */
+  padding?: 'default' | 'none';
+}
+
+/**
+ * Scrollable content area between the Header and Footer. Default padding is
+ * `var(--space-4)`. Pass `padding="none"` for edge-to-edge layouts (e.g. a
+ * full-bleed Tabs strip).
+ */
+export const Body = forwardRef<HTMLDivElement, ModalBodyProps>(function Body(
+  { padding = 'default', className, children, ...rest },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      className={clsx(styles.body, padding === 'none' && styles.bodyPaddingNone, className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+});

--- a/packages/design-system/src/components/Modal/Close.tsx
+++ b/packages/design-system/src/components/Modal/Close.tsx
@@ -1,0 +1,50 @@
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  type MouseEvent as ReactMouseEvent,
+  type ReactElement,
+} from 'react';
+import { useModalContext } from './context';
+import { chain } from '../_internal/refs';
+
+export interface ModalCloseProps {
+  /**
+   * Exactly one React element. Close clones this element to inject an
+   * `onClick` that closes the modal, chained with the child's existing
+   * `onClick` (consumer runs first).
+   */
+  children: ReactElement;
+}
+
+/**
+ * Wraps any single element with an onClick that closes the modal.
+ * Useful for Cancel buttons inside `<Modal.Footer>`.
+ *
+ * @example
+ * <Modal.Close>
+ *   <Button variant="secondary">Cancel</Button>
+ * </Modal.Close>
+ */
+export function Close({ children }: ModalCloseProps) {
+  const ctx = useModalContext('Close');
+
+  if (!isValidElement(children)) {
+    throw new Error('<Modal.Close> requires exactly one React element child.');
+  }
+
+  const childProps = children.props as {
+    onClick?: (e: ReactMouseEvent<HTMLElement>) => void;
+  };
+
+  const handleClick = useCallback(
+    (_e: ReactMouseEvent<HTMLElement>) => {
+      ctx.setOpen(false);
+    },
+    [ctx],
+  );
+
+  return cloneElement(children, {
+    onClick: chain(childProps.onClick, handleClick),
+  } as object);
+}

--- a/packages/design-system/src/components/Modal/Content.tsx
+++ b/packages/design-system/src/components/Modal/Content.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useLayoutEffect, type CSSProperties, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { useModalContext } from './context';
+import { useFocusTrap } from './useFocusTrap';
+import { modalStack } from './useModalStack';
+import styles from './Modal.module.scss';
+
+export interface ContentProps {
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * Dialog container. `role="dialog"`, `aria-modal="true"`, tabIndex=-1 so
+ * the focus trap can take over. Owns:
+ * - Initial focus on open (either initialFocusRef or the container itself).
+ * - Focus trap (active only when this modal is top of the stack).
+ * - Escape capture-phase listener (also gated by isTop).
+ * - Renders the compound children (Header/Body/Footer/Close) inside the dialog.
+ */
+export function Content({ children, className, style }: ContentProps) {
+  const ctx = useModalContext('Content');
+
+  // Initial focus on open. Try the ref first; if it points to a non-focusable
+  // node, the browser .focus() no-ops and the focusin recapture in
+  // useFocusTrap will bring focus back to the container.
+  useLayoutEffect(() => {
+    if (!ctx.open) return;
+    if (!ctx.isTop) return; // lower modals are display:none — focusing them would scroll
+    queueMicrotask(() => {
+      const target = ctx.initialFocusRef?.current ?? ctx.contentRef.current;
+      target?.focus({ preventScroll: true });
+    });
+  }, [ctx.open, ctx.isTop, ctx.initialFocusRef, ctx.contentRef]);
+
+  // Escape closes the topmost modal only. Capture-phase to beat focused
+  // widgets that stopPropagation on Esc (matches Popover).
+  useEffect(() => {
+    if (!ctx.open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      if (!modalStack.isTop(ctx.modalId)) return;
+      if (ctx.disableEscapeClose) return;
+      e.preventDefault();
+      ctx.setOpen(false);
+    }
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [ctx.open, ctx.modalId, ctx.disableEscapeClose, ctx.setOpen]);
+
+  // Focus trap — active only when this modal is on top of the stack.
+  useFocusTrap(ctx.contentRef, ctx.open && ctx.isTop);
+
+  return (
+    <div
+      ref={ctx.contentRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={ctx.headingId ?? undefined}
+      aria-label={!ctx.headingId ? ctx.ariaLabel : undefined}
+      aria-describedby={ctx.ariaDescribedBy}
+      tabIndex={-1}
+      data-state={ctx.open ? 'open' : 'closed'}
+      data-size={ctx.size}
+      className={clsx(styles.content, styles[`size-${ctx.size}`], className)}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/design-system/src/components/Modal/Footer.tsx
+++ b/packages/design-system/src/components/Modal/Footer.tsx
@@ -1,0 +1,30 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './Modal.module.scss';
+
+export interface ModalFooterProps extends HTMLAttributes<HTMLDivElement> {
+  /** Horizontal action alignment. Default 'end'. */
+  align?: 'start' | 'end' | 'space-between';
+}
+
+/**
+ * Pinned action bar at the bottom of the modal. `role="group"` so screen
+ * readers announce the action set as a unit. `align='end'` (default)
+ * right-aligns the actions; `'space-between'` splits primary actions to
+ * opposite ends (e.g. a danger action on the left, save/cancel on the right).
+ */
+export const Footer = forwardRef<HTMLDivElement, ModalFooterProps>(function Footer(
+  { align = 'end', className, children, ...rest },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      role="group"
+      className={clsx(styles.footer, styles[`footerAlign-${align}`], className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+});

--- a/packages/design-system/src/components/Modal/Header.tsx
+++ b/packages/design-system/src/components/Modal/Header.tsx
@@ -1,0 +1,49 @@
+import { forwardRef, useEffect, useId, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import { X } from 'lucide-react';
+import { useModalContext } from './context';
+import { sanitizeId } from '../_internal/refs';
+import styles from './Modal.module.scss';
+
+export interface ModalHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  /** Show the built-in × close button on the right edge. Default true. */
+  closeButton?: boolean;
+}
+
+/**
+ * Title bar at the top of the modal. Auto-registers its heading id with
+ * the modal's context so `<Content>` can wire `aria-labelledby`. Renders
+ * a built-in × close button at the right edge unless `closeButton={false}`
+ * (used for forced-step modals).
+ */
+export const Header = forwardRef<HTMLDivElement, ModalHeaderProps>(function Header(
+  { closeButton = true, className, children, ...rest },
+  ref,
+) {
+  const ctx = useModalContext('Header');
+  const rawId = useId();
+  const headingId = `modal-heading-${sanitizeId(rawId)}`;
+
+  useEffect(() => {
+    ctx.setHeadingId(headingId);
+    return () => ctx.setHeadingId(null);
+  }, [ctx, headingId]);
+
+  return (
+    <div ref={ref} className={clsx(styles.header, className)} {...rest}>
+      <h2 id={headingId} className={styles.headerTitle}>
+        {children}
+      </h2>
+      {closeButton && (
+        <button
+          type="button"
+          aria-label="Close dialog"
+          className={styles.headerCloseButton}
+          onClick={() => ctx.setOpen(false)}
+        >
+          <X size={16} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+});

--- a/packages/design-system/src/components/Modal/Modal.module.scss
+++ b/packages/design-system/src/components/Modal/Modal.module.scss
@@ -30,7 +30,7 @@
 }
 
 // Stacked-modal display model: lower overlays are hidden via display:none
-// while a deeper modal is open. React state stays intact; pop is instant.
+// while a deeper modal is open in replace mode. React state stays intact.
 .overlay[data-stack-position='hidden'] {
   display: none;
 }
@@ -43,6 +43,17 @@
   backdrop-filter: blur(4px);
   // stylelint-disable-next-line property-no-vendor-prefix, scale-unlimited/declaration-strict-value -- Safari < 18 requires the prefix
   -webkit-backdrop-filter: blur(4px);
+}
+
+// In overlay-stack mode, only the bottom of the stack paints the dim/blur.
+// Upper modals' overlays are transparent so the parent's dim shows through.
+// This rule intentionally appears AFTER the blur variant so source order
+// makes it win on background and backdrop-filter.
+.overlay[data-overlay-paint='no'] {
+  background: transparent;
+  backdrop-filter: none;
+  // stylelint-disable-next-line property-no-vendor-prefix -- Safari < 18 mirror
+  -webkit-backdrop-filter: none;
 }
 // stylelint-enable property-disallowed-list
 

--- a/packages/design-system/src/components/Modal/Modal.module.scss
+++ b/packages/design-system/src/components/Modal/Modal.module.scss
@@ -79,7 +79,20 @@
 
 // stylelint-disable property-disallowed-list -- internal positioning, not consumer layout
 .content {
+  // position: relative establishes a containing block for any
+  // absolutely-positioned descendants consumers render inside the modal
+  // (e.g., a floating tag inside Modal.Body). Without this, those
+  // descendants would position relative to the overlay (position:fixed).
   position: relative;
+
+  // Size-variant tokens consumed by sub-component rules below. .size-sm
+  // overrides these to tighter values. Routing through custom props keeps
+  // each sub-component rule at single-class specificity (0,1,0), so a
+  // consumer-supplied className on e.g. <Modal.Header> can always win.
+  --modal-pad: var(--space-4);
+  --modal-title-size: var(--font-size-lg);
+  --modal-close-size: 28px;
+
   display: flex;
   flex-direction: column;
   background: var(--color-bg);
@@ -112,6 +125,9 @@
 // prop keeps the size logic in one place.
 .size-sm {
   --modal-width: var(--size-modal-sm);
+  --modal-pad: var(--space-3);
+  --modal-title-size: var(--font-size-md);
+  --modal-close-size: 24px;
 }
 
 .size-md {
@@ -122,22 +138,6 @@
   --modal-width: var(--size-modal-lg);
 }
 
-// ─── Compact sizing for size="sm" ───────────────────────────────────────
-.content.size-sm .header,
-.content.size-sm .body,
-.content.size-sm .footer {
-  padding: var(--space-3);
-}
-
-.content.size-sm .headerTitle {
-  font-size: var(--font-size-md);
-}
-
-.content.size-sm .headerCloseButton {
-  width: 24px;
-  height: 24px;
-}
-
 // ─── Header ─────────────────────────────────────────────────────────────
 
 .header {
@@ -145,14 +145,14 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
-  padding: var(--space-4);
+  padding: var(--modal-pad);
   border-bottom: var(--border-width) solid var(--color-border);
 }
 
 .headerTitle {
   // stylelint-disable-next-line property-disallowed-list -- reset browser default h2 margin; internal to component
   margin: 0;
-  font-size: var(--font-size-lg);
+  font-size: var(--modal-title-size);
   font-weight: var(--font-weight-semibold);
   color: var(--color-fg);
 }
@@ -161,8 +161,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: var(--modal-close-size);
+  height: var(--modal-close-size);
   padding: 0;
   border: none;
   background: transparent;
@@ -188,7 +188,7 @@
 // ─── Body ───────────────────────────────────────────────────────────────
 
 .body {
-  padding: var(--space-4);
+  padding: var(--modal-pad);
   overflow-y: auto;
   flex: 1 1 auto;
 
@@ -207,7 +207,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-4);
+  padding: var(--modal-pad);
   border-top: var(--border-width) solid var(--color-border);
 }
 

--- a/packages/design-system/src/components/Modal/Modal.module.scss
+++ b/packages/design-system/src/components/Modal/Modal.module.scss
@@ -60,6 +60,7 @@
   box-shadow: var(--shadow-lg);
   z-index: calc(var(--z-modal) + var(--modal-depth, 0) * 2 + 1);
   max-height: calc(100vh - 64px);
+  max-height: calc(100dvh - 64px);
   width: min(100% - 32px, var(--modal-width, var(--size-modal-md)));
   opacity: var(--opacity-visible);
   transform: translateY(0) scale(1);
@@ -179,11 +180,26 @@
 
 // stylelint-disable property-disallowed-list -- internal layout for narrow viewports
 @media (max-width: 640px) {
+  // Anchor content to the top of the overlay so iOS Safari's collapsing address
+  // bar can't push it off-screen. Centering is meaningless when content fills
+  // the full viewport anyway.
+  .overlay {
+    align-items: flex-start;
+  }
+
   .content {
+    // vw/vh fallbacks for browsers that don't support dvw/dvh (Safari < 15.4).
+    // dvw/dvh track the *actual* visible viewport; on iOS Safari, 100vh is the
+    // "large viewport" (address bar hidden) which is taller than what's visible
+    // when the address bar is shown — causing the modal to overflow.
     width: 100vw;
+    width: 100dvw;
     height: 100vh;
+    height: 100dvh;
     max-width: 100vw;
+    max-width: 100dvw;
     max-height: 100vh;
+    max-height: 100dvh;
     border-radius: 0;
   }
 }

--- a/packages/design-system/src/components/Modal/Modal.module.scss
+++ b/packages/design-system/src/components/Modal/Modal.module.scss
@@ -1,0 +1,188 @@
+@use '../../styles/mixins' as *;
+
+// ─── Overlay ────────────────────────────────────────────────────────────
+// Dimming / blurred backdrop. Portaled directly inside <body>. Fills the
+// viewport, centers the content via flex. The --modal-depth custom prop
+// (set by Overlay.tsx) is available for any per-depth styling — but with
+// the display-toggle stacking model, at most one overlay is visible at a
+// time, so depth-aware z-index ordering is largely a no-op.
+
+// stylelint-disable property-disallowed-list -- internal positioning, not consumer layout
+.overlay {
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- overlay must be fixed to fill viewport
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-overlay);
+  z-index: calc(var(--z-modal) + var(--modal-depth, 0) * 2);
+  opacity: var(--opacity-visible);
+  transition: opacity var(--transition-base);
+
+  @starting-style {
+    opacity: var(--opacity-hidden);
+  }
+}
+
+.overlay[data-state='closed'] {
+  opacity: var(--opacity-hidden);
+}
+
+// Stacked-modal display model: lower overlays are hidden via display:none
+// while a deeper modal is open. React state stays intact; pop is instant.
+.overlay[data-stack-position='hidden'] {
+  display: none;
+}
+
+// Frosted-glass variant. Light tinted background + backdrop-filter for the
+// glass effect. -webkit prefix for Safari < 18.
+.overlay[data-variant='blur'] {
+  background: var(--color-bg-overlay-blur);
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value
+  backdrop-filter: blur(8px);
+  // stylelint-disable-next-line property-no-vendor-prefix, scale-unlimited/declaration-strict-value -- Safari < 18 requires the prefix
+  -webkit-backdrop-filter: blur(8px);
+}
+// stylelint-enable property-disallowed-list
+
+// ─── Content (dialog) ───────────────────────────────────────────────────
+// The dialog box itself. Flex column so Header/Body/Footer stack with the
+// Body taking remaining height (scrollable when overflowing).
+
+// stylelint-disable property-disallowed-list -- internal positioning, not consumer layout
+.content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  z-index: calc(var(--z-modal) + var(--modal-depth, 0) * 2 + 1);
+  max-height: calc(100vh - 64px);
+  width: min(100% - 32px, var(--modal-width, var(--size-modal-md)));
+  opacity: var(--opacity-visible);
+  transform: translateY(0) scale(1);
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base);
+
+  @starting-style {
+    opacity: var(--opacity-hidden);
+    transform: translateY(8px) scale(0.96);
+  }
+}
+
+.content[data-state='closed'] {
+  opacity: var(--opacity-hidden);
+  transform: translateY(8px) scale(0.96);
+}
+// stylelint-enable property-disallowed-list
+
+// Size presets — each one sets --modal-width which `.content` consumes via
+// the `min(100% - 32px, var(--modal-width, ...))` clamp above. Using a custom
+// prop keeps the size logic in one place.
+.size-sm { --modal-width: var(--size-modal-sm); }
+.size-md { --modal-width: var(--size-modal-md); }
+.size-lg { --modal-width: var(--size-modal-lg); }
+
+// ─── Header ─────────────────────────────────────────────────────────────
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.headerTitle {
+  // stylelint-disable-next-line property-disallowed-list -- reset browser default h2 margin; internal to component
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-fg);
+}
+
+.headerCloseButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+
+  &:hover {
+    background: var(--color-bg-muted);
+    color: var(--color-fg);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+
+    outline: none;
+  }
+}
+
+// ─── Body ───────────────────────────────────────────────────────────────
+
+.body {
+  padding: var(--space-4);
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.bodyPaddingNone {
+  padding: 0;
+}
+
+// ─── Footer ─────────────────────────────────────────────────────────────
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border-top: var(--border-width) solid var(--color-border);
+}
+
+.footerAlign-start { justify-content: flex-start; }
+.footerAlign-end { justify-content: flex-end; }
+.footerAlign-space-between { justify-content: space-between; }
+
+// ─── Mobile fullscreen breakpoint ───────────────────────────────────────
+
+// stylelint-disable property-disallowed-list -- internal layout for narrow viewports
+@media (max-width: 640px) {
+  .content {
+    width: 100vw;
+    height: 100vh;
+    max-width: 100vw;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+}
+// stylelint-enable property-disallowed-list
+
+// ─── Reduced motion ─────────────────────────────────────────────────────
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay,
+  .content {
+    transition: none;
+
+    @starting-style {
+      opacity: var(--opacity-visible);
+      transform: none;
+    }
+  }
+}

--- a/packages/design-system/src/components/Modal/Modal.module.scss
+++ b/packages/design-system/src/components/Modal/Modal.module.scss
@@ -40,9 +40,9 @@
 .overlay[data-variant='blur'] {
   background: var(--color-bg-overlay-blur);
   // stylelint-disable-next-line scale-unlimited/declaration-strict-value
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(4px);
   // stylelint-disable-next-line property-no-vendor-prefix, scale-unlimited/declaration-strict-value -- Safari < 18 requires the prefix
-  -webkit-backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(4px);
 }
 // stylelint-enable property-disallowed-list
 
@@ -85,6 +85,22 @@
 .size-sm { --modal-width: var(--size-modal-sm); }
 .size-md { --modal-width: var(--size-modal-md); }
 .size-lg { --modal-width: var(--size-modal-lg); }
+
+// ─── Compact sizing for size="sm" ───────────────────────────────────────
+.content.size-sm .header,
+.content.size-sm .body,
+.content.size-sm .footer {
+  padding: var(--space-3);
+}
+
+.content.size-sm .headerTitle {
+  font-size: var(--font-size-md);
+}
+
+.content.size-sm .headerCloseButton {
+  width: 24px;
+  height: 24px;
+}
 
 // ─── Header ─────────────────────────────────────────────────────────────
 

--- a/packages/design-system/src/components/Modal/Modal.module.scss
+++ b/packages/design-system/src/components/Modal/Modal.module.scss
@@ -83,9 +83,15 @@
 // Size presets — each one sets --modal-width which `.content` consumes via
 // the `min(100% - 32px, var(--modal-width, ...))` clamp above. Using a custom
 // prop keeps the size logic in one place.
-.size-sm { --modal-width: var(--size-modal-sm); }
-.size-md { --modal-width: var(--size-modal-md); }
-.size-lg { --modal-width: var(--size-modal-lg); }
+.size-sm {
+  --modal-width: var(--size-modal-sm);
+}
+.size-md {
+  --modal-width: var(--size-modal-md);
+}
+.size-lg {
+  --modal-width: var(--size-modal-lg);
+}
 
 // ─── Compact sizing for size="sm" ───────────────────────────────────────
 .content.size-sm .header,
@@ -172,9 +178,15 @@
   border-top: var(--border-width) solid var(--color-border);
 }
 
-.footerAlign-start { justify-content: flex-start; }
-.footerAlign-end { justify-content: flex-end; }
-.footerAlign-space-between { justify-content: space-between; }
+.footerAlign-start {
+  justify-content: flex-start;
+}
+.footerAlign-end {
+  justify-content: flex-end;
+}
+.footerAlign-space-between {
+  justify-content: space-between;
+}
 
 // ─── Mobile fullscreen breakpoint ───────────────────────────────────────
 

--- a/packages/design-system/src/components/Modal/Modal.module.scss
+++ b/packages/design-system/src/components/Modal/Modal.module.scss
@@ -86,9 +86,11 @@
 .size-sm {
   --modal-width: var(--size-modal-sm);
 }
+
 .size-md {
   --modal-width: var(--size-modal-md);
 }
+
 .size-lg {
   --modal-width: var(--size-modal-lg);
 }
@@ -181,9 +183,11 @@
 .footerAlign-start {
   justify-content: flex-start;
 }
+
 .footerAlign-end {
   justify-content: flex-end;
 }
+
 .footerAlign-space-between {
   justify-content: space-between;
 }

--- a/packages/design-system/src/components/Modal/Modal.module.scss
+++ b/packages/design-system/src/components/Modal/Modal.module.scss
@@ -11,7 +11,20 @@
 .overlay {
   // stylelint-disable-next-line declaration-property-value-disallowed-list -- overlay must be fixed to fill viewport
   position: fixed;
-  inset: 0;
+
+  // Explicit top/left/width/height instead of `inset: 0` so that the dvw/dvh
+  // fallback pair can be written for width and height independently. On iOS
+  // Safari, `inset: 0` anchors to the layout viewport; using dvw/dvh tracks
+  // the *dynamic* viewport (accounts for collapsing address bar) and prevents
+  // the overlay from being smaller than the visible area.
+  top: 0;
+  left: 0;
+
+  // vw/vh first as a fallback for browsers without dvw/dvh support (Safari < 15.4).
+  width: 100vw;
+  width: 100dvw;
+  height: 100vh;
+  height: 100dvh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -19,6 +32,9 @@
   z-index: calc(var(--z-modal) + var(--modal-depth, 0) * 2);
   opacity: var(--opacity-visible);
   transition: opacity var(--transition-base);
+
+  // Prevent touch-scroll chaining from modal body scrolling to the document.
+  overscroll-behavior: contain;
 
   @starting-style {
     opacity: var(--opacity-hidden);
@@ -175,6 +191,10 @@
   padding: var(--space-4);
   overflow-y: auto;
   flex: 1 1 auto;
+
+  // Stop scroll chaining: when modal body content reaches its scroll bounds,
+  // do not propagate the scroll gesture to the overlay or the document.
+  overscroll-behavior: contain;
 }
 
 .bodyPaddingNone {

--- a/packages/design-system/src/components/Modal/Modal.test.tsx
+++ b/packages/design-system/src/components/Modal/Modal.test.tsx
@@ -1,0 +1,393 @@
+/**
+ * Integration tests for <Modal>. The three hooks (useFocusTrap, useScrollLock,
+ * useModalStack) have their own unit tests; these tests exercise the
+ * assembled component behavior.
+ */
+import { useRef, useState, type ComponentProps, type RefObject } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Modal } from './Modal';
+import { modalStack } from './useModalStack';
+
+function Harness(props: Partial<ComponentProps<typeof Modal>>) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open</button>
+      <Modal open={open} onOpenChange={setOpen} {...props}>
+        {props.children ?? (
+          <>
+            <Modal.Header>Title</Modal.Header>
+            <Modal.Body>
+              <button>Inner button</button>
+            </Modal.Body>
+            <Modal.Footer>
+              <Modal.Close>
+                <button>Cancel</button>
+              </Modal.Close>
+            </Modal.Footer>
+          </>
+        )}
+      </Modal>
+    </>
+  );
+}
+
+describe('<Modal>', () => {
+  afterEach(() => {
+    modalStack._reset();
+    document.body.style.overflow = '';
+    document.body.style.paddingRight = '';
+  });
+
+  it('renders nothing when closed', () => {
+    render(<Harness />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders dialog with role="dialog" and aria-modal when open', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByText('Open'));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('wires aria-labelledby to Modal.Header heading', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByText('Open'));
+    const dialog = screen.getByRole('dialog');
+    const labelledBy = dialog.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    const heading = document.getElementById(labelledBy!);
+    expect(heading?.textContent).toBe('Title');
+  });
+
+  it('uses aria-label fallback when no Header is rendered', async () => {
+    const user = userEvent.setup();
+    function NoHeaderHarness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open</button>
+          <Modal open={open} onOpenChange={setOpen} aria-label="Confirm action">
+            <Modal.Body>Body</Modal.Body>
+          </Modal>
+        </>
+      );
+    }
+    render(<NoHeaderHarness />);
+    await user.click(screen.getByText('Open'));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-label', 'Confirm action');
+    expect(dialog).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('Escape fires onOpenChange(false) by default', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    function Ctrl() {
+      const [open, setOpen] = useState(true);
+      return (
+        <Modal
+          open={open}
+          onOpenChange={(next) => {
+            setOpen(next);
+            onOpenChange(next);
+          }}
+        >
+          <Modal.Header>Title</Modal.Header>
+          <Modal.Body>x</Modal.Body>
+        </Modal>
+      );
+    }
+    render(<Ctrl />);
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('Escape is ignored when disableEscapeClose is true', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Modal open onOpenChange={onOpenChange} disableEscapeClose aria-label="x">
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('overlay click fires onOpenChange(false) by default', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <Modal open onOpenChange={onOpenChange} aria-label="x">
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    const overlay = container.ownerDocument.querySelector(
+      '[data-modal-portal-root]',
+    ) as HTMLElement;
+    await user.click(overlay);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('overlay click is ignored when dismissOnOverlayClick is false', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <Modal open onOpenChange={onOpenChange} dismissOnOverlayClick={false} aria-label="x">
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    const overlay = container.ownerDocument.querySelector(
+      '[data-modal-portal-root]',
+    ) as HTMLElement;
+    await user.click(overlay);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('clicking inside Content does NOT fire onOpenChange', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Modal open onOpenChange={onOpenChange} aria-label="x">
+        <Modal.Body>
+          <p>click me</p>
+        </Modal.Body>
+      </Modal>,
+    );
+    await user.click(screen.getByText('click me'));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('Modal.Close click fires onOpenChange(false)', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Modal open onOpenChange={onOpenChange} aria-label="x">
+        <Modal.Body>x</Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <button>Cancel</button>
+          </Modal.Close>
+        </Modal.Footer>
+      </Modal>,
+    );
+    await user.click(screen.getByText('Cancel'));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('Header × close button fires onOpenChange(false) by default', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Modal open onOpenChange={onOpenChange}>
+        <Modal.Header>Title</Modal.Header>
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    await user.click(screen.getByRole('button', { name: /close dialog/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('Header with closeButton={false} does NOT render the × button', () => {
+    render(
+      <Modal open onOpenChange={() => {}}>
+        <Modal.Header closeButton={false}>Title</Modal.Header>
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    expect(screen.queryByRole('button', { name: /close dialog/i })).toBeNull();
+  });
+
+  it('initialFocusRef receives focus on open', async () => {
+    const user = userEvent.setup();
+    function FocusHarness() {
+      const [open, setOpen] = useState(false);
+      const inputRef = useRef<HTMLInputElement | null>(null);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open</button>
+          <Modal
+            open={open}
+            onOpenChange={setOpen}
+            initialFocusRef={inputRef as RefObject<HTMLElement | null>}
+          >
+            <Modal.Header>Title</Modal.Header>
+            <Modal.Body>
+              <input ref={inputRef} aria-label="Name" />
+            </Modal.Body>
+          </Modal>
+        </>
+      );
+    }
+    render(<FocusHarness />);
+    await user.click(screen.getByText('Open'));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(document.activeElement).toBe(screen.getByLabelText('Name'));
+  });
+
+  it('locks body scroll while open', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    expect(document.body.style.overflow).toBe('');
+    await user.click(screen.getByText('Open'));
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('releases body scroll after close', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByText('Open'));
+    expect(document.body.style.overflow).toBe('hidden');
+    await user.keyboard('{Escape}');
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('data-size reflects size prop', async () => {
+    const user = userEvent.setup();
+    render(<Harness size="lg" />);
+    await user.click(screen.getByText('Open'));
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-size', 'lg');
+  });
+
+  it('warns in dev when neither Header nor aria-label is provided', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <Modal open onOpenChange={() => {}}>
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('Footer applies align prop class', () => {
+    const { container } = render(
+      <Modal open onOpenChange={() => {}} aria-label="x">
+        <Modal.Body>x</Modal.Body>
+        <Modal.Footer align="space-between">
+          <button>Left</button>
+          <button>Right</button>
+        </Modal.Footer>
+      </Modal>,
+    );
+    const footer = container.ownerDocument.querySelector('[role="group"]');
+    expect(footer?.className).toMatch(/footerAlign-space-between/);
+  });
+
+  it('stacked modals: Esc only closes topmost', async () => {
+    const user = userEvent.setup();
+    const onOuter = vi.fn();
+    const onInner = vi.fn();
+    function Stacked() {
+      const [outer, setOuter] = useState(true);
+      const [inner, setInner] = useState(true);
+      return (
+        <>
+          <Modal
+            open={outer}
+            onOpenChange={(next) => {
+              setOuter(next);
+              onOuter(next);
+            }}
+            aria-label="Outer"
+          >
+            <Modal.Body>outer</Modal.Body>
+          </Modal>
+          <Modal
+            open={inner}
+            onOpenChange={(next) => {
+              setInner(next);
+              onInner(next);
+            }}
+            aria-label="Inner"
+          >
+            <Modal.Body>inner</Modal.Body>
+          </Modal>
+        </>
+      );
+    }
+    render(<Stacked />);
+    await user.keyboard('{Escape}');
+    expect(onInner).toHaveBeenCalledWith(false);
+    expect(onOuter).not.toHaveBeenCalled();
+  });
+
+  it('forces step combo: open + disableEscapeClose + dismissOnOverlayClick=false + no Close', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <Modal
+        open
+        onOpenChange={onOpenChange}
+        disableEscapeClose
+        dismissOnOverlayClick={false}
+        aria-label="Forced"
+      >
+        <Modal.Header closeButton={false}>Forced</Modal.Header>
+        <Modal.Body>Cannot escape.</Modal.Body>
+      </Modal>,
+    );
+    await user.keyboard('{Escape}');
+    const overlay = container.ownerDocument.querySelector(
+      '[data-modal-portal-root]',
+    ) as HTMLElement;
+    await user.click(overlay);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  // ─── Amendment A: overlay variant ───────────────────────────────────
+
+  it('overlay variant defaults to data-variant="solid"', () => {
+    const { container } = render(
+      <Modal open onOpenChange={() => {}} aria-label="x">
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    const overlay = container.ownerDocument.querySelector(
+      '[data-modal-portal-root]',
+    ) as HTMLElement;
+    expect(overlay).toHaveAttribute('data-variant', 'solid');
+  });
+
+  it('overlay="blur" writes data-variant="blur"', () => {
+    const { container } = render(
+      <Modal open onOpenChange={() => {}} overlay="blur" aria-label="x">
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    const overlay = container.ownerDocument.querySelector(
+      '[data-modal-portal-root]',
+    ) as HTMLElement;
+    expect(overlay).toHaveAttribute('data-variant', 'blur');
+  });
+
+  // ─── Amendment B: stack display model ───────────────────────────────
+
+  it('stacked modals: outer is data-stack-position="hidden", inner is "top"', () => {
+    const { container } = render(
+      <>
+        <Modal open onOpenChange={() => {}} aria-label="Outer">
+          <Modal.Body>outer</Modal.Body>
+        </Modal>
+        <Modal open onOpenChange={() => {}} aria-label="Inner">
+          <Modal.Body>inner</Modal.Body>
+        </Modal>
+      </>,
+    );
+    const overlays = Array.from(
+      container.ownerDocument.querySelectorAll('[data-modal-portal-root]'),
+    ) as HTMLElement[];
+    expect(overlays).toHaveLength(2);
+    // Last-registered modal (inner) is top; first-registered (outer) is hidden.
+    const positions = overlays.map((el) => el.getAttribute('data-stack-position'));
+    expect(positions).toContain('top');
+    expect(positions).toContain('hidden');
+    // Exactly one top.
+    expect(positions.filter((p) => p === 'top')).toHaveLength(1);
+  });
+});

--- a/packages/design-system/src/components/Modal/Modal.test.tsx
+++ b/packages/design-system/src/components/Modal/Modal.test.tsx
@@ -415,6 +415,29 @@ describe('<Modal>', () => {
     expect(positions.filter((p) => p === 'top')).toHaveLength(1);
   });
 
+  it('stacked modals: inner modal portal is NOT inert (delete-confirmation regression)', () => {
+    render(
+      <>
+        <Modal open onOpenChange={() => {}} aria-label="Outer">
+          <Modal.Body>outer</Modal.Body>
+        </Modal>
+        <Modal open onOpenChange={() => {}} aria-label="Inner">
+          <Modal.Body>
+            <button>Confirm delete</button>
+          </Modal.Body>
+        </Modal>
+      </>,
+    );
+    const overlays = Array.from(
+      document.querySelectorAll('[data-modal-portal-root]'),
+    ) as HTMLElement[];
+    // Neither modal portal should be inert — both must remain interactive
+    // (the lower one is display:none anyway; the top one must be clickable).
+    for (const el of overlays) {
+      expect(el.hasAttribute('inert')).toBe(false);
+    }
+  });
+
   it('restores focus to the previously-focused element on close', async () => {
     const user = userEvent.setup();
     function FocusRestoreHarness() {

--- a/packages/design-system/src/components/Modal/Modal.test.tsx
+++ b/packages/design-system/src/components/Modal/Modal.test.tsx
@@ -254,14 +254,38 @@ describe('<Modal>', () => {
     expect(screen.getByRole('dialog')).toHaveAttribute('data-size', 'lg');
   });
 
-  it('warns in dev when neither Header nor aria-label is provided', () => {
+  it('warns in dev when neither Header nor aria-label is provided', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     render(
       <Modal open onOpenChange={() => {}}>
         <Modal.Body>x</Modal.Body>
       </Modal>,
     );
+    await new Promise((r) => setTimeout(r, 0)); // flush microtasks
     expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('does NOT warn when <Modal.Header> is provided', async () => {
+    const user = userEvent.setup();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<Harness />);
+    await user.click(screen.getByText('Open'));
+    // Flush microtasks so the deferred warning check has a chance to fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('does NOT warn when aria-label is provided without <Modal.Header>', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <Modal open onOpenChange={() => {}} aria-label="Confirm">
+        <Modal.Body>x</Modal.Body>
+      </Modal>,
+    );
+    await new Promise((r) => setTimeout(r, 0)); // flush microtasks
+    expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });
 
@@ -389,5 +413,33 @@ describe('<Modal>', () => {
     expect(positions).toContain('hidden');
     // Exactly one top.
     expect(positions.filter((p) => p === 'top')).toHaveLength(1);
+  });
+
+  it('restores focus to the previously-focused element on close', async () => {
+    const user = userEvent.setup();
+    function FocusRestoreHarness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)} data-testid="trigger">
+            Open
+          </button>
+          <Modal open={open} onOpenChange={setOpen} aria-label="x">
+            <Modal.Body>x</Modal.Body>
+          </Modal>
+        </>
+      );
+    }
+    render(<FocusRestoreHarness />);
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+    await user.click(trigger);
+    // Modal opens; focus moves to dialog.
+    expect(document.activeElement).not.toBe(trigger);
+    await user.keyboard('{Escape}');
+    // Modal closes; focus restored to the trigger.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(document.activeElement).toBe(trigger);
   });
 });

--- a/packages/design-system/src/components/Modal/Modal.test.tsx
+++ b/packages/design-system/src/components/Modal/Modal.test.tsx
@@ -233,18 +233,18 @@ describe('<Modal>', () => {
   it('locks body scroll while open', async () => {
     const user = userEvent.setup();
     render(<Harness />);
-    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.position).toBe('');
     await user.click(screen.getByText('Open'));
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
   });
 
   it('releases body scroll after close', async () => {
     const user = userEvent.setup();
     render(<Harness />);
     await user.click(screen.getByText('Open'));
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
     await user.keyboard('{Escape}');
-    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.position).toBe('');
   });
 
   it('data-size reflects size prop', async () => {

--- a/packages/design-system/src/components/Modal/Modal.test.tsx
+++ b/packages/design-system/src/components/Modal/Modal.test.tsx
@@ -392,13 +392,13 @@ describe('<Modal>', () => {
 
   // ─── Amendment B: stack display model ───────────────────────────────
 
-  it('stacked modals: outer is data-stack-position="hidden", inner is "top"', () => {
+  it('stacked modals (replace mode): outer is data-stack-position="hidden", inner is "top"', () => {
     const { container } = render(
       <>
-        <Modal open onOpenChange={() => {}} aria-label="Outer">
+        <Modal open onOpenChange={() => {}} aria-label="Outer" stackMode="replace">
           <Modal.Body>outer</Modal.Body>
         </Modal>
-        <Modal open onOpenChange={() => {}} aria-label="Inner">
+        <Modal open onOpenChange={() => {}} aria-label="Inner" stackMode="replace">
           <Modal.Body>inner</Modal.Body>
         </Modal>
       </>,
@@ -413,6 +413,53 @@ describe('<Modal>', () => {
     expect(positions).toContain('hidden');
     // Exactly one top.
     expect(positions.filter((p) => p === 'top')).toHaveLength(1);
+  });
+
+  it('stackMode="replace": top paints overlay, hidden does not', () => {
+    render(
+      <>
+        <Modal open onOpenChange={() => {}} aria-label="Outer" stackMode="replace">
+          <Modal.Body>outer</Modal.Body>
+        </Modal>
+        <Modal open onOpenChange={() => {}} aria-label="Inner" stackMode="replace">
+          <Modal.Body>inner</Modal.Body>
+        </Modal>
+      </>,
+    );
+    const overlays = Array.from(
+      document.querySelectorAll('[data-modal-portal-root]'),
+    ) as HTMLElement[];
+    expect(overlays).toHaveLength(2);
+    const top = overlays.find((el) => el.getAttribute('data-stack-position') === 'top')!;
+    const hidden = overlays.find((el) => el.getAttribute('data-stack-position') === 'hidden')!;
+    expect(top.getAttribute('data-overlay-paint')).toBe('yes');
+    expect(hidden.getAttribute('data-overlay-paint')).toBe('no');
+  });
+
+  it('stackMode="overlay" (default): outer is underneath, inner is top transparent (paint=no)', () => {
+    render(
+      <>
+        <Modal open onOpenChange={() => {}} aria-label="Outer">
+          <Modal.Body>outer</Modal.Body>
+        </Modal>
+        <Modal open onOpenChange={() => {}} aria-label="Inner">
+          <Modal.Body>inner</Modal.Body>
+        </Modal>
+      </>,
+    );
+    const overlays = Array.from(
+      document.querySelectorAll('[data-modal-portal-root]'),
+    ) as HTMLElement[];
+    expect(overlays).toHaveLength(2);
+    const positions = overlays.map((el) => el.getAttribute('data-stack-position')).sort();
+    expect(positions).toEqual(['top', 'underneath']);
+    // Bottom (depth 0) paints; top is transparent (paint=no).
+    const top = overlays.find((el) => el.getAttribute('data-stack-position') === 'top')!;
+    const underneath = overlays.find(
+      (el) => el.getAttribute('data-stack-position') === 'underneath',
+    )!;
+    expect(top.getAttribute('data-overlay-paint')).toBe('no');
+    expect(underneath.getAttribute('data-overlay-paint')).toBe('yes');
   });
 
   it('stacked modals: inner modal portal is NOT inert (delete-confirmation regression)', () => {

--- a/packages/design-system/src/components/Modal/Modal.test.tsx
+++ b/packages/design-system/src/components/Modal/Modal.test.tsx
@@ -512,4 +512,41 @@ describe('<Modal>', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(document.activeElement).toBe(trigger);
   });
+
+  it('does not throw when the previously-focused trigger is removed while modal is open', async () => {
+    const user = userEvent.setup();
+    function TriggerRemovalHarness() {
+      const [open, setOpen] = useState(false);
+      const [triggerVisible, setTriggerVisible] = useState(true);
+      return (
+        <>
+          {triggerVisible && (
+            <button
+              onClick={() => {
+                setOpen(true);
+                // Remove the trigger from the DOM while the modal is open
+                setTriggerVisible(false);
+              }}
+              data-testid="trigger"
+            >
+              Open
+            </button>
+          )}
+          <Modal open={open} onOpenChange={setOpen} aria-label="x">
+            <Modal.Body>x</Modal.Body>
+          </Modal>
+        </>
+      );
+    }
+    render(<TriggerRemovalHarness />);
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+    await user.click(trigger);
+    expect(screen.queryByTestId('trigger')).toBeNull();
+    // Should close without throwing — the document.contains() guard skips the
+    // focus() call when the saved element is no longer in the DOM.
+    await user.keyboard('{Escape}');
+    // Focus should land somewhere sensible; document.body is fine for jsdom.
+    expect(document.activeElement).toBeDefined();
+  });
 });

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -1,0 +1,23 @@
+import { ModalRoot } from './ModalRoot';
+import { Header } from './Header';
+import { Body } from './Body';
+import { Footer } from './Footer';
+import { Close } from './Close';
+
+/**
+ * Compound `<Modal>` family. Subcomponents attached via Object.assign so
+ * consumers write `<Modal.Header>` etc., not separate imports.
+ */
+export const Modal = Object.assign(ModalRoot, {
+  Header,
+  Body,
+  Footer,
+  Close,
+});
+
+export type { ModalProps } from './ModalRoot';
+export type { ModalSize, ModalOverlayVariant } from './context';
+export type { ModalHeaderProps } from './Header';
+export type { ModalBodyProps } from './Body';
+export type { ModalFooterProps } from './Footer';
+export type { ModalCloseProps } from './Close';

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -16,7 +16,7 @@ export const Modal = Object.assign(ModalRoot, {
 });
 
 export type { ModalProps } from './ModalRoot';
-export type { ModalSize, ModalOverlayVariant } from './context';
+export type { ModalSize, ModalOverlayVariant, ModalStackMode } from './context';
 export type { ModalHeaderProps } from './Header';
 export type { ModalBodyProps } from './Body';
 export type { ModalFooterProps } from './Footer';

--- a/packages/design-system/src/components/Modal/ModalRoot.tsx
+++ b/packages/design-system/src/components/Modal/ModalRoot.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useRef,
   useState,
   type CSSProperties,
@@ -178,14 +179,40 @@ export function ModalRoot({
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [headingId, setHeadingId] = useState<string | null>(null);
 
-  // previouslyFocused: capture when transitioning false → true; restore on close.
+  // previouslyFocused: capture the trigger element when transitioning false → true,
+  // then restore focus to it on close.
+  //
+  // useLayoutEffect is required here (not useEffect) for two reasons:
+  //
+  // 1. Capture timing: Content.tsx uses queueMicrotask inside its useLayoutEffect
+  //    to steal focus to the dialog. Microtasks flush after the current task but
+  //    BEFORE the next macrotask — and useEffect runs as a macrotask-scheduled
+  //    callback (after paint). This means a useEffect would see document.activeElement
+  //    as the dialog div, not the trigger button, and would save the wrong element.
+  //    useLayoutEffect runs synchronously after the DOM commit but BEFORE microtasks
+  //    are processed, so it captures the trigger while it still has focus.
+  //
+  // 2. Close ordering: useScrollLock (below) is also a useLayoutEffect. React runs
+  //    layout-effect cleanups in reverse mount order, so useScrollLock's cleanup
+  //    (unlock → scrollTo) fires FIRST, restoring the scroll position. This
+  //    useLayoutEffect then fires and calls target.focus({ preventScroll: true }),
+  //    which does not disturb the just-restored scroll position. If focus restore
+  //    ran before unlock, a browser scrollIntoView triggered by focus could
+  //    override the scrollTo.
+  //
+  // Source order matters: this hook MUST stay above useScrollLock(open).
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
   const prevOpenRef = useRef<boolean>(open);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (open && !prevOpenRef.current) {
+      // Modal is opening: snapshot the currently focused element before the
+      // dialog's queueMicrotask fires and steals focus.
       previouslyFocusedRef.current = (document.activeElement as HTMLElement | null) ?? null;
     }
     if (!open && prevOpenRef.current) {
+      // Modal is closing: restore focus to the element that triggered it.
+      // preventScroll keeps the browser from scrollIntoView-ing the trigger,
+      // which would fight the scroll restoration in useScrollLock's cleanup.
       const target = previouslyFocusedRef.current;
       if (target && document.contains(target)) {
         target.focus({ preventScroll: true });
@@ -196,6 +223,8 @@ export function ModalRoot({
   }, [open]);
 
   // Stack registration + scroll lock are driven by `open`.
+  // useScrollLock MUST stay below the focus-restore useLayoutEffect above so
+  // that its cleanup (unlock → scrollTo) fires before focus is restored.
   const { depth, isTop, topMode } = useModalStack(modalId, open, stackMode);
   useScrollLock(open);
 

--- a/packages/design-system/src/components/Modal/ModalRoot.tsx
+++ b/packages/design-system/src/components/Modal/ModalRoot.tsx
@@ -189,16 +189,23 @@ export function ModalRoot({
   );
 
   // Dev warning: must have either a Header (sets headingId in context) OR aria-label.
+  // Deferred via microtask so <Modal.Header>'s registration effect has a chance to run.
   useEffect(() => {
     if (!open) return;
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV === 'production') return;
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
       if (!headingId && !ariaLabel) {
         // eslint-disable-next-line no-console
         console.warn(
           '<Modal> must be labelled. Either render <Modal.Header> or pass an `aria-label` prop. Screen-reader users get no announcement otherwise.',
         );
       }
-    }
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [open, headingId, ariaLabel]);
 
   const value: ModalContextValue = {

--- a/packages/design-system/src/components/Modal/ModalRoot.tsx
+++ b/packages/design-system/src/components/Modal/ModalRoot.tsx
@@ -1,0 +1,233 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  type RefObject,
+} from 'react';
+import {
+  ModalContext,
+  type ModalContextValue,
+  type ModalOverlayVariant,
+  type ModalSize,
+} from './context';
+import { useModalStack } from './useModalStack';
+import { useScrollLock } from './useScrollLock';
+import { Overlay } from './Overlay';
+import { Content } from './Content';
+import { sanitizeId } from '../_internal/refs';
+
+export interface ModalProps {
+  /** Controlled open state. Required. */
+  open: boolean;
+  /** Fired when Modal wants to change open state — Esc, overlay click, Close button, programmatic. */
+  onOpenChange: (open: boolean) => void;
+
+  /** Size preset. Defaults to 'md'. */
+  size?: ModalSize;
+
+  /**
+   * Overlay variant. 'solid' (default) paints a dark dimming layer.
+   * 'blur' uses a light tinted background plus `backdrop-filter: blur(8px)`
+   * for a frosted-glass effect. 'blur' costs an extra compositor layer —
+   * fine for normal use; avoid stacking three blurred modals at once.
+   */
+  overlay?: ModalOverlayVariant;
+
+  /**
+   * Disable Escape-to-close. Default false. Combined with `dismissOnOverlayClick: false`
+   * and omitting `<Modal.Close>` produces a fully forced step.
+   */
+  disableEscapeClose?: boolean;
+  /**
+   * When false, clicking the overlay backdrop does NOT close the modal. Default true.
+   */
+  dismissOnOverlayClick?: boolean;
+
+  /**
+   * Initial focus target on open. Default: the dialog container itself.
+   * Pass a ref to override (e.g. focus the first input in a form).
+   */
+  initialFocusRef?: RefObject<HTMLElement | null>;
+
+  /** Compound children: Header / Body / Footer / Close + any consumer JSX. */
+  children: ReactNode;
+
+  /** className passes through to the dialog container. */
+  className?: string;
+  /** style passes through to the dialog container. */
+  style?: CSSProperties;
+
+  /**
+   * Required for a11y when no Modal.Header is rendered. When Header IS rendered,
+   * aria-labelledby auto-binds to the heading id; this prop is then ignored.
+   */
+  'aria-label'?: string;
+  /** Optional id of an external descriptor element; sets aria-describedby on the dialog. */
+  'aria-describedby'?: string;
+}
+
+/**
+ * Modal dialog: focus-locked, scroll-locked, ARIA-correct overlay panel.
+ *
+ * Compound API:
+ * - `<Modal.Header>` renders the title bar (auto-wires aria-labelledby).
+ * - `<Modal.Body>` is the scrollable content area.
+ * - `<Modal.Footer>` is the pinned action bar.
+ * - `<Modal.Close>` wraps a clickable child to dismiss the modal.
+ *
+ * Controlled-only — Modal has no uncontrolled mode. Consumer holds `open`
+ * state and passes `open` + `onOpenChange`.
+ *
+ * Stacked modals: only the topmost is visible. Lower modals stay mounted
+ * (React state preserved) but hide via `display: none`. Re-show on pop is
+ * instant.
+ *
+ * @example
+ * const [open, setOpen] = useState(false);
+ * <Button onClick={() => setOpen(true)}>Edit contact</Button>
+ * <Modal open={open} onOpenChange={setOpen} size="md">
+ *   <Modal.Header>Edit contact</Modal.Header>
+ *   <Modal.Body>
+ *     <Stack gap="md">
+ *       <Input label="Name" value={name} onChange={...} />
+ *     </Stack>
+ *   </Modal.Body>
+ *   <Modal.Footer>
+ *     <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
+ *     <Button onClick={save}>Save</Button>
+ *   </Modal.Footer>
+ * </Modal>
+ *
+ * @example
+ * // Forced step — no Esc, no overlay-click dismiss, no built-in close button:
+ * <Modal
+ *   open
+ *   onOpenChange={() => {}}
+ *   size="sm"
+ *   disableEscapeClose
+ *   dismissOnOverlayClick={false}
+ *   aria-label="Session expired"
+ * >
+ *   <Modal.Header closeButton={false}>Session expired</Modal.Header>
+ *   <Modal.Body>Please sign in again to continue.</Modal.Body>
+ *   <Modal.Footer><Button onClick={reauth}>Sign in</Button></Modal.Footer>
+ * </Modal>
+ *
+ * @example
+ * // Frosted-glass overlay variant:
+ * <Modal open onOpenChange={setOpen} overlay="blur">
+ *   <Modal.Header>Subtle overlay</Modal.Header>
+ *   <Modal.Body>The page behind is blurred instead of dimmed.</Modal.Body>
+ * </Modal>
+ *
+ * @remarks When NOT to use
+ * - For lightweight popovers anchored to a trigger — use `<Popover>` or `<DropdownMenu>`.
+ * - For non-blocking notifications — use `<Toast>` (not yet shipped).
+ * - For inline confirms attached to a button — use `<ConfirmationPopover>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Rendering long, scrollable forms with sticky footers that contain
+ *   additional sticky elements inside Body — flexbox + sticky compose badly.
+ *   Either use `<Modal.Footer>` for the actions and let Body scroll, or
+ *   render outside Modal.
+ * - ❌ Opening a modal from inside another modal without using `<Modal>` itself
+ *   (e.g. a custom div with `position: fixed`). Skipping the stack registry
+ *   breaks Esc routing and z-index ordering.
+ * - ❌ Passing neither a `<Modal.Header>` nor an `aria-label` — Modal will
+ *   warn in development. Screen-reader users get no announcement on open.
+ */
+export function ModalRoot({
+  open,
+  onOpenChange,
+  size = 'md',
+  overlay = 'solid',
+  disableEscapeClose = false,
+  dismissOnOverlayClick = true,
+  initialFocusRef,
+  children,
+  className,
+  style,
+  'aria-label': ariaLabel,
+  'aria-describedby': ariaDescribedBy,
+}: ModalProps) {
+  const rawId = useId();
+  const modalId = `modal-${sanitizeId(rawId)}`;
+
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [headingId, setHeadingId] = useState<string | null>(null);
+
+  // previouslyFocused: capture when transitioning false → true; restore on close.
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  const prevOpenRef = useRef<boolean>(open);
+  useEffect(() => {
+    if (open && !prevOpenRef.current) {
+      previouslyFocusedRef.current = (document.activeElement as HTMLElement | null) ?? null;
+    }
+    if (!open && prevOpenRef.current) {
+      const target = previouslyFocusedRef.current;
+      if (target && document.contains(target)) {
+        target.focus({ preventScroll: true });
+      }
+      previouslyFocusedRef.current = null;
+    }
+    prevOpenRef.current = open;
+  }, [open]);
+
+  // Stack registration + scroll lock are driven by `open`.
+  const { depth, isTop } = useModalStack(modalId, open);
+  useScrollLock(open);
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      onOpenChange(next);
+    },
+    [onOpenChange],
+  );
+
+  // Dev warning: must have either a Header (sets headingId in context) OR aria-label.
+  useEffect(() => {
+    if (!open) return;
+    if (process.env.NODE_ENV !== 'production') {
+      if (!headingId && !ariaLabel) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '<Modal> must be labelled. Either render <Modal.Header> or pass an `aria-label` prop. Screen-reader users get no announcement otherwise.',
+        );
+      }
+    }
+  }, [open, headingId, ariaLabel]);
+
+  const value: ModalContextValue = {
+    open,
+    setOpen,
+    modalId,
+    contentRef,
+    headingId,
+    setHeadingId,
+    size,
+    overlay,
+    disableEscapeClose,
+    dismissOnOverlayClick,
+    initialFocusRef,
+    ariaLabel,
+    ariaDescribedBy,
+    depth: depth ?? 0,
+    isTop,
+  };
+
+  return (
+    <ModalContext.Provider value={value}>
+      {open && (
+        <Overlay>
+          <Content className={className} style={style}>
+            {children}
+          </Content>
+        </Overlay>
+      )}
+    </ModalContext.Provider>
+  );
+}

--- a/packages/design-system/src/components/Modal/ModalRoot.tsx
+++ b/packages/design-system/src/components/Modal/ModalRoot.tsx
@@ -31,7 +31,7 @@ export interface ModalProps {
 
   /**
    * Overlay variant. 'solid' (default) paints a dark dimming layer.
-   * 'blur' uses a light tinted background plus `backdrop-filter: blur(8px)`
+   * 'blur' uses a light tinted background plus `backdrop-filter: blur(4px)`
    * for a frosted-glass effect. 'blur' costs an extra compositor layer —
    * fine for normal use; avoid stacking three blurred modals at once.
    */

--- a/packages/design-system/src/components/Modal/ModalRoot.tsx
+++ b/packages/design-system/src/components/Modal/ModalRoot.tsx
@@ -14,7 +14,7 @@ import {
   type ModalOverlayVariant,
   type ModalSize,
 } from './context';
-import { useModalStack } from './useModalStack';
+import { useModalStack, type ModalStackMode } from './useModalStack';
 import { useScrollLock } from './useScrollLock';
 import { Overlay } from './Overlay';
 import { Content } from './Content';
@@ -36,6 +36,22 @@ export interface ModalProps {
    * fine for normal use; avoid stacking three blurred modals at once.
    */
   overlay?: ModalOverlayVariant;
+
+  /**
+   * How this modal relates to existing modals in the stack when it opens.
+   *
+   * - `'overlay'` (default): if there's a modal below this one, it stays
+   *   visible underneath. This modal's own overlay paints transparent so
+   *   the parent's dim shows through. Only the bottom modal (depth 0)
+   *   paints the actual dim/blur. The user sees the parent's context behind
+   *   the active modal.
+   * - `'replace'`: any modals below this one are hidden via `display: none`
+   *   (React state preserved). This modal paints its own overlay normally.
+   *   Best for forced-step modals where the parent context is irrelevant.
+   *
+   * Has no effect when this is the only open modal.
+   */
+  stackMode?: ModalStackMode;
 
   /**
    * Disable Escape-to-close. Default false. Combined with `dismissOnOverlayClick: false`
@@ -82,9 +98,10 @@ export interface ModalProps {
  * Controlled-only — Modal has no uncontrolled mode. Consumer holds `open`
  * state and passes `open` + `onOpenChange`.
  *
- * Stacked modals: only the topmost is visible. Lower modals stay mounted
- * (React state preserved) but hide via `display: none`. Re-show on pop is
- * instant.
+ * Stacked modals: default `stackMode="overlay"` keeps parent modals visible
+ * underneath with a transparent inner overlay so the user sees parent context.
+ * Use `stackMode="replace"` to hide lower modals via `display: none` (React
+ * state preserved) — best for forced steps where parent context is irrelevant.
  *
  * @example
  * const [open, setOpen] = useState(false);
@@ -145,6 +162,7 @@ export function ModalRoot({
   onOpenChange,
   size = 'md',
   overlay = 'solid',
+  stackMode = 'overlay',
   disableEscapeClose = false,
   dismissOnOverlayClick = true,
   initialFocusRef,
@@ -178,7 +196,7 @@ export function ModalRoot({
   }, [open]);
 
   // Stack registration + scroll lock are driven by `open`.
-  const { depth, isTop } = useModalStack(modalId, open);
+  const { depth, isTop, topMode } = useModalStack(modalId, open, stackMode);
   useScrollLock(open);
 
   const setOpen = useCallback(
@@ -224,6 +242,8 @@ export function ModalRoot({
     ariaDescribedBy,
     depth: depth ?? 0,
     isTop,
+    stackMode,
+    topMode,
   };
 
   return (

--- a/packages/design-system/src/components/Modal/Overlay.tsx
+++ b/packages/design-system/src/components/Modal/Overlay.tsx
@@ -18,11 +18,15 @@ export interface OverlayProps {
  * dismissal (only fires when the click target is the overlay itself,
  * not bubbled from content).
  *
- * Carries two data-attributes consumed by SCSS:
+ * Carries three data-attributes consumed by SCSS:
  * - `data-variant`        : 'solid' | 'blur' — visual variant
- * - `data-stack-position` : 'top' | 'hidden' — whether this overlay is the
- *                           topmost open modal (visible) or a lower one
- *                           (display: none; React state preserved).
+ * - `data-stack-position` : 'top' | 'underneath' | 'hidden'
+ *     - 'top'       — this is the topmost open modal
+ *     - 'underneath' — lower modal in overlay-stack mode (stays visible)
+ *     - 'hidden'    — lower modal in replace-stack mode (display: none)
+ * - `data-overlay-paint`  : 'yes' | 'no'
+ *     - 'yes' — this overlay paints its dim/blur background
+ *     - 'no'  — transparent (upper modal in overlay-stack mode)
  */
 export function Overlay({ children }: OverlayProps) {
   const ctx = useModalContext('Overlay');
@@ -56,9 +60,25 @@ export function Overlay({ children }: OverlayProps) {
     ctx.setOpen(false);
   };
 
-  // Custom prop carries depth to SCSS so any future per-depth styling can
-  // read it; for the current display-toggle stacking, only the topmost
-  // overlay is visible, so this collapses to a no-op for most callers.
+  // Visibility classification
+  let stackPosition: 'top' | 'hidden' | 'underneath';
+  if (ctx.isTop) {
+    stackPosition = 'top';
+  } else if (ctx.topMode === 'replace') {
+    stackPosition = 'hidden';
+  } else {
+    // topMode === 'overlay' && !isTop
+    stackPosition = 'underneath';
+  }
+
+  // Paint classification: only paint dim/blur if this is the visible "ground
+  // level". In replace mode the top modal paints; in overlay mode only the
+  // bottom of the stack (depth 0) paints so upper overlays are transparent.
+  const paint =
+    (ctx.topMode === 'replace' && ctx.isTop) ||
+    (ctx.topMode === 'overlay' && ctx.depth === 0);
+
+  // Custom prop carries depth to SCSS for any per-depth styling.
   const style = { ['--modal-depth' as string]: String(ctx.depth) } as CSSProperties;
 
   return createPortal(
@@ -66,7 +86,8 @@ export function Overlay({ children }: OverlayProps) {
       data-modal-portal-root=""
       data-state={ctx.open ? 'open' : 'closed'}
       data-variant={ctx.overlay}
-      data-stack-position={ctx.isTop ? 'top' : 'hidden'}
+      data-stack-position={stackPosition}
+      data-overlay-paint={paint ? 'yes' : 'no'}
       className={styles.overlay}
       style={style}
       onClick={onClick}

--- a/packages/design-system/src/components/Modal/Overlay.tsx
+++ b/packages/design-system/src/components/Modal/Overlay.tsx
@@ -75,8 +75,7 @@ export function Overlay({ children }: OverlayProps) {
   // level". In replace mode the top modal paints; in overlay mode only the
   // bottom of the stack (depth 0) paints so upper overlays are transparent.
   const paint =
-    (ctx.topMode === 'replace' && ctx.isTop) ||
-    (ctx.topMode === 'overlay' && ctx.depth === 0);
+    (ctx.topMode === 'replace' && ctx.isTop) || (ctx.topMode === 'overlay' && ctx.depth === 0);
 
   // Custom prop carries depth to SCSS for any per-depth styling.
   const style = { ['--modal-depth' as string]: String(ctx.depth) } as CSSProperties;

--- a/packages/design-system/src/components/Modal/Overlay.tsx
+++ b/packages/design-system/src/components/Modal/Overlay.tsx
@@ -1,0 +1,73 @@
+import { useEffect, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { useModalContext } from './context';
+import styles from './Modal.module.scss';
+
+export interface OverlayProps {
+  children: ReactNode;
+}
+
+/**
+ * Portaled dimming/blurred backdrop rendered behind the dialog. Owns the
+ * inert-background attribute on body children + the overlay-click
+ * dismissal (only fires when the click target is the overlay itself,
+ * not bubbled from content).
+ *
+ * Carries two data-attributes consumed by SCSS:
+ * - `data-variant`        : 'solid' | 'blur' — visual variant
+ * - `data-stack-position` : 'top' | 'hidden' — whether this overlay is the
+ *                           topmost open modal (visible) or a lower one
+ *                           (display: none; React state preserved).
+ */
+export function Overlay({ children }: OverlayProps) {
+  const ctx = useModalContext('Overlay');
+
+  // Inert background — applied to all body children EXCEPT the portal root.
+  // Only the topmost modal sets it; nested modals' lower overlays are
+  // display:none anyway so they're inherently exempt.
+  useEffect(() => {
+    if (!ctx.isTop) return;
+    const portalRoot = document.querySelector('[data-modal-portal-root]') as HTMLElement | null;
+    const bodyChildren = Array.from(document.body.children) as HTMLElement[];
+    const toRestore: Array<{ el: HTMLElement; had: boolean }> = [];
+    for (const el of bodyChildren) {
+      if (el === portalRoot) continue;
+      const had = el.hasAttribute('inert');
+      if (!had) el.setAttribute('inert', '');
+      toRestore.push({ el, had });
+    }
+    return () => {
+      for (const { el, had } of toRestore) {
+        if (!had) el.removeAttribute('inert');
+      }
+    };
+  }, [ctx.isTop]);
+
+  const onClick = (e: ReactMouseEvent<HTMLDivElement>) => {
+    // Only dismiss when the click is on the backdrop itself.
+    if (e.target !== e.currentTarget) return;
+    if (!ctx.dismissOnOverlayClick) return;
+    if (!ctx.isTop) return; // safety: lower overlays are display:none, but guard anyway
+    ctx.setOpen(false);
+  };
+
+  // Custom prop carries depth to SCSS so any future per-depth styling can
+  // read it; for the current display-toggle stacking, only the topmost
+  // overlay is visible, so this collapses to a no-op for most callers.
+  const style = { ['--modal-depth' as string]: String(ctx.depth) } as CSSProperties;
+
+  return createPortal(
+    <div
+      data-modal-portal-root=""
+      data-state={ctx.open ? 'open' : 'closed'}
+      data-variant={ctx.overlay}
+      data-stack-position={ctx.isTop ? 'top' : 'hidden'}
+      className={styles.overlay}
+      style={style}
+      onClick={onClick}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}

--- a/packages/design-system/src/components/Modal/Overlay.tsx
+++ b/packages/design-system/src/components/Modal/Overlay.tsx
@@ -1,4 +1,9 @@
-import { useEffect, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
+import {
+  useEffect,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { useModalContext } from './context';
 import styles from './Modal.module.scss';

--- a/packages/design-system/src/components/Modal/Overlay.tsx
+++ b/packages/design-system/src/components/Modal/Overlay.tsx
@@ -27,16 +27,16 @@ export interface OverlayProps {
 export function Overlay({ children }: OverlayProps) {
   const ctx = useModalContext('Overlay');
 
-  // Inert background — applied to all body children EXCEPT the portal root.
-  // Only the topmost modal sets it; nested modals' lower overlays are
-  // display:none anyway so they're inherently exempt.
+  // Inert background — applied to all body children EXCEPT any modal portal
+  // root. Skipping ALL modal portals (not just the first) is critical for
+  // stacked modals: the inner modal's portal is also a body child, and it
+  // must remain interactive even though it was added after the outer's.
   useEffect(() => {
     if (!ctx.isTop) return;
-    const portalRoot = document.querySelector('[data-modal-portal-root]') as HTMLElement | null;
     const bodyChildren = Array.from(document.body.children) as HTMLElement[];
     const toRestore: Array<{ el: HTMLElement; had: boolean }> = [];
     for (const el of bodyChildren) {
-      if (el === portalRoot) continue;
+      if (el.hasAttribute('data-modal-portal-root')) continue;
       const had = el.hasAttribute('inert');
       if (!had) el.setAttribute('inert', '');
       toRestore.push({ el, had });

--- a/packages/design-system/src/components/Modal/context.ts
+++ b/packages/design-system/src/components/Modal/context.ts
@@ -1,0 +1,44 @@
+import { createContext, useContext, type RefObject } from 'react';
+
+export type ModalSize = 'sm' | 'md' | 'lg';
+export type ModalOverlayVariant = 'solid' | 'blur';
+
+export interface ModalContextValue {
+  open: boolean;
+  setOpen: (next: boolean) => void;
+  /** Stable modal id, used by the stack registry + aria-controls bindings. */
+  modalId: string;
+  /** Ref to the dialog container, populated by <Content>. Used for focus trap + outside-click. */
+  contentRef: RefObject<HTMLDivElement | null>;
+  /** Stable id for the heading registered by <Header>, used for aria-labelledby. */
+  headingId: string | null;
+  /** Called by <Header> to register its heading id. */
+  setHeadingId: (id: string | null) => void;
+  /** Size preset; drives the content's --modal-size CSS class. */
+  size: ModalSize;
+  /** Overlay variant; drives data-variant on the portal root. */
+  overlay: ModalOverlayVariant;
+  /** Forwarded from props for the Esc handler in Content. */
+  disableEscapeClose: boolean;
+  /** Forwarded for the overlay click handler. */
+  dismissOnOverlayClick: boolean;
+  /** Forwarded so Content can override initial focus. */
+  initialFocusRef: RefObject<HTMLElement | null> | undefined;
+  /** From Modal props; used by Content for aria-label when no heading is registered. */
+  ariaLabel: string | undefined;
+  ariaDescribedBy: string | undefined;
+  /** Current stack depth (for the --modal-depth custom prop on the overlay). */
+  depth: number;
+  /** Whether this modal is currently the topmost open modal. Drives Escape/focus-trap activity. */
+  isTop: boolean;
+}
+
+export const ModalContext = createContext<ModalContextValue | null>(null);
+
+export function useModalContext(componentName: string): ModalContextValue {
+  const ctx = useContext(ModalContext);
+  if (!ctx) {
+    throw new Error(`<Modal.${componentName}> must be used inside <Modal>.`);
+  }
+  return ctx;
+}

--- a/packages/design-system/src/components/Modal/context.ts
+++ b/packages/design-system/src/components/Modal/context.ts
@@ -1,4 +1,7 @@
 import { createContext, useContext, type RefObject } from 'react';
+import { type ModalStackMode } from './useModalStack';
+
+export type { ModalStackMode };
 
 export type ModalSize = 'sm' | 'md' | 'lg';
 export type ModalOverlayVariant = 'solid' | 'blur';
@@ -31,6 +34,10 @@ export interface ModalContextValue {
   depth: number;
   /** Whether this modal is currently the topmost open modal. Drives Escape/focus-trap activity. */
   isTop: boolean;
+  /** This modal's own stackMode prop. */
+  stackMode: ModalStackMode;
+  /** Mode of the current top modal (null if stack is empty). */
+  topMode: ModalStackMode | null;
 }
 
 export const ModalContext = createContext<ModalContextValue | null>(null);

--- a/packages/design-system/src/components/Modal/index.ts
+++ b/packages/design-system/src/components/Modal/index.ts
@@ -1,0 +1,10 @@
+export { Modal } from './Modal';
+export type {
+  ModalProps,
+  ModalSize,
+  ModalOverlayVariant,
+  ModalHeaderProps,
+  ModalBodyProps,
+  ModalFooterProps,
+  ModalCloseProps,
+} from './Modal';

--- a/packages/design-system/src/components/Modal/index.ts
+++ b/packages/design-system/src/components/Modal/index.ts
@@ -3,6 +3,7 @@ export type {
   ModalProps,
   ModalSize,
   ModalOverlayVariant,
+  ModalStackMode,
   ModalHeaderProps,
   ModalBodyProps,
   ModalFooterProps,

--- a/packages/design-system/src/components/Modal/useFocusTrap.test.ts
+++ b/packages/design-system/src/components/Modal/useFocusTrap.test.ts
@@ -106,6 +106,38 @@ describe('useFocusTrap', () => {
     expect(document.activeElement).toBe(outside);
   });
 
+  it('does NOT recapture focus when target is inside a popover portal', () => {
+    const container = makeContainer(`<button id="a">A</button>`);
+    container.tabIndex = -1;
+    // Simulate Popover content portaled to body.
+    const popover = document.createElement('div');
+    popover.setAttribute('data-popover-content', '');
+    const popoverInput = document.createElement('input');
+    popover.appendChild(popoverInput);
+    document.body.appendChild(popover);
+    trapHook(container);
+
+    popoverInput.focus();
+    popoverInput.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(document.activeElement).toBe(popoverInput);
+  });
+
+  it('does NOT recapture focus when target is inside a dropdown menu portal', () => {
+    const container = makeContainer(`<button id="a">A</button>`);
+    container.tabIndex = -1;
+    const menu = document.createElement('div');
+    menu.setAttribute('data-dropdown-menu-content', '');
+    menu.setAttribute('role', 'menu');
+    const item = document.createElement('button');
+    menu.appendChild(item);
+    document.body.appendChild(menu);
+    trapHook(container);
+
+    item.focus();
+    item.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(document.activeElement).toBe(item);
+  });
+
   it('zero focusables: focus stays on container, Tab is preventDefault-ed without movement', () => {
     const container = makeContainer(`<p>read-only</p>`);
     container.tabIndex = -1;

--- a/packages/design-system/src/components/Modal/useFocusTrap.test.ts
+++ b/packages/design-system/src/components/Modal/useFocusTrap.test.ts
@@ -1,0 +1,119 @@
+import { renderHook } from '@testing-library/react';
+import { useRef, type RefObject } from 'react';
+import { useFocusTrap } from './useFocusTrap';
+
+function makeContainer(html: string): HTMLDivElement {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  document.body.appendChild(div);
+  return div;
+}
+
+function trapHook(container: HTMLElement | null, options?: { active?: boolean }) {
+  return renderHook(() => {
+    const ref = useRef<HTMLElement | null>(container);
+    useFocusTrap(ref as RefObject<HTMLElement | null>, options?.active ?? true);
+    return ref;
+  });
+}
+
+describe('useFocusTrap', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('Tab from the last focusable wraps to the first', () => {
+    const container = makeContainer(`
+      <button id="a">A</button>
+      <button id="b">B</button>
+      <button id="c">C</button>
+    `);
+    trapHook(container);
+    const c = container.querySelector<HTMLButtonElement>('#c')!;
+    c.focus();
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    c.dispatchEvent(event);
+    expect(document.activeElement?.id).toBe('a');
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('Shift+Tab from the first focusable wraps to the last', () => {
+    const container = makeContainer(`
+      <button id="a">A</button>
+      <button id="b">B</button>
+      <button id="c">C</button>
+    `);
+    trapHook(container);
+    const a = container.querySelector<HTMLButtonElement>('#a')!;
+    a.focus();
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    a.dispatchEvent(event);
+    expect(document.activeElement?.id).toBe('c');
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('Tab in the middle of the focusables is left to the browser', () => {
+    const container = makeContainer(`
+      <button id="a">A</button>
+      <button id="b">B</button>
+      <button id="c">C</button>
+    `);
+    trapHook(container);
+    const b = container.querySelector<HTMLButtonElement>('#b')!;
+    b.focus();
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    b.dispatchEvent(event);
+    // Hook does not intercept the middle of the cycle.
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('redirects focus back to the container when focus escapes', () => {
+    const container = makeContainer(`<button id="a">A</button>`);
+    container.tabIndex = -1;
+    const outside = document.createElement('button');
+    outside.id = 'outside';
+    document.body.appendChild(outside);
+    trapHook(container);
+
+    outside.focus();
+    // focusin is async via the listener; trigger a dispatch.
+    outside.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(document.activeElement).toBe(container);
+  });
+
+  it('does nothing when container ref is null', () => {
+    expect(() => trapHook(null)).not.toThrow();
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
+    outside.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(document.activeElement).toBe(outside);
+  });
+
+  it('does nothing when active is false', () => {
+    const container = makeContainer(`<button id="a">A</button>`);
+    container.tabIndex = -1;
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    trapHook(container, { active: false });
+    outside.focus();
+    outside.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(document.activeElement).toBe(outside);
+  });
+
+  it('zero focusables: focus stays on container, Tab is preventDefault-ed without movement', () => {
+    const container = makeContainer(`<p>read-only</p>`);
+    container.tabIndex = -1;
+    trapHook(container);
+    container.focus();
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    container.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(container);
+  });
+});

--- a/packages/design-system/src/components/Modal/useFocusTrap.ts
+++ b/packages/design-system/src/components/Modal/useFocusTrap.ts
@@ -1,0 +1,74 @@
+import { useEffect, type RefObject } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'button:not([disabled])',
+  '[href]',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function getFocusables(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+/**
+ * Focus trap: keeps Tab focus cycling inside `containerRef`. Attaches a
+ * `keydown` listener to detect Tab at the first/last focusable and wrap, plus
+ * a `focusin` listener at document level to redirect any focus that escapes
+ * the container back to it.
+ *
+ * `active = false` no-ops the trap (used by Modal when not top of stack — the
+ * inner modal mounts but only the topmost modal owns focus).
+ *
+ * @example
+ * const contentRef = useRef<HTMLDivElement | null>(null);
+ * useFocusTrap(contentRef, open);
+ */
+export function useFocusTrap(
+  containerRef: RefObject<HTMLElement | null>,
+  active: boolean,
+): void {
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Tab') return;
+      const focusables = getFocusables(container!);
+      if (focusables.length === 0) {
+        // Zero focusables: prevent Tab from escaping the container.
+        e.preventDefault();
+        container!.focus();
+        return;
+      }
+      const first = focusables[0]!;
+      const last = focusables[focusables.length - 1]!;
+      if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      } else if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+      // Middle of the cycle: browser handles it natively.
+    }
+
+    function onFocusIn(e: FocusEvent) {
+      const target = e.target as Node | null;
+      if (!target || !container) return;
+      if (container.contains(target)) return;
+      // Focus escaped — redirect to the container.
+      container.focus();
+    }
+
+    container.addEventListener('keydown', onKeyDown);
+    document.addEventListener('focusin', onFocusIn);
+    return () => {
+      container.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('focusin', onFocusIn);
+    };
+  }, [containerRef, active]);
+}

--- a/packages/design-system/src/components/Modal/useFocusTrap.ts
+++ b/packages/design-system/src/components/Modal/useFocusTrap.ts
@@ -38,10 +38,7 @@ function getFocusables(container: HTMLElement): HTMLElement[] {
  * const contentRef = useRef<HTMLDivElement | null>(null);
  * useFocusTrap(contentRef, open);
  */
-export function useFocusTrap(
-  containerRef: RefObject<HTMLElement | null>,
-  active: boolean,
-): void {
+export function useFocusTrap(containerRef: RefObject<HTMLElement | null>, active: boolean): void {
   useEffect(() => {
     if (!active) return;
     const container = containerRef.current;

--- a/packages/design-system/src/components/Modal/useFocusTrap.ts
+++ b/packages/design-system/src/components/Modal/useFocusTrap.ts
@@ -9,6 +9,18 @@ const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(',');
 
+// Floating UI surfaces whose portals are direct body-siblings of our modal
+// portal. Focus moving into these should not be redirected back to the modal —
+// the popover / dropdown / tooltip is handling its own focus session.
+const FLOATING_BYPASS_SELECTOR = [
+  '[data-popover-content]',
+  '[data-dropdown-menu-content]',
+  '[role="tooltip"]',
+  '[role="menu"]',
+  '[role="listbox"]',
+  '[role="dialog"]',
+].join(',');
+
 function getFocusables(container: HTMLElement): HTMLElement[] {
   return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
 }
@@ -57,9 +69,14 @@ export function useFocusTrap(
     }
 
     function onFocusIn(e: FocusEvent) {
-      const target = e.target as Node | null;
+      const target = e.target as HTMLElement | null;
       if (!target || !container) return;
       if (container.contains(target)) return;
+      // Allow focus to live inside floating UI surfaces that were opened
+      // from within this modal (Popover, DropdownMenu, Tooltip, nested Modal).
+      // Their portals are body-direct siblings of our portal — checking by
+      // selector instead of containment.
+      if (target.closest(FLOATING_BYPASS_SELECTOR)) return;
       // Focus escaped — redirect to the container.
       container.focus();
     }

--- a/packages/design-system/src/components/Modal/useModalStack.test.ts
+++ b/packages/design-system/src/components/Modal/useModalStack.test.ts
@@ -1,0 +1,83 @@
+import { renderHook, act } from '@testing-library/react';
+import { useModalStack, modalStack } from './useModalStack';
+
+describe('modalStack singleton', () => {
+  afterEach(() => {
+    // Reset the stack between tests.
+    modalStack._reset();
+  });
+
+  it('register returns 0 for the first modal, 1 for the second', () => {
+    expect(modalStack.register('a')).toBe(0);
+    expect(modalStack.register('b')).toBe(1);
+  });
+
+  it('unregister removes a modal from the stack', () => {
+    modalStack.register('a');
+    modalStack.register('b');
+    modalStack.unregister('a');
+    expect(modalStack.isTop('b')).toBe(true);
+    expect(modalStack.depthOf('b')).toBe(0);
+  });
+
+  it('isTop returns true for the most-recently-registered modal', () => {
+    modalStack.register('a');
+    modalStack.register('b');
+    expect(modalStack.isTop('b')).toBe(true);
+    expect(modalStack.isTop('a')).toBe(false);
+  });
+
+  it('topDepth returns the current stack height', () => {
+    expect(modalStack.topDepth()).toBe(0);
+    modalStack.register('a');
+    expect(modalStack.topDepth()).toBe(1);
+    modalStack.register('b');
+    expect(modalStack.topDepth()).toBe(2);
+    modalStack.unregister('a');
+    // 'b' is still open; topDepth reflects open count.
+    expect(modalStack.topDepth()).toBe(1);
+  });
+
+  it('depthOf compacts indexes after a mid-stack unregister', () => {
+    modalStack.register('a');
+    modalStack.register('b');
+    modalStack.register('c');
+    modalStack.unregister('a');
+    expect(modalStack.depthOf('b')).toBe(0);
+    expect(modalStack.depthOf('c')).toBe(1);
+  });
+});
+
+describe('useModalStack', () => {
+  afterEach(() => {
+    modalStack._reset();
+  });
+
+  it('returns null depth when active=false', () => {
+    const { result } = renderHook(() => useModalStack('a', false));
+    expect(result.current.depth).toBeNull();
+  });
+
+  it('registers when active goes true and returns depth', () => {
+    const { result, rerender } = renderHook(({ active }) => useModalStack('a', active), {
+      initialProps: { active: false },
+    });
+    expect(result.current.depth).toBeNull();
+    rerender({ active: true });
+    expect(result.current.depth).toBe(0);
+  });
+
+  it('isTop reflects current top state', () => {
+    renderHook(() => useModalStack('a', true));
+    const { result } = renderHook(() => useModalStack('b', true));
+    // b registered second, so b is top.
+    expect(result.current.isTop).toBe(true);
+  });
+
+  it('unregisters on unmount', () => {
+    const { unmount } = renderHook(() => useModalStack('a', true));
+    expect(modalStack.depthOf('a')).toBe(0);
+    unmount();
+    expect(modalStack.depthOf('a')).toBe(-1);
+  });
+});

--- a/packages/design-system/src/components/Modal/useModalStack.test.ts
+++ b/packages/design-system/src/components/Modal/useModalStack.test.ts
@@ -70,12 +70,9 @@ describe('useModalStack', () => {
   });
 
   it('registers when active goes true and returns depth', () => {
-    const { result, rerender } = renderHook(
-      ({ active }) => useModalStack('a', active, 'replace'),
-      {
-        initialProps: { active: false },
-      },
-    );
+    const { result, rerender } = renderHook(({ active }) => useModalStack('a', active, 'replace'), {
+      initialProps: { active: false },
+    });
     expect(result.current.depth).toBeNull();
     rerender({ active: true });
     expect(result.current.depth).toBe(0);

--- a/packages/design-system/src/components/Modal/useModalStack.test.ts
+++ b/packages/design-system/src/components/Modal/useModalStack.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { useModalStack, modalStack } from './useModalStack';
 
 describe('modalStack singleton', () => {

--- a/packages/design-system/src/components/Modal/useModalStack.test.ts
+++ b/packages/design-system/src/components/Modal/useModalStack.test.ts
@@ -8,30 +8,30 @@ describe('modalStack singleton', () => {
   });
 
   it('register returns 0 for the first modal, 1 for the second', () => {
-    expect(modalStack.register('a')).toBe(0);
-    expect(modalStack.register('b')).toBe(1);
+    expect(modalStack.register('a', 'replace')).toBe(0);
+    expect(modalStack.register('b', 'replace')).toBe(1);
   });
 
   it('unregister removes a modal from the stack', () => {
-    modalStack.register('a');
-    modalStack.register('b');
+    modalStack.register('a', 'replace');
+    modalStack.register('b', 'replace');
     modalStack.unregister('a');
     expect(modalStack.isTop('b')).toBe(true);
     expect(modalStack.depthOf('b')).toBe(0);
   });
 
   it('isTop returns true for the most-recently-registered modal', () => {
-    modalStack.register('a');
-    modalStack.register('b');
+    modalStack.register('a', 'replace');
+    modalStack.register('b', 'replace');
     expect(modalStack.isTop('b')).toBe(true);
     expect(modalStack.isTop('a')).toBe(false);
   });
 
   it('topDepth returns the current stack height', () => {
     expect(modalStack.topDepth()).toBe(0);
-    modalStack.register('a');
+    modalStack.register('a', 'replace');
     expect(modalStack.topDepth()).toBe(1);
-    modalStack.register('b');
+    modalStack.register('b', 'replace');
     expect(modalStack.topDepth()).toBe(2);
     modalStack.unregister('a');
     // 'b' is still open; topDepth reflects open count.
@@ -39,12 +39,23 @@ describe('modalStack singleton', () => {
   });
 
   it('depthOf compacts indexes after a mid-stack unregister', () => {
-    modalStack.register('a');
-    modalStack.register('b');
-    modalStack.register('c');
+    modalStack.register('a', 'replace');
+    modalStack.register('b', 'replace');
+    modalStack.register('c', 'replace');
     modalStack.unregister('a');
     expect(modalStack.depthOf('b')).toBe(0);
     expect(modalStack.depthOf('c')).toBe(1);
+  });
+
+  it('topMode reflects the top entry', () => {
+    modalStack.register('a', 'overlay');
+    expect(modalStack.topMode()).toBe('overlay');
+    modalStack.register('b', 'replace');
+    expect(modalStack.topMode()).toBe('replace');
+  });
+
+  it('topMode returns null when stack is empty', () => {
+    expect(modalStack.topMode()).toBeNull();
   });
 });
 
@@ -54,36 +65,39 @@ describe('useModalStack', () => {
   });
 
   it('returns null depth when active=false', () => {
-    const { result } = renderHook(() => useModalStack('a', false));
+    const { result } = renderHook(() => useModalStack('a', false, 'replace'));
     expect(result.current.depth).toBeNull();
   });
 
   it('registers when active goes true and returns depth', () => {
-    const { result, rerender } = renderHook(({ active }) => useModalStack('a', active), {
-      initialProps: { active: false },
-    });
+    const { result, rerender } = renderHook(
+      ({ active }) => useModalStack('a', active, 'replace'),
+      {
+        initialProps: { active: false },
+      },
+    );
     expect(result.current.depth).toBeNull();
     rerender({ active: true });
     expect(result.current.depth).toBe(0);
   });
 
   it('isTop reflects current top state', () => {
-    renderHook(() => useModalStack('a', true));
-    const { result } = renderHook(() => useModalStack('b', true));
+    renderHook(() => useModalStack('a', true, 'replace'));
+    const { result } = renderHook(() => useModalStack('b', true, 'replace'));
     // b registered second, so b is top.
     expect(result.current.isTop).toBe(true);
   });
 
   it('first modal isTop flips to false when a second modal registers', () => {
-    const a = renderHook(() => useModalStack('a', true));
+    const a = renderHook(() => useModalStack('a', true, 'replace'));
     expect(a.result.current.isTop).toBe(true);
-    renderHook(() => useModalStack('b', true));
+    renderHook(() => useModalStack('b', true, 'replace'));
     // a must now reflect that b is on top.
     expect(a.result.current.isTop).toBe(false);
   });
 
   it('unregisters on unmount', () => {
-    const { unmount } = renderHook(() => useModalStack('a', true));
+    const { unmount } = renderHook(() => useModalStack('a', true, 'replace'));
     expect(modalStack.depthOf('a')).toBe(0);
     unmount();
     expect(modalStack.depthOf('a')).toBe(-1);

--- a/packages/design-system/src/components/Modal/useModalStack.test.ts
+++ b/packages/design-system/src/components/Modal/useModalStack.test.ts
@@ -74,6 +74,14 @@ describe('useModalStack', () => {
     expect(result.current.isTop).toBe(true);
   });
 
+  it('first modal isTop flips to false when a second modal registers', () => {
+    const a = renderHook(() => useModalStack('a', true));
+    expect(a.result.current.isTop).toBe(true);
+    renderHook(() => useModalStack('b', true));
+    // a must now reflect that b is on top.
+    expect(a.result.current.isTop).toBe(false);
+  });
+
   it('unregisters on unmount', () => {
     const { unmount } = renderHook(() => useModalStack('a', true));
     expect(modalStack.depthOf('a')).toBe(0);

--- a/packages/design-system/src/components/Modal/useModalStack.ts
+++ b/packages/design-system/src/components/Modal/useModalStack.ts
@@ -132,6 +132,14 @@ export function useModalStack(id: string, active: boolean, mode: ModalStackMode)
       unsubscribe();
       modalStack.unregister(id);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mode handled by separate effect below to avoid tear-down on mode change
+  }, [id, active]);
+
+  // Update mode in place without tearing down the entry. modalStack.register
+  // handles existing entries by updating their mode and re-notifying.
+  useLayoutEffect(() => {
+    if (!active) return;
+    modalStack.register(id, mode);
   }, [id, active, mode]);
 
   return state;

--- a/packages/design-system/src/components/Modal/useModalStack.ts
+++ b/packages/design-system/src/components/Modal/useModalStack.ts
@@ -2,6 +2,11 @@ import { useEffect, useState } from 'react';
 
 // Internal ordered list of open modal ids, most-recently-registered last.
 const stack: string[] = [];
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const fn of listeners) fn();
+}
 
 function depthOf(id: string): number {
   return stack.indexOf(id);
@@ -15,15 +20,23 @@ function topId(): string | null {
  * Module-level singleton tracking open modal ids in registration order.
  * Each modal calls `register` on open and `unregister` on close. Depth is
  * the modal's index in the open-stack (0 = bottom, length-1 = top).
+ * Subscribers are notified after every register/unregister so consumers
+ * can re-derive `isTop` / `depth`.
  */
 export const modalStack = {
   register(id: string): number {
-    if (!stack.includes(id)) stack.push(id);
+    if (!stack.includes(id)) {
+      stack.push(id);
+      notify();
+    }
     return depthOf(id);
   },
   unregister(id: string): void {
     const idx = stack.indexOf(id);
-    if (idx >= 0) stack.splice(idx, 1);
+    if (idx >= 0) {
+      stack.splice(idx, 1);
+      notify();
+    }
   },
   isTop(id: string): boolean {
     return topId() === id;
@@ -32,9 +45,17 @@ export const modalStack = {
     return stack.length;
   },
   depthOf,
+  /** Subscribe to register/unregister notifications. Returns unsubscribe. */
+  _subscribe(fn: () => void): () => void {
+    listeners.add(fn);
+    return () => {
+      listeners.delete(fn);
+    };
+  },
   /** Test-only escape hatch. */
   _reset(): void {
     stack.length = 0;
+    listeners.clear();
   },
 };
 
@@ -47,8 +68,8 @@ export interface ModalStackState {
 
 /**
  * Register/unregister this modal in the singleton stack while `active` is
- * true. Returns the current depth + whether this modal is on top, so
- * callers can route Escape, focus, and z-index correctly.
+ * true. Returns the current depth + whether this modal is on top. Subscribes
+ * to stack mutations so `isTop` stays accurate when sibling modals open/close.
  *
  * Re-renders on stack changes elsewhere (e.g. a sibling modal opens) so
  * `isTop` stays accurate. The state is cheap (one number + one boolean).
@@ -62,22 +83,19 @@ export function useModalStack(id: string, active: boolean): ModalStackState {
       return;
     }
     modalStack.register(id);
-    setState({ depth: modalStack.depthOf(id), isTop: modalStack.isTop(id) });
+    const sync = () => {
+      setState({
+        depth: modalStack.depthOf(id),
+        isTop: modalStack.isTop(id),
+      });
+    };
+    sync();
+    const unsubscribe = modalStack._subscribe(sync);
     return () => {
+      unsubscribe();
       modalStack.unregister(id);
     };
   }, [id, active]);
-
-  // Re-sync whenever the stack might have changed elsewhere. This effect
-  // runs on every render and reads the singleton; cheap, no setState if
-  // nothing changed.
-  useEffect(() => {
-    if (!active) return;
-    const next = { depth: modalStack.depthOf(id), isTop: modalStack.isTop(id) };
-    if (next.depth !== state.depth || next.isTop !== state.isTop) {
-      setState(next);
-    }
-  });
 
   return state;
 }

--- a/packages/design-system/src/components/Modal/useModalStack.ts
+++ b/packages/design-system/src/components/Modal/useModalStack.ts
@@ -95,11 +95,7 @@ export interface ModalStackState {
  * top modal's stackMode. Subscribes to stack mutations so state stays
  * accurate when sibling modals open/close.
  */
-export function useModalStack(
-  id: string,
-  active: boolean,
-  mode: ModalStackMode,
-): ModalStackState {
+export function useModalStack(id: string, active: boolean, mode: ModalStackMode): ModalStackState {
   const [state, setState] = useState<ModalStackState>({
     depth: null,
     isTop: false,

--- a/packages/design-system/src/components/Modal/useModalStack.ts
+++ b/packages/design-system/src/components/Modal/useModalStack.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
 export type ModalStackMode = 'replace' | 'overlay';
 
@@ -96,13 +96,24 @@ export interface ModalStackState {
  * accurate when sibling modals open/close.
  */
 export function useModalStack(id: string, active: boolean, mode: ModalStackMode): ModalStackState {
-  const [state, setState] = useState<ModalStackState>({
-    depth: null,
-    isTop: false,
-    topMode: null,
+  // Lazy initializer pre-computes the post-registration state so the FIRST
+  // render of an opened modal already has correct `topMode` / `isTop` /
+  // `depth`. Without this, paint and stack-position attributes would be
+  // wrong on the first paint (transparent overlay flash, etc.). The actual
+  // register() still happens in useLayoutEffect; this is read-only.
+  const [state, setState] = useState<ModalStackState>(() => {
+    if (!active) return { depth: null, isTop: false, topMode: null };
+    return {
+      depth: modalStack.topDepth(),
+      isTop: true,
+      topMode: mode,
+    };
   });
 
-  useEffect(() => {
+  // useLayoutEffect (not useEffect) so registration + state sync happen
+  // synchronously after commit, before the browser paints. Prevents a
+  // one-frame flash of the wrong overlay attributes.
+  useLayoutEffect(() => {
     if (!active) {
       setState({ depth: null, isTop: false, topMode: null });
       return;

--- a/packages/design-system/src/components/Modal/useModalStack.ts
+++ b/packages/design-system/src/components/Modal/useModalStack.ts
@@ -1,18 +1,29 @@
 import { useEffect, useState } from 'react';
 
-// Internal ordered list of open modal ids, most-recently-registered last.
-const stack: string[] = [];
+export type ModalStackMode = 'replace' | 'overlay';
+
+interface Entry {
+  id: string;
+  mode: ModalStackMode;
+}
+
+// Internal ordered list of open modal entries, most-recently-registered last.
+const stack: Entry[] = [];
 const listeners = new Set<() => void>();
 
 function notify() {
   for (const fn of listeners) fn();
 }
 
-function depthOf(id: string): number {
-  return stack.indexOf(id);
+function indexOf(id: string): number {
+  return stack.findIndex((e) => e.id === id);
 }
 
-function topId(): string | null {
+function depthOf(id: string): number {
+  return indexOf(id);
+}
+
+function topEntry(): Entry | null {
   return stack.length === 0 ? null : stack[stack.length - 1]!;
 }
 
@@ -21,28 +32,38 @@ function topId(): string | null {
  * Each modal calls `register` on open and `unregister` on close. Depth is
  * the modal's index in the open-stack (0 = bottom, length-1 = top).
  * Subscribers are notified after every register/unregister so consumers
- * can re-derive `isTop` / `depth`.
+ * can re-derive `isTop` / `depth` / `topMode`.
  */
 export const modalStack = {
-  register(id: string): number {
-    if (!stack.includes(id)) {
-      stack.push(id);
-      notify();
+  /**
+   * Register this modal. If already present, update its mode in place
+   * (handles a parent re-render where stackMode prop changed).
+   */
+  register(id: string, mode: ModalStackMode): number {
+    const idx = indexOf(id);
+    if (idx === -1) {
+      stack.push({ id, mode });
+    } else {
+      stack[idx]!.mode = mode;
     }
+    notify();
     return depthOf(id);
   },
   unregister(id: string): void {
-    const idx = stack.indexOf(id);
+    const idx = indexOf(id);
     if (idx >= 0) {
       stack.splice(idx, 1);
       notify();
     }
   },
   isTop(id: string): boolean {
-    return topId() === id;
+    return topEntry()?.id === id;
   },
   topDepth(): number {
     return stack.length;
+  },
+  topMode(): ModalStackMode | null {
+    return topEntry()?.mode ?? null;
   },
   depthOf,
   /** Subscribe to register/unregister notifications. Returns unsubscribe. */
@@ -64,29 +85,38 @@ export interface ModalStackState {
   depth: number | null;
   /** True iff this modal is the topmost open modal. */
   isTop: boolean;
+  /** Mode of the current top modal (null if stack is empty). */
+  topMode: ModalStackMode | null;
 }
 
 /**
  * Register/unregister this modal in the singleton stack while `active` is
- * true. Returns the current depth + whether this modal is on top. Subscribes
- * to stack mutations so `isTop` stays accurate when sibling modals open/close.
- *
- * Re-renders on stack changes elsewhere (e.g. a sibling modal opens) so
- * `isTop` stays accurate. The state is cheap (one number + one boolean).
+ * true. Returns the current depth, whether this modal is on top, and the
+ * top modal's stackMode. Subscribes to stack mutations so state stays
+ * accurate when sibling modals open/close.
  */
-export function useModalStack(id: string, active: boolean): ModalStackState {
-  const [state, setState] = useState<ModalStackState>({ depth: null, isTop: false });
+export function useModalStack(
+  id: string,
+  active: boolean,
+  mode: ModalStackMode,
+): ModalStackState {
+  const [state, setState] = useState<ModalStackState>({
+    depth: null,
+    isTop: false,
+    topMode: null,
+  });
 
   useEffect(() => {
     if (!active) {
-      setState({ depth: null, isTop: false });
+      setState({ depth: null, isTop: false, topMode: null });
       return;
     }
-    modalStack.register(id);
+    modalStack.register(id, mode);
     const sync = () => {
       setState({
         depth: modalStack.depthOf(id),
         isTop: modalStack.isTop(id),
+        topMode: modalStack.topMode(),
       });
     };
     sync();
@@ -95,7 +125,7 @@ export function useModalStack(id: string, active: boolean): ModalStackState {
       unsubscribe();
       modalStack.unregister(id);
     };
-  }, [id, active]);
+  }, [id, active, mode]);
 
   return state;
 }

--- a/packages/design-system/src/components/Modal/useModalStack.ts
+++ b/packages/design-system/src/components/Modal/useModalStack.ts
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+
+// Internal ordered list of open modal ids, most-recently-registered last.
+const stack: string[] = [];
+
+function depthOf(id: string): number {
+  return stack.indexOf(id);
+}
+
+function topId(): string | null {
+  return stack.length === 0 ? null : stack[stack.length - 1]!;
+}
+
+/**
+ * Module-level singleton tracking open modal ids in registration order.
+ * Each modal calls `register` on open and `unregister` on close. Depth is
+ * the modal's index in the open-stack (0 = bottom, length-1 = top).
+ */
+export const modalStack = {
+  register(id: string): number {
+    if (!stack.includes(id)) stack.push(id);
+    return depthOf(id);
+  },
+  unregister(id: string): void {
+    const idx = stack.indexOf(id);
+    if (idx >= 0) stack.splice(idx, 1);
+  },
+  isTop(id: string): boolean {
+    return topId() === id;
+  },
+  topDepth(): number {
+    return stack.length;
+  },
+  depthOf,
+  /** Test-only escape hatch. */
+  _reset(): void {
+    stack.length = 0;
+  },
+};
+
+export interface ModalStackState {
+  /** Current depth in the stack, or null if not registered. */
+  depth: number | null;
+  /** True iff this modal is the topmost open modal. */
+  isTop: boolean;
+}
+
+/**
+ * Register/unregister this modal in the singleton stack while `active` is
+ * true. Returns the current depth + whether this modal is on top, so
+ * callers can route Escape, focus, and z-index correctly.
+ *
+ * Re-renders on stack changes elsewhere (e.g. a sibling modal opens) so
+ * `isTop` stays accurate. The state is cheap (one number + one boolean).
+ */
+export function useModalStack(id: string, active: boolean): ModalStackState {
+  const [state, setState] = useState<ModalStackState>({ depth: null, isTop: false });
+
+  useEffect(() => {
+    if (!active) {
+      setState({ depth: null, isTop: false });
+      return;
+    }
+    modalStack.register(id);
+    setState({ depth: modalStack.depthOf(id), isTop: modalStack.isTop(id) });
+    return () => {
+      modalStack.unregister(id);
+    };
+  }, [id, active]);
+
+  // Re-sync whenever the stack might have changed elsewhere. This effect
+  // runs on every render and reads the singleton; cheap, no setState if
+  // nothing changed.
+  useEffect(() => {
+    if (!active) return;
+    const next = { depth: modalStack.depthOf(id), isTop: modalStack.isTop(id) };
+    if (next.depth !== state.depth || next.isTop !== state.isTop) {
+      setState(next);
+    }
+  });
+
+  return state;
+}

--- a/packages/design-system/src/components/Modal/useScrollLock.test.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.test.ts
@@ -3,54 +3,54 @@ import { useScrollLock } from './useScrollLock';
 
 describe('useScrollLock', () => {
   beforeEach(() => {
-    document.documentElement.style.overflow = '';
-    document.body.style.overflow = '';
+    document.body.style.position = '';
+    document.body.style.top = '';
+    document.body.style.left = '';
+    document.body.style.width = '';
     document.body.style.paddingRight = '';
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 0 });
+    Object.defineProperty(window, 'scrollX', { configurable: true, value: 0 });
   });
 
-  it('locks scroll on first acquire (overflow: hidden on html and body)', () => {
+  it('pins body to position:fixed on first acquire', () => {
     const { unmount } = renderHook(() => useScrollLock(true));
-    expect(document.documentElement.style.overflow).toBe('hidden');
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
+    expect(document.body.style.width).toBe('100%');
     unmount();
   });
 
-  it('restores scroll when refcount drops to zero', () => {
+  it('restores body styles when refcount drops to zero', () => {
     const { unmount } = renderHook(() => useScrollLock(true));
-    expect(document.documentElement.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
     unmount();
-    expect(document.documentElement.style.overflow).toBe('');
-    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.position).toBe('');
+    expect(document.body.style.top).toBe('');
+    expect(document.body.style.left).toBe('');
+    expect(document.body.style.width).toBe('');
   });
 
   it('second acquire while locked is a no-op (refcount only)', () => {
     const a = renderHook(() => useScrollLock(true));
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
     const b = renderHook(() => useScrollLock(true));
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
     b.unmount();
-    // First lock still active.
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
     a.unmount();
-    // Now released.
-    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.position).toBe('');
   });
 
-  it('restores ORIGINAL overflow values, not blank', () => {
-    document.documentElement.style.overflow = 'auto';
-    document.body.style.overflow = 'scroll';
+  it('restores ORIGINAL body position value, not blank', () => {
+    document.body.style.position = 'relative';
     const { unmount } = renderHook(() => useScrollLock(true));
-    expect(document.documentElement.style.overflow).toBe('hidden');
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
     unmount();
-    expect(document.documentElement.style.overflow).toBe('auto');
-    expect(document.body.style.overflow).toBe('scroll');
+    expect(document.body.style.position).toBe('relative');
   });
 
   it('active=false is a no-op', () => {
     renderHook(() => useScrollLock(false));
-    expect(document.documentElement.style.overflow).toBe('');
-    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.position).toBe('');
   });
 
   it('pads body-right by the disappearing scrollbar width to prevent layout shift', () => {
@@ -82,5 +82,19 @@ describe('useScrollLock', () => {
     const { unmount } = renderHook(() => useScrollLock(true));
     expect(document.body.style.paddingRight).toBe('');
     unmount();
+  });
+
+  it('captures scroll position into body offsets and restores on unlock via scrollTo', () => {
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 300 });
+    Object.defineProperty(window, 'scrollX', { configurable: true, value: 50 });
+
+    const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.top).toBe('-300px');
+    expect(document.body.style.left).toBe('-50px');
+
+    const spy = vi.spyOn(window, 'scrollTo');
+    unmount();
+    expect(spy).toHaveBeenCalledWith({ left: 50, top: 300, behavior: 'instant' });
+    spy.mockRestore();
   });
 });

--- a/packages/design-system/src/components/Modal/useScrollLock.test.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.test.ts
@@ -1,0 +1,49 @@
+import { renderHook } from '@testing-library/react';
+import { useScrollLock } from './useScrollLock';
+
+describe('useScrollLock', () => {
+  beforeEach(() => {
+    document.body.style.overflow = '';
+    document.body.style.paddingRight = '';
+  });
+
+  it('locks body scroll on first acquire', () => {
+    const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+  });
+
+  it('restores body scroll when refcount drops to zero', () => {
+    const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('second acquire while locked is a no-op (refcount only)', () => {
+    const a = renderHook(() => useScrollLock(true));
+    document.body.style.overflow = 'hidden'; // sanity
+    const b = renderHook(() => useScrollLock(true));
+    // Still locked.
+    expect(document.body.style.overflow).toBe('hidden');
+    b.unmount();
+    // First lock still active.
+    expect(document.body.style.overflow).toBe('hidden');
+    a.unmount();
+    // Now released.
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('restores ORIGINAL overflow value, not blank', () => {
+    document.body.style.overflow = 'scroll';
+    const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('scroll');
+  });
+
+  it('active=false is a no-op', () => {
+    renderHook(() => useScrollLock(false));
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/packages/design-system/src/components/Modal/useScrollLock.test.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.test.ts
@@ -113,7 +113,7 @@ describe('useScrollLock', () => {
     const spy = vi.spyOn(window, 'scrollTo');
 
     unmount();
-    expect(spy).toHaveBeenCalledWith(50, 300);
+    expect(spy).toHaveBeenCalledWith({ left: 50, top: 300, behavior: 'instant' });
     spy.mockRestore();
 
     // Restore patched values.

--- a/packages/design-system/src/components/Modal/useScrollLock.test.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.test.ts
@@ -3,69 +3,57 @@ import { useScrollLock } from './useScrollLock';
 
 describe('useScrollLock', () => {
   beforeEach(() => {
-    // Reset body styles that the lock manipulates.
+    document.documentElement.style.overflow = '';
     document.body.style.overflow = '';
-    document.body.style.position = '';
-    document.body.style.top = '';
-    document.body.style.left = '';
-    document.body.style.width = '';
     document.body.style.paddingRight = '';
-    // Reset scroll position (jsdom supports this).
-    window.scrollTo(0, 0);
   });
 
-  it('locks body scroll on first acquire (position: fixed)', () => {
+  it('locks scroll on first acquire (overflow: hidden on html and body)', () => {
     const { unmount } = renderHook(() => useScrollLock(true));
-    expect(document.body.style.position).toBe('fixed');
+    expect(document.documentElement.style.overflow).toBe('hidden');
     expect(document.body.style.overflow).toBe('hidden');
     unmount();
   });
 
-  it('restores body position and scroll when refcount drops to zero', () => {
+  it('restores scroll when refcount drops to zero', () => {
     const { unmount } = renderHook(() => useScrollLock(true));
-    expect(document.body.style.position).toBe('fixed');
+    expect(document.documentElement.style.overflow).toBe('hidden');
     unmount();
-    expect(document.body.style.position).toBe('');
+    expect(document.documentElement.style.overflow).toBe('');
     expect(document.body.style.overflow).toBe('');
-    expect(document.body.style.top).toBe('');
-    expect(document.body.style.left).toBe('');
-    expect(document.body.style.width).toBe('');
   });
 
   it('second acquire while locked is a no-op (refcount only)', () => {
     const a = renderHook(() => useScrollLock(true));
-    expect(document.body.style.position).toBe('fixed');
+    expect(document.body.style.overflow).toBe('hidden');
     const b = renderHook(() => useScrollLock(true));
-    // Still locked.
-    expect(document.body.style.position).toBe('fixed');
+    expect(document.body.style.overflow).toBe('hidden');
     b.unmount();
     // First lock still active.
-    expect(document.body.style.position).toBe('fixed');
+    expect(document.body.style.overflow).toBe('hidden');
     a.unmount();
     // Now released.
-    expect(document.body.style.position).toBe('');
+    expect(document.body.style.overflow).toBe('');
   });
 
-  it('restores ORIGINAL position and overflow values, not blank', () => {
+  it('restores ORIGINAL overflow values, not blank', () => {
+    document.documentElement.style.overflow = 'auto';
     document.body.style.overflow = 'scroll';
-    document.body.style.position = 'relative';
     const { unmount } = renderHook(() => useScrollLock(true));
-    expect(document.body.style.position).toBe('fixed');
+    expect(document.documentElement.style.overflow).toBe('hidden');
     expect(document.body.style.overflow).toBe('hidden');
     unmount();
-    expect(document.body.style.position).toBe('relative');
+    expect(document.documentElement.style.overflow).toBe('auto');
     expect(document.body.style.overflow).toBe('scroll');
   });
 
   it('active=false is a no-op', () => {
     renderHook(() => useScrollLock(false));
-    expect(document.body.style.position).toBe('');
+    expect(document.documentElement.style.overflow).toBe('');
     expect(document.body.style.overflow).toBe('');
   });
 
   it('pads body-right by the disappearing scrollbar width to prevent layout shift', () => {
-    // Simulate a vertical scrollbar of 17px by making window.innerWidth
-    // 17 wider than documentElement.clientWidth.
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 });
     Object.defineProperty(document.documentElement, 'clientWidth', {
       configurable: true,
@@ -77,7 +65,6 @@ describe('useScrollLock', () => {
     unmount();
     expect(document.body.style.paddingRight).toBe('');
 
-    // Restore.
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
     Object.defineProperty(document.documentElement, 'clientWidth', {
       configurable: true,
@@ -95,29 +82,5 @@ describe('useScrollLock', () => {
     const { unmount } = renderHook(() => useScrollLock(true));
     expect(document.body.style.paddingRight).toBe('');
     unmount();
-  });
-
-  it('saves scroll position on lock and restores it on unlock', () => {
-    // Simulate the page being scrolled before the modal opens.
-    // jsdom supports window.scrollTo but scrollY/scrollX stay 0 in the test
-    // environment; we patch them to simulate a real scroll position.
-    Object.defineProperty(window, 'scrollY', { configurable: true, value: 300 });
-    Object.defineProperty(window, 'scrollX', { configurable: true, value: 50 });
-
-    const { unmount } = renderHook(() => useScrollLock(true));
-    // Body should be offset to counteract the scroll visually.
-    expect(document.body.style.top).toBe('-300px');
-    expect(document.body.style.left).toBe('-50px');
-
-    // Track what scrollTo is called with on unlock.
-    const spy = vi.spyOn(window, 'scrollTo');
-
-    unmount();
-    expect(spy).toHaveBeenCalledWith({ left: 50, top: 300, behavior: 'instant' });
-    spy.mockRestore();
-
-    // Restore patched values.
-    Object.defineProperty(window, 'scrollY', { configurable: true, value: 0 });
-    Object.defineProperty(window, 'scrollX', { configurable: true, value: 0 });
   });
 });

--- a/packages/design-system/src/components/Modal/useScrollLock.test.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.test.ts
@@ -3,47 +3,86 @@ import { useScrollLock } from './useScrollLock';
 
 describe('useScrollLock', () => {
   beforeEach(() => {
+    // Reset body styles that the lock manipulates.
     document.body.style.overflow = '';
-    document.body.style.paddingRight = '';
+    document.body.style.position = '';
+    document.body.style.top = '';
+    document.body.style.left = '';
+    document.body.style.width = '';
+    // Reset scroll position (jsdom supports this).
+    window.scrollTo(0, 0);
   });
 
-  it('locks body scroll on first acquire', () => {
+  it('locks body scroll on first acquire (position: fixed)', () => {
     const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.position).toBe('fixed');
     expect(document.body.style.overflow).toBe('hidden');
     unmount();
   });
 
-  it('restores body scroll when refcount drops to zero', () => {
+  it('restores body position and scroll when refcount drops to zero', () => {
     const { unmount } = renderHook(() => useScrollLock(true));
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
     unmount();
+    expect(document.body.style.position).toBe('');
     expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.top).toBe('');
+    expect(document.body.style.left).toBe('');
+    expect(document.body.style.width).toBe('');
   });
 
   it('second acquire while locked is a no-op (refcount only)', () => {
     const a = renderHook(() => useScrollLock(true));
-    document.body.style.overflow = 'hidden'; // sanity
+    expect(document.body.style.position).toBe('fixed');
     const b = renderHook(() => useScrollLock(true));
     // Still locked.
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
     b.unmount();
     // First lock still active.
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
     a.unmount();
     // Now released.
-    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.position).toBe('');
   });
 
-  it('restores ORIGINAL overflow value, not blank', () => {
+  it('restores ORIGINAL position and overflow values, not blank', () => {
     document.body.style.overflow = 'scroll';
+    document.body.style.position = 'relative';
     const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.position).toBe('fixed');
     expect(document.body.style.overflow).toBe('hidden');
     unmount();
+    expect(document.body.style.position).toBe('relative');
     expect(document.body.style.overflow).toBe('scroll');
   });
 
   it('active=false is a no-op', () => {
     renderHook(() => useScrollLock(false));
+    expect(document.body.style.position).toBe('');
     expect(document.body.style.overflow).toBe('');
+  });
+
+  it('saves scroll position on lock and restores it on unlock', () => {
+    // Simulate the page being scrolled before the modal opens.
+    // jsdom supports window.scrollTo but scrollY/scrollX stay 0 in the test
+    // environment; we patch them to simulate a real scroll position.
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 300 });
+    Object.defineProperty(window, 'scrollX', { configurable: true, value: 50 });
+
+    const { unmount } = renderHook(() => useScrollLock(true));
+    // Body should be offset to counteract the scroll visually.
+    expect(document.body.style.top).toBe('-300px');
+    expect(document.body.style.left).toBe('-50px');
+
+    // Track what scrollTo is called with on unlock.
+    const spy = vi.spyOn(window, 'scrollTo');
+
+    unmount();
+    expect(spy).toHaveBeenCalledWith(50, 300);
+    spy.mockRestore();
+
+    // Restore patched values.
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 0 });
+    Object.defineProperty(window, 'scrollX', { configurable: true, value: 0 });
   });
 });

--- a/packages/design-system/src/components/Modal/useScrollLock.test.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.test.ts
@@ -9,6 +9,7 @@ describe('useScrollLock', () => {
     document.body.style.top = '';
     document.body.style.left = '';
     document.body.style.width = '';
+    document.body.style.paddingRight = '';
     // Reset scroll position (jsdom supports this).
     window.scrollTo(0, 0);
   });
@@ -60,6 +61,40 @@ describe('useScrollLock', () => {
     renderHook(() => useScrollLock(false));
     expect(document.body.style.position).toBe('');
     expect(document.body.style.overflow).toBe('');
+  });
+
+  it('pads body-right by the disappearing scrollbar width to prevent layout shift', () => {
+    // Simulate a vertical scrollbar of 17px by making window.innerWidth
+    // 17 wider than documentElement.clientWidth.
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      configurable: true,
+      value: 1183,
+    });
+
+    const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.paddingRight).toBe('17px');
+    unmount();
+    expect(document.body.style.paddingRight).toBe('');
+
+    // Restore.
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      configurable: true,
+      value: 1024,
+    });
+  });
+
+  it('does not pad when no scrollbar is present (innerWidth === clientWidth)', () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      configurable: true,
+      value: 390,
+    });
+
+    const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.paddingRight).toBe('');
+    unmount();
   });
 
   it('saves scroll position on lock and restores it on unlock', () => {

--- a/packages/design-system/src/components/Modal/useScrollLock.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.ts
@@ -2,18 +2,36 @@ import { useLayoutEffect } from 'react';
 
 // Module-level state shared across all useScrollLock callers.
 let count = 0;
+let savedScrollX = 0;
+let savedScrollY = 0;
 let originalOverflow: string | null = null;
-let originalPaddingRight: string | null = null;
+let originalPosition: string | null = null;
+let originalTop: string | null = null;
+let originalLeft: string | null = null;
+let originalWidth: string | null = null;
 
 function lock() {
   if (count === 0) {
+    savedScrollY = window.scrollY;
+    savedScrollX = window.scrollX;
+
     originalOverflow = document.body.style.overflow;
-    originalPaddingRight = document.body.style.paddingRight;
-    // Compensate for the disappearing scrollbar to avoid horizontal layout shift.
-    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
-    if (scrollbarWidth > 0) {
-      document.body.style.paddingRight = `${scrollbarWidth}px`;
-    }
+    originalPosition = document.body.style.position;
+    originalTop = document.body.style.top;
+    originalLeft = document.body.style.left;
+    originalWidth = document.body.style.width;
+
+    // position: fixed is the iOS-safe scroll lock. It prevents momentum
+    // scrolling rubber-banding past the overlay on Safari, which
+    // `overflow: hidden` alone does not. Negative top/left offsets keep the
+    // visual position unchanged while the body is locked in place.
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${savedScrollY}px`;
+    document.body.style.left = `-${savedScrollX}px`;
+    document.body.style.width = '100%';
+    // overflow: hidden is no longer strictly needed with position: fixed, but
+    // we set it defensively for non-iOS browsers where fixed alone may not
+    // suppress all scroll paths (e.g. keyboard scrolling on desktop).
     document.body.style.overflow = 'hidden';
   }
   count += 1;
@@ -23,17 +41,34 @@ function unlock() {
   count = Math.max(0, count - 1);
   if (count === 0) {
     document.body.style.overflow = originalOverflow ?? '';
-    document.body.style.paddingRight = originalPaddingRight ?? '';
+    document.body.style.position = originalPosition ?? '';
+    document.body.style.top = originalTop ?? '';
+    document.body.style.left = originalLeft ?? '';
+    document.body.style.width = originalWidth ?? '';
+
     originalOverflow = null;
-    originalPaddingRight = null;
+    originalPosition = null;
+    originalTop = null;
+    originalLeft = null;
+    originalWidth = null;
+
+    // Restore the scroll position that was active when the lock was acquired.
+    window.scrollTo(savedScrollX, savedScrollY);
   }
 }
 
 /**
  * Body scroll lock. Ref-counted across all callers so nested modals share
  * the same lock — the first acquire suppresses scrolling, the last release
- * restores it. The original `overflow` value is captured on first acquire
- * and restored on final release (so non-default values are preserved).
+ * restores it.
+ *
+ * Uses the `position: fixed` body technique rather than `overflow: hidden`
+ * alone. On iOS Safari, `overflow: hidden` does not fully suppress momentum
+ * scrolling — the user can still rubber-band the body past a `position:fixed`
+ * overlay. Pinning `body` to `position: fixed` with `top: -<scrollY>px` and
+ * `left: -<scrollX>px` prevents this. Scroll position is saved on lock and
+ * restored via `window.scrollTo` on unlock so the page returns exactly where
+ * the user left it.
  */
 export function useScrollLock(active: boolean): void {
   useLayoutEffect(() => {

--- a/packages/design-system/src/components/Modal/useScrollLock.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.ts
@@ -75,8 +75,28 @@ function unlock() {
     // tells ESLint/Prettier the read is intentional.
     void document.body.offsetHeight;
 
+    const targetX = savedScrollX;
+    const targetY = savedScrollY;
+
     // Restore the scroll position that was active when the lock was acquired.
-    window.scrollTo(savedScrollX, savedScrollY);
+    // Synchronous call works on desktop and most modern browsers.
+    window.scrollTo(targetX, targetY);
+
+    // iOS Safari fallback: the layout pipeline sometimes hasn't fully
+    // committed after removing `position: fixed` from body, so the
+    // synchronous scrollTo above lands at scrollY = 0 (clamped, because
+    // scrollable height is still 0 from the browser's perspective). A
+    // second scrollTo deferred by one animation frame fires after the next
+    // layout commit, at which point the document height is correct and the
+    // scroll lands where it should. If the synchronous call already
+    // succeeded this is a no-op at the same coordinates. If the user has
+    // intentionally scrolled during this frame (extremely unlikely on
+    // close), we respect their position and skip the correction.
+    requestAnimationFrame(() => {
+      if (window.scrollY !== targetY || window.scrollX !== targetX) {
+        window.scrollTo(targetX, targetY);
+      }
+    });
   }
 }
 

--- a/packages/design-system/src/components/Modal/useScrollLock.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.ts
@@ -66,6 +66,15 @@ function unlock() {
     originalWidth = null;
     originalPaddingRight = null;
 
+    // Force a synchronous reflow so the document's scrollable height is
+    // recalculated from the now-restored body BEFORE we scrollTo. Without
+    // this, the browser may clamp scrollTo to maxScrollY = 0 — the height
+    // while body was still fixed — and the page jumps to the top instead
+    // of returning to where the user left it.
+    // Reading offsetHeight is the standard reflow trigger; the void cast
+    // tells ESLint/Prettier the read is intentional.
+    void document.body.offsetHeight;
+
     // Restore the scroll position that was active when the lock was acquired.
     window.scrollTo(savedScrollX, savedScrollY);
   }

--- a/packages/design-system/src/components/Modal/useScrollLock.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.ts
@@ -1,0 +1,44 @@
+import { useLayoutEffect } from 'react';
+
+// Module-level state shared across all useScrollLock callers.
+let count = 0;
+let originalOverflow: string | null = null;
+let originalPaddingRight: string | null = null;
+
+function lock() {
+  if (count === 0) {
+    originalOverflow = document.body.style.overflow;
+    originalPaddingRight = document.body.style.paddingRight;
+    // Compensate for the disappearing scrollbar to avoid horizontal layout shift.
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
+    }
+    document.body.style.overflow = 'hidden';
+  }
+  count += 1;
+}
+
+function unlock() {
+  count = Math.max(0, count - 1);
+  if (count === 0) {
+    document.body.style.overflow = originalOverflow ?? '';
+    document.body.style.paddingRight = originalPaddingRight ?? '';
+    originalOverflow = null;
+    originalPaddingRight = null;
+  }
+}
+
+/**
+ * Body scroll lock. Ref-counted across all callers so nested modals share
+ * the same lock — the first acquire suppresses scrolling, the last release
+ * restores it. The original `overflow` value is captured on first acquire
+ * and restored on final release (so non-default values are preserved).
+ */
+export function useScrollLock(active: boolean): void {
+  useLayoutEffect(() => {
+    if (!active) return;
+    lock();
+    return unlock;
+  }, [active]);
+}

--- a/packages/design-system/src/components/Modal/useScrollLock.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.ts
@@ -2,29 +2,40 @@ import { useLayoutEffect } from 'react';
 
 // Module-level state shared across all useScrollLock callers.
 let count = 0;
-let originalHtmlOverflow: string | null = null;
-let originalBodyOverflow: string | null = null;
+let originalPosition: string | null = null;
+let originalTop: string | null = null;
+let originalLeft: string | null = null;
+let originalWidth: string | null = null;
 let originalPaddingRight: string | null = null;
 
 function lock() {
   if (count === 0) {
-    originalHtmlOverflow = document.documentElement.style.overflow;
-    originalBodyOverflow = document.body.style.overflow;
+    const scrollY = window.scrollY;
+    const scrollX = window.scrollX;
+
+    originalPosition = document.body.style.position;
+    originalTop = document.body.style.top;
+    originalLeft = document.body.style.left;
+    originalWidth = document.body.style.width;
     originalPaddingRight = document.body.style.paddingRight;
 
-    // Compensate for the disappearing scrollbar so the page doesn't shift
-    // horizontally when its scrollbar is removed by overflow:hidden.
+    // Scrollbar-width compensation: body becomes position:fixed, the html
+    // scrollbar disappears, and content would otherwise reflow horizontally
+    // into the freed space. Padding on body absorbs that shift.
     const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
     if (scrollbarWidth > 0) {
       document.body.style.paddingRight = `${scrollbarWidth}px`;
     }
 
-    // Suppress scroll without moving the body. The page stays exactly where
-    // it was — no scroll position to save, no scrollTo dance on unlock, no
-    // smooth-scroll animation to fight. Setting both html and body covers
-    // browsers that route scroll to either element.
-    document.documentElement.style.overflow = 'hidden';
-    document.body.style.overflow = 'hidden';
+    // Fix the body in place at the user's current visual scroll position.
+    // top: -<scrollY>px keeps the content visually where it was; the body
+    // is now out of flow so no scrolling is possible. This avoids the
+    // scroll-to-top jump that `overflow: hidden` causes on the html element
+    // (overflow:hidden clamps scrollTop to 0).
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.left = `-${scrollX}px`;
+    document.body.style.width = '100%';
   }
   count += 1;
 }
@@ -32,13 +43,41 @@ function lock() {
 function unlock() {
   count = Math.max(0, count - 1);
   if (count === 0) {
-    document.documentElement.style.overflow = originalHtmlOverflow ?? '';
-    document.body.style.overflow = originalBodyOverflow ?? '';
+    // Read saved scroll position from the body's top/left offset BEFORE
+    // restoring, so we can scroll back to exactly where we were.
+    const savedY = -parseFloat(document.body.style.top || '0');
+    const savedX = -parseFloat(document.body.style.left || '0');
+
+    document.body.style.position = originalPosition ?? '';
+    document.body.style.top = originalTop ?? '';
+    document.body.style.left = originalLeft ?? '';
+    document.body.style.width = originalWidth ?? '';
     document.body.style.paddingRight = originalPaddingRight ?? '';
 
-    originalHtmlOverflow = null;
-    originalBodyOverflow = null;
+    originalPosition = null;
+    originalTop = null;
+    originalLeft = null;
+    originalWidth = null;
     originalPaddingRight = null;
+
+    // Force a synchronous reflow so the document's scrollable height is
+    // recalculated from the now-restored body BEFORE we scrollTo. Without
+    // this, the browser can clamp scrollTo to maxScrollY = 0 (the height
+    // while body was still fixed) and the page jumps to the top.
+    void document.body.offsetHeight;
+
+    // `behavior: 'instant'` bypasses any smooth-scroll preference and forces
+    // a single-frame jump. Without it, an animated scroll could be
+    // interrupted by post-unlock reflow (focus restoration) and land at an
+    // intermediate position.
+    window.scrollTo({ left: savedX, top: savedY, behavior: 'instant' });
+
+    // Belt-and-braces: re-issue on the next frame in case the synchronous
+    // call was clamped because the layout pipeline hadn't yet committed.
+    // No-op when the first call already succeeded.
+    requestAnimationFrame(() => {
+      window.scrollTo({ left: savedX, top: savedY, behavior: 'instant' });
+    });
   }
 }
 
@@ -47,12 +86,12 @@ function unlock() {
  * the same lock — the first acquire suppresses scrolling, the last release
  * restores it.
  *
- * Uses `overflow: hidden` on both html and body. The page stays exactly
- * where the user left it (no position change, no scroll-position
- * save/restore). Scrollbar-width compensation on body keeps the content
- * area horizontally stable when the disappearing scrollbar would otherwise
- * cause a layout shift. Pairs with `overscroll-behavior: contain` on the
- * overlay (in Modal.module.scss) to prevent touch-scroll chaining on iOS.
+ * Pins `body` to `position: fixed` with `top: -<scrollY>px` and
+ * `left: -<scrollX>px` so the user's visual scroll position is preserved
+ * while the body is locked. On unlock, the saved offsets are read back from
+ * body's inline styles and `scrollTo` returns the page to where the user
+ * left it. `overflow: hidden` on html is intentionally NOT used here
+ * because it clamps `scrollTop` to 0 and jumps the page to the top.
  */
 export function useScrollLock(active: boolean): void {
   useLayoutEffect(() => {

--- a/packages/design-system/src/components/Modal/useScrollLock.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.ts
@@ -2,48 +2,28 @@ import { useLayoutEffect } from 'react';
 
 // Module-level state shared across all useScrollLock callers.
 let count = 0;
-let savedScrollX = 0;
-let savedScrollY = 0;
-let originalOverflow: string | null = null;
-let originalPosition: string | null = null;
-let originalTop: string | null = null;
-let originalLeft: string | null = null;
-let originalWidth: string | null = null;
+let originalHtmlOverflow: string | null = null;
+let originalBodyOverflow: string | null = null;
 let originalPaddingRight: string | null = null;
 
 function lock() {
   if (count === 0) {
-    savedScrollY = window.scrollY;
-    savedScrollX = window.scrollX;
-
-    originalOverflow = document.body.style.overflow;
-    originalPosition = document.body.style.position;
-    originalTop = document.body.style.top;
-    originalLeft = document.body.style.left;
-    originalWidth = document.body.style.width;
+    originalHtmlOverflow = document.documentElement.style.overflow;
+    originalBodyOverflow = document.body.style.overflow;
     originalPaddingRight = document.body.style.paddingRight;
 
-    // Compensate for the disappearing scrollbar BEFORE we make body fixed.
-    // When body becomes position:fixed it leaves the flow → html element
-    // has no overflow → scrollbar disappears → content reflows into the
-    // freed space → page visibly shifts. Pad body by the scrollbar width
-    // so the content area stays exactly where it was.
+    // Compensate for the disappearing scrollbar so the page doesn't shift
+    // horizontally when its scrollbar is removed by overflow:hidden.
     const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
     if (scrollbarWidth > 0) {
       document.body.style.paddingRight = `${scrollbarWidth}px`;
     }
 
-    // position: fixed is the iOS-safe scroll lock. It prevents momentum
-    // scrolling rubber-banding past the overlay on Safari, which
-    // `overflow: hidden` alone does not. Negative top/left offsets keep the
-    // visual position unchanged while the body is locked in place.
-    document.body.style.position = 'fixed';
-    document.body.style.top = `-${savedScrollY}px`;
-    document.body.style.left = `-${savedScrollX}px`;
-    document.body.style.width = '100%';
-    // overflow: hidden is no longer strictly needed with position: fixed, but
-    // we set it defensively for non-iOS browsers where fixed alone may not
-    // suppress all scroll paths (e.g. keyboard scrolling on desktop).
+    // Suppress scroll without moving the body. The page stays exactly where
+    // it was — no scroll position to save, no scrollTo dance on unlock, no
+    // smooth-scroll animation to fight. Setting both html and body covers
+    // browsers that route scroll to either element.
+    document.documentElement.style.overflow = 'hidden';
     document.body.style.overflow = 'hidden';
   }
   count += 1;
@@ -52,56 +32,13 @@ function lock() {
 function unlock() {
   count = Math.max(0, count - 1);
   if (count === 0) {
-    document.body.style.overflow = originalOverflow ?? '';
-    document.body.style.position = originalPosition ?? '';
-    document.body.style.top = originalTop ?? '';
-    document.body.style.left = originalLeft ?? '';
-    document.body.style.width = originalWidth ?? '';
+    document.documentElement.style.overflow = originalHtmlOverflow ?? '';
+    document.body.style.overflow = originalBodyOverflow ?? '';
     document.body.style.paddingRight = originalPaddingRight ?? '';
 
-    originalOverflow = null;
-    originalPosition = null;
-    originalTop = null;
-    originalLeft = null;
-    originalWidth = null;
+    originalHtmlOverflow = null;
+    originalBodyOverflow = null;
     originalPaddingRight = null;
-
-    // Force a synchronous reflow so the document's scrollable height is
-    // recalculated from the now-restored body BEFORE we scrollTo. Without
-    // this, the browser may clamp scrollTo to maxScrollY = 0 — the height
-    // while body was still fixed — and the page jumps to the top instead
-    // of returning to where the user left it.
-    // Reading offsetHeight is the standard reflow trigger; the void cast
-    // tells ESLint/Prettier the read is intentional.
-    void document.body.offsetHeight;
-
-    const targetX = savedScrollX;
-    const targetY = savedScrollY;
-
-    // Restore the scroll position that was active when the lock was acquired.
-    //
-    // `behavior: 'instant'` is critical: it overrides any OS-level or
-    // browser smooth-scroll setting (Chrome's "Smooth Scrolling" flag,
-    // macOS/Windows scroll animations). Without it, `window.scrollTo(x, y)`
-    // starts an async animation — `window.scrollY` reports intermediate
-    // values, and if the page reflows during the animation (e.g., from the
-    // focus restoration that immediately follows), the animation is interrupted
-    // and the page lands at an unpredictable position. `behavior: 'instant'`
-    // forces a synchronous, single-frame jump regardless of user preferences.
-    window.scrollTo({ left: targetX, top: targetY, behavior: 'instant' });
-
-    // iOS Safari / desktop Chrome fallback: the layout pipeline sometimes
-    // hasn't fully committed after removing `position: fixed` from body, so
-    // the synchronous scrollTo above may be clamped to maxScrollY = 0 (the
-    // height while body was still fixed). A second scrollTo deferred by one
-    // animation frame fires after the next layout commit when document height
-    // is correct and the scroll lands where it should. The unconditional call
-    // is safe: if the first already succeeded, this is a no-op at the same
-    // coordinates. The rAF is short enough that intentional user scroll in
-    // this window is not a concern.
-    requestAnimationFrame(() => {
-      window.scrollTo({ left: targetX, top: targetY, behavior: 'instant' });
-    });
   }
 }
 
@@ -110,13 +47,12 @@ function unlock() {
  * the same lock — the first acquire suppresses scrolling, the last release
  * restores it.
  *
- * Uses the `position: fixed` body technique rather than `overflow: hidden`
- * alone. On iOS Safari, `overflow: hidden` does not fully suppress momentum
- * scrolling — the user can still rubber-band the body past a `position:fixed`
- * overlay. Pinning `body` to `position: fixed` with `top: -<scrollY>px` and
- * `left: -<scrollX>px` prevents this. Scroll position is saved on lock and
- * restored via `window.scrollTo` on unlock so the page returns exactly where
- * the user left it.
+ * Uses `overflow: hidden` on both html and body. The page stays exactly
+ * where the user left it (no position change, no scroll-position
+ * save/restore). Scrollbar-width compensation on body keeps the content
+ * area horizontally stable when the disappearing scrollbar would otherwise
+ * cause a layout shift. Pairs with `overscroll-behavior: contain` on the
+ * overlay (in Modal.module.scss) to prevent touch-scroll chaining on iOS.
  */
 export function useScrollLock(active: boolean): void {
   useLayoutEffect(() => {

--- a/packages/design-system/src/components/Modal/useScrollLock.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.ts
@@ -79,23 +79,28 @@ function unlock() {
     const targetY = savedScrollY;
 
     // Restore the scroll position that was active when the lock was acquired.
-    // Synchronous call works on desktop and most modern browsers.
-    window.scrollTo(targetX, targetY);
+    //
+    // `behavior: 'instant'` is critical: it overrides any OS-level or
+    // browser smooth-scroll setting (Chrome's "Smooth Scrolling" flag,
+    // macOS/Windows scroll animations). Without it, `window.scrollTo(x, y)`
+    // starts an async animation — `window.scrollY` reports intermediate
+    // values, and if the page reflows during the animation (e.g., from the
+    // focus restoration that immediately follows), the animation is interrupted
+    // and the page lands at an unpredictable position. `behavior: 'instant'`
+    // forces a synchronous, single-frame jump regardless of user preferences.
+    window.scrollTo({ left: targetX, top: targetY, behavior: 'instant' });
 
-    // iOS Safari fallback: the layout pipeline sometimes hasn't fully
-    // committed after removing `position: fixed` from body, so the
-    // synchronous scrollTo above lands at scrollY = 0 (clamped, because
-    // scrollable height is still 0 from the browser's perspective). A
-    // second scrollTo deferred by one animation frame fires after the next
-    // layout commit, at which point the document height is correct and the
-    // scroll lands where it should. If the synchronous call already
-    // succeeded this is a no-op at the same coordinates. If the user has
-    // intentionally scrolled during this frame (extremely unlikely on
-    // close), we respect their position and skip the correction.
+    // iOS Safari / desktop Chrome fallback: the layout pipeline sometimes
+    // hasn't fully committed after removing `position: fixed` from body, so
+    // the synchronous scrollTo above may be clamped to maxScrollY = 0 (the
+    // height while body was still fixed). A second scrollTo deferred by one
+    // animation frame fires after the next layout commit when document height
+    // is correct and the scroll lands where it should. The unconditional call
+    // is safe: if the first already succeeded, this is a no-op at the same
+    // coordinates. The rAF is short enough that intentional user scroll in
+    // this window is not a concern.
     requestAnimationFrame(() => {
-      if (window.scrollY !== targetY || window.scrollX !== targetX) {
-        window.scrollTo(targetX, targetY);
-      }
+      window.scrollTo({ left: targetX, top: targetY, behavior: 'instant' });
     });
   }
 }

--- a/packages/design-system/src/components/Modal/useScrollLock.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.ts
@@ -9,6 +9,7 @@ let originalPosition: string | null = null;
 let originalTop: string | null = null;
 let originalLeft: string | null = null;
 let originalWidth: string | null = null;
+let originalPaddingRight: string | null = null;
 
 function lock() {
   if (count === 0) {
@@ -20,6 +21,17 @@ function lock() {
     originalTop = document.body.style.top;
     originalLeft = document.body.style.left;
     originalWidth = document.body.style.width;
+    originalPaddingRight = document.body.style.paddingRight;
+
+    // Compensate for the disappearing scrollbar BEFORE we make body fixed.
+    // When body becomes position:fixed it leaves the flow → html element
+    // has no overflow → scrollbar disappears → content reflows into the
+    // freed space → page visibly shifts. Pad body by the scrollbar width
+    // so the content area stays exactly where it was.
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
+    }
 
     // position: fixed is the iOS-safe scroll lock. It prevents momentum
     // scrolling rubber-banding past the overlay on Safari, which
@@ -45,12 +57,14 @@ function unlock() {
     document.body.style.top = originalTop ?? '';
     document.body.style.left = originalLeft ?? '';
     document.body.style.width = originalWidth ?? '';
+    document.body.style.paddingRight = originalPaddingRight ?? '';
 
     originalOverflow = null;
     originalPosition = null;
     originalTop = null;
     originalLeft = null;
     originalWidth = null;
+    originalPaddingRight = null;
 
     // Restore the scroll position that was active when the lock was acquired.
     window.scrollTo(savedScrollX, savedScrollY);

--- a/packages/design-system/src/components/Modal/useScrollLock.ts
+++ b/packages/design-system/src/components/Modal/useScrollLock.ts
@@ -7,8 +7,16 @@ let originalTop: string | null = null;
 let originalLeft: string | null = null;
 let originalWidth: string | null = null;
 let originalPaddingRight: string | null = null;
+let rAFHandle: number | null = null;
 
 function lock() {
+  // Cancel any pending unlock rAF — if a new modal opens before the
+  // previous unlock's rAF fired, we don't want the deferred scrollTo
+  // to fire after the new lock has set body.style.top.
+  if (rAFHandle !== null) {
+    cancelAnimationFrame(rAFHandle);
+    rAFHandle = null;
+  }
   if (count === 0) {
     const scrollY = window.scrollY;
     const scrollX = window.scrollX;
@@ -74,8 +82,10 @@ function unlock() {
 
     // Belt-and-braces: re-issue on the next frame in case the synchronous
     // call was clamped because the layout pipeline hadn't yet committed.
-    // No-op when the first call already succeeded.
-    requestAnimationFrame(() => {
+    // No-op when the first call already succeeded. The handle is tracked so
+    // lock() can cancel this if a new modal opens before the frame fires.
+    rAFHandle = requestAnimationFrame(() => {
+      rAFHandle = null;
       window.scrollTo({ left: savedX, top: savedY, behavior: 'instant' });
     });
   }

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -80,6 +80,7 @@ export type {
   ModalProps,
   ModalSize,
   ModalOverlayVariant,
+  ModalStackMode,
   ModalHeaderProps,
   ModalBodyProps,
   ModalFooterProps,

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -75,6 +75,17 @@ export type {
   ConfirmationVariant,
 } from './components/ConfirmationPopover';
 
+export { Modal } from './components/Modal';
+export type {
+  ModalProps,
+  ModalSize,
+  ModalOverlayVariant,
+  ModalHeaderProps,
+  ModalBodyProps,
+  ModalFooterProps,
+  ModalCloseProps,
+} from './components/Modal';
+
 export { Radio, RadioGroup } from './components/Radio';
 export type {
   RadioProps,

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -222,7 +222,8 @@
   ); /* subtle tint for always-visible pinned rows */
 
   // Modal overlay — dimming backdrop behind modal
-  --color-bg-overlay: rgb(15 23 42 / 50%);
+  --color-bg-overlay: rgb(15 23 42 / 50%); /* solid variant: opaque dim */
+  --color-bg-overlay-blur: rgb(255 255 255 / 30%); /* blur variant: frosted-glass tint, paired with backdrop-filter: blur(8px) */
 
   // Presence dots (Avatar status). Aliases over the existing semantic
   // palette — theme changes propagate.

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -181,6 +181,11 @@
   // 15rem grids side-by-side + var(--space-3) gutter + popover padding.
   --size-daterange-popover-width: 32rem;
 
+  // Modal — width per size variant
+  --size-modal-sm: 400px;
+  --size-modal-md: 560px;
+  --size-modal-lg: 800px;
+
   // Border weights — emphasis = tab underline/focus rings; strong = accent
   // stripes on cards or other "this stands out" visuals.
   --border-width: 1px;
@@ -215,6 +220,9 @@
   --color-bg-row-pinned: var(
     --color-accent-bg-subtle
   ); /* subtle tint for always-visible pinned rows */
+
+  // Modal overlay — dimming backdrop behind modal
+  --color-bg-overlay: rgb(15 23 42 / 50%);
 
   // Presence dots (Avatar status). Aliases over the existing semantic
   // palette — theme changes propagate.

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -223,7 +223,7 @@
 
   // Modal overlay — dimming backdrop behind modal
   --color-bg-overlay: rgb(15 23 42 / 35%); /* solid variant: opaque dim */
-  --color-bg-overlay-blur: rgb(255 255 255 / 30%); /* blur variant: frosted-glass tint, paired with backdrop-filter: blur(8px) */
+  --color-bg-overlay-blur: rgb(255 255 255 / 30%); /* blur variant: frosted-glass tint, paired with backdrop-filter: blur(4px) */
 
   // Presence dots (Avatar status). Aliases over the existing semantic
   // palette — theme changes propagate.

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -222,7 +222,7 @@
   ); /* subtle tint for always-visible pinned rows */
 
   // Modal overlay — dimming backdrop behind modal
-  --color-bg-overlay: rgb(15 23 42 / 50%); /* solid variant: opaque dim */
+  --color-bg-overlay: rgb(15 23 42 / 35%); /* solid variant: opaque dim */
   --color-bg-overlay-blur: rgb(255 255 255 / 30%); /* blur variant: frosted-glass tint, paired with backdrop-filter: blur(8px) */
 
   // Presence dots (Avatar status). Aliases over the existing semantic

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -223,7 +223,9 @@
 
   // Modal overlay — dimming backdrop behind modal
   --color-bg-overlay: rgb(15 23 42 / 35%); /* solid variant: opaque dim */
-  --color-bg-overlay-blur: rgb(255 255 255 / 30%); /* blur variant: frosted-glass tint, paired with backdrop-filter: blur(4px) */
+  --color-bg-overlay-blur: rgb(
+    255 255 255 / 30%
+  ); /* blur variant: frosted-glass tint, paired with backdrop-filter: blur(4px) */
 
   // Presence dots (Avatar status). Aliases over the existing semantic
   // palette — theme changes propagate.

--- a/packages/design-system/vitest.setup.ts
+++ b/packages/design-system/vitest.setup.ts
@@ -1,3 +1,17 @@
+// jsdom doesn't implement window.scrollTo. Modal's useScrollLock invokes
+// it on unlock; stub it so the warnings don't flood test output. Tests that
+// actually need to verify scrollTo calls do it via vi.spyOn locally.
+if (typeof window !== 'undefined' && typeof window.scrollTo === 'function') {
+  // Replace only if not already replaced by a test spy.
+  const original = window.scrollTo;
+  window.scrollTo = ((...args: unknown[]) => {
+    // No-op in jsdom. Real browser behavior is tested via Playwright.
+    void args;
+  }) as typeof window.scrollTo;
+  // Preserve original for restoration if a test needs it.
+  (window as unknown as { __originalScrollTo?: typeof window.scrollTo }).__originalScrollTo = original;
+}
+
 // Extends Vitest's `expect` with the @testing-library/jest-dom matchers
 // (toBeInTheDocument, toHaveAttribute, toBeDisabled, etc.) and registers
 // their TypeScript augmentations.

--- a/packages/design-system/vitest.setup.ts
+++ b/packages/design-system/vitest.setup.ts
@@ -9,7 +9,8 @@ if (typeof window !== 'undefined' && typeof window.scrollTo === 'function') {
     void args;
   }) as typeof window.scrollTo;
   // Preserve original for restoration if a test needs it.
-  (window as unknown as { __originalScrollTo?: typeof window.scrollTo }).__originalScrollTo = original;
+  (window as unknown as { __originalScrollTo?: typeof window.scrollTo }).__originalScrollTo =
+    original;
 }
 
 // Extends Vitest's `expect` with the @testing-library/jest-dom matchers

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -25,6 +25,7 @@ import { BadgeDemo } from './pages/components/BadgeDemo';
 import { TabsDemo } from './pages/components/TabsDemo';
 import { DropdownMenuDemo } from './pages/components/DropdownMenuDemo';
 import { TooltipDemo } from './pages/components/TooltipDemo';
+import { ModalDemo } from './pages/components/ModalDemo';
 import { PopoverDemo } from './pages/components/PopoverDemo';
 import { RadioDemo } from './pages/components/RadioDemo';
 import { CalendarDemo } from './pages/components/CalendarDemo';
@@ -68,6 +69,7 @@ export default function App() {
           <Route path="/components/tabs" element={<TabsDemo />} />
           <Route path="/components/dropdown-menu" element={<DropdownMenuDemo />} />
           <Route path="/components/tooltip" element={<TooltipDemo />} />
+          <Route path="/components/modal" element={<ModalDemo />} />
           <Route path="/components/popover" element={<PopoverDemo />} />
           <Route path="/components/radio" element={<RadioDemo />} />
           <Route path="/components/calendar" element={<CalendarDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -24,6 +24,7 @@ import {
   Layers,
   ArrowRight,
   MessageSquare,
+  AppWindow,
   MoreHorizontal,
   KeyRound,
   PanelLeft,
@@ -103,6 +104,7 @@ const componentGroups = [
     heading: 'Overlays',
     items: [
       { to: '/components/dropdown-menu', label: 'DropdownMenu', icon: MoreHorizontal, end: false },
+      { to: '/components/modal', label: 'Modal', icon: AppWindow, end: false },
       { to: '/components/tooltip', label: 'Tooltip', icon: MessageSquare, end: false },
       { to: '/components/popover', label: 'Popover', icon: PanelLeft, end: false },
       {

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -331,6 +331,61 @@ const items: { to: string; name: string; description: string; preview: React.Rea
     ),
   },
   {
+    to: '/components/modal',
+    name: 'Modal',
+    description: 'Focus-locked dialog with header / body / footer slots and overlay variants.',
+    preview: (
+      <div
+        style={{
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          pointerEvents: 'none',
+        }}
+      >
+        <div
+          style={{
+            width: 180,
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius-md)',
+            background: 'var(--color-bg)',
+            boxShadow: 'var(--shadow-lg)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              padding: '8px 12px',
+              borderBottom: '1px solid var(--color-border)',
+              fontWeight: 600,
+              fontSize: '0.75rem',
+            }}
+          >
+            Dialog title
+          </div>
+          <div style={{ padding: '8px 12px', fontSize: '0.7rem', color: 'var(--color-fg-muted)' }}>
+            Dialog content goes here.
+          </div>
+          <div
+            style={{
+              padding: '8px 12px',
+              borderTop: '1px solid var(--color-border)',
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: 6,
+            }}
+          >
+            <Button size="sm" variant="secondary">
+              Cancel
+            </Button>
+            <Button size="sm">OK</Button>
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  {
     to: '/components/popover',
     name: 'Popover',
     description: 'Non-modal floating panel for arbitrary small surfaces.',

--- a/packages/playground/src/pages/components/ModalDemo.tsx
+++ b/packages/playground/src/pages/components/ModalDemo.tsx
@@ -109,7 +109,7 @@ function OverlayVariantsExample() {
   return (
     <Example
       title="Overlay variants"
-      description='`overlay="solid"` (default) paints the standard dark dim. `overlay="blur"` paints a light frosted-glass effect (`backdrop-filter: blur(8px)`). Open both with rich content visible behind to compare.'
+      description='`overlay="solid"` (default) paints the standard dark dim. `overlay="blur"` paints a light frosted-glass effect (`backdrop-filter: blur(4px)`). Open both with rich content visible behind to compare.'
       code={`<Modal open={open} onOpenChange={setOpen} overlay="blur">
   <Modal.Header>Subtle overlay</Modal.Header>
   <Modal.Body>The page behind is blurred instead of dimmed.</Modal.Body>

--- a/packages/playground/src/pages/components/ModalDemo.tsx
+++ b/packages/playground/src/pages/components/ModalDemo.tsx
@@ -10,7 +10,7 @@ export function ModalDemo() {
     <DemoLayout
       name="Modal"
       componentName="Modal"
-      description="Focus-locked, scroll-locked dialog with a compound API (Header / Body / Footer / Close). Three size presets, solid + blur overlay variants, fullscreen on mobile, display-toggle stacked-modal support."
+      description="Focus-locked, scroll-locked dialog with a compound API (Header / Body / Footer / Close). Three size presets, solid + blur overlay variants, fullscreen on mobile. Stacked-modal support: overlay mode (default) keeps the parent visible; replace mode hides it."
       tsxSource={tsxSource}
       scssSource={scssSource}
       tsxFilename="ModalRoot.tsx"
@@ -242,15 +242,15 @@ function StackedExample() {
   const [confirmOpen, setConfirmOpen] = useState(false);
   return (
     <Example
-      title="Stacked modals (display-toggle model)"
-      description="Opening a modal from inside another stacks. Only the topmost is visible — the outer is hidden via `display: none` while the inner is open (React state preserved), then reappears instantly when the inner closes. Escape closes only the topmost; body scroll stays locked across the whole stack."
-      code={`<Modal open={editOpen} ...>
+      title="Stacked modals (overlay mode — default)"
+      description='Opening a modal from inside another stacks visually. With the default `stackMode="overlay"`, the parent stays visible underneath and the inner overlay is transparent — one effective dim layer for the whole stack, parent context stays in view. Use `stackMode="replace"` to hide the parent via `display: none` (React state preserved) — best for forced steps where parent context is irrelevant. Escape closes only the topmost; body scroll stays locked across the whole stack.'
+      code={`<Modal open={editOpen} stackMode="overlay" ...>
   <Modal.Footer align="space-between">
     <Button variant="danger" onClick={() => setConfirmOpen(true)}>Delete</Button>
     ...
   </Modal.Footer>
 </Modal>
-<Modal open={confirmOpen} ...>
+<Modal open={confirmOpen} stackMode="overlay" ...>
   <Modal.Header>Delete contact?</Modal.Header>
   <Modal.Footer>
     <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>

--- a/packages/playground/src/pages/components/ModalDemo.tsx
+++ b/packages/playground/src/pages/components/ModalDemo.tsx
@@ -1,12 +1,5 @@
 import { useRef, useState } from 'react';
-import {
-  Badge,
-  Button,
-  Cluster,
-  Input,
-  Modal,
-  Stack,
-} from '@eocrm/design-system';
+import { Badge, Button, Cluster, Input, Modal, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import tsxSource from '@lib-source/components/Modal/ModalRoot.tsx?raw';

--- a/packages/playground/src/pages/components/ModalDemo.tsx
+++ b/packages/playground/src/pages/components/ModalDemo.tsx
@@ -1,0 +1,355 @@
+import { useRef, useState } from 'react';
+import {
+  Badge,
+  Button,
+  Cluster,
+  Input,
+  Modal,
+  Stack,
+} from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Modal/ModalRoot.tsx?raw';
+import scssSource from '@lib-source/components/Modal/Modal.module.scss?raw';
+
+export function ModalDemo() {
+  return (
+    <DemoLayout
+      name="Modal"
+      componentName="Modal"
+      description="Focus-locked, scroll-locked dialog with a compound API (Header / Body / Footer / Close). Three size presets, solid + blur overlay variants, fullscreen on mobile, display-toggle stacked-modal support."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="ModalRoot.tsx"
+      scssFilename="Modal.module.scss"
+    >
+      <BasicExample />
+      <SizesExample />
+      <OverlayVariantsExample />
+      <FormExample />
+      <ForcedStepExample />
+      <StackedExample />
+      <NoHeaderExample />
+    </DemoLayout>
+  );
+}
+
+function BasicExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Example
+      title="Basic"
+      description="Controlled open state. Header wires aria-labelledby automatically. Built-in × close button + Esc + overlay click all dismiss."
+      code={`const [open, setOpen] = useState(false);
+<Button onClick={() => setOpen(true)}>Open modal</Button>
+<Modal open={open} onOpenChange={setOpen}>
+  <Modal.Header>Hello</Modal.Header>
+  <Modal.Body>This is a modal.</Modal.Body>
+  <Modal.Footer>
+    <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
+    <Button onClick={() => setOpen(false)}>OK</Button>
+  </Modal.Footer>
+</Modal>`}
+    >
+      <Cluster>
+        <Button onClick={() => setOpen(true)}>Open modal</Button>
+      </Cluster>
+      <Modal open={open} onOpenChange={setOpen}>
+        <Modal.Header>Hello</Modal.Header>
+        <Modal.Body>This is a modal. Click outside, press Esc, or use the × to close.</Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button onClick={() => setOpen(false)}>OK</Button>
+        </Modal.Footer>
+      </Modal>
+    </Example>
+  );
+}
+
+function SizesExample() {
+  const [openSize, setOpenSize] = useState<'sm' | 'md' | 'lg' | null>(null);
+  return (
+    <Example
+      title="Sizes"
+      description='`size="sm"` (400px) / `"md"` (560px, default) / `"lg"` (800px). Below 640px viewport width the modal goes fullscreen regardless.'
+      code={`<Modal size="sm" open={open} onOpenChange={setOpen}>...</Modal>`}
+    >
+      <Cluster gap="sm">
+        <Button variant="secondary" size="sm" onClick={() => setOpenSize('sm')}>
+          Small
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setOpenSize('md')}>
+          Medium
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setOpenSize('lg')}>
+          Large
+        </Button>
+      </Cluster>
+      <Modal
+        open={openSize !== null}
+        onOpenChange={(next) => !next && setOpenSize(null)}
+        size={openSize ?? 'md'}
+      >
+        <Modal.Header>Size: {openSize ?? 'md'}</Modal.Header>
+        <Modal.Body>The width is determined by the `size` prop.</Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button>Close</Button>
+          </Modal.Close>
+        </Modal.Footer>
+      </Modal>
+    </Example>
+  );
+}
+
+function OverlayVariantsExample() {
+  const [variant, setVariant] = useState<'solid' | 'blur' | null>(null);
+  return (
+    <Example
+      title="Overlay variants"
+      description='`overlay="solid"` (default) paints the standard dark dim. `overlay="blur"` paints a light frosted-glass effect (`backdrop-filter: blur(8px)`). Open both with rich content visible behind to compare.'
+      code={`<Modal open={open} onOpenChange={setOpen} overlay="blur">
+  <Modal.Header>Subtle overlay</Modal.Header>
+  <Modal.Body>The page behind is blurred instead of dimmed.</Modal.Body>
+</Modal>`}
+    >
+      <Cluster gap="sm">
+        <Button variant="secondary" size="sm" onClick={() => setVariant('solid')}>
+          Solid overlay
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setVariant('blur')}>
+          Blur overlay
+        </Button>
+      </Cluster>
+      <Modal
+        open={variant !== null}
+        onOpenChange={(next) => !next && setVariant(null)}
+        overlay={variant ?? 'solid'}
+        size="sm"
+      >
+        <Modal.Header>{variant === 'blur' ? 'Frosted glass' : 'Solid dim'}</Modal.Header>
+        <Modal.Body>
+          {variant === 'blur'
+            ? 'Backdrop is blurred. Try opening this on a page with rich content behind to see it best.'
+            : 'Standard dark dimming. Default variant.'}
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button>Close</Button>
+          </Modal.Close>
+        </Modal.Footer>
+      </Modal>
+    </Example>
+  );
+}
+
+function FormExample() {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('Acme Inc.');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  return (
+    <Example
+      title="Form modal with initial focus"
+      description="Use `initialFocusRef` to focus the first input on open. Body content stays in a Stack."
+      code={`const inputRef = useRef<HTMLInputElement>(null);
+<Modal open={open} onOpenChange={setOpen} initialFocusRef={inputRef}>
+  <Modal.Header>Edit contact</Modal.Header>
+  <Modal.Body>
+    <label>
+      Company name
+      <Input ref={inputRef} value={name} onChange={...} />
+    </label>
+  </Modal.Body>
+  <Modal.Footer>...</Modal.Footer>
+</Modal>`}
+    >
+      <Cluster>
+        <Button onClick={() => setOpen(true)}>Edit contact</Button>
+      </Cluster>
+      <Modal open={open} onOpenChange={setOpen} initialFocusRef={inputRef}>
+        <Modal.Header>Edit contact</Modal.Header>
+        <Modal.Body>
+          <Stack gap="md">
+            <label>
+              Company name
+              <Input
+                ref={inputRef}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Acme Inc."
+              />
+            </label>
+            <label>
+              Owner
+              <Input placeholder="Sara" />
+            </label>
+          </Stack>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button onClick={() => setOpen(false)}>Save</Button>
+        </Modal.Footer>
+      </Modal>
+    </Example>
+  );
+}
+
+function ForcedStepExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Example
+      title="Forced step (non-dismissible)"
+      description="`disableEscapeClose` + `dismissOnOverlayClick={false}` + `<Modal.Header closeButton={false}>` + no `<Modal.Close>` = the user can only resolve via the in-modal action."
+      code={`<Modal
+  open
+  onOpenChange={() => {}}
+  size="sm"
+  disableEscapeClose
+  dismissOnOverlayClick={false}
+  aria-label="Session expired"
+>
+  <Modal.Header closeButton={false}>Session expired</Modal.Header>
+  <Modal.Body>Please sign in again.</Modal.Body>
+  <Modal.Footer>
+    <Button onClick={reauth}>Sign in</Button>
+  </Modal.Footer>
+</Modal>`}
+    >
+      <Cluster>
+        <Button variant="danger" onClick={() => setOpen(true)}>
+          Trigger forced step
+        </Button>
+      </Cluster>
+      <Modal
+        open={open}
+        onOpenChange={() => {}}
+        size="sm"
+        disableEscapeClose
+        dismissOnOverlayClick={false}
+        aria-label="Session expired"
+      >
+        <Modal.Header closeButton={false}>Session expired</Modal.Header>
+        <Modal.Body>
+          This modal can&apos;t be dismissed via Esc or overlay click. Use the button below.
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={() => setOpen(false)}>Sign in again</Button>
+        </Modal.Footer>
+      </Modal>
+    </Example>
+  );
+}
+
+function StackedExample() {
+  const [editOpen, setEditOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  return (
+    <Example
+      title="Stacked modals (display-toggle model)"
+      description="Opening a modal from inside another stacks. Only the topmost is visible — the outer is hidden via `display: none` while the inner is open (React state preserved), then reappears instantly when the inner closes. Escape closes only the topmost; body scroll stays locked across the whole stack."
+      code={`<Modal open={editOpen} ...>
+  <Modal.Footer align="space-between">
+    <Button variant="danger" onClick={() => setConfirmOpen(true)}>Delete</Button>
+    ...
+  </Modal.Footer>
+</Modal>
+<Modal open={confirmOpen} ...>
+  <Modal.Header>Delete contact?</Modal.Header>
+  <Modal.Footer>
+    <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
+    <Button variant="danger" onClick={confirmDelete}>Delete</Button>
+  </Modal.Footer>
+</Modal>`}
+    >
+      <Cluster>
+        <Button onClick={() => setEditOpen(true)}>Edit (with delete inside)</Button>
+      </Cluster>
+      <Modal open={editOpen} onOpenChange={setEditOpen} size="md">
+        <Modal.Header>Edit contact</Modal.Header>
+        <Modal.Body>
+          <Stack gap="md">
+            <label>
+              Company
+              <Input defaultValue="Acme Inc." />
+            </label>
+            <Cluster gap="sm" align="center">
+              <Badge tone="success">Active</Badge>
+            </Cluster>
+          </Stack>
+        </Modal.Body>
+        <Modal.Footer align="space-between">
+          <Button variant="danger" onClick={() => setConfirmOpen(true)}>
+            Delete
+          </Button>
+          <Cluster gap="sm">
+            <Modal.Close>
+              <Button variant="secondary">Cancel</Button>
+            </Modal.Close>
+            <Button onClick={() => setEditOpen(false)}>Save</Button>
+          </Cluster>
+        </Modal.Footer>
+      </Modal>
+      <Modal open={confirmOpen} onOpenChange={setConfirmOpen} size="sm">
+        <Modal.Header>Delete contact?</Modal.Header>
+        <Modal.Body>This cannot be undone.</Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button
+            variant="danger"
+            onClick={() => {
+              setConfirmOpen(false);
+              setEditOpen(false);
+            }}
+          >
+            Delete
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </Example>
+  );
+}
+
+function NoHeaderExample() {
+  return (
+    <Example
+      title="No Header (aria-label fallback)"
+      description="Omit `<Modal.Header>` and pass `aria-label` for the dialog's accessible name."
+      code={`<Modal open={open} onOpenChange={setOpen} aria-label="Confirm action">
+  <Modal.Body>Are you sure?</Modal.Body>
+  <Modal.Footer>...</Modal.Footer>
+</Modal>`}
+    >
+      <NoHeaderInline />
+    </Example>
+  );
+}
+
+function NoHeaderInline() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Cluster>
+        <Button variant="secondary" onClick={() => setOpen(true)}>
+          Open (no Header)
+        </Button>
+      </Cluster>
+      <Modal open={open} onOpenChange={setOpen} aria-label="Confirm action">
+        <Modal.Body>
+          <p style={{ margin: 0 }}>Are you sure you want to continue?</p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button onClick={() => setOpen(false)}>Continue</Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -18,6 +18,7 @@ export type ComponentName =
   | 'InlineDatePicker'
   | 'InlineDateRangePicker'
   | 'Input'
+  | 'Modal'
   | 'Pagination'
   | 'PasswordInput'
   | 'PasswordStrengthMeter'


### PR DESCRIPTION
## Summary

- New `<Modal>` compound component (`ModalRoot` + `Header` / `Body` / `Footer` / `Close`) with hand-rolled focus trap, ref-counted body scroll lock, and a module-level depth registry. Controlled-only API; portals to `document.body`; `@starting-style` animations matching Popover.
- Three size presets (`sm` / `md` / `lg`), with `sm` getting compact paddings + smaller close button. Fullscreen on viewports ≤ 640px via `100dvw / 100dvh` progressive enhancement.
- Two overlay variants: `overlay="solid"` (default, dark dim at 35%) and `overlay="blur"` (frosted-glass via `backdrop-filter: blur(4px)`).
- Stacked modals use a display-toggle model: only the topmost is visible (lower modals are `display: none` with React state preserved); the stack registry has a subscription mechanism so sibling modals re-sync `isTop` on mutation.
- Focus trap bypass for known floating-UI portals (`[data-popover-content]`, `[data-dropdown-menu-content]`, `[role="tooltip" | "menu" | "listbox" | "dialog"]`) so Popovers/DropdownMenus/Tooltips opened inside a modal stay interactive.

## Test plan

- [x] Unit tests for the three hooks (`useFocusTrap` 9, `useScrollLock` 5, `useModalStack` 10)
- [x] Integration tests for the assembled component (23 cases): ARIA wiring, Esc routing, overlay click, Modal.Close, initial focus, focus restore, scroll lock, stacked Esc, forced-step combo, overlay variants, stack display-position, popover/dropdown focus-bypass, no-warn under labelling
- [x] All gates green: `make test` (1145/1145), `make build-lib`, `make lint`, `make build`, `npm pack --dry-run` (no test files in tarball)
- [x] Playground demo at `/components/modal` with 7 examples (basic, sizes, overlay variants, form + initial focus, forced step, stacked, no-Header aria-label)
- [x] Hard-Rule-8 review-fix cycle: 3 rounds (round 1: 1 Critical + 3 Important fixed; round 2: 4 Important doc-drift fixed; round 3: clean exit)
- [x] Mobile verified via Playwright at 390×844 viewport — fullscreen layout correct after the `100dvh` / `align-items: flex-start` fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)