### PR TITLE
Toast: imperative transient notifications (singleton + portal viewport)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-toast.md
+++ b/docs/superpowers/plans/2026-05-23-toast.md
@@ -1,0 +1,2702 @@
+# Toast Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `toast` — an imperative transient notification primitive with portal-based rendering, 6 positions, 5 tones, queue/stack with hover-to-expand, auto-dismiss with pause-on-hover/focus/hidden, action slot, programmatic update, `toast.promise()` sugar, and `prefers-reduced-motion` support.
+
+**Architecture:** Three-layer split. (1) A vanilla observable store (`store.ts`, no React) holds the toast list. (2) A thin public API module (`api.ts`) wraps the store with tone shorthands + promise sugar — exported as the `toast` singleton. (3) A single `<ToastViewport>` React component uses `useSyncExternalStore` to subscribe to the store, renders a `createPortal` containing 6 position sub-stacks, and orchestrates timers + animations. Auto-dismiss timers are owned by a dedicated `useToastTimer` hook with pause-on-hover/focus/document-hidden plumbing.
+
+**Tech Stack:** React 18 + TypeScript (source-distributed). `react-dom` for `createPortal`. `lucide-react` (existing peer dep) for tone icons. No new packages, no new tokens. CSS Modules + SCSS. Vitest + RTL + userEvent + fake timers.
+
+**Source of truth:** `docs/superpowers/specs/2026-05-23-toast-design.md` (commit `4de813b`).
+
+**Branch:** `feat/toast`. Commit per task. Open the PR after the Hard-Rule-8 cycle (Task 8).
+
+---
+
+## File Structure
+
+```
+packages/design-system/src/components/Toast/
+  store.ts              ← Task 1. Vanilla observable store. add/update/dismiss/dismissAll/subscribe + id generator. No React imports.
+  store.test.ts         ← Task 1. Store mechanics tests (no DOM, no React).
+  api.ts                ← Task 2. Public `toast` singleton: tones, promise(), update(), dismiss(). Calls store + reads _viewportConfig.
+  api.test.ts           ← Task 2. API shape + tone-to-store-payload tests.
+  useToastTimer.ts      ← Task 3. Custom hook: setTimeout + pause-on-hover/focus/document.visibilityState.
+  useToastTimer.test.ts ← Task 3. Pause/resume math tests, fake timers, mocked visibility.
+  Toast.tsx             ← Task 4. Internal single-toast component. role="alert"/role="status", action button, close button.
+  ToastViewport.tsx     ← Task 4. Exported portal + 6 position buckets + useSyncExternalStore + hover-expand state.
+  Toast.module.scss     ← Task 4. Card + viewport positions + 6 keyframe directions + reduced-motion + peek-collapse.
+  Toast.test.tsx        ← Task 5. Integration tests (~20) — RTL + userEvent + fake timers.
+  index.ts              ← Task 6. Public re-exports.
+
+packages/design-system/src/index.ts                            ← Task 6. MODIFY: re-export toast + ToastViewport + types
+packages/design-system/AGENTS.md                               ← Task 6. MODIFY: TL;DR slot after Tooltip section
+
+packages/playground/src/pages/components/ToastDemo.tsx         ← Task 7. NEW: 8 examples
+packages/playground/src/App.tsx                                ← Task 7. MODIFY: route + viewport mount at app root
+packages/playground/src/layout/AppShell/AppShell.tsx           ← Task 7. MODIFY: new "Feedback" group containing Toast
+packages/playground/src/pages/components/ComponentsIndex.tsx   ← Task 7. MODIFY: overview card
+packages/playground/src/pages/mockups/registry.ts              ← Task 7. MODIFY: 'Toast' in ComponentName union
+```
+
+**Decomposition rationale:**
+
+- **Task 1 (store) and Task 2 (api) are split** because they're independent pure-JS modules with separate test surfaces. Each landing on its own commit gives a reviewable diff. The store is the foundation; the API depends on it.
+- **Task 3 (useToastTimer) is its own task** because pause/resume math is the most failure-prone surface. Isolating it as a custom hook + dedicated test file pays for itself the first time someone changes a timer rule.
+- **Task 4 bundles Toast.tsx + ToastViewport.tsx + Toast.module.scss** in one commit. These three files cross-reference (viewport renders `<Toast>`, both use the SCSS module) and can't sensibly land separately. Modal and Drawer used the same bundled approach.
+- **Task 5 (Toast.test.tsx integration) is separate** so the test diff (~20 cases, ~400 lines) is reviewable in isolation.
+- **Task 6 (exports + AGENTS.md)** is small and conceptually paired — both are "public API surface" changes.
+- **Task 7 bundles all 4 playground wiring spots + the demo** so the demo lands routable in one commit.
+- **Task 8 is the Hard-Rule-8 closeout** — gates, fresh-context review-fix cycle, push, PR.
+
+---
+
+## Task 1 — Store (vanilla observable, pure JS)
+
+Pure JS module + its tests. No React imports anywhere in this commit.
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Toast/store.ts`
+- Create: `packages/design-system/src/components/Toast/store.test.ts`
+
+- [ ] **Step 1: Verify branch + clean tree**
+
+```bash
+cd /home/dpws/projects/design-system
+git status
+git branch --show-current
+git log --oneline -3
+```
+
+Expected:
+- Branch: `feat/toast`
+- Working tree clean
+- Most recent commits include `4de813b Toast: spec — correct tone token names` and `27ea60b Toast: design spec`.
+
+- [ ] **Step 2: Create the component directory + write `store.ts`**
+
+```bash
+mkdir -p packages/design-system/src/components/Toast
+```
+
+Create `packages/design-system/src/components/Toast/store.ts`:
+
+```ts
+import type { ReactNode } from 'react';
+
+export type ToastTone = 'info' | 'success' | 'warning' | 'error' | 'loading';
+
+export type ToastPosition =
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';
+
+export interface ToastEntry {
+  id: string;
+  tone: ToastTone;
+  message: ReactNode;
+  description?: ReactNode;
+  duration: number | 'persistent';
+  position: ToastPosition;
+  action?: { label: string; onClick: () => void };
+  dismissible: boolean;
+  icon?: ReactNode | null;
+  createdAt: number;
+  status: 'visible' | 'exiting';
+}
+
+/** Input shape accepted by `store.add` — `createdAt` and `status` are computed internally. */
+export type ToastInput = Omit<ToastEntry, 'createdAt' | 'status'>;
+
+/** Partial shape accepted by `store.update` — internal-only fields are also acceptable
+ *  (the viewport uses this to flip a toast to `exiting` before removal). */
+export type ToastUpdate = Partial<Omit<ToastEntry, 'id' | 'createdAt'>>;
+
+type Listener = () => void;
+
+interface StoreState {
+  toasts: readonly ToastEntry[];
+}
+
+/** Duration of the exit animation. The store delays full removal by this many ms
+ *  so the viewport can animate `data-status="exiting"` before unmount. */
+export const EXIT_ANIMATION_MS = 250;
+
+let state: StoreState = { toasts: [] };
+const listeners = new Set<Listener>();
+
+function notify() {
+  listeners.forEach((l) => l());
+}
+
+let nextSeq = 0;
+/** Generates a short id with millisecond timestamp + monotonic counter so
+ *  rapid-fire calls within the same ms never collide. */
+export function generateId(): string {
+  return `t${Date.now().toString(36)}${(++nextSeq).toString(36)}`;
+}
+
+export const store = {
+  getSnapshot(): StoreState {
+    return state;
+  },
+  subscribe(listener: Listener): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+  add(input: ToastInput): string {
+    // Reusing an id is an implicit update — lets `toast.success('done', { id })`
+    // mutate an existing loading toast in place.
+    if (state.toasts.some((t) => t.id === input.id)) {
+      return store.update(input.id, input);
+    }
+    const entry: ToastEntry = { ...input, createdAt: Date.now(), status: 'visible' };
+    state = { toasts: [...state.toasts, entry] };
+    notify();
+    return entry.id;
+  },
+  update(id: string, partial: ToastUpdate): string {
+    state = {
+      toasts: state.toasts.map((t) => (t.id === id ? { ...t, ...partial } : t)),
+    };
+    notify();
+    return id;
+  },
+  dismiss(id?: string): void {
+    if (id === undefined) {
+      state = { toasts: state.toasts.map((t) => ({ ...t, status: 'exiting' })) };
+      notify();
+      setTimeout(() => {
+        state = { toasts: [] };
+        notify();
+      }, EXIT_ANIMATION_MS);
+      return;
+    }
+    if (!state.toasts.some((t) => t.id === id)) return;
+    state = {
+      toasts: state.toasts.map((t) => (t.id === id ? { ...t, status: 'exiting' } : t)),
+    };
+    notify();
+    setTimeout(() => {
+      state = { toasts: state.toasts.filter((t) => t.id !== id) };
+      notify();
+    }, EXIT_ANIMATION_MS);
+  },
+  /** Test-only: synchronously clears state. NOT exported from the package. */
+  _reset(): void {
+    state = { toasts: [] };
+    nextSeq = 0;
+    listeners.clear();
+  },
+};
+```
+
+- [ ] **Step 3: Write `store.test.ts`**
+
+Create `packages/design-system/src/components/Toast/store.test.ts`:
+
+```ts
+import { store, generateId, EXIT_ANIMATION_MS, type ToastInput } from './store';
+
+const baseInput = (overrides: Partial<ToastInput> = {}): ToastInput => ({
+  id: 't1',
+  tone: 'info',
+  message: 'Hello',
+  duration: 4000,
+  position: 'bottom-right',
+  dismissible: true,
+  ...overrides,
+});
+
+describe('toast store', () => {
+  beforeEach(() => {
+    store._reset();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts with an empty toast list', () => {
+    expect(store.getSnapshot().toasts).toEqual([]);
+  });
+
+  it('add() appends an entry and returns the id', () => {
+    const id = store.add(baseInput({ id: 'a' }));
+    expect(id).toBe('a');
+    expect(store.getSnapshot().toasts).toHaveLength(1);
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      id: 'a',
+      tone: 'info',
+      status: 'visible',
+    });
+  });
+
+  it('add() preserves the message field', () => {
+    store.add(baseInput({ id: 'a', message: 'Saved' }));
+    expect(store.getSnapshot().toasts[0].message).toBe('Saved');
+  });
+
+  it('add() with an existing id delegates to update (no duplicate)', () => {
+    store.add(baseInput({ id: 'a', tone: 'info' }));
+    store.add(baseInput({ id: 'a', tone: 'success', message: 'Done' }));
+    expect(store.getSnapshot().toasts).toHaveLength(1);
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'success',
+      message: 'Done',
+    });
+  });
+
+  it('update() mutates an existing entry', () => {
+    store.add(baseInput({ id: 'a' }));
+    store.update('a', { tone: 'success', message: 'Done' });
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'success',
+      message: 'Done',
+    });
+  });
+
+  it('update() is a no-op on unknown id', () => {
+    store.add(baseInput({ id: 'a' }));
+    store.update('nope', { tone: 'error' });
+    expect(store.getSnapshot().toasts[0].tone).toBe('info');
+  });
+
+  it('dismiss(id) flips status to exiting, then removes after EXIT_ANIMATION_MS', () => {
+    store.add(baseInput({ id: 'a' }));
+    store.dismiss('a');
+    expect(store.getSnapshot().toasts[0].status).toBe('exiting');
+    vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    expect(store.getSnapshot().toasts).toEqual([]);
+  });
+
+  it('dismiss(unknownId) is a no-op', () => {
+    store.add(baseInput({ id: 'a' }));
+    store.dismiss('nope');
+    expect(store.getSnapshot().toasts).toHaveLength(1);
+    expect(store.getSnapshot().toasts[0].status).toBe('visible');
+  });
+
+  it('dismiss() with no id marks all exiting then clears', () => {
+    store.add(baseInput({ id: 'a' }));
+    store.add(baseInput({ id: 'b' }));
+    store.dismiss();
+    expect(store.getSnapshot().toasts.every((t) => t.status === 'exiting')).toBe(true);
+    vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    expect(store.getSnapshot().toasts).toEqual([]);
+  });
+
+  it('subscribe() listener fires on add/update/dismiss', () => {
+    const listener = vi.fn();
+    store.subscribe(listener);
+    store.add(baseInput({ id: 'a' }));
+    store.update('a', { message: 'b' });
+    store.dismiss('a');
+    expect(listener.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('subscribe() returns an unsubscribe function', () => {
+    const listener = vi.fn();
+    const unsub = store.subscribe(listener);
+    unsub();
+    store.add(baseInput({ id: 'a' }));
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('generateId() returns unique ids across rapid calls', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 1000; i++) ids.add(generateId());
+    expect(ids.size).toBe(1000);
+  });
+
+  it('add() with no id field is allowed only if caller passes one; consumers use generateId()', () => {
+    // The store doesn't auto-generate — that's the API layer's job.
+    // This test documents the contract: id is required on ToastInput.
+    const id = store.add(baseInput({ id: generateId() }));
+    expect(id).toMatch(/^t/);
+  });
+});
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test -w @eocrm/design-system -- --run src/components/Toast/store.test.ts
+```
+
+Expected: all 13 tests pass.
+
+- [ ] **Step 5: Run the typecheck**
+
+```bash
+cd /home/dpws/projects/design-system
+make build-lib
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Toast/store.ts \
+        packages/design-system/src/components/Toast/store.test.ts
+git commit -m "$(cat <<'EOF'
+Toast: store — vanilla observable for the toast list
+
+Pure JS module (no React imports). Owns add/update/dismiss/subscribe and
+the id generator. Two-step dismiss (mark exiting → remove after 250ms) so
+the viewport can play the exit animation before unmount. add() with an
+existing id delegates to update so 'toast.loading' → 'toast.success' with
+the same id mutates in place.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2 — Public API (the `toast` singleton)
+
+Wraps the store in tone shorthands, programmatic update, dismiss, and the promise sugar. Pure JS too — no React imports.
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Toast/api.ts`
+- Create: `packages/design-system/src/components/Toast/api.test.ts`
+
+- [ ] **Step 1: Write `api.ts`**
+
+Create `packages/design-system/src/components/Toast/api.ts`:
+
+```ts
+import type { ReactNode } from 'react';
+import {
+  store,
+  generateId,
+  type ToastTone,
+  type ToastPosition,
+  type ToastInput,
+} from './store';
+
+export interface ToastOptions {
+  /** Optional second-line content. ReactNode so consumers can embed links/icons. */
+  description?: ReactNode;
+  /** Auto-dismiss timeout (ms) or `'persistent'` for no auto-dismiss. Default: 4000. */
+  duration?: number | 'persistent';
+  /** Per-call override of the viewport's default position. */
+  position?: ToastPosition;
+  /** Stable id (else auto-generated). Reusing an existing id triggers an update. */
+  id?: string;
+  /** Single primary action button rendered inside the toast. */
+  action?: { label: string; onClick: () => void };
+  /** Show the close (×) button. Default: true. Forced true when `duration: 'persistent'`. */
+  dismissible?: boolean;
+  /** Override the tone's default icon. Pass `null` to hide. */
+  icon?: ReactNode | null;
+}
+
+/** Partial shape accepted by `toast.update`. id/createdAt/status are internal-only. */
+export type ToastUpdateOptions = Partial<
+  Omit<ToastOptions, 'id'> & { message: ReactNode; tone: ToastTone }
+>;
+
+interface ViewportConfig {
+  position: ToastPosition;
+  duration: number;
+}
+
+/** Mutable defaults written by ToastViewport on mount. Module-level so the API
+ *  layer can read them without depending on React. If no viewport mounts, the
+ *  constants below stand in — toasts fired into the void are stored but never
+ *  rendered, which is the correct behavior. */
+let viewportConfig: ViewportConfig = { position: 'bottom-right', duration: 4000 };
+
+/** Called by ToastViewport. NOT exported from the package barrel. */
+export function _setViewportConfig(cfg: ViewportConfig): void {
+  viewportConfig = cfg;
+}
+
+function buildInput(
+  tone: ToastTone,
+  message: ReactNode,
+  options: ToastOptions = {}
+): ToastInput {
+  const isLoading = tone === 'loading';
+  const duration =
+    options.duration ?? (isLoading ? 'persistent' : viewportConfig.duration);
+  const isPersistent = duration === 'persistent';
+  return {
+    id: options.id ?? generateId(),
+    tone,
+    message,
+    description: options.description,
+    duration,
+    position: options.position ?? viewportConfig.position,
+    action: options.action,
+    // Persistent toasts force dismissible: true so the user has a way out.
+    dismissible: isPersistent ? true : (options.dismissible ?? true),
+    icon: options.icon,
+  };
+}
+
+function fire(
+  tone: ToastTone,
+  message: ReactNode,
+  options?: ToastOptions
+): string {
+  return store.add(buildInput(tone, message, options));
+}
+
+type PromiseMessages<T> = {
+  loading: string;
+  success: string | ((value: T) => string);
+  error: string | ((err: unknown) => string);
+  options?: Omit<ToastOptions, 'duration'>;
+};
+
+export const toast = Object.assign(
+  (message: ReactNode, options?: ToastOptions) => fire('info', message, options),
+  {
+    info: (m: ReactNode, o?: ToastOptions) => fire('info', m, o),
+    success: (m: ReactNode, o?: ToastOptions) => fire('success', m, o),
+    warning: (m: ReactNode, o?: ToastOptions) => fire('warning', m, o),
+    error: (m: ReactNode, o?: ToastOptions) => fire('error', m, o),
+    loading: (m: ReactNode, o?: ToastOptions) => fire('loading', m, o),
+    update: (id: string, partial: ToastUpdateOptions): void => {
+      store.update(id, partial);
+    },
+    dismiss: (id?: string): void => store.dismiss(id),
+    promise<T>(p: Promise<T>, msgs: PromiseMessages<T>): Promise<T> {
+      const id = fire('loading', msgs.loading, msgs.options);
+      return p.then(
+        (value) => {
+          const successMsg =
+            typeof msgs.success === 'function' ? msgs.success(value) : msgs.success;
+          store.update(id, {
+            tone: 'success',
+            message: successMsg,
+            duration: viewportConfig.duration,
+            status: 'visible',
+          });
+          return value;
+        },
+        (err) => {
+          const errorMsg =
+            typeof msgs.error === 'function' ? msgs.error(err) : msgs.error;
+          store.update(id, {
+            tone: 'error',
+            message: errorMsg,
+            duration: viewportConfig.duration,
+            status: 'visible',
+          });
+          throw err;
+        }
+      );
+    },
+  }
+);
+```
+
+- [ ] **Step 2: Write `api.test.ts`**
+
+Create `packages/design-system/src/components/Toast/api.test.ts`:
+
+```ts
+import { toast, _setViewportConfig } from './api';
+import { store } from './store';
+
+describe('toast api', () => {
+  beforeEach(() => {
+    store._reset();
+    _setViewportConfig({ position: 'bottom-right', duration: 4000 });
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('toast() defaults to info tone', () => {
+    toast('Hello');
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'info',
+      message: 'Hello',
+    });
+  });
+
+  it.each([
+    ['info', 'info'],
+    ['success', 'success'],
+    ['warning', 'warning'],
+    ['error', 'error'],
+    ['loading', 'loading'],
+  ] as const)('toast.%s writes tone=%s', (method, expectedTone) => {
+    toast[method]('Hi');
+    expect(store.getSnapshot().toasts[0].tone).toBe(expectedTone);
+  });
+
+  it('toast.loading defaults to duration: persistent', () => {
+    toast.loading('Uploading');
+    expect(store.getSnapshot().toasts[0].duration).toBe('persistent');
+  });
+
+  it('toast.success picks up viewport.duration default', () => {
+    _setViewportConfig({ position: 'top-right', duration: 7000 });
+    toast.success('Saved');
+    expect(store.getSnapshot().toasts[0].duration).toBe(7000);
+  });
+
+  it('toast.success picks up viewport.position default', () => {
+    _setViewportConfig({ position: 'top-center', duration: 4000 });
+    toast.success('Saved');
+    expect(store.getSnapshot().toasts[0].position).toBe('top-center');
+  });
+
+  it('per-call position overrides the viewport default', () => {
+    toast.success('Saved', { position: 'top-left' });
+    expect(store.getSnapshot().toasts[0].position).toBe('top-left');
+  });
+
+  it('per-call duration overrides the viewport default', () => {
+    toast.success('Saved', { duration: 1000 });
+    expect(store.getSnapshot().toasts[0].duration).toBe(1000);
+  });
+
+  it('dismissible defaults to true', () => {
+    toast.success('Saved');
+    expect(store.getSnapshot().toasts[0].dismissible).toBe(true);
+  });
+
+  it('dismissible: false is respected for non-persistent toasts', () => {
+    toast.success('Saved', { dismissible: false });
+    expect(store.getSnapshot().toasts[0].dismissible).toBe(false);
+  });
+
+  it('dismissible is FORCED true when duration: persistent', () => {
+    toast.error('Boom', { duration: 'persistent', dismissible: false });
+    expect(store.getSnapshot().toasts[0].dismissible).toBe(true);
+  });
+
+  it('toast.success returns the id (auto-generated)', () => {
+    const id = toast.success('Saved');
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('toast.update mutates a stored entry', () => {
+    const id = toast.loading('Uploading');
+    toast.update(id, { tone: 'success', message: 'Uploaded' });
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'success',
+      message: 'Uploaded',
+    });
+  });
+
+  it('toast.success with an existing id updates in place (no duplicate)', () => {
+    const id = toast.loading('Uploading');
+    toast.success('Uploaded', { id });
+    expect(store.getSnapshot().toasts).toHaveLength(1);
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'success',
+      message: 'Uploaded',
+    });
+  });
+
+  it('toast.dismiss(id) flips status to exiting', () => {
+    const id = toast.success('Saved');
+    toast.dismiss(id);
+    expect(store.getSnapshot().toasts[0].status).toBe('exiting');
+  });
+
+  it('toast.dismiss() with no id dismisses all', () => {
+    toast.success('a');
+    toast.success('b');
+    toast.dismiss();
+    expect(store.getSnapshot().toasts.every((t) => t.status === 'exiting')).toBe(true);
+  });
+
+  it('toast.promise: loading then success on resolve', async () => {
+    const p = Promise.resolve({ name: 'file.pdf' });
+    const wrapped = toast.promise(p, {
+      loading: 'Uploading',
+      success: (r) => `Uploaded ${r.name}`,
+      error: 'Failed',
+    });
+    // After the first microtask flush, we should still be in loading.
+    expect(store.getSnapshot().toasts[0].tone).toBe('loading');
+    const value = await wrapped;
+    expect(value).toEqual({ name: 'file.pdf' });
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'success',
+      message: 'Uploaded file.pdf',
+    });
+  });
+
+  it('toast.promise: loading then error on reject (and rethrows)', async () => {
+    const err = new Error('500');
+    const p = Promise.reject(err);
+    const wrapped = toast.promise(p, {
+      loading: 'Uploading',
+      success: 'Uploaded',
+      error: (e) => `Failed: ${(e as Error).message}`,
+    });
+    await expect(wrapped).rejects.toBe(err);
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'error',
+      message: 'Failed: 500',
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test -w @eocrm/design-system -- --run src/components/Toast/api.test.ts
+```
+
+Expected: all 19 tests pass.
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+make build-lib
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Toast/api.ts \
+        packages/design-system/src/components/Toast/api.test.ts
+git commit -m "$(cat <<'EOF'
+Toast: api — public `toast` singleton (tones, update, dismiss, promise)
+
+Thin wrapper over the store. tone shorthands (info/success/warning/error/
+loading), programmatic update by id, dismiss(id?) for one or all,
+toast.promise() sugar that cycles loading → success/error and returns the
+original promise untouched. Reads viewport defaults from a module-level
+config slot written by ToastViewport on mount (no React dep here).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 — `useToastTimer` hook (pause/resume math)
+
+A custom hook that owns the per-toast auto-dismiss timer with pause-on-hover / pause-on-focus / pause-when-hidden semantics. Isolating this from the components makes the gnarly math testable.
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Toast/useToastTimer.ts`
+- Create: `packages/design-system/src/components/Toast/useToastTimer.test.ts`
+
+- [ ] **Step 1: Write `useToastTimer.ts`**
+
+Create `packages/design-system/src/components/Toast/useToastTimer.ts`:
+
+```ts
+import { useEffect, useRef } from 'react';
+
+interface UseToastTimerArgs {
+  /** Toast id — used purely as a stable dependency key. */
+  id: string;
+  /** ms or 'persistent'. Persistent skips the timer entirely. */
+  duration: number | 'persistent';
+  /** Whether the timer is currently paused (hover / focus / hidden tab). */
+  paused: boolean;
+  /** Called when the timer expires. */
+  onExpire: () => void;
+  /** Indirection so tests can mock visibility without poking jsdom internals.
+   *  Defaults to `document.visibilityState === 'visible'`. */
+  getVisible?: () => boolean;
+}
+
+/** Manages a per-toast dismiss timer with pause/resume math.
+ *
+ *  Behavior:
+ *  - duration === 'persistent': no timer ever runs.
+ *  - paused flips true: capture remaining ms, clear timeout.
+ *  - paused flips false (and document visible): re-arm with remaining ms.
+ *  - document becomes hidden: behaves like paused = true (auto).
+ *  - document becomes visible: behaves like paused = false (auto).
+ *  - On unmount: clear timeout, remove visibility listener.
+ */
+export function useToastTimer({
+  id,
+  duration,
+  paused,
+  onExpire,
+  getVisible = defaultGetVisible,
+}: UseToastTimerArgs): void {
+  const remainingRef = useRef<number>(typeof duration === 'number' ? duration : Infinity);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startedAtRef = useRef<number>(0);
+  const onExpireRef = useRef(onExpire);
+  onExpireRef.current = onExpire;
+
+  // Track document visibility imperatively so we don't trigger React rerenders
+  // for tab focus changes.
+  const docHiddenRef = useRef(!getVisible());
+
+  useEffect(() => {
+    if (duration === 'persistent') return;
+    remainingRef.current = duration;
+  }, [duration]);
+
+  useEffect(() => {
+    if (duration === 'persistent') return;
+
+    const tick = () => {
+      onExpireRef.current();
+    };
+
+    const arm = () => {
+      if (timeoutRef.current !== null) return;
+      startedAtRef.current = Date.now();
+      timeoutRef.current = setTimeout(tick, remainingRef.current);
+    };
+
+    const disarm = () => {
+      if (timeoutRef.current === null) return;
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+      const elapsed = Date.now() - startedAtRef.current;
+      remainingRef.current = Math.max(0, remainingRef.current - elapsed);
+    };
+
+    const sync = () => {
+      const shouldRun = !paused && !docHiddenRef.current;
+      if (shouldRun) arm();
+      else disarm();
+    };
+
+    const onVisibilityChange = () => {
+      docHiddenRef.current = !getVisible();
+      sync();
+    };
+
+    sync();
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      disarm();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, duration, paused]);
+}
+
+function defaultGetVisible(): boolean {
+  return typeof document === 'undefined' ? true : document.visibilityState === 'visible';
+}
+```
+
+- [ ] **Step 2: Write `useToastTimer.test.ts`**
+
+Create `packages/design-system/src/components/Toast/useToastTimer.test.ts`:
+
+```ts
+import { renderHook, act } from '@testing-library/react';
+import { useToastTimer } from './useToastTimer';
+
+describe('useToastTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls onExpire after `duration` ms when not paused', () => {
+    const onExpire = vi.fn();
+    renderHook(() =>
+      useToastTimer({
+        id: 'a',
+        duration: 1000,
+        paused: false,
+        onExpire,
+        getVisible: () => true,
+      })
+    );
+    expect(onExpire).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('never calls onExpire when duration is persistent', () => {
+    const onExpire = vi.fn();
+    renderHook(() =>
+      useToastTimer({
+        id: 'a',
+        duration: 'persistent',
+        paused: false,
+        onExpire,
+        getVisible: () => true,
+      })
+    );
+    act(() => {
+      vi.advanceTimersByTime(100_000);
+    });
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+
+  it('pause captures remaining; resume re-arms with that remaining', () => {
+    const onExpire = vi.fn();
+    const { rerender } = renderHook(
+      ({ paused }) =>
+        useToastTimer({
+          id: 'a',
+          duration: 1000,
+          paused,
+          onExpire,
+          getVisible: () => true,
+        }),
+      { initialProps: { paused: false } }
+    );
+
+    act(() => vi.advanceTimersByTime(400));
+    expect(onExpire).not.toHaveBeenCalled();
+
+    rerender({ paused: true });
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onExpire).not.toHaveBeenCalled();
+
+    rerender({ paused: false });
+    // Only 600ms should remain.
+    act(() => vi.advanceTimersByTime(599));
+    expect(onExpire).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('paused at mount: no timer running until paused flips false', () => {
+    const onExpire = vi.fn();
+    const { rerender } = renderHook(
+      ({ paused }) =>
+        useToastTimer({
+          id: 'a',
+          duration: 500,
+          paused,
+          onExpire,
+          getVisible: () => true,
+        }),
+      { initialProps: { paused: true } }
+    );
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onExpire).not.toHaveBeenCalled();
+
+    rerender({ paused: false });
+    act(() => vi.advanceTimersByTime(500));
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('hidden document acts like paused', () => {
+    const onExpire = vi.fn();
+    let visible = false;
+    const { rerender: _ } = renderHook(() =>
+      useToastTimer({
+        id: 'a',
+        duration: 1000,
+        paused: false,
+        onExpire,
+        getVisible: () => visible,
+      })
+    );
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onExpire).not.toHaveBeenCalled();
+
+    visible = true;
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    act(() => vi.advanceTimersByTime(1000));
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('unmount clears the timer and visibility listener', () => {
+    const onExpire = vi.fn();
+    const { unmount } = renderHook(() =>
+      useToastTimer({
+        id: 'a',
+        duration: 1000,
+        paused: false,
+        onExpire,
+        getVisible: () => true,
+      })
+    );
+    unmount();
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+
+  it('changing duration mid-life resets the remaining (and re-arms if not paused)', () => {
+    const onExpire = vi.fn();
+    const { rerender } = renderHook(
+      ({ duration }) =>
+        useToastTimer({
+          id: 'a',
+          duration,
+          paused: false,
+          onExpire,
+          getVisible: () => true,
+        }),
+      { initialProps: { duration: 1000 } }
+    );
+    act(() => vi.advanceTimersByTime(500));
+    rerender({ duration: 2000 });
+    // Old 500 is forgotten; new full 2000 should elapse before expire.
+    act(() => vi.advanceTimersByTime(1999));
+    expect(onExpire).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test -w @eocrm/design-system -- --run src/components/Toast/useToastTimer.test.ts
+```
+
+Expected: all 7 tests pass.
+
+- [ ] **Step 4: Typecheck + lint**
+
+```bash
+make build-lib
+make lint
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/Toast/useToastTimer.ts \
+        packages/design-system/src/components/Toast/useToastTimer.test.ts
+git commit -m "$(cat <<'EOF'
+Toast: useToastTimer hook — pause/resume math for auto-dismiss
+
+Owns the per-toast setTimeout with pause-on-hover/focus/document-hidden
+semantics. Captures remaining-ms on pause, re-arms with the same on
+resume. getVisible() indirection so tests can simulate document hidden
+without touching jsdom's read-only visibilityState property.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 — `<Toast>` + `<ToastViewport>` + SCSS (the React surface)
+
+The three files cross-reference (viewport renders Toast, both use the SCSS module). Single bundled commit.
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Toast/Toast.tsx`
+- Create: `packages/design-system/src/components/Toast/ToastViewport.tsx`
+- Create: `packages/design-system/src/components/Toast/Toast.module.scss`
+
+- [ ] **Step 1: Write the SCSS module**
+
+Create `packages/design-system/src/components/Toast/Toast.module.scss`:
+
+```scss
+@use '../../styles/mixins' as *;
+
+// ─── Viewport stacks ─────────────────────────────────────────────────────
+.stack {
+  position: fixed;
+  z-index: var(--z-toast);
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  pointer-events: none; // stack itself doesn't intercept clicks
+  max-width: calc(100vw - 2 * var(--space-3));
+  width: 360px;
+}
+
+.stack > li {
+  pointer-events: auto;
+}
+
+// Position variants — fixed positioning. Top-anchored stacks grow downward
+// (newest farther from edge); bottom-anchored grow upward via column-reverse.
+
+.posTopLeft {
+  top: var(--space-3);
+  left: var(--space-3);
+}
+
+.posTopCenter {
+  top: var(--space-3);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.posTopRight {
+  top: var(--space-3);
+  right: var(--space-3);
+}
+
+.posBottomLeft {
+  bottom: var(--space-3);
+  left: var(--space-3);
+  flex-direction: column-reverse;
+}
+
+.posBottomCenter {
+  bottom: var(--space-3);
+  left: 50%;
+  transform: translateX(-50%);
+  flex-direction: column-reverse;
+}
+
+.posBottomRight {
+  bottom: var(--space-3);
+  right: var(--space-3);
+  flex-direction: column-reverse;
+}
+
+// Gap between stacked toasts. column-reverse stacks need margin-bottom
+// instead of margin-top to space the same way visually.
+.gapSm > li + li {
+  margin-top: var(--space-2);
+}
+
+.gapMd > li + li {
+  margin-top: var(--space-3);
+}
+
+.posBottomLeft.gapSm > li + li,
+.posBottomCenter.gapSm > li + li,
+.posBottomRight.gapSm > li + li {
+  margin-top: 0;
+  margin-bottom: var(--space-2);
+}
+
+.posBottomLeft.gapMd > li + li,
+.posBottomCenter.gapMd > li + li,
+.posBottomRight.gapMd > li + li {
+  margin-top: 0;
+  margin-bottom: var(--space-3);
+}
+
+// ─── Toast card ─────────────────────────────────────────────────────────
+.toast {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-2);
+  align-items: start;
+  padding: var(--space-3);
+  background: var(--color-bg);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  border-left: 3px solid var(--color-fg-muted); // overridden per tone
+  color: var(--color-fg);
+  transition: transform 200ms ease-out;
+}
+
+.toneInfo {
+  border-left-color: var(--color-info);
+}
+
+.toneSuccess {
+  border-left-color: var(--color-success);
+}
+
+.toneWarning {
+  border-left-color: var(--color-warning);
+}
+
+.toneError {
+  border-left-color: var(--color-danger);
+}
+
+.toneLoading {
+  border-left-color: var(--color-fg-muted);
+}
+
+.icon {
+  color: var(--color-fg-muted);
+  display: grid;
+  place-items: center;
+}
+
+.toneInfo .icon {
+  color: var(--color-info);
+}
+
+.toneSuccess .icon {
+  color: var(--color-success);
+}
+
+.toneWarning .icon {
+  color: var(--color-warning);
+}
+
+.toneError .icon {
+  color: var(--color-danger);
+}
+
+.body {
+  min-width: 0; // allow text truncation inside grid
+}
+
+.message {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.4;
+}
+
+.description {
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+  margin-top: var(--space-1);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.tail {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.action {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.action:hover {
+  background: var(--color-bg-muted);
+}
+
+.action:focus-visible {
+  @include focus-ring;
+
+  outline: none;
+}
+
+.close {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-fg-muted);
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+}
+
+.close:hover {
+  color: var(--color-fg);
+  background: var(--color-bg-muted);
+}
+
+.close:focus-visible {
+  @include focus-ring;
+
+  outline: none;
+}
+
+// ─── Enter / exit animations ─────────────────────────────────────────────
+// Slide direction depends on the position. We expose six keyframes and pick
+// via [data-position] on the parent stack.
+
+@keyframes enterFromRight {
+  from {
+    transform: translateX(30px);
+    opacity: 0;
+  }
+}
+
+@keyframes enterFromLeft {
+  from {
+    transform: translateX(-30px);
+    opacity: 0;
+  }
+}
+
+@keyframes enterFromTop {
+  from {
+    transform: translateY(-30px);
+    opacity: 0;
+  }
+}
+
+@keyframes enterFromBottom {
+  from {
+    transform: translateY(30px);
+    opacity: 0;
+  }
+}
+
+@keyframes exitToRight {
+  to {
+    transform: translateX(30px);
+    opacity: 0;
+  }
+}
+
+@keyframes exitToLeft {
+  to {
+    transform: translateX(-30px);
+    opacity: 0;
+  }
+}
+
+[data-position='top-left'] .toast[data-status='visible'],
+[data-position='bottom-left'] .toast[data-status='visible'] {
+  animation: enterFromLeft 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-position='top-right'] .toast[data-status='visible'],
+[data-position='bottom-right'] .toast[data-status='visible'] {
+  animation: enterFromRight 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-position='top-center'] .toast[data-status='visible'] {
+  animation: enterFromTop 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-position='bottom-center'] .toast[data-status='visible'] {
+  animation: enterFromBottom 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-position='top-left'] .toast[data-status='exiting'],
+[data-position='bottom-left'] .toast[data-status='exiting'] {
+  animation: exitToLeft 250ms ease-in forwards;
+}
+
+[data-position='top-right'] .toast[data-status='exiting'],
+[data-position='bottom-right'] .toast[data-status='exiting'] {
+  animation: exitToRight 250ms ease-in forwards;
+}
+
+[data-position='top-center'] .toast[data-status='exiting'],
+[data-position='bottom-center'] .toast[data-status='exiting'] {
+  animation: exitToRight 250ms ease-in forwards;
+}
+
+// Peek-collapsed toasts (beyond maxVisible). Compressed and dimmed.
+.toast[data-peek='true'] {
+  transform: scale(0.95) translateY(8px);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.stack[data-expanded='true'] .toast[data-peek='true'] {
+  transform: none;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+// ─── Reduced motion — kill enter/exit animations + the reflow transition ─
+@media (prefers-reduced-motion: reduce) {
+  .toast,
+  [data-position] .toast[data-status='visible'],
+  [data-position] .toast[data-status='exiting'] {
+    animation: none;
+    transition: none;
+  }
+}
+
+// ─── Loading spinner ─────────────────────────────────────────────────────
+.spin {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+```
+
+- [ ] **Step 2: Write `Toast.tsx`**
+
+Create `packages/design-system/src/components/Toast/Toast.tsx`:
+
+```tsx
+import { useState, type ReactNode } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Info,
+  Loader2,
+  X,
+  XCircle,
+} from 'lucide-react';
+import { clsx } from '../../utils/clsx';
+import { store, type ToastEntry } from './store';
+import { useToastTimer } from './useToastTimer';
+import styles from './Toast.module.scss';
+
+interface ToastProps {
+  entry: ToastEntry;
+  /** Whether this toast is rendered as a peek-collapsed card (beyond maxVisible). */
+  isPeek: boolean;
+  /** Default fallback duration when entry.duration is 'persistent' but rendered;
+   *  forwarded by the viewport for completeness, unused here today. */
+  // viewportDuration: number;  // (reserved for future use; not in v1)
+}
+
+const DEFAULT_ICONS: Record<ToastEntry['tone'], typeof Info> = {
+  info: Info,
+  success: CheckCircle2,
+  warning: AlertTriangle,
+  error: XCircle,
+  loading: Loader2,
+};
+
+/**
+ * Single toast card. NOT exported from the package — internal to ToastViewport.
+ *
+ * Spread order: Pattern B (component owns ARIA contract — role, aria-live,
+ * data-* cannot be overridden by consumer props).
+ */
+export function Toast({ entry, isPeek }: ToastProps) {
+  // Local "should the timer run" — flips when the user hovers OR a child has focus.
+  const [paused, setPaused] = useState(false);
+
+  useToastTimer({
+    id: entry.id,
+    duration: entry.duration,
+    paused,
+    onExpire: () => store.dismiss(entry.id),
+  });
+
+  const role = entry.tone === 'error' ? 'alert' : 'status';
+  const ariaLive = entry.tone === 'error' ? 'assertive' : 'polite';
+
+  const IconComponent = DEFAULT_ICONS[entry.tone];
+  const renderedIcon =
+    entry.icon === null
+      ? null
+      : entry.icon ?? (
+          <IconComponent
+            size={16}
+            aria-hidden="true"
+            className={entry.tone === 'loading' ? styles.spin : undefined}
+          />
+        );
+
+  const toneClass = {
+    info: styles.toneInfo,
+    success: styles.toneSuccess,
+    warning: styles.toneWarning,
+    error: styles.toneError,
+    loading: styles.toneLoading,
+  }[entry.tone];
+
+  return (
+    <li
+      role={role}
+      aria-live={ariaLive}
+      aria-atomic="true"
+      data-status={entry.status}
+      data-peek={isPeek ? 'true' : undefined}
+      data-tone={entry.tone}
+      className={clsx(styles.toast, toneClass)}
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      onFocus={() => setPaused(true)}
+      onBlur={(e) => {
+        // Only un-pause when focus leaves the toast entirely, not when moving
+        // from action button to close button.
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+          setPaused(false);
+        }
+      }}
+    >
+      {renderedIcon && <div className={styles.icon}>{renderedIcon}</div>}
+
+      <div className={styles.body}>
+        <div className={styles.message}>{entry.message}</div>
+        {entry.description && (
+          <div className={styles.description}>{entry.description}</div>
+        )}
+      </div>
+
+      <div className={styles.tail}>
+        {entry.action && (
+          <button
+            type="button"
+            className={styles.action}
+            onClick={() => {
+              entry.action!.onClick();
+              store.dismiss(entry.id);
+            }}
+          >
+            {entry.action.label}
+          </button>
+        )}
+        {entry.dismissible && (
+          <button
+            type="button"
+            className={styles.close}
+            aria-label="Dismiss"
+            onClick={() => store.dismiss(entry.id)}
+          >
+            <X size={14} aria-hidden="true" />
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}
+```
+
+- [ ] **Step 3: Write `ToastViewport.tsx`**
+
+Create `packages/design-system/src/components/Toast/ToastViewport.tsx`:
+
+```tsx
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
+import { clsx } from '../../utils/clsx';
+import { _setViewportConfig } from './api';
+import { store, type ToastEntry, type ToastPosition } from './store';
+import { Toast } from './Toast';
+import styles from './Toast.module.scss';
+
+const POSITIONS: readonly ToastPosition[] = [
+  'top-left',
+  'top-center',
+  'top-right',
+  'bottom-left',
+  'bottom-center',
+  'bottom-right',
+];
+
+const POSITION_CLASS: Record<ToastPosition, string> = {
+  'top-left': styles.posTopLeft,
+  'top-center': styles.posTopCenter,
+  'top-right': styles.posTopRight,
+  'bottom-left': styles.posBottomLeft,
+  'bottom-center': styles.posBottomCenter,
+  'bottom-right': styles.posBottomRight,
+};
+
+let mountedViewportCount = 0;
+
+export interface ToastViewportProps {
+  /** Default position for toasts that don't specify one. Default: 'bottom-right'. */
+  position?: ToastPosition;
+  /** Default duration (ms) for toasts without explicit duration. Default: 4000. */
+  duration?: number;
+  /** How many toasts are fully visible per position bucket. Default: 3. */
+  maxVisible?: number;
+  /** Spacing between stacked toasts. Default: 'sm' (8px). */
+  gap?: 'sm' | 'md';
+  /** false (default): peek-collapsed stack, hover to fan out. true: always fanned. */
+  expand?: boolean;
+}
+
+/**
+ * The single Toast portal. Mount exactly one of these at your app root.
+ *
+ * @example
+ * ```tsx
+ * <ToastViewport position="bottom-right" />
+ * ```
+ *
+ * @remarks
+ * - **Mount once.** A dev-warning logs if a second one mounts; only the first renders.
+ * - **Mounts before consumers can fire are fine.** Toasts fired before this is in
+ *   the tree sit in the store and render the moment this mounts.
+ * - **Portal target is `document.body`.** Toasts are not constrained by any
+ *   parent overflow/transform/contain context.
+ */
+export function ToastViewport({
+  position = 'bottom-right',
+  duration = 4000,
+  maxVisible = 3,
+  gap = 'sm',
+  expand = false,
+}: ToastViewportProps) {
+  // Track viewport count for dev-warning. State so React doesn't unmount us
+  // when the count flips back to 1.
+  const [isFirstViewport] = useState(() => {
+    mountedViewportCount += 1;
+    return mountedViewportCount === 1;
+  });
+
+  useEffect(() => {
+    if (!isFirstViewport && process.env.NODE_ENV !== 'production') {
+      console.error(
+        '[ToastViewport] Multiple <ToastViewport> instances detected. Only the first one renders. Mount exactly one at your app root.'
+      );
+    }
+    return () => {
+      mountedViewportCount -= 1;
+    };
+  }, [isFirstViewport]);
+
+  useEffect(() => {
+    _setViewportConfig({ position, duration });
+  }, [position, duration]);
+
+  const state = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot
+  );
+
+  const [hovered, setHovered] = useState<Set<ToastPosition>>(() => new Set());
+  // useRef instead of state so we don't trigger an extra render
+  // when the portal target appears.
+  const portalTargetRef = useRef<HTMLElement | null>(null);
+  if (portalTargetRef.current === null && typeof document !== 'undefined') {
+    portalTargetRef.current = document.body;
+  }
+
+  if (!isFirstViewport) return null;
+  if (portalTargetRef.current === null) return null;
+
+  const buckets = groupByPosition(state.toasts);
+
+  const content = (
+    <>
+      {POSITIONS.map((pos) => {
+        const list = buckets[pos];
+        if (!list || list.length === 0) return null;
+        const isExpanded = expand || hovered.has(pos);
+        return (
+          <ol
+            key={pos}
+            className={clsx(
+              styles.stack,
+              POSITION_CLASS[pos],
+              gap === 'sm' ? styles.gapSm : styles.gapMd
+            )}
+            aria-label="Notifications"
+            data-position={pos}
+            data-expanded={isExpanded ? 'true' : 'false'}
+            onMouseEnter={() => {
+              setHovered((prev) => {
+                if (prev.has(pos)) return prev;
+                const next = new Set(prev);
+                next.add(pos);
+                return next;
+              });
+            }}
+            onMouseLeave={() => {
+              setHovered((prev) => {
+                if (!prev.has(pos)) return prev;
+                const next = new Set(prev);
+                next.delete(pos);
+                return next;
+              });
+            }}
+          >
+            {list.map((entry, idx) => (
+              <Toast
+                key={entry.id}
+                entry={entry}
+                isPeek={!isExpanded && idx >= maxVisible}
+              />
+            ))}
+          </ol>
+        );
+      })}
+    </>
+  );
+
+  return createPortal(content, portalTargetRef.current);
+}
+
+function groupByPosition(
+  toasts: readonly ToastEntry[]
+): Partial<Record<ToastPosition, ToastEntry[]>> {
+  const out: Partial<Record<ToastPosition, ToastEntry[]>> = {};
+  for (const t of toasts) {
+    (out[t.position] ??= []).push(t);
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Confirm `utils/clsx` exists**
+
+```bash
+ls packages/design-system/src/utils/
+```
+
+Expected: a `clsx.ts` file is listed. If missing, find the canonical alternative used by other components:
+
+```bash
+grep -nE "import .* clsx" packages/design-system/src/components/Button/Button.tsx
+```
+
+Whichever path the existing components use, use it consistently.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+make build-lib
+```
+
+Expected: clean. If you see errors about `_setViewportConfig` not being a function (typo), or about `ToastEntry` field access, fix before moving on.
+
+- [ ] **Step 6: Lint**
+
+```bash
+make lint
+```
+
+Expected: clean. Rule 4 caveats covered by header comment on the SCSS file — the viewport stacks ARE intrinsically positioned (fixed) and aren't laid out by parents. If stylelint flags the `position: fixed`, address with an inline disable + comment ("viewport owns its own positioning — it's not a flow component"). Don't apply this to `.toast` itself.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/Toast/Toast.tsx \
+        packages/design-system/src/components/Toast/ToastViewport.tsx \
+        packages/design-system/src/components/Toast/Toast.module.scss
+git commit -m "$(cat <<'EOF'
+Toast: <Toast> + <ToastViewport> + SCSS
+
+Internal <Toast> renders one entry — role="alert" for error, role="status"
+otherwise, pause-on-hover/focus via local state, optional action button +
+close button. <ToastViewport> portals into document.body, subscribes via
+useSyncExternalStore, splits the toast list into 6 position buckets, and
+manages hover-expand state per bucket. SCSS provides 6 enter/exit
+keyframes (one per slide direction), peek-collapsed scale-down state,
+and prefers-reduced-motion fallback.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 — `Toast.test.tsx` integration tests
+
+The viewport + toast + store + api + timer all wired together. Renders the viewport, fires through the public API, asserts on the DOM.
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Toast/Toast.test.tsx`
+
+- [ ] **Step 1: Write `Toast.test.tsx`**
+
+Create `packages/design-system/src/components/Toast/Toast.test.tsx`:
+
+```tsx
+import { render, screen, act, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ToastViewport, type ToastViewportProps } from './ToastViewport';
+import { toast, _setViewportConfig } from './api';
+import { store } from './store';
+
+function renderViewport(props: Partial<ToastViewportProps> = {}) {
+  return render(<ToastViewport {...props} />);
+}
+
+describe('<ToastViewport>', () => {
+  beforeEach(() => {
+    store._reset();
+    _setViewportConfig({ position: 'bottom-right', duration: 4000 });
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when the store is empty', () => {
+    const { container } = renderViewport();
+    // Portal renders into document.body; viewport returns null fragment.
+    expect(container.firstChild).toBeNull();
+    expect(document.body.querySelector('[data-position]')).toBeNull();
+  });
+
+  it('renders a single toast after toast.success', () => {
+    renderViewport();
+    act(() => {
+      toast.success('Saved');
+    });
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['info', 'status', 'polite'],
+    ['success', 'status', 'polite'],
+    ['warning', 'status', 'polite'],
+    ['loading', 'status', 'polite'],
+    ['error', 'alert', 'assertive'],
+  ] as const)('tone=%s gets role=%s aria-live=%s', (tone, expectedRole, expectedLive) => {
+    renderViewport();
+    act(() => {
+      toast[tone]('msg');
+    });
+    const node = screen.getByText('msg').closest('[role]');
+    expect(node).toHaveAttribute('role', expectedRole);
+    expect(node).toHaveAttribute('aria-live', expectedLive);
+  });
+
+  it('auto-dismisses after the default duration', () => {
+    renderViewport({ duration: 1000 });
+    act(() => {
+      toast.success('Saved');
+    });
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    // status flips to exiting, then the store removes after 250ms.
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+  });
+
+  it('duration: persistent does not auto-dismiss', () => {
+    renderViewport({ duration: 1000 });
+    act(() => {
+      toast.error('Boom', { duration: 'persistent' });
+    });
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(screen.getByText('Boom')).toBeInTheDocument();
+  });
+
+  it('pauses the timer while hovered', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderViewport({ duration: 1000 });
+    act(() => {
+      toast.success('Saved');
+    });
+    const toastNode = screen.getByText('Saved').closest('[role]')!;
+    await user.hover(toastNode as Element);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+  });
+
+  it('action button fires onClick AND dismisses the toast', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onUndo = vi.fn();
+    renderViewport();
+    act(() => {
+      toast.success('Item deleted', { action: { label: 'Undo', onClick: onUndo } });
+    });
+    await user.click(screen.getByRole('button', { name: 'Undo' }));
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText('Item deleted')).not.toBeInTheDocument();
+  });
+
+  it('close button (×) dismisses the toast', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderViewport();
+    act(() => {
+      toast.success('Saved');
+    });
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+  });
+
+  it('close button is hidden when dismissible: false', () => {
+    renderViewport();
+    act(() => {
+      toast.success('Saved', { dismissible: false });
+    });
+    expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull();
+  });
+
+  it('persistent toasts always show the close button (overrides dismissible: false)', () => {
+    renderViewport();
+    act(() => {
+      toast.error('Boom', { duration: 'persistent', dismissible: false });
+    });
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+  });
+
+  it('toast.dismiss(id) dismisses programmatically', () => {
+    renderViewport();
+    let id = '';
+    act(() => {
+      id = toast.success('Saved');
+    });
+    act(() => {
+      toast.dismiss(id);
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+  });
+
+  it('toast.update(id, ...) mutates the rendered card', () => {
+    renderViewport();
+    let id = '';
+    act(() => {
+      id = toast.loading('Uploading');
+    });
+    expect(screen.getByText('Uploading')).toBeInTheDocument();
+    act(() => {
+      toast.update(id, { tone: 'success', message: 'Uploaded' });
+    });
+    expect(screen.queryByText('Uploading')).not.toBeInTheDocument();
+    expect(screen.getByText('Uploaded')).toBeInTheDocument();
+  });
+
+  it('two toasts stack in the same position bucket', () => {
+    renderViewport();
+    act(() => {
+      toast.success('a');
+      toast.success('b');
+    });
+    const stack = document.body.querySelector('[data-position="bottom-right"]')!;
+    expect(within(stack as HTMLElement).getByText('a')).toBeInTheDocument();
+    expect(within(stack as HTMLElement).getByText('b')).toBeInTheDocument();
+  });
+
+  it('per-call position routes to the right bucket', () => {
+    renderViewport({ position: 'bottom-right' });
+    act(() => {
+      toast.success('here', { position: 'top-center' });
+    });
+    const topCenter = document.body.querySelector('[data-position="top-center"]');
+    expect(topCenter).not.toBeNull();
+    expect(within(topCenter as HTMLElement).getByText('here')).toBeInTheDocument();
+  });
+
+  it('beyond maxVisible, toasts get data-peek="true"', () => {
+    renderViewport({ maxVisible: 2 });
+    act(() => {
+      toast.success('a');
+      toast.success('b');
+      toast.success('c');
+      toast.success('d');
+    });
+    const peekItems = document.body.querySelectorAll('[data-peek="true"]');
+    expect(peekItems.length).toBe(2);
+  });
+
+  it('hovering the stack expands peek-collapsed toasts', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderViewport({ maxVisible: 1 });
+    act(() => {
+      toast.success('a');
+      toast.success('b');
+    });
+    const stack = document.body.querySelector('[data-position="bottom-right"]')!;
+    expect(stack.getAttribute('data-expanded')).toBe('false');
+    await user.hover(stack as Element);
+    expect(stack.getAttribute('data-expanded')).toBe('true');
+  });
+
+  it('expand: true keeps the stack fanned without hover', () => {
+    renderViewport({ maxVisible: 1, expand: true });
+    act(() => {
+      toast.success('a');
+      toast.success('b');
+    });
+    const stack = document.body.querySelector('[data-position="bottom-right"]')!;
+    expect(stack.getAttribute('data-expanded')).toBe('true');
+  });
+
+  it('toast.promise: loading then success on resolve', async () => {
+    renderViewport();
+    let p!: Promise<{ name: string }>;
+    act(() => {
+      p = toast.promise(Promise.resolve({ name: 'file.pdf' }), {
+        loading: 'Uploading',
+        success: (r) => `Uploaded ${r.name}`,
+        error: 'Failed',
+      });
+    });
+    expect(screen.getByText('Uploading')).toBeInTheDocument();
+    await act(async () => {
+      await p;
+    });
+    expect(screen.getByText('Uploaded file.pdf')).toBeInTheDocument();
+  });
+
+  it('toast.promise: loading then error on reject', async () => {
+    renderViewport();
+    const err = new Error('500');
+    let p!: Promise<never>;
+    act(() => {
+      p = toast.promise(Promise.reject(err) as Promise<never>, {
+        loading: 'Uploading',
+        success: 'Uploaded',
+        error: (e) => `Failed: ${(e as Error).message}`,
+      });
+    });
+    await act(async () => {
+      await p.catch(() => {});
+    });
+    expect(screen.getByText('Failed: 500')).toBeInTheDocument();
+  });
+
+  it('two <ToastViewport> instances: dev-warn fires and only the first renders', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <>
+        <ToastViewport />
+        <ToastViewport />
+      </>
+    );
+    act(() => {
+      toast.success('once');
+    });
+    expect(screen.getAllByText('once')).toHaveLength(1);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Multiple <ToastViewport>')
+    );
+    errSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test -w @eocrm/design-system -- --run src/components/Toast/Toast.test.tsx
+```
+
+Expected: all 22 tests pass.
+
+If a test fails due to a fake-timer + microtask issue (common with `toast.promise`), wrap the awaits in `await act(async () => { ... })` and ensure `shouldAdvanceTime: true` is in the `vi.useFakeTimers()` call.
+
+- [ ] **Step 3: Full test suite + typecheck + lint**
+
+```bash
+make test
+make build-lib
+make lint
+```
+
+Expected: all green. Total Toast test count should be 13 (store) + 19 (api) + 7 (timer) + 22 (integration) = 61 new tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Toast/Toast.test.tsx
+git commit -m "$(cat <<'EOF'
+Toast: integration tests
+
+22 cases wiring the public API through the viewport: tone → role mapping,
+auto-dismiss + pause-on-hover, action + close buttons, programmatic
+dismiss/update, position routing, maxVisible peek-collapse, hover-expand,
+toast.promise() resolve+reject, multi-viewport dev-warning.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6 — Public exports + AGENTS.md TL;DR
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Toast/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Write the folder barrel**
+
+Create `packages/design-system/src/components/Toast/index.ts`:
+
+```ts
+export { toast } from './api';
+export { ToastViewport } from './ToastViewport';
+export type { ToastOptions, ToastUpdateOptions, ToastViewportProps } from './api';
+export type { ToastTone, ToastPosition } from './store';
+```
+
+- [ ] **Step 2: Re-export from the package barrel**
+
+In `packages/design-system/src/index.ts`, add (alphabetical ordering matches existing pattern — place between `Tabs` and `Tooltip`):
+
+```ts
+export { toast, ToastViewport } from './components/Toast';
+export type {
+  ToastOptions,
+  ToastUpdateOptions,
+  ToastViewportProps,
+  ToastTone,
+  ToastPosition,
+} from './components/Toast';
+```
+
+Verify the existing file structure first:
+
+```bash
+grep -n "export.*Tabs\|export.*Tooltip\|export.*ButtonGroup" packages/design-system/src/index.ts | head
+```
+
+Place the new exports near `Tooltip` (the other `T` component) to keep alpha ordering.
+
+- [ ] **Step 3: Add the AGENTS.md TL;DR**
+
+Find the `### <Tooltip>` section header in `packages/design-system/AGENTS.md`. Insert a new section AFTER `### <Popover>` (which currently ends around line 446) and BEFORE the next section. Use this content verbatim:
+
+````markdown
+### `<ToastViewport>` + `toast` — transient notifications
+
+Imperative singleton + one portal. Fire from anywhere; no provider, no hook.
+
+```tsx
+import { ToastViewport, toast } from '@eocrm/design-system';
+
+// Mount once at app root
+<ToastViewport position="bottom-right" />;
+
+// Fire from anywhere
+toast.success('Saved');
+toast.error('Request failed', { description: err.message });
+toast.success('Item deleted', { action: { label: 'Undo', onClick: restore } });
+
+// Async sugar
+toast.promise(api.upload(file), {
+  loading: 'Uploading…',
+  success: (r) => `Uploaded ${r.name}`,
+  error: (e) => `Failed: ${e.message}`,
+});
+
+// Update in place
+const id = toast.loading('Saving…');
+await api.save();
+toast.success('Saved', { id });
+```
+
+- **One viewport.** Mount exactly one `<ToastViewport>` at the app root. A second one logs a dev-warning and renders null.
+- **Five tones.** `info`, `success`, `warning`, `error`, `loading`. `error` is `role="alert"` (assertive); the rest are `role="status"` (polite).
+- **Auto-dismiss defaults to 4000ms.** Per-call `duration` (ms or `'persistent'`). `loading` defaults to `'persistent'`.
+- **Pause on hover / focus / hidden tab.** Hovering the toast or tabbing into its action pauses the timer; document `visibilitychange` to `hidden` pauses all timers globally.
+- **maxVisible: 3 default.** Toasts beyond render as peek-collapsed cards behind the visible stack; hovering the stack fans them out. `expand: true` keeps the stack always fanned.
+- **All 6 positions supported** via `<ToastViewport position="…">`. Per-call `position` override exists as an escape hatch but a single global position is the recommended UX.
+
+#### When NOT to use
+
+- ❌ For form validation feedback under the field. That's inline error text, not a toast.
+- ❌ For destructive confirmations. Use `<ConfirmationPopover>` or `<Modal>` — the user needs an explicit yes/no decision, not a transient banner.
+- ❌ For long-form messages. Toasts are 1–2 lines. If you need more, link to a page from the description.
+- ❌ As a substitute for in-page progress UI. A toast can announce "Upload started" but the persistent progress bar belongs in the page.
+````
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+make build-lib
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Verify the public API is reachable**
+
+Quick smoke check that the public re-exports compile in a consumer-style import:
+
+```bash
+node -e "const m = require('./packages/design-system/dist/index.cjs'); console.log(Object.keys(m).filter(k => k.toLowerCase().includes('toast')));" 2>/dev/null || echo "(no dist yet — that's fine; the playground build below will exercise the imports)"
+```
+
+Or just ensure the playground build still works:
+
+```bash
+make build
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Toast/index.ts \
+        packages/design-system/src/index.ts \
+        packages/design-system/AGENTS.md
+git commit -m "$(cat <<'EOF'
+Toast: public exports + AGENTS.md TL;DR
+
+Re-exports `toast`, `ToastViewport`, and the four public type names
+(ToastOptions, ToastUpdateOptions, ToastViewportProps, ToastTone,
+ToastPosition) from the package barrel. AGENTS.md gains a TL;DR block
+with the canonical mount + tone shorthands + promise sugar + update
+pattern, plus a "when NOT to use" list.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7 — Playground demo + nav wiring
+
+8 examples, 4 nav touchpoints, viewport mount at app root.
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/ToastDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Write the demo page**
+
+Create `packages/playground/src/pages/components/ToastDemo.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { Button, Cluster, Stack, toast } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import apiSource from '@lib-source/components/Toast/api.ts?raw';
+import scssSource from '@lib-source/components/Toast/Toast.module.scss?raw';
+
+export function ToastDemo() {
+  const [bursting, setBursting] = useState(false);
+
+  return (
+    <DemoLayout
+      name="Toast"
+      componentName="Toast"
+      description="Imperative transient notifications. Singleton `toast` API + one `<ToastViewport>` mounted at app root."
+      tsxSource={apiSource}
+      scssSource={scssSource}
+      tsxFilename="api.ts"
+      scssFilename="Toast.module.scss"
+    >
+      <Example
+        title="Tones"
+        description="Five tones with sensible icon + accent color defaults. Error toasts use role='alert' (assertive); the others use role='status' (polite)."
+        code={`toast.info('Heads up');
+toast.success('Saved');
+toast.warning('Storage almost full');
+toast.error('Request failed');
+toast.loading('Uploading…');`}
+      >
+        <Cluster gap="sm">
+          <Button onClick={() => toast.info('Heads up')}>info</Button>
+          <Button onClick={() => toast.success('Saved')}>success</Button>
+          <Button onClick={() => toast.warning('Storage almost full')}>warning</Button>
+          <Button onClick={() => toast.error('Request failed')}>error</Button>
+          <Button onClick={() => toast.loading('Uploading…')}>loading</Button>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="With a description"
+        description="Description is a second line, line-clamped to 2 lines."
+        code={`toast.success('Saved', {
+  description: 'Your changes are now live.',
+});`}
+      >
+        <Button
+          onClick={() =>
+            toast.success('Saved', {
+              description: 'Your changes are now live.',
+            })
+          }
+        >
+          Fire with description
+        </Button>
+      </Example>
+
+      <Example
+        title="Action (Undo)"
+        description="Single primary action. Clicking the button fires onClick AND dismisses the toast."
+        code={`toast.success('Item deleted', {
+  action: {
+    label: 'Undo',
+    onClick: () => toast.info('Restored'),
+  },
+});`}
+      >
+        <Button
+          onClick={() =>
+            toast.success('Item deleted', {
+              action: {
+                label: 'Undo',
+                onClick: () => toast.info('Restored'),
+              },
+            })
+          }
+        >
+          Delete (with Undo)
+        </Button>
+      </Example>
+
+      <Example
+        title="Programmatic update"
+        description="Fire a loading toast, mutate it in place after the async op completes."
+        code={`const id = toast.loading('Uploading…');
+setTimeout(() => {
+  toast.success('Uploaded', { id });
+}, 2000);`}
+      >
+        <Button
+          onClick={() => {
+            const id = toast.loading('Uploading…');
+            setTimeout(() => {
+              toast.success('Uploaded', { id });
+            }, 2000);
+          }}
+        >
+          Start upload
+        </Button>
+      </Example>
+
+      <Example
+        title="toast.promise (async sugar)"
+        description="Pass a promise; the toast cycles loading → success/error automatically. Returns the original promise."
+        code={`toast.promise(
+  new Promise((resolve, reject) =>
+    setTimeout(() => (Math.random() > 0.5 ? resolve('done') : reject(new Error('500'))), 1500)
+  ),
+  {
+    loading: 'Working…',
+    success: 'Worked',
+    error: (e) => \`Failed: \${(e as Error).message}\`,
+  }
+);`}
+      >
+        <Button
+          onClick={() =>
+            toast.promise(
+              new Promise((resolve, reject) =>
+                setTimeout(
+                  () =>
+                    Math.random() > 0.5
+                      ? resolve('done')
+                      : reject(new Error('500')),
+                  1500
+                )
+              ),
+              {
+                loading: 'Working…',
+                success: 'Worked',
+                error: (e) => `Failed: ${(e as Error).message}`,
+              }
+            )
+          }
+        >
+          Fire promise toast
+        </Button>
+      </Example>
+
+      <Example
+        title="Persistent error"
+        description="duration: 'persistent' disables auto-dismiss. The close (×) button is force-enabled even if you pass dismissible: false."
+        code={`toast.error('Connection lost', { duration: 'persistent' });`}
+      >
+        <Button
+          onClick={() =>
+            toast.error('Connection lost', { duration: 'persistent' })
+          }
+        >
+          Fire persistent error
+        </Button>
+      </Example>
+
+      <Example
+        title="Per-call position override"
+        description="A per-call `position` routes that toast into a different bucket. Use sparingly — mixing positions in one app is unusual UX."
+        code={`toast.info('top-right', { position: 'top-right' });
+toast.info('top-center', { position: 'top-center' });
+toast.info('bottom-left', { position: 'bottom-left' });
+toast.info('bottom-center', { position: 'bottom-center' });`}
+      >
+        <Cluster gap="sm">
+          <Button onClick={() => toast.info('top-right', { position: 'top-right' })}>
+            top-right
+          </Button>
+          <Button onClick={() => toast.info('top-center', { position: 'top-center' })}>
+            top-center
+          </Button>
+          <Button onClick={() => toast.info('bottom-left', { position: 'bottom-left' })}>
+            bottom-left
+          </Button>
+          <Button onClick={() => toast.info('bottom-center', { position: 'bottom-center' })}>
+            bottom-center
+          </Button>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Burst + hover to expand"
+        description="Fires 7 toasts in rapid succession. Only the top 3 are visible; the rest peek-collapse. Hover the stack to fan them out."
+        code={`for (let i = 1; i <= 7; i++) {
+  setTimeout(() => toast.info(\`Message #\${i}\`), i * 60);
+}`}
+      >
+        <Stack gap="sm">
+          <Button
+            disabled={bursting}
+            onClick={() => {
+              setBursting(true);
+              for (let i = 1; i <= 7; i++) {
+                setTimeout(() => toast.info(`Message #${i}`), i * 60);
+              }
+              setTimeout(() => setBursting(false), 600);
+            }}
+          >
+            Fire 7 toasts
+          </Button>
+        </Stack>
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+- [ ] **Step 2: Wire the route + viewport mount in `App.tsx`**
+
+In `packages/playground/src/App.tsx`, add the import alphabetically with the other component-page imports:
+
+```tsx
+import { ToastDemo } from './pages/components/ToastDemo';
+```
+
+Add the `<Route>` inside `<Routes>` near the other component routes (alphabetical — after `/components/tabs`):
+
+```tsx
+<Route path="/components/toast" element={<ToastDemo />} />
+```
+
+Add the import for the library viewport:
+
+```tsx
+import { ToastViewport } from '@eocrm/design-system';
+```
+
+And mount the viewport ONCE inside `<BrowserRouter>` but OUTSIDE `<AppShell>` so it's a sibling and renders via portal regardless of route:
+
+```tsx
+return (
+  <BrowserRouter basename={import.meta.env.BASE_URL}>
+    <AppShell>
+      <Routes>
+        {/* …existing routes… */}
+        <Route path="/components/toast" element={<ToastDemo />} />
+      </Routes>
+    </AppShell>
+    <ToastViewport position="bottom-right" />
+  </BrowserRouter>
+);
+```
+
+- [ ] **Step 3: Add a "Feedback" sidebar group in `AppShell.tsx`**
+
+In `packages/playground/src/layout/AppShell/AppShell.tsx`, find the `componentGroups` array. Add a new group between `Display` and `Navigation`:
+
+```tsx
+{
+  heading: 'Feedback',
+  items: [
+    { to: '/components/toast', label: 'Toast', icon: Bell, end: false },
+  ],
+},
+```
+
+Add the `Bell` icon to the lucide-react import at the top of the file (find the existing `import { ..., Layers, ... } from 'lucide-react'` line):
+
+```tsx
+import {
+  // …existing icons…
+  Bell,
+  // …rest…
+} from 'lucide-react';
+```
+
+- [ ] **Step 4: Add the overview card in `ComponentsIndex.tsx`**
+
+In `packages/playground/src/pages/components/ComponentsIndex.tsx`, find the items array (the existing pattern shows imports at the top + items with name/to/description/preview entries). Add the Toast import to the existing `@eocrm/design-system` import line:
+
+```tsx
+import { /* …existing… */ Button, toast } from '@eocrm/design-system';
+```
+
+Add an item to the array (alphabetical position with the other items):
+
+```tsx
+{
+  to: '/components/toast',
+  name: 'Toast',
+  description: 'Imperative transient notifications.',
+  preview: (
+    <Button size="sm" onClick={() => toast.success('Saved')}>
+      Fire toast
+    </Button>
+  ),
+},
+```
+
+- [ ] **Step 5: Register the component name in `registry.ts`**
+
+In `packages/playground/src/pages/mockups/registry.ts`, find `export type ComponentName =` and add `'Toast'` to the union (alphabetical):
+
+```ts
+export type ComponentName =
+  // …existing names…
+  | 'Toast'
+  // …rest…;
+```
+
+No existing mockup uses Toast yet, so no `usesComponents` lists need updating. The union extension is enough.
+
+- [ ] **Step 6: Run the playground build**
+
+```bash
+cd /home/dpws/projects/design-system
+make build
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Spot-check the demo in the dev server (manual)**
+
+```bash
+cd packages/playground
+PORT=8090 npm run dev
+```
+
+Open http://localhost:8090/components/toast, verify:
+- Tone gallery: each button fires a toast in bottom-right with the right color stripe
+- Description toast shows two-line content
+- Action button works + dismisses
+- Programmatic update flips loading → success in place
+- Promise toast cycles
+- Persistent error stays until ×
+- Position override routes correctly
+- Burst stacks 7 toasts; hover-to-expand fans them out
+
+Stop the dev server with `Ctrl+C`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/playground/src/pages/components/ToastDemo.tsx \
+        packages/playground/src/App.tsx \
+        packages/playground/src/layout/AppShell/AppShell.tsx \
+        packages/playground/src/pages/components/ComponentsIndex.tsx \
+        packages/playground/src/pages/mockups/registry.ts
+git commit -m "$(cat <<'EOF'
+playground: ToastDemo + viewport mount + nav wiring
+
+8 examples (tones, description, action, update, promise, persistent,
+position override, burst+expand). Viewport mounts once in App.tsx at the
+root so toasts render regardless of route. New "Feedback" sidebar group
+contains Toast.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8 — Hard-Rule-8 cycle + push + PR
+
+The library-change review-fix loop per `packages/design-system/CLAUDE.md` Hard rule 8. Run until 0 Critical + 0 Important findings, all gates green.
+
+- [ ] **Step 1: Final gate run**
+
+```bash
+cd /home/dpws/projects/design-system
+make test
+make build-lib
+make build
+make lint
+```
+
+Expected: all green. Total Toast test count is 13 + 19 + 7 + 22 = **61 new tests**.
+
+- [ ] **Step 2: Dry-pack to confirm tarball contents**
+
+```bash
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -E "Toast|test\.|module\.scss|store|api|useToastTimer"
+```
+
+Expected: source files in the package, NO test files (`*.test.*`) appear in the published tarball.
+
+- [ ] **Step 3: Dispatch a fresh-context Hard-Rule-8 reviewer**
+
+Use a `general-purpose` subagent with model `opus`. Brief it on the full 10 review categories from `packages/design-system/CLAUDE.md` Rule 8 (bugs, a11y, API inconsistencies, type safety, rule violations Rules 1–7, test coverage, token discipline, SCSS, cross-package leakage, package/distribution). Tell it to read `packages/design-system/CLAUDE.md`, `AGENTS.md`, and `README.md` first.
+
+Prompt template:
+
+> Fresh-context Hard-Rule-8 review of the Toast PR. Branch `feat/toast` at HEAD `<sha>`. Per `packages/design-system/CLAUDE.md` Rule 8 — review the full diff against `main` and report findings as Critical / Important / Nice-to-have / Regression-watch.
+>
+> Files in scope: everything under `packages/design-system/src/components/Toast/`, `packages/design-system/src/index.ts`, `packages/design-system/AGENTS.md`, and the playground wiring touched on this branch.
+>
+> Verify:
+> - All 7 hard rules (tests exist, demo exists, tokens not raw, no layout properties on components, exports correct, forwardRef where applicable, JSDoc on every exported symbol)
+> - ARIA: `role="alert"` only for error, `role="status"` for others, `aria-live` correct, `aria-label="Notifications"` on stacks, close button has `aria-label="Dismiss"`
+> - Pause-on-hover/focus actually works (read the test or trace the code)
+> - Persistent toasts force dismissible: true
+> - Multi-viewport dev-warning fires AND only the first renders
+> - No raw colors / spacings / shadows in `Toast.module.scss` — all `var(--…)`
+> - `prefers-reduced-motion` block actually disables animations
+> - No `position` / `margin` / `align-self` etc. on `.toast` itself; only on the viewport (which is a fixed positioning container, not a flow component — documented exception)
+> - `_setViewportConfig` is not exported from the package barrel
+> - Public types are all exported (ToastOptions, ToastUpdateOptions, ToastViewportProps, ToastTone, ToastPosition)
+> - `npm pack --dry-run` doesn't include `*.test.*` files
+>
+> End with verdict: **clean enough to stop** OR **keep iterating**.
+
+- [ ] **Step 4: Fix every Critical + Important finding**
+
+Group findings into a fix commit with subject `Toast: review-cycle fixes (round N)`. Document any deliberately-skipped Nice-to-have findings with a one-line reason in the commit body.
+
+If a finding requires a non-trivial code change, run the relevant test file after the fix:
+
+```bash
+npm test -w @eocrm/design-system -- --run src/components/Toast/<file>.test.ts
+```
+
+- [ ] **Step 5: Re-run gates after each fix round**
+
+```bash
+make test && make build-lib && make build && make lint
+```
+
+- [ ] **Step 6: Re-dispatch a fresh reviewer**
+
+Same prompt, same model, fresh context. Repeat until verdict is **clean enough to stop** with 0 Critical + 0 Important.
+
+- [ ] **Step 7: Push the branch**
+
+```bash
+git push -u origin feat/toast
+```
+
+The husky `pre-push` hook runs `format:check` + `lint` + `typecheck` locally. If it fails on `format:check`, fix with:
+
+```bash
+npx prettier --write docs/superpowers/specs/2026-05-23-toast-design.md \
+                     docs/superpowers/plans/2026-05-23-toast.md \
+                     packages/design-system/src/components/Toast/ \
+                     packages/playground/src/pages/components/ToastDemo.tsx
+git add -A
+git commit -m "$(cat <<'EOF'
+Toast: prettier --write
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin feat/toast
+```
+
+- [ ] **Step 8: Open the PR**
+
+```bash
+gh pr create --title "Toast: imperative transient notifications (singleton + portal viewport)" --body "$(cat <<'EOF'
+## Summary
+
+- Imperative singleton `toast` API + a single `<ToastViewport>` portal. Mount once at app root; fire from anywhere.
+- 5 tones (`info`, `success`, `warning`, `error`, `loading`) with sensible icon + color defaults. `error` is `role="alert"` (assertive); the rest are `role="status"` (polite).
+- All 6 positions supported via the viewport's `position` prop; per-call `position` override available as an escape hatch.
+- Auto-dismiss defaults to 4000ms; per-call `duration` (ms or `'persistent'`). Pause-on-hover / pause-on-focus / pause-when-tab-hidden.
+- Action slot (Undo/Retry), close (×) button, programmatic dismiss + update by id, `toast.promise()` sugar.
+- `maxVisible: 3` default with peek-collapsed stack behind the visible toasts; hover-to-expand or `expand: true`.
+- `prefers-reduced-motion: reduce` disables enter/exit + reflow animations.
+- No new packages, no new tokens. Uses existing `--z-toast`, `--shadow-md`, tone colors, `--space-*`, `lucide-react` icons.
+
+## Design
+
+- **Three-layer split.** `store.ts` is a vanilla observable (no React) — testable in isolation. `api.ts` is the public `toast` singleton — also pure JS, reads a module-level config slot the viewport writes to on mount. `ToastViewport.tsx` is the only React surface.
+- **Two-step dismiss.** `dismiss` flips status to `'exiting'` then removes after 250ms so the viewport can play the exit animation before unmount.
+- **Per-toast timer hook.** `useToastTimer` owns pause/resume math (capture remaining ms on pause, re-arm with same on resume). Indirected `getVisible()` so tests can simulate document-hidden without poking jsdom's read-only `visibilityState`.
+- **Six position buckets inside ONE viewport.** `<ToastViewport>` splits the toast list into 6 groups by position and renders empty buckets as nothing. Per-call `position` override routes that toast to the matching bucket.
+- **Spread order Pattern B** on `<Toast>` — ARIA contract (`role`, `aria-live`, `data-*`) cannot be overridden.
+
+## Hard Rule 8
+
+Multiple rounds with fresh-context reviewers until 0 Critical + 0 Important. 61 new tests (13 store, 19 api, 7 timer, 22 integration). All four gates green.
+
+## Test plan
+
+- [ ] Tone gallery renders 5 toasts with correct accent stripe color + icon
+- [ ] `toast.error` produces `role="alert" aria-live="assertive"`; other tones use `role="status" aria-live="polite"`
+- [ ] Auto-dismisses after `duration` ms; `duration: 'persistent'` does not
+- [ ] Hovering a toast pauses its timer; leaving resumes
+- [ ] Tabbing into the action or close button pauses; blurring resumes
+- [ ] Switching to a different browser tab pauses all timers; switching back resumes
+- [ ] Action button fires onClick AND dismisses
+- [ ] Close (×) dismisses; `dismissible: false` hides it; `duration: 'persistent'` force-shows it
+- [ ] Programmatic `toast.update(id, ...)` mutates the rendered card in place
+- [ ] `toast.success('msg', { id })` with an existing id updates instead of duplicating
+- [ ] `toast.promise(p, msgs)` cycles loading → success/error and returns the original promise (chainable)
+- [ ] Per-call `position` routes to the correct bucket
+- [ ] `maxVisible: 3` with 5 toasts shows 3 fully + 2 peek-collapsed; hovering the stack fans them out
+- [ ] `expand: true` keeps the stack always fanned
+- [ ] `prefers-reduced-motion: reduce` disables enter/exit animations (computed style check or headless e2e)
+- [ ] Two `<ToastViewport>` mounted → dev-warning fires, only the first renders
+- [ ] Playground demo at `/components/toast` runs all 8 examples without console errors
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 9: Confirm CI**
+
+Watch the GitHub Actions Quality check on the PR. If it fails for the same `format:check` reason, run the prettier fix locally and push again. If a test fails on CI but passed locally, investigate immediately — don't merge until green.
+
+- [ ] **Step 10: Mark task complete**
+
+Once verdict is `clean enough to stop`, gates green, CI green, PR open — task done. Hand off to the human reviewer for merge.
+
+---
+
+## Summary of expected commits on the branch (before review-fix rounds)
+
+```
+Toast: spec — correct tone token names (--color-info/success/warning/danger)
+Toast: design spec — singleton API, 6 positions, queue + promise sugar
+Toast: store — vanilla observable for the toast list
+Toast: api — public `toast` singleton (tones, update, dismiss, promise)
+Toast: useToastTimer hook — pause/resume math for auto-dismiss
+Toast: <Toast> + <ToastViewport> + SCSS
+Toast: integration tests
+Toast: public exports + AGENTS.md TL;DR
+playground: ToastDemo + viewport mount + nav wiring
+```
+
+Plus review-cycle fix commits and the prettier fix-up as needed.

--- a/docs/superpowers/plans/2026-05-23-toast.md
+++ b/docs/superpowers/plans/2026-05-23-toast.md
@@ -71,6 +71,7 @@ git log --oneline -3
 ```
 
 Expected:
+
 - Branch: `feat/toast`
 - Working tree clean
 - Most recent commits include `4de813b Toast: spec — correct tone token names` and `27ea60b Toast: design spec`.
@@ -379,13 +380,7 @@ Create `packages/design-system/src/components/Toast/api.ts`:
 
 ```ts
 import type { ReactNode } from 'react';
-import {
-  store,
-  generateId,
-  type ToastTone,
-  type ToastPosition,
-  type ToastInput,
-} from './store';
+import { store, generateId, type ToastTone, type ToastPosition, type ToastInput } from './store';
 
 export interface ToastOptions {
   /** Optional second-line content. ReactNode so consumers can embed links/icons. */
@@ -425,14 +420,9 @@ export function _setViewportConfig(cfg: ViewportConfig): void {
   viewportConfig = cfg;
 }
 
-function buildInput(
-  tone: ToastTone,
-  message: ReactNode,
-  options: ToastOptions = {}
-): ToastInput {
+function buildInput(tone: ToastTone, message: ReactNode, options: ToastOptions = {}): ToastInput {
   const isLoading = tone === 'loading';
-  const duration =
-    options.duration ?? (isLoading ? 'persistent' : viewportConfig.duration);
+  const duration = options.duration ?? (isLoading ? 'persistent' : viewportConfig.duration);
   const isPersistent = duration === 'persistent';
   return {
     id: options.id ?? generateId(),
@@ -448,11 +438,7 @@ function buildInput(
   };
 }
 
-function fire(
-  tone: ToastTone,
-  message: ReactNode,
-  options?: ToastOptions
-): string {
+function fire(tone: ToastTone, message: ReactNode, options?: ToastOptions): string {
   return store.add(buildInput(tone, message, options));
 }
 
@@ -490,8 +476,7 @@ export const toast = Object.assign(
           return value;
         },
         (err) => {
-          const errorMsg =
-            typeof msgs.error === 'function' ? msgs.error(err) : msgs.error;
+          const errorMsg = typeof msgs.error === 'function' ? msgs.error(err) : msgs.error;
           store.update(id, {
             tone: 'error',
             message: errorMsg,
@@ -499,10 +484,10 @@ export const toast = Object.assign(
             status: 'visible',
           });
           throw err;
-        }
+        },
       );
     },
-  }
+  },
 );
 ```
 
@@ -830,7 +815,7 @@ describe('useToastTimer', () => {
         paused: false,
         onExpire,
         getVisible: () => true,
-      })
+      }),
     );
     expect(onExpire).not.toHaveBeenCalled();
     act(() => {
@@ -848,7 +833,7 @@ describe('useToastTimer', () => {
         paused: false,
         onExpire,
         getVisible: () => true,
-      })
+      }),
     );
     act(() => {
       vi.advanceTimersByTime(100_000);
@@ -867,7 +852,7 @@ describe('useToastTimer', () => {
           onExpire,
           getVisible: () => true,
         }),
-      { initialProps: { paused: false } }
+      { initialProps: { paused: false } },
     );
 
     act(() => vi.advanceTimersByTime(400));
@@ -896,7 +881,7 @@ describe('useToastTimer', () => {
           onExpire,
           getVisible: () => true,
         }),
-      { initialProps: { paused: true } }
+      { initialProps: { paused: true } },
     );
     act(() => vi.advanceTimersByTime(10_000));
     expect(onExpire).not.toHaveBeenCalled();
@@ -916,7 +901,7 @@ describe('useToastTimer', () => {
         paused: false,
         onExpire,
         getVisible: () => visible,
-      })
+      }),
     );
     act(() => vi.advanceTimersByTime(10_000));
     expect(onExpire).not.toHaveBeenCalled();
@@ -938,7 +923,7 @@ describe('useToastTimer', () => {
         paused: false,
         onExpire,
         getVisible: () => true,
-      })
+      }),
     );
     unmount();
     act(() => vi.advanceTimersByTime(10_000));
@@ -956,7 +941,7 @@ describe('useToastTimer', () => {
           onExpire,
           getVisible: () => true,
         }),
-      { initialProps: { duration: 1000 } }
+      { initialProps: { duration: 1000 } },
     );
     act(() => vi.advanceTimersByTime(500));
     rerender({ duration: 2000 });
@@ -1351,14 +1336,7 @@ Create `packages/design-system/src/components/Toast/Toast.tsx`:
 
 ```tsx
 import { useState, type ReactNode } from 'react';
-import {
-  AlertTriangle,
-  CheckCircle2,
-  Info,
-  Loader2,
-  X,
-  XCircle,
-} from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Info, Loader2, X, XCircle } from 'lucide-react';
 import { clsx } from '../../utils/clsx';
 import { store, type ToastEntry } from './store';
 import { useToastTimer } from './useToastTimer';
@@ -1405,13 +1383,13 @@ export function Toast({ entry, isPeek }: ToastProps) {
   const renderedIcon =
     entry.icon === null
       ? null
-      : entry.icon ?? (
+      : (entry.icon ?? (
           <IconComponent
             size={16}
             aria-hidden="true"
             className={entry.tone === 'loading' ? styles.spin : undefined}
           />
-        );
+        ));
 
   const toneClass = {
     info: styles.toneInfo,
@@ -1445,9 +1423,7 @@ export function Toast({ entry, isPeek }: ToastProps) {
 
       <div className={styles.body}>
         <div className={styles.message}>{entry.message}</div>
-        {entry.description && (
-          <div className={styles.description}>{entry.description}</div>
-        )}
+        {entry.description && <div className={styles.description}>{entry.description}</div>}
       </div>
 
       <div className={styles.tail}>
@@ -1483,7 +1459,7 @@ export function Toast({ entry, isPeek }: ToastProps) {
 
 Create `packages/design-system/src/components/Toast/ToastViewport.tsx`:
 
-```tsx
+````tsx
 import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 import { clsx } from '../../utils/clsx';
@@ -1557,7 +1533,7 @@ export function ToastViewport({
   useEffect(() => {
     if (!isFirstViewport && process.env.NODE_ENV !== 'production') {
       console.error(
-        '[ToastViewport] Multiple <ToastViewport> instances detected. Only the first one renders. Mount exactly one at your app root.'
+        '[ToastViewport] Multiple <ToastViewport> instances detected. Only the first one renders. Mount exactly one at your app root.',
       );
     }
     return () => {
@@ -1569,11 +1545,7 @@ export function ToastViewport({
     _setViewportConfig({ position, duration });
   }, [position, duration]);
 
-  const state = useSyncExternalStore(
-    store.subscribe,
-    store.getSnapshot,
-    store.getSnapshot
-  );
+  const state = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
 
   const [hovered, setHovered] = useState<Set<ToastPosition>>(() => new Set());
   // useRef instead of state so we don't trigger an extra render
@@ -1600,7 +1572,7 @@ export function ToastViewport({
             className={clsx(
               styles.stack,
               POSITION_CLASS[pos],
-              gap === 'sm' ? styles.gapSm : styles.gapMd
+              gap === 'sm' ? styles.gapSm : styles.gapMd,
             )}
             aria-label="Notifications"
             data-position={pos}
@@ -1623,11 +1595,7 @@ export function ToastViewport({
             }}
           >
             {list.map((entry, idx) => (
-              <Toast
-                key={entry.id}
-                entry={entry}
-                isPeek={!isExpanded && idx >= maxVisible}
-              />
+              <Toast key={entry.id} entry={entry} isPeek={!isExpanded && idx >= maxVisible} />
             ))}
           </ol>
         );
@@ -1639,7 +1607,7 @@ export function ToastViewport({
 }
 
 function groupByPosition(
-  toasts: readonly ToastEntry[]
+  toasts: readonly ToastEntry[],
 ): Partial<Record<ToastPosition, ToastEntry[]>> {
   const out: Partial<Record<ToastPosition, ToastEntry[]>> = {};
   for (const t of toasts) {
@@ -1647,7 +1615,7 @@ function groupByPosition(
   }
   return out;
 }
-```
+````
 
 - [ ] **Step 4: Confirm `utils/clsx` exists**
 
@@ -1975,15 +1943,13 @@ describe('<ToastViewport>', () => {
       <>
         <ToastViewport />
         <ToastViewport />
-      </>
+      </>,
     );
     act(() => {
       toast.success('once');
     });
     expect(screen.getAllByText('once')).toHaveLength(1);
-    expect(errSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Multiple <ToastViewport>')
-    );
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Multiple <ToastViewport>'));
     errSpy.mockRestore();
   });
 });
@@ -2301,18 +2267,15 @@ setTimeout(() => {
             toast.promise(
               new Promise((resolve, reject) =>
                 setTimeout(
-                  () =>
-                    Math.random() > 0.5
-                      ? resolve('done')
-                      : reject(new Error('500')),
-                  1500
-                )
+                  () => (Math.random() > 0.5 ? resolve('done') : reject(new Error('500'))),
+                  1500,
+                ),
               ),
               {
                 loading: 'Working…',
                 success: 'Worked',
                 error: (e) => `Failed: ${(e as Error).message}`,
-              }
+              },
             )
           }
         >
@@ -2325,11 +2288,7 @@ setTimeout(() => {
         description="duration: 'persistent' disables auto-dismiss. The close (×) button is force-enabled even if you pass dismissible: false."
         code={`toast.error('Connection lost', { duration: 'persistent' });`}
       >
-        <Button
-          onClick={() =>
-            toast.error('Connection lost', { duration: 'persistent' })
-          }
-        >
+        <Button onClick={() => toast.error('Connection lost', { duration: 'persistent' })}>
           Fire persistent error
         </Button>
       </Example>
@@ -2474,8 +2433,8 @@ In `packages/playground/src/pages/mockups/registry.ts`, find `export type Compon
 ```ts
 export type ComponentName =
   // …existing names…
-  | 'Toast'
-  // …rest…;
+  'Toast';
+// …rest…;
 ```
 
 No existing mockup uses Toast yet, so no `usesComponents` lists need updating. The union extension is enough.
@@ -2497,6 +2456,7 @@ PORT=8090 npm run dev
 ```
 
 Open http://localhost:8090/components/toast, verify:
+
 - Tone gallery: each button fires a toast in bottom-right with the right color stripe
 - Description toast shows two-line content
 - Action button works + dismisses
@@ -2566,6 +2526,7 @@ Prompt template:
 > Files in scope: everything under `packages/design-system/src/components/Toast/`, `packages/design-system/src/index.ts`, `packages/design-system/AGENTS.md`, and the playground wiring touched on this branch.
 >
 > Verify:
+>
 > - All 7 hard rules (tests exist, demo exists, tokens not raw, no layout properties on components, exports correct, forwardRef where applicable, JSDoc on every exported symbol)
 > - ARIA: `role="alert"` only for error, `role="status"` for others, `aria-live` correct, `aria-label="Notifications"` on stacks, close button has `aria-label="Dismiss"`
 > - Pause-on-hover/focus actually works (read the test or trace the code)

--- a/docs/superpowers/specs/2026-05-23-toast-design.md
+++ b/docs/superpowers/specs/2026-05-23-toast-design.md
@@ -32,6 +32,7 @@ Provide a single global notification primitive that any consumer code can fire f
 ### Dependencies
 
 No new packages. Reuses:
+
 - React + ReactDOM (peer)
 - `lucide-react` (already a peer dep) for default tone icons: `Info`, `CheckCircle2`, `AlertTriangle`, `XCircle`, `Loader2`
 - Existing tokens: `--z-toast`, `--shadow-md`, `--shadow-lg`, `--radius-md`, `--space-*`, `--color-fg-*` (info/success/warning/danger/muted), `--color-bg`, `--color-fg`, `--font-size-md`, `--font-size-sm`, `--font-weight-medium`, `--transition-base`
@@ -123,12 +124,17 @@ toast.dismiss(): void             // dismiss ALL toasts
 ```
 
 **Types:**
+
 ```ts
 type ToastTone = 'info' | 'success' | 'warning' | 'error' | 'loading';
 
 type ToastPosition =
-  | 'top-left'    | 'top-center'    | 'top-right'
-  | 'bottom-left' | 'bottom-center' | 'bottom-right';
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';
 
 interface ToastOptions {
   /** Optional second-line content. Accepts `ReactNode` so you can embed links/icons. */
@@ -185,7 +191,7 @@ interface ToastEntry {
   dismissible: boolean;
   icon?: ReactNode | null;
   createdAt: number;
-  status: 'visible' | 'exiting';   // 'entering' is a CSS-only state on the DOM
+  status: 'visible' | 'exiting'; // 'entering' is a CSS-only state on the DOM
 }
 
 interface StoreState {
@@ -254,6 +260,7 @@ export function generateId(): string {
 ```
 
 **Key choices:**
+
 - `add` with an existing id delegates to `update` — this is what makes the `toast.success('done', { id: existingId })` pattern work.
 - `dismiss` does a two-step (mark exiting → remove after 250ms) so the viewport can play the exit animation before the DOM unmounts.
 - IDs are timestamp-based; no nanoid dependency.
@@ -267,7 +274,7 @@ function buildEntry(
   tone: ToastTone,
   message: ReactNode,
   options: ToastOptions = {},
-  defaults: { duration: number; position: ToastPosition }
+  defaults: { duration: number; position: ToastPosition },
 ): Omit<ToastEntry, 'createdAt' | 'status'> {
   const isLoading = tone === 'loading';
   const duration = options.duration ?? (isLoading ? 'persistent' : defaults.duration);
@@ -291,9 +298,14 @@ function buildEntry(
 // that ToastViewport writes to on mount/update. This is how we let viewport
 // props (position, duration) influence the API without a React context.
 
-interface ViewportConfig { position: ToastPosition; duration: number; }
+interface ViewportConfig {
+  position: ToastPosition;
+  duration: number;
+}
 let viewportConfig: ViewportConfig = { position: 'bottom-right', duration: 4000 };
-export function _setViewportConfig(cfg: ViewportConfig) { viewportConfig = cfg; }
+export function _setViewportConfig(cfg: ViewportConfig) {
+  viewportConfig = cfg;
+}
 
 function fire(tone: ToastTone, message: ReactNode, options?: ToastOptions): string {
   return store.add(buildEntry(tone, message, options, viewportConfig));
@@ -309,27 +321,40 @@ export const toast = Object.assign(
     loading: (m: string, o?: ToastOptions) => fire('loading', m, o),
     update: (id: string, partial: Partial<ToastEntry>) => store.update(id, partial),
     dismiss: (id?: string) => store.dismiss(id),
-    promise: <T>(p: Promise<T>, msgs: {
-      loading: string;
-      success: string | ((v: T) => string);
-      error: string | ((e: unknown) => string);
-      options?: Omit<ToastOptions, 'duration'>;
-    }): Promise<T> => {
+    promise: <T>(
+      p: Promise<T>,
+      msgs: {
+        loading: string;
+        success: string | ((v: T) => string);
+        error: string | ((e: unknown) => string);
+        options?: Omit<ToastOptions, 'duration'>;
+      },
+    ): Promise<T> => {
       const id = fire('loading', msgs.loading, msgs.options);
       return p.then(
         (v) => {
           const successMsg = typeof msgs.success === 'function' ? msgs.success(v) : msgs.success;
-          store.update(id, { tone: 'success', message: successMsg, duration: viewportConfig.duration, status: 'visible' });
+          store.update(id, {
+            tone: 'success',
+            message: successMsg,
+            duration: viewportConfig.duration,
+            status: 'visible',
+          });
           return v;
         },
         (err) => {
           const errorMsg = typeof msgs.error === 'function' ? msgs.error(err) : msgs.error;
-          store.update(id, { tone: 'error', message: errorMsg, duration: viewportConfig.duration, status: 'visible' });
+          store.update(id, {
+            tone: 'error',
+            message: errorMsg,
+            duration: viewportConfig.duration,
+            status: 'visible',
+          });
           throw err;
-        }
+        },
       );
     },
-  }
+  },
 );
 ```
 
@@ -367,6 +392,7 @@ function useToastTimer(args: {
 Internal one-toast component. Receives an entry + viewport-level config (max-visible position, expand state).
 
 Owns:
+
 - The card markup
 - `role="alert"` for `tone: 'error'`, `role="status"` for everything else
 - `aria-live="assertive"` paired with role="alert" (technically redundant since `role="alert"` implies assertive, but explicit is fine and matches Radix); `aria-live="polite"` for status
@@ -381,6 +407,7 @@ Owns:
 Exported. The single React entry point.
 
 Owns:
+
 - Subscribing to `store` via `useSyncExternalStore`
 - Pushing its `position`/`duration` defaults to `_setViewportConfig` on mount + on prop change
 - Dev-warning if a second viewport mounts (uses a module-level counter)
@@ -402,40 +429,46 @@ function ToastViewport({
   useDevWarnSecondViewport();
 
   // Push config to API
-  useEffect(() => { _setViewportConfig({ position, duration }); }, [position, duration]);
+  useEffect(() => {
+    _setViewportConfig({ position, duration });
+  }, [position, duration]);
 
   const state = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
-  const buckets = groupByPosition(state.toasts);   // { 'top-left': [...], ... }
+  const buckets = groupByPosition(state.toasts); // { 'top-left': [...], ... }
 
   return createPortal(
     <>
-      {POSITIONS.map((pos) => buckets[pos]?.length ? (
-        <ol
-          key={pos}
-          className={clsx(styles.stack, styles[`pos-${pos}`], styles[`gap-${gap}`])}
-          aria-label="Notifications"
-          data-position={pos}
-          data-expanded={expand || hovered.has(pos) ? 'true' : 'false'}
-          onMouseEnter={() => setHovered(prev => new Set(prev).add(pos))}
-          onMouseLeave={() => setHovered(prev => { const next = new Set(prev); next.delete(pos); return next; })}
-        >
-          {buckets[pos].map((t, idx) => (
-            <Toast
-              key={t.id}
-              entry={t}
-              indexFromEdge={idx}
-              maxVisible={maxVisible}
-            />
-          ))}
-        </ol>
-      ) : null)}
+      {POSITIONS.map((pos) =>
+        buckets[pos]?.length ? (
+          <ol
+            key={pos}
+            className={clsx(styles.stack, styles[`pos-${pos}`], styles[`gap-${gap}`])}
+            aria-label="Notifications"
+            data-position={pos}
+            data-expanded={expand || hovered.has(pos) ? 'true' : 'false'}
+            onMouseEnter={() => setHovered((prev) => new Set(prev).add(pos))}
+            onMouseLeave={() =>
+              setHovered((prev) => {
+                const next = new Set(prev);
+                next.delete(pos);
+                return next;
+              })
+            }
+          >
+            {buckets[pos].map((t, idx) => (
+              <Toast key={t.id} entry={t} indexFromEdge={idx} maxVisible={maxVisible} />
+            ))}
+          </ol>
+        ) : null,
+      )}
     </>,
-    document.body
+    document.body,
   );
 }
 ```
 
 **Stack direction is encoded in SCSS** via `flex-direction`:
+
 - Top positions: `flex-direction: column` — first child is closest to top edge, last child further from edge
 - Bottom positions: `flex-direction: column-reverse` — last child is closest to bottom edge
 
@@ -455,28 +488,60 @@ Combined with the `createdAt`-sorted store array, this puts the newest toast nea
   list-style: none;
   margin: 0;
   padding: 0;
-  pointer-events: none;       // stack itself doesn't intercept clicks
+  pointer-events: none; // stack itself doesn't intercept clicks
   max-width: calc(100vw - 2 * var(--space-3));
   width: 360px;
 }
 
-.stack > li { pointer-events: auto; }   // individual toasts do
+.stack > li {
+  pointer-events: auto;
+} // individual toasts do
 
 // 6 position variants
-.pos-top-left    { top: var(--space-3); left: var(--space-3); }
-.pos-top-center  { top: var(--space-3); left: 50%; transform: translateX(-50%); }
-.pos-top-right   { top: var(--space-3); right: var(--space-3); }
-.pos-bottom-left { bottom: var(--space-3); left: var(--space-3); flex-direction: column-reverse; }
-.pos-bottom-center { bottom: var(--space-3); left: 50%; transform: translateX(-50%); flex-direction: column-reverse; }
-.pos-bottom-right { bottom: var(--space-3); right: var(--space-3); flex-direction: column-reverse; }
+.pos-top-left {
+  top: var(--space-3);
+  left: var(--space-3);
+}
+.pos-top-center {
+  top: var(--space-3);
+  left: 50%;
+  transform: translateX(-50%);
+}
+.pos-top-right {
+  top: var(--space-3);
+  right: var(--space-3);
+}
+.pos-bottom-left {
+  bottom: var(--space-3);
+  left: var(--space-3);
+  flex-direction: column-reverse;
+}
+.pos-bottom-center {
+  bottom: var(--space-3);
+  left: 50%;
+  transform: translateX(-50%);
+  flex-direction: column-reverse;
+}
+.pos-bottom-right {
+  bottom: var(--space-3);
+  right: var(--space-3);
+  flex-direction: column-reverse;
+}
 
-.gap-sm > li + li { margin-top: var(--space-2); }
-.gap-md > li + li { margin-top: var(--space-3); }
+.gap-sm > li + li {
+  margin-top: var(--space-2);
+}
+.gap-md > li + li {
+  margin-top: var(--space-3);
+}
 
 // Bottom-anchored stacks: gap goes the other way
 .pos-bottom-left.gap-sm > li + li,
 .pos-bottom-center.gap-sm > li + li,
-.pos-bottom-right.gap-sm > li + li { margin-top: 0; margin-bottom: var(--space-2); }
+.pos-bottom-right.gap-sm > li + li {
+  margin-top: 0;
+  margin-bottom: var(--space-2);
+}
 // (and md variant)
 
 // ─── Toast card ─────────────────────────────────────────────────────────
@@ -489,20 +554,40 @@ Combined with the `createdAt`-sorted store array, this puts the newest toast nea
   background: var(--color-bg);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-md);
-  border-left: 3px solid var(--color-fg-muted);   // overridden per tone
+  border-left: 3px solid var(--color-fg-muted); // overridden per tone
 }
 
-.tone-info     { border-left-color: var(--color-info); }
-.tone-success  { border-left-color: var(--color-success); }
-.tone-warning  { border-left-color: var(--color-warning); }
-.tone-error    { border-left-color: var(--color-danger); }
-.tone-loading  { border-left-color: var(--color-fg-muted); }
+.tone-info {
+  border-left-color: var(--color-info);
+}
+.tone-success {
+  border-left-color: var(--color-success);
+}
+.tone-warning {
+  border-left-color: var(--color-warning);
+}
+.tone-error {
+  border-left-color: var(--color-danger);
+}
+.tone-loading {
+  border-left-color: var(--color-fg-muted);
+}
 
-.icon { color: var(--color-fg-muted); }
-.tone-info .icon    { color: var(--color-info); }
-.tone-success .icon { color: var(--color-success); }
-.tone-warning .icon { color: var(--color-warning); }
-.tone-error .icon   { color: var(--color-danger); }
+.icon {
+  color: var(--color-fg-muted);
+}
+.tone-info .icon {
+  color: var(--color-info);
+}
+.tone-success .icon {
+  color: var(--color-success);
+}
+.tone-warning .icon {
+  color: var(--color-warning);
+}
+.tone-error .icon {
+  color: var(--color-danger);
+}
 // loading icon spins via animation
 
 .message {
@@ -533,7 +618,10 @@ Combined with the `createdAt`-sorted store array, this puts the newest toast nea
   color: var(--color-fg);
   cursor: pointer;
 }
-.action:focus-visible { @include focus-ring; outline: none; }
+.action:focus-visible {
+  @include focus-ring;
+  outline: none;
+}
 
 .close {
   background: transparent;
@@ -544,19 +632,35 @@ Combined with the `createdAt`-sorted store array, this puts the newest toast nea
   display: grid;
   place-items: center;
 }
-.close:hover { color: var(--color-fg); }
-.close:focus-visible { @include focus-ring; outline: none; }
+.close:hover {
+  color: var(--color-fg);
+}
+.close:focus-visible {
+  @include focus-ring;
+  outline: none;
+}
 
 // ─── Animations ─────────────────────────────────────────────────────────
-.toast[data-status='visible']  { animation: enter 300ms cubic-bezier(0.22, 1, 0.36, 1); }
-.toast[data-status='exiting']  { animation: exit 250ms ease-in forwards; }
+.toast[data-status='visible'] {
+  animation: enter 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.toast[data-status='exiting'] {
+  animation: exit 250ms ease-in forwards;
+}
 
 // Slide direction varies by position — defined as 6 keyframes
-@keyframes enter-from-right { from { transform: translateX(30px); opacity: 0; } }
+@keyframes enter-from-right {
+  from {
+    transform: translateX(30px);
+    opacity: 0;
+  }
+}
 // ...etc per direction
 
 // Reflow animation when stack shifts after a dismissal
-.toast { transition: transform 200ms ease-out; }
+.toast {
+  transition: transform 200ms ease-out;
+}
 
 // Peek-collapsed: toasts beyond maxVisible
 .toast[data-peek='true'] {
@@ -581,31 +685,38 @@ Combined with the `createdAt`-sorted store array, this puts the newest toast nea
 }
 
 // Loading spin
-.spin { animation: spin 1s linear infinite; }
-@keyframes spin { to { transform: rotate(360deg); } }
+.spin {
+  animation: spin 1s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 ```
 
 **Rule 4 check:** Every component-internal `position`, `margin`, `transform` here is either on the viewport (which is layout-by-design — it's a fixed-position container, not a flow component) or on the toast for animation purposes. The toast card itself doesn't claim layout space in any parent grid. Documented as "viewport owns its own positioning" exception.
 
 ## ARIA + behavior reference
 
-| Concern | Behavior |
-|---|---|
-| Live region announcement | Each toast renders with `role="status"` (polite) or `role="alert"` (assertive, error only). SR announces on insertion. |
-| Focus management | Never auto-focus. Toasts reachable via natural Tab order. |
-| Pause-on-hover | Pointer entering the viewport stack pauses ALL timers in that bucket. Leaving resumes. |
-| Pause-on-focus | Focusing any element inside a toast (action / close) pauses that toast's timer. Blurring resumes. |
-| Pause when hidden | `document.visibilityState === 'hidden'` pauses all timers. Becoming visible resumes. |
-| Reduced motion | `prefers-reduced-motion: reduce` disables enter/exit/reflow animations; toasts appear/disappear instantly. |
-| Multiple viewports | First viewport renders; subsequent ones render `null` and log a dev warning. |
-| Mount-before-viewport | Toasts fired before viewport mounts sit in the store, render on mount. |
-| Close button visibility | Shown when `dismissible: true` (default) OR `duration: 'persistent'`. Hidden when consumer passes `dismissible: false` and a finite duration. |
+| Concern                  | Behavior                                                                                                                                      |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Live region announcement | Each toast renders with `role="status"` (polite) or `role="alert"` (assertive, error only). SR announces on insertion.                        |
+| Focus management         | Never auto-focus. Toasts reachable via natural Tab order.                                                                                     |
+| Pause-on-hover           | Pointer entering the viewport stack pauses ALL timers in that bucket. Leaving resumes.                                                        |
+| Pause-on-focus           | Focusing any element inside a toast (action / close) pauses that toast's timer. Blurring resumes.                                             |
+| Pause when hidden        | `document.visibilityState === 'hidden'` pauses all timers. Becoming visible resumes.                                                          |
+| Reduced motion           | `prefers-reduced-motion: reduce` disables enter/exit/reflow animations; toasts appear/disappear instantly.                                    |
+| Multiple viewports       | First viewport renders; subsequent ones render `null` and log a dev warning.                                                                  |
+| Mount-before-viewport    | Toasts fired before viewport mounts sit in the store, render on mount.                                                                        |
+| Close button visibility  | Shown when `dismissible: true` (default) OR `duration: 'persistent'`. Hidden when consumer passes `dismissible: false` and a finite duration. |
 
 ## Testing
 
 **Coverage by file:**
 
 `store.test.ts` (~15 cases, no DOM):
+
 - `add()` returns id and appends; auto-generates id if not provided
 - `add()` with existing id is treated as `update`
 - `update(id, partial)` mutates entry; unknown id is no-op
@@ -615,6 +726,7 @@ Combined with the `createdAt`-sorted store array, this puts the newest toast nea
 - IDs are unique across 1000 rapid `add()` calls
 
 `api.test.ts` (~10 cases):
+
 - Each tone shorthand writes the right `tone` field
 - `loading` defaults to `duration: 'persistent'`
 - `update(id, partial)` calls store.update
@@ -624,6 +736,7 @@ Combined with the `createdAt`-sorted store array, this puts the newest toast nea
 - `_setViewportConfig` controls the defaults used by subsequent fires
 
 `Toast.test.tsx` (~20 cases, RTL + userEvent + fake timers):
+
 - Renders nothing when store is empty
 - Adding a toast renders one card with the message
 - All 5 tones render with the right class + icon
@@ -647,6 +760,7 @@ Combined with the `createdAt`-sorted store array, this puts the newest toast nea
 - Two `<ToastViewport>` mounted: only first renders, console.error called
 
 **Vitest fake-timer specifics:**
+
 - `vi.useFakeTimers()` in `beforeEach`, `vi.useRealTimers()` in `afterEach`
 - Use `await act(() => vi.advanceTimersByTime(ms))` to flush both timer + React effects
 - Reset store between tests via a `store._reset()` test helper (export-only, no public API)
@@ -672,7 +786,7 @@ After EmptyState. Section title `### Toast`. One ~30-line block showing:
 
 ```tsx
 // Mount once at app root
-<ToastViewport position="bottom-right" />
+<ToastViewport position="bottom-right" />;
 
 // Fire from anywhere
 toast.success('Saved');
@@ -695,6 +809,7 @@ toast.success('Saved', { id });
 ## Open questions (none)
 
 All clarifications made during brainstorming are baked in above. Locked decisions:
+
 - All 6 positions supported; default `bottom-right`; per-call override available but documented as an escape hatch.
 - 5 tones; `role="alert"` only for `error`; warning stays polite.
 - Action slot + close button + persistent + promise + update — all in scope.

--- a/docs/superpowers/specs/2026-05-23-toast-design.md
+++ b/docs/superpowers/specs/2026-05-23-toast-design.md
@@ -492,17 +492,17 @@ Combined with the `createdAt`-sorted store array, this puts the newest toast nea
   border-left: 3px solid var(--color-fg-muted);   // overridden per tone
 }
 
-.tone-info     { border-left-color: var(--color-fg-info); }
-.tone-success  { border-left-color: var(--color-fg-success); }
-.tone-warning  { border-left-color: var(--color-fg-warning); }
-.tone-error    { border-left-color: var(--color-fg-danger); }
+.tone-info     { border-left-color: var(--color-info); }
+.tone-success  { border-left-color: var(--color-success); }
+.tone-warning  { border-left-color: var(--color-warning); }
+.tone-error    { border-left-color: var(--color-danger); }
 .tone-loading  { border-left-color: var(--color-fg-muted); }
 
 .icon { color: var(--color-fg-muted); }
-.tone-info .icon    { color: var(--color-fg-info); }
-.tone-success .icon { color: var(--color-fg-success); }
-.tone-warning .icon { color: var(--color-fg-warning); }
-.tone-error .icon   { color: var(--color-fg-danger); }
+.tone-info .icon    { color: var(--color-info); }
+.tone-success .icon { color: var(--color-success); }
+.tone-warning .icon { color: var(--color-warning); }
+.tone-error .icon   { color: var(--color-danger); }
 // loading icon spins via animation
 
 .message {

--- a/docs/superpowers/specs/2026-05-23-toast-design.md
+++ b/docs/superpowers/specs/2026-05-23-toast-design.md
@@ -1,0 +1,707 @@
+# Toast — design spec
+
+**Date:** 2026-05-23
+**Branch:** `feat/toast`
+**Scope:** New `Toast` component for `@eocrm/design-system` — imperative transient notification primitive with portal-based rendering, 6 positions, 5 tones, queue/stack management, auto-dismiss with pause-on-hover/focus, action slot, programmatic update, `toast.promise()` sugar, and `prefers-reduced-motion` support.
+
+## Goal
+
+Provide a single global notification primitive that any consumer code can fire from anywhere — event handlers, async flows, error boundaries — without threading providers or hooks. The runtime is a vanilla observable store; the React surface is one `<ToastViewport>` component mounted at the app root. Tone-prefixed shorthands (`toast.success`, `toast.error`) cover the common cases; programmatic update + promise sugar covers async flows; an action slot covers undo/retry.
+
+## Why now
+
+- The CRM has open-coded notification UI in multiple places: inline alerts under forms, ad-hoc `<div>`s in the topbar, plain `alert()` calls during prototypes. None are consistent and none survive route changes.
+- Async flows (save, upload, send) need a "Uploading…" → "Uploaded" pattern that has no current primitive.
+- Errors that need user acknowledgement are currently swallowed or shown as inline text — Toast with `duration: 'persistent'` + `role="alert"` is the right shape.
+- The token reserve already has `--z-toast: 1200` waiting for this exact use.
+
+## Non-goals (v1)
+
+- **No alternate visual treatments.** One look — white card, accent stripe, shadow. No "filled" variant matching the tone background; no outlined variant. Defer until requested.
+- **No grouping/threading.** Each toast is independent. No "5 errors collapsed into one" UI.
+- **No keyboard hotkey to focus the viewport.** Sonner adds `Alt+T`; we skip until requested. Toasts remain reachable via natural tab order.
+- **No richest-content slots.** Description accepts `ReactNode`, but we don't expose explicit "header / body / footer" slots like Modal. Toasts are short by design.
+- **No swipe-to-dismiss.** Desktop primary; touch gestures deferred.
+- **No vertical-stacking direction prop.** Direction is auto from the position (top-anchored stacks grow downward; bottom-anchored grow upward).
+- **No undo timer on the action.** The action button just fires its `onClick` and dismisses the toast — no "undo expires in 3s" timer ring. If a consumer needs that, they can compose with the `duration` prop.
+- **No persistence across reloads.** Pure in-memory.
+- **No theming hooks beyond the existing tokens.** No `<ToastViewport theme={...}>` override. If a consumer needs different colors, they layer CSS over the existing tokens.
+
+## Architecture
+
+### Dependencies
+
+No new packages. Reuses:
+- React + ReactDOM (peer)
+- `lucide-react` (already a peer dep) for default tone icons: `Info`, `CheckCircle2`, `AlertTriangle`, `XCircle`, `Loader2`
+- Existing tokens: `--z-toast`, `--shadow-md`, `--shadow-lg`, `--radius-md`, `--space-*`, `--color-fg-*` (info/success/warning/danger/muted), `--color-bg`, `--color-fg`, `--font-size-md`, `--font-size-sm`, `--font-weight-medium`, `--transition-base`
+
+Animation durations (300ms enter, 250ms exit, 200ms reflow) are hardcoded — they're meaningfully longer than `--transition-base: 140ms` because slide-in is more visible and 140ms feels too abrupt. We can token-ify later if a second component needs the same scale.
+
+### File layout
+
+```
+packages/design-system/src/components/Toast/
+  store.ts              ← Vanilla observable store: add/update/dismiss/dismissAll/subscribe. NO React imports. Pure JS singleton.
+  store.test.ts         ← Unit tests for store mechanics (no DOM, no React).
+  api.ts                ← Public `toast` singleton: tones, promise(), update(), dismiss(). Thin wrapper over store.
+  api.test.ts           ← Tests the public API shape + tone-to-store-payload mapping.
+  useToastTimer.ts      ← Custom hook: per-toast timeout with pause-on-hover/focus/document-hidden.
+  Toast.tsx             ← Internal <Toast> renders one entry. Owns toast card markup, role="status"/role="alert" branching, action button, close button.
+  ToastViewport.tsx     ← Exported. Portal + 6 position sub-stacks. Subscribes via useSyncExternalStore. Owns position + animation state + hover-expand state.
+  Toast.module.scss     ← Card + viewport positioning + 6 position variants + slide animations (per direction).
+  Toast.test.tsx        ← <ToastViewport> rendering + integration tests with userEvent + fake timers.
+  index.ts              ← exports `toast`, `ToastViewport`, types
+```
+
+Plus standard integration points:
+
+- `packages/design-system/src/index.ts` — re-export `toast`, `ToastViewport`, types
+- `packages/design-system/AGENTS.md` — TL;DR slot after EmptyState
+- `packages/playground/src/pages/components/ToastDemo.tsx` — 8-example demo
+- `packages/playground/src/App.tsx` — route + viewport mount at app root
+- `packages/playground/src/layout/AppShell/AppShell.tsx` — sidebar entry (create new "Feedback" group; siblings: Skeleton, EmptyState)
+- `packages/playground/src/pages/components/ComponentsIndex.tsx` — overview card
+- `packages/playground/src/pages/mockups/registry.ts` — `'Toast'` in `ComponentName` union
+
+### Composition
+
+```
+        Consumer code                  (no React import needed)
+              │
+              ▼
+        toast.success("Saved") ────►  store.add({ tone, message, ... })
+                                          │
+                                          │ store notifies subscribers
+                                          ▼
+                              <ToastViewport> (subscribed via useSyncExternalStore)
+                                          │
+                                          ▼
+                              createPortal → 6 position regions → <Toast> nodes
+```
+
+The store + API are pure JS — testable without React. The viewport is the only React surface. Consumers see exactly two public symbols: `toast` and `<ToastViewport />`.
+
+## Public API
+
+```ts
+// ─── Tone shorthands (most common) ─────────────────────────────────────
+toast.success(message: string, options?: ToastOptions): string
+toast.error(message: string, options?: ToastOptions): string
+toast.warning(message: string, options?: ToastOptions): string
+toast.info(message: string, options?: ToastOptions): string
+toast.loading(message: string, options?: ToastOptions): string
+// `loading` defaults to `duration: 'persistent'` — clears via update or dismiss.
+
+// ─── Untoned default (tone: 'info') ────────────────────────────────────
+toast(message: string, options?: ToastOptions): string
+
+// ─── Programmatic update ───────────────────────────────────────────────
+toast.update(id: string, partial: ToastUpdateOptions): void
+// where:
+//   type ToastUpdateOptions = Partial<Omit<ToastOptions, 'id'>> & {
+//     message?: ReactNode;
+//     tone?: ToastTone;
+//   };
+// (id, createdAt, status are internal-only — not consumer-settable)
+// Or use the `id` option on a tone shorthand to update in place:
+const id = toast.loading('Uploading…');
+toast.success('Uploaded', { id });   // mutates the existing entry instead of adding a new one
+
+// ─── Promise sugar (Sonner-style) ──────────────────────────────────────
+toast.promise<T>(promise: Promise<T>, msgs: {
+  loading: string;
+  success: string | ((value: T) => string);
+  error: string | ((err: unknown) => string);
+  options?: Omit<ToastOptions, 'duration'>;
+}): Promise<T>
+// Returns the original promise unmodified, so consumers can chain `.then`/`await`.
+
+// ─── Dismissal ─────────────────────────────────────────────────────────
+toast.dismiss(id: string): void   // dismiss a specific toast
+toast.dismiss(): void             // dismiss ALL toasts
+```
+
+**Types:**
+```ts
+type ToastTone = 'info' | 'success' | 'warning' | 'error' | 'loading';
+
+type ToastPosition =
+  | 'top-left'    | 'top-center'    | 'top-right'
+  | 'bottom-left' | 'bottom-center' | 'bottom-right';
+
+interface ToastOptions {
+  /** Optional second-line content. Accepts `ReactNode` so you can embed links/icons. */
+  description?: ReactNode;
+  /** Auto-dismiss timeout (ms) or `'persistent'` for no auto-dismiss. Default: 4000. */
+  duration?: number | 'persistent';
+  /** Per-call override of the viewport's default position. */
+  position?: ToastPosition;
+  /** Assign a stable id (else auto-generated). Reusing an existing id triggers `update`. */
+  id?: string;
+  /** Single primary action button rendered inside the toast. */
+  action?: { label: string; onClick: () => void };
+  /** Show the close (×) button. Default: true. Forced `true` when `duration: 'persistent'`. */
+  dismissible?: boolean;
+  /** Override the tone's default icon. Pass `null` to hide. */
+  icon?: ReactNode | null;
+}
+
+interface ToastViewportProps {
+  /** Default position for toasts that don't specify one. Default: 'bottom-right'. */
+  position?: ToastPosition;
+  /** Default duration for toasts without explicit duration. Default: 4000. */
+  duration?: number;
+  /** How many toasts are fully visible at once per position bucket. Default: 3. Beyond this, toasts render as collapsed peek-cards behind the visible stack. */
+  maxVisible?: number;
+  /** Spacing between stacked toasts. Default: 'sm' (8px). */
+  gap?: 'sm' | 'md';
+  /** false (default): collapsed stack with peek-cards behind, hover to fan out. true: always fanned. */
+  expand?: boolean;
+}
+```
+
+**All `toast.x()` calls return the toast id (string).** This is what consumers use for `update()` / `dismiss(id)`. Auto-generated ids are nanoid-style short strings; consumers may pass their own via `options.id`.
+
+**No exported `Toast` component.** The internal `<Toast>` is implementation detail. The only React export is `<ToastViewport>`.
+
+## Architecture flow
+
+### Store (`store.ts`)
+
+Vanilla JS module, no React:
+
+```ts
+type Listener = () => void;
+
+interface ToastEntry {
+  id: string;
+  tone: ToastTone;
+  message: ReactNode;
+  description?: ReactNode;
+  duration: number | 'persistent';
+  position: ToastPosition;
+  action?: { label: string; onClick: () => void };
+  dismissible: boolean;
+  icon?: ReactNode | null;
+  createdAt: number;
+  status: 'visible' | 'exiting';   // 'entering' is a CSS-only state on the DOM
+}
+
+interface StoreState {
+  toasts: ToastEntry[];
+}
+
+// Internal state + listener set
+let state: StoreState = { toasts: [] };
+const listeners = new Set<Listener>();
+
+export const store = {
+  getSnapshot: (): StoreState => state,
+  subscribe(listener: Listener): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  add(entry: Omit<ToastEntry, 'createdAt' | 'status'>): string {
+    if (state.toasts.some((t) => t.id === entry.id)) {
+      // Reusing an id is an implicit update.
+      return store.update(entry.id, entry);
+    }
+    state = {
+      toasts: [...state.toasts, { ...entry, createdAt: Date.now(), status: 'visible' }],
+    };
+    notify();
+    return entry.id;
+  },
+  update(id: string, partial: Partial<ToastEntry>): string {
+    state = {
+      toasts: state.toasts.map((t) => (t.id === id ? { ...t, ...partial } : t)),
+    };
+    notify();
+    return id;
+  },
+  dismiss(id?: string): void {
+    if (id === undefined) {
+      // Mark all as exiting; full removal happens after exit-animation timeout (~250ms)
+      state = { toasts: state.toasts.map((t) => ({ ...t, status: 'exiting' })) };
+      notify();
+      setTimeout(() => {
+        state = { toasts: [] };
+        notify();
+      }, 250);
+      return;
+    }
+    state = {
+      toasts: state.toasts.map((t) => (t.id === id ? { ...t, status: 'exiting' } : t)),
+    };
+    notify();
+    setTimeout(() => {
+      state = { toasts: state.toasts.filter((t) => t.id !== id) };
+      notify();
+    }, 250);
+  },
+};
+
+function notify() {
+  listeners.forEach((l) => l());
+}
+
+// id generator — short, URL-safe, no external dep
+let nextId = 0;
+export function generateId(): string {
+  return `t${Date.now().toString(36)}${(++nextId).toString(36)}`;
+}
+```
+
+**Key choices:**
+- `add` with an existing id delegates to `update` — this is what makes the `toast.success('done', { id: existingId })` pattern work.
+- `dismiss` does a two-step (mark exiting → remove after 250ms) so the viewport can play the exit animation before the DOM unmounts.
+- IDs are timestamp-based; no nanoid dependency.
+
+### API (`api.ts`)
+
+```ts
+import { store, generateId } from './store';
+
+function buildEntry(
+  tone: ToastTone,
+  message: ReactNode,
+  options: ToastOptions = {},
+  defaults: { duration: number; position: ToastPosition }
+): Omit<ToastEntry, 'createdAt' | 'status'> {
+  const isLoading = tone === 'loading';
+  const duration = options.duration ?? (isLoading ? 'persistent' : defaults.duration);
+  const isPersistent = duration === 'persistent';
+  return {
+    id: options.id ?? generateId(),
+    tone,
+    message,
+    description: options.description,
+    duration,
+    position: options.position ?? defaults.position,
+    action: options.action,
+    // Persistent toasts force dismissible: true (so the user has a way out).
+    // Otherwise consumer override wins; default true.
+    dismissible: isPersistent ? true : (options.dismissible ?? true),
+    icon: options.icon,
+  };
+}
+
+// Note: defaults are read from the viewport via a tiny "config" sub-store
+// that ToastViewport writes to on mount/update. This is how we let viewport
+// props (position, duration) influence the API without a React context.
+
+interface ViewportConfig { position: ToastPosition; duration: number; }
+let viewportConfig: ViewportConfig = { position: 'bottom-right', duration: 4000 };
+export function _setViewportConfig(cfg: ViewportConfig) { viewportConfig = cfg; }
+
+function fire(tone: ToastTone, message: ReactNode, options?: ToastOptions): string {
+  return store.add(buildEntry(tone, message, options, viewportConfig));
+}
+
+export const toast = Object.assign(
+  (message: string, options?: ToastOptions) => fire('info', message, options),
+  {
+    info: (m: string, o?: ToastOptions) => fire('info', m, o),
+    success: (m: string, o?: ToastOptions) => fire('success', m, o),
+    warning: (m: string, o?: ToastOptions) => fire('warning', m, o),
+    error: (m: string, o?: ToastOptions) => fire('error', m, o),
+    loading: (m: string, o?: ToastOptions) => fire('loading', m, o),
+    update: (id: string, partial: Partial<ToastEntry>) => store.update(id, partial),
+    dismiss: (id?: string) => store.dismiss(id),
+    promise: <T>(p: Promise<T>, msgs: {
+      loading: string;
+      success: string | ((v: T) => string);
+      error: string | ((e: unknown) => string);
+      options?: Omit<ToastOptions, 'duration'>;
+    }): Promise<T> => {
+      const id = fire('loading', msgs.loading, msgs.options);
+      return p.then(
+        (v) => {
+          const successMsg = typeof msgs.success === 'function' ? msgs.success(v) : msgs.success;
+          store.update(id, { tone: 'success', message: successMsg, duration: viewportConfig.duration, status: 'visible' });
+          return v;
+        },
+        (err) => {
+          const errorMsg = typeof msgs.error === 'function' ? msgs.error(err) : msgs.error;
+          store.update(id, { tone: 'error', message: errorMsg, duration: viewportConfig.duration, status: 'visible' });
+          throw err;
+        }
+      );
+    },
+  }
+);
+```
+
+**On `_setViewportConfig`:** the API needs the viewport's default position + duration but the API can't depend on React. Solution is a tiny mutable config slot the viewport writes to on mount. If no viewport mounts, config stays at the constants (`'bottom-right'`, `4000`), which is the right behavior anyway.
+
+### useToastTimer (`useToastTimer.ts`)
+
+Hook used by each `<Toast>` to manage its dismiss timer. Encapsulates pause/resume math.
+
+```ts
+interface TimerControls {
+  pause: () => void;
+  resume: () => void;
+}
+
+function useToastTimer(args: {
+  id: string;
+  duration: number | 'persistent';
+  onDismiss: () => void;
+}): TimerControls {
+  // Internals:
+  // - if duration === 'persistent', no-op
+  // - else: setTimeout, store expectedEnd. pause(): clearTimeout, capture remaining.
+  //   resume(): setTimeout(onDismiss, remaining)
+  // - On `document.visibilityState === 'hidden'`, pause; on visible, resume.
+  //   (Subscribed via document.addEventListener once per hook instance.)
+  // - On unmount, clearTimeout + remove visibility listener.
+  // - Indirection: use a getVisibility() function so tests can mock without
+  //   poking at the read-only document.visibilityState property in jsdom.
+}
+```
+
+### Toast (`Toast.tsx`)
+
+Internal one-toast component. Receives an entry + viewport-level config (max-visible position, expand state).
+
+Owns:
+- The card markup
+- `role="alert"` for `tone: 'error'`, `role="status"` for everything else
+- `aria-live="assertive"` paired with role="alert" (technically redundant since `role="alert"` implies assertive, but explicit is fine and matches Radix); `aria-live="polite"` for status
+- Mounting `data-status="visible"` / `data-status="exiting"` for the CSS animation hook
+- Hover/focus handlers that call `timer.pause()` / `timer.resume()` (the viewport wires these up across all toasts inside it — see below)
+- Action button rendering (when present): `<button onClick={() => { entry.action.onClick(); store.dismiss(entry.id); }}>{entry.action.label}</button>`
+- Close button (×) — when `entry.dismissible` is true OR `entry.duration === 'persistent'`
+- Spread order: Pattern B (component owns ARIA contract — `role`, `aria-live`, `data-*` cannot be overridden by consumer props)
+
+### ToastViewport (`ToastViewport.tsx`)
+
+Exported. The single React entry point.
+
+Owns:
+- Subscribing to `store` via `useSyncExternalStore`
+- Pushing its `position`/`duration` defaults to `_setViewportConfig` on mount + on prop change
+- Dev-warning if a second viewport mounts (uses a module-level counter)
+- Creating the portal — `createPortal` into `document.body` (or `props.container` if we want to expose that — not in v1)
+- Splitting the toasts array into 6 buckets by `position`
+- Rendering 6 sub-stack `<ol>` elements with `data-position={key}`. Empty buckets render nothing.
+- Hover-expand state per bucket: `isHovered: Set<ToastPosition>` — when a bucket is hovered, render its stack expanded; otherwise collapsed (unless `props.expand`).
+- `aria-label="Notifications"` on each rendered stack `<ol>` for landmark navigation.
+
+```tsx
+function ToastViewport({
+  position = 'bottom-right',
+  duration = 4000,
+  maxVisible = 3,
+  gap = 'sm',
+  expand = false,
+}: ToastViewportProps) {
+  // Dev-warn second viewport
+  useDevWarnSecondViewport();
+
+  // Push config to API
+  useEffect(() => { _setViewportConfig({ position, duration }); }, [position, duration]);
+
+  const state = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
+  const buckets = groupByPosition(state.toasts);   // { 'top-left': [...], ... }
+
+  return createPortal(
+    <>
+      {POSITIONS.map((pos) => buckets[pos]?.length ? (
+        <ol
+          key={pos}
+          className={clsx(styles.stack, styles[`pos-${pos}`], styles[`gap-${gap}`])}
+          aria-label="Notifications"
+          data-position={pos}
+          data-expanded={expand || hovered.has(pos) ? 'true' : 'false'}
+          onMouseEnter={() => setHovered(prev => new Set(prev).add(pos))}
+          onMouseLeave={() => setHovered(prev => { const next = new Set(prev); next.delete(pos); return next; })}
+        >
+          {buckets[pos].map((t, idx) => (
+            <Toast
+              key={t.id}
+              entry={t}
+              indexFromEdge={idx}
+              maxVisible={maxVisible}
+            />
+          ))}
+        </ol>
+      ) : null)}
+    </>,
+    document.body
+  );
+}
+```
+
+**Stack direction is encoded in SCSS** via `flex-direction`:
+- Top positions: `flex-direction: column` — first child is closest to top edge, last child further from edge
+- Bottom positions: `flex-direction: column-reverse` — last child is closest to bottom edge
+
+Combined with the `createdAt`-sorted store array, this puts the newest toast nearest the screen edge in both cases without any JS sorting on render.
+
+## Styling — `Toast.module.scss`
+
+```scss
+@use '../../styles/mixins' as *;
+
+// ─── Viewport stacks ─────────────────────────────────────────────────────
+.stack {
+  position: fixed;
+  z-index: var(--z-toast);
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;       // stack itself doesn't intercept clicks
+  max-width: calc(100vw - 2 * var(--space-3));
+  width: 360px;
+}
+
+.stack > li { pointer-events: auto; }   // individual toasts do
+
+// 6 position variants
+.pos-top-left    { top: var(--space-3); left: var(--space-3); }
+.pos-top-center  { top: var(--space-3); left: 50%; transform: translateX(-50%); }
+.pos-top-right   { top: var(--space-3); right: var(--space-3); }
+.pos-bottom-left { bottom: var(--space-3); left: var(--space-3); flex-direction: column-reverse; }
+.pos-bottom-center { bottom: var(--space-3); left: 50%; transform: translateX(-50%); flex-direction: column-reverse; }
+.pos-bottom-right { bottom: var(--space-3); right: var(--space-3); flex-direction: column-reverse; }
+
+.gap-sm > li + li { margin-top: var(--space-2); }
+.gap-md > li + li { margin-top: var(--space-3); }
+
+// Bottom-anchored stacks: gap goes the other way
+.pos-bottom-left.gap-sm > li + li,
+.pos-bottom-center.gap-sm > li + li,
+.pos-bottom-right.gap-sm > li + li { margin-top: 0; margin-bottom: var(--space-2); }
+// (and md variant)
+
+// ─── Toast card ─────────────────────────────────────────────────────────
+.toast {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-2);
+  align-items: start;
+  padding: var(--space-3);
+  background: var(--color-bg);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  border-left: 3px solid var(--color-fg-muted);   // overridden per tone
+}
+
+.tone-info     { border-left-color: var(--color-fg-info); }
+.tone-success  { border-left-color: var(--color-fg-success); }
+.tone-warning  { border-left-color: var(--color-fg-warning); }
+.tone-error    { border-left-color: var(--color-fg-danger); }
+.tone-loading  { border-left-color: var(--color-fg-muted); }
+
+.icon { color: var(--color-fg-muted); }
+.tone-info .icon    { color: var(--color-fg-info); }
+.tone-success .icon { color: var(--color-fg-success); }
+.tone-warning .icon { color: var(--color-fg-warning); }
+.tone-error .icon   { color: var(--color-fg-danger); }
+// loading icon spins via animation
+
+.message {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg);
+  line-height: 1.4;
+}
+
+.description {
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+  margin-top: var(--space-1);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.action {
+  // tone-colored compact button
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg);
+  cursor: pointer;
+}
+.action:focus-visible { @include focus-ring; outline: none; }
+
+.close {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-fg-muted);
+  padding: 0;
+  display: grid;
+  place-items: center;
+}
+.close:hover { color: var(--color-fg); }
+.close:focus-visible { @include focus-ring; outline: none; }
+
+// ─── Animations ─────────────────────────────────────────────────────────
+.toast[data-status='visible']  { animation: enter 300ms cubic-bezier(0.22, 1, 0.36, 1); }
+.toast[data-status='exiting']  { animation: exit 250ms ease-in forwards; }
+
+// Slide direction varies by position — defined as 6 keyframes
+@keyframes enter-from-right { from { transform: translateX(30px); opacity: 0; } }
+// ...etc per direction
+
+// Reflow animation when stack shifts after a dismissal
+.toast { transition: transform 200ms ease-out; }
+
+// Peek-collapsed: toasts beyond maxVisible
+.toast[data-peek='true'] {
+  transform: scale(0.95) translateY(8px);
+  opacity: 0.6;
+  pointer-events: none;
+}
+.stack[data-expanded='true'] .toast[data-peek='true'] {
+  transform: none;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+// Reduced motion: kill all animations
+@media (prefers-reduced-motion: reduce) {
+  .toast,
+  .toast[data-status='visible'],
+  .toast[data-status='exiting'] {
+    animation: none;
+    transition: none;
+  }
+}
+
+// Loading spin
+.spin { animation: spin 1s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+```
+
+**Rule 4 check:** Every component-internal `position`, `margin`, `transform` here is either on the viewport (which is layout-by-design — it's a fixed-position container, not a flow component) or on the toast for animation purposes. The toast card itself doesn't claim layout space in any parent grid. Documented as "viewport owns its own positioning" exception.
+
+## ARIA + behavior reference
+
+| Concern | Behavior |
+|---|---|
+| Live region announcement | Each toast renders with `role="status"` (polite) or `role="alert"` (assertive, error only). SR announces on insertion. |
+| Focus management | Never auto-focus. Toasts reachable via natural Tab order. |
+| Pause-on-hover | Pointer entering the viewport stack pauses ALL timers in that bucket. Leaving resumes. |
+| Pause-on-focus | Focusing any element inside a toast (action / close) pauses that toast's timer. Blurring resumes. |
+| Pause when hidden | `document.visibilityState === 'hidden'` pauses all timers. Becoming visible resumes. |
+| Reduced motion | `prefers-reduced-motion: reduce` disables enter/exit/reflow animations; toasts appear/disappear instantly. |
+| Multiple viewports | First viewport renders; subsequent ones render `null` and log a dev warning. |
+| Mount-before-viewport | Toasts fired before viewport mounts sit in the store, render on mount. |
+| Close button visibility | Shown when `dismissible: true` (default) OR `duration: 'persistent'`. Hidden when consumer passes `dismissible: false` and a finite duration. |
+
+## Testing
+
+**Coverage by file:**
+
+`store.test.ts` (~15 cases, no DOM):
+- `add()` returns id and appends; auto-generates id if not provided
+- `add()` with existing id is treated as `update`
+- `update(id, partial)` mutates entry; unknown id is no-op
+- `dismiss(id)` marks exiting then removes after 250ms
+- `dismiss()` clears all
+- `subscribe(listener)` fires on every state change; returns unsub
+- IDs are unique across 1000 rapid `add()` calls
+
+`api.test.ts` (~10 cases):
+- Each tone shorthand writes the right `tone` field
+- `loading` defaults to `duration: 'persistent'`
+- `update(id, partial)` calls store.update
+- `dismiss()` and `dismiss(id)` both delegate
+- `promise(p, msgs)` writes loading, then success on resolve, error on reject
+- `promise()` returns the original promise (chain-through works)
+- `_setViewportConfig` controls the defaults used by subsequent fires
+
+`Toast.test.tsx` (~20 cases, RTL + userEvent + fake timers):
+- Renders nothing when store is empty
+- Adding a toast renders one card with the message
+- All 5 tones render with the right class + icon
+- `role="alert"` only for error tone; `role="status"` for others
+- Auto-dismisses after `duration` ms
+- `duration: 'persistent'` does not auto-dismiss
+- Pause-on-hover: timer advances while hovered → no dismiss
+- Pause-on-focus: tabbing into the action button pauses
+- Document-hidden pauses globally (via mocked `getVisibility()`)
+- Action button click fires onClick AND dismisses
+- Close button (×) dismisses
+- `toast.dismiss(id)` dismisses programmatically
+- `toast.update(id, ...)` mutates the rendered card
+- 2 toasts → 2 cards in the right position bucket
+- Per-call `position` routes to the right bucket
+- `maxVisible: 2` with 4 toasts → 2 visible + 2 peek-collapsed via `data-peek="true"`
+- Hovering the stack expands peek-collapsed toasts (`data-expanded="true"`)
+- `expand: true` keeps stack fanned without hover
+- `prefers-reduced-motion`: no enter animation (computed style)
+- `toast.promise()` loading → success on resolve
+- Two `<ToastViewport>` mounted: only first renders, console.error called
+
+**Vitest fake-timer specifics:**
+- `vi.useFakeTimers()` in `beforeEach`, `vi.useRealTimers()` in `afterEach`
+- Use `await act(() => vi.advanceTimersByTime(ms))` to flush both timer + React effects
+- Reset store between tests via a `store._reset()` test helper (export-only, no public API)
+
+## Playground demo — `ToastDemo.tsx`
+
+8 buttons grouped into sections:
+
+1. **Tone gallery** — 5 buttons firing each tone with a representative message
+2. **With description** — `toast.success('Saved', { description: 'Your changes are now live.' })`
+3. **Action slot (Undo)** — fires `toast.success('Item deleted', { action: { label: 'Undo', onClick: () => toast.info('Restored') } })`
+4. **Programmatic update** — button fires `const id = toast.loading('Uploading…')`, sets a setTimeout to `toast.success('Uploaded', { id })` after 2s
+5. **`toast.promise()`** — button kicks off a 2s fake promise (50% resolve / 50% reject) with all three messages wired
+6. **Persistent error** — fires `toast.error('Request failed', { duration: 'persistent' })`
+7. **Per-call position override** — 4 buttons each firing into a different position (top-right, top-center, bottom-left, bottom-center)
+8. **Burst** — fires 7 toasts in rapid succession to show stacking + maxVisible + hover-to-expand
+
+The viewport mounts once in `App.tsx`, at app root, position default `bottom-right`, maxVisible 3, expand false. All demo buttons share that one viewport.
+
+## AGENTS.md TL;DR slot
+
+After EmptyState. Section title `### Toast`. One ~30-line block showing:
+
+```tsx
+// Mount once at app root
+<ToastViewport position="bottom-right" />
+
+// Fire from anywhere
+toast.success('Saved');
+toast.error('Request failed', { description: err.message });
+toast.success('Item deleted', { action: { label: 'Undo', onClick: restore } });
+
+// Async sugar
+toast.promise(api.upload(file), {
+  loading: 'Uploading…',
+  success: (r) => `Uploaded ${r.name}`,
+  error: (e) => `Failed: ${e.message}`,
+});
+
+// Update in place
+const id = toast.loading('Saving…');
+await api.save();
+toast.success('Saved', { id });
+```
+
+## Open questions (none)
+
+All clarifications made during brainstorming are baked in above. Locked decisions:
+- All 6 positions supported; default `bottom-right`; per-call override available but documented as an escape hatch.
+- 5 tones; `role="alert"` only for `error`; warning stays polite.
+- Action slot + close button + persistent + promise + update — all in scope.
+- maxVisible: 3 default, hover-to-expand collapsed peek-cards beneath.
+- `expand: false` default.
+- No new tokens.
+
+## Hard Rule 8 closeout (executed during plan Task 5)
+
+Pre-push review-fix cycle with fresh-context reviewers, repeated until 0 Critical + 0 Important. Gates green (test, typecheck, stylelint, build) before each review round.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -481,6 +481,48 @@ const [tab, setTab] = useState('overview');
 - Z-layer `--z-popover: 1050` — above dropdown, below modal/toast/tooltip.
 - For passive hover/focus hints → `<Tooltip>`. For lists of actions → `<DropdownMenu>`. For focus-locked dialogs → `<Modal>`.
 
+### `<ToastViewport>` + `toast` — transient notifications
+
+Imperative singleton + one portal. Fire from anywhere; no provider, no hook.
+
+```tsx
+import { ToastViewport, toast } from '@eocrm/design-system';
+
+// Mount once at app root
+<ToastViewport position="bottom-right" />;
+
+// Fire from anywhere
+toast.success('Saved');
+toast.error('Request failed', { description: err.message });
+toast.success('Item deleted', { action: { label: 'Undo', onClick: restore } });
+
+// Async sugar
+toast.promise(api.upload(file), {
+  loading: 'Uploading…',
+  success: (r) => `Uploaded ${r.name}`,
+  error: (e) => `Failed: ${e.message}`,
+});
+
+// Update in place
+const id = toast.loading('Saving…');
+await api.save();
+toast.success('Saved', { id });
+```
+
+- **One viewport.** Mount exactly one `<ToastViewport>` at the app root. A second one logs a dev-warning and renders null.
+- **Five tones.** `info`, `success`, `warning`, `error`, `loading`. `error` is `role="alert"` (assertive); the rest are `role="status"` (polite).
+- **Auto-dismiss defaults to 4000ms.** Per-call `duration` (ms or `'persistent'`). `loading` defaults to `'persistent'`.
+- **Pause on hover / focus / hidden tab.** Hovering the toast or tabbing into its action pauses the timer; document `visibilitychange` to `hidden` pauses all timers globally.
+- **maxVisible: 3 default.** Toasts beyond render as peek-collapsed cards behind the visible stack; hovering the stack fans them out. `expand: true` keeps the stack always fanned.
+- **All 6 positions supported** via `<ToastViewport position="…">`. Per-call `position` override exists as an escape hatch but a single global position is the recommended UX.
+
+#### When NOT to use
+
+- ❌ For form validation feedback under the field. That's inline error text, not a toast.
+- ❌ For destructive confirmations. Use `<ConfirmationPopover>` or `<Modal>` — the user needs an explicit yes/no decision, not a transient banner.
+- ❌ For long-form messages. Toasts are 1–2 lines. If you need more, link to a page from the description.
+- ❌ As a substitute for in-page progress UI. A toast can announce "Upload started" but the persistent progress bar belongs in the page.
+
 ### `<ConfirmationPopover>` — opinionated "Are you sure?" preset
 
 ```tsx

--- a/packages/design-system/src/components/Toast/Toast.module.scss
+++ b/packages/design-system/src/components/Toast/Toast.module.scss
@@ -316,6 +316,12 @@
     animation: none;
     transition: none;
   }
+
+  // The loading spinner rotates continuously — exactly the kind of persistent
+  // motion that causes issues for vestibular-sensitivity and migraine sufferers.
+  .spin {
+    animation: none;
+  }
 }
 
 // ─── Loading spinner ─────────────────────────────────────────────────────

--- a/packages/design-system/src/components/Toast/Toast.module.scss
+++ b/packages/design-system/src/components/Toast/Toast.module.scss
@@ -98,7 +98,7 @@
   background: var(--color-bg);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-md);
-  border-left: var(--border-width) solid var(--color-fg-muted); // overridden per tone
+  border-left: var(--border-width-strong) solid var(--color-fg-muted); // overridden per tone
   color: var(--color-fg);
   transition: transform 200ms ease-out;
 }

--- a/packages/design-system/src/components/Toast/Toast.module.scss
+++ b/packages/design-system/src/components/Toast/Toast.module.scss
@@ -1,0 +1,330 @@
+@use '../../styles/mixins' as *;
+
+// ─── Viewport stacks ─────────────────────────────────────────────────────
+.stack {
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- viewport owns its own positioning, not a flow component
+  position: fixed;
+  z-index: var(--z-toast);
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  // stylelint-disable-next-line property-disallowed-list -- stack resets browser default list margin; not consumer layout
+  margin: 0;
+  padding: 0;
+  pointer-events: none; // stack itself doesn't intercept clicks
+  max-width: calc(100vw - 2 * var(--space-3));
+  width: 360px;
+}
+
+.stack > li {
+  pointer-events: auto;
+}
+
+// Position variants — fixed positioning. Top-anchored stacks grow downward
+// (newest farther from edge); bottom-anchored grow upward via column-reverse.
+
+.posTopLeft {
+  top: var(--space-3);
+  left: var(--space-3);
+}
+
+.posTopCenter {
+  top: var(--space-3);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.posTopRight {
+  top: var(--space-3);
+  right: var(--space-3);
+}
+
+.posBottomLeft {
+  bottom: var(--space-3);
+  left: var(--space-3);
+  flex-direction: column-reverse;
+}
+
+.posBottomCenter {
+  bottom: var(--space-3);
+  left: 50%;
+  transform: translateX(-50%);
+  flex-direction: column-reverse;
+}
+
+.posBottomRight {
+  bottom: var(--space-3);
+  right: var(--space-3);
+  flex-direction: column-reverse;
+}
+
+// Gap between stacked toasts. column-reverse stacks need margin-bottom
+// instead of margin-top to space the same way visually.
+.gapSm > li + li {
+  // stylelint-disable-next-line property-disallowed-list -- gap between sibling toasts; internal to viewport stack
+  margin-top: var(--space-2);
+}
+
+.gapMd > li + li {
+  // stylelint-disable-next-line property-disallowed-list -- gap between sibling toasts; internal to viewport stack
+  margin-top: var(--space-3);
+}
+
+.posBottomLeft.gapSm > li + li,
+.posBottomCenter.gapSm > li + li,
+.posBottomRight.gapSm > li + li {
+  // stylelint-disable-next-line property-disallowed-list -- gap between sibling toasts in reversed stack; internal
+  margin-top: 0;
+  // stylelint-disable-next-line property-disallowed-list -- gap between sibling toasts in reversed stack; internal
+  margin-bottom: var(--space-2);
+}
+
+.posBottomLeft.gapMd > li + li,
+.posBottomCenter.gapMd > li + li,
+.posBottomRight.gapMd > li + li {
+  // stylelint-disable-next-line property-disallowed-list -- gap between sibling toasts in reversed stack; internal
+  margin-top: 0;
+  // stylelint-disable-next-line property-disallowed-list -- gap between sibling toasts in reversed stack; internal
+  margin-bottom: var(--space-3);
+}
+
+// ─── Toast card ─────────────────────────────────────────────────────────
+.toast {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-2);
+  align-items: start;
+  padding: var(--space-3);
+  background: var(--color-bg);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  border-left: var(--border-width) solid var(--color-fg-muted); // overridden per tone
+  color: var(--color-fg);
+  transition: transform 200ms ease-out;
+}
+
+.toneInfo {
+  border-left-color: var(--color-info);
+}
+
+.toneSuccess {
+  border-left-color: var(--color-success);
+}
+
+.toneWarning {
+  border-left-color: var(--color-warning);
+}
+
+.toneError {
+  border-left-color: var(--color-danger);
+}
+
+.toneLoading {
+  border-left-color: var(--color-fg-muted);
+}
+
+.icon {
+  color: var(--color-fg-muted);
+  display: grid;
+  place-items: center;
+}
+
+.toneInfo .icon {
+  color: var(--color-info);
+}
+
+.toneSuccess .icon {
+  color: var(--color-success);
+}
+
+.toneWarning .icon {
+  color: var(--color-warning);
+}
+
+.toneError .icon {
+  color: var(--color-danger);
+}
+
+.body {
+  min-width: 0; // allow text truncation inside grid
+}
+
+.message {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.4;
+}
+
+.description {
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+  // stylelint-disable-next-line property-disallowed-list -- internal spacing within the toast body; not consumer layout
+  margin-top: var(--space-1);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.tail {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.action {
+  background: transparent;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.action:hover {
+  background: var(--color-bg-muted);
+}
+
+.action:focus-visible {
+  @include focus-ring;
+
+  outline: none;
+}
+
+.close {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-fg-muted);
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+}
+
+.close:hover {
+  color: var(--color-fg);
+  background: var(--color-bg-muted);
+}
+
+.close:focus-visible {
+  @include focus-ring;
+
+  outline: none;
+}
+
+// ─── Enter / exit animations ─────────────────────────────────────────────
+// Slide direction depends on the position. We expose six keyframes and pick
+// via [data-position] on the parent stack.
+
+@keyframes enter-from-right {
+  from {
+    transform: translateX(30px);
+    opacity: var(--opacity-hidden);
+  }
+}
+
+@keyframes enter-from-left {
+  from {
+    transform: translateX(-30px);
+    opacity: var(--opacity-hidden);
+  }
+}
+
+@keyframes enter-from-top {
+  from {
+    transform: translateY(-30px);
+    opacity: var(--opacity-hidden);
+  }
+}
+
+@keyframes enter-from-bottom {
+  from {
+    transform: translateY(30px);
+    opacity: var(--opacity-hidden);
+  }
+}
+
+@keyframes exit-to-right {
+  to {
+    transform: translateX(30px);
+    opacity: var(--opacity-hidden);
+  }
+}
+
+@keyframes exit-to-left {
+  to {
+    transform: translateX(-30px);
+    opacity: var(--opacity-hidden);
+  }
+}
+
+[data-position='top-left'] .toast[data-status='visible'],
+[data-position='bottom-left'] .toast[data-status='visible'] {
+  animation: enter-from-left 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-position='top-right'] .toast[data-status='visible'],
+[data-position='bottom-right'] .toast[data-status='visible'] {
+  animation: enter-from-right 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-position='top-center'] .toast[data-status='visible'] {
+  animation: enter-from-top 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-position='bottom-center'] .toast[data-status='visible'] {
+  animation: enter-from-bottom 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-position='top-left'] .toast[data-status='exiting'],
+[data-position='bottom-left'] .toast[data-status='exiting'] {
+  animation: exit-to-left 250ms ease-in forwards;
+}
+
+[data-position='top-right'] .toast[data-status='exiting'],
+[data-position='bottom-right'] .toast[data-status='exiting'] {
+  animation: exit-to-right 250ms ease-in forwards;
+}
+
+[data-position='top-center'] .toast[data-status='exiting'],
+[data-position='bottom-center'] .toast[data-status='exiting'] {
+  animation: exit-to-right 250ms ease-in forwards;
+}
+
+// Peek-collapsed toasts (beyond maxVisible). Compressed and dimmed.
+.toast[data-peek='true'] {
+  transform: scale(0.95) translateY(8px);
+  opacity: var(--opacity-subtle);
+  pointer-events: none;
+}
+
+.stack[data-expanded='true'] .toast[data-peek='true'] {
+  transform: none;
+  opacity: var(--opacity-visible);
+  pointer-events: auto;
+}
+
+// ─── Reduced motion — kill enter/exit animations + the reflow transition ─
+@media (prefers-reduced-motion: reduce) {
+  .toast,
+  [data-position] .toast[data-status='visible'],
+  [data-position] .toast[data-status='exiting'] {
+    animation: none;
+    transition: none;
+  }
+}
+
+// ─── Loading spinner ─────────────────────────────────────────────────────
+.spin {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/design-system/src/components/Toast/Toast.test.tsx
+++ b/packages/design-system/src/components/Toast/Toast.test.tsx
@@ -90,6 +90,22 @@ describe('<ToastViewport>', () => {
     expect(screen.getByText('Saved')).toBeInTheDocument();
   });
 
+  it('pauses the timer while a child has focus', async () => {
+    renderViewport({ duration: 1000 });
+    act(() => {
+      toast.success('Saved', { action: { label: 'Undo', onClick: vi.fn() } });
+    });
+    // Focus the action button directly — more reliable than tab() when the
+    // document's initial focus position isn't deterministic in jsdom.
+    act(() => {
+      (screen.getByRole('button', { name: 'Undo' }) as HTMLButtonElement).focus();
+    });
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+  });
+
   it('action button fires onClick AND dismisses the toast', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     const onUndo = vi.fn();

--- a/packages/design-system/src/components/Toast/Toast.test.tsx
+++ b/packages/design-system/src/components/Toast/Toast.test.tsx
@@ -273,15 +273,13 @@ describe('<ToastViewport>', () => {
       <>
         <ToastViewport />
         <ToastViewport />
-      </>
+      </>,
     );
     act(() => {
       toast.success('once');
     });
     expect(screen.getAllByText('once')).toHaveLength(1);
-    expect(errSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Multiple <ToastViewport>')
-    );
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Multiple <ToastViewport>'));
     errSpy.mockRestore();
   });
 });

--- a/packages/design-system/src/components/Toast/Toast.test.tsx
+++ b/packages/design-system/src/components/Toast/Toast.test.tsx
@@ -1,0 +1,271 @@
+import { render, screen, act, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ToastViewport, type ToastViewportProps } from './ToastViewport';
+import { toast, _setViewportConfig } from './api';
+import { store } from './store';
+
+function renderViewport(props: Partial<ToastViewportProps> = {}) {
+  return render(<ToastViewport {...props} />);
+}
+
+describe('<ToastViewport>', () => {
+  beforeEach(() => {
+    store._reset();
+    _setViewportConfig({ position: 'bottom-right', duration: 4000 });
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when the store is empty', () => {
+    const { container } = renderViewport();
+    // Portal renders into document.body; viewport returns null fragment.
+    expect(container.firstChild).toBeNull();
+    expect(document.body.querySelector('[data-position]')).toBeNull();
+  });
+
+  it('renders a single toast after toast.success', () => {
+    renderViewport();
+    act(() => {
+      toast.success('Saved');
+    });
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['info', 'status', 'polite'],
+    ['success', 'status', 'polite'],
+    ['warning', 'status', 'polite'],
+    ['loading', 'status', 'polite'],
+    ['error', 'alert', 'assertive'],
+  ] as const)('tone=%s gets role=%s aria-live=%s', (tone, expectedRole, expectedLive) => {
+    renderViewport();
+    act(() => {
+      toast[tone]('msg');
+    });
+    const node = screen.getByText('msg').closest('[role]');
+    expect(node).toHaveAttribute('role', expectedRole);
+    expect(node).toHaveAttribute('aria-live', expectedLive);
+  });
+
+  it('auto-dismisses after the default duration', () => {
+    renderViewport({ duration: 1000 });
+    act(() => {
+      toast.success('Saved');
+    });
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    // status flips to exiting, then the store removes after 250ms.
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+  });
+
+  it('duration: persistent does not auto-dismiss', () => {
+    renderViewport({ duration: 1000 });
+    act(() => {
+      toast.error('Boom', { duration: 'persistent' });
+    });
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(screen.getByText('Boom')).toBeInTheDocument();
+  });
+
+  it('pauses the timer while hovered', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderViewport({ duration: 1000 });
+    act(() => {
+      toast.success('Saved');
+    });
+    const toastNode = screen.getByText('Saved').closest('[role]')!;
+    await user.hover(toastNode as Element);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+  });
+
+  it('action button fires onClick AND dismisses the toast', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onUndo = vi.fn();
+    renderViewport();
+    act(() => {
+      toast.success('Item deleted', { action: { label: 'Undo', onClick: onUndo } });
+    });
+    await user.click(screen.getByRole('button', { name: 'Undo' }));
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText('Item deleted')).not.toBeInTheDocument();
+  });
+
+  it('close button (×) dismisses the toast', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderViewport();
+    act(() => {
+      toast.success('Saved');
+    });
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+  });
+
+  it('close button is hidden when dismissible: false', () => {
+    renderViewport();
+    act(() => {
+      toast.success('Saved', { dismissible: false });
+    });
+    expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull();
+  });
+
+  it('persistent toasts always show the close button (overrides dismissible: false)', () => {
+    renderViewport();
+    act(() => {
+      toast.error('Boom', { duration: 'persistent', dismissible: false });
+    });
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+  });
+
+  it('toast.dismiss(id) dismisses programmatically', () => {
+    renderViewport();
+    let id = '';
+    act(() => {
+      id = toast.success('Saved');
+    });
+    act(() => {
+      toast.dismiss(id);
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+  });
+
+  it('toast.update(id, ...) mutates the rendered card', () => {
+    renderViewport();
+    let id = '';
+    act(() => {
+      id = toast.loading('Uploading');
+    });
+    expect(screen.getByText('Uploading')).toBeInTheDocument();
+    act(() => {
+      toast.update(id, { tone: 'success', message: 'Uploaded' });
+    });
+    expect(screen.queryByText('Uploading')).not.toBeInTheDocument();
+    expect(screen.getByText('Uploaded')).toBeInTheDocument();
+  });
+
+  it('two toasts stack in the same position bucket', () => {
+    renderViewport();
+    act(() => {
+      toast.success('a');
+      toast.success('b');
+    });
+    const stack = document.body.querySelector('[data-position="bottom-right"]')!;
+    expect(within(stack as HTMLElement).getByText('a')).toBeInTheDocument();
+    expect(within(stack as HTMLElement).getByText('b')).toBeInTheDocument();
+  });
+
+  it('per-call position routes to the right bucket', () => {
+    renderViewport({ position: 'bottom-right' });
+    act(() => {
+      toast.success('here', { position: 'top-center' });
+    });
+    const topCenter = document.body.querySelector('[data-position="top-center"]');
+    expect(topCenter).not.toBeNull();
+    expect(within(topCenter as HTMLElement).getByText('here')).toBeInTheDocument();
+  });
+
+  it('beyond maxVisible, toasts get data-peek="true"', () => {
+    renderViewport({ maxVisible: 2 });
+    act(() => {
+      toast.success('a');
+      toast.success('b');
+      toast.success('c');
+      toast.success('d');
+    });
+    const peekItems = document.body.querySelectorAll('[data-peek="true"]');
+    expect(peekItems.length).toBe(2);
+  });
+
+  it('hovering the stack expands peek-collapsed toasts', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderViewport({ maxVisible: 1 });
+    act(() => {
+      toast.success('a');
+      toast.success('b');
+    });
+    const stack = document.body.querySelector('[data-position="bottom-right"]')!;
+    expect(stack.getAttribute('data-expanded')).toBe('false');
+    await user.hover(stack as Element);
+    expect(stack.getAttribute('data-expanded')).toBe('true');
+  });
+
+  it('expand: true keeps the stack fanned without hover', () => {
+    renderViewport({ maxVisible: 1, expand: true });
+    act(() => {
+      toast.success('a');
+      toast.success('b');
+    });
+    const stack = document.body.querySelector('[data-position="bottom-right"]')!;
+    expect(stack.getAttribute('data-expanded')).toBe('true');
+  });
+
+  it('toast.promise: loading then success on resolve', async () => {
+    renderViewport();
+    let p!: Promise<{ name: string }>;
+    act(() => {
+      p = toast.promise(Promise.resolve({ name: 'file.pdf' }), {
+        loading: 'Uploading',
+        success: (r) => `Uploaded ${r.name}`,
+        error: 'Failed',
+      });
+    });
+    expect(screen.getByText('Uploading')).toBeInTheDocument();
+    await act(async () => {
+      await p;
+    });
+    expect(screen.getByText('Uploaded file.pdf')).toBeInTheDocument();
+  });
+
+  it('toast.promise: loading then error on reject', async () => {
+    renderViewport();
+    const err = new Error('500');
+    let p!: Promise<never>;
+    act(() => {
+      p = toast.promise(Promise.reject(err) as Promise<never>, {
+        loading: 'Uploading',
+        success: 'Uploaded',
+        error: (e) => `Failed: ${(e as Error).message}`,
+      });
+    });
+    await act(async () => {
+      await p.catch(() => {});
+    });
+    expect(screen.getByText('Failed: 500')).toBeInTheDocument();
+  });
+
+  it('two <ToastViewport> instances: dev-warn fires and only the first renders', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <>
+        <ToastViewport />
+        <ToastViewport />
+      </>
+    );
+    act(() => {
+      toast.success('once');
+    });
+    expect(screen.getAllByText('once')).toHaveLength(1);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Multiple <ToastViewport>')
+    );
+    errSpy.mockRestore();
+  });
+});

--- a/packages/design-system/src/components/Toast/Toast.tsx
+++ b/packages/design-system/src/components/Toast/Toast.tsx
@@ -1,12 +1,5 @@
 import { useState } from 'react';
-import {
-  AlertTriangle,
-  CheckCircle2,
-  Info,
-  Loader2,
-  X,
-  XCircle,
-} from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Info, Loader2, X, XCircle } from 'lucide-react';
 import clsx from 'clsx';
 import { store, type ToastEntry } from './store';
 import { useToastTimer } from './useToastTimer';
@@ -53,13 +46,13 @@ export function Toast({ entry, isPeek }: ToastProps) {
   const renderedIcon =
     entry.icon === null
       ? null
-      : entry.icon ?? (
+      : (entry.icon ?? (
           <IconComponent
             size={16}
             aria-hidden="true"
             className={entry.tone === 'loading' ? styles.spin : undefined}
           />
-        );
+        ));
 
   const toneClass = {
     info: styles.toneInfo,
@@ -93,9 +86,7 @@ export function Toast({ entry, isPeek }: ToastProps) {
 
       <div className={styles.body}>
         <div className={styles.message}>{entry.message}</div>
-        {entry.description && (
-          <div className={styles.description}>{entry.description}</div>
-        )}
+        {entry.description && <div className={styles.description}>{entry.description}</div>}
       </div>
 
       <div className={styles.tail}>
@@ -125,4 +116,3 @@ export function Toast({ entry, isPeek }: ToastProps) {
     </li>
   );
 }
-

--- a/packages/design-system/src/components/Toast/Toast.tsx
+++ b/packages/design-system/src/components/Toast/Toast.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Info,
+  Loader2,
+  X,
+  XCircle,
+} from 'lucide-react';
+import clsx from 'clsx';
+import { store, type ToastEntry } from './store';
+import { useToastTimer } from './useToastTimer';
+import styles from './Toast.module.scss';
+
+interface ToastProps {
+  entry: ToastEntry;
+  /** Whether this toast is rendered as a peek-collapsed card (beyond maxVisible). */
+  isPeek: boolean;
+  /** Default fallback duration when entry.duration is 'persistent' but rendered;
+   *  forwarded by the viewport for completeness, unused here today. */
+  // viewportDuration: number;  // (reserved for future use; not in v1)
+}
+
+const DEFAULT_ICONS: Record<ToastEntry['tone'], typeof Info> = {
+  info: Info,
+  success: CheckCircle2,
+  warning: AlertTriangle,
+  error: XCircle,
+  loading: Loader2,
+};
+
+/**
+ * Single toast card. NOT exported from the package — internal to ToastViewport.
+ *
+ * Spread order: Pattern B (component owns ARIA contract — role, aria-live,
+ * data-* cannot be overridden by consumer props).
+ */
+export function Toast({ entry, isPeek }: ToastProps) {
+  // Local "should the timer run" — flips when the user hovers OR a child has focus.
+  const [paused, setPaused] = useState(false);
+
+  useToastTimer({
+    id: entry.id,
+    duration: entry.duration,
+    paused,
+    onExpire: () => store.dismiss(entry.id),
+  });
+
+  const role = entry.tone === 'error' ? 'alert' : 'status';
+  const ariaLive = entry.tone === 'error' ? 'assertive' : 'polite';
+
+  const IconComponent = DEFAULT_ICONS[entry.tone];
+  const renderedIcon =
+    entry.icon === null
+      ? null
+      : entry.icon ?? (
+          <IconComponent
+            size={16}
+            aria-hidden="true"
+            className={entry.tone === 'loading' ? styles.spin : undefined}
+          />
+        );
+
+  const toneClass = {
+    info: styles.toneInfo,
+    success: styles.toneSuccess,
+    warning: styles.toneWarning,
+    error: styles.toneError,
+    loading: styles.toneLoading,
+  }[entry.tone];
+
+  return (
+    <li
+      role={role}
+      aria-live={ariaLive}
+      aria-atomic="true"
+      data-status={entry.status}
+      data-peek={isPeek ? 'true' : undefined}
+      data-tone={entry.tone}
+      className={clsx(styles.toast, toneClass)}
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      onFocus={() => setPaused(true)}
+      onBlur={(e) => {
+        // Only un-pause when focus leaves the toast entirely, not when moving
+        // from action button to close button.
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+          setPaused(false);
+        }
+      }}
+    >
+      {renderedIcon && <div className={styles.icon}>{renderedIcon}</div>}
+
+      <div className={styles.body}>
+        <div className={styles.message}>{entry.message}</div>
+        {entry.description && (
+          <div className={styles.description}>{entry.description}</div>
+        )}
+      </div>
+
+      <div className={styles.tail}>
+        {entry.action && (
+          <button
+            type="button"
+            className={styles.action}
+            onClick={() => {
+              entry.action!.onClick();
+              store.dismiss(entry.id);
+            }}
+          >
+            {entry.action.label}
+          </button>
+        )}
+        {entry.dismissible && (
+          <button
+            type="button"
+            className={styles.close}
+            aria-label="Dismiss"
+            onClick={() => store.dismiss(entry.id)}
+          >
+            <X size={14} aria-hidden="true" />
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}
+

--- a/packages/design-system/src/components/Toast/ToastViewport.tsx
+++ b/packages/design-system/src/components/Toast/ToastViewport.tsx
@@ -71,7 +71,7 @@ export function ToastViewport({
   useEffect(() => {
     if (!isFirstViewport && process.env.NODE_ENV !== 'production') {
       console.error(
-        '[ToastViewport] Multiple <ToastViewport> instances detected. Only the first one renders. Mount exactly one at your app root.'
+        '[ToastViewport] Multiple <ToastViewport> instances detected. Only the first one renders. Mount exactly one at your app root.',
       );
     }
     return () => {
@@ -83,11 +83,7 @@ export function ToastViewport({
     _setViewportConfig({ position, duration });
   }, [position, duration]);
 
-  const state = useSyncExternalStore(
-    store.subscribe,
-    store.getSnapshot,
-    store.getSnapshot
-  );
+  const state = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
 
   const [hovered, setHovered] = useState<Set<ToastPosition>>(() => new Set());
   // useRef instead of state so we don't trigger an extra render
@@ -114,7 +110,7 @@ export function ToastViewport({
             className={clsx(
               styles.stack,
               POSITION_CLASS[pos],
-              gap === 'sm' ? styles.gapSm : styles.gapMd
+              gap === 'sm' ? styles.gapSm : styles.gapMd,
             )}
             aria-label="Notifications"
             data-position={pos}
@@ -137,11 +133,7 @@ export function ToastViewport({
             }}
           >
             {list.map((entry, idx) => (
-              <Toast
-                key={entry.id}
-                entry={entry}
-                isPeek={!isExpanded && idx >= maxVisible}
-              />
+              <Toast key={entry.id} entry={entry} isPeek={!isExpanded && idx >= maxVisible} />
             ))}
           </ol>
         );
@@ -153,7 +145,7 @@ export function ToastViewport({
 }
 
 function groupByPosition(
-  toasts: readonly ToastEntry[]
+  toasts: readonly ToastEntry[],
 ): Partial<Record<ToastPosition, ToastEntry[]>> {
   const out: Partial<Record<ToastPosition, ToastEntry[]>> = {};
   for (const t of toasts) {

--- a/packages/design-system/src/components/Toast/ToastViewport.tsx
+++ b/packages/design-system/src/components/Toast/ToastViewport.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
+import clsx from 'clsx';
+import { _setViewportConfig } from './api';
+import { store, type ToastEntry, type ToastPosition } from './store';
+import { Toast } from './Toast';
+import styles from './Toast.module.scss';
+
+const POSITIONS: readonly ToastPosition[] = [
+  'top-left',
+  'top-center',
+  'top-right',
+  'bottom-left',
+  'bottom-center',
+  'bottom-right',
+];
+
+const POSITION_CLASS: Record<ToastPosition, string> = {
+  'top-left': styles.posTopLeft,
+  'top-center': styles.posTopCenter,
+  'top-right': styles.posTopRight,
+  'bottom-left': styles.posBottomLeft,
+  'bottom-center': styles.posBottomCenter,
+  'bottom-right': styles.posBottomRight,
+};
+
+let mountedViewportCount = 0;
+
+export interface ToastViewportProps {
+  /** Default position for toasts that don't specify one. Default: 'bottom-right'. */
+  position?: ToastPosition;
+  /** Default duration (ms) for toasts without explicit duration. Default: 4000. */
+  duration?: number;
+  /** How many toasts are fully visible per position bucket. Default: 3. */
+  maxVisible?: number;
+  /** Spacing between stacked toasts. Default: 'sm' (8px). */
+  gap?: 'sm' | 'md';
+  /** false (default): peek-collapsed stack, hover to fan out. true: always fanned. */
+  expand?: boolean;
+}
+
+/**
+ * The single Toast portal. Mount exactly one of these at your app root.
+ *
+ * @example
+ * ```tsx
+ * <ToastViewport position="bottom-right" />
+ * ```
+ *
+ * @remarks
+ * - **Mount once.** A dev-warning logs if a second one mounts; only the first renders.
+ * - **Mounts before consumers can fire are fine.** Toasts fired before this is in
+ *   the tree sit in the store and render the moment this mounts.
+ * - **Portal target is `document.body`.** Toasts are not constrained by any
+ *   parent overflow/transform/contain context.
+ */
+export function ToastViewport({
+  position = 'bottom-right',
+  duration = 4000,
+  maxVisible = 3,
+  gap = 'sm',
+  expand = false,
+}: ToastViewportProps) {
+  // Track viewport count for dev-warning. State so React doesn't unmount us
+  // when the count flips back to 1.
+  const [isFirstViewport] = useState(() => {
+    mountedViewportCount += 1;
+    return mountedViewportCount === 1;
+  });
+
+  useEffect(() => {
+    if (!isFirstViewport && process.env.NODE_ENV !== 'production') {
+      console.error(
+        '[ToastViewport] Multiple <ToastViewport> instances detected. Only the first one renders. Mount exactly one at your app root.'
+      );
+    }
+    return () => {
+      mountedViewportCount -= 1;
+    };
+  }, [isFirstViewport]);
+
+  useEffect(() => {
+    _setViewportConfig({ position, duration });
+  }, [position, duration]);
+
+  const state = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot
+  );
+
+  const [hovered, setHovered] = useState<Set<ToastPosition>>(() => new Set());
+  // useRef instead of state so we don't trigger an extra render
+  // when the portal target appears.
+  const portalTargetRef = useRef<HTMLElement | null>(null);
+  if (portalTargetRef.current === null && typeof document !== 'undefined') {
+    portalTargetRef.current = document.body;
+  }
+
+  if (!isFirstViewport) return null;
+  if (portalTargetRef.current === null) return null;
+
+  const buckets = groupByPosition(state.toasts);
+
+  const content = (
+    <>
+      {POSITIONS.map((pos) => {
+        const list = buckets[pos];
+        if (!list || list.length === 0) return null;
+        const isExpanded = expand || hovered.has(pos);
+        return (
+          <ol
+            key={pos}
+            className={clsx(
+              styles.stack,
+              POSITION_CLASS[pos],
+              gap === 'sm' ? styles.gapSm : styles.gapMd
+            )}
+            aria-label="Notifications"
+            data-position={pos}
+            data-expanded={isExpanded ? 'true' : 'false'}
+            onMouseEnter={() => {
+              setHovered((prev) => {
+                if (prev.has(pos)) return prev;
+                const next = new Set(prev);
+                next.add(pos);
+                return next;
+              });
+            }}
+            onMouseLeave={() => {
+              setHovered((prev) => {
+                if (!prev.has(pos)) return prev;
+                const next = new Set(prev);
+                next.delete(pos);
+                return next;
+              });
+            }}
+          >
+            {list.map((entry, idx) => (
+              <Toast
+                key={entry.id}
+                entry={entry}
+                isPeek={!isExpanded && idx >= maxVisible}
+              />
+            ))}
+          </ol>
+        );
+      })}
+    </>
+  );
+
+  return createPortal(content, portalTargetRef.current);
+}
+
+function groupByPosition(
+  toasts: readonly ToastEntry[]
+): Partial<Record<ToastPosition, ToastEntry[]>> {
+  const out: Partial<Record<ToastPosition, ToastEntry[]>> = {};
+  for (const t of toasts) {
+    (out[t.position] ??= []).push(t);
+  }
+  return out;
+}

--- a/packages/design-system/src/components/Toast/api.test.ts
+++ b/packages/design-system/src/components/Toast/api.test.ts
@@ -1,0 +1,144 @@
+import { toast, _setViewportConfig } from './api';
+import { store } from './store';
+
+describe('toast api', () => {
+  beforeEach(() => {
+    store._reset();
+    _setViewportConfig({ position: 'bottom-right', duration: 4000 });
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('toast() defaults to info tone', () => {
+    toast('Hello');
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'info',
+      message: 'Hello',
+    });
+  });
+
+  it.each([
+    ['info', 'info'],
+    ['success', 'success'],
+    ['warning', 'warning'],
+    ['error', 'error'],
+    ['loading', 'loading'],
+  ] as const)('toast.%s writes tone=%s', (method, expectedTone) => {
+    toast[method]('Hi');
+    expect(store.getSnapshot().toasts[0].tone).toBe(expectedTone);
+  });
+
+  it('toast.loading defaults to duration: persistent', () => {
+    toast.loading('Uploading');
+    expect(store.getSnapshot().toasts[0].duration).toBe('persistent');
+  });
+
+  it('toast.success picks up viewport.duration default', () => {
+    _setViewportConfig({ position: 'top-right', duration: 7000 });
+    toast.success('Saved');
+    expect(store.getSnapshot().toasts[0].duration).toBe(7000);
+  });
+
+  it('toast.success picks up viewport.position default', () => {
+    _setViewportConfig({ position: 'top-center', duration: 4000 });
+    toast.success('Saved');
+    expect(store.getSnapshot().toasts[0].position).toBe('top-center');
+  });
+
+  it('per-call position overrides the viewport default', () => {
+    toast.success('Saved', { position: 'top-left' });
+    expect(store.getSnapshot().toasts[0].position).toBe('top-left');
+  });
+
+  it('per-call duration overrides the viewport default', () => {
+    toast.success('Saved', { duration: 1000 });
+    expect(store.getSnapshot().toasts[0].duration).toBe(1000);
+  });
+
+  it('dismissible defaults to true', () => {
+    toast.success('Saved');
+    expect(store.getSnapshot().toasts[0].dismissible).toBe(true);
+  });
+
+  it('dismissible: false is respected for non-persistent toasts', () => {
+    toast.success('Saved', { dismissible: false });
+    expect(store.getSnapshot().toasts[0].dismissible).toBe(false);
+  });
+
+  it('dismissible is FORCED true when duration: persistent', () => {
+    toast.error('Boom', { duration: 'persistent', dismissible: false });
+    expect(store.getSnapshot().toasts[0].dismissible).toBe(true);
+  });
+
+  it('toast.success returns the id (auto-generated)', () => {
+    const id = toast.success('Saved');
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('toast.update mutates a stored entry', () => {
+    const id = toast.loading('Uploading');
+    toast.update(id, { tone: 'success', message: 'Uploaded' });
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'success',
+      message: 'Uploaded',
+    });
+  });
+
+  it('toast.success with an existing id updates in place (no duplicate)', () => {
+    const id = toast.loading('Uploading');
+    toast.success('Uploaded', { id });
+    expect(store.getSnapshot().toasts).toHaveLength(1);
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'success',
+      message: 'Uploaded',
+    });
+  });
+
+  it('toast.dismiss(id) flips status to exiting', () => {
+    const id = toast.success('Saved');
+    toast.dismiss(id);
+    expect(store.getSnapshot().toasts[0].status).toBe('exiting');
+  });
+
+  it('toast.dismiss() with no id dismisses all', () => {
+    toast.success('a');
+    toast.success('b');
+    toast.dismiss();
+    expect(store.getSnapshot().toasts.every((t) => t.status === 'exiting')).toBe(true);
+  });
+
+  it('toast.promise: loading then success on resolve', async () => {
+    const p = Promise.resolve({ name: 'file.pdf' });
+    const wrapped = toast.promise(p, {
+      loading: 'Uploading',
+      success: (r) => `Uploaded ${r.name}`,
+      error: 'Failed',
+    });
+    // After the first microtask flush, we should still be in loading.
+    expect(store.getSnapshot().toasts[0].tone).toBe('loading');
+    const value = await wrapped;
+    expect(value).toEqual({ name: 'file.pdf' });
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'success',
+      message: 'Uploaded file.pdf',
+    });
+  });
+
+  it('toast.promise: loading then error on reject (and rethrows)', async () => {
+    const err = new Error('500');
+    const p = Promise.reject(err);
+    const wrapped = toast.promise(p, {
+      loading: 'Uploading',
+      success: 'Uploaded',
+      error: (e) => `Failed: ${(e as Error).message}`,
+    });
+    await expect(wrapped).rejects.toBe(err);
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'error',
+      message: 'Failed: 500',
+    });
+  });
+});

--- a/packages/design-system/src/components/Toast/api.ts
+++ b/packages/design-system/src/components/Toast/api.ts
@@ -1,0 +1,126 @@
+import type { ReactNode } from 'react';
+import {
+  store,
+  generateId,
+  type ToastTone,
+  type ToastPosition,
+  type ToastInput,
+} from './store';
+
+export interface ToastOptions {
+  /** Optional second-line content. ReactNode so consumers can embed links/icons. */
+  description?: ReactNode;
+  /** Auto-dismiss timeout (ms) or `'persistent'` for no auto-dismiss. Default: 4000. */
+  duration?: number | 'persistent';
+  /** Per-call override of the viewport's default position. */
+  position?: ToastPosition;
+  /** Stable id (else auto-generated). Reusing an existing id triggers an update. */
+  id?: string;
+  /** Single primary action button rendered inside the toast. */
+  action?: { label: string; onClick: () => void };
+  /** Show the close (×) button. Default: true. Forced true when `duration: 'persistent'`. */
+  dismissible?: boolean;
+  /** Override the tone's default icon. Pass `null` to hide. */
+  icon?: ReactNode | null;
+}
+
+/** Partial shape accepted by `toast.update`. id/createdAt/status are internal-only. */
+export type ToastUpdateOptions = Partial<
+  Omit<ToastOptions, 'id'> & { message: ReactNode; tone: ToastTone }
+>;
+
+interface ViewportConfig {
+  position: ToastPosition;
+  duration: number;
+}
+
+/** Mutable defaults written by ToastViewport on mount. Module-level so the API
+ *  layer can read them without depending on React. If no viewport mounts, the
+ *  constants below stand in — toasts fired into the void are stored but never
+ *  rendered, which is the correct behavior. */
+let viewportConfig: ViewportConfig = { position: 'bottom-right', duration: 4000 };
+
+/** Called by ToastViewport. NOT exported from the package barrel. */
+export function _setViewportConfig(cfg: ViewportConfig): void {
+  viewportConfig = cfg;
+}
+
+function buildInput(
+  tone: ToastTone,
+  message: ReactNode,
+  options: ToastOptions = {}
+): ToastInput {
+  const isLoading = tone === 'loading';
+  const duration =
+    options.duration ?? (isLoading ? 'persistent' : viewportConfig.duration);
+  const isPersistent = duration === 'persistent';
+  return {
+    id: options.id ?? generateId(),
+    tone,
+    message,
+    description: options.description,
+    duration,
+    position: options.position ?? viewportConfig.position,
+    action: options.action,
+    // Persistent toasts force dismissible: true so the user has a way out.
+    dismissible: isPersistent ? true : (options.dismissible ?? true),
+    icon: options.icon,
+  };
+}
+
+function fire(
+  tone: ToastTone,
+  message: ReactNode,
+  options?: ToastOptions
+): string {
+  return store.add(buildInput(tone, message, options));
+}
+
+type PromiseMessages<T> = {
+  loading: string;
+  success: string | ((value: T) => string);
+  error: string | ((err: unknown) => string);
+  options?: Omit<ToastOptions, 'duration'>;
+};
+
+export const toast = Object.assign(
+  (message: ReactNode, options?: ToastOptions) => fire('info', message, options),
+  {
+    info: (m: ReactNode, o?: ToastOptions) => fire('info', m, o),
+    success: (m: ReactNode, o?: ToastOptions) => fire('success', m, o),
+    warning: (m: ReactNode, o?: ToastOptions) => fire('warning', m, o),
+    error: (m: ReactNode, o?: ToastOptions) => fire('error', m, o),
+    loading: (m: ReactNode, o?: ToastOptions) => fire('loading', m, o),
+    update: (id: string, partial: ToastUpdateOptions): void => {
+      store.update(id, partial);
+    },
+    dismiss: (id?: string): void => store.dismiss(id),
+    promise<T>(p: Promise<T>, msgs: PromiseMessages<T>): Promise<T> {
+      const id = fire('loading', msgs.loading, msgs.options);
+      return p.then(
+        (value) => {
+          const successMsg =
+            typeof msgs.success === 'function' ? msgs.success(value) : msgs.success;
+          store.update(id, {
+            tone: 'success',
+            message: successMsg,
+            duration: viewportConfig.duration,
+            status: 'visible',
+          });
+          return value;
+        },
+        (err) => {
+          const errorMsg =
+            typeof msgs.error === 'function' ? msgs.error(err) : msgs.error;
+          store.update(id, {
+            tone: 'error',
+            message: errorMsg,
+            duration: viewportConfig.duration,
+            status: 'visible',
+          });
+          throw err;
+        }
+      );
+    },
+  }
+);

--- a/packages/design-system/src/components/Toast/api.ts
+++ b/packages/design-system/src/components/Toast/api.ts
@@ -24,7 +24,11 @@ export interface ToastOptions {
   icon?: ReactNode | null;
 }
 
-/** Partial shape accepted by `toast.update`. id/createdAt/status are internal-only. */
+/**
+ * Partial shape accepted by `toast.update`. Any writable field of a live toast
+ * may be changed. The `id`, `createdAt`, and `status` fields are managed
+ * internally and cannot be patched directly through this type.
+ */
 export type ToastUpdateOptions = Partial<
   Omit<ToastOptions, 'id'> & { message: ReactNode; tone: ToastTone }
 >;
@@ -83,18 +87,80 @@ type PromiseMessages<T> = {
   options?: Omit<ToastOptions, 'duration'>;
 };
 
+/**
+ * Fire an informational toast (the default tone). Equivalent to `toast.info(message, options)`.
+ *
+ * All `toast.*` methods return the toast id (string) so it can be passed to
+ * `toast.update` or `toast.dismiss` later.
+ *
+ * @example
+ * // Quick one-liner
+ * toast('Profile saved');
+ *
+ * @example
+ * // With a description and action
+ * toast('File deleted', {
+ *   description: 'This action cannot be undone.',
+ *   action: { label: 'Undo', onClick: handleUndo },
+ * });
+ */
 export const toast = Object.assign(
-  (message: ReactNode, options?: ToastOptions) => fire('info', message, options),
+  (message: ReactNode, options?: ToastOptions): string => fire('info', message, options),
   {
-    info: (m: ReactNode, o?: ToastOptions) => fire('info', m, o),
-    success: (m: ReactNode, o?: ToastOptions) => fire('success', m, o),
-    warning: (m: ReactNode, o?: ToastOptions) => fire('warning', m, o),
-    error: (m: ReactNode, o?: ToastOptions) => fire('error', m, o),
-    loading: (m: ReactNode, o?: ToastOptions) => fire('loading', m, o),
+    /**
+     * Fire an informational toast. Returns the toast id.
+     */
+    info: (m: ReactNode, o?: ToastOptions): string => fire('info', m, o),
+    /**
+     * Fire a success toast. Returns the toast id.
+     */
+    success: (m: ReactNode, o?: ToastOptions): string => fire('success', m, o),
+    /**
+     * Fire a warning toast. Returns the toast id.
+     */
+    warning: (m: ReactNode, o?: ToastOptions): string => fire('warning', m, o),
+    /**
+     * Fire an error toast. Returns the toast id. Error toasts use `role="alert"`
+     * and `aria-live="assertive"` for immediate screen-reader announcement.
+     */
+    error: (m: ReactNode, o?: ToastOptions): string => fire('error', m, o),
+    /**
+     * Fire a loading toast. Returns the toast id. Defaults to
+     * `duration: 'persistent'` — the toast stays until explicitly updated or
+     * dismissed (e.g. via `toast.update` once the async work completes).
+     */
+    loading: (m: ReactNode, o?: ToastOptions): string => fire('loading', m, o),
+    /**
+     * Mutate a live toast by id. Any field in `ToastUpdateOptions` may be
+     * patched. Commonly used to transition a loading toast to success/error
+     * once an async operation settles.
+     *
+     * If the id does not correspond to a currently-stored toast the call is a
+     * no-op — there is no resurrection of dismissed toasts.
+     */
     update: (id: string, partial: ToastUpdateOptions): void => {
       store.update(id, partial);
     },
+    /**
+     * Dismiss a toast by id. If `id` is omitted, all currently visible toasts
+     * are dismissed at once. The toast plays its exit animation before being
+     * removed from the store.
+     */
     dismiss: (id?: string): void => store.dismiss(id),
+    /**
+     * Track a promise with automatic loading → success/error transitions.
+     * Returns the original promise so the call is awaitable and chainable.
+     * Rejections are re-thrown after updating the toast to the error state —
+     * callers should handle them with `.catch()` if they don't want an
+     * unhandled-rejection warning.
+     *
+     * @example
+     * await toast.promise(uploadFile(file), {
+     *   loading: 'Uploading…',
+     *   success: (res) => `Uploaded ${res.filename}`,
+     *   error: (err) => `Upload failed: ${err.message}`,
+     * });
+     */
     promise<T>(p: Promise<T>, msgs: PromiseMessages<T>): Promise<T> {
       const id = fire('loading', msgs.loading, msgs.options);
       return p.then(

--- a/packages/design-system/src/components/Toast/api.ts
+++ b/packages/design-system/src/components/Toast/api.ts
@@ -1,11 +1,5 @@
 import type { ReactNode } from 'react';
-import {
-  store,
-  generateId,
-  type ToastTone,
-  type ToastPosition,
-  type ToastInput,
-} from './store';
+import { store, generateId, type ToastTone, type ToastPosition, type ToastInput } from './store';
 
 export interface ToastOptions {
   /** Optional second-line content. ReactNode so consumers can embed links/icons. */
@@ -49,14 +43,9 @@ export function _setViewportConfig(cfg: ViewportConfig): void {
   viewportConfig = cfg;
 }
 
-function buildInput(
-  tone: ToastTone,
-  message: ReactNode,
-  options: ToastOptions = {}
-): ToastInput {
+function buildInput(tone: ToastTone, message: ReactNode, options: ToastOptions = {}): ToastInput {
   const isLoading = tone === 'loading';
-  const duration =
-    options.duration ?? (isLoading ? 'persistent' : viewportConfig.duration);
+  const duration = options.duration ?? (isLoading ? 'persistent' : viewportConfig.duration);
   const isPersistent = duration === 'persistent';
   return {
     id: options.id ?? generateId(),
@@ -72,11 +61,7 @@ function buildInput(
   };
 }
 
-function fire(
-  tone: ToastTone,
-  message: ReactNode,
-  options?: ToastOptions
-): string {
+function fire(tone: ToastTone, message: ReactNode, options?: ToastOptions): string {
   return store.add(buildInput(tone, message, options));
 }
 
@@ -176,8 +161,7 @@ export const toast = Object.assign(
           return value;
         },
         (err) => {
-          const errorMsg =
-            typeof msgs.error === 'function' ? msgs.error(err) : msgs.error;
+          const errorMsg = typeof msgs.error === 'function' ? msgs.error(err) : msgs.error;
           store.update(id, {
             tone: 'error',
             message: errorMsg,
@@ -185,8 +169,8 @@ export const toast = Object.assign(
             status: 'visible',
           });
           throw err;
-        }
+        },
       );
     },
-  }
+  },
 );

--- a/packages/design-system/src/components/Toast/index.ts
+++ b/packages/design-system/src/components/Toast/index.ts
@@ -1,0 +1,5 @@
+export { toast } from './api';
+export { ToastViewport } from './ToastViewport';
+export type { ToastOptions, ToastUpdateOptions } from './api';
+export type { ToastViewportProps } from './ToastViewport';
+export type { ToastTone, ToastPosition } from './store';

--- a/packages/design-system/src/components/Toast/store.test.ts
+++ b/packages/design-system/src/components/Toast/store.test.ts
@@ -1,0 +1,120 @@
+import { store, generateId, EXIT_ANIMATION_MS, type ToastInput } from './store';
+
+const baseInput = (overrides: Partial<ToastInput> = {}): ToastInput => ({
+  id: 't1',
+  tone: 'info',
+  message: 'Hello',
+  duration: 4000,
+  position: 'bottom-right',
+  dismissible: true,
+  ...overrides,
+});
+
+describe('toast store', () => {
+  beforeEach(() => {
+    store._reset();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts with an empty toast list', () => {
+    expect(store.getSnapshot().toasts).toEqual([]);
+  });
+
+  it('add() appends an entry and returns the id', () => {
+    const id = store.add(baseInput({ id: 'a' }));
+    expect(id).toBe('a');
+    expect(store.getSnapshot().toasts).toHaveLength(1);
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      id: 'a',
+      tone: 'info',
+      status: 'visible',
+    });
+  });
+
+  it('add() preserves the message field', () => {
+    store.add(baseInput({ id: 'a', message: 'Saved' }));
+    expect(store.getSnapshot().toasts[0].message).toBe('Saved');
+  });
+
+  it('add() with an existing id delegates to update (no duplicate)', () => {
+    store.add(baseInput({ id: 'a', tone: 'info' }));
+    store.add(baseInput({ id: 'a', tone: 'success', message: 'Done' }));
+    expect(store.getSnapshot().toasts).toHaveLength(1);
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'success',
+      message: 'Done',
+    });
+  });
+
+  it('update() mutates an existing entry', () => {
+    store.add(baseInput({ id: 'a' }));
+    store.update('a', { tone: 'success', message: 'Done' });
+    expect(store.getSnapshot().toasts[0]).toMatchObject({
+      tone: 'success',
+      message: 'Done',
+    });
+  });
+
+  it('update() is a no-op on unknown id', () => {
+    store.add(baseInput({ id: 'a' }));
+    store.update('nope', { tone: 'error' });
+    expect(store.getSnapshot().toasts[0].tone).toBe('info');
+  });
+
+  it('dismiss(id) flips status to exiting, then removes after EXIT_ANIMATION_MS', () => {
+    store.add(baseInput({ id: 'a' }));
+    store.dismiss('a');
+    expect(store.getSnapshot().toasts[0].status).toBe('exiting');
+    vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    expect(store.getSnapshot().toasts).toEqual([]);
+  });
+
+  it('dismiss(unknownId) is a no-op', () => {
+    store.add(baseInput({ id: 'a' }));
+    store.dismiss('nope');
+    expect(store.getSnapshot().toasts).toHaveLength(1);
+    expect(store.getSnapshot().toasts[0].status).toBe('visible');
+  });
+
+  it('dismiss() with no id marks all exiting then clears', () => {
+    store.add(baseInput({ id: 'a' }));
+    store.add(baseInput({ id: 'b' }));
+    store.dismiss();
+    expect(store.getSnapshot().toasts.every((t) => t.status === 'exiting')).toBe(true);
+    vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    expect(store.getSnapshot().toasts).toEqual([]);
+  });
+
+  it('subscribe() listener fires on add/update/dismiss', () => {
+    const listener = vi.fn();
+    store.subscribe(listener);
+    store.add(baseInput({ id: 'a' }));
+    store.update('a', { message: 'b' });
+    store.dismiss('a');
+    expect(listener.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('subscribe() returns an unsubscribe function', () => {
+    const listener = vi.fn();
+    const unsub = store.subscribe(listener);
+    unsub();
+    store.add(baseInput({ id: 'a' }));
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('generateId() returns unique ids across rapid calls', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 1000; i++) ids.add(generateId());
+    expect(ids.size).toBe(1000);
+  });
+
+  it('add() with no id field is allowed only if caller passes one; consumers use generateId()', () => {
+    // The store doesn't auto-generate — that's the API layer's job.
+    // This test documents the contract: id is required on ToastInput.
+    const id = store.add(baseInput({ id: generateId() }));
+    expect(id).toMatch(/^t/);
+  });
+});

--- a/packages/design-system/src/components/Toast/store.ts
+++ b/packages/design-system/src/components/Toast/store.ts
@@ -1,0 +1,112 @@
+import type { ReactNode } from 'react';
+
+export type ToastTone = 'info' | 'success' | 'warning' | 'error' | 'loading';
+
+export type ToastPosition =
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';
+
+export interface ToastEntry {
+  id: string;
+  tone: ToastTone;
+  message: ReactNode;
+  description?: ReactNode;
+  duration: number | 'persistent';
+  position: ToastPosition;
+  action?: { label: string; onClick: () => void };
+  dismissible: boolean;
+  icon?: ReactNode | null;
+  createdAt: number;
+  status: 'visible' | 'exiting';
+}
+
+/** Input shape accepted by `store.add` — `createdAt` and `status` are computed internally. */
+export type ToastInput = Omit<ToastEntry, 'createdAt' | 'status'>;
+
+/** Partial shape accepted by `store.update` — internal-only fields are also acceptable
+ *  (the viewport uses this to flip a toast to `exiting` before removal). */
+export type ToastUpdate = Partial<Omit<ToastEntry, 'id' | 'createdAt'>>;
+
+type Listener = () => void;
+
+interface StoreState {
+  toasts: readonly ToastEntry[];
+}
+
+/** Duration of the exit animation. The store delays full removal by this many ms
+ *  so the viewport can animate `data-status="exiting"` before unmount. */
+export const EXIT_ANIMATION_MS = 250;
+
+let state: StoreState = { toasts: [] };
+const listeners = new Set<Listener>();
+
+function notify() {
+  listeners.forEach((l) => l());
+}
+
+let nextSeq = 0;
+/** Generates a short id with millisecond timestamp + monotonic counter so
+ *  rapid-fire calls within the same ms never collide. */
+export function generateId(): string {
+  return `t${Date.now().toString(36)}${(++nextSeq).toString(36)}`;
+}
+
+export const store = {
+  getSnapshot(): StoreState {
+    return state;
+  },
+  subscribe(listener: Listener): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+  add(input: ToastInput): string {
+    // Reusing an id is an implicit update — lets `toast.success('done', { id })`
+    // mutate an existing loading toast in place.
+    if (state.toasts.some((t) => t.id === input.id)) {
+      return store.update(input.id, input);
+    }
+    const entry: ToastEntry = { ...input, createdAt: Date.now(), status: 'visible' };
+    state = { toasts: [...state.toasts, entry] };
+    notify();
+    return entry.id;
+  },
+  update(id: string, partial: ToastUpdate): string {
+    state = {
+      toasts: state.toasts.map((t) => (t.id === id ? { ...t, ...partial } : t)),
+    };
+    notify();
+    return id;
+  },
+  dismiss(id?: string): void {
+    if (id === undefined) {
+      state = { toasts: state.toasts.map((t) => ({ ...t, status: 'exiting' })) };
+      notify();
+      setTimeout(() => {
+        state = { toasts: [] };
+        notify();
+      }, EXIT_ANIMATION_MS);
+      return;
+    }
+    if (!state.toasts.some((t) => t.id === id)) return;
+    state = {
+      toasts: state.toasts.map((t) => (t.id === id ? { ...t, status: 'exiting' } : t)),
+    };
+    notify();
+    setTimeout(() => {
+      state = { toasts: state.toasts.filter((t) => t.id !== id) };
+      notify();
+    }, EXIT_ANIMATION_MS);
+  },
+  /** Test-only: synchronously clears state. NOT exported from the package. */
+  _reset(): void {
+    state = { toasts: [] };
+    nextSeq = 0;
+    listeners.clear();
+  },
+};

--- a/packages/design-system/src/components/Toast/useToastTimer.test.ts
+++ b/packages/design-system/src/components/Toast/useToastTimer.test.ts
@@ -18,7 +18,7 @@ describe('useToastTimer', () => {
         paused: false,
         onExpire,
         getVisible: () => true,
-      })
+      }),
     );
     expect(onExpire).not.toHaveBeenCalled();
     act(() => {
@@ -36,7 +36,7 @@ describe('useToastTimer', () => {
         paused: false,
         onExpire,
         getVisible: () => true,
-      })
+      }),
     );
     act(() => {
       vi.advanceTimersByTime(100_000);
@@ -55,7 +55,7 @@ describe('useToastTimer', () => {
           onExpire,
           getVisible: () => true,
         }),
-      { initialProps: { paused: false } }
+      { initialProps: { paused: false } },
     );
 
     act(() => vi.advanceTimersByTime(400));
@@ -84,7 +84,7 @@ describe('useToastTimer', () => {
           onExpire,
           getVisible: () => true,
         }),
-      { initialProps: { paused: true } }
+      { initialProps: { paused: true } },
     );
     act(() => vi.advanceTimersByTime(10_000));
     expect(onExpire).not.toHaveBeenCalled();
@@ -104,7 +104,7 @@ describe('useToastTimer', () => {
         paused: false,
         onExpire,
         getVisible: () => visible,
-      })
+      }),
     );
     act(() => vi.advanceTimersByTime(10_000));
     expect(onExpire).not.toHaveBeenCalled();
@@ -126,7 +126,7 @@ describe('useToastTimer', () => {
         paused: false,
         onExpire,
         getVisible: () => true,
-      })
+      }),
     );
     unmount();
     act(() => vi.advanceTimersByTime(10_000));
@@ -144,7 +144,7 @@ describe('useToastTimer', () => {
           onExpire,
           getVisible: () => true,
         }),
-      { initialProps: { duration: 1000 } }
+      { initialProps: { duration: 1000 } },
     );
     act(() => vi.advanceTimersByTime(500));
     rerender({ duration: 2000 });

--- a/packages/design-system/src/components/Toast/useToastTimer.test.ts
+++ b/packages/design-system/src/components/Toast/useToastTimer.test.ts
@@ -1,0 +1,157 @@
+import { renderHook, act } from '@testing-library/react';
+import { useToastTimer } from './useToastTimer';
+
+describe('useToastTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls onExpire after `duration` ms when not paused', () => {
+    const onExpire = vi.fn();
+    renderHook(() =>
+      useToastTimer({
+        id: 'a',
+        duration: 1000,
+        paused: false,
+        onExpire,
+        getVisible: () => true,
+      })
+    );
+    expect(onExpire).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('never calls onExpire when duration is persistent', () => {
+    const onExpire = vi.fn();
+    renderHook(() =>
+      useToastTimer({
+        id: 'a',
+        duration: 'persistent',
+        paused: false,
+        onExpire,
+        getVisible: () => true,
+      })
+    );
+    act(() => {
+      vi.advanceTimersByTime(100_000);
+    });
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+
+  it('pause captures remaining; resume re-arms with that remaining', () => {
+    const onExpire = vi.fn();
+    const { rerender } = renderHook(
+      ({ paused }) =>
+        useToastTimer({
+          id: 'a',
+          duration: 1000,
+          paused,
+          onExpire,
+          getVisible: () => true,
+        }),
+      { initialProps: { paused: false } }
+    );
+
+    act(() => vi.advanceTimersByTime(400));
+    expect(onExpire).not.toHaveBeenCalled();
+
+    rerender({ paused: true });
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onExpire).not.toHaveBeenCalled();
+
+    rerender({ paused: false });
+    // Only 600ms should remain.
+    act(() => vi.advanceTimersByTime(599));
+    expect(onExpire).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('paused at mount: no timer running until paused flips false', () => {
+    const onExpire = vi.fn();
+    const { rerender } = renderHook(
+      ({ paused }) =>
+        useToastTimer({
+          id: 'a',
+          duration: 500,
+          paused,
+          onExpire,
+          getVisible: () => true,
+        }),
+      { initialProps: { paused: true } }
+    );
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onExpire).not.toHaveBeenCalled();
+
+    rerender({ paused: false });
+    act(() => vi.advanceTimersByTime(500));
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('hidden document acts like paused', () => {
+    const onExpire = vi.fn();
+    let visible = false;
+    const { rerender: _ } = renderHook(() =>
+      useToastTimer({
+        id: 'a',
+        duration: 1000,
+        paused: false,
+        onExpire,
+        getVisible: () => visible,
+      })
+    );
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onExpire).not.toHaveBeenCalled();
+
+    visible = true;
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    act(() => vi.advanceTimersByTime(1000));
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('unmount clears the timer and visibility listener', () => {
+    const onExpire = vi.fn();
+    const { unmount } = renderHook(() =>
+      useToastTimer({
+        id: 'a',
+        duration: 1000,
+        paused: false,
+        onExpire,
+        getVisible: () => true,
+      })
+    );
+    unmount();
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+
+  it('changing duration mid-life resets the remaining (and re-arms if not paused)', () => {
+    const onExpire = vi.fn();
+    const { rerender } = renderHook(
+      ({ duration }) =>
+        useToastTimer({
+          id: 'a',
+          duration,
+          paused: false,
+          onExpire,
+          getVisible: () => true,
+        }),
+      { initialProps: { duration: 1000 } }
+    );
+    act(() => vi.advanceTimersByTime(500));
+    rerender({ duration: 2000 });
+    // Old 500 is forgotten; new full 2000 should elapse before expire.
+    act(() => vi.advanceTimersByTime(1999));
+    expect(onExpire).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/design-system/src/components/Toast/useToastTimer.ts
+++ b/packages/design-system/src/components/Toast/useToastTimer.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef } from 'react';
+
+interface UseToastTimerArgs {
+  /** Toast id — used purely as a stable dependency key. */
+  id: string;
+  /** ms or 'persistent'. Persistent skips the timer entirely. */
+  duration: number | 'persistent';
+  /** Whether the timer is currently paused (hover / focus / hidden tab). */
+  paused: boolean;
+  /** Called when the timer expires. */
+  onExpire: () => void;
+  /** Indirection so tests can mock visibility without poking jsdom internals.
+   *  Defaults to `document.visibilityState === 'visible'`. */
+  getVisible?: () => boolean;
+}
+
+/** Manages a per-toast dismiss timer with pause/resume math.
+ *
+ *  Behavior:
+ *  - duration === 'persistent': no timer ever runs.
+ *  - paused flips true: capture remaining ms, clear timeout.
+ *  - paused flips false (and document visible): re-arm with remaining ms.
+ *  - document becomes hidden: behaves like paused = true (auto).
+ *  - document becomes visible: behaves like paused = false (auto).
+ *  - On unmount: clear timeout, remove visibility listener.
+ */
+export function useToastTimer({
+  id,
+  duration,
+  paused,
+  onExpire,
+  getVisible = defaultGetVisible,
+}: UseToastTimerArgs): void {
+  const remainingRef = useRef<number>(typeof duration === 'number' ? duration : Infinity);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startedAtRef = useRef<number>(0);
+  const onExpireRef = useRef(onExpire);
+  onExpireRef.current = onExpire;
+
+  // Track document visibility imperatively so we don't trigger React rerenders
+  // for tab focus changes.
+  const docHiddenRef = useRef(!getVisible());
+
+  useEffect(() => {
+    if (duration === 'persistent') return;
+    remainingRef.current = duration;
+  }, [duration]);
+
+  useEffect(() => {
+    if (duration === 'persistent') return;
+
+    const tick = () => {
+      onExpireRef.current();
+    };
+
+    const arm = () => {
+      if (timeoutRef.current !== null) return;
+      startedAtRef.current = Date.now();
+      timeoutRef.current = setTimeout(tick, remainingRef.current);
+    };
+
+    const disarm = () => {
+      if (timeoutRef.current === null) return;
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+      const elapsed = Date.now() - startedAtRef.current;
+      remainingRef.current = Math.max(0, remainingRef.current - elapsed);
+    };
+
+    const sync = () => {
+      const shouldRun = !paused && !docHiddenRef.current;
+      if (shouldRun) arm();
+      else disarm();
+    };
+
+    const onVisibilityChange = () => {
+      docHiddenRef.current = !getVisible();
+      sync();
+    };
+
+    sync();
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      disarm();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, duration, paused]);
+}
+
+function defaultGetVisible(): boolean {
+  return typeof document === 'undefined' ? true : document.visibilityState === 'visible';
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -71,6 +71,15 @@ export type {
   EmptyStateHeadingLevel,
 } from './components/EmptyState';
 
+export { toast, ToastViewport } from './components/Toast';
+export type {
+  ToastOptions,
+  ToastUpdateOptions,
+  ToastViewportProps,
+  ToastTone,
+  ToastPosition,
+} from './components/Toast';
+
 export { Tooltip } from './components/Tooltip';
 export type { TooltipProps, TooltipSide, TooltipAlign } from './components/Tooltip';
 

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -37,9 +37,12 @@ describe('library structure', () => {
   );
 
   it.each(components)('%s is re-exported from src/index.ts', (name) => {
-    // Look for either a named re-export of `<Name>` or a star-export from its
-    // path. Reasonably strict — doesn't catch typos in the name, which is fine.
-    const namedRe = new RegExp(`export\\s*\\{[^}]*\\b${name}\\b[^}]*\\}`);
+    // Look for either a named re-export of `<Name>` (or a symbol whose name
+    // starts with `<Name>`, e.g. `ToastViewport` satisfies `Toast`) or a
+    // star-export from its path. The prefix form handles components whose
+    // primary export is an API function with a lowercase alias (toast →
+    // ToastViewport is exported as the canonical React surface).
+    const namedRe = new RegExp(`export\\s*\\{[^}]*\\b${name}[^}]*\\}`);
     const starRe = new RegExp(`export\\s+\\*\\s+from\\s+['"][^'"]*${name}[^'"]*['"]`);
     expect(namedRe.test(indexContent) || starRe.test(indexContent)).toBe(true);
   });

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -37,12 +37,15 @@ describe('library structure', () => {
   );
 
   it.each(components)('%s is re-exported from src/index.ts', (name) => {
-    // Look for either a named re-export of `<Name>` (or a symbol whose name
-    // starts with `<Name>`, e.g. `ToastViewport` satisfies `Toast`) or a
-    // star-export from its path. The prefix form handles components whose
-    // primary export is an API function with a lowercase alias (toast →
-    // ToastViewport is exported as the canonical React surface).
-    const namedRe = new RegExp(`export\\s*\\{[^}]*\\b${name}[^}]*\\}`);
+    // Match `<Name>` followed by a word boundary OR an uppercase letter.
+    // The word-boundary branch catches the exact name (e.g. `Toast` as a
+    // standalone export). The uppercase branch allows compound exports whose
+    // name starts with `<Name>` (e.g. `ToastViewport` satisfies `Toast`).
+    // Crucially, a purely lowercase continuation is NOT matched, so `Button`
+    // does NOT accidentally satisfy itself via a hypothetical `Buttons` export,
+    // and `Toast` does NOT satisfy `Toasty`. This tightens the earlier
+    // `\b${name}[^}]*` form which was over-permissive.
+    const namedRe = new RegExp(`export\\s*\\{[^}]*\\b${name}(\\b|[A-Z])[^}]*\\}`);
     const starRe = new RegExp(`export\\s+\\*\\s+from\\s+['"][^'"]*${name}[^'"]*['"]`);
     expect(namedRe.test(indexContent) || starRe.test(indexContent)).toBe(true);
   });

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -35,6 +35,8 @@ import { DataTableDemo } from './pages/components/DataTableDemo';
 import { EmptyStateDemo } from './pages/components/EmptyStateDemo';
 import { DrawerDemo } from './pages/components/DrawerDemo';
 import { GridDemo } from './pages/components/GridDemo';
+import { ToastDemo } from './pages/components/ToastDemo';
+import { ToastViewport } from '@eocrm/design-system';
 
 export default function App() {
   return (
@@ -82,8 +84,10 @@ export default function App() {
           <Route path="/components/empty-state" element={<EmptyStateDemo />} />
           <Route path="/components/drawer" element={<DrawerDemo />} />
           <Route path="/components/grid" element={<GridDemo />} />
+          <Route path="/components/toast" element={<ToastDemo />} />
         </Routes>
       </AppShell>
+      <ToastViewport position="bottom-right" />
     </BrowserRouter>
   );
 }

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -103,9 +103,7 @@ const componentGroups = [
   },
   {
     heading: 'Feedback',
-    items: [
-      { to: '/components/toast', label: 'Toast', icon: Bell, end: false },
-    ],
+    items: [{ to: '/components/toast', label: 'Toast', icon: Bell, end: false }],
   },
   {
     heading: 'Navigation',

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -102,6 +102,12 @@ const componentGroups = [
     ],
   },
   {
+    heading: 'Feedback',
+    items: [
+      { to: '/components/toast', label: 'Toast', icon: Bell, end: false },
+    ],
+  },
+  {
     heading: 'Navigation',
     items: [{ to: '/components/tabs', label: 'Tabs', icon: PanelTop, end: false }],
   },

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -25,6 +25,7 @@ import { DataTable, useDataTable, type ColumnDef } from '@eocrm/design-system';
 import { EmptyState } from '@eocrm/design-system';
 import { Pagination } from '@eocrm/design-system';
 import { Radio, RadioGroup } from '@eocrm/design-system';
+import { toast } from '@eocrm/design-system';
 import styles from './ComponentsIndex.module.scss';
 
 type _PreviewRow = { id: string; name: string; stage: string; amount: string };
@@ -351,6 +352,16 @@ const items: { to: string; name: string; description: string; preview: React.Rea
           </DropdownMenu.Content>
         </DropdownMenu>
       </Cluster>
+    ),
+  },
+  {
+    to: '/components/toast',
+    name: 'Toast',
+    description: 'Imperative transient notifications.',
+    preview: (
+      <Button size="sm" onClick={() => toast.success('Saved')}>
+        Fire toast
+      </Button>
     ),
   },
   {

--- a/packages/playground/src/pages/components/ToastDemo.tsx
+++ b/packages/playground/src/pages/components/ToastDemo.tsx
@@ -1,0 +1,201 @@
+import { useState } from 'react';
+import { Button, Cluster, Stack, toast } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import apiSource from '@lib-source/components/Toast/api.ts?raw';
+import scssSource from '@lib-source/components/Toast/Toast.module.scss?raw';
+
+export function ToastDemo() {
+  const [bursting, setBursting] = useState(false);
+
+  return (
+    <DemoLayout
+      name="Toast"
+      componentName="Toast"
+      description="Imperative transient notifications. Singleton `toast` API + one `<ToastViewport>` mounted at app root."
+      tsxSource={apiSource}
+      scssSource={scssSource}
+      tsxFilename="api.ts"
+      scssFilename="Toast.module.scss"
+    >
+      <Example
+        title="Tones"
+        description="Five tones with sensible icon + accent color defaults. Error toasts use role='alert' (assertive); the others use role='status' (polite)."
+        code={`toast.info('Heads up');
+toast.success('Saved');
+toast.warning('Storage almost full');
+toast.error('Request failed');
+toast.loading('Uploading…');`}
+      >
+        <Cluster gap="sm">
+          <Button onClick={() => toast.info('Heads up')}>info</Button>
+          <Button onClick={() => toast.success('Saved')}>success</Button>
+          <Button onClick={() => toast.warning('Storage almost full')}>warning</Button>
+          <Button onClick={() => toast.error('Request failed')}>error</Button>
+          <Button onClick={() => toast.loading('Uploading…')}>loading</Button>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="With a description"
+        description="Description is a second line, line-clamped to 2 lines."
+        code={`toast.success('Saved', {
+  description: 'Your changes are now live.',
+});`}
+      >
+        <Button
+          onClick={() =>
+            toast.success('Saved', {
+              description: 'Your changes are now live.',
+            })
+          }
+        >
+          Fire with description
+        </Button>
+      </Example>
+
+      <Example
+        title="Action (Undo)"
+        description="Single primary action. Clicking the button fires onClick AND dismisses the toast."
+        code={`toast.success('Item deleted', {
+  action: {
+    label: 'Undo',
+    onClick: () => toast.info('Restored'),
+  },
+});`}
+      >
+        <Button
+          onClick={() =>
+            toast.success('Item deleted', {
+              action: {
+                label: 'Undo',
+                onClick: () => toast.info('Restored'),
+              },
+            })
+          }
+        >
+          Delete (with Undo)
+        </Button>
+      </Example>
+
+      <Example
+        title="Programmatic update"
+        description="Fire a loading toast, mutate it in place after the async op completes."
+        code={`const id = toast.loading('Uploading…');
+setTimeout(() => {
+  toast.success('Uploaded', { id });
+}, 2000);`}
+      >
+        <Button
+          onClick={() => {
+            const id = toast.loading('Uploading…');
+            setTimeout(() => {
+              toast.success('Uploaded', { id });
+            }, 2000);
+          }}
+        >
+          Start upload
+        </Button>
+      </Example>
+
+      <Example
+        title="toast.promise (async sugar)"
+        description="Pass a promise; the toast cycles loading → success/error automatically. Returns the original promise."
+        code={`toast.promise(
+  new Promise((resolve, reject) =>
+    setTimeout(() => (Math.random() > 0.5 ? resolve('done') : reject(new Error('500'))), 1500)
+  ),
+  {
+    loading: 'Working…',
+    success: 'Worked',
+    error: (e) => \`Failed: \${(e as Error).message}\`,
+  }
+);`}
+      >
+        <Button
+          onClick={() =>
+            toast.promise(
+              new Promise((resolve, reject) =>
+                setTimeout(
+                  () =>
+                    Math.random() > 0.5
+                      ? resolve('done')
+                      : reject(new Error('500')),
+                  1500
+                )
+              ),
+              {
+                loading: 'Working…',
+                success: 'Worked',
+                error: (e) => `Failed: ${(e as Error).message}`,
+              }
+            )
+          }
+        >
+          Fire promise toast
+        </Button>
+      </Example>
+
+      <Example
+        title="Persistent error"
+        description="duration: 'persistent' disables auto-dismiss. The close (×) button is force-enabled even if you pass dismissible: false."
+        code={`toast.error('Connection lost', { duration: 'persistent' });`}
+      >
+        <Button
+          onClick={() =>
+            toast.error('Connection lost', { duration: 'persistent' })
+          }
+        >
+          Fire persistent error
+        </Button>
+      </Example>
+
+      <Example
+        title="Per-call position override"
+        description="A per-call `position` routes that toast into a different bucket. Use sparingly — mixing positions in one app is unusual UX."
+        code={`toast.info('top-right', { position: 'top-right' });
+toast.info('top-center', { position: 'top-center' });
+toast.info('bottom-left', { position: 'bottom-left' });
+toast.info('bottom-center', { position: 'bottom-center' });`}
+      >
+        <Cluster gap="sm">
+          <Button onClick={() => toast.info('top-right', { position: 'top-right' })}>
+            top-right
+          </Button>
+          <Button onClick={() => toast.info('top-center', { position: 'top-center' })}>
+            top-center
+          </Button>
+          <Button onClick={() => toast.info('bottom-left', { position: 'bottom-left' })}>
+            bottom-left
+          </Button>
+          <Button onClick={() => toast.info('bottom-center', { position: 'bottom-center' })}>
+            bottom-center
+          </Button>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Burst + hover to expand"
+        description="Fires 7 toasts in rapid succession. Only the top 3 are visible; the rest peek-collapse. Hover the stack to fan them out."
+        code={`for (let i = 1; i <= 7; i++) {
+  setTimeout(() => toast.info(\`Message #\${i}\`), i * 60);
+}`}
+      >
+        <Stack gap="sm">
+          <Button
+            disabled={bursting}
+            onClick={() => {
+              setBursting(true);
+              for (let i = 1; i <= 7; i++) {
+                setTimeout(() => toast.info(`Message #${i}`), i * 60);
+              }
+              setTimeout(() => setBursting(false), 600);
+            }}
+          >
+            Fire 7 toasts
+          </Button>
+        </Stack>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/components/ToastDemo.tsx
+++ b/packages/playground/src/pages/components/ToastDemo.tsx
@@ -117,18 +117,15 @@ setTimeout(() => {
             toast.promise(
               new Promise((resolve, reject) =>
                 setTimeout(
-                  () =>
-                    Math.random() > 0.5
-                      ? resolve('done')
-                      : reject(new Error('500')),
-                  1500
-                )
+                  () => (Math.random() > 0.5 ? resolve('done') : reject(new Error('500'))),
+                  1500,
+                ),
               ),
               {
                 loading: 'Working…',
                 success: 'Worked',
                 error: (e) => `Failed: ${(e as Error).message}`,
-              }
+              },
             )
           }
         >
@@ -141,11 +138,7 @@ setTimeout(() => {
         description="duration: 'persistent' disables auto-dismiss. The close (×) button is force-enabled even if you pass dismissible: false."
         code={`toast.error('Connection lost', { duration: 'persistent' });`}
       >
-        <Button
-          onClick={() =>
-            toast.error('Connection lost', { duration: 'persistent' })
-          }
-        >
+        <Button onClick={() => toast.error('Connection lost', { duration: 'persistent' })}>
           Fire persistent error
         </Button>
       </Example>

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -33,6 +33,7 @@ export type ComponentName =
   | 'Stack'
   | 'Table'
   | 'Tabs'
+  | 'Toast'
   | 'Tooltip';
 
 export interface MockupEntry {


### PR DESCRIPTION
## Summary

- Imperative singleton `toast` API + a single `<ToastViewport>` portal. Mount once at app root; fire from anywhere — no provider, no hook.
- 5 tones (`info`, `success`, `warning`, `error`, `loading`) with sensible icon + color defaults. `error` is `role=\"alert\"` (assertive); the rest are `role=\"status\"` (polite).
- All 6 positions supported via the viewport's `position` prop; per-call `position` override available as an escape hatch.
- Auto-dismiss defaults to 4000ms; per-call `duration` (ms or `'persistent'`). Pause-on-hover / pause-on-focus / pause-when-tab-hidden.
- Action slot (Undo/Retry), close (×) button, programmatic dismiss + update by id, `toast.promise()` sugar.
- \`maxVisible: 3\` default with peek-collapsed stack behind the visible toasts; hover-to-expand or \`expand: true\`.
- \`prefers-reduced-motion: reduce\` disables enter/exit + reflow + spinner animations.
- No new packages, no new tokens.

## Architecture

Three-layer split:

- **\`store.ts\`** — vanilla observable (no React imports). \`add/update/dismiss/subscribe\`. Testable in isolation.
- **\`api.ts\`** — public \`toast\` singleton. Thin wrapper over the store. Pure JS too. Reads viewport defaults from a module-level config slot the viewport writes on mount.
- **\`<ToastViewport>\`** — the only React surface. \`useSyncExternalStore\` + \`createPortal\` to \`document.body\`. Owns hover-expand state per position bucket. Detects multiple-viewport mounts and dev-warns + renders null on the second instance.

Per-toast dismiss timer is its own hook (\`useToastTimer\`) — captures remaining ms on pause, re-arms on resume, integrates with \`document.visibilitychange\` via a \`getVisible()\` indirection so tests can simulate hidden tabs without poking jsdom internals.

## Test coverage

**65 new tests** across 4 files:

- \`store.test.ts\` — 13 cases (add/update/dismiss mechanics, subscribe, id uniqueness)
- \`api.test.ts\` — 21 cases (tone shorthands, persistent default for loading, dismissible-forced-on-persistent, promise resolve+reject)
- \`useToastTimer.test.ts\` — 7 cases (pause/resume math, persistent skip, hidden=paused, unmount cleanup, mid-life duration change)
- \`Toast.test.tsx\` — 24 cases (integration: tones, role mapping, auto-dismiss, pause-on-hover/focus, action+close buttons, programmatic dismiss/update, position routing, maxVisible peek-collapse, hover-expand, \`toast.promise\` resolve+reject, multi-viewport dev-warning)

## Hard Rule 8

Two rounds with fresh-context reviewers (opus). Round 1 surfaced 4 Important findings:

1. **JSDoc on \`toast\` API was missing** — added to the callable + every method, with \`@example\` blocks on \`toast()\` and \`toast.promise()\`.
2. **\`prefers-reduced-motion\` didn't silence the spinner** — added \`.spin { animation: none }\` inside the media query.
3. **\`structure.test.ts\` regex was over-permissive after the T6 loosening** — tightened from \`\\b\${name}\` to \`\\b\${name}(\\b|[A-Z])\` so \`Toast\` matches \`ToastViewport\` but \`Button\` doesn't false-match a missing-Button scenario.
4. **No pause-on-focus integration test** — added one wired through the action button.

Round 2 verdict: clean enough to stop. 0 Critical + 0 Important.

All four gates green: \`make test\` (1324 passing) + \`make build-lib\` + \`make build\` + \`make lint\` + \`npm pack --dry-run\` (no test files in tarball).

## Regression-watch (flagged for future work, NOT in scope here)

- **\`lucide-react\` is missing from \`peerDependencies\`.** Pre-existing repo-wide issue; 16+ library files import from it but the package.json doesn't declare the dep. Workspace hoisting masks it locally. Should be filed as a separate fix.
- **\`mountedViewportCount\` is fragile under future React lifecycle changes.** StrictMode-safe today; future-proofing would use a \`Set<symbol>\` subscribed via useEffect exclusively.

## Test plan

- [ ] Tone gallery renders 5 toasts with correct accent stripe color + icon (3px stripe, not 1px)
- [ ] \`toast.error\` produces \`role=\"alert\" aria-live=\"assertive\"\`; other tones use \`role=\"status\" aria-live=\"polite\"\`
- [ ] Auto-dismisses after the configured duration; \`duration: 'persistent'\` does not
- [ ] Hovering pauses the timer; leaving resumes
- [ ] Tabbing into the action or close button pauses; blurring resumes (verified by the new round-1 test)
- [ ] Switching browser tabs pauses ALL timers; switching back resumes
- [ ] Action button fires \`onClick\` AND dismisses
- [ ] Close (×) dismisses; \`dismissible: false\` hides it; \`duration: 'persistent'\` force-shows it
- [ ] Programmatic \`toast.update(id, ...)\` mutates in place
- [ ] \`toast.success('msg', { id })\` with an existing id updates rather than duplicating
- [ ] \`toast.promise(p, msgs)\` cycles loading → success/error and returns the original promise
- [ ] Per-call \`position\` routes to the right bucket
- [ ] \`maxVisible: 3\` with 5 toasts shows 3 fully + 2 peek-collapsed; hovering fans them out
- [ ] \`expand: true\` keeps the stack always fanned
- [ ] \`prefers-reduced-motion: reduce\` disables enter/exit AND the loading spinner
- [ ] Two \`<ToastViewport>\` mounted → dev-warning fires, only the first renders
- [ ] Playground demo at \`/components/toast\` runs all 8 examples without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)