### PR TITLE
Divider: thin separator primitive (orientation, variant, size, label slot)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-divider.md
+++ b/docs/superpowers/plans/2026-05-23-divider.md
@@ -1,0 +1,1106 @@
+# Divider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Divider>` — a thin separator primitive. Horizontal (default) or vertical orientation, solid or dashed variant, three size tiers (`sm`/`md`/`lg`), optional centered label slot.
+
+**Architecture:** A single `forwardRef` component that branches on `children`: renders `<hr>` when no children (native HTML semantics), `<div role="separator">` with two `.line` spans flanking a `.label` span when labeled (HTML `<hr>` can't have children). Orientation × variant × size driven by class composition. No new tokens — sizes map directly to `--border-width` / `--border-width-emphasis` / `--border-width-strong`.
+
+**Tech Stack:** React 19 + TypeScript (source-distributed). `clsx` for class composition. CSS Modules + SCSS. Vitest + RTL. No new packages, no new tokens.
+
+**Source of truth:** `docs/superpowers/specs/2026-05-23-divider-design.md` (commit `88d59b3`).
+
+**Branch:** `feat/divider`. Commit per task. Open the PR after the Hard-Rule-8 cycle (Task 5).
+
+---
+
+## File Structure
+
+```
+packages/design-system/src/components/Divider/
+  Divider.tsx           ← Task 1. forwardRef, branches on `children`, full JSDoc.
+  Divider.module.scss   ← Task 1. Base + orientation × variant × size matrix + labeled flex layout.
+  index.ts              ← Task 1. exports Divider + types.
+  Divider.test.tsx      ← Task 2. ~14 cases.
+
+packages/design-system/src/index.ts                              ← Task 3. MODIFY: re-export Divider + types.
+packages/design-system/AGENTS.md                                 ← Task 3. MODIFY: TL;DR after Grid section (layout cluster).
+
+packages/playground/src/pages/components/DividerDemo.tsx         ← Task 4. NEW: 6 examples.
+packages/playground/src/App.tsx                                  ← Task 4. MODIFY: route + import.
+packages/playground/src/layout/AppShell/AppShell.tsx             ← Task 4. MODIFY: Layout group, between Cluster and Grid.
+packages/playground/src/pages/components/ComponentsIndex.tsx     ← Task 4. MODIFY: overview card.
+packages/playground/src/pages/mockups/registry.ts                ← Task 4. MODIFY: 'Divider' in ComponentName union.
+```
+
+**Decomposition rationale:**
+
+- **Task 1 (source bundle)** keeps `Divider.tsx` + SCSS + barrel together (cross-reference). Same as Textarea/Switch/Alert precedent.
+- **Task 2 (tests)** lands separately so the test diff is reviewable.
+- **Task 3 (exports + AGENTS)** is small and paired.
+- **Task 4 (playground demo + 4-place wiring)** bundles the demo + nav touchpoints.
+- **Task 5 (Hard-Rule-8)** — gates, fresh reviewer, push, PR.
+
+---
+
+## Task 1 — Source bundle (Divider.tsx + SCSS + barrel)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Divider/Divider.tsx`
+- Create: `packages/design-system/src/components/Divider/Divider.module.scss`
+- Create: `packages/design-system/src/components/Divider/index.ts`
+
+- [ ] **Step 1: Verify branch + clean tree**
+
+```bash
+cd /home/dpws/projects/design-system
+git status
+git branch --show-current
+git log --oneline -3
+```
+
+Expected:
+- Branch: `feat/divider`
+- Working tree clean
+- Most recent: `88d59b3 Divider: design spec — thin separator primitive`
+
+- [ ] **Step 2: Create the component directory + write the SCSS**
+
+```bash
+mkdir -p packages/design-system/src/components/Divider
+```
+
+Create `packages/design-system/src/components/Divider/Divider.module.scss`:
+
+```scss
+.divider {
+  border: 0;
+  color: var(--color-border);
+}
+
+// ─── No-label cases: <hr> with a single border edge ─────────────────────
+
+.horizontal {
+  width: 100%;
+  border-top: var(--border-width) solid var(--color-border);
+}
+
+// Rule 4 exception: vertical separators need parent height. Without
+// align-self the line collapses to 0 in flex/grid parents. Same documented
+// exception as ButtonGroup uses for `align-self: flex-start`.
+// stylelint-disable-next-line property-disallowed-list -- vertical separator needs parent height
+.vertical {
+  align-self: stretch;
+  border-left: var(--border-width) solid var(--color-border);
+  min-height: var(--space-3);
+}
+
+// ─── Variants ──────────────────────────────────────────────────────────
+
+.dashed.horizontal {
+  border-top-style: dashed;
+}
+
+.dashed.vertical {
+  border-left-style: dashed;
+}
+
+// ─── Sizes (no-label cases) ─────────────────────────────────────────────
+
+.sizeMd.horizontal {
+  border-top-width: var(--border-width-emphasis);
+}
+
+.sizeMd.vertical {
+  border-left-width: var(--border-width-emphasis);
+}
+
+.sizeLg.horizontal {
+  border-top-width: var(--border-width-strong);
+}
+
+.sizeLg.vertical {
+  border-left-width: var(--border-width-strong);
+}
+
+// ─── Labeled — flex layout with two line spans flanking the label ───────
+
+.labeled {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  border-top: 0;
+  border-left: 0;
+}
+
+// stylelint-disable-next-line property-disallowed-list -- vertical separator needs parent height; same exception as the no-label case
+.labeled.vertical {
+  flex-direction: column;
+  align-self: stretch;
+  min-height: var(--space-3);
+}
+
+.line {
+  flex: 1;
+  border: 0;
+  background: var(--color-border);
+  height: var(--border-width);
+  border-radius: 0;
+}
+
+.labeled.vertical .line {
+  width: var(--border-width);
+  height: auto;
+  align-self: stretch;
+}
+
+// Dashed lines collapse the height to 0 and rely on the border for the dash
+// pattern. Without this, the height + dashed border would visually stack.
+.dashed .line {
+  background: transparent;
+  height: 0;
+  border-top: var(--border-width) dashed var(--color-border);
+}
+
+.dashed.vertical .line {
+  width: 0;
+  border-top: 0;
+  border-left: var(--border-width) dashed var(--color-border);
+}
+
+.sizeMd .line {
+  height: var(--border-width-emphasis);
+}
+
+.sizeLg .line {
+  height: var(--border-width-strong);
+}
+
+.sizeMd.vertical .line {
+  width: var(--border-width-emphasis);
+  height: auto;
+}
+
+.sizeLg.vertical .line {
+  width: var(--border-width-strong);
+  height: auto;
+}
+
+.sizeMd.dashed .line {
+  border-top-width: var(--border-width-emphasis);
+  height: 0;
+}
+
+.sizeLg.dashed .line {
+  border-top-width: var(--border-width-strong);
+  height: 0;
+}
+
+.sizeMd.dashed.vertical .line {
+  border-left-width: var(--border-width-emphasis);
+  width: 0;
+}
+
+.sizeLg.dashed.vertical .line {
+  border-left-width: var(--border-width-strong);
+  width: 0;
+}
+
+.label {
+  flex: 0 0 auto;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg-muted);
+  white-space: nowrap;
+}
+```
+
+- [ ] **Step 3: Write `Divider.tsx`**
+
+Create `packages/design-system/src/components/Divider/Divider.tsx`:
+
+```tsx
+import { forwardRef, type HTMLAttributes, type ReactNode, type Ref } from 'react';
+import clsx from 'clsx';
+import styles from './Divider.module.scss';
+
+/** Layout direction. Defaults to `'horizontal'`. */
+export type DividerOrientation = 'horizontal' | 'vertical';
+
+/** Line style. Defaults to `'solid'`. */
+export type DividerVariant = 'solid' | 'dashed';
+
+/**
+ * Line thickness tier. Defaults to `'sm'` (1px).
+ * - `'sm'` — `--border-width` (1px). Default. Quiet separation.
+ * - `'md'` — `--border-width-emphasis` (2px). Section breaks.
+ * - `'lg'` — `--border-width-strong` (3px). Heavy emphasis; rare.
+ */
+export type DividerSize = 'sm' | 'md' | 'lg';
+
+export interface DividerProps
+  extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'children'> {
+  /** Layout direction. Defaults to `'horizontal'`. */
+  orientation?: DividerOrientation;
+
+  /** Line style. Defaults to `'solid'`. */
+  variant?: DividerVariant;
+
+  /** Line thickness tier. Defaults to `'sm'`. */
+  size?: DividerSize;
+
+  /**
+   * Optional centered label rendered between two line segments.
+   * Common pattern: `<Divider>OR</Divider>` for auth-form section breaks.
+   *
+   * When `children` is set, the root becomes `<div role="separator">`
+   * instead of `<hr>` (HTML `<hr>` cannot have children).
+   *
+   * Works with `orientation="vertical"` but renders awkwardly (text wraps
+   * across two short line segments). Avoid vertical + label combos.
+   */
+  children?: ReactNode;
+}
+
+const ORIENTATION_CLASS: Record<DividerOrientation, string> = {
+  horizontal: styles.horizontal,
+  vertical: styles.vertical,
+};
+
+const VARIANT_CLASS: Record<DividerVariant, string> = {
+  solid: '',
+  dashed: styles.dashed,
+};
+
+const SIZE_CLASS: Record<DividerSize, string> = {
+  sm: '',
+  md: styles.sizeMd,
+  lg: styles.sizeLg,
+};
+
+/**
+ * Thin separator primitive. Horizontal (default) or vertical, solid or
+ * dashed, three size tiers, optional centered label.
+ *
+ * When no `children` are passed, renders a native `<hr>` (the right HTML
+ * semantic for a thematic break). When `children` is set, the root becomes
+ * `<div role="separator">` with two line spans flanking the label — HTML
+ * `<hr>` cannot have children.
+ *
+ * No spacing prop — the parent owns layout per Rule 4. Use Stack's `gap`
+ * around the Divider to control spacing.
+ *
+ * @example
+ * // Default — horizontal solid line
+ * <Divider />
+ *
+ * @example
+ * // Vertical separator inside a toolbar Cluster
+ * <Cluster gap="sm">
+ *   <Button>Edit</Button>
+ *   <Divider orientation="vertical" />
+ *   <Button>Duplicate</Button>
+ * </Cluster>
+ *
+ * @example
+ * // Labeled (auth-form pattern)
+ * <Divider>OR</Divider>
+ *
+ * @example
+ * // Variants + sizes
+ * <Divider variant="dashed" />
+ * <Divider size="lg" />
+ *
+ * @remarks When NOT to use
+ * - Below a heading → just use the heading's `border-bottom`.
+ * - Between unrelated stacked sections → use Stack with `gap` instead.
+ * - Tone-driven separators ("error" / "success") → use `<Alert>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ `<Divider orientation="vertical">OR</Divider>` — text wraps awkwardly.
+ * - ❌ `<Divider size="lg" />` for casual breaks. Reserve `lg` (3px) for strong hierarchy.
+ * - ❌ `<Divider style={{ marginY: 16 }} />` — parent owns spacing.
+ */
+export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
+  {
+    orientation = 'horizontal',
+    variant = 'solid',
+    size = 'sm',
+    children,
+    className,
+    ...props
+  },
+  ref,
+) {
+  const classes = clsx(
+    styles.divider,
+    ORIENTATION_CLASS[orientation],
+    VARIANT_CLASS[variant],
+    SIZE_CLASS[size],
+    children != null && styles.labeled,
+    className,
+  );
+
+  if (children == null) {
+    return (
+      <hr
+        ref={ref as Ref<HTMLHRElement>}
+        {...props}
+        role="separator"
+        aria-orientation={orientation}
+        className={classes}
+      />
+    );
+  }
+
+  return (
+    <div
+      ref={ref as Ref<HTMLDivElement>}
+      {...props}
+      role="separator"
+      aria-orientation={orientation}
+      data-labeled="true"
+      className={classes}
+    >
+      <span className={styles.line} aria-hidden="true" />
+      <span className={styles.label}>{children}</span>
+      <span className={styles.line} aria-hidden="true" />
+    </div>
+  );
+});
+```
+
+- [ ] **Step 4: Write the folder barrel**
+
+Create `packages/design-system/src/components/Divider/index.ts`:
+
+```ts
+export { Divider } from './Divider';
+export type {
+  DividerProps,
+  DividerOrientation,
+  DividerVariant,
+  DividerSize,
+} from './Divider';
+```
+
+- [ ] **Step 5: Typecheck + lint**
+
+```bash
+cd /home/dpws/projects/design-system
+make build-lib
+make lint
+```
+
+Expected: both clean. The two `align-self: stretch` rules have inline `stylelint-disable-next-line property-disallowed-list -- vertical separator needs parent height` comments — verify the comment is on the immediately preceding line (not on the rule block opener).
+
+If stylelint flags `rule-empty-line-before` between sibling top-level rules, add blank lines.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/Divider/Divider.tsx \
+        packages/design-system/src/components/Divider/Divider.module.scss \
+        packages/design-system/src/components/Divider/index.ts
+git commit -m "$(cat <<'EOF'
+Divider: source — thin separator primitive
+
+Single forwardRef component that branches on `children`: renders
+<hr role="separator"> when no children (native HTML semantic for a
+thematic break), <div role="separator"> with two line spans flanking
+a label span when labeled. Orientation (horizontal/vertical), variant
+(solid/dashed), and size (sm/md/lg) drive class composition. Sizes
+map to the existing border-width tokens (sm=1px, md=2px, lg=3px).
+
+Vertical orientation uses align-self: stretch — Rule 4 exception
+documented inline since the line otherwise collapses in flex/grid
+parents. min-height: var(--space-3) is a sanity floor for vertical
+dividers outside flex/grid contexts.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2 — Unit tests (`Divider.test.tsx`)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Divider/Divider.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+Create `packages/design-system/src/components/Divider/Divider.test.tsx`:
+
+```tsx
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { Divider } from './Divider';
+
+describe('<Divider>', () => {
+  // ─── Element + ARIA ────────────────────────────────────────────────────
+
+  it('renders an <hr> when no children', () => {
+    const { container } = render(<Divider />);
+    expect(container.querySelector('hr')).toBeInTheDocument();
+    expect(container.querySelector('div[role="separator"]')).toBeNull();
+  });
+
+  it('renders a <div role="separator"> when children present', () => {
+    const { container } = render(<Divider>OR</Divider>);
+    expect(container.querySelector('hr')).toBeNull();
+    expect(container.querySelector('div[role="separator"]')).toBeInTheDocument();
+  });
+
+  it('always has role="separator"', () => {
+    render(<Divider />);
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
+  it('aria-orientation defaults to "horizontal"', () => {
+    render(<Divider />);
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  it('aria-orientation="vertical" when orientation="vertical"', () => {
+    render(<Divider orientation="vertical" />);
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'vertical');
+  });
+
+  // ─── Variants + sizes (classes) ────────────────────────────────────────
+
+  it('default: applies horizontal class, no dashed/sizeMd/sizeLg', () => {
+    render(<Divider />);
+    const sep = screen.getByRole('separator');
+    expect(sep.className).toMatch(/horizontal/);
+    expect(sep.className).not.toMatch(/dashed/);
+    expect(sep.className).not.toMatch(/sizeMd/);
+    expect(sep.className).not.toMatch(/sizeLg/);
+  });
+
+  it('variant="dashed" applies the dashed class', () => {
+    render(<Divider variant="dashed" />);
+    expect(screen.getByRole('separator').className).toMatch(/dashed/);
+  });
+
+  it('size="md" applies the sizeMd class', () => {
+    render(<Divider size="md" />);
+    expect(screen.getByRole('separator').className).toMatch(/sizeMd/);
+  });
+
+  it('size="lg" applies the sizeLg class', () => {
+    render(<Divider size="lg" />);
+    expect(screen.getByRole('separator').className).toMatch(/sizeLg/);
+  });
+
+  // ─── Label slot ────────────────────────────────────────────────────────
+
+  it('children render inside the .label span', () => {
+    render(<Divider>OR</Divider>);
+    expect(screen.getByText('OR')).toBeInTheDocument();
+  });
+
+  it('labeled divider has two .line spans flanking the label', () => {
+    const { container } = render(<Divider>OR</Divider>);
+    const lines = container.querySelectorAll('span[aria-hidden="true"]');
+    expect(lines).toHaveLength(2);
+  });
+
+  it('the .line spans have aria-hidden="true"', () => {
+    const { container } = render(<Divider>OR</Divider>);
+    const lines = container.querySelectorAll('span[aria-hidden="true"]');
+    lines.forEach((line) => {
+      expect(line).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  // ─── Misc ──────────────────────────────────────────────────────────────
+
+  it('className merges, does not replace', () => {
+    render(<Divider className="custom" />);
+    const sep = screen.getByRole('separator');
+    expect(sep.className).toMatch(/divider/);
+    expect(sep.className).toMatch(/custom/);
+  });
+
+  it('ref forwards to the <hr> root (no children case)', () => {
+    const ref = createRef<HTMLElement>();
+    render(<Divider ref={ref} />);
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('HR');
+  });
+
+  it('ref forwards to the <div> root (labeled case)', () => {
+    const ref = createRef<HTMLElement>();
+    render(<Divider ref={ref}>OR</Divider>);
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('DIV');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test -w @eocrm/design-system -- --run src/components/Divider/Divider.test.tsx
+```
+
+Expected: 15 tests pass.
+
+If a test fails on the `<hr>` vs `<div>` branching, verify the JSX's `if (children == null)` check correctly handles both `null` and `undefined`. The strict `== null` (double-equals) matches both.
+
+If the label aria-hidden test fails, the `<span class="label">` might also be matching the selector — narrow the selector if needed:
+```ts
+const lines = container.querySelectorAll('div[role="separator"] > span[aria-hidden="true"]');
+```
+
+- [ ] **Step 3: Full suite + lint + typecheck**
+
+```bash
+make test
+make build-lib
+make lint
+```
+
+Expected: everything clean. Test count goes up by 15.
+
+`structure.test.ts` will report 1 failure ("Divider is re-exported from src/index.ts") — Task 3 fixes it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Divider/Divider.test.tsx
+git commit -m "$(cat <<'EOF'
+Divider: unit tests
+
+15 cases: <hr> when no children, <div role="separator"> when labeled,
+role="separator" always set, aria-orientation defaults to horizontal
+and switches with the prop, default classes / dashed variant / sizeMd /
+sizeLg / labeled all apply expected class fragments, children render
+in the .label span, two .line spans with aria-hidden flank the label,
+className merges, ref forwards to the right root element in both
+shapes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 — Public exports + AGENTS.md TL;DR
+
+**Files:**
+
+- Modify: `packages/design-system/src/index.ts`
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Add Divider to `src/index.ts`**
+
+```ts
+export { Divider } from './components/Divider';
+export type {
+  DividerProps,
+  DividerOrientation,
+  DividerVariant,
+  DividerSize,
+} from './components/Divider';
+```
+
+Place wherever the file's surrounding pattern suggests (file isn't strictly alphabetical; recent components are appended near the bottom). Match the convention.
+
+Verify:
+
+```bash
+grep -n "Divider\|Drawer\|DropdownMenu" packages/design-system/src/index.ts | head
+```
+
+- [ ] **Step 2: Add TL;DR to AGENTS.md**
+
+Open `packages/design-system/AGENTS.md`. Find `### \`<Grid>\`` (around line 382). Insert the new Divider section AFTER Grid and BEFORE `### \`<Avatar>\`` (around line 410). The Divider sits in the layout cluster alongside Stack/Cluster/Grid.
+
+Use grep to confirm:
+
+```bash
+grep -nE "^### " packages/design-system/AGENTS.md | head -20
+```
+
+Add this content verbatim:
+
+````markdown
+### `<Divider>` — separator primitive
+
+Thin rule between content sections. Horizontal (default) or vertical. Optional centered label slot. Three size tiers + solid/dashed variants.
+
+```tsx
+import { Divider } from '@eocrm/design-system';
+
+// Default horizontal
+<Divider />
+
+// Vertical inside a Cluster (toolbar separator)
+<Cluster gap="sm">
+  <Button>Edit</Button>
+  <Divider orientation="vertical" />
+  <Button>Duplicate</Button>
+</Cluster>
+
+// Labeled (auth-form pattern)
+<Divider>OR</Divider>
+
+// Variants + sizes
+<Divider variant="dashed" />
+<Divider size="lg" />
+```
+
+- **Default**: solid, size `'sm'` (1px), horizontal.
+- **Labeled** dividers use `<div role="separator">` instead of `<hr>` because HTML `<hr>` can't have children.
+- **Vertical** dividers stretch to the parent's height — works inside Cluster/Stack/Flex but needs a parent with known height. Falls back to `--space-3` minimum height as a sanity floor.
+- **No spacing prop** — parent owns layout per Rule 4. Use Stack `gap` around the Divider.
+
+#### When NOT to use
+
+- ❌ Decorative under a heading → just style the heading's `border-bottom`.
+- ❌ Between unrelated stacked sections → use Stack with `gap` instead.
+- ❌ A tone-driven separator (warning/danger) → use `<Alert>` for persistent tone-tied messages.
+
+#### Anti-patterns
+
+- ❌ `<Divider>OR</Divider>` with `orientation="vertical"` — text wraps awkwardly across two short line segments.
+- ❌ `<Divider size="lg" />` for casual section breaks. Reserve `lg` (3px) for strong visual hierarchy.
+- ❌ Adding `margin` via inline `style`. The parent should own spacing.
+````
+
+- [ ] **Step 3: Run gates**
+
+```bash
+make test
+make build-lib
+```
+
+Expected: everything green. `structure.test.ts` now finds Divider in the barrel.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/index.ts packages/design-system/AGENTS.md
+git commit -m "$(cat <<'EOF'
+Divider: public exports + AGENTS.md TL;DR
+
+Re-exports Divider + DividerProps/DividerOrientation/DividerVariant/
+DividerSize from the package barrel. AGENTS.md gains a TL;DR section
+in the layout cluster (after Grid, before Avatar): the canonical four
+patterns (default / vertical-in-Cluster / labeled / variants-and-sizes)
+plus the when-NOT-to-use list and anti-patterns.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 — Playground demo + 4-place nav wiring
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/DividerDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Write the demo page**
+
+Create `packages/playground/src/pages/components/DividerDemo.tsx`:
+
+```tsx
+import { Button, Card, Cluster, Divider, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Divider/Divider.tsx?raw';
+import scssSource from '@lib-source/components/Divider/Divider.module.scss?raw';
+
+export function DividerDemo() {
+  return (
+    <DemoLayout
+      name="Divider"
+      componentName="Divider"
+      description="Thin separator primitive. Horizontal or vertical, solid or dashed, three size tiers, optional centered label."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Divider.tsx"
+      scssFilename="Divider.module.scss"
+    >
+      <Example
+        title="Horizontal default"
+        description="A single thin line between two paragraphs."
+        code={`<Divider />`}
+      >
+        <Stack gap="md">
+          <p style={{ margin: 0 }}>First section content.</p>
+          <Divider />
+          <p style={{ margin: 0 }}>Second section content.</p>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Variants and sizes"
+        description="Solid (default) and dashed variants. Three size tiers (sm=1px, md=2px, lg=3px)."
+        code={`<Divider size="sm" />
+<Divider size="md" />
+<Divider size="lg" />
+<Divider variant="dashed" size="sm" />
+<Divider variant="dashed" size="md" />
+<Divider variant="dashed" size="lg" />`}
+      >
+        <Stack gap="md">
+          <Divider size="sm" />
+          <Divider size="md" />
+          <Divider size="lg" />
+          <Divider variant="dashed" size="sm" />
+          <Divider variant="dashed" size="md" />
+          <Divider variant="dashed" size="lg" />
+        </Stack>
+      </Example>
+
+      <Example
+        title="Labeled (auth-form pattern)"
+        description="`<Divider>OR</Divider>` between two grouped actions. Switches to <div role='separator'> internally."
+        code={`<Button>Sign in with email</Button>
+<Divider>OR</Divider>
+<Button variant="secondary">Sign in with SSO</Button>`}
+      >
+        <Stack gap="md">
+          <Button>Sign in with email</Button>
+          <Divider>OR</Divider>
+          <Button variant="secondary">Sign in with SSO</Button>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Vertical inside a Cluster (toolbar)"
+        description="Use vertical dividers to separate grouped actions in a horizontal cluster."
+        code={`<Cluster gap="sm" align="center">
+  <Button variant="ghost" size="sm">Edit</Button>
+  <Divider orientation="vertical" />
+  <Button variant="ghost" size="sm">Duplicate</Button>
+  <Divider orientation="vertical" />
+  <Button variant="ghost" size="sm">Archive</Button>
+</Cluster>`}
+      >
+        <Cluster gap="sm" align="center">
+          <Button variant="ghost" size="sm">Edit</Button>
+          <Divider orientation="vertical" />
+          <Button variant="ghost" size="sm">Duplicate</Button>
+          <Divider orientation="vertical" />
+          <Button variant="ghost" size="sm">Archive</Button>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Inside a Card (section break)"
+        description="A header + Divider + body to clearly separate metadata from content."
+        code={`<Card padding="md">
+  <Stack gap="sm">
+    <strong>Card heading</strong>
+    <Divider />
+    <p style={{ margin: 0 }}>Card body content goes here.</p>
+  </Stack>
+</Card>`}
+      >
+        <Card padding="md">
+          <Stack gap="sm">
+            <strong>Card heading</strong>
+            <Divider />
+            <p style={{ margin: 0 }}>Card body content goes here.</p>
+          </Stack>
+        </Card>
+      </Example>
+
+      <Example
+        title="Dashed labeled"
+        description="Combine variant + label for a softer visual break."
+        code={`<Divider variant="dashed">SECTION 2</Divider>`}
+      >
+        <Divider variant="dashed">SECTION 2</Divider>
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+- [ ] **Step 2: Wire route + import in `App.tsx`**
+
+Add the import alphabetically:
+
+```tsx
+import { DividerDemo } from './pages/components/DividerDemo';
+```
+
+Add the route inside `<Routes>` near alphabetical D-prefixed entries:
+
+```tsx
+<Route path="/components/divider" element={<DividerDemo />} />
+```
+
+(Match the surrounding file convention — alphabetical or chronological per existing pattern.)
+
+- [ ] **Step 3: Add sidebar entry in `AppShell.tsx`**
+
+Open `packages/playground/src/layout/AppShell/AppShell.tsx`. Find the `Layout` group (around line 69-76). Add Divider as the entry between `Cluster` and `Grid`:
+
+```tsx
+{
+  heading: 'Layout',
+  items: [
+    { to: '/components/stack', label: 'Stack', icon: Rows3, end: false },
+    { to: '/components/cluster', label: 'Cluster', icon: Columns3, end: false },
+    { to: '/components/divider', label: 'Divider', icon: Minus, end: false },
+    { to: '/components/grid', label: 'Grid', icon: LayoutGrid, end: false },
+    { to: '/components/card', label: 'Card', icon: RectangleHorizontal, end: false },
+  ],
+},
+```
+
+Add `Minus` to the existing lucide-react import at the top of the file. Verify it exists:
+
+```bash
+node -e "console.log(Object.keys(require('lucide-react')).filter(k => k === 'Minus').join(', '))"
+```
+
+If `Minus` is unavailable, fall back to `SeparatorHorizontal` or `MoreHorizontal`.
+
+- [ ] **Step 4: Add overview card in `ComponentsIndex.tsx`**
+
+Open `packages/playground/src/pages/components/ComponentsIndex.tsx`. Add `Divider` to the existing `@eocrm/design-system` import.
+
+Find the items array. Add a card alphabetically (near other D-prefixed entries OR in the layout cluster with Stack/Cluster/Grid — match the file's organization):
+
+```tsx
+{
+  to: '/components/divider',
+  name: 'Divider',
+  description: 'Thin separator. Horizontal/vertical, solid/dashed, optional label.',
+  preview: (
+    <div style={{ width: '100%', maxWidth: '200px' }}>
+      <Divider>OR</Divider>
+    </div>
+  ),
+},
+```
+
+- [ ] **Step 5: Register the component name in `registry.ts`**
+
+Open `packages/playground/src/pages/mockups/registry.ts`. Find `export type ComponentName =` and add `'Divider'` alphabetically (between `'DateRangePicker'` and `'Drawer'` — adjust based on actual current entries):
+
+```ts
+export type ComponentName =
+  // …existing through DatePicker/DateRangePicker…
+  | 'DateRangePicker'
+  | 'Divider'
+  | 'Drawer'
+  // …rest unchanged…;
+```
+
+No existing mockup uses Divider yet, so no `usesComponents` arrays need updating.
+
+- [ ] **Step 6: Build + test**
+
+```bash
+make test
+make build-lib
+make build
+make lint
+```
+
+Expected: everything clean.
+
+- [ ] **Step 7: Spot-check in dev server (OPTIONAL)**
+
+Skip unless a gate fails. We'll do visual checks in Task 5's HR8 round if needed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/playground/src/pages/components/DividerDemo.tsx \
+        packages/playground/src/App.tsx \
+        packages/playground/src/layout/AppShell/AppShell.tsx \
+        packages/playground/src/pages/components/ComponentsIndex.tsx \
+        packages/playground/src/pages/mockups/registry.ts
+git commit -m "$(cat <<'EOF'
+playground: DividerDemo + 4-place nav wiring
+
+6 examples (horizontal default / variants+sizes matrix / labeled
+auth-form / vertical-in-Cluster toolbar / inside-Card section break /
+dashed labeled). Wired into Layout sidebar group (alphabetical between
+Cluster and Grid), Components route, overview-grid card, and the
+mockups ComponentName union.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 — Hard-Rule-8 cycle + push + PR
+
+Per `packages/design-system/CLAUDE.md` Rule 8. Run until 0 Critical + 0 Important findings, all gates green.
+
+- [ ] **Step 1: Final gate run**
+
+```bash
+cd /home/dpws/projects/design-system
+make test
+make build-lib
+make build
+make lint
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Dry-pack to confirm tarball contents**
+
+```bash
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -E "Divider|test\."
+```
+
+Expected:
+- Divider source files (`Divider.tsx`, `Divider.module.scss`, `index.ts`) in the tarball
+- NO `*.test.*` files
+
+- [ ] **Step 3: Dispatch a fresh-context Hard-Rule-8 reviewer**
+
+Use a `general-purpose` subagent with model `opus`. Prompt template:
+
+> Fresh-context Hard-Rule-8 review of the Divider PR. Branch `feat/divider` at HEAD `<sha>`. Per `packages/design-system/CLAUDE.md` Rule 8 — review the full diff against `main`.
+>
+> Files in scope:
+> - `packages/design-system/src/components/Divider/` (Divider.tsx + .module.scss + .test.tsx + index.ts)
+> - `packages/design-system/src/index.ts`, `AGENTS.md`
+> - `packages/playground/src/pages/components/DividerDemo.tsx`
+> - `packages/playground/src/App.tsx`, `AppShell.tsx`, `ComponentsIndex.tsx`, `registry.ts`
+>
+> Read first: `packages/design-system/CLAUDE.md` (Rules 1–7), `AGENTS.md` (Divider section + surrounding Stack/Cluster/Grid), `docs/superpowers/specs/2026-05-23-divider-design.md`.
+>
+> Verify:
+> - **Rule 1**: tests exist (~15 cases).
+> - **Rule 3**: NO raw values in `Divider.module.scss`. All `var(--…)`. The `align-self: stretch` and `min-height` rules have inline disables with rationale (Rule 4 documented exception for vertically-aligned primitives).
+> - **Rule 4**: NO layout properties on the no-label `.divider` boundary other than the documented `align-self: stretch` for vertical orientation. The `flex` on `.labeled` is internal layout of children — allowed.
+> - **Rule 5**: re-exported from `src/index.ts`.
+> - **Rule 6**: `forwardRef` used; ref targets the root (either `<hr>` or `<div>` depending on children). Note: ref type is `HTMLElement` because the rendered tag varies — this is intentional. Document in any review.
+> - **Rule 7**: full JSDoc on Divider (component, every prop, all 4 type aliases). At least 3 `@example` blocks. "When NOT to use" + "Anti-patterns" in `@remarks`.
+> - **ARIA**: `role="separator"` always set. `aria-orientation` matches the prop. Line spans have `aria-hidden="true"`.
+> - **Branching logic**: `children == null` (double-equals, both null AND undefined) correctly distinguishes the `<hr>` path from the `<div>` path.
+> - **SCSS attribute selectors**: the `.labeled.vertical` and `.dashed.vertical` cascades — verify the size variants compose with both orientation and variant correctly.
+> - **Dashed line height: 0**: dashed lines collapse the height to 0 so the border doesn't double-stack with the solid line's background-height approach. Verify this in the SCSS.
+> - **Cross-package leakage**: Divider imports only from `react`/`clsx`/local SCSS.
+> - **Package/distribution**: `npm pack --dry-run` excludes test files.
+>
+> End with verdict: **clean enough to stop** OR **keep iterating**.
+
+- [ ] **Step 4: Fix every Critical + Important finding**
+
+Group into one commit: `Divider: review-cycle fixes (round N)`.
+
+- [ ] **Step 5: Re-run gates after each fix round**
+
+```bash
+make test && make build-lib && make build && make lint
+```
+
+- [ ] **Step 6: Re-dispatch fresh reviewer**
+
+Same prompt, same model, fresh context. Repeat until **clean enough to stop**.
+
+- [ ] **Step 7: Push the branch**
+
+```bash
+git push -u origin feat/divider
+```
+
+If the husky `pre-push` hook fails on `format:check`:
+
+```bash
+npx prettier --write docs/superpowers/specs/2026-05-23-divider-design.md \
+                     docs/superpowers/plans/2026-05-23-divider.md \
+                     packages/design-system/src/components/Divider/ \
+                     packages/playground/src/pages/components/DividerDemo.tsx
+git add -A
+git commit -m "$(cat <<'EOF'
+Divider: prettier --write
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin feat/divider
+```
+
+- [ ] **Step 8: Open the PR**
+
+```bash
+gh pr create --title "Divider: thin separator primitive (horizontal/vertical, solid/dashed, label slot)" --body "$(cat <<'EOF'
+## Summary
+
+- New \`<Divider>\` — thin separator primitive. Fills the gap between ad-hoc \`<hr>\` and inline border-trick separators.
+- **Horizontal (default) or vertical** orientation.
+- **Solid (default) or dashed** variant.
+- **Three size tiers** (\`sm\`=1px, \`md\`=2px, \`lg\`=3px) mapping to existing border-width tokens.
+- **Optional centered label** (\`<Divider>OR</Divider>\`) — switches root from \`<hr>\` to \`<div role=\"separator\">\` because HTML \`<hr>\` can't have children.
+- **No spacing prop** — parent owns layout per Rule 4.
+
+## Design highlights
+
+- **Branches on `children`** for native-vs-div root. \`<hr>\` is the semantically correct element for thematic breaks; \`<div role=\"separator\">\` is required when label content is present.
+- **\`role=\"separator\" + aria-orientation\`** always set. Line spans inside labeled dividers have \`aria-hidden=\"true\"\`.
+- **Rule 4 exception** documented for vertical orientation's \`align-self: stretch\` — without it, the line collapses to 0 height in flex/grid parents.
+- **Dashed line \`height: 0\`** so the border draws the dash pattern without stacking with the solid line's background-height approach.
+
+## Hard Rule 8
+
+Fresh-context reviewer cycle. 15 new tests covering element branching (\`<hr>\` vs \`<div>\`), ARIA (\`role=\"separator\"\` + \`aria-orientation\`), all variants and size class applications, label slot rendering with two flanking line spans, className merge, ref forwarding to both root shapes.
+
+All four gates green: \`make test\` · \`make build-lib\` · \`make build\` · \`make lint\` · \`npm pack --dry-run\` (no test files in tarball).
+
+## Test plan
+
+- [ ] \`<Divider />\` renders a native \`<hr>\` with \`role=\"separator\"\` and \`aria-orientation=\"horizontal\"\`
+- [ ] \`<Divider orientation=\"vertical\" />\` renders an \`<hr>\` with \`aria-orientation=\"vertical\"\`
+- [ ] \`<Divider>OR</Divider>\` renders a \`<div role=\"separator\">\` with two line spans flanking the label
+- [ ] All three sizes (\`sm\`/\`md\`/\`lg\`) show distinct thickness
+- [ ] Dashed variant shows the dashed pattern (not solid)
+- [ ] Vertical divider stretches to parent height inside a Cluster
+- [ ] Labeled divider centers the text between two line segments
+- [ ] Playground demo at \`/components/divider\` renders all 6 examples without console errors
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 9: Confirm CI**
+
+Watch the GitHub Actions Quality check on the PR. If it fails for format:check, run prettier locally and push again.
+
+- [ ] **Step 10: Mark task complete**
+
+Once verdict is `clean enough to stop`, gates green, CI green, PR open — task done.
+
+---
+
+## Summary of expected commits on the branch (before review-fix rounds)
+
+```
+Divider: design spec — thin separator primitive
+Divider: source — thin separator primitive
+Divider: unit tests
+Divider: public exports + AGENTS.md TL;DR
+playground: DividerDemo + 4-place nav wiring
+```
+
+Plus review-cycle fix commits + prettier fix-up as needed.

--- a/docs/superpowers/plans/2026-05-23-divider.md
+++ b/docs/superpowers/plans/2026-05-23-divider.md
@@ -61,6 +61,7 @@ git log --oneline -3
 ```
 
 Expected:
+
 - Branch: `feat/divider`
 - Working tree clean
 - Most recent: `88d59b3 Divider: design spec — thin separator primitive`
@@ -239,8 +240,7 @@ export type DividerVariant = 'solid' | 'dashed';
  */
 export type DividerSize = 'sm' | 'md' | 'lg';
 
-export interface DividerProps
-  extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'children'> {
+export interface DividerProps extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'children'> {
   /** Layout direction. Defaults to `'horizontal'`. */
   orientation?: DividerOrientation;
 
@@ -323,14 +323,7 @@ const SIZE_CLASS: Record<DividerSize, string> = {
  * - ❌ `<Divider style={{ marginY: 16 }} />` — parent owns spacing.
  */
 export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
-  {
-    orientation = 'horizontal',
-    variant = 'solid',
-    size = 'sm',
-    children,
-    className,
-    ...props
-  },
+  { orientation = 'horizontal', variant = 'solid', size = 'sm', children, className, ...props },
   ref,
 ) {
   const classes = clsx(
@@ -377,12 +370,7 @@ Create `packages/design-system/src/components/Divider/index.ts`:
 
 ```ts
 export { Divider } from './Divider';
-export type {
-  DividerProps,
-  DividerOrientation,
-  DividerVariant,
-  DividerSize,
-} from './Divider';
+export type { DividerProps, DividerOrientation, DividerVariant, DividerSize } from './Divider';
 ```
 
 - [ ] **Step 5: Typecheck + lint**
@@ -554,6 +542,7 @@ Expected: 15 tests pass.
 If a test fails on the `<hr>` vs `<div>` branching, verify the JSX's `if (children == null)` check correctly handles both `null` and `undefined`. The strict `== null` (double-equals) matches both.
 
 If the label aria-hidden test fails, the `<span class="label">` might also be matching the selector — narrow the selector if needed:
+
 ```ts
 const lines = container.querySelectorAll('div[role="separator"] > span[aria-hidden="true"]');
 ```
@@ -621,7 +610,7 @@ grep -n "Divider\|Drawer\|DropdownMenu" packages/design-system/src/index.ts | he
 
 - [ ] **Step 2: Add TL;DR to AGENTS.md**
 
-Open `packages/design-system/AGENTS.md`. Find `### \`<Grid>\`` (around line 382). Insert the new Divider section AFTER Grid and BEFORE `### \`<Avatar>\`` (around line 410). The Divider sits in the layout cluster alongside Stack/Cluster/Grid.
+Open `packages/design-system/AGENTS.md`. Find `### \`<Grid>\``(around line 382). Insert the new Divider section AFTER Grid and BEFORE`### \`<Avatar>\`` (around line 410). The Divider sits in the layout cluster alongside Stack/Cluster/Grid.
 
 Use grep to confirm:
 
@@ -794,11 +783,17 @@ export function DividerDemo() {
 </Cluster>`}
       >
         <Cluster gap="sm" align="center">
-          <Button variant="ghost" size="sm">Edit</Button>
+          <Button variant="ghost" size="sm">
+            Edit
+          </Button>
           <Divider orientation="vertical" />
-          <Button variant="ghost" size="sm">Duplicate</Button>
+          <Button variant="ghost" size="sm">
+            Duplicate
+          </Button>
           <Divider orientation="vertical" />
-          <Button variant="ghost" size="sm">Archive</Button>
+          <Button variant="ghost" size="sm">
+            Archive
+          </Button>
         </Cluster>
       </Example>
 
@@ -901,10 +896,8 @@ Open `packages/playground/src/pages/mockups/registry.ts`. Find `export type Comp
 ```ts
 export type ComponentName =
   // …existing through DatePicker/DateRangePicker…
-  | 'DateRangePicker'
-  | 'Divider'
-  | 'Drawer'
-  // …rest unchanged…;
+  'DateRangePicker' | 'Divider' | 'Drawer';
+// …rest unchanged…;
 ```
 
 No existing mockup uses Divider yet, so no `usesComponents` arrays need updating.
@@ -971,6 +964,7 @@ npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -E "Divider|test\."
 ```
 
 Expected:
+
 - Divider source files (`Divider.tsx`, `Divider.module.scss`, `index.ts`) in the tarball
 - NO `*.test.*` files
 
@@ -981,6 +975,7 @@ Use a `general-purpose` subagent with model `opus`. Prompt template:
 > Fresh-context Hard-Rule-8 review of the Divider PR. Branch `feat/divider` at HEAD `<sha>`. Per `packages/design-system/CLAUDE.md` Rule 8 — review the full diff against `main`.
 >
 > Files in scope:
+>
 > - `packages/design-system/src/components/Divider/` (Divider.tsx + .module.scss + .test.tsx + index.ts)
 > - `packages/design-system/src/index.ts`, `AGENTS.md`
 > - `packages/playground/src/pages/components/DividerDemo.tsx`
@@ -989,6 +984,7 @@ Use a `general-purpose` subagent with model `opus`. Prompt template:
 > Read first: `packages/design-system/CLAUDE.md` (Rules 1–7), `AGENTS.md` (Divider section + surrounding Stack/Cluster/Grid), `docs/superpowers/specs/2026-05-23-divider-design.md`.
 >
 > Verify:
+>
 > - **Rule 1**: tests exist (~15 cases).
 > - **Rule 3**: NO raw values in `Divider.module.scss`. All `var(--…)`. The `align-self: stretch` and `min-height` rules have inline disables with rationale (Rule 4 documented exception for vertically-aligned primitives).
 > - **Rule 4**: NO layout properties on the no-label `.divider` boundary other than the documented `align-self: stretch` for vertical orientation. The `flex` on `.labeled` is internal layout of children — allowed.

--- a/docs/superpowers/specs/2026-05-23-divider-design.md
+++ b/docs/superpowers/specs/2026-05-23-divider-design.md
@@ -1,0 +1,428 @@
+# Divider — design spec
+
+**Date:** 2026-05-23
+**Branch:** `feat/divider`
+**Scope:** New `<Divider>` component for `@eocrm/design-system` — a thin separator primitive. Horizontal or vertical orientation, solid or dashed variant, three size tiers (`sm`/`md`/`lg`), optional center label slot.
+
+## Goal
+
+Replace ad-hoc `<hr>` and inline border-trick separators across the CRM. Provide one primitive that handles the three common use cases: (1) a plain rule between content sections, (2) a vertical separator inside a toolbar Cluster, (3) an "OR" divider between two grouped form sections.
+
+## Why now
+
+- Mockups currently use raw `<hr>` for horizontal separators (no styling consistency) and inline `<span>` borders for vertical separators inside Cluster (inconsistent thickness and color).
+- The "OR" between auth-form sections is a recurring pattern in the CRM and adjacent products (login + reset password). Today it's open-coded with a flex layout + two `<span>` lines.
+- The design system has token-correct values for line thickness (`--border-width` 1px / `--border-width-emphasis` 2px / `--border-width-strong` 3px) but no component that exposes them. Divider closes that loop.
+
+## Non-goals (v1)
+
+- **No `inset` / `flush` variants.** Consumer manages parent padding; Divider doesn't reach out to the container.
+- **No color variants.** Always `--color-border`. If you need a danger-toned divider, use `<Alert tone="error">` instead.
+- **No animation.** Divider is static.
+- **No "dotted" variant.** Solid + dashed cover the use cases; dotted reads as noise.
+- **No `align="start" | "center" | "end"` for the label.** Label is always centered. If the consumer needs left-anchored, they compose `<Stack><h3>Heading</h3><Divider /></Stack>` themselves.
+- **No `<hr>`-as-root with label support.** When `children` is present, root MUST be `<div role="separator">` because `<hr>` can't have children per HTML spec. Documented in JSDoc.
+
+## Architecture
+
+### Dependencies
+
+No new packages. Reuses:
+
+- React (peer)
+- `clsx` (existing dep)
+- Existing tokens: `--color-border`, `--color-fg-muted`, `--border-width`, `--border-width-emphasis`, `--border-width-strong`, `--font-size-sm`, `--space-2`/`--space-3`, `--font-weight-medium`
+
+No new tokens needed. The three border-width tokens map directly to the three size tiers.
+
+### File layout
+
+```
+packages/design-system/src/components/Divider/
+  Divider.tsx           ← forwardRef, branches on `children` presence → <hr> vs <div role=separator>
+  Divider.module.scss   ← orientation × variant × size matrix + label-slot flex layout
+  Divider.test.tsx      ← ~14 cases
+  index.ts              ← exports Divider + types
+```
+
+Plus integration points:
+
+- `packages/design-system/src/index.ts` — re-export `Divider`, `DividerProps`, `DividerOrientation`, `DividerVariant`, `DividerSize`
+- `packages/design-system/AGENTS.md` — TL;DR slot near other layout primitives (Stack/Cluster/Grid cluster)
+- `packages/playground/src/pages/components/DividerDemo.tsx` — 6 examples
+- `packages/playground/src/App.tsx` — route at `/components/divider`
+- `packages/playground/src/layout/AppShell/AppShell.tsx` — sidebar entry in the **Layout** group, alphabetically between `Cluster` and `Grid`
+- `packages/playground/src/pages/components/ComponentsIndex.tsx` — overview card
+- `packages/playground/src/pages/mockups/registry.ts` — `'Divider'` in `ComponentName` union
+
+### Composition
+
+```
+        Divider WITHOUT children (no label):
+        <Divider orientation="horizontal" />        →  <hr role="separator" aria-orientation="horizontal" />
+        <Divider orientation="vertical" />          →  <div role="separator" aria-orientation="vertical" />
+
+        Divider WITH children (centered label):
+        <Divider>OR</Divider>                       →  <div role="separator" aria-orientation="horizontal">
+                                                          <span class="line" />
+                                                          <span class="label">OR</span>
+                                                          <span class="line" />
+                                                        </div>
+```
+
+Branching on `children` is the only conditional logic. The horizontal/vertical orientation drives CSS class selection; same for variant/size.
+
+## Public API
+
+```ts
+import type { HTMLAttributes, ReactNode } from 'react';
+
+/** Layout direction. Defaults to `'horizontal'`. */
+export type DividerOrientation = 'horizontal' | 'vertical';
+
+/** Line style. Defaults to `'solid'`. */
+export type DividerVariant = 'solid' | 'dashed';
+
+/**
+ * Line thickness tier. Defaults to `'sm'` (1px).
+ * - `'sm'` — `--border-width` (1px). Default. Quiet separation.
+ * - `'md'` — `--border-width-emphasis` (2px). Section breaks.
+ * - `'lg'` — `--border-width-strong` (3px). Heavy emphasis; rare.
+ */
+export type DividerSize = 'sm' | 'md' | 'lg';
+
+export interface DividerProps extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'children'> {
+  /** Layout direction. Defaults to `'horizontal'`. */
+  orientation?: DividerOrientation;
+
+  /** Line style. Defaults to `'solid'`. */
+  variant?: DividerVariant;
+
+  /** Line thickness tier. Defaults to `'sm'`. */
+  size?: DividerSize;
+
+  /**
+   * Optional centered label rendered between two line segments.
+   * Common pattern: `<Divider>OR</Divider>`.
+   *
+   * When `children` is set, the root element becomes `<div role="separator">`
+   * instead of `<hr>` (HTML `<hr>` cannot have children). Otherwise the
+   * default `<hr>` is used for horizontal-no-label cases.
+   *
+   * Works with `orientation="vertical"` too but renders awkwardly (text wraps
+   * across two short line segments). Avoid vertical + label combos.
+   */
+  children?: ReactNode;
+}
+```
+
+**Spread order — Pattern A** (consumer wins) for ARIA + data-*, with component-owned attrs after:
+
+```tsx
+<hr
+  ref={ref}
+  {...props}
+  role="separator"
+  aria-orientation={orientation}
+  className={clsx(styles.divider, ORIENTATION_CLASS[orientation], VARIANT_CLASS[variant], SIZE_CLASS[size], className)}
+/>
+```
+
+For the labeled case:
+
+```tsx
+<div
+  ref={ref}
+  {...props}
+  role="separator"
+  aria-orientation={orientation}
+  data-labeled="true"
+  className={clsx(styles.divider, styles.labeled, ORIENTATION_CLASS[orientation], VARIANT_CLASS[variant], SIZE_CLASS[size], className)}
+>
+  <span className={styles.line} aria-hidden="true" />
+  <span className={styles.label}>{children}</span>
+  <span className={styles.line} aria-hidden="true" />
+</div>
+```
+
+Component-owned attrs (after spread) — `role`, `aria-orientation`, `data-labeled`, `className`. Consumer can override aria-* attrs via override, but not these specifically; ref forwards to the root.
+
+## Architecture flow
+
+Two render paths:
+
+1. **`children == null`**: render `<hr>` with the right classes. Simple, native HTML semantics. `<hr>` already implies `role="separator"`, but we set it explicitly for parity with the labeled path.
+
+2. **`children != null`**: render `<div role="separator">` with three children: two `.line` spans (flanking) and a `.label` span (center). Flex layout — `.line` gets `flex: 1` (allowed: internal layout of children, not at component boundary). 
+
+```tsx
+export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
+  { orientation = 'horizontal', variant = 'solid', size = 'sm', children, className, ...props },
+  ref,
+) {
+  const classes = clsx(
+    styles.divider,
+    ORIENTATION_CLASS[orientation],
+    VARIANT_CLASS[variant],
+    SIZE_CLASS[size],
+    children != null && styles.labeled,
+    className,
+  );
+
+  if (children == null) {
+    return (
+      <hr
+        ref={ref as React.Ref<HTMLHRElement>}
+        {...props}
+        role="separator"
+        aria-orientation={orientation}
+        className={classes}
+      />
+    );
+  }
+
+  return (
+    <div
+      ref={ref as React.Ref<HTMLDivElement>}
+      {...props}
+      role="separator"
+      aria-orientation={orientation}
+      data-labeled="true"
+      className={classes}
+    >
+      <span className={styles.line} aria-hidden="true" />
+      <span className={styles.label}>{children}</span>
+      <span className={styles.line} aria-hidden="true" />
+    </div>
+  );
+});
+```
+
+**Why `forwardRef<HTMLElement>`**: the ref's target type changes between `HTMLHRElement` (no children path) and `HTMLDivElement` (with label). React's `forwardRef` requires one ref type; `HTMLElement` is the closest common ancestor. Consumers needing a specific type can cast. Documented in JSDoc.
+
+## Styling — `Divider.module.scss`
+
+```scss
+.divider {
+  // Base — no implicit margin so the consumer's parent owns spacing.
+  border: 0;
+  // Default to the size token; refined per variant/orientation below.
+  color: var(--color-border);
+}
+
+// ─── No-label cases: <hr> styled with border-top or border-left ─────────
+
+.horizontal {
+  width: 100%;
+  border-top: var(--border-width) solid var(--color-border);
+}
+
+.vertical {
+  align-self: stretch;
+  border-left: var(--border-width) solid var(--color-border);
+  // Reserve some intrinsic width so the line is visible without parent height.
+  min-height: var(--space-3);
+}
+
+// ─── Variant — dashed swaps the border-style ────────────────────────────
+
+.dashed.horizontal {
+  border-top-style: dashed;
+}
+
+.dashed.vertical {
+  border-left-style: dashed;
+}
+
+// ─── Size tiers — bump the border width ─────────────────────────────────
+
+.sizeMd.horizontal { border-top-width: var(--border-width-emphasis); }
+.sizeMd.vertical   { border-left-width: var(--border-width-emphasis); }
+
+.sizeLg.horizontal { border-top-width: var(--border-width-strong); }
+.sizeLg.vertical   { border-left-width: var(--border-width-strong); }
+
+// ─── Labeled — flex layout with two line spans flanking the label ───────
+
+.labeled {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  // The root div no longer holds the line — the spans do.
+  border-top: 0;
+  border-left: 0;
+}
+
+.labeled.vertical {
+  flex-direction: column;
+  align-self: stretch;
+  min-height: var(--space-3);
+}
+
+.line {
+  flex: 1;
+  border: 0;
+  background: var(--color-border);
+  height: var(--border-width);
+  border-radius: 0;
+}
+
+.labeled.vertical .line {
+  width: var(--border-width);
+  height: auto;
+  align-self: stretch;
+}
+
+// Dashed lines: collapse the height to 0 and rely on the border to draw
+// the dashed pattern. Otherwise the height + border would stack visually.
+.dashed .line {
+  background: transparent;
+  height: 0;
+  border-top: var(--border-width) dashed var(--color-border);
+}
+
+.dashed.vertical .line {
+  width: 0;
+  border-top: 0;
+  border-left: var(--border-width) dashed var(--color-border);
+}
+
+.sizeMd .line { height: var(--border-width-emphasis); }
+.sizeLg .line { height: var(--border-width-strong); }
+
+.sizeMd.vertical .line { width: var(--border-width-emphasis); height: auto; }
+.sizeLg.vertical .line { width: var(--border-width-strong); height: auto; }
+
+.sizeMd.dashed .line { border-top-width: var(--border-width-emphasis); height: 0; }
+.sizeLg.dashed .line { border-top-width: var(--border-width-strong); height: 0; }
+
+.sizeMd.dashed.vertical .line { border-left-width: var(--border-width-emphasis); width: 0; }
+.sizeLg.dashed.vertical .line { border-left-width: var(--border-width-strong); width: 0; }
+
+.label {
+  flex: 0 0 auto;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg-muted);
+  white-space: nowrap;
+}
+```
+
+**Rule 4 check**:
+- `.horizontal` has `width: 100%` — intrinsic-of-parent width, NOT layout claim. Allowed (matches Input/Textarea precedent).
+- `.vertical` has `align-self: stretch` — needed because the parent (typically a Cluster) doesn't know to stretch this child; without it, the vertical line collapses to 0 height. This IS layout-at-component-boundary and would normally violate Rule 4, but the documented exception for "intrinsically vertical primitives that need parent height" applies (same as how ButtonGroup uses `align-self: flex-start`). Add inline `stylelint-disable-next-line property-disallowed-list -- vertical separator needs parent height; same Rule 4 exception as ButtonGroup` comment.
+- `min-height: var(--space-3)` on `.vertical` — a fallback so the vertical divider has SOME visible height even outside flex/grid parents. Pragmatic.
+- `.line` uses `flex: 1` — that's INTERNAL layout of the labeled-divider's children, not at the component boundary. Allowed.
+
+## ARIA + behavior reference
+
+| Concern | Behavior |
+|---|---|
+| **Default element (no label)** | `<hr role="separator" aria-orientation="...">`. Native HTML semantics. |
+| **Labeled element** | `<div role="separator" aria-orientation="...">` with two `<span class="line" aria-hidden>` siblings and a `<span class="label">`. |
+| **role** | Always `"separator"`. WAI-ARIA recommended for visual separators. |
+| **aria-orientation** | Always set (`"horizontal"` or `"vertical"`). Default for `role="separator"` is "horizontal" but explicit is clearer. |
+| **Line spans** | `aria-hidden="true"` — purely decorative; the role on the root carries the semantic. |
+| **Focus** | Not focusable. Divider is informational, not interactive. |
+| **Ref target** | The root (`<hr>` or `<div>` depending on `children`). Consumers needing a specific element type can cast the ref. |
+
+## Testing
+
+`Divider.test.tsx` — 14 cases.
+
+### Element + ARIA
+
+1. Renders `<hr>` when no children
+2. Renders `<div>` when children present
+3. Always has `role="separator"`
+4. `aria-orientation="horizontal"` when orientation omitted (default)
+5. `aria-orientation="vertical"` when orientation="vertical"
+
+### Variants + sizes
+
+6. Default variant=solid, size=sm → class `horizontal` + no `dashed` class + no `sizeMd`/`sizeLg`
+7. `variant="dashed"` applies `dashed` class
+8. `size="md"` applies `sizeMd` class
+9. `size="lg"` applies `sizeLg` class
+
+### Label slot
+
+10. `children="OR"` renders the OR text inside `.label`
+11. Labeled divider has two `.line` spans flanking the label
+12. The `.line` spans have `aria-hidden="true"`
+
+### Misc
+
+13. `className` merges, doesn't replace
+14. `ref` forwards to the root element (assert `tagName` matches HR or DIV based on children)
+
+**Vitest gotchas**:
+- The `aria-hidden` test on `.line` spans: `container.querySelectorAll('span[aria-hidden="true"]')` should return 2 elements.
+- The ref test conditionally asserts tagName: when children passed, `expect(ref.current?.tagName).toBe('DIV')`; otherwise `'HR'`.
+
+## Playground demo — `DividerDemo.tsx`
+
+6 examples:
+
+1. **Horizontal default** — `<Divider />` between two `<p>` elements.
+2. **Variant + size matrix** — 6 dividers stacked: solid sm/md/lg, then dashed sm/md/lg.
+3. **Labeled** — `<Divider>OR</Divider>` between two `<Button variant="secondary">` blocks (simulating an auth form).
+4. **Vertical inside Cluster** — `<Cluster>Edit <Divider orientation="vertical" /> Duplicate <Divider orientation="vertical" /> Archive</Cluster>`.
+5. **Inside Card** — a Card with header + Divider + body to show section separation.
+6. **Custom className** — show how consumers extend with their own styles via className override (e.g., a custom color).
+
+## AGENTS.md TL;DR slot
+
+Insert after `### <Grid>` (around line 382), in the layout cluster.
+
+```markdown
+### `<Divider>` — separator primitive
+
+Thin rule between content sections. Horizontal (default) or vertical. Optional centered label slot. Three size tiers + solid/dashed variants.
+
+```tsx
+import { Divider } from '@eocrm/design-system';
+
+// Default horizontal
+<Divider />
+
+// Vertical (inside a Cluster)
+<Cluster gap="sm">
+  <Button>Edit</Button>
+  <Divider orientation="vertical" />
+  <Button>Duplicate</Button>
+</Cluster>
+
+// Labeled (auth-form pattern)
+<Divider>OR</Divider>
+
+// Variants + sizes
+<Divider variant="dashed" />
+<Divider size="lg" />
+```
+
+- **Default**: solid, size `'sm'` (1px), horizontal.
+- **Labeled** dividers use `<div role="separator">` instead of `<hr>` because HTML `<hr>` can't have children.
+- **Vertical** dividers stretch to the parent's height — works inside Cluster/Stack/Flex but needs a parent with known height. Falls back to `--space-3` minimum height as a sanity floor.
+- **No spacing prop** — parent owns layout per Rule 4. Use Stack `gap` around the Divider.
+
+#### When NOT to use
+
+- ❌ Decorative under a heading → just style the heading's `border-bottom`.
+- ❌ A vertical separator between unrelated stacked sections → use Stack with `gap` instead.
+- ❌ A colored "tone" separator → use `<Alert>` for tone-driven persistent messages.
+
+#### Anti-patterns
+
+- ❌ `<Divider>OR</Divider>` inside `orientation="vertical"` — text wraps awkwardly across two short line segments. Use horizontal.
+- ❌ `<Divider size="lg" />` for casual section breaks. Reserve `lg` (3px) for strong visual hierarchy.
+- ❌ Adding `margin` via `style={{ marginY: 16 }}`. The parent should own spacing.
+```
+
+## Hard Rule 8
+
+The pre-push review-fix cycle on library changes is mandatory. Gates green, fresh-context reviewer, fix Critical + Important, repeat until clean.
+
+## Open questions
+
+None. All clarifications baked in.

--- a/docs/superpowers/specs/2026-05-23-divider-design.md
+++ b/docs/superpowers/specs/2026-05-23-divider-design.md
@@ -116,7 +116,7 @@ export interface DividerProps extends Omit<HTMLAttributes<HTMLElement>, 'role' |
 }
 ```
 
-**Spread order — Pattern A** (consumer wins) for ARIA + data-*, with component-owned attrs after:
+**Spread order — Pattern A** (consumer wins) for ARIA + data-\*, with component-owned attrs after:
 
 ```tsx
 <hr
@@ -124,7 +124,13 @@ export interface DividerProps extends Omit<HTMLAttributes<HTMLElement>, 'role' |
   {...props}
   role="separator"
   aria-orientation={orientation}
-  className={clsx(styles.divider, ORIENTATION_CLASS[orientation], VARIANT_CLASS[variant], SIZE_CLASS[size], className)}
+  className={clsx(
+    styles.divider,
+    ORIENTATION_CLASS[orientation],
+    VARIANT_CLASS[variant],
+    SIZE_CLASS[size],
+    className,
+  )}
 />
 ```
 
@@ -137,7 +143,14 @@ For the labeled case:
   role="separator"
   aria-orientation={orientation}
   data-labeled="true"
-  className={clsx(styles.divider, styles.labeled, ORIENTATION_CLASS[orientation], VARIANT_CLASS[variant], SIZE_CLASS[size], className)}
+  className={clsx(
+    styles.divider,
+    styles.labeled,
+    ORIENTATION_CLASS[orientation],
+    VARIANT_CLASS[variant],
+    SIZE_CLASS[size],
+    className,
+  )}
 >
   <span className={styles.line} aria-hidden="true" />
   <span className={styles.label}>{children}</span>
@@ -145,7 +158,7 @@ For the labeled case:
 </div>
 ```
 
-Component-owned attrs (after spread) — `role`, `aria-orientation`, `data-labeled`, `className`. Consumer can override aria-* attrs via override, but not these specifically; ref forwards to the root.
+Component-owned attrs (after spread) — `role`, `aria-orientation`, `data-labeled`, `className`. Consumer can override aria-\* attrs via override, but not these specifically; ref forwards to the root.
 
 ## Architecture flow
 
@@ -153,7 +166,7 @@ Two render paths:
 
 1. **`children == null`**: render `<hr>` with the right classes. Simple, native HTML semantics. `<hr>` already implies `role="separator"`, but we set it explicitly for parity with the labeled path.
 
-2. **`children != null`**: render `<div role="separator">` with three children: two `.line` spans (flanking) and a `.label` span (center). Flex layout — `.line` gets `flex: 1` (allowed: internal layout of children, not at component boundary). 
+2. **`children != null`**: render `<div role="separator">` with three children: two `.line` spans (flanking) and a `.label` span (center). Flex layout — `.line` gets `flex: 1` (allowed: internal layout of children, not at component boundary).
 
 ```tsx
 export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
@@ -236,11 +249,19 @@ export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
 
 // ─── Size tiers — bump the border width ─────────────────────────────────
 
-.sizeMd.horizontal { border-top-width: var(--border-width-emphasis); }
-.sizeMd.vertical   { border-left-width: var(--border-width-emphasis); }
+.sizeMd.horizontal {
+  border-top-width: var(--border-width-emphasis);
+}
+.sizeMd.vertical {
+  border-left-width: var(--border-width-emphasis);
+}
 
-.sizeLg.horizontal { border-top-width: var(--border-width-strong); }
-.sizeLg.vertical   { border-left-width: var(--border-width-strong); }
+.sizeLg.horizontal {
+  border-top-width: var(--border-width-strong);
+}
+.sizeLg.vertical {
+  border-left-width: var(--border-width-strong);
+}
 
 // ─── Labeled — flex layout with two line spans flanking the label ───────
 
@@ -287,17 +308,39 @@ export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
   border-left: var(--border-width) dashed var(--color-border);
 }
 
-.sizeMd .line { height: var(--border-width-emphasis); }
-.sizeLg .line { height: var(--border-width-strong); }
+.sizeMd .line {
+  height: var(--border-width-emphasis);
+}
+.sizeLg .line {
+  height: var(--border-width-strong);
+}
 
-.sizeMd.vertical .line { width: var(--border-width-emphasis); height: auto; }
-.sizeLg.vertical .line { width: var(--border-width-strong); height: auto; }
+.sizeMd.vertical .line {
+  width: var(--border-width-emphasis);
+  height: auto;
+}
+.sizeLg.vertical .line {
+  width: var(--border-width-strong);
+  height: auto;
+}
 
-.sizeMd.dashed .line { border-top-width: var(--border-width-emphasis); height: 0; }
-.sizeLg.dashed .line { border-top-width: var(--border-width-strong); height: 0; }
+.sizeMd.dashed .line {
+  border-top-width: var(--border-width-emphasis);
+  height: 0;
+}
+.sizeLg.dashed .line {
+  border-top-width: var(--border-width-strong);
+  height: 0;
+}
 
-.sizeMd.dashed.vertical .line { border-left-width: var(--border-width-emphasis); width: 0; }
-.sizeLg.dashed.vertical .line { border-left-width: var(--border-width-strong); width: 0; }
+.sizeMd.dashed.vertical .line {
+  border-left-width: var(--border-width-emphasis);
+  width: 0;
+}
+.sizeLg.dashed.vertical .line {
+  border-left-width: var(--border-width-strong);
+  width: 0;
+}
 
 .label {
   flex: 0 0 auto;
@@ -309,6 +352,7 @@ export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
 ```
 
 **Rule 4 check**:
+
 - `.horizontal` has `width: 100%` — intrinsic-of-parent width, NOT layout claim. Allowed (matches Input/Textarea precedent).
 - `.vertical` has `align-self: stretch` — needed because the parent (typically a Cluster) doesn't know to stretch this child; without it, the vertical line collapses to 0 height. This IS layout-at-component-boundary and would normally violate Rule 4, but the documented exception for "intrinsically vertical primitives that need parent height" applies (same as how ButtonGroup uses `align-self: flex-start`). Add inline `stylelint-disable-next-line property-disallowed-list -- vertical separator needs parent height; same Rule 4 exception as ButtonGroup` comment.
 - `min-height: var(--space-3)` on `.vertical` — a fallback so the vertical divider has SOME visible height even outside flex/grid parents. Pragmatic.
@@ -316,15 +360,15 @@ export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
 
 ## ARIA + behavior reference
 
-| Concern | Behavior |
-|---|---|
-| **Default element (no label)** | `<hr role="separator" aria-orientation="...">`. Native HTML semantics. |
-| **Labeled element** | `<div role="separator" aria-orientation="...">` with two `<span class="line" aria-hidden>` siblings and a `<span class="label">`. |
-| **role** | Always `"separator"`. WAI-ARIA recommended for visual separators. |
-| **aria-orientation** | Always set (`"horizontal"` or `"vertical"`). Default for `role="separator"` is "horizontal" but explicit is clearer. |
-| **Line spans** | `aria-hidden="true"` — purely decorative; the role on the root carries the semantic. |
-| **Focus** | Not focusable. Divider is informational, not interactive. |
-| **Ref target** | The root (`<hr>` or `<div>` depending on `children`). Consumers needing a specific element type can cast the ref. |
+| Concern                        | Behavior                                                                                                                          |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Default element (no label)** | `<hr role="separator" aria-orientation="...">`. Native HTML semantics.                                                            |
+| **Labeled element**            | `<div role="separator" aria-orientation="...">` with two `<span class="line" aria-hidden>` siblings and a `<span class="label">`. |
+| **role**                       | Always `"separator"`. WAI-ARIA recommended for visual separators.                                                                 |
+| **aria-orientation**           | Always set (`"horizontal"` or `"vertical"`). Default for `role="separator"` is "horizontal" but explicit is clearer.              |
+| **Line spans**                 | `aria-hidden="true"` — purely decorative; the role on the root carries the semantic.                                              |
+| **Focus**                      | Not focusable. Divider is informational, not interactive.                                                                         |
+| **Ref target**                 | The root (`<hr>` or `<div>` depending on `children`). Consumers needing a specific element type can cast the ref.                 |
 
 ## Testing
 
@@ -357,6 +401,7 @@ export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
 14. `ref` forwards to the root element (assert `tagName` matches HR or DIV based on children)
 
 **Vitest gotchas**:
+
 - The `aria-hidden` test on `.line` spans: `container.querySelectorAll('span[aria-hidden="true"]')` should return 2 elements.
 - The ref test conditionally asserts tagName: when children passed, `expect(ref.current?.tagName).toBe('DIV')`; otherwise `'HR'`.
 
@@ -375,7 +420,7 @@ export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
 
 Insert after `### <Grid>` (around line 382), in the layout cluster.
 
-```markdown
+````markdown
 ### `<Divider>` — separator primitive
 
 Thin rule between content sections. Horizontal (default) or vertical. Optional centered label slot. Three size tiers + solid/dashed variants.
@@ -400,6 +445,7 @@ import { Divider } from '@eocrm/design-system';
 <Divider variant="dashed" />
 <Divider size="lg" />
 ```
+````
 
 - **Default**: solid, size `'sm'` (1px), horizontal.
 - **Labeled** dividers use `<div role="separator">` instead of `<hr>` because HTML `<hr>` can't have children.
@@ -417,6 +463,7 @@ import { Divider } from '@eocrm/design-system';
 - ❌ `<Divider>OR</Divider>` inside `orientation="vertical"` — text wraps awkwardly across two short line segments. Use horizontal.
 - ❌ `<Divider size="lg" />` for casual section breaks. Reserve `lg` (3px) for strong visual hierarchy.
 - ❌ Adding `margin` via `style={{ marginY: 16 }}`. The parent should own spacing.
+
 ```
 
 ## Hard Rule 8
@@ -426,3 +473,4 @@ The pre-push review-fix cycle on library changes is mandatory. Gates green, fres
 ## Open questions
 
 None. All clarifications baked in.
+```

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -407,6 +407,48 @@ import { Switch } from '@eocrm/design-system';
 - ❌ `<Grid columns="auto 1fr">` strings — not supported in v1. For asymmetric / named tracks, use raw CSS Grid via className.
 - ❌ `<Grid as="ul">` with non-`<li>` children. The component doesn't enforce list semantics; consumers must.
 
+### `<Divider>` — separator primitive
+
+Thin rule between content sections. Horizontal (default) or vertical. Optional centered label slot. Three size tiers + solid/dashed variants.
+
+```tsx
+import { Divider } from '@eocrm/design-system';
+
+// Default horizontal
+<Divider />
+
+// Vertical inside a Cluster (toolbar separator)
+<Cluster gap="sm">
+  <Button>Edit</Button>
+  <Divider orientation="vertical" />
+  <Button>Duplicate</Button>
+</Cluster>
+
+// Labeled (auth-form pattern)
+<Divider>OR</Divider>
+
+// Variants + sizes
+<Divider variant="dashed" />
+<Divider size="lg" />
+```
+
+- **Default**: solid, size `'sm'` (1px), horizontal.
+- **Labeled** dividers use `<div role="separator">` instead of `<hr>` because HTML `<hr>` can't have children.
+- **Vertical** dividers stretch to the parent's height — works inside Cluster/Stack/Flex but needs a parent with known height. Falls back to `--space-3` minimum height as a sanity floor.
+- **No spacing prop** — parent owns layout per Rule 4. Use Stack `gap` around the Divider.
+
+#### When NOT to use
+
+- ❌ Decorative under a heading → just style the heading's `border-bottom`.
+- ❌ Between unrelated stacked sections → use Stack with `gap` instead.
+- ❌ A tone-driven separator (warning/danger) → use `<Alert>` for persistent tone-tied messages.
+
+#### Anti-patterns
+
+- ❌ `<Divider>OR</Divider>` with `orientation="vertical"` — text wraps awkwardly across two short line segments.
+- ❌ `<Divider size="lg" />` for casual section breaks. Reserve `lg` (3px) for strong visual hierarchy.
+- ❌ Adding `margin` via inline `style`. The parent should own spacing.
+
 ### `<Avatar>` — profile circle
 
 ```tsx

--- a/packages/design-system/src/components/Divider/Divider.module.scss
+++ b/packages/design-system/src/components/Divider/Divider.module.scss
@@ -1,0 +1,142 @@
+.divider {
+  border: 0;
+  color: var(--color-border);
+}
+
+// ─── No-label cases: <hr> with a single border edge ─────────────────────
+
+.horizontal {
+  width: 100%;
+  border-top: var(--border-width) solid var(--color-border);
+}
+
+// Rule 4 exception: vertical separators need parent height. Without
+// align-self the line collapses to 0 in flex/grid parents. Same documented
+// exception as ButtonGroup uses for `align-self: flex-start`.
+.vertical {
+  // stylelint-disable-next-line property-disallowed-list -- vertical separator needs parent height
+  align-self: stretch;
+  border-left: var(--border-width) solid var(--color-border);
+  min-height: var(--space-3);
+}
+
+// ─── Variants ──────────────────────────────────────────────────────────
+
+.dashed.horizontal {
+  border-top-style: dashed;
+}
+
+.dashed.vertical {
+  border-left-style: dashed;
+}
+
+// ─── Sizes (no-label cases) ─────────────────────────────────────────────
+
+.sizeMd.horizontal {
+  border-top-width: var(--border-width-emphasis);
+}
+
+.sizeMd.vertical {
+  border-left-width: var(--border-width-emphasis);
+}
+
+.sizeLg.horizontal {
+  border-top-width: var(--border-width-strong);
+}
+
+.sizeLg.vertical {
+  border-left-width: var(--border-width-strong);
+}
+
+// ─── Labeled — flex layout with two line spans flanking the label ───────
+
+.labeled {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  border-top: 0;
+  border-left: 0;
+}
+
+// Same Rule 4 exception as the no-label .vertical case.
+.labeled.vertical {
+  flex-direction: column;
+  // stylelint-disable-next-line property-disallowed-list -- vertical separator needs parent height; same exception as the no-label case
+  align-self: stretch;
+  min-height: var(--space-3);
+}
+
+.line {
+  flex: 1;
+  border: 0;
+  background: var(--color-border);
+  height: var(--border-width);
+  border-radius: 0;
+}
+
+.labeled.vertical .line {
+  width: var(--border-width);
+  height: auto;
+  // stylelint-disable-next-line property-disallowed-list -- internal child layout; line span must stretch to fill the vertical container
+  align-self: stretch;
+}
+
+// Dashed lines collapse the height to 0 and rely on the border for the dash
+// pattern. Without this, the height + dashed border would visually stack.
+.dashed .line {
+  background: transparent;
+  height: 0;
+  border-top: var(--border-width) dashed var(--color-border);
+}
+
+.dashed.vertical .line {
+  width: 0;
+  border-top: 0;
+  border-left: var(--border-width) dashed var(--color-border);
+}
+
+.sizeMd .line {
+  height: var(--border-width-emphasis);
+}
+
+.sizeLg .line {
+  height: var(--border-width-strong);
+}
+
+.sizeMd.vertical .line {
+  width: var(--border-width-emphasis);
+  height: auto;
+}
+
+.sizeLg.vertical .line {
+  width: var(--border-width-strong);
+  height: auto;
+}
+
+.sizeMd.dashed .line {
+  border-top-width: var(--border-width-emphasis);
+  height: 0;
+}
+
+.sizeLg.dashed .line {
+  border-top-width: var(--border-width-strong);
+  height: 0;
+}
+
+.sizeMd.dashed.vertical .line {
+  border-left-width: var(--border-width-emphasis);
+  width: 0;
+}
+
+.sizeLg.dashed.vertical .line {
+  border-left-width: var(--border-width-strong);
+  width: 0;
+}
+
+.label {
+  flex: 0 0 auto;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg-muted);
+  white-space: nowrap;
+}

--- a/packages/design-system/src/components/Divider/Divider.test.tsx
+++ b/packages/design-system/src/components/Divider/Divider.test.tsx
@@ -32,6 +32,13 @@ describe('<Divider>', () => {
     expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'vertical');
   });
 
+  it('aria-orientation propagates to the labeled <div> branch too', () => {
+    render(<Divider orientation="vertical">SECTION</Divider>);
+    const sep = screen.getByRole('separator');
+    expect(sep.tagName).toBe('DIV');
+    expect(sep).toHaveAttribute('aria-orientation', 'vertical');
+  });
+
   // ─── Variants + sizes (classes) ────────────────────────────────────────
 
   it('default: applies horizontal class, no dashed/sizeMd/sizeLg', () => {

--- a/packages/design-system/src/components/Divider/Divider.test.tsx
+++ b/packages/design-system/src/components/Divider/Divider.test.tsx
@@ -1,0 +1,104 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { Divider } from './Divider';
+
+describe('<Divider>', () => {
+  // ─── Element + ARIA ────────────────────────────────────────────────────
+
+  it('renders an <hr> when no children', () => {
+    const { container } = render(<Divider />);
+    expect(container.querySelector('hr')).toBeInTheDocument();
+    expect(container.querySelector('div[role="separator"]')).toBeNull();
+  });
+
+  it('renders a <div role="separator"> when children present', () => {
+    const { container } = render(<Divider>OR</Divider>);
+    expect(container.querySelector('hr')).toBeNull();
+    expect(container.querySelector('div[role="separator"]')).toBeInTheDocument();
+  });
+
+  it('always has role="separator"', () => {
+    render(<Divider />);
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
+  it('aria-orientation defaults to "horizontal"', () => {
+    render(<Divider />);
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  it('aria-orientation="vertical" when orientation="vertical"', () => {
+    render(<Divider orientation="vertical" />);
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'vertical');
+  });
+
+  // ─── Variants + sizes (classes) ────────────────────────────────────────
+
+  it('default: applies horizontal class, no dashed/sizeMd/sizeLg', () => {
+    render(<Divider />);
+    const sep = screen.getByRole('separator');
+    expect(sep.className).toMatch(/horizontal/);
+    expect(sep.className).not.toMatch(/dashed/);
+    expect(sep.className).not.toMatch(/sizeMd/);
+    expect(sep.className).not.toMatch(/sizeLg/);
+  });
+
+  it('variant="dashed" applies the dashed class', () => {
+    render(<Divider variant="dashed" />);
+    expect(screen.getByRole('separator').className).toMatch(/dashed/);
+  });
+
+  it('size="md" applies the sizeMd class', () => {
+    render(<Divider size="md" />);
+    expect(screen.getByRole('separator').className).toMatch(/sizeMd/);
+  });
+
+  it('size="lg" applies the sizeLg class', () => {
+    render(<Divider size="lg" />);
+    expect(screen.getByRole('separator').className).toMatch(/sizeLg/);
+  });
+
+  // ─── Label slot ────────────────────────────────────────────────────────
+
+  it('children render inside the .label span', () => {
+    render(<Divider>OR</Divider>);
+    expect(screen.getByText('OR')).toBeInTheDocument();
+  });
+
+  it('labeled divider has two .line spans flanking the label', () => {
+    const { container } = render(<Divider>OR</Divider>);
+    const lines = container.querySelectorAll('span[aria-hidden="true"]');
+    expect(lines).toHaveLength(2);
+  });
+
+  it('the .line spans have aria-hidden="true"', () => {
+    const { container } = render(<Divider>OR</Divider>);
+    const lines = container.querySelectorAll('span[aria-hidden="true"]');
+    lines.forEach((line) => {
+      expect(line).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  // ─── Misc ──────────────────────────────────────────────────────────────
+
+  it('className merges, does not replace', () => {
+    render(<Divider className="custom" />);
+    const sep = screen.getByRole('separator');
+    expect(sep.className).toMatch(/divider/);
+    expect(sep.className).toMatch(/custom/);
+  });
+
+  it('ref forwards to the <hr> root (no children case)', () => {
+    const ref = createRef<HTMLElement>();
+    render(<Divider ref={ref} />);
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('HR');
+  });
+
+  it('ref forwards to the <div> root (labeled case)', () => {
+    const ref = createRef<HTMLElement>();
+    render(<Divider ref={ref}>OR</Divider>);
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('DIV');
+  });
+});

--- a/packages/design-system/src/components/Divider/Divider.tsx
+++ b/packages/design-system/src/components/Divider/Divider.tsx
@@ -16,8 +16,7 @@ export type DividerVariant = 'solid' | 'dashed';
  */
 export type DividerSize = 'sm' | 'md' | 'lg';
 
-export interface DividerProps
-  extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'children'> {
+export interface DividerProps extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'children'> {
   /** Layout direction. Defaults to `'horizontal'`. */
   orientation?: DividerOrientation;
 
@@ -100,14 +99,7 @@ const SIZE_CLASS: Record<DividerSize, string> = {
  * - ❌ `<Divider style={{ marginY: 16 }} />` — parent owns spacing.
  */
 export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
-  {
-    orientation = 'horizontal',
-    variant = 'solid',
-    size = 'sm',
-    children,
-    className,
-    ...props
-  },
+  { orientation = 'horizontal', variant = 'solid', size = 'sm', children, className, ...props },
   ref,
 ) {
   const classes = clsx(

--- a/packages/design-system/src/components/Divider/Divider.tsx
+++ b/packages/design-system/src/components/Divider/Divider.tsx
@@ -1,0 +1,148 @@
+import { forwardRef, type HTMLAttributes, type ReactNode, type Ref } from 'react';
+import clsx from 'clsx';
+import styles from './Divider.module.scss';
+
+/** Layout direction. Defaults to `'horizontal'`. */
+export type DividerOrientation = 'horizontal' | 'vertical';
+
+/** Line style. Defaults to `'solid'`. */
+export type DividerVariant = 'solid' | 'dashed';
+
+/**
+ * Line thickness tier. Defaults to `'sm'` (1px).
+ * - `'sm'` — `--border-width` (1px). Default. Quiet separation.
+ * - `'md'` — `--border-width-emphasis` (2px). Section breaks.
+ * - `'lg'` — `--border-width-strong` (3px). Heavy emphasis; rare.
+ */
+export type DividerSize = 'sm' | 'md' | 'lg';
+
+export interface DividerProps
+  extends Omit<HTMLAttributes<HTMLElement>, 'role' | 'children'> {
+  /** Layout direction. Defaults to `'horizontal'`. */
+  orientation?: DividerOrientation;
+
+  /** Line style. Defaults to `'solid'`. */
+  variant?: DividerVariant;
+
+  /** Line thickness tier. Defaults to `'sm'`. */
+  size?: DividerSize;
+
+  /**
+   * Optional centered label rendered between two line segments.
+   * Common pattern: `<Divider>OR</Divider>` for auth-form section breaks.
+   *
+   * When `children` is set, the root becomes `<div role="separator">`
+   * instead of `<hr>` (HTML `<hr>` cannot have children).
+   *
+   * Works with `orientation="vertical"` but renders awkwardly (text wraps
+   * across two short line segments). Avoid vertical + label combos.
+   */
+  children?: ReactNode;
+}
+
+const ORIENTATION_CLASS: Record<DividerOrientation, string> = {
+  horizontal: styles.horizontal,
+  vertical: styles.vertical,
+};
+
+const VARIANT_CLASS: Record<DividerVariant, string> = {
+  solid: '',
+  dashed: styles.dashed,
+};
+
+const SIZE_CLASS: Record<DividerSize, string> = {
+  sm: '',
+  md: styles.sizeMd,
+  lg: styles.sizeLg,
+};
+
+/**
+ * Thin separator primitive. Horizontal (default) or vertical, solid or
+ * dashed, three size tiers, optional centered label.
+ *
+ * When no `children` are passed, renders a native `<hr>` (the right HTML
+ * semantic for a thematic break). When `children` is set, the root becomes
+ * `<div role="separator">` with two line spans flanking the label — HTML
+ * `<hr>` cannot have children.
+ *
+ * No spacing prop — the parent owns layout per Rule 4. Use Stack's `gap`
+ * around the Divider to control spacing.
+ *
+ * @example
+ * // Default — horizontal solid line
+ * <Divider />
+ *
+ * @example
+ * // Vertical separator inside a toolbar Cluster
+ * <Cluster gap="sm">
+ *   <Button>Edit</Button>
+ *   <Divider orientation="vertical" />
+ *   <Button>Duplicate</Button>
+ * </Cluster>
+ *
+ * @example
+ * // Labeled (auth-form pattern)
+ * <Divider>OR</Divider>
+ *
+ * @example
+ * // Variants + sizes
+ * <Divider variant="dashed" />
+ * <Divider size="lg" />
+ *
+ * @remarks When NOT to use
+ * - Below a heading → just use the heading's `border-bottom`.
+ * - Between unrelated stacked sections → use Stack with `gap` instead.
+ * - Tone-driven separators ("error" / "success") → use `<Alert>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ `<Divider orientation="vertical">OR</Divider>` — text wraps awkwardly.
+ * - ❌ `<Divider size="lg" />` for casual breaks. Reserve `lg` (3px) for strong hierarchy.
+ * - ❌ `<Divider style={{ marginY: 16 }} />` — parent owns spacing.
+ */
+export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
+  {
+    orientation = 'horizontal',
+    variant = 'solid',
+    size = 'sm',
+    children,
+    className,
+    ...props
+  },
+  ref,
+) {
+  const classes = clsx(
+    styles.divider,
+    ORIENTATION_CLASS[orientation],
+    VARIANT_CLASS[variant],
+    SIZE_CLASS[size],
+    children != null && styles.labeled,
+    className,
+  );
+
+  if (children == null) {
+    return (
+      <hr
+        ref={ref as Ref<HTMLHRElement>}
+        {...props}
+        role="separator"
+        aria-orientation={orientation}
+        className={classes}
+      />
+    );
+  }
+
+  return (
+    <div
+      ref={ref as Ref<HTMLDivElement>}
+      {...props}
+      role="separator"
+      aria-orientation={orientation}
+      data-labeled="true"
+      className={classes}
+    >
+      <span className={styles.line} aria-hidden="true" />
+      <span className={styles.label}>{children}</span>
+      <span className={styles.line} aria-hidden="true" />
+    </div>
+  );
+});

--- a/packages/design-system/src/components/Divider/Divider.tsx
+++ b/packages/design-system/src/components/Divider/Divider.tsx
@@ -120,6 +120,7 @@ export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
   );
 
   if (children == null) {
+    // Pattern B — {...props} first so role/aria-orientation/className can't be overridden.
     return (
       <hr
         ref={ref as Ref<HTMLHRElement>}
@@ -131,6 +132,7 @@ export const Divider = forwardRef<HTMLElement, DividerProps>(function Divider(
     );
   }
 
+  // Pattern B — {...props} first so role/aria-orientation/className can't be overridden.
   return (
     <div
       ref={ref as Ref<HTMLDivElement>}

--- a/packages/design-system/src/components/Divider/index.ts
+++ b/packages/design-system/src/components/Divider/index.ts
@@ -1,7 +1,2 @@
 export { Divider } from './Divider';
-export type {
-  DividerProps,
-  DividerOrientation,
-  DividerVariant,
-  DividerSize,
-} from './Divider';
+export type { DividerProps, DividerOrientation, DividerVariant, DividerSize } from './Divider';

--- a/packages/design-system/src/components/Divider/index.ts
+++ b/packages/design-system/src/components/Divider/index.ts
@@ -1,0 +1,7 @@
+export { Divider } from './Divider';
+export type {
+  DividerProps,
+  DividerOrientation,
+  DividerVariant,
+  DividerSize,
+} from './Divider';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -36,6 +36,14 @@ export type {
   GridAs,
 } from './components/Grid';
 
+export { Divider } from './components/Divider';
+export type {
+  DividerProps,
+  DividerOrientation,
+  DividerVariant,
+  DividerSize,
+} from './components/Divider';
+
 export { Alert } from './components/Alert';
 export type { AlertProps, AlertTone } from './components/Alert';
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -37,6 +37,7 @@ import { CalendarDemo } from './pages/components/CalendarDemo';
 import { ConfirmationPopoverDemo } from './pages/components/ConfirmationPopoverDemo';
 import { DataTableDemo } from './pages/components/DataTableDemo';
 import { EmptyStateDemo } from './pages/components/EmptyStateDemo';
+import { DividerDemo } from './pages/components/DividerDemo';
 import { DrawerDemo } from './pages/components/DrawerDemo';
 import { GridDemo } from './pages/components/GridDemo';
 import { LinkDemo } from './pages/components/LinkDemo';
@@ -90,6 +91,7 @@ export default function App() {
           <Route path="/components/confirmation-popover" element={<ConfirmationPopoverDemo />} />
           <Route path="/components/datatable" element={<DataTableDemo />} />
           <Route path="/components/empty-state" element={<EmptyStateDemo />} />
+          <Route path="/components/divider" element={<DividerDemo />} />
           <Route path="/components/drawer" element={<DrawerDemo />} />
           <Route path="/components/grid" element={<GridDemo />} />
           <Route path="/components/link" element={<LinkDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -29,6 +29,7 @@ import {
   MessageSquare,
   MessageSquareText,
   AppWindow,
+  Minus,
   MoreHorizontal,
   KeyRound,
   PanelLeft,
@@ -70,6 +71,7 @@ const componentGroups = [
     items: [
       { to: '/components/stack', label: 'Stack', icon: Rows3, end: false },
       { to: '/components/cluster', label: 'Cluster', icon: Columns3, end: false },
+      { to: '/components/divider', label: 'Divider', icon: Minus, end: false },
       { to: '/components/grid', label: 'Grid', icon: LayoutGrid, end: false },
       { to: '/components/card', label: 'Card', icon: RectangleHorizontal, end: false },
     ],

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -10,6 +10,7 @@ import { ButtonGroup } from '@eocrm/design-system';
 import { Card } from '@eocrm/design-system';
 import { Checkbox } from '@eocrm/design-system';
 import { Cluster } from '@eocrm/design-system';
+import { Divider } from '@eocrm/design-system';
 import { Grid } from '@eocrm/design-system';
 import { Input } from '@eocrm/design-system';
 import { PasswordInput } from '@eocrm/design-system';
@@ -294,6 +295,16 @@ const items: { to: string; name: string; description: string; preview: React.Rea
         <div className={styles.tile} />
         <div className={styles.tile} />
       </Cluster>
+    ),
+  },
+  {
+    to: '/components/divider',
+    name: 'Divider',
+    description: 'Thin separator. Horizontal/vertical, solid/dashed, optional label.',
+    preview: (
+      <div style={{ width: '100%', maxWidth: '200px' }}>
+        <Divider>OR</Divider>
+      </div>
     ),
   },
   {

--- a/packages/playground/src/pages/components/DividerDemo.tsx
+++ b/packages/playground/src/pages/components/DividerDemo.tsx
@@ -1,0 +1,113 @@
+import { Button, Card, Cluster, Divider, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Divider/Divider.tsx?raw';
+import scssSource from '@lib-source/components/Divider/Divider.module.scss?raw';
+
+export function DividerDemo() {
+  return (
+    <DemoLayout
+      name="Divider"
+      componentName="Divider"
+      description="Thin separator primitive. Horizontal or vertical, solid or dashed, three size tiers, optional centered label."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Divider.tsx"
+      scssFilename="Divider.module.scss"
+    >
+      <Example
+        title="Horizontal default"
+        description="A single thin line between two paragraphs."
+        code={`<Divider />`}
+      >
+        <Stack gap="md">
+          <p style={{ margin: 0 }}>First section content.</p>
+          <Divider />
+          <p style={{ margin: 0 }}>Second section content.</p>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Variants and sizes"
+        description="Solid (default) and dashed variants. Three size tiers (sm=1px, md=2px, lg=3px)."
+        code={`<Divider size="sm" />
+<Divider size="md" />
+<Divider size="lg" />
+<Divider variant="dashed" size="sm" />
+<Divider variant="dashed" size="md" />
+<Divider variant="dashed" size="lg" />`}
+      >
+        <Stack gap="md">
+          <Divider size="sm" />
+          <Divider size="md" />
+          <Divider size="lg" />
+          <Divider variant="dashed" size="sm" />
+          <Divider variant="dashed" size="md" />
+          <Divider variant="dashed" size="lg" />
+        </Stack>
+      </Example>
+
+      <Example
+        title="Labeled (auth-form pattern)"
+        description="`<Divider>OR</Divider>` between two grouped actions. Switches to <div role='separator'> internally."
+        code={`<Button>Sign in with email</Button>
+<Divider>OR</Divider>
+<Button variant="secondary">Sign in with SSO</Button>`}
+      >
+        <Stack gap="md">
+          <Button>Sign in with email</Button>
+          <Divider>OR</Divider>
+          <Button variant="secondary">Sign in with SSO</Button>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Vertical inside a Cluster (toolbar)"
+        description="Use vertical dividers to separate grouped actions in a horizontal cluster."
+        code={`<Cluster gap="sm" align="center">
+  <Button variant="ghost" size="sm">Edit</Button>
+  <Divider orientation="vertical" />
+  <Button variant="ghost" size="sm">Duplicate</Button>
+  <Divider orientation="vertical" />
+  <Button variant="ghost" size="sm">Archive</Button>
+</Cluster>`}
+      >
+        <Cluster gap="sm" align="center">
+          <Button variant="ghost" size="sm">Edit</Button>
+          <Divider orientation="vertical" />
+          <Button variant="ghost" size="sm">Duplicate</Button>
+          <Divider orientation="vertical" />
+          <Button variant="ghost" size="sm">Archive</Button>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Inside a Card (section break)"
+        description="A header + Divider + body to clearly separate metadata from content."
+        code={`<Card padding="md">
+  <Stack gap="sm">
+    <strong>Card heading</strong>
+    <Divider />
+    <p style={{ margin: 0 }}>Card body content goes here.</p>
+  </Stack>
+</Card>`}
+      >
+        <Card padding="md">
+          <Stack gap="sm">
+            <strong>Card heading</strong>
+            <Divider />
+            <p style={{ margin: 0 }}>Card body content goes here.</p>
+          </Stack>
+        </Card>
+      </Example>
+
+      <Example
+        title="Dashed labeled"
+        description="Combine variant + label for a softer visual break."
+        code={`<Divider variant="dashed">SECTION 2</Divider>`}
+      >
+        <Divider variant="dashed">SECTION 2</Divider>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/components/DividerDemo.tsx
+++ b/packages/playground/src/pages/components/DividerDemo.tsx
@@ -73,11 +73,17 @@ export function DividerDemo() {
 </Cluster>`}
       >
         <Cluster gap="sm" align="center">
-          <Button variant="ghost" size="sm">Edit</Button>
+          <Button variant="ghost" size="sm">
+            Edit
+          </Button>
           <Divider orientation="vertical" />
-          <Button variant="ghost" size="sm">Duplicate</Button>
+          <Button variant="ghost" size="sm">
+            Duplicate
+          </Button>
           <Divider orientation="vertical" />
-          <Button variant="ghost" size="sm">Archive</Button>
+          <Button variant="ghost" size="sm">
+            Archive
+          </Button>
         </Cluster>
       </Example>
 

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -16,6 +16,7 @@ export type ComponentName =
   | 'DataTable'
   | 'DatePicker'
   | 'DateRangePicker'
+  | 'Divider'
   | 'Drawer'
   | 'DropdownMenu'
   | 'EmptyState'


### PR DESCRIPTION
## Summary

- New \`<Divider>\` — thin separator primitive. Fills the gap between ad-hoc \`<hr>\` and inline border-trick separators across the mockups.
- **Horizontal (default) or vertical** orientation.
- **Solid (default) or dashed** variant.
- **Three size tiers** (\`sm\`=1px, \`md\`=2px, \`lg\`=3px) mapping to existing border-width tokens.
- **Optional centered label** (\`<Divider>OR</Divider>\`) — switches root from \`<hr>\` to \`<div role=\"separator\">\` because HTML \`<hr>\` can't have children.
- **No spacing prop** — parent owns layout per Rule 4.
- No new tokens.

## Design highlights

- **Branches on \`children\`** for native-vs-div root. \`<hr>\` is the semantically correct element for thematic breaks; \`<div role=\"separator\">\` is required when label content is present.
- **\`role=\"separator\"\` + \`aria-orientation\`** always set on both branches. Line spans (when labeled) have \`aria-hidden=\"true\"\`.
- **Rule 4 exception** documented for vertical orientation's \`align-self: stretch\` — without it, the line collapses to 0 height in flex/grid parents. Same documented exception as ButtonGroup.
- **Dashed line \`height: 0\`** so the border draws the dash pattern without stacking with the solid line's background-height approach.
- **Spread order Pattern B** with explanatory JSX comment per Rule 7 hygiene.

## Hard Rule 8

**Round 1 verdict: clean enough to stop** (0 Critical + 0 Important). Two cheap Nice-to-haves folded in: JSX spread-order comments (Rule 7 cosmetic), missing test for \`aria-orientation\` on the labeled \`<div>\` branch.

**16 new tests** covering element branching (\`<hr>\` vs \`<div>\`), ARIA, variants, sizes, label slot rendering with two flanking line spans, className merge, ref forwarding to both root shapes. Suite total: **1460 passing**.

All four gates green: \`make test\` · \`make build-lib\` · \`make build\` · \`make lint\` · \`npm pack --dry-run\` (no test files in tarball).

## Test plan

- [ ] \`<Divider />\` renders a native \`<hr>\` with \`role=\"separator\"\` + \`aria-orientation=\"horizontal\"\`
- [ ] \`<Divider orientation=\"vertical\" />\` renders an \`<hr>\` with \`aria-orientation=\"vertical\"\`
- [ ] \`<Divider>OR</Divider>\` renders a \`<div role=\"separator\">\` with two line spans flanking the label
- [ ] All three sizes (\`sm\` / \`md\` / \`lg\`) show distinct thickness
- [ ] Dashed variant shows dashed pattern, not solid
- [ ] Vertical divider stretches to parent height inside a Cluster
- [ ] Labeled divider centers the text between two line segments
- [ ] Ref forwards correctly to both \`<hr>\` and \`<div>\` shapes
- [ ] Playground demo at \`/components/divider\` renders all 6 examples without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)