### PR TITLE
Accordion: compound collapsible panels (single/multiple + keyboard nav)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-accordion.md
+++ b/docs/superpowers/plans/2026-05-23-accordion.md
@@ -1,0 +1,1851 @@
+# Accordion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Accordion>` — a compound vertically-stacked collapsible-panels component. Two selection modes (`type="single"` with optional `collapsible`, `type="multiple"`), controlled + uncontrolled state, per-item `disabled` + custom trigger icon + configurable heading level, smooth CSS grid-template-rows animation, full WAI-ARIA APG keyboard support.
+
+**Architecture:** Compound API via `Object.assign(AccordionRoot, { Item, Trigger, Content })`. Two contexts: `AccordionContext` (mode + isOpen + toggle + collapsible) and `AccordionItemContext` (value + disabled + isOpen + triggerId + contentId). Discriminated union on `type` drives the value-shape branch (`string` vs `string[]`). Keyboard nav uses DOM-order querying (no item registration). Content animation via `display: grid; grid-template-rows: 0fr → 1fr` (no JS measurement).
+
+**Tech Stack:** React 19 + TypeScript (source-distributed). `clsx` for class composition. `lucide-react` peer dep (ChevronDown default indicator). CSS Modules + SCSS. Vitest + RTL + userEvent. No new packages, no new tokens.
+
+**Source of truth:** `docs/superpowers/specs/2026-05-23-accordion-design.md` (commit `e83466d`).
+
+**Branch:** `feat/accordion`. Commit per task. Open the PR after the Hard-Rule-8 cycle (Task 5).
+
+---
+
+## File Structure
+
+```
+packages/design-system/src/components/Accordion/
+  Accordion.tsx           ← Task 1. Root + Object.assign compound. Single/multiple mode dispatch. Context provider.
+  AccordionItem.tsx       ← Task 1. Item wrapper. Reads root context, provides AccordionItemContext.
+  AccordionTrigger.tsx    ← Task 1. Heading-wrapped button with keyboard nav handler + default ChevronDown.
+  AccordionContent.tsx    ← Task 1. Animated grid-row panel with role="region" + aria-labelledby.
+  context.ts              ← Task 1. AccordionContext + AccordionItemContext + use* hooks.
+  Accordion.module.scss   ← Task 1. Borders / triggers / content animation / disabled / focus-visible.
+  index.ts                ← Task 1. Public re-exports.
+  Accordion.test.tsx      ← Task 2. ~26 cases.
+
+packages/design-system/src/index.ts                              ← Task 3. MODIFY: re-export Accordion + types.
+packages/design-system/AGENTS.md                                 ← Task 3. MODIFY: TL;DR slot between Tabs and Breadcrumb.
+
+packages/playground/src/pages/components/AccordionDemo.tsx       ← Task 4. NEW: 6 examples.
+packages/playground/src/App.tsx                                  ← Task 4. MODIFY: route + import.
+packages/playground/src/layout/AppShell/AppShell.tsx             ← Task 4. MODIFY: Navigation group, first item before Breadcrumb.
+packages/playground/src/pages/components/ComponentsIndex.tsx     ← Task 4. MODIFY: overview card.
+packages/playground/src/pages/mockups/registry.ts                ← Task 4. MODIFY: 'Accordion' first in ComponentName union.
+```
+
+**Decomposition rationale:**
+
+- **Task 1 (source bundle)** lands all 8 source files in ONE commit. The 4 components + 2 contexts + SCSS cross-reference heavily; splitting per-file produces unreviewable intermediate states. Modal/Drawer/Toast used the same bundled approach for compound components.
+- **Task 2 (tests)** lands separately — the ~26-case suite is ~500 lines on its own.
+- **Task 3 (exports + AGENTS)** is small and conceptually paired.
+- **Task 4 (playground demo + 4-place wiring)** is bundled so the demo lands routable in one commit.
+- **Task 5 (Hard-Rule-8)** — gates, fresh-context reviewer, push, PR.
+
+---
+
+## Task 1 — Source bundle (8 files)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Accordion/context.ts`
+- Create: `packages/design-system/src/components/Accordion/Accordion.tsx`
+- Create: `packages/design-system/src/components/Accordion/AccordionItem.tsx`
+- Create: `packages/design-system/src/components/Accordion/AccordionTrigger.tsx`
+- Create: `packages/design-system/src/components/Accordion/AccordionContent.tsx`
+- Create: `packages/design-system/src/components/Accordion/Accordion.module.scss`
+- Create: `packages/design-system/src/components/Accordion/index.ts`
+
+- [ ] **Step 1: Verify branch + clean tree**
+
+```bash
+cd /home/dpws/projects/design-system
+git status
+git branch --show-current
+git log --oneline -3
+```
+
+Expected: branch `feat/accordion`, clean tree, most recent commit `e83466d Accordion: design spec`.
+
+- [ ] **Step 2: Create the component directory + write the SCSS**
+
+```bash
+mkdir -p packages/design-system/src/components/Accordion
+```
+
+Create `packages/design-system/src/components/Accordion/Accordion.module.scss`:
+
+```scss
+@use '../../styles/mixins' as *;
+
+.accordion {
+  display: flex;
+  flex-direction: column;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  overflow: hidden;
+}
+
+.item {
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.item:last-child {
+  border-bottom: 0;
+}
+
+.header {
+  // stylelint-disable-next-line property-disallowed-list -- native heading margin reset
+  margin: 0;
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-md);
+}
+
+.trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  background: transparent;
+  border: 0;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  color: var(--color-fg);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition-fast);
+
+  &:hover:not(:disabled) {
+    background: var(--color-bg-muted);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 var(--ring-width) var(--ring-accent);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: var(--opacity-disabled);
+  }
+}
+
+.label {
+  flex: 1;
+  min-width: 0;
+}
+
+.indicator {
+  flex-shrink: 0;
+  transition: transform var(--transition-fast);
+  color: var(--color-fg-muted);
+}
+
+.item[data-state='open'] .indicator {
+  transform: rotate(180deg);
+}
+
+.content {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--transition-base);
+}
+
+.content[data-state='open'] {
+  grid-template-rows: 1fr;
+}
+
+.inner {
+  overflow: hidden;
+}
+
+.content[data-state='open'] .inner {
+  padding: var(--space-3) var(--space-4);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .content,
+  .indicator {
+    transition: none;
+  }
+}
+```
+
+- [ ] **Step 3: Write `context.ts`**
+
+Create `packages/design-system/src/components/Accordion/context.ts`:
+
+```ts
+import { createContext, useContext } from 'react';
+
+export interface AccordionContextValue {
+  /** Selection mode. */
+  mode: 'single' | 'multiple';
+  /** Whether the given item value is currently open. */
+  isOpen: (value: string) => boolean;
+  /** Toggle the given item value. Closes others in single mode; flips membership in multiple mode. */
+  toggle: (value: string) => void;
+}
+
+export const AccordionContext = createContext<AccordionContextValue | null>(null);
+
+/**
+ * Hook for child components to read the root context. Throws if used outside
+ * an `<Accordion>` — surfaces the bug early instead of silently no-op'ing.
+ */
+export function useAccordionContext(componentName: string): AccordionContextValue {
+  const ctx = useContext(AccordionContext);
+  if (ctx === null) {
+    throw new Error(`<Accordion.${componentName}> must be used inside <Accordion>`);
+  }
+  return ctx;
+}
+
+export interface AccordionItemContextValue {
+  /** This item's unique value. */
+  value: string;
+  /** Whether the item is disabled (Trigger non-interactive, keyboard nav skips). */
+  disabled: boolean;
+  /** Whether the item is currently open (mirrored from root context for convenience). */
+  isOpen: boolean;
+  /** Stable id for the Trigger (so Content's aria-labelledby points at it). */
+  triggerId: string;
+  /** Stable id for the Content (so Trigger's aria-controls points at it). */
+  contentId: string;
+}
+
+export const AccordionItemContext = createContext<AccordionItemContextValue | null>(null);
+
+export function useAccordionItemContext(componentName: string): AccordionItemContextValue {
+  const ctx = useContext(AccordionItemContext);
+  if (ctx === null) {
+    throw new Error(`<Accordion.${componentName}> must be used inside <Accordion.Item>`);
+  }
+  return ctx;
+}
+```
+
+- [ ] **Step 4: Write `Accordion.tsx`** (root component)
+
+Create `packages/design-system/src/components/Accordion/Accordion.tsx`:
+
+```tsx
+import {
+  forwardRef,
+  useCallback,
+  useMemo,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import { AccordionContext, type AccordionContextValue } from './context';
+import { AccordionItem } from './AccordionItem';
+import { AccordionTrigger } from './AccordionTrigger';
+import { AccordionContent } from './AccordionContent';
+import styles from './Accordion.module.scss';
+
+/** Selection mode. */
+export type AccordionMode = 'single' | 'multiple';
+
+/** Heading level wrapping the trigger button. Defaults to 'h3'. */
+export type AccordionHeaderLevel = 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+interface AccordionBaseProps extends Omit<HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
+  children: ReactNode;
+}
+
+/** Root props — `type='single'` variant. */
+interface AccordionSingleProps {
+  type: 'single';
+  /** Controlled open item value. `''` = nothing open (only meaningful when `collapsible`). */
+  value?: string;
+  /** Initial open item for uncontrolled use. */
+  defaultValue?: string;
+  /** Fires when the open item changes. */
+  onValueChange?: (next: string) => void;
+  /**
+   * When true, clicking the currently-open item closes it. Default: `false`
+   * (matches Radix; prevents accidentally closing the only available content).
+   */
+  collapsible?: boolean;
+}
+
+/** Root props — `type='multiple'` variant. */
+interface AccordionMultipleProps {
+  type: 'multiple';
+  /** Controlled open items array. */
+  value?: string[];
+  /** Initial open items for uncontrolled use. */
+  defaultValue?: string[];
+  /** Fires when the set of open items changes. */
+  onValueChange?: (next: string[]) => void;
+  collapsible?: never;
+}
+
+/** Discriminated union — `type` drives which variant of value/onValueChange is required. */
+export type AccordionProps = AccordionBaseProps & (AccordionSingleProps | AccordionMultipleProps);
+
+/**
+ * Vertically-stacked collapsible panels. Compound component:
+ *
+ * - `<Accordion>` — root (this component). Configures mode + state + collapsible.
+ * - `<Accordion.Item value>` — one section, identified by a string value.
+ * - `<Accordion.Trigger>` — clickable header (wrapped in `<h3>` by default).
+ * - `<Accordion.Content>` — the collapsible body.
+ *
+ * Two modes via the discriminated `type` prop:
+ * - `type='single'` — one item open at a time. Optional `collapsible` lets the user close the open item.
+ * - `type='multiple'` — any combination of items can be open.
+ *
+ * Both controlled (`value` + `onValueChange`) and uncontrolled (`defaultValue`) supported.
+ *
+ * @example
+ * // Single-open with collapsible (FAQ-style)
+ * <Accordion type="single" collapsible defaultValue="faq-2">
+ *   <Accordion.Item value="faq-1">
+ *     <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>
+ *     <Accordion.Content>Visit Settings → Security → Reset.</Accordion.Content>
+ *   </Accordion.Item>
+ *   <Accordion.Item value="faq-2">
+ *     <Accordion.Trigger>How do I export my data?</Accordion.Trigger>
+ *     <Accordion.Content>Use the gear icon → Export → CSV.</Accordion.Content>
+ *   </Accordion.Item>
+ * </Accordion>
+ *
+ * @example
+ * // Multiple — independent sections
+ * <Accordion type="multiple" defaultValue={['account', 'notifications']}>
+ *   <Accordion.Item value="account">...</Accordion.Item>
+ *   <Accordion.Item value="notifications">...</Accordion.Item>
+ * </Accordion>
+ *
+ * @example
+ * // Controlled
+ * const [open, setOpen] = useState('');
+ * <Accordion type="single" collapsible value={open} onValueChange={setOpen}>
+ *   ...
+ * </Accordion>
+ *
+ * @remarks When NOT to use
+ * - Mutually-exclusive view switchers → `<Tabs>`.
+ * - Single show/hide toggle → `<Button>` + conditional render.
+ * - Sequential wizard flows → dedicated Stepper (not yet shipped).
+ *
+ * @remarks Anti-patterns
+ * - ❌ Nesting `<Accordion.Trigger>` inside a heading the consumer also renders. Trigger wraps itself in a heading.
+ * - ❌ Manually setting `aria-expanded` on the Trigger via `{...props}`. The component owns the ARIA contract.
+ * - ❌ Using `headerLevel="h1"`. There should only be one `<h1>` per page; Accordion lives below it.
+ */
+const AccordionRoot = forwardRef<HTMLDivElement, AccordionProps>(function AccordionRoot(
+  props,
+  ref,
+) {
+  if (props.type === 'single') {
+    return <AccordionSingleImpl {...props} ref={ref} />;
+  }
+  return <AccordionMultipleImpl {...props} ref={ref} />;
+});
+
+interface SingleImplProps extends AccordionBaseProps, AccordionSingleProps {}
+
+const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
+  function AccordionSingleImpl(
+    {
+      type: _type,
+      value,
+      defaultValue,
+      onValueChange,
+      collapsible = false,
+      children,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    const [internalValue, setInternalValue] = useState<string>(defaultValue ?? '');
+    const isControlled = value !== undefined;
+    const currentValue = isControlled ? value : internalValue;
+
+    const isOpen = useCallback(
+      (itemValue: string) => currentValue === itemValue,
+      [currentValue],
+    );
+
+    const toggle = useCallback(
+      (itemValue: string) => {
+        if (currentValue === itemValue) {
+          if (collapsible) {
+            if (!isControlled) setInternalValue('');
+            onValueChange?.('');
+          }
+        } else {
+          if (!isControlled) setInternalValue(itemValue);
+          onValueChange?.(itemValue);
+        }
+      },
+      [currentValue, collapsible, isControlled, onValueChange],
+    );
+
+    const ctx = useMemo<AccordionContextValue>(
+      () => ({ mode: 'single', isOpen, toggle }),
+      [isOpen, toggle],
+    );
+
+    return (
+      <AccordionContext.Provider value={ctx}>
+        <div
+          ref={ref}
+          {...rest}
+          data-accordion=""
+          className={clsx(styles.accordion, className)}
+        >
+          {children}
+        </div>
+      </AccordionContext.Provider>
+    );
+  },
+);
+
+interface MultipleImplProps extends AccordionBaseProps, AccordionMultipleProps {}
+
+const AccordionMultipleImpl = forwardRef<HTMLDivElement, MultipleImplProps>(
+  function AccordionMultipleImpl(
+    { type: _type, value, defaultValue, onValueChange, children, className, ...rest },
+    ref,
+  ) {
+    const [internalValue, setInternalValue] = useState<string[]>(defaultValue ?? []);
+    const isControlled = value !== undefined;
+    const currentValue = isControlled ? value : internalValue;
+
+    const isOpen = useCallback(
+      (itemValue: string) => currentValue.includes(itemValue),
+      [currentValue],
+    );
+
+    const toggle = useCallback(
+      (itemValue: string) => {
+        const next = currentValue.includes(itemValue)
+          ? currentValue.filter((v) => v !== itemValue)
+          : [...currentValue, itemValue];
+        if (!isControlled) setInternalValue(next);
+        onValueChange?.(next);
+      },
+      [currentValue, isControlled, onValueChange],
+    );
+
+    const ctx = useMemo<AccordionContextValue>(
+      () => ({ mode: 'multiple', isOpen, toggle }),
+      [isOpen, toggle],
+    );
+
+    return (
+      <AccordionContext.Provider value={ctx}>
+        <div
+          ref={ref}
+          {...rest}
+          data-accordion=""
+          className={clsx(styles.accordion, className)}
+        >
+          {children}
+        </div>
+      </AccordionContext.Provider>
+    );
+  },
+);
+
+/** Compound export. */
+export const Accordion = Object.assign(AccordionRoot, {
+  Item: AccordionItem,
+  Trigger: AccordionTrigger,
+  Content: AccordionContent,
+});
+```
+
+- [ ] **Step 5: Write `AccordionItem.tsx`**
+
+Create `packages/design-system/src/components/Accordion/AccordionItem.tsx`:
+
+```tsx
+import { forwardRef, useId, useMemo, type HTMLAttributes, type ReactNode } from 'react';
+import clsx from 'clsx';
+import {
+  AccordionItemContext,
+  useAccordionContext,
+  type AccordionItemContextValue,
+} from './context';
+import type { AccordionHeaderLevel } from './Accordion';
+import styles from './Accordion.module.scss';
+
+export interface AccordionItemProps extends Omit<HTMLAttributes<HTMLDivElement>, 'value'> {
+  /** Unique value used to identify the item in the root's `value`/`onValueChange`. */
+  value: string;
+  /** When true, the trigger is non-interactive and keyboard nav skips this item. */
+  disabled?: boolean;
+  /**
+   * Heading level wrapping the trigger. WAI-ARIA APG requires triggers to live
+   * inside a heading element. Defaults to `'h3'`.
+   */
+  headerLevel?: AccordionHeaderLevel;
+  children: ReactNode;
+}
+
+/**
+ * Item wrapper. Provides `AccordionItemContext` so Trigger and Content can
+ * read this item's value, disabled state, open state, and stable ids.
+ */
+export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
+  function AccordionItem(
+    { value, disabled = false, headerLevel = 'h3', children, className, ...props },
+    ref,
+  ) {
+    const { isOpen } = useAccordionContext('Item');
+    const open = isOpen(value);
+    const reactId = useId();
+    const triggerId = `accordion-trigger-${reactId}`;
+    const contentId = `accordion-content-${reactId}`;
+
+    const ctx = useMemo<AccordionItemContextValue & { headerLevel: AccordionHeaderLevel }>(
+      () => ({
+        value,
+        disabled,
+        isOpen: open,
+        triggerId,
+        contentId,
+        headerLevel,
+      }),
+      [value, disabled, open, triggerId, contentId, headerLevel],
+    );
+
+    return (
+      <AccordionItemContext.Provider value={ctx}>
+        <div
+          ref={ref}
+          {...props}
+          data-state={open ? 'open' : 'closed'}
+          data-disabled={disabled ? 'true' : undefined}
+          className={clsx(styles.item, className)}
+        >
+          {children}
+        </div>
+      </AccordionItemContext.Provider>
+    );
+  },
+);
+```
+
+- [ ] **Step 6: Write `AccordionTrigger.tsx`**
+
+Create `packages/design-system/src/components/Accordion/AccordionTrigger.tsx`:
+
+```tsx
+import {
+  forwardRef,
+  type ButtonHTMLAttributes,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+import { ChevronDown } from 'lucide-react';
+import clsx from 'clsx';
+import {
+  useAccordionContext,
+  useAccordionItemContext,
+  type AccordionItemContextValue,
+} from './context';
+import type { AccordionHeaderLevel } from './Accordion';
+import styles from './Accordion.module.scss';
+
+export interface AccordionTriggerProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  /**
+   * Override the default trigger indicator icon (rotates 180° when open).
+   * Pass `null` to suppress the icon entirely. Default: `<ChevronDown />`.
+   */
+  icon?: ReactNode | null;
+  children: ReactNode;
+}
+
+interface ItemContextWithHeaderLevel extends AccordionItemContextValue {
+  headerLevel: AccordionHeaderLevel;
+}
+
+/**
+ * Heading-wrapped button that toggles the parent Item. Default indicator is a
+ * `<ChevronDown>` icon that rotates 180° when open.
+ */
+export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerProps>(
+  function AccordionTrigger({ icon, children, className, onKeyDown, ...props }, ref) {
+    const { toggle } = useAccordionContext('Trigger');
+    const itemCtx = useAccordionItemContext('Trigger') as ItemContextWithHeaderLevel;
+    const { value, disabled, isOpen, triggerId, contentId, headerLevel } = itemCtx;
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+      onKeyDown?.(e);
+      if (e.defaultPrevented) return;
+      const isNav = ['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(e.key);
+      if (!isNav) return;
+      e.preventDefault();
+
+      const root = e.currentTarget.closest<HTMLElement>('[data-accordion]');
+      if (!root) return;
+
+      const triggers = Array.from(
+        root.querySelectorAll<HTMLButtonElement>(
+          'button[aria-expanded]:not(:disabled)',
+        ),
+      );
+      if (triggers.length === 0) return;
+
+      const current = triggers.indexOf(e.currentTarget);
+      let next = current;
+
+      if (e.key === 'ArrowDown') next = (current + 1) % triggers.length;
+      else if (e.key === 'ArrowUp')
+        next = (current - 1 + triggers.length) % triggers.length;
+      else if (e.key === 'Home') next = 0;
+      else if (e.key === 'End') next = triggers.length - 1;
+
+      triggers[next]?.focus();
+    };
+
+    const renderedIcon =
+      icon === null
+        ? null
+        : (icon ?? (
+            <ChevronDown
+              size={16}
+              aria-hidden="true"
+              className={styles.indicator}
+            />
+          ));
+
+    // headerLevel is a string union of valid HTML heading tag names; cast to
+    // ElementType for JSX use.
+    const Heading = headerLevel as 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+    return (
+      <Heading className={styles.header}>
+        <button
+          {...props}
+          ref={ref}
+          type="button"
+          id={triggerId}
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          disabled={disabled}
+          onClick={() => toggle(value)}
+          onKeyDown={handleKeyDown}
+          className={clsx(styles.trigger, className)}
+        >
+          <span className={styles.label}>{children}</span>
+          {renderedIcon}
+        </button>
+      </Heading>
+    );
+  },
+);
+```
+
+- [ ] **Step 7: Write `AccordionContent.tsx`**
+
+Create `packages/design-system/src/components/Accordion/AccordionContent.tsx`:
+
+```tsx
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { useAccordionItemContext } from './context';
+import styles from './Accordion.module.scss';
+
+export interface AccordionContentProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+/**
+ * Collapsible region announced via `role="region"` + `aria-labelledby` pointing
+ * at the trigger. Animated via CSS `grid-template-rows: 0fr → 1fr`.
+ */
+export const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
+  function AccordionContent({ children, className, ...props }, ref) {
+    const { isOpen, triggerId, contentId } = useAccordionItemContext('Content');
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        id={contentId}
+        role="region"
+        aria-labelledby={triggerId}
+        data-state={isOpen ? 'open' : 'closed'}
+        className={clsx(styles.content, className)}
+      >
+        <div className={styles.inner}>{children}</div>
+      </div>
+    );
+  },
+);
+```
+
+- [ ] **Step 8: Write the folder barrel**
+
+Create `packages/design-system/src/components/Accordion/index.ts`:
+
+```ts
+export { Accordion } from './Accordion';
+export type {
+  AccordionProps,
+  AccordionMode,
+  AccordionHeaderLevel,
+} from './Accordion';
+export type { AccordionItemProps } from './AccordionItem';
+export type { AccordionTriggerProps } from './AccordionTrigger';
+export type { AccordionContentProps } from './AccordionContent';
+```
+
+- [ ] **Step 9: Typecheck + lint**
+
+```bash
+cd /home/dpws/projects/design-system
+make build-lib
+make lint
+```
+
+Expected: both clean.
+
+If stylelint flags `rule-empty-line-before` between sibling top-level rules, add blank lines between them.
+
+If stylelint flags the `margin: 0` on `.header`, verify the `stylelint-disable-next-line property-disallowed-list -- native heading margin reset` comment is on the immediately preceding line (not on the rule block opener).
+
+If TypeScript flags the discriminated union shape (the `_type` discard in the impl components is intentional — TS prefers `_`-prefix for unused), that's expected; it satisfies the strict noUnusedParameters rule.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/design-system/src/components/Accordion/
+git commit -m "$(cat <<'EOF'
+Accordion: source — compound collapsible panels (8 files)
+
+Bundled source for the Accordion compound component:
+
+- Accordion.tsx — root with discriminated-union types (type='single' |
+  'multiple'), Object.assign for the compound API. Internal mirror
+  pattern for uncontrolled state.
+- AccordionItem.tsx — item wrapper providing AccordionItemContext
+  (value/disabled/isOpen/triggerId/contentId) + heading level passed
+  through to Trigger.
+- AccordionTrigger.tsx — heading-wrapped button (h2/h3/h4/h5/h6),
+  WAI-ARIA APG keyboard nav handler (ArrowDown/Up/Home/End skipping
+  disabled), default ChevronDown indicator that rotates 180° when
+  open via [data-state='open'].
+- AccordionContent.tsx — role="region" + aria-labelledby. Animated
+  via grid-template-rows: 0fr → 1fr (no JS measurement).
+- context.ts — AccordionContext + AccordionItemContext + use* hooks
+  that throw outside the right ancestor.
+- Accordion.module.scss — borders, trigger styling, focus-visible
+  (inset ring because trigger is full-width), grid-row animation,
+  reduced-motion fallback.
+- index.ts — barrel.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2 — Unit tests (`Accordion.test.tsx`)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Accordion/Accordion.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+Create `packages/design-system/src/components/Accordion/Accordion.test.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Plus } from 'lucide-react';
+import { Accordion } from './Accordion';
+
+function BasicSingle({
+  collapsible = false,
+  defaultValue,
+}: {
+  collapsible?: boolean;
+  defaultValue?: string;
+}) {
+  return (
+    <Accordion type="single" collapsible={collapsible} defaultValue={defaultValue}>
+      <Accordion.Item value="a">
+        <Accordion.Trigger>A trigger</Accordion.Trigger>
+        <Accordion.Content>A content</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="b">
+        <Accordion.Trigger>B trigger</Accordion.Trigger>
+        <Accordion.Content>B content</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="c">
+        <Accordion.Trigger>C trigger</Accordion.Trigger>
+        <Accordion.Content>C content</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}
+
+function BasicMultiple({ defaultValue }: { defaultValue?: string[] }) {
+  return (
+    <Accordion type="multiple" defaultValue={defaultValue}>
+      <Accordion.Item value="a">
+        <Accordion.Trigger>A trigger</Accordion.Trigger>
+        <Accordion.Content>A content</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="b">
+        <Accordion.Trigger>B trigger</Accordion.Trigger>
+        <Accordion.Content>B content</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="c">
+        <Accordion.Trigger>C trigger</Accordion.Trigger>
+        <Accordion.Content>C content</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}
+
+describe('<Accordion>', () => {
+  // ─── Rendering + structure ─────────────────────────────────────────────
+
+  it('renders without crashing with minimal compound markup', () => {
+    render(<BasicSingle />);
+    expect(screen.getByText('A trigger')).toBeInTheDocument();
+    expect(screen.getByText('B trigger')).toBeInTheDocument();
+  });
+
+  it('renders items in DOM order', () => {
+    const { container } = render(<BasicSingle />);
+    const triggers = container.querySelectorAll('button[aria-expanded]');
+    expect(triggers[0]).toHaveTextContent('A trigger');
+    expect(triggers[1]).toHaveTextContent('B trigger');
+    expect(triggers[2]).toHaveTextContent('C trigger');
+  });
+
+  it('Trigger is wrapped in the default <h3>', () => {
+    const { container } = render(<BasicSingle />);
+    expect(container.querySelectorAll('h3').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('headerLevel="h2" wraps the trigger in <h2>', () => {
+    const { container } = render(
+      <Accordion type="single">
+        <Accordion.Item value="a" headerLevel="h2">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>content</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(container.querySelector('h2')).toBeInTheDocument();
+  });
+
+  it('aria-controls on trigger matches id on content panel', () => {
+    render(<BasicSingle />);
+    const trigger = screen.getByRole('button', { name: 'A trigger' });
+    const ariaControls = trigger.getAttribute('aria-controls');
+    expect(ariaControls).toBeTruthy();
+    const panel = document.getElementById(ariaControls!);
+    expect(panel).not.toBeNull();
+  });
+
+  it('aria-labelledby on content matches id on trigger', () => {
+    render(<BasicSingle />);
+    const trigger = screen.getByRole('button', { name: 'A trigger' });
+    const triggerId = trigger.id;
+    // Content panel: find via aria-labelledby. Note: closed panels still
+    // exist in the DOM (only height is 0).
+    const panels = document.querySelectorAll('[role="region"]');
+    const panel = Array.from(panels).find(
+      (p) => p.getAttribute('aria-labelledby') === triggerId,
+    );
+    expect(panel).toBeDefined();
+  });
+
+  it('default state: no item open; all aria-expanded="false"', () => {
+    render(<BasicSingle />);
+    const triggers = screen.getAllByRole('button');
+    triggers.forEach((t) => {
+      expect(t).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  // ─── State (single mode) ───────────────────────────────────────────────
+
+  it('defaultValue="a" opens item a on initial render', () => {
+    render(<BasicSingle defaultValue="a" />);
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'B trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('clicking a closed item opens it AND closes any previously open item', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle defaultValue="a" />);
+    await user.click(screen.getByRole('button', { name: 'B trigger' }));
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.getByRole('button', { name: 'B trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('collapsible={false} (default): clicking the open item does NOT close it', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle defaultValue="a" />);
+    await user.click(screen.getByRole('button', { name: 'A trigger' }));
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('collapsible={true}: clicking the open item closes it', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle collapsible defaultValue="a" />);
+    await user.click(screen.getByRole('button', { name: 'A trigger' }));
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('controlled single: value + onValueChange round-trip', async () => {
+    const user = userEvent.setup();
+    function Controlled() {
+      const [v, setV] = useState('');
+      return (
+        <>
+          <span data-testid="state">{v}</span>
+          <Accordion type="single" value={v} onValueChange={setV}>
+            <Accordion.Item value="a">
+              <Accordion.Trigger>A trigger</Accordion.Trigger>
+              <Accordion.Content>A content</Accordion.Content>
+            </Accordion.Item>
+            <Accordion.Item value="b">
+              <Accordion.Trigger>B trigger</Accordion.Trigger>
+              <Accordion.Content>B content</Accordion.Content>
+            </Accordion.Item>
+          </Accordion>
+        </>
+      );
+    }
+    render(<Controlled />);
+    await user.click(screen.getByRole('button', { name: 'B trigger' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('b');
+    await user.click(screen.getByRole('button', { name: 'A trigger' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('a');
+  });
+
+  // ─── State (multiple mode) ─────────────────────────────────────────────
+
+  it('multiple mode: defaultValue={["a","b"]} opens both items', () => {
+    render(<BasicMultiple defaultValue={['a', 'b']} />);
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'B trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'C trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('multiple mode: clicking a closed item adds it to the open set', async () => {
+    const user = userEvent.setup();
+    render(<BasicMultiple defaultValue={['a']} />);
+    await user.click(screen.getByRole('button', { name: 'C trigger' }));
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'C trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('multiple mode: clicking an open item removes it from the set', async () => {
+    const user = userEvent.setup();
+    render(<BasicMultiple defaultValue={['a', 'b']} />);
+    await user.click(screen.getByRole('button', { name: 'A trigger' }));
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.getByRole('button', { name: 'B trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('controlled multiple: value + onValueChange round-trip', async () => {
+    const user = userEvent.setup();
+    function Controlled() {
+      const [v, setV] = useState<string[]>([]);
+      return (
+        <>
+          <span data-testid="state">{v.join(',')}</span>
+          <Accordion type="multiple" value={v} onValueChange={setV}>
+            <Accordion.Item value="a">
+              <Accordion.Trigger>A trigger</Accordion.Trigger>
+              <Accordion.Content>A content</Accordion.Content>
+            </Accordion.Item>
+            <Accordion.Item value="b">
+              <Accordion.Trigger>B trigger</Accordion.Trigger>
+              <Accordion.Content>B content</Accordion.Content>
+            </Accordion.Item>
+          </Accordion>
+        </>
+      );
+    }
+    render(<Controlled />);
+    await user.click(screen.getByRole('button', { name: 'A trigger' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('a');
+    await user.click(screen.getByRole('button', { name: 'B trigger' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('a,b');
+    await user.click(screen.getByRole('button', { name: 'A trigger' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('b');
+  });
+
+  // ─── Disabled ──────────────────────────────────────────────────────────
+
+  it('disabled item: trigger has the disabled attribute', () => {
+    render(
+      <Accordion type="single">
+        <Accordion.Item value="a" disabled>
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>content</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(screen.getByRole('button', { name: 'A' })).toBeDisabled();
+  });
+
+  it('clicking a disabled trigger does NOT toggle the item', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <Accordion type="single" onValueChange={handleChange}>
+        <Accordion.Item value="a" disabled>
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>content</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    await user.click(screen.getByRole('button', { name: 'A' }));
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  // ─── Keyboard ──────────────────────────────────────────────────────────
+
+  it('ArrowDown from the first trigger focuses the second', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle />);
+    const first = screen.getByRole('button', { name: 'A trigger' });
+    first.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('button', { name: 'B trigger' })).toHaveFocus();
+  });
+
+  it('ArrowUp from the second trigger focuses the first', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle />);
+    const second = screen.getByRole('button', { name: 'B trigger' });
+    second.focus();
+    await user.keyboard('{ArrowUp}');
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveFocus();
+  });
+
+  it('ArrowDown wraps from last to first', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle />);
+    const last = screen.getByRole('button', { name: 'C trigger' });
+    last.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveFocus();
+  });
+
+  it('Home focuses the first non-disabled trigger', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle />);
+    const second = screen.getByRole('button', { name: 'B trigger' });
+    second.focus();
+    await user.keyboard('{Home}');
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveFocus();
+  });
+
+  it('End focuses the last non-disabled trigger', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle />);
+    const first = screen.getByRole('button', { name: 'A trigger' });
+    first.focus();
+    await user.keyboard('{End}');
+    expect(screen.getByRole('button', { name: 'C trigger' })).toHaveFocus();
+  });
+
+  it('ArrowDown skips disabled items', async () => {
+    const user = userEvent.setup();
+    render(
+      <Accordion type="single">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="b" disabled>
+          <Accordion.Trigger>B</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="c">
+          <Accordion.Trigger>C</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    const first = screen.getByRole('button', { name: 'A' });
+    first.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('button', { name: 'C' })).toHaveFocus();
+  });
+
+  // ─── Icon ──────────────────────────────────────────────────────────────
+
+  it('custom icon on Trigger replaces the default ChevronDown', () => {
+    const { container } = render(
+      <Accordion type="single">
+        <Accordion.Item value="a">
+          <Accordion.Trigger icon={<Plus data-testid="custom" />}>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(screen.getByTestId('custom')).toBeInTheDocument();
+  });
+
+  it('icon={null} hides the indicator entirely', () => {
+    const { container } = render(
+      <Accordion type="single">
+        <Accordion.Item value="a">
+          <Accordion.Trigger icon={null}>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    const trigger = screen.getByRole('button', { name: 'A' });
+    expect(within(trigger).queryByRole('img')).toBeNull();
+    expect(trigger.querySelector('svg')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd /home/dpws/projects/design-system
+npm test -w @eocrm/design-system -- --run src/components/Accordion/Accordion.test.tsx
+```
+
+Expected: 26 tests passing.
+
+If a test fails:
+- **`useId` SSR-warning** in jsdom: the warning is benign for our tests but if it surfaces, wrap the render in `act()`.
+- **`role="region"` query failing**: the spec uses role="region" on the content. Verify the AccordionContent JSX sets `role="region"`.
+- **Keyboard nav test failing**: the handler queries `button[aria-expanded]:not(:disabled)` — confirm Trigger sets `aria-expanded` (yes, it does via `aria-expanded={isOpen}`).
+
+- [ ] **Step 3: Full suite + lint + typecheck**
+
+```bash
+make test
+make build-lib
+make lint
+```
+
+Expected: everything clean. Total test count goes up by 26.
+
+`structure.test.ts` will report 1 failure ("Accordion is re-exported from src/index.ts") — Task 3 fixes it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/Accordion/Accordion.test.tsx
+git commit -m "$(cat <<'EOF'
+Accordion: unit tests
+
+26 cases: rendering (compound markup, default h3 heading, custom
+headerLevel, aria-controls/aria-labelledby pairing, default all
+aria-expanded="false"), state in single mode (defaultValue,
+click-to-open-and-close-others, collapsible behavior, controlled
+round-trip), state in multiple mode (defaultValue array, add/remove
+membership, controlled round-trip), disabled (disabled attr, click
+no-op), keyboard nav (ArrowDown/Up/Home/End, wrap, skip disabled),
+icon override + icon={null} suppression.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 — Public exports + AGENTS.md TL;DR
+
+**Files:**
+
+- Modify: `packages/design-system/src/index.ts`
+- Modify: `packages/design-system/AGENTS.md`
+
+- [ ] **Step 1: Add re-exports to `src/index.ts`**
+
+```ts
+export { Accordion } from './components/Accordion';
+export type {
+  AccordionProps,
+  AccordionItemProps,
+  AccordionTriggerProps,
+  AccordionContentProps,
+  AccordionMode,
+  AccordionHeaderLevel,
+} from './components/Accordion';
+```
+
+Place wherever the file's surrounding pattern suggests (file is not strictly alphabetical; recent components are appended near the bottom). Match the convention.
+
+Verify with:
+
+```bash
+grep -n "Accordion\|Alert\|Avatar" packages/design-system/src/index.ts | head
+```
+
+- [ ] **Step 2: Add TL;DR to AGENTS.md**
+
+Open `packages/design-system/AGENTS.md`. Find `### \`<Tabs>\`` (around line 497). The new Accordion section goes AFTER Tabs and BEFORE `### \`<Breadcrumb>\`` (around line 521).
+
+Use grep to confirm line numbers:
+
+```bash
+grep -nE "^### " packages/design-system/AGENTS.md | head -30
+```
+
+Add this content verbatim:
+
+````markdown
+### `<Accordion>` — vertically-stacked collapsible panels
+
+Compound component for FAQ-style content, settings sections, and any case where you have a list of headings with optional drill-down detail. Two modes: `single` (one open at a time) or `multiple` (any combination).
+
+```tsx
+import { Accordion } from '@eocrm/design-system';
+
+// Single-open with collapsible (FAQ-style)
+<Accordion type="single" collapsible defaultValue="faq-2">
+  <Accordion.Item value="faq-1">
+    <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>
+    <Accordion.Content>Visit Settings → Security → Reset.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="faq-2">
+    <Accordion.Trigger>How do I export my data?</Accordion.Trigger>
+    <Accordion.Content>Use the gear icon → Export → CSV.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>
+
+// Multiple — independent sections
+<Accordion type="multiple" defaultValue={['account', 'notifications']}>
+  <Accordion.Item value="account">...</Accordion.Item>
+  <Accordion.Item value="notifications">...</Accordion.Item>
+</Accordion>
+
+// Disabled item
+<Accordion.Item value="advanced" disabled>...</Accordion.Item>
+
+// Controlled
+<Accordion type="single" value={open} onValueChange={setOpen}>...</Accordion>
+```
+
+- **`type="single"`** + `collapsible={true}` — one item open at a time, click to close.
+- **`type="multiple"`** — any combination.
+- **Smooth animation** via CSS `grid-template-rows: 0fr → 1fr`. No JS measurement.
+- **Heading wrapping** — Trigger is wrapped in `<h3>` by default per WAI-ARIA APG. Override via `headerLevel` on Item.
+- **Keyboard**: ArrowDown/Up cycles between triggers, Home/End jumps to ends, Space/Enter toggles. Disabled items are skipped.
+
+#### When NOT to use
+
+- ❌ Mutually-exclusive view switchers → `<Tabs>` (tabs imply parallel content; accordions imply hierarchy).
+- ❌ A simple show/hide toggle for a single section → use a `<Button>` + conditional render.
+- ❌ Step-by-step wizard flows → a dedicated Stepper (not shipped).
+
+#### Anti-patterns
+
+- ❌ Nesting `<Accordion.Trigger>` inside a heading the consumer also renders manually. Trigger ALREADY wraps itself in a heading.
+- ❌ Setting `aria-expanded` manually on the Trigger via `{...props}`. The component owns the ARIA contract.
+- ❌ Using `headerLevel="h1"`. There should only be one `<h1>` per page; Accordion lives below it.
+````
+
+- [ ] **Step 3: Run gates**
+
+```bash
+make test
+make build-lib
+make build
+make lint
+```
+
+Expected: everything clean. `structure.test.ts` finds Accordion in the barrel.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/index.ts packages/design-system/AGENTS.md
+git commit -m "$(cat <<'EOF'
+Accordion: public exports + AGENTS.md TL;DR
+
+Re-exports Accordion + AccordionProps/AccordionItemProps/
+AccordionTriggerProps/AccordionContentProps/AccordionMode/
+AccordionHeaderLevel from the package barrel. AGENTS.md gains a
+TL;DR section between Tabs and Breadcrumb (navigation cluster) with
+the canonical four patterns (single + collapsible / multiple /
+disabled item / controlled), the when-NOT-to-use list, and the
+manually-wrapping-heading anti-pattern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 — Playground demo + 4-place nav wiring
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/AccordionDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Write the demo page**
+
+Create `packages/playground/src/pages/components/AccordionDemo.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { Accordion, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Accordion/Accordion.tsx?raw';
+import scssSource from '@lib-source/components/Accordion/Accordion.module.scss?raw';
+
+export function AccordionDemo() {
+  const [controlled, setControlled] = useState<string>('');
+
+  return (
+    <DemoLayout
+      name="Accordion"
+      componentName="Accordion"
+      description="Vertically-stacked collapsible panels. Compound component (Accordion.Item + Accordion.Trigger + Accordion.Content). Two modes: type='single' (one open at a time) or type='multiple' (any combination)."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Accordion.tsx"
+      scssFilename="Accordion.module.scss"
+    >
+      <Example
+        title="Single, collapsible (FAQ-style)"
+        description="Only one item open at a time. Clicking the open item closes it (collapsible)."
+        code={`<Accordion type="single" collapsible defaultValue="faq-1">
+  <Accordion.Item value="faq-1">
+    <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>
+    <Accordion.Content>Visit Settings → Security → Reset password.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="faq-2">
+    <Accordion.Trigger>How do I export my data?</Accordion.Trigger>
+    <Accordion.Content>Use the gear icon → Export → CSV.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="faq-3">
+    <Accordion.Trigger>How do I invite teammates?</Accordion.Trigger>
+    <Accordion.Content>Settings → Team → Invite via email.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>`}
+      >
+        <Accordion type="single" collapsible defaultValue="faq-1">
+          <Accordion.Item value="faq-1">
+            <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>
+            <Accordion.Content>Visit Settings → Security → Reset password.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="faq-2">
+            <Accordion.Trigger>How do I export my data?</Accordion.Trigger>
+            <Accordion.Content>Use the gear icon → Export → CSV.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="faq-3">
+            <Accordion.Trigger>How do I invite teammates?</Accordion.Trigger>
+            <Accordion.Content>Settings → Team → Invite via email.</Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Example>
+
+      <Example
+        title="Multiple — independent sections"
+        description="Any combination of items can be open. Useful for settings panels where each section is independent."
+        code={`<Accordion type="multiple" defaultValue={['account']}>
+  <Accordion.Item value="account">
+    <Accordion.Trigger>Account</Accordion.Trigger>
+    <Accordion.Content>Email, name, profile picture.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="notifications">
+    <Accordion.Trigger>Notifications</Accordion.Trigger>
+    <Accordion.Content>Email digest, in-app alerts.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="security">
+    <Accordion.Trigger>Security</Accordion.Trigger>
+    <Accordion.Content>2FA, active sessions, API keys.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="billing">
+    <Accordion.Trigger>Billing</Accordion.Trigger>
+    <Accordion.Content>Plan, invoices, payment method.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>`}
+      >
+        <Accordion type="multiple" defaultValue={['account']}>
+          <Accordion.Item value="account">
+            <Accordion.Trigger>Account</Accordion.Trigger>
+            <Accordion.Content>Email, name, profile picture.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="notifications">
+            <Accordion.Trigger>Notifications</Accordion.Trigger>
+            <Accordion.Content>Email digest, in-app alerts.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="security">
+            <Accordion.Trigger>Security</Accordion.Trigger>
+            <Accordion.Content>2FA, active sessions, API keys.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="billing">
+            <Accordion.Trigger>Billing</Accordion.Trigger>
+            <Accordion.Content>Plan, invoices, payment method.</Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Example>
+
+      <Example
+        title="Controlled"
+        description="The consumer owns the open state via value + onValueChange. Useful for syncing with URL state or external state stores."
+        code={`const [open, setOpen] = useState('');
+
+<Accordion type="single" collapsible value={open} onValueChange={setOpen}>
+  <Accordion.Item value="a">
+    <Accordion.Trigger>Section A</Accordion.Trigger>
+    <Accordion.Content>Content A</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="b">
+    <Accordion.Trigger>Section B</Accordion.Trigger>
+    <Accordion.Content>Content B</Accordion.Content>
+  </Accordion.Item>
+</Accordion>
+
+<p>Currently open: {open || '(none)'}</p>`}
+      >
+        <Stack gap="sm">
+          <Accordion
+            type="single"
+            collapsible
+            value={controlled}
+            onValueChange={setControlled}
+          >
+            <Accordion.Item value="a">
+              <Accordion.Trigger>Section A</Accordion.Trigger>
+              <Accordion.Content>Content A</Accordion.Content>
+            </Accordion.Item>
+            <Accordion.Item value="b">
+              <Accordion.Trigger>Section B</Accordion.Trigger>
+              <Accordion.Content>Content B</Accordion.Content>
+            </Accordion.Item>
+          </Accordion>
+          <p style={{ margin: 0, fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+            Currently open: {controlled || '(none)'}
+          </p>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Disabled item"
+        description="A disabled item is non-interactive (button disabled, keyboard nav skips). Useful for sections that aren't applicable to the current user/plan."
+        code={`<Accordion type="single" collapsible>
+  <Accordion.Item value="basic">
+    <Accordion.Trigger>Basic settings</Accordion.Trigger>
+    <Accordion.Content>Always available.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="premium" disabled>
+    <Accordion.Trigger>Premium settings (upgrade required)</Accordion.Trigger>
+    <Accordion.Content>You won't see this.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="advanced">
+    <Accordion.Trigger>Advanced settings</Accordion.Trigger>
+    <Accordion.Content>For power users.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>`}
+      >
+        <Accordion type="single" collapsible>
+          <Accordion.Item value="basic">
+            <Accordion.Trigger>Basic settings</Accordion.Trigger>
+            <Accordion.Content>Always available.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="premium" disabled>
+            <Accordion.Trigger>Premium settings (upgrade required)</Accordion.Trigger>
+            <Accordion.Content>You won't see this.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="advanced">
+            <Accordion.Trigger>Advanced settings</Accordion.Trigger>
+            <Accordion.Content>For power users.</Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Example>
+
+      <Example
+        title="Custom icon (Plus)"
+        description="Override the default ChevronDown indicator via the Trigger's icon prop. The icon rotates 180° when the item is open."
+        code={`<Accordion type="single" collapsible>
+  <Accordion.Item value="a">
+    <Accordion.Trigger icon={<Plus size={16} />}>Toggle me</Accordion.Trigger>
+    <Accordion.Content>The Plus icon rotates 180° to become a Minus when open.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>`}
+      >
+        <Accordion type="single" collapsible>
+          <Accordion.Item value="a">
+            <Accordion.Trigger icon={<Plus size={16} aria-hidden="true" />}>
+              Toggle me
+            </Accordion.Trigger>
+            <Accordion.Content>
+              The Plus icon rotates 180° to become a Minus when open.
+            </Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Example>
+
+      <Example
+        title="Heading level override"
+        description="Trigger is wrapped in <h3> by default. Override via Item.headerLevel to fit the surrounding page heading hierarchy."
+        code={`<Accordion type="single" collapsible>
+  <Accordion.Item value="a" headerLevel="h2">
+    <Accordion.Trigger>This trigger sits inside an &lt;h2&gt;</Accordion.Trigger>
+    <Accordion.Content>Inspect the DOM to verify.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>`}
+      >
+        <Accordion type="single" collapsible>
+          <Accordion.Item value="a" headerLevel="h2">
+            <Accordion.Trigger>This trigger sits inside an &lt;h2&gt;</Accordion.Trigger>
+            <Accordion.Content>Inspect the DOM to verify.</Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+- [ ] **Step 2: Wire route + import in `App.tsx`**
+
+Add the import alphabetically:
+
+```tsx
+import { AccordionDemo } from './pages/components/AccordionDemo';
+```
+
+Add the route inside `<Routes>`:
+
+```tsx
+<Route path="/components/accordion" element={<AccordionDemo />} />
+```
+
+(Match the surrounding file convention.)
+
+- [ ] **Step 3: Add sidebar entry in `AppShell.tsx`**
+
+Open `packages/playground/src/layout/AppShell/AppShell.tsx`. Find the `Navigation` group (around line 121). Add Accordion as the FIRST item (alphabetical before Breadcrumb):
+
+```tsx
+{
+  heading: 'Navigation',
+  items: [
+    { to: '/components/accordion', label: 'Accordion', icon: ListCollapse, end: false },
+    { to: '/components/breadcrumb', label: 'Breadcrumb', icon: MoveRight, end: false },
+    { to: '/components/link', label: 'Link', icon: ExternalLink, end: false },
+    { to: '/components/tabs', label: 'Tabs', icon: PanelTop, end: false },
+  ],
+},
+```
+
+Add `ListCollapse` to the existing lucide-react import. Verify it exists:
+
+```bash
+node -e "console.log(Object.keys(require('lucide-react')).filter(k => k === 'ListCollapse').join(', '))"
+```
+
+If `ListCollapse` is missing in lucide-react 1.x, fall back to `ChevronsUpDown` or `Rows3`.
+
+- [ ] **Step 4: Add overview card in `ComponentsIndex.tsx`**
+
+Open `packages/playground/src/pages/components/ComponentsIndex.tsx`. Add `Accordion` to the library imports.
+
+Add a card alphabetically (first, before Alert):
+
+```tsx
+{
+  to: '/components/accordion',
+  name: 'Accordion',
+  description: 'Stacked collapsible panels. Single-open or multi-open mode.',
+  preview: (
+    <div style={{ width: '100%', maxWidth: '260px' }}>
+      <Accordion type="single" collapsible defaultValue="a">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>Section</Accordion.Trigger>
+          <Accordion.Content>Body</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>
+    </div>
+  ),
+},
+```
+
+- [ ] **Step 5: Register the component name in `registry.ts`**
+
+Open `packages/playground/src/pages/mockups/registry.ts`. Find `export type ComponentName =` and add `'Accordion'` FIRST in the union (alphabetical before `'Alert'`):
+
+```ts
+export type ComponentName =
+  | 'Accordion'
+  | 'Alert'
+  | 'Avatar'
+  // …rest unchanged…;
+```
+
+No existing mockup uses Accordion yet, so no `usesComponents` arrays need updating.
+
+- [ ] **Step 6: Build + test**
+
+```bash
+make test
+make build-lib
+make build
+make lint
+```
+
+Expected: everything clean.
+
+- [ ] **Step 7: Spot-check in dev server (OPTIONAL)**
+
+Skip unless a gate fails. We'll do visual checks in Task 5's HR8 round if needed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/playground/src/pages/components/AccordionDemo.tsx \
+        packages/playground/src/App.tsx \
+        packages/playground/src/layout/AppShell/AppShell.tsx \
+        packages/playground/src/pages/components/ComponentsIndex.tsx \
+        packages/playground/src/pages/mockups/registry.ts
+git commit -m "$(cat <<'EOF'
+playground: AccordionDemo + 4-place nav wiring
+
+6 examples (single+collapsible FAQ, multiple settings sections,
+controlled, disabled item, custom Plus icon, heading-level override).
+Wired into Navigation sidebar group (first item, before Breadcrumb),
+Components route, overview-grid card (first item, alphabetical),
+and the mockups ComponentName union.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 — Hard-Rule-8 cycle + push + PR
+
+Per `packages/design-system/CLAUDE.md` Rule 8. Run until 0 Critical + 0 Important findings, all gates green.
+
+- [ ] **Step 1: Final gate run**
+
+```bash
+cd /home/dpws/projects/design-system
+make test
+make build-lib
+make build
+make lint
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Dry-pack to confirm tarball contents**
+
+```bash
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -E "Accordion|test\."
+```
+
+Expected:
+- Accordion source files (`Accordion.tsx`, `AccordionItem.tsx`, `AccordionTrigger.tsx`, `AccordionContent.tsx`, `Accordion.module.scss`, `context.ts`, `index.ts`) in the tarball
+- NO `*.test.*` files
+
+- [ ] **Step 3: Dispatch a fresh-context Hard-Rule-8 reviewer**
+
+Use a `general-purpose` subagent with model `opus`. Prompt template:
+
+> Fresh-context Hard-Rule-8 review of the Accordion PR. Branch `feat/accordion` at HEAD `<sha>`. Per `packages/design-system/CLAUDE.md` Rule 8 — review the full diff against `main`.
+>
+> Files in scope:
+> - `packages/design-system/src/components/Accordion/` (8 source files)
+> - `packages/design-system/src/index.ts`, `AGENTS.md`
+> - `packages/playground/src/pages/components/AccordionDemo.tsx`
+> - `packages/playground/src/App.tsx`, `AppShell.tsx`, `ComponentsIndex.tsx`, `registry.ts`
+>
+> Read first: `packages/design-system/CLAUDE.md` (Rules 1–7), `AGENTS.md` (Accordion section + surrounding Tabs/Breadcrumb), `docs/superpowers/specs/2026-05-23-accordion-design.md`. Compare against ButtonGroup (compound API precedent) and DropdownMenu (context + keyboard nav precedent).
+>
+> Verify:
+> - **Rule 1**: tests exist (~26 cases).
+> - **Rule 3**: NO raw values in `Accordion.module.scss`. All `var(--…)`. The `margin: 0` on `.header` has the documented inline disable for native heading reset.
+> - **Rule 4**: NO `position`/`align-self`/`flex: 1`/`width` at the component boundary. The `display: flex` on `.accordion` is internal layout of its own children (items), not at the boundary. The `display: grid` on `.content` is internal animation. The `flex: 1` on `.label` is inside `.trigger` — internal child of the button, not at the component boundary.
+> - **Rule 5**: re-exported from `src/index.ts`.
+> - **Rule 6**: all four subcomponents use `forwardRef`.
+> - **Rule 7**: full JSDoc on Accordion (root + each subcomponent + every prop + all 6 type aliases). At least 3 `@example` blocks on the root.
+> - **ARIA**: `aria-expanded` on Trigger reflects isOpen. `aria-controls` matches Content's id. `aria-labelledby` on Content matches Trigger's id. `role="region"` on Content. Triggers wrapped in heading element (h2/h3/h4/h5/h6).
+> - **Compound API**: `Object.assign` correctly attaches Item/Trigger/Content. Both contexts have `null` initial value + throwing `use*Context(name)` guards.
+> - **Discriminated union**: `<Accordion type="single">` requires `value: string` / `defaultValue?: string` and accepts `collapsible`; `<Accordion type="multiple">` requires `value: string[]` / `defaultValue?: string[]` and rejects `collapsible` (TS error). Spot-check the TS types.
+> - **Keyboard nav**: ArrowDown/Up wraps; Home/End correct; disabled items skipped (via `:not(:disabled)` selector); doesn't escape the accordion via `[data-accordion]` scoping.
+> - **Animation**: `grid-template-rows: 0fr → 1fr` works for arbitrary content; `prefers-reduced-motion: reduce` disables transitions.
+> - **Cross-package leakage**: imports only `react`, `clsx`, `lucide-react`. No playground imports.
+> - **Package/distribution**: `npm pack --dry-run` excludes test files.
+>
+> End with verdict: **clean enough to stop** OR **keep iterating**.
+
+- [ ] **Step 4: Fix every Critical + Important finding**
+
+Single commit: `Accordion: review-cycle fixes (round N)`.
+
+- [ ] **Step 5: Re-run gates after each fix round**
+
+```bash
+make test && make build-lib && make build && make lint
+```
+
+- [ ] **Step 6: Re-dispatch fresh reviewer**
+
+Same prompt, same model, fresh context. Repeat until **clean enough to stop**.
+
+- [ ] **Step 7: Push the branch**
+
+```bash
+git push -u origin feat/accordion
+```
+
+If the husky `pre-push` hook fails on `format:check`:
+
+```bash
+npx prettier --write docs/superpowers/specs/2026-05-23-accordion-design.md \
+                     docs/superpowers/plans/2026-05-23-accordion.md \
+                     packages/design-system/src/components/Accordion/ \
+                     packages/playground/src/pages/components/AccordionDemo.tsx
+git add -A
+git commit -m "$(cat <<'EOF'
+Accordion: prettier --write
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin feat/accordion
+```
+
+- [ ] **Step 8: Open the PR**
+
+```bash
+gh pr create --title "Accordion: compound collapsible panels (single/multiple + keyboard nav)" --body "$(cat <<'EOF'
+## Summary
+
+- New \`<Accordion>\` compound component — vertically-stacked collapsible panels for FAQ-style content, settings sections, and any case with a list of headings + optional drill-down detail.
+- **Two modes** via discriminated \`type\` prop: \`single\` (one open at a time, optional \`collapsible\`) or \`multiple\` (any combination open).
+- **Both controlled** (\`value\` + \`onValueChange\`) **and uncontrolled** (\`defaultValue\`) supported.
+- **Per-item** \`disabled\`, custom trigger icon, configurable \`headerLevel\` (default h3 per WAI-ARIA APG).
+- **Smooth CSS grid-template-rows animation** (no JS measurement); \`prefers-reduced-motion\` respected.
+- **Full WAI-ARIA APG keyboard support**: ArrowDown/Up/Home/End for trigger-to-trigger nav, skipping disabled items.
+
+## Design highlights
+
+- **Compound API via \`Object.assign\`** — \`Accordion\` + \`.Item\` + \`.Trigger\` + \`.Content\`. Same pattern as ButtonGroup.
+- **Two contexts**: \`AccordionContext\` (mode + isOpen + toggle) and \`AccordionItemContext\` (value + disabled + isOpen + triggerId + contentId). Both throw if consumed outside the right ancestor.
+- **Discriminated union props**: \`type='single'\` requires \`value: string\` / \`defaultValue?: string\` and accepts \`collapsible\`; \`type='multiple'\` requires \`value: string[]\` / \`defaultValue?: string[]\` and rejects \`collapsible\` at the type level.
+- **DOM-order keyboard nav** via \`document.querySelectorAll\` on \`[data-accordion]\` — no registration plumbing, matches the recent ButtonGroup precedent.
+- **CSS grid-row animation**: \`display: grid; grid-template-rows: 0fr → 1fr\` smoothly animates arbitrary content height without JS measurement. The \`.inner\` wrapper with \`overflow: hidden\` ensures the closed state is invisible.
+- **Inset focus ring** on the trigger because the button is full-width inside the accordion's border-radius — an outer ring would clip.
+
+## Hard Rule 8
+
+Fresh-context reviewer cycle. ~26 new tests covering rendering, state in both modes, controlled+uncontrolled, disabled, keyboard nav (ArrowDown/Up wrap, Home/End, skip disabled), and icon override.
+
+All four gates green: \`make test\` · \`make build-lib\` · \`make build\` · \`make lint\` · \`npm pack --dry-run\` (no test files in tarball).
+
+## Test plan
+
+- [ ] Single + collapsible mode opens/closes one item at a time
+- [ ] Single + NOT collapsible: clicking the open item is a no-op
+- [ ] Multiple mode supports any combination open
+- [ ] Controlled \`value\` + \`onValueChange\` round-trips in both modes
+- [ ] \`disabled\` item's trigger is non-clickable AND keyboard nav skips it
+- [ ] ArrowDown/Up cycles between triggers (wraps at edges)
+- [ ] Home/End jumps to first/last non-disabled trigger
+- [ ] Custom \`icon\` on Trigger replaces the default ChevronDown; \`icon={null}\` hides it
+- [ ] \`headerLevel="h2"\` wraps the trigger in \`<h2>\` (verify in DOM)
+- [ ] \`aria-controls\` on each trigger matches \`id\` on the corresponding content panel
+- [ ] \`prefers-reduced-motion: reduce\` disables the grid-row animation
+- [ ] Playground demo at \`/components/accordion\` renders all 6 examples without console errors
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 9: Confirm CI**
+
+Watch the GitHub Actions Quality check on the PR. If it fails for format:check, run prettier locally and push again.
+
+- [ ] **Step 10: Mark task complete**
+
+Once verdict is `clean enough to stop`, gates green, CI green, PR open — task done.
+
+---
+
+## Summary of expected commits on the branch (before review-fix rounds)
+
+```
+Accordion: design spec — compound collapsible panels
+Accordion: implementation plan (5 tasks)
+Accordion: source — compound collapsible panels (8 files)
+Accordion: unit tests
+Accordion: public exports + AGENTS.md TL;DR
+playground: AccordionDemo + 4-place nav wiring
+```
+
+Plus review-cycle fix commits + prettier fix-up as needed.

--- a/docs/superpowers/plans/2026-05-23-accordion.md
+++ b/docs/superpowers/plans/2026-05-23-accordion.md
@@ -257,7 +257,10 @@ export type AccordionMode = 'single' | 'multiple';
 /** Heading level wrapping the trigger button. Defaults to 'h3'. */
 export type AccordionHeaderLevel = 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
-interface AccordionBaseProps extends Omit<HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
+interface AccordionBaseProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'defaultValue' | 'onChange'
+> {
   children: ReactNode;
 }
 
@@ -343,15 +346,14 @@ export type AccordionProps = AccordionBaseProps & (AccordionSingleProps | Accord
  * - ❌ Manually setting `aria-expanded` on the Trigger via `{...props}`. The component owns the ARIA contract.
  * - ❌ Using `headerLevel="h1"`. There should only be one `<h1>` per page; Accordion lives below it.
  */
-const AccordionRoot = forwardRef<HTMLDivElement, AccordionProps>(function AccordionRoot(
-  props,
-  ref,
-) {
-  if (props.type === 'single') {
-    return <AccordionSingleImpl {...props} ref={ref} />;
-  }
-  return <AccordionMultipleImpl {...props} ref={ref} />;
-});
+const AccordionRoot = forwardRef<HTMLDivElement, AccordionProps>(
+  function AccordionRoot(props, ref) {
+    if (props.type === 'single') {
+      return <AccordionSingleImpl {...props} ref={ref} />;
+    }
+    return <AccordionMultipleImpl {...props} ref={ref} />;
+  },
+);
 
 interface SingleImplProps extends AccordionBaseProps, AccordionSingleProps {}
 
@@ -373,10 +375,7 @@ const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
     const isControlled = value !== undefined;
     const currentValue = isControlled ? value : internalValue;
 
-    const isOpen = useCallback(
-      (itemValue: string) => currentValue === itemValue,
-      [currentValue],
-    );
+    const isOpen = useCallback((itemValue: string) => currentValue === itemValue, [currentValue]);
 
     const toggle = useCallback(
       (itemValue: string) => {
@@ -400,12 +399,7 @@ const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
 
     return (
       <AccordionContext.Provider value={ctx}>
-        <div
-          ref={ref}
-          {...rest}
-          data-accordion=""
-          className={clsx(styles.accordion, className)}
-        >
+        <div ref={ref} {...rest} data-accordion="" className={clsx(styles.accordion, className)}>
           {children}
         </div>
       </AccordionContext.Provider>
@@ -447,12 +441,7 @@ const AccordionMultipleImpl = forwardRef<HTMLDivElement, MultipleImplProps>(
 
     return (
       <AccordionContext.Provider value={ctx}>
-        <div
-          ref={ref}
-          {...rest}
-          data-accordion=""
-          className={clsx(styles.accordion, className)}
-        >
+        <div ref={ref} {...rest} data-accordion="" className={clsx(styles.accordion, className)}>
           {children}
         </div>
       </AccordionContext.Provider>
@@ -500,44 +489,42 @@ export interface AccordionItemProps extends Omit<HTMLAttributes<HTMLDivElement>,
  * Item wrapper. Provides `AccordionItemContext` so Trigger and Content can
  * read this item's value, disabled state, open state, and stable ids.
  */
-export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
-  function AccordionItem(
-    { value, disabled = false, headerLevel = 'h3', children, className, ...props },
-    ref,
-  ) {
-    const { isOpen } = useAccordionContext('Item');
-    const open = isOpen(value);
-    const reactId = useId();
-    const triggerId = `accordion-trigger-${reactId}`;
-    const contentId = `accordion-content-${reactId}`;
+export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(function AccordionItem(
+  { value, disabled = false, headerLevel = 'h3', children, className, ...props },
+  ref,
+) {
+  const { isOpen } = useAccordionContext('Item');
+  const open = isOpen(value);
+  const reactId = useId();
+  const triggerId = `accordion-trigger-${reactId}`;
+  const contentId = `accordion-content-${reactId}`;
 
-    const ctx = useMemo<AccordionItemContextValue & { headerLevel: AccordionHeaderLevel }>(
-      () => ({
-        value,
-        disabled,
-        isOpen: open,
-        triggerId,
-        contentId,
-        headerLevel,
-      }),
-      [value, disabled, open, triggerId, contentId, headerLevel],
-    );
+  const ctx = useMemo<AccordionItemContextValue & { headerLevel: AccordionHeaderLevel }>(
+    () => ({
+      value,
+      disabled,
+      isOpen: open,
+      triggerId,
+      contentId,
+      headerLevel,
+    }),
+    [value, disabled, open, triggerId, contentId, headerLevel],
+  );
 
-    return (
-      <AccordionItemContext.Provider value={ctx}>
-        <div
-          ref={ref}
-          {...props}
-          data-state={open ? 'open' : 'closed'}
-          data-disabled={disabled ? 'true' : undefined}
-          className={clsx(styles.item, className)}
-        >
-          {children}
-        </div>
-      </AccordionItemContext.Provider>
-    );
-  },
-);
+  return (
+    <AccordionItemContext.Provider value={ctx}>
+      <div
+        ref={ref}
+        {...props}
+        data-state={open ? 'open' : 'closed'}
+        data-disabled={disabled ? 'true' : undefined}
+        className={clsx(styles.item, className)}
+      >
+        {children}
+      </div>
+    </AccordionItemContext.Provider>
+  );
+});
 ```
 
 - [ ] **Step 6: Write `AccordionTrigger.tsx`**
@@ -545,12 +532,7 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
 Create `packages/design-system/src/components/Accordion/AccordionTrigger.tsx`:
 
 ```tsx
-import {
-  forwardRef,
-  type ButtonHTMLAttributes,
-  type KeyboardEvent,
-  type ReactNode,
-} from 'react';
+import { forwardRef, type ButtonHTMLAttributes, type KeyboardEvent, type ReactNode } from 'react';
 import { ChevronDown } from 'lucide-react';
 import clsx from 'clsx';
 import {
@@ -561,8 +543,10 @@ import {
 import type { AccordionHeaderLevel } from './Accordion';
 import styles from './Accordion.module.scss';
 
-export interface AccordionTriggerProps
-  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+export interface AccordionTriggerProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children'
+> {
   /**
    * Override the default trigger indicator icon (rotates 180° when open).
    * Pass `null` to suppress the icon entirely. Default: `<ChevronDown />`.
@@ -596,9 +580,7 @@ export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerPr
       if (!root) return;
 
       const triggers = Array.from(
-        root.querySelectorAll<HTMLButtonElement>(
-          'button[aria-expanded]:not(:disabled)',
-        ),
+        root.querySelectorAll<HTMLButtonElement>('button[aria-expanded]:not(:disabled)'),
       );
       if (triggers.length === 0) return;
 
@@ -606,8 +588,7 @@ export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerPr
       let next = current;
 
       if (e.key === 'ArrowDown') next = (current + 1) % triggers.length;
-      else if (e.key === 'ArrowUp')
-        next = (current - 1 + triggers.length) % triggers.length;
+      else if (e.key === 'ArrowUp') next = (current - 1 + triggers.length) % triggers.length;
       else if (e.key === 'Home') next = 0;
       else if (e.key === 'End') next = triggers.length - 1;
 
@@ -617,13 +598,7 @@ export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerPr
     const renderedIcon =
       icon === null
         ? null
-        : (icon ?? (
-            <ChevronDown
-              size={16}
-              aria-hidden="true"
-              className={styles.indicator}
-            />
-          ));
+        : (icon ?? <ChevronDown size={16} aria-hidden="true" className={styles.indicator} />);
 
     // headerLevel is a string union of valid HTML heading tag names; cast to
     // ElementType for JSX use.
@@ -697,11 +672,7 @@ Create `packages/design-system/src/components/Accordion/index.ts`:
 
 ```ts
 export { Accordion } from './Accordion';
-export type {
-  AccordionProps,
-  AccordionMode,
-  AccordionHeaderLevel,
-} from './Accordion';
+export type { AccordionProps, AccordionMode, AccordionHeaderLevel } from './Accordion';
 export type { AccordionItemProps } from './AccordionItem';
 export type { AccordionTriggerProps } from './AccordionTrigger';
 export type { AccordionContentProps } from './AccordionContent';
@@ -869,9 +840,7 @@ describe('<Accordion>', () => {
     // Content panel: find via aria-labelledby. Note: closed panels still
     // exist in the DOM (only height is 0).
     const panels = document.querySelectorAll('[role="region"]');
-    const panel = Array.from(panels).find(
-      (p) => p.getAttribute('aria-labelledby') === triggerId,
-    );
+    const panel = Array.from(panels).find((p) => p.getAttribute('aria-labelledby') === triggerId);
     expect(panel).toBeDefined();
   });
 
@@ -1173,6 +1142,7 @@ npm test -w @eocrm/design-system -- --run src/components/Accordion/Accordion.tes
 Expected: 26 tests passing.
 
 If a test fails:
+
 - **`useId` SSR-warning** in jsdom: the warning is benign for our tests but if it surfaces, wrap the render in `act()`.
 - **`role="region"` query failing**: the spec uses role="region" on the content. Verify the AccordionContent JSX sets `role="region"`.
 - **Keyboard nav test failing**: the handler queries `button[aria-expanded]:not(:disabled)` — confirm Trigger sets `aria-expanded` (yes, it does via `aria-expanded={isOpen}`).
@@ -1243,7 +1213,7 @@ grep -n "Accordion\|Alert\|Avatar" packages/design-system/src/index.ts | head
 
 - [ ] **Step 2: Add TL;DR to AGENTS.md**
 
-Open `packages/design-system/AGENTS.md`. Find `### \`<Tabs>\`` (around line 497). The new Accordion section goes AFTER Tabs and BEFORE `### \`<Breadcrumb>\`` (around line 521).
+Open `packages/design-system/AGENTS.md`. Find `### \`<Tabs>\``(around line 497). The new Accordion section goes AFTER Tabs and BEFORE`### \`<Breadcrumb>\`` (around line 521).
 
 Use grep to confirm line numbers:
 
@@ -1469,12 +1439,7 @@ export function AccordionDemo() {
 <p>Currently open: {open || '(none)'}</p>`}
       >
         <Stack gap="sm">
-          <Accordion
-            type="single"
-            collapsible
-            value={controlled}
-            onValueChange={setControlled}
-          >
+          <Accordion type="single" collapsible value={controlled} onValueChange={setControlled}>
             <Accordion.Item value="a">
               <Accordion.Trigger>Section A</Accordion.Trigger>
               <Accordion.Content>Content A</Accordion.Content>
@@ -1637,11 +1602,8 @@ Add a card alphabetically (first, before Alert):
 Open `packages/playground/src/pages/mockups/registry.ts`. Find `export type ComponentName =` and add `'Accordion'` FIRST in the union (alphabetical before `'Alert'`):
 
 ```ts
-export type ComponentName =
-  | 'Accordion'
-  | 'Alert'
-  | 'Avatar'
-  // …rest unchanged…;
+export type ComponentName = 'Accordion' | 'Alert' | 'Avatar';
+// …rest unchanged…;
 ```
 
 No existing mockup uses Accordion yet, so no `usesComponents` arrays need updating.
@@ -1708,6 +1670,7 @@ npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -E "Accordion|test\."
 ```
 
 Expected:
+
 - Accordion source files (`Accordion.tsx`, `AccordionItem.tsx`, `AccordionTrigger.tsx`, `AccordionContent.tsx`, `Accordion.module.scss`, `context.ts`, `index.ts`) in the tarball
 - NO `*.test.*` files
 
@@ -1718,6 +1681,7 @@ Use a `general-purpose` subagent with model `opus`. Prompt template:
 > Fresh-context Hard-Rule-8 review of the Accordion PR. Branch `feat/accordion` at HEAD `<sha>`. Per `packages/design-system/CLAUDE.md` Rule 8 — review the full diff against `main`.
 >
 > Files in scope:
+>
 > - `packages/design-system/src/components/Accordion/` (8 source files)
 > - `packages/design-system/src/index.ts`, `AGENTS.md`
 > - `packages/playground/src/pages/components/AccordionDemo.tsx`
@@ -1726,6 +1690,7 @@ Use a `general-purpose` subagent with model `opus`. Prompt template:
 > Read first: `packages/design-system/CLAUDE.md` (Rules 1–7), `AGENTS.md` (Accordion section + surrounding Tabs/Breadcrumb), `docs/superpowers/specs/2026-05-23-accordion-design.md`. Compare against ButtonGroup (compound API precedent) and DropdownMenu (context + keyboard nav precedent).
 >
 > Verify:
+>
 > - **Rule 1**: tests exist (~26 cases).
 > - **Rule 3**: NO raw values in `Accordion.module.scss`. All `var(--…)`. The `margin: 0` on `.header` has the documented inline disable for native heading reset.
 > - **Rule 4**: NO `position`/`align-self`/`flex: 1`/`width` at the component boundary. The `display: flex` on `.accordion` is internal layout of its own children (items), not at the boundary. The `display: grid` on `.content` is internal animation. The `flex: 1` on `.label` is inside `.trigger` — internal child of the button, not at the component boundary.

--- a/docs/superpowers/specs/2026-05-23-accordion-design.md
+++ b/docs/superpowers/specs/2026-05-23-accordion-design.md
@@ -1,0 +1,642 @@
+# Accordion — design spec
+
+**Date:** 2026-05-23
+**Branch:** `feat/accordion`
+**Scope:** New `<Accordion>` compound component for `@eocrm/design-system` — a vertically-stacked collapsible-panels primitive. Two selection modes (`type="single"` with optional collapsible, `type="multiple"`), controlled + uncontrolled state, per-item disabled, custom trigger icon, configurable heading level for trigger wrapping, smooth CSS grid-template-rows animation, full WAI-ARIA APG keyboard support.
+
+## Goal
+
+Provide the standard "stacked collapsible sections" primitive for FAQ-style content, settings sections that show only one detail at a time, and dashboards with optional drill-down detail. Same compound-component pattern as `Tabs` / `DropdownMenu`: `<Accordion>` root + `<Accordion.Item>` + `<Accordion.Trigger>` + `<Accordion.Content>`.
+
+## Why now
+
+- Contact-detail pages have "Activity / Deals / Notes" tabs but the natural pattern for long-running sections (Custom fields, Notes history, Permissions) is an accordion, not tabs. No primitive ships today.
+- Settings pages with optional collapsible sub-panels are open-coded with `useState` + manual `<button>` + manual `<div>` per page.
+- Standard WAI-ARIA APG accordion pattern is non-trivial to get right (heading-wrapped triggers, `aria-controls`, `aria-expanded`, Arrow Down/Up nav, Home/End). Building it once in the design system saves every consumer.
+
+## Non-goals (v1)
+
+- **No nested accordions.** An Accordion.Content can contain another Accordion if the consumer wants, but no special API. Nested Accordions just work.
+- **No animation customization** (no `duration`/`easing` props). One animation curve (200ms ease-out) covers the standard use case. Override via CSS if needed.
+- **No "filled" / "outline" visual variants.** One look: bordered list with chevron indicator. Solid/outline cosmetic variants can be added v2.
+- **No header-actions slot** (e.g., a button in the header row next to the trigger label). The trigger IS the whole row; consumers needing actions in the header can compose differently.
+- **No "always open" item lock.** If a consumer wants an item to be uncloseable, they manage state externally.
+- **No drag-to-reorder.** Accordion is for display, not editing.
+- **No URL state sync.** Consumers wire that up themselves via the controlled `value`/`onValueChange` props.
+
+## Architecture
+
+### Dependencies
+
+No new packages. Reuses:
+
+- React (peer)
+- `clsx` (existing dep)
+- `lucide-react` peer dep — `ChevronDown` for the default trigger indicator
+- Existing tokens: `--color-fg`, `--color-fg-muted`, `--color-bg`, `--color-bg-muted`, `--color-border`, `--border-width`, `--radius-md`, `--space-1`/`--space-2`/`--space-3`/`--space-4`, `--font-size-md`, `--font-weight-medium`, `--transition-fast`, `--transition-base`, `--ring-accent`, `--ring-width`, `--opacity-disabled`
+
+No new tokens. Animation duration baked into the component (200ms ease-out for the grid-row transition).
+
+### File layout
+
+```
+packages/design-system/src/components/Accordion/
+  Accordion.tsx           ← Root component + Object.assign for compound API. Owns the value state + dispatches.
+  AccordionItem.tsx       ← Wrapper with item-level context (value, disabled, isOpen).
+  AccordionTrigger.tsx    ← Heading-wrapped button (h2/h3/h4 based on item's headerLevel). Icon + chevron.
+  AccordionContent.tsx    ← Animated panel using grid-template-rows: 0fr → 1fr.
+  context.ts              ← AccordionContext (mode/value/onChange/registerItem) + AccordionItemContext (value/disabled/isOpen).
+  Accordion.module.scss   ← Borders / triggers / content / animation / disabled / focus-visible.
+  Accordion.test.tsx      ← ~24 cases.
+  index.ts                ← Public re-exports.
+```
+
+Plus integration points:
+
+- `packages/design-system/src/index.ts` — re-export `Accordion`, `AccordionProps`, `AccordionItemProps`, `AccordionTriggerProps`, `AccordionContentProps`
+- `packages/design-system/AGENTS.md` — TL;DR slot near `<Tabs>` (navigation cluster)
+- `packages/playground/src/pages/components/AccordionDemo.tsx` — 6 examples
+- `packages/playground/src/App.tsx` — route at `/components/accordion`
+- `packages/playground/src/layout/AppShell/AppShell.tsx` — sidebar entry in the **Navigation** group, alphabetical first (before `Breadcrumb`)
+- `packages/playground/src/pages/components/ComponentsIndex.tsx` — overview card
+- `packages/playground/src/pages/mockups/registry.ts` — `'Accordion'` in `ComponentName` union (alphabetical first)
+
+### Composition
+
+```
+        <Accordion type="single" defaultValue="faq-2">
+          <Accordion.Item value="faq-1">
+            <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>
+            <Accordion.Content>Visit the settings page → Security → Reset password.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="faq-2">
+            <Accordion.Trigger>How do I export my data?</Accordion.Trigger>
+            <Accordion.Content>Use the gear icon → Export → CSV.</Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+                          │
+                          ▼
+                <div role="region" class="accordion" data-mode="single">
+                  <div class="item">
+                    <h3 class="header">
+                      <button class="trigger" aria-expanded="false" aria-controls="content-faq-1" id="trigger-faq-1">
+                        How do I reset my password?
+                        <ChevronDown class="indicator" />
+                      </button>
+                    </h3>
+                    <div id="content-faq-1" role="region" aria-labelledby="trigger-faq-1" class="content" data-state="closed">
+                      <div class="inner">Visit the settings page → ...</div>
+                    </div>
+                  </div>
+                  ... (item 2 with aria-expanded="true" / data-state="open")
+                </div>
+```
+
+The root `<div>` doesn't have a role by default — accordion's container is just a list of headings + panels. Heading + button pairs carry the semantic.
+
+### Compound assembly
+
+```ts
+export const Accordion = Object.assign(AccordionRoot, {
+  Item: AccordionItem,
+  Trigger: AccordionTrigger,
+  Content: AccordionContent,
+});
+```
+
+## Public API
+
+```ts
+import type { ChangeEvent, HTMLAttributes, ReactNode } from 'react';
+
+/** Selection mode. */
+export type AccordionMode = 'single' | 'multiple';
+
+/** Heading level wrapping the trigger button. WAI-ARIA APG requires triggers
+ *  to live inside a heading. Defaults to 'h3'. */
+export type AccordionHeaderLevel = 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+/** Root props — `type='single'` variant. */
+interface AccordionSingleProps {
+  type: 'single';
+  /**
+   * Controlled open item value. Pair with `onValueChange`. Use empty string
+   * (`''`) to indicate nothing open (collapsible mode only).
+   */
+  value?: string;
+  /** Initial open item for uncontrolled use. `''` = nothing open. */
+  defaultValue?: string;
+  /** Fires when the open item changes. */
+  onValueChange?: (next: string) => void;
+  /**
+   * When true, clicking the currently-open item closes it (no item open).
+   * When false, the user must open a different item to close the current one.
+   * Default: `false` (Radix's default — prevents accidentally closing the
+   * only available content).
+   */
+  collapsible?: boolean;
+}
+
+/** Root props — `type='multiple'` variant. */
+interface AccordionMultipleProps {
+  type: 'multiple';
+  /** Controlled open items array. Pair with `onValueChange`. */
+  value?: string[];
+  /** Initial open items for uncontrolled use. */
+  defaultValue?: string[];
+  /** Fires when the set of open items changes. */
+  onValueChange?: (next: string[]) => void;
+  collapsible?: never; // not applicable in multi-mode
+}
+
+interface AccordionBaseProps extends Omit<HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
+  children: ReactNode;
+}
+
+/** Discriminated union — `type` drives which variant of value/onValueChange is required. */
+export type AccordionProps = AccordionBaseProps & (AccordionSingleProps | AccordionMultipleProps);
+
+export interface AccordionItemProps extends Omit<HTMLAttributes<HTMLDivElement>, 'value'> {
+  /** Unique value used to identify the item in `value`/`defaultValue`/`onValueChange`. */
+  value: string;
+  /** When true, the trigger is non-interactive and keyboard nav skips this item. */
+  disabled?: boolean;
+  /**
+   * Heading level wrapping the trigger. WAI-ARIA APG requires triggers to
+   * live inside a heading element. Defaults to `'h3'`.
+   *
+   * Pick the level that fits the surrounding page heading hierarchy — e.g.,
+   * if the section above the accordion is an `<h2>`, set `headerLevel="h3"`
+   * (the default). If the accordion is at the top of a page, use `h2`.
+   */
+  headerLevel?: AccordionHeaderLevel;
+  children: ReactNode;
+}
+
+export interface AccordionTriggerProps extends Omit<HTMLAttributes<HTMLButtonElement>, 'children'> {
+  /**
+   * Override the default trigger indicator icon (rotates 180° when open).
+   * Pass `null` to suppress the icon entirely. Default: `<ChevronDown />`.
+   */
+  icon?: ReactNode | null;
+  children: ReactNode;
+}
+
+export interface AccordionContentProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+```
+
+**Spread order — Pattern B** (component owns ARIA contract):
+
+```tsx
+<button
+  {...props}
+  type="button"
+  aria-expanded={isOpen}
+  aria-controls={contentId}
+  id={triggerId}
+  disabled={disabled}
+  onClick={handleClick}
+  onKeyDown={handleKeyDown}
+  className={clsx(styles.trigger, className)}
+>
+```
+
+Component-owned attrs that consumer CAN'T override: `type`, `aria-expanded`, `aria-controls`, `id`, `disabled` (derived from item-level disabled), `onClick`, `onKeyDown`.
+
+## Architecture flow
+
+### Root state machine
+
+The root component owns the value state. For `type='single'`, value is `string` (current open item or `''` for none). For `type='multiple'`, value is `string[]` (open items).
+
+```tsx
+function AccordionRoot(props: AccordionProps) {
+  if (props.type === 'single') {
+    return <AccordionSingleImpl {...props} />;
+  }
+  return <AccordionMultipleImpl {...props} />;
+}
+```
+
+Each impl wraps in `AccordionContext.Provider` with:
+- `mode: 'single' | 'multiple'`
+- `isOpen(value: string): boolean`
+- `toggle(value: string): void`
+- `triggerIds: Map<string, string>` for the registered item triggers (for keyboard nav target lookup)
+- `registerItem(value: string): () => void` — items register on mount so the keyboard handler can iterate
+
+### Item registration + keyboard nav
+
+Each `<Accordion.Item>` registers its value with the root on mount via `useEffect`. The root maintains the registration order (insertion order via Array). Keyboard nav (ArrowDown/Up, Home/End) iterates this array.
+
+Actually — registration via context is overkill if we use DOM order. Simpler approach: keyboard handler queries `document.activeElement.closest('[data-accordion]')` and then `querySelectorAll('button.trigger:not(:disabled)')` to find siblings in DOM order. Matches the recent ButtonGroup precedent. **Going with DOM-order querying** (no registration).
+
+### Item-level open detection
+
+Each `<Accordion.Item>` reads from `AccordionContext.isOpen(value)`. The Item provides an `AccordionItemContext`:
+- `value: string`
+- `disabled: boolean`
+- `isOpen: boolean`
+- `triggerId: string` (e.g., `accordion-trigger-{value}`)
+- `contentId: string` (e.g., `accordion-content-{value}`)
+
+`useId()` generates a base id per Item; trigger/content ids are derived.
+
+### Trigger
+
+The Trigger consumes both contexts. Renders:
+
+```tsx
+const Heading = headerLevel; // 'h2' | 'h3' | ...
+
+return (
+  <Heading className={styles.header}>
+    <button
+      type="button"
+      ref={ref}
+      {...props}
+      id={triggerId}
+      aria-expanded={isOpen}
+      aria-controls={contentId}
+      disabled={disabled}
+      onClick={() => toggle(value)}
+      onKeyDown={handleKeyDown}
+      className={clsx(styles.trigger, className)}
+    >
+      <span className={styles.label}>{children}</span>
+      {renderedIcon}
+    </button>
+  </Heading>
+);
+```
+
+`renderedIcon = icon === null ? null : (icon ?? <ChevronDown size={16} className={styles.indicator} aria-hidden />)`. The `.indicator` class rotates 180° when the item is open (driven by `data-state` on the Item wrapper).
+
+### Content (animated panel)
+
+Uses the modern CSS grid-template-rows technique:
+
+```scss
+.content {
+  display: grid;
+  grid-template-rows: 0fr; // closed
+  transition: grid-template-rows 200ms ease-out;
+}
+
+.content[data-state='open'] {
+  grid-template-rows: 1fr;
+}
+
+.inner {
+  overflow: hidden;
+}
+```
+
+Wrapping the content in an `.inner` div with `overflow: hidden` ensures the closed state hides the content (height 0 from `0fr`). The animation transitions smoothly between 0fr and 1fr — works for arbitrary content height without JS measurement.
+
+```tsx
+<div
+  ref={ref}
+  {...props}
+  id={contentId}
+  role="region"
+  aria-labelledby={triggerId}
+  data-state={isOpen ? 'open' : 'closed'}
+  hidden={!isOpen && /* let CSS animation finish first */ false}
+  className={clsx(styles.content, className)}
+>
+  <div className={styles.inner}>
+    {children}
+  </div>
+</div>
+```
+
+Note on `hidden`: ideally, when fully closed (post-animation), the panel should have `hidden` set so screen readers skip it AND it's removed from the tab order. But applying `hidden` immediately on close would skip the animation. Two options:
+1. Use a transitionend listener to set hidden after animation
+2. Skip the hidden attribute — rely on `aria-expanded="false"` on the trigger to convey "this panel is closed"
+
+Going with option 2 (skip `hidden`). The grid-template-rows: 0fr already makes the content unfocusable (zero height + overflow: hidden in the inner wrapper). `aria-expanded="false"` on the trigger handles the AT side. Cleaner, no transitionend plumbing.
+
+### Keyboard handling
+
+Per WAI-ARIA APG:
+- **Space / Enter** on trigger → toggle (handled by native button)
+- **ArrowDown** → focus next non-disabled trigger (DOM order, wraps to first)
+- **ArrowUp** → focus previous non-disabled trigger (wraps to last)
+- **Home** → focus first non-disabled trigger
+- **End** → focus last non-disabled trigger
+- **Tab** → moves out of the accordion (out of group); browsers handle natively
+
+```tsx
+const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+  const isNav = ['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(e.key);
+  if (!isNav) return;
+  e.preventDefault();
+
+  const root = (e.currentTarget as HTMLElement).closest('[data-accordion]');
+  if (!root) return;
+
+  const triggers = Array.from(
+    root.querySelectorAll<HTMLButtonElement>('button[aria-expanded]:not(:disabled)')
+  );
+  if (triggers.length === 0) return;
+
+  const current = triggers.indexOf(e.currentTarget as HTMLButtonElement);
+  let next = current;
+
+  if (e.key === 'ArrowDown') next = (current + 1) % triggers.length;
+  else if (e.key === 'ArrowUp') next = (current - 1 + triggers.length) % triggers.length;
+  else if (e.key === 'Home') next = 0;
+  else if (e.key === 'End') next = triggers.length - 1;
+
+  triggers[next]?.focus();
+};
+```
+
+The `data-accordion` attribute on the root limits the keyboard handler to siblings within the same accordion (in case multiple accordions live on a page).
+
+### Single + collapsible interaction
+
+For `type='single'`:
+
+```tsx
+function toggle(itemValue: string) {
+  if (mode === 'single') {
+    if (value === itemValue) {
+      // currently open — close iff collapsible
+      if (collapsible) onValueChange?.('');
+    } else {
+      // open this item (and close any other)
+      onValueChange?.(itemValue);
+    }
+  } else {
+    // multiple — toggle membership
+    const next = value.includes(itemValue)
+      ? value.filter((v) => v !== itemValue)
+      : [...value, itemValue];
+    onValueChange?.(next);
+  }
+}
+```
+
+Internal-controlled mirror handles the uncontrolled case (same pattern as Textarea/Switch/Toast).
+
+## Styling — `Accordion.module.scss`
+
+```scss
+@use '../../styles/mixins' as *;
+
+.accordion {
+  display: flex;
+  flex-direction: column;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  overflow: hidden;
+}
+
+.item {
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.item:last-child {
+  border-bottom: 0;
+}
+
+.header {
+  // Reset native heading margin/font-weight — the heading element is purely
+  // semantic; visual styling lives on .trigger.
+  // stylelint-disable-next-line property-disallowed-list -- native heading margin reset
+  margin: 0;
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-md);
+}
+
+.trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  background: transparent;
+  border: 0;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  color: var(--color-fg);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition-fast);
+
+  &:hover:not(:disabled) {
+    background: var(--color-bg-muted);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+
+    outline: none;
+    // Move the ring inside since the trigger is full-width.
+    box-shadow: inset 0 0 0 var(--ring-width) var(--ring-accent);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: var(--opacity-disabled);
+  }
+}
+
+.label {
+  flex: 1;
+  min-width: 0; // allow long labels to wrap inside flex
+}
+
+.indicator {
+  flex-shrink: 0;
+  transition: transform var(--transition-fast);
+  color: var(--color-fg-muted);
+}
+
+// When the item is open, rotate the indicator 180°.
+.item[data-state='open'] .indicator {
+  transform: rotate(180deg);
+}
+
+.content {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--transition-base);
+}
+
+.content[data-state='open'] {
+  grid-template-rows: 1fr;
+}
+
+.inner {
+  overflow: hidden;
+}
+
+.content[data-state='open'] .inner {
+  // Reserve some padding around the content when open.
+  padding: var(--space-3) var(--space-4);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .content,
+  .indicator {
+    transition: none;
+  }
+}
+```
+
+**Rule 4 check**:
+- `.accordion` has `display: flex` — internal layout of its own children (Items), not at the component boundary. Allowed.
+- `.header` has `margin: 0` (native heading reset) — inline-disabled with rationale.
+- `.trigger` has `padding` — internal styling, not layout. Allowed.
+- `.content` uses `display: grid; grid-template-rows: 0fr/1fr` — internal animation mechanic, not at the component boundary.
+- `.inner` has `padding` (when content open) — internal child spacing.
+
+The `box-shadow: inset` on the trigger's focus ring is a deliberate choice — the trigger is `width: 100%` inside a bordered list, so an outer ring would clip against the accordion's border-radius. Inset ring works cleanly.
+
+## ARIA + behavior reference
+
+| Concern | Behavior |
+|---|---|
+| **Root element** | `<div data-accordion>` — no `role` (the heading+button+region triple carries semantics). |
+| **Item element** | `<div data-state="open"|"closed">` — drives the chevron rotation + content state. |
+| **Heading wrapper** | `<h2>`/`<h3>`/`<h4>` (consumer-configurable). Defaults to `<h3>`. |
+| **Trigger** | `<button type="button" aria-expanded={open} aria-controls={contentId} id={triggerId}>`. |
+| **Content panel** | `<div role="region" aria-labelledby={triggerId} id={contentId} data-state="open"|"closed">`. |
+| **Disabled item** | `disabled` attr on the trigger; keyboard nav skips via `:not(:disabled)` selector. |
+| **Keyboard** | Space/Enter toggle (native); ArrowDown/Up/Home/End for trigger-to-trigger nav. Tab moves out (native). |
+| **Reduced motion** | `prefers-reduced-motion: reduce` disables grid + indicator transitions. |
+| **Focus ring** | Inset box-shadow (the trigger is full-width inside the accordion's border). |
+
+## Testing
+
+`Accordion.test.tsx` — ~24 cases.
+
+### Rendering + structure
+
+1. Renders without crashing with minimal compound markup
+2. Items render in DOM order
+3. Trigger is wrapped in the default `<h3>` heading
+4. `headerLevel="h2"` wraps the trigger in `<h2>`
+5. `aria-controls` on trigger matches `id` on content panel
+6. `aria-labelledby` on content panel matches `id` on trigger
+7. Default state: no item open (`type='single'` with no `defaultValue`); all `aria-expanded="false"`
+
+### State (single mode)
+
+8. `defaultValue="item-1"` opens item-1 on initial render
+9. Clicking a closed item opens it AND closes any previously open item
+10. `collapsible={false}` (default): clicking the open item does NOT close it
+11. `collapsible={true}`: clicking the open item closes it (no item open)
+12. Controlled: `value` + `onValueChange` round-trip; `onValueChange` fires with the next string
+
+### State (multiple mode)
+
+13. `defaultValue={['a','b']}` opens both items
+14. Clicking a closed item adds it to the open set
+15. Clicking an open item removes it from the open set
+16. Controlled: `value` + `onValueChange` round-trip; `onValueChange` fires with the next array
+
+### Disabled
+
+17. `disabled` Item's trigger has the `disabled` attribute
+18. Clicking a disabled trigger does NOT toggle the item
+
+### Keyboard
+
+19. ArrowDown from the first trigger focuses the second
+20. ArrowUp from the second trigger focuses the first
+21. ArrowDown wraps from last to first
+22. Home focuses the first non-disabled trigger
+23. End focuses the last non-disabled trigger
+24. ArrowDown skips disabled items
+
+### Misc
+
+25. Custom `icon` on Trigger replaces the default ChevronDown
+26. `icon={null}` hides the indicator entirely
+
+**Vitest gotchas**:
+- The keyboard test queries triggers via `button[aria-expanded]:not(:disabled)`. Verify the selector matches what the component renders.
+- `userEvent.tab()` won't trigger the ArrowDown handler — use `await user.keyboard('{ArrowDown}')` while a trigger is focused.
+
+## Playground demo — `AccordionDemo.tsx`
+
+6 examples:
+
+1. **Single, collapsible (FAQ-style)** — 3 items, only one open at a time, clicking the open one closes it.
+2. **Multiple (independent sections)** — 4 items, any combination can be open.
+3. **Controlled** — `useState` wired to the value; show "Currently open: X" elsewhere on the page.
+4. **Disabled item** — 3 items, middle one disabled.
+5. **Custom icon (Plus)** — replaces the default ChevronDown.
+6. **Heading levels** — three side-by-side Accordions with `headerLevel="h2"`, `h3` (default), and `h4` to demonstrate the prop.
+
+## AGENTS.md TL;DR slot
+
+After `### <Tabs>` (around line 455), before `### <Breadcrumb>` (around line 479). Navigation cluster.
+
+```markdown
+### `<Accordion>` — vertically-stacked collapsible panels
+
+Compound component for FAQ-style content, settings sections, and any case where you have a list of headings with optional drill-down detail. Two modes: `single` (one open at a time) or `multiple` (any combination).
+
+```tsx
+import { Accordion } from '@eocrm/design-system';
+
+// Single-open with collapsible (FAQ-style)
+<Accordion type="single" collapsible defaultValue="faq-2">
+  <Accordion.Item value="faq-1">
+    <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>
+    <Accordion.Content>Visit Settings → Security → Reset.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="faq-2">
+    <Accordion.Trigger>How do I export my data?</Accordion.Trigger>
+    <Accordion.Content>Use the gear icon → Export → CSV.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>
+
+// Multiple — independent sections
+<Accordion type="multiple" defaultValue={['account', 'notifications']}>
+  <Accordion.Item value="account">...</Accordion.Item>
+  <Accordion.Item value="notifications">...</Accordion.Item>
+</Accordion>
+
+// Disabled item
+<Accordion.Item value="advanced" disabled>...</Accordion.Item>
+
+// Controlled
+<Accordion type="single" value={open} onValueChange={setOpen}>...</Accordion>
+```
+
+- **`type="single"`** + `collapsible={true}` — one item open at a time, click to close.
+- **`type="multiple"`** — any combination.
+- **Smooth animation** via CSS `grid-template-rows: 0fr → 1fr`. No JS measurement.
+- **Heading wrapping** — Trigger is wrapped in `<h3>` by default per WAI-ARIA APG. Override via `headerLevel` on Item.
+- **Keyboard**: Arrow Down/Up cycles between triggers, Home/End jumps to ends, Space/Enter toggles. Disabled items are skipped.
+
+#### When NOT to use
+
+- ❌ Mutually-exclusive view switchers → `<Tabs>` (tabs imply parallel content; accordions imply hierarchy).
+- ❌ A simple show/hide toggle for a single section → use a `<Button>` + conditional render. Accordion is for ≥2 sections.
+- ❌ Step-by-step wizard flows → a dedicated Stepper (not shipped). Accordion is for parallel sections, not sequential ones.
+
+#### Anti-patterns
+
+- ❌ Nesting `<Accordion.Trigger>` inside a heading the consumer also renders manually. Trigger ALREADY wraps itself in a heading.
+- ❌ Setting `aria-expanded` manually on the Trigger via `{...props}`. The component owns the ARIA contract.
+- ❌ Using `headerLevel="h1"`. There should only be one `<h1>` per page; Accordion lives below it.
+```
+
+## Hard Rule 8
+
+The pre-push review-fix cycle on library changes is mandatory. Gates green, fresh-context reviewer, fix Critical + Important, repeat until clean.
+
+## Open questions
+
+None. All clarifications baked in.

--- a/docs/superpowers/specs/2026-05-23-accordion-design.md
+++ b/docs/superpowers/specs/2026-05-23-accordion-design.md
@@ -149,7 +149,10 @@ interface AccordionMultipleProps {
   collapsible?: never; // not applicable in multi-mode
 }
 
-interface AccordionBaseProps extends Omit<HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
+interface AccordionBaseProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'defaultValue' | 'onChange'
+> {
   children: ReactNode;
 }
 
@@ -221,6 +224,7 @@ function AccordionRoot(props: AccordionProps) {
 ```
 
 Each impl wraps in `AccordionContext.Provider` with:
+
 - `mode: 'single' | 'multiple'`
 - `isOpen(value: string): boolean`
 - `toggle(value: string): void`
@@ -236,6 +240,7 @@ Actually — registration via context is overkill if we use DOM order. Simpler a
 ### Item-level open detection
 
 Each `<Accordion.Item>` reads from `AccordionContext.isOpen(value)`. The Item provides an `AccordionItemContext`:
+
 - `value: string`
 - `disabled: boolean`
 - `isOpen: boolean`
@@ -307,13 +312,12 @@ Wrapping the content in an `.inner` div with `overflow: hidden` ensures the clos
   hidden={!isOpen && /* let CSS animation finish first */ false}
   className={clsx(styles.content, className)}
 >
-  <div className={styles.inner}>
-    {children}
-  </div>
+  <div className={styles.inner}>{children}</div>
 </div>
 ```
 
 Note on `hidden`: ideally, when fully closed (post-animation), the panel should have `hidden` set so screen readers skip it AND it's removed from the tab order. But applying `hidden` immediately on close would skip the animation. Two options:
+
 1. Use a transitionend listener to set hidden after animation
 2. Skip the hidden attribute — rely on `aria-expanded="false"` on the trigger to convey "this panel is closed"
 
@@ -322,6 +326,7 @@ Going with option 2 (skip `hidden`). The grid-template-rows: 0fr already makes t
 ### Keyboard handling
 
 Per WAI-ARIA APG:
+
 - **Space / Enter** on trigger → toggle (handled by native button)
 - **ArrowDown** → focus next non-disabled trigger (DOM order, wraps to first)
 - **ArrowUp** → focus previous non-disabled trigger (wraps to last)
@@ -339,7 +344,7 @@ const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
   if (!root) return;
 
   const triggers = Array.from(
-    root.querySelectorAll<HTMLButtonElement>('button[aria-expanded]:not(:disabled)')
+    root.querySelectorAll<HTMLButtonElement>('button[aria-expanded]:not(:disabled)'),
   );
   if (triggers.length === 0) return;
 
@@ -492,6 +497,7 @@ Internal-controlled mirror handles the uncontrolled case (same pattern as Textar
 ```
 
 **Rule 4 check**:
+
 - `.accordion` has `display: flex` — internal layout of its own children (Items), not at the component boundary. Allowed.
 - `.header` has `margin: 0` (native heading reset) — inline-disabled with rationale.
 - `.trigger` has `padding` — internal styling, not layout. Allowed.
@@ -502,17 +508,17 @@ The `box-shadow: inset` on the trigger's focus ring is a deliberate choice — t
 
 ## ARIA + behavior reference
 
-| Concern | Behavior |
-|---|---|
-| **Root element** | `<div data-accordion>` — no `role` (the heading+button+region triple carries semantics). |
-| **Item element** | `<div data-state="open"|"closed">` — drives the chevron rotation + content state. |
-| **Heading wrapper** | `<h2>`/`<h3>`/`<h4>` (consumer-configurable). Defaults to `<h3>`. |
-| **Trigger** | `<button type="button" aria-expanded={open} aria-controls={contentId} id={triggerId}>`. |
-| **Content panel** | `<div role="region" aria-labelledby={triggerId} id={contentId} data-state="open"|"closed">`. |
-| **Disabled item** | `disabled` attr on the trigger; keyboard nav skips via `:not(:disabled)` selector. |
-| **Keyboard** | Space/Enter toggle (native); ArrowDown/Up/Home/End for trigger-to-trigger nav. Tab moves out (native). |
-| **Reduced motion** | `prefers-reduced-motion: reduce` disables grid + indicator transitions. |
-| **Focus ring** | Inset box-shadow (the trigger is full-width inside the accordion's border). |
+| Concern             | Behavior                                                                                               |
+| ------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| **Root element**    | `<div data-accordion>` — no `role` (the heading+button+region triple carries semantics).               |
+| **Item element**    | `<div data-state="open"                                                                                | "closed">` — drives the chevron rotation + content state. |
+| **Heading wrapper** | `<h2>`/`<h3>`/`<h4>` (consumer-configurable). Defaults to `<h3>`.                                      |
+| **Trigger**         | `<button type="button" aria-expanded={open} aria-controls={contentId} id={triggerId}>`.                |
+| **Content panel**   | `<div role="region" aria-labelledby={triggerId} id={contentId} data-state="open"                       | "closed">`.                                               |
+| **Disabled item**   | `disabled` attr on the trigger; keyboard nav skips via `:not(:disabled)` selector.                     |
+| **Keyboard**        | Space/Enter toggle (native); ArrowDown/Up/Home/End for trigger-to-trigger nav. Tab moves out (native). |
+| **Reduced motion**  | `prefers-reduced-motion: reduce` disables grid + indicator transitions.                                |
+| **Focus ring**      | Inset box-shadow (the trigger is full-width inside the accordion's border).                            |
 
 ## Testing
 
@@ -563,6 +569,7 @@ The `box-shadow: inset` on the trigger's focus ring is a deliberate choice — t
 26. `icon={null}` hides the indicator entirely
 
 **Vitest gotchas**:
+
 - The keyboard test queries triggers via `button[aria-expanded]:not(:disabled)`. Verify the selector matches what the component renders.
 - `userEvent.tab()` won't trigger the ArrowDown handler — use `await user.keyboard('{ArrowDown}')` while a trigger is focused.
 
@@ -581,7 +588,7 @@ The `box-shadow: inset` on the trigger's focus ring is a deliberate choice — t
 
 After `### <Tabs>` (around line 455), before `### <Breadcrumb>` (around line 479). Navigation cluster.
 
-```markdown
+````markdown
 ### `<Accordion>` — vertically-stacked collapsible panels
 
 Compound component for FAQ-style content, settings sections, and any case where you have a list of headings with optional drill-down detail. Two modes: `single` (one open at a time) or `multiple` (any combination).
@@ -613,6 +620,7 @@ import { Accordion } from '@eocrm/design-system';
 // Controlled
 <Accordion type="single" value={open} onValueChange={setOpen}>...</Accordion>
 ```
+````
 
 - **`type="single"`** + `collapsible={true}` — one item open at a time, click to close.
 - **`type="multiple"`** — any combination.
@@ -631,6 +639,7 @@ import { Accordion } from '@eocrm/design-system';
 - ❌ Nesting `<Accordion.Trigger>` inside a heading the consumer also renders manually. Trigger ALREADY wraps itself in a heading.
 - ❌ Setting `aria-expanded` manually on the Trigger via `{...props}`. The component owns the ARIA contract.
 - ❌ Using `headerLevel="h1"`. There should only be one `<h1>` per page; Accordion lives below it.
+
 ```
 
 ## Hard Rule 8
@@ -640,3 +649,4 @@ The pre-push review-fix cycle on library changes is mandatory. Gates green, fres
 ## Open questions
 
 None. All clarifications baked in.
+```

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -552,6 +552,8 @@ import { Accordion } from '@eocrm/design-system';
 
 - **`type="single"`** + `collapsible={true}` — one item open at a time, click to close.
 - **`type="multiple"`** — any combination.
+- **`variant`** — `"bordered"` (default; outer border + radius + item dividers) or `"borderless"` (no chrome; for nesting inside Cards or as a quiet section divider).
+- **`size`** — `"sm"` / `"md"` (default) / `"lg"` controls trigger font-size + padding (and content padding).
 - **Smooth animation** via CSS `grid-template-rows: 0fr → 1fr`. No JS measurement.
 - **Heading wrapping** — Trigger is wrapped in `<h3>` by default per WAI-ARIA APG. Override via `headerLevel` on Item.
 - **Keyboard**: ArrowDown/Up cycles between triggers, Home/End jumps to ends, Space/Enter toggles. Disabled items are skipped.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -518,6 +518,56 @@ const [tab, setTab] = useState('overview');
 - `panelIdPrefix`: optional. When set, each tab gets `aria-controls="${prefix}-${itemId}-panel"`. Set this if you render the panels in the DOM and want assistive tech to follow the link.
 - The active-tab underline slides between tabs when `activeId` changes. Respects `prefers-reduced-motion: reduce`.
 
+### `<Accordion>` — vertically-stacked collapsible panels
+
+Compound component for FAQ-style content, settings sections, and any case where you have a list of headings with optional drill-down detail. Two modes: `single` (one open at a time) or `multiple` (any combination).
+
+```tsx
+import { Accordion } from '@eocrm/design-system';
+
+// Single-open with collapsible (FAQ-style)
+<Accordion type="single" collapsible defaultValue="faq-2">
+  <Accordion.Item value="faq-1">
+    <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>
+    <Accordion.Content>Visit Settings → Security → Reset.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="faq-2">
+    <Accordion.Trigger>How do I export my data?</Accordion.Trigger>
+    <Accordion.Content>Use the gear icon → Export → CSV.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>
+
+// Multiple — independent sections
+<Accordion type="multiple" defaultValue={['account', 'notifications']}>
+  <Accordion.Item value="account">...</Accordion.Item>
+  <Accordion.Item value="notifications">...</Accordion.Item>
+</Accordion>
+
+// Disabled item
+<Accordion.Item value="advanced" disabled>...</Accordion.Item>
+
+// Controlled
+<Accordion type="single" value={open} onValueChange={setOpen}>...</Accordion>
+```
+
+- **`type="single"`** + `collapsible={true}` — one item open at a time, click to close.
+- **`type="multiple"`** — any combination.
+- **Smooth animation** via CSS `grid-template-rows: 0fr → 1fr`. No JS measurement.
+- **Heading wrapping** — Trigger is wrapped in `<h3>` by default per WAI-ARIA APG. Override via `headerLevel` on Item.
+- **Keyboard**: ArrowDown/Up cycles between triggers, Home/End jumps to ends, Space/Enter toggles. Disabled items are skipped.
+
+#### When NOT to use
+
+- ❌ Mutually-exclusive view switchers → `<Tabs>` (tabs imply parallel content; accordions imply hierarchy).
+- ❌ A simple show/hide toggle for a single section → use a `<Button>` + conditional render.
+- ❌ Step-by-step wizard flows → a dedicated Stepper (not shipped).
+
+#### Anti-patterns
+
+- ❌ Nesting `<Accordion.Trigger>` inside a heading the consumer also renders manually. Trigger ALREADY wraps itself in a heading.
+- ❌ Setting `aria-expanded` manually on the Trigger via `{...props}`. The component owns the ARIA contract.
+- ❌ Using `headerLevel="h1"`. There should only be one `<h1>` per page; Accordion lives below it.
+
 ### `<Breadcrumb>` — navigation trail
 
 Compound (Breadcrumb.Item) navigation breadcrumb. Last child is auto-marked as the current page (`<span aria-current="page">`); non-last items are muted Links. Default separator is a ChevronRight icon.

--- a/packages/design-system/src/components/Accordion/Accordion.module.scss
+++ b/packages/design-system/src/components/Accordion/Accordion.module.scss
@@ -9,11 +9,24 @@
   overflow: hidden;
 }
 
+// Borderless variant: strip the outer chrome. Item dividing lines also
+// disappear so the accordion blends into the surrounding container.
+.accordion[data-variant='borderless'] {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  overflow: visible;
+}
+
 .item {
   border-bottom: var(--border-width) solid var(--color-border);
 }
 
 .item:last-child {
+  border-bottom: 0;
+}
+
+.accordion[data-variant='borderless'] .item {
   border-bottom: 0;
 }
 
@@ -29,6 +42,8 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
+
+  // Default padding belongs to size='md'; the per-size rules below override.
   padding: var(--space-3) var(--space-4);
   background: transparent;
   border: 0;
@@ -98,7 +113,55 @@
 }
 
 .content[data-state='open'] .inner {
+  // Default content padding belongs to size='md'; the per-size rules below
+  // override.
   padding: var(--space-3) var(--space-4);
+}
+
+// ─── Size variants ─────────────────────────────────────────────────────
+// Drive both the trigger padding+font-size and the content padding from a
+// single data-size on the root. .header also inherits font-size for the
+// heading element.
+
+.accordion[data-size='sm'] .header {
+  font-size: var(--font-size-sm);
+}
+
+.accordion[data-size='sm'] .trigger {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-sm);
+}
+
+.accordion[data-size='sm'] .content[data-state='open'] .inner {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-sm);
+}
+
+.accordion[data-size='md'] .header {
+  font-size: var(--font-size-md);
+}
+
+.accordion[data-size='md'] .trigger {
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--font-size-md);
+}
+
+.accordion[data-size='md'] .content[data-state='open'] .inner {
+  padding: var(--space-3) var(--space-4);
+}
+
+.accordion[data-size='lg'] .header {
+  font-size: var(--font-size-lg);
+}
+
+.accordion[data-size='lg'] .trigger {
+  padding: var(--space-4) var(--space-5);
+  font-size: var(--font-size-lg);
+}
+
+.accordion[data-size='lg'] .content[data-state='open'] .inner {
+  padding: var(--space-4) var(--space-5);
+  font-size: var(--font-size-md);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/design-system/src/components/Accordion/Accordion.module.scss
+++ b/packages/design-system/src/components/Accordion/Accordion.module.scss
@@ -74,6 +74,14 @@
   display: grid;
   grid-template-rows: 0fr;
   transition: grid-template-rows var(--transition-base);
+
+  // Hint to the browser that grid-template-rows will animate, AND that this
+  // subtree's layout can be isolated from siblings (it can — only the
+  // accordion item itself reads .content's height). Same spirit as Drawer's
+  // will-change: transform hint — give the browser advance notice so it
+  // doesn't recompute layout from scratch on every frame.
+  will-change: grid-template-rows;
+  contain: layout style;
 }
 
 .content[data-state='open'] {
@@ -82,6 +90,11 @@
 
 .inner {
   overflow: hidden;
+
+  // Promote to its own compositor layer. Combined with the parent's
+  // will-change + contain hints, this keeps the row-resize animation off
+  // the main-layout path and on the compositor.
+  transform: translateZ(0);
 }
 
 .content[data-state='open'] .inner {

--- a/packages/design-system/src/components/Accordion/Accordion.module.scss
+++ b/packages/design-system/src/components/Accordion/Accordion.module.scss
@@ -1,0 +1,96 @@
+@use '../../styles/mixins' as *;
+
+.accordion {
+  display: flex;
+  flex-direction: column;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  overflow: hidden;
+}
+
+.item {
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.item:last-child {
+  border-bottom: 0;
+}
+
+.header {
+  // stylelint-disable-next-line property-disallowed-list -- native heading margin reset
+  margin: 0;
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-md);
+}
+
+.trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  background: transparent;
+  border: 0;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  color: var(--color-fg);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition-fast);
+
+  &:hover:not(:disabled) {
+    background: var(--color-bg-muted);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 var(--ring-width) var(--ring-accent);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: var(--opacity-disabled);
+  }
+}
+
+.label {
+  flex: 1;
+  min-width: 0;
+}
+
+.indicator {
+  flex-shrink: 0;
+  transition: transform var(--transition-fast);
+  color: var(--color-fg-muted);
+}
+
+.item[data-state='open'] .indicator {
+  transform: rotate(180deg);
+}
+
+.content {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--transition-base);
+}
+
+.content[data-state='open'] {
+  grid-template-rows: 1fr;
+}
+
+.inner {
+  overflow: hidden;
+}
+
+.content[data-state='open'] .inner {
+  padding: var(--space-3) var(--space-4);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .content,
+  .indicator {
+    transition: none;
+  }
+}

--- a/packages/design-system/src/components/Accordion/Accordion.test.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.test.tsx
@@ -1,0 +1,392 @@
+import { useState } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Plus } from 'lucide-react';
+import { Accordion } from './Accordion';
+
+function BasicSingle({
+  collapsible = false,
+  defaultValue,
+}: {
+  collapsible?: boolean;
+  defaultValue?: string;
+}) {
+  return (
+    <Accordion type="single" collapsible={collapsible} defaultValue={defaultValue}>
+      <Accordion.Item value="a">
+        <Accordion.Trigger>A trigger</Accordion.Trigger>
+        <Accordion.Content>A content</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="b">
+        <Accordion.Trigger>B trigger</Accordion.Trigger>
+        <Accordion.Content>B content</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="c">
+        <Accordion.Trigger>C trigger</Accordion.Trigger>
+        <Accordion.Content>C content</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}
+
+function BasicMultiple({ defaultValue }: { defaultValue?: string[] }) {
+  return (
+    <Accordion type="multiple" defaultValue={defaultValue}>
+      <Accordion.Item value="a">
+        <Accordion.Trigger>A trigger</Accordion.Trigger>
+        <Accordion.Content>A content</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="b">
+        <Accordion.Trigger>B trigger</Accordion.Trigger>
+        <Accordion.Content>B content</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="c">
+        <Accordion.Trigger>C trigger</Accordion.Trigger>
+        <Accordion.Content>C content</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}
+
+describe('<Accordion>', () => {
+  // ─── Rendering + structure ─────────────────────────────────────────────
+
+  it('renders without crashing with minimal compound markup', () => {
+    render(<BasicSingle />);
+    expect(screen.getByText('A trigger')).toBeInTheDocument();
+    expect(screen.getByText('B trigger')).toBeInTheDocument();
+  });
+
+  it('renders items in DOM order', () => {
+    const { container } = render(<BasicSingle />);
+    const triggers = container.querySelectorAll('button[aria-expanded]');
+    expect(triggers[0]).toHaveTextContent('A trigger');
+    expect(triggers[1]).toHaveTextContent('B trigger');
+    expect(triggers[2]).toHaveTextContent('C trigger');
+  });
+
+  it('Trigger is wrapped in the default <h3>', () => {
+    const { container } = render(<BasicSingle />);
+    expect(container.querySelectorAll('h3').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('headerLevel="h2" wraps the trigger in <h2>', () => {
+    const { container } = render(
+      <Accordion type="single">
+        <Accordion.Item value="a" headerLevel="h2">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>content</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(container.querySelector('h2')).toBeInTheDocument();
+  });
+
+  it('aria-controls on trigger matches id on content panel', () => {
+    render(<BasicSingle />);
+    const trigger = screen.getByRole('button', { name: 'A trigger' });
+    const ariaControls = trigger.getAttribute('aria-controls');
+    expect(ariaControls).toBeTruthy();
+    const panel = document.getElementById(ariaControls!);
+    expect(panel).not.toBeNull();
+  });
+
+  it('aria-labelledby on content matches id on trigger', () => {
+    render(<BasicSingle />);
+    const trigger = screen.getByRole('button', { name: 'A trigger' });
+    const triggerId = trigger.id;
+    // Content panel: find via aria-labelledby. Note: closed panels still
+    // exist in the DOM (only height is 0).
+    const panels = document.querySelectorAll('[role="region"]');
+    const panel = Array.from(panels).find(
+      (p) => p.getAttribute('aria-labelledby') === triggerId,
+    );
+    expect(panel).toBeDefined();
+  });
+
+  it('default state: no item open; all aria-expanded="false"', () => {
+    render(<BasicSingle />);
+    const triggers = screen.getAllByRole('button');
+    triggers.forEach((t) => {
+      expect(t).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  // ─── State (single mode) ───────────────────────────────────────────────
+
+  it('defaultValue="a" opens item a on initial render', () => {
+    render(<BasicSingle defaultValue="a" />);
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'B trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('clicking a closed item opens it AND closes any previously open item', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle defaultValue="a" />);
+    await user.click(screen.getByRole('button', { name: 'B trigger' }));
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.getByRole('button', { name: 'B trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('collapsible={false} (default): clicking the open item does NOT close it', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle defaultValue="a" />);
+    await user.click(screen.getByRole('button', { name: 'A trigger' }));
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('collapsible={true}: clicking the open item closes it', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle collapsible defaultValue="a" />);
+    await user.click(screen.getByRole('button', { name: 'A trigger' }));
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('controlled single: value + onValueChange round-trip', async () => {
+    const user = userEvent.setup();
+    function Controlled() {
+      const [v, setV] = useState('');
+      return (
+        <>
+          <span data-testid="state">{v}</span>
+          <Accordion type="single" value={v} onValueChange={setV}>
+            <Accordion.Item value="a">
+              <Accordion.Trigger>A trigger</Accordion.Trigger>
+              <Accordion.Content>A content</Accordion.Content>
+            </Accordion.Item>
+            <Accordion.Item value="b">
+              <Accordion.Trigger>B trigger</Accordion.Trigger>
+              <Accordion.Content>B content</Accordion.Content>
+            </Accordion.Item>
+          </Accordion>
+        </>
+      );
+    }
+    render(<Controlled />);
+    await user.click(screen.getByRole('button', { name: 'B trigger' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('b');
+    await user.click(screen.getByRole('button', { name: 'A trigger' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('a');
+  });
+
+  // ─── State (multiple mode) ─────────────────────────────────────────────
+
+  it('multiple mode: defaultValue={["a","b"]} opens both items', () => {
+    render(<BasicMultiple defaultValue={['a', 'b']} />);
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'B trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'C trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('multiple mode: clicking a closed item adds it to the open set', async () => {
+    const user = userEvent.setup();
+    render(<BasicMultiple defaultValue={['a']} />);
+    await user.click(screen.getByRole('button', { name: 'C trigger' }));
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'C trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('multiple mode: clicking an open item removes it from the set', async () => {
+    const user = userEvent.setup();
+    render(<BasicMultiple defaultValue={['a', 'b']} />);
+    await user.click(screen.getByRole('button', { name: 'A trigger' }));
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.getByRole('button', { name: 'B trigger' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('controlled multiple: value + onValueChange round-trip', async () => {
+    const user = userEvent.setup();
+    function Controlled() {
+      const [v, setV] = useState<string[]>([]);
+      return (
+        <>
+          <span data-testid="state">{v.join(',')}</span>
+          <Accordion type="multiple" value={v} onValueChange={setV}>
+            <Accordion.Item value="a">
+              <Accordion.Trigger>A trigger</Accordion.Trigger>
+              <Accordion.Content>A content</Accordion.Content>
+            </Accordion.Item>
+            <Accordion.Item value="b">
+              <Accordion.Trigger>B trigger</Accordion.Trigger>
+              <Accordion.Content>B content</Accordion.Content>
+            </Accordion.Item>
+          </Accordion>
+        </>
+      );
+    }
+    render(<Controlled />);
+    await user.click(screen.getByRole('button', { name: 'A trigger' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('a');
+    await user.click(screen.getByRole('button', { name: 'B trigger' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('a,b');
+    await user.click(screen.getByRole('button', { name: 'A trigger' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('b');
+  });
+
+  // ─── Disabled ──────────────────────────────────────────────────────────
+
+  it('disabled item: trigger has the disabled attribute', () => {
+    render(
+      <Accordion type="single">
+        <Accordion.Item value="a" disabled>
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>content</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(screen.getByRole('button', { name: 'A' })).toBeDisabled();
+  });
+
+  it('clicking a disabled trigger does NOT toggle the item', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <Accordion type="single" onValueChange={handleChange}>
+        <Accordion.Item value="a" disabled>
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>content</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    await user.click(screen.getByRole('button', { name: 'A' }));
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  // ─── Keyboard ──────────────────────────────────────────────────────────
+
+  it('ArrowDown from the first trigger focuses the second', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle />);
+    const first = screen.getByRole('button', { name: 'A trigger' });
+    first.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('button', { name: 'B trigger' })).toHaveFocus();
+  });
+
+  it('ArrowUp from the second trigger focuses the first', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle />);
+    const second = screen.getByRole('button', { name: 'B trigger' });
+    second.focus();
+    await user.keyboard('{ArrowUp}');
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveFocus();
+  });
+
+  it('ArrowDown wraps from last to first', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle />);
+    const last = screen.getByRole('button', { name: 'C trigger' });
+    last.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveFocus();
+  });
+
+  it('Home focuses the first non-disabled trigger', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle />);
+    const second = screen.getByRole('button', { name: 'B trigger' });
+    second.focus();
+    await user.keyboard('{Home}');
+    expect(screen.getByRole('button', { name: 'A trigger' })).toHaveFocus();
+  });
+
+  it('End focuses the last non-disabled trigger', async () => {
+    const user = userEvent.setup();
+    render(<BasicSingle />);
+    const first = screen.getByRole('button', { name: 'A trigger' });
+    first.focus();
+    await user.keyboard('{End}');
+    expect(screen.getByRole('button', { name: 'C trigger' })).toHaveFocus();
+  });
+
+  it('ArrowDown skips disabled items', async () => {
+    const user = userEvent.setup();
+    render(
+      <Accordion type="single">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="b" disabled>
+          <Accordion.Trigger>B</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="c">
+          <Accordion.Trigger>C</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    const first = screen.getByRole('button', { name: 'A' });
+    first.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('button', { name: 'C' })).toHaveFocus();
+  });
+
+  // ─── Icon ──────────────────────────────────────────────────────────────
+
+  it('custom icon on Trigger replaces the default ChevronDown', () => {
+    render(
+      <Accordion type="single">
+        <Accordion.Item value="a">
+          <Accordion.Trigger icon={<Plus data-testid="custom" />}>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(screen.getByTestId('custom')).toBeInTheDocument();
+  });
+
+  it('icon={null} hides the indicator entirely', () => {
+    render(
+      <Accordion type="single">
+        <Accordion.Item value="a">
+          <Accordion.Trigger icon={null}>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    const trigger = screen.getByRole('button', { name: 'A' });
+    expect(within(trigger).queryByRole('img')).toBeNull();
+    expect(trigger.querySelector('svg')).toBeNull();
+  });
+});

--- a/packages/design-system/src/components/Accordion/Accordion.test.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.test.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { createRef, useState } from 'react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Plus } from 'lucide-react';
@@ -388,5 +388,126 @@ describe('<Accordion>', () => {
     const trigger = screen.getByRole('button', { name: 'A' });
     expect(within(trigger).queryByRole('img')).toBeNull();
     expect(trigger.querySelector('svg')).toBeNull();
+  });
+
+  // ─── Rule 1 minimum coverage: ref + className ──────────────────────────
+
+  it('Accordion root: ref forwards to the root <div>', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <Accordion type="single" ref={ref}>
+        <Accordion.Item value="a">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('DIV');
+    expect(ref.current?.getAttribute('data-accordion')).toBe('');
+  });
+
+  it('Item: ref forwards to the item <div>', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <Accordion type="single">
+        <Accordion.Item ref={ref} value="a">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('DIV');
+    expect(ref.current?.getAttribute('data-state')).toBe('closed');
+  });
+
+  it('Trigger: ref forwards to the <button>', () => {
+    const ref = createRef<HTMLButtonElement>();
+    render(
+      <Accordion type="single">
+        <Accordion.Item value="a">
+          <Accordion.Trigger ref={ref}>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('BUTTON');
+    expect(ref.current?.type).toBe('button');
+  });
+
+  it('Content: ref forwards to the content <div>', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <Accordion type="single">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content ref={ref}>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('DIV');
+    expect(ref.current?.getAttribute('role')).toBe('region');
+  });
+
+  it('className merges (not replaces) on all four parts', () => {
+    const { container } = render(
+      <Accordion type="single" className="custom-root">
+        <Accordion.Item value="a" className="custom-item">
+          <Accordion.Trigger className="custom-trigger">A</Accordion.Trigger>
+          <Accordion.Content className="custom-content">x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    const root = container.querySelector('[data-accordion]')!;
+    expect(root.className).toMatch(/custom-root/);
+    expect(root.className).toMatch(/accordion/);
+
+    const item = container.querySelector('[data-state]')!;
+    expect(item.className).toMatch(/custom-item/);
+    expect(item.className).toMatch(/item/);
+
+    const trigger = screen.getByRole('button', { name: 'A' });
+    expect(trigger.className).toMatch(/custom-trigger/);
+    expect(trigger.className).toMatch(/trigger/);
+
+    const content = container.querySelector('[role="region"]')!;
+    expect(content.className).toMatch(/custom-content/);
+    expect(content.className).toMatch(/content/);
+  });
+
+  // ─── Nested accordion keyboard scope ──────────────────────────────────
+
+  it('ArrowDown on outer trigger does NOT escape into a nested Accordion', async () => {
+    const user = userEvent.setup();
+    render(
+      <Accordion type="multiple" defaultValue={['outer-1']}>
+        <Accordion.Item value="outer-1">
+          <Accordion.Trigger>Outer A</Accordion.Trigger>
+          <Accordion.Content>
+            <Accordion type="single">
+              <Accordion.Item value="inner-1">
+                <Accordion.Trigger>Inner A</Accordion.Trigger>
+                <Accordion.Content>inner content A</Accordion.Content>
+              </Accordion.Item>
+              <Accordion.Item value="inner-2">
+                <Accordion.Trigger>Inner B</Accordion.Trigger>
+                <Accordion.Content>inner content B</Accordion.Content>
+              </Accordion.Item>
+            </Accordion>
+          </Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="outer-2">
+          <Accordion.Trigger>Outer B</Accordion.Trigger>
+          <Accordion.Content>outer content B</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    const outerA = screen.getByRole('button', { name: 'Outer A' });
+    outerA.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('button', { name: 'Outer B' })).toHaveFocus();
   });
 });

--- a/packages/design-system/src/components/Accordion/Accordion.test.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.test.tsx
@@ -478,6 +478,72 @@ describe('<Accordion>', () => {
 
   // ─── Nested accordion keyboard scope ──────────────────────────────────
 
+  // ─── Variant + size ─────────────────────────────────────────────────────
+
+  it('default variant is "bordered" (data-variant attr)', () => {
+    const { container } = render(<BasicSingle />);
+    const root = container.querySelector('[data-accordion]')!;
+    expect(root).toHaveAttribute('data-variant', 'bordered');
+  });
+
+  it('variant="borderless" sets data-variant on the root', () => {
+    const { container } = render(
+      <Accordion type="single" variant="borderless">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    const root = container.querySelector('[data-accordion]')!;
+    expect(root).toHaveAttribute('data-variant', 'borderless');
+  });
+
+  it('default size is "md" (data-size attr)', () => {
+    const { container } = render(<BasicSingle />);
+    const root = container.querySelector('[data-accordion]')!;
+    expect(root).toHaveAttribute('data-size', 'md');
+  });
+
+  it.each(['sm', 'md', 'lg'] as const)('size="%s" sets data-size="%s" on the root', (size) => {
+    const { container } = render(
+      <Accordion type="single" size={size}>
+        <Accordion.Item value="a">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    const root = container.querySelector('[data-accordion]')!;
+    expect(root).toHaveAttribute('data-size', size);
+  });
+
+  it('variant + size apply on both single and multiple modes', () => {
+    const { container: c1 } = render(
+      <Accordion type="single" variant="borderless" size="lg">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    const r1 = c1.querySelector('[data-accordion]')!;
+    expect(r1).toHaveAttribute('data-variant', 'borderless');
+    expect(r1).toHaveAttribute('data-size', 'lg');
+
+    const { container: c2 } = render(
+      <Accordion type="multiple" variant="borderless" size="sm">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    const r2 = c2.querySelector('[data-accordion]')!;
+    expect(r2).toHaveAttribute('data-variant', 'borderless');
+    expect(r2).toHaveAttribute('data-size', 'sm');
+  });
+
   it('ArrowDown on outer trigger does NOT escape into a nested Accordion', async () => {
     const user = userEvent.setup();
     render(

--- a/packages/design-system/src/components/Accordion/Accordion.test.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.test.tsx
@@ -98,9 +98,7 @@ describe('<Accordion>', () => {
     // Content panel: find via aria-labelledby. Note: closed panels still
     // exist in the DOM (only height is 0).
     const panels = document.querySelectorAll('[role="region"]');
-    const panel = Array.from(panels).find(
-      (p) => p.getAttribute('aria-labelledby') === triggerId,
-    );
+    const panel = Array.from(panels).find((p) => p.getAttribute('aria-labelledby') === triggerId);
     expect(panel).toBeDefined();
   });
 

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -162,6 +162,9 @@ const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
 
     return (
       <AccordionContext.Provider value={ctx}>
+        {/* Pattern A — consumer props reach the div, but data-accordion and
+            className are set AFTER the spread so the keyboard-scope marker
+            and the component class can't be removed by a consumer. */}
         <div
           ref={ref}
           {...rest}
@@ -209,6 +212,9 @@ const AccordionMultipleImpl = forwardRef<HTMLDivElement, MultipleImplProps>(
 
     return (
       <AccordionContext.Provider value={ctx}>
+        {/* Pattern A — consumer props reach the div, but data-accordion and
+            className are set AFTER the spread so the keyboard-scope marker
+            and the component class can't be removed by a consumer. */}
         <div
           ref={ref}
           {...rest}

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -19,7 +19,10 @@ export type AccordionMode = 'single' | 'multiple';
 /** Heading level wrapping the trigger button. Defaults to 'h3'. */
 export type AccordionHeaderLevel = 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
-interface AccordionBaseProps extends Omit<HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
+interface AccordionBaseProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'defaultValue' | 'onChange'
+> {
   children: ReactNode;
 }
 
@@ -105,15 +108,14 @@ export type AccordionProps = AccordionBaseProps & (AccordionSingleProps | Accord
  * - ❌ Manually setting `aria-expanded` on the Trigger via `{...props}`. The component owns the ARIA contract.
  * - ❌ Using `headerLevel="h1"`. There should only be one `<h1>` per page; Accordion lives below it.
  */
-const AccordionRoot = forwardRef<HTMLDivElement, AccordionProps>(function AccordionRoot(
-  props,
-  ref,
-) {
-  if (props.type === 'single') {
-    return <AccordionSingleImpl {...props} ref={ref} />;
-  }
-  return <AccordionMultipleImpl {...props} ref={ref} />;
-});
+const AccordionRoot = forwardRef<HTMLDivElement, AccordionProps>(
+  function AccordionRoot(props, ref) {
+    if (props.type === 'single') {
+      return <AccordionSingleImpl {...props} ref={ref} />;
+    }
+    return <AccordionMultipleImpl {...props} ref={ref} />;
+  },
+);
 
 interface SingleImplProps extends AccordionBaseProps, AccordionSingleProps {}
 
@@ -135,10 +137,7 @@ const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
     const isControlled = value !== undefined;
     const currentValue = isControlled ? value : internalValue;
 
-    const isOpen = useCallback(
-      (itemValue: string) => currentValue === itemValue,
-      [currentValue],
-    );
+    const isOpen = useCallback((itemValue: string) => currentValue === itemValue, [currentValue]);
 
     const toggle = useCallback(
       (itemValue: string) => {
@@ -165,12 +164,7 @@ const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
         {/* Pattern A — consumer props reach the div, but data-accordion and
             className are set AFTER the spread so the keyboard-scope marker
             and the component class can't be removed by a consumer. */}
-        <div
-          ref={ref}
-          {...rest}
-          data-accordion=""
-          className={clsx(styles.accordion, className)}
-        >
+        <div ref={ref} {...rest} data-accordion="" className={clsx(styles.accordion, className)}>
           {children}
         </div>
       </AccordionContext.Provider>
@@ -215,12 +209,7 @@ const AccordionMultipleImpl = forwardRef<HTMLDivElement, MultipleImplProps>(
         {/* Pattern A — consumer props reach the div, but data-accordion and
             className are set AFTER the spread so the keyboard-scope marker
             and the component class can't be removed by a consumer. */}
-        <div
-          ref={ref}
-          {...rest}
-          data-accordion=""
-          className={clsx(styles.accordion, className)}
-        >
+        <div ref={ref} {...rest} data-accordion="" className={clsx(styles.accordion, className)}>
           {children}
         </div>
       </AccordionContext.Provider>

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -117,6 +117,12 @@ export type AccordionProps = AccordionBaseProps & (AccordionSingleProps | Accord
  *   ...
  * </Accordion>
  *
+ * @example
+ * // Borderless + large for hero FAQ sections
+ * <Accordion type="single" collapsible variant="borderless" size="lg">
+ *   ...
+ * </Accordion>
+ *
  * @remarks When NOT to use
  * - Mutually-exclusive view switchers → `<Tabs>`.
  * - Single show/hide toggle → `<Button>` + conditional render.

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -1,0 +1,230 @@
+import {
+  forwardRef,
+  useCallback,
+  useMemo,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import { AccordionContext, type AccordionContextValue } from './context';
+import { AccordionItem } from './AccordionItem';
+import { AccordionTrigger } from './AccordionTrigger';
+import { AccordionContent } from './AccordionContent';
+import styles from './Accordion.module.scss';
+
+/** Selection mode. */
+export type AccordionMode = 'single' | 'multiple';
+
+/** Heading level wrapping the trigger button. Defaults to 'h3'. */
+export type AccordionHeaderLevel = 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+interface AccordionBaseProps extends Omit<HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
+  children: ReactNode;
+}
+
+/** Root props — `type='single'` variant. */
+interface AccordionSingleProps {
+  type: 'single';
+  /** Controlled open item value. `''` = nothing open (only meaningful when `collapsible`). */
+  value?: string;
+  /** Initial open item for uncontrolled use. */
+  defaultValue?: string;
+  /** Fires when the open item changes. */
+  onValueChange?: (next: string) => void;
+  /**
+   * When true, clicking the currently-open item closes it. Default: `false`
+   * (matches Radix; prevents accidentally closing the only available content).
+   */
+  collapsible?: boolean;
+}
+
+/** Root props — `type='multiple'` variant. */
+interface AccordionMultipleProps {
+  type: 'multiple';
+  /** Controlled open items array. */
+  value?: string[];
+  /** Initial open items for uncontrolled use. */
+  defaultValue?: string[];
+  /** Fires when the set of open items changes. */
+  onValueChange?: (next: string[]) => void;
+  collapsible?: never;
+}
+
+/** Discriminated union — `type` drives which variant of value/onValueChange is required. */
+export type AccordionProps = AccordionBaseProps & (AccordionSingleProps | AccordionMultipleProps);
+
+/**
+ * Vertically-stacked collapsible panels. Compound component:
+ *
+ * - `<Accordion>` — root (this component). Configures mode + state + collapsible.
+ * - `<Accordion.Item value>` — one section, identified by a string value.
+ * - `<Accordion.Trigger>` — clickable header (wrapped in `<h3>` by default).
+ * - `<Accordion.Content>` — the collapsible body.
+ *
+ * Two modes via the discriminated `type` prop:
+ * - `type='single'` — one item open at a time. Optional `collapsible` lets the user close the open item.
+ * - `type='multiple'` — any combination of items can be open.
+ *
+ * Both controlled (`value` + `onValueChange`) and uncontrolled (`defaultValue`) supported.
+ *
+ * @example
+ * // Single-open with collapsible (FAQ-style)
+ * <Accordion type="single" collapsible defaultValue="faq-2">
+ *   <Accordion.Item value="faq-1">
+ *     <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>
+ *     <Accordion.Content>Visit Settings → Security → Reset.</Accordion.Content>
+ *   </Accordion.Item>
+ *   <Accordion.Item value="faq-2">
+ *     <Accordion.Trigger>How do I export my data?</Accordion.Trigger>
+ *     <Accordion.Content>Use the gear icon → Export → CSV.</Accordion.Content>
+ *   </Accordion.Item>
+ * </Accordion>
+ *
+ * @example
+ * // Multiple — independent sections
+ * <Accordion type="multiple" defaultValue={['account', 'notifications']}>
+ *   <Accordion.Item value="account">...</Accordion.Item>
+ *   <Accordion.Item value="notifications">...</Accordion.Item>
+ * </Accordion>
+ *
+ * @example
+ * // Controlled
+ * const [open, setOpen] = useState('');
+ * <Accordion type="single" collapsible value={open} onValueChange={setOpen}>
+ *   ...
+ * </Accordion>
+ *
+ * @remarks When NOT to use
+ * - Mutually-exclusive view switchers → `<Tabs>`.
+ * - Single show/hide toggle → `<Button>` + conditional render.
+ * - Sequential wizard flows → dedicated Stepper (not yet shipped).
+ *
+ * @remarks Anti-patterns
+ * - ❌ Nesting `<Accordion.Trigger>` inside a heading the consumer also renders. Trigger wraps itself in a heading.
+ * - ❌ Manually setting `aria-expanded` on the Trigger via `{...props}`. The component owns the ARIA contract.
+ * - ❌ Using `headerLevel="h1"`. There should only be one `<h1>` per page; Accordion lives below it.
+ */
+const AccordionRoot = forwardRef<HTMLDivElement, AccordionProps>(function AccordionRoot(
+  props,
+  ref,
+) {
+  if (props.type === 'single') {
+    return <AccordionSingleImpl {...props} ref={ref} />;
+  }
+  return <AccordionMultipleImpl {...props} ref={ref} />;
+});
+
+interface SingleImplProps extends AccordionBaseProps, AccordionSingleProps {}
+
+const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
+  function AccordionSingleImpl(
+    {
+      type: _type,
+      value,
+      defaultValue,
+      onValueChange,
+      collapsible = false,
+      children,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    const [internalValue, setInternalValue] = useState<string>(defaultValue ?? '');
+    const isControlled = value !== undefined;
+    const currentValue = isControlled ? value : internalValue;
+
+    const isOpen = useCallback(
+      (itemValue: string) => currentValue === itemValue,
+      [currentValue],
+    );
+
+    const toggle = useCallback(
+      (itemValue: string) => {
+        if (currentValue === itemValue) {
+          if (collapsible) {
+            if (!isControlled) setInternalValue('');
+            onValueChange?.('');
+          }
+        } else {
+          if (!isControlled) setInternalValue(itemValue);
+          onValueChange?.(itemValue);
+        }
+      },
+      [currentValue, collapsible, isControlled, onValueChange],
+    );
+
+    const ctx = useMemo<AccordionContextValue>(
+      () => ({ mode: 'single', isOpen, toggle }),
+      [isOpen, toggle],
+    );
+
+    return (
+      <AccordionContext.Provider value={ctx}>
+        <div
+          ref={ref}
+          {...rest}
+          data-accordion=""
+          className={clsx(styles.accordion, className)}
+        >
+          {children}
+        </div>
+      </AccordionContext.Provider>
+    );
+  },
+);
+
+interface MultipleImplProps extends AccordionBaseProps, AccordionMultipleProps {}
+
+const AccordionMultipleImpl = forwardRef<HTMLDivElement, MultipleImplProps>(
+  function AccordionMultipleImpl(
+    { type: _type, value, defaultValue, onValueChange, children, className, ...rest },
+    ref,
+  ) {
+    const [internalValue, setInternalValue] = useState<string[]>(defaultValue ?? []);
+    const isControlled = value !== undefined;
+    const currentValue = isControlled ? value : internalValue;
+
+    const isOpen = useCallback(
+      (itemValue: string) => currentValue.includes(itemValue),
+      [currentValue],
+    );
+
+    const toggle = useCallback(
+      (itemValue: string) => {
+        const next = currentValue.includes(itemValue)
+          ? currentValue.filter((v) => v !== itemValue)
+          : [...currentValue, itemValue];
+        if (!isControlled) setInternalValue(next);
+        onValueChange?.(next);
+      },
+      [currentValue, isControlled, onValueChange],
+    );
+
+    const ctx = useMemo<AccordionContextValue>(
+      () => ({ mode: 'multiple', isOpen, toggle }),
+      [isOpen, toggle],
+    );
+
+    return (
+      <AccordionContext.Provider value={ctx}>
+        <div
+          ref={ref}
+          {...rest}
+          data-accordion=""
+          className={clsx(styles.accordion, className)}
+        >
+          {children}
+        </div>
+      </AccordionContext.Provider>
+    );
+  },
+);
+
+/** Compound export. */
+export const Accordion = Object.assign(AccordionRoot, {
+  Item: AccordionItem,
+  Trigger: AccordionTrigger,
+  Content: AccordionContent,
+});

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -19,10 +19,29 @@ export type AccordionMode = 'single' | 'multiple';
 /** Heading level wrapping the trigger button. Defaults to 'h3'. */
 export type AccordionHeaderLevel = 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
+/**
+ * Visual variant. Defaults to `'bordered'`.
+ * - `'bordered'` — outer border + radius + dividing lines between items. Standard standalone look.
+ * - `'borderless'` — no outer border, no item borders, transparent background. Use when the accordion sits inside another bordered container (e.g., a Card) or as a section divider.
+ */
+export type AccordionVariant = 'bordered' | 'borderless';
+
+/**
+ * Trigger size — controls font-size + padding. Defaults to `'md'`.
+ * - `'sm'` — `--font-size-sm`, tighter padding. Dense settings panels.
+ * - `'md'` — `--font-size-md`, default padding. Most use cases.
+ * - `'lg'` — `--font-size-lg`, larger padding. Hero FAQ sections.
+ */
+export type AccordionSize = 'sm' | 'md' | 'lg';
+
 interface AccordionBaseProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   'defaultValue' | 'onChange'
 > {
+  /** Visual variant. Defaults to `'bordered'`. */
+  variant?: AccordionVariant;
+  /** Trigger size (font + padding). Defaults to `'md'`. */
+  size?: AccordionSize;
   children: ReactNode;
 }
 
@@ -127,6 +146,8 @@ const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
       defaultValue,
       onValueChange,
       collapsible = false,
+      variant = 'bordered',
+      size = 'md',
       children,
       className,
       ...rest
@@ -161,10 +182,18 @@ const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
 
     return (
       <AccordionContext.Provider value={ctx}>
-        {/* Pattern A — consumer props reach the div, but data-accordion and
-            className are set AFTER the spread so the keyboard-scope marker
-            and the component class can't be removed by a consumer. */}
-        <div ref={ref} {...rest} data-accordion="" className={clsx(styles.accordion, className)}>
+        {/* Pattern A — consumer props reach the div, but data-accordion /
+            data-variant / data-size / className are set AFTER the spread so
+            the keyboard-scope marker, variant, size, and component class
+            can't be overridden by a consumer. */}
+        <div
+          ref={ref}
+          {...rest}
+          data-accordion=""
+          data-variant={variant}
+          data-size={size}
+          className={clsx(styles.accordion, className)}
+        >
           {children}
         </div>
       </AccordionContext.Provider>
@@ -176,7 +205,17 @@ interface MultipleImplProps extends AccordionBaseProps, AccordionMultipleProps {
 
 const AccordionMultipleImpl = forwardRef<HTMLDivElement, MultipleImplProps>(
   function AccordionMultipleImpl(
-    { type: _type, value, defaultValue, onValueChange, children, className, ...rest },
+    {
+      type: _type,
+      value,
+      defaultValue,
+      onValueChange,
+      variant = 'bordered',
+      size = 'md',
+      children,
+      className,
+      ...rest
+    },
     ref,
   ) {
     const [internalValue, setInternalValue] = useState<string[]>(defaultValue ?? []);
@@ -206,10 +245,18 @@ const AccordionMultipleImpl = forwardRef<HTMLDivElement, MultipleImplProps>(
 
     return (
       <AccordionContext.Provider value={ctx}>
-        {/* Pattern A — consumer props reach the div, but data-accordion and
-            className are set AFTER the spread so the keyboard-scope marker
-            and the component class can't be removed by a consumer. */}
-        <div ref={ref} {...rest} data-accordion="" className={clsx(styles.accordion, className)}>
+        {/* Pattern A — consumer props reach the div, but data-accordion /
+            data-variant / data-size / className are set AFTER the spread so
+            the keyboard-scope marker, variant, size, and component class
+            can't be overridden by a consumer. */}
+        <div
+          ref={ref}
+          {...rest}
+          data-accordion=""
+          data-variant={variant}
+          data-size={size}
+          className={clsx(styles.accordion, className)}
+        >
           {children}
         </div>
       </AccordionContext.Provider>

--- a/packages/design-system/src/components/Accordion/AccordionContent.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionContent.tsx
@@ -1,0 +1,32 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { useAccordionItemContext } from './context';
+import styles from './Accordion.module.scss';
+
+export interface AccordionContentProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+/**
+ * Collapsible region announced via `role="region"` + `aria-labelledby` pointing
+ * at the trigger. Animated via CSS `grid-template-rows: 0fr → 1fr`.
+ */
+export const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
+  function AccordionContent({ children, className, ...props }, ref) {
+    const { isOpen, triggerId, contentId } = useAccordionItemContext('Content');
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        id={contentId}
+        role="region"
+        aria-labelledby={triggerId}
+        data-state={isOpen ? 'open' : 'closed'}
+        className={clsx(styles.content, className)}
+      >
+        <div className={styles.inner}>{children}</div>
+      </div>
+    );
+  },
+);

--- a/packages/design-system/src/components/Accordion/AccordionContent.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionContent.tsx
@@ -16,6 +16,8 @@ export const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps
     const { isOpen, triggerId, contentId } = useAccordionItemContext('Content');
 
     return (
+      // Pattern B — {...props} first so component-owned id/role/
+      // aria-labelledby/data-state/className win.
       <div
         {...props}
         ref={ref}

--- a/packages/design-system/src/components/Accordion/AccordionItem.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionItem.tsx
@@ -25,44 +25,42 @@ export interface AccordionItemProps extends Omit<HTMLAttributes<HTMLDivElement>,
  * Item wrapper. Provides `AccordionItemContext` so Trigger and Content can
  * read this item's value, disabled state, open state, and stable ids.
  */
-export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
-  function AccordionItem(
-    { value, disabled = false, headerLevel = 'h3', children, className, ...props },
-    ref,
-  ) {
-    const { isOpen } = useAccordionContext('Item');
-    const open = isOpen(value);
-    const reactId = useId();
-    const triggerId = `accordion-trigger-${reactId}`;
-    const contentId = `accordion-content-${reactId}`;
+export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(function AccordionItem(
+  { value, disabled = false, headerLevel = 'h3', children, className, ...props },
+  ref,
+) {
+  const { isOpen } = useAccordionContext('Item');
+  const open = isOpen(value);
+  const reactId = useId();
+  const triggerId = `accordion-trigger-${reactId}`;
+  const contentId = `accordion-content-${reactId}`;
 
-    const ctx = useMemo<AccordionItemContextValue & { headerLevel: AccordionHeaderLevel }>(
-      () => ({
-        value,
-        disabled,
-        isOpen: open,
-        triggerId,
-        contentId,
-        headerLevel,
-      }),
-      [value, disabled, open, triggerId, contentId, headerLevel],
-    );
+  const ctx = useMemo<AccordionItemContextValue & { headerLevel: AccordionHeaderLevel }>(
+    () => ({
+      value,
+      disabled,
+      isOpen: open,
+      triggerId,
+      contentId,
+      headerLevel,
+    }),
+    [value, disabled, open, triggerId, contentId, headerLevel],
+  );
 
-    return (
-      <AccordionItemContext.Provider value={ctx}>
-        {/* Pattern A — {...props} after ref so consumer attrs reach the div,
+  return (
+    <AccordionItemContext.Provider value={ctx}>
+      {/* Pattern A — {...props} after ref so consumer attrs reach the div,
             but data-state/data-disabled/className are set AFTER the spread
             so the component wins on those three. */}
-        <div
-          ref={ref}
-          {...props}
-          data-state={open ? 'open' : 'closed'}
-          data-disabled={disabled ? 'true' : undefined}
-          className={clsx(styles.item, className)}
-        >
-          {children}
-        </div>
-      </AccordionItemContext.Provider>
-    );
-  },
-);
+      <div
+        ref={ref}
+        {...props}
+        data-state={open ? 'open' : 'closed'}
+        data-disabled={disabled ? 'true' : undefined}
+        className={clsx(styles.item, className)}
+      >
+        {children}
+      </div>
+    </AccordionItemContext.Provider>
+  );
+});

--- a/packages/design-system/src/components/Accordion/AccordionItem.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionItem.tsx
@@ -50,6 +50,9 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
 
     return (
       <AccordionItemContext.Provider value={ctx}>
+        {/* Pattern A — {...props} after ref so consumer attrs reach the div,
+            but data-state/data-disabled/className are set AFTER the spread
+            so the component wins on those three. */}
         <div
           ref={ref}
           {...props}

--- a/packages/design-system/src/components/Accordion/AccordionItem.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionItem.tsx
@@ -1,0 +1,65 @@
+import { forwardRef, useId, useMemo, type HTMLAttributes, type ReactNode } from 'react';
+import clsx from 'clsx';
+import {
+  AccordionItemContext,
+  useAccordionContext,
+  type AccordionItemContextValue,
+} from './context';
+import type { AccordionHeaderLevel } from './Accordion';
+import styles from './Accordion.module.scss';
+
+export interface AccordionItemProps extends Omit<HTMLAttributes<HTMLDivElement>, 'value'> {
+  /** Unique value used to identify the item in the root's `value`/`onValueChange`. */
+  value: string;
+  /** When true, the trigger is non-interactive and keyboard nav skips this item. */
+  disabled?: boolean;
+  /**
+   * Heading level wrapping the trigger. WAI-ARIA APG requires triggers to live
+   * inside a heading element. Defaults to `'h3'`.
+   */
+  headerLevel?: AccordionHeaderLevel;
+  children: ReactNode;
+}
+
+/**
+ * Item wrapper. Provides `AccordionItemContext` so Trigger and Content can
+ * read this item's value, disabled state, open state, and stable ids.
+ */
+export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
+  function AccordionItem(
+    { value, disabled = false, headerLevel = 'h3', children, className, ...props },
+    ref,
+  ) {
+    const { isOpen } = useAccordionContext('Item');
+    const open = isOpen(value);
+    const reactId = useId();
+    const triggerId = `accordion-trigger-${reactId}`;
+    const contentId = `accordion-content-${reactId}`;
+
+    const ctx = useMemo<AccordionItemContextValue & { headerLevel: AccordionHeaderLevel }>(
+      () => ({
+        value,
+        disabled,
+        isOpen: open,
+        triggerId,
+        contentId,
+        headerLevel,
+      }),
+      [value, disabled, open, triggerId, contentId, headerLevel],
+    );
+
+    return (
+      <AccordionItemContext.Provider value={ctx}>
+        <div
+          ref={ref}
+          {...props}
+          data-state={open ? 'open' : 'closed'}
+          data-disabled={disabled ? 'true' : undefined}
+          className={clsx(styles.item, className)}
+        >
+          {children}
+        </div>
+      </AccordionItemContext.Provider>
+    );
+  },
+);

--- a/packages/design-system/src/components/Accordion/AccordionTrigger.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionTrigger.tsx
@@ -48,11 +48,16 @@ export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerPr
       const root = e.currentTarget.closest<HTMLElement>('[data-accordion]');
       if (!root) return;
 
+      // querySelectorAll matches all descendants — including triggers in a
+      // NESTED Accordion inside an open Content. Scope keyboard nav to the
+      // current root by filtering to triggers whose nearest accordion ancestor
+      // IS this root. Without this, ArrowDown from an outer trigger jumps into
+      // the inner accordion.
       const triggers = Array.from(
         root.querySelectorAll<HTMLButtonElement>(
           'button[aria-expanded]:not(:disabled)',
         ),
-      );
+      ).filter((btn) => btn.closest('[data-accordion]') === root);
       if (triggers.length === 0) return;
 
       const current = triggers.indexOf(e.currentTarget);
@@ -84,6 +89,9 @@ export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerPr
 
     return (
       <Heading className={styles.header}>
+        {/* Pattern B — {...props} first so component-owned id/aria-expanded/
+            aria-controls/disabled/onClick/onKeyDown/className win and the ARIA
+            contract can't be overridden by a consumer. */}
         <button
           {...props}
           ref={ref}

--- a/packages/design-system/src/components/Accordion/AccordionTrigger.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionTrigger.tsx
@@ -1,0 +1,105 @@
+import {
+  forwardRef,
+  type ButtonHTMLAttributes,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+import { ChevronDown } from 'lucide-react';
+import clsx from 'clsx';
+import {
+  useAccordionContext,
+  useAccordionItemContext,
+  type AccordionItemContextValue,
+} from './context';
+import type { AccordionHeaderLevel } from './Accordion';
+import styles from './Accordion.module.scss';
+
+export interface AccordionTriggerProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  /**
+   * Override the default trigger indicator icon (rotates 180° when open).
+   * Pass `null` to suppress the icon entirely. Default: `<ChevronDown />`.
+   */
+  icon?: ReactNode | null;
+  children: ReactNode;
+}
+
+interface ItemContextWithHeaderLevel extends AccordionItemContextValue {
+  headerLevel: AccordionHeaderLevel;
+}
+
+/**
+ * Heading-wrapped button that toggles the parent Item. Default indicator is a
+ * `<ChevronDown>` icon that rotates 180° when open.
+ */
+export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerProps>(
+  function AccordionTrigger({ icon, children, className, onKeyDown, ...props }, ref) {
+    const { toggle } = useAccordionContext('Trigger');
+    const itemCtx = useAccordionItemContext('Trigger') as ItemContextWithHeaderLevel;
+    const { value, disabled, isOpen, triggerId, contentId, headerLevel } = itemCtx;
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+      onKeyDown?.(e);
+      if (e.defaultPrevented) return;
+      const isNav = ['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(e.key);
+      if (!isNav) return;
+      e.preventDefault();
+
+      const root = e.currentTarget.closest<HTMLElement>('[data-accordion]');
+      if (!root) return;
+
+      const triggers = Array.from(
+        root.querySelectorAll<HTMLButtonElement>(
+          'button[aria-expanded]:not(:disabled)',
+        ),
+      );
+      if (triggers.length === 0) return;
+
+      const current = triggers.indexOf(e.currentTarget);
+      let next = current;
+
+      if (e.key === 'ArrowDown') next = (current + 1) % triggers.length;
+      else if (e.key === 'ArrowUp')
+        next = (current - 1 + triggers.length) % triggers.length;
+      else if (e.key === 'Home') next = 0;
+      else if (e.key === 'End') next = triggers.length - 1;
+
+      triggers[next]?.focus();
+    };
+
+    const renderedIcon =
+      icon === null
+        ? null
+        : (icon ?? (
+            <ChevronDown
+              size={16}
+              aria-hidden="true"
+              className={styles.indicator}
+            />
+          ));
+
+    // headerLevel is a string union of valid HTML heading tag names; cast to
+    // ElementType for JSX use.
+    const Heading = headerLevel as 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+    return (
+      <Heading className={styles.header}>
+        <button
+          {...props}
+          ref={ref}
+          type="button"
+          id={triggerId}
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          disabled={disabled}
+          onClick={() => toggle(value)}
+          onKeyDown={handleKeyDown}
+          className={clsx(styles.trigger, className)}
+        >
+          <span className={styles.label}>{children}</span>
+          {renderedIcon}
+        </button>
+      </Heading>
+    );
+  },
+);

--- a/packages/design-system/src/components/Accordion/AccordionTrigger.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionTrigger.tsx
@@ -1,9 +1,4 @@
-import {
-  forwardRef,
-  type ButtonHTMLAttributes,
-  type KeyboardEvent,
-  type ReactNode,
-} from 'react';
+import { forwardRef, type ButtonHTMLAttributes, type KeyboardEvent, type ReactNode } from 'react';
 import { ChevronDown } from 'lucide-react';
 import clsx from 'clsx';
 import {
@@ -14,8 +9,10 @@ import {
 import type { AccordionHeaderLevel } from './Accordion';
 import styles from './Accordion.module.scss';
 
-export interface AccordionTriggerProps
-  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+export interface AccordionTriggerProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children'
+> {
   /**
    * Override the default trigger indicator icon (rotates 180° when open).
    * Pass `null` to suppress the icon entirely. Default: `<ChevronDown />`.
@@ -54,9 +51,7 @@ export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerPr
       // IS this root. Without this, ArrowDown from an outer trigger jumps into
       // the inner accordion.
       const triggers = Array.from(
-        root.querySelectorAll<HTMLButtonElement>(
-          'button[aria-expanded]:not(:disabled)',
-        ),
+        root.querySelectorAll<HTMLButtonElement>('button[aria-expanded]:not(:disabled)'),
       ).filter((btn) => btn.closest('[data-accordion]') === root);
       if (triggers.length === 0) return;
 
@@ -64,8 +59,7 @@ export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerPr
       let next = current;
 
       if (e.key === 'ArrowDown') next = (current + 1) % triggers.length;
-      else if (e.key === 'ArrowUp')
-        next = (current - 1 + triggers.length) % triggers.length;
+      else if (e.key === 'ArrowUp') next = (current - 1 + triggers.length) % triggers.length;
       else if (e.key === 'Home') next = 0;
       else if (e.key === 'End') next = triggers.length - 1;
 
@@ -75,13 +69,7 @@ export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerPr
     const renderedIcon =
       icon === null
         ? null
-        : (icon ?? (
-            <ChevronDown
-              size={16}
-              aria-hidden="true"
-              className={styles.indicator}
-            />
-          ));
+        : (icon ?? <ChevronDown size={16} aria-hidden="true" className={styles.indicator} />);
 
     // headerLevel is a string union of valid HTML heading tag names; cast to
     // ElementType for JSX use.

--- a/packages/design-system/src/components/Accordion/context.ts
+++ b/packages/design-system/src/components/Accordion/context.ts
@@ -1,0 +1,47 @@
+import { createContext, useContext } from 'react';
+
+export interface AccordionContextValue {
+  /** Selection mode. */
+  mode: 'single' | 'multiple';
+  /** Whether the given item value is currently open. */
+  isOpen: (value: string) => boolean;
+  /** Toggle the given item value. Closes others in single mode; flips membership in multiple mode. */
+  toggle: (value: string) => void;
+}
+
+export const AccordionContext = createContext<AccordionContextValue | null>(null);
+
+/**
+ * Hook for child components to read the root context. Throws if used outside
+ * an `<Accordion>` — surfaces the bug early instead of silently no-op'ing.
+ */
+export function useAccordionContext(componentName: string): AccordionContextValue {
+  const ctx = useContext(AccordionContext);
+  if (ctx === null) {
+    throw new Error(`<Accordion.${componentName}> must be used inside <Accordion>`);
+  }
+  return ctx;
+}
+
+export interface AccordionItemContextValue {
+  /** This item's unique value. */
+  value: string;
+  /** Whether the item is disabled (Trigger non-interactive, keyboard nav skips). */
+  disabled: boolean;
+  /** Whether the item is currently open (mirrored from root context for convenience). */
+  isOpen: boolean;
+  /** Stable id for the Trigger (so Content's aria-labelledby points at it). */
+  triggerId: string;
+  /** Stable id for the Content (so Trigger's aria-controls points at it). */
+  contentId: string;
+}
+
+export const AccordionItemContext = createContext<AccordionItemContextValue | null>(null);
+
+export function useAccordionItemContext(componentName: string): AccordionItemContextValue {
+  const ctx = useContext(AccordionItemContext);
+  if (ctx === null) {
+    throw new Error(`<Accordion.${componentName}> must be used inside <Accordion.Item>`);
+  }
+  return ctx;
+}

--- a/packages/design-system/src/components/Accordion/index.ts
+++ b/packages/design-system/src/components/Accordion/index.ts
@@ -1,0 +1,9 @@
+export { Accordion } from './Accordion';
+export type {
+  AccordionProps,
+  AccordionMode,
+  AccordionHeaderLevel,
+} from './Accordion';
+export type { AccordionItemProps } from './AccordionItem';
+export type { AccordionTriggerProps } from './AccordionTrigger';
+export type { AccordionContentProps } from './AccordionContent';

--- a/packages/design-system/src/components/Accordion/index.ts
+++ b/packages/design-system/src/components/Accordion/index.ts
@@ -1,5 +1,11 @@
 export { Accordion } from './Accordion';
-export type { AccordionProps, AccordionMode, AccordionHeaderLevel } from './Accordion';
+export type {
+  AccordionProps,
+  AccordionMode,
+  AccordionHeaderLevel,
+  AccordionVariant,
+  AccordionSize,
+} from './Accordion';
 export type { AccordionItemProps } from './AccordionItem';
 export type { AccordionTriggerProps } from './AccordionTrigger';
 export type { AccordionContentProps } from './AccordionContent';

--- a/packages/design-system/src/components/Accordion/index.ts
+++ b/packages/design-system/src/components/Accordion/index.ts
@@ -1,9 +1,5 @@
 export { Accordion } from './Accordion';
-export type {
-  AccordionProps,
-  AccordionMode,
-  AccordionHeaderLevel,
-} from './Accordion';
+export type { AccordionProps, AccordionMode, AccordionHeaderLevel } from './Accordion';
 export type { AccordionItemProps } from './AccordionItem';
 export type { AccordionTriggerProps } from './AccordionTrigger';
 export type { AccordionContentProps } from './AccordionContent';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -219,6 +219,16 @@ export type {
 export { Link } from './components/Link';
 export type { LinkProps, LinkVariant } from './components/Link';
 
+export { Accordion } from './components/Accordion';
+export type {
+  AccordionProps,
+  AccordionItemProps,
+  AccordionTriggerProps,
+  AccordionContentProps,
+  AccordionMode,
+  AccordionHeaderLevel,
+} from './components/Accordion';
+
 export { Breadcrumb } from './components/Breadcrumb';
 export type { BreadcrumbProps, BreadcrumbItemProps } from './components/Breadcrumb';
 

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -227,6 +227,8 @@ export type {
   AccordionContentProps,
   AccordionMode,
   AccordionHeaderLevel,
+  AccordionVariant,
+  AccordionSize,
 } from './components/Accordion';
 
 export { Breadcrumb } from './components/Breadcrumb';

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -7,6 +7,7 @@ import { Contacts } from './pages/mockups/Contacts/Contacts';
 import { ContactDetail } from './pages/mockups/ContactDetail/ContactDetail';
 import { Members } from './pages/mockups/Members/Members';
 import { ComponentsIndex } from './pages/components/ComponentsIndex';
+import { AccordionDemo } from './pages/components/AccordionDemo';
 import { AlertDemo } from './pages/components/AlertDemo';
 import { BreadcrumbDemo } from './pages/components/BreadcrumbDemo';
 import { ButtonDemo } from './pages/components/ButtonDemo';
@@ -59,6 +60,7 @@ export default function App() {
           <Route path="/mockups/members" element={<Members />} />
 
           <Route path="/components" element={<ComponentsIndex />} />
+          <Route path="/components/accordion" element={<AccordionDemo />} />
           <Route path="/components/alert" element={<AlertDemo />} />
           <Route path="/components/breadcrumb" element={<BreadcrumbDemo />} />
           <Route path="/components/button" element={<ButtonDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -42,6 +42,7 @@ import {
   TableProperties,
   ListOrdered,
   LayoutPanelLeft,
+  ListCollapse,
   MoveRight,
   ToggleRight,
   type LucideIcon,
@@ -120,6 +121,7 @@ const componentGroups = [
   {
     heading: 'Navigation',
     items: [
+      { to: '/components/accordion', label: 'Accordion', icon: ListCollapse, end: false },
       { to: '/components/breadcrumb', label: 'Breadcrumb', icon: MoveRight, end: false },
       { to: '/components/link', label: 'Link', icon: ExternalLink, end: false },
       { to: '/components/tabs', label: 'Tabs', icon: PanelTop, end: false },

--- a/packages/playground/src/pages/components/AccordionDemo.tsx
+++ b/packages/playground/src/pages/components/AccordionDemo.tsx
@@ -203,6 +203,72 @@ export function AccordionDemo() {
           </Accordion.Item>
         </Accordion>
       </Example>
+
+      <Example
+        title="Three sizes"
+        description="size controls trigger font + padding (and content padding). Default is md."
+        code={`<Accordion type="single" collapsible size="sm">...</Accordion>
+<Accordion type="single" collapsible size="md">...</Accordion>
+<Accordion type="single" collapsible size="lg">...</Accordion>`}
+      >
+        <Stack gap="md">
+          <Accordion type="single" collapsible size="sm" defaultValue="a">
+            <Accordion.Item value="a">
+              <Accordion.Trigger>Small (sm)</Accordion.Trigger>
+              <Accordion.Content>Tighter padding and smaller font.</Accordion.Content>
+            </Accordion.Item>
+            <Accordion.Item value="b">
+              <Accordion.Trigger>Second item</Accordion.Trigger>
+              <Accordion.Content>...</Accordion.Content>
+            </Accordion.Item>
+          </Accordion>
+          <Accordion type="single" collapsible size="md" defaultValue="a">
+            <Accordion.Item value="a">
+              <Accordion.Trigger>Medium (md, default)</Accordion.Trigger>
+              <Accordion.Content>Default padding and font.</Accordion.Content>
+            </Accordion.Item>
+            <Accordion.Item value="b">
+              <Accordion.Trigger>Second item</Accordion.Trigger>
+              <Accordion.Content>...</Accordion.Content>
+            </Accordion.Item>
+          </Accordion>
+          <Accordion type="single" collapsible size="lg" defaultValue="a">
+            <Accordion.Item value="a">
+              <Accordion.Trigger>Large (lg)</Accordion.Trigger>
+              <Accordion.Content>Larger padding and font.</Accordion.Content>
+            </Accordion.Item>
+            <Accordion.Item value="b">
+              <Accordion.Trigger>Second item</Accordion.Trigger>
+              <Accordion.Content>...</Accordion.Content>
+            </Accordion.Item>
+          </Accordion>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Borderless variant"
+        description="variant='borderless' strips the outer border + item dividing lines. Use when the accordion lives inside another bordered container, or as a quiet section divider."
+        code={`<Accordion type="multiple" variant="borderless" defaultValue={['account']}>
+  <Accordion.Item value="account">...</Accordion.Item>
+  <Accordion.Item value="notifications">...</Accordion.Item>
+  <Accordion.Item value="security">...</Accordion.Item>
+</Accordion>`}
+      >
+        <Accordion type="multiple" variant="borderless" defaultValue={['account']}>
+          <Accordion.Item value="account">
+            <Accordion.Trigger>Account</Accordion.Trigger>
+            <Accordion.Content>Email, name, profile picture.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="notifications">
+            <Accordion.Trigger>Notifications</Accordion.Trigger>
+            <Accordion.Content>Email digest, in-app alerts.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="security">
+            <Accordion.Trigger>Security</Accordion.Trigger>
+            <Accordion.Content>2FA, active sessions, API keys.</Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Example>
     </DemoLayout>
   );
 }

--- a/packages/playground/src/pages/components/AccordionDemo.tsx
+++ b/packages/playground/src/pages/components/AccordionDemo.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { Accordion, Stack } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Accordion/Accordion.tsx?raw';
+import scssSource from '@lib-source/components/Accordion/Accordion.module.scss?raw';
+
+export function AccordionDemo() {
+  const [controlled, setControlled] = useState<string>('');
+
+  return (
+    <DemoLayout
+      name="Accordion"
+      componentName="Accordion"
+      description="Vertically-stacked collapsible panels. Compound component (Accordion.Item + Accordion.Trigger + Accordion.Content). Two modes: type='single' (one open at a time) or type='multiple' (any combination)."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Accordion.tsx"
+      scssFilename="Accordion.module.scss"
+    >
+      <Example
+        title="Single, collapsible (FAQ-style)"
+        description="Only one item open at a time. Clicking the open item closes it (collapsible)."
+        code={`<Accordion type="single" collapsible defaultValue="faq-1">
+  <Accordion.Item value="faq-1">
+    <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>
+    <Accordion.Content>Visit Settings → Security → Reset password.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="faq-2">
+    <Accordion.Trigger>How do I export my data?</Accordion.Trigger>
+    <Accordion.Content>Use the gear icon → Export → CSV.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="faq-3">
+    <Accordion.Trigger>How do I invite teammates?</Accordion.Trigger>
+    <Accordion.Content>Settings → Team → Invite via email.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>`}
+      >
+        <Accordion type="single" collapsible defaultValue="faq-1">
+          <Accordion.Item value="faq-1">
+            <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>
+            <Accordion.Content>Visit Settings → Security → Reset password.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="faq-2">
+            <Accordion.Trigger>How do I export my data?</Accordion.Trigger>
+            <Accordion.Content>Use the gear icon → Export → CSV.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="faq-3">
+            <Accordion.Trigger>How do I invite teammates?</Accordion.Trigger>
+            <Accordion.Content>Settings → Team → Invite via email.</Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Example>
+
+      <Example
+        title="Multiple — independent sections"
+        description="Any combination of items can be open. Useful for settings panels where each section is independent."
+        code={`<Accordion type="multiple" defaultValue={['account']}>
+  <Accordion.Item value="account">
+    <Accordion.Trigger>Account</Accordion.Trigger>
+    <Accordion.Content>Email, name, profile picture.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="notifications">
+    <Accordion.Trigger>Notifications</Accordion.Trigger>
+    <Accordion.Content>Email digest, in-app alerts.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="security">
+    <Accordion.Trigger>Security</Accordion.Trigger>
+    <Accordion.Content>2FA, active sessions, API keys.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="billing">
+    <Accordion.Trigger>Billing</Accordion.Trigger>
+    <Accordion.Content>Plan, invoices, payment method.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>`}
+      >
+        <Accordion type="multiple" defaultValue={['account']}>
+          <Accordion.Item value="account">
+            <Accordion.Trigger>Account</Accordion.Trigger>
+            <Accordion.Content>Email, name, profile picture.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="notifications">
+            <Accordion.Trigger>Notifications</Accordion.Trigger>
+            <Accordion.Content>Email digest, in-app alerts.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="security">
+            <Accordion.Trigger>Security</Accordion.Trigger>
+            <Accordion.Content>2FA, active sessions, API keys.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="billing">
+            <Accordion.Trigger>Billing</Accordion.Trigger>
+            <Accordion.Content>Plan, invoices, payment method.</Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Example>
+
+      <Example
+        title="Controlled"
+        description="The consumer owns the open state via value + onValueChange. Useful for syncing with URL state or external state stores."
+        code={`const [open, setOpen] = useState('');
+
+<Accordion type="single" collapsible value={open} onValueChange={setOpen}>
+  <Accordion.Item value="a">
+    <Accordion.Trigger>Section A</Accordion.Trigger>
+    <Accordion.Content>Content A</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="b">
+    <Accordion.Trigger>Section B</Accordion.Trigger>
+    <Accordion.Content>Content B</Accordion.Content>
+  </Accordion.Item>
+</Accordion>
+
+<p>Currently open: {open || '(none)'}</p>`}
+      >
+        <Stack gap="sm">
+          <Accordion
+            type="single"
+            collapsible
+            value={controlled}
+            onValueChange={setControlled}
+          >
+            <Accordion.Item value="a">
+              <Accordion.Trigger>Section A</Accordion.Trigger>
+              <Accordion.Content>Content A</Accordion.Content>
+            </Accordion.Item>
+            <Accordion.Item value="b">
+              <Accordion.Trigger>Section B</Accordion.Trigger>
+              <Accordion.Content>Content B</Accordion.Content>
+            </Accordion.Item>
+          </Accordion>
+          <p style={{ margin: 0, fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+            Currently open: {controlled || '(none)'}
+          </p>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Disabled item"
+        description="A disabled item is non-interactive (button disabled, keyboard nav skips). Useful for sections that aren't applicable to the current user/plan."
+        code={`<Accordion type="single" collapsible>
+  <Accordion.Item value="basic">
+    <Accordion.Trigger>Basic settings</Accordion.Trigger>
+    <Accordion.Content>Always available.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="premium" disabled>
+    <Accordion.Trigger>Premium settings (upgrade required)</Accordion.Trigger>
+    <Accordion.Content>You won't see this.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="advanced">
+    <Accordion.Trigger>Advanced settings</Accordion.Trigger>
+    <Accordion.Content>For power users.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>`}
+      >
+        <Accordion type="single" collapsible>
+          <Accordion.Item value="basic">
+            <Accordion.Trigger>Basic settings</Accordion.Trigger>
+            <Accordion.Content>Always available.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="premium" disabled>
+            <Accordion.Trigger>Premium settings (upgrade required)</Accordion.Trigger>
+            <Accordion.Content>You won't see this.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="advanced">
+            <Accordion.Trigger>Advanced settings</Accordion.Trigger>
+            <Accordion.Content>For power users.</Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Example>
+
+      <Example
+        title="Custom icon (Plus)"
+        description="Override the default ChevronDown indicator via the Trigger's icon prop. The icon rotates 180° when the item is open."
+        code={`<Accordion type="single" collapsible>
+  <Accordion.Item value="a">
+    <Accordion.Trigger icon={<Plus size={16} />}>Toggle me</Accordion.Trigger>
+    <Accordion.Content>The Plus icon rotates 180° to become a Minus when open.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>`}
+      >
+        <Accordion type="single" collapsible>
+          <Accordion.Item value="a">
+            <Accordion.Trigger icon={<Plus size={16} aria-hidden="true" />}>
+              Toggle me
+            </Accordion.Trigger>
+            <Accordion.Content>
+              The Plus icon rotates 180° to become a Minus when open.
+            </Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Example>
+
+      <Example
+        title="Heading level override"
+        description="Trigger is wrapped in <h3> by default. Override via Item.headerLevel to fit the surrounding page heading hierarchy."
+        code={`<Accordion type="single" collapsible>
+  <Accordion.Item value="a" headerLevel="h2">
+    <Accordion.Trigger>This trigger sits inside an &lt;h2&gt;</Accordion.Trigger>
+    <Accordion.Content>Inspect the DOM to verify.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>`}
+      >
+        <Accordion type="single" collapsible>
+          <Accordion.Item value="a" headerLevel="h2">
+            <Accordion.Trigger>This trigger sits inside an &lt;h2&gt;</Accordion.Trigger>
+            <Accordion.Content>Inspect the DOM to verify.</Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/components/AccordionDemo.tsx
+++ b/packages/playground/src/pages/components/AccordionDemo.tsx
@@ -114,12 +114,7 @@ export function AccordionDemo() {
 <p>Currently open: {open || '(none)'}</p>`}
       >
         <Stack gap="sm">
-          <Accordion
-            type="single"
-            collapsible
-            value={controlled}
-            onValueChange={setControlled}
-          >
+          <Accordion type="single" collapsible value={controlled} onValueChange={setControlled}>
             <Accordion.Item value="a">
               <Accordion.Trigger>Section A</Accordion.Trigger>
               <Accordion.Content>Content A</Accordion.Content>

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { ArrowRight, Inbox } from 'lucide-react';
+import { Accordion } from '@eocrm/design-system';
 import { Alert } from '@eocrm/design-system';
 import { Avatar } from '@eocrm/design-system';
 import { Badge } from '@eocrm/design-system';
@@ -58,6 +59,21 @@ function DataTablePreview() {
 }
 
 const items: { to: string; name: string; description: string; preview: React.ReactNode }[] = [
+  {
+    to: '/components/accordion',
+    name: 'Accordion',
+    description: 'Stacked collapsible panels. Single-open or multi-open mode.',
+    preview: (
+      <div style={{ width: '100%', maxWidth: '260px' }}>
+        <Accordion type="single" collapsible defaultValue="a">
+          <Accordion.Item value="a">
+            <Accordion.Trigger>Section</Accordion.Trigger>
+            <Accordion.Content>Body</Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </div>
+    ),
+  },
   {
     to: '/components/alert',
     name: 'Alert',

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -1,6 +1,7 @@
 // packages/playground/src/pages/mockups/registry.ts
 
 export type ComponentName =
+  | 'Accordion'
   | 'Alert'
   | 'Avatar'
   | 'Badge'


### PR DESCRIPTION
## Summary

- New \`<Accordion>\` compound component — vertically-stacked collapsible panels for FAQ-style content, settings sections, and any case with a list of headings + optional drill-down detail.
- **Two modes** via discriminated \`type\` prop: \`single\` (one open at a time, optional \`collapsible\`) or \`multiple\` (any combination open).
- **Both controlled** (\`value\` + \`onValueChange\`) **and uncontrolled** (\`defaultValue\`) supported.
- **Per-item** \`disabled\`, custom trigger icon, configurable \`headerLevel\` (default h3 per WAI-ARIA APG).
- **Smooth CSS grid-template-rows animation** with browser-hint optimizations (no JS measurement); \`prefers-reduced-motion\` respected.
- **Full WAI-ARIA APG keyboard support**: ArrowDown/Up/Home/End for trigger-to-trigger nav, skipping disabled items, scoped to the current accordion (works correctly when nested).

## Design highlights

- **Compound API via \`Object.assign\`** — \`Accordion\` + \`.Item\` + \`.Trigger\` + \`.Content\`. Same pattern as ButtonGroup.
- **Two contexts**: \`AccordionContext\` (mode + isOpen + toggle) and \`AccordionItemContext\` (value + disabled + isOpen + triggerId + contentId). Both throw if consumed outside the right ancestor.
- **Discriminated union props**: \`type='single'\` requires \`value: string\` / \`defaultValue?: string\` and accepts \`collapsible\`; \`type='multiple'\` requires \`value: string[]\` / \`defaultValue?: string[]\` and rejects \`collapsible\` at the type level.
- **DOM-order keyboard nav** via \`document.querySelectorAll\` on \`[data-accordion]\` + filtering to direct-descendants — scopes nav to the current accordion even when a nested Accordion lives inside an open Content.
- **CSS grid-row animation** with \`will-change\` + \`contain: layout style\` + GPU-promoted inner wrapper — smooth on the dev server without resorting to JS measurement. Same browser-hint strategy as Drawer's animation fix.

## Hard Rule 8

**Round 1 verdict: keep iterating** (3 Important findings):

1. **Nested-accordion keyboard escape**: ArrowDown from an outer trigger jumped into a nested Accordion's first trigger. Fixed by filtering the keyboard handler's trigger list to direct descendants of the current root (\`btn.closest('[data-accordion]') === root\`). New test pins the behavior.
2. **Missing Rule-1 minimum coverage**: added 4 ref tests (Accordion / Item / Trigger / Content all forward refs to the right element) + 1 className-merge test covering all four parts.
3. **Missing Rule-7 spread-order comments**: added JSX comments above all four subcomponents' return statements documenting Pattern A vs B.

**Plus user-reported animation lag fix**: \`will-change: grid-template-rows\` + \`contain: layout style\` on the .content wrapper, \`transform: translateZ(0)\` on .inner to promote it to its own compositor layer. Same spirit as Drawer's \`will-change: transform\` fix — give the browser advance notice so it doesn't recompute layout from scratch each frame.

32 new tests (was 26, +6 from R1 fixes). Suite total: **1494 passing**.

All four gates green: \`make test\` · \`make build-lib\` · \`make build\` · \`make lint\` · \`npm pack --dry-run\` (no test files in tarball).

## Test plan

- [ ] Single + collapsible mode opens/closes one item at a time
- [ ] Single + NOT collapsible: clicking the open item is a no-op
- [ ] Multiple mode supports any combination open
- [ ] Controlled \`value\` + \`onValueChange\` round-trips in both modes
- [ ] \`disabled\` item's trigger is non-clickable AND keyboard nav skips it
- [ ] ArrowDown/Up cycles between triggers (wraps at edges)
- [ ] Home/End jumps to first/last non-disabled trigger
- [ ] **Nested Accordion**: ArrowDown on the outer trigger stays in the outer (does NOT jump into the inner's first trigger)
- [ ] Custom \`icon\` on Trigger replaces the default ChevronDown; \`icon={null}\` hides it
- [ ] \`headerLevel=\"h2\"\` wraps the trigger in \`<h2>\` (verify in DOM)
- [ ] \`aria-controls\` on each trigger matches \`id\` on the corresponding content panel
- [ ] **Animation smoothness**: dev server at \`/components/accordion\` shows smooth open/close on toggle (no choppy frames)
- [ ] \`prefers-reduced-motion: reduce\` disables the grid-row animation
- [ ] Playground demo at \`/components/accordion\` renders all 6 examples without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)