### PR TITLE
Card tone + Badge stripe variant: tone-coded left stripes

### DIFF
--- a/docs/superpowers/specs/2026-05-23-card-badge-stripe-design.md
+++ b/docs/superpowers/specs/2026-05-23-card-badge-stripe-design.md
@@ -1,0 +1,235 @@
+# Card tone + Badge stripe variant — design spec
+
+**Date:** 2026-05-23
+**Branch:** `feat/card-badge-stripe`
+**Scope:** Two related visual additions in one PR. (1) Card gets an optional `tone` prop that draws a tone-colored left stripe (matches the inline pattern in `Dashboard.module.scss`'s `.statCard`). (2) Badge gets a new `variant="stripe"` that renders rectangular (not pill) with a tone-colored left stripe + tinted body.
+
+## Goal
+
+Formalize the "tone-coded left stripe" emphasis pattern that the dashboard already uses inline. Two surfaces:
+
+- **Card**: an opt-in `tone` prop. Default = no stripe (current bordered look). When set, draws a 3px stripe in the tone color on the left edge.
+- **Badge**: a new `variant="stripe"` that swaps the pill shape for a rectangular block with a tone-colored left stripe + a softly-tinted body. Coexists with the default `variant="filled"` (the current pill).
+
+Both use the existing tone vocabulary (`accent` / `info` / `success` / `warning` / `danger`), driven by the same color tokens Alert uses.
+
+## Why now
+
+- `Dashboard.tsx` already paints accent stripes on stat cards via inline className override + hand-rolled SCSS. Any other page wanting the same pattern would copy the recipe. Promoting it to a Card prop unifies.
+- Badge currently has only the filled-pill shape. Several CRM patterns (deal-stage labels, task tags) want a rectangular tone-coded chip that reads as "category marker" rather than "loud status pill". A `variant="stripe"` covers that gap without losing the existing pill.
+- Same tone vocabulary as Alert means consumers learn it once.
+
+## Non-goals (v1)
+
+- **No `tone` on Card without left stripe** (e.g., "tone but as tinted bg"). The dashboard pattern is specifically the left stripe; Alert already covers the tinted-bg case.
+- **No right-stripe / top-stripe / bottom-stripe variants on either component.** Left only.
+- **No outline variant on Badge** (e.g., colored border + transparent bg). Solid pill + stripe rectangle cover the use cases; outline can be added v2.
+- **No removable Badge.** No `onClose` / `×` button. Out of scope.
+- **No nested tone propagation** (e.g., a Card with `tone="success"` doesn't change the tone of Badges inside it). Each component owns its own tone.
+- **No new tokens.** All five tones reuse existing `--color-{accent,info,success,warning,danger}` + `--color-{accent,info,success,warning,danger}-bg-subtle` tokens (Alert already uses them).
+
+## Architecture
+
+### Card
+
+```ts
+import type { HTMLAttributes } from 'react';
+
+/** Optional left-stripe tone. When set, draws a 3px accent-colored bar on the left edge. */
+export type CardTone = 'accent' | 'info' | 'success' | 'warning' | 'danger';
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  padding?: CardPadding;  // existing
+  /**
+   * Optional left-edge tone stripe (3px). Useful for "stat card" / "status card"
+   * patterns where one card in a row needs visual emphasis. Default: no stripe
+   * (the card keeps its standard bordered look).
+   */
+  tone?: CardTone;
+}
+```
+
+The component renders the same `<div>` as today, with an additional `data-tone={tone}` attribute when `tone` is set. SCSS attribute selectors paint the left stripe via `border-left-color` (overriding the default transparent border-left).
+
+**SCSS**:
+
+```scss
+.card {
+  // existing rules…
+  // Reserve a 3px transparent border-left on every card so the layout doesn't
+  // shift when tone is added/removed.
+  border-left: var(--border-width-strong) solid transparent;
+}
+
+.card[data-tone='accent']  { border-left-color: var(--color-accent); }
+.card[data-tone='info']    { border-left-color: var(--color-info); }
+.card[data-tone='success'] { border-left-color: var(--color-success); }
+.card[data-tone='warning'] { border-left-color: var(--color-warning); }
+.card[data-tone='danger']  { border-left-color: var(--color-danger); }
+```
+
+The reserved-transparent-border trick avoids layout reflow when toggling the prop (vs. only setting `border-left` when tone is present, which would shift content 3px). Same approach as Alert.
+
+### Badge
+
+```ts
+/** Visual variant. Defaults to `'filled'` (the existing pill look). */
+export type BadgeVariant = 'filled' | 'stripe';
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: BadgeTone;     // existing
+  size?: BadgeSize;     // existing
+  dot?: boolean;        // existing
+  dotPosition?: BadgeDot; // existing
+  /**
+   * Visual variant.
+   * - `'filled'` (default) — solid tone-tinted pill. The standard "loud status" look.
+   * - `'stripe'` — rectangular block with a tone-colored left stripe + soft tinted body.
+   *   Use for category markers or sidebar labels where pill emphasis is too loud.
+   */
+  variant?: BadgeVariant;
+}
+```
+
+When `variant="stripe"`:
+- Shape: rectangular (no `border-radius` — or a small `--radius-sm` for a soft edge)
+- Body bg: tone's `*-bg-subtle` token (e.g., `--color-success-bg-subtle`)
+- Body text: tone's regular fg color (e.g., `--color-success`)
+- Left edge: 3px stripe in tone color
+- No uppercase / no letter-spacing (rectangular labels read as labels, not loud pills)
+
+**SCSS**:
+
+```scss
+// Existing .badge / .sm / .md / .neutral / .info / .success etc. rules.
+
+// New variant: rectangular block with left stripe.
+.stripe {
+  border-radius: var(--radius-sm);
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: var(--font-weight-medium);
+  // Reserve transparent border-left so toggling tone doesn't shift layout.
+  border-left: var(--border-width-strong) solid transparent;
+  padding-left: var(--space-2);
+}
+
+// Tone overrides for stripe variant — body bg + fg + border-left color.
+.stripe.accent  { background: var(--color-accent-bg-subtle); color: var(--color-accent);  border-left-color: var(--color-accent); }
+.stripe.info    { background: var(--color-info-bg-subtle);    color: var(--color-info);    border-left-color: var(--color-info); }
+.stripe.success { background: var(--color-success-bg-subtle); color: var(--color-success); border-left-color: var(--color-success); }
+.stripe.warning { background: var(--color-warning-bg-subtle); color: var(--color-warning); border-left-color: var(--color-warning); }
+.stripe.danger  { background: var(--color-danger-bg-subtle);  color: var(--color-danger);  border-left-color: var(--color-danger); }
+.stripe.neutral { background: var(--color-bg-muted);           color: var(--color-fg);      border-left-color: var(--color-fg-muted); }
+.stripe.purple  { background: var(--color-badge-purple-bg);    color: var(--color-badge-purple-fg); border-left-color: var(--color-badge-purple-fg); }
+```
+
+(Note: `accent` isn't a current Badge tone — adding it for parity with Card. If we don't want to expand BadgeTone, we'll skip `accent` on Badge and keep current 6 tones.)
+
+**Decision**: keep the BadgeTone union unchanged (neutral/info/success/warning/danger/purple). The stripe variant uses these 6 tones. Card's `tone` includes `accent` because Card doesn't already have a `tone` prop — different naming surface.
+
+### File touches
+
+**Library**:
+- `packages/design-system/src/components/Card/Card.tsx` — add `tone` prop, `data-tone` attr, JSDoc
+- `packages/design-system/src/components/Card/Card.module.scss` — add reserved-transparent border-left + 5 tone selectors
+- `packages/design-system/src/components/Card/Card.test.tsx` — add ~5 cases
+- `packages/design-system/src/components/Badge/Badge.tsx` — add `variant` prop, JSDoc, route to stripe SCSS class when set
+- `packages/design-system/src/components/Badge/Badge.module.scss` — add `.stripe` + tone overrides
+- `packages/design-system/src/components/Badge/Badge.test.tsx` — add ~5 cases
+- `packages/design-system/src/index.ts` — re-export `CardTone`, `BadgeVariant`
+
+**Playground**:
+- `packages/playground/src/pages/components/CardDemo.tsx` — add tone gallery example
+- `packages/playground/src/pages/components/BadgeDemo.tsx` — add stripe-variant gallery example
+- (Mockup refactor — optional, see below)
+
+**Mockup cleanup** (within this PR):
+- `Dashboard.module.scss` — delete `.statCard { border-left: ... }` and switch to `<Card tone="accent">` in `Dashboard.tsx`. Demonstrates the new prop in a real mockup.
+
+### AGENTS.md updates
+
+- Card section: add `tone` bullet to the existing list.
+- Badge section: add `variant` bullet, add a stripe example.
+
+## Public API summary
+
+```tsx
+// Card
+<Card padding="md" tone="accent">...</Card>
+<Card tone="success">Healthy</Card>
+<Card>Plain bordered (existing)</Card>
+
+// Badge
+<Badge tone="info">Lead</Badge>                          // existing filled pill
+<Badge variant="stripe" tone="warning">Renewal due</Badge>   // new
+<Badge variant="stripe" tone="success" size="sm">Active</Badge>
+```
+
+## Testing
+
+### Card (~5 new cases on top of existing tests)
+
+1. No `tone` prop: no `data-tone` attribute
+2. `tone="accent"`: `data-tone="accent"` set
+3. Each of the 5 tones (it.each): `data-tone` value matches
+4. `tone` does NOT affect `padding` (regression check that they compose)
+5. `tone="accent"` + `className="custom"` merges (no replacement)
+
+### Badge (~5 new cases on top of existing tests)
+
+1. Default variant is `'filled'` (no `.stripe` class)
+2. `variant="filled"` explicit: no `.stripe` class (verify the default path is identical)
+3. `variant="stripe"` adds `.stripe` class
+4. `variant="stripe" tone="success"` applies both `.stripe` and `.success` classes
+5. `variant="stripe"` works with `size="sm"` and `size="md"` (verify the size classes still apply)
+
+## Demo additions
+
+**`CardDemo.tsx`**:
+```tsx
+<Example title="Tone-coded cards (left stripe)">
+  <Cluster gap="md" wrap>
+    <Card padding="md" tone="accent">Accent</Card>
+    <Card padding="md" tone="info">Info</Card>
+    <Card padding="md" tone="success">Success</Card>
+    <Card padding="md" tone="warning">Warning</Card>
+    <Card padding="md" tone="danger">Danger</Card>
+  </Cluster>
+</Example>
+```
+
+**`BadgeDemo.tsx`**:
+```tsx
+<Example title='Stripe variant (rectangular with left stripe)'>
+  <Cluster gap="sm" wrap>
+    <Badge variant="stripe" tone="info">Lead</Badge>
+    <Badge variant="stripe" tone="success">Active</Badge>
+    <Badge variant="stripe" tone="warning">Renewal due</Badge>
+    <Badge variant="stripe" tone="danger">Churned</Badge>
+    <Badge variant="stripe" tone="neutral">Archived</Badge>
+    <Badge variant="stripe" tone="purple">Enterprise</Badge>
+  </Cluster>
+</Example>
+```
+
+## Mockup cleanup (in-scope)
+
+`Dashboard.tsx`:
+```tsx
+// Before
+<Card padding="md" className={styles.statCard}>...</Card>
+
+// After
+<Card padding="md" tone="accent">...</Card>
+```
+
+`Dashboard.module.scss`: delete the `.statCard { border-left: ... }` block. The component handles it now.
+
+## Hard Rule 8
+
+Standard cycle: gates green, fresh-context reviewer, fix Critical + Important, repeat until clean.
+
+## Open questions
+
+None.

--- a/docs/superpowers/specs/2026-05-23-card-badge-stripe-design.md
+++ b/docs/superpowers/specs/2026-05-23-card-badge-stripe-design.md
@@ -39,7 +39,7 @@ import type { HTMLAttributes } from 'react';
 export type CardTone = 'accent' | 'info' | 'success' | 'warning' | 'danger';
 
 export interface CardProps extends HTMLAttributes<HTMLDivElement> {
-  padding?: CardPadding;  // existing
+  padding?: CardPadding; // existing
   /**
    * Optional left-edge tone stripe (3px). Useful for "stat card" / "status card"
    * patterns where one card in a row needs visual emphasis. Default: no stripe
@@ -61,11 +61,21 @@ The component renders the same `<div>` as today, with an additional `data-tone={
   border-left: var(--border-width-strong) solid transparent;
 }
 
-.card[data-tone='accent']  { border-left-color: var(--color-accent); }
-.card[data-tone='info']    { border-left-color: var(--color-info); }
-.card[data-tone='success'] { border-left-color: var(--color-success); }
-.card[data-tone='warning'] { border-left-color: var(--color-warning); }
-.card[data-tone='danger']  { border-left-color: var(--color-danger); }
+.card[data-tone='accent'] {
+  border-left-color: var(--color-accent);
+}
+.card[data-tone='info'] {
+  border-left-color: var(--color-info);
+}
+.card[data-tone='success'] {
+  border-left-color: var(--color-success);
+}
+.card[data-tone='warning'] {
+  border-left-color: var(--color-warning);
+}
+.card[data-tone='danger'] {
+  border-left-color: var(--color-danger);
+}
 ```
 
 The reserved-transparent-border trick avoids layout reflow when toggling the prop (vs. only setting `border-left` when tone is present, which would shift content 3px). Same approach as Alert.
@@ -77,9 +87,9 @@ The reserved-transparent-border trick avoids layout reflow when toggling the pro
 export type BadgeVariant = 'filled' | 'stripe';
 
 export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
-  tone?: BadgeTone;     // existing
-  size?: BadgeSize;     // existing
-  dot?: boolean;        // existing
+  tone?: BadgeTone; // existing
+  size?: BadgeSize; // existing
+  dot?: boolean; // existing
   dotPosition?: BadgeDot; // existing
   /**
    * Visual variant.
@@ -92,6 +102,7 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
 ```
 
 When `variant="stripe"`:
+
 - Shape: rectangular (no `border-radius` — or a small `--radius-sm` for a soft edge)
 - Body bg: tone's `*-bg-subtle` token (e.g., `--color-success-bg-subtle`)
 - Body text: tone's regular fg color (e.g., `--color-success`)
@@ -115,13 +126,41 @@ When `variant="stripe"`:
 }
 
 // Tone overrides for stripe variant — body bg + fg + border-left color.
-.stripe.accent  { background: var(--color-accent-bg-subtle); color: var(--color-accent);  border-left-color: var(--color-accent); }
-.stripe.info    { background: var(--color-info-bg-subtle);    color: var(--color-info);    border-left-color: var(--color-info); }
-.stripe.success { background: var(--color-success-bg-subtle); color: var(--color-success); border-left-color: var(--color-success); }
-.stripe.warning { background: var(--color-warning-bg-subtle); color: var(--color-warning); border-left-color: var(--color-warning); }
-.stripe.danger  { background: var(--color-danger-bg-subtle);  color: var(--color-danger);  border-left-color: var(--color-danger); }
-.stripe.neutral { background: var(--color-bg-muted);           color: var(--color-fg);      border-left-color: var(--color-fg-muted); }
-.stripe.purple  { background: var(--color-badge-purple-bg);    color: var(--color-badge-purple-fg); border-left-color: var(--color-badge-purple-fg); }
+.stripe.accent {
+  background: var(--color-accent-bg-subtle);
+  color: var(--color-accent);
+  border-left-color: var(--color-accent);
+}
+.stripe.info {
+  background: var(--color-info-bg-subtle);
+  color: var(--color-info);
+  border-left-color: var(--color-info);
+}
+.stripe.success {
+  background: var(--color-success-bg-subtle);
+  color: var(--color-success);
+  border-left-color: var(--color-success);
+}
+.stripe.warning {
+  background: var(--color-warning-bg-subtle);
+  color: var(--color-warning);
+  border-left-color: var(--color-warning);
+}
+.stripe.danger {
+  background: var(--color-danger-bg-subtle);
+  color: var(--color-danger);
+  border-left-color: var(--color-danger);
+}
+.stripe.neutral {
+  background: var(--color-bg-muted);
+  color: var(--color-fg);
+  border-left-color: var(--color-fg-muted);
+}
+.stripe.purple {
+  background: var(--color-badge-purple-bg);
+  color: var(--color-badge-purple-fg);
+  border-left-color: var(--color-badge-purple-fg);
+}
 ```
 
 (Note: `accent` isn't a current Badge tone — adding it for parity with Card. If we don't want to expand BadgeTone, we'll skip `accent` on Badge and keep current 6 tones.)
@@ -131,6 +170,7 @@ When `variant="stripe"`:
 ### File touches
 
 **Library**:
+
 - `packages/design-system/src/components/Card/Card.tsx` — add `tone` prop, `data-tone` attr, JSDoc
 - `packages/design-system/src/components/Card/Card.module.scss` — add reserved-transparent border-left + 5 tone selectors
 - `packages/design-system/src/components/Card/Card.test.tsx` — add ~5 cases
@@ -140,11 +180,13 @@ When `variant="stripe"`:
 - `packages/design-system/src/index.ts` — re-export `CardTone`, `BadgeVariant`
 
 **Playground**:
+
 - `packages/playground/src/pages/components/CardDemo.tsx` — add tone gallery example
 - `packages/playground/src/pages/components/BadgeDemo.tsx` — add stripe-variant gallery example
 - (Mockup refactor — optional, see below)
 
 **Mockup cleanup** (within this PR):
+
 - `Dashboard.module.scss` — delete `.statCard { border-left: ... }` and switch to `<Card tone="accent">` in `Dashboard.tsx`. Demonstrates the new prop in a real mockup.
 
 ### AGENTS.md updates
@@ -187,28 +229,52 @@ When `variant="stripe"`:
 ## Demo additions
 
 **`CardDemo.tsx`**:
+
 ```tsx
 <Example title="Tone-coded cards (left stripe)">
   <Cluster gap="md" wrap>
-    <Card padding="md" tone="accent">Accent</Card>
-    <Card padding="md" tone="info">Info</Card>
-    <Card padding="md" tone="success">Success</Card>
-    <Card padding="md" tone="warning">Warning</Card>
-    <Card padding="md" tone="danger">Danger</Card>
+    <Card padding="md" tone="accent">
+      Accent
+    </Card>
+    <Card padding="md" tone="info">
+      Info
+    </Card>
+    <Card padding="md" tone="success">
+      Success
+    </Card>
+    <Card padding="md" tone="warning">
+      Warning
+    </Card>
+    <Card padding="md" tone="danger">
+      Danger
+    </Card>
   </Cluster>
 </Example>
 ```
 
 **`BadgeDemo.tsx`**:
+
 ```tsx
-<Example title='Stripe variant (rectangular with left stripe)'>
+<Example title="Stripe variant (rectangular with left stripe)">
   <Cluster gap="sm" wrap>
-    <Badge variant="stripe" tone="info">Lead</Badge>
-    <Badge variant="stripe" tone="success">Active</Badge>
-    <Badge variant="stripe" tone="warning">Renewal due</Badge>
-    <Badge variant="stripe" tone="danger">Churned</Badge>
-    <Badge variant="stripe" tone="neutral">Archived</Badge>
-    <Badge variant="stripe" tone="purple">Enterprise</Badge>
+    <Badge variant="stripe" tone="info">
+      Lead
+    </Badge>
+    <Badge variant="stripe" tone="success">
+      Active
+    </Badge>
+    <Badge variant="stripe" tone="warning">
+      Renewal due
+    </Badge>
+    <Badge variant="stripe" tone="danger">
+      Churned
+    </Badge>
+    <Badge variant="stripe" tone="neutral">
+      Archived
+    </Badge>
+    <Badge variant="stripe" tone="purple">
+      Enterprise
+    </Badge>
   </Cluster>
 </Example>
 ```
@@ -216,6 +282,7 @@ When `variant="stripe"`:
 ## Mockup cleanup (in-scope)
 
 `Dashboard.tsx`:
+
 ```tsx
 // Before
 <Card padding="md" className={styles.statCard}>...</Card>

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -333,9 +333,13 @@ import { Switch } from '@eocrm/design-system';
 <Card padding="md">
   <Stack gap="md">...</Stack>
 </Card>
+
+// Tone-coded stat card — 3px left-edge stripe in the tone color:
+<Card padding="md" tone="accent">Open deals</Card>
 ```
 
 - `padding`: `none` / `sm` / `md` (default) / `lg`
+- `tone`: `accent` / `info` / `success` / `warning` / `danger` — draws a 3px left-edge stripe in the tone color. Default: no stripe (standard bordered look). A transparent border-left is always reserved so toggling `tone` never shifts layout.
 - **Never nest Card in Card.**
 - Use `padding="none"` when the card contains a table or list that should bleed edge-to-edge.
 
@@ -486,10 +490,15 @@ import { Divider } from '@eocrm/design-system';
 ```tsx
 <Badge tone="success">Active</Badge>
 <Badge tone="danger">Churned</Badge>
+
+// Stripe variant — rectangular category marker with left stripe:
+<Badge variant="stripe" tone="info">Lead</Badge>
+<Badge variant="stripe" tone="warning">Renewal due</Badge>
 ```
 
 - `tone`: `neutral` (default) / `info` / `success` / `warning` / `danger` / `purple`
 - `size`: `md` (20, default) / `sm` (16). `md` is the uppercase tracked "loud label" pill. `sm` drops the uppercase + tracking and renders case as-typed — use it for dense table cells, compact toolbars, or anywhere the uppercase treatment shouts next to body copy.
+- `variant`: `filled` (default) / `stripe`. `filled` is the standard pill. `stripe` renders a rectangular block with a tone-colored 3px left stripe and a softly tinted body — no uppercase or letter-spacing. Use for category markers or sidebar labels where pill emphasis is too loud. Composes with all six existing tones.
 - `dot`: `start` / `end` — adds a small filled circle in the badge's text color before or after the content. Use for Slack/GitHub-style status indicators (`<Badge tone="success" dot="start">Online</Badge>`). Decorative only (`aria-hidden`); the text is still the accessible label.
 - **Non-interactive.** If it's clickable, use `<Button>` instead.
 - Doesn't auto-add `role="status"`. Wrap in `aria-live` if a state change should be announced.

--- a/packages/design-system/src/components/Badge/Badge.module.scss
+++ b/packages/design-system/src/components/Badge/Badge.module.scss
@@ -61,3 +61,53 @@
   background: currentColor;
   flex-shrink: 0;
 }
+
+// Stripe variant — rectangular block with a tone-colored left stripe + tinted body.
+// Rules come AFTER the filled tone rules so .stripe.* overrides .filled tone backgrounds.
+.stripe {
+  border-radius: var(--radius-sm);
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: var(--font-weight-medium);
+
+  // Reserve transparent border-left so toggling tone doesn't shift layout.
+  border-left: var(--border-width-strong) solid transparent;
+  padding-left: var(--space-2);
+}
+
+// Stripe + tone overrides — specificity 0,2,0 beats the plain tone rules (0,1,0).
+.stripe.neutral {
+  background: var(--color-bg-muted);
+  color: var(--color-fg);
+  border-left-color: var(--color-fg-muted);
+}
+
+.stripe.info {
+  background: var(--color-info-bg-subtle);
+  color: var(--color-info);
+  border-left-color: var(--color-info);
+}
+
+.stripe.success {
+  background: var(--color-success-bg-subtle);
+  color: var(--color-success);
+  border-left-color: var(--color-success);
+}
+
+.stripe.warning {
+  background: var(--color-warning-bg-subtle);
+  color: var(--color-warning);
+  border-left-color: var(--color-warning);
+}
+
+.stripe.danger {
+  background: var(--color-danger-bg-subtle);
+  color: var(--color-danger);
+  border-left-color: var(--color-danger);
+}
+
+.stripe.purple {
+  background: var(--color-badge-purple-bg);
+  color: var(--color-badge-purple-fg);
+  border-left-color: var(--color-badge-purple-fg);
+}

--- a/packages/design-system/src/components/Badge/Badge.test.tsx
+++ b/packages/design-system/src/components/Badge/Badge.test.tsx
@@ -79,24 +79,43 @@ describe('Badge', () => {
   });
 
   it('variant="filled" explicit: no stripe class', () => {
-    const { container } = render(<Badge variant="filled" tone="success">x</Badge>);
+    const { container } = render(
+      <Badge variant="filled" tone="success">
+        x
+      </Badge>,
+    );
     expect(container.firstElementChild!.className).not.toMatch(/stripe/);
   });
 
   it('variant="stripe" adds the stripe class', () => {
-    const { container } = render(<Badge variant="stripe" tone="success">x</Badge>);
+    const { container } = render(
+      <Badge variant="stripe" tone="success">
+        x
+      </Badge>,
+    );
     expect(container.firstElementChild!.className).toMatch(/stripe/);
   });
 
   it('variant="stripe" composes with tone (both classes present)', () => {
-    const { container } = render(<Badge variant="stripe" tone="warning">x</Badge>);
+    const { container } = render(
+      <Badge variant="stripe" tone="warning">
+        x
+      </Badge>,
+    );
     const root = container.firstElementChild!;
     expect(root.className).toMatch(/stripe/);
     expect(root.className).toMatch(/warning/);
   });
 
-  it.each(['sm', 'md'] as const)('variant="stripe" + size="%s": size class still applies', (size: BadgeSize) => {
-    const { container } = render(<Badge variant="stripe" size={size} tone="info">x</Badge>);
-    expect(container.firstElementChild!.className).toMatch(new RegExp(size));
-  });
+  it.each(['sm', 'md'] as const)(
+    'variant="stripe" + size="%s": size class still applies',
+    (size: BadgeSize) => {
+      const { container } = render(
+        <Badge variant="stripe" size={size} tone="info">
+          x
+        </Badge>,
+      );
+      expect(container.firstElementChild!.className).toMatch(new RegExp(size));
+    },
+  );
 });

--- a/packages/design-system/src/components/Badge/Badge.test.tsx
+++ b/packages/design-system/src/components/Badge/Badge.test.tsx
@@ -72,4 +72,31 @@ describe('Badge', () => {
     expect(dot.getAttribute('aria-hidden')).toBe('true');
     expect(screen.getByText('Active')).toBeInTheDocument();
   });
+
+  it('default variant is "filled" (no stripe class)', () => {
+    const { container } = render(<Badge tone="success">x</Badge>);
+    expect(container.firstElementChild!.className).not.toMatch(/stripe/);
+  });
+
+  it('variant="filled" explicit: no stripe class', () => {
+    const { container } = render(<Badge variant="filled" tone="success">x</Badge>);
+    expect(container.firstElementChild!.className).not.toMatch(/stripe/);
+  });
+
+  it('variant="stripe" adds the stripe class', () => {
+    const { container } = render(<Badge variant="stripe" tone="success">x</Badge>);
+    expect(container.firstElementChild!.className).toMatch(/stripe/);
+  });
+
+  it('variant="stripe" composes with tone (both classes present)', () => {
+    const { container } = render(<Badge variant="stripe" tone="warning">x</Badge>);
+    const root = container.firstElementChild!;
+    expect(root.className).toMatch(/stripe/);
+    expect(root.className).toMatch(/warning/);
+  });
+
+  it.each(['sm', 'md'] as const)('variant="stripe" + size="%s": size class still applies', (size: BadgeSize) => {
+    const { container } = render(<Badge variant="stripe" size={size} tone="info">x</Badge>);
+    expect(container.firstElementChild!.className).toMatch(new RegExp(size));
+  });
 });

--- a/packages/design-system/src/components/Badge/Badge.tsx
+++ b/packages/design-system/src/components/Badge/Badge.tsx
@@ -6,6 +6,14 @@ import styles from './Badge.module.scss';
 export type BadgeTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger' | 'purple';
 
 /**
+ * Visual variant.
+ * - `'filled'` (default) — solid tone-tinted pill. The standard "loud status" look.
+ * - `'stripe'` — rectangular block with a tone-colored left stripe + soft tinted body.
+ *   Use for category markers or sidebar labels where pill emphasis is too loud.
+ */
+export type BadgeVariant = 'filled' | 'stripe';
+
+/**
  * Pill height. See BadgeProps#size for when to use each. Intentionally only
  * two heights — a 40px badge would be Button-shaped. If you need something
  * larger, use `<Button>` or rethink the layout.
@@ -48,6 +56,13 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
    * text remains the accessible label.
    */
   dot?: BadgeDot;
+  /**
+   * Visual variant.
+   * - `'filled'` (default) — solid tone-tinted pill. The standard "loud status" look.
+   * - `'stripe'` — rectangular block with a tone-colored left stripe + soft tinted body.
+   *   Use for category markers or sidebar labels where pill emphasis is too loud.
+   */
+  variant?: BadgeVariant;
 }
 
 const toneClass: Record<BadgeTone, string> = {
@@ -65,8 +80,11 @@ const sizeClass: Record<BadgeSize, string> = {
 };
 
 /**
- * Small inline pill for status, category, or count. Non-interactive — wrap
- * in a `<Button>` if you need it clickable.
+ * Small inline pill for status, category, or count. Supports two variants:
+ * the default `'filled'` pill and a `'stripe'` rectangular block with a
+ * tone-colored left stripe and a softly tinted body — useful for category
+ * markers or sidebar labels where the uppercase pill is too loud. Non-interactive
+ * — wrap in a `<Button>` if you need it clickable.
  *
  * Badge does NOT auto-add `role="status"`. Tone is a visual signal only.
  * If a state change should be announced to screen readers, wrap the badge
@@ -88,6 +106,14 @@ const sizeClass: Record<BadgeSize, string> = {
  *   <Badge tone="info">Pipeline 2026</Badge>
  * </Cluster>
  *
+ * @example
+ * // Stripe variant — rectangular category markers:
+ * <Cluster gap="sm">
+ *   <Badge variant="stripe" tone="info">Lead</Badge>
+ *   <Badge variant="stripe" tone="warning">Renewal due</Badge>
+ *   <Badge variant="stripe" tone="success">Active</Badge>
+ * </Cluster>
+ *
  * @remarks When NOT to use
  * - As a button. Badges are non-interactive labels. If it's clickable, use
  *   a `Button` or `Link`.
@@ -103,14 +129,20 @@ const sizeClass: Record<BadgeSize, string> = {
  *   with an appropriate variant instead.
  */
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
-  { tone = 'neutral', size = 'md', dot, className, children, ...props },
+  { tone = 'neutral', size = 'md', dot, variant = 'filled', className, children, ...props },
   ref,
 ) {
   // {...props} last so consumer overrides win (Pattern A).
   return (
     <span
       ref={ref}
-      className={clsx(styles.badge, toneClass[tone], sizeClass[size], className)}
+      className={clsx(
+        styles.badge,
+        toneClass[tone],
+        sizeClass[size],
+        variant === 'stripe' && styles.stripe,
+        className,
+      )}
       {...props}
     >
       {dot === 'start' && <span aria-hidden="true" className={styles.dot} />}

--- a/packages/design-system/src/components/Badge/index.ts
+++ b/packages/design-system/src/components/Badge/index.ts
@@ -1,2 +1,2 @@
 export { Badge } from './Badge';
-export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot } from './Badge';
+export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot, BadgeVariant } from './Badge';

--- a/packages/design-system/src/components/Card/Card.module.scss
+++ b/packages/design-system/src/components/Card/Card.module.scss
@@ -3,18 +3,41 @@
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
-
-  // Reserve 3px transparent border-left on every card so toggling `tone`
-  // doesn't shift layout (same pattern as Alert's left-stripe).
-  border-left: var(--border-width-strong) solid transparent;
 }
 
-// Tone-coded left-stripe selectors — override only border-left-color.
-.card[data-tone='accent']  { border-left-color: var(--color-accent); }
-.card[data-tone='info']    { border-left-color: var(--color-info); }
-.card[data-tone='success'] { border-left-color: var(--color-success); }
-.card[data-tone='warning'] { border-left-color: var(--color-warning); }
-.card[data-tone='danger']  { border-left-color: var(--color-danger); }
+// Tone-coded left-stripe via inset box-shadow. Drawn inside the card on top
+// of the existing border, so untoned cards stay pixel-identical to before
+// (no layout shift, no width change). The existing --shadow-sm stays on
+// every card; the inset stripe layers on top when `data-tone` is set.
+.card[data-tone='accent'] {
+  box-shadow:
+    inset var(--border-width-strong) 0 0 var(--color-accent),
+    var(--shadow-sm);
+}
+
+.card[data-tone='info'] {
+  box-shadow:
+    inset var(--border-width-strong) 0 0 var(--color-info),
+    var(--shadow-sm);
+}
+
+.card[data-tone='success'] {
+  box-shadow:
+    inset var(--border-width-strong) 0 0 var(--color-success),
+    var(--shadow-sm);
+}
+
+.card[data-tone='warning'] {
+  box-shadow:
+    inset var(--border-width-strong) 0 0 var(--color-warning),
+    var(--shadow-sm);
+}
+
+.card[data-tone='danger'] {
+  box-shadow:
+    inset var(--border-width-strong) 0 0 var(--color-danger),
+    var(--shadow-sm);
+}
 
 .paddingNone {
   padding: 0;

--- a/packages/design-system/src/components/Card/Card.module.scss
+++ b/packages/design-system/src/components/Card/Card.module.scss
@@ -3,7 +3,18 @@
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
+
+  // Reserve 3px transparent border-left on every card so toggling `tone`
+  // doesn't shift layout (same pattern as Alert's left-stripe).
+  border-left: var(--border-width-strong) solid transparent;
 }
+
+// Tone-coded left-stripe selectors — override only border-left-color.
+.card[data-tone='accent']  { border-left-color: var(--color-accent); }
+.card[data-tone='info']    { border-left-color: var(--color-info); }
+.card[data-tone='success'] { border-left-color: var(--color-success); }
+.card[data-tone='warning'] { border-left-color: var(--color-warning); }
+.card[data-tone='danger']  { border-left-color: var(--color-danger); }
 
 .paddingNone {
   padding: 0;

--- a/packages/design-system/src/components/Card/Card.test.tsx
+++ b/packages/design-system/src/components/Card/Card.test.tsx
@@ -45,14 +45,22 @@ describe('Card', () => {
   );
 
   it('tone composes with padding without affecting either', () => {
-    const { container } = render(<Card padding="lg" tone="success">x</Card>);
+    const { container } = render(
+      <Card padding="lg" tone="success">
+        x
+      </Card>,
+    );
     const root = container.firstElementChild!;
     expect(root).toHaveAttribute('data-tone', 'success');
     expect(root.className).toMatch(/padding/);
   });
 
   it('tone="accent" with custom className merges (does not replace)', () => {
-    const { container } = render(<Card tone="accent" className="custom">x</Card>);
+    const { container } = render(
+      <Card tone="accent" className="custom">
+        x
+      </Card>,
+    );
     const root = container.firstElementChild!;
     expect(root).toHaveAttribute('data-tone', 'accent');
     expect(root.className).toMatch(/custom/);

--- a/packages/design-system/src/components/Card/Card.test.tsx
+++ b/packages/design-system/src/components/Card/Card.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { createRef } from 'react';
-import { Card, type CardPadding } from './Card';
+import { Card, type CardPadding, type CardTone } from './Card';
 
 describe('Card', () => {
   it('renders its children', () => {
@@ -29,5 +29,32 @@ describe('Card', () => {
     const ref = createRef<HTMLDivElement>();
     render(<Card ref={ref}>x</Card>);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('no tone prop: data-tone attribute is not set', () => {
+    const { container } = render(<Card>x</Card>);
+    expect(container.firstElementChild).not.toHaveAttribute('data-tone');
+  });
+
+  it.each(['accent', 'info', 'success', 'warning', 'danger'] as const)(
+    'tone="%s" sets data-tone="%s"',
+    (tone: CardTone) => {
+      const { container } = render(<Card tone={tone}>x</Card>);
+      expect(container.firstElementChild).toHaveAttribute('data-tone', tone);
+    },
+  );
+
+  it('tone composes with padding without affecting either', () => {
+    const { container } = render(<Card padding="lg" tone="success">x</Card>);
+    const root = container.firstElementChild!;
+    expect(root).toHaveAttribute('data-tone', 'success');
+    expect(root.className).toMatch(/padding/);
+  });
+
+  it('tone="accent" with custom className merges (does not replace)', () => {
+    const { container } = render(<Card tone="accent" className="custom">x</Card>);
+    const root = container.firstElementChild!;
+    expect(root).toHaveAttribute('data-tone', 'accent');
+    expect(root.className).toMatch(/custom/);
   });
 });

--- a/packages/design-system/src/components/Card/Card.tsx
+++ b/packages/design-system/src/components/Card/Card.tsx
@@ -5,6 +5,12 @@ import styles from './Card.module.scss';
 /** Inner padding. See CardProps#padding for guidance on each. */
 export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
 
+/**
+ * Optional left-edge tone stripe color. When set on a Card, draws a 3px
+ * accent-colored bar on the left edge. Uses the same token vocabulary as Alert.
+ */
+export type CardTone = 'accent' | 'info' | 'success' | 'warning' | 'danger';
+
 export interface CardProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Inner padding.
@@ -15,6 +21,15 @@ export interface CardProps extends HTMLAttributes<HTMLDivElement> {
    * - `lg` (24px) — emphasis cards, marketing-style panels.
    */
   padding?: CardPadding;
+  /**
+   * Optional left-edge tone stripe (3px). Useful for "stat card" / "status card"
+   * patterns where one card in a row needs visual emphasis. Default: no stripe
+   * (the card keeps its standard bordered look).
+   *
+   * Uses the same tone vocabulary as `Alert`: `accent` / `info` / `success` /
+   * `warning` / `danger`.
+   */
+  tone?: CardTone;
 }
 
 const paddingClass: Record<CardPadding, string> = {
@@ -25,9 +40,11 @@ const paddingClass: Record<CardPadding, string> = {
 };
 
 /**
- * Bordered container for grouped content. **Don't nest Card in Card** — if
- * you need to subdivide, use spacing or a horizontal rule instead. If everything
- * on your page is a card, none of them are.
+ * Bordered container for grouped content. Supports an optional `tone` prop
+ * that draws a 3px left-edge stripe in the tone color — useful for stat cards
+ * or status panels where one card in a row needs visual emphasis. **Don't
+ * nest Card in Card** — if you need to subdivide, use spacing or a horizontal
+ * rule instead. If everything on your page is a card, none of them are.
  *
  * @example
  * <Card padding="md">
@@ -48,6 +65,14 @@ const paddingClass: Record<CardPadding, string> = {
  *   <ul>...</ul>
  * </Card>
  *
+ * @example
+ * // Tone-coded stat cards — row of cards, each with a left-edge stripe:
+ * <Cluster gap="md" wrap>
+ *   <Card padding="md" tone="accent">Open deals</Card>
+ *   <Card padding="md" tone="success">Won this month</Card>
+ *   <Card padding="md" tone="danger">Churned</Card>
+ * </Cluster>
+ *
  * @remarks When NOT to use
  * - As the only child of another Card. **Never nest cards.** If you need to
  *   subdivide, use spacing or a horizontal rule inside one card.
@@ -63,12 +88,20 @@ const paddingClass: Record<CardPadding, string> = {
  *   is clickable, that's a different component (`LinkCard`, not yet shipped).
  * - ❌ Cards nested in Cards. Almost always means your information
  *   architecture is wrong.
+ * - ❌ Hand-rolling a left-stripe via `className` / `style`. Use the `tone`
+ *   prop — it reserves the border-left space so layout never shifts.
  */
 export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
-  { padding = 'md', className, ...props },
+  { padding = 'md', tone, className, ...props },
   ref,
 ) {
+  // {...props} last so consumer overrides win (Pattern A).
   return (
-    <div ref={ref} className={clsx(styles.card, paddingClass[padding], className)} {...props} />
+    <div
+      ref={ref}
+      className={clsx(styles.card, paddingClass[padding], className)}
+      data-tone={tone}
+      {...props}
+    />
   );
 });

--- a/packages/design-system/src/components/Card/index.ts
+++ b/packages/design-system/src/components/Card/index.ts
@@ -1,2 +1,2 @@
 export { Card } from './Card';
-export type { CardProps, CardPadding } from './Card';
+export type { CardProps, CardPadding, CardTone } from './Card';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -13,7 +13,7 @@ export { Input } from './components/Input';
 export type { InputProps, InputSize } from './components/Input';
 
 export { Card } from './components/Card';
-export type { CardProps, CardPadding } from './components/Card';
+export type { CardProps, CardPadding, CardTone } from './components/Card';
 
 export { Checkbox } from './components/Checkbox';
 export type { CheckboxProps, CheckboxSize } from './components/Checkbox';
@@ -51,7 +51,7 @@ export { Avatar, AvatarGroup, avatarColorIndex } from './components/Avatar';
 export type { AvatarProps, AvatarSize, AvatarStatus, AvatarGroupProps } from './components/Avatar';
 
 export { Badge } from './components/Badge';
-export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot } from './components/Badge';
+export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot, BadgeVariant } from './components/Badge';
 
 export { Tabs } from './components/Tabs';
 export type { TabsProps, TabItem, TabsActivationMode, TabsOrientation } from './components/Tabs';

--- a/packages/playground/src/pages/components/BadgeDemo.tsx
+++ b/packages/playground/src/pages/components/BadgeDemo.tsx
@@ -172,12 +172,24 @@ export function BadgeDemo() {
 <Badge variant="stripe" tone="purple">Enterprise</Badge>`}
       >
         <Cluster gap="sm" wrap>
-          <Badge variant="stripe" tone="info">Lead</Badge>
-          <Badge variant="stripe" tone="success">Active</Badge>
-          <Badge variant="stripe" tone="warning">Renewal due</Badge>
-          <Badge variant="stripe" tone="danger">Churned</Badge>
-          <Badge variant="stripe" tone="neutral">Archived</Badge>
-          <Badge variant="stripe" tone="purple">Enterprise</Badge>
+          <Badge variant="stripe" tone="info">
+            Lead
+          </Badge>
+          <Badge variant="stripe" tone="success">
+            Active
+          </Badge>
+          <Badge variant="stripe" tone="warning">
+            Renewal due
+          </Badge>
+          <Badge variant="stripe" tone="danger">
+            Churned
+          </Badge>
+          <Badge variant="stripe" tone="neutral">
+            Archived
+          </Badge>
+          <Badge variant="stripe" tone="purple">
+            Enterprise
+          </Badge>
         </Cluster>
       </Example>
 

--- a/packages/playground/src/pages/components/BadgeDemo.tsx
+++ b/packages/playground/src/pages/components/BadgeDemo.tsx
@@ -162,6 +162,26 @@ export function BadgeDemo() {
       </Example>
 
       <Example
+        title="Stripe variant (rectangular with left stripe)"
+        description={`variant="stripe" renders a rectangular block with a tone-colored 3px left stripe and a softly tinted body. No uppercase, no letter-spacing — reads as a category label rather than a loud status pill. Composes with all six existing tones.`}
+        code={`<Badge variant="stripe" tone="info">Lead</Badge>
+<Badge variant="stripe" tone="success">Active</Badge>
+<Badge variant="stripe" tone="warning">Renewal due</Badge>
+<Badge variant="stripe" tone="danger">Churned</Badge>
+<Badge variant="stripe" tone="neutral">Archived</Badge>
+<Badge variant="stripe" tone="purple">Enterprise</Badge>`}
+      >
+        <Cluster gap="sm" wrap>
+          <Badge variant="stripe" tone="info">Lead</Badge>
+          <Badge variant="stripe" tone="success">Active</Badge>
+          <Badge variant="stripe" tone="warning">Renewal due</Badge>
+          <Badge variant="stripe" tone="danger">Churned</Badge>
+          <Badge variant="stripe" tone="neutral">Archived</Badge>
+          <Badge variant="stripe" tone="purple">Enterprise</Badge>
+        </Cluster>
+      </Example>
+
+      <Example
         title="Status patterns"
         description="The most common CRM usage: status pill on a contact, deal, or invitation."
         code={`// Contact statuses

--- a/packages/playground/src/pages/components/CardDemo.tsx
+++ b/packages/playground/src/pages/components/CardDemo.tsx
@@ -79,6 +79,24 @@ export function CardDemo() {
       </Example>
 
       <Example
+        title="Tone-coded cards (left stripe)"
+        description="Five tones: accent / info / success / warning / danger. Each draws a 3px left-edge stripe in the tone color. The border-left is always reserved (transparent) so toggling tone never shifts layout."
+        code={`<Card padding="md" tone="accent">Accent</Card>
+<Card padding="md" tone="info">Info</Card>
+<Card padding="md" tone="success">Success</Card>
+<Card padding="md" tone="warning">Warning</Card>
+<Card padding="md" tone="danger">Danger</Card>`}
+      >
+        <Cluster gap="sm" align="start" wrap>
+          <Card padding="md" style={{ minWidth: 120 }} tone="accent">Accent</Card>
+          <Card padding="md" style={{ minWidth: 120 }} tone="info">Info</Card>
+          <Card padding="md" style={{ minWidth: 120 }} tone="success">Success</Card>
+          <Card padding="md" style={{ minWidth: 120 }} tone="warning">Warning</Card>
+          <Card padding="md" style={{ minWidth: 120 }} tone="danger">Danger</Card>
+        </Cluster>
+      </Example>
+
+      <Example
         title="Padding=none with header + list"
         description="When the card contains a list or table, use padding='none' and let the inner sections control their own padding."
         code={`<Card padding="none">

--- a/packages/playground/src/pages/components/CardDemo.tsx
+++ b/packages/playground/src/pages/components/CardDemo.tsx
@@ -88,11 +88,21 @@ export function CardDemo() {
 <Card padding="md" tone="danger">Danger</Card>`}
       >
         <Cluster gap="sm" align="start" wrap>
-          <Card padding="md" style={{ minWidth: 120 }} tone="accent">Accent</Card>
-          <Card padding="md" style={{ minWidth: 120 }} tone="info">Info</Card>
-          <Card padding="md" style={{ minWidth: 120 }} tone="success">Success</Card>
-          <Card padding="md" style={{ minWidth: 120 }} tone="warning">Warning</Card>
-          <Card padding="md" style={{ minWidth: 120 }} tone="danger">Danger</Card>
+          <Card padding="md" style={{ minWidth: 120 }} tone="accent">
+            Accent
+          </Card>
+          <Card padding="md" style={{ minWidth: 120 }} tone="info">
+            Info
+          </Card>
+          <Card padding="md" style={{ minWidth: 120 }} tone="success">
+            Success
+          </Card>
+          <Card padding="md" style={{ minWidth: 120 }} tone="warning">
+            Warning
+          </Card>
+          <Card padding="md" style={{ minWidth: 120 }} tone="danger">
+            Danger
+          </Card>
         </Cluster>
       </Example>
 

--- a/packages/playground/src/pages/mockups/Dashboard/Dashboard.module.scss
+++ b/packages/playground/src/pages/mockups/Dashboard/Dashboard.module.scss
@@ -17,10 +17,6 @@
   gap: var(--space-4);
 }
 
-.statCard {
-  border-left: var(--border-width-strong) solid var(--color-accent);
-}
-
 .statLabel {
   font-size: var(--font-size-sm);
   color: var(--color-fg-muted);

--- a/packages/playground/src/pages/mockups/Dashboard/Dashboard.tsx
+++ b/packages/playground/src/pages/mockups/Dashboard/Dashboard.tsx
@@ -68,7 +68,7 @@ export function Dashboard() {
 
       <div className={styles.statsGrid}>
         {stats.map(({ label, value, delta, deltaTone, icon: Icon }) => (
-          <Card key={label} padding="md" className={styles.statCard}>
+          <Card key={label} padding="md" tone="accent">
             <Cluster justify="between" align="start" gap="md" wrap={false}>
               <Stack gap="xs">
                 <span className={styles.statLabel}>{label}</span>


### PR DESCRIPTION
## Summary

Two related visual additions:

- **Card** gains an optional \`tone\` prop (\`accent\` / \`info\` / \`success\` / \`warning\` / \`danger\`). When set, draws a 3px tone-colored left stripe via inset box-shadow. Default = no stripe (current behavior fully preserved).
- **Badge** gains a new \`variant: 'filled' | 'stripe'\` (default \`'filled'\`). Stripe is rectangular (not pill) with a tone-colored left stripe + tinted body. Coexists with the default filled pill across all 6 existing tones.

Plus mockup cleanup: \`Dashboard.tsx\` switches \`.statCard\` className override to \`<Card tone=\"accent\">\`, deleting the inline SCSS recipe.

No new tokens. Same tone vocabulary as Alert.

## Design highlights

- **Card stripe via inset box-shadow** (not border-left). HR8 R1 flagged that the original border-left approach would have added a one-time 2px width shift to every existing untoned Card. Switched to \`box-shadow: inset 3px 0 0 var(--tone)\` which paints inside the existing border — untoned cards are now pixel-identical to before. Composes with the existing shadow stack.
- **Badge stripe variant** uses SCSS attribute combinator (\`.stripe.success\` etc.) to override the filled tone backgrounds. Cascade order is correct (stripe rules after filled tone rules). Composes cleanly with all 6 tones (neutral/info/success/warning/danger/purple) and both sizes (sm/md).
- **Symmetric API design**: Card's \`tone\` and Badge's \`variant\` use the same tone vocabulary as Alert. Each component owns its own tone (no nested propagation).

## Hard Rule 8

**Round 1 verdict: clean enough to stop** (0 Critical + 0 Important). Reviewer flagged one Regression-watch about the original \`border-left\` approach causing a 2px shift on every untoned Card. **Proactively fixed** with the inset box-shadow approach — no regression remains.

**1515 tests passing** (1501 → 1515, +14 net). All four gates green: \`make test\` · \`make build-lib\` · \`make build\` · \`make lint\` · \`npm pack --dry-run\` (no test files in tarball).

## Test plan

- [ ] \`<Card>x</Card>\` renders pixel-identical to the previous behavior (no width or content offset change)
- [ ] \`<Card tone=\"accent\">x</Card>\` shows a 3px accent stripe on the left edge
- [ ] All 5 Card tones render with distinct stripe colors
- [ ] \`<Badge tone=\"info\">x</Badge>\` is the existing filled pill (unchanged)
- [ ] \`<Badge variant=\"stripe\" tone=\"success\">x</Badge>\` renders as a rectangular block with green stripe + tinted bg
- [ ] All 6 Badge tones render correctly in stripe variant
- [ ] \`<Badge variant=\"stripe\" size=\"sm\">x</Badge>\` and \`size=\"md\"\` both work
- [ ] Dashboard mockup at \`/mockups/dashboard\` still shows the accent stripe on stat cards (now via the prop, not inline SCSS)
- [ ] No \`.statCard\` rule remains in \`Dashboard.module.scss\`
- [ ] Card demo at \`/components/card\` has the new tone gallery
- [ ] Badge demo at \`/components/badge\` has the new stripe gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)