### PR TITLE
Grid: 2D layout primitive (auto-fit + fixed columns, token-driven gap, polymorphic as)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-grid.md
+++ b/docs/superpowers/plans/2026-05-23-grid.md
@@ -50,6 +50,7 @@ packages/playground/src/pages/mockups/registry.ts            ← MODIFY: 'Grid' 
 The component, its styles, and the folder barrel. Single commit since Grid is small and these files all change together.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Grid/Grid.tsx`
 - Create: `packages/design-system/src/components/Grid/Grid.module.scss`
 - Create: `packages/design-system/src/components/Grid/index.ts`
@@ -64,6 +65,7 @@ git log --oneline -3
 ```
 
 Expected:
+
 - Branch: `feat/grid`
 - Working tree clean
 - Most recent commit: `dee4ebe Grid: design spec ...`
@@ -342,13 +344,7 @@ Notes for the implementer:
 
 ```ts
 export { Grid } from './Grid';
-export type {
-  GridProps,
-  GridGap,
-  GridAlignItems,
-  GridJustifyItems,
-  GridAs,
-} from './Grid';
+export type { GridProps, GridGap, GridAlignItems, GridJustifyItems, GridAs } from './Grid';
 ```
 
 - [ ] **Step 5: Verify build + lint**
@@ -390,6 +386,7 @@ EOF
 Cover the public surface: default behavior, columns/minColumnWidth template generation, gap classes, alignItems/justifyItems classes, `as` polymorphism, className merge, style merge, ref forwarding, and a TS-level mutual exclusion check.
 
 **Files:**
+
 - Create: `packages/design-system/src/components/Grid/Grid.test.tsx`
 
 - [ ] **Step 1: Write the failing tests**
@@ -562,6 +559,7 @@ EOF
 Tiny prose-and-export changes that unblock structure tests and update the docs to point at the new primitive.
 
 **Files:**
+
 - Modify: `packages/design-system/src/index.ts`
 - Modify: `packages/design-system/AGENTS.md`
 - Modify: `packages/design-system/src/components/Stack/Stack.tsx`
@@ -693,6 +691,7 @@ EOF
 ## Task 4 — Playground demo + nav wiring (4 places)
 
 **Files:**
+
 - Create: `packages/playground/src/pages/components/GridDemo.tsx`
 - Modify: `packages/playground/src/App.tsx`
 - Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
@@ -930,10 +929,11 @@ Important caveats — match precedents:
 In `packages/playground/src/App.tsx`:
 
 Add import + route:
+
 ```tsx
 import { GridDemo } from './pages/components/GridDemo';
 // Inside <Routes>:
-<Route path="/components/grid" element={<GridDemo />} />
+<Route path="/components/grid" element={<GridDemo />} />;
 ```
 
 In `packages/playground/src/layout/AppShell/AppShell.tsx`, find the `componentGroups` array's **Layout** group (alongside Stack and Cluster). Add:
@@ -1095,21 +1095,21 @@ Return the PR URL.
 
 **Spec coverage:**
 
-| Spec section | Task implementing it |
-|---|---|
-| `Grid.tsx` + `Grid.module.scss` + `index.ts` | 1 |
-| Discriminated-union props with `never` | 1 (types) + 2 (TS test) |
-| Default minColumnWidth="240px" when neither prop set | 1 (component logic) + 2 (test) |
-| Gap scale matching Stack/Cluster | 1 (SCSS + classes) + 2 (tests) |
-| alignItems / justifyItems | 1 (component + SCSS) + 2 (tests) |
-| Limited polymorphic `as` (10 elements) | 1 (component) + 2 (div/section/ul tests cover the pattern) |
-| --grid-columns CSS custom prop wiring | 1 (component + SCSS) + 2 (tests) |
-| Public exports | 3 |
-| AGENTS.md TL;DR | 3 |
-| Stack/Cluster JSDoc cross-link updates | 3 |
-| Playground demo (6 examples) | 4 |
-| Nav wiring (4 places) | 4 |
-| Hard Rule 8 + PR | 5 |
+| Spec section                                         | Task implementing it                                       |
+| ---------------------------------------------------- | ---------------------------------------------------------- |
+| `Grid.tsx` + `Grid.module.scss` + `index.ts`         | 1                                                          |
+| Discriminated-union props with `never`               | 1 (types) + 2 (TS test)                                    |
+| Default minColumnWidth="240px" when neither prop set | 1 (component logic) + 2 (test)                             |
+| Gap scale matching Stack/Cluster                     | 1 (SCSS + classes) + 2 (tests)                             |
+| alignItems / justifyItems                            | 1 (component + SCSS) + 2 (tests)                           |
+| Limited polymorphic `as` (10 elements)               | 1 (component) + 2 (div/section/ul tests cover the pattern) |
+| --grid-columns CSS custom prop wiring                | 1 (component + SCSS) + 2 (tests)                           |
+| Public exports                                       | 3                                                          |
+| AGENTS.md TL;DR                                      | 3                                                          |
+| Stack/Cluster JSDoc cross-link updates               | 3                                                          |
+| Playground demo (6 examples)                         | 4                                                          |
+| Nav wiring (4 places)                                | 4                                                          |
+| Hard Rule 8 + PR                                     | 5                                                          |
 
 **Placeholder scan:** None. Every step has the actual code or command.
 

--- a/docs/superpowers/plans/2026-05-23-grid.md
+++ b/docs/superpowers/plans/2026-05-23-grid.md
@@ -1,0 +1,1131 @@
+# Grid Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Grid>` — a 2D layout primitive wrapping CSS Grid with token-driven gap, mutually-exclusive `columns` (fixed) / `minColumnWidth` (auto-fit responsive), `alignItems` / `justifyItems`, and a limited polymorphic `as` prop.
+
+**Architecture:** Single-file forwardRef component plus SCSS module. No behavior, no portal, no compound API. Discriminated-union TypeScript props enforce mutual exclusion between `columns` and `minColumnWidth` at compile time. The `--grid-columns` CSS custom property — set inline by the component — drives `grid-template-columns` from SCSS so default fallbacks survive even if a consumer strips the inline style.
+
+**Tech Stack:** React 18 + TypeScript (source-distributed). No new packages, no new tokens. CSS Modules + SCSS. Vitest + RTL for tests.
+
+**Source of truth:** `docs/superpowers/specs/2026-05-23-grid-design.md` (commit `dee4ebe`). Read it for any requirement not explicit in a task.
+
+**Branch:** `feat/grid`. Commit per task. Open the PR after the Hard-Rule-8 cycle (Task 5).
+
+---
+
+## File Structure
+
+```
+packages/design-system/src/components/Grid/
+  Grid.tsx              ← forwardRef + spread; renders `as` element; sets --grid-columns inline
+  Grid.module.scss      ← .grid base + gap/alignItems/justifyItems classes (camelCase, matching Stack/Cluster)
+  Grid.test.tsx         ← ~12 unit tests including a TS-level @ts-expect-error for mutual exclusion
+  index.ts              ← Public re-exports
+
+packages/design-system/src/index.ts                          ← MODIFY: re-export Grid + types
+packages/design-system/src/components/Stack/Stack.tsx        ← MODIFY: JSDoc "use CSS Grid" → "use <Grid>"
+packages/design-system/src/components/Cluster/Cluster.tsx    ← MODIFY: JSDoc "use CSS Grid" → "use <Grid>"
+packages/design-system/AGENTS.md                             ← MODIFY: add Grid TL;DR near Stack/Cluster
+
+packages/playground/src/pages/components/GridDemo.tsx        ← NEW: 6 examples
+packages/playground/src/App.tsx                              ← MODIFY: route
+packages/playground/src/layout/AppShell/AppShell.tsx         ← MODIFY: sidebar nav (Layout group)
+packages/playground/src/pages/components/ComponentsIndex.tsx ← MODIFY: grid tile
+packages/playground/src/pages/mockups/registry.ts            ← MODIFY: 'Grid' in ComponentName union
+```
+
+**Decomposition rationale:**
+
+- One bundled commit for source + styles + folder index (Task 1). Grid is small enough that splitting `Grid.tsx` from `Grid.module.scss` adds no review value — the SCSS class names are direct consumers of the TS prop unions.
+- Tests as a separate commit (Task 2). Independent review of test coverage. Matches Stack/Cluster precedent.
+- Library plumbing + cross-link doc updates in one task (Task 3). All three changes (`src/index.ts`, `Stack.tsx` JSDoc, `Cluster.tsx` JSDoc, `AGENTS.md`) are tiny and conceptually related.
+- Playground + nav in one task (Task 4). Same shape as Modal/Drawer.
+- Final closeout in one task (Task 5).
+
+---
+
+## Task 1 — `Grid.tsx` + `Grid.module.scss` + `index.ts`
+
+The component, its styles, and the folder barrel. Single commit since Grid is small and these files all change together.
+
+**Files:**
+- Create: `packages/design-system/src/components/Grid/Grid.tsx`
+- Create: `packages/design-system/src/components/Grid/Grid.module.scss`
+- Create: `packages/design-system/src/components/Grid/index.ts`
+
+- [ ] **Step 1: Verify branch + clean tree**
+
+```bash
+cd /home/dpws/projects/design-system
+git status
+git branch --show-current
+git log --oneline -3
+```
+
+Expected:
+- Branch: `feat/grid`
+- Working tree clean
+- Most recent commit: `dee4ebe Grid: design spec ...`
+
+- [ ] **Step 2: Create the SCSS module**
+
+```bash
+mkdir -p packages/design-system/src/components/Grid
+```
+
+Create `packages/design-system/src/components/Grid/Grid.module.scss`:
+
+```scss
+.grid {
+  display: grid;
+  grid-template-columns: var(--grid-columns, repeat(auto-fit, minmax(240px, 1fr)));
+}
+
+// Gap presets — mirror Stack/Cluster scale + camelCase naming
+.gapXs {
+  gap: var(--space-1);
+}
+
+.gapSm {
+  gap: var(--space-2);
+}
+
+.gapMd {
+  gap: var(--space-3);
+}
+
+.gapLg {
+  gap: var(--space-4);
+}
+
+.gapXl {
+  gap: var(--space-6);
+}
+
+.gap2xl {
+  gap: var(--space-8);
+}
+
+// Item alignment — cross-axis
+.alignItemsStart {
+  align-items: start;
+}
+
+.alignItemsCenter {
+  align-items: center;
+}
+
+.alignItemsEnd {
+  align-items: end;
+}
+
+.alignItemsStretch {
+  align-items: stretch;
+}
+
+// Item alignment — main-axis
+.justifyItemsStart {
+  justify-items: start;
+}
+
+.justifyItemsCenter {
+  justify-items: center;
+}
+
+.justifyItemsEnd {
+  justify-items: end;
+}
+
+.justifyItemsStretch {
+  justify-items: stretch;
+}
+```
+
+- [ ] **Step 3: Create the component**
+
+Create `packages/design-system/src/components/Grid/Grid.tsx`:
+
+```tsx
+import { forwardRef, type CSSProperties, type HTMLAttributes, type ReactElement } from 'react';
+import clsx from 'clsx';
+import styles from './Grid.module.scss';
+
+/** Gap between cells. Same scale as Stack/Cluster: pixels 4/8/12/16/24/32. */
+export type GridGap = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+/** Cross-axis (vertical within row) alignment of each cell. */
+export type GridAlignItems = 'start' | 'center' | 'end' | 'stretch';
+
+/** Main-axis (horizontal within track) alignment of each cell. */
+export type GridJustifyItems = 'start' | 'center' | 'end' | 'stretch';
+
+/** Limited polymorphic element type. Covers the layout / semantic elements Grid is likely to render as. */
+export type GridAs =
+  | 'div'
+  | 'section'
+  | 'ul'
+  | 'ol'
+  | 'nav'
+  | 'main'
+  | 'aside'
+  | 'article'
+  | 'header'
+  | 'footer';
+
+interface GridBaseProps {
+  /**
+   * Gap between cells.
+   * `xs` (4) / `sm` (8) / `md` (12, default) / `lg` (16) / `xl` (24) / `2xl` (32).
+   * Same scale as Stack and Cluster.
+   */
+  gap?: GridGap;
+  /**
+   * Cross-axis (vertical within row) alignment of each cell. Default browser
+   * behavior is `stretch`; omit to use the default.
+   */
+  alignItems?: GridAlignItems;
+  /**
+   * Main-axis (horizontal within track) alignment of each cell. Default
+   * browser behavior is `stretch`; omit to use the default.
+   */
+  justifyItems?: GridJustifyItems;
+  /** Element to render. Default `'div'`. Limited to common layout / semantic elements. */
+  as?: GridAs;
+}
+
+interface GridFixedColumns extends GridBaseProps, HTMLAttributes<HTMLElement> {
+  /** Fixed number of equal-width columns. Mutually exclusive with `minColumnWidth`. */
+  columns: number;
+  minColumnWidth?: never;
+}
+
+interface GridAutoFit extends GridBaseProps, HTMLAttributes<HTMLElement> {
+  /**
+   * Minimum column width for auto-fit responsive layout. Columns reflow
+   * based on container width — no breakpoints needed. CSS length string
+   * like `'240px'` or `'15rem'`. Defaults to `'240px'` when neither
+   * `columns` nor `minColumnWidth` is provided.
+   */
+  minColumnWidth?: string;
+  columns?: never;
+}
+
+/** Public props — discriminated union enforces mutual exclusion. */
+export type GridProps = GridFixedColumns | GridAutoFit;
+
+const gapClass: Record<GridGap, string> = {
+  xs: styles.gapXs,
+  sm: styles.gapSm,
+  md: styles.gapMd,
+  lg: styles.gapLg,
+  xl: styles.gapXl,
+  '2xl': styles.gap2xl,
+};
+
+const alignItemsClass: Record<GridAlignItems, string> = {
+  start: styles.alignItemsStart,
+  center: styles.alignItemsCenter,
+  end: styles.alignItemsEnd,
+  stretch: styles.alignItemsStretch,
+};
+
+const justifyItemsClass: Record<GridJustifyItems, string> = {
+  start: styles.justifyItemsStart,
+  center: styles.justifyItemsCenter,
+  end: styles.justifyItemsEnd,
+  stretch: styles.justifyItemsStretch,
+};
+
+/**
+ * 2D layout primitive — CSS Grid wrapper with token-driven gap. Sibling to
+ * `<Stack>` (vertical) and `<Cluster>` (horizontal-with-wrap). Use when you
+ * need equal-width columns OR a responsive tile layout that reflows by
+ * container width (no breakpoints needed).
+ *
+ * Pick exactly one of `columns` (fixed N equal columns) or `minColumnWidth`
+ * (auto-fit responsive). TypeScript enforces this — passing both is a
+ * compile error. If you pass neither, Grid defaults to
+ * `minColumnWidth="240px"`.
+ *
+ * @example
+ * // Dashboard tile layout — auto-fits to viewport.
+ * <Grid gap="md">
+ *   {metrics.map(m => <Card key={m.id}>{m.label}: {m.value}</Card>)}
+ * </Grid>
+ *
+ * @example
+ * // Two-column form — exactly 2 equal columns at any width.
+ * <Grid columns={2} gap="lg">
+ *   <Input label="First name" />
+ *   <Input label="Last name" />
+ *   <Input label="Email" />
+ *   <Input label="Phone" />
+ * </Grid>
+ *
+ * @example
+ * // Photo gallery — auto-fit with smaller minimum.
+ * <Grid minColumnWidth="160px" gap="sm">
+ *   {photos.map(p => <img key={p.id} src={p.src} />)}
+ * </Grid>
+ *
+ * @example
+ * // Semantic element via `as`.
+ * <Grid as="section" columns={3} gap="md" aria-labelledby="dashboard-title">
+ *   <Card>...</Card>
+ *   <Card>...</Card>
+ *   <Card>...</Card>
+ * </Grid>
+ *
+ * @remarks When NOT to use
+ * - For vertical flow with a single column — use `<Stack>`.
+ * - For unaligned wrapping rows (toolbars, tag lists) — use `<Cluster>`.
+ * - For asymmetric or named tracks (`auto 1fr`, named lines) — not
+ *   supported in v1; use raw CSS Grid via `className`.
+ * - For per-cell span / placement — same answer; raw CSS Grid.
+ *
+ * @remarks Anti-patterns
+ * - ❌ `<Grid>` for a list of clickable items — semantics matter. Use
+ *   `<ul><li>` or render Grid with `as="ul"` and `<li>` children.
+ * - ❌ `<Grid as="ul">` with non-`<li>` children. The component doesn't
+ *   enforce list semantics; consumers must.
+ * - ❌ Inline `gridTemplateColumns` in the `style` prop instead of using
+ *   `columns` / `minColumnWidth`. Bypasses tokens and the responsive default.
+ */
+export const Grid = forwardRef<HTMLElement, GridProps>(function Grid(
+  {
+    gap = 'md',
+    alignItems,
+    justifyItems,
+    as = 'div',
+    columns,
+    minColumnWidth,
+    className,
+    style,
+    ...rest
+  },
+  ref,
+) {
+  const template =
+    columns !== undefined
+      ? `repeat(${columns}, minmax(0, 1fr))`
+      : `repeat(auto-fit, minmax(${minColumnWidth ?? '240px'}, 1fr))`;
+
+  // `as` is a string union of intrinsic JSX elements; index into JSX.IntrinsicElements via createElement.
+  // Using uppercase `Tag` so JSX treats it as a component, then casting through unknown for the limited union.
+  const Tag = as as unknown as 'div';
+
+  return (
+    <Tag
+      ref={ref as React.Ref<HTMLDivElement>}
+      className={clsx(
+        styles.grid,
+        gapClass[gap],
+        alignItems && alignItemsClass[alignItems],
+        justifyItems && justifyItemsClass[justifyItems],
+        className,
+      )}
+      style={{ ...(style as CSSProperties), ['--grid-columns' as string]: template }}
+      {...(rest as HTMLAttributes<HTMLDivElement>)}
+    />
+  );
+}) as <T extends GridProps>(props: T & { ref?: React.Ref<HTMLElement> }) => ReactElement;
+```
+
+Notes for the implementer:
+
+- The double cast (`as unknown as 'div'`) on `Tag` is the standard workaround for rendering a string-union element when you don't want full polymorphic typing. It compiles cleanly and at runtime React just uses the element name string.
+- The outer `as <T extends GridProps>` cast at the end keeps the discriminated-union behavior visible to consumers (the type error for `<Grid columns={2} minColumnWidth="240px" />` is what we want).
+- `--grid-columns` is appended to the style object AFTER `...style` so the component's value wins if the consumer didn't explicitly set their own. If a consumer wants to override, they can pass `style={{ '--grid-columns': 'custom' }}` and it'll come first in the merge — but the inline template re-applies after, so the component wins. If consumers need true override, they should use `className` + their own CSS, which is the canonical way. (If this turns out to bite, swap the spread order. For v1 keep component-wins.)
+
+- [ ] **Step 4: Create the folder `index.ts`**
+
+```ts
+export { Grid } from './Grid';
+export type {
+  GridProps,
+  GridGap,
+  GridAlignItems,
+  GridJustifyItems,
+  GridAs,
+} from './Grid';
+```
+
+- [ ] **Step 5: Verify build + lint**
+
+```bash
+cd /home/dpws/projects/design-system
+make build-lib 2>&1 | tail -5
+make lint 2>&1 | tail -5
+```
+
+Expected: both clean. If stylelint flags anything (raw values, missing comments, etc.), fix minimally — Stack.module.scss is the precedent for what's allowed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Grid/Grid.tsx \
+        packages/design-system/src/components/Grid/Grid.module.scss \
+        packages/design-system/src/components/Grid/index.ts
+git commit -m "$(cat <<'EOF'
+Grid: 2D layout primitive (forwardRef + SCSS + barrel)
+
+Discriminated-union props for mutual exclusion between fixed `columns`
+and responsive `minColumnWidth`. Token-driven gap matching Stack/Cluster.
+Optional alignItems/justifyItems. Limited polymorphic `as` prop covering
+10 common semantic elements without the full polymorphic-ref TS dance.
+
+The --grid-columns CSS custom prop is set inline so default fallbacks
+survive even if a consumer strips the inline style attribute.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2 — `Grid.test.tsx`
+
+Cover the public surface: default behavior, columns/minColumnWidth template generation, gap classes, alignItems/justifyItems classes, `as` polymorphism, className merge, style merge, ref forwarding, and a TS-level mutual exclusion check.
+
+**Files:**
+- Create: `packages/design-system/src/components/Grid/Grid.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { Grid, type GridAlignItems, type GridGap, type GridJustifyItems } from './Grid';
+
+const capitalize = (s: string) => s[0]!.toUpperCase() + s.slice(1);
+
+describe('<Grid>', () => {
+  it('renders its children', () => {
+    render(<Grid>Hello</Grid>);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('defaults to auto-fit with minColumnWidth=240px', () => {
+    const { container } = render(<Grid>x</Grid>);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.getPropertyValue('--grid-columns')).toBe(
+      'repeat(auto-fit, minmax(240px, 1fr))',
+    );
+  });
+
+  it('applies the default gap (md) when no gap prop is given', () => {
+    const { container } = render(<Grid>x</Grid>);
+    expect((container.firstChild as HTMLElement).className).toMatch(/gapMd/);
+  });
+
+  it('columns={4} sets --grid-columns to repeat(4, minmax(0, 1fr))', () => {
+    const { container } = render(<Grid columns={4}>x</Grid>);
+    expect((container.firstChild as HTMLElement).style.getPropertyValue('--grid-columns')).toBe(
+      'repeat(4, minmax(0, 1fr))',
+    );
+  });
+
+  it('minColumnWidth="200px" sets --grid-columns to repeat(auto-fit, minmax(200px, 1fr))', () => {
+    const { container } = render(<Grid minColumnWidth="200px">x</Grid>);
+    expect((container.firstChild as HTMLElement).style.getPropertyValue('--grid-columns')).toBe(
+      'repeat(auto-fit, minmax(200px, 1fr))',
+    );
+  });
+
+  it.each<GridGap>(['xs', 'sm', 'md', 'lg', 'xl', '2xl'])('applies the %s gap class', (gap) => {
+    const { container } = render(<Grid gap={gap}>x</Grid>);
+    const expected = gap === '2xl' ? 'gap2xl' : `gap${capitalize(gap)}`;
+    expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(expected));
+  });
+
+  it.each<GridAlignItems>(['start', 'center', 'end', 'stretch'])(
+    'applies alignItems=%s class when set',
+    (a) => {
+      const { container } = render(<Grid alignItems={a}>x</Grid>);
+      expect((container.firstChild as HTMLElement).className).toMatch(
+        new RegExp(`alignItems${capitalize(a)}`),
+      );
+    },
+  );
+
+  it.each<GridJustifyItems>(['start', 'center', 'end', 'stretch'])(
+    'applies justifyItems=%s class when set',
+    (j) => {
+      const { container } = render(<Grid justifyItems={j}>x</Grid>);
+      expect((container.firstChild as HTMLElement).className).toMatch(
+        new RegExp(`justifyItems${capitalize(j)}`),
+      );
+    },
+  );
+
+  it('applies no alignItems/justifyItems class when those props are omitted', () => {
+    const { container } = render(<Grid>x</Grid>);
+    const className = (container.firstChild as HTMLElement).className;
+    expect(className).not.toMatch(/alignItems/);
+    expect(className).not.toMatch(/justifyItems/);
+  });
+
+  it('renders as <div> by default', () => {
+    const { container } = render(<Grid>x</Grid>);
+    expect((container.firstChild as HTMLElement).tagName).toBe('DIV');
+  });
+
+  it('renders as the element specified by `as`', () => {
+    const { container } = render(<Grid as="section">x</Grid>);
+    expect((container.firstChild as HTMLElement).tagName).toBe('SECTION');
+  });
+
+  it('renders as <ul>', () => {
+    const { container } = render(
+      <Grid as="ul">
+        <li>a</li>
+      </Grid>,
+    );
+    expect((container.firstChild as HTMLElement).tagName).toBe('UL');
+  });
+
+  it('merges the className prop', () => {
+    const { container } = render(<Grid className="external">x</Grid>);
+    expect((container.firstChild as HTMLElement).className).toMatch(/external/);
+  });
+
+  it('merges consumer style with the internal --grid-columns', () => {
+    const { container } = render(<Grid style={{ backgroundColor: 'red' }}>x</Grid>);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.backgroundColor).toBe('red');
+    expect(el.style.getPropertyValue('--grid-columns')).toBeTruthy();
+  });
+
+  it('forwards ref to the underlying element', () => {
+    const ref = createRef<HTMLElement>();
+    render(<Grid ref={ref}>x</Grid>);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+
+  it('forwards ref to a <section> when as="section"', () => {
+    const ref = createRef<HTMLElement>();
+    render(
+      <Grid ref={ref} as="section">
+        x
+      </Grid>,
+    );
+    expect(ref.current?.tagName).toBe('SECTION');
+  });
+
+  // TypeScript-level: passing both `columns` and `minColumnWidth` must be a type error.
+  // This is enforced by the @ts-expect-error directive below — if the directive is
+  // ever ignored (because the constraint slipped), tsc will error on the unused directive.
+  it('TS: columns and minColumnWidth are mutually exclusive', () => {
+    // @ts-expect-error — passing both should be a type error.
+    const ConflictingGrid = <Grid columns={2} minColumnWidth="240px" />;
+    // Reference the value so the variable isn't reported as unused.
+    expect(ConflictingGrid).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect pass**
+
+```bash
+cd /home/dpws/projects/design-system
+make test 2>&1 | tail -8
+```
+
+Expected: all previous tests still pass + new Grid tests pass. Total = previous baseline + ~15 cases (the `.each` parameterized tests count as one entry per value).
+
+If a structure test fails on "Grid is re-exported from src/index.ts" — that's expected; it resolves in Task 3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/Grid/Grid.test.tsx
+git commit -m "$(cat <<'EOF'
+Grid: unit tests
+
+Default behavior, columns/minColumnWidth template generation, all 6 gap
+classes, all 4 alignItems / justifyItems variants, `as` polymorphism
+(div / section / ul), className + style merge, ref forwarding, and a
+@ts-expect-error compile-time check for the columns vs minColumnWidth
+mutual exclusion.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 — Public exports + AGENTS.md TL;DR + Stack/Cluster JSDoc cross-links
+
+Tiny prose-and-export changes that unblock structure tests and update the docs to point at the new primitive.
+
+**Files:**
+- Modify: `packages/design-system/src/index.ts`
+- Modify: `packages/design-system/AGENTS.md`
+- Modify: `packages/design-system/src/components/Stack/Stack.tsx`
+- Modify: `packages/design-system/src/components/Cluster/Cluster.tsx`
+
+- [ ] **Step 1: Re-export Grid from the library root**
+
+Open `packages/design-system/src/index.ts`. Find the Cluster export block (Grid is a layout primitive so it slots near Stack/Cluster). Append:
+
+```ts
+export { Grid } from './components/Grid';
+export type {
+  GridProps,
+  GridGap,
+  GridAlignItems,
+  GridJustifyItems,
+  GridAs,
+} from './components/Grid';
+```
+
+- [ ] **Step 2: Update Stack.tsx JSDoc**
+
+Open `packages/design-system/src/components/Stack/Stack.tsx`. Find the line in the JSDoc that reads:
+
+```ts
+ * - For tabular data — use a real `<table>` or CSS Grid.
+```
+
+Replace with:
+
+```ts
+ * - For tabular data — use a real `<table>` or `<Grid>`.
+```
+
+- [ ] **Step 3: Update Cluster.tsx JSDoc**
+
+Open `packages/design-system/src/components/Cluster/Cluster.tsx`. Find:
+
+```ts
+ * - For aligned columns of equal width — use CSS Grid. Cluster wraps
+ *   unpredictably at narrow widths and isn't a column system.
+```
+
+Replace with:
+
+```ts
+ * - For aligned columns of equal width — use `<Grid>`. Cluster wraps
+ *   unpredictably at narrow widths and isn't a column system.
+```
+
+Also find:
+
+```ts
+ * - ❌ Cluster as a 2-column layout. Use CSS Grid for "two columns, always".
+```
+
+Replace with:
+
+```ts
+ * - ❌ Cluster as a 2-column layout. Use `<Grid columns={2}>` for "two columns, always".
+```
+
+- [ ] **Step 4: Add Grid TL;DR to AGENTS.md**
+
+Open `packages/design-system/AGENTS.md`. Find the Stack and Cluster TL;DR sections (they're together in the Layout primitives block). Add a new section right after Cluster:
+
+````markdown
+### `<Grid>` — 2D layout primitive
+
+```tsx
+// Auto-fit responsive (default) — columns reflow by container width.
+<Grid gap="md">
+  {cards.map(c => <Card key={c.id}>...</Card>)}
+</Grid>
+
+// Fixed N equal columns.
+<Grid columns={2} gap="lg">
+  <Input label="First name" />
+  <Input label="Last name" />
+</Grid>
+```
+
+- **One of `columns` or `minColumnWidth`, not both.** TypeScript enforces it.
+- **Default** when neither is set: `minColumnWidth="240px"`. Naturally responsive without breakpoints.
+- **Gap scale:** `xs` (4px) / `sm` (8) / `md` (12, default) / `lg` (16) / `xl` (24) / `2xl` (32) — same as Stack and Cluster.
+- **alignItems / justifyItems** — pass `start` / `center` / `end` / `stretch` to override the default browser stretch on either axis. Useful for cards of varying intrinsic height.
+- **`as` prop** — 10 common semantic elements (`div` default, `section`, `ul`, `ol`, `nav`, `main`, `aside`, `article`, `header`, `footer`). Limited rather than fully polymorphic to keep types simple.
+
+**Anti-patterns:**
+
+- ❌ Grid for a single column of vertical flow — use Stack.
+- ❌ Grid for unaligned wrapping rows (toolbars, tag lists) — use Cluster.
+- ❌ `<Grid columns="auto 1fr">` strings — not supported in v1. For asymmetric / named tracks, use raw CSS Grid via className.
+- ❌ `<Grid as="ul">` with non-`<li>` children. The component doesn't enforce list semantics; consumers must.
+````
+
+- [ ] **Step 5: Run all gates**
+
+```bash
+cd /home/dpws/projects/design-system
+make test 2>&1 | tail -8
+make build-lib 2>&1 | tail -3
+make lint 2>&1 | tail -3
+```
+
+Expected: all green. The structure test that validates "Grid is re-exported from src/index.ts" should now pass. The structure test that validates the four required files in `Grid/` (`Grid.tsx`, `Grid.test.tsx`, `Grid.module.scss`, `index.ts`) should also pass — all four exist after Tasks 1 and 2.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/index.ts \
+        packages/design-system/AGENTS.md \
+        packages/design-system/src/components/Stack/Stack.tsx \
+        packages/design-system/src/components/Cluster/Cluster.tsx
+git commit -m "$(cat <<'EOF'
+Grid: public exports + AGENTS.md TL;DR + Stack/Cluster JSDoc cross-links
+
+Library root re-exports Grid + 5 type exports. AGENTS.md TL;DR sits in
+the Layout primitives section near Stack/Cluster. Stack and Cluster's
+JSDoc "use CSS Grid" mentions now point at the new <Grid> component.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 — Playground demo + nav wiring (4 places)
+
+**Files:**
+- Create: `packages/playground/src/pages/components/GridDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Write the demo**
+
+Create `packages/playground/src/pages/components/GridDemo.tsx`:
+
+```tsx
+import { Card, Cluster, Grid, Input, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Grid/Grid.tsx?raw';
+import scssSource from '@lib-source/components/Grid/Grid.module.scss?raw';
+
+export function GridDemo() {
+  return (
+    <DemoLayout
+      name="Grid"
+      componentName="Grid"
+      description="2D layout primitive — CSS Grid wrapper. Use it when you need equal-width columns OR a responsive tile layout that reflows by container width (no breakpoints needed). Pair with Stack (vertical) and Cluster (horizontal-with-wrap)."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Grid.tsx"
+      scssFilename="Grid.module.scss"
+    >
+      <AutoFitExample />
+      <FixedColumnsExample />
+      <GapScaleExample />
+      <MinColumnWidthExample />
+      <AlignmentExample />
+      <SemanticElementExample />
+    </DemoLayout>
+  );
+}
+
+function AutoFitExample() {
+  return (
+    <Example
+      title="Auto-fit (default)"
+      description="No props set. Defaults to `minColumnWidth='240px'`. Resize your viewport to watch the columns reflow."
+      code={`<Grid gap="md">
+  <Card>...</Card>
+  <Card>...</Card>
+  ...
+</Grid>`}
+    >
+      <Grid gap="md">
+        {Array.from({ length: 6 }, (_, i) => (
+          <Card key={i}>
+            <strong>Tile {i + 1}</strong>
+            <p style={{ margin: 0, color: 'var(--color-fg-muted)' }}>
+              Auto-fitted to fill the row.
+            </p>
+          </Card>
+        ))}
+      </Grid>
+    </Example>
+  );
+}
+
+function FixedColumnsExample() {
+  return (
+    <Example
+      title="Fixed columns (2-column form)"
+      description="`columns={2}` for exactly two equal-width columns regardless of viewport. The canonical label/field form layout."
+      code={`<Grid columns={2} gap="lg">
+  <Input ... />
+  <Input ... />
+  ...
+</Grid>`}
+    >
+      <Grid columns={2} gap="lg">
+        <label>
+          First name
+          <Input placeholder="Ada" />
+        </label>
+        <label>
+          Last name
+          <Input placeholder="Lovelace" />
+        </label>
+        <label>
+          Email
+          <Input placeholder="ada@example.com" />
+        </label>
+        <label>
+          Phone
+          <Input placeholder="+1 555 0100" />
+        </label>
+      </Grid>
+    </Example>
+  );
+}
+
+function GapScaleExample() {
+  return (
+    <Example
+      title="Gap scale"
+      description="Same scale as Stack and Cluster: xs (4) / sm (8) / md (12) / lg (16) / xl (24) / 2xl (32) — all in pixels."
+      code={`<Grid columns={3} gap="xs">...</Grid>
+<Grid columns={3} gap="md">...</Grid>
+<Grid columns={3} gap="2xl">...</Grid>`}
+    >
+      <Stack gap="md">
+        {(['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const).map((g) => (
+          <Stack key={g} gap="xs">
+            <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+              gap=&quot;{g}&quot;
+            </div>
+            <Grid columns={3} gap={g}>
+              {Array.from({ length: 3 }, (_, i) => (
+                <Card key={i}>cell {i + 1}</Card>
+              ))}
+            </Grid>
+          </Stack>
+        ))}
+      </Stack>
+    </Example>
+  );
+}
+
+function MinColumnWidthExample() {
+  return (
+    <Example
+      title="minColumnWidth variants"
+      description="Three grids at different minimums. Wider minColumnWidth = fewer, wider columns at the same viewport."
+      code={`<Grid minColumnWidth="200px">...</Grid>
+<Grid minColumnWidth="280px">...</Grid>
+<Grid minColumnWidth="360px">...</Grid>`}
+    >
+      <Stack gap="md">
+        {(['200px', '280px', '360px'] as const).map((m) => (
+          <Stack key={m} gap="xs">
+            <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+              minColumnWidth=&quot;{m}&quot;
+            </div>
+            <Grid minColumnWidth={m} gap="sm">
+              {Array.from({ length: 5 }, (_, i) => (
+                <Card key={i}>cell {i + 1}</Card>
+              ))}
+            </Grid>
+          </Stack>
+        ))}
+      </Stack>
+    </Example>
+  );
+}
+
+function AlignmentExample() {
+  return (
+    <Example
+      title="alignItems / justifyItems"
+      description="Cells of varying intrinsic content height. alignItems=start aligns content to the top of each track; alignItems=stretch (default browser behavior) makes them all match the tallest. Try changing the value to compare."
+      code={`<Grid columns={3} gap="md" alignItems="start">
+  <Card>short</Card>
+  <Card>medium content here that takes more lines</Card>
+  <Card>short</Card>
+</Grid>`}
+    >
+      <Stack gap="md">
+        <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+          alignItems=&quot;start&quot;
+        </div>
+        <Grid columns={3} gap="md" alignItems="start">
+          <Card>short</Card>
+          <Card>
+            medium content here that takes a couple of lines so the card grows taller than the
+            others
+          </Card>
+          <Card>short</Card>
+        </Grid>
+        <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+          alignItems=&quot;stretch&quot; (default)
+        </div>
+        <Grid columns={3} gap="md" alignItems="stretch">
+          <Card>short</Card>
+          <Card>
+            medium content here that takes a couple of lines so the card grows taller than the
+            others
+          </Card>
+          <Card>short</Card>
+        </Grid>
+      </Stack>
+    </Example>
+  );
+}
+
+function SemanticElementExample() {
+  return (
+    <Example
+      title="Semantic elements via `as`"
+      description="Render Grid as a `<section>` (landmark) or `<ul>` (list). Limited to 10 common layout/semantic elements."
+      code={`<Grid as="section" columns={2} gap="md" aria-labelledby="section-title">
+  ...
+</Grid>
+
+<Grid as="ul" minColumnWidth="200px" gap="sm">
+  <li>...</li>
+</Grid>`}
+    >
+      <Stack gap="md">
+        <Grid as="section" columns={2} gap="md">
+          <Card>section cell 1</Card>
+          <Card>section cell 2</Card>
+        </Grid>
+        <Cluster gap="sm">
+          <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+            Below: rendered as &lt;ul&gt; with &lt;li&gt; children.
+          </span>
+        </Cluster>
+        <Grid as="ul" minColumnWidth="160px" gap="sm" style={{ listStyle: 'none', padding: 0 }}>
+          {['Alpha', 'Bravo', 'Charlie', 'Delta'].map((label) => (
+            <li key={label}>
+              <Card>{label}</Card>
+            </li>
+          ))}
+        </Grid>
+      </Stack>
+    </Example>
+  );
+}
+```
+
+Important caveats — match precedents:
+
+- `<Input>` doesn't have a `label` prop. Wrap with native `<label>` like the InputDemo precedent.
+- `<DemoLayout>` and `<Example>` are siblings of GridDemo (`./DemoLayout`, `./Example`).
+- `@lib-source` Vite alias for `?raw` imports of library source.
+- The ComponentsIndex card should render a static visual mock (a small 2x2 of div boxes with gaps) rather than a live `<Grid>` — the live one is fine here because Grid is just a div with CSS, not a portal, but a static mock keeps the card visually consistent with how other cards do it. Match the precedent set by Stack and Cluster's cards.
+
+- [ ] **Step 2: Wire the demo into the four playground integration points**
+
+In `packages/playground/src/App.tsx`:
+
+Add import + route:
+```tsx
+import { GridDemo } from './pages/components/GridDemo';
+// Inside <Routes>:
+<Route path="/components/grid" element={<GridDemo />} />
+```
+
+In `packages/playground/src/layout/AppShell/AppShell.tsx`, find the `componentGroups` array's **Layout** group (alongside Stack and Cluster). Add:
+
+```ts
+{ to: '/components/grid', label: 'Grid' }
+```
+
+matching the existing entry shape (and add an icon from `lucide-react` if the group uses icons — Stack/Cluster's entries will show you the pattern).
+
+In `packages/playground/src/pages/components/ComponentsIndex.tsx`, add a card for Grid. Description: "2D layout primitive with token-driven gap, auto-fit responsive columns, and equal-width fixed columns."
+
+In `packages/playground/src/pages/mockups/registry.ts`, add `'Grid'` to the `ComponentName` union (alphabetical placement — between `'EmptyState'` and a later alphabetical entry; check the file for the exact spot).
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+cd /home/dpws/projects/design-system
+make build 2>&1 | tail -8
+```
+
+Both library and playground build cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/playground/src/pages/components/GridDemo.tsx \
+        packages/playground/src/App.tsx \
+        packages/playground/src/layout/AppShell/AppShell.tsx \
+        packages/playground/src/pages/components/ComponentsIndex.tsx \
+        packages/playground/src/pages/mockups/registry.ts
+git commit -m "$(cat <<'EOF'
+playground: GridDemo + nav wiring (4 places)
+
+Six examples: auto-fit (default), fixed columns (2-col form), gap scale,
+minColumnWidth variants, alignItems/justifyItems, and the `as` prop with
+semantic elements (section, ul).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 — Hard-Rule-8 review-fix cycle + push + PR
+
+Same shape as Modal/Drawer.
+
+- [ ] **Step 1: Run all gates**
+
+```bash
+cd /home/dpws/projects/design-system
+make test 2>&1 | tail -5
+make build-lib 2>&1 | tail -3
+make lint 2>&1 | tail -3
+make build 2>&1 | tail -5
+npm pack --dry-run --workspace @eocrm/design-system 2>&1 | grep -E "\.test\." | head -5 && echo "(should be empty)"
+```
+
+All exit 0 and no test files in the tarball.
+
+- [ ] **Step 2: Spawn a fresh-context reviewer (opus)**
+
+Use the `Agent` tool with `subagent_type: "general-purpose"`, model `opus`. Brief it on the 10 review categories from `packages/design-system/CLAUDE.md` (Hard Rule 8). Point it at:
+
+- `packages/design-system/CLAUDE.md`
+- `packages/design-system/AGENTS.md`
+- `docs/superpowers/specs/2026-05-23-grid-design.md`
+- `packages/design-system/src/components/Grid/`
+- The Stack and Cluster source files (for the JSDoc cross-link verification)
+- `packages/design-system/src/index.ts` (export verification)
+
+Grid-specific things to scrutinize:
+
+- The discriminated-union props with `never` actually enforce mutual exclusion (the `@ts-expect-error` test in `Grid.test.tsx` should be the load-bearing check)
+- `--grid-columns` is set correctly for both fixed and auto-fit branches
+- Gap class names match Stack/Cluster naming (camelCase, the `gap2xl` exception)
+- `as` rendering produces the right element tag at runtime
+- Ref forwarding works for all `as` values
+- Stack and Cluster's JSDoc was actually updated (grep for "CSS Grid" should find zero occurrences in Stack.tsx and Cluster.tsx after Task 3)
+
+Output: Critical / Important / Nice-to-have / Regression-watch + verdict.
+
+- [ ] **Step 3: Fix every Critical + Important finding**
+
+For each, fix in code and re-run gates.
+
+- [ ] **Step 4: Spawn second reviewer with the same prompt**
+
+Loop until verdict is "clean enough to stop".
+
+- [ ] **Step 5: Commit review-cycle fixes (if any)**
+
+```bash
+git add -A
+git commit -m "Grid: review-cycle fixes (round N)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 6: Push the branch**
+
+```bash
+git push -u origin feat/grid
+```
+
+If Husky pre-push blocks on prettier:
+
+```bash
+npx prettier --write \
+  docs/superpowers/plans/2026-05-23-grid.md \
+  docs/superpowers/specs/2026-05-23-grid-design.md \
+  packages/design-system/src/components/Grid/ \
+  packages/design-system/src/components/Stack/Stack.tsx \
+  packages/design-system/src/components/Cluster/Cluster.tsx \
+  packages/design-system/src/index.ts \
+  packages/design-system/AGENTS.md \
+  packages/playground/src/pages/components/GridDemo.tsx
+git add -A
+git commit -m "Grid: prettier --write
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push
+```
+
+If Husky fires stylelint --fix changes, commit and push again.
+
+- [ ] **Step 7: Open the PR**
+
+```bash
+gh pr create --title "Grid: 2D layout primitive (auto-fit + fixed columns, token-driven gap, polymorphic as)" --body "$(cat <<'EOF'
+## Summary
+
+- New `<Grid>` layout primitive at `packages/design-system/src/components/Grid/`. Single-file forwardRef component plus SCSS module — no behavior, no portal, no compound.
+- **Mutually-exclusive `columns` / `minColumnWidth`** via TypeScript discriminated union with `never` — passing both is a compile error. Default behavior when neither is set: `minColumnWidth="240px"` for a naturally responsive layout.
+- **Token-driven gap** matching Stack/Cluster exactly: `xs` / `sm` / `md` / `lg` / `xl` / `2xl`, default `md`.
+- **alignItems / justifyItems** props for cross- and main-axis cell alignment.
+- **Limited polymorphic `as` prop** — ten common layout/semantic elements (`div` / `section` / `ul` / `ol` / `nav` / `main` / `aside` / `article` / `header` / `footer`). Keeps types simple, covers real-world needs.
+- **Cross-links updated** — Stack and Cluster's JSDoc references to "CSS Grid" now point at `<Grid>`.
+
+## Test plan
+
+- [x] ~15 unit tests covering: default behavior, columns/minColumnWidth template generation, all 6 gap variants, all 4 alignItems / justifyItems variants, `as` polymorphism (div / section / ul), className + style merge, ref forwarding, and a `@ts-expect-error` compile-time check for the mutual exclusion.
+- [x] All gates green: tests, typecheck, stylelint, build, `npm pack --dry-run` shows no test files in the tarball.
+- [x] Playground demo at `/components/grid` with 6 examples.
+- [x] Hard-Rule-8 review-fix cycle: clean exit.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Return the PR URL.
+
+---
+
+## Self-Review (controller, not subagent)
+
+**Spec coverage:**
+
+| Spec section | Task implementing it |
+|---|---|
+| `Grid.tsx` + `Grid.module.scss` + `index.ts` | 1 |
+| Discriminated-union props with `never` | 1 (types) + 2 (TS test) |
+| Default minColumnWidth="240px" when neither prop set | 1 (component logic) + 2 (test) |
+| Gap scale matching Stack/Cluster | 1 (SCSS + classes) + 2 (tests) |
+| alignItems / justifyItems | 1 (component + SCSS) + 2 (tests) |
+| Limited polymorphic `as` (10 elements) | 1 (component) + 2 (div/section/ul tests cover the pattern) |
+| --grid-columns CSS custom prop wiring | 1 (component + SCSS) + 2 (tests) |
+| Public exports | 3 |
+| AGENTS.md TL;DR | 3 |
+| Stack/Cluster JSDoc cross-link updates | 3 |
+| Playground demo (6 examples) | 4 |
+| Nav wiring (4 places) | 4 |
+| Hard Rule 8 + PR | 5 |
+
+**Placeholder scan:** None. Every step has the actual code or command.
+
+**Type consistency:**
+
+- `GridGap`, `GridAlignItems`, `GridJustifyItems`, `GridAs` defined in Task 1 and used in tests in Task 2 with the same names.
+- Lookup tables (`gapClass`, `alignItemsClass`, `justifyItemsClass`) use the canonical class names from SCSS (`styles.gapXs`, etc.).
+- The discriminated union (`GridFixedColumns | GridAutoFit`) uses `never` on the unused field — same pattern in both branches.
+- `--grid-columns` custom prop name consistent between component (Task 1), SCSS (Task 1), and tests (Task 2).
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-23-grid.md`.** Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, two-stage review per task, same rhythm as Modal/Drawer.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-23-grid-design.md
+++ b/docs/superpowers/specs/2026-05-23-grid-design.md
@@ -1,0 +1,272 @@
+# Grid — design spec
+
+**Date:** 2026-05-23
+**Branch:** `feat/grid`
+**Scope:** New `<Grid>` 2D layout primitive — CSS-Grid wrapper with token-driven gap, mutually-exclusive `columns` (fixed) / `minColumnWidth` (auto-fit responsive), optional `alignItems` / `justifyItems`, and a limited polymorphic `as` prop.
+
+## Goal
+
+Close the third leg of the layout-primitive stool. `<Stack>` covers vertical flow, `<Cluster>` covers horizontal-with-wrap. `<Grid>` covers everything that needs **equal-width columns** or **a responsive tile layout** — dashboard cards, form label/field columns, photo galleries, two-column page layouts. Both existing primitives' "When NOT to use" sections already point readers toward CSS Grid for this case; this component formalizes the boundary.
+
+## Why now
+
+- Modal + Drawer are shipped. The next CRM mockups need dashboard tile layouts and form column layouts — both of which are clumsy with raw `<div style={{ display: 'grid', ... }}>`.
+- Token-aware gap presets matter most when the same scale (`xs` / `sm` / `md` / `lg` / `xl` / `2xl`) is shared across Stack / Cluster / Grid. Encoding that as a typed prop on a layout component prevents off-scale spacing drift.
+- `minColumnWidth + auto-fit` is the "responsive without breakpoints" pattern that consumers reach for repeatedly. Wrapping it in a single prop turns five lines of CSS into one prop.
+
+## Non-goals (v1)
+
+- **No string `columns` for custom track lists.** `<Grid columns="auto 1fr">` is NOT supported. Consumers who need named tracks or asymmetric column widths use raw CSS Grid via `className`. Keeping the prop as `number` only prevents off-token escape hatches.
+- **No per-cell `span` / placement props.** That's what raw CSS Grid is for. Grid is a container primitive, not a placement system.
+- **No breakpoint object syntax** (e.g., `columns={{ base: 1, md: 2, lg: 4 }}`). `minColumnWidth` covers the responsive case more elegantly without consumers having to know the breakpoint scale.
+- **No `rows` prop.** Almost always unnecessary in real layouts; cells stack into rows naturally based on the column count.
+- **No full polymorphic `as` with ElementType.** Limited string union of ten common semantic elements (`div` / `section` / `ul` / `ol` / `nav` / `main` / `aside` / `article` / `header` / `footer`). The full TS polymorphic-ref pattern is ~30 lines of type gymnastics for almost no real-world benefit.
+
+## Architecture
+
+### Dependencies
+
+No new packages, no new tokens. Reuses `--space-*` via the gap class mapping.
+
+### File layout
+
+```
+packages/design-system/src/components/Grid/
+  Grid.tsx              ← forwardRef + spread; renders the chosen `as` element
+  Grid.module.scss      ← Token-driven gap, alignItems/justifyItems classes, columns via --grid-columns custom prop
+  Grid.test.tsx         ← Unit tests
+  index.ts              ← Public re-exports
+```
+
+Plus standard integration points:
+
+- `packages/design-system/src/index.ts` — re-export Grid + types
+- `packages/design-system/AGENTS.md` — TL;DR slot near Stack/Cluster
+- `packages/playground/src/pages/components/GridDemo.tsx` — new demo
+- `packages/playground/src/App.tsx` — route
+- `packages/playground/src/layout/AppShell/AppShell.tsx` — sidebar nav, Layout group (alongside Stack/Cluster)
+- `packages/playground/src/pages/components/ComponentsIndex.tsx` — overview grid tile
+- `packages/playground/src/pages/mockups/registry.ts` — `'Grid'` in `ComponentName` union
+
+### Composition
+
+- Pairs with Stack (vertical) and Cluster (horizontal-with-wrap).
+- Reuses the existing `--space-*` tokens for gap.
+- No new behavioral primitives. Pure CSS wrapper.
+
+## Public API
+
+```ts
+export type GridGap = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+export type GridAlignItems = 'start' | 'center' | 'end' | 'stretch';
+export type GridJustifyItems = 'start' | 'center' | 'end' | 'stretch';
+export type GridAs =
+  | 'div' | 'section' | 'ul' | 'ol' | 'nav'
+  | 'main' | 'aside' | 'article' | 'header' | 'footer';
+
+interface GridBaseProps {
+  /**
+   * Gap between cells.
+   * `xs` (4) / `sm` (8) / `md` (12, default) / `lg` (16) / `xl` (24) / `2xl` (32).
+   * Same scale as Stack and Cluster.
+   */
+  gap?: GridGap;
+  /** Cross-axis (vertical-within-row) alignment of each cell. Default 'stretch'. */
+  alignItems?: GridAlignItems;
+  /** Main-axis (horizontal-within-track) alignment of each cell. Default 'stretch'. */
+  justifyItems?: GridJustifyItems;
+  /** Element to render. Default 'div'. Limited to common layout / semantic elements. */
+  as?: GridAs;
+}
+
+interface GridFixedColumns extends GridBaseProps, HTMLAttributes<HTMLElement> {
+  /** Fixed equal-width columns. Mutually exclusive with `minColumnWidth`. */
+  columns: number;
+  minColumnWidth?: never;
+}
+
+interface GridAutoFit extends GridBaseProps, HTMLAttributes<HTMLElement> {
+  /**
+   * Minimum column width for auto-fit responsive layout. Columns reflow based on
+   * container width (no breakpoints needed). String must be a CSS length:
+   * '240px' / '15rem'. If neither `columns` nor `minColumnWidth` is provided,
+   * defaults to '240px'.
+   */
+  minColumnWidth?: string;
+  columns?: never;
+}
+
+export type GridProps = GridFixedColumns | GridAutoFit;
+```
+
+Discriminated-union `never` enforces mutual exclusion at compile time — `<Grid columns={2} minColumnWidth="240px" />` is a type error.
+
+`as` is a string union rather than `ElementType` to keep types simple. Ref is typed as `HTMLElement` (broad but covers all valid `as` choices).
+
+## Architecture flow
+
+### Rendering
+
+```tsx
+// Lookup tables mirror Stack/Cluster precedent — explicit object literals
+// keyed by the prop value, mapping to the (camelCase) CSS Module class.
+const gapClass: Record<GridGap, string> = {
+  xs: styles.gapXs,
+  sm: styles.gapSm,
+  md: styles.gapMd,
+  lg: styles.gapLg,
+  xl: styles.gapXl,
+  '2xl': styles.gap2xl,
+};
+const alignItemsClass: Record<GridAlignItems, string> = {
+  start: styles.alignItemsStart,
+  center: styles.alignItemsCenter,
+  end: styles.alignItemsEnd,
+  stretch: styles.alignItemsStretch,
+};
+const justifyItemsClass: Record<GridJustifyItems, string> = {
+  start: styles.justifyItemsStart,
+  center: styles.justifyItemsCenter,
+  end: styles.justifyItemsEnd,
+  stretch: styles.justifyItemsStretch,
+};
+
+function Grid({
+  gap = 'md',
+  alignItems,
+  justifyItems,
+  as = 'div',
+  columns,
+  minColumnWidth,
+  className,
+  style,
+  ...rest
+}, ref) {
+  const template = columns !== undefined
+    ? `repeat(${columns}, minmax(0, 1fr))`
+    : `repeat(auto-fit, minmax(${minColumnWidth ?? '240px'}, 1fr))`;
+
+  const Tag = as;
+  return (
+    <Tag
+      ref={ref}
+      className={clsx(
+        styles.grid,
+        gapClass[gap],
+        alignItems && alignItemsClass[alignItems],
+        justifyItems && justifyItemsClass[justifyItems],
+        className,
+      )}
+      style={{ ['--grid-columns' as string]: template, ...style }}
+      {...rest}
+    />
+  );
+}
+```
+
+Notes:
+- The `--grid-columns` inline custom property drives `grid-template-columns` from SCSS. Keeping the template string off the inline style attribute (and behind a custom prop) makes it easy to override later via CSS without specificity wars.
+- `minmax(0, 1fr)` is the standard fix for "long content blows the column out". Without the `0` floor, a long unbreakable word can force the track wider than `1fr`.
+- Consumer `style` spreads AFTER `--grid-columns`, so a consumer can override the template entirely if they want; but `style={{ '--grid-columns': '...' }}` from the consumer would also work.
+
+### SCSS
+
+```scss
+.grid {
+  display: grid;
+  grid-template-columns: var(--grid-columns, repeat(auto-fit, minmax(240px, 1fr)));
+}
+
+// Gap presets — mirror Stack/Cluster scale + camelCase naming
+.gapXs  { gap: var(--space-1); }
+.gapSm  { gap: var(--space-2); }
+.gapMd  { gap: var(--space-3); }
+.gapLg  { gap: var(--space-4); }
+.gapXl  { gap: var(--space-6); }
+.gap2xl { gap: var(--space-8); }
+
+// Item alignment (cross-axis)
+.alignItemsStart   { align-items: start; }
+.alignItemsCenter  { align-items: center; }
+.alignItemsEnd     { align-items: end; }
+.alignItemsStretch { align-items: stretch; }
+
+// Item alignment (main-axis)
+.justifyItemsStart   { justify-items: start; }
+.justifyItemsCenter  { justify-items: center; }
+.justifyItemsEnd     { justify-items: end; }
+.justifyItemsStretch { justify-items: stretch; }
+```
+
+The base `.grid` rule's `grid-template-columns` has a fallback to `repeat(auto-fit, minmax(240px, 1fr))` so that even if the `--grid-columns` custom prop fails to apply for some reason (consumer-style override stripping it), the component still renders a sane default.
+
+CSS-class naming convention is camelCase — `.gapMd`, `.alignItemsStart`, `.justifyItemsCenter`. Matches the precedent Stack and Cluster set (verify with `grep "^\.gap" packages/design-system/src/components/Stack/Stack.module.scss` during implementation).
+
+## ARIA contract
+
+Grid is a presentational primitive. No roles, no labels, no focus management. The element it renders (`as` prop) governs semantics:
+
+- `as="div"` (default) — no implicit role
+- `as="section"` / `"article"` / `"main"` / `"header"` / `"footer"` / `"nav"` / `"aside"` — landmark semantics
+- `as="ul"` / `"ol"` — list semantics. **Implementation caveat:** when `as="ul"` or `"ol"`, consumers are responsible for ensuring children are `<li>` elements. The component does not enforce this. Consider adding a dev-mode warning if `as="ul" || "ol"` and a non-`<li>` child is detected — but this can be a follow-up if it ever bites. Out of scope for v1.
+
+## Testing strategy
+
+`Grid.test.tsx` (~12 cases, matching the test density of Stack/Cluster):
+
+- Renders without crashing with default props (no `columns` / `minColumnWidth`)
+- Default behavior applies `repeat(auto-fit, minmax(240px, 1fr))` to the `--grid-columns` style
+- `columns={4}` sets `--grid-columns` to `repeat(4, minmax(0, 1fr))`
+- `minColumnWidth="200px"` sets `--grid-columns` to `repeat(auto-fit, minmax(200px, 1fr))`
+- Each `gap` variant (`xs` / `sm` / `md` / `lg` / `xl` / `2xl`) applies the matching CSS class
+- `alignItems` and `justifyItems` apply matching CSS classes; absence applies no class
+- `as="section"` renders a `<section>` element
+- `as="ul"` renders a `<ul>` element
+- `className` is merged onto the rendered element, not replaced
+- Consumer `style` merges with the internal `--grid-columns` (consumer-provided style values take precedence per spread order, but `--grid-columns` is preserved if the consumer doesn't override it)
+- `ref` is forwarded to the rendered element (test via DOM identity)
+- **TS-level**: a single `// @ts-expect-error` test asserts that `<Grid columns={2} minColumnWidth="240px" />` fails type-check (mutual exclusion enforced via discriminated union)
+
+## Demo page
+
+`packages/playground/src/pages/components/GridDemo.tsx` — 6 examples:
+
+1. **Auto-fit (default)** — `<Grid>` containing 6 Cards, viewport resize demonstrates the reflow. No props set; relies on default `minColumnWidth="240px"`.
+2. **Fixed columns** — `<Grid columns={2}>` for a label/field form layout demonstrating equal-width columns.
+3. **Gap scale** — six grids side-by-side, each with a different gap (`xs` through `2xl`), so the visual difference is immediate.
+4. **minColumnWidth variants** — three grids at 200px / 280px / 360px so consumers see how the prop affects layout density at the current viewport.
+5. **alignItems / justifyItems** — cells of varying intrinsic height, demonstrating `start` / `center` / `end` / `stretch`.
+6. **Semantic elements** — `<Grid as="section">` and `<Grid as="ul">` (with `<li>` children) showing the `as` prop in use.
+
+Standard playground integration: route in `App.tsx`, sidebar entry in `AppShell.tsx` (Layout group with Stack/Cluster), card in `ComponentsIndex.tsx`, `'Grid'` added to `mockups/registry.ts` `ComponentName` union.
+
+## AGENTS.md + JSDoc updates
+
+Append a `<Grid>` TL;DR to AGENTS.md near the Stack/Cluster sections.
+
+Cross-link from Stack and Cluster's existing "use CSS Grid" references in BOTH places they appear:
+- **JSDoc in `Stack.tsx`**: change `For tabular data — use a real <table> or CSS Grid.` → `For tabular data — use a real <table> or <Grid>.`
+- **JSDoc in `Cluster.tsx`**: change `For aligned columns of equal width — use CSS Grid.` → `For aligned columns of equal width — use <Grid>.`
+- **AGENTS.md** Stack/Cluster TL;DRs if they have matching language.
+
+Anti-patterns specific to Grid:
+
+- ❌ Grid for vertical lists with single column — use Stack.
+- ❌ Grid for unaligned button rows that wrap — use Cluster.
+- ❌ `<Grid columns="auto 1fr">` strings — not supported in v1. For asymmetric or named tracks, use raw CSS Grid via className.
+- ❌ `<Grid as="ul">` with non-`<li>` children — the component doesn't enforce list semantics; consumers must.
+
+## Hard Rule 8 cycle
+
+Same as Modal / Drawer:
+1. Run all gates (test, build-lib, lint, build, npm pack --dry-run).
+2. Spawn a fresh-context reviewer with the 10 review categories.
+3. Fix Critical + Important findings; re-run gates; re-review.
+4. Loop until verdict is "clean enough to stop".
+
+## Out-of-PR follow-ups (noted, not in v1)
+
+- Dev-mode warning when `as="ul" || "ol"` and a non-`<li>` child is rendered.
+- String `columns` for custom grid-template-columns (`columns="auto 1fr"`). Only if real consumer demand surfaces.
+- Per-cell `<Grid.Cell>` subcomponent for span / placement props. Only if real consumer demand surfaces.
+- Breakpoint object syntax (`columns={{ base: 1, md: 2, lg: 4 }}`). The minColumnWidth approach should cover most cases; revisit only if specific consumer needs aren't satisfied.

--- a/docs/superpowers/specs/2026-05-23-grid-design.md
+++ b/docs/superpowers/specs/2026-05-23-grid-design.md
@@ -61,8 +61,16 @@ export type GridGap = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 export type GridAlignItems = 'start' | 'center' | 'end' | 'stretch';
 export type GridJustifyItems = 'start' | 'center' | 'end' | 'stretch';
 export type GridAs =
-  | 'div' | 'section' | 'ul' | 'ol' | 'nav'
-  | 'main' | 'aside' | 'article' | 'header' | 'footer';
+  | 'div'
+  | 'section'
+  | 'ul'
+  | 'ol'
+  | 'nav'
+  | 'main'
+  | 'aside'
+  | 'article'
+  | 'header'
+  | 'footer';
 
 interface GridBaseProps {
   /**
@@ -131,20 +139,24 @@ const justifyItemsClass: Record<GridJustifyItems, string> = {
   stretch: styles.justifyItemsStretch,
 };
 
-function Grid({
-  gap = 'md',
-  alignItems,
-  justifyItems,
-  as = 'div',
-  columns,
-  minColumnWidth,
-  className,
-  style,
-  ...rest
-}, ref) {
-  const template = columns !== undefined
-    ? `repeat(${columns}, minmax(0, 1fr))`
-    : `repeat(auto-fit, minmax(${minColumnWidth ?? '240px'}, 1fr))`;
+function Grid(
+  {
+    gap = 'md',
+    alignItems,
+    justifyItems,
+    as = 'div',
+    columns,
+    minColumnWidth,
+    className,
+    style,
+    ...rest
+  },
+  ref,
+) {
+  const template =
+    columns !== undefined
+      ? `repeat(${columns}, minmax(0, 1fr))`
+      : `repeat(auto-fit, minmax(${minColumnWidth ?? '240px'}, 1fr))`;
 
   const Tag = as;
   return (
@@ -165,6 +177,7 @@ function Grid({
 ```
 
 Notes:
+
 - The `--grid-columns` inline custom property drives `grid-template-columns` from SCSS. Keeping the template string off the inline style attribute (and behind a custom prop) makes it easy to override later via CSS without specificity wars.
 - `minmax(0, 1fr)` is the standard fix for "long content blows the column out". Without the `0` floor, a long unbreakable word can force the track wider than `1fr`.
 - Internal `--grid-columns` wins on conflict (the value spreads AFTER any consumer `style`). Consumers who genuinely need to override the template should use raw CSS Grid via `className` rather than fighting the prop. This keeps the prop API authoritative.
@@ -178,24 +191,52 @@ Notes:
 }
 
 // Gap presets — mirror Stack/Cluster scale + camelCase naming
-.gapXs  { gap: var(--space-1); }
-.gapSm  { gap: var(--space-2); }
-.gapMd  { gap: var(--space-3); }
-.gapLg  { gap: var(--space-4); }
-.gapXl  { gap: var(--space-6); }
-.gap2xl { gap: var(--space-8); }
+.gapXs {
+  gap: var(--space-1);
+}
+.gapSm {
+  gap: var(--space-2);
+}
+.gapMd {
+  gap: var(--space-3);
+}
+.gapLg {
+  gap: var(--space-4);
+}
+.gapXl {
+  gap: var(--space-6);
+}
+.gap2xl {
+  gap: var(--space-8);
+}
 
 // Item alignment (cross-axis)
-.alignItemsStart   { align-items: start; }
-.alignItemsCenter  { align-items: center; }
-.alignItemsEnd     { align-items: end; }
-.alignItemsStretch { align-items: stretch; }
+.alignItemsStart {
+  align-items: start;
+}
+.alignItemsCenter {
+  align-items: center;
+}
+.alignItemsEnd {
+  align-items: end;
+}
+.alignItemsStretch {
+  align-items: stretch;
+}
 
 // Item alignment (main-axis)
-.justifyItemsStart   { justify-items: start; }
-.justifyItemsCenter  { justify-items: center; }
-.justifyItemsEnd     { justify-items: end; }
-.justifyItemsStretch { justify-items: stretch; }
+.justifyItemsStart {
+  justify-items: start;
+}
+.justifyItemsCenter {
+  justify-items: center;
+}
+.justifyItemsEnd {
+  justify-items: end;
+}
+.justifyItemsStretch {
+  justify-items: stretch;
+}
 ```
 
 The base `.grid` rule's `grid-template-columns` has a fallback to `repeat(auto-fit, minmax(240px, 1fr))` so that even if the `--grid-columns` custom prop fails to apply for some reason (consumer-style override stripping it), the component still renders a sane default.
@@ -245,6 +286,7 @@ Standard playground integration: route in `App.tsx`, sidebar entry in `AppShell.
 Append a `<Grid>` TL;DR to AGENTS.md near the Stack/Cluster sections.
 
 Cross-link from Stack and Cluster's existing "use CSS Grid" references in BOTH places they appear:
+
 - **JSDoc in `Stack.tsx`**: change `For tabular data — use a real <table> or CSS Grid.` → `For tabular data — use a real <table> or <Grid>.`
 - **JSDoc in `Cluster.tsx`**: change `For aligned columns of equal width — use CSS Grid.` → `For aligned columns of equal width — use <Grid>.`
 - **AGENTS.md** Stack/Cluster TL;DRs if they have matching language.
@@ -259,6 +301,7 @@ Anti-patterns specific to Grid:
 ## Hard Rule 8 cycle
 
 Same as Modal / Drawer:
+
 1. Run all gates (test, build-lib, lint, build, npm pack --dry-run).
 2. Spawn a fresh-context reviewer with the 10 review categories.
 3. Fix Critical + Important findings; re-run gates; re-review.

--- a/docs/superpowers/specs/2026-05-23-grid-design.md
+++ b/docs/superpowers/specs/2026-05-23-grid-design.md
@@ -157,7 +157,7 @@ function Grid({
         justifyItems && justifyItemsClass[justifyItems],
         className,
       )}
-      style={{ ['--grid-columns' as string]: template, ...style }}
+      style={{ ...style, ['--grid-columns' as string]: template }}
       {...rest}
     />
   );
@@ -167,7 +167,7 @@ function Grid({
 Notes:
 - The `--grid-columns` inline custom property drives `grid-template-columns` from SCSS. Keeping the template string off the inline style attribute (and behind a custom prop) makes it easy to override later via CSS without specificity wars.
 - `minmax(0, 1fr)` is the standard fix for "long content blows the column out". Without the `0` floor, a long unbreakable word can force the track wider than `1fr`.
-- Consumer `style` spreads AFTER `--grid-columns`, so a consumer can override the template entirely if they want; but `style={{ '--grid-columns': '...' }}` from the consumer would also work.
+- Internal `--grid-columns` wins on conflict (the value spreads AFTER any consumer `style`). Consumers who genuinely need to override the template should use raw CSS Grid via `className` rather than fighting the prop. This keeps the prop API authoritative.
 
 ### SCSS
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -212,6 +212,34 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 - `align`: `start` / `center` (default) / `end` / `baseline`
 - `wrap`: `true` (default). Set `false` only for narrow table cells where overflow is preferable to wrapping.
 
+### `<Grid>` — 2D layout primitive
+
+```tsx
+// Auto-fit responsive (default) — columns reflow by container width.
+<Grid gap="md">
+  {cards.map(c => <Card key={c.id}>...</Card>)}
+</Grid>
+
+// Fixed N equal columns.
+<Grid columns={2} gap="lg">
+  <Input label="First name" />
+  <Input label="Last name" />
+</Grid>
+```
+
+- **One of `columns` or `minColumnWidth`, not both.** TypeScript enforces it.
+- **Default** when neither is set: `minColumnWidth="240px"`. Naturally responsive without breakpoints.
+- **Gap scale:** `xs` (4px) / `sm` (8) / `md` (12, default) / `lg` (16) / `xl` (24) / `2xl` (32) — same as Stack and Cluster.
+- **alignItems / justifyItems** — pass `start` / `center` / `end` / `stretch` to override the default browser stretch on either axis. Useful for cards of varying intrinsic height.
+- **`as` prop** — 10 common semantic elements (`div` default, `section`, `ul`, `ol`, `nav`, `main`, `aside`, `article`, `header`, `footer`). Limited rather than fully polymorphic to keep types simple.
+
+**Anti-patterns:**
+
+- ❌ Grid for a single column of vertical flow — use Stack.
+- ❌ Grid for unaligned wrapping rows (toolbars, tag lists) — use Cluster.
+- ❌ `<Grid columns="auto 1fr">` strings — not supported in v1. For asymmetric / named tracks, use raw CSS Grid via className.
+- ❌ `<Grid as="ul">` with non-`<li>` children. The component doesn't enforce list semantics; consumers must.
+
 ### `<Avatar>` — profile circle
 
 ```tsx

--- a/packages/design-system/src/components/Cluster/Cluster.tsx
+++ b/packages/design-system/src/components/Cluster/Cluster.tsx
@@ -91,13 +91,13 @@ const alignClass: Record<ClusterAlign, string> = {
  * </Cluster>
  *
  * @remarks When NOT to use
- * - For aligned columns of equal width — use CSS Grid. Cluster wraps
+ * - For aligned columns of equal width — use `<Grid>`. Cluster wraps
  *   unpredictably at narrow widths and isn't a column system.
  * - For content that must never wrap — set `wrap={false}` if you must, but
  *   reconsider whether that's truly required on narrow viewports.
  *
  * @remarks Anti-patterns
- * - ❌ Cluster as a 2-column layout. Use CSS Grid for "two columns, always".
+ * - ❌ Cluster as a 2-column layout. Use `<Grid columns={2}>` for "two columns, always".
  * - ❌ Inline `style={{ marginLeft: 'auto' }}` on a child to push it right.
  *   Use `justify="between"` (with a sibling on the left) or split into two
  *   Clusters in the parent.

--- a/packages/design-system/src/components/Grid/Grid.module.scss
+++ b/packages/design-system/src/components/Grid/Grid.module.scss
@@ -1,0 +1,63 @@
+.grid {
+  display: grid;
+  grid-template-columns: var(--grid-columns, repeat(auto-fit, minmax(240px, 1fr)));
+}
+
+// Gap presets — mirror Stack/Cluster scale + camelCase naming
+.gapXs {
+  gap: var(--space-1);
+}
+
+.gapSm {
+  gap: var(--space-2);
+}
+
+.gapMd {
+  gap: var(--space-3);
+}
+
+.gapLg {
+  gap: var(--space-4);
+}
+
+.gapXl {
+  gap: var(--space-6);
+}
+
+.gap2xl {
+  gap: var(--space-8);
+}
+
+// Item alignment — cross-axis
+.alignItemsStart {
+  align-items: start;
+}
+
+.alignItemsCenter {
+  align-items: center;
+}
+
+.alignItemsEnd {
+  align-items: end;
+}
+
+.alignItemsStretch {
+  align-items: stretch;
+}
+
+// Item alignment — main-axis
+.justifyItemsStart {
+  justify-items: start;
+}
+
+.justifyItemsCenter {
+  justify-items: center;
+}
+
+.justifyItemsEnd {
+  justify-items: end;
+}
+
+.justifyItemsStretch {
+  justify-items: stretch;
+}

--- a/packages/design-system/src/components/Grid/Grid.test.tsx
+++ b/packages/design-system/src/components/Grid/Grid.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { createRef } from 'react';
+import { createRef, type CSSProperties } from 'react';
 import { Grid, type GridAlignItems, type GridGap, type GridJustifyItems } from './Grid';
 
 const capitalize = (s: string) => s[0]!.toUpperCase() + s.slice(1);
@@ -99,6 +99,20 @@ describe('<Grid>', () => {
     const el = container.firstChild as HTMLElement;
     expect(el.style.backgroundColor).toBe('red');
     expect(el.style.getPropertyValue('--grid-columns')).toBeTruthy();
+  });
+
+  it('internal --grid-columns wins when consumer style sets the same custom prop', () => {
+    const { container } = render(
+      <Grid
+        columns={3}
+        style={{ ['--grid-columns' as string]: 'repeat(99, 1fr)' } as CSSProperties}
+      >
+        x
+      </Grid>,
+    );
+    expect((container.firstChild as HTMLElement).style.getPropertyValue('--grid-columns')).toBe(
+      'repeat(3, minmax(0, 1fr))',
+    );
   });
 
   it('forwards ref to the underlying element', () => {

--- a/packages/design-system/src/components/Grid/Grid.test.tsx
+++ b/packages/design-system/src/components/Grid/Grid.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { Grid, type GridAlignItems, type GridGap, type GridJustifyItems } from './Grid';
+
+const capitalize = (s: string) => s[0]!.toUpperCase() + s.slice(1);
+
+describe('<Grid>', () => {
+  it('renders its children', () => {
+    render(<Grid>Hello</Grid>);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('defaults to auto-fit with minColumnWidth=240px', () => {
+    const { container } = render(<Grid>x</Grid>);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.getPropertyValue('--grid-columns')).toBe(
+      'repeat(auto-fit, minmax(240px, 1fr))',
+    );
+  });
+
+  it('applies the default gap (md) when no gap prop is given', () => {
+    const { container } = render(<Grid>x</Grid>);
+    expect((container.firstChild as HTMLElement).className).toMatch(/gapMd/);
+  });
+
+  it('columns={4} sets --grid-columns to repeat(4, minmax(0, 1fr))', () => {
+    const { container } = render(<Grid columns={4}>x</Grid>);
+    expect((container.firstChild as HTMLElement).style.getPropertyValue('--grid-columns')).toBe(
+      'repeat(4, minmax(0, 1fr))',
+    );
+  });
+
+  it('minColumnWidth="200px" sets --grid-columns to repeat(auto-fit, minmax(200px, 1fr))', () => {
+    const { container } = render(<Grid minColumnWidth="200px">x</Grid>);
+    expect((container.firstChild as HTMLElement).style.getPropertyValue('--grid-columns')).toBe(
+      'repeat(auto-fit, minmax(200px, 1fr))',
+    );
+  });
+
+  it.each<GridGap>(['xs', 'sm', 'md', 'lg', 'xl', '2xl'])('applies the %s gap class', (gap) => {
+    const { container } = render(<Grid gap={gap}>x</Grid>);
+    const expected = gap === '2xl' ? 'gap2xl' : `gap${capitalize(gap)}`;
+    expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(expected));
+  });
+
+  it.each<GridAlignItems>(['start', 'center', 'end', 'stretch'])(
+    'applies alignItems=%s class when set',
+    (a) => {
+      const { container } = render(<Grid alignItems={a}>x</Grid>);
+      expect((container.firstChild as HTMLElement).className).toMatch(
+        new RegExp(`alignItems${capitalize(a)}`),
+      );
+    },
+  );
+
+  it.each<GridJustifyItems>(['start', 'center', 'end', 'stretch'])(
+    'applies justifyItems=%s class when set',
+    (j) => {
+      const { container } = render(<Grid justifyItems={j}>x</Grid>);
+      expect((container.firstChild as HTMLElement).className).toMatch(
+        new RegExp(`justifyItems${capitalize(j)}`),
+      );
+    },
+  );
+
+  it('applies no alignItems/justifyItems class when those props are omitted', () => {
+    const { container } = render(<Grid>x</Grid>);
+    const className = (container.firstChild as HTMLElement).className;
+    expect(className).not.toMatch(/alignItems/);
+    expect(className).not.toMatch(/justifyItems/);
+  });
+
+  it('renders as <div> by default', () => {
+    const { container } = render(<Grid>x</Grid>);
+    expect((container.firstChild as HTMLElement).tagName).toBe('DIV');
+  });
+
+  it('renders as the element specified by `as`', () => {
+    const { container } = render(<Grid as="section">x</Grid>);
+    expect((container.firstChild as HTMLElement).tagName).toBe('SECTION');
+  });
+
+  it('renders as <ul>', () => {
+    const { container } = render(
+      <Grid as="ul">
+        <li>a</li>
+      </Grid>,
+    );
+    expect((container.firstChild as HTMLElement).tagName).toBe('UL');
+  });
+
+  it('merges the className prop', () => {
+    const { container } = render(<Grid className="external">x</Grid>);
+    expect((container.firstChild as HTMLElement).className).toMatch(/external/);
+  });
+
+  it('merges consumer style with the internal --grid-columns', () => {
+    const { container } = render(<Grid style={{ backgroundColor: 'red' }}>x</Grid>);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.backgroundColor).toBe('red');
+    expect(el.style.getPropertyValue('--grid-columns')).toBeTruthy();
+  });
+
+  it('forwards ref to the underlying element', () => {
+    const ref = createRef<HTMLElement>();
+    render(<Grid ref={ref}>x</Grid>);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+
+  it('forwards ref to a <section> when as="section"', () => {
+    const ref = createRef<HTMLElement>();
+    render(
+      <Grid ref={ref} as="section">
+        x
+      </Grid>,
+    );
+    expect(ref.current?.tagName).toBe('SECTION');
+  });
+
+  // TypeScript-level: passing both `columns` and `minColumnWidth` must be a type error.
+  // This is enforced by the @ts-expect-error directive below — if the directive is
+  // ever ignored (because the constraint slipped), tsc will error on the unused directive.
+  it('TS: columns and minColumnWidth are mutually exclusive', () => {
+    // @ts-expect-error — passing both should be a type error.
+    const ConflictingGrid = <Grid columns={2} minColumnWidth="240px" />;
+    // Reference the value so the variable isn't reported as unused.
+    expect(ConflictingGrid).toBeDefined();
+  });
+});

--- a/packages/design-system/src/components/Grid/Grid.tsx
+++ b/packages/design-system/src/components/Grid/Grid.tsx
@@ -1,0 +1,183 @@
+import { forwardRef, type CSSProperties, type HTMLAttributes, type ReactElement } from 'react';
+import clsx from 'clsx';
+import styles from './Grid.module.scss';
+
+/** Gap between cells. Same scale as Stack/Cluster: pixels 4/8/12/16/24/32. */
+export type GridGap = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+/** Cross-axis (vertical within row) alignment of each cell. */
+export type GridAlignItems = 'start' | 'center' | 'end' | 'stretch';
+
+/** Main-axis (horizontal within track) alignment of each cell. */
+export type GridJustifyItems = 'start' | 'center' | 'end' | 'stretch';
+
+/** Limited polymorphic element type. Covers the layout / semantic elements Grid is likely to render as. */
+export type GridAs =
+  | 'div'
+  | 'section'
+  | 'ul'
+  | 'ol'
+  | 'nav'
+  | 'main'
+  | 'aside'
+  | 'article'
+  | 'header'
+  | 'footer';
+
+interface GridBaseProps {
+  /**
+   * Gap between cells.
+   * `xs` (4) / `sm` (8) / `md` (12, default) / `lg` (16) / `xl` (24) / `2xl` (32).
+   * Same scale as Stack and Cluster.
+   */
+  gap?: GridGap;
+  /**
+   * Cross-axis (vertical within row) alignment of each cell. Default browser
+   * behavior is `stretch`; omit to use the default.
+   */
+  alignItems?: GridAlignItems;
+  /**
+   * Main-axis (horizontal within track) alignment of each cell. Default
+   * browser behavior is `stretch`; omit to use the default.
+   */
+  justifyItems?: GridJustifyItems;
+  /** Element to render. Default `'div'`. Limited to common layout / semantic elements. */
+  as?: GridAs;
+}
+
+interface GridFixedColumns extends GridBaseProps, HTMLAttributes<HTMLElement> {
+  /** Fixed number of equal-width columns. Mutually exclusive with `minColumnWidth`. */
+  columns: number;
+  minColumnWidth?: never;
+}
+
+interface GridAutoFit extends GridBaseProps, HTMLAttributes<HTMLElement> {
+  /**
+   * Minimum column width for auto-fit responsive layout. Columns reflow
+   * based on container width — no breakpoints needed. CSS length string
+   * like `'240px'` or `'15rem'`. Defaults to `'240px'` when neither
+   * `columns` nor `minColumnWidth` is provided.
+   */
+  minColumnWidth?: string;
+  columns?: never;
+}
+
+/** Public props — discriminated union enforces mutual exclusion. */
+export type GridProps = GridFixedColumns | GridAutoFit;
+
+const gapClass: Record<GridGap, string> = {
+  xs: styles.gapXs,
+  sm: styles.gapSm,
+  md: styles.gapMd,
+  lg: styles.gapLg,
+  xl: styles.gapXl,
+  '2xl': styles.gap2xl,
+};
+
+const alignItemsClass: Record<GridAlignItems, string> = {
+  start: styles.alignItemsStart,
+  center: styles.alignItemsCenter,
+  end: styles.alignItemsEnd,
+  stretch: styles.alignItemsStretch,
+};
+
+const justifyItemsClass: Record<GridJustifyItems, string> = {
+  start: styles.justifyItemsStart,
+  center: styles.justifyItemsCenter,
+  end: styles.justifyItemsEnd,
+  stretch: styles.justifyItemsStretch,
+};
+
+/**
+ * 2D layout primitive — CSS Grid wrapper with token-driven gap. Sibling to
+ * `<Stack>` (vertical) and `<Cluster>` (horizontal-with-wrap). Use when you
+ * need equal-width columns OR a responsive tile layout that reflows by
+ * container width (no breakpoints needed).
+ *
+ * Pick exactly one of `columns` (fixed N equal columns) or `minColumnWidth`
+ * (auto-fit responsive). TypeScript enforces this — passing both is a
+ * compile error. If you pass neither, Grid defaults to
+ * `minColumnWidth="240px"`.
+ *
+ * @example
+ * // Dashboard tile layout — auto-fits to viewport.
+ * <Grid gap="md">
+ *   {metrics.map(m => <Card key={m.id}>{m.label}: {m.value}</Card>)}
+ * </Grid>
+ *
+ * @example
+ * // Two-column form — exactly 2 equal columns at any width.
+ * <Grid columns={2} gap="lg">
+ *   <Input label="First name" />
+ *   <Input label="Last name" />
+ *   <Input label="Email" />
+ *   <Input label="Phone" />
+ * </Grid>
+ *
+ * @example
+ * // Photo gallery — auto-fit with smaller minimum.
+ * <Grid minColumnWidth="160px" gap="sm">
+ *   {photos.map(p => <img key={p.id} src={p.src} />)}
+ * </Grid>
+ *
+ * @example
+ * // Semantic element via `as`.
+ * <Grid as="section" columns={3} gap="md" aria-labelledby="dashboard-title">
+ *   <Card>...</Card>
+ *   <Card>...</Card>
+ *   <Card>...</Card>
+ * </Grid>
+ *
+ * @remarks When NOT to use
+ * - For vertical flow with a single column — use `<Stack>`.
+ * - For unaligned wrapping rows (toolbars, tag lists) — use `<Cluster>`.
+ * - For asymmetric or named tracks (`auto 1fr`, named lines) — not
+ *   supported in v1; use raw CSS Grid via `className`.
+ * - For per-cell span / placement — same answer; raw CSS Grid.
+ *
+ * @remarks Anti-patterns
+ * - ❌ `<Grid>` for a list of clickable items — semantics matter. Use
+ *   `<ul><li>` or render Grid with `as="ul"` and `<li>` children.
+ * - ❌ `<Grid as="ul">` with non-`<li>` children. The component doesn't
+ *   enforce list semantics; consumers must.
+ * - ❌ Inline `gridTemplateColumns` in the `style` prop instead of using
+ *   `columns` / `minColumnWidth`. Bypasses tokens and the responsive default.
+ */
+export const Grid = forwardRef<HTMLElement, GridProps>(function Grid(
+  {
+    gap = 'md',
+    alignItems,
+    justifyItems,
+    as = 'div',
+    columns,
+    minColumnWidth,
+    className,
+    style,
+    ...rest
+  },
+  ref,
+) {
+  const template =
+    columns !== undefined
+      ? `repeat(${columns}, minmax(0, 1fr))`
+      : `repeat(auto-fit, minmax(${minColumnWidth ?? '240px'}, 1fr))`;
+
+  // `as` is a string union of intrinsic JSX elements; cast through unknown
+  // for the limited union. At runtime React just uses the element name.
+  const Tag = as as unknown as 'div';
+
+  return (
+    <Tag
+      ref={ref as React.Ref<HTMLDivElement>}
+      className={clsx(
+        styles.grid,
+        gapClass[gap],
+        alignItems && alignItemsClass[alignItems],
+        justifyItems && justifyItemsClass[justifyItems],
+        className,
+      )}
+      style={{ ...(style as CSSProperties), ['--grid-columns' as string]: template }}
+      {...(rest as HTMLAttributes<HTMLDivElement>)}
+    />
+  );
+}) as <T extends GridProps>(props: T & { ref?: React.Ref<HTMLElement> }) => ReactElement;

--- a/packages/design-system/src/components/Grid/Grid.tsx
+++ b/packages/design-system/src/components/Grid/Grid.tsx
@@ -166,6 +166,8 @@ export const Grid = forwardRef<HTMLElement, GridProps>(function Grid(
   // for the limited union. At runtime React just uses the element name.
   const Tag = as as unknown as 'div';
 
+  // Tag is constrained at the type level via GridAs; the ref + rest casts
+  // satisfy React's intrinsic-element signature without per-tag branching.
   return (
     <Tag
       ref={ref as React.Ref<HTMLDivElement>}

--- a/packages/design-system/src/components/Grid/index.ts
+++ b/packages/design-system/src/components/Grid/index.ts
@@ -1,0 +1,8 @@
+export { Grid } from './Grid';
+export type {
+  GridProps,
+  GridGap,
+  GridAlignItems,
+  GridJustifyItems,
+  GridAs,
+} from './Grid';

--- a/packages/design-system/src/components/Grid/index.ts
+++ b/packages/design-system/src/components/Grid/index.ts
@@ -1,8 +1,2 @@
 export { Grid } from './Grid';
-export type {
-  GridProps,
-  GridGap,
-  GridAlignItems,
-  GridJustifyItems,
-  GridAs,
-} from './Grid';
+export type { GridProps, GridGap, GridAlignItems, GridJustifyItems, GridAs } from './Grid';

--- a/packages/design-system/src/components/Stack/Stack.tsx
+++ b/packages/design-system/src/components/Stack/Stack.tsx
@@ -64,7 +64,7 @@ const alignClass: Record<StackAlign, string> = {
  * </Stack>
  *
  * @remarks When NOT to use
- * - For tabular data — use a real `<table>` or CSS Grid.
+ * - For tabular data — use a real `<table>` or `<Grid>`.
  * - For a list of clickable items — semantics matter. Use `<ul><li>` with
  *   appropriate styling.
  *

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -17,6 +17,15 @@ export type { StackProps, StackGap, StackAlign } from './components/Stack';
 export { Cluster } from './components/Cluster';
 export type { ClusterProps, ClusterGap, ClusterJustify, ClusterAlign } from './components/Cluster';
 
+export { Grid } from './components/Grid';
+export type {
+  GridProps,
+  GridGap,
+  GridAlignItems,
+  GridJustifyItems,
+  GridAs,
+} from './components/Grid';
+
 export { Avatar, AvatarGroup, avatarColorIndex } from './components/Avatar';
 export type { AvatarProps, AvatarSize, AvatarStatus, AvatarGroupProps } from './components/Avatar';
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -33,6 +33,7 @@ import { ConfirmationPopoverDemo } from './pages/components/ConfirmationPopoverD
 import { DataTableDemo } from './pages/components/DataTableDemo';
 import { EmptyStateDemo } from './pages/components/EmptyStateDemo';
 import { DrawerDemo } from './pages/components/DrawerDemo';
+import { GridDemo } from './pages/components/GridDemo';
 
 export default function App() {
   return (
@@ -78,6 +79,7 @@ export default function App() {
           <Route path="/components/datatable" element={<DataTableDemo />} />
           <Route path="/components/empty-state" element={<EmptyStateDemo />} />
           <Route path="/components/drawer" element={<DrawerDemo />} />
+          <Route path="/components/grid" element={<GridDemo />} />
         </Routes>
       </AppShell>
     </BrowserRouter>

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -18,6 +18,7 @@ import {
   RectangleHorizontal,
   Rows3,
   Columns3,
+  LayoutGrid,
   CircleUser,
   Tag,
   PanelTop,
@@ -63,6 +64,7 @@ const componentGroups = [
     items: [
       { to: '/components/stack', label: 'Stack', icon: Rows3, end: false },
       { to: '/components/cluster', label: 'Cluster', icon: Columns3, end: false },
+      { to: '/components/grid', label: 'Grid', icon: LayoutGrid, end: false },
       { to: '/components/card', label: 'Card', icon: RectangleHorizontal, end: false },
     ],
   },

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -6,6 +6,7 @@ import { Button } from '@eocrm/design-system';
 import { Card } from '@eocrm/design-system';
 import { Checkbox } from '@eocrm/design-system';
 import { Cluster } from '@eocrm/design-system';
+import { Grid } from '@eocrm/design-system';
 import { Input } from '@eocrm/design-system';
 import { PasswordInput } from '@eocrm/design-system';
 import { PasswordStrengthMeter } from '@eocrm/design-system';
@@ -253,6 +254,19 @@ const items: { to: string; name: string; description: string; preview: React.Rea
         <div className={styles.tile} />
         <div className={styles.tile} />
       </Cluster>
+    ),
+  },
+  {
+    to: '/components/grid',
+    name: 'Grid',
+    description: '2D layout primitive with token-driven gap, auto-fit responsive columns, and equal-width fixed columns.',
+    preview: (
+      <Grid gap="xs">
+        <div className={styles.tile} />
+        <div className={styles.tile} />
+        <div className={styles.tile} />
+        <div className={styles.tile} />
+      </Grid>
     ),
   },
   {

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -259,7 +259,8 @@ const items: { to: string; name: string; description: string; preview: React.Rea
   {
     to: '/components/grid',
     name: 'Grid',
-    description: '2D layout primitive with token-driven gap, auto-fit responsive columns, and equal-width fixed columns.',
+    description:
+      '2D layout primitive with token-driven gap, auto-fit responsive columns, and equal-width fixed columns.',
     preview: (
       <Grid gap="xs">
         <div className={styles.tile} />

--- a/packages/playground/src/pages/components/GridDemo.tsx
+++ b/packages/playground/src/pages/components/GridDemo.tsx
@@ -1,0 +1,218 @@
+import { Card, Cluster, Grid, Input, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Grid/Grid.tsx?raw';
+import scssSource from '@lib-source/components/Grid/Grid.module.scss?raw';
+
+export function GridDemo() {
+  return (
+    <DemoLayout
+      name="Grid"
+      componentName="Grid"
+      description="2D layout primitive — CSS Grid wrapper. Use it when you need equal-width columns OR a responsive tile layout that reflows by container width (no breakpoints needed). Pair with Stack (vertical) and Cluster (horizontal-with-wrap)."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Grid.tsx"
+      scssFilename="Grid.module.scss"
+    >
+      <AutoFitExample />
+      <FixedColumnsExample />
+      <GapScaleExample />
+      <MinColumnWidthExample />
+      <AlignmentExample />
+      <SemanticElementExample />
+    </DemoLayout>
+  );
+}
+
+function AutoFitExample() {
+  return (
+    <Example
+      title="Auto-fit (default)"
+      description="No props set. Defaults to `minColumnWidth='240px'`. Resize your viewport to watch the columns reflow."
+      code={`<Grid gap="md">
+  <Card>...</Card>
+  <Card>...</Card>
+  ...
+</Grid>`}
+    >
+      <Grid gap="md">
+        {Array.from({ length: 6 }, (_, i) => (
+          <Card key={i}>
+            <strong>Tile {i + 1}</strong>
+            <p style={{ margin: 0, color: 'var(--color-fg-muted)' }}>
+              Auto-fitted to fill the row.
+            </p>
+          </Card>
+        ))}
+      </Grid>
+    </Example>
+  );
+}
+
+function FixedColumnsExample() {
+  return (
+    <Example
+      title="Fixed columns (2-column form)"
+      description="`columns={2}` for exactly two equal-width columns regardless of viewport. The canonical label/field form layout."
+      code={`<Grid columns={2} gap="lg">
+  <label>
+    First name
+    <Input placeholder="Ada" />
+  </label>
+  <label>
+    Last name
+    <Input placeholder="Lovelace" />
+  </label>
+  ...
+</Grid>`}
+    >
+      <Grid columns={2} gap="lg">
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <span style={{ fontSize: 'var(--font-size-sm)', fontWeight: 500 }}>First name</span>
+          <Input placeholder="Ada" />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <span style={{ fontSize: 'var(--font-size-sm)', fontWeight: 500 }}>Last name</span>
+          <Input placeholder="Lovelace" />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <span style={{ fontSize: 'var(--font-size-sm)', fontWeight: 500 }}>Email</span>
+          <Input placeholder="ada@example.com" />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <span style={{ fontSize: 'var(--font-size-sm)', fontWeight: 500 }}>Phone</span>
+          <Input placeholder="+1 555 0100" />
+        </label>
+      </Grid>
+    </Example>
+  );
+}
+
+function GapScaleExample() {
+  return (
+    <Example
+      title="Gap scale"
+      description="Same scale as Stack and Cluster: xs (4) / sm (8) / md (12) / lg (16) / xl (24) / 2xl (32) — all in pixels."
+      code={`<Grid columns={3} gap="xs">...</Grid>
+<Grid columns={3} gap="md">...</Grid>
+<Grid columns={3} gap="2xl">...</Grid>`}
+    >
+      <Stack gap="md">
+        {(['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const).map((g) => (
+          <Stack key={g} gap="xs">
+            <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+              gap=&quot;{g}&quot;
+            </div>
+            <Grid columns={3} gap={g}>
+              {Array.from({ length: 3 }, (_, i) => (
+                <Card key={i}>cell {i + 1}</Card>
+              ))}
+            </Grid>
+          </Stack>
+        ))}
+      </Stack>
+    </Example>
+  );
+}
+
+function MinColumnWidthExample() {
+  return (
+    <Example
+      title="minColumnWidth variants"
+      description="Three grids at different minimums. Wider minColumnWidth = fewer, wider columns at the same viewport."
+      code={`<Grid minColumnWidth="200px">...</Grid>
+<Grid minColumnWidth="280px">...</Grid>
+<Grid minColumnWidth="360px">...</Grid>`}
+    >
+      <Stack gap="md">
+        {(['200px', '280px', '360px'] as const).map((m) => (
+          <Stack key={m} gap="xs">
+            <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+              minColumnWidth=&quot;{m}&quot;
+            </div>
+            <Grid minColumnWidth={m} gap="sm">
+              {Array.from({ length: 5 }, (_, i) => (
+                <Card key={i}>cell {i + 1}</Card>
+              ))}
+            </Grid>
+          </Stack>
+        ))}
+      </Stack>
+    </Example>
+  );
+}
+
+function AlignmentExample() {
+  return (
+    <Example
+      title="alignItems / justifyItems"
+      description="Cells of varying intrinsic content height. alignItems=start aligns content to the top of each track; alignItems=stretch (default browser behavior) makes them all match the tallest. Try changing the value to compare."
+      code={`<Grid columns={3} gap="md" alignItems="start">
+  <Card>short</Card>
+  <Card>medium content here that takes more lines</Card>
+  <Card>short</Card>
+</Grid>`}
+    >
+      <Stack gap="md">
+        <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+          alignItems=&quot;start&quot;
+        </div>
+        <Grid columns={3} gap="md" alignItems="start">
+          <Card>short</Card>
+          <Card>
+            medium content here that takes a couple of lines so the card grows taller than the
+            others
+          </Card>
+          <Card>short</Card>
+        </Grid>
+        <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+          alignItems=&quot;stretch&quot; (default)
+        </div>
+        <Grid columns={3} gap="md" alignItems="stretch">
+          <Card>short</Card>
+          <Card>
+            medium content here that takes a couple of lines so the card grows taller than the
+            others
+          </Card>
+          <Card>short</Card>
+        </Grid>
+      </Stack>
+    </Example>
+  );
+}
+
+function SemanticElementExample() {
+  return (
+    <Example
+      title="Semantic elements via `as`"
+      description="Render Grid as a `<section>` (landmark) or `<ul>` (list). Limited to 10 common layout/semantic elements."
+      code={`<Grid as="section" columns={2} gap="md">
+  ...
+</Grid>
+
+<Grid as="ul" minColumnWidth="200px" gap="sm">
+  <li>...</li>
+</Grid>`}
+    >
+      <Stack gap="md">
+        <Grid as="section" columns={2} gap="md">
+          <Card>section cell 1</Card>
+          <Card>section cell 2</Card>
+        </Grid>
+        <Cluster gap="sm">
+          <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+            Below: rendered as &lt;ul&gt; with &lt;li&gt; children.
+          </span>
+        </Cluster>
+        <Grid as="ul" minColumnWidth="160px" gap="sm" style={{ listStyle: 'none', padding: 0 }}>
+          {['Alpha', 'Bravo', 'Charlie', 'Delta'].map((label) => (
+            <li key={label}>
+              <Card>{label}</Card>
+            </li>
+          ))}
+        </Grid>
+      </Stack>
+    </Example>
+  );
+}

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -16,6 +16,7 @@ export type ComponentName =
   | 'Drawer'
   | 'DropdownMenu'
   | 'EmptyState'
+  | 'Grid'
   | 'InlineDatePicker'
   | 'InlineDateRangePicker'
   | 'Input'


### PR DESCRIPTION
## Summary

- New `<Grid>` layout primitive at `packages/design-system/src/components/Grid/`. Single-file forwardRef component plus SCSS module — no behavior, no portal, no compound.
- **Mutually-exclusive `columns` / `minColumnWidth`** via TypeScript discriminated union with `never` — passing both is a compile error. Default when neither is set: `minColumnWidth="240px"` for a naturally responsive layout.
- **Token-driven gap** matching Stack/Cluster: `xs` / `sm` / `md` / `lg` / `xl` / `2xl`, default `md`.
- **alignItems / justifyItems** props for cross- and main-axis cell alignment.
- **Limited polymorphic `as` prop** — ten common semantic elements (`div` / `section` / `ul` / `ol` / `nav` / `main` / `aside` / `article` / `header` / `footer`).
- **Cross-links updated** — Stack and Cluster's JSDoc references to "CSS Grid" now point at `<Grid>`.

## Test plan

- [x] 16 unit tests covering: default behavior, columns/minColumnWidth template generation, all 6 gap variants, all 4 alignItems / justifyItems variants, `as` polymorphism (div / section / ul), className + style merge, internal --grid-columns vs consumer-supplied conflict, ref forwarding, and a `@ts-expect-error` compile-time check for the mutual exclusion.
- [x] All gates green: 1228 tests pass, typecheck clean, stylelint clean, build clean, npm pack --dry-run shows no test files in the tarball.
- [x] Playground demo at `/components/grid` with 6 examples (auto-fit / fixed columns / gap scale / minColumnWidth variants / alignment / semantic `as`).
- [x] Hard-Rule-8 review-fix cycle: 2 rounds, exit verdict "clean enough to stop" (0 Critical, 0 Important).

🤖 Generated with [Claude Code](https://claude.com/claude-code)