### PR TITLE
Alert: persistent in-flow notification (4 tones + dismissible)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-alert.md
+++ b/docs/superpowers/plans/2026-05-23-alert.md
@@ -61,6 +61,7 @@ git log --oneline -3
 ```
 
 Expected:
+
 - Branch: `feat/alert`
 - Working tree clean
 - Most recent commit: `71b30e4 Alert: design spec — persistent in-flow notification`
@@ -185,7 +186,7 @@ Create `packages/design-system/src/components/Alert/Alert.module.scss`:
 
 Create `packages/design-system/src/components/Alert/Alert.tsx`:
 
-```tsx
+````tsx
 import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
 import { AlertTriangle, CheckCircle2, Info, X, XCircle } from 'lucide-react';
 import clsx from 'clsx';
@@ -202,8 +203,7 @@ import styles from './Alert.module.scss';
  */
 export type AlertTone = 'info' | 'success' | 'warning' | 'error';
 
-export interface AlertProps
-  extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'title'> {
+export interface AlertProps extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'title'> {
   /** Tone. Defaults to `'info'`. See `AlertTone` for full descriptions. */
   tone?: AlertTone;
 
@@ -327,19 +327,14 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(function Alert(
         {actions && <div className={styles.actions}>{actions}</div>}
       </div>
       {onDismiss && (
-        <button
-          type="button"
-          aria-label="Dismiss"
-          className={styles.close}
-          onClick={onDismiss}
-        >
+        <button type="button" aria-label="Dismiss" className={styles.close} onClick={onDismiss}>
           <X size={14} aria-hidden="true" />
         </button>
       )}
     </div>
   );
 });
-```
+````
 
 - [ ] **Step 4: Write the folder barrel**
 
@@ -447,9 +442,7 @@ describe('<Alert>', () => {
   });
 
   it('title and children both render together', () => {
-    render(
-      <Alert title="Heading">Body content</Alert>,
-    );
+    render(<Alert title="Heading">Body content</Alert>);
     expect(screen.getByText('Heading')).toBeInTheDocument();
     expect(screen.getByText('Body content')).toBeInTheDocument();
   });
@@ -544,6 +537,7 @@ npm test -w @eocrm/design-system -- --run src/components/Alert/Alert.test.tsx
 Expected: ~20 tests pass (17 top-level `it()` + 3 from `it.each` expansion).
 
 If a test fails:
+
 - **Default-tone `role="status"` test** failing: verify the JSX assigns `role={tone === 'error' ? 'alert' : 'status'}`.
 - **Icon `<svg>` test** failing: the lucide-react peer dep must be installed. Run `grep "lucide-react" packages/design-system/package.json` — should show in `peerDependencies` from PR #45.
 
@@ -608,7 +602,7 @@ grep -n "Alert\|Avatar\|Badge" packages/design-system/src/index.ts | head
 
 - [ ] **Step 2: Add TL;DR to AGENTS.md**
 
-Open `packages/design-system/AGENTS.md`. Find the `### \`<ToastViewport>\` + \`toast\`` section header (around line 657). The Toast section ends just before `### \`<ConfirmationPopover>\`` (around line 699). Insert the new Alert section between them.
+Open `packages/design-system/AGENTS.md`. Find the `### \`<ToastViewport>\` + \`toast\``section header (around line 657). The Toast section ends just before`### \`<ConfirmationPopover>\`` (around line 699). Insert the new Alert section between them.
 
 Use grep to confirm exact line numbers:
 
@@ -895,11 +889,8 @@ Find the items array. Add a card alphabetically (with other A-prefixed items, be
 Open `packages/playground/src/pages/mockups/registry.ts`. Find `export type ComponentName =` (around line 3) and add `'Alert'` FIRST in the union (alphabetical before `'Avatar'`):
 
 ```ts
-export type ComponentName =
-  | 'Alert'
-  | 'Avatar'
-  | 'Badge'
-  // …rest unchanged…;
+export type ComponentName = 'Alert' | 'Avatar' | 'Badge';
+// …rest unchanged…;
 ```
 
 No existing mockup uses Alert yet, so no `usesComponents` arrays need updating.
@@ -964,6 +955,7 @@ npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -E "Alert|test\."
 ```
 
 Expected:
+
 - Alert source files (`Alert.tsx`, `Alert.module.scss`, `index.ts`) in the tarball
 - NO `*.test.*` files
 
@@ -974,6 +966,7 @@ Use a `general-purpose` subagent with model `opus`. Prompt template (substitute 
 > Fresh-context Hard-Rule-8 review of the Alert PR. Branch `feat/alert` at HEAD `<sha>`. Per `packages/design-system/CLAUDE.md` Rule 8 — review the full diff against `main` and report findings as Critical / Important / Nice-to-have / Regression-watch.
 >
 > Files in scope:
+>
 > - `packages/design-system/src/components/Alert/` (Alert.tsx + .module.scss + .test.tsx + index.ts)
 > - `packages/design-system/src/index.ts`
 > - `packages/design-system/AGENTS.md`
@@ -983,6 +976,7 @@ Use a `general-purpose` subagent with model `opus`. Prompt template (substitute 
 > Read first: `packages/design-system/CLAUDE.md` (Rules 1–7), `AGENTS.md` (Alert section + surrounding Toast/ConfirmationPopover sections), `docs/superpowers/specs/2026-05-23-alert-design.md`. Compare against Toast for tone-pattern parity.
 >
 > Verify:
+>
 > - **Rule 1**: tests exist (~20 cases including it.each).
 > - **Rule 3**: NO raw values in `Alert.module.scss`. All `var(--…)`. The two `margin-top` rules have inline disables.
 > - **Rule 4**: NO `position`/`align-self`/`flex: 1`/`width` at the component boundary. The `display: grid` on `.alert` is internal layout of children, not at the boundary.

--- a/docs/superpowers/plans/2026-05-23-alert.md
+++ b/docs/superpowers/plans/2026-05-23-alert.md
@@ -1,0 +1,1103 @@
+# Alert Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Alert>` — a persistent in-flow notification primitive that fills the gap between `<Toast>` (transient, auto-dismissing) and inline error text. Four tones (info/success/warning/error), single visual variant (subtle tinted background + left accent stripe), optional title/description/icon/actions/dismiss.
+
+**Architecture:** A single `forwardRef` component, no compound API, no internal state. The component owns `role` (derived from tone) and `data-tone` (drives SCSS variant styling); everything else passes through. Default icon per tone via a `DEFAULT_ICONS` lookup; consumer overrides via the `icon` prop or suppresses with `icon={null}`. Dismissal is controlled — the component does NOT manage hidden state; the consumer conditionally renders.
+
+**Tech Stack:** React 19 + TypeScript (source-distributed). `clsx` for class composition. `lucide-react` peer dep for tone icons (Info, CheckCircle2, AlertTriangle, XCircle) + the dismiss X. CSS Modules + SCSS. Vitest + RTL + userEvent. No new packages, no new tokens.
+
+**Source of truth:** `docs/superpowers/specs/2026-05-23-alert-design.md` (commit `71b30e4`).
+
+**Branch:** `feat/alert`. Commit per task. Open the PR after the Hard-Rule-8 cycle (Task 5).
+
+---
+
+## File Structure
+
+```
+packages/design-system/src/components/Alert/
+  Alert.tsx           ← Task 1. forwardRef, tone-driven role, default-icon table, dismiss button, action slot. Full JSDoc.
+  Alert.module.scss   ← Task 1. Grid layout + 4 tone variants via [data-tone='...'] + internal child spacing.
+  index.ts            ← Task 1. exports Alert + types.
+  Alert.test.tsx      ← Task 2. ~18 cases.
+
+packages/design-system/src/index.ts                              ← Task 3. MODIFY: re-export Alert + types.
+packages/design-system/AGENTS.md                                 ← Task 3. MODIFY: TL;DR after Toast section.
+
+packages/playground/src/pages/components/AlertDemo.tsx           ← Task 4. NEW: 6 examples.
+packages/playground/src/App.tsx                                  ← Task 4. MODIFY: route + import.
+packages/playground/src/layout/AppShell/AppShell.tsx             ← Task 4. MODIFY: Feedback group, first item alphabetically (before Toast).
+packages/playground/src/pages/components/ComponentsIndex.tsx     ← Task 4. MODIFY: overview card.
+packages/playground/src/pages/mockups/registry.ts                ← Task 4. MODIFY: 'Alert' first in ComponentName union.
+```
+
+**Decomposition rationale:**
+
+- **Task 1 (source bundle)** keeps Alert.tsx + SCSS + barrel together — they cross-reference. Same as the Textarea/Switch precedent.
+- **Task 2 (tests)** lands separately so the ~250-line test diff is reviewable in isolation.
+- **Task 3 (exports + AGENTS)** is small and conceptually paired.
+- **Task 4 (playground demo + 4-place wiring)** bundles the demo + nav touchpoints into one commit so it lands routable.
+- **Task 5 (Hard-Rule-8)** — gates, fresh-context reviewer cycle, push, PR.
+
+---
+
+## Task 1 — Source bundle (Alert.tsx + SCSS + barrel)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Alert/Alert.tsx`
+- Create: `packages/design-system/src/components/Alert/Alert.module.scss`
+- Create: `packages/design-system/src/components/Alert/index.ts`
+
+- [ ] **Step 1: Verify branch + clean tree**
+
+```bash
+cd /home/dpws/projects/design-system
+git status
+git branch --show-current
+git log --oneline -3
+```
+
+Expected:
+- Branch: `feat/alert`
+- Working tree clean
+- Most recent commit: `71b30e4 Alert: design spec — persistent in-flow notification`
+
+- [ ] **Step 2: Create the component directory + write the SCSS**
+
+```bash
+mkdir -p packages/design-system/src/components/Alert
+```
+
+Create `packages/design-system/src/components/Alert/Alert.module.scss`:
+
+```scss
+@use '../../styles/mixins' as *;
+
+.alert {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-3);
+  align-items: start;
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bg);
+  border-radius: var(--radius-md);
+  border-left: var(--border-width-strong) solid var(--color-fg-muted);
+  color: var(--color-fg);
+}
+
+.alert[data-tone='info'] {
+  background: var(--color-info-bg-subtle);
+  border-left-color: var(--color-info);
+}
+
+.alert[data-tone='success'] {
+  background: var(--color-success-bg-subtle);
+  border-left-color: var(--color-success);
+}
+
+.alert[data-tone='warning'] {
+  background: var(--color-warning-bg-subtle);
+  border-left-color: var(--color-warning);
+}
+
+.alert[data-tone='error'] {
+  background: var(--color-danger-bg-subtle);
+  border-left-color: var(--color-danger);
+}
+
+.icon {
+  display: grid;
+  place-items: center;
+  color: var(--color-fg-muted);
+}
+
+.alert[data-tone='info'] .icon {
+  color: var(--color-info);
+}
+
+.alert[data-tone='success'] .icon {
+  color: var(--color-success);
+}
+
+.alert[data-tone='warning'] .icon {
+  color: var(--color-warning);
+}
+
+.alert[data-tone='error'] .icon {
+  color: var(--color-danger);
+}
+
+.body {
+  min-width: 0;
+}
+
+.title {
+  display: block;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.4;
+  color: var(--color-fg);
+}
+
+.description {
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+  line-height: 1.5;
+}
+
+// stylelint-disable-next-line property-disallowed-list -- internal spacing between alert title and its description child
+.title + .description {
+  margin-top: var(--space-1);
+}
+
+// stylelint-disable-next-line property-disallowed-list -- internal spacing between alert body content and its action row
+.actions {
+  margin-top: var(--space-2);
+}
+
+.close {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-fg-muted);
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast);
+
+  &:hover {
+    color: var(--color-fg);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+
+    outline: none;
+  }
+}
+```
+
+- [ ] **Step 3: Write `Alert.tsx`**
+
+Create `packages/design-system/src/components/Alert/Alert.tsx`:
+
+```tsx
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import { AlertTriangle, CheckCircle2, Info, X, XCircle } from 'lucide-react';
+import clsx from 'clsx';
+import styles from './Alert.module.scss';
+
+/**
+ * Tone — drives icon, accent stripe color, tinted background, and ARIA role.
+ *
+ * - `'info'` — blue accent. Neutral updates ("Synced 5 minutes ago").
+ * - `'success'` — green accent. Confirmations ("Changes saved").
+ * - `'warning'` — orange accent. Non-blocking heads-up ("Storage at 85%").
+ * - `'error'` — red accent. Failures. ALSO sets `role="alert"` (assertive); the
+ *   other tones use `role="status"` (polite).
+ */
+export type AlertTone = 'info' | 'success' | 'warning' | 'error';
+
+export interface AlertProps
+  extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'title'> {
+  /** Tone. Defaults to `'info'`. See `AlertTone` for full descriptions. */
+  tone?: AlertTone;
+
+  /**
+   * Optional bold heading. Renders above the description. ReactNode so you
+   * can embed inline emphasis (`<>Update <strong>1.2.3</strong> available</>`).
+   *
+   * The native HTML `title` attribute (tooltip-on-hover) is collapsed by this
+   * prop. Use `aria-label` if you need that.
+   */
+  title?: ReactNode;
+
+  /** Description body. Rendered below the title in muted color. */
+  children?: ReactNode;
+
+  /**
+   * Override the tone's default icon. Pass any ReactNode (typically a
+   * lucide-react icon). Pass `null` to hide the icon entirely.
+   *
+   * Defaults: `info` → `Info`, `success` → `CheckCircle2`,
+   * `warning` → `AlertTriangle`, `error` → `XCircle`.
+   */
+  icon?: ReactNode | null;
+
+  /**
+   * Optional action row rendered below the description. Typically a single
+   * Button or a Cluster of two ("Retry", "Dismiss"). The component doesn't
+   * manage the action row's layout — pass a pre-laid-out node.
+   */
+  actions?: ReactNode;
+
+  /**
+   * Called when the user clicks the close (×) button. When set, the close
+   * button renders; when omitted, no close button. Alert is **controlled** —
+   * the component does NOT manage internal hidden state. Hide via
+   * conditional render in the consumer:
+   *
+   * ```tsx
+   * const [show, setShow] = useState(true);
+   * {show && <Alert tone="success" onDismiss={() => setShow(false)}>Saved</Alert>}
+   * ```
+   */
+  onDismiss?: () => void;
+}
+
+const DEFAULT_ICONS: Record<AlertTone, ReactNode> = {
+  info: <Info size={16} aria-hidden="true" />,
+  success: <CheckCircle2 size={16} aria-hidden="true" />,
+  warning: <AlertTriangle size={16} aria-hidden="true" />,
+  error: <XCircle size={16} aria-hidden="true" />,
+};
+
+/**
+ * Persistent in-flow notification. Fills the gap between `<Toast>` (transient,
+ * auto-dismissing, portal-rendered) and inline error text. Use Alert when the
+ * message needs to stay visible while the user reads the page — subscription
+ * warnings, save failures, "Update available" notices.
+ *
+ * Four tones (info / success / warning / error) with a subtle tinted background
+ * + left accent stripe per tone. Optional title, description (children), icon,
+ * action row, and dismiss button. No internal state, no animations, no
+ * auto-dismiss.
+ *
+ * @example
+ * // Basic
+ * <Alert tone="info" title="Synced 5 minutes ago" />
+ * <Alert tone="warning">Your storage is at 85% capacity.</Alert>
+ *
+ * @example
+ * // With title + description + actions
+ * <Alert tone="warning" title="Update available" actions={<Button size="sm">Reload</Button>}>
+ *   A new version is ready. Reload to apply.
+ * </Alert>
+ *
+ * @example
+ * // Dismissible (controlled by consumer)
+ * const [show, setShow] = useState(true);
+ * {show && (
+ *   <Alert tone="success" onDismiss={() => setShow(false)}>
+ *     Changes saved.
+ *   </Alert>
+ * )}
+ *
+ * @example
+ * // Custom icon / suppressed icon
+ * <Alert tone="info" icon={<Bell size={16} />} title="New mention" />
+ * <Alert tone="info" icon={null}>Quietly informative.</Alert>
+ *
+ * @remarks When NOT to use
+ * - Transient confirmations → `toast.success(...)`.
+ * - Empty-state placeholders ("No deals yet") → `<EmptyState>`.
+ * - Form-field validation messages → inline error text + `aria-describedby`.
+ * - Destructive confirmations needing yes/no → `<ConfirmationPopover>` or `<Modal>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Auto-dismissing the Alert with `setTimeout` — that's what Toast is for.
+ * - ❌ `tone="error"` for non-critical warnings. Reserve `error` for genuine
+ *   failures; `role="alert"` interrupts screen readers.
+ * - ❌ Multiple stacked Alerts above a page — pick one (most urgent tone) or
+ *   compose into the page layout with explicit hierarchy.
+ */
+export const Alert = forwardRef<HTMLDivElement, AlertProps>(function Alert(
+  { tone = 'info', title, children, icon, actions, onDismiss, className, ...props },
+  ref,
+) {
+  const role = tone === 'error' ? 'alert' : 'status';
+  const renderedIcon = icon === null ? null : (icon ?? DEFAULT_ICONS[tone]);
+
+  return (
+    <div
+      ref={ref}
+      role={role}
+      data-tone={tone}
+      {...props}
+      className={clsx(styles.alert, className)}
+    >
+      {renderedIcon && <div className={styles.icon}>{renderedIcon}</div>}
+      <div className={styles.body}>
+        {title && <strong className={styles.title}>{title}</strong>}
+        {children && <div className={styles.description}>{children}</div>}
+        {actions && <div className={styles.actions}>{actions}</div>}
+      </div>
+      {onDismiss && (
+        <button
+          type="button"
+          aria-label="Dismiss"
+          className={styles.close}
+          onClick={onDismiss}
+        >
+          <X size={14} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+});
+```
+
+- [ ] **Step 4: Write the folder barrel**
+
+Create `packages/design-system/src/components/Alert/index.ts`:
+
+```ts
+export { Alert } from './Alert';
+export type { AlertProps, AlertTone } from './Alert';
+```
+
+- [ ] **Step 5: Typecheck + lint**
+
+```bash
+cd /home/dpws/projects/design-system
+make build-lib
+make lint
+```
+
+Expected: both clean. The inline `stylelint-disable-next-line property-disallowed-list -- internal spacing ...` comments cover the `margin-top` rules on `.title + .description` and `.actions`. If stylelint flags `rule-empty-line-before` between sibling top-level rules (`.alert[data-tone='info']` → `.alert[data-tone='success']` etc.), add blank lines between them (standard convention).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Alert/Alert.tsx \
+        packages/design-system/src/components/Alert/Alert.module.scss \
+        packages/design-system/src/components/Alert/index.ts
+git commit -m "$(cat <<'EOF'
+Alert: source — persistent in-flow notification
+
+Single forwardRef component with four tone variants (info/success/
+warning/error). Tone drives the ARIA role (error → "alert" assertive;
+others → "status" polite), the default icon (Info/CheckCircle2/
+AlertTriangle/XCircle from lucide-react), the accent-stripe color,
+and the tinted background. No internal state — onDismiss is the
+consumer's hook to hide via conditional render.
+
+Grid layout with three columns (icon / body / close), gap via
+--space-3. Body holds optional title (<strong>), description (children),
+and actions row. Internal child spacing uses stylelint-disabled
+margin-top with documented rationale.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2 — Unit tests (`Alert.test.tsx`)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Alert/Alert.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+Create `packages/design-system/src/components/Alert/Alert.test.tsx`:
+
+```tsx
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Bell } from 'lucide-react';
+import { Alert } from './Alert';
+
+describe('<Alert>', () => {
+  // ─── Baseline ──────────────────────────────────────────────────────────
+
+  it('renders without crashing with default props (info tone implicit)', () => {
+    const { container } = render(<Alert>Body</Alert>);
+    expect(container.querySelector('[data-tone="info"]')).toBeInTheDocument();
+  });
+
+  it('default tone is info (role="status")', () => {
+    render(<Alert>x</Alert>);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['info', 'status'],
+    ['success', 'status'],
+    ['warning', 'status'],
+  ] as const)('tone="%s" uses role="%s" (polite)', (tone, expectedRole) => {
+    const { container } = render(<Alert tone={tone}>x</Alert>);
+    expect(container.querySelector(`[data-tone="${tone}"]`)).toBeInTheDocument();
+    expect(screen.getByRole(expectedRole)).toBeInTheDocument();
+  });
+
+  it('tone="error" uses role="alert" (assertive)', () => {
+    const { container } = render(<Alert tone="error">x</Alert>);
+    expect(container.querySelector('[data-tone="error"]')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('title renders inside <strong>', () => {
+    const { container } = render(<Alert title="Heading">desc</Alert>);
+    const strong = container.querySelector('strong');
+    expect(strong).not.toBeNull();
+    expect(strong).toHaveTextContent('Heading');
+  });
+
+  it('children render as the description body', () => {
+    render(<Alert>Body content</Alert>);
+    expect(screen.getByText('Body content')).toBeInTheDocument();
+  });
+
+  it('title and children both render together', () => {
+    render(
+      <Alert title="Heading">Body content</Alert>,
+    );
+    expect(screen.getByText('Heading')).toBeInTheDocument();
+    expect(screen.getByText('Body content')).toBeInTheDocument();
+  });
+
+  it('className is merged onto the root, not replaced', () => {
+    const { container } = render(<Alert className="custom">x</Alert>);
+    const root = container.firstElementChild!;
+    expect(root.className).toMatch(/alert/);
+    expect(root.className).toMatch(/custom/);
+  });
+
+  it('ref forwards to the root <div>', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Alert ref={ref}>x</Alert>);
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('DIV');
+  });
+
+  // ─── Icon ──────────────────────────────────────────────────────────────
+
+  it('default icon renders for each tone (SVG present)', () => {
+    const { container, rerender } = render(<Alert tone="info">x</Alert>);
+    expect(container.querySelector('svg')).not.toBeNull();
+    rerender(<Alert tone="success">x</Alert>);
+    expect(container.querySelector('svg')).not.toBeNull();
+    rerender(<Alert tone="warning">x</Alert>);
+    expect(container.querySelector('svg')).not.toBeNull();
+    rerender(<Alert tone="error">x</Alert>);
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('icon prop replaces the default', () => {
+    const { container } = render(
+      <Alert icon={<Bell size={16} data-testid="custom-icon" />}>x</Alert>,
+    );
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+
+  it('icon={null} hides the icon entirely', () => {
+    const { container } = render(<Alert icon={null}>x</Alert>);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  // ─── Actions ───────────────────────────────────────────────────────────
+
+  it('actions render inside the body when provided', () => {
+    render(
+      <Alert title="t" actions={<button data-testid="action">Retry</button>}>
+        desc
+      </Alert>,
+    );
+    expect(screen.getByTestId('action')).toBeInTheDocument();
+  });
+
+  // ─── Dismiss ───────────────────────────────────────────────────────────
+
+  it('onDismiss not provided → no close button', () => {
+    render(<Alert>x</Alert>);
+    expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull();
+  });
+
+  it('onDismiss provided → close button with aria-label="Dismiss"', () => {
+    render(<Alert onDismiss={() => {}}>x</Alert>);
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+  });
+
+  it('clicking the close button fires onDismiss', async () => {
+    const user = userEvent.setup();
+    const handleDismiss = vi.fn();
+    render(<Alert onDismiss={handleDismiss}>x</Alert>);
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(handleDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('close button does NOT manage hidden state internally (still in DOM after click)', async () => {
+    const user = userEvent.setup();
+    render(<Alert onDismiss={() => {}}>Body</Alert>);
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+    // Alert stays in the DOM — consumer would hide via conditional render.
+    expect(screen.getByText('Body')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test -w @eocrm/design-system -- --run src/components/Alert/Alert.test.tsx
+```
+
+Expected: ~20 tests pass (17 top-level `it()` + 3 from `it.each` expansion).
+
+If a test fails:
+- **Default-tone `role="status"` test** failing: verify the JSX assigns `role={tone === 'error' ? 'alert' : 'status'}`.
+- **Icon `<svg>` test** failing: the lucide-react peer dep must be installed. Run `grep "lucide-react" packages/design-system/package.json` — should show in `peerDependencies` from PR #45.
+
+- [ ] **Step 3: Full suite + lint + typecheck**
+
+```bash
+make test
+make build-lib
+make lint
+```
+
+Expected: everything clean. Test count goes up by ~20.
+
+`structure.test.ts` will report 1 failure ("Alert is re-exported from src/index.ts") because Task 3 hasn't run yet. That's expected; Task 3 fixes it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Alert/Alert.test.tsx
+git commit -m "$(cat <<'EOF'
+Alert: unit tests
+
+17 cases (20 with it.each tone expansion): rendering, default tone =
+info, all 4 tones map to right role (error → alert assertive; others
+→ status polite), title renders as <strong>, children as description,
+className merge, ref forwards to root <div>, default icon present for
+each tone, custom icon prop overrides, icon={null} hides, actions
+render in body, onDismiss controls close button presence, click fires
+the handler, close does NOT manage hidden state (controlled by
+consumer).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 — Public exports + AGENTS.md TL;DR
+
+**Files:**
+
+- Modify: `packages/design-system/src/index.ts`
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Add Alert to `src/index.ts`**
+
+Open `packages/design-system/src/index.ts`. Add:
+
+```ts
+export { Alert } from './components/Alert';
+export type { AlertProps, AlertTone } from './components/Alert';
+```
+
+The file isn't strictly alphabetical (recent additions live near the bottom). Match the surrounding convention — append near other recently-added components OR slot alphabetically.
+
+Verify with:
+
+```bash
+grep -n "Alert\|Avatar\|Badge" packages/design-system/src/index.ts | head
+```
+
+- [ ] **Step 2: Add TL;DR to AGENTS.md**
+
+Open `packages/design-system/AGENTS.md`. Find the `### \`<ToastViewport>\` + \`toast\`` section header (around line 657). The Toast section ends just before `### \`<ConfirmationPopover>\`` (around line 699). Insert the new Alert section between them.
+
+Use grep to confirm exact line numbers:
+
+```bash
+grep -nE "^### " packages/design-system/AGENTS.md | head -25
+```
+
+Add this content verbatim:
+
+````markdown
+### `<Alert>` — persistent in-flow notification
+
+Tone-driven banner for messages that need to stay visible while the user reads the page (subscription warnings, save failures, "update available" notices). Complements `<Toast>` (transient).
+
+```tsx
+import { Alert } from '@eocrm/design-system';
+
+// Basic
+<Alert tone="info" title="Synced 5 minutes ago" />
+<Alert tone="warning">Your storage is at 85% capacity.</Alert>
+
+// With actions
+<Alert tone="warning" title="Update available" actions={<Button size="sm">Reload</Button>}>
+  A new version is ready. Reload to apply.
+</Alert>
+
+// Dismissible (controlled by consumer)
+const [show, setShow] = useState(true);
+{show && (
+  <Alert tone="success" onDismiss={() => setShow(false)}>
+    Changes saved.
+  </Alert>
+)}
+```
+
+- **Four tones** (`info` / `success` / `warning` / `error`). Default icon + accent stripe per tone.
+- **`role="alert"`** only for `error` (assertive, interrupts SR). Others use `role="status"` (polite).
+- **Persistent** — no auto-dismiss. Use Toast for transient messages.
+- **Controlled dismiss** — `onDismiss` callback fires on × click; consumer hides via conditional render.
+- **`icon={null}`** suppresses the icon entirely; any ReactNode overrides the default.
+
+#### When NOT to use
+
+- ❌ Transient confirmations → `<Toast>` / `toast.success(...)`.
+- ❌ Empty-state placeholders ("No deals yet") → `<EmptyState>`.
+- ❌ Form-field validation messages → inline error text + `aria-describedby`.
+- ❌ Destructive confirmations needing yes/no → `<ConfirmationPopover>` or `<Modal>`.
+
+#### Anti-patterns
+
+- ❌ Auto-dismissing the Alert with a `setTimeout` — that's what Toast is for.
+- ❌ Using `tone="error"` for non-critical warnings. Reserve `error` for genuine failures.
+- ❌ Multiple stacked Alerts above a page — pick one (most urgent tone) or compose into the page layout with explicit hierarchy.
+````
+
+- [ ] **Step 3: Run gates**
+
+```bash
+make test
+make build-lib
+```
+
+Expected: everything green. `structure.test.ts` now finds Alert in the barrel.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/index.ts packages/design-system/AGENTS.md
+git commit -m "$(cat <<'EOF'
+Alert: public exports + AGENTS.md TL;DR
+
+Re-exports Alert + AlertProps/AlertTone from the package barrel.
+AGENTS.md gains a TL;DR section between Toast and ConfirmationPopover
+(feedback cluster) — the canonical three patterns (basic / with
+actions / dismissible), the when-NOT-to-use list, and the
+auto-dismiss-with-setTimeout anti-pattern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 — Playground demo + 4-place nav wiring
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/AlertDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Write the demo page**
+
+Create `packages/playground/src/pages/components/AlertDemo.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { Bell } from 'lucide-react';
+import { Alert, Button, Cluster, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Alert/Alert.tsx?raw';
+import scssSource from '@lib-source/components/Alert/Alert.module.scss?raw';
+
+export function AlertDemo() {
+  const [showSaved, setShowSaved] = useState(true);
+
+  return (
+    <DemoLayout
+      name="Alert"
+      componentName="Alert"
+      description="Persistent in-flow notification. Four tones with tinted background + accent stripe. Optional title / description / icon / actions / dismiss. Use Toast for transient messages instead."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Alert.tsx"
+      scssFilename="Alert.module.scss"
+    >
+      <Example
+        title="Four tones"
+        description="info / success / warning / error. Default icon + accent stripe per tone. Error gets role='alert' (assertive); others use role='status' (polite)."
+        code={`<Alert tone="info" title="Synced 5 minutes ago" />
+<Alert tone="success" title="Changes saved" />
+<Alert tone="warning" title="Storage at 85%" />
+<Alert tone="error" title="Request failed" />`}
+      >
+        <Stack gap="sm">
+          <Alert tone="info" title="Synced 5 minutes ago" />
+          <Alert tone="success" title="Changes saved" />
+          <Alert tone="warning" title="Storage at 85%" />
+          <Alert tone="error" title="Request failed" />
+        </Stack>
+      </Example>
+
+      <Example
+        title="Title only"
+        description="The simplest form. Useful for short status messages."
+        code={`<Alert tone="info" title="Synced 5 minutes ago" />`}
+      >
+        <Alert tone="info" title="Synced 5 minutes ago" />
+      </Example>
+
+      <Example
+        title="Description only (no title)"
+        description="Short text body without a heading. Reads as a sentence."
+        code={`<Alert tone="warning">Your storage is at 85% capacity.</Alert>`}
+      >
+        <Alert tone="warning">Your storage is at 85% capacity.</Alert>
+      </Example>
+
+      <Example
+        title="With actions"
+        description="Pass a pre-laid-out node as `actions`. Renders below the description."
+        code={`<Alert
+  tone="warning"
+  title="Update available"
+  actions={
+    <Cluster gap="sm">
+      <Button size="sm">Reload</Button>
+      <Button size="sm" variant="ghost">Later</Button>
+    </Cluster>
+  }
+>
+  A new version is ready. Reload to apply the latest improvements.
+</Alert>`}
+      >
+        <Alert
+          tone="warning"
+          title="Update available"
+          actions={
+            <Cluster gap="sm">
+              <Button size="sm">Reload</Button>
+              <Button size="sm" variant="ghost">
+                Later
+              </Button>
+            </Cluster>
+          }
+        >
+          A new version is ready. Reload to apply the latest improvements.
+        </Alert>
+      </Example>
+
+      <Example
+        title="Dismissible"
+        description="onDismiss callback fires when the × is clicked. The component does NOT manage hidden state — the consumer conditionally renders."
+        code={`const [show, setShow] = useState(true);
+
+{show && (
+  <Alert tone="success" onDismiss={() => setShow(false)}>
+    Changes saved.
+  </Alert>
+)}`}
+      >
+        <Stack gap="sm">
+          {showSaved ? (
+            <Alert tone="success" onDismiss={() => setShowSaved(false)}>
+              Changes saved.
+            </Alert>
+          ) : (
+            <Button size="sm" variant="ghost" onClick={() => setShowSaved(true)}>
+              Show again
+            </Button>
+          )}
+        </Stack>
+      </Example>
+
+      <Example
+        title="Custom icon + suppressed icon"
+        description="Pass any ReactNode to icon for an override. icon={null} hides the icon entirely."
+        code={`<Alert tone="info" icon={<Bell size={16} />} title="New mention" />
+<Alert tone="info" icon={null}>Quietly informative.</Alert>`}
+      >
+        <Stack gap="sm">
+          <Alert tone="info" icon={<Bell size={16} aria-hidden />} title="New mention" />
+          <Alert tone="info" icon={null}>
+            Quietly informative.
+          </Alert>
+        </Stack>
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+- [ ] **Step 2: Wire the route + import in `App.tsx`**
+
+Open `packages/playground/src/App.tsx`. Add the import alphabetically with other A-prefixed components:
+
+```tsx
+import { AlertDemo } from './pages/components/AlertDemo';
+```
+
+Add the `<Route>` inside `<Routes>` near other component routes. Alphabetical position with `A*`:
+
+```tsx
+<Route path="/components/alert" element={<AlertDemo />} />
+```
+
+(The file order isn't strictly alphabetical — match the surrounding pattern. If recent additions get appended near the bottom, slot accordingly.)
+
+- [ ] **Step 3: Add sidebar entry in `AppShell.tsx`**
+
+Open `packages/playground/src/layout/AppShell/AppShell.tsx`. Find the `Feedback` group (currently around line 111 with just Toast). Add Alert as the FIRST item (alphabetical before Toast):
+
+```tsx
+{
+  heading: 'Feedback',
+  items: [
+    { to: '/components/alert', label: 'Alert', icon: AlertCircle, end: false },
+    { to: '/components/toast', label: 'Toast', icon: Bell, end: false },
+  ],
+},
+```
+
+Add `AlertCircle` to the existing lucide-react import at the top of the file. Verify it exists:
+
+```bash
+node -e "console.log(Object.keys(require('lucide-react')).filter(k => k === 'AlertCircle').join(', '))"
+```
+
+If `AlertCircle` doesn't exist in lucide-react 1.x, fall back to `AlertTriangle` (which definitely exists — Alert.tsx uses it).
+
+- [ ] **Step 4: Add overview card in `ComponentsIndex.tsx`**
+
+Open `packages/playground/src/pages/components/ComponentsIndex.tsx`. Add `Alert` to the `@eocrm/design-system` import line (or its own line, matching the surrounding convention).
+
+Find the items array. Add a card alphabetically (with other A-prefixed items, before Avatar/Badge etc.):
+
+```tsx
+{
+  to: '/components/alert',
+  name: 'Alert',
+  description: 'Persistent in-flow notification with four tones.',
+  preview: (
+    <Alert tone="info" title="Synced 5 minutes ago" />
+  ),
+},
+```
+
+- [ ] **Step 5: Register the component name in `registry.ts`**
+
+Open `packages/playground/src/pages/mockups/registry.ts`. Find `export type ComponentName =` (around line 3) and add `'Alert'` FIRST in the union (alphabetical before `'Avatar'`):
+
+```ts
+export type ComponentName =
+  | 'Alert'
+  | 'Avatar'
+  | 'Badge'
+  // …rest unchanged…;
+```
+
+No existing mockup uses Alert yet, so no `usesComponents` arrays need updating.
+
+- [ ] **Step 6: Run the playground build**
+
+```bash
+cd /home/dpws/projects/design-system
+make build
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Spot-check in dev server (OPTIONAL)**
+
+Skip unless a gate fails.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/playground/src/pages/components/AlertDemo.tsx \
+        packages/playground/src/App.tsx \
+        packages/playground/src/layout/AppShell/AppShell.tsx \
+        packages/playground/src/pages/components/ComponentsIndex.tsx \
+        packages/playground/src/pages/mockups/registry.ts
+git commit -m "$(cat <<'EOF'
+playground: AlertDemo + 4-place nav wiring
+
+6 examples (four tones gallery, title-only, description-only,
+with-actions, dismissible with useState, custom icon + suppressed
+icon). Wired into Feedback sidebar group (first item, before Toast),
+Components route, overview-grid card, and the mockups ComponentName
+union.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 — Hard-Rule-8 cycle + push + PR
+
+Per `packages/design-system/CLAUDE.md` Rule 8. Run until 0 Critical + 0 Important findings, all gates green.
+
+- [ ] **Step 1: Final gate run**
+
+```bash
+cd /home/dpws/projects/design-system
+make test
+make build-lib
+make build
+make lint
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Dry-pack to confirm tarball contents**
+
+```bash
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -E "Alert|test\."
+```
+
+Expected:
+- Alert source files (`Alert.tsx`, `Alert.module.scss`, `index.ts`) in the tarball
+- NO `*.test.*` files
+
+- [ ] **Step 3: Dispatch a fresh-context Hard-Rule-8 reviewer**
+
+Use a `general-purpose` subagent with model `opus`. Prompt template (substitute `<sha>` with the current HEAD):
+
+> Fresh-context Hard-Rule-8 review of the Alert PR. Branch `feat/alert` at HEAD `<sha>`. Per `packages/design-system/CLAUDE.md` Rule 8 — review the full diff against `main` and report findings as Critical / Important / Nice-to-have / Regression-watch.
+>
+> Files in scope:
+> - `packages/design-system/src/components/Alert/` (Alert.tsx + .module.scss + .test.tsx + index.ts)
+> - `packages/design-system/src/index.ts`
+> - `packages/design-system/AGENTS.md`
+> - `packages/playground/src/pages/components/AlertDemo.tsx`
+> - `packages/playground/src/App.tsx`, `AppShell.tsx`, `ComponentsIndex.tsx`, `registry.ts`
+>
+> Read first: `packages/design-system/CLAUDE.md` (Rules 1–7), `AGENTS.md` (Alert section + surrounding Toast/ConfirmationPopover sections), `docs/superpowers/specs/2026-05-23-alert-design.md`. Compare against Toast for tone-pattern parity.
+>
+> Verify:
+> - **Rule 1**: tests exist (~20 cases including it.each).
+> - **Rule 3**: NO raw values in `Alert.module.scss`. All `var(--…)`. The two `margin-top` rules have inline disables.
+> - **Rule 4**: NO `position`/`align-self`/`flex: 1`/`width` at the component boundary. The `display: grid` on `.alert` is internal layout of children, not at the boundary.
+> - **Rule 5**: re-exported from `src/index.ts`.
+> - **Rule 6**: `forwardRef` used; ref targets the root `<div>`.
+> - **Rule 7**: full JSDoc on Alert (component, every prop, type alias). At least 3 `@example` blocks. "When NOT to use" + "Anti-patterns" in `@remarks`.
+> - **ARIA**: `role="alert"` only for error tone; `role="status"` for others. Close button has `aria-label="Dismiss"`. Default icons set `aria-hidden="true"`.
+> - **Tone→role mapping** is correct: `tone === 'error' ? 'alert' : 'status'`.
+> - **`icon={null}` actually hides the icon**: verify by tracing `icon === null ? null : (icon ?? DEFAULT_ICONS[tone])`. The null branch must short-circuit.
+> - **`onDismiss` omitted → no close button**: verify the conditional `{onDismiss && <button>}` renders nothing when undefined.
+> - **Cross-package leakage**: Alert imports from `@eocrm/design-system` internals only; no playground imports.
+> - **Package/distribution**: `npm pack --dry-run` excludes test files.
+>
+> End with verdict: **clean enough to stop** OR **keep iterating**.
+
+- [ ] **Step 4: Fix every Critical + Important finding**
+
+Group fixes into a single commit titled `Alert: review-cycle fixes (round N)`. Document deliberately-skipped Nice-to-have items in the commit body.
+
+- [ ] **Step 5: Re-run gates after each fix round**
+
+```bash
+make test && make build-lib && make build && make lint
+```
+
+- [ ] **Step 6: Re-dispatch fresh reviewer**
+
+Same prompt, same model, fresh context. Repeat until **clean enough to stop**.
+
+- [ ] **Step 7: Push the branch**
+
+```bash
+git push -u origin feat/alert
+```
+
+If the husky `pre-push` hook fails on `format:check`:
+
+```bash
+npx prettier --write docs/superpowers/specs/2026-05-23-alert-design.md \
+                     docs/superpowers/plans/2026-05-23-alert.md \
+                     packages/design-system/src/components/Alert/ \
+                     packages/playground/src/pages/components/AlertDemo.tsx
+git add -A
+git commit -m "$(cat <<'EOF'
+Alert: prettier --write
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin feat/alert
+```
+
+- [ ] **Step 8: Open the PR**
+
+```bash
+gh pr create --title "Alert: persistent in-flow notification (4 tones + dismissible)" --body "$(cat <<'EOF'
+## Summary
+
+- New \`<Alert>\` — fills the persistent-feedback gap between \`<Toast>\` (transient, auto-dismissing) and inline error text.
+- **Four tones** (\`info\` / \`success\` / \`warning\` / \`error\`) with subtle tinted background + left accent stripe + default icon per tone.
+- **\`role=\"alert\"\`** (assertive) only for the \`error\` tone; others use \`role=\"status\"\` (polite).
+- Optional title (rendered as \`<strong>\`), description (children), icon override (or \`null\` to hide), action row, and controlled dismiss button.
+- No internal state, no animations, no auto-dismiss. Consumer controls visibility via conditional render.
+
+## Design highlights
+
+- **Single visual variant** (subtle tinted + accent stripe). Solid/outline variants can be added v2 if a concrete need surfaces.
+- **No compound API** — title/description/actions are props, not slots. Keeps the surface tight and the consumer pattern obvious.
+- **Default icon per tone** via a lookup table; \`icon\` prop overrides; \`icon={null}\` suppresses.
+- **Controlled dismiss**: \`onDismiss\` callback fires on × click; the component stays in the DOM until the consumer hides it. Matches React's controlled-input philosophy.
+
+## Hard Rule 8
+
+Multiple rounds with fresh-context reviewers (opus). ~20 new tests covering rendering, all 4 tones (role + data-tone), title+description+icon variants, action slot, dismiss button presence/click/no-internal-state.
+
+All four gates green: \`make test\` · \`make build-lib\` · \`make build\` · \`make lint\` · \`npm pack --dry-run\` (no test files in tarball).
+
+## Test plan
+
+- [ ] All four tones render with distinct accent stripe colors
+- [ ] \`tone=\"error\"\` produces \`role=\"alert\"\`; others use \`role=\"status\"\`
+- [ ] Title renders inside \`<strong>\`
+- [ ] Children render as the description body
+- [ ] Default icon appears per tone (SVG present)
+- [ ] \`icon={null}\` hides the icon entirely
+- [ ] Custom \`icon\` prop replaces the default
+- [ ] \`actions\` slot renders below the description
+- [ ] No close button when \`onDismiss\` is omitted
+- [ ] Close button has \`aria-label=\"Dismiss\"\` and fires \`onDismiss\` on click
+- [ ] Component does NOT manage hidden state — stays in DOM after click; consumer conditionally renders
+- [ ] Playground demo at \`/components/alert\` renders all 6 examples without console errors
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 9: Confirm CI**
+
+Watch the GitHub Actions Quality check on the PR. If it fails for the same `format:check` reason, run the prettier fix locally and push again.
+
+- [ ] **Step 10: Mark task complete**
+
+Once verdict is `clean enough to stop`, gates green, CI green, PR open — task done.
+
+---
+
+## Summary of expected commits on the branch (before review-fix rounds)
+
+```
+Alert: design spec — persistent in-flow notification
+Alert: source — persistent in-flow notification
+Alert: unit tests
+Alert: public exports + AGENTS.md TL;DR
+playground: AlertDemo + 4-place nav wiring
+```
+
+Plus review-cycle fix commits + prettier fix-up as needed.

--- a/docs/superpowers/specs/2026-05-23-alert-design.md
+++ b/docs/superpowers/specs/2026-05-23-alert-design.md
@@ -1,0 +1,442 @@
+# Alert — design spec
+
+**Date:** 2026-05-23
+**Branch:** `feat/alert`
+**Scope:** New `<Alert>` component for `@eocrm/design-system` — a persistent in-flow notification primitive. Four tones (info/success/warning/error), single visual variant (subtle tinted background + left accent stripe), optional title/description/icon/actions/dismiss. Complements `<Toast>` (transient, portal-rendered).
+
+## Goal
+
+Fill the persistent-feedback gap. Toast handles transient notifications that auto-dismiss; Alert handles persistent in-flow messages that the user must see while reading the page — "Your subscription expires in 5 days", "Update available — reload to apply", "Save failed: API quota exceeded". Same tone vocabulary as Toast, same icon defaults, but rendered in the document flow at the position the consumer places it.
+
+## Why now
+
+- The CRM has multiple places where persistent feedback belongs (deal-detail pages with "Pending review" status, settings pages with "Changes saved" sticky notice, payment screens with quota warnings). Today these are open-coded with inline `<div className={styles.notice}>` patterns that drift visually.
+- Toast is the wrong primitive for these — Toast disappears, but the message needs to stay visible until the underlying condition resolves.
+- The feedback family currently has Toast (transient) + EmptyState (full-section "nothing here") + Skeleton (loading). Alert fills the persistent-in-flow slot, completing the family.
+
+## Non-goals (v1)
+
+- **No solid / outline visual variants.** One look: tinted background + left accent stripe + tone-colored icon. Solid (saturated bg) and outline (border-only) variants can be added v2 if a concrete need surfaces.
+- **No auto-dismiss timer.** Alert is persistent by definition. If you want auto-dismiss, use Toast.
+- **No animation on mount.** Alert sits in the document flow; mount/unmount happens naturally as the consumer conditionally renders. No enter/exit transition.
+- **No size variants.** One size. The Alert scales with its content (heading + description + actions).
+- **No "compact" variant.** Same — one size, one density.
+- **No stacking management.** Multiple Alerts on a page lay out via the consumer's parent (Stack, etc.) — no shared queue / max-visible / collision logic. That's Toast's job.
+- **No icon-only mode.** Alert always renders content (title and/or description). For icon-only persistent indicators, use Badge.
+- **No floating / sticky positioning.** Alert is a normal flow element. Consumers manage sticky placement via CSS on the parent.
+- **No promise integration.** Alert isn't tied to async flows the way `toast.promise` is. If you need "saving…" → "saved", use Toast.
+
+## Architecture
+
+### Dependencies
+
+No new packages. Reuses:
+
+- React (peer)
+- `clsx` (existing dep)
+- `lucide-react` peer dep — `Info`, `CheckCircle2`, `AlertTriangle`, `XCircle` for tone icons (matches Toast); `X` for the dismiss button
+- Existing tokens: `--color-info`, `--color-info-bg-subtle`, `--color-success`, `--color-success-bg-subtle`, `--color-warning`, `--color-warning-bg-subtle`, `--color-danger`, `--color-danger-bg-subtle`, `--color-fg`, `--color-fg-muted`, `--color-bg`, `--radius-md`, `--space-1`/`--space-2`/`--space-3`/`--space-4`, `--font-size-sm`/`--font-size-md`, `--font-weight-medium`, `--border-width-strong`, `--transition-fast`, `--ring-accent`, `--ring-width`
+
+No new tokens needed.
+
+### File layout
+
+```
+packages/design-system/src/components/Alert/
+  Alert.tsx           ← forwardRef, tone → role mapping, default-icon table, dismiss button, action slot
+  Alert.module.scss   ← wrapper / icon / body / title / description / actions / close + 4 tone variants
+  Alert.test.tsx      ← ~18 cases
+  index.ts            ← exports Alert + types
+```
+
+Plus integration points:
+
+- `packages/design-system/src/index.ts` — re-export `Alert`, `AlertProps`, `AlertTone`
+- `packages/design-system/AGENTS.md` — TL;DR slot near Toast / EmptyState (feedback cluster)
+- `packages/playground/src/pages/components/AlertDemo.tsx` — 6 examples
+- `packages/playground/src/App.tsx` — route at `/components/alert`
+- `packages/playground/src/layout/AppShell/AppShell.tsx` — sidebar entry in the **Feedback** group (existing group, currently holds Toast); slot alphabetically as first entry
+- `packages/playground/src/pages/components/ComponentsIndex.tsx` — overview card
+- `packages/playground/src/pages/mockups/registry.ts` — `'Alert'` in `ComponentName` union
+
+### Composition
+
+```
+        <Alert tone="warning" title="Update available" onDismiss={...} actions={...}>
+          A new version is ready. Reload to apply.
+        </Alert>
+                          │
+                          ▼
+                   <div role="status" data-tone="warning">
+                          │
+                ┌─────────┼──────────┬─────────┐
+                ▼         ▼          ▼         ▼
+              <Icon>   <body>      <actions> <close>
+                       ┌─────┐                  X
+                       title
+                       desc
+```
+
+A single forwardRef component. No subcomponents, no compound API. Title / description / actions / close are all configured via props (not children slots).
+
+## Public API
+
+```ts
+import type { HTMLAttributes, ReactNode } from 'react';
+
+/** Tone — drives icon, accent stripe color, tinted background, and ARIA role. */
+export type AlertTone = 'info' | 'success' | 'warning' | 'error';
+
+export interface AlertProps extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'title'> {
+  /**
+   * Tone. Defaults to `'info'`.
+   * - `'info'` — blue accent. Default for neutral updates.
+   * - `'success'` — green accent. Confirmations, "saved successfully".
+   * - `'warning'` — orange accent. Non-blocking heads-up ("quota at 90%").
+   * - `'error'` — red accent. Failures / blocking issues. Also sets
+   *   `role="alert"` (assertive); other tones use `role="status"` (polite).
+   */
+  tone?: AlertTone;
+
+  /**
+   * Optional bold heading. Renders above the description. May be a plain
+   * string OR rich content (e.g. `<>Update <strong>1.2.3</strong> available</>`).
+   *
+   * The native HTML `title` attribute is collapsed by this prop — Alert
+   * doesn't surface a tooltip-on-hover. Use `aria-label` if you need that.
+   */
+  title?: ReactNode;
+
+  /**
+   * Description body. Rendered below the title in muted color. Either
+   * `title` or `children` (or both) must be set.
+   */
+  children?: ReactNode;
+
+  /**
+   * Override the tone's default icon. Pass any ReactNode (typically a
+   * lucide-react icon). Pass `null` to hide the icon entirely.
+   *
+   * Defaults:
+   * - `info` → `Info`
+   * - `success` → `CheckCircle2`
+   * - `warning` → `AlertTriangle`
+   * - `error` → `XCircle`
+   */
+  icon?: ReactNode | null;
+
+  /**
+   * Optional action row rendered below the description. Typically a single
+   * Button or a Cluster of two ("Retry", "Dismiss"). The component doesn't
+   * manage the action row's layout — pass a pre-laid-out node.
+   */
+  actions?: ReactNode;
+
+  /**
+   * Called when the user clicks the close (×) button. When set, the close
+   * button renders; when omitted, no close button. Alert is controlled —
+   * the component does NOT manage internal "hidden" state. Hide via
+   * conditional render in the consumer.
+   */
+  onDismiss?: () => void;
+}
+```
+
+**Spread order — Pattern A (consumer wins)** for most attrs:
+
+```tsx
+<div
+  ref={ref}
+  role={tone === 'error' ? 'alert' : 'status'}
+  data-tone={tone}
+  {...props}
+  className={clsx(styles.alert, TONE_CLASS[tone], props.className)}
+>
+```
+
+Component-owned attrs that consumer cannot override:
+- `role` — derived from tone for ARIA correctness
+- `data-tone` — used by SCSS for tone-variant styling
+- `className` (spread AFTER props but merges via clsx so consumer's className appends)
+
+## Architecture flow
+
+A near-pure render component. Three branches:
+
+1. **Icon**: read `icon` prop or default per tone; render nothing if `icon === null`
+2. **Body**: render `<strong>title</strong>` if title set; render description if children set; render `<div class="actions">{actions}</div>` if actions set
+3. **Close**: render `<button aria-label="Dismiss" onClick={onDismiss}>` if onDismiss set
+
+No internal state. No effects. No timers.
+
+```tsx
+function Alert({
+  tone = 'info',
+  title,
+  children,
+  icon,
+  actions,
+  onDismiss,
+  className,
+  ...props
+}, ref) {
+  const role = tone === 'error' ? 'alert' : 'status';
+  const renderedIcon = icon === null ? null : (icon ?? DEFAULT_ICONS[tone]);
+
+  return (
+    <div
+      ref={ref}
+      role={role}
+      data-tone={tone}
+      {...props}
+      className={clsx(styles.alert, TONE_CLASS[tone], className)}
+    >
+      {renderedIcon && <div className={styles.icon}>{renderedIcon}</div>}
+      <div className={styles.body}>
+        {title && <strong className={styles.title}>{title}</strong>}
+        {children && <div className={styles.description}>{children}</div>}
+        {actions && <div className={styles.actions}>{actions}</div>}
+      </div>
+      {onDismiss && (
+        <button
+          type="button"
+          aria-label="Dismiss"
+          className={styles.close}
+          onClick={onDismiss}
+        >
+          <X size={14} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+**Why `<strong>` for the title**: it conveys "strongly emphasized text" semantically without claiming a specific heading level (which would disrupt the page's outline). An Alert is in-flow content; the title isn't a section heading.
+
+**Why role="status"/"alert"** (not aria-live): the implicit `aria-live` of these roles handles announcement. Adding `aria-live` explicitly would be redundant (and Radix/Material confirm this is the pattern).
+
+## Styling — `Alert.module.scss`
+
+```scss
+@use '../../styles/mixins' as *;
+
+.alert {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-3);
+  align-items: start;
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bg);     // overridden per tone
+  border-radius: var(--radius-md);
+  border-left: var(--border-width-strong) solid var(--color-fg-muted);  // overridden per tone
+  color: var(--color-fg);
+}
+
+.alert[data-tone='info'] {
+  background: var(--color-info-bg-subtle);
+  border-left-color: var(--color-info);
+}
+
+.alert[data-tone='success'] {
+  background: var(--color-success-bg-subtle);
+  border-left-color: var(--color-success);
+}
+
+.alert[data-tone='warning'] {
+  background: var(--color-warning-bg-subtle);
+  border-left-color: var(--color-warning);
+}
+
+.alert[data-tone='error'] {
+  background: var(--color-danger-bg-subtle);
+  border-left-color: var(--color-danger);
+}
+
+.icon {
+  display: grid;
+  place-items: center;
+  // Top-align with the first line of the title (or body if no title).
+  // Tweaked via the icon's intrinsic size + the wrapper's place-items: start
+  // on the grid parent.
+  color: var(--color-fg-muted);
+}
+
+.alert[data-tone='info'] .icon { color: var(--color-info); }
+.alert[data-tone='success'] .icon { color: var(--color-success); }
+.alert[data-tone='warning'] .icon { color: var(--color-warning); }
+.alert[data-tone='error'] .icon { color: var(--color-danger); }
+
+.body {
+  min-width: 0;     // allow long words/URLs to wrap inside the grid
+}
+
+.title {
+  display: block;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.4;
+  color: var(--color-fg);
+}
+
+.description {
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+  line-height: 1.5;
+}
+
+.title + .description {
+  margin-top: var(--space-1);
+}
+
+.actions {
+  margin-top: var(--space-2);
+}
+
+.close {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-fg-muted);
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast);
+
+  &:hover {
+    color: var(--color-fg);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+
+    outline: none;
+  }
+}
+```
+
+**Rule 4 check**:
+- `.alert` has `display: grid` + `grid-template-columns` — that's internal layout of the Alert's own children, NOT layout-at-component-boundary. Allowed.
+- `padding`, `border-radius`, `border-left` — internal styling, not layout.
+- `min-width: 0` on `.body` — needed for grid text wrapping, not layout.
+- `margin-top` on `.title + .description` and `.actions` — internal spacing between children, not at component boundary. May need `stylelint-disable-next-line property-disallowed-list -- internal spacing between alert child elements` comments if stylelint flags it.
+
+## ARIA + behavior reference
+
+| Concern | Behavior |
+|---|---|
+| **Element** | Plain `<div>` (in-flow). |
+| **Role** | `role="alert"` for `tone='error'` (assertive); `role="status"` for info/success/warning (polite). |
+| **Title** | `<strong>` — semantic emphasis, not a heading. Doesn't disrupt page heading outline. |
+| **Description** | `<div>` containing arbitrary ReactNode. |
+| **Close button** | Native `<button type="button">` with `aria-label="Dismiss"`. |
+| **Focus** | The close button is the only focusable element by default. Action buttons (inside `actions`) are reachable via Tab. |
+| **Live announcement** | Implicit from `role="alert"` / `role="status"`. No explicit `aria-live`. |
+| **Dismissal model** | Controlled — consumer hides via conditional render. Alert doesn't manage internal hidden state. |
+
+## Testing
+
+`Alert.test.tsx` — ~18 cases.
+
+### Baseline
+
+1. Renders without crashing with default props (tone="info" implicit)
+2. Default tone is `info`; `data-tone="info"` set
+3. `tone="success"` sets `data-tone="success"` AND `role="status"`
+4. `tone="warning"` sets `data-tone="warning"` AND `role="status"`
+5. `tone="error"` sets `data-tone="error"` AND `role="alert"` (assertive)
+6. `title` renders inside `<strong>`
+7. `children` renders inside the description container
+8. Both `title` and `children` together render correctly (both present)
+9. `className` merges, doesn't replace
+10. `ref` forwards to the root `<div>`
+
+### Icon
+
+11. Default icon renders for each tone (e.g., success → CheckCircle2 SVG present)
+12. `icon` override replaces the default
+13. `icon={null}` hides the icon entirely (no SVG in DOM)
+
+### Actions + dismiss
+
+14. `actions` renders inside `.actions` container
+15. `onDismiss` not provided → no close button
+16. `onDismiss` provided → close button with `aria-label="Dismiss"` renders
+17. Clicking the close button fires `onDismiss`
+18. Close button does NOT manage hidden state internally (verifying it's still in the DOM after click; consumer would conditionally unmount)
+
+**Vitest gotchas**:
+- The default icon test queries by SVG (lucide-react icons render `<svg>`). Use `container.querySelectorAll('svg').length > 0`.
+- The `tone="error"` role test: `expect(screen.getByRole('alert'))...` works because role="alert" is set on the root div.
+- The close button click test uses `userEvent.click(screen.getByRole('button', { name: 'Dismiss' }))`.
+
+## Playground demo — `AlertDemo.tsx`
+
+6 examples:
+
+1. **Four tones gallery** — info, success, warning, error side by side with title + description.
+2. **Title only** — `<Alert tone="info" title="Synced 5 minutes ago" />`.
+3. **Description only** — `<Alert tone="warning">Your storage is at 85% capacity.</Alert>`.
+4. **With actions** — `<Alert tone="warning" title="Update available" actions={<Button size="sm">Reload</Button>}>...</Alert>`.
+5. **Dismissible** — `useState`-driven hide pattern, with the `onDismiss` callback toggling a flag.
+6. **Custom icon + suppressed icon** — side by side: one with a custom Bell icon, one with `icon={null}`.
+
+The viewport mount is irrelevant — Alert is a flow element.
+
+## AGENTS.md TL;DR slot
+
+After `### <ToastViewport> + toast` (Toast section, around line ~578), before `### <ConfirmationPopover>`. Same "feedback" cluster.
+
+```markdown
+### `<Alert>` — persistent in-flow notification
+
+Tone-driven banner for messages that need to stay visible (subscription warnings, save failures, "update available" notices). Complements `<Toast>` (transient).
+
+```tsx
+import { Alert } from '@eocrm/design-system';
+
+// Basic
+<Alert tone="info" title="Synced 5 minutes ago" />
+<Alert tone="warning">Your storage is at 85% capacity.</Alert>
+
+// With actions
+<Alert tone="warning" title="Update available" actions={<Button size="sm">Reload</Button>}>
+  A new version is ready. Reload to apply.
+</Alert>
+
+// Dismissible
+const [show, setShow] = useState(true);
+{show && (
+  <Alert tone="success" onDismiss={() => setShow(false)}>
+    Changes saved.
+  </Alert>
+)}
+```
+
+- **Four tones** (`info` / `success` / `warning` / `error`). Default icon + accent stripe per tone.
+- **`role="alert"`** only for `error` (interrupts SR). Others use `role="status"` (polite).
+- **Persistent** — no auto-dismiss. Use Toast for transient messages.
+- **Controlled dismiss** — consumer hides via conditional render.
+
+#### When NOT to use
+
+- ❌ Transient confirmations → `<Toast>` / `toast.success(...)`.
+- ❌ Empty-state placeholders ("No deals yet") → `<EmptyState>`.
+- ❌ Form-field validation messages → inline error text under the field with `aria-describedby`.
+- ❌ Destructive confirmations needing yes/no → `<ConfirmationPopover>` or `<Modal>`.
+
+#### Anti-patterns
+
+- ❌ Auto-dismissing the Alert with a setTimeout — that's what Toast is for.
+- ❌ Using `tone="error"` for non-critical warnings. Reserve `error` for genuine failures; `role="alert"` interrupts screen readers.
+- ❌ Multiple stacked Alerts above a page — use one Alert with the most urgent tone, or compose into the page layout with explicit hierarchy.
+```
+
+## Hard Rule 8
+
+The pre-push review-fix cycle on library changes is mandatory. Gates green (`make test`, `make build-lib`, `make build`, `make lint`, `npm pack --dry-run`), spawn fresh-context reviewer with the standard prompt, fix Critical + Important, repeat until clean.
+
+## Open questions
+
+None. All clarifications baked in above.

--- a/docs/superpowers/specs/2026-05-23-alert-design.md
+++ b/docs/superpowers/specs/2026-05-23-alert-design.md
@@ -155,6 +155,7 @@ export interface AlertProps extends Omit<HTMLAttributes<HTMLElement>, 'role' | '
 ```
 
 Component-owned attrs that consumer cannot override:
+
 - `role` — derived from tone for ARIA correctness
 - `data-tone` — used by SCSS for tone-variant styling
 - `className` (spread AFTER props but merges via clsx so consumer's className appends)
@@ -170,16 +171,10 @@ A near-pure render component. Three branches:
 No internal state. No effects. No timers.
 
 ```tsx
-function Alert({
-  tone = 'info',
-  title,
-  children,
-  icon,
-  actions,
-  onDismiss,
-  className,
-  ...props
-}, ref) {
+function Alert(
+  { tone = 'info', title, children, icon, actions, onDismiss, className, ...props },
+  ref,
+) {
   const role = tone === 'error' ? 'alert' : 'status';
   const renderedIcon = icon === null ? null : (icon ?? DEFAULT_ICONS[tone]);
 
@@ -198,12 +193,7 @@ function Alert({
         {actions && <div className={styles.actions}>{actions}</div>}
       </div>
       {onDismiss && (
-        <button
-          type="button"
-          aria-label="Dismiss"
-          className={styles.close}
-          onClick={onDismiss}
-        >
+        <button type="button" aria-label="Dismiss" className={styles.close} onClick={onDismiss}>
           <X size={14} aria-hidden="true" />
         </button>
       )}
@@ -227,9 +217,9 @@ function Alert({
   gap: var(--space-3);
   align-items: start;
   padding: var(--space-3) var(--space-4);
-  background: var(--color-bg);     // overridden per tone
+  background: var(--color-bg); // overridden per tone
   border-radius: var(--radius-md);
-  border-left: var(--border-width-strong) solid var(--color-fg-muted);  // overridden per tone
+  border-left: var(--border-width-strong) solid var(--color-fg-muted); // overridden per tone
   color: var(--color-fg);
 }
 
@@ -262,13 +252,21 @@ function Alert({
   color: var(--color-fg-muted);
 }
 
-.alert[data-tone='info'] .icon { color: var(--color-info); }
-.alert[data-tone='success'] .icon { color: var(--color-success); }
-.alert[data-tone='warning'] .icon { color: var(--color-warning); }
-.alert[data-tone='error'] .icon { color: var(--color-danger); }
+.alert[data-tone='info'] .icon {
+  color: var(--color-info);
+}
+.alert[data-tone='success'] .icon {
+  color: var(--color-success);
+}
+.alert[data-tone='warning'] .icon {
+  color: var(--color-warning);
+}
+.alert[data-tone='error'] .icon {
+  color: var(--color-danger);
+}
 
 .body {
-  min-width: 0;     // allow long words/URLs to wrap inside the grid
+  min-width: 0; // allow long words/URLs to wrap inside the grid
 }
 
 .title {
@@ -317,6 +315,7 @@ function Alert({
 ```
 
 **Rule 4 check**:
+
 - `.alert` has `display: grid` + `grid-template-columns` — that's internal layout of the Alert's own children, NOT layout-at-component-boundary. Allowed.
 - `padding`, `border-radius`, `border-left` — internal styling, not layout.
 - `min-width: 0` on `.body` — needed for grid text wrapping, not layout.
@@ -324,16 +323,16 @@ function Alert({
 
 ## ARIA + behavior reference
 
-| Concern | Behavior |
-|---|---|
-| **Element** | Plain `<div>` (in-flow). |
-| **Role** | `role="alert"` for `tone='error'` (assertive); `role="status"` for info/success/warning (polite). |
-| **Title** | `<strong>` — semantic emphasis, not a heading. Doesn't disrupt page heading outline. |
-| **Description** | `<div>` containing arbitrary ReactNode. |
-| **Close button** | Native `<button type="button">` with `aria-label="Dismiss"`. |
-| **Focus** | The close button is the only focusable element by default. Action buttons (inside `actions`) are reachable via Tab. |
-| **Live announcement** | Implicit from `role="alert"` / `role="status"`. No explicit `aria-live`. |
-| **Dismissal model** | Controlled — consumer hides via conditional render. Alert doesn't manage internal hidden state. |
+| Concern               | Behavior                                                                                                            |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Element**           | Plain `<div>` (in-flow).                                                                                            |
+| **Role**              | `role="alert"` for `tone='error'` (assertive); `role="status"` for info/success/warning (polite).                   |
+| **Title**             | `<strong>` — semantic emphasis, not a heading. Doesn't disrupt page heading outline.                                |
+| **Description**       | `<div>` containing arbitrary ReactNode.                                                                             |
+| **Close button**      | Native `<button type="button">` with `aria-label="Dismiss"`.                                                        |
+| **Focus**             | The close button is the only focusable element by default. Action buttons (inside `actions`) are reachable via Tab. |
+| **Live announcement** | Implicit from `role="alert"` / `role="status"`. No explicit `aria-live`.                                            |
+| **Dismissal model**   | Controlled — consumer hides via conditional render. Alert doesn't manage internal hidden state.                     |
 
 ## Testing
 
@@ -367,6 +366,7 @@ function Alert({
 18. Close button does NOT manage hidden state internally (verifying it's still in the DOM after click; consumer would conditionally unmount)
 
 **Vitest gotchas**:
+
 - The default icon test queries by SVG (lucide-react icons render `<svg>`). Use `container.querySelectorAll('svg').length > 0`.
 - The `tone="error"` role test: `expect(screen.getByRole('alert'))...` works because role="alert" is set on the root div.
 - The close button click test uses `userEvent.click(screen.getByRole('button', { name: 'Dismiss' }))`.
@@ -388,7 +388,7 @@ The viewport mount is irrelevant — Alert is a flow element.
 
 After `### <ToastViewport> + toast` (Toast section, around line ~578), before `### <ConfirmationPopover>`. Same "feedback" cluster.
 
-```markdown
+````markdown
 ### `<Alert>` — persistent in-flow notification
 
 Tone-driven banner for messages that need to stay visible (subscription warnings, save failures, "update available" notices). Complements `<Toast>` (transient).
@@ -413,6 +413,7 @@ const [show, setShow] = useState(true);
   </Alert>
 )}
 ```
+````
 
 - **Four tones** (`info` / `success` / `warning` / `error`). Default icon + accent stripe per tone.
 - **`role="alert"`** only for `error` (interrupts SR). Others use `role="status"` (polite).
@@ -431,6 +432,7 @@ const [show, setShow] = useState(true);
 - ❌ Auto-dismissing the Alert with a setTimeout — that's what Toast is for.
 - ❌ Using `tone="error"` for non-critical warnings. Reserve `error` for genuine failures; `role="alert"` interrupts screen readers.
 - ❌ Multiple stacked Alerts above a page — use one Alert with the most urgent tone, or compose into the page layout with explicit hierarchy.
+
 ```
 
 ## Hard Rule 8
@@ -440,3 +442,4 @@ The pre-push review-fix cycle on library changes is mandatory. Gates green (`mak
 ## Open questions
 
 None. All clarifications baked in above.
+```

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -696,6 +696,50 @@ toast.success('Saved', { id });
 - ❌ For long-form messages. Toasts are 1–2 lines. If you need more, link to a page from the description.
 - ❌ As a substitute for in-page progress UI. A toast can announce "Upload started" but the persistent progress bar belongs in the page.
 
+### `<Alert>` — persistent in-flow notification
+
+Tone-driven banner for messages that need to stay visible while the user reads the page (subscription warnings, save failures, "update available" notices). Complements `<Toast>` (transient).
+
+```tsx
+import { Alert } from '@eocrm/design-system';
+
+// Basic
+<Alert tone="info" title="Synced 5 minutes ago" />
+<Alert tone="warning">Your storage is at 85% capacity.</Alert>
+
+// With actions
+<Alert tone="warning" title="Update available" actions={<Button size="sm">Reload</Button>}>
+  A new version is ready. Reload to apply.
+</Alert>
+
+// Dismissible (controlled by consumer)
+const [show, setShow] = useState(true);
+{show && (
+  <Alert tone="success" onDismiss={() => setShow(false)}>
+    Changes saved.
+  </Alert>
+)}
+```
+
+- **Four tones** (`info` / `success` / `warning` / `error`). Default icon + accent stripe per tone.
+- **`role="alert"`** only for `error` (assertive, interrupts SR). Others use `role="status"` (polite).
+- **Persistent** — no auto-dismiss. Use Toast for transient messages.
+- **Controlled dismiss** — `onDismiss` callback fires on × click; consumer hides via conditional render.
+- **`icon={null}`** suppresses the icon entirely; any ReactNode overrides the default.
+
+#### When NOT to use
+
+- ❌ Transient confirmations → `<Toast>` / `toast.success(...)`.
+- ❌ Empty-state placeholders ("No deals yet") → `<EmptyState>`.
+- ❌ Form-field validation messages → inline error text + `aria-describedby`.
+- ❌ Destructive confirmations needing yes/no → `<ConfirmationPopover>` or `<Modal>`.
+
+#### Anti-patterns
+
+- ❌ Auto-dismissing the Alert with a `setTimeout` — that's what Toast is for.
+- ❌ Using `tone="error"` for non-critical warnings. Reserve `error` for genuine failures.
+- ❌ Multiple stacked Alerts above a page — pick one (most urgent tone) or compose into the page layout with explicit hierarchy.
+
 ### `<ConfirmationPopover>` — opinionated "Are you sure?" preset
 
 ```tsx

--- a/packages/design-system/src/components/Alert/Alert.module.scss
+++ b/packages/design-system/src/components/Alert/Alert.module.scss
@@ -1,0 +1,105 @@
+@use '../../styles/mixins' as *;
+
+.alert {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-3);
+  align-items: start;
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bg);
+  border-radius: var(--radius-md);
+  border-left: var(--border-width-strong) solid var(--color-fg-muted);
+  color: var(--color-fg);
+}
+
+.alert[data-tone='info'] {
+  background: var(--color-info-bg-subtle);
+  border-left-color: var(--color-info);
+}
+
+.alert[data-tone='success'] {
+  background: var(--color-success-bg-subtle);
+  border-left-color: var(--color-success);
+}
+
+.alert[data-tone='warning'] {
+  background: var(--color-warning-bg-subtle);
+  border-left-color: var(--color-warning);
+}
+
+.alert[data-tone='error'] {
+  background: var(--color-danger-bg-subtle);
+  border-left-color: var(--color-danger);
+}
+
+.icon {
+  display: grid;
+  place-items: center;
+  color: var(--color-fg-muted);
+}
+
+.alert[data-tone='info'] .icon {
+  color: var(--color-info);
+}
+
+.alert[data-tone='success'] .icon {
+  color: var(--color-success);
+}
+
+.alert[data-tone='warning'] .icon {
+  color: var(--color-warning);
+}
+
+.alert[data-tone='error'] .icon {
+  color: var(--color-danger);
+}
+
+.body {
+  min-width: 0;
+}
+
+.title {
+  display: block;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.4;
+  color: var(--color-fg);
+}
+
+.description {
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+  line-height: 1.5;
+}
+
+.title + .description {
+  // stylelint-disable-next-line property-disallowed-list -- internal spacing between alert title and its description child
+  margin-top: var(--space-1);
+}
+
+.actions {
+  // stylelint-disable-next-line property-disallowed-list -- internal spacing between alert body content and its action row
+  margin-top: var(--space-2);
+}
+
+.close {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-fg-muted);
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast);
+
+  &:hover {
+    color: var(--color-fg);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+
+    outline: none;
+  }
+}

--- a/packages/design-system/src/components/Alert/Alert.test.tsx
+++ b/packages/design-system/src/components/Alert/Alert.test.tsx
@@ -59,9 +59,7 @@ describe('<Alert>', () => {
   });
 
   it('title and children both render together', () => {
-    render(
-      <Alert title="Heading">Body content</Alert>,
-    );
+    render(<Alert title="Heading">Body content</Alert>);
     expect(screen.getByText('Heading')).toBeInTheDocument();
     expect(screen.getByText('Body content')).toBeInTheDocument();
   });
@@ -94,9 +92,7 @@ describe('<Alert>', () => {
   });
 
   it('icon prop replaces the default', () => {
-    render(
-      <Alert icon={<Bell size={16} data-testid="custom-icon" />}>x</Alert>,
-    );
+    render(<Alert icon={<Bell size={16} data-testid="custom-icon" />}>x</Alert>);
     expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
   });
 

--- a/packages/design-system/src/components/Alert/Alert.test.tsx
+++ b/packages/design-system/src/components/Alert/Alert.test.tsx
@@ -33,6 +33,19 @@ describe('<Alert>', () => {
     expect(screen.getByRole('alert')).toBeInTheDocument();
   });
 
+  it('component-owned data-tone survives consumer-passed data-tone (spread order)', () => {
+    // Consumer attempts to override data-tone via a passthrough prop.
+    // The component's data-tone (driven by `tone`) MUST win.
+    const { container } = render(
+      // data-* attrs are loosely typed — TS accepts this; the runtime assertion below is the guard
+      <Alert tone="success" data-tone="bogus">
+        x
+      </Alert>,
+    );
+    expect(container.querySelector('[data-tone="success"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-tone="bogus"]')).toBeNull();
+  });
+
   it('title renders inside <strong>', () => {
     const { container } = render(<Alert title="Heading">desc</Alert>);
     const strong = container.querySelector('strong');

--- a/packages/design-system/src/components/Alert/Alert.test.tsx
+++ b/packages/design-system/src/components/Alert/Alert.test.tsx
@@ -1,0 +1,133 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Bell } from 'lucide-react';
+import { Alert } from './Alert';
+
+describe('<Alert>', () => {
+  // ─── Baseline ──────────────────────────────────────────────────────────
+
+  it('renders without crashing with default props (info tone implicit)', () => {
+    const { container } = render(<Alert>Body</Alert>);
+    expect(container.querySelector('[data-tone="info"]')).toBeInTheDocument();
+  });
+
+  it('default tone is info (role="status")', () => {
+    render(<Alert>x</Alert>);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['info', 'status'],
+    ['success', 'status'],
+    ['warning', 'status'],
+  ] as const)('tone="%s" uses role="%s" (polite)', (tone, expectedRole) => {
+    const { container } = render(<Alert tone={tone}>x</Alert>);
+    expect(container.querySelector(`[data-tone="${tone}"]`)).toBeInTheDocument();
+    expect(screen.getByRole(expectedRole)).toBeInTheDocument();
+  });
+
+  it('tone="error" uses role="alert" (assertive)', () => {
+    const { container } = render(<Alert tone="error">x</Alert>);
+    expect(container.querySelector('[data-tone="error"]')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('title renders inside <strong>', () => {
+    const { container } = render(<Alert title="Heading">desc</Alert>);
+    const strong = container.querySelector('strong');
+    expect(strong).not.toBeNull();
+    expect(strong).toHaveTextContent('Heading');
+  });
+
+  it('children render as the description body', () => {
+    render(<Alert>Body content</Alert>);
+    expect(screen.getByText('Body content')).toBeInTheDocument();
+  });
+
+  it('title and children both render together', () => {
+    render(
+      <Alert title="Heading">Body content</Alert>,
+    );
+    expect(screen.getByText('Heading')).toBeInTheDocument();
+    expect(screen.getByText('Body content')).toBeInTheDocument();
+  });
+
+  it('className is merged onto the root, not replaced', () => {
+    const { container } = render(<Alert className="custom">x</Alert>);
+    const root = container.firstElementChild!;
+    expect(root.className).toMatch(/alert/);
+    expect(root.className).toMatch(/custom/);
+  });
+
+  it('ref forwards to the root <div>', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Alert ref={ref}>x</Alert>);
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('DIV');
+  });
+
+  // ─── Icon ──────────────────────────────────────────────────────────────
+
+  it('default icon renders for each tone (SVG present)', () => {
+    const { container, rerender } = render(<Alert tone="info">x</Alert>);
+    expect(container.querySelector('svg')).not.toBeNull();
+    rerender(<Alert tone="success">x</Alert>);
+    expect(container.querySelector('svg')).not.toBeNull();
+    rerender(<Alert tone="warning">x</Alert>);
+    expect(container.querySelector('svg')).not.toBeNull();
+    rerender(<Alert tone="error">x</Alert>);
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('icon prop replaces the default', () => {
+    render(
+      <Alert icon={<Bell size={16} data-testid="custom-icon" />}>x</Alert>,
+    );
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+
+  it('icon={null} hides the icon entirely', () => {
+    const { container } = render(<Alert icon={null}>x</Alert>);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  // ─── Actions ───────────────────────────────────────────────────────────
+
+  it('actions render inside the body when provided', () => {
+    render(
+      <Alert title="t" actions={<button data-testid="action">Retry</button>}>
+        desc
+      </Alert>,
+    );
+    expect(screen.getByTestId('action')).toBeInTheDocument();
+  });
+
+  // ─── Dismiss ───────────────────────────────────────────────────────────
+
+  it('onDismiss not provided → no close button', () => {
+    render(<Alert>x</Alert>);
+    expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull();
+  });
+
+  it('onDismiss provided → close button with aria-label="Dismiss"', () => {
+    render(<Alert onDismiss={() => {}}>x</Alert>);
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+  });
+
+  it('clicking the close button fires onDismiss', async () => {
+    const user = userEvent.setup();
+    const handleDismiss = vi.fn();
+    render(<Alert onDismiss={handleDismiss}>x</Alert>);
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(handleDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('close button does NOT manage hidden state internally (still in DOM after click)', async () => {
+    const user = userEvent.setup();
+    render(<Alert onDismiss={() => {}}>Body</Alert>);
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+    // Alert stays in the DOM — consumer would hide via conditional render.
+    expect(screen.getByText('Body')).toBeInTheDocument();
+  });
+});

--- a/packages/design-system/src/components/Alert/Alert.tsx
+++ b/packages/design-system/src/components/Alert/Alert.tsx
@@ -14,8 +14,7 @@ import styles from './Alert.module.scss';
  */
 export type AlertTone = 'info' | 'success' | 'warning' | 'error';
 
-export interface AlertProps
-  extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'title'> {
+export interface AlertProps extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'title'> {
   /** Tone. Defaults to `'info'`. See `AlertTone` for full descriptions. */
   tone?: AlertTone;
 
@@ -139,12 +138,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(function Alert(
         {actions && <div className={styles.actions}>{actions}</div>}
       </div>
       {onDismiss && (
-        <button
-          type="button"
-          aria-label="Dismiss"
-          className={styles.close}
-          onClick={onDismiss}
-        >
+        <button type="button" aria-label="Dismiss" className={styles.close} onClick={onDismiss}>
           <X size={14} aria-hidden="true" />
         </button>
       )}

--- a/packages/design-system/src/components/Alert/Alert.tsx
+++ b/packages/design-system/src/components/Alert/Alert.tsx
@@ -127,9 +127,9 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(function Alert(
   return (
     <div
       ref={ref}
+      {...props}
       role={role}
       data-tone={tone}
-      {...props}
       className={clsx(styles.alert, className)}
     >
       {renderedIcon && <div className={styles.icon}>{renderedIcon}</div>}

--- a/packages/design-system/src/components/Alert/Alert.tsx
+++ b/packages/design-system/src/components/Alert/Alert.tsx
@@ -1,0 +1,153 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import { AlertTriangle, CheckCircle2, Info, X, XCircle } from 'lucide-react';
+import clsx from 'clsx';
+import styles from './Alert.module.scss';
+
+/**
+ * Tone — drives icon, accent stripe color, tinted background, and ARIA role.
+ *
+ * - `'info'` — blue accent. Neutral updates ("Synced 5 minutes ago").
+ * - `'success'` — green accent. Confirmations ("Changes saved").
+ * - `'warning'` — orange accent. Non-blocking heads-up ("Storage at 85%").
+ * - `'error'` — red accent. Failures. ALSO sets `role="alert"` (assertive); the
+ *   other tones use `role="status"` (polite).
+ */
+export type AlertTone = 'info' | 'success' | 'warning' | 'error';
+
+export interface AlertProps
+  extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'title'> {
+  /** Tone. Defaults to `'info'`. See `AlertTone` for full descriptions. */
+  tone?: AlertTone;
+
+  /**
+   * Optional bold heading. Renders above the description. ReactNode so you
+   * can embed inline emphasis (`<>Update <strong>1.2.3</strong> available</>`).
+   *
+   * The native HTML `title` attribute (tooltip-on-hover) is collapsed by this
+   * prop. Use `aria-label` if you need that.
+   */
+  title?: ReactNode;
+
+  /** Description body. Rendered below the title in muted color. */
+  children?: ReactNode;
+
+  /**
+   * Override the tone's default icon. Pass any ReactNode (typically a
+   * lucide-react icon). Pass `null` to hide the icon entirely.
+   *
+   * Defaults: `info` → `Info`, `success` → `CheckCircle2`,
+   * `warning` → `AlertTriangle`, `error` → `XCircle`.
+   */
+  icon?: ReactNode | null;
+
+  /**
+   * Optional action row rendered below the description. Typically a single
+   * Button or a Cluster of two ("Retry", "Dismiss"). The component doesn't
+   * manage the action row's layout — pass a pre-laid-out node.
+   */
+  actions?: ReactNode;
+
+  /**
+   * Called when the user clicks the close (×) button. When set, the close
+   * button renders; when omitted, no close button. Alert is **controlled** —
+   * the component does NOT manage internal hidden state. Hide via
+   * conditional render in the consumer:
+   *
+   * ```tsx
+   * const [show, setShow] = useState(true);
+   * {show && <Alert tone="success" onDismiss={() => setShow(false)}>Saved</Alert>}
+   * ```
+   */
+  onDismiss?: () => void;
+}
+
+const DEFAULT_ICONS: Record<AlertTone, ReactNode> = {
+  info: <Info size={16} aria-hidden="true" />,
+  success: <CheckCircle2 size={16} aria-hidden="true" />,
+  warning: <AlertTriangle size={16} aria-hidden="true" />,
+  error: <XCircle size={16} aria-hidden="true" />,
+};
+
+/**
+ * Persistent in-flow notification. Fills the gap between `<Toast>` (transient,
+ * auto-dismissing, portal-rendered) and inline error text. Use Alert when the
+ * message needs to stay visible while the user reads the page — subscription
+ * warnings, save failures, "Update available" notices.
+ *
+ * Four tones (info / success / warning / error) with a subtle tinted background
+ * + left accent stripe per tone. Optional title, description (children), icon,
+ * action row, and dismiss button. No internal state, no animations, no
+ * auto-dismiss.
+ *
+ * @example
+ * // Basic
+ * <Alert tone="info" title="Synced 5 minutes ago" />
+ * <Alert tone="warning">Your storage is at 85% capacity.</Alert>
+ *
+ * @example
+ * // With title + description + actions
+ * <Alert tone="warning" title="Update available" actions={<Button size="sm">Reload</Button>}>
+ *   A new version is ready. Reload to apply.
+ * </Alert>
+ *
+ * @example
+ * // Dismissible (controlled by consumer)
+ * const [show, setShow] = useState(true);
+ * {show && (
+ *   <Alert tone="success" onDismiss={() => setShow(false)}>
+ *     Changes saved.
+ *   </Alert>
+ * )}
+ *
+ * @example
+ * // Custom icon / suppressed icon
+ * <Alert tone="info" icon={<Bell size={16} />} title="New mention" />
+ * <Alert tone="info" icon={null}>Quietly informative.</Alert>
+ *
+ * @remarks When NOT to use
+ * - Transient confirmations → `toast.success(...)`.
+ * - Empty-state placeholders ("No deals yet") → `<EmptyState>`.
+ * - Form-field validation messages → inline error text + `aria-describedby`.
+ * - Destructive confirmations needing yes/no → `<ConfirmationPopover>` or `<Modal>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Auto-dismissing the Alert with `setTimeout` — that's what Toast is for.
+ * - ❌ `tone="error"` for non-critical warnings. Reserve `error` for genuine
+ *   failures; `role="alert"` interrupts screen readers.
+ * - ❌ Multiple stacked Alerts above a page — pick one (most urgent tone) or
+ *   compose into the page layout with explicit hierarchy.
+ */
+export const Alert = forwardRef<HTMLDivElement, AlertProps>(function Alert(
+  { tone = 'info', title, children, icon, actions, onDismiss, className, ...props },
+  ref,
+) {
+  const role = tone === 'error' ? 'alert' : 'status';
+  const renderedIcon = icon === null ? null : (icon ?? DEFAULT_ICONS[tone]);
+
+  return (
+    <div
+      ref={ref}
+      role={role}
+      data-tone={tone}
+      {...props}
+      className={clsx(styles.alert, className)}
+    >
+      {renderedIcon && <div className={styles.icon}>{renderedIcon}</div>}
+      <div className={styles.body}>
+        {title && <strong className={styles.title}>{title}</strong>}
+        {children && <div className={styles.description}>{children}</div>}
+        {actions && <div className={styles.actions}>{actions}</div>}
+      </div>
+      {onDismiss && (
+        <button
+          type="button"
+          aria-label="Dismiss"
+          className={styles.close}
+          onClick={onDismiss}
+        >
+          <X size={14} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+});

--- a/packages/design-system/src/components/Alert/index.ts
+++ b/packages/design-system/src/components/Alert/index.ts
@@ -1,0 +1,2 @@
+export { Alert } from './Alert';
+export type { AlertProps, AlertTone } from './Alert';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -36,6 +36,9 @@ export type {
   GridAs,
 } from './components/Grid';
 
+export { Alert } from './components/Alert';
+export type { AlertProps, AlertTone } from './components/Alert';
+
 export { Avatar, AvatarGroup, avatarColorIndex } from './components/Avatar';
 export type { AvatarProps, AvatarSize, AvatarStatus, AvatarGroupProps } from './components/Avatar';
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -7,6 +7,7 @@ import { Contacts } from './pages/mockups/Contacts/Contacts';
 import { ContactDetail } from './pages/mockups/ContactDetail/ContactDetail';
 import { Members } from './pages/mockups/Members/Members';
 import { ComponentsIndex } from './pages/components/ComponentsIndex';
+import { AlertDemo } from './pages/components/AlertDemo';
 import { BreadcrumbDemo } from './pages/components/BreadcrumbDemo';
 import { ButtonDemo } from './pages/components/ButtonDemo';
 import { ButtonGroupDemo } from './pages/components/ButtonGroupDemo';
@@ -57,6 +58,7 @@ export default function App() {
           <Route path="/mockups/members" element={<Members />} />
 
           <Route path="/components" element={<ComponentsIndex />} />
+          <Route path="/components/alert" element={<AlertDemo />} />
           <Route path="/components/breadcrumb" element={<BreadcrumbDemo />} />
           <Route path="/components/button" element={<ButtonDemo />} />
           <Route path="/components/button-group" element={<ButtonGroupDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import {
+  AlertCircle,
   LayoutDashboard,
   KanbanSquare,
   Users,
@@ -109,7 +110,10 @@ const componentGroups = [
   },
   {
     heading: 'Feedback',
-    items: [{ to: '/components/toast', label: 'Toast', icon: Bell, end: false }],
+    items: [
+      { to: '/components/alert', label: 'Alert', icon: AlertCircle, end: false },
+      { to: '/components/toast', label: 'Toast', icon: Bell, end: false },
+    ],
   },
   {
     heading: 'Navigation',

--- a/packages/playground/src/pages/components/AlertDemo.tsx
+++ b/packages/playground/src/pages/components/AlertDemo.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { Bell } from 'lucide-react';
+import { Alert, Button, Cluster, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Alert/Alert.tsx?raw';
+import scssSource from '@lib-source/components/Alert/Alert.module.scss?raw';
+
+export function AlertDemo() {
+  const [showSaved, setShowSaved] = useState(true);
+
+  return (
+    <DemoLayout
+      name="Alert"
+      componentName="Alert"
+      description="Persistent in-flow notification. Four tones with tinted background + accent stripe. Optional title / description / icon / actions / dismiss. Use Toast for transient messages instead."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Alert.tsx"
+      scssFilename="Alert.module.scss"
+    >
+      <Example
+        title="Four tones"
+        description="info / success / warning / error. Default icon + accent stripe per tone. Error gets role='alert' (assertive); others use role='status' (polite)."
+        code={`<Alert tone="info" title="Synced 5 minutes ago" />
+<Alert tone="success" title="Changes saved" />
+<Alert tone="warning" title="Storage at 85%" />
+<Alert tone="error" title="Request failed" />`}
+      >
+        <Stack gap="sm">
+          <Alert tone="info" title="Synced 5 minutes ago" />
+          <Alert tone="success" title="Changes saved" />
+          <Alert tone="warning" title="Storage at 85%" />
+          <Alert tone="error" title="Request failed" />
+        </Stack>
+      </Example>
+
+      <Example
+        title="Title only"
+        description="The simplest form. Useful for short status messages."
+        code={`<Alert tone="info" title="Synced 5 minutes ago" />`}
+      >
+        <Alert tone="info" title="Synced 5 minutes ago" />
+      </Example>
+
+      <Example
+        title="Description only (no title)"
+        description="Short text body without a heading. Reads as a sentence."
+        code={`<Alert tone="warning">Your storage is at 85% capacity.</Alert>`}
+      >
+        <Alert tone="warning">Your storage is at 85% capacity.</Alert>
+      </Example>
+
+      <Example
+        title="With actions"
+        description="Pass a pre-laid-out node as `actions`. Renders below the description."
+        code={`<Alert
+  tone="warning"
+  title="Update available"
+  actions={
+    <Cluster gap="sm">
+      <Button size="sm">Reload</Button>
+      <Button size="sm" variant="ghost">Later</Button>
+    </Cluster>
+  }
+>
+  A new version is ready. Reload to apply the latest improvements.
+</Alert>`}
+      >
+        <Alert
+          tone="warning"
+          title="Update available"
+          actions={
+            <Cluster gap="sm">
+              <Button size="sm">Reload</Button>
+              <Button size="sm" variant="ghost">
+                Later
+              </Button>
+            </Cluster>
+          }
+        >
+          A new version is ready. Reload to apply the latest improvements.
+        </Alert>
+      </Example>
+
+      <Example
+        title="Dismissible"
+        description="onDismiss callback fires when the × is clicked. The component does NOT manage hidden state — the consumer conditionally renders."
+        code={`const [show, setShow] = useState(true);
+
+{show && (
+  <Alert tone="success" onDismiss={() => setShow(false)}>
+    Changes saved.
+  </Alert>
+)}`}
+      >
+        <Stack gap="sm">
+          {showSaved ? (
+            <Alert tone="success" onDismiss={() => setShowSaved(false)}>
+              Changes saved.
+            </Alert>
+          ) : (
+            <Button size="sm" variant="ghost" onClick={() => setShowSaved(true)}>
+              Show again
+            </Button>
+          )}
+        </Stack>
+      </Example>
+
+      <Example
+        title="Custom icon + suppressed icon"
+        description="Pass any ReactNode to icon for an override. icon={null} hides the icon entirely."
+        code={`<Alert tone="info" icon={<Bell size={16} />} title="New mention" />
+<Alert tone="info" icon={null}>Quietly informative.</Alert>`}
+      >
+        <Stack gap="sm">
+          <Alert tone="info" icon={<Bell size={16} aria-hidden />} title="New mention" />
+          <Alert tone="info" icon={null}>
+            Quietly informative.
+          </Alert>
+        </Stack>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { ArrowRight, Inbox } from 'lucide-react';
+import { Alert } from '@eocrm/design-system';
 import { Avatar } from '@eocrm/design-system';
 import { Badge } from '@eocrm/design-system';
 import { Breadcrumb } from '@eocrm/design-system';
@@ -56,6 +57,12 @@ function DataTablePreview() {
 }
 
 const items: { to: string; name: string; description: string; preview: React.ReactNode }[] = [
+  {
+    to: '/components/alert',
+    name: 'Alert',
+    description: 'Persistent in-flow notification with four tones.',
+    preview: <Alert tone="info" title="Synced 5 minutes ago" />,
+  },
   {
     to: '/components/button',
     name: 'Button',

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -1,6 +1,7 @@
 // packages/playground/src/pages/mockups/registry.ts
 
 export type ComponentName =
+  | 'Alert'
   | 'Avatar'
   | 'Badge'
   | 'Breadcrumb'


### PR DESCRIPTION
## Summary

- New \`<Alert>\` — persistent in-flow notification. Fills the gap between \`<Toast>\` (transient, auto-dismissing, portal-rendered) and inline error text.
- **Four tones** (\`info\` / \`success\` / \`warning\` / \`error\`) with subtle tinted background + left accent stripe + default icon per tone.
- **\`role=\"alert\"\`** (assertive) only for the \`error\` tone; others use \`role=\"status\"\` (polite). Matches Toast's policy.
- Optional title (rendered as \`<strong>\`), description (children), icon override (or \`null\` to hide), action row, controlled dismiss button.
- No internal state, no animations, no auto-dismiss. Consumer controls visibility via conditional render.

## Design highlights

- **Single visual variant** (subtle tinted + left accent stripe). Solid/outline variants can be added v2 if a concrete need surfaces.
- **No compound API** — title/description/actions are props, not slots. Keeps the surface tight; the consumer pattern is obvious.
- **Default icon per tone** via a \`DEFAULT_ICONS\` lookup; \`icon\` prop overrides; \`icon={null}\` suppresses (strict-null check distinguishes from undefined fallback).
- **Controlled dismiss**: \`onDismiss\` callback fires on × click; the component stays in the DOM until the consumer hides it. Matches React's controlled-input philosophy.
- **Component-owned attrs are spread AFTER consumer props** (\`role\`, \`data-tone\`, \`className\`) so accidental \`data-tone=\"bogus\"\` passthroughs can't silently break the tone styling.

## Hard Rule 8

**Round 1** found 1 Important finding — \`data-tone\` was being spread BEFORE \`{...props}\`, making it consumer-overridable at runtime despite the spec saying it's component-owned. Fix moved both \`role\` and \`data-tone\` to AFTER the spread + added a regression test.

**Round 2 verdict: clean enough to stop.** 0 Critical + 0 Important.

20 new tests covering rendering, all 4 tones (role + data-tone mapping), title+description+icon variants, action slot, dismiss button presence/click/no-internal-state, and the \`data-tone\` spread-order regression. Suite total: **1442 passing**.

All four gates green: \`make test\` · \`make build-lib\` · \`make build\` · \`make lint\` · \`npm pack --dry-run\` (no test files in tarball).

## Test plan

- [ ] All four tones render with distinct accent stripe colors + tinted backgrounds
- [ ] \`tone=\"error\"\` produces \`role=\"alert\"\`; others use \`role=\"status\"\`
- [ ] Title renders inside \`<strong>\`; description renders as muted body
- [ ] Default icon appears per tone (SVG present); \`icon={null}\` hides; custom \`icon\` overrides
- [ ] \`actions\` slot renders below the description
- [ ] No close button when \`onDismiss\` is omitted; close button has \`aria-label=\"Dismiss\"\` and fires \`onDismiss\` on click
- [ ] Component does NOT manage hidden state — stays in DOM after click; consumer conditionally renders
- [ ] Consumer-passed \`data-tone=\"bogus\"\` does NOT clobber the component's tone styling
- [ ] Playground demo at \`/components/alert\` renders all 6 examples without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)