### PR TITLE
Switch: binary toggle with tones + loading + invalid

### DIFF
--- a/docs/superpowers/plans/2026-05-23-switch.md
+++ b/docs/superpowers/plans/2026-05-23-switch.md
@@ -61,6 +61,7 @@ git log --oneline -3
 ```
 
 Expected:
+
 - Branch: `feat/switch`
 - Working tree clean
 - Most recent commit: `562fdca Switch: design spec — binary toggle with tones + loading + invalid`
@@ -252,7 +253,7 @@ Create `packages/design-system/src/components/Switch/Switch.module.scss`:
 
 Create `packages/design-system/src/components/Switch/Switch.tsx`:
 
-```tsx
+````tsx
 import {
   forwardRef,
   useState,
@@ -275,11 +276,10 @@ export type SwitchSize = 'sm' | 'md' | 'lg';
  */
 export type SwitchTone = 'accent' | 'success' | 'danger';
 
-export interface SwitchProps
-  extends Omit<
-    InputHTMLAttributes<HTMLInputElement>,
-    'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
-  > {
+export interface SwitchProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
+> {
   /**
    * Visual scale. Defaults to `'md'`.
    * - `'sm'` — 28×16 track, 12px thumb, `--font-size-sm` label.
@@ -440,9 +440,7 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(function Switch(
   },
   ref,
 ) {
-  const [internalChecked, setInternalChecked] = useState<boolean>(
-    defaultChecked ?? false,
-  );
+  const [internalChecked, setInternalChecked] = useState<boolean>(defaultChecked ?? false);
   const isControlled = checked !== undefined;
   const currentChecked = isControlled ? checked : internalChecked;
 
@@ -479,22 +477,14 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(function Switch(
         aria-hidden="true"
       >
         <span className={styles.thumb}>
-          {loading && (
-            <Loader2
-              size={SPIN_SIZE[size]}
-              className={styles.spin}
-              aria-hidden="true"
-            />
-          )}
+          {loading && <Loader2 size={SPIN_SIZE[size]} className={styles.spin} aria-hidden="true" />}
         </span>
       </span>
-      {children && (
-        <span className={clsx(styles.label, LABEL_CLASS[size])}>{children}</span>
-      )}
+      {children && <span className={clsx(styles.label, LABEL_CLASS[size])}>{children}</span>}
     </label>
   );
 });
-```
+````
 
 - [ ] **Step 4: Write the folder barrel**
 
@@ -514,6 +504,7 @@ make lint
 ```
 
 Expected: both clean. The inline `stylelint-disable` comments cover the visually-hidden recipe and the track/thumb absolute positioning. If stylelint flags anything else:
+
 - A blank line between sibling top-level rules (`.sizeSm` → `.sizeMd`) is a stylelint convention (`rule-empty-line-before`). Confirm the file has them.
 - A blank line between a comment and the rule it disables — `stylelint-disable-next-line` must be the IMMEDIATELY preceding line (no blank line between).
 
@@ -627,9 +618,7 @@ describe('<Switch>', () => {
   });
 
   it('className is merged onto the wrapper, not replaced', () => {
-    const { container } = render(
-      <Switch aria-label="x" className="custom-wrap" />,
-    );
+    const { container } = render(<Switch aria-label="x" className="custom-wrap" />);
     const wrapper = container.querySelector('label')!;
     expect(wrapper.className).toMatch(/custom-wrap/);
     expect(wrapper.className).toMatch(/wrapper/);
@@ -650,9 +639,7 @@ describe('<Switch>', () => {
   // ─── State ─────────────────────────────────────────────────────────────
 
   it('controlled: checked={true} reflects in the input AND data-checked on track', () => {
-    const { container } = render(
-      <Switch aria-label="x" checked onChange={() => {}} />,
-    );
+    const { container } = render(<Switch aria-label="x" checked onChange={() => {}} />);
     const input = screen.getByRole('switch') as HTMLInputElement;
     const track = container.querySelector('[data-tone]')!;
     expect(input.checked).toBe(true);
@@ -662,9 +649,7 @@ describe('<Switch>', () => {
   it('controlled: clicking the label fires onChange with the next boolean', async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
-    render(
-      <Switch aria-label="x" checked={false} onChange={handleChange} />,
-    );
+    render(<Switch aria-label="x" checked={false} onChange={handleChange} />);
     await user.click(screen.getByRole('switch'));
     expect(handleChange).toHaveBeenCalledTimes(1);
     expect(handleChange.mock.calls[0][0]).toBe(true);
@@ -780,6 +765,7 @@ npm test -w @eocrm/design-system -- --run src/components/Switch/Switch.test.tsx
 Expected: ~25 tests passing (24 top-level `it()` + 3 from `it.each` expanding to individual cases = 27 total in Vitest's count).
 
 If a test fails:
+
 - **"toBeDisabled is not a function"**: `@testing-library/jest-dom` is set up repo-wide; confirm the test file doesn't need explicit imports (it doesn't — vitest config wires globals).
 - **Spinner test failing**: the `[class*="spin"]` selector matches anything with `spin` in its className. If the SCSS class hash differs, this may still match because CSS modules append the local name. If it doesn't match, switch to querying the `Loader2` SVG path directly: `container.querySelector('svg[aria-hidden="true"]')` filtered to those INSIDE the thumb.
 - **Space-key test failing**: jsdom's native checkbox `Space` handling works when the input is focused. If `input.focus()` doesn't take effect, try `await user.tab()` from `document.body` and verify with `document.activeElement`.
@@ -840,7 +826,7 @@ The file may not be strictly alphabetical (recent additions get appended near th
 
 - [ ] **Step 2: Add TL;DR to AGENTS.md**
 
-Find the `### \`<Checkbox>\`` section header (around line 188) and the `### \`<Radio>\`` section header (around line 205). Insert the new Switch section between them.
+Find the `### \`<Checkbox>\``section header (around line 188) and the`### \`<Radio>\`` section header (around line 205). Insert the new Switch section between them.
 
 Use this content verbatim (copy from spec — keep the closing `````` mark intact):
 
@@ -1045,12 +1031,7 @@ const handleToggle = async (next: boolean) => {
   Two-factor auth
 </Switch>`}
       >
-        <Switch
-          checked={asyncEnabled}
-          loading={saving}
-          onChange={handleAsyncToggle}
-          tone="success"
-        >
+        <Switch checked={asyncEnabled} loading={saving} onChange={handleAsyncToggle} tone="success">
           Two-factor auth ({saving ? 'saving…' : asyncEnabled ? 'ON' : 'OFF'})
         </Switch>
       </Example>
@@ -1162,10 +1143,8 @@ Open `packages/playground/src/pages/mockups/registry.ts`. Find `export type Comp
 ```ts
 export type ComponentName =
   // …existing names through 'Stack'…
-  | 'Stack'
-  | 'Switch'
-  | 'Table'
-  // …rest…;
+  'Stack' | 'Switch' | 'Table';
+// …rest…;
 ```
 
 No existing mockup uses Switch yet, so no `usesComponents` arrays need updating.
@@ -1189,6 +1168,7 @@ PORT=8090 npm run dev
 ```
 
 Visit http://localhost:8090/components/switch. Verify:
+
 - Default switch toggles on click
 - Three sizes look proportional
 - Three tones show different checked-state colors
@@ -1246,6 +1226,7 @@ npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -E "Switch|test\."
 ```
 
 Expected:
+
 - Switch source files (`Switch.tsx`, `Switch.module.scss`, `index.ts`) in the tarball
 - NO `*.test.*` files
 
@@ -1260,6 +1241,7 @@ Use a `general-purpose` subagent with model `opus`. Prompt template (substitute 
 > Read first: `packages/design-system/CLAUDE.md` (Rules 1–7), `packages/design-system/AGENTS.md` (Switch section + the surrounding Checkbox/Radio sections for convention check), `docs/superpowers/specs/2026-05-23-switch-design.md`. Also peek at `packages/design-system/src/components/Checkbox/Checkbox.tsx` — Switch is supposed to mirror Checkbox's pattern for `onChange(checked, event)`, the visually-hidden input, and the wrapper-label.
 >
 > Verify:
+>
 > - **Rule 1**: `Switch.test.tsx` exists with ~24 cases. Spot-check coverage matches what the spec lists.
 > - **Rule 3**: no raw values in `Switch.module.scss` — every color/spacing/shadow/radius via `var(--…)`. The track/thumb pixel dimensions (28/16/etc.) are component-specific and acceptable per "tokens for tokens-eligible properties" interpretation.
 > - **Rule 4**: no `position` / `align-self` / `flex: 1` / margin at the component boundary on `.wrapper`. `position: absolute` on `.input` and `.thumb` is documented internal positioning with inline disables.

--- a/docs/superpowers/plans/2026-05-23-switch.md
+++ b/docs/superpowers/plans/2026-05-23-switch.md
@@ -1,0 +1,1379 @@
+# Switch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Switch>` — the binary on/off toggle that wraps a native `<input type="checkbox" role="switch">` with a hand-rolled track + sliding thumb. Three tones (accent/success/danger), a `loading` state with thumb-spinner for async toggles, and `invalid` parity with Input/Textarea.
+
+**Architecture:** A `forwardRef` component that renders `<label>` → `<input visually-hidden>` + `<span track>` + `<span thumb>` + optional `<span label>`. Internal-checked mirror keeps the `data-checked` track attribute reactive for both controlled and uncontrolled use. `loading` always disables the input (sets `aria-busy` + `disabled`) and renders a `Loader2` icon inside the thumb. Per-size CSS custom property (`--thumb-travel`) drives the `transform: translateX(...)` distance.
+
+**Tech Stack:** React 19 + TypeScript (source-distributed). `clsx` for class composition. `lucide-react` for the loading spinner (peer dep, used by Toast). CSS Modules + SCSS. Vitest + RTL + userEvent. No new packages, no new tokens.
+
+**Source of truth:** `docs/superpowers/specs/2026-05-23-switch-design.md` (commit `562fdca`).
+
+**Branch:** `feat/switch`. Commit per task. Open the PR after the Hard-Rule-8 cycle (Task 5).
+
+---
+
+## File Structure
+
+```
+packages/design-system/src/components/Switch/
+  Switch.tsx          ← Task 1. forwardRef + internal-checked mirror + custom onChange + visually-hidden input + track/thumb spans. Full JSDoc.
+  Switch.module.scss  ← Task 1. .wrapper / .input (visually-hidden) / .track / .thumb / .label + sm/md/lg sizes + accent/success/danger tones + invalid + reduced-motion.
+  index.ts            ← Task 1. Public re-exports (Switch + types).
+  Switch.test.tsx     ← Task 2. ~22 cases — RTL + userEvent.
+
+packages/design-system/src/index.ts                            ← Task 3. MODIFY: re-export Switch + types (alphabetical between Stack and Tabs)
+packages/design-system/AGENTS.md                               ← Task 3. MODIFY: TL;DR slot between <Checkbox> and <Radio>
+
+packages/playground/src/pages/components/SwitchDemo.tsx        ← Task 4. NEW: 7 examples
+packages/playground/src/App.tsx                                ← Task 4. MODIFY: route + import (alphabetical, after Select, before Skeleton)
+packages/playground/src/layout/AppShell/AppShell.tsx           ← Task 4. MODIFY: Forms group, between Select and PasswordStrengthMeter alphabetically (Switch comes after Select)
+packages/playground/src/pages/components/ComponentsIndex.tsx   ← Task 4. MODIFY: overview card (place near other form components)
+packages/playground/src/pages/mockups/registry.ts              ← Task 4. MODIFY: 'Switch' in ComponentName union (alphabetical between Stack and Table)
+```
+
+**Decomposition rationale:**
+
+- **Task 1 (source bundle)** keeps `Switch.tsx`, `Switch.module.scss`, `index.ts` together — they cross-reference. Same approach as Modal/Drawer/Textarea.
+- **Task 2 (tests)** lands separately so the ~400-line test diff is reviewable in isolation.
+- **Task 3 (exports + AGENTS)** is small and conceptually paired.
+- **Task 4 (playground)** bundles the demo + 4 nav touchpoints so the demo is routable in one commit.
+- **Task 5 (Hard-Rule-8)** — gates, fresh-context reviewer cycle, push, PR.
+
+---
+
+## Task 1 — Source bundle (Switch.tsx + SCSS + barrel)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Switch/Switch.tsx`
+- Create: `packages/design-system/src/components/Switch/Switch.module.scss`
+- Create: `packages/design-system/src/components/Switch/index.ts`
+
+- [ ] **Step 1: Verify branch + clean tree**
+
+```bash
+cd /home/dpws/projects/design-system
+git status
+git branch --show-current
+git log --oneline -3
+```
+
+Expected:
+- Branch: `feat/switch`
+- Working tree clean
+- Most recent commit: `562fdca Switch: design spec — binary toggle with tones + loading + invalid`
+
+- [ ] **Step 2: Create the component directory + write the SCSS**
+
+```bash
+mkdir -p packages/design-system/src/components/Switch
+```
+
+Create `packages/design-system/src/components/Switch/Switch.module.scss`:
+
+```scss
+@use '../../styles/mixins' as *;
+
+.wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+  user-select: none;
+
+  &[data-disabled='true'] {
+    cursor: not-allowed;
+    opacity: var(--opacity-disabled);
+  }
+}
+
+// Visually-hidden but interactive native input. Same recipe as
+// Checkbox/Radio's hidden inputs.
+.input {
+  /* stylelint-disable property-disallowed-list -- visually-hidden recipe */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+  /* stylelint-enable property-disallowed-list */
+}
+
+.track {
+  /* stylelint-disable-next-line property-disallowed-list -- internal child positioning for the thumb */
+  position: relative;
+  display: inline-block;
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-full);
+  border: var(--border-width) solid transparent;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+  flex-shrink: 0;
+
+  &:hover {
+    background: var(--color-bg-sunken);
+  }
+}
+
+.track[data-checked='true'][data-tone='accent'] {
+  background: var(--color-accent);
+}
+
+.track[data-checked='true'][data-tone='success'] {
+  background: var(--color-success);
+}
+
+.track[data-checked='true'][data-tone='danger'] {
+  background: var(--color-danger);
+}
+
+.track[data-checked='true'][data-tone='accent']:hover {
+  background: var(--color-accent-hover);
+}
+
+.track[data-checked='true'][data-tone='success']:hover {
+  background: var(--color-success-hover);
+}
+
+.track[data-checked='true'][data-tone='danger']:hover {
+  background: var(--color-danger-hover);
+}
+
+.track[data-invalid='true'] {
+  border-color: var(--color-danger);
+}
+
+.thumb {
+  /* stylelint-disable property-disallowed-list -- internal absolute positioning of the thumb inside the track */
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  /* stylelint-enable property-disallowed-list */
+  background: var(--color-bg);
+  border-radius: 50%;
+  transition: transform var(--transition-base);
+  display: grid;
+  place-items: center;
+}
+
+.track[data-checked='true'] .thumb {
+  transform: translateX(var(--thumb-travel, 14px));
+}
+
+// Sizes — set track dimensions, thumb diameter, and travel distance.
+.sizeSm {
+  width: 28px;
+  height: 16px;
+  --thumb-travel: 12px;
+}
+
+.sizeSm .thumb {
+  width: 12px;
+  height: 12px;
+}
+
+.sizeMd {
+  width: 36px;
+  height: 20px;
+  --thumb-travel: 14px;
+}
+
+.sizeMd .thumb {
+  width: 16px;
+  height: 16px;
+}
+
+.sizeLg {
+  width: 44px;
+  height: 24px;
+  --thumb-travel: 18px;
+}
+
+.sizeLg .thumb {
+  width: 20px;
+  height: 20px;
+}
+
+.label {
+  font-family: inherit;
+  color: var(--color-fg);
+}
+
+.labelSm {
+  font-size: var(--font-size-sm);
+}
+
+.labelMd {
+  font-size: var(--font-size-md);
+}
+
+.labelLg {
+  font-size: var(--font-size-lg);
+}
+
+// Focus ring on the track when the (visually-hidden) input is focus-visible.
+.input:focus-visible + .track {
+  @include focus-ring;
+}
+
+.input:focus-visible + .track[data-invalid='true'] {
+  @include focus-ring(var(--ring-danger));
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+  color: var(--color-fg-muted);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thumb,
+  .track,
+  .spin {
+    transition: none;
+    animation: none;
+  }
+}
+```
+
+- [ ] **Step 3: Write `Switch.tsx`**
+
+Create `packages/design-system/src/components/Switch/Switch.tsx`:
+
+```tsx
+import {
+  forwardRef,
+  useState,
+  type ChangeEvent,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from 'react';
+import { Loader2 } from 'lucide-react';
+import clsx from 'clsx';
+import styles from './Switch.module.scss';
+
+/**
+ * Track + thumb scale + label font. Pairs with Checkbox/Radio sizes.
+ */
+export type SwitchSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Color of the track when checked. Unchecked track is always
+ * `--color-bg-muted` regardless of tone.
+ */
+export type SwitchTone = 'accent' | 'success' | 'danger';
+
+export interface SwitchProps
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
+  > {
+  /**
+   * Visual scale. Defaults to `'md'`.
+   * - `'sm'` — 28×16 track, 12px thumb, `--font-size-sm` label.
+   * - `'md'` — 36×20 track, 16px thumb, `--font-size-md` label (default).
+   * - `'lg'` — 44×24 track, 20px thumb, `--font-size-lg` label.
+   *
+   * Note: shadows the native HTML `<input size>` attribute (meaningless on checkboxes).
+   */
+  size?: SwitchSize;
+
+  /**
+   * Track color when checked. Defaults to `'accent'`.
+   * - `'accent'` — blue (default).
+   * - `'success'` — green. Use for affirmative toggles ("Enable notifications").
+   * - `'danger'` — red. Use for destructive toggles ("Allow root access").
+   */
+  tone?: SwitchTone;
+
+  /**
+   * Controlled checked state. Pair with `onChange`. Omit (with optional
+   * `defaultChecked`) for uncontrolled use.
+   */
+  checked?: boolean;
+
+  /** Initial checked state for uncontrolled use. Defaults to `false`. */
+  defaultChecked?: boolean;
+
+  /**
+   * Fires when the user toggles the switch. The first arg is the next
+   * boolean (convenience); the original change event is the second arg.
+   * Matches `<Checkbox>`'s signature.
+   */
+  onChange?: (checked: boolean, e: ChangeEvent<HTMLInputElement>) => void;
+
+  /**
+   * Toggles `aria-invalid="true"` and adds a danger-tone border to the
+   * track. Use when the switch's state has caused a validation error.
+   */
+  invalid?: boolean;
+
+  /**
+   * Disables interaction and shows a spinner inside the thumb. Use for
+   * toggles that persist to a server. Sets `aria-busy="true"` and
+   * `disabled` on the native input so neither click nor Space-key can
+   * fire onChange while the async operation is in flight.
+   *
+   * The consumer is responsible for managing the optimistic-update flow:
+   *
+   * ```tsx
+   * const [enabled, setEnabled] = useState(initial);
+   * const [saving, setSaving] = useState(false);
+   *
+   * const handleToggle = async (next: boolean) => {
+   *   setSaving(true);
+   *   setEnabled(next);            // optimistic
+   *   try { await api.save(next); }
+   *   catch { setEnabled(!next); } // rollback
+   *   finally { setSaving(false); }
+   * };
+   *
+   * <Switch checked={enabled} loading={saving} onChange={handleToggle} />
+   * ```
+   */
+  loading?: boolean;
+
+  /**
+   * Label rendered next to the track. The whole `<label>` is the click
+   * target — clicking anywhere toggles. Omit for icon-only switches +
+   * pair with `aria-label`.
+   */
+  children?: ReactNode;
+}
+
+const SIZE_CLASS: Record<SwitchSize, string> = {
+  sm: styles.sizeSm,
+  md: styles.sizeMd,
+  lg: styles.sizeLg,
+};
+
+const LABEL_CLASS: Record<SwitchSize, string> = {
+  sm: styles.labelSm,
+  md: styles.labelMd,
+  lg: styles.labelLg,
+};
+
+const SPIN_SIZE: Record<SwitchSize, number> = {
+  sm: 8,
+  md: 10,
+  lg: 12,
+};
+
+/**
+ * Binary on/off toggle. Hand-rolled track + sliding thumb on a native
+ * `<input type="checkbox" role="switch">`. The dumb companion to
+ * `<Checkbox>` and `<Radio>` for binary state (settings, feature flags,
+ * server-persisted toggles).
+ *
+ * Forwards ref to the underlying `<input>`. Spread native attrs reach
+ * the input (e.g., `name`, `value`, `disabled`, `aria-label`).
+ *
+ * @example
+ * // Default — uncontrolled, accent tone.
+ * <Switch>Enable notifications</Switch>
+ *
+ * @example
+ * // Controlled, success tone.
+ * <Switch tone="success" checked={enabled} onChange={(next) => setEnabled(next)}>
+ *   Daily digest
+ * </Switch>
+ *
+ * @example
+ * // Async toggle with loading spinner.
+ * <Switch
+ *   checked={enabled}
+ *   loading={saving}
+ *   onChange={async (next) => {
+ *     setSaving(true);
+ *     setEnabled(next);
+ *     try { await api.save(next); }
+ *     catch { setEnabled(!next); }
+ *     finally { setSaving(false); }
+ *   }}
+ * >
+ *   Two-factor auth
+ * </Switch>
+ *
+ * @example
+ * // Icon-only.
+ * <Switch aria-label="Mute notifications" />
+ *
+ * @remarks When NOT to use
+ * - Mutually-exclusive choice → `<Radio>` / `<RadioGroup>`.
+ * - Multi-select list → `<Checkbox>`.
+ * - Mixed / indeterminate state → use Checkbox's `indeterminate`.
+ * - Immediate action without state → `<Button>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Using "ON" / "OFF" labels inside the track. Use a real adjacent label.
+ * - ❌ Setting `loading` without an external optimistic-update flow — the
+ *   user clicks, the spinner appears, the visual state never updates,
+ *   confusing.
+ * - ❌ `tone="success"` for "Mark as failed". Tone communicates the
+ *   meaning of the "on" state.
+ */
+export const Switch = forwardRef<HTMLInputElement, SwitchProps>(function Switch(
+  {
+    size = 'md',
+    tone = 'accent',
+    checked,
+    defaultChecked,
+    onChange,
+    invalid,
+    loading,
+    disabled,
+    children,
+    className,
+    ...props
+  },
+  ref,
+) {
+  const [internalChecked, setInternalChecked] = useState<boolean>(
+    defaultChecked ?? false,
+  );
+  const isControlled = checked !== undefined;
+  const currentChecked = isControlled ? checked : internalChecked;
+
+  // Loading implies disabled — blocks both click and Space-key toggles.
+  const isInteractionDisabled = disabled || loading;
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!isControlled) setInternalChecked(e.target.checked);
+    onChange?.(e.target.checked, e);
+  };
+
+  return (
+    <label
+      className={clsx(styles.wrapper, className)}
+      data-disabled={isInteractionDisabled || undefined}
+    >
+      <input
+        {...props}
+        ref={ref}
+        type="checkbox"
+        role="switch"
+        checked={currentChecked}
+        disabled={isInteractionDisabled}
+        aria-invalid={invalid || undefined}
+        aria-busy={loading || undefined}
+        onChange={handleChange}
+        className={styles.input}
+      />
+      <span
+        className={clsx(styles.track, SIZE_CLASS[size])}
+        data-checked={currentChecked ? 'true' : 'false'}
+        data-tone={tone}
+        data-invalid={invalid ? 'true' : undefined}
+        aria-hidden="true"
+      >
+        <span className={styles.thumb}>
+          {loading && (
+            <Loader2
+              size={SPIN_SIZE[size]}
+              className={styles.spin}
+              aria-hidden="true"
+            />
+          )}
+        </span>
+      </span>
+      {children && (
+        <span className={clsx(styles.label, LABEL_CLASS[size])}>{children}</span>
+      )}
+    </label>
+  );
+});
+```
+
+- [ ] **Step 4: Write the folder barrel**
+
+Create `packages/design-system/src/components/Switch/index.ts`:
+
+```ts
+export { Switch } from './Switch';
+export type { SwitchProps, SwitchSize, SwitchTone } from './Switch';
+```
+
+- [ ] **Step 5: Typecheck + lint**
+
+```bash
+cd /home/dpws/projects/design-system
+make build-lib
+make lint
+```
+
+Expected: both clean. The inline `stylelint-disable` comments cover the visually-hidden recipe and the track/thumb absolute positioning. If stylelint flags anything else:
+- A blank line between sibling top-level rules (`.sizeSm` → `.sizeMd`) is a stylelint convention (`rule-empty-line-before`). Confirm the file has them.
+- A blank line between a comment and the rule it disables — `stylelint-disable-next-line` must be the IMMEDIATELY preceding line (no blank line between).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Switch/Switch.tsx \
+        packages/design-system/src/components/Switch/Switch.module.scss \
+        packages/design-system/src/components/Switch/index.ts
+git commit -m "$(cat <<'EOF'
+Switch: source — track + sliding thumb on native checkbox
+
+forwardRef component wrapping a visually-hidden `<input type="checkbox"
+role="switch">` in a `<label>`, with painted track + sliding thumb spans.
+Internal-checked mirror keeps the `data-checked` track attribute reactive
+for both controlled and uncontrolled use. `loading={true}` forces disabled
+on the input AND renders a Loader2 spinner inside the thumb. Per-size CSS
+custom property (`--thumb-travel`) drives the `transform: translateX(...)`
+distance so each size has a precise thumb travel.
+
+Custom `onChange(checked, event)` signature matches Checkbox/Radio.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2 — Unit tests (`Switch.test.tsx`)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Switch/Switch.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+Create `packages/design-system/src/components/Switch/Switch.test.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Switch } from './Switch';
+
+describe('<Switch>', () => {
+  // ─── Baseline ──────────────────────────────────────────────────────────
+
+  it('renders without crashing with default props', () => {
+    render(<Switch aria-label="Notifications" />);
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+  });
+
+  it('renders the label from children', () => {
+    render(<Switch>Enable notifications</Switch>);
+    expect(screen.getByText('Enable notifications')).toBeInTheDocument();
+  });
+
+  it('icon-only works with aria-label and no children', () => {
+    render(<Switch aria-label="Mute" />);
+    expect(screen.getByRole('switch', { name: 'Mute' })).toBeInTheDocument();
+  });
+
+  it('defaults to size="md"', () => {
+    const { container } = render(<Switch aria-label="x" />);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track.className).toMatch(/sizeMd/);
+  });
+
+  it('size="sm" applies the sm class', () => {
+    const { container } = render(<Switch aria-label="x" size="sm" />);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track.className).toMatch(/sizeSm/);
+  });
+
+  it('size="lg" applies the lg class', () => {
+    const { container } = render(<Switch aria-label="x" size="lg" />);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track.className).toMatch(/sizeLg/);
+  });
+
+  it('defaults to tone="accent"', () => {
+    const { container } = render(<Switch aria-label="x" />);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track).toHaveAttribute('data-tone', 'accent');
+  });
+
+  it.each([
+    ['success', 'success'],
+    ['danger', 'danger'],
+    ['accent', 'accent'],
+  ] as const)('tone="%s" sets data-tone="%s"', (toneIn, toneOut) => {
+    const { container } = render(<Switch aria-label="x" tone={toneIn} />);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track).toHaveAttribute('data-tone', toneOut);
+  });
+
+  it('forwards ref to the <input> element', () => {
+    let captured: HTMLInputElement | null = null;
+    render(
+      <Switch
+        aria-label="x"
+        ref={(node) => {
+          captured = node;
+        }}
+      />,
+    );
+    expect(captured).not.toBeNull();
+    expect(captured?.tagName).toBe('INPUT');
+    expect(captured?.type).toBe('checkbox');
+  });
+
+  it('className is merged onto the wrapper, not replaced', () => {
+    const { container } = render(
+      <Switch aria-label="x" className="custom-wrap" />,
+    );
+    const wrapper = container.querySelector('label')!;
+    expect(wrapper.className).toMatch(/custom-wrap/);
+    expect(wrapper.className).toMatch(/wrapper/);
+  });
+
+  it('role="switch" is set on the input', () => {
+    render(<Switch aria-label="x" />);
+    const input = screen.getByRole('switch');
+    expect(input).toHaveAttribute('role', 'switch');
+  });
+
+  it('the native input has type="checkbox"', () => {
+    render(<Switch aria-label="x" />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    expect(input.type).toBe('checkbox');
+  });
+
+  // ─── State ─────────────────────────────────────────────────────────────
+
+  it('controlled: checked={true} reflects in the input AND data-checked on track', () => {
+    const { container } = render(
+      <Switch aria-label="x" checked onChange={() => {}} />,
+    );
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    const track = container.querySelector('[data-tone]')!;
+    expect(input.checked).toBe(true);
+    expect(track).toHaveAttribute('data-checked', 'true');
+  });
+
+  it('controlled: clicking the label fires onChange with the next boolean', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <Switch aria-label="x" checked={false} onChange={handleChange} />,
+    );
+    await user.click(screen.getByRole('switch'));
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange.mock.calls[0][0]).toBe(true);
+    // Second arg is the change event.
+    expect(handleChange.mock.calls[0][1]).toHaveProperty('target');
+  });
+
+  it('uncontrolled: defaultChecked={true} starts checked', () => {
+    const { container } = render(<Switch aria-label="x" defaultChecked />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    const track = container.querySelector('[data-tone]')!;
+    expect(input.checked).toBe(true);
+    expect(track).toHaveAttribute('data-checked', 'true');
+  });
+
+  it('uncontrolled: defaultChecked={false} (or omitted) starts unchecked', () => {
+    const { container } = render(<Switch aria-label="x" />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    const track = container.querySelector('[data-tone]')!;
+    expect(input.checked).toBe(false);
+    expect(track).toHaveAttribute('data-checked', 'false');
+  });
+
+  it('uncontrolled: click toggles the input + flips data-checked', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Switch aria-label="x" />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    const track = container.querySelector('[data-tone]')!;
+    await user.click(input);
+    expect(input.checked).toBe(true);
+    expect(track).toHaveAttribute('data-checked', 'true');
+  });
+
+  it('disabled={true} sets disabled on the input AND blocks onChange', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<Switch aria-label="x" disabled onChange={handleChange} />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    expect(input).toBeDisabled();
+    await user.click(input);
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('Space-key toggles when the input is focused (uncontrolled)', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Switch aria-label="x" />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    input.focus();
+    await user.keyboard(' ');
+    expect(input.checked).toBe(true);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track).toHaveAttribute('data-checked', 'true');
+  });
+
+  // ─── Loading ───────────────────────────────────────────────────────────
+
+  it('loading={true} sets aria-busy="true" on the input', () => {
+    render(<Switch aria-label="x" loading />);
+    const input = screen.getByRole('switch');
+    expect(input).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('loading={true} also disables the input (so clicks do not fire onChange)', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<Switch aria-label="x" loading onChange={handleChange} />);
+    const input = screen.getByRole('switch');
+    expect(input).toBeDisabled();
+    await user.click(input);
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('loading={true} renders a spinner inside the thumb', () => {
+    // The spinner is the Loader2 lucide icon; we identify it via the spin class.
+    const { container } = render(<Switch aria-label="x" loading />);
+    const spinner = container.querySelector('[class*="spin"]');
+    expect(spinner).not.toBeNull();
+  });
+
+  it('loading={false} (default) does NOT render the spinner', () => {
+    const { container } = render(<Switch aria-label="x" />);
+    const spinner = container.querySelector('[class*="spin"]');
+    expect(spinner).toBeNull();
+  });
+
+  // ─── Invalid ───────────────────────────────────────────────────────────
+
+  it('invalid={true} sets aria-invalid="true" on the input', () => {
+    render(<Switch aria-label="x" invalid />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('invalid={true} sets data-invalid="true" on the track', () => {
+    const { container } = render(<Switch aria-label="x" invalid />);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track).toHaveAttribute('data-invalid', 'true');
+  });
+
+  it('invalid omitted does NOT set aria-invalid', () => {
+    render(<Switch aria-label="x" />);
+    expect(screen.getByRole('switch')).not.toHaveAttribute('aria-invalid');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test -w @eocrm/design-system -- --run src/components/Switch/Switch.test.tsx
+```
+
+Expected: ~25 tests passing (24 top-level `it()` + 3 from `it.each` expanding to individual cases = 27 total in Vitest's count).
+
+If a test fails:
+- **"toBeDisabled is not a function"**: `@testing-library/jest-dom` is set up repo-wide; confirm the test file doesn't need explicit imports (it doesn't — vitest config wires globals).
+- **Spinner test failing**: the `[class*="spin"]` selector matches anything with `spin` in its className. If the SCSS class hash differs, this may still match because CSS modules append the local name. If it doesn't match, switch to querying the `Loader2` SVG path directly: `container.querySelector('svg[aria-hidden="true"]')` filtered to those INSIDE the thumb.
+- **Space-key test failing**: jsdom's native checkbox `Space` handling works when the input is focused. If `input.focus()` doesn't take effect, try `await user.tab()` from `document.body` and verify with `document.activeElement`.
+
+- [ ] **Step 3: Full suite + lint + typecheck**
+
+```bash
+make test
+make build-lib
+make lint
+```
+
+Expected: everything clean. Total test count goes up by ~27 (Vitest's `it.each` expansion).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Switch/Switch.test.tsx
+git commit -m "$(cat <<'EOF'
+Switch: unit tests
+
+24 cases (27 with it.each expansion): baseline (rendering, label, sizes,
+tones, ref forwarding, className merge, role+type), state (controlled
++ uncontrolled, default, disabled, Space-key), loading (aria-busy,
+disabled coupling, spinner present/absent), invalid (aria-invalid +
+data-invalid).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 — Public exports + AGENTS.md TL;DR
+
+**Files:**
+
+- Modify: `packages/design-system/src/index.ts`
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Add re-exports to `src/index.ts`**
+
+Find the existing exports near `Stack` and the next `T*`-prefixed exports (likely `Tabs`). Insert the Switch exports alphabetically (S-w sorts after `Stack` and before `Tabs`):
+
+```ts
+export { Switch } from './components/Switch';
+export type { SwitchProps, SwitchSize, SwitchTone } from './components/Switch';
+```
+
+Verify with:
+
+```bash
+grep -n "Stack\|Switch\|Tabs\|Table" packages/design-system/src/index.ts | head
+```
+
+The file may not be strictly alphabetical (recent additions get appended near the bottom — see Toast/Textarea precedent). If that's the established pattern here, place Switch with the other recently-added components. Match what the surrounding code does.
+
+- [ ] **Step 2: Add TL;DR to AGENTS.md**
+
+Find the `### \`<Checkbox>\`` section header (around line 188) and the `### \`<Radio>\`` section header (around line 205). Insert the new Switch section between them.
+
+Use this content verbatim (copy from spec — keep the closing `````` mark intact):
+
+````markdown
+### `<Switch>` — binary toggle
+
+Hand-rolled track + thumb on a native `<input type="checkbox" role="switch">`. The dumb on/off toggle for settings, feature flags, and async persisted state.
+
+```tsx
+import { Switch } from '@eocrm/design-system';
+
+// Default — uncontrolled, accent tone.
+<Switch>Enable notifications</Switch>
+
+// Controlled, success tone.
+<Switch tone="success" checked={enabled} onChange={(next) => setEnabled(next)}>
+  Daily digest
+</Switch>
+
+// Async (server-persisted) toggle.
+<Switch
+  checked={enabled}
+  loading={saving}
+  onChange={async (next) => {
+    setSaving(true);
+    setEnabled(next);            // optimistic
+    try { await api.save(next); }
+    catch { setEnabled(!next); } // rollback
+    finally { setSaving(false); }
+  }}
+>
+  Two-factor auth
+</Switch>
+
+// Icon-only.
+<Switch aria-label="Mute notifications" />
+```
+
+- **Native `<input type="checkbox" role="switch">`**. Form submission works; AT announces as switch.
+- **Three tones** (`accent`/`success`/`danger`) for the checked track. Unchecked track is always neutral muted.
+- **`loading={true}`** shows a spinner inside the thumb + disables the input (sets `aria-busy`). Consumer manages the optimistic-update flow.
+- **`onChange(checked, event)`** signature matches Checkbox — first arg is the next boolean, second is the raw event.
+
+#### When NOT to use
+
+- ❌ Selecting one option from a list of mutually-exclusive choices → `<Radio>` / `<RadioGroup>`.
+- ❌ Selecting multiple from a list → `<Checkbox>`.
+- ❌ A mixed / indeterminate state ("some-but-not-all enabled") → use Checkbox's `indeterminate`.
+- ❌ Triggering an action immediately on click (no state) → `<Button>`.
+
+#### Anti-patterns
+
+- ❌ Using `placeholder`-style hints inside the track ("OFF" / "ON" text). Use a real label.
+- ❌ Toggle without an external optimistic-update flow when `loading` is set. Without it, the user clicks the switch, the spinner appears, and the visual state never changes — confusing.
+- ❌ `tone="success"` for "Mark as failed". Tone communicates the meaning of "on", not just decoration.
+````
+
+- [ ] **Step 3: Run gates**
+
+```bash
+make test
+make build-lib
+```
+
+Expected: everything clean. `structure.test.ts` will now find Switch in `src/index.ts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/index.ts packages/design-system/AGENTS.md
+git commit -m "$(cat <<'EOF'
+Switch: public exports + AGENTS.md TL;DR
+
+Re-exports Switch + SwitchProps/SwitchSize/SwitchTone from the package
+barrel. AGENTS.md gains a TL;DR section between Checkbox and Radio
+with the canonical four patterns (default / controlled-with-tone /
+async with loading / icon-only), the when-NOT-to-use list, and the
+anti-patterns including the loading-without-optimistic-update gotcha.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 — Playground demo + 4-place nav wiring
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/SwitchDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Write the demo page**
+
+Create `packages/playground/src/pages/components/SwitchDemo.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { Cluster, Stack, Switch } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Switch/Switch.tsx?raw';
+import scssSource from '@lib-source/components/Switch/Switch.module.scss?raw';
+
+export function SwitchDemo() {
+  const [controlled, setControlled] = useState(false);
+  const [asyncEnabled, setAsyncEnabled] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const handleAsyncToggle = async (next: boolean) => {
+    setSaving(true);
+    setAsyncEnabled(next);
+    // Fake server roundtrip.
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    setSaving(false);
+  };
+
+  return (
+    <DemoLayout
+      name="Switch"
+      componentName="Switch"
+      description="Binary on/off toggle. Native checkbox with switch role + sliding thumb. Three tones, loading state with thumb-spinner, invalid parity with Input/Textarea."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Switch.tsx"
+      scssFilename="Switch.module.scss"
+    >
+      <Example
+        title="Default + with label"
+        description="Uncontrolled. Click the label or the track to toggle."
+        code={`<Switch>Enable notifications</Switch>`}
+      >
+        <Switch>Enable notifications</Switch>
+      </Example>
+
+      <Example
+        title="Three sizes"
+        description="Size scales track + thumb + label font together."
+        code={`<Switch size="sm">Small</Switch>
+<Switch size="md">Medium (default)</Switch>
+<Switch size="lg">Large</Switch>`}
+      >
+        <Stack gap="sm">
+          <Switch size="sm">Small</Switch>
+          <Switch size="md">Medium (default)</Switch>
+          <Switch size="lg">Large</Switch>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Three tones (all checked)"
+        description="Tone only affects the checked-state track color. Unchecked is always neutral."
+        code={`<Switch defaultChecked tone="accent">Accent (default)</Switch>
+<Switch defaultChecked tone="success">Success</Switch>
+<Switch defaultChecked tone="danger">Danger</Switch>`}
+      >
+        <Stack gap="sm">
+          <Switch defaultChecked tone="accent">
+            Accent (default)
+          </Switch>
+          <Switch defaultChecked tone="success">
+            Success
+          </Switch>
+          <Switch defaultChecked tone="danger">
+            Danger
+          </Switch>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Controlled"
+        description="onChange receives (nextBool, event). The component is otherwise dumb — consumer drives the state."
+        code={`const [enabled, setEnabled] = useState(false);
+
+<Switch checked={enabled} onChange={(next) => setEnabled(next)}>
+  Marketing emails
+</Switch>`}
+      >
+        <Switch checked={controlled} onChange={(next) => setControlled(next)}>
+          Marketing emails ({controlled ? 'ON' : 'OFF'})
+        </Switch>
+      </Example>
+
+      <Example
+        title="Loading (async toggle with optimistic update)"
+        description="The button fakes a 1.5s server roundtrip. The switch updates immediately (optimistic), spins while saving, and would rollback on error. loading={true} disables the input."
+        code={`const [enabled, setEnabled] = useState(false);
+const [saving, setSaving] = useState(false);
+
+const handleToggle = async (next: boolean) => {
+  setSaving(true);
+  setEnabled(next);
+  await api.save(next);  // ...with try/catch + rollback in real code
+  setSaving(false);
+};
+
+<Switch checked={enabled} loading={saving} onChange={handleToggle}>
+  Two-factor auth
+</Switch>`}
+      >
+        <Switch
+          checked={asyncEnabled}
+          loading={saving}
+          onChange={handleAsyncToggle}
+          tone="success"
+        >
+          Two-factor auth ({saving ? 'saving…' : asyncEnabled ? 'ON' : 'OFF'})
+        </Switch>
+      </Example>
+
+      <Example
+        title="Invalid state"
+        description="aria-invalid + danger-tone border on the track. Use when validation has surfaced an error."
+        code={`<Switch invalid aria-describedby="terms-error">
+  I agree to the terms
+</Switch>
+<p id="terms-error" style={{ color: 'var(--color-danger)' }}>
+  You must agree to the terms before continuing.
+</p>`}
+      >
+        <Stack gap="sm">
+          <Switch invalid aria-describedby="terms-error">
+            I agree to the terms
+          </Switch>
+          <p
+            id="terms-error"
+            style={{
+              color: 'var(--color-danger)',
+              margin: 0,
+              fontSize: 'var(--font-size-sm)',
+            }}
+          >
+            You must agree to the terms before continuing.
+          </p>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Disabled"
+        description="Native disabled attribute. Unchecked and checked variants shown."
+        code={`<Switch disabled>Disabled (off)</Switch>
+<Switch disabled defaultChecked>Disabled (on)</Switch>`}
+      >
+        <Cluster gap="md">
+          <Switch disabled>Disabled (off)</Switch>
+          <Switch disabled defaultChecked>
+            Disabled (on)
+          </Switch>
+        </Cluster>
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+- [ ] **Step 2: Wire the route + import in `App.tsx`**
+
+Open `packages/playground/src/App.tsx`. Add the import alphabetically — looking at the existing pattern, place `SwitchDemo` after `SkeletonDemo` (currently around line 18):
+
+```tsx
+import { SkeletonDemo } from './pages/components/SkeletonDemo';
+import { SwitchDemo } from './pages/components/SwitchDemo';
+```
+
+Add the `<Route>` inside `<Routes>` alphabetically with the existing S-routes. After `/components/skeleton` (currently around line 68):
+
+```tsx
+<Route path="/components/skeleton" element={<SkeletonDemo />} />
+<Route path="/components/switch" element={<SwitchDemo />} />
+```
+
+- [ ] **Step 3: Add sidebar entry in `AppShell.tsx`**
+
+Open `packages/playground/src/layout/AppShell/AppShell.tsx`. Find the `componentGroups` array, then the `Forms` group. Switch goes after `Select`:
+
+```tsx
+{
+  heading: 'Forms',
+  items: [
+    // …existing items: Button, ButtonGroup, Checkbox, Date pickers, Input,
+    //  PasswordInput, PasswordStrengthMeter, Radio, Select…
+    { to: '/components/switch', label: 'Switch', icon: ToggleRight, end: false },
+    { to: '/components/textarea', label: 'Textarea', icon: MessageSquareText, end: false },
+  ],
+},
+```
+
+Add the `ToggleRight` icon to the existing lucide-react import at the top of the file. If `ToggleRight` doesn't exist in lucide-react 1.x, check alternatives:
+
+```bash
+node -e "console.log(Object.keys(require('lucide-react')).filter(k => k.toLowerCase().includes('toggle')).join(', '))"
+```
+
+Likely options: `ToggleRight`, `ToggleLeft`. Use whichever matches the existing visual style. Fall back to `Power` or `CircleDot` if neither exists.
+
+- [ ] **Step 4: Add overview card in `ComponentsIndex.tsx`**
+
+Open `packages/playground/src/pages/components/ComponentsIndex.tsx`. The file already imports many components from `@eocrm/design-system` — add `Switch` to the appropriate existing import line (or add it on its own line in alphabetical order, matching the file's convention).
+
+Find the items array. Add a card. The file isn't strictly alphabetical, so place near other small form primitives (Checkbox / Radio area):
+
+```tsx
+{
+  to: '/components/switch',
+  name: 'Switch',
+  description: 'Binary on/off toggle. Three tones + async loading state.',
+  preview: <Switch defaultChecked tone="success" aria-label="Preview" />,
+},
+```
+
+- [ ] **Step 5: Register the component name in `registry.ts`**
+
+Open `packages/playground/src/pages/mockups/registry.ts`. Find `export type ComponentName =` and add `'Switch'` to the union alphabetically (between `'Stack'` and `'Table'`):
+
+```ts
+export type ComponentName =
+  // …existing names through 'Stack'…
+  | 'Stack'
+  | 'Switch'
+  | 'Table'
+  // …rest…;
+```
+
+No existing mockup uses Switch yet, so no `usesComponents` arrays need updating.
+
+- [ ] **Step 6: Run the playground build**
+
+```bash
+cd /home/dpws/projects/design-system
+make build
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Spot-check in the dev server (OPTIONAL)**
+
+Skip the manual check unless a gate fails. If you do want to look:
+
+```bash
+cd packages/playground
+PORT=8090 npm run dev
+```
+
+Visit http://localhost:8090/components/switch. Verify:
+- Default switch toggles on click
+- Three sizes look proportional
+- Three tones show different checked-state colors
+- Controlled example reflects the boolean
+- Async example: click → spinner appears in thumb → 1.5s → spinner disappears
+- Invalid state shows danger border + error message
+- Disabled state is muted and non-interactive
+
+Stop the dev server with `Ctrl+C`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/playground/src/pages/components/SwitchDemo.tsx \
+        packages/playground/src/App.tsx \
+        packages/playground/src/layout/AppShell/AppShell.tsx \
+        packages/playground/src/pages/components/ComponentsIndex.tsx \
+        packages/playground/src/pages/mockups/registry.ts
+git commit -m "$(cat <<'EOF'
+playground: SwitchDemo + 4-place nav wiring
+
+7 examples (default / three sizes / three tones / controlled / async
+with optimistic-update + spinner / invalid + error / disabled). Wired
+into Forms sidebar group (alphabetical between Select and Textarea),
+Components route, overview-grid card, and the mockups ComponentName
+union.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 — Hard-Rule-8 cycle + push + PR
+
+Per `packages/design-system/CLAUDE.md` Rule 8. Run until 0 Critical + 0 Important findings, all gates green.
+
+- [ ] **Step 1: Final gate run**
+
+```bash
+cd /home/dpws/projects/design-system
+make test
+make build-lib
+make build
+make lint
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Dry-pack to confirm tarball contents**
+
+```bash
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -E "Switch|test\."
+```
+
+Expected:
+- Switch source files (`Switch.tsx`, `Switch.module.scss`, `index.ts`) in the tarball
+- NO `*.test.*` files
+
+- [ ] **Step 3: Dispatch a fresh-context Hard-Rule-8 reviewer**
+
+Use a `general-purpose` subagent with model `opus`. Prompt template (substitute `<sha>` with the current HEAD):
+
+> Fresh-context Hard-Rule-8 review of the Switch PR. Branch `feat/switch` at HEAD `<sha>`. Per `packages/design-system/CLAUDE.md` Rule 8 — review the full diff against `main` and report findings as Critical / Important / Nice-to-have / Regression-watch.
+>
+> Files in scope: everything under `packages/design-system/src/components/Switch/`, `packages/design-system/src/index.ts`, `packages/design-system/AGENTS.md`, and the playground wiring touched on this branch.
+>
+> Read first: `packages/design-system/CLAUDE.md` (Rules 1–7), `packages/design-system/AGENTS.md` (Switch section + the surrounding Checkbox/Radio sections for convention check), `docs/superpowers/specs/2026-05-23-switch-design.md`. Also peek at `packages/design-system/src/components/Checkbox/Checkbox.tsx` — Switch is supposed to mirror Checkbox's pattern for `onChange(checked, event)`, the visually-hidden input, and the wrapper-label.
+>
+> Verify:
+> - **Rule 1**: `Switch.test.tsx` exists with ~24 cases. Spot-check coverage matches what the spec lists.
+> - **Rule 3**: no raw values in `Switch.module.scss` — every color/spacing/shadow/radius via `var(--…)`. The track/thumb pixel dimensions (28/16/etc.) are component-specific and acceptable per "tokens for tokens-eligible properties" interpretation.
+> - **Rule 4**: no `position` / `align-self` / `flex: 1` / margin at the component boundary on `.wrapper`. `position: absolute` on `.input` and `.thumb` is documented internal positioning with inline disables.
+> - **Rule 5**: re-exported from `src/index.ts` (alphabetical with the other recently-added components or wherever the file's convention places it).
+> - **Rule 6**: `forwardRef` used; ref targets the `<input>` element (not the wrapper). Native checkbox attrs are spread via `{...props}`.
+> - **Rule 7**: full JSDoc on `Switch`, every prop, both type aliases (`SwitchSize`, `SwitchTone`). At least 3 `@example` blocks. "When NOT to use" + "Anti-patterns" in `@remarks`.
+> - **ARIA**: `aria-invalid="true"` only when `invalid={true}`. `aria-busy="true"` only when `loading={true}`. `role="switch"` set explicitly. The implicit checkbox-role overridden cleanly.
+> - **Internal-checked mirror**: works for both controlled and uncontrolled. The `data-checked` attribute reflects current state in both modes.
+> - **Loading + disabled coupling**: `disabled={disabled || loading}` ensures both click and Space-key are blocked when loading.
+> - **Custom onChange signature**: `(checked, event)` matches Checkbox exactly.
+> - **Cross-package leakage**: Switch imports from `@eocrm/design-system` internals only; no playground imports.
+> - **Package/distribution**: `npm pack --dry-run` excludes test files.
+>
+> End with verdict: **clean enough to stop** OR **keep iterating**.
+
+- [ ] **Step 4: Fix every Critical + Important finding**
+
+Group fixes into a single commit titled `Switch: review-cycle fixes (round N)`. Document deliberately-skipped Nice-to-have items in the commit body.
+
+- [ ] **Step 5: Re-run gates after each fix round**
+
+```bash
+make test && make build-lib && make build && make lint
+```
+
+- [ ] **Step 6: Re-dispatch fresh reviewer**
+
+Same prompt, same model, fresh context. Repeat until **clean enough to stop**.
+
+- [ ] **Step 7: Push the branch**
+
+```bash
+git push -u origin feat/switch
+```
+
+If the husky `pre-push` hook fails on `format:check`:
+
+```bash
+npx prettier --write docs/superpowers/specs/2026-05-23-switch-design.md \
+                     docs/superpowers/plans/2026-05-23-switch.md \
+                     packages/design-system/src/components/Switch/ \
+                     packages/playground/src/pages/components/SwitchDemo.tsx
+git add -A
+git commit -m "$(cat <<'EOF'
+Switch: prettier --write
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin feat/switch
+```
+
+- [ ] **Step 8: Open the PR**
+
+```bash
+gh pr create --title "Switch: binary toggle with tones + loading + invalid" --body "$(cat <<'EOF'
+## Summary
+
+- New \`<Switch>\` — the binary on/off companion to \`<Checkbox>\` and \`<Radio>\`. Hand-rolled track + sliding thumb on a native \`<input type=\"checkbox\" role=\"switch\">\`.
+- Three tones (\`accent\` / \`success\` / \`danger\`) for the checked-state track color. Unchecked is always neutral.
+- Three sizes (\`sm\` / \`md\` / \`lg\`) — track, thumb, and label font scale together. Same scale as Checkbox/Radio.
+- \`loading\` state with spinner inside the thumb + auto-disable (\`aria-busy\` + \`disabled\`). Consumer manages the optimistic-update flow.
+- \`invalid\` state parity with Input/Textarea — \`aria-invalid=\"true\"\` + danger-tone border.
+- Custom \`onChange(checked, event)\` signature matches Checkbox.
+
+## Design highlights
+
+- **Native checkbox underneath.** Form submission works (the visually-hidden \`<input type=\"checkbox\">\` participates normally), but AT announces as switch via \`role=\"switch\"\`.
+- **Internal-checked mirror** keeps the \`data-checked\` track attribute reactive for both controlled (via \`checked\`) and uncontrolled (via \`useState\`) use. Same pattern as Textarea's value mirror.
+- **Per-size CSS custom property** (\`--thumb-travel\`) drives the \`transform: translateX(...)\` distance, so the thumb travels precisely from one end of the track to the other in each size.
+- **\`loading\` implies \`disabled\`**. Setting \`loading={true}\` forces \`disabled\` on the input — blocks both click-to-toggle and Space-key. Documented in JSDoc.
+
+## Hard Rule 8
+
+Multiple rounds with fresh-context reviewers (opus). 24 new tests covering rendering, sizes, tones, controlled+uncontrolled, disabled, Space-key, loading (aria-busy + disabled coupling + spinner present/absent), and invalid (aria-invalid + data-invalid).
+
+All four gates green: \`make test\` · \`make build-lib\` · \`make build\` · \`make lint\`. \`npm pack --dry-run\` shows no test files in the tarball.
+
+## Test plan
+
+- [ ] Default \`<Switch>Label</Switch>\` toggles on click (uncontrolled)
+- [ ] Three sizes show proportional track + thumb + label font
+- [ ] Three tones show different checked-state track colors
+- [ ] Controlled: \`onChange\` fires \`(nextBool, event)\` on click
+- [ ] Async toggle with \`loading={true}\` — spinner shows, click does NOT fire onChange
+- [ ] Invalid state shows red track border + \`aria-invalid=\"true\"\`
+- [ ] Disabled state is muted and non-interactive
+- [ ] Space-key toggles the focused input (native checkbox behavior survives the role override)
+- [ ] Ref targets the \`<input>\` element (not the wrapper label)
+- [ ] Playground demo at \`/components/switch\` renders all 7 examples without console errors
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 9: Confirm CI**
+
+Watch the GitHub Actions Quality check on the PR. If it fails for the same `format:check` reason, run the prettier fix locally and push again.
+
+- [ ] **Step 10: Mark task complete**
+
+Once verdict is `clean enough to stop`, gates green, CI green, PR open — task done.
+
+---
+
+## Summary of expected commits on the branch (before review-fix rounds)
+
+```
+Switch: design spec — binary toggle with tones + loading + invalid
+Switch: source — track + sliding thumb on native checkbox
+Switch: unit tests
+Switch: public exports + AGENTS.md TL;DR
+playground: SwitchDemo + 4-place nav wiring
+```
+
+Plus review-cycle fix commits + prettier fix-up as needed.

--- a/docs/superpowers/specs/2026-05-23-switch-design.md
+++ b/docs/superpowers/specs/2026-05-23-switch-design.md
@@ -83,7 +83,7 @@ Plus standard integration points:
 
 ## Public API
 
-```ts
+````ts
 import type { ChangeEvent, InputHTMLAttributes, ReactNode } from 'react';
 
 /** Track + thumb scale + label font. Pairs with Checkbox/Radio sizes. */
@@ -179,7 +179,7 @@ export interface SwitchProps extends Omit<
    */
   children?: ReactNode;
 }
-```
+````
 
 **Native attrs spread to the `<input>`**: all of `InputHTMLAttributes<HTMLInputElement>` minus `size`, `type`, `checked`, `defaultChecked`, `onChange`. Includes `disabled`, `required`, `name`, `id`, `value` (form submission value), `aria-*`, `data-*`, `onFocus`, `onBlur`, etc.
 
@@ -222,6 +222,7 @@ Same pattern as Textarea's value mirror + Checkbox's checked mirror. The `data-c
 ### Loading + disabled coupling
 
 `disabled={disabled || loading}` on the input — `loading` implies disabled. This:
+
 - Blocks click-to-toggle via the label (the input doesn't fire change events)
 - Blocks Space-key toggle (focused-but-disabled input doesn't accept input)
 - Sets the native `:disabled` pseudoclass that the SCSS can style against
@@ -231,7 +232,9 @@ If a consumer wants `disabled={false}` while `loading={true}`... they can't. Loa
 ### Spinner mount
 
 ```tsx
-{loading && <Loader2 className={styles.spin} size={SPIN_SIZE[size]} aria-hidden="true" />}
+{
+  loading && <Loader2 className={styles.spin} size={SPIN_SIZE[size]} aria-hidden="true" />;
+}
 ```
 
 The spinner sits inside `<span class="thumb">`. The thumb itself doesn't change size — the spinner is positioned absolutely inside, slightly smaller than the thumb.
@@ -244,8 +247,8 @@ The thumb is positioned with `transform: translateX(...)` and the SCSS uses CSS 
 
 ```scss
 .track {
-  --thumb-travel: 0;  // overridden per size
-  
+  --thumb-travel: 0; // overridden per size
+
   .thumb {
     transform: translateX(0);
     transition: transform var(--transition-base);
@@ -256,9 +259,15 @@ The thumb is positioned with `transform: translateX(...)` and the SCSS uses CSS 
   transform: translateX(var(--thumb-travel));
 }
 
-.sm { --thumb-travel: 12px; }  // 28 - 12 - 4
-.md { --thumb-travel: 14px; }  // 36 - 16 - 6 (2px inset on each side)
-.lg { --thumb-travel: 18px; }  // 44 - 20 - 6
+.sm {
+  --thumb-travel: 12px;
+} // 28 - 12 - 4
+.md {
+  --thumb-travel: 14px;
+} // 36 - 16 - 6 (2px inset on each side)
+.lg {
+  --thumb-travel: 18px;
+} // 44 - 20 - 6
 ```
 
 (Exact pixel math will be verified in implementation — point is the travel distance is a per-size value.)
@@ -308,13 +317,25 @@ The thumb is positioned with `transform: translateX(...)` and the SCSS uses CSS 
   }
 }
 
-.track[data-checked='true'][data-tone='accent']  { background: var(--color-accent); }
-.track[data-checked='true'][data-tone='success'] { background: var(--color-success); }
-.track[data-checked='true'][data-tone='danger']  { background: var(--color-danger); }
+.track[data-checked='true'][data-tone='accent'] {
+  background: var(--color-accent);
+}
+.track[data-checked='true'][data-tone='success'] {
+  background: var(--color-success);
+}
+.track[data-checked='true'][data-tone='danger'] {
+  background: var(--color-danger);
+}
 
-.track[data-checked='true'][data-tone='accent']:hover  { background: var(--color-accent-hover); }
-.track[data-checked='true'][data-tone='success']:hover { background: var(--color-success-hover); }
-.track[data-checked='true'][data-tone='danger']:hover  { background: var(--color-danger-hover); }
+.track[data-checked='true'][data-tone='accent']:hover {
+  background: var(--color-accent-hover);
+}
+.track[data-checked='true'][data-tone='success']:hover {
+  background: var(--color-success-hover);
+}
+.track[data-checked='true'][data-tone='danger']:hover {
+  background: var(--color-danger-hover);
+}
 
 .thumb {
   position: absolute;
@@ -337,30 +358,45 @@ The thumb is positioned with `transform: translateX(...)` and the SCSS uses CSS 
   height: 16px;
   --thumb-travel: 12px;
 }
-.sm .thumb { width: 12px; height: 12px; }
+.sm .thumb {
+  width: 12px;
+  height: 12px;
+}
 
 .md {
   width: 36px;
   height: 20px;
   --thumb-travel: 14px;
 }
-.md .thumb { width: 16px; height: 16px; }
+.md .thumb {
+  width: 16px;
+  height: 16px;
+}
 
 .lg {
   width: 44px;
   height: 24px;
   --thumb-travel: 18px;
 }
-.lg .thumb { width: 20px; height: 20px; }
+.lg .thumb {
+  width: 20px;
+  height: 20px;
+}
 
 .label {
   font-family: inherit;
   color: var(--color-fg);
 }
 
-.labelSm { font-size: var(--font-size-sm); }
-.labelMd { font-size: var(--font-size-md); }
-.labelLg { font-size: var(--font-size-lg); }
+.labelSm {
+  font-size: var(--font-size-sm);
+}
+.labelMd {
+  font-size: var(--font-size-md);
+}
+.labelLg {
+  font-size: var(--font-size-lg);
+}
 
 // Focus ring on the wrapper when the (hidden) input is focused.
 .input:focus-visible + .track {
@@ -397,6 +433,7 @@ The thumb is positioned with `transform: translateX(...)` and the SCSS uses CSS 
 ```
 
 **Rule 4 check:**
+
 - `.wrapper` has `display: inline-flex` — that's intrinsic display, not layout. `gap: var(--space-2)` is internal spacing between children.
 - `.input` uses the visually-hidden pattern (`position: absolute`, etc.) — this is internal-only, not a flow component. Same disable-line treatment as Checkbox/Radio.
 - `.track` and `.thumb` use `position: relative`/`absolute` — internal child positioning, not at the component boundary. Same pattern as Checkbox's painted box.
@@ -406,18 +443,18 @@ If stylelint flags the `position: absolute` on the input or thumb, add inline-di
 
 ## ARIA + behavior reference
 
-| Concern | Behavior |
-|---|---|
-| Element | `<input type="checkbox" role="switch">` — native checkbox semantics for form submission, switch role for AT announcement |
-| Checked state | `aria-checked` reflected automatically from the native `checked` attribute (no manual ARIA needed) |
-| Invalid state | `aria-invalid="true"` only when `invalid={true}` |
-| Loading state | `aria-busy="true"` only when `loading={true}` |
-| Disabled state | Native `disabled` attribute |
-| Focus | Focus lands on the input (natural Tab). Wrapper has `:focus-within` styling via the `.input:focus-visible + .track` selector |
-| Keyboard | Space toggles (native checkbox behavior — works because the underlying element IS a checkbox) |
-| Label association | The whole `<label>` is the click target — no `htmlFor` plumbing needed |
-| Spread order | Component owns `type`, `role`, `checked`, `disabled`, `aria-invalid`, `aria-busy`, `onChange`. Other native attrs follow Pattern A (consumer wins). |
-| Ref target | The `<input>` element. Consumers can `.focus()`, read `.checked`, etc. |
+| Concern           | Behavior                                                                                                                                            |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Element           | `<input type="checkbox" role="switch">` — native checkbox semantics for form submission, switch role for AT announcement                            |
+| Checked state     | `aria-checked` reflected automatically from the native `checked` attribute (no manual ARIA needed)                                                  |
+| Invalid state     | `aria-invalid="true"` only when `invalid={true}`                                                                                                    |
+| Loading state     | `aria-busy="true"` only when `loading={true}`                                                                                                       |
+| Disabled state    | Native `disabled` attribute                                                                                                                         |
+| Focus             | Focus lands on the input (natural Tab). Wrapper has `:focus-within` styling via the `.input:focus-visible + .track` selector                        |
+| Keyboard          | Space toggles (native checkbox behavior — works because the underlying element IS a checkbox)                                                       |
+| Label association | The whole `<label>` is the click target — no `htmlFor` plumbing needed                                                                              |
+| Spread order      | Component owns `type`, `role`, `checked`, `disabled`, `aria-invalid`, `aria-busy`, `onChange`. Other native attrs follow Pattern A (consumer wins). |
+| Ref target        | The `<input>` element. Consumers can `.focus()`, read `.checked`, etc.                                                                              |
 
 ## Testing
 
@@ -460,7 +497,8 @@ If stylelint flags the `position: absolute` on the input or thumb, add inline-di
 
 22. Each tone (`accent`/`success`/`danger`) sets a unique `data-tone` attribute on the track
 
-**Vitest gotchas**: 
+**Vitest gotchas**:
+
 - `screen.getByRole('switch')` works because `role="switch"` overrides the implicit `role="checkbox"`.
 - Space-key test needs the input to be focused first: `await user.tab(); await user.keyboard(' ');`.
 

--- a/docs/superpowers/specs/2026-05-23-switch-design.md
+++ b/docs/superpowers/specs/2026-05-23-switch-design.md
@@ -1,0 +1,545 @@
+# Switch — design spec
+
+**Date:** 2026-05-23
+**Branch:** `feat/switch`
+**Scope:** New `<Switch>` component for `@eocrm/design-system` — a hand-rolled toggle (track + sliding thumb) that wraps a native `<input type="checkbox" role="switch">`. Completes the binary-control family alongside `<Checkbox>` and `<Radio>`.
+
+## Goal
+
+Provide an on/off toggle primitive for settings panels, "enabled/disabled" rows, and any UI that maps cleanly to a binary state. Same JSDoc + a11y conventions as Checkbox/Radio (`size`, `disabled`, controlled+uncontrolled, label-as-children, custom `onChange(checked, event)` signature). Adds three things Checkbox doesn't need: `tone` (color of the checked track), `loading` (spinner inside the thumb for async toggles), and the visual switch track+thumb mechanic.
+
+## Why now
+
+- The CRM has multiple open-coded `<input type="checkbox">` usages styled as switches. Inconsistent visual treatment across screens.
+- Settings panels and feature flag dashboards need an "on/off" affordance that's clearly distinct from a tick-box. Checkbox semantically means "select me from a list"; Switch means "this state is on or off". Different mental model → different visual primitive.
+- Async toggles (server-persisted settings) need a loading state. Without a shipped Switch, every consumer rolls their own spinner-while-saving treatment.
+
+## Non-goals (v1)
+
+- **No "thumb icon" slot.** The thumb stays a plain circle. Material's "checked = checkmark inside thumb" is not part of v1.
+- **No "size: xs".** Switch starts at `sm`. Below that the thumb gets too tiny to click reliably.
+- **No vertical orientation.** Horizontal only.
+- **No "off label" / "on label" inside the track.** Some designs put "ON"/"OFF" text inside the track. Skip — not a CRM pattern.
+- **No `tone="warning"` or `tone="info"`.** Warning checked-state doesn't have a clear meaning. Info is what `accent` already covers. Three tones is enough.
+- **No `indeterminate` state.** Switch is binary by definition (unlike Checkbox which has the "select all" mixed state). Consumers needing tri-state use Checkbox.
+- **No optimistic / pessimistic toggle helpers.** Consumers manage the async flow themselves via `loading` + their own onChange logic.
+
+## Architecture
+
+### Dependencies
+
+No new packages. Reuses:
+
+- React (peer)
+- `clsx` (existing dep)
+- `lucide-react` peer dep — `Loader2` icon for the loading state (already used by Toast)
+- Existing tokens: `--color-bg`, `--color-bg-muted`, `--color-bg-sunken`, `--color-bg-subtle`, `--color-fg`, `--color-fg-muted`, `--color-fg-subtle`, `--color-accent`, `--color-accent-hover`, `--color-success`, `--color-success-hover`, `--color-danger`, `--color-danger-hover`, `--color-border`, `--ring-accent`, `--ring-danger`, `--ring-width`, `--font-size-sm`/`--font-size-md`/`--font-size-lg`, `--space-1`/`--space-2`/`--space-3`, `--transition-fast`, `--transition-base`, `--opacity-disabled`
+
+No new tokens needed. The track/thumb size values are hardcoded per-size — they're component-specific dimensions, not generic tokens.
+
+### File layout
+
+```
+packages/design-system/src/components/Switch/
+  Switch.tsx          ← forwardRef + internal-checked mirror + custom onChange + visually-hidden input
+  Switch.module.scss  ← wrapper / hidden input / track / thumb / label + size variants + tone variants + states
+  Switch.test.tsx     ← ~22 cases
+  index.ts            ← exports
+```
+
+Plus standard integration points:
+
+- `packages/design-system/src/index.ts` — re-export `Switch`, `SwitchProps`, `SwitchSize`, `SwitchTone`
+- `packages/design-system/AGENTS.md` — TL;DR slot directly after `<Checkbox>` (alphabetical with the form components)
+- `packages/playground/src/pages/components/SwitchDemo.tsx` — 7 examples
+- `packages/playground/src/App.tsx` — route at `/components/switch`
+- `packages/playground/src/layout/AppShell/AppShell.tsx` — sidebar entry in the **Forms** group, alphabetically between `Select` and `Textarea`
+- `packages/playground/src/pages/components/ComponentsIndex.tsx` — overview card with a checked switch preview
+- `packages/playground/src/pages/mockups/registry.ts` — `'Switch'` in `ComponentName` union (alphabetical between `'Stack'` and `'Table'`)
+
+### Composition
+
+```
+        <Switch checked tone="success" onChange={(next) => setEnabled(next)}>Notifications</Switch>
+                                                            │
+                                                            ▼
+                                                     <label .wrapper>
+                                                            │
+                                          ┌─────────────────┼─────────────────┐
+                                          ▼                 ▼                 ▼
+                              <input type="checkbox"   <span .track       <span .label>
+                                role="switch"           data-checked        "Notifications"
+                                aria-checked            data-tone
+                                aria-invalid            data-invalid>
+                                aria-busy                 │
+                                ref={consumerRef}         ▼
+                                .visuallyHidden>      <span .thumb>
+                                                          │  Loader2 only when loading
+                                                          ▼
+                                                       (sliding circle, optional spinner)
+```
+
+`<label>` wraps everything so click-anywhere-toggles. Real `<input>` is visually-hidden but reachable by Tab and clickable via the label. Track + thumb are painted spans.
+
+## Public API
+
+```ts
+import type { ChangeEvent, InputHTMLAttributes, ReactNode } from 'react';
+
+/** Track + thumb scale + label font. Pairs with Checkbox/Radio sizes. */
+export type SwitchSize = 'sm' | 'md' | 'lg';
+
+/** Color of the track when checked. */
+export type SwitchTone = 'accent' | 'success' | 'danger';
+
+export interface SwitchProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
+> {
+  /**
+   * Visual scale. Defaults to `'md'`.
+   * - `'sm'` — 28×16 track, 12px thumb, `--font-size-sm` label
+   * - `'md'` — 36×20 track, 16px thumb, `--font-size-md` label (default)
+   * - `'lg'` — 44×24 track, 20px thumb, `--font-size-lg` label
+   *
+   * Note: shadows the native HTML `<input size>` attribute (meaningless on checkboxes).
+   */
+  size?: SwitchSize;
+
+  /**
+   * Track color when checked. Defaults to `'accent'`.
+   * - `'accent'` — blue (default).
+   * - `'success'` — green. Use for affirmative toggles ("Enable notifications").
+   * - `'danger'` — red. Use for destructive toggles ("Allow root access").
+   *
+   * Unchecked track is always `--color-bg-muted` regardless of tone.
+   */
+  tone?: SwitchTone;
+
+  /**
+   * Controlled checked state. Pair with `onChange`. Omit (with optional
+   * `defaultChecked`) for uncontrolled use.
+   */
+  checked?: boolean;
+
+  /** Initial checked state for uncontrolled use. Defaults to `false`. */
+  defaultChecked?: boolean;
+
+  /**
+   * Fires when the user toggles the switch. The first arg is the next
+   * boolean (convenience); the original change event is the second arg.
+   * Matches `<Checkbox>`'s signature.
+   *
+   * Note: this collapses the native `onChange` event prop. To access the
+   * raw event without the boolean convenience, use `e` (second arg).
+   */
+  onChange?: (checked: boolean, e: ChangeEvent<HTMLInputElement>) => void;
+
+  /**
+   * Toggles `aria-invalid="true"` and adds a danger-tone border to the
+   * track. Use when the switch's state has caused a validation error
+   * (rare — switches are binary, but consistency with Input/Textarea is
+   * cheap).
+   */
+  invalid?: boolean;
+
+  /**
+   * Disables interaction and shows a spinner inside the thumb. Use for
+   * toggles that persist to a server. Sets `aria-busy="true"` and
+   * `disabled` on the native input so neither click nor Space-key can
+   * fire onChange while the async operation is in flight.
+   *
+   * The consumer is responsible for managing the optimistic-update flow:
+   *
+   * ```tsx
+   * const [enabled, setEnabled] = useState(initial);
+   * const [saving, setSaving] = useState(false);
+   *
+   * const handleToggle = async (next: boolean) => {
+   *   setSaving(true);
+   *   setEnabled(next);  // optimistic
+   *   try {
+   *     await api.saveSetting(next);
+   *   } catch {
+   *     setEnabled(!next);  // rollback
+   *   } finally {
+   *     setSaving(false);
+   *   }
+   * };
+   *
+   * <Switch checked={enabled} loading={saving} onChange={handleToggle} />
+   * ```
+   */
+  loading?: boolean;
+
+  /**
+   * Label rendered next to the track. The whole `<label>` element is the
+   * click target — clicking the label toggles the switch. Omit for
+   * icon-only switches + pair with `aria-label`.
+   */
+  children?: ReactNode;
+}
+```
+
+**Native attrs spread to the `<input>`**: all of `InputHTMLAttributes<HTMLInputElement>` minus `size`, `type`, `checked`, `defaultChecked`, `onChange`. Includes `disabled`, `required`, `name`, `id`, `value` (form submission value), `aria-*`, `data-*`, `onFocus`, `onBlur`, etc.
+
+**Spread order — Pattern A (consumer wins)** for non-ARIA attrs, with the controlled attrs (`checked`, `aria-checked`, `aria-invalid`, `aria-busy`, `role`, `type`, `disabled`) explicitly set AFTER the spread when the component owns them:
+
+```tsx
+<input
+  ref={ref}
+  {...props}
+  type="checkbox"
+  role="switch"
+  checked={currentChecked}
+  disabled={disabled || loading}
+  aria-invalid={invalid || undefined}
+  aria-busy={loading || undefined}
+  onChange={handleChange}
+  className={clsx(styles.input, props.className)}
+/>
+```
+
+The component owns `type`, `role`, `checked`, `disabled` (with loading-merge), `aria-invalid`, `aria-busy`, and `onChange`. Consumer can't override these — preserving the switch contract is more important than full Pattern A here. This is the same pattern Checkbox uses.
+
+## Architecture flow
+
+### Internal checked mirror
+
+```tsx
+const [internalChecked, setInternalChecked] = useState(defaultChecked ?? false);
+const isControlled = checked !== undefined;
+const currentChecked = isControlled ? checked : internalChecked;
+
+const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  if (!isControlled) setInternalChecked(e.target.checked);
+  onChange?.(e.target.checked, e);
+};
+```
+
+Same pattern as Textarea's value mirror + Checkbox's checked mirror. The `data-checked` attribute on the track reads from `currentChecked`, so the track repaints synchronously for both controlled (via `checked` prop) and uncontrolled (via the local state).
+
+### Loading + disabled coupling
+
+`disabled={disabled || loading}` on the input — `loading` implies disabled. This:
+- Blocks click-to-toggle via the label (the input doesn't fire change events)
+- Blocks Space-key toggle (focused-but-disabled input doesn't accept input)
+- Sets the native `:disabled` pseudoclass that the SCSS can style against
+
+If a consumer wants `disabled={false}` while `loading={true}`... they can't. Loading always disables. Documented in the `loading` JSDoc.
+
+### Spinner mount
+
+```tsx
+{loading && <Loader2 className={styles.spin} size={SPIN_SIZE[size]} aria-hidden="true" />}
+```
+
+The spinner sits inside `<span class="thumb">`. The thumb itself doesn't change size — the spinner is positioned absolutely inside, slightly smaller than the thumb.
+
+Spinner sizes: sm=8, md=10, lg=12 (smaller than the thumb diameter so it visually fits).
+
+### Track + thumb positioning
+
+The thumb is positioned with `transform: translateX(...)` and the SCSS uses CSS custom properties on the track for the per-size travel distance:
+
+```scss
+.track {
+  --thumb-travel: 0;  // overridden per size
+  
+  .thumb {
+    transform: translateX(0);
+    transition: transform var(--transition-base);
+  }
+}
+
+.track[data-checked='true'] .thumb {
+  transform: translateX(var(--thumb-travel));
+}
+
+.sm { --thumb-travel: 12px; }  // 28 - 12 - 4
+.md { --thumb-travel: 14px; }  // 36 - 16 - 6 (2px inset on each side)
+.lg { --thumb-travel: 18px; }  // 44 - 20 - 6
+```
+
+(Exact pixel math will be verified in implementation — point is the travel distance is a per-size value.)
+
+## Styling — `Switch.module.scss`
+
+```scss
+@use '../../styles/mixins' as *;
+
+.wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+
+  &[data-disabled='true'] {
+    cursor: not-allowed;
+    opacity: var(--opacity-disabled);
+  }
+}
+
+.input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.track {
+  position: relative;
+  display: inline-block;
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-full);
+  border: var(--border-width) solid transparent;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+  flex-shrink: 0;
+
+  &:hover {
+    background: var(--color-bg-sunken);
+  }
+}
+
+.track[data-checked='true'][data-tone='accent']  { background: var(--color-accent); }
+.track[data-checked='true'][data-tone='success'] { background: var(--color-success); }
+.track[data-checked='true'][data-tone='danger']  { background: var(--color-danger); }
+
+.track[data-checked='true'][data-tone='accent']:hover  { background: var(--color-accent-hover); }
+.track[data-checked='true'][data-tone='success']:hover { background: var(--color-success-hover); }
+.track[data-checked='true'][data-tone='danger']:hover  { background: var(--color-danger-hover); }
+
+.thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  background: var(--color-bg);
+  border-radius: 50%;
+  transition: transform var(--transition-base);
+  display: grid;
+  place-items: center;
+}
+
+.track[data-checked='true'] .thumb {
+  transform: translateX(var(--thumb-travel, 14px));
+}
+
+// Sizes — set track dimensions + thumb diameter + travel distance.
+.sm {
+  width: 28px;
+  height: 16px;
+  --thumb-travel: 12px;
+}
+.sm .thumb { width: 12px; height: 12px; }
+
+.md {
+  width: 36px;
+  height: 20px;
+  --thumb-travel: 14px;
+}
+.md .thumb { width: 16px; height: 16px; }
+
+.lg {
+  width: 44px;
+  height: 24px;
+  --thumb-travel: 18px;
+}
+.lg .thumb { width: 20px; height: 20px; }
+
+.label {
+  font-family: inherit;
+  color: var(--color-fg);
+}
+
+.labelSm { font-size: var(--font-size-sm); }
+.labelMd { font-size: var(--font-size-md); }
+.labelLg { font-size: var(--font-size-lg); }
+
+// Focus ring on the wrapper when the (hidden) input is focused.
+.input:focus-visible + .track {
+  @include focus-ring;
+}
+
+.input:focus-visible + .track[data-invalid='true'] {
+  @include focus-ring(var(--ring-danger));
+}
+
+.track[data-invalid='true'] {
+  border-color: var(--color-danger);
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+  color: var(--color-fg-muted);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thumb,
+  .track,
+  .spin {
+    transition: none;
+    animation: none;
+  }
+}
+```
+
+**Rule 4 check:**
+- `.wrapper` has `display: inline-flex` — that's intrinsic display, not layout. `gap: var(--space-2)` is internal spacing between children.
+- `.input` uses the visually-hidden pattern (`position: absolute`, etc.) — this is internal-only, not a flow component. Same disable-line treatment as Checkbox/Radio.
+- `.track` and `.thumb` use `position: relative`/`absolute` — internal child positioning, not at the component boundary. Same pattern as Checkbox's painted box.
+- No `align-self`, no `flex-grow`, no `margin` at the component boundary.
+
+If stylelint flags the `position: absolute` on the input or thumb, add inline-disables with "internal-only visually-hidden recipe" / "internal thumb positioning" rationale, matching Checkbox/Radio's existing comments.
+
+## ARIA + behavior reference
+
+| Concern | Behavior |
+|---|---|
+| Element | `<input type="checkbox" role="switch">` — native checkbox semantics for form submission, switch role for AT announcement |
+| Checked state | `aria-checked` reflected automatically from the native `checked` attribute (no manual ARIA needed) |
+| Invalid state | `aria-invalid="true"` only when `invalid={true}` |
+| Loading state | `aria-busy="true"` only when `loading={true}` |
+| Disabled state | Native `disabled` attribute |
+| Focus | Focus lands on the input (natural Tab). Wrapper has `:focus-within` styling via the `.input:focus-visible + .track` selector |
+| Keyboard | Space toggles (native checkbox behavior — works because the underlying element IS a checkbox) |
+| Label association | The whole `<label>` is the click target — no `htmlFor` plumbing needed |
+| Spread order | Component owns `type`, `role`, `checked`, `disabled`, `aria-invalid`, `aria-busy`, `onChange`. Other native attrs follow Pattern A (consumer wins). |
+| Ref target | The `<input>` element. Consumers can `.focus()`, read `.checked`, etc. |
+
+## Testing
+
+`Switch.test.tsx` — 22 cases, RTL + userEvent.
+
+### Baseline
+
+1. Renders without crashing with default props
+2. Renders the label from `children`
+3. Renders icon-only with `aria-label` and no children
+4. Default size = `'md'`; `sm` and `lg` apply the corresponding classes
+5. Default tone = `'accent'`; `success` and `danger` apply the right `data-tone`
+6. `ref` forwards to the `<input>` element (not the wrapper)
+7. `className` (passed via spread) merges, doesn't replace
+8. `role="switch"` is set on the input
+9. The native input has `type="checkbox"`
+
+### State
+
+10. Controlled: `checked={true}` reflects in the input's checked AND `data-checked='true'` on the track
+11. Controlled: clicking the label fires `onChange(true, event)` then `onChange(false, event)`
+12. Uncontrolled: starts at `defaultChecked` (test both true and false)
+13. Uncontrolled: click toggles + `data-checked` flips
+14. `disabled={true}` blocks `onChange` from firing on click + sets `disabled` on the input
+15. Space-key on the focused input toggles (controlled with `onChange`)
+
+### Loading
+
+16. `loading={true}` sets `aria-busy="true"` on the input
+17. `loading={true}` renders a spinner element inside the thumb
+18. `loading={true}` disables the input — click does NOT fire `onChange`
+19. `loading={false}` (default) does NOT render the spinner
+
+### Invalid
+
+20. `invalid={true}` sets `aria-invalid="true"` on the input
+21. `invalid={true}` applies `data-invalid='true'` (or invalid class) on the track
+
+### Tone
+
+22. Each tone (`accent`/`success`/`danger`) sets a unique `data-tone` attribute on the track
+
+**Vitest gotchas**: 
+- `screen.getByRole('switch')` works because `role="switch"` overrides the implicit `role="checkbox"`.
+- Space-key test needs the input to be focused first: `await user.tab(); await user.keyboard(' ');`.
+
+## Playground demo — `SwitchDemo.tsx`
+
+7 examples:
+
+1. **Default + with label** — `<Switch>Enable notifications</Switch>` (uncontrolled).
+2. **Three sizes** — `sm` / `md` / `lg` side by side, same label.
+3. **Three tones** — accent (default), success, danger, all checked.
+4. **Controlled** — wired to `useState`. Demonstrates the `onChange(next, e)` callback signature.
+5. **Loading (async toggle)** — button-triggered: fires `setLoading(true)`, waits 1.5s, then flips and clears loading. Demonstrates the optimistic-update pattern from the JSDoc.
+6. **Invalid state** — `invalid` with a danger-toned error message below.
+7. **Disabled** — `disabled` with a label, checked and unchecked side by side.
+
+The viewport mount is irrelevant — Switch is a flow element.
+
+## AGENTS.md TL;DR slot
+
+After `### \`<Checkbox>\``, before `### \`<Radio>\``. ~25-line block:
+
+````markdown
+### `<Switch>` — binary toggle
+
+Hand-rolled track + thumb on a native `<input type="checkbox" role="switch">`. The dumb on/off toggle for settings, feature flags, and async persisted state.
+
+```tsx
+import { Switch } from '@eocrm/design-system';
+
+// Default — uncontrolled, accent tone.
+<Switch>Enable notifications</Switch>
+
+// Controlled, success tone.
+<Switch tone="success" checked={enabled} onChange={(next) => setEnabled(next)}>
+  Daily digest
+</Switch>
+
+// Async (server-persisted) toggle.
+<Switch
+  checked={enabled}
+  loading={saving}
+  onChange={async (next) => {
+    setSaving(true);
+    setEnabled(next);            // optimistic
+    try { await api.save(next); }
+    catch { setEnabled(!next); } // rollback
+    finally { setSaving(false); }
+  }}
+>
+  Two-factor auth
+</Switch>
+
+// Icon-only.
+<Switch aria-label="Mute notifications" />
+```
+
+- **Native `<input type="checkbox" role="switch">`**. Form submission works; AT announces as switch.
+- **Three tones** (`accent`/`success`/`danger`) for the checked track. Unchecked track is always neutral muted.
+- **`loading={true}`** shows a spinner inside the thumb + disables the input (sets `aria-busy`). Consumer manages the optimistic-update flow.
+- **`onChange(checked, event)`** signature matches Checkbox — first arg is the next boolean, second is the raw event.
+
+#### When NOT to use
+
+- ❌ Selecting one option from a list of mutually-exclusive choices → `<Radio>` / `<RadioGroup>`.
+- ❌ Selecting multiple from a list → `<Checkbox>`.
+- ❌ A mixed / indeterminate state ("some-but-not-all enabled") → use Checkbox's `indeterminate`.
+- ❌ Triggering an action immediately on click (no state) → `<Button>`.
+
+#### Anti-patterns
+
+- ❌ Using `placeholder`-style hints inside the track ("OFF" / "ON" text). Use a real label.
+- ❌ Toggle without an external optimistic-update flow when `loading` is set. Without it, the user clicks the switch, the spinner appears, and the visual state never changes — confusing.
+- ❌ `tone="success"` for "Mark as failed". Tone communicates the meaning of "on", not just decoration.
+````
+
+## Hard Rule 8
+
+The pre-push review-fix cycle on library changes is mandatory. Gates green (`make test`, `make build-lib`, `make build`, `make lint`, `npm pack --dry-run`), spawn fresh-context reviewer with the standard Toast/ButtonGroup/Textarea prompt, fix every Critical + Important, repeat until clean.
+
+## Open questions
+
+None. All clarifications baked in above.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -202,6 +202,58 @@ import { Textarea } from '@eocrm/design-system';
 - Native HTML attrs flow through (`name`, `value`, `required`, `form`, `autoFocus`, etc.). `FormData.getAll(name)` returns the array of checked values for same-`name` checkboxes.
 - forwardRef points at the native `<input>` so consumers can `.focus()` or programmatically set `.indeterminate`.
 
+### `<Switch>` — binary toggle
+
+Hand-rolled track + thumb on a native `<input type="checkbox" role="switch">`. The dumb on/off toggle for settings, feature flags, and async persisted state.
+
+```tsx
+import { Switch } from '@eocrm/design-system';
+
+// Default — uncontrolled, accent tone.
+<Switch>Enable notifications</Switch>
+
+// Controlled, success tone.
+<Switch tone="success" checked={enabled} onChange={(next) => setEnabled(next)}>
+  Daily digest
+</Switch>
+
+// Async (server-persisted) toggle.
+<Switch
+  checked={enabled}
+  loading={saving}
+  onChange={async (next) => {
+    setSaving(true);
+    setEnabled(next);            // optimistic
+    try { await api.save(next); }
+    catch { setEnabled(!next); } // rollback
+    finally { setSaving(false); }
+  }}
+>
+  Two-factor auth
+</Switch>
+
+// Icon-only.
+<Switch aria-label="Mute notifications" />
+```
+
+- **Native `<input type="checkbox" role="switch">`**. Form submission works; AT announces as switch.
+- **Three tones** (`accent`/`success`/`danger`) for the checked track. Unchecked track is always neutral muted.
+- **`loading={true}`** shows a spinner inside the thumb + disables the input (sets `aria-busy`). Consumer manages the optimistic-update flow.
+- **`onChange(checked, event)`** signature matches Checkbox — first arg is the next boolean, second is the raw event.
+
+#### When NOT to use
+
+- ❌ Selecting one option from a list of mutually-exclusive choices → `<Radio>` / `<RadioGroup>`.
+- ❌ Selecting multiple from a list → `<Checkbox>`.
+- ❌ A mixed / indeterminate state ("some-but-not-all enabled") → use Checkbox's `indeterminate`.
+- ❌ Triggering an action immediately on click (no state) → `<Button>`.
+
+#### Anti-patterns
+
+- ❌ Using `placeholder`-style hints inside the track ("OFF" / "ON" text). Use a real label.
+- ❌ Toggle without an external optimistic-update flow when `loading` is set. Without it, the user clicks the switch, the spinner appears, and the visual state never changes — confusing.
+- ❌ `tone="success"` for "Mark as failed". Tone communicates the meaning of "on", not just decoration.
+
 ### `<Radio>` — single radio button
 
 ```tsx

--- a/packages/design-system/src/components/Switch/Switch.module.scss
+++ b/packages/design-system/src/components/Switch/Switch.module.scss
@@ -33,7 +33,7 @@
   /* stylelint-disable-next-line property-disallowed-list -- internal child positioning for the thumb */
   position: relative;
   display: inline-block;
-  background: var(--color-bg-muted);
+  background: var(--color-border-strong);
   border-radius: var(--radius-full);
   border: var(--border-width) solid transparent;
   transition:
@@ -42,7 +42,7 @@
   flex-shrink: 0;
 
   &:hover {
-    background: var(--color-bg-sunken);
+    background: var(--color-fg-disabled);
   }
 }
 
@@ -77,18 +77,23 @@
 .thumb {
   /* stylelint-disable property-disallowed-list -- internal absolute positioning of the thumb inside the track */
   position: absolute;
-  top: 2px;
+  top: 50%;
   left: 2px;
   /* stylelint-enable property-disallowed-list */
   background: var(--color-bg);
   border-radius: 50%;
+
+  // translateY(-50%) keeps the thumb vertically centered regardless of the
+  // track's border or padding box quirks. translateX composes on top when
+  // the checked-state rule fires.
+  transform: translateY(-50%);
   transition: transform var(--transition-base);
   display: grid;
   place-items: center;
 }
 
 .track[data-checked='true'] .thumb {
-  transform: translateX(var(--thumb-travel, 14px));
+  transform: translateY(-50%) translateX(var(--thumb-travel, 14px));
 }
 
 // Sizes — set track dimensions, thumb diameter, and travel distance.

--- a/packages/design-system/src/components/Switch/Switch.module.scss
+++ b/packages/design-system/src/components/Switch/Switch.module.scss
@@ -1,0 +1,172 @@
+@use '../../styles/mixins' as *;
+
+.wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+  user-select: none;
+
+  &[data-disabled='true'] {
+    cursor: not-allowed;
+    opacity: var(--opacity-disabled);
+  }
+}
+
+// Visually-hidden but interactive native input. Same recipe as
+// Checkbox/Radio's hidden inputs.
+.input {
+  /* stylelint-disable property-disallowed-list -- visually-hidden recipe */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+  /* stylelint-enable property-disallowed-list */
+}
+
+.track {
+  /* stylelint-disable-next-line property-disallowed-list -- internal child positioning for the thumb */
+  position: relative;
+  display: inline-block;
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-full);
+  border: var(--border-width) solid transparent;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+  flex-shrink: 0;
+
+  &:hover {
+    background: var(--color-bg-sunken);
+  }
+}
+
+.track[data-checked='true'][data-tone='accent'] {
+  background: var(--color-accent);
+}
+
+.track[data-checked='true'][data-tone='success'] {
+  background: var(--color-success);
+}
+
+.track[data-checked='true'][data-tone='danger'] {
+  background: var(--color-danger);
+}
+
+.track[data-checked='true'][data-tone='accent']:hover {
+  background: var(--color-accent-hover);
+}
+
+.track[data-checked='true'][data-tone='success']:hover {
+  background: var(--color-success-hover);
+}
+
+.track[data-checked='true'][data-tone='danger']:hover {
+  background: var(--color-danger-hover);
+}
+
+.track[data-invalid='true'] {
+  border-color: var(--color-danger);
+}
+
+.thumb {
+  /* stylelint-disable property-disallowed-list -- internal absolute positioning of the thumb inside the track */
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  /* stylelint-enable property-disallowed-list */
+  background: var(--color-bg);
+  border-radius: 50%;
+  transition: transform var(--transition-base);
+  display: grid;
+  place-items: center;
+}
+
+.track[data-checked='true'] .thumb {
+  transform: translateX(var(--thumb-travel, 14px));
+}
+
+// Sizes — set track dimensions, thumb diameter, and travel distance.
+.sizeSm {
+  width: 28px;
+  height: 16px;
+  --thumb-travel: 12px;
+}
+
+.sizeSm .thumb {
+  width: 12px;
+  height: 12px;
+}
+
+.sizeMd {
+  width: 36px;
+  height: 20px;
+  --thumb-travel: 14px;
+}
+
+.sizeMd .thumb {
+  width: 16px;
+  height: 16px;
+}
+
+.sizeLg {
+  width: 44px;
+  height: 24px;
+  --thumb-travel: 18px;
+}
+
+.sizeLg .thumb {
+  width: 20px;
+  height: 20px;
+}
+
+.label {
+  font-family: inherit;
+  color: var(--color-fg);
+}
+
+.labelSm {
+  font-size: var(--font-size-sm);
+}
+
+.labelMd {
+  font-size: var(--font-size-md);
+}
+
+.labelLg {
+  font-size: var(--font-size-lg);
+}
+
+// Focus ring on the track when the (visually-hidden) input is focus-visible.
+.input:focus-visible + .track {
+  @include focus-ring;
+}
+
+.input:focus-visible + .track[data-invalid='true'] {
+  @include focus-ring(var(--ring-danger));
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+  color: var(--color-fg-muted);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thumb,
+  .track,
+  .spin {
+    transition: none;
+    animation: none;
+  }
+}

--- a/packages/design-system/src/components/Switch/Switch.test.tsx
+++ b/packages/design-system/src/components/Switch/Switch.test.tsx
@@ -1,0 +1,207 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Switch } from './Switch';
+
+describe('<Switch>', () => {
+  // ─── Baseline ──────────────────────────────────────────────────────────
+
+  it('renders without crashing with default props', () => {
+    render(<Switch aria-label="Notifications" />);
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+  });
+
+  it('renders the label from children', () => {
+    render(<Switch>Enable notifications</Switch>);
+    expect(screen.getByText('Enable notifications')).toBeInTheDocument();
+  });
+
+  it('icon-only works with aria-label and no children', () => {
+    render(<Switch aria-label="Mute" />);
+    expect(screen.getByRole('switch', { name: 'Mute' })).toBeInTheDocument();
+  });
+
+  it('defaults to size="md"', () => {
+    const { container } = render(<Switch aria-label="x" />);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track.className).toMatch(/sizeMd/);
+  });
+
+  it('size="sm" applies the sm class', () => {
+    const { container } = render(<Switch aria-label="x" size="sm" />);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track.className).toMatch(/sizeSm/);
+  });
+
+  it('size="lg" applies the lg class', () => {
+    const { container } = render(<Switch aria-label="x" size="lg" />);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track.className).toMatch(/sizeLg/);
+  });
+
+  it('defaults to tone="accent"', () => {
+    const { container } = render(<Switch aria-label="x" />);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track).toHaveAttribute('data-tone', 'accent');
+  });
+
+  it.each([
+    ['success', 'success'],
+    ['danger', 'danger'],
+    ['accent', 'accent'],
+  ] as const)('tone="%s" sets data-tone="%s"', (toneIn, toneOut) => {
+    const { container } = render(<Switch aria-label="x" tone={toneIn} />);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track).toHaveAttribute('data-tone', toneOut);
+  });
+
+  it('forwards ref to the <input> element', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<Switch aria-label="x" ref={ref} />);
+    expect(ref.current).not.toBeNull();
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    expect(ref.current?.type).toBe('checkbox');
+  });
+
+  it('className is merged onto the wrapper, not replaced', () => {
+    const { container } = render(
+      <Switch aria-label="x" className="custom-wrap" />,
+    );
+    const wrapper = container.querySelector('label')!;
+    expect(wrapper.className).toMatch(/custom-wrap/);
+    expect(wrapper.className).toMatch(/wrapper/);
+  });
+
+  it('role="switch" is set on the input', () => {
+    render(<Switch aria-label="x" />);
+    const input = screen.getByRole('switch');
+    expect(input).toHaveAttribute('role', 'switch');
+  });
+
+  it('the native input has type="checkbox"', () => {
+    render(<Switch aria-label="x" />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    expect(input.type).toBe('checkbox');
+  });
+
+  // ─── State ─────────────────────────────────────────────────────────────
+
+  it('controlled: checked={true} reflects in the input AND data-checked on track', () => {
+    const { container } = render(
+      <Switch aria-label="x" checked onChange={() => {}} />,
+    );
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    const track = container.querySelector('[data-tone]')!;
+    expect(input.checked).toBe(true);
+    expect(track).toHaveAttribute('data-checked', 'true');
+  });
+
+  it('controlled: clicking the label fires onChange with the next boolean', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <Switch aria-label="x" checked={false} onChange={handleChange} />,
+    );
+    await user.click(screen.getByRole('switch'));
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange.mock.calls[0][0]).toBe(true);
+    // Second arg is the change event.
+    expect(handleChange.mock.calls[0][1]).toHaveProperty('target');
+  });
+
+  it('uncontrolled: defaultChecked={true} starts checked', () => {
+    const { container } = render(<Switch aria-label="x" defaultChecked />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    const track = container.querySelector('[data-tone]')!;
+    expect(input.checked).toBe(true);
+    expect(track).toHaveAttribute('data-checked', 'true');
+  });
+
+  it('uncontrolled: defaultChecked={false} (or omitted) starts unchecked', () => {
+    const { container } = render(<Switch aria-label="x" />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    const track = container.querySelector('[data-tone]')!;
+    expect(input.checked).toBe(false);
+    expect(track).toHaveAttribute('data-checked', 'false');
+  });
+
+  it('uncontrolled: click toggles the input + flips data-checked', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Switch aria-label="x" />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    const track = container.querySelector('[data-tone]')!;
+    await user.click(input);
+    expect(input.checked).toBe(true);
+    expect(track).toHaveAttribute('data-checked', 'true');
+  });
+
+  it('disabled={true} sets disabled on the input AND blocks onChange', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<Switch aria-label="x" disabled onChange={handleChange} />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    expect(input).toBeDisabled();
+    await user.click(input);
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('Space-key toggles when the input is focused (uncontrolled)', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Switch aria-label="x" />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    input.focus();
+    await user.keyboard(' ');
+    expect(input.checked).toBe(true);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track).toHaveAttribute('data-checked', 'true');
+  });
+
+  // ─── Loading ───────────────────────────────────────────────────────────
+
+  it('loading={true} sets aria-busy="true" on the input', () => {
+    render(<Switch aria-label="x" loading />);
+    const input = screen.getByRole('switch');
+    expect(input).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('loading={true} also disables the input (so clicks do not fire onChange)', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<Switch aria-label="x" loading onChange={handleChange} />);
+    const input = screen.getByRole('switch');
+    expect(input).toBeDisabled();
+    await user.click(input);
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('loading={true} renders a spinner inside the thumb', () => {
+    // The spinner is the Loader2 lucide icon; we identify it via the spin class.
+    const { container } = render(<Switch aria-label="x" loading />);
+    const spinner = container.querySelector('[class*="spin"]');
+    expect(spinner).not.toBeNull();
+  });
+
+  it('loading={false} (default) does NOT render the spinner', () => {
+    const { container } = render(<Switch aria-label="x" />);
+    const spinner = container.querySelector('[class*="spin"]');
+    expect(spinner).toBeNull();
+  });
+
+  // ─── Invalid ───────────────────────────────────────────────────────────
+
+  it('invalid={true} sets aria-invalid="true" on the input', () => {
+    render(<Switch aria-label="x" invalid />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('invalid={true} sets data-invalid="true" on the track', () => {
+    const { container } = render(<Switch aria-label="x" invalid />);
+    const track = container.querySelector('[data-tone]')!;
+    expect(track).toHaveAttribute('data-invalid', 'true');
+  });
+
+  it('invalid omitted does NOT set aria-invalid', () => {
+    render(<Switch aria-label="x" />);
+    expect(screen.getByRole('switch')).not.toHaveAttribute('aria-invalid');
+  });
+});

--- a/packages/design-system/src/components/Switch/Switch.test.tsx
+++ b/packages/design-system/src/components/Switch/Switch.test.tsx
@@ -64,9 +64,7 @@ describe('<Switch>', () => {
   });
 
   it('className is merged onto the wrapper, not replaced', () => {
-    const { container } = render(
-      <Switch aria-label="x" className="custom-wrap" />,
-    );
+    const { container } = render(<Switch aria-label="x" className="custom-wrap" />);
     const wrapper = container.querySelector('label')!;
     expect(wrapper.className).toMatch(/custom-wrap/);
     expect(wrapper.className).toMatch(/wrapper/);
@@ -87,9 +85,7 @@ describe('<Switch>', () => {
   // ─── State ─────────────────────────────────────────────────────────────
 
   it('controlled: checked={true} reflects in the input AND data-checked on track', () => {
-    const { container } = render(
-      <Switch aria-label="x" checked onChange={() => {}} />,
-    );
+    const { container } = render(<Switch aria-label="x" checked onChange={() => {}} />);
     const input = screen.getByRole('switch') as HTMLInputElement;
     const track = container.querySelector('[data-tone]')!;
     expect(input.checked).toBe(true);
@@ -115,9 +111,15 @@ describe('<Switch>', () => {
     render(<Controlled />);
     const input = screen.getByRole('switch');
     await user.click(input);
-    expect(handleChange).toHaveBeenLastCalledWith(true, expect.objectContaining({ target: expect.anything() }));
+    expect(handleChange).toHaveBeenLastCalledWith(
+      true,
+      expect.objectContaining({ target: expect.anything() }),
+    );
     await user.click(input);
-    expect(handleChange).toHaveBeenLastCalledWith(false, expect.objectContaining({ target: expect.anything() }));
+    expect(handleChange).toHaveBeenLastCalledWith(
+      false,
+      expect.objectContaining({ target: expect.anything() }),
+    );
   });
 
   it('uncontrolled: defaultChecked={true} starts checked', () => {

--- a/packages/design-system/src/components/Switch/Switch.test.tsx
+++ b/packages/design-system/src/components/Switch/Switch.test.tsx
@@ -1,4 +1,4 @@
-import { createRef } from 'react';
+import { createRef, useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Switch } from './Switch';
@@ -96,17 +96,28 @@ describe('<Switch>', () => {
     expect(track).toHaveAttribute('data-checked', 'true');
   });
 
-  it('controlled: clicking the label fires onChange with the next boolean', async () => {
+  it('controlled: clicking fires onChange with the next boolean (both directions)', async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
-    render(
-      <Switch aria-label="x" checked={false} onChange={handleChange} />,
-    );
-    await user.click(screen.getByRole('switch'));
-    expect(handleChange).toHaveBeenCalledTimes(1);
-    expect(handleChange.mock.calls[0][0]).toBe(true);
-    // Second arg is the change event.
-    expect(handleChange.mock.calls[0][1]).toHaveProperty('target');
+    function Controlled() {
+      const [v, setV] = useState(false);
+      return (
+        <Switch
+          aria-label="x"
+          checked={v}
+          onChange={(next, e) => {
+            handleChange(next, e);
+            setV(next);
+          }}
+        />
+      );
+    }
+    render(<Controlled />);
+    const input = screen.getByRole('switch');
+    await user.click(input);
+    expect(handleChange).toHaveBeenLastCalledWith(true, expect.objectContaining({ target: expect.anything() }));
+    await user.click(input);
+    expect(handleChange).toHaveBeenLastCalledWith(false, expect.objectContaining({ target: expect.anything() }));
   });
 
   it('uncontrolled: defaultChecked={true} starts checked', () => {
@@ -154,6 +165,17 @@ describe('<Switch>', () => {
     expect(input.checked).toBe(true);
     const track = container.querySelector('[data-tone]')!;
     expect(track).toHaveAttribute('data-checked', 'true');
+  });
+
+  it('Space-key does NOT toggle when loading (input is disabled)', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<Switch aria-label="x" loading onChange={handleChange} />);
+    const input = screen.getByRole('switch') as HTMLInputElement;
+    input.focus();
+    await user.keyboard(' ');
+    expect(input.checked).toBe(false);
+    expect(handleChange).not.toHaveBeenCalled();
   });
 
   // ─── Loading ───────────────────────────────────────────────────────────

--- a/packages/design-system/src/components/Switch/Switch.tsx
+++ b/packages/design-system/src/components/Switch/Switch.tsx
@@ -20,11 +20,10 @@ export type SwitchSize = 'sm' | 'md' | 'lg';
  */
 export type SwitchTone = 'accent' | 'success' | 'danger';
 
-export interface SwitchProps
-  extends Omit<
-    InputHTMLAttributes<HTMLInputElement>,
-    'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
-  > {
+export interface SwitchProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
+> {
   /**
    * Visual scale. Defaults to `'md'`.
    * - `'sm'` — 28×16 track, 12px thumb, `--font-size-sm` label.
@@ -185,9 +184,7 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(function Switch(
   },
   ref,
 ) {
-  const [internalChecked, setInternalChecked] = useState<boolean>(
-    defaultChecked ?? false,
-  );
+  const [internalChecked, setInternalChecked] = useState<boolean>(defaultChecked ?? false);
   const isControlled = checked !== undefined;
   const currentChecked = isControlled ? checked : internalChecked;
 
@@ -225,18 +222,10 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(function Switch(
         aria-hidden="true"
       >
         <span className={styles.thumb}>
-          {loading && (
-            <Loader2
-              size={SPIN_SIZE[size]}
-              className={styles.spin}
-              aria-hidden="true"
-            />
-          )}
+          {loading && <Loader2 size={SPIN_SIZE[size]} className={styles.spin} aria-hidden="true" />}
         </span>
       </span>
-      {children && (
-        <span className={clsx(styles.label, LABEL_CLASS[size])}>{children}</span>
-      )}
+      {children && <span className={clsx(styles.label, LABEL_CLASS[size])}>{children}</span>}
     </label>
   );
 });

--- a/packages/design-system/src/components/Switch/Switch.tsx
+++ b/packages/design-system/src/components/Switch/Switch.tsx
@@ -204,6 +204,7 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(function Switch(
       className={clsx(styles.wrapper, className)}
       data-disabled={isInteractionDisabled || undefined}
     >
+      {/* Pattern B — {...props} first so component-owned attrs (type, role, checked, disabled, aria-*, onChange, className) win. */}
       <input
         {...props}
         ref={ref}

--- a/packages/design-system/src/components/Switch/Switch.tsx
+++ b/packages/design-system/src/components/Switch/Switch.tsx
@@ -1,0 +1,241 @@
+import {
+  forwardRef,
+  useState,
+  type ChangeEvent,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from 'react';
+import { Loader2 } from 'lucide-react';
+import clsx from 'clsx';
+import styles from './Switch.module.scss';
+
+/**
+ * Track + thumb scale + label font. Pairs with Checkbox/Radio sizes.
+ */
+export type SwitchSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Color of the track when checked. Unchecked track is always
+ * `--color-bg-muted` regardless of tone.
+ */
+export type SwitchTone = 'accent' | 'success' | 'danger';
+
+export interface SwitchProps
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    'size' | 'type' | 'checked' | 'defaultChecked' | 'onChange'
+  > {
+  /**
+   * Visual scale. Defaults to `'md'`.
+   * - `'sm'` — 28×16 track, 12px thumb, `--font-size-sm` label.
+   * - `'md'` — 36×20 track, 16px thumb, `--font-size-md` label (default).
+   * - `'lg'` — 44×24 track, 20px thumb, `--font-size-lg` label.
+   *
+   * Note: shadows the native HTML `<input size>` attribute (meaningless on checkboxes).
+   */
+  size?: SwitchSize;
+
+  /**
+   * Track color when checked. Defaults to `'accent'`.
+   * - `'accent'` — blue (default).
+   * - `'success'` — green. Use for affirmative toggles ("Enable notifications").
+   * - `'danger'` — red. Use for destructive toggles ("Allow root access").
+   */
+  tone?: SwitchTone;
+
+  /**
+   * Controlled checked state. Pair with `onChange`. Omit (with optional
+   * `defaultChecked`) for uncontrolled use.
+   */
+  checked?: boolean;
+
+  /** Initial checked state for uncontrolled use. Defaults to `false`. */
+  defaultChecked?: boolean;
+
+  /**
+   * Fires when the user toggles the switch. The first arg is the next
+   * boolean (convenience); the original change event is the second arg.
+   * Matches `<Checkbox>`'s signature.
+   */
+  onChange?: (checked: boolean, e: ChangeEvent<HTMLInputElement>) => void;
+
+  /**
+   * Toggles `aria-invalid="true"` and adds a danger-tone border to the
+   * track. Use when the switch's state has caused a validation error.
+   */
+  invalid?: boolean;
+
+  /**
+   * Disables interaction and shows a spinner inside the thumb. Use for
+   * toggles that persist to a server. Sets `aria-busy="true"` and
+   * `disabled` on the native input so neither click nor Space-key can
+   * fire onChange while the async operation is in flight.
+   *
+   * The consumer is responsible for managing the optimistic-update flow:
+   *
+   * ```tsx
+   * const [enabled, setEnabled] = useState(initial);
+   * const [saving, setSaving] = useState(false);
+   *
+   * const handleToggle = async (next: boolean) => {
+   *   setSaving(true);
+   *   setEnabled(next);            // optimistic
+   *   try { await api.save(next); }
+   *   catch { setEnabled(!next); } // rollback
+   *   finally { setSaving(false); }
+   * };
+   *
+   * <Switch checked={enabled} loading={saving} onChange={handleToggle} />
+   * ```
+   */
+  loading?: boolean;
+
+  /**
+   * Label rendered next to the track. The whole `<label>` is the click
+   * target — clicking anywhere toggles. Omit for icon-only switches +
+   * pair with `aria-label`.
+   */
+  children?: ReactNode;
+}
+
+const SIZE_CLASS: Record<SwitchSize, string> = {
+  sm: styles.sizeSm,
+  md: styles.sizeMd,
+  lg: styles.sizeLg,
+};
+
+const LABEL_CLASS: Record<SwitchSize, string> = {
+  sm: styles.labelSm,
+  md: styles.labelMd,
+  lg: styles.labelLg,
+};
+
+const SPIN_SIZE: Record<SwitchSize, number> = {
+  sm: 8,
+  md: 10,
+  lg: 12,
+};
+
+/**
+ * Binary on/off toggle. Hand-rolled track + sliding thumb on a native
+ * `<input type="checkbox" role="switch">`. The dumb companion to
+ * `<Checkbox>` and `<Radio>` for binary state (settings, feature flags,
+ * server-persisted toggles).
+ *
+ * Forwards ref to the underlying `<input>`. Spread native attrs reach
+ * the input (e.g., `name`, `value`, `disabled`, `aria-label`).
+ *
+ * @example
+ * // Default — uncontrolled, accent tone.
+ * <Switch>Enable notifications</Switch>
+ *
+ * @example
+ * // Controlled, success tone.
+ * <Switch tone="success" checked={enabled} onChange={(next) => setEnabled(next)}>
+ *   Daily digest
+ * </Switch>
+ *
+ * @example
+ * // Async toggle with loading spinner.
+ * <Switch
+ *   checked={enabled}
+ *   loading={saving}
+ *   onChange={async (next) => {
+ *     setSaving(true);
+ *     setEnabled(next);
+ *     try { await api.save(next); }
+ *     catch { setEnabled(!next); }
+ *     finally { setSaving(false); }
+ *   }}
+ * >
+ *   Two-factor auth
+ * </Switch>
+ *
+ * @example
+ * // Icon-only.
+ * <Switch aria-label="Mute notifications" />
+ *
+ * @remarks When NOT to use
+ * - Mutually-exclusive choice → `<Radio>` / `<RadioGroup>`.
+ * - Multi-select list → `<Checkbox>`.
+ * - Mixed / indeterminate state → use Checkbox's `indeterminate`.
+ * - Immediate action without state → `<Button>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Using "ON" / "OFF" labels inside the track. Use a real adjacent label.
+ * - ❌ Setting `loading` without an external optimistic-update flow — the
+ *   user clicks, the spinner appears, the visual state never updates,
+ *   confusing.
+ * - ❌ `tone="success"` for "Mark as failed". Tone communicates the
+ *   meaning of the "on" state.
+ */
+export const Switch = forwardRef<HTMLInputElement, SwitchProps>(function Switch(
+  {
+    size = 'md',
+    tone = 'accent',
+    checked,
+    defaultChecked,
+    onChange,
+    invalid,
+    loading,
+    disabled,
+    children,
+    className,
+    ...props
+  },
+  ref,
+) {
+  const [internalChecked, setInternalChecked] = useState<boolean>(
+    defaultChecked ?? false,
+  );
+  const isControlled = checked !== undefined;
+  const currentChecked = isControlled ? checked : internalChecked;
+
+  // Loading implies disabled — blocks both click and Space-key toggles.
+  const isInteractionDisabled = disabled || loading;
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!isControlled) setInternalChecked(e.target.checked);
+    onChange?.(e.target.checked, e);
+  };
+
+  return (
+    <label
+      className={clsx(styles.wrapper, className)}
+      data-disabled={isInteractionDisabled || undefined}
+    >
+      <input
+        {...props}
+        ref={ref}
+        type="checkbox"
+        role="switch"
+        checked={currentChecked}
+        disabled={isInteractionDisabled}
+        aria-invalid={invalid || undefined}
+        aria-busy={loading || undefined}
+        onChange={handleChange}
+        className={styles.input}
+      />
+      <span
+        className={clsx(styles.track, SIZE_CLASS[size])}
+        data-checked={currentChecked ? 'true' : 'false'}
+        data-tone={tone}
+        data-invalid={invalid ? 'true' : undefined}
+        aria-hidden="true"
+      >
+        <span className={styles.thumb}>
+          {loading && (
+            <Loader2
+              size={SPIN_SIZE[size]}
+              className={styles.spin}
+              aria-hidden="true"
+            />
+          )}
+        </span>
+      </span>
+      {children && (
+        <span className={clsx(styles.label, LABEL_CLASS[size])}>{children}</span>
+      )}
+    </label>
+  );
+});

--- a/packages/design-system/src/components/Switch/index.ts
+++ b/packages/design-system/src/components/Switch/index.ts
@@ -1,0 +1,2 @@
+export { Switch } from './Switch';
+export type { SwitchProps, SwitchSize, SwitchTone } from './Switch';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -21,6 +21,9 @@ export type { CheckboxProps, CheckboxSize } from './components/Checkbox';
 export { Stack } from './components/Stack';
 export type { StackProps, StackGap, StackAlign } from './components/Stack';
 
+export { Switch } from './components/Switch';
+export type { SwitchProps, SwitchSize, SwitchTone } from './components/Switch';
+
 export { Cluster } from './components/Cluster';
 export type { ClusterProps, ClusterGap, ClusterJustify, ClusterAlign } from './components/Cluster';
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -16,6 +16,7 @@ import { PasswordStrengthMeterDemo } from './pages/components/PasswordStrengthMe
 import { PaginationDemo } from './pages/components/PaginationDemo';
 import { SelectDemo } from './pages/components/SelectDemo';
 import { SkeletonDemo } from './pages/components/SkeletonDemo';
+import { SwitchDemo } from './pages/components/SwitchDemo';
 import { TableDemo } from './pages/components/TableDemo';
 import { TextareaDemo } from './pages/components/TextareaDemo';
 import { CardDemo } from './pages/components/CardDemo';
@@ -66,6 +67,7 @@ export default function App() {
           />
           <Route path="/components/select" element={<SelectDemo />} />
           <Route path="/components/skeleton" element={<SkeletonDemo />} />
+          <Route path="/components/switch" element={<SwitchDemo />} />
           <Route path="/components/table" element={<TableDemo />} />
           <Route path="/components/card" element={<CardDemo />} />
           <Route path="/components/checkbox" element={<CheckboxDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -39,6 +39,7 @@ import {
   TableProperties,
   ListOrdered,
   LayoutPanelLeft,
+  ToggleRight,
   type LucideIcon,
 } from 'lucide-react';
 import { Avatar } from '@eocrm/design-system';
@@ -87,6 +88,7 @@ const componentGroups = [
       },
       { to: '/components/radio', label: 'Radio', icon: CircleDot, end: false },
       { to: '/components/select', label: 'Select', icon: ChevronsUpDown, end: false },
+      { to: '/components/switch', label: 'Switch', icon: ToggleRight, end: false },
       { to: '/components/textarea', label: 'Textarea', icon: MessageSquareText, end: false },
     ],
   },

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -14,6 +14,7 @@ import { PasswordStrengthMeter } from '@eocrm/design-system';
 import { Select } from '@eocrm/design-system';
 import { Skeleton } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
+import { Switch } from '@eocrm/design-system';
 import { Table } from '@eocrm/design-system';
 import { Tabs } from '@eocrm/design-system';
 import { Textarea } from '@eocrm/design-system';
@@ -180,6 +181,12 @@ const items: { to: string; name: string; description: string; preview: React.Rea
         />
       </div>
     ),
+  },
+  {
+    to: '/components/switch',
+    name: 'Switch',
+    description: 'Binary on/off toggle. Three tones + async loading state.',
+    preview: <Switch defaultChecked tone="success" aria-label="Preview" />,
   },
   {
     to: '/components/skeleton',

--- a/packages/playground/src/pages/components/SwitchDemo.tsx
+++ b/packages/playground/src/pages/components/SwitchDemo.tsx
@@ -101,12 +101,7 @@ const handleToggle = async (next: boolean) => {
   Two-factor auth
 </Switch>`}
       >
-        <Switch
-          checked={asyncEnabled}
-          loading={saving}
-          onChange={handleAsyncToggle}
-          tone="success"
-        >
+        <Switch checked={asyncEnabled} loading={saving} onChange={handleAsyncToggle} tone="success">
           Two-factor auth ({saving ? 'saving…' : asyncEnabled ? 'ON' : 'OFF'})
         </Switch>
       </Example>

--- a/packages/playground/src/pages/components/SwitchDemo.tsx
+++ b/packages/playground/src/pages/components/SwitchDemo.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react';
+import { Cluster, Stack, Switch } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Switch/Switch.tsx?raw';
+import scssSource from '@lib-source/components/Switch/Switch.module.scss?raw';
+
+export function SwitchDemo() {
+  const [controlled, setControlled] = useState(false);
+  const [asyncEnabled, setAsyncEnabled] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const handleAsyncToggle = async (next: boolean) => {
+    setSaving(true);
+    setAsyncEnabled(next);
+    // Fake server roundtrip.
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    setSaving(false);
+  };
+
+  return (
+    <DemoLayout
+      name="Switch"
+      componentName="Switch"
+      description="Binary on/off toggle. Native checkbox with switch role + sliding thumb. Three tones, loading state with thumb-spinner, invalid parity with Input/Textarea."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Switch.tsx"
+      scssFilename="Switch.module.scss"
+    >
+      <Example
+        title="Default + with label"
+        description="Uncontrolled. Click the label or the track to toggle."
+        code={`<Switch>Enable notifications</Switch>`}
+      >
+        <Switch>Enable notifications</Switch>
+      </Example>
+
+      <Example
+        title="Three sizes"
+        description="Size scales track + thumb + label font together."
+        code={`<Switch size="sm">Small</Switch>
+<Switch size="md">Medium (default)</Switch>
+<Switch size="lg">Large</Switch>`}
+      >
+        <Stack gap="sm">
+          <Switch size="sm">Small</Switch>
+          <Switch size="md">Medium (default)</Switch>
+          <Switch size="lg">Large</Switch>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Three tones (all checked)"
+        description="Tone only affects the checked-state track color. Unchecked is always neutral."
+        code={`<Switch defaultChecked tone="accent">Accent (default)</Switch>
+<Switch defaultChecked tone="success">Success</Switch>
+<Switch defaultChecked tone="danger">Danger</Switch>`}
+      >
+        <Stack gap="sm">
+          <Switch defaultChecked tone="accent">
+            Accent (default)
+          </Switch>
+          <Switch defaultChecked tone="success">
+            Success
+          </Switch>
+          <Switch defaultChecked tone="danger">
+            Danger
+          </Switch>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Controlled"
+        description="onChange receives (nextBool, event). The component is otherwise dumb — consumer drives the state."
+        code={`const [enabled, setEnabled] = useState(false);
+
+<Switch checked={enabled} onChange={(next) => setEnabled(next)}>
+  Marketing emails
+</Switch>`}
+      >
+        <Switch checked={controlled} onChange={(next) => setControlled(next)}>
+          Marketing emails ({controlled ? 'ON' : 'OFF'})
+        </Switch>
+      </Example>
+
+      <Example
+        title="Loading (async toggle with optimistic update)"
+        description="The button fakes a 1.5s server roundtrip. The switch updates immediately (optimistic), spins while saving, and would rollback on error. loading={true} disables the input."
+        code={`const [enabled, setEnabled] = useState(false);
+const [saving, setSaving] = useState(false);
+
+const handleToggle = async (next: boolean) => {
+  setSaving(true);
+  setEnabled(next);
+  await api.save(next);  // ...with try/catch + rollback in real code
+  setSaving(false);
+};
+
+<Switch checked={enabled} loading={saving} onChange={handleToggle}>
+  Two-factor auth
+</Switch>`}
+      >
+        <Switch
+          checked={asyncEnabled}
+          loading={saving}
+          onChange={handleAsyncToggle}
+          tone="success"
+        >
+          Two-factor auth ({saving ? 'saving…' : asyncEnabled ? 'ON' : 'OFF'})
+        </Switch>
+      </Example>
+
+      <Example
+        title="Invalid state"
+        description="aria-invalid + danger-tone border on the track. Use when validation has surfaced an error."
+        code={`<Switch invalid aria-describedby="terms-error">
+  I agree to the terms
+</Switch>
+<p id="terms-error" style={{ color: 'var(--color-danger)' }}>
+  You must agree to the terms before continuing.
+</p>`}
+      >
+        <Stack gap="sm">
+          <Switch invalid aria-describedby="terms-error">
+            I agree to the terms
+          </Switch>
+          <p
+            id="terms-error"
+            style={{
+              color: 'var(--color-danger)',
+              margin: 0,
+              fontSize: 'var(--font-size-sm)',
+            }}
+          >
+            You must agree to the terms before continuing.
+          </p>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Disabled"
+        description="Native disabled attribute. Unchecked and checked variants shown."
+        code={`<Switch disabled>Disabled (off)</Switch>
+<Switch disabled defaultChecked>Disabled (on)</Switch>`}
+      >
+        <Cluster gap="md">
+          <Switch disabled>Disabled (off)</Switch>
+          <Switch disabled defaultChecked>
+            Disabled (on)
+          </Switch>
+        </Cluster>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -31,6 +31,7 @@ export type ComponentName =
   | 'Select'
   | 'Skeleton'
   | 'Stack'
+  | 'Switch'
   | 'Table'
   | 'Tabs'
   | 'Textarea'


### PR DESCRIPTION
## Summary

- New \`<Switch>\` — the binary on/off companion to \`<Checkbox>\` and \`<Radio>\`. Hand-rolled track + sliding thumb on a native \`<input type=\"checkbox\" role=\"switch\">\`.
- **Three tones** (\`accent\` / \`success\` / \`danger\`) for the checked-state track color. Unchecked is always neutral.
- **Three sizes** (\`sm\` / \`md\` / \`lg\`) — track, thumb, and label font scale together. Same scale as Checkbox/Radio.
- **\`loading\`** state with spinner inside the thumb + auto-disable (\`aria-busy\` + native \`disabled\`). Consumer manages the optimistic-update flow.
- **\`invalid\`** parity with Input/Textarea — \`aria-invalid=\"true\"\` + danger-tone border.
- Custom \`onChange(checked, event)\` signature matches Checkbox.

## Design highlights

- **Native checkbox underneath.** Form submission works (the visually-hidden \`<input type=\"checkbox\">\` participates normally), but AT announces as switch via \`role=\"switch\"\`. \`<label>\` wraps everything so click-anywhere-toggles.
- **Internal-checked mirror** keeps the \`data-checked\` track attribute reactive for both controlled (via \`checked\`) and uncontrolled (via \`useState\`) use. Same pattern as Textarea's value mirror.
- **Per-size CSS custom property** (\`--thumb-travel\`) drives the \`transform: translateX(...)\` distance, so each size has a precise thumb travel.
- **\`loading\` implies \`disabled\`**. Setting \`loading={true}\` forces \`disabled\` on the input — blocks both click-to-toggle and Space-key. Documented in JSDoc.
- **Three data-attributes on the track**: \`data-checked\`, \`data-tone\`, \`data-invalid\`. SCSS drives all visual variation from these (not from \`input:checked\` directly), so the painted track stays in sync with both controlled and uncontrolled state.

## Hard Rule 8

**Round 1 verdict: clean enough to stop** (0 Critical + 0 Important). Three Nice-to-haves folded in as polish:

1. JSX spread-order comment on the \`<input>\` (Pattern B / Rule 7 hygiene; matches Checkbox precedent).
2. New test \"Space-key does NOT toggle when loading\" — pins the loading-implies-disabled behavior for the keyboard path.
3. Tightened the controlled \`onChange\` test to exercise both directions (false→true, then true→false) instead of just the first click.

**29 new tests** for Switch (24 top-level \`it()\` + 3 from \`it.each\` tone expansion + 2 from the round-1 folds). Total suite: **1388 passing**.

All four gates green: \`make test\` · \`make build-lib\` · \`make build\` · \`make lint\` · \`npm pack --dry-run\` (no test files in tarball).

## Test plan

- [ ] Default \`<Switch>Label</Switch>\` toggles on click (uncontrolled)
- [ ] Three sizes show proportional track + thumb + label font
- [ ] Three tones show different checked-state track colors
- [ ] Controlled: \`onChange\` fires \`(nextBool, event)\` on click — both directions
- [ ] Async toggle with \`loading={true}\`: click fires nothing, Space-key fires nothing, spinner renders inside the thumb
- [ ] \`invalid\` shows danger border on the track + \`aria-invalid=\"true\"\` on the input
- [ ] \`disabled\` renders the muted background visual + blocks all interaction
- [ ] Space-key toggles the focused input when not disabled/loading (native checkbox behavior survives the role override)
- [ ] Ref targets the \`<input>\` element (not the wrapper label)
- [ ] Playground demo at \`/components/switch\` renders all 7 examples without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)