### PR TITLE
Textarea: multi-line Input with auto-grow + counter + resize

### DIFF
--- a/docs/superpowers/plans/2026-05-23-textarea.md
+++ b/docs/superpowers/plans/2026-05-23-textarea.md
@@ -1,0 +1,1416 @@
+# Textarea Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Textarea>` — the multi-line companion to `<Input>`, with auto-grow (capped by `minRows`/`maxRows`), configurable resize handle, and an optional character counter.
+
+**Architecture:** A single `forwardRef` component that wraps `<textarea>` in a `<div>` so the optional counter has a place to live. `useLayoutEffect` measures `scrollHeight` after each value change and sets a computed inline `height`. An internal value mirror tracks length for the counter in both controlled and uncontrolled cases. Same `invalid` / `disableAutofill` smart-default behavior as Input.
+
+**Tech Stack:** React 19 + TypeScript (source-distributed). `clsx` for class composition (existing dep). CSS Modules + SCSS. Vitest + RTL + userEvent. No new packages, no new tokens.
+
+**Source of truth:** `docs/superpowers/specs/2026-05-23-textarea-design.md` (commit `b025edc`).
+
+**Branch:** `feat/textarea`. Commit per task. Open the PR after the Hard-Rule-8 cycle (Task 5).
+
+---
+
+## File Structure
+
+```
+packages/design-system/src/components/Textarea/
+  Textarea.tsx          ← Task 1. forwardRef + useLayoutEffect (auto-grow) + internal value mirror + ref merger. Full JSDoc.
+  Textarea.module.scss  ← Task 1. .wrapper / .textarea / size variants / resize variants / .invalid / .counter.
+  index.ts              ← Task 1. Public re-exports (Textarea + types).
+  Textarea.test.tsx     ← Task 2. ~22 cases — RTL + userEvent + scrollHeight stubs.
+
+packages/design-system/src/index.ts                            ← Task 3. MODIFY: re-export Textarea + types
+packages/design-system/AGENTS.md                               ← Task 3. MODIFY: TL;DR slot directly after <Input> section
+
+packages/playground/src/pages/components/TextareaDemo.tsx      ← Task 4. NEW: 7-8 examples
+packages/playground/src/App.tsx                                ← Task 4. MODIFY: route + import (alphabetical)
+packages/playground/src/layout/AppShell/AppShell.tsx           ← Task 4. MODIFY: Forms group, last item after Select
+packages/playground/src/pages/components/ComponentsIndex.tsx   ← Task 4. MODIFY: overview card with 2-row preview
+packages/playground/src/pages/mockups/registry.ts              ← Task 4. MODIFY: 'Textarea' in ComponentName union (between Tabs and Toast)
+```
+
+**Decomposition rationale:**
+
+- **Task 1 (source bundle)** keeps the three files together because they cross-reference (TS reads styles + barrel re-exports both). Modal and Drawer used the same approach. Splitting per-file would produce unreviewable intermediate states.
+- **Task 2 (tests)** is its own commit so the test diff (~400 lines) is reviewable independently.
+- **Task 3 (exports + AGENTS)** is small and conceptually paired — both are "public API surface" changes.
+- **Task 4 (playground)** bundles the demo + 4 nav touchpoints so the demo lands routable in one commit.
+- **Task 5 (Hard-Rule-8)** — gates, fresh-context review-fix cycle, push, PR.
+
+---
+
+## Task 1 — Source bundle (Textarea.tsx + SCSS + barrel)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Textarea/Textarea.tsx`
+- Create: `packages/design-system/src/components/Textarea/Textarea.module.scss`
+- Create: `packages/design-system/src/components/Textarea/index.ts`
+
+- [ ] **Step 1: Verify branch + clean tree**
+
+```bash
+cd /home/dpws/projects/design-system
+git status
+git branch --show-current
+git log --oneline -3
+```
+
+Expected:
+- Branch: `feat/textarea`
+- Working tree clean
+- Most recent commit: `b025edc Textarea: design spec — multi-line Input with auto-grow + counter + resize`
+
+- [ ] **Step 2: Create the component directory + write the SCSS**
+
+```bash
+mkdir -p packages/design-system/src/components/Textarea
+```
+
+Create `packages/design-system/src/components/Textarea/Textarea.module.scss`:
+
+```scss
+.wrapper {
+  width: 100%;
+  display: block;
+}
+
+.textarea {
+  display: block;
+  width: 100%;
+  border: var(--border-width) solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font-family: inherit;
+  line-height: var(--line-height-normal);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+
+  &::placeholder {
+    color: var(--color-fg-subtle);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 var(--ring-width) var(--ring-accent);
+  }
+
+  &:disabled {
+    background: var(--color-bg-subtle);
+    border-color: var(--color-border);
+    color: var(--color-fg-subtle);
+    cursor: not-allowed;
+  }
+
+  &[readonly] {
+    background: var(--color-bg-subtle);
+  }
+}
+
+// Size — typography + padding. NO height (textarea height comes from rows + autoGrow).
+.sizeSm {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+}
+.sizeMd {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-md);
+}
+.sizeLg {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-lg);
+}
+
+// Resize direction
+.resizeNone {
+  resize: none;
+}
+.resizeVertical {
+  resize: vertical;
+}
+.resizeBoth {
+  resize: both;
+}
+
+.invalid {
+  border-color: var(--color-danger);
+
+  &:focus-visible {
+    border-color: var(--color-danger);
+    box-shadow: 0 0 0 var(--ring-width) var(--ring-danger);
+  }
+}
+
+// Counter — internal spacing between textarea and child counter. The counter
+// is a child element inside the wrapper, not a layout property at the
+// component boundary, so this is allowed.
+// stylelint-disable-next-line property-disallowed-list -- internal spacing between textarea and its counter child
+.counter {
+  display: block;
+  text-align: right;
+  margin-top: var(--space-1);
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+  line-height: 1;
+}
+```
+
+- [ ] **Step 3: Write `Textarea.tsx`**
+
+Create `packages/design-system/src/components/Textarea/Textarea.tsx`:
+
+```tsx
+import {
+  forwardRef,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type TextareaHTMLAttributes,
+} from 'react';
+import clsx from 'clsx';
+import styles from './Textarea.module.scss';
+
+/**
+ * Field typography + padding scale. Pairs with Input's `size`.
+ *
+ * Unlike Input, size does NOT affect the textarea's height — height is
+ * driven by `minRows` (and capped by `maxRows` if auto-grow is on).
+ */
+export type TextareaSize = 'sm' | 'md' | 'lg';
+
+/** User-drag resize handle direction. Maps to CSS `resize`. */
+export type TextareaResize = 'none' | 'vertical' | 'both';
+
+export interface TextareaProps
+  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'size' | 'rows'> {
+  /**
+   * Toggles the error visual (red border + danger focus ring) and sets
+   * `aria-invalid="true"`. Pair with a visible error message and an
+   * `aria-describedby` pointer at the message id.
+   */
+  invalid?: boolean;
+
+  /**
+   * Visual size. Defaults to `'md'`.
+   * - `'sm'` — tighter padding + `--font-size-sm`. Used in dense forms.
+   * - `'md'` — default padding + `--font-size-md`. Most form contexts.
+   * - `'lg'` — same padding as md but `--font-size-lg`. Hero / focus textareas.
+   *
+   * Note: this collapses the native HTML `<textarea size>` attribute. Use
+   * `style={{ width }}` or a parent container for explicit width.
+   */
+  size?: TextareaSize;
+
+  /**
+   * Block browser autofill AND password managers from offering to fill
+   * this textarea. Same heuristic as Input — see Input's JSDoc for the
+   * full set of opt-out attributes applied.
+   *
+   * Smart default: when omitted, block iff `autoComplete` is also omitted
+   * (or `'off'`). Explicit autocomplete hints opt back IN to autofill.
+   * Pass `true` to force-block, `false` to force-allow.
+   */
+  disableAutofill?: boolean;
+
+  /**
+   * Minimum visible rows. The textarea never renders shorter than this,
+   * regardless of content. Default: `3`. Also seeds the native `rows`
+   * attribute for SSR / no-JS rendering.
+   */
+  minRows?: number;
+
+  /**
+   * Maximum visible rows. Beyond this, content scrolls inside the field
+   * instead of expanding further. Only meaningful when `autoGrow` is true.
+   * Default: `undefined` (unbounded growth).
+   */
+  maxRows?: number;
+
+  /**
+   * When true, height adapts to content between `minRows` and `maxRows`.
+   * Default: `true`. When false, height locks at `minRows` and a scrollbar
+   * appears past it.
+   */
+  autoGrow?: boolean;
+
+  /**
+   * User-drag resize handle direction. Default: `'vertical'`.
+   *
+   * **Forced to `'none'`** when `autoGrow` is `true` — user-drag fights
+   * the auto-grow measurement and produces erratic behavior. To enable
+   * a resize handle, opt out of auto-grow with `autoGrow={false}`.
+   */
+  resize?: TextareaResize;
+
+  /**
+   * Show the character counter (`${value.length}` or
+   * `${value.length} / ${maxLength}` when both are set).
+   *
+   * Default: `true` when `maxLength` is set, `false` otherwise.
+   *
+   * The counter renders as a `<span aria-live="polite" aria-atomic="true">`
+   * inside the wrapper, below the textarea. It updates on every input —
+   * works for both controlled and uncontrolled textareas.
+   */
+  showCount?: boolean;
+}
+
+const AUTOFILL_DISABLED_PROPS = {
+  autoComplete: 'off' as const,
+  'data-1p-ignore': '' as const,
+  'data-lpignore': 'true' as const,
+  'data-form-type': 'other' as const,
+};
+
+const SIZE_CLASS: Record<TextareaSize, string> = {
+  sm: styles.sizeSm,
+  md: styles.sizeMd,
+  lg: styles.sizeLg,
+};
+
+const RESIZE_CLASS: Record<TextareaResize, string> = {
+  none: styles.resizeNone,
+  vertical: styles.resizeVertical,
+  both: styles.resizeBoth,
+};
+
+/**
+ * Multi-line text input. The dumb companion to `<Input>` — same `invalid` +
+ * `disableAutofill` smart-default behavior, plus auto-grow, resize-handle
+ * direction, and an optional character counter.
+ *
+ * Forwards the `<textarea>` element via ref (not the wrapper div). All
+ * native textarea attributes pass through except `size` (shadowed by the
+ * component-level size prop) and `rows` (computed from `minRows`).
+ *
+ * Always renders a `<div>` wrapper so the optional counter has a place
+ * to live — unlike Input, which is a single `<input>`.
+ *
+ * @example
+ * // Default — auto-grows, 3 min rows.
+ * <Textarea placeholder="Write something…" />
+ *
+ * @example
+ * // Twitter-style counter, controlled.
+ * <Textarea
+ *   maxLength={140}
+ *   value={value}
+ *   onChange={(e) => setValue(e.target.value)}
+ * />
+ *
+ * @example
+ * // Fixed rows + drag-to-resize.
+ * <Textarea autoGrow={false} minRows={4} resize="vertical" />
+ *
+ * @example
+ * // Error state.
+ * <Textarea invalid aria-describedby="bio-error" />
+ * <p id="bio-error">Bio is required.</p>
+ *
+ * @remarks When NOT to use
+ * - Single-line text → use `<Input>`.
+ * - Choosing from a fixed list → use `<Select>`.
+ * - Rich text editing / mentions / markdown → no shipped primitive yet.
+ * - Password fields → use `<PasswordInput>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Using `placeholder` as a label. Placeholders disappear on focus.
+ * - ❌ Setting both `autoGrow={true}` AND expecting `resize="vertical"`
+ *   to render a drag handle. Auto-grow wins; the handle is hidden.
+ * - ❌ Building a separate character counter outside the component when
+ *   `maxLength` / `showCount` would do it.
+ */
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  function Textarea(
+    {
+      invalid,
+      size = 'md',
+      disableAutofill,
+      minRows = 3,
+      maxRows,
+      autoGrow = true,
+      resize = 'vertical',
+      showCount,
+      className,
+      value,
+      defaultValue,
+      onChange,
+      maxLength,
+      ...props
+    },
+    ref,
+  ) {
+    // Merge external ref with internal ref so we don't lose either.
+    const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+    const setRefs = useCallback(
+      (node: HTMLTextAreaElement | null) => {
+        textareaRef.current = node;
+        if (typeof ref === 'function') ref(node);
+        else if (ref) ref.current = node;
+      },
+      [ref],
+    );
+
+    // Internal value mirror — keeps the counter in sync for uncontrolled
+    // inputs. For controlled inputs, currentValue tracks `value` directly.
+    const [internalValue, setInternalValue] = useState<string>(() =>
+      typeof defaultValue === 'string' ? defaultValue : '',
+    );
+    const isControlled = value !== undefined;
+    const currentValue = isControlled ? String(value) : internalValue;
+
+    const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+      if (!isControlled) setInternalValue(e.target.value);
+      onChange?.(e);
+    };
+
+    // Auto-grow: synchronously after render, reset height to auto, then
+    // set to scrollHeight clamped between minRows and maxRows.
+    useLayoutEffect(() => {
+      if (!autoGrow) return;
+      const el = textareaRef.current;
+      if (!el) return;
+
+      el.style.height = 'auto';
+
+      const computed = window.getComputedStyle(el);
+      const lineHeight = parseFloat(computed.lineHeight);
+      const paddingY =
+        parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
+      const borderY =
+        parseFloat(computed.borderTopWidth) +
+        parseFloat(computed.borderBottomWidth);
+
+      const minHeight = lineHeight * minRows + paddingY + borderY;
+      const maxHeight =
+        maxRows !== undefined
+          ? lineHeight * maxRows + paddingY + borderY
+          : Infinity;
+
+      const desired = el.scrollHeight + borderY;
+      const target = Math.min(Math.max(desired, minHeight), maxHeight);
+      el.style.height = `${target}px`;
+      el.style.overflowY = desired > maxHeight ? 'auto' : 'hidden';
+    }, [currentValue, autoGrow, minRows, maxRows, size]);
+
+    // Smart autofill default — same heuristic as Input.
+    const hasAutocompleteHint =
+      typeof props.autoComplete === 'string' && props.autoComplete !== 'off';
+    const blockAutofill = disableAutofill ?? !hasAutocompleteHint;
+
+    // Effective resize: auto-grow forces 'none' because user-drag and
+    // measured-height fight each other.
+    const effectiveResize: TextareaResize = autoGrow ? 'none' : resize;
+
+    const shouldShowCount = showCount ?? maxLength !== undefined;
+
+    return (
+      <div className={styles.wrapper}>
+        <textarea
+          ref={setRefs}
+          rows={minRows}
+          aria-invalid={invalid || undefined}
+          {...(blockAutofill ? AUTOFILL_DISABLED_PROPS : {})}
+          value={value}
+          defaultValue={defaultValue}
+          maxLength={maxLength}
+          {...props}
+          onChange={handleChange}
+          className={clsx(
+            styles.textarea,
+            SIZE_CLASS[size],
+            RESIZE_CLASS[effectiveResize],
+            invalid && styles.invalid,
+            className,
+          )}
+        />
+        {shouldShowCount && (
+          <span
+            className={styles.counter}
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {currentValue.length}
+            {maxLength !== undefined && ` / ${maxLength}`}
+          </span>
+        )}
+      </div>
+    );
+  },
+);
+```
+
+- [ ] **Step 4: Write the folder barrel**
+
+Create `packages/design-system/src/components/Textarea/index.ts`:
+
+```ts
+export { Textarea } from './Textarea';
+export type { TextareaProps, TextareaSize, TextareaResize } from './Textarea';
+```
+
+- [ ] **Step 5: Typecheck + lint**
+
+```bash
+cd /home/dpws/projects/design-system
+make build-lib
+make lint
+```
+
+Expected: both clean. If stylelint flags any of the SCSS rules:
+- `margin: var(--space-1)` on `.counter` should be allowed by the inline `stylelint-disable-next-line property-disallowed-list` comment. If not, double-check the comment is on the correct line (immediately preceding `.counter` block).
+- Other unexpected lint failures: re-read the SCSS against this plan — copy/paste loss is the most common cause.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Textarea/Textarea.tsx \
+        packages/design-system/src/components/Textarea/Textarea.module.scss \
+        packages/design-system/src/components/Textarea/index.ts
+git commit -m "$(cat <<'EOF'
+Textarea: source — multi-line Input with auto-grow + counter + resize
+
+forwardRef component wrapping <textarea> in a <div> so the optional
+character counter has a place to live. useLayoutEffect measures
+scrollHeight after each value change and sets a clamped inline height
+(between minRows and maxRows worth of line-height). Internal value
+mirror keeps the counter in sync for both controlled and uncontrolled
+inputs. Smart autofill blocking matches Input. Resize handle is forced
+to 'none' when autoGrow is true.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2 — Unit tests (`Textarea.test.tsx`)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Textarea/Textarea.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+Create `packages/design-system/src/components/Textarea/Textarea.test.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Textarea } from './Textarea';
+
+describe('<Textarea>', () => {
+  // ─── Baseline parity with Input ────────────────────────────────────────
+
+  it('renders without crashing with default props', () => {
+    render(<Textarea aria-label="Notes" />);
+    expect(screen.getByRole('textbox', { name: 'Notes' })).toBeInTheDocument();
+  });
+
+  it('defaults to size="md"', () => {
+    render(<Textarea aria-label="Notes" />);
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.className).toMatch(/sizeMd/);
+  });
+
+  it('applies size="sm" class', () => {
+    render(<Textarea aria-label="Notes" size="sm" />);
+    expect(screen.getByRole('textbox').className).toMatch(/sizeSm/);
+  });
+
+  it('applies size="lg" class', () => {
+    render(<Textarea aria-label="Notes" size="lg" />);
+    expect(screen.getByRole('textbox').className).toMatch(/sizeLg/);
+  });
+
+  it('invalid={true} adds the invalid class and aria-invalid', () => {
+    render(<Textarea aria-label="Notes" invalid />);
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+    expect(textarea.className).toMatch(/invalid/);
+  });
+
+  it('invalid omitted does NOT set aria-invalid', () => {
+    render(<Textarea aria-label="Notes" />);
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('disableAutofill smart default blocks when no autoComplete', () => {
+    render(<Textarea aria-label="Notes" />);
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('autoComplete', 'off');
+    expect(textarea).toHaveAttribute('data-1p-ignore', '');
+    expect(textarea).toHaveAttribute('data-lpignore', 'true');
+    expect(textarea).toHaveAttribute('data-form-type', 'other');
+  });
+
+  it('disableAutofill smart default allows when autoComplete is set', () => {
+    render(<Textarea aria-label="Notes" autoComplete="street-address" />);
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'autoComplete',
+      'street-address',
+    );
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('data-1p-ignore');
+  });
+
+  it('disableAutofill={true} force-blocks even with autoComplete set', () => {
+    render(
+      <Textarea
+        aria-label="Notes"
+        autoComplete="street-address"
+        disableAutofill
+      />,
+    );
+    expect(screen.getByRole('textbox')).toHaveAttribute('autoComplete', 'off');
+  });
+
+  it('forwards ref to the <textarea> element (not the wrapper)', () => {
+    let captured: HTMLTextAreaElement | null = null;
+    render(
+      <Textarea
+        aria-label="Notes"
+        ref={(node) => {
+          captured = node;
+        }}
+      />,
+    );
+    expect(captured).not.toBeNull();
+    expect(captured?.tagName).toBe('TEXTAREA');
+  });
+
+  it('className is merged with internal classes, not replaced', () => {
+    render(<Textarea aria-label="Notes" className="custom" />);
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.className).toMatch(/custom/);
+    expect(textarea.className).toMatch(/textarea/);
+  });
+
+  it('controlled: value + onChange round-trip', async () => {
+    const user = userEvent.setup();
+    function Controlled() {
+      const [v, setV] = useState('');
+      return (
+        <Textarea
+          aria-label="Notes"
+          value={v}
+          onChange={(e) => setV(e.target.value)}
+        />
+      );
+    }
+    render(<Controlled />);
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello');
+    expect(textarea).toHaveValue('hello');
+  });
+
+  it('uncontrolled: typing updates content even without onChange', async () => {
+    const user = userEvent.setup();
+    render(<Textarea aria-label="Notes" defaultValue="hi" />);
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, ' there');
+    expect(textarea).toHaveValue('hi there');
+  });
+
+  // ─── Textarea-specific ─────────────────────────────────────────────────
+
+  it('minRows={5} seeds the native rows attribute', () => {
+    render(<Textarea aria-label="Notes" minRows={5} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '5');
+  });
+
+  it('minRows default is 3 (rows attribute = 3)', () => {
+    render(<Textarea aria-label="Notes" />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '3');
+  });
+
+  describe('auto-grow', () => {
+    // jsdom returns scrollHeight=0 for textareas by default; we stub it so
+    // the auto-grow effect can compute a meaningful height.
+    let originalDescriptor: PropertyDescriptor | undefined;
+    let stubbedScrollHeight = 0;
+
+    beforeAll(() => {
+      originalDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        'scrollHeight',
+      );
+      Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+        configurable: true,
+        get() {
+          return stubbedScrollHeight;
+        },
+      });
+    });
+
+    afterAll(() => {
+      if (originalDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          'scrollHeight',
+          originalDescriptor,
+        );
+      } else {
+        // @ts-expect-error — restoring to no descriptor
+        delete HTMLTextAreaElement.prototype.scrollHeight;
+      }
+    });
+
+    it('autoGrow=true (default) sets an inline height after mount', () => {
+      stubbedScrollHeight = 200;
+      const { container } = render(<Textarea aria-label="Notes" />);
+      const textarea = container.querySelector('textarea')!;
+      expect(textarea.style.height).not.toBe('');
+      expect(textarea.style.height).toMatch(/px$/);
+    });
+
+    it('autoGrow=false leaves inline height unset', () => {
+      stubbedScrollHeight = 200;
+      const { container } = render(
+        <Textarea aria-label="Notes" autoGrow={false} />,
+      );
+      const textarea = container.querySelector('textarea')!;
+      expect(textarea.style.height).toBe('');
+    });
+
+    it('maxRows clamps the inline height + sets overflowY to auto past the ceiling', () => {
+      // Big scrollHeight so we'd exceed the cap.
+      stubbedScrollHeight = 10000;
+      const { container } = render(
+        <Textarea aria-label="Notes" minRows={2} maxRows={4} />,
+      );
+      const textarea = container.querySelector('textarea')!;
+      // overflowY should be 'auto' (we're past the cap).
+      expect(textarea.style.overflowY).toBe('auto');
+    });
+
+    it('typing updates the inline height (re-measures on value change)', async () => {
+      stubbedScrollHeight = 50;
+      function Controlled() {
+        const [v, setV] = useState('');
+        return (
+          <Textarea
+            aria-label="Notes"
+            value={v}
+            onChange={(e) => setV(e.target.value)}
+          />
+        );
+      }
+      const { container } = render(<Controlled />);
+      const textarea = container.querySelector('textarea')!;
+      const heightBefore = textarea.style.height;
+      // Simulate scrollHeight growing as the user types.
+      stubbedScrollHeight = 150;
+      const user = userEvent.setup();
+      await user.type(textarea, 'hello');
+      const heightAfter = textarea.style.height;
+      expect(heightAfter).not.toBe(heightBefore);
+    });
+  });
+
+  // ─── Resize handle ─────────────────────────────────────────────────────
+
+  it('resize defaults to "vertical" when autoGrow is false', () => {
+    const { container } = render(
+      <Textarea aria-label="Notes" autoGrow={false} />,
+    );
+    expect(container.querySelector('textarea')!.className).toMatch(
+      /resizeVertical/,
+    );
+  });
+
+  it('resize is forced to "none" when autoGrow is true (even if vertical passed)', () => {
+    const { container } = render(
+      <Textarea aria-label="Notes" autoGrow={true} resize="vertical" />,
+    );
+    const textarea = container.querySelector('textarea')!;
+    expect(textarea.className).toMatch(/resizeNone/);
+    expect(textarea.className).not.toMatch(/resizeVertical/);
+  });
+
+  it('resize="both" applies the right class when autoGrow=false', () => {
+    const { container } = render(
+      <Textarea aria-label="Notes" autoGrow={false} resize="both" />,
+    );
+    expect(container.querySelector('textarea')!.className).toMatch(/resizeBoth/);
+  });
+
+  // ─── Counter ───────────────────────────────────────────────────────────
+
+  it('counter shows automatically when maxLength is set', () => {
+    render(
+      <Textarea aria-label="Notes" maxLength={140} defaultValue="hi" />,
+    );
+    expect(screen.getByText('2 / 140')).toBeInTheDocument();
+  });
+
+  it('counter format is ${len} (no slash) when showCount=true and no maxLength', () => {
+    render(<Textarea aria-label="Notes" showCount defaultValue="hello" />);
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('counter is hidden when showCount=false even if maxLength is set', () => {
+    render(
+      <Textarea
+        aria-label="Notes"
+        maxLength={140}
+        showCount={false}
+        defaultValue="hi"
+      />,
+    );
+    expect(screen.queryByText(/\/\s*140/)).not.toBeInTheDocument();
+  });
+
+  it('counter is hidden when neither maxLength nor showCount is set', () => {
+    const { container } = render(<Textarea aria-label="Notes" />);
+    // No counter span exists at all.
+    expect(container.querySelector('span[aria-live]')).toBeNull();
+  });
+
+  it('counter updates as the user types (uncontrolled)', async () => {
+    const user = userEvent.setup();
+    render(<Textarea aria-label="Notes" maxLength={140} />);
+    expect(screen.getByText('0 / 140')).toBeInTheDocument();
+    await user.type(screen.getByRole('textbox'), 'hello');
+    expect(screen.getByText('5 / 140')).toBeInTheDocument();
+  });
+
+  it('counter has aria-live="polite" and aria-atomic="true"', () => {
+    const { container } = render(
+      <Textarea aria-label="Notes" maxLength={140} />,
+    );
+    const counter = container.querySelector('span[aria-live]')!;
+    expect(counter).toHaveAttribute('aria-live', 'polite');
+    expect(counter).toHaveAttribute('aria-atomic', 'true');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test -w @eocrm/design-system -- --run src/components/Textarea/Textarea.test.tsx
+```
+
+Expected: all 24 tests pass (the auto-grow describe contributes 4; other top-level its add up to 20).
+
+If a test fails:
+- **Auto-grow tests with scrollHeight stub:** verify the stub is on `HTMLTextAreaElement.prototype` not `HTMLElement.prototype`. The `originalDescriptor` capture should target `HTMLElement.prototype.scrollHeight` (where the native one lives), but the override should be on `HTMLTextAreaElement.prototype` so jsdom resolves it specifically for textareas.
+- **Counter tests failing because `screen.getByText('2 / 140')` doesn't find the element:** jsdom may collapse the `${len}{maxLength && ' / ' + maxLength}` JSX into separate text nodes — use `screen.getByText((_, node) => node?.textContent === '2 / 140')` if needed.
+- **"Cannot find name 'vi'":** the file uses Vitest globals (`vi`, `describe`, `it`, `expect`) — confirmed available repo-wide via the vitest config (no import needed).
+
+- [ ] **Step 3: Full suite + lint + typecheck**
+
+```bash
+make test
+make build-lib
+make lint
+```
+
+Expected: everything clean. Total test count goes up by ~24.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Textarea/Textarea.test.tsx
+git commit -m "$(cat <<'EOF'
+Textarea: unit tests
+
+24 cases: baseline parity with Input (size/invalid/autofill/ref/className/
+controlled-or-uncontrolled), plus textarea-specific behavior (minRows
+seeds rows attribute, auto-grow sets inline height after mount and
+re-measures on value change, maxRows clamps with overflowY=auto, resize
+prop applies the right class, autoGrow forces resize to 'none', counter
+shows automatically with maxLength + opts in/out via showCount + has
+aria-live="polite").
+
+Auto-grow tests stub HTMLTextAreaElement.prototype.scrollHeight because
+jsdom defaults it to 0.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 — Public exports + AGENTS.md TL;DR
+
+**Files:**
+
+- Modify: `packages/design-system/src/index.ts`
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Add re-exports to `src/index.ts`**
+
+Open `packages/design-system/src/index.ts`. Find the existing block of `T*`-prefixed exports (Tabs, Toast, Tooltip). Insert the Textarea exports alphabetically between `Tabs` and `Toast`:
+
+Find this:
+
+```ts
+export { Tabs } from './components/Tabs';
+export type { /* …Tabs types… */ } from './components/Tabs';
+```
+
+Add immediately after it (and before Toast / Tooltip):
+
+```ts
+export { Textarea } from './components/Textarea';
+export type {
+  TextareaProps,
+  TextareaSize,
+  TextareaResize,
+} from './components/Textarea';
+```
+
+If the existing file groups exports differently (e.g. one big block vs interleaved per-component), match the surrounding pattern. Use grep to confirm position:
+
+```bash
+grep -n "Textarea\|Toast\|Tabs\|Tooltip" packages/design-system/src/index.ts | head
+```
+
+The result should show Tabs → Textarea → Toast → Tooltip in that order.
+
+- [ ] **Step 2: Add TL;DR to AGENTS.md**
+
+Open `packages/design-system/AGENTS.md`. Find the `### \`<Input>\`` section header (around line 101 in current state). Insert the new Textarea section immediately after the Input section ends and BEFORE `### \`<PasswordInput>\`` (line 114).
+
+To locate the precise insertion point:
+
+```bash
+grep -n "^### " packages/design-system/AGENTS.md
+```
+
+Insert this block:
+
+````markdown
+### `<Textarea>` — multi-line text
+
+The dumb multi-line companion to `<Input>`. Auto-grows by default; capped by `maxRows`. Optional character counter below the field.
+
+```tsx
+import { Textarea } from '@eocrm/design-system';
+
+// Default — auto-grows, 3 min rows, no max.
+<Textarea placeholder="Write something…" />
+
+// With counter (Twitter-style).
+<Textarea maxLength={140} defaultValue={value} onChange={(e) => setValue(e.target.value)} />
+
+// Fixed rows + drag-to-resize.
+<Textarea autoGrow={false} minRows={4} resize="vertical" />
+
+// Capped growth.
+<Textarea minRows={2} maxRows={8} />
+
+// Error state.
+<Textarea invalid aria-describedby="bio-error" />
+<p id="bio-error">Bio is required.</p>
+```
+
+- **Auto-grow is on by default** (`autoGrow={true}`). When on, `resize` is forced to `'none'` because the two conflict.
+- **Counter** shows automatically when `maxLength` is set. Force on with `showCount`, force off with `showCount={false}`.
+- **Sizes** (`sm` / `md` / `lg`) affect typography + padding only, not height. Height comes from `minRows`.
+- **Smart autofill blocking** — same heuristic as Input.
+
+#### When NOT to use
+
+- ❌ Single-line input → `<Input>`.
+- ❌ Choosing from a fixed list → `<Select>`.
+- ❌ Rich text editing (bold, lists, mentions) → no shipped primitive; defer to a `RichTextEditor` when one exists.
+- ❌ Password fields → `<PasswordInput>`.
+
+#### Anti-patterns
+
+- ❌ Using `placeholder` as a label.
+- ❌ Setting both `autoGrow={true}` AND expecting `resize="vertical"` to render a drag handle — auto-grow wins; the handle is hidden.
+- ❌ Building your own character counter outside the component when `maxLength` / `showCount` would do it.
+````
+
+- [ ] **Step 3: Typecheck + structure tests pass**
+
+```bash
+cd /home/dpws/projects/design-system
+make test
+make build-lib
+```
+
+Expected: everything green. The repo has a `structure.test.ts` that enforces every folder under `src/components/` is re-exported from `src/index.ts` — Textarea should now satisfy that check.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/index.ts packages/design-system/AGENTS.md
+git commit -m "$(cat <<'EOF'
+Textarea: public exports + AGENTS.md TL;DR
+
+Re-exports Textarea + TextareaProps/TextareaSize/TextareaResize from the
+package barrel, alphabetical between Tabs and Toast. AGENTS.md gains a
+TL;DR block directly after the <Input> section: the canonical four
+patterns (default / counter / fixed-rows / capped-growth / error),
+followed by a when-NOT-to-use list and the auto-grow-vs-resize gotcha.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 — Playground demo + 4-place nav wiring
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/TextareaDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Write the demo page**
+
+Create `packages/playground/src/pages/components/TextareaDemo.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { Cluster, Stack, Textarea } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Textarea/Textarea.tsx?raw';
+import scssSource from '@lib-source/components/Textarea/Textarea.module.scss?raw';
+
+export function TextareaDemo() {
+  const [tweet, setTweet] = useState("What's happening?");
+  const [autoGrowDemo, setAutoGrowDemo] = useState('');
+
+  return (
+    <DemoLayout
+      name="Textarea"
+      componentName="Textarea"
+      description="Multi-line text input. Auto-grows by default, optional character counter, configurable resize handle."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Textarea.tsx"
+      scssFilename="Textarea.module.scss"
+    >
+      <Example
+        title="Default"
+        description="Auto-grows on input, 3 row minimum, no max. Resize handle hidden because auto-grow is on."
+        code={`<Textarea placeholder="Write something…" />`}
+      >
+        <Textarea placeholder="Write something…" />
+      </Example>
+
+      <Example
+        title="Three sizes"
+        description="Size affects typography + padding only (height comes from minRows). Useful when matching Input alongside."
+        code={`<Textarea size="sm" minRows={2} placeholder="sm" />
+<Textarea size="md" minRows={2} placeholder="md" />
+<Textarea size="lg" minRows={2} placeholder="lg" />`}
+      >
+        <Stack gap="sm">
+          <Textarea size="sm" minRows={2} placeholder="sm" />
+          <Textarea size="md" minRows={2} placeholder="md" />
+          <Textarea size="lg" minRows={2} placeholder="lg" />
+        </Stack>
+      </Example>
+
+      <Example
+        title="Auto-grow in action (capped at 8 rows)"
+        description="Type multiple lines — the field expands up to 8 rows, then scrolls."
+        code={`<Textarea
+  minRows={2}
+  maxRows={8}
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+  placeholder="Try multiple lines…"
+/>`}
+      >
+        <Textarea
+          minRows={2}
+          maxRows={8}
+          value={autoGrowDemo}
+          onChange={(e) => setAutoGrowDemo(e.target.value)}
+          placeholder="Try multiple lines…"
+        />
+      </Example>
+
+      <Example
+        title="Fixed rows (no auto-grow) with resize handle"
+        description="Opting out of auto-grow lets the user drag the resize handle in the bottom-right corner."
+        code={`<Textarea autoGrow={false} minRows={4} resize="vertical" />`}
+      >
+        <Textarea autoGrow={false} minRows={4} resize="vertical" />
+      </Example>
+
+      <Example
+        title="Twitter-style counter"
+        description="When maxLength is set, the counter appears automatically. Controlled state shown."
+        code={`<Textarea
+  maxLength={140}
+  value={tweet}
+  onChange={(e) => setTweet(e.target.value)}
+/>`}
+      >
+        <Textarea
+          maxLength={140}
+          value={tweet}
+          onChange={(e) => setTweet(e.target.value)}
+        />
+      </Example>
+
+      <Example
+        title="Bare counter (no maxLength)"
+        description="showCount={true} forces the counter even without a hard limit — shows just the running count."
+        code={`<Textarea showCount minRows={3} placeholder="Free-form…" />`}
+      >
+        <Textarea showCount minRows={3} placeholder="Free-form…" />
+      </Example>
+
+      <Example
+        title="Error state"
+        description="invalid={true} adds the red border + danger focus ring. Pair with a visible error message via aria-describedby."
+        code={`<Textarea invalid aria-describedby="bio-error" defaultValue="" />
+<p id="bio-error" style={{ color: 'var(--color-danger)' }}>
+  Bio must not be empty.
+</p>`}
+      >
+        <Stack gap="sm">
+          <Textarea invalid aria-describedby="bio-error" defaultValue="" />
+          <p
+            id="bio-error"
+            style={{
+              color: 'var(--color-danger)',
+              margin: 0,
+              fontSize: 'var(--font-size-sm)',
+            }}
+          >
+            Bio must not be empty.
+          </p>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Disabled and readOnly"
+        description="Native attributes — same visual treatment as Input."
+        code={`<Textarea disabled defaultValue="Disabled — can't focus or edit." />
+<Textarea readOnly defaultValue="Read-only — focusable, content selectable, not editable." />`}
+      >
+        <Cluster gap="sm">
+          <Textarea disabled defaultValue="Disabled — can't focus or edit." />
+          <Textarea
+            readOnly
+            defaultValue="Read-only — focusable, content selectable, not editable."
+          />
+        </Cluster>
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+- [ ] **Step 2: Wire the route in `App.tsx`**
+
+Open `packages/playground/src/App.tsx`. Add the import alphabetically with the other `T*` component-page imports (after `TableDemo`, before `ToastDemo`):
+
+```tsx
+import { TextareaDemo } from './pages/components/TextareaDemo';
+```
+
+Add the `<Route>` inside `<Routes>` after the existing `/components/table` route:
+
+```tsx
+<Route path="/components/textarea" element={<TextareaDemo />} />
+```
+
+(Or wherever the existing alphabetical T-routes are grouped — match the surrounding ordering.)
+
+- [ ] **Step 3: Add the sidebar entry in `AppShell.tsx`**
+
+Open `packages/playground/src/layout/AppShell/AppShell.tsx`. Add `MessageSquareText` (or another sensible textarea-y icon) to the lucide-react import at the top:
+
+```bash
+grep -n "from 'lucide-react'" packages/playground/src/layout/AppShell/AppShell.tsx
+```
+
+Add `MessageSquareText` to the existing destructured import line. (If lucide-react doesn't have `MessageSquareText`, fall back to `Type` — the typography lucide icon — or `AlignLeft`.)
+
+In the `componentGroups` array, find the `Forms` group and add a new item as the LAST entry after `Select`:
+
+```tsx
+{
+  heading: 'Forms',
+  items: [
+    // …existing items (Button, ButtonGroup, Checkbox, Date pickers,
+    //  Input, PasswordInput, PasswordStrengthMeter, Radio, Select)…
+    { to: '/components/textarea', label: 'Textarea', icon: MessageSquareText, end: false },
+  ],
+},
+```
+
+- [ ] **Step 4: Add the overview card in `ComponentsIndex.tsx`**
+
+Open `packages/playground/src/pages/components/ComponentsIndex.tsx`. Add `Textarea` to the existing `@eocrm/design-system` import (find a line like `import { Input } from '@eocrm/design-system';`):
+
+```tsx
+import { Textarea } from '@eocrm/design-system';
+```
+
+(Or extend the appropriate existing multi-import line — the file may use multiple separate imports per the existing pattern.)
+
+Find the items array. Add an entry, alphabetically positioned (after `Tabs`, before `Toast` or `Tooltip` — match the existing alphabetical ordering):
+
+```tsx
+{
+  to: '/components/textarea',
+  name: 'Textarea',
+  description: 'Multi-line text with auto-grow + character counter.',
+  preview: (
+    <Textarea
+      minRows={2}
+      autoGrow={false}
+      defaultValue="Multi-line text…"
+      aria-label="Preview"
+    />
+  ),
+},
+```
+
+- [ ] **Step 5: Register the component name in `registry.ts`**
+
+Open `packages/playground/src/pages/mockups/registry.ts`. Find `export type ComponentName =` and add `'Textarea'` to the union, alphabetically between `'Tabs'` and `'Toast'`:
+
+```ts
+export type ComponentName =
+  // …existing names…
+  | 'Tabs'
+  | 'Textarea'
+  | 'Toast'
+  | 'Tooltip';
+```
+
+No existing mockup uses Textarea yet, so no `usesComponents` arrays need updating. The union extension is enough.
+
+- [ ] **Step 6: Run the playground build**
+
+```bash
+cd /home/dpws/projects/design-system
+make build
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Spot-check in the dev server (optional)**
+
+```bash
+cd packages/playground
+PORT=8090 npm run dev
+```
+
+Open http://localhost:8090/components/textarea, verify:
+- Default textarea auto-grows as you type
+- Three sizes show different padding + font-size, same minRows
+- Auto-grow capped at 8 rows shows scrollbar past the cap
+- Fixed-rows example has a visible drag handle in bottom-right
+- Twitter-style counter shows `XX / 140` and updates live
+- Bare counter (showCount, no max) shows just a running number
+- Invalid state renders red border + error message below
+- Disabled and readOnly both render the muted background
+
+Stop the dev server with `Ctrl+C`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/playground/src/pages/components/TextareaDemo.tsx \
+        packages/playground/src/App.tsx \
+        packages/playground/src/layout/AppShell/AppShell.tsx \
+        packages/playground/src/pages/components/ComponentsIndex.tsx \
+        packages/playground/src/pages/mockups/registry.ts
+git commit -m "$(cat <<'EOF'
+playground: TextareaDemo + 4-place nav wiring
+
+8 examples (default / three sizes / auto-grow capped at 8 / fixed-rows
+with resize handle / Twitter-style counter / bare counter / invalid +
+error / disabled + readOnly). Wired into Forms sidebar group (last item
+after Select), Components route, overview-grid card, and the mockups
+ComponentName union.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 — Hard-Rule-8 cycle + push + PR
+
+Per `packages/design-system/CLAUDE.md` Hard rule 8. Run until 0 Critical + 0 Important findings, all gates green.
+
+- [ ] **Step 1: Final gate run**
+
+```bash
+cd /home/dpws/projects/design-system
+make test
+make build-lib
+make build
+make lint
+```
+
+Expected: all green. Total Textarea test count is 24.
+
+- [ ] **Step 2: Dry-pack to confirm tarball contents**
+
+```bash
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -E "Textarea|test\."
+```
+
+Expected:
+- Textarea source files appear (`Textarea.tsx`, `Textarea.module.scss`, `index.ts`)
+- NO `*.test.*` files anywhere in the output
+
+- [ ] **Step 3: Dispatch a fresh-context Hard-Rule-8 reviewer**
+
+Use a `general-purpose` subagent with model `opus`. Prompt template:
+
+> Fresh-context Hard-Rule-8 review of the Textarea PR. Branch `feat/textarea` at HEAD `<sha>`. Per `packages/design-system/CLAUDE.md` Rule 8 — review the full diff against `main` and report findings as Critical / Important / Nice-to-have / Regression-watch.
+>
+> Files in scope: everything under `packages/design-system/src/components/Textarea/`, `packages/design-system/src/index.ts`, `packages/design-system/AGENTS.md`, and the playground wiring touched on this branch.
+>
+> Read first: `packages/design-system/CLAUDE.md` (Rules 1–7), `packages/design-system/AGENTS.md` (Textarea section + the surrounding Input section for convention check), `docs/superpowers/specs/2026-05-23-textarea-design.md`.
+>
+> Verify:
+> - **Rule 1**: `Textarea.test.tsx` exists alongside the component with the documented ~24 cases
+> - **Rule 3**: no raw values in `Textarea.module.scss` — all `var(--…)`. The `margin-top` on `.counter` has the documented inline-disable.
+> - **Rule 4**: no `position` / `align-self` / `flex: 1` / `width` other than 100% on `.textarea` itself. `.wrapper` is allowed `width: 100%` because that's intrinsic. `.counter`'s `margin-top` is the documented internal-spacing exception.
+> - **Rule 5**: `Textarea` + types are exported from `src/index.ts` alphabetically between Tabs and Toast
+> - **Rule 6**: `forwardRef` is used, ref targets the `<textarea>` element (not the wrapper), `TextareaHTMLAttributes` is the base, `size` and `rows` are Omit-stripped (rows comes from `minRows`)
+> - **Rule 7**: full JSDoc on `Textarea` component, every prop, both type aliases (`TextareaSize`, `TextareaResize`). At least 3 `@example` blocks. "When NOT to use" + "Anti-patterns" in @remarks.
+> - **ARIA**: `aria-invalid="true"` only when `invalid={true}`. Counter has `aria-live="polite"` + `aria-atomic="true"`.
+> - **Auto-grow correctness**: `useLayoutEffect` (not `useEffect`). Resets to `'auto'` before measuring. Clamped between minHeight and maxHeight. Sets `overflowY: 'auto'` past the cap, `'hidden'` otherwise. Dependency array includes the inputs that affect the math.
+> - **Counter correctness**: shows when `maxLength` set OR `showCount` is true. Hidden when both omitted (no empty span). Works for both controlled (via `value`) and uncontrolled (via `internalValue` mirror).
+> - **resize/autoGrow conflict**: when `autoGrow={true}`, `effectiveResize` is forced to `'none'` regardless of the `resize` prop. JSDoc on `resize` documents this.
+> - **Cross-package leakage**: Textarea imports from `@eocrm/design-system`'s internals only; no playground imports.
+> - **Package/distribution**: `npm pack --dry-run` excludes test files.
+>
+> End with verdict: **clean enough to stop** OR **keep iterating**.
+
+- [ ] **Step 4: Fix every Critical + Important finding**
+
+Group fixes into a single commit titled `Textarea: review-cycle fixes (round N)`. Document deliberately-skipped Nice-to-have items in the commit body.
+
+- [ ] **Step 5: Re-run gates after each fix round**
+
+```bash
+make test && make build-lib && make build && make lint
+```
+
+- [ ] **Step 6: Re-dispatch fresh reviewer**
+
+Same prompt, same model, fresh context. Repeat until verdict is **clean enough to stop**.
+
+- [ ] **Step 7: Push the branch**
+
+```bash
+git push -u origin feat/textarea
+```
+
+If the husky `pre-push` hook fails on `format:check`, run:
+
+```bash
+npx prettier --write docs/superpowers/specs/2026-05-23-textarea-design.md \
+                     docs/superpowers/plans/2026-05-23-textarea.md \
+                     packages/design-system/src/components/Textarea/ \
+                     packages/playground/src/pages/components/TextareaDemo.tsx
+git add -A
+git commit -m "$(cat <<'EOF'
+Textarea: prettier --write
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin feat/textarea
+```
+
+- [ ] **Step 8: Open the PR**
+
+```bash
+gh pr create --title "Textarea: multi-line Input with auto-grow + counter + resize" --body "$(cat <<'EOF'
+## Summary
+
+- New `<Textarea>` component — the dumb multi-line companion to `<Input>`.
+- Auto-grow on by default (`autoGrow={true}`), capped by `minRows` / `maxRows`.
+- Optional character counter — shows automatically when `maxLength` is set, force on/off via `showCount`.
+- Configurable resize handle (`'none' | 'vertical' | 'both'`) — forced to `'none'` when auto-grow is on (they conflict).
+- Same `invalid` + smart `disableAutofill` behavior as Input.
+- Three sizes (`'sm' | 'md' | 'lg'`) — affect typography + padding only, NOT height. Height comes from `minRows`.
+- No new packages, no new tokens.
+
+## Design highlights
+
+- **Single wrapper element.** `<Textarea>` always renders a `<div>` around the `<textarea>` so the optional counter has a place to live — unlike `<Input>`, which renders just `<input>`. Documented in JSDoc.
+- **Ref targets the `<textarea>`**, not the wrapper. Consumers can `.focus()`, set `.value`, scroll, etc. Internal ref merger handles both the measurement ref and the consumer's ref.
+- **`useLayoutEffect` for auto-grow** so the height adjustment happens synchronously before paint — no one-frame flicker between the old height and the new height.
+- **Internal value mirror.** Counter and auto-grow both need a reactive "current value". For controlled, we use `value`. For uncontrolled, an internal `useState` mirrors the textarea's value via the wrapped `onChange`. Works for both.
+- **`resize` is silently forced to `'none'` when `autoGrow={true}`** — user-drag and `scrollHeight` measurement fight each other. JSDoc documents this.
+
+## Hard Rule 8
+
+Multiple rounds with fresh-context reviewers (opus) until 0 Critical + 0 Important. 24 new tests cover both Input-parity behavior (size/invalid/autofill/ref/className/controlled-or-uncontrolled) and textarea-specific behavior (rows seeding, auto-grow inline height, maxRows clamp + overflowY, resize class application, autoGrow forcing resize to 'none', counter auto-show + opt-in + opt-out + aria-live).
+
+All four gates green: `make test` · `make build-lib` · `make build` · `make lint`. `npm pack --dry-run` shows no test files in the tarball.
+
+## Test plan
+
+- [ ] Default `<Textarea />` auto-grows as you type
+- [ ] `minRows={2} maxRows={8}` caps growth at 8 rows then scrolls
+- [ ] `autoGrow={false}` keeps the textarea at `minRows` and shows the drag handle
+- [ ] `size="sm" | "md" | "lg"` change padding + font, not height
+- [ ] `maxLength={140}` shows the counter automatically (e.g. `5 / 140`)
+- [ ] `showCount` without `maxLength` shows just the count
+- [ ] `showCount={false}` with `maxLength` set hides the counter
+- [ ] `invalid` adds red border and `aria-invalid="true"`
+- [ ] `disableAutofill` smart default blocks when no `autoComplete`, allows when set
+- [ ] `disableAutofill={true}` force-blocks even with `autoComplete` set
+- [ ] `ref` targets the `<textarea>` element (not the wrapper div)
+- [ ] `disabled` and `readOnly` render the muted background visual
+- [ ] Playground demo at `/components/textarea` renders all 8 examples without console errors
+- [ ] Sidebar `Forms` group shows Textarea as the last item
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 9: Confirm CI**
+
+Watch the GitHub Actions Quality check on the PR. If it fails for the same `format:check` reason, run the prettier fix locally and push again. If a test fails on CI but passed locally, investigate immediately — don't merge until green.
+
+- [ ] **Step 10: Mark task complete**
+
+Once verdict is `clean enough to stop`, gates green, CI green, PR open — task done. Hand off to the human reviewer for merge.
+
+---
+
+## Summary of expected commits on the branch (before review-fix rounds)
+
+```
+Textarea: design spec — multi-line Input with auto-grow + counter + resize
+Textarea: source — multi-line Input with auto-grow + counter + resize
+Textarea: unit tests
+Textarea: public exports + AGENTS.md TL;DR
+playground: TextareaDemo + 4-place nav wiring
+```
+
+Plus review-cycle fix commits and the prettier fix-up as needed.

--- a/docs/superpowers/plans/2026-05-23-textarea.md
+++ b/docs/superpowers/plans/2026-05-23-textarea.md
@@ -61,6 +61,7 @@ git log --oneline -3
 ```
 
 Expected:
+
 - Branch: `feat/textarea`
 - Working tree clean
 - Most recent commit: `b025edc Textarea: design spec — multi-line Input with auto-grow + counter + resize`
@@ -190,8 +191,10 @@ export type TextareaSize = 'sm' | 'md' | 'lg';
 /** User-drag resize handle direction. Maps to CSS `resize`. */
 export type TextareaResize = 'none' | 'vertical' | 'both';
 
-export interface TextareaProps
-  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'size' | 'rows'> {
+export interface TextareaProps extends Omit<
+  TextareaHTMLAttributes<HTMLTextAreaElement>,
+  'size' | 'rows'
+> {
   /**
    * Toggles the error visual (red border + danger focus ring) and sets
    * `aria-invalid="true"`. Pair with a visible error message and an
@@ -329,124 +332,112 @@ const RESIZE_CLASS: Record<TextareaResize, string> = {
  * - ❌ Building a separate character counter outside the component when
  *   `maxLength` / `showCount` would do it.
  */
-export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  function Textarea(
-    {
-      invalid,
-      size = 'md',
-      disableAutofill,
-      minRows = 3,
-      maxRows,
-      autoGrow = true,
-      resize = 'vertical',
-      showCount,
-      className,
-      value,
-      defaultValue,
-      onChange,
-      maxLength,
-      ...props
-    },
-    ref,
-  ) {
-    // Merge external ref with internal ref so we don't lose either.
-    const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-    const setRefs = useCallback(
-      (node: HTMLTextAreaElement | null) => {
-        textareaRef.current = node;
-        if (typeof ref === 'function') ref(node);
-        else if (ref) ref.current = node;
-      },
-      [ref],
-    );
-
-    // Internal value mirror — keeps the counter in sync for uncontrolled
-    // inputs. For controlled inputs, currentValue tracks `value` directly.
-    const [internalValue, setInternalValue] = useState<string>(() =>
-      typeof defaultValue === 'string' ? defaultValue : '',
-    );
-    const isControlled = value !== undefined;
-    const currentValue = isControlled ? String(value) : internalValue;
-
-    const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-      if (!isControlled) setInternalValue(e.target.value);
-      onChange?.(e);
-    };
-
-    // Auto-grow: synchronously after render, reset height to auto, then
-    // set to scrollHeight clamped between minRows and maxRows.
-    useLayoutEffect(() => {
-      if (!autoGrow) return;
-      const el = textareaRef.current;
-      if (!el) return;
-
-      el.style.height = 'auto';
-
-      const computed = window.getComputedStyle(el);
-      const lineHeight = parseFloat(computed.lineHeight);
-      const paddingY =
-        parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
-      const borderY =
-        parseFloat(computed.borderTopWidth) +
-        parseFloat(computed.borderBottomWidth);
-
-      const minHeight = lineHeight * minRows + paddingY + borderY;
-      const maxHeight =
-        maxRows !== undefined
-          ? lineHeight * maxRows + paddingY + borderY
-          : Infinity;
-
-      const desired = el.scrollHeight + borderY;
-      const target = Math.min(Math.max(desired, minHeight), maxHeight);
-      el.style.height = `${target}px`;
-      el.style.overflowY = desired > maxHeight ? 'auto' : 'hidden';
-    }, [currentValue, autoGrow, minRows, maxRows, size]);
-
-    // Smart autofill default — same heuristic as Input.
-    const hasAutocompleteHint =
-      typeof props.autoComplete === 'string' && props.autoComplete !== 'off';
-    const blockAutofill = disableAutofill ?? !hasAutocompleteHint;
-
-    // Effective resize: auto-grow forces 'none' because user-drag and
-    // measured-height fight each other.
-    const effectiveResize: TextareaResize = autoGrow ? 'none' : resize;
-
-    const shouldShowCount = showCount ?? maxLength !== undefined;
-
-    return (
-      <div className={styles.wrapper}>
-        <textarea
-          ref={setRefs}
-          rows={minRows}
-          aria-invalid={invalid || undefined}
-          {...(blockAutofill ? AUTOFILL_DISABLED_PROPS : {})}
-          value={value}
-          defaultValue={defaultValue}
-          maxLength={maxLength}
-          {...props}
-          onChange={handleChange}
-          className={clsx(
-            styles.textarea,
-            SIZE_CLASS[size],
-            RESIZE_CLASS[effectiveResize],
-            invalid && styles.invalid,
-            className,
-          )}
-        />
-        {shouldShowCount && (
-          <span
-            className={styles.counter}
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {currentValue.length}
-            {maxLength !== undefined && ` / ${maxLength}`}
-          </span>
-        )}
-      </div>
-    );
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  {
+    invalid,
+    size = 'md',
+    disableAutofill,
+    minRows = 3,
+    maxRows,
+    autoGrow = true,
+    resize = 'vertical',
+    showCount,
+    className,
+    value,
+    defaultValue,
+    onChange,
+    maxLength,
+    ...props
   },
-);
+  ref,
+) {
+  // Merge external ref with internal ref so we don't lose either.
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const setRefs = useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      textareaRef.current = node;
+      if (typeof ref === 'function') ref(node);
+      else if (ref) ref.current = node;
+    },
+    [ref],
+  );
+
+  // Internal value mirror — keeps the counter in sync for uncontrolled
+  // inputs. For controlled inputs, currentValue tracks `value` directly.
+  const [internalValue, setInternalValue] = useState<string>(() =>
+    typeof defaultValue === 'string' ? defaultValue : '',
+  );
+  const isControlled = value !== undefined;
+  const currentValue = isControlled ? String(value) : internalValue;
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    if (!isControlled) setInternalValue(e.target.value);
+    onChange?.(e);
+  };
+
+  // Auto-grow: synchronously after render, reset height to auto, then
+  // set to scrollHeight clamped between minRows and maxRows.
+  useLayoutEffect(() => {
+    if (!autoGrow) return;
+    const el = textareaRef.current;
+    if (!el) return;
+
+    el.style.height = 'auto';
+
+    const computed = window.getComputedStyle(el);
+    const lineHeight = parseFloat(computed.lineHeight);
+    const paddingY = parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
+    const borderY = parseFloat(computed.borderTopWidth) + parseFloat(computed.borderBottomWidth);
+
+    const minHeight = lineHeight * minRows + paddingY + borderY;
+    const maxHeight = maxRows !== undefined ? lineHeight * maxRows + paddingY + borderY : Infinity;
+
+    const desired = el.scrollHeight + borderY;
+    const target = Math.min(Math.max(desired, minHeight), maxHeight);
+    el.style.height = `${target}px`;
+    el.style.overflowY = desired > maxHeight ? 'auto' : 'hidden';
+  }, [currentValue, autoGrow, minRows, maxRows, size]);
+
+  // Smart autofill default — same heuristic as Input.
+  const hasAutocompleteHint =
+    typeof props.autoComplete === 'string' && props.autoComplete !== 'off';
+  const blockAutofill = disableAutofill ?? !hasAutocompleteHint;
+
+  // Effective resize: auto-grow forces 'none' because user-drag and
+  // measured-height fight each other.
+  const effectiveResize: TextareaResize = autoGrow ? 'none' : resize;
+
+  const shouldShowCount = showCount ?? maxLength !== undefined;
+
+  return (
+    <div className={styles.wrapper}>
+      <textarea
+        ref={setRefs}
+        rows={minRows}
+        aria-invalid={invalid || undefined}
+        {...(blockAutofill ? AUTOFILL_DISABLED_PROPS : {})}
+        value={value}
+        defaultValue={defaultValue}
+        maxLength={maxLength}
+        {...props}
+        onChange={handleChange}
+        className={clsx(
+          styles.textarea,
+          SIZE_CLASS[size],
+          RESIZE_CLASS[effectiveResize],
+          invalid && styles.invalid,
+          className,
+        )}
+      />
+      {shouldShowCount && (
+        <span className={styles.counter} aria-live="polite" aria-atomic="true">
+          {currentValue.length}
+          {maxLength !== undefined && ` / ${maxLength}`}
+        </span>
+      )}
+    </div>
+  );
+});
 ```
 
 - [ ] **Step 4: Write the folder barrel**
@@ -467,6 +458,7 @@ make lint
 ```
 
 Expected: both clean. If stylelint flags any of the SCSS rules:
+
 - `margin: var(--space-1)` on `.counter` should be allowed by the inline `stylelint-disable-next-line property-disallowed-list` comment. If not, double-check the comment is on the correct line (immediately preceding `.counter` block).
 - Other unexpected lint failures: re-read the SCSS against this plan — copy/paste loss is the most common cause.
 
@@ -557,21 +549,12 @@ describe('<Textarea>', () => {
 
   it('disableAutofill smart default allows when autoComplete is set', () => {
     render(<Textarea aria-label="Notes" autoComplete="street-address" />);
-    expect(screen.getByRole('textbox')).toHaveAttribute(
-      'autoComplete',
-      'street-address',
-    );
+    expect(screen.getByRole('textbox')).toHaveAttribute('autoComplete', 'street-address');
     expect(screen.getByRole('textbox')).not.toHaveAttribute('data-1p-ignore');
   });
 
   it('disableAutofill={true} force-blocks even with autoComplete set', () => {
-    render(
-      <Textarea
-        aria-label="Notes"
-        autoComplete="street-address"
-        disableAutofill
-      />,
-    );
+    render(<Textarea aria-label="Notes" autoComplete="street-address" disableAutofill />);
     expect(screen.getByRole('textbox')).toHaveAttribute('autoComplete', 'off');
   });
 
@@ -600,13 +583,7 @@ describe('<Textarea>', () => {
     const user = userEvent.setup();
     function Controlled() {
       const [v, setV] = useState('');
-      return (
-        <Textarea
-          aria-label="Notes"
-          value={v}
-          onChange={(e) => setV(e.target.value)}
-        />
-      );
+      return <Textarea aria-label="Notes" value={v} onChange={(e) => setV(e.target.value)} />;
     }
     render(<Controlled />);
     const textarea = screen.getByRole('textbox');
@@ -641,10 +618,7 @@ describe('<Textarea>', () => {
     let stubbedScrollHeight = 0;
 
     beforeAll(() => {
-      originalDescriptor = Object.getOwnPropertyDescriptor(
-        HTMLElement.prototype,
-        'scrollHeight',
-      );
+      originalDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
       Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
         configurable: true,
         get() {
@@ -655,11 +629,7 @@ describe('<Textarea>', () => {
 
     afterAll(() => {
       if (originalDescriptor) {
-        Object.defineProperty(
-          HTMLElement.prototype,
-          'scrollHeight',
-          originalDescriptor,
-        );
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalDescriptor);
       } else {
         // @ts-expect-error — restoring to no descriptor
         delete HTMLTextAreaElement.prototype.scrollHeight;
@@ -676,9 +646,7 @@ describe('<Textarea>', () => {
 
     it('autoGrow=false leaves inline height unset', () => {
       stubbedScrollHeight = 200;
-      const { container } = render(
-        <Textarea aria-label="Notes" autoGrow={false} />,
-      );
+      const { container } = render(<Textarea aria-label="Notes" autoGrow={false} />);
       const textarea = container.querySelector('textarea')!;
       expect(textarea.style.height).toBe('');
     });
@@ -686,9 +654,7 @@ describe('<Textarea>', () => {
     it('maxRows clamps the inline height + sets overflowY to auto past the ceiling', () => {
       // Big scrollHeight so we'd exceed the cap.
       stubbedScrollHeight = 10000;
-      const { container } = render(
-        <Textarea aria-label="Notes" minRows={2} maxRows={4} />,
-      );
+      const { container } = render(<Textarea aria-label="Notes" minRows={2} maxRows={4} />);
       const textarea = container.querySelector('textarea')!;
       // overflowY should be 'auto' (we're past the cap).
       expect(textarea.style.overflowY).toBe('auto');
@@ -698,13 +664,7 @@ describe('<Textarea>', () => {
       stubbedScrollHeight = 50;
       function Controlled() {
         const [v, setV] = useState('');
-        return (
-          <Textarea
-            aria-label="Notes"
-            value={v}
-            onChange={(e) => setV(e.target.value)}
-          />
-        );
+        return <Textarea aria-label="Notes" value={v} onChange={(e) => setV(e.target.value)} />;
       }
       const { container } = render(<Controlled />);
       const textarea = container.querySelector('textarea')!;
@@ -721,36 +681,26 @@ describe('<Textarea>', () => {
   // ─── Resize handle ─────────────────────────────────────────────────────
 
   it('resize defaults to "vertical" when autoGrow is false', () => {
-    const { container } = render(
-      <Textarea aria-label="Notes" autoGrow={false} />,
-    );
-    expect(container.querySelector('textarea')!.className).toMatch(
-      /resizeVertical/,
-    );
+    const { container } = render(<Textarea aria-label="Notes" autoGrow={false} />);
+    expect(container.querySelector('textarea')!.className).toMatch(/resizeVertical/);
   });
 
   it('resize is forced to "none" when autoGrow is true (even if vertical passed)', () => {
-    const { container } = render(
-      <Textarea aria-label="Notes" autoGrow={true} resize="vertical" />,
-    );
+    const { container } = render(<Textarea aria-label="Notes" autoGrow={true} resize="vertical" />);
     const textarea = container.querySelector('textarea')!;
     expect(textarea.className).toMatch(/resizeNone/);
     expect(textarea.className).not.toMatch(/resizeVertical/);
   });
 
   it('resize="both" applies the right class when autoGrow=false', () => {
-    const { container } = render(
-      <Textarea aria-label="Notes" autoGrow={false} resize="both" />,
-    );
+    const { container } = render(<Textarea aria-label="Notes" autoGrow={false} resize="both" />);
     expect(container.querySelector('textarea')!.className).toMatch(/resizeBoth/);
   });
 
   // ─── Counter ───────────────────────────────────────────────────────────
 
   it('counter shows automatically when maxLength is set', () => {
-    render(
-      <Textarea aria-label="Notes" maxLength={140} defaultValue="hi" />,
-    );
+    render(<Textarea aria-label="Notes" maxLength={140} defaultValue="hi" />);
     expect(screen.getByText('2 / 140')).toBeInTheDocument();
   });
 
@@ -760,14 +710,7 @@ describe('<Textarea>', () => {
   });
 
   it('counter is hidden when showCount=false even if maxLength is set', () => {
-    render(
-      <Textarea
-        aria-label="Notes"
-        maxLength={140}
-        showCount={false}
-        defaultValue="hi"
-      />,
-    );
+    render(<Textarea aria-label="Notes" maxLength={140} showCount={false} defaultValue="hi" />);
     expect(screen.queryByText(/\/\s*140/)).not.toBeInTheDocument();
   });
 
@@ -786,9 +729,7 @@ describe('<Textarea>', () => {
   });
 
   it('counter has aria-live="polite" and aria-atomic="true"', () => {
-    const { container } = render(
-      <Textarea aria-label="Notes" maxLength={140} />,
-    );
+    const { container } = render(<Textarea aria-label="Notes" maxLength={140} />);
     const counter = container.querySelector('span[aria-live]')!;
     expect(counter).toHaveAttribute('aria-live', 'polite');
     expect(counter).toHaveAttribute('aria-atomic', 'true');
@@ -806,6 +747,7 @@ npm test -w @eocrm/design-system -- --run src/components/Textarea/Textarea.test.
 Expected: all 24 tests pass (the auto-grow describe contributes 4; other top-level its add up to 20).
 
 If a test fails:
+
 - **Auto-grow tests with scrollHeight stub:** verify the stub is on `HTMLTextAreaElement.prototype` not `HTMLElement.prototype`. The `originalDescriptor` capture should target `HTMLElement.prototype.scrollHeight` (where the native one lives), but the override should be on `HTMLTextAreaElement.prototype` so jsdom resolves it specifically for textareas.
 - **Counter tests failing because `screen.getByText('2 / 140')` doesn't find the element:** jsdom may collapse the `${len}{maxLength && ' / ' + maxLength}` JSX into separate text nodes — use `screen.getByText((_, node) => node?.textContent === '2 / 140')` if needed.
 - **"Cannot find name 'vi'":** the file uses Vitest globals (`vi`, `describe`, `it`, `expect`) — confirmed available repo-wide via the vitest config (no import needed).
@@ -860,18 +802,14 @@ Find this:
 
 ```ts
 export { Tabs } from './components/Tabs';
-export type { /* …Tabs types… */ } from './components/Tabs';
+export type {} from /* …Tabs types… */ './components/Tabs';
 ```
 
 Add immediately after it (and before Toast / Tooltip):
 
 ```ts
 export { Textarea } from './components/Textarea';
-export type {
-  TextareaProps,
-  TextareaSize,
-  TextareaResize,
-} from './components/Textarea';
+export type { TextareaProps, TextareaSize, TextareaResize } from './components/Textarea';
 ```
 
 If the existing file groups exports differently (e.g. one big block vs interleaved per-component), match the surrounding pattern. Use grep to confirm position:
@@ -884,7 +822,7 @@ The result should show Tabs → Textarea → Toast → Tooltip in that order.
 
 - [ ] **Step 2: Add TL;DR to AGENTS.md**
 
-Open `packages/design-system/AGENTS.md`. Find the `### \`<Input>\`` section header (around line 101 in current state). Insert the new Textarea section immediately after the Input section ends and BEFORE `### \`<PasswordInput>\`` (line 114).
+Open `packages/design-system/AGENTS.md`. Find the `### \`<Input>\``section header (around line 101 in current state). Insert the new Textarea section immediately after the Input section ends and BEFORE`### \`<PasswordInput>\`` (line 114).
 
 To locate the precise insertion point:
 
@@ -1063,11 +1001,7 @@ export function TextareaDemo() {
   onChange={(e) => setTweet(e.target.value)}
 />`}
       >
-        <Textarea
-          maxLength={140}
-          value={tweet}
-          onChange={(e) => setTweet(e.target.value)}
-        />
+        <Textarea maxLength={140} value={tweet} onChange={(e) => setTweet(e.target.value)} />
       </Example>
 
       <Example
@@ -1194,10 +1128,7 @@ Open `packages/playground/src/pages/mockups/registry.ts`. Find `export type Comp
 ```ts
 export type ComponentName =
   // …existing names…
-  | 'Tabs'
-  | 'Textarea'
-  | 'Toast'
-  | 'Tooltip';
+  'Tabs' | 'Textarea' | 'Toast' | 'Tooltip';
 ```
 
 No existing mockup uses Textarea yet, so no `usesComponents` arrays need updating. The union extension is enough.
@@ -1219,6 +1150,7 @@ PORT=8090 npm run dev
 ```
 
 Open http://localhost:8090/components/textarea, verify:
+
 - Default textarea auto-grows as you type
 - Three sizes show different padding + font-size, same minRows
 - Auto-grow capped at 8 rows shows scrollbar past the cap
@@ -1277,6 +1209,7 @@ npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -E "Textarea|test\."
 ```
 
 Expected:
+
 - Textarea source files appear (`Textarea.tsx`, `Textarea.module.scss`, `index.ts`)
 - NO `*.test.*` files anywhere in the output
 
@@ -1291,6 +1224,7 @@ Use a `general-purpose` subagent with model `opus`. Prompt template:
 > Read first: `packages/design-system/CLAUDE.md` (Rules 1–7), `packages/design-system/AGENTS.md` (Textarea section + the surrounding Input section for convention check), `docs/superpowers/specs/2026-05-23-textarea-design.md`.
 >
 > Verify:
+>
 > - **Rule 1**: `Textarea.test.tsx` exists alongside the component with the documented ~24 cases
 > - **Rule 3**: no raw values in `Textarea.module.scss` — all `var(--…)`. The `margin-top` on `.counter` has the documented inline-disable.
 > - **Rule 4**: no `position` / `align-self` / `flex: 1` / `width` other than 100% on `.textarea` itself. `.wrapper` is allowed `width: 100%` because that's intrinsic. `.counter`'s `margin-top` is the documented internal-spacing exception.

--- a/docs/superpowers/specs/2026-05-23-textarea-design.md
+++ b/docs/superpowers/specs/2026-05-23-textarea-design.md
@@ -89,8 +89,10 @@ export type TextareaSize = 'sm' | 'md' | 'lg';
 /** User-drag resize handle direction. Maps to CSS `resize` property. */
 export type TextareaResize = 'none' | 'vertical' | 'both';
 
-export interface TextareaProps
-  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'size' | 'rows'> {
+export interface TextareaProps extends Omit<
+  TextareaHTMLAttributes<HTMLTextAreaElement>,
+  'size' | 'rows'
+> {
   /**
    * Toggles the error visual (red border + danger focus ring) and sets
    * `aria-invalid="true"`. Pair with a visible error message and an
@@ -188,12 +190,13 @@ export interface TextareaProps
   aria-invalid={invalid || undefined}
   {...(blockAutofill ? AUTOFILL_DISABLED_PROPS : {})}
   {...props}
-  onChange={handleChange}  // wraps consumer's onChange to keep counter in sync
+  onChange={handleChange} // wraps consumer's onChange to keep counter in sync
   className={clsx(styles.textarea, sizeClass, resizeClass, invalid && styles.invalid, className)}
 />
 ```
 
 Notes on the spread:
+
 - `ref={setRefs}` — ref is not a regular prop in React, so spread order doesn't affect it. The internal handler updates the local ref (for measurement) and forwards to the consumer's ref via the merger.
 - `rows={minRows}` before `{...props}` — consumer's literal `rows` is `Omit`-stripped from the props type, so nothing in `props` overrides this anyway. The attribute is here for SSR / no-JS rendering.
 - `aria-invalid` before `{...props}` — consumer could pass `aria-invalid={false}` to override. That's Pattern A (consumer wins), matching Input.
@@ -214,7 +217,7 @@ const setRefs = useCallback(
     if (typeof ref === 'function') ref(node);
     else if (ref) ref.current = node;
   },
-  [ref]
+  [ref],
 );
 
 useLayoutEffect(() => {
@@ -227,16 +230,11 @@ useLayoutEffect(() => {
 
   const computed = window.getComputedStyle(el);
   const lineHeight = parseFloat(computed.lineHeight);
-  const paddingY =
-    parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
-  const borderY =
-    parseFloat(computed.borderTopWidth) + parseFloat(computed.borderBottomWidth);
+  const paddingY = parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
+  const borderY = parseFloat(computed.borderTopWidth) + parseFloat(computed.borderBottomWidth);
 
   const minHeight = lineHeight * minRows + paddingY + borderY;
-  const maxHeight =
-    maxRows !== undefined
-      ? lineHeight * maxRows + paddingY + borderY
-      : Infinity;
+  const maxHeight = maxRows !== undefined ? lineHeight * maxRows + paddingY + borderY : Infinity;
 
   // `scrollHeight` already includes padding (box-sizing matters here:
   // border-box totals include border but typically scrollHeight does not
@@ -260,7 +258,7 @@ useLayoutEffect(() => {
 
 ```tsx
 const [internalValue, setInternalValue] = useState<string>(() =>
-  typeof defaultValue === 'string' ? defaultValue : ''
+  typeof defaultValue === 'string' ? defaultValue : '',
 );
 const isControlled = value !== undefined;
 const currentValue = isControlled ? String(value) : internalValue;
@@ -280,12 +278,14 @@ const shouldShowCount = showCount ?? maxLength !== undefined;
 **Counter rendering:**
 
 ```tsx
-{shouldShowCount && (
-  <span className={styles.counter} aria-live="polite" aria-atomic="true">
-    {currentValue.length}
-    {maxLength !== undefined && ` / ${maxLength}`}
-  </span>
-)}
+{
+  shouldShowCount && (
+    <span className={styles.counter} aria-live="polite" aria-atomic="true">
+      {currentValue.length}
+      {maxLength !== undefined && ` / ${maxLength}`}
+    </span>
+  );
+}
 ```
 
 **aria-atomic="true"** — the whole count is re-announced as a unit, not just the changed digit (otherwise SRs might say "1" instead of "121").
@@ -358,9 +358,15 @@ This is invisible to the consumer's API — they pass `resize="vertical"` and `a
 }
 
 // Resize direction
-.resizeNone     { resize: none; }
-.resizeVertical { resize: vertical; }
-.resizeBoth     { resize: both; }
+.resizeNone {
+  resize: none;
+}
+.resizeVertical {
+  resize: vertical;
+}
+.resizeBoth {
+  resize: both;
+}
 
 .invalid {
   border-color: var(--color-danger);
@@ -383,6 +389,7 @@ This is invisible to the consumer's API — they pass `resize="vertical"` and `a
 ```
 
 **Rule 4 check:**
+
 - `.wrapper` and `.textarea` get only intrinsic dimensions (`width: 100%` / `display: block`), no layout.
 - `.counter` has `margin-top: var(--space-1)` — that's INTERNAL spacing between a wrapper-child and the textarea above it, not a layout property at the component boundary. Stylelint's `property-disallowed-list` may flag it. If so, the line gets an inline `/* stylelint-disable-next-line property-disallowed-list -- internal spacing between textarea and its counter child */` comment.
 
@@ -390,17 +397,17 @@ This is invisible to the consumer's API — they pass `resize="vertical"` and `a
 
 ## ARIA + behavior reference
 
-| Concern | Behavior |
-|---|---|
-| Invalid state | `aria-invalid="true"` on the textarea, red border + danger focus ring via SCSS |
-| Label association | Consumer wraps in `<label>` or uses `htmlFor` + `id` — Textarea forwards `id`. No built-in label |
+| Concern              | Behavior                                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Invalid state        | `aria-invalid="true"` on the textarea, red border + danger focus ring via SCSS                                      |
+| Label association    | Consumer wraps in `<label>` or uses `htmlFor` + `id` — Textarea forwards `id`. No built-in label                    |
 | Counter announcement | `<span aria-live="polite" aria-atomic="true">` — polite (not interruptive); atomic so the whole string re-announces |
-| Disabled | Native `disabled` attribute; CSS `:disabled` selectors handle visual |
-| Read-only | Native `readOnly`; CSS `[readonly]` selector handles visual (subtle bg, still focusable) |
-| Focus management | None — native focus on the textarea is enough. The wrapper div has no role |
-| Autofill | Smart default identical to Input: block iff no autoComplete hint; explicit `disableAutofill` overrides |
-| Spread order | Pattern A (consumer wins) — matches Input |
-| Ref target | The `<textarea>` element, NOT the wrapper. Consumers can call `.focus()`, set `.value` directly, scroll, etc. |
+| Disabled             | Native `disabled` attribute; CSS `:disabled` selectors handle visual                                                |
+| Read-only            | Native `readOnly`; CSS `[readonly]` selector handles visual (subtle bg, still focusable)                            |
+| Focus management     | None — native focus on the textarea is enough. The wrapper div has no role                                          |
+| Autofill             | Smart default identical to Input: block iff no autoComplete hint; explicit `disableAutofill` overrides              |
+| Spread order         | Pattern A (consumer wins) — matches Input                                                                           |
+| Ref target           | The `<textarea>` element, NOT the wrapper. Consumers can call `.focus()`, set `.value` directly, scroll, etc.       |
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-05-23-textarea-design.md
+++ b/docs/superpowers/specs/2026-05-23-textarea-design.md
@@ -1,0 +1,520 @@
+# Textarea — design spec
+
+**Date:** 2026-05-23
+**Branch:** `feat/textarea`
+**Scope:** New `<Textarea>` component for `@eocrm/design-system` — multi-line text input matching `<Input>`'s API surface plus auto-grow, configurable resize handle, and an optional character counter.
+
+## Goal
+
+Provide the dumb multi-line companion to `<Input>`. Same JSDoc + a11y conventions (`invalid` + `aria-invalid`, autofill blocking, forwardRef + spread). Three additions Input doesn't need: auto-grow height clamped by `minRows`/`maxRows`, a `resize` direction prop, and an optional character counter that renders below the field when `maxLength` is set or `showCount` is true.
+
+## Why now
+
+- The CRM has multiple open-coded `<textarea>` usages (notes fields, ticket descriptions, comment composers). They're inconsistent: some have fixed rows, some auto-grow with hand-rolled hooks, none share styling with the rest of the forms.
+- Auto-grow is the dominant pattern in modern textareas (Slack composer, GitHub PR body, Linear comment box). Building it once in the design system saves every consumer from reimplementing the `scrollHeight` measurement dance.
+- Without a shipped Textarea, the playground's component grid has an obvious gap right next to Input. AGENTS.md anti-patterns for Input already direct users to "use Textarea" — a primitive we never shipped.
+
+## Non-goals (v1)
+
+- **No rich text editing.** No bold/italic, no markdown preview, no mentions, no syntax highlighting. That's `RichTextEditor` (out of scope, no current plan).
+- **No autocomplete-from-list.** Suggestions ("type @ to mention…", emoji autocomplete) belong to a different primitive.
+- **No threshold warnings on the counter.** No orange-at-90%, red-at-100%. The counter is one muted color; consumers who want color thresholds can compose externally.
+- **No polymorphism (`as` prop).** Textarea is always `<textarea>`.
+- **No image / file paste handling.** Native paste events fire on the textarea; consumers wire onPaste themselves if they want it.
+- **No "soft" max-length** (counter shows, but native attribute also blocks input past it). v1 only respects native `maxLength` behavior — if a consumer wants soft enforcement they manage it in their onChange.
+- **No min-content height adjustment for resize handle interactions.** When `resize='vertical'` and `autoGrow={false}`, the user can drag the field to any height. That's native behavior; we don't intervene.
+
+## Architecture
+
+### Dependencies
+
+No new packages. Reuses:
+
+- React (peer)
+- `clsx` (existing dep) for className composition
+- Existing tokens: `--border-width`, `--color-border-strong`, `--color-border`, `--radius-md`, `--color-bg`, `--color-bg-subtle`, `--color-fg`, `--color-fg-subtle`, `--color-fg-muted`, `--color-accent`, `--color-danger`, `--ring-accent`, `--ring-danger`, `--ring-width`, `--line-height-normal`, `--font-size-sm`/`--font-size-md`/`--font-size-lg`, `--space-1`/`--space-2`/`--space-3`, `--transition-fast`
+
+No new tokens needed. Auto-grow math reads `line-height`, `padding-top/bottom`, `border-top/bottom-width` from computed style at runtime — those are derived from the tokens above plus the size variant.
+
+### File layout
+
+```
+packages/design-system/src/components/Textarea/
+  Textarea.tsx          ← forwardRef + spread + useLayoutEffect (auto-grow) + internal state branch (counter)
+  Textarea.module.scss  ← wrapper / textarea / size variants / resize variants / invalid / counter
+  Textarea.test.tsx     ← ~20 cases
+  index.ts              ← export { Textarea }, type re-exports
+```
+
+Plus standard integration points:
+
+- `packages/design-system/src/index.ts` — re-export `Textarea`, `TextareaProps`, `TextareaSize`, `TextareaResize`
+- `packages/design-system/AGENTS.md` — TL;DR slot directly after `<Input>` section
+- `packages/playground/src/pages/components/TextareaDemo.tsx` — 7-example demo
+- `packages/playground/src/App.tsx` — route at `/components/textarea`
+- `packages/playground/src/layout/AppShell/AppShell.tsx` — sidebar entry in the **Forms** group, last alphabetically (after `Select`, since "T" follows "S")
+- `packages/playground/src/pages/components/ComponentsIndex.tsx` — overview card with a 2-row preview textarea
+- `packages/playground/src/pages/mockups/registry.ts` — `'Textarea'` in `ComponentName` union
+
+### Composition
+
+```
+        <Textarea {...props} ref={consumerRef} />
+                          │
+                          ▼
+                   <div .wrapper>
+                          │
+              ┌───────────┴───────────┐
+              ▼                       ▼
+        <textarea>              <span .counter aria-live="polite">
+        (consumerRef)             "120 / 500"
+        ┌────────────┐            (only when shouldShowCount)
+        │ measured + │
+        │ resized via│
+        │ useLayout- │
+        │ Effect     │
+        └────────────┘
+```
+
+Always a wrapper. ref points at the `<textarea>`, not the wrapper. Counter renders conditionally inside the wrapper.
+
+## Public API
+
+```ts
+import type { TextareaHTMLAttributes } from 'react';
+
+/** Field typography + padding scale. Pairs with Input's `size`. */
+export type TextareaSize = 'sm' | 'md' | 'lg';
+
+/** User-drag resize handle direction. Maps to CSS `resize` property. */
+export type TextareaResize = 'none' | 'vertical' | 'both';
+
+export interface TextareaProps
+  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'size' | 'rows'> {
+  /**
+   * Toggles the error visual (red border + danger focus ring) and sets
+   * `aria-invalid="true"`. Pair with a visible error message and an
+   * `aria-describedby` pointer at the message id.
+   */
+  invalid?: boolean;
+
+  /**
+   * Visual size. Defaults to `'md'`.
+   * - `'sm'` — tighter padding + `--font-size-sm`. Used in dense forms.
+   * - `'md'` — default padding + `--font-size-md`. Most form contexts.
+   * - `'lg'` — same padding as md but `--font-size-lg`. Hero / focus textareas.
+   *
+   * Unlike Input, the size prop does NOT affect height — the textarea
+   * height comes from `minRows` (and `maxRows` if capped). Size only
+   * controls typography and padding.
+   *
+   * Shadowing note: this collapses the native HTML `<textarea size>`
+   * attribute (which Omit already drops from the props type). Use
+   * `style={{ width }}` or a parent container for explicit width.
+   */
+  size?: TextareaSize;
+
+  /**
+   * Block browser autofill AND password managers from offering to fill
+   * this textarea. Same heuristic and prop shape as Input — see Input's
+   * JSDoc for the full set of opt-out attributes applied.
+   *
+   * Smart default: when omitted, block iff `autoComplete` is also omitted
+   * (or `'off'`). Pass `true`/`false` to override the heuristic.
+   */
+  disableAutofill?: boolean;
+
+  /**
+   * Minimum visible rows. The textarea will never render shorter than this,
+   * regardless of content. Default: `3`.
+   *
+   * Implementation: contributes `lineHeight × minRows + paddingY + borderY`
+   * as a height floor in the auto-grow effect, AND seeds the `rows`
+   * attribute on the underlying `<textarea>` so SSR / no-JS users get a
+   * sensible initial height.
+   */
+  minRows?: number;
+
+  /**
+   * Maximum visible rows. Beyond this, content scrolls inside the field
+   * instead of expanding further. Default: `undefined` (unbounded growth).
+   *
+   * Only meaningful when `autoGrow` is true.
+   */
+  maxRows?: number;
+
+  /**
+   * When true, height adapts to content between `minRows` and `maxRows`.
+   * Default: `true`.
+   *
+   * When false, height is locked at `minRows`'s height and a scrollbar
+   * appears when content overflows — equivalent to a stock `<textarea rows={minRows}>`.
+   */
+  autoGrow?: boolean;
+
+  /**
+   * User-drag resize handle direction. Default: `'vertical'`.
+   *
+   * **Forced to `'none'`** when `autoGrow` is `true` — user-drag fights the
+   * auto-grow measurement and produces erratic behavior. Consumers who
+   * want both must pick: set `autoGrow={false}` to enable a resize handle,
+   * or accept `'none'` while auto-grow is on.
+   */
+  resize?: TextareaResize;
+
+  /**
+   * Show the character counter (`${value.length}` or
+   * `${value.length} / ${maxLength}` when both are set).
+   *
+   * Default: `true` when `maxLength` is set, `false` otherwise.
+   *
+   * The counter renders as a `<span aria-live="polite" aria-atomic="true">`
+   * inside the wrapper, below the textarea. It updates on every input,
+   * works for both controlled and uncontrolled textareas (the component
+   * keeps an internal value mirror for the uncontrolled case).
+   */
+  showCount?: boolean;
+}
+```
+
+**Native attrs spread to `<textarea>`:** all of `TextareaHTMLAttributes` minus `size` (shadowed) and `rows` (computed from `minRows`). That includes `value`, `defaultValue`, `placeholder`, `disabled`, `readOnly`, `required`, `name`, `id`, `aria-*`, `data-*`, `maxLength`, `minLength`, `onChange`, `onInput`, `onFocus`, `onBlur`, `onPaste`, etc.
+
+**Spread order — Pattern A (consumer wins):**
+
+```tsx
+<textarea
+  ref={setRefs}
+  rows={minRows}
+  aria-invalid={invalid || undefined}
+  {...(blockAutofill ? AUTOFILL_DISABLED_PROPS : {})}
+  {...props}
+  onChange={handleChange}  // wraps consumer's onChange to keep counter in sync
+  className={clsx(styles.textarea, sizeClass, resizeClass, invalid && styles.invalid, className)}
+/>
+```
+
+Notes on the spread:
+- `ref={setRefs}` — ref is not a regular prop in React, so spread order doesn't affect it. The internal handler updates the local ref (for measurement) and forwards to the consumer's ref via the merger.
+- `rows={minRows}` before `{...props}` — consumer's literal `rows` is `Omit`-stripped from the props type, so nothing in `props` overrides this anyway. The attribute is here for SSR / no-JS rendering.
+- `aria-invalid` before `{...props}` — consumer could pass `aria-invalid={false}` to override. That's Pattern A (consumer wins), matching Input.
+- Autofill block before `{...props}` so consumer's explicit `autoComplete` overrides.
+- `onChange={handleChange}` AFTER `{...props}` — we deliberately want our wrapper to win, because we need to keep the internal value mirror (and therefore the counter + auto-grow) in sync. `handleChange` calls the consumer's `onChange` internally, so nothing is lost.
+- `className={...}` after props so the composed clsx string wins (Input uses the same approach).
+
+## Architecture flow
+
+### Auto-grow
+
+```tsx
+const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+const setRefs = useCallback(
+  (node: HTMLTextAreaElement | null) => {
+    textareaRef.current = node;
+    if (typeof ref === 'function') ref(node);
+    else if (ref) ref.current = node;
+  },
+  [ref]
+);
+
+useLayoutEffect(() => {
+  if (!autoGrow) return;
+  const el = textareaRef.current;
+  if (!el) return;
+
+  // Reset to 'auto' first so scrollHeight reflects content, not the previous height.
+  el.style.height = 'auto';
+
+  const computed = window.getComputedStyle(el);
+  const lineHeight = parseFloat(computed.lineHeight);
+  const paddingY =
+    parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
+  const borderY =
+    parseFloat(computed.borderTopWidth) + parseFloat(computed.borderBottomWidth);
+
+  const minHeight = lineHeight * minRows + paddingY + borderY;
+  const maxHeight =
+    maxRows !== undefined
+      ? lineHeight * maxRows + paddingY + borderY
+      : Infinity;
+
+  // `scrollHeight` already includes padding (box-sizing matters here:
+  // border-box totals include border but typically scrollHeight does not
+  // — adding borderY normalizes).
+  const desired = el.scrollHeight + borderY;
+  const target = Math.min(Math.max(desired, minHeight), maxHeight);
+  el.style.height = `${target}px`;
+  el.style.overflowY = desired > maxHeight ? 'auto' : 'hidden';
+}, [currentValue, autoGrow, minRows, maxRows, size]);
+```
+
+**Why `useLayoutEffect`:** synchronous before paint — prevents a one-frame flicker between the old height and the new height. `useEffect` would let the user see the stale height for a frame.
+
+**Why reset to `'auto'` first:** without it, `scrollHeight` returns the current rendered height, which already includes any height we set. Setting `'auto'` lets the browser collapse to the content's natural minimum before we re-measure.
+
+**Dependency array:** `currentValue` (the merged controlled/uncontrolled value), `autoGrow`, `minRows`, `maxRows`, `size`. We deliberately do NOT depend on every prop — only the inputs that change the math.
+
+**SSR-safe:** the effect doesn't run on the server. The textarea renders with `rows={minRows}` so the initial server-rendered HTML has a sensible height; the client effect re-measures after hydration.
+
+### Counter + internal value mirror
+
+```tsx
+const [internalValue, setInternalValue] = useState<string>(() =>
+  typeof defaultValue === 'string' ? defaultValue : ''
+);
+const isControlled = value !== undefined;
+const currentValue = isControlled ? String(value) : internalValue;
+
+const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+  if (!isControlled) setInternalValue(e.target.value);
+  onChange?.(e);
+};
+
+const shouldShowCount = showCount ?? maxLength !== undefined;
+```
+
+**Why an internal mirror:** the counter and the auto-grow effect both need a reactive "current value" to recompute on. For controlled mode, `value` already is reactive — we just use it. For uncontrolled mode, we'd otherwise have to read `el.value` imperatively, which doesn't trigger re-renders and would leave the counter stale. The internal mirror covers the uncontrolled path without complicating the controlled one.
+
+**Edge case — switching between controlled and uncontrolled:** if a consumer starts with `value={undefined}` then later passes `value="x"`, React already warns. The mirror's `internalValue` would diverge from `value` but `currentValue` correctly switches over because `isControlled` flips. No bespoke handling needed.
+
+**Counter rendering:**
+
+```tsx
+{shouldShowCount && (
+  <span className={styles.counter} aria-live="polite" aria-atomic="true">
+    {currentValue.length}
+    {maxLength !== undefined && ` / ${maxLength}`}
+  </span>
+)}
+```
+
+**aria-atomic="true"** — the whole count is re-announced as a unit, not just the changed digit (otherwise SRs might say "1" instead of "121").
+
+### Resize-handle / auto-grow interaction
+
+```tsx
+const effectiveResize: TextareaResize = autoGrow ? 'none' : (resize ?? 'vertical');
+```
+
+Forcing `'none'` when auto-grow is on prevents the user-drag from desyncing with the `scrollHeight` measurement. If the user wants a draggable handle, they opt out of auto-grow.
+
+This is invisible to the consumer's API — they pass `resize="vertical"` and `autoGrow={true}` and the resize silently becomes `'none'` at render time. Documented in the `resize` prop's JSDoc.
+
+## Styling — `Textarea.module.scss`
+
+```scss
+.wrapper {
+  width: 100%;
+  display: block;
+}
+
+.textarea {
+  display: block;
+  width: 100%;
+  border: var(--border-width) solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font-family: inherit;
+  line-height: var(--line-height-normal);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+
+  &::placeholder {
+    color: var(--color-fg-subtle);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 var(--ring-width) var(--ring-accent);
+  }
+
+  &:disabled {
+    background: var(--color-bg-subtle);
+    border-color: var(--color-border);
+    color: var(--color-fg-subtle);
+    cursor: not-allowed;
+  }
+
+  &[readonly] {
+    background: var(--color-bg-subtle);
+  }
+}
+
+// Size — typography + padding. NO height (textarea height comes from rows + autoGrow).
+.sizeSm {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+}
+.sizeMd {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-md);
+}
+.sizeLg {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-lg);
+}
+
+// Resize direction
+.resizeNone     { resize: none; }
+.resizeVertical { resize: vertical; }
+.resizeBoth     { resize: both; }
+
+.invalid {
+  border-color: var(--color-danger);
+
+  &:focus-visible {
+    border-color: var(--color-danger);
+    box-shadow: 0 0 0 var(--ring-width) var(--ring-danger);
+  }
+}
+
+// Counter — non-intrusive, right-aligned, muted.
+.counter {
+  display: block;
+  text-align: right;
+  margin-top: var(--space-1);
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+  line-height: 1;
+}
+```
+
+**Rule 4 check:**
+- `.wrapper` and `.textarea` get only intrinsic dimensions (`width: 100%` / `display: block`), no layout.
+- `.counter` has `margin-top: var(--space-1)` — that's INTERNAL spacing between a wrapper-child and the textarea above it, not a layout property at the component boundary. Stylelint's `property-disallowed-list` may flag it. If so, the line gets an inline `/* stylelint-disable-next-line property-disallowed-list -- internal spacing between textarea and its counter child */` comment.
+
+**Tokens used:** only the existing set listed under Architecture / Dependencies.
+
+## ARIA + behavior reference
+
+| Concern | Behavior |
+|---|---|
+| Invalid state | `aria-invalid="true"` on the textarea, red border + danger focus ring via SCSS |
+| Label association | Consumer wraps in `<label>` or uses `htmlFor` + `id` — Textarea forwards `id`. No built-in label |
+| Counter announcement | `<span aria-live="polite" aria-atomic="true">` — polite (not interruptive); atomic so the whole string re-announces |
+| Disabled | Native `disabled` attribute; CSS `:disabled` selectors handle visual |
+| Read-only | Native `readOnly`; CSS `[readonly]` selector handles visual (subtle bg, still focusable) |
+| Focus management | None — native focus on the textarea is enough. The wrapper div has no role |
+| Autofill | Smart default identical to Input: block iff no autoComplete hint; explicit `disableAutofill` overrides |
+| Spread order | Pattern A (consumer wins) — matches Input |
+| Ref target | The `<textarea>` element, NOT the wrapper. Consumers can call `.focus()`, set `.value` directly, scroll, etc. |
+
+## Testing
+
+`Textarea.test.tsx` — ~20 cases, RTL + userEvent.
+
+### Baseline parity with Input
+
+1. Renders without crashing with default props
+2. Defaults to `size='md'` class
+3. `size='sm'` and `size='lg'` apply the right class
+4. `invalid={true}` adds the invalid class AND sets `aria-invalid="true"`
+5. `invalid={false}` (or omitted) does NOT set `aria-invalid`
+6. `disableAutofill` smart default: blocks when no autoComplete, allows when autoComplete is set to a meaningful value
+7. `disableAutofill={true}` force-blocks even with autoComplete set
+8. `ref` forwards to the `<textarea>` element (not the wrapper) — `expect(ref.current?.tagName).toBe('TEXTAREA')`
+9. `className` is merged with the internal classes, not replaced
+10. Controlled: `value` + `onChange` round-trip; the consumer's onChange fires with each keystroke
+11. Uncontrolled: typing into a `defaultValue` textarea updates the visible content (no onChange required)
+
+### Textarea-specific
+
+12. `minRows={5}` results in the textarea's inline `rows` attribute being `5`
+13. `autoGrow={true}` (default) — typing more content increases the inline `style.height`. Mock `scrollHeight` getter via `Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', { get: () => 200, configurable: true })`. Assert `style.height` advances.
+14. `autoGrow={false}` — typing more content does NOT change the inline `style.height` (remains empty / unset)
+15. `maxRows={3}` clamps the auto-grow height; the textarea gets `overflowY: 'auto'` when content overflows. Verify by mocking scrollHeight beyond the ceiling.
+16. `resize='vertical'` (default when no autoGrow) applies `.resizeVertical`. With `autoGrow={true}` AND `resize='vertical'`, the rendered class is `.resizeNone` (forced).
+17. `resize='both'` applies `.resizeBoth` when `autoGrow={false}`.
+18. `maxLength={140}` automatically shows the counter with format `${len} / 140`. Initial render shows `0 / 140`. Typing updates it.
+19. `showCount={true}` without `maxLength` shows just the bare count number, no `/ N`.
+20. `showCount={false}` with `maxLength` set still hides the counter (explicit opt-out wins).
+21. Counter is absent when neither `maxLength` nor `showCount` is set.
+22. Counter has `aria-live="polite"` and `aria-atomic="true"`.
+
+### Vitest gotchas
+
+- `useLayoutEffect` runs synchronously under React 19 + jsdom, no `act()` needed beyond what RTL provides.
+- `getComputedStyle` in jsdom returns real values for properties that come from inline style or matching stylesheets — `line-height` from `--line-height-normal` will be the computed pixel value as long as the SCSS is loaded.
+- `scrollHeight` in jsdom defaults to `0`. For auto-grow tests, stub it: `Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', { configurable: true, get: () => 200 })` in a `beforeAll` + restore in `afterAll`.
+- Counter test for uncontrolled: use `userEvent.type(textarea, 'hello')`, then `expect(screen.getByText('5 / 140')).toBeInTheDocument()` (or similar).
+
+## Playground demo — `TextareaDemo.tsx`
+
+7 examples grouped via `<Example>`:
+
+1. **Default** — `<Textarea placeholder="Write something…" />`. Notes "auto-grows by default, 3 rows minimum, vertical resize disabled because of auto-grow".
+
+2. **Three sizes** — `sm` / `md` / `lg` side by side. Same `minRows={2}`. Demonstrates typography + padding differences.
+
+3. **Auto-grow in action** — controlled, `minRows={2}`, `maxRows={8}`. Hint text: "type multiple lines — the field grows up to 8 rows, then scrolls."
+
+4. **Fixed rows (no auto-grow, with resize handle)** — `<Textarea autoGrow={false} minRows={4} resize="vertical" />`. Shows the drag-to-resize affordance.
+
+5. **With counter (Twitter-style)** — `<Textarea maxLength={140} defaultValue="What's happening?" />`. Counter appears automatically.
+
+6. **Explicit counter (no max)** — `<Textarea showCount minRows={3} />`. Bare count, no `/ N`.
+
+7. **Invalid state + error message** — `<Textarea invalid aria-describedby="bio-error" />` with a `<p id="bio-error">Bio must not be empty.</p>` underneath.
+
+8. **Disabled + readOnly** — `<Textarea disabled defaultValue="…" />` and `<Textarea readOnly defaultValue="…" />` side by side.
+
+The viewport mount is irrelevant — Textarea is a flow element.
+
+## AGENTS.md TL;DR slot
+
+After `### <Input>`. Section title `### <Textarea>`. ~30-line block:
+
+````markdown
+### `<Textarea>` — multi-line text
+
+The dumb multi-line companion to `<Input>`. Auto-grows by default; capped by `maxRows`. Optional character counter below the field.
+
+```tsx
+import { Textarea } from '@eocrm/design-system';
+
+// Default — auto-grows, 3 min rows, no max.
+<Textarea placeholder="Write something…" />
+
+// With counter (Twitter-style).
+<Textarea maxLength={140} defaultValue={value} onChange={(e) => setValue(e.target.value)} />
+
+// Fixed rows + drag-to-resize.
+<Textarea autoGrow={false} minRows={4} resize="vertical" />
+
+// Capped growth.
+<Textarea minRows={2} maxRows={8} />
+
+// Error state.
+<Textarea invalid aria-describedby="bio-error" />
+<p id="bio-error">Bio is required.</p>
+```
+
+- **Auto-grow is on by default** (`autoGrow={true}`). When on, `resize` is forced to `'none'` because the two conflict.
+- **Counter** shows automatically when `maxLength` is set. Force on with `showCount`, force off with `showCount={false}`.
+- **Sizes** (`sm` / `md` / `lg`) affect typography + padding only, not height. Height comes from `minRows`.
+- **Smart autofill blocking** — same heuristic as Input.
+
+#### When NOT to use
+
+- ❌ Single-line input → `<Input>`.
+- ❌ Choosing from a fixed list → `<Select>`.
+- ❌ Rich text editing (bold, lists, mentions) → no current primitive; defer to a `RichTextEditor` when one exists.
+- ❌ Password fields → `<PasswordInput>`.
+
+#### Anti-patterns
+
+- ❌ Using `placeholder` as a label.
+- ❌ Setting both `autoGrow={true}` and expecting `resize="vertical"` to render a drag handle — auto-grow wins; the handle is hidden.
+- ❌ Building your own character counter outside the component when `maxLength`/`showCount` would do it.
+````
+
+## Hard Rule 8
+
+The pre-push review-fix cycle on library changes is mandatory. Run gates (`make test`, `make build-lib`, `make build`, `make lint`, `npm pack --dry-run`), spawn a fresh-context reviewer with the standard Toast/ButtonGroup prompt, fix every Critical + Important, repeat until clean.
+
+## Open questions
+
+None. All clarifications baked in above.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -111,6 +111,48 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 - **Autofill is BLOCKED by default** — `<Input />` carries `autoComplete="off"` + the 1Password / LastPass / generic data-\* opt-out hints so password managers don't misfire on search / filter / free-text fields. Set `autoComplete="email"` (or `"username"`, `"current-password"`, etc.) to opt INTO autofill for real form fields. Force the behavior either way via `disableAutofill={true | false}`.
 - Validation logic lives in your form layer (React Hook Form + Zod recommended), not in the component.
 
+### `<Textarea>` — multi-line text
+
+The dumb multi-line companion to `<Input>`. Auto-grows by default; capped by `maxRows`. Optional character counter below the field.
+
+```tsx
+import { Textarea } from '@eocrm/design-system';
+
+// Default — auto-grows, 3 min rows, no max.
+<Textarea placeholder="Write something…" />
+
+// With counter (Twitter-style).
+<Textarea maxLength={140} defaultValue={value} onChange={(e) => setValue(e.target.value)} />
+
+// Fixed rows + drag-to-resize.
+<Textarea autoGrow={false} minRows={4} resize="vertical" />
+
+// Capped growth.
+<Textarea minRows={2} maxRows={8} />
+
+// Error state.
+<Textarea invalid aria-describedby="bio-error" />
+<p id="bio-error">Bio is required.</p>
+```
+
+- **Auto-grow is on by default** (`autoGrow={true}`). When on, `resize` is forced to `'none'` because the two conflict.
+- **Counter** shows automatically when `maxLength` is set. Force on with `showCount`, force off with `showCount={false}`.
+- **Sizes** (`sm` / `md` / `lg`) affect typography + padding only, not height. Height comes from `minRows`.
+- **Smart autofill blocking** — same heuristic as Input.
+
+#### When NOT to use
+
+- ❌ Single-line input → `<Input>`.
+- ❌ Choosing from a fixed list → `<Select>`.
+- ❌ Rich text editing (bold, lists, mentions) → no shipped primitive; defer to a `RichTextEditor` when one exists.
+- ❌ Password fields → `<PasswordInput>`.
+
+#### Anti-patterns
+
+- ❌ Using `placeholder` as a label.
+- ❌ Setting both `autoGrow={true}` AND expecting `resize="vertical"` to render a drag handle — auto-grow wins; the handle is hidden.
+- ❌ Building your own character counter outside the component when `maxLength` / `showCount` would do it.
+
 ### `<PasswordInput>` — password field with eye toggle + optional warnings
 
 ```tsx

--- a/packages/design-system/src/components/Input/Input.tsx
+++ b/packages/design-system/src/components/Input/Input.tsx
@@ -81,10 +81,10 @@ const AUTOFILL_DISABLED_PROPS = {
  * <p id="email-error">Enter a valid email.</p>
  *
  * @remarks When NOT to use
- * - Multi-line → use `Textarea` (not yet shipped).
+ * - Multi-line → use `Textarea`.
  * - Choosing from a fixed list → use `Select`.
  * - Date/time → use `DatePicker` / `DateRangePicker`.
- * - Password reveal/toggle → use `PasswordInput` (not yet shipped).
+ * - Password reveal/toggle → use `PasswordInput`.
  *
  * @remarks Anti-patterns
  * - ❌ Putting validation logic *inside* the component. The Input is dumb on

--- a/packages/design-system/src/components/Textarea/Textarea.module.scss
+++ b/packages/design-system/src/components/Textarea/Textarea.module.scss
@@ -1,0 +1,90 @@
+.wrapper {
+  width: 100%;
+  display: block;
+}
+
+.textarea {
+  display: block;
+  width: 100%;
+  border: var(--border-width) solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font-family: inherit;
+  line-height: var(--line-height-normal);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+
+  &::placeholder {
+    color: var(--color-fg-subtle);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 var(--ring-width) var(--ring-accent);
+  }
+
+  &:disabled {
+    background: var(--color-bg-subtle);
+    border-color: var(--color-border);
+    color: var(--color-fg-subtle);
+    cursor: not-allowed;
+  }
+
+  &[readonly] {
+    background: var(--color-bg-subtle);
+  }
+}
+
+// Size — typography + padding. NO height (textarea height comes from rows + autoGrow).
+.sizeSm {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+}
+
+.sizeMd {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-md);
+}
+
+.sizeLg {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-lg);
+}
+
+// Resize direction
+.resizeNone {
+  resize: none;
+}
+
+.resizeVertical {
+  resize: vertical;
+}
+
+.resizeBoth {
+  resize: both;
+}
+
+.invalid {
+  border-color: var(--color-danger);
+
+  &:focus-visible {
+    border-color: var(--color-danger);
+    box-shadow: 0 0 0 var(--ring-width) var(--ring-danger);
+  }
+}
+
+// Counter — internal spacing between textarea and child counter. The counter
+// is a child element inside the wrapper, not a layout property at the
+// component boundary, so this is allowed.
+.counter {
+  display: block;
+  text-align: right;
+  // stylelint-disable-next-line property-disallowed-list -- internal spacing between textarea and its counter child
+  margin-top: var(--space-1);
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+  line-height: 1;
+}

--- a/packages/design-system/src/components/Textarea/Textarea.test.tsx
+++ b/packages/design-system/src/components/Textarea/Textarea.test.tsx
@@ -1,0 +1,294 @@
+import { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Textarea } from './Textarea';
+
+describe('<Textarea>', () => {
+  // ─── Baseline parity with Input ────────────────────────────────────────
+
+  it('renders without crashing with default props', () => {
+    render(<Textarea aria-label="Notes" />);
+    expect(screen.getByRole('textbox', { name: 'Notes' })).toBeInTheDocument();
+  });
+
+  it('defaults to size="md"', () => {
+    render(<Textarea aria-label="Notes" />);
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.className).toMatch(/sizeMd/);
+  });
+
+  it('applies size="sm" class', () => {
+    render(<Textarea aria-label="Notes" size="sm" />);
+    expect(screen.getByRole('textbox').className).toMatch(/sizeSm/);
+  });
+
+  it('applies size="lg" class', () => {
+    render(<Textarea aria-label="Notes" size="lg" />);
+    expect(screen.getByRole('textbox').className).toMatch(/sizeLg/);
+  });
+
+  it('invalid={true} adds the invalid class and aria-invalid', () => {
+    render(<Textarea aria-label="Notes" invalid />);
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+    expect(textarea.className).toMatch(/invalid/);
+  });
+
+  it('invalid omitted does NOT set aria-invalid', () => {
+    render(<Textarea aria-label="Notes" />);
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('disableAutofill smart default blocks when no autoComplete', () => {
+    render(<Textarea aria-label="Notes" />);
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('autoComplete', 'off');
+    expect(textarea).toHaveAttribute('data-1p-ignore', '');
+    expect(textarea).toHaveAttribute('data-lpignore', 'true');
+    expect(textarea).toHaveAttribute('data-form-type', 'other');
+  });
+
+  it('disableAutofill smart default allows when autoComplete is set', () => {
+    render(<Textarea aria-label="Notes" autoComplete="street-address" />);
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'autoComplete',
+      'street-address',
+    );
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('data-1p-ignore');
+  });
+
+  it('disableAutofill={true} force-blocks even with autoComplete set', () => {
+    render(
+      <Textarea
+        aria-label="Notes"
+        autoComplete="street-address"
+        disableAutofill
+      />,
+    );
+    const textarea = screen.getByRole('textbox');
+    // Consumer's autoComplete still wins (spread order matches Input)…
+    expect(textarea).toHaveAttribute('autocomplete', 'street-address');
+    // …but the data-* opt-outs ARE applied.
+    expect(textarea).toHaveAttribute('data-1p-ignore');
+  });
+
+  it('forwards ref to the <textarea> element (not the wrapper)', () => {
+    let captured: HTMLTextAreaElement | null = null;
+    render(
+      <Textarea
+        aria-label="Notes"
+        ref={(node) => {
+          captured = node;
+        }}
+      />,
+    );
+    expect(captured).not.toBeNull();
+    // TS cannot track that the ref callback ran — cast through unknown.
+    expect((captured as unknown as HTMLTextAreaElement).tagName).toBe('TEXTAREA');
+  });
+
+  it('className is merged with internal classes, not replaced', () => {
+    render(<Textarea aria-label="Notes" className="custom" />);
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.className).toMatch(/custom/);
+    expect(textarea.className).toMatch(/textarea/);
+  });
+
+  it('controlled: value + onChange round-trip', async () => {
+    const user = userEvent.setup();
+    function Controlled() {
+      const [v, setV] = useState('');
+      return (
+        <Textarea
+          aria-label="Notes"
+          value={v}
+          onChange={(e) => setV(e.target.value)}
+        />
+      );
+    }
+    render(<Controlled />);
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello');
+    expect(textarea).toHaveValue('hello');
+  });
+
+  it('uncontrolled: typing updates content even without onChange', async () => {
+    const user = userEvent.setup();
+    render(<Textarea aria-label="Notes" defaultValue="hi" />);
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, ' there');
+    expect(textarea).toHaveValue('hi there');
+  });
+
+  // ─── Textarea-specific ─────────────────────────────────────────────────
+
+  it('minRows={5} seeds the native rows attribute', () => {
+    render(<Textarea aria-label="Notes" minRows={5} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '5');
+  });
+
+  it('minRows default is 3 (rows attribute = 3)', () => {
+    render(<Textarea aria-label="Notes" />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '3');
+  });
+
+  describe('auto-grow', () => {
+    // jsdom returns scrollHeight=0 for textareas by default; we stub it so
+    // the auto-grow effect can compute a meaningful height.
+    let originalDescriptor: PropertyDescriptor | undefined;
+    let stubbedScrollHeight = 0;
+
+    beforeAll(() => {
+      originalDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        'scrollHeight',
+      );
+      Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+        configurable: true,
+        get() {
+          return stubbedScrollHeight;
+        },
+      });
+    });
+
+    afterAll(() => {
+      if (originalDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          'scrollHeight',
+          originalDescriptor,
+        );
+      } else {
+        // @ts-expect-error — restoring to no descriptor
+        delete HTMLTextAreaElement.prototype.scrollHeight;
+      }
+    });
+
+    it('autoGrow=true (default) sets an inline height after mount', () => {
+      stubbedScrollHeight = 200;
+      const { container } = render(<Textarea aria-label="Notes" />);
+      const textarea = container.querySelector('textarea')!;
+      expect(textarea.style.height).not.toBe('');
+      expect(textarea.style.height).toMatch(/px$/);
+    });
+
+    it('autoGrow=false leaves inline height unset', () => {
+      stubbedScrollHeight = 200;
+      const { container } = render(
+        <Textarea aria-label="Notes" autoGrow={false} />,
+      );
+      const textarea = container.querySelector('textarea')!;
+      expect(textarea.style.height).toBe('');
+    });
+
+    it('maxRows clamps the inline height + sets overflowY to auto past the ceiling', () => {
+      // Big scrollHeight so we'd exceed the cap.
+      stubbedScrollHeight = 10000;
+      const { container } = render(
+        <Textarea aria-label="Notes" minRows={2} maxRows={4} />,
+      );
+      const textarea = container.querySelector('textarea')!;
+      // overflowY should be 'auto' (we're past the cap).
+      expect(textarea.style.overflowY).toBe('auto');
+    });
+
+    it('typing updates the inline height (re-measures on value change)', async () => {
+      stubbedScrollHeight = 50;
+      function Controlled() {
+        const [v, setV] = useState('');
+        return (
+          <Textarea
+            aria-label="Notes"
+            value={v}
+            onChange={(e) => setV(e.target.value)}
+          />
+        );
+      }
+      const { container } = render(<Controlled />);
+      const textarea = container.querySelector('textarea')!;
+      const heightBefore = textarea.style.height;
+      // Simulate scrollHeight growing as the user types.
+      stubbedScrollHeight = 150;
+      const user = userEvent.setup();
+      await user.type(textarea, 'hello');
+      const heightAfter = textarea.style.height;
+      expect(heightAfter).not.toBe(heightBefore);
+    });
+  });
+
+  // ─── Resize handle ─────────────────────────────────────────────────────
+
+  it('resize defaults to "vertical" when autoGrow is false', () => {
+    const { container } = render(
+      <Textarea aria-label="Notes" autoGrow={false} />,
+    );
+    expect(container.querySelector('textarea')!.className).toMatch(
+      /resizeVertical/,
+    );
+  });
+
+  it('resize is forced to "none" when autoGrow is true (even if vertical passed)', () => {
+    const { container } = render(
+      <Textarea aria-label="Notes" autoGrow={true} resize="vertical" />,
+    );
+    const textarea = container.querySelector('textarea')!;
+    expect(textarea.className).toMatch(/resizeNone/);
+    expect(textarea.className).not.toMatch(/resizeVertical/);
+  });
+
+  it('resize="both" applies the right class when autoGrow=false', () => {
+    const { container } = render(
+      <Textarea aria-label="Notes" autoGrow={false} resize="both" />,
+    );
+    expect(container.querySelector('textarea')!.className).toMatch(/resizeBoth/);
+  });
+
+  // ─── Counter ───────────────────────────────────────────────────────────
+
+  it('counter shows automatically when maxLength is set', () => {
+    render(
+      <Textarea aria-label="Notes" maxLength={140} defaultValue="hi" />,
+    );
+    expect(screen.getByText('2 / 140')).toBeInTheDocument();
+  });
+
+  it('counter format is ${len} (no slash) when showCount=true and no maxLength', () => {
+    render(<Textarea aria-label="Notes" showCount defaultValue="hello" />);
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('counter is hidden when showCount=false even if maxLength is set', () => {
+    render(
+      <Textarea
+        aria-label="Notes"
+        maxLength={140}
+        showCount={false}
+        defaultValue="hi"
+      />,
+    );
+    expect(screen.queryByText(/\/\s*140/)).not.toBeInTheDocument();
+  });
+
+  it('counter is hidden when neither maxLength nor showCount is set', () => {
+    const { container } = render(<Textarea aria-label="Notes" />);
+    // No counter span exists at all.
+    expect(container.querySelector('span[aria-live]')).toBeNull();
+  });
+
+  it('counter updates as the user types (uncontrolled)', async () => {
+    const user = userEvent.setup();
+    render(<Textarea aria-label="Notes" maxLength={140} />);
+    expect(screen.getByText('0 / 140')).toBeInTheDocument();
+    await user.type(screen.getByRole('textbox'), 'hello');
+    expect(screen.getByText('5 / 140')).toBeInTheDocument();
+  });
+
+  it('counter has aria-live="polite" and aria-atomic="true"', () => {
+    const { container } = render(
+      <Textarea aria-label="Notes" maxLength={140} />,
+    );
+    const counter = container.querySelector('span[aria-live]')!;
+    expect(counter).toHaveAttribute('aria-live', 'polite');
+    expect(counter).toHaveAttribute('aria-atomic', 'true');
+  });
+});

--- a/packages/design-system/src/components/Textarea/Textarea.test.tsx
+++ b/packages/design-system/src/components/Textarea/Textarea.test.tsx
@@ -192,6 +192,17 @@ describe('<Textarea>', () => {
       expect(textarea.style.overflowY).toBe('auto');
     });
 
+    it('toggling autoGrow off clears the prior inline height/overflowY', () => {
+      stubbedScrollHeight = 200;
+      const { container, rerender } = render(<Textarea aria-label="Notes" autoGrow />);
+      const textarea = container.querySelector('textarea')!;
+      expect(textarea.style.height).toMatch(/px$/);
+
+      rerender(<Textarea aria-label="Notes" autoGrow={false} />);
+      expect(textarea.style.height).toBe('');
+      expect(textarea.style.overflowY).toBe('');
+    });
+
     it('typing updates the inline height (re-measures on value change)', async () => {
       stubbedScrollHeight = 50;
       function Controlled() {
@@ -290,5 +301,17 @@ describe('<Textarea>', () => {
     const counter = container.querySelector('span[aria-live]')!;
     expect(counter).toHaveAttribute('aria-live', 'polite');
     expect(counter).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('numeric defaultValue is reflected in the counter', () => {
+    render(<Textarea aria-label="Notes" defaultValue={123} showCount />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('disableAutofill={false} force-allows autofill even without an autoComplete hint', () => {
+    render(<Textarea aria-label="Notes" disableAutofill={false} />);
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).not.toHaveAttribute('autocomplete');
+    expect(textarea).not.toHaveAttribute('data-1p-ignore');
   });
 });

--- a/packages/design-system/src/components/Textarea/Textarea.test.tsx
+++ b/packages/design-system/src/components/Textarea/Textarea.test.tsx
@@ -50,21 +50,12 @@ describe('<Textarea>', () => {
 
   it('disableAutofill smart default allows when autoComplete is set', () => {
     render(<Textarea aria-label="Notes" autoComplete="street-address" />);
-    expect(screen.getByRole('textbox')).toHaveAttribute(
-      'autoComplete',
-      'street-address',
-    );
+    expect(screen.getByRole('textbox')).toHaveAttribute('autoComplete', 'street-address');
     expect(screen.getByRole('textbox')).not.toHaveAttribute('data-1p-ignore');
   });
 
   it('disableAutofill={true} force-blocks even with autoComplete set', () => {
-    render(
-      <Textarea
-        aria-label="Notes"
-        autoComplete="street-address"
-        disableAutofill
-      />,
-    );
+    render(<Textarea aria-label="Notes" autoComplete="street-address" disableAutofill />);
     const textarea = screen.getByRole('textbox');
     // Consumer's autoComplete still wins (spread order matches Input)…
     expect(textarea).toHaveAttribute('autocomplete', 'street-address');
@@ -98,13 +89,7 @@ describe('<Textarea>', () => {
     const user = userEvent.setup();
     function Controlled() {
       const [v, setV] = useState('');
-      return (
-        <Textarea
-          aria-label="Notes"
-          value={v}
-          onChange={(e) => setV(e.target.value)}
-        />
-      );
+      return <Textarea aria-label="Notes" value={v} onChange={(e) => setV(e.target.value)} />;
     }
     render(<Controlled />);
     const textarea = screen.getByRole('textbox');
@@ -139,10 +124,7 @@ describe('<Textarea>', () => {
     let stubbedScrollHeight = 0;
 
     beforeAll(() => {
-      originalDescriptor = Object.getOwnPropertyDescriptor(
-        HTMLElement.prototype,
-        'scrollHeight',
-      );
+      originalDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
       Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
         configurable: true,
         get() {
@@ -153,11 +135,7 @@ describe('<Textarea>', () => {
 
     afterAll(() => {
       if (originalDescriptor) {
-        Object.defineProperty(
-          HTMLElement.prototype,
-          'scrollHeight',
-          originalDescriptor,
-        );
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalDescriptor);
       } else {
         // @ts-expect-error — restoring to no descriptor
         delete HTMLTextAreaElement.prototype.scrollHeight;
@@ -174,9 +152,7 @@ describe('<Textarea>', () => {
 
     it('autoGrow=false leaves inline height unset', () => {
       stubbedScrollHeight = 200;
-      const { container } = render(
-        <Textarea aria-label="Notes" autoGrow={false} />,
-      );
+      const { container } = render(<Textarea aria-label="Notes" autoGrow={false} />);
       const textarea = container.querySelector('textarea')!;
       expect(textarea.style.height).toBe('');
     });
@@ -184,9 +160,7 @@ describe('<Textarea>', () => {
     it('maxRows clamps the inline height + sets overflowY to auto past the ceiling', () => {
       // Big scrollHeight so we'd exceed the cap.
       stubbedScrollHeight = 10000;
-      const { container } = render(
-        <Textarea aria-label="Notes" minRows={2} maxRows={4} />,
-      );
+      const { container } = render(<Textarea aria-label="Notes" minRows={2} maxRows={4} />);
       const textarea = container.querySelector('textarea')!;
       // overflowY should be 'auto' (we're past the cap).
       expect(textarea.style.overflowY).toBe('auto');
@@ -207,13 +181,7 @@ describe('<Textarea>', () => {
       stubbedScrollHeight = 50;
       function Controlled() {
         const [v, setV] = useState('');
-        return (
-          <Textarea
-            aria-label="Notes"
-            value={v}
-            onChange={(e) => setV(e.target.value)}
-          />
-        );
+        return <Textarea aria-label="Notes" value={v} onChange={(e) => setV(e.target.value)} />;
       }
       const { container } = render(<Controlled />);
       const textarea = container.querySelector('textarea')!;
@@ -230,36 +198,26 @@ describe('<Textarea>', () => {
   // ─── Resize handle ─────────────────────────────────────────────────────
 
   it('resize defaults to "vertical" when autoGrow is false', () => {
-    const { container } = render(
-      <Textarea aria-label="Notes" autoGrow={false} />,
-    );
-    expect(container.querySelector('textarea')!.className).toMatch(
-      /resizeVertical/,
-    );
+    const { container } = render(<Textarea aria-label="Notes" autoGrow={false} />);
+    expect(container.querySelector('textarea')!.className).toMatch(/resizeVertical/);
   });
 
   it('resize is forced to "none" when autoGrow is true (even if vertical passed)', () => {
-    const { container } = render(
-      <Textarea aria-label="Notes" autoGrow={true} resize="vertical" />,
-    );
+    const { container } = render(<Textarea aria-label="Notes" autoGrow={true} resize="vertical" />);
     const textarea = container.querySelector('textarea')!;
     expect(textarea.className).toMatch(/resizeNone/);
     expect(textarea.className).not.toMatch(/resizeVertical/);
   });
 
   it('resize="both" applies the right class when autoGrow=false', () => {
-    const { container } = render(
-      <Textarea aria-label="Notes" autoGrow={false} resize="both" />,
-    );
+    const { container } = render(<Textarea aria-label="Notes" autoGrow={false} resize="both" />);
     expect(container.querySelector('textarea')!.className).toMatch(/resizeBoth/);
   });
 
   // ─── Counter ───────────────────────────────────────────────────────────
 
   it('counter shows automatically when maxLength is set', () => {
-    render(
-      <Textarea aria-label="Notes" maxLength={140} defaultValue="hi" />,
-    );
+    render(<Textarea aria-label="Notes" maxLength={140} defaultValue="hi" />);
     expect(screen.getByText('2 / 140')).toBeInTheDocument();
   });
 
@@ -269,14 +227,7 @@ describe('<Textarea>', () => {
   });
 
   it('counter is hidden when showCount=false even if maxLength is set', () => {
-    render(
-      <Textarea
-        aria-label="Notes"
-        maxLength={140}
-        showCount={false}
-        defaultValue="hi"
-      />,
-    );
+    render(<Textarea aria-label="Notes" maxLength={140} showCount={false} defaultValue="hi" />);
     expect(screen.queryByText(/\/\s*140/)).not.toBeInTheDocument();
   });
 
@@ -295,9 +246,7 @@ describe('<Textarea>', () => {
   });
 
   it('counter has aria-live="polite" and aria-atomic="true"', () => {
-    const { container } = render(
-      <Textarea aria-label="Notes" maxLength={140} />,
-    );
+    const { container } = render(<Textarea aria-label="Notes" maxLength={140} />);
     const counter = container.querySelector('span[aria-live]')!;
     expect(counter).toHaveAttribute('aria-live', 'polite');
     expect(counter).toHaveAttribute('aria-atomic', 'true');

--- a/packages/design-system/src/components/Textarea/Textarea.tsx
+++ b/packages/design-system/src/components/Textarea/Textarea.tsx
@@ -1,0 +1,280 @@
+import {
+  forwardRef,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type TextareaHTMLAttributes,
+} from 'react';
+import clsx from 'clsx';
+import styles from './Textarea.module.scss';
+
+/**
+ * Field typography + padding scale. Pairs with Input's `size`.
+ *
+ * Unlike Input, size does NOT affect the textarea's height — height is
+ * driven by `minRows` (and capped by `maxRows` if auto-grow is on).
+ */
+export type TextareaSize = 'sm' | 'md' | 'lg';
+
+/** User-drag resize handle direction. Maps to CSS `resize`. */
+export type TextareaResize = 'none' | 'vertical' | 'both';
+
+export interface TextareaProps
+  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'size' | 'rows'> {
+  /**
+   * Toggles the error visual (red border + danger focus ring) and sets
+   * `aria-invalid="true"`. Pair with a visible error message and an
+   * `aria-describedby` pointer at the message id.
+   */
+  invalid?: boolean;
+
+  /**
+   * Visual size. Defaults to `'md'`.
+   * - `'sm'` — tighter padding + `--font-size-sm`. Used in dense forms.
+   * - `'md'` — default padding + `--font-size-md`. Most form contexts.
+   * - `'lg'` — same padding as md but `--font-size-lg`. Hero / focus textareas.
+   *
+   * Note: this collapses the native HTML `<textarea size>` attribute. Use
+   * `style={{ width }}` or a parent container for explicit width.
+   */
+  size?: TextareaSize;
+
+  /**
+   * Block browser autofill AND password managers from offering to fill
+   * this textarea. Same heuristic as Input — see Input's JSDoc for the
+   * full set of opt-out attributes applied.
+   *
+   * Smart default: when omitted, block iff `autoComplete` is also omitted
+   * (or `'off'`). Explicit autocomplete hints opt back IN to autofill.
+   * Pass `true` to force-block, `false` to force-allow.
+   */
+  disableAutofill?: boolean;
+
+  /**
+   * Minimum visible rows. The textarea never renders shorter than this,
+   * regardless of content. Default: `3`. Also seeds the native `rows`
+   * attribute for SSR / no-JS rendering.
+   */
+  minRows?: number;
+
+  /**
+   * Maximum visible rows. Beyond this, content scrolls inside the field
+   * instead of expanding further. Only meaningful when `autoGrow` is true.
+   * Default: `undefined` (unbounded growth).
+   */
+  maxRows?: number;
+
+  /**
+   * When true, height adapts to content between `minRows` and `maxRows`.
+   * Default: `true`. When false, height locks at `minRows` and a scrollbar
+   * appears past it.
+   */
+  autoGrow?: boolean;
+
+  /**
+   * User-drag resize handle direction. Default: `'vertical'`.
+   *
+   * **Forced to `'none'`** when `autoGrow` is `true` — user-drag fights
+   * the auto-grow measurement and produces erratic behavior. To enable
+   * a resize handle, opt out of auto-grow with `autoGrow={false}`.
+   */
+  resize?: TextareaResize;
+
+  /**
+   * Show the character counter (`${value.length}` or
+   * `${value.length} / ${maxLength}` when both are set).
+   *
+   * Default: `true` when `maxLength` is set, `false` otherwise.
+   *
+   * The counter renders as a `<span aria-live="polite" aria-atomic="true">`
+   * inside the wrapper, below the textarea. It updates on every input —
+   * works for both controlled and uncontrolled textareas.
+   */
+  showCount?: boolean;
+}
+
+const AUTOFILL_DISABLED_PROPS = {
+  autoComplete: 'off' as const,
+  'data-1p-ignore': '' as const,
+  'data-lpignore': 'true' as const,
+  'data-form-type': 'other' as const,
+};
+
+const SIZE_CLASS: Record<TextareaSize, string> = {
+  sm: styles.sizeSm,
+  md: styles.sizeMd,
+  lg: styles.sizeLg,
+};
+
+const RESIZE_CLASS: Record<TextareaResize, string> = {
+  none: styles.resizeNone,
+  vertical: styles.resizeVertical,
+  both: styles.resizeBoth,
+};
+
+/**
+ * Multi-line text input. The dumb companion to `<Input>` — same `invalid` +
+ * `disableAutofill` smart-default behavior, plus auto-grow, resize-handle
+ * direction, and an optional character counter.
+ *
+ * Forwards the `<textarea>` element via ref (not the wrapper div). All
+ * native textarea attributes pass through except `size` (shadowed by the
+ * component-level size prop) and `rows` (computed from `minRows`).
+ *
+ * Always renders a `<div>` wrapper so the optional counter has a place
+ * to live — unlike Input, which is a single `<input>`.
+ *
+ * @example
+ * // Default — auto-grows, 3 min rows.
+ * <Textarea placeholder="Write something…" />
+ *
+ * @example
+ * // Twitter-style counter, controlled.
+ * <Textarea
+ *   maxLength={140}
+ *   value={value}
+ *   onChange={(e) => setValue(e.target.value)}
+ * />
+ *
+ * @example
+ * // Fixed rows + drag-to-resize.
+ * <Textarea autoGrow={false} minRows={4} resize="vertical" />
+ *
+ * @example
+ * // Error state.
+ * <Textarea invalid aria-describedby="bio-error" />
+ * <p id="bio-error">Bio is required.</p>
+ *
+ * @remarks When NOT to use
+ * - Single-line text → use `<Input>`.
+ * - Choosing from a fixed list → use `<Select>`.
+ * - Rich text editing / mentions / markdown → no shipped primitive yet.
+ * - Password fields → use `<PasswordInput>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Using `placeholder` as a label. Placeholders disappear on focus.
+ * - ❌ Setting both `autoGrow={true}` AND expecting `resize="vertical"`
+ *   to render a drag handle. Auto-grow wins; the handle is hidden.
+ * - ❌ Building a separate character counter outside the component when
+ *   `maxLength` / `showCount` would do it.
+ */
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  function Textarea(
+    {
+      invalid,
+      size = 'md',
+      disableAutofill,
+      minRows = 3,
+      maxRows,
+      autoGrow = true,
+      resize = 'vertical',
+      showCount,
+      className,
+      value,
+      defaultValue,
+      onChange,
+      maxLength,
+      ...props
+    },
+    ref,
+  ) {
+    // Merge external ref with internal ref so we don't lose either.
+    const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+    const setRefs = useCallback(
+      (node: HTMLTextAreaElement | null) => {
+        textareaRef.current = node;
+        if (typeof ref === 'function') ref(node);
+        else if (ref) ref.current = node;
+      },
+      [ref],
+    );
+
+    // Internal value mirror — keeps the counter in sync for uncontrolled
+    // inputs. For controlled inputs, currentValue tracks `value` directly.
+    const [internalValue, setInternalValue] = useState<string>(() =>
+      typeof defaultValue === 'string' ? defaultValue : '',
+    );
+    const isControlled = value !== undefined;
+    const currentValue = isControlled ? String(value) : internalValue;
+
+    const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+      if (!isControlled) setInternalValue(e.target.value);
+      onChange?.(e);
+    };
+
+    // Auto-grow: synchronously after render, reset height to auto, then
+    // set to scrollHeight clamped between minRows and maxRows.
+    useLayoutEffect(() => {
+      if (!autoGrow) return;
+      const el = textareaRef.current;
+      if (!el) return;
+
+      el.style.height = 'auto';
+
+      const computed = window.getComputedStyle(el);
+      const lineHeight = parseFloat(computed.lineHeight);
+      const paddingY =
+        parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
+      const borderY =
+        parseFloat(computed.borderTopWidth) +
+        parseFloat(computed.borderBottomWidth);
+
+      const minHeight = lineHeight * minRows + paddingY + borderY;
+      const maxHeight =
+        maxRows !== undefined
+          ? lineHeight * maxRows + paddingY + borderY
+          : Infinity;
+
+      const desired = el.scrollHeight + borderY;
+      const target = Math.min(Math.max(desired, minHeight), maxHeight);
+      el.style.height = `${target}px`;
+      el.style.overflowY = desired > maxHeight ? 'auto' : 'hidden';
+    }, [currentValue, autoGrow, minRows, maxRows, size]);
+
+    // Smart autofill default — same heuristic as Input.
+    const hasAutocompleteHint =
+      typeof props.autoComplete === 'string' && props.autoComplete !== 'off';
+    const blockAutofill = disableAutofill ?? !hasAutocompleteHint;
+
+    // Effective resize: auto-grow forces 'none' because user-drag and
+    // measured-height fight each other.
+    const effectiveResize: TextareaResize = autoGrow ? 'none' : resize;
+
+    const shouldShowCount = showCount ?? maxLength !== undefined;
+
+    return (
+      <div className={styles.wrapper}>
+        <textarea
+          ref={setRefs}
+          rows={minRows}
+          aria-invalid={invalid || undefined}
+          {...(blockAutofill ? AUTOFILL_DISABLED_PROPS : {})}
+          value={value}
+          defaultValue={defaultValue}
+          maxLength={maxLength}
+          {...props}
+          onChange={handleChange}
+          className={clsx(
+            styles.textarea,
+            SIZE_CLASS[size],
+            RESIZE_CLASS[effectiveResize],
+            invalid && styles.invalid,
+            className,
+          )}
+        />
+        {shouldShowCount && (
+          <span
+            className={styles.counter}
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {currentValue.length}
+            {maxLength !== undefined && ` / ${maxLength}`}
+          </span>
+        )}
+      </div>
+    );
+  },
+);

--- a/packages/design-system/src/components/Textarea/Textarea.tsx
+++ b/packages/design-system/src/components/Textarea/Textarea.tsx
@@ -214,12 +214,15 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       el.style.height = 'auto';
 
       const computed = window.getComputedStyle(el);
-      const lineHeight = parseFloat(computed.lineHeight);
+      // jsdom may return 'normal' for lineHeight — fall back to 0 so the
+      // math degrades gracefully (minHeight becomes 0, target = scrollHeight).
+      const lineHeight = parseFloat(computed.lineHeight) || 0;
       const paddingY =
-        parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
+        (parseFloat(computed.paddingTop) || 0) +
+        (parseFloat(computed.paddingBottom) || 0);
       const borderY =
-        parseFloat(computed.borderTopWidth) +
-        parseFloat(computed.borderBottomWidth);
+        (parseFloat(computed.borderTopWidth) || 0) +
+        (parseFloat(computed.borderBottomWidth) || 0);
 
       const minHeight = lineHeight * minRows + paddingY + borderY;
       const maxHeight =
@@ -250,6 +253,8 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           ref={setRefs}
           rows={minRows}
           aria-invalid={invalid || undefined}
+          // Autofill blocking goes before {...props} — matches Input's spread
+          // order. Consumer's autoComplete wins; data-* opt-outs still apply.
           {...(blockAutofill ? AUTOFILL_DISABLED_PROPS : {})}
           value={value}
           defaultValue={defaultValue}

--- a/packages/design-system/src/components/Textarea/Textarea.tsx
+++ b/packages/design-system/src/components/Textarea/Textarea.tsx
@@ -21,8 +21,10 @@ export type TextareaSize = 'sm' | 'md' | 'lg';
 /** User-drag resize handle direction. Maps to CSS `resize`. */
 export type TextareaResize = 'none' | 'vertical' | 'both';
 
-export interface TextareaProps
-  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'size' | 'rows'> {
+export interface TextareaProps extends Omit<
+  TextareaHTMLAttributes<HTMLTextAreaElement>,
+  'size' | 'rows'
+> {
   /**
    * Toggles the error visual (red border + danger focus ring) and sets
    * `aria-invalid="true"`. Pair with a visible error message and an
@@ -160,137 +162,126 @@ const RESIZE_CLASS: Record<TextareaResize, string> = {
  * - ❌ Building a separate character counter outside the component when
  *   `maxLength` / `showCount` would do it.
  */
-export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  function Textarea(
-    {
-      invalid,
-      size = 'md',
-      disableAutofill,
-      minRows = 3,
-      maxRows,
-      autoGrow = true,
-      resize = 'vertical',
-      showCount,
-      className,
-      value,
-      defaultValue,
-      onChange,
-      maxLength,
-      ...props
-    },
-    ref,
-  ) {
-    // Merge external ref with internal ref so we don't lose either.
-    const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-    const setRefs = useCallback(
-      (node: HTMLTextAreaElement | null) => {
-        textareaRef.current = node;
-        if (typeof ref === 'function') ref(node);
-        else if (ref) ref.current = node;
-      },
-      [ref],
-    );
-
-    // Internal value mirror — keeps the counter in sync for uncontrolled
-    // inputs. For controlled inputs, currentValue tracks `value` directly.
-    const [internalValue, setInternalValue] = useState<string>(() => {
-      if (defaultValue == null) return '';
-      return String(defaultValue);
-    });
-    const isControlled = value !== undefined;
-    const currentValue = isControlled ? String(value) : internalValue;
-
-    const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-      if (!isControlled) setInternalValue(e.target.value);
-      onChange?.(e);
-    };
-
-    // Auto-grow: synchronously after render, reset height to auto, then
-    // set to scrollHeight clamped between minRows and maxRows.
-    useLayoutEffect(() => {
-      const el = textareaRef.current;
-      if (!el) return;
-
-      if (!autoGrow) {
-        // Clear any prior auto-grow inline styles so toggling autoGrow OFF
-        // returns control to the native textarea (rows attribute + user drag).
-        el.style.height = '';
-        el.style.overflowY = '';
-        return;
-      }
-
-      // Reset to 'auto' first so scrollHeight reflects content, not the prior height.
-      el.style.height = 'auto';
-
-      const computed = window.getComputedStyle(el);
-      // jsdom may return 'normal' for lineHeight — fall back to 0 so the
-      // math degrades gracefully (minHeight becomes 0, target = scrollHeight).
-      const lineHeight = parseFloat(computed.lineHeight) || 0;
-      const paddingY =
-        (parseFloat(computed.paddingTop) || 0) +
-        (parseFloat(computed.paddingBottom) || 0);
-      const borderY =
-        (parseFloat(computed.borderTopWidth) || 0) +
-        (parseFloat(computed.borderBottomWidth) || 0);
-
-      const minHeight = lineHeight * minRows + paddingY + borderY;
-      const maxHeight =
-        maxRows !== undefined
-          ? lineHeight * maxRows + paddingY + borderY
-          : Infinity;
-
-      const desired = el.scrollHeight + borderY;
-      const target = Math.min(Math.max(desired, minHeight), maxHeight);
-      el.style.height = `${target}px`;
-      el.style.overflowY = desired > maxHeight ? 'auto' : 'hidden';
-      // NOTE: `size` is in the deps array because it changes padding, which
-      // changes paddingY in the math above. Don't remove it.
-    }, [currentValue, autoGrow, minRows, maxRows, size]);
-
-    // Smart autofill default — same heuristic as Input.
-    const hasAutocompleteHint =
-      typeof props.autoComplete === 'string' && props.autoComplete !== 'off';
-    const blockAutofill = disableAutofill ?? !hasAutocompleteHint;
-
-    // Effective resize: auto-grow forces 'none' because user-drag and
-    // measured-height fight each other.
-    const effectiveResize: TextareaResize = autoGrow ? 'none' : resize;
-
-    const shouldShowCount = showCount ?? maxLength !== undefined;
-
-    return (
-      <div className={styles.wrapper}>
-        <textarea
-          ref={setRefs}
-          rows={minRows}
-          aria-invalid={invalid || undefined}
-          // Autofill blocking goes before {...props} — matches Input's spread
-          // order. Consumer's autoComplete wins; data-* opt-outs still apply.
-          {...(blockAutofill ? AUTOFILL_DISABLED_PROPS : {})}
-          value={value}
-          defaultValue={defaultValue}
-          maxLength={maxLength}
-          {...props}
-          onChange={handleChange}
-          className={clsx(
-            styles.textarea,
-            SIZE_CLASS[size],
-            RESIZE_CLASS[effectiveResize],
-            invalid && styles.invalid,
-            className,
-          )}
-        />
-        {shouldShowCount && (
-          <span
-            className={styles.counter}
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {currentValue.length}
-            {maxLength !== undefined && ` / ${maxLength}`}
-          </span>
-        )}
-      </div>
-    );
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  {
+    invalid,
+    size = 'md',
+    disableAutofill,
+    minRows = 3,
+    maxRows,
+    autoGrow = true,
+    resize = 'vertical',
+    showCount,
+    className,
+    value,
+    defaultValue,
+    onChange,
+    maxLength,
+    ...props
   },
-);
+  ref,
+) {
+  // Merge external ref with internal ref so we don't lose either.
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const setRefs = useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      textareaRef.current = node;
+      if (typeof ref === 'function') ref(node);
+      else if (ref) ref.current = node;
+    },
+    [ref],
+  );
+
+  // Internal value mirror — keeps the counter in sync for uncontrolled
+  // inputs. For controlled inputs, currentValue tracks `value` directly.
+  const [internalValue, setInternalValue] = useState<string>(() => {
+    if (defaultValue == null) return '';
+    return String(defaultValue);
+  });
+  const isControlled = value !== undefined;
+  const currentValue = isControlled ? String(value) : internalValue;
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    if (!isControlled) setInternalValue(e.target.value);
+    onChange?.(e);
+  };
+
+  // Auto-grow: synchronously after render, reset height to auto, then
+  // set to scrollHeight clamped between minRows and maxRows.
+  useLayoutEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+
+    if (!autoGrow) {
+      // Clear any prior auto-grow inline styles so toggling autoGrow OFF
+      // returns control to the native textarea (rows attribute + user drag).
+      el.style.height = '';
+      el.style.overflowY = '';
+      return;
+    }
+
+    // Reset to 'auto' first so scrollHeight reflects content, not the prior height.
+    el.style.height = 'auto';
+
+    const computed = window.getComputedStyle(el);
+    // jsdom may return 'normal' for lineHeight — fall back to 0 so the
+    // math degrades gracefully (minHeight becomes 0, target = scrollHeight).
+    const lineHeight = parseFloat(computed.lineHeight) || 0;
+    const paddingY =
+      (parseFloat(computed.paddingTop) || 0) + (parseFloat(computed.paddingBottom) || 0);
+    const borderY =
+      (parseFloat(computed.borderTopWidth) || 0) + (parseFloat(computed.borderBottomWidth) || 0);
+
+    const minHeight = lineHeight * minRows + paddingY + borderY;
+    const maxHeight = maxRows !== undefined ? lineHeight * maxRows + paddingY + borderY : Infinity;
+
+    const desired = el.scrollHeight + borderY;
+    const target = Math.min(Math.max(desired, minHeight), maxHeight);
+    el.style.height = `${target}px`;
+    el.style.overflowY = desired > maxHeight ? 'auto' : 'hidden';
+    // NOTE: `size` is in the deps array because it changes padding, which
+    // changes paddingY in the math above. Don't remove it.
+  }, [currentValue, autoGrow, minRows, maxRows, size]);
+
+  // Smart autofill default — same heuristic as Input.
+  const hasAutocompleteHint =
+    typeof props.autoComplete === 'string' && props.autoComplete !== 'off';
+  const blockAutofill = disableAutofill ?? !hasAutocompleteHint;
+
+  // Effective resize: auto-grow forces 'none' because user-drag and
+  // measured-height fight each other.
+  const effectiveResize: TextareaResize = autoGrow ? 'none' : resize;
+
+  const shouldShowCount = showCount ?? maxLength !== undefined;
+
+  return (
+    <div className={styles.wrapper}>
+      <textarea
+        ref={setRefs}
+        rows={minRows}
+        aria-invalid={invalid || undefined}
+        // Autofill blocking goes before {...props} — matches Input's spread
+        // order. Consumer's autoComplete wins; data-* opt-outs still apply.
+        {...(blockAutofill ? AUTOFILL_DISABLED_PROPS : {})}
+        value={value}
+        defaultValue={defaultValue}
+        maxLength={maxLength}
+        {...props}
+        onChange={handleChange}
+        className={clsx(
+          styles.textarea,
+          SIZE_CLASS[size],
+          RESIZE_CLASS[effectiveResize],
+          invalid && styles.invalid,
+          className,
+        )}
+      />
+      {shouldShowCount && (
+        <span className={styles.counter} aria-live="polite" aria-atomic="true">
+          {currentValue.length}
+          {maxLength !== undefined && ` / ${maxLength}`}
+        </span>
+      )}
+    </div>
+  );
+});

--- a/packages/design-system/src/components/Textarea/Textarea.tsx
+++ b/packages/design-system/src/components/Textarea/Textarea.tsx
@@ -193,9 +193,10 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 
     // Internal value mirror — keeps the counter in sync for uncontrolled
     // inputs. For controlled inputs, currentValue tracks `value` directly.
-    const [internalValue, setInternalValue] = useState<string>(() =>
-      typeof defaultValue === 'string' ? defaultValue : '',
-    );
+    const [internalValue, setInternalValue] = useState<string>(() => {
+      if (defaultValue == null) return '';
+      return String(defaultValue);
+    });
     const isControlled = value !== undefined;
     const currentValue = isControlled ? String(value) : internalValue;
 
@@ -207,10 +208,18 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     // Auto-grow: synchronously after render, reset height to auto, then
     // set to scrollHeight clamped between minRows and maxRows.
     useLayoutEffect(() => {
-      if (!autoGrow) return;
       const el = textareaRef.current;
       if (!el) return;
 
+      if (!autoGrow) {
+        // Clear any prior auto-grow inline styles so toggling autoGrow OFF
+        // returns control to the native textarea (rows attribute + user drag).
+        el.style.height = '';
+        el.style.overflowY = '';
+        return;
+      }
+
+      // Reset to 'auto' first so scrollHeight reflects content, not the prior height.
       el.style.height = 'auto';
 
       const computed = window.getComputedStyle(el);
@@ -234,6 +243,8 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       const target = Math.min(Math.max(desired, minHeight), maxHeight);
       el.style.height = `${target}px`;
       el.style.overflowY = desired > maxHeight ? 'auto' : 'hidden';
+      // NOTE: `size` is in the deps array because it changes padding, which
+      // changes paddingY in the math above. Don't remove it.
     }, [currentValue, autoGrow, minRows, maxRows, size]);
 
     // Smart autofill default — same heuristic as Input.

--- a/packages/design-system/src/components/Textarea/index.ts
+++ b/packages/design-system/src/components/Textarea/index.ts
@@ -1,0 +1,2 @@
+export { Textarea } from './Textarea';
+export type { TextareaProps, TextareaSize, TextareaResize } from './Textarea';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -179,6 +179,9 @@ export type { PaginationProps, PaginationSize, PaginationItem } from './componen
 export { CursorPagination } from './components/CursorPagination';
 export type { CursorPaginationProps } from './components/CursorPagination';
 
+export { Textarea } from './components/Textarea';
+export type { TextareaProps, TextareaSize, TextareaResize } from './components/Textarea';
+
 export { DataTable, useDataTable, ColumnVisibilityTrigger } from './components/DataTable';
 export type {
   DataTableProps,

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -17,6 +17,7 @@ import { PaginationDemo } from './pages/components/PaginationDemo';
 import { SelectDemo } from './pages/components/SelectDemo';
 import { SkeletonDemo } from './pages/components/SkeletonDemo';
 import { TableDemo } from './pages/components/TableDemo';
+import { TextareaDemo } from './pages/components/TextareaDemo';
 import { CardDemo } from './pages/components/CardDemo';
 import { CheckboxDemo } from './pages/components/CheckboxDemo';
 import { StackDemo } from './pages/components/StackDemo';
@@ -84,6 +85,7 @@ export default function App() {
           <Route path="/components/empty-state" element={<EmptyStateDemo />} />
           <Route path="/components/drawer" element={<DrawerDemo />} />
           <Route path="/components/grid" element={<GridDemo />} />
+          <Route path="/components/textarea" element={<TextareaDemo />} />
           <Route path="/components/toast" element={<ToastDemo />} />
         </Routes>
       </AppShell>

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -25,6 +25,7 @@ import {
   Layers,
   ArrowRight,
   MessageSquare,
+  MessageSquareText,
   AppWindow,
   MoreHorizontal,
   KeyRound,
@@ -86,6 +87,7 @@ const componentGroups = [
       },
       { to: '/components/radio', label: 'Radio', icon: CircleDot, end: false },
       { to: '/components/select', label: 'Select', icon: ChevronsUpDown, end: false },
+      { to: '/components/textarea', label: 'Textarea', icon: MessageSquareText, end: false },
     ],
   },
   {

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -360,12 +360,7 @@ const items: { to: string; name: string; description: string; preview: React.Rea
     name: 'Textarea',
     description: 'Multi-line text with auto-grow + character counter.',
     preview: (
-      <Textarea
-        minRows={2}
-        autoGrow={false}
-        defaultValue="Multi-line text…"
-        aria-label="Preview"
-      />
+      <Textarea minRows={2} autoGrow={false} defaultValue="Multi-line text…" aria-label="Preview" />
     ),
   },
   {

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -16,6 +16,7 @@ import { Skeleton } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { Table } from '@eocrm/design-system';
 import { Tabs } from '@eocrm/design-system';
+import { Textarea } from '@eocrm/design-system';
 import { DropdownMenu } from '@eocrm/design-system';
 import { Tooltip } from '@eocrm/design-system';
 import { Calendar } from '@eocrm/design-system';
@@ -352,6 +353,19 @@ const items: { to: string; name: string; description: string; preview: React.Rea
           </DropdownMenu.Content>
         </DropdownMenu>
       </Cluster>
+    ),
+  },
+  {
+    to: '/components/textarea',
+    name: 'Textarea',
+    description: 'Multi-line text with auto-grow + character counter.',
+    preview: (
+      <Textarea
+        minRows={2}
+        autoGrow={false}
+        defaultValue="Multi-line text…"
+        aria-label="Preview"
+      />
     ),
   },
   {

--- a/packages/playground/src/pages/components/TextareaDemo.tsx
+++ b/packages/playground/src/pages/components/TextareaDemo.tsx
@@ -78,11 +78,7 @@ export function TextareaDemo() {
   onChange={(e) => setTweet(e.target.value)}
 />`}
       >
-        <Textarea
-          maxLength={140}
-          value={tweet}
-          onChange={(e) => setTweet(e.target.value)}
-        />
+        <Textarea maxLength={140} value={tweet} onChange={(e) => setTweet(e.target.value)} />
       </Example>
 
       <Example

--- a/packages/playground/src/pages/components/TextareaDemo.tsx
+++ b/packages/playground/src/pages/components/TextareaDemo.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { Cluster, Stack, Textarea } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Textarea/Textarea.tsx?raw';
+import scssSource from '@lib-source/components/Textarea/Textarea.module.scss?raw';
+
+export function TextareaDemo() {
+  const [tweet, setTweet] = useState("What's happening?");
+  const [autoGrowDemo, setAutoGrowDemo] = useState('');
+
+  return (
+    <DemoLayout
+      name="Textarea"
+      componentName="Textarea"
+      description="Multi-line text input. Auto-grows by default, optional character counter, configurable resize handle."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Textarea.tsx"
+      scssFilename="Textarea.module.scss"
+    >
+      <Example
+        title="Default"
+        description="Auto-grows on input, 3 row minimum, no max. Resize handle hidden because auto-grow is on."
+        code={`<Textarea placeholder="Write something…" />`}
+      >
+        <Textarea placeholder="Write something…" />
+      </Example>
+
+      <Example
+        title="Three sizes"
+        description="Size affects typography + padding only (height comes from minRows). Useful when matching Input alongside."
+        code={`<Textarea size="sm" minRows={2} placeholder="sm" />
+<Textarea size="md" minRows={2} placeholder="md" />
+<Textarea size="lg" minRows={2} placeholder="lg" />`}
+      >
+        <Stack gap="sm">
+          <Textarea size="sm" minRows={2} placeholder="sm" />
+          <Textarea size="md" minRows={2} placeholder="md" />
+          <Textarea size="lg" minRows={2} placeholder="lg" />
+        </Stack>
+      </Example>
+
+      <Example
+        title="Auto-grow in action (capped at 8 rows)"
+        description="Type multiple lines — the field expands up to 8 rows, then scrolls."
+        code={`<Textarea
+  minRows={2}
+  maxRows={8}
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+  placeholder="Try multiple lines…"
+/>`}
+      >
+        <Textarea
+          minRows={2}
+          maxRows={8}
+          value={autoGrowDemo}
+          onChange={(e) => setAutoGrowDemo(e.target.value)}
+          placeholder="Try multiple lines…"
+        />
+      </Example>
+
+      <Example
+        title="Fixed rows (no auto-grow) with resize handle"
+        description="Opting out of auto-grow lets the user drag the resize handle in the bottom-right corner."
+        code={`<Textarea autoGrow={false} minRows={4} resize="vertical" />`}
+      >
+        <Textarea autoGrow={false} minRows={4} resize="vertical" />
+      </Example>
+
+      <Example
+        title="Twitter-style counter"
+        description="When maxLength is set, the counter appears automatically. Controlled state shown."
+        code={`<Textarea
+  maxLength={140}
+  value={tweet}
+  onChange={(e) => setTweet(e.target.value)}
+/>`}
+      >
+        <Textarea
+          maxLength={140}
+          value={tweet}
+          onChange={(e) => setTweet(e.target.value)}
+        />
+      </Example>
+
+      <Example
+        title="Bare counter (no maxLength)"
+        description="showCount={true} forces the counter even without a hard limit — shows just the running count."
+        code={`<Textarea showCount minRows={3} placeholder="Free-form…" />`}
+      >
+        <Textarea showCount minRows={3} placeholder="Free-form…" />
+      </Example>
+
+      <Example
+        title="Error state"
+        description="invalid={true} adds the red border + danger focus ring. Pair with a visible error message via aria-describedby."
+        code={`<Textarea invalid aria-describedby="bio-error" defaultValue="" />
+<p id="bio-error" style={{ color: 'var(--color-danger)' }}>
+  Bio must not be empty.
+</p>`}
+      >
+        <Stack gap="sm">
+          <Textarea invalid aria-describedby="bio-error" defaultValue="" />
+          <p
+            id="bio-error"
+            style={{
+              color: 'var(--color-danger)',
+              margin: 0,
+              fontSize: 'var(--font-size-sm)',
+            }}
+          >
+            Bio must not be empty.
+          </p>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Disabled and readOnly"
+        description="Native attributes — same visual treatment as Input."
+        code={`<Textarea disabled defaultValue="Disabled — can't focus or edit." />
+<Textarea readOnly defaultValue="Read-only — focusable, content selectable, not editable." />`}
+      >
+        <Cluster gap="sm">
+          <Textarea disabled defaultValue="Disabled — can't focus or edit." />
+          <Textarea
+            readOnly
+            defaultValue="Read-only — focusable, content selectable, not editable."
+          />
+        </Cluster>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -33,6 +33,7 @@ export type ComponentName =
   | 'Stack'
   | 'Table'
   | 'Tabs'
+  | 'Textarea'
   | 'Toast'
   | 'Tooltip';
 


### PR DESCRIPTION
## Summary

- New \`<Textarea>\` — the dumb multi-line companion to \`<Input>\`.
- Auto-grow on by default (\`autoGrow={true}\`), capped by \`minRows\` / \`maxRows\`.
- Optional character counter — shows automatically when \`maxLength\` is set, force on/off via \`showCount\`.
- Configurable resize handle (\`'none' | 'vertical' | 'both'\`) — forced to \`'none'\` when auto-grow is on (they conflict).
- Same \`invalid\` + smart \`disableAutofill\` partial-block behavior as Input.
- Three sizes (\`'sm' | 'md' | 'lg'\`) — affect typography + padding only, NOT height. Height comes from \`minRows\`.
- No new packages, no new tokens.

## Design highlights

- **Single wrapper element.** \`<Textarea>\` always renders a \`<div>\` around the \`<textarea>\` so the optional counter has a place to live — unlike \`<Input>\`, which renders just \`<input>\`. Documented in JSDoc.
- **Ref targets the \`<textarea>\`**, not the wrapper. Consumers can \`.focus()\`, set \`.value\`, scroll, etc. Internal ref merger handles both the measurement ref and the consumer's ref.
- **\`useLayoutEffect\` for auto-grow** so the height adjustment happens synchronously before paint — no one-frame flicker between the old height and the new height.
- **Toggle-safe.** When the consumer flips \`autoGrow\` from \`true\` → \`false\`, the effect clears the prior inline \`height\` and \`overflowY\` instead of leaving the textarea stuck at the last measured height.
- **Internal value mirror handles both controlled and uncontrolled.** Counter and auto-grow both need a reactive \"current value\". For controlled, we use \`value\`. For uncontrolled, an internal \`useState\` mirrors via the wrapped \`onChange\`. Numeric/array \`defaultValue\` is coerced with \`String(...)\` to keep the counter in sync.
- **\`resize\` is silently forced to \`'none'\` when \`autoGrow={true}\`** — user-drag and \`scrollHeight\` measurement fight each other. JSDoc documents this.
- **Autofill behavior matches Input exactly.** Smart default: block iff no \`autoComplete\` hint. \`disableAutofill={true}\` is a partial block — consumer's \`autoComplete\` survives (browser sees the hint), but \`data-1p-ignore\` / \`data-lpignore\` / \`data-form-type\` ARE applied (password managers see the opt-out signal). This matches the contract Input's own test documents.

## Hard Rule 8

Two rounds with fresh-context reviewers (opus). Round 1 found 2 Important findings + 4 cheap items folded in:

1. **\`autoGrow\` toggle stale height** — the early-return now clears \`style.height\` and \`style.overflowY\` so the textarea returns to native behavior.
2. **Non-string \`defaultValue\` desyncing the counter** — mirror initialization coerces via \`String(...)\` for parity with the controlled path.
3. Struck \`(not yet shipped)\` from Input.tsx's JSDoc for Textarea AND PasswordInput (both shipped now).
4. Added a \`disableAutofill={false}\` force-allow test for parity with Input's coverage.

Round 2 verdict: clean enough to stop. 0 Critical + 0 Important.

All four gates green: \`make test\` (1357 passing) · \`make build-lib\` · \`make build\` · \`make lint\` · \`npm pack --dry-run\` (no test files in tarball).

## Test plan

- [ ] Default \`<Textarea />\` auto-grows as you type
- [ ] \`minRows={2} maxRows={8}\` caps growth at 8 rows then scrolls
- [ ] \`autoGrow={false}\` keeps the textarea at \`minRows\` and shows the drag handle
- [ ] Toggling \`autoGrow\` from \`true\` to \`false\` returns the textarea to native height behavior (no stale inline height)
- [ ] \`size=\"sm\" | \"md\" | \"lg\"\` change padding + font, not height
- [ ] \`maxLength={140}\` shows the counter automatically (e.g. \`5 / 140\`)
- [ ] \`showCount\` without \`maxLength\` shows just the count
- [ ] \`showCount={false}\` with \`maxLength\` set hides the counter
- [ ] Numeric \`defaultValue\` (e.g. \`123\`) shows correctly in the counter (\`3\`, not \`0\`)
- [ ] \`invalid\` adds red border and \`aria-invalid=\"true\"\`
- [ ] \`disableAutofill\` smart default blocks when no \`autoComplete\`, allows when set
- [ ] \`disableAutofill={true}\` keeps consumer's \`autoComplete\` but applies \`data-1p-ignore\` / \`data-lpignore\` / \`data-form-type\`
- [ ] \`disableAutofill={false}\` force-allows even without an \`autoComplete\` hint
- [ ] \`ref\` targets the \`<textarea>\` element (not the wrapper div)
- [ ] \`disabled\` and \`readOnly\` render the muted background visual
- [ ] Playground demo at \`/components/textarea\` renders all 8 examples without console errors
- [ ] Sidebar \`Forms\` group shows Textarea as the last item

🤖 Generated with [Claude Code](https://claude.com/claude-code)