### PR TITLE
Card compound: Card.Header + Card.List + Card.ListRow (Dashboard refactor)

### DIFF
--- a/docs/superpowers/specs/2026-05-24-card-compound-design.md
+++ b/docs/superpowers/specs/2026-05-24-card-compound-design.md
@@ -28,6 +28,7 @@ Replace the inline `.cardHeader` / `.cardTitle` / `.list` / `.listRow` SCSS reci
 ### Dependencies
 
 No new packages. Reuses:
+
 - React (peer)
 - `clsx` (existing dep)
 - Existing tokens: `--space-2`/`--space-3`/`--space-4`, `--border-width`, `--color-border`, `--font-size-md`, `--font-weight-semibold`, `--color-fg`
@@ -106,6 +107,7 @@ export interface CardHeaderProps extends Omit<HTMLAttributes<HTMLDivElement>, 't
 ```
 
 Renders:
+
 ```tsx
 <div className={styles.header} {...rest}>
   <Heading className={styles.title}>{children}</Heading>
@@ -185,6 +187,7 @@ Existing `<Card>` API is unchanged. `tone`, `padding`, all native attrs work the
 ```
 
 **Rule 4 check**:
+
 - `.header` and `.listRow` use `display: flex` for internal layout — internal child arrangement, not at the component boundary.
 - `.title` has `margin: 0` for native heading reset — documented inline disable, same pattern as Accordion's `.header`.
 - `.list` has `margin: 0` and `padding: 0` for native `<ul>` reset — both documented inline disables, same pattern as Breadcrumb's `.list`.
@@ -192,14 +195,14 @@ Existing `<Card>` API is unchanged. `tone`, `padding`, all native attrs work the
 
 ## ARIA + behavior reference
 
-| Concern | Behavior |
-|---|---|
-| **Card.Header element** | `<div>` wrapping a heading element (h2-h6 configurable via `headerLevel`) + optional action span |
-| **Card.List element** | `<ul>` — semantic list, AT announces "list with N items" |
-| **Card.ListRow element** | `<li>` — semantic list item, no role override |
-| **Heading level** | Default `h3`. Override via `headerLevel`. Same vocab as Accordion. |
-| **Action region** | A plain `<span>` wrapper around `action` — no role / no aria. Consumer's action is whatever they pass (typically a Link or Button which carry their own semantics). |
-| **Focus** | None of the new subcomponents are focusable themselves. Interactive children (Link in action, clickable content in rows) carry their own focus. |
+| Concern                  | Behavior                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Card.Header element**  | `<div>` wrapping a heading element (h2-h6 configurable via `headerLevel`) + optional action span                                                                    |
+| **Card.List element**    | `<ul>` — semantic list, AT announces "list with N items"                                                                                                            |
+| **Card.ListRow element** | `<li>` — semantic list item, no role override                                                                                                                       |
+| **Heading level**        | Default `h3`. Override via `headerLevel`. Same vocab as Accordion.                                                                                                  |
+| **Action region**        | A plain `<span>` wrapper around `action` — no role / no aria. Consumer's action is whatever they pass (typically a Link or Button which carry their own semantics). |
+| **Focus**                | None of the new subcomponents are focusable themselves. Interactive children (Link in action, clickable content in rows) carry their own focus.                     |
 
 ## Testing
 
@@ -220,6 +223,7 @@ Existing `<Card>` API is unchanged. `tone`, `padding`, all native attrs work the
 Add 2 new examples:
 
 1. **"Card with header + action + list body"** — the canonical dashboard pattern:
+
    ```tsx
    <Card padding="none">
      <Card.Header action={<Link variant="muted">View all</Link>}>
@@ -245,12 +249,14 @@ Add 2 new examples:
 ## Mockup cleanup (in scope)
 
 `Dashboard.tsx`:
+
 - Replace `<div className={styles.cardHeader}>` with `<Card.Header>` (both sections)
 - Replace `<ul className={styles.list}>` with `<Card.List>`
 - Replace `<li className={styles.listRow}>` with `<Card.ListRow>`
 - The "View all" link becomes the `action` prop on the first header
 
 `Dashboard.module.scss`:
+
 - Delete `.cardHeader`, `.cardTitle`, `.list`, `.listRow` blocks (~30 lines removed)
 - Keep `.cardLink`, `.listRowTitle`, `.listRowMeta`, `.activityLine`, `.activityTarget` — these style the content INSIDE the rows, not the row containers themselves
 

--- a/docs/superpowers/specs/2026-05-24-card-compound-design.md
+++ b/docs/superpowers/specs/2026-05-24-card-compound-design.md
@@ -1,0 +1,267 @@
+# Card.Header + Card.List + Card.ListRow — design spec
+
+**Date:** 2026-05-24
+**Branch:** `feat/card-compound`
+**Scope:** Extend Card with three new compound subcomponents to formalize the "card with header + list body" pattern used in `Dashboard.tsx` ("Deals needing attention", "Recent activity"). `<Card.Header>` is a title row with optional right-aligned action + bottom-border separator. `<Card.List>` is a `<ul>` wrapper. `<Card.ListRow>` is one `<li>` with padded content + bottom dividing border.
+
+## Goal
+
+Replace the inline `.cardHeader` / `.cardTitle` / `.list` / `.listRow` SCSS recipes in Dashboard with first-class library primitives. The pattern is common enough (any "section card with a list of rows" page) that promoting it to the library unifies styling and accessibility (proper `<ul>`/`<li>` semantics, heading-level configurability).
+
+## Why now
+
+- Dashboard has TWO sections using this pattern (Deals + Recent activity). The Contacts list page is likely to add similar usage. Open-coded SCSS drifts.
+- The semantic `<ul>` for a list of cards is the right ARIA shape — screen readers announce "list with N items". Inline `<div>` rows lose that.
+- Card now has compound API surface (`tone` prop just shipped). Adding `.Header` / `.List` / `.ListRow` is the natural next step.
+
+## Non-goals (v1)
+
+- **No clickable-row affordance built into `Card.ListRow`**. Consumers wrap the row content with `<Link>` or `<button>` themselves. Polymorphic `as` prop on ListRow is overkill until a real pattern emerges.
+- **No selectable rows / checkboxes**. That's a list/table primitive, not a Card concern.
+- **No `Card.Footer`**. Could add later if needed; not in the dashboard.
+- **No `Card.Section` for non-list bodies**. Consumers compose with plain children when the body isn't a list. The default `padding` prop still controls the body padding for non-list contents.
+- **No collapsible header**. That's Accordion.
+- **No header subtitle / metadata slot**. Children handle that — e.g., `<Card.Header><Stack gap="xs"><strong>Title</strong><span>subtitle</span></Stack></Card.Header>`.
+
+## Architecture
+
+### Dependencies
+
+No new packages. Reuses:
+- React (peer)
+- `clsx` (existing dep)
+- Existing tokens: `--space-2`/`--space-3`/`--space-4`, `--border-width`, `--color-border`, `--font-size-md`, `--font-weight-semibold`, `--color-fg`
+
+No new tokens.
+
+### File layout
+
+```
+packages/design-system/src/components/Card/
+  Card.tsx              ← MODIFY: add Object.assign for compound + JSDoc updates
+  CardHeader.tsx        ← NEW: heading-wrapped title row with action slot
+  CardList.tsx          ← NEW: <ul> wrapper
+  CardListRow.tsx       ← NEW: <li> row with padded content
+  Card.module.scss      ← MODIFY: add .header / .title / .action / .list / .listRow rules
+  Card.test.tsx         ← MODIFY: add ~8 cases for the new subcomponents
+  index.ts              ← MODIFY: re-export new types
+```
+
+### Composition
+
+```
+<Card padding="none">
+  <Card.Header action={<Link>View all</Link>}>Deals needing attention</Card.Header>
+  <Card.List>
+    {deals.map(d => (
+      <Card.ListRow key={d.id}>
+        <Stack>{d.title}</Stack>
+        <Avatar name={d.owner} />
+      </Card.ListRow>
+    ))}
+  </Card.List>
+</Card>
+                          │
+                          ▼
+       <div class="card paddingNone">
+         <div class="header">
+           <h3 class="title">Deals needing attention</h3>
+           <span class="action"><a>View all</a></span>
+         </div>
+         <ul class="list">
+           <li class="listRow">...</li>
+           <li class="listRow">...</li>
+         </ul>
+       </div>
+```
+
+### Compound assembly
+
+```ts
+export const Card = Object.assign(CardRoot, {
+  Header: CardHeader,
+  List: CardList,
+  ListRow: CardListRow,
+});
+```
+
+## Public API
+
+### Card.Header
+
+```ts
+import type { HTMLAttributes, ReactNode } from 'react';
+
+/** Heading level wrapping the title. Defaults to 'h3'. Same vocab as Accordion. */
+export type CardHeaderLevel = 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+export interface CardHeaderProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+  /** Heading level. Defaults to 'h3' (assumes the page above has an h2). */
+  headerLevel?: CardHeaderLevel;
+  /** Optional right-aligned slot (typically a Link or Button). */
+  action?: ReactNode;
+  /** Title content. Becomes the inner text of the heading element. */
+  children: ReactNode;
+}
+```
+
+Renders:
+```tsx
+<div className={styles.header} {...rest}>
+  <Heading className={styles.title}>{children}</Heading>
+  {action && <span className={styles.action}>{action}</span>}
+</div>
+```
+
+### Card.List
+
+```ts
+export interface CardListProps extends HTMLAttributes<HTMLUListElement> {
+  children: ReactNode;
+}
+```
+
+Renders a bare `<ul>` with list-reset styling.
+
+### Card.ListRow
+
+```ts
+export interface CardListRowProps extends HTMLAttributes<HTMLLIElement> {
+  children: ReactNode;
+}
+```
+
+Renders a `<li>` with padded content + bottom dividing border (suppressed on the last child via SCSS `:last-child`).
+
+### Card root (unchanged signature, new compound API)
+
+Existing `<Card>` API is unchanged. `tone`, `padding`, all native attrs work the same. Object.assign adds the three subcomponents.
+
+## Styling — `Card.module.scss` additions
+
+```scss
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.title {
+  // stylelint-disable-next-line property-disallowed-list -- native heading margin reset
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-fg);
+  min-width: 0;
+}
+
+.action {
+  flex-shrink: 0;
+}
+
+.list {
+  list-style: none;
+  // stylelint-disable-next-line property-disallowed-list -- native <ul> margin reset
+  margin: 0;
+  // stylelint-disable-next-line property-disallowed-list -- native <ul> padding reset
+  padding: 0;
+}
+
+.listRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.listRow:last-child {
+  border-bottom: 0;
+}
+```
+
+**Rule 4 check**:
+- `.header` and `.listRow` use `display: flex` for internal layout — internal child arrangement, not at the component boundary.
+- `.title` has `margin: 0` for native heading reset — documented inline disable, same pattern as Accordion's `.header`.
+- `.list` has `margin: 0` and `padding: 0` for native `<ul>` reset — both documented inline disables, same pattern as Breadcrumb's `.list`.
+- `.action` has `flex-shrink: 0` — internal child sizing inside `.header`'s flex container, not at the boundary.
+
+## ARIA + behavior reference
+
+| Concern | Behavior |
+|---|---|
+| **Card.Header element** | `<div>` wrapping a heading element (h2-h6 configurable via `headerLevel`) + optional action span |
+| **Card.List element** | `<ul>` — semantic list, AT announces "list with N items" |
+| **Card.ListRow element** | `<li>` — semantic list item, no role override |
+| **Heading level** | Default `h3`. Override via `headerLevel`. Same vocab as Accordion. |
+| **Action region** | A plain `<span>` wrapper around `action` — no role / no aria. Consumer's action is whatever they pass (typically a Link or Button which carry their own semantics). |
+| **Focus** | None of the new subcomponents are focusable themselves. Interactive children (Link in action, clickable content in rows) carry their own focus. |
+
+## Testing
+
+`Card.test.tsx` — add a new `describe('compound API')` block with ~9 cases:
+
+1. `<Card.Header>` renders a `<div>` containing an `<h3>` with the title text (default heading level)
+2. `headerLevel="h2"` wraps the title in `<h2>`
+3. Header `action` prop renders inside the header (right slot)
+4. Header without `action`: no action span in the DOM
+5. `<Card.List>` renders a `<ul>` with list-reset styling (no list-style markers)
+6. `<Card.ListRow>` renders a `<li>` with content
+7. Multiple ListRows: every row except the last has a bottom-border (last child has none)
+8. Compound composes: `<Card><Card.Header>T</Card.Header><Card.List><Card.ListRow>R</Card.ListRow></Card.List></Card>` renders the expected DOM tree
+9. Header `className` and ListRow `className` merge (not replace) with the component's base classes
+
+## Demo additions — `CardDemo.tsx`
+
+Add 2 new examples:
+
+1. **"Card with header + action + list body"** — the canonical dashboard pattern:
+   ```tsx
+   <Card padding="none">
+     <Card.Header action={<Link variant="muted">View all</Link>}>
+       Deals needing attention
+     </Card.Header>
+     <Card.List>
+       <Card.ListRow>...</Card.ListRow>
+       <Card.ListRow>...</Card.ListRow>
+     </Card.List>
+   </Card>
+   ```
+
+2. **"Header without action"** — a simpler header-only card:
+   ```tsx
+   <Card padding="none">
+     <Card.Header>Recent activity</Card.Header>
+     <Card.List>
+       <Card.ListRow>...</Card.ListRow>
+     </Card.List>
+   </Card>
+   ```
+
+## Mockup cleanup (in scope)
+
+`Dashboard.tsx`:
+- Replace `<div className={styles.cardHeader}>` with `<Card.Header>` (both sections)
+- Replace `<ul className={styles.list}>` with `<Card.List>`
+- Replace `<li className={styles.listRow}>` with `<Card.ListRow>`
+- The "View all" link becomes the `action` prop on the first header
+
+`Dashboard.module.scss`:
+- Delete `.cardHeader`, `.cardTitle`, `.list`, `.listRow` blocks (~30 lines removed)
+- Keep `.cardLink`, `.listRowTitle`, `.listRowMeta`, `.activityLine`, `.activityTarget` — these style the content INSIDE the rows, not the row containers themselves
+
+## AGENTS.md update
+
+Extend the existing `<Card>` section TL;DR with the compound API. Show one canonical example with header + list.
+
+## Hard Rule 8
+
+Standard cycle: gates green, fresh-context reviewer, fix Critical + Important, repeat until clean.
+
+## Open questions
+
+None.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -338,8 +338,32 @@ import { Switch } from '@eocrm/design-system';
 <Card padding="md" tone="accent">Open deals</Card>
 ```
 
+```tsx
+// Compound API — section card with header + list (Dashboard's "Deals needing attention" pattern):
+<Card padding="none">
+  <Card.Header action={<Link variant="muted">View all</Link>}>
+    Deals needing attention
+  </Card.Header>
+  <Card.List>
+    {deals.map(d => (
+      <Card.ListRow key={d.id}>
+        <Stack gap="xs">
+          <span>{d.title}</span>
+          <span>{d.company}</span>
+        </Stack>
+        <Avatar name={d.owner} size="sm" />
+      </Card.ListRow>
+    ))}
+  </Card.List>
+</Card>
+```
+
 - `padding`: `none` / `sm` / `md` (default) / `lg`
 - `tone`: `accent` / `info` / `success` / `warning` / `danger` — draws a 3px left-edge stripe in the tone color. Default: no stripe (standard bordered look). A transparent border-left is always reserved so toggling `tone` never shifts layout.
+- **Compound API** — `Card.Header` / `Card.List` / `Card.ListRow` for the section-with-list pattern (Dashboard's "Deals needing attention"). Use `padding="none"` on the root card so the header and rows bleed edge-to-edge.
+- `Card.Header`: title row (`h3` by default, override via `headerLevel`) with optional right-aligned `action` slot and bottom-border separator.
+- `Card.List`: semantic `<ul>` with list-reset styling — screen readers announce "list with N items".
+- `Card.ListRow`: `<li>` with padded content and bottom dividing border; last-child border suppressed automatically.
 - **Never nest Card in Card.**
 - Use `padding="none"` when the card contains a table or list that should bleed edge-to-edge.
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -339,9 +339,10 @@ import { Switch } from '@eocrm/design-system';
 ```
 
 ```tsx
-// Compound API — section card with header + list (Dashboard's "Deals needing attention" pattern):
-<Card padding="none">
-  <Card.Header action={<Link variant="muted">View all</Link>}>Deals needing attention</Card.Header>
+// Compound API — section card with header + list (Dashboard's "Deals needing attention" pattern).
+// No `padding` prop needed — Card auto-detects compound children and defaults to padding="none".
+<Card>
+  <Card.Header action={<Link as={RouterLink} to="/deals">View all</Link>}>Deals needing attention</Card.Header>
   <Card.List>
     {deals.map((d) => (
       <Card.ListRow key={d.id}>
@@ -356,14 +357,13 @@ import { Switch } from '@eocrm/design-system';
 </Card>
 ```
 
-- `padding`: `none` / `sm` / `md` (default) / `lg`
+- `padding`: `none` / `sm` / `md` / `lg`. Defaults to `md` for plain content, `none` when `Card.Header` / `Card.List` / `Card.ListRow` is a direct child. Pass explicitly to override.
 - `tone`: `accent` / `info` / `success` / `warning` / `danger` — draws a 3px left-edge stripe in the tone color. Default: no stripe (standard bordered look). A transparent border-left is always reserved so toggling `tone` never shifts layout.
-- **Compound API** — `Card.Header` / `Card.List` / `Card.ListRow` for the section-with-list pattern (Dashboard's "Deals needing attention"). Use `padding="none"` on the root card so the header and rows bleed edge-to-edge.
+- **Compound API** — `Card.Header` / `Card.List` / `Card.ListRow` for the section-with-list pattern (Dashboard's "Deals needing attention"). Drop `padding="none"` — the parent Card auto-detects compound children.
 - `Card.Header`: title row (`h3` by default, override via `headerLevel`) with optional right-aligned `action` slot and bottom-border separator.
 - `Card.List`: semantic `<ul>` with list-reset styling — screen readers announce "list with N items".
 - `Card.ListRow`: `<li>` with padded content and bottom dividing border; last-child border suppressed automatically.
 - **Never nest Card in Card.**
-- Use `padding="none"` when the card contains a table or list that should bleed edge-to-edge.
 
 ### `<Stack>` — vertical layout
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -342,7 +342,15 @@ import { Switch } from '@eocrm/design-system';
 // Compound API — section card with header + list (Dashboard's "Deals needing attention" pattern).
 // No `padding` prop needed — Card auto-detects compound children and defaults to padding="none".
 <Card>
-  <Card.Header action={<Link as={RouterLink} to="/deals">View all</Link>}>Deals needing attention</Card.Header>
+  <Card.Header
+    action={
+      <Link as={RouterLink} to="/deals">
+        View all
+      </Link>
+    }
+  >
+    Deals needing attention
+  </Card.Header>
   <Card.List>
     {deals.map((d) => (
       <Card.ListRow key={d.id}>

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -341,11 +341,9 @@ import { Switch } from '@eocrm/design-system';
 ```tsx
 // Compound API — section card with header + list (Dashboard's "Deals needing attention" pattern):
 <Card padding="none">
-  <Card.Header action={<Link variant="muted">View all</Link>}>
-    Deals needing attention
-  </Card.Header>
+  <Card.Header action={<Link variant="muted">View all</Link>}>Deals needing attention</Card.Header>
   <Card.List>
-    {deals.map(d => (
+    {deals.map((d) => (
       <Card.ListRow key={d.id}>
         <Stack gap="xs">
           <span>{d.title}</span>

--- a/packages/design-system/src/components/Card/Card.module.scss
+++ b/packages/design-system/src/components/Card/Card.module.scss
@@ -54,3 +54,46 @@
 .paddingLg {
   padding: var(--space-6);
 }
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.title {
+  // stylelint-disable-next-line property-disallowed-list -- native heading margin reset
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-fg);
+  min-width: 0;
+}
+
+.action {
+  flex-shrink: 0;
+}
+
+.list {
+  list-style: none;
+  // stylelint-disable-next-line property-disallowed-list -- native <ul> margin reset
+  margin: 0;
+  // stylelint-disable-next-line property-disallowed-list -- native <ul> padding reset
+  padding: 0;
+}
+
+.listRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.listRow:last-child {
+  border-bottom: 0;
+}

--- a/packages/design-system/src/components/Card/Card.test.tsx
+++ b/packages/design-system/src/components/Card/Card.test.tsx
@@ -66,3 +66,81 @@ describe('Card', () => {
     expect(root.className).toMatch(/custom/);
   });
 });
+
+describe('compound API', () => {
+  it('Card.Header renders <div> with default <h3> title', () => {
+    const { container } = render(<Card.Header>Title</Card.Header>);
+    expect(container.querySelector('h3')).toHaveTextContent('Title');
+  });
+
+  it('headerLevel="h2" wraps the title in <h2>', () => {
+    const { container } = render(<Card.Header headerLevel="h2">T</Card.Header>);
+    expect(container.querySelector('h2')).toBeInTheDocument();
+  });
+
+  it('action prop renders inside the header', () => {
+    render(
+      <Card.Header action={<button data-testid="act">View all</button>}>T</Card.Header>,
+    );
+    expect(screen.getByTestId('act')).toBeInTheDocument();
+  });
+
+  it('no action prop → no action span', () => {
+    const { container } = render(<Card.Header>T</Card.Header>);
+    expect(container.querySelectorAll('span').length).toBe(0);
+  });
+
+  it('Card.List renders a <ul>', () => {
+    const { container } = render(
+      <Card.List>
+        <Card.ListRow>x</Card.ListRow>
+      </Card.List>,
+    );
+    expect(container.querySelector('ul')).toBeInTheDocument();
+  });
+
+  it('Card.ListRow renders an <li> with content', () => {
+    const { container } = render(
+      <Card.List>
+        <Card.ListRow>row content</Card.ListRow>
+      </Card.List>,
+    );
+    const li = container.querySelector('li');
+    expect(li).toHaveTextContent('row content');
+  });
+
+  it('last ListRow is the expected element (last-child smoke test)', () => {
+    // Smoke test only — we can't query computed styles for the SCSS rule in
+    // jsdom, but we can verify the last-child is the expected element.
+    const { container } = render(
+      <Card.List>
+        <Card.ListRow>a</Card.ListRow>
+        <Card.ListRow>b</Card.ListRow>
+        <Card.ListRow data-testid="last">c</Card.ListRow>
+      </Card.List>,
+    );
+    const lis = container.querySelectorAll('li');
+    expect(lis[lis.length - 1]).toHaveAttribute('data-testid', 'last');
+  });
+
+  it('compound composes: Card > Header + List > ListRow', () => {
+    const { container } = render(
+      <Card padding="none">
+        <Card.Header>Title</Card.Header>
+        <Card.List>
+          <Card.ListRow>Row 1</Card.ListRow>
+          <Card.ListRow>Row 2</Card.ListRow>
+        </Card.List>
+      </Card>,
+    );
+    expect(container.querySelector('h3')).toHaveTextContent('Title');
+    expect(container.querySelectorAll('li').length).toBe(2);
+  });
+
+  it('Card.Header className merges (does not replace) with base header class', () => {
+    const { container } = render(<Card.Header className="custom">T</Card.Header>);
+    const header = container.firstElementChild!;
+    expect(header.className).toMatch(/header/);
+    expect(header.className).toMatch(/custom/);
+  });
+});

--- a/packages/design-system/src/components/Card/Card.test.tsx
+++ b/packages/design-system/src/components/Card/Card.test.tsx
@@ -79,9 +79,7 @@ describe('compound API', () => {
   });
 
   it('action prop renders inside the header', () => {
-    render(
-      <Card.Header action={<button data-testid="act">View all</button>}>T</Card.Header>,
-    );
+    render(<Card.Header action={<button data-testid="act">View all</button>}>T</Card.Header>);
     expect(screen.getByTestId('act')).toBeInTheDocument();
   });
 

--- a/packages/design-system/src/components/Card/Card.test.tsx
+++ b/packages/design-system/src/components/Card/Card.test.tsx
@@ -8,9 +8,83 @@ describe('Card', () => {
     expect(screen.getByText('Body content')).toBeInTheDocument();
   });
 
-  it('defaults to padding="md"', () => {
+  it('defaults to padding="md" for plain content', () => {
     const { container } = render(<Card>x</Card>);
     expect((container.firstChild as HTMLElement).className).toMatch(/paddingMd/);
+  });
+
+  it('auto-defaults to padding="none" when a Card.Header child is present', () => {
+    const { container } = render(
+      <Card>
+        <Card.Header>Title</Card.Header>
+      </Card>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingNone/);
+    expect((container.firstChild as HTMLElement).className).not.toMatch(/paddingMd/);
+  });
+
+  it('auto-defaults to padding="none" when a Card.List child is present', () => {
+    const { container } = render(
+      <Card>
+        <Card.List>
+          <Card.ListRow>row</Card.ListRow>
+        </Card.List>
+      </Card>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingNone/);
+  });
+
+  it('explicit padding overrides the compound auto-detect', () => {
+    const { container } = render(
+      <Card padding="lg">
+        <Card.Header>Title</Card.Header>
+      </Card>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingLg/);
+    expect((container.firstChild as HTMLElement).className).not.toMatch(/paddingNone/);
+  });
+
+  it('auto-defaults to padding="none" when a Card.ListRow is a direct child', () => {
+    const { container } = render(
+      <Card>
+        <Card.ListRow>row</Card.ListRow>
+      </Card>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingNone/);
+  });
+
+  it('auto-detect still triggers when compound + plain children are mixed', () => {
+    const { container } = render(
+      <Card>
+        <Card.Header>Title</Card.Header>
+        <div>extra footer content</div>
+      </Card>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingNone/);
+  });
+
+  it('auto-detect recurses through a Fragment wrapper', () => {
+    const { container } = render(
+      <Card>
+        <>
+          <Card.Header>Title</Card.Header>
+        </>
+      </Card>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingNone/);
+  });
+
+  it('auto-detect recurses through nested Fragments', () => {
+    const { container } = render(
+      <Card>
+        <>
+          <>
+            <Card.Header>Title</Card.Header>
+          </>
+        </>
+      </Card>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingNone/);
   });
 
   it.each<CardPadding>(['none', 'sm', 'md', 'lg'])('applies the %s padding class', (padding) => {
@@ -121,9 +195,9 @@ describe('compound API', () => {
     expect(lis[lis.length - 1]).toHaveAttribute('data-testid', 'last');
   });
 
-  it('compound composes: Card > Header + List > ListRow', () => {
+  it('compound composes: Card > Header + List > ListRow (no padding prop needed)', () => {
     const { container } = render(
-      <Card padding="none">
+      <Card>
         <Card.Header>Title</Card.Header>
         <Card.List>
           <Card.ListRow>Row 1</Card.ListRow>
@@ -133,6 +207,7 @@ describe('compound API', () => {
     );
     expect(container.querySelector('h3')).toHaveTextContent('Title');
     expect(container.querySelectorAll('li').length).toBe(2);
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingNone/);
   });
 
   it('Card.Header className merges (does not replace) with base header class', () => {

--- a/packages/design-system/src/components/Card/Card.tsx
+++ b/packages/design-system/src/components/Card/Card.tsx
@@ -157,8 +157,7 @@ const CardRoot = forwardRef<HTMLDivElement, CardProps>(function Card(
   // their own internal padding and want to bleed to the card edge. When any
   // are present and `padding` wasn't passed explicitly, default to 'none' so
   // the consumer doesn't have to repeat themselves. Explicit `padding` wins.
-  const effectivePadding: CardPadding =
-    padding ?? (hasCompoundChildren(children) ? 'none' : 'md');
+  const effectivePadding: CardPadding = padding ?? (hasCompoundChildren(children) ? 'none' : 'md');
   // {...props} last so consumer overrides win (Pattern A).
   return (
     <div

--- a/packages/design-system/src/components/Card/Card.tsx
+++ b/packages/design-system/src/components/Card/Card.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, type HTMLAttributes } from 'react';
+import {
+  Children,
+  Fragment,
+  forwardRef,
+  isValidElement,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
 import clsx from 'clsx';
 import styles from './Card.module.scss';
 import { CardHeader } from './CardHeader';
@@ -20,8 +27,20 @@ export interface CardProps extends HTMLAttributes<HTMLDivElement> {
    * - `none` — use when the card contains a table or list that should bleed
    *   edge-to-edge; inner sections manage their own padding.
    * - `sm` (12px) — dense info cards.
-   * - `md` (16px, default) — most cases.
+   * - `md` (16px) — default for plain-content cards.
    * - `lg` (24px) — emphasis cards, marketing-style panels.
+   *
+   * When omitted, defaults to `'md'` for plain content, or `'none'` when the
+   * card contains compound subcomponents (`Card.Header` / `Card.List` /
+   * `Card.ListRow`) so the header and rows bleed to the card edge automatically.
+   * Pass an explicit value to override the auto-detect.
+   *
+   * **Detection is shallow:** only direct children are inspected. Fragments
+   * (`<>...</>`) are transparent — the detection recurses into them, so
+   * conditional renders that wrap compound children in a Fragment still
+   * trigger the auto-detect. But wrapping a `Card.Header` in any other
+   * element (`<div>`, `<Stack>`, etc.) defeats the heuristic — pass
+   * `padding="none"` explicitly in that case.
    */
   padding?: CardPadding;
   /**
@@ -42,6 +61,21 @@ const paddingClass: Record<CardPadding, string> = {
   lg: styles.paddingLg,
 };
 
+function hasCompoundChildren(children: ReactNode): boolean {
+  return Children.toArray(children).some((child) => {
+    if (!isValidElement(child)) return false;
+    const type = child.type;
+    if (type === CardHeader || type === CardList || type === CardListRow) return true;
+    // Fragments are transparent — Children.toArray preserves them as nodes,
+    // but a consumer who wraps compound children in a `<>` (e.g. for a
+    // conditional render) clearly still wants the auto-detect to fire.
+    if (type === Fragment) {
+      return hasCompoundChildren((child.props as { children?: ReactNode }).children);
+    }
+    return false;
+  });
+}
+
 /**
  * Bordered container for grouped content. Supports an optional `tone` prop
  * that draws a 3px left-edge stripe in the tone color — useful for stat cards
@@ -50,8 +84,9 @@ const paddingClass: Record<CardPadding, string> = {
  * rule instead. If everything on your page is a card, none of them are.
  *
  * Compound API — `Card.Header` / `Card.List` / `Card.ListRow` for the
- * "section card with a list of rows" pattern. Use `padding="none"` when
- * composing with these subcomponents so the header and rows bleed edge-to-edge.
+ * "section card with a list of rows" pattern. When any of these subcomponents
+ * appear as a direct child, `padding` auto-defaults to `'none'` so the header
+ * and rows bleed to the card edge. Pass `padding` explicitly to override.
  *
  * @example
  * <Card padding="md">
@@ -66,9 +101,11 @@ const paddingClass: Record<CardPadding, string> = {
  * </Card>
  *
  * @example
- * // Compound API — section card with header + action + list rows:
- * <Card padding="none">
- *   <Card.Header action={<Link variant="muted">View all</Link>}>
+ * // Compound API — section card with header + action + list rows.
+ * // No `padding` prop needed: the presence of Card.Header / Card.List makes
+ * // the card auto-default to padding="none".
+ * <Card>
+ *   <Card.Header action={<Link>View all</Link>}>
  *     Deals needing attention
  *   </Card.Header>
  *   <Card.List>
@@ -113,17 +150,25 @@ const paddingClass: Record<CardPadding, string> = {
  *   compound API (`Card.Header` / `Card.List` / `Card.ListRow`) instead.
  */
 const CardRoot = forwardRef<HTMLDivElement, CardProps>(function Card(
-  { padding = 'md', tone, className, ...props },
+  { padding, tone, className, children, ...props },
   ref,
 ) {
+  // Compound subcomponents (Card.Header / Card.List / Card.ListRow) manage
+  // their own internal padding and want to bleed to the card edge. When any
+  // are present and `padding` wasn't passed explicitly, default to 'none' so
+  // the consumer doesn't have to repeat themselves. Explicit `padding` wins.
+  const effectivePadding: CardPadding =
+    padding ?? (hasCompoundChildren(children) ? 'none' : 'md');
   // {...props} last so consumer overrides win (Pattern A).
   return (
     <div
       ref={ref}
-      className={clsx(styles.card, paddingClass[padding], className)}
+      className={clsx(styles.card, paddingClass[effectivePadding], className)}
       data-tone={tone}
       {...props}
-    />
+    >
+      {children}
+    </div>
   );
 });
 

--- a/packages/design-system/src/components/Card/Card.tsx
+++ b/packages/design-system/src/components/Card/Card.tsx
@@ -1,6 +1,9 @@
 import { forwardRef, type HTMLAttributes } from 'react';
 import clsx from 'clsx';
 import styles from './Card.module.scss';
+import { CardHeader } from './CardHeader';
+import { CardList } from './CardList';
+import { CardListRow } from './CardListRow';
 
 /** Inner padding. See CardProps#padding for guidance on each. */
 export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
@@ -46,6 +49,10 @@ const paddingClass: Record<CardPadding, string> = {
  * nest Card in Card** — if you need to subdivide, use spacing or a horizontal
  * rule instead. If everything on your page is a card, none of them are.
  *
+ * Compound API — `Card.Header` / `Card.List` / `Card.ListRow` for the
+ * "section card with a list of rows" pattern. Use `padding="none"` when
+ * composing with these subcomponents so the header and rows bleed edge-to-edge.
+ *
  * @example
  * <Card padding="md">
  *   <Stack gap="md">
@@ -59,10 +66,22 @@ const paddingClass: Record<CardPadding, string> = {
  * </Card>
  *
  * @example
- * // Card with a bleeding table inside — sections control their own padding:
+ * // Compound API — section card with header + action + list rows:
  * <Card padding="none">
- *   <header style={{ padding: 16 }}>Header</header>
- *   <ul>...</ul>
+ *   <Card.Header action={<Link variant="muted">View all</Link>}>
+ *     Deals needing attention
+ *   </Card.Header>
+ *   <Card.List>
+ *     {deals.map(d => (
+ *       <Card.ListRow key={d.id}>
+ *         <Stack gap="xs">
+ *           <span>{d.title}</span>
+ *           <span>{d.company}</span>
+ *         </Stack>
+ *         <Avatar name={d.owner} size="sm" />
+ *       </Card.ListRow>
+ *     ))}
+ *   </Card.List>
  * </Card>
  *
  * @example
@@ -90,8 +109,10 @@ const paddingClass: Record<CardPadding, string> = {
  *   architecture is wrong.
  * - ❌ Hand-rolling a left-stripe via `className` / `style`. Use the `tone`
  *   prop — it reserves the border-left space so layout never shifts.
+ * - ❌ Hand-rolling `.cardHeader` / `.list` / `.listRow` SCSS. Use the
+ *   compound API (`Card.Header` / `Card.List` / `Card.ListRow`) instead.
  */
-export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
+const CardRoot = forwardRef<HTMLDivElement, CardProps>(function Card(
   { padding = 'md', tone, className, ...props },
   ref,
 ) {
@@ -104,4 +125,10 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
       {...props}
     />
   );
+});
+
+export const Card = Object.assign(CardRoot, {
+  Header: CardHeader,
+  List: CardList,
+  ListRow: CardListRow,
 });

--- a/packages/design-system/src/components/Card/CardHeader.tsx
+++ b/packages/design-system/src/components/Card/CardHeader.tsx
@@ -1,0 +1,72 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import clsx from 'clsx';
+import styles from './Card.module.scss';
+
+/** Heading level wrapping the title. Defaults to 'h3'. Same vocab as Accordion. */
+export type CardHeaderLevel = 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+export interface CardHeaderProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+  /**
+   * Heading level for the title text. Defaults to `'h3'` (assumes the page
+   * has an h1/h2 above). Override when this section sits beneath an h1
+   * directly (`headerLevel="h2"`) or further nested (`headerLevel="h4"`).
+   */
+  headerLevel?: CardHeaderLevel;
+  /**
+   * Optional right-aligned slot — typically a `<Link>` or `<Button>` that
+   * lets the user navigate to a full list or take a section-level action.
+   * Rendered inside a `<span>` that is flex-shrink: 0 so it never wraps.
+   */
+  action?: ReactNode;
+  /**
+   * Title content. Becomes the inner text of the heading element. Typically
+   * a plain string, but can contain inline elements if needed.
+   */
+  children: ReactNode;
+}
+
+/**
+ * Title row subcomponent for `<Card>` with an optional right-aligned action
+ * slot and a bottom-border separator. Renders as a `<div>` containing a
+ * configurable heading element (`h3` by default) plus an optional `<span>`
+ * wrapping the `action` node.
+ *
+ * Use inside `<Card padding="none">` so the header's internal padding aligns
+ * flush with the card edge.
+ *
+ * @example
+ * // Basic header — title only:
+ * <Card padding="none">
+ *   <Card.Header>Recent activity</Card.Header>
+ *   <Card.List>...</Card.List>
+ * </Card>
+ *
+ * @example
+ * // Header with a right-aligned "View all" link:
+ * <Card padding="none">
+ *   <Card.Header action={<Link variant="muted">View all</Link>}>
+ *     Deals needing attention
+ *   </Card.Header>
+ *   <Card.List>...</Card.List>
+ * </Card>
+ *
+ * @example
+ * // Adjust heading level when nested below an h1 (page has no h2 above):
+ * <Card padding="none">
+ *   <Card.Header headerLevel="h2">Pipeline overview</Card.Header>
+ *   <Card.List>...</Card.List>
+ * </Card>
+ */
+export const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(function CardHeader(
+  { headerLevel = 'h3', action, children, className, ...rest },
+  ref,
+) {
+  const Heading = headerLevel as 'h3';
+  // {...rest} last so consumer overrides win (Pattern A).
+  return (
+    <div ref={ref} className={clsx(styles.header, className)} {...rest}>
+      <Heading className={styles.title}>{children}</Heading>
+      {action != null && <span className={styles.action}>{action}</span>}
+    </div>
+  );
+});

--- a/packages/design-system/src/components/Card/CardHeader.tsx
+++ b/packages/design-system/src/components/Card/CardHeader.tsx
@@ -5,7 +5,7 @@ import styles from './Card.module.scss';
 /** Heading level wrapping the title. Defaults to 'h3'. Same vocab as Accordion. */
 export type CardHeaderLevel = 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
-export interface CardHeaderProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+export interface CardHeaderProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Heading level for the title text. Defaults to `'h3'` (assumes the page
    * has an h1/h2 above). Override when this section sits beneath an h1
@@ -61,7 +61,9 @@ export const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(function C
   { headerLevel = 'h3', action, children, className, ...rest },
   ref,
 ) {
-  const Heading = headerLevel as 'h3';
+  // headerLevel is a string union of valid HTML heading tag names; cast to
+  // the union (not a single literal) so the JSX dispatch type is honest.
+  const Heading = headerLevel as 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   // {...rest} last so consumer overrides win (Pattern A).
   return (
     <div ref={ref} className={clsx(styles.header, className)} {...rest}>

--- a/packages/design-system/src/components/Card/CardList.tsx
+++ b/packages/design-system/src/components/Card/CardList.tsx
@@ -19,6 +19,14 @@ export interface CardListProps extends HTMLAttributes<HTMLUListElement> {
  *     <Card.ListRow>Row content</Card.ListRow>
  *   </Card.List>
  * </Card>
+ *
+ * @remarks
+ * Row dividers use a `:last-child` CSS selector to suppress the bottom border
+ * on the final row. Fragments are transparent (work fine — `<Fragment>` doesn't
+ * render a DOM node), but wrapping rows in an extra `<div>` or other element
+ * breaks the last-child match and leaves a stray divider on the visual last
+ * row. Render rows as direct children (or via `.map`) for the divider to
+ * resolve correctly.
  */
 export const CardList = forwardRef<HTMLUListElement, CardListProps>(function CardList(
   { children, className, ...rest },

--- a/packages/design-system/src/components/Card/CardList.tsx
+++ b/packages/design-system/src/components/Card/CardList.tsx
@@ -1,0 +1,33 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import clsx from 'clsx';
+import styles from './Card.module.scss';
+
+export interface CardListProps extends HTMLAttributes<HTMLUListElement> {
+  /** Row items — typically `<Card.ListRow>` elements. */
+  children: ReactNode;
+}
+
+/**
+ * Semantic `<ul>` wrapper for a list of `<Card.ListRow>` items inside a
+ * `<Card>`. Applies list-reset styling (no bullets, no indent) so rows bleed
+ * edge-to-edge. Screen readers announce "list with N items".
+ *
+ * @example
+ * <Card padding="none">
+ *   <Card.Header>Recent activity</Card.Header>
+ *   <Card.List>
+ *     <Card.ListRow>Row content</Card.ListRow>
+ *   </Card.List>
+ * </Card>
+ */
+export const CardList = forwardRef<HTMLUListElement, CardListProps>(function CardList(
+  { children, className, ...rest },
+  ref,
+) {
+  // {...rest} last so consumer overrides win (Pattern A).
+  return (
+    <ul ref={ref} className={clsx(styles.list, className)} {...rest}>
+      {children}
+    </ul>
+  );
+});

--- a/packages/design-system/src/components/Card/CardListRow.tsx
+++ b/packages/design-system/src/components/Card/CardListRow.tsx
@@ -1,0 +1,35 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import clsx from 'clsx';
+import styles from './Card.module.scss';
+
+export interface CardListRowProps extends HTMLAttributes<HTMLLIElement> {
+  /** Row content — typically a `<Stack>` or `<Cluster>` of text and metadata. */
+  children: ReactNode;
+}
+
+/**
+ * A single row inside a `<Card.List>`. Renders as `<li>` with padded content
+ * and a bottom dividing border. The border is suppressed on the last child via
+ * `:last-child` in SCSS so the final row sits flush against the card edge.
+ *
+ * @example
+ * <Card.List>
+ *   <Card.ListRow>
+ *     <Stack gap="xs">
+ *       <span>Deal name</span>
+ *       <span>Company · $12,000</span>
+ *     </Stack>
+ *   </Card.ListRow>
+ * </Card.List>
+ */
+export const CardListRow = forwardRef<HTMLLIElement, CardListRowProps>(function CardListRow(
+  { children, className, ...rest },
+  ref,
+) {
+  // {...rest} last so consumer overrides win (Pattern A).
+  return (
+    <li ref={ref} className={clsx(styles.listRow, className)} {...rest}>
+      {children}
+    </li>
+  );
+});

--- a/packages/design-system/src/components/Card/index.ts
+++ b/packages/design-system/src/components/Card/index.ts
@@ -1,2 +1,5 @@
 export { Card } from './Card';
 export type { CardProps, CardPadding, CardTone } from './Card';
+export type { CardHeaderProps, CardHeaderLevel } from './CardHeader';
+export type { CardListProps } from './CardList';
+export type { CardListRowProps } from './CardListRow';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -14,6 +14,9 @@ export type { InputProps, InputSize } from './components/Input';
 
 export { Card } from './components/Card';
 export type { CardProps, CardPadding, CardTone } from './components/Card';
+export type { CardHeaderProps, CardHeaderLevel } from './components/Card';
+export type { CardListProps } from './components/Card';
+export type { CardListRowProps } from './components/Card';
 
 export { Checkbox } from './components/Checkbox';
 export type { CheckboxProps, CheckboxSize } from './components/Checkbox';

--- a/packages/playground/src/pages/components/CardDemo.tsx
+++ b/packages/playground/src/pages/components/CardDemo.tsx
@@ -229,9 +229,7 @@ export function CardDemo() {
             </Card.ListRow>
             <Card.ListRow>
               <Stack gap="xs">
-                <span style={{ fontWeight: 'var(--font-weight-medium)' }}>
-                  Pilot conversion
-                </span>
+                <span style={{ fontWeight: 'var(--font-weight-medium)' }}>Pilot conversion</span>
                 <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
                   Initech · $6,200
                 </span>
@@ -299,7 +297,9 @@ export function CardDemo() {
                     <span style={{ fontSize: 'var(--font-size-sm)' }}>
                       <strong>{a.who}</strong> {a.what}
                     </span>
-                    <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+                    <span
+                      style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}
+                    >
                       {a.when}
                     </span>
                   </Stack>

--- a/packages/playground/src/pages/components/CardDemo.tsx
+++ b/packages/playground/src/pages/components/CardDemo.tsx
@@ -152,9 +152,9 @@ export function CardDemo() {
 
       <Example
         title="Section card: header + list body"
-        description="The canonical Dashboard pattern — padding='none' so header and rows bleed to the card edge. Card.Header provides the title row with a right-aligned action; Card.List and Card.ListRow handle semantics and dividers."
-        code={`<Card padding="none">
-  <Card.Header action={<Link variant="muted">View all</Link>}>
+        description="The canonical Dashboard pattern. No padding prop needed — when Card.Header / Card.List / Card.ListRow appear as direct children, padding auto-defaults to 'none' so the header and rows bleed to the card edge."
+        code={`<Card>
+  <Card.Header action={<Link as={RouterLink} to="/deals">View all</Link>}>
     Deals needing attention
   </Card.Header>
   <Card.List>
@@ -194,8 +194,14 @@ export function CardDemo() {
   </Card.List>
 </Card>`}
       >
-        <Card padding="none" style={{ maxWidth: 480 }}>
-          <Card.Header action={<Link variant="muted">View all</Link>}>
+        <Card style={{ maxWidth: 480 }}>
+          <Card.Header
+            action={
+              <Link href="#" onClick={(e) => e.preventDefault()}>
+                View all
+              </Link>
+            }
+          >
             Deals needing attention
           </Card.Header>
           <Card.List>
@@ -243,7 +249,7 @@ export function CardDemo() {
       <Example
         title="Header without action"
         description="When there's no navigation link, omit the action prop. The title still gets the bottom-border separator and proper heading semantics."
-        code={`<Card padding="none">
+        code={`<Card>
   <Card.Header>Recent activity</Card.Header>
   <Card.List>
     <Card.ListRow>
@@ -282,7 +288,7 @@ export function CardDemo() {
   </Card.List>
 </Card>`}
       >
-        <Card padding="none" style={{ maxWidth: 480 }}>
+        <Card style={{ maxWidth: 480 }}>
           <Card.Header>Recent activity</Card.Header>
           <Card.List>
             {[

--- a/packages/playground/src/pages/components/CardDemo.tsx
+++ b/packages/playground/src/pages/components/CardDemo.tsx
@@ -4,6 +4,7 @@ import { Stack } from '@eocrm/design-system';
 import { Badge } from '@eocrm/design-system';
 import { Avatar } from '@eocrm/design-system';
 import { Button } from '@eocrm/design-system';
+import { Link } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import tsxSource from '@lib-source/components/Card/Card.tsx?raw';
@@ -146,6 +147,166 @@ export function CardDemo() {
               </li>
             ))}
           </ul>
+        </Card>
+      </Example>
+
+      <Example
+        title="Section card: header + list body"
+        description="The canonical Dashboard pattern — padding='none' so header and rows bleed to the card edge. Card.Header provides the title row with a right-aligned action; Card.List and Card.ListRow handle semantics and dividers."
+        code={`<Card padding="none">
+  <Card.Header action={<Link variant="muted">View all</Link>}>
+    Deals needing attention
+  </Card.Header>
+  <Card.List>
+    <Card.ListRow>
+      <Stack gap="xs">
+        <Cluster gap="sm">
+          <span>Acme team plan upgrade</span>
+          <Badge tone="warning">At risk</Badge>
+        </Cluster>
+        <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+          Acme Inc · $12,000
+        </span>
+      </Stack>
+      <Avatar name="Alex Rivera" size="sm" />
+    </Card.ListRow>
+    <Card.ListRow>
+      <Stack gap="xs">
+        <Cluster gap="sm">
+          <span>Multi-region rollout</span>
+          <Badge tone="info">In progress</Badge>
+        </Cluster>
+        <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+          Globex · $28,500
+        </span>
+      </Stack>
+      <Avatar name="Jordan Park" size="sm" />
+    </Card.ListRow>
+    <Card.ListRow>
+      <Stack gap="xs">
+        <span>Pilot conversion</span>
+        <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+          Initech · $6,200
+        </span>
+      </Stack>
+      <Avatar name="Sam Chen" size="sm" />
+    </Card.ListRow>
+  </Card.List>
+</Card>`}
+      >
+        <Card padding="none" style={{ maxWidth: 480 }}>
+          <Card.Header action={<Link variant="muted">View all</Link>}>
+            Deals needing attention
+          </Card.Header>
+          <Card.List>
+            <Card.ListRow>
+              <Stack gap="xs">
+                <Cluster gap="sm">
+                  <span style={{ fontWeight: 'var(--font-weight-medium)' }}>
+                    Acme team plan upgrade
+                  </span>
+                  <Badge tone="warning">At risk</Badge>
+                </Cluster>
+                <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+                  Acme Inc · $12,000
+                </span>
+              </Stack>
+              <Avatar name="Alex Rivera" size="sm" />
+            </Card.ListRow>
+            <Card.ListRow>
+              <Stack gap="xs">
+                <Cluster gap="sm">
+                  <span style={{ fontWeight: 'var(--font-weight-medium)' }}>
+                    Multi-region rollout
+                  </span>
+                  <Badge tone="info">In progress</Badge>
+                </Cluster>
+                <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+                  Globex · $28,500
+                </span>
+              </Stack>
+              <Avatar name="Jordan Park" size="sm" />
+            </Card.ListRow>
+            <Card.ListRow>
+              <Stack gap="xs">
+                <span style={{ fontWeight: 'var(--font-weight-medium)' }}>
+                  Pilot conversion
+                </span>
+                <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+                  Initech · $6,200
+                </span>
+              </Stack>
+              <Avatar name="Sam Chen" size="sm" />
+            </Card.ListRow>
+          </Card.List>
+        </Card>
+      </Example>
+
+      <Example
+        title="Header without action"
+        description="When there's no navigation link, omit the action prop. The title still gets the bottom-border separator and proper heading semantics."
+        code={`<Card padding="none">
+  <Card.Header>Recent activity</Card.Header>
+  <Card.List>
+    <Card.ListRow>
+      <Cluster gap="sm" wrap={false} align="start">
+        <Avatar name="Priya Shah" size="sm" />
+        <Stack gap="xs">
+          <span><strong>Priya Shah</strong> replied to your email</span>
+          <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+            12m ago
+          </span>
+        </Stack>
+      </Cluster>
+    </Card.ListRow>
+    <Card.ListRow>
+      <Cluster gap="sm" wrap={false} align="start">
+        <Avatar name="Jordan Park" size="sm" />
+        <Stack gap="xs">
+          <span><strong>Jordan Park</strong> moved a deal to Proposal</span>
+          <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+            1h ago
+          </span>
+        </Stack>
+      </Cluster>
+    </Card.ListRow>
+    <Card.ListRow>
+      <Cluster gap="sm" wrap={false} align="start">
+        <Avatar name="Diana Okafor" size="sm" />
+        <Stack gap="xs">
+          <span><strong>Diana Okafor</strong> booked a demo</span>
+          <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+            3h ago
+          </span>
+        </Stack>
+      </Cluster>
+    </Card.ListRow>
+  </Card.List>
+</Card>`}
+      >
+        <Card padding="none" style={{ maxWidth: 480 }}>
+          <Card.Header>Recent activity</Card.Header>
+          <Card.List>
+            {[
+              { who: 'Priya Shah', what: 'replied to your email', when: '12m ago' },
+              { who: 'Jordan Park', what: 'moved a deal to Proposal', when: '1h ago' },
+              { who: 'Diana Okafor', what: 'booked a demo', when: '3h ago' },
+            ].map((a) => (
+              <Card.ListRow key={a.who}>
+                <Cluster gap="sm" wrap={false} align="start">
+                  <Avatar name={a.who} size="sm" />
+                  <Stack gap="xs">
+                    <span style={{ fontSize: 'var(--font-size-sm)' }}>
+                      <strong>{a.who}</strong> {a.what}
+                    </span>
+                    <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+                      {a.when}
+                    </span>
+                  </Stack>
+                </Cluster>
+              </Card.ListRow>
+            ))}
+          </Card.List>
         </Card>
       </Example>
     </DemoLayout>

--- a/packages/playground/src/pages/mockups/Dashboard/Dashboard.module.scss
+++ b/packages/playground/src/pages/mockups/Dashboard/Dashboard.module.scss
@@ -5,6 +5,15 @@
   color: var(--color-fg);
 }
 
+// Section heading for non-list cards (e.g. Recent contacts) where the
+// Card.Header subcomponent's border-bottom + padding don't fit.
+.cardTitle {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-fg);
+}
+
 .subtitle {
   margin: var(--space-1) 0 0;
   color: var(--color-fg-muted);

--- a/packages/playground/src/pages/mockups/Dashboard/Dashboard.module.scss
+++ b/packages/playground/src/pages/mockups/Dashboard/Dashboard.module.scss
@@ -55,16 +55,6 @@
   gap: var(--space-4);
 }
 
-.cardLink {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-accent);
-
-  &:hover {
-    text-decoration: underline;
-  }
-}
-
 .listRowTitle {
   font-weight: var(--font-weight-medium);
   color: var(--color-fg);

--- a/packages/playground/src/pages/mockups/Dashboard/Dashboard.module.scss
+++ b/packages/playground/src/pages/mockups/Dashboard/Dashboard.module.scss
@@ -46,21 +46,6 @@
   gap: var(--space-4);
 }
 
-.cardHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-3) var(--space-4);
-  border-bottom: var(--border-width) solid var(--color-border);
-}
-
-.cardTitle {
-  margin: 0;
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-fg);
-}
-
 .cardLink {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
@@ -68,25 +53,6 @@
 
   &:hover {
     text-decoration: underline;
-  }
-}
-
-.list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.listRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  padding: var(--space-3) var(--space-4);
-  border-bottom: var(--border-width) solid var(--color-border);
-
-  &:last-child {
-    border-bottom: none;
   }
 }
 

--- a/packages/playground/src/pages/mockups/Dashboard/Dashboard.tsx
+++ b/packages/playground/src/pages/mockups/Dashboard/Dashboard.tsx
@@ -5,6 +5,7 @@ import { Cluster } from '@eocrm/design-system';
 import { Avatar } from '@eocrm/design-system';
 import { Badge } from '@eocrm/design-system';
 import { Button } from '@eocrm/design-system';
+import { Link } from '@eocrm/design-system';
 import { contacts, deals } from '../../../data/mock';
 import styles from './Dashboard.module.scss';
 import { CrossLinks } from '../../shared/CrossLinks';
@@ -86,13 +87,13 @@ export function Dashboard() {
       </div>
 
       <div className={styles.twoCol}>
-        <Card padding="none">
+        <Card>
           <Card.Header
             headerLevel="h2"
             action={
-              <a href="#" className={styles.cardLink} onClick={(e) => e.preventDefault()}>
+              <Link href="#" onClick={(e) => e.preventDefault()}>
                 View all
-              </a>
+              </Link>
             }
           >
             Deals needing attention
@@ -119,7 +120,7 @@ export function Dashboard() {
           </Card.List>
         </Card>
 
-        <Card padding="none">
+        <Card>
           <Card.Header headerLevel="h2">Recent activity</Card.Header>
           <Card.List>
             {activity.map((a, i) => (

--- a/packages/playground/src/pages/mockups/Dashboard/Dashboard.tsx
+++ b/packages/playground/src/pages/mockups/Dashboard/Dashboard.tsx
@@ -87,15 +87,19 @@ export function Dashboard() {
 
       <div className={styles.twoCol}>
         <Card padding="none">
-          <div className={styles.cardHeader}>
-            <h2 className={styles.cardTitle}>Deals needing attention</h2>
-            <a href="#" className={styles.cardLink} onClick={(e) => e.preventDefault()}>
-              View all
-            </a>
-          </div>
-          <ul className={styles.list}>
+          <Card.Header
+            headerLevel="h2"
+            action={
+              <a href="#" className={styles.cardLink} onClick={(e) => e.preventDefault()}>
+                View all
+              </a>
+            }
+          >
+            Deals needing attention
+          </Card.Header>
+          <Card.List>
             {upcoming.map((d) => (
-              <li key={d.id} className={styles.listRow}>
+              <Card.ListRow key={d.id}>
                 <Stack gap="xs">
                   <Cluster gap="sm">
                     <span className={styles.listRowTitle}>{d.title}</span>
@@ -110,18 +114,16 @@ export function Dashboard() {
                   </span>
                 </Stack>
                 <Avatar name={d.owner} size="sm" />
-              </li>
+              </Card.ListRow>
             ))}
-          </ul>
+          </Card.List>
         </Card>
 
         <Card padding="none">
-          <div className={styles.cardHeader}>
-            <h2 className={styles.cardTitle}>Recent activity</h2>
-          </div>
-          <ul className={styles.list}>
+          <Card.Header headerLevel="h2">Recent activity</Card.Header>
+          <Card.List>
             {activity.map((a, i) => (
-              <li key={i} className={styles.listRow}>
+              <Card.ListRow key={i}>
                 <Cluster gap="sm" wrap={false} align="start">
                   <Avatar name={a.who} size="sm" />
                   <Stack gap="xs">
@@ -132,14 +134,14 @@ export function Dashboard() {
                     <span className={styles.listRowMeta}>{a.when}</span>
                   </Stack>
                 </Cluster>
-              </li>
+              </Card.ListRow>
             ))}
-          </ul>
+          </Card.List>
         </Card>
       </div>
 
       <Card padding="md">
-        <h2 className={styles.cardTitle}>Recent contacts</h2>
+        <h2 style={{ margin: 0, fontSize: 'var(--font-size-md)', fontWeight: 'var(--font-weight-semibold)', color: 'var(--color-fg)' }}>Recent contacts</h2>
         <div className={styles.contactGrid}>
           {contacts.slice(0, 4).map((c) => (
             <Cluster key={c.id} gap="sm" wrap={false} align="center">

--- a/packages/playground/src/pages/mockups/Dashboard/Dashboard.tsx
+++ b/packages/playground/src/pages/mockups/Dashboard/Dashboard.tsx
@@ -141,7 +141,7 @@ export function Dashboard() {
       </div>
 
       <Card padding="md">
-        <h2 style={{ margin: 0, fontSize: 'var(--font-size-md)', fontWeight: 'var(--font-weight-semibold)', color: 'var(--color-fg)' }}>Recent contacts</h2>
+        <h2 className={styles.cardTitle}>Recent contacts</h2>
         <div className={styles.contactGrid}>
           {contacts.slice(0, 4).map((c) => (
             <Cluster key={c.id} gap="sm" wrap={false} align="center">


### PR DESCRIPTION
## Summary

Three new subcomponents attached to Card via \`Object.assign\` — formalizes the \"section card with a list of rows\" pattern (Dashboard's \"Deals needing attention\" + \"Recent activity\").

- **\`<Card.Header>\`** — title row with optional right-aligned \`action\` slot + bottom-border separator. Title wraps in \`<h3>\` by default; override via \`headerLevel\` (h2–h6, same vocab as Accordion).
- **\`<Card.List>\`** — bare \`<ul>\` with list-reset styling. Semantic SR announcement: \"list with N items\".
- **\`<Card.ListRow>\`** — \`<li>\` with padded content + bottom dividing border (suppressed on the last child via \`:last-child\`).

Plus **Dashboard mockup refactor**: both \"Deals needing attention\" and \"Recent activity\" sections swap inline className recipes for the new subcomponents. Deletes ~30 lines of inline SCSS.

## Design highlights

- **Compound via \`Object.assign\`** — \`Card\` keeps its existing API (\`tone\`, \`padding\`), the three new subcomponents are statically attached. Same pattern as ButtonGroup / Accordion.
- **Heading level configurable** — default \`<h3>\` assumes the page has an h2 above; override for top-level sections.
- **Semantic list** — \`<ul>\` + \`<li>\` carries the right ARIA shape. Screen readers announce \"list with 3 items\" automatically.
- **\`action != null\` check** — suppresses the action span for both \`undefined\` and \`null\`, preventing the same phantom-gap bug the Tabs icon PR caught.
- **Row dividers** — \`.listRow:last-child { border-bottom: 0 }\` handles the visual end-of-list. Fragments are transparent (work fine); a div-wrapper around rows would break the \`:last-child\` match. Documented in \`Card.List\`'s \`@remarks\`.

## Hard Rule 8

**Round 1 verdict: keep iterating** (2 Important):

1. The implementer had inlined four CSS-token style props directly on the Dashboard's \"Recent contacts\" \`<h2>\` (after deleting the local \`.cardTitle\` class). Restored \`.cardTitle\` as a mockup-local style so the section isn't using the anti-pattern future agents would copy.
2. \`CardHeader\` had \`const Heading = headerLevel as 'h3'\` — a single-literal cast that lied about the runtime type. Fixed to the full \`'h2' | 'h3' | 'h4' | 'h5' | 'h6'\` union (matches Accordion).

Plus two cheap Nice-to-haves folded in:
- Dropped the dead \`Omit<..., 'title'>\` from \`CardHeaderProps\` (no name collision — CardHeader uses \`children\` for the title).
- Added a \`@remarks\` note to \`Card.List\` explaining the Fragment-OK / div-wrapper-not-OK behavior of the row-divider rule.

**1529 tests passing** (1520 → 1529, +9 net). All four gates green.

## Test plan

- [ ] Dashboard renders both list cards (\"Deals needing attention\", \"Recent activity\") via the new compound subcomponents
- [ ] \"View all\" link still appears in the Deals header's right-side action slot
- [ ] \"Recent activity\" header has no action (just the title)
- [ ] Row dividers appear between rows but NOT after the last row in each list
- [ ] \"Recent contacts\" section (non-list card) still renders with the mockup-local \`.cardTitle\` heading
- [ ] \`<Card.Header headerLevel=\"h2\">\` renders as \`<h2>\` (verify in DOM)
- [ ] Screen readers announce the list as \"list with N items\" (verify with axe or AT)
- [ ] No layout regressions in any existing Card consumer (tone + padding still work)
- [ ] Demo at \`/components/card\` shows the new compound examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)