### PR TITLE
Slider: controlled single + range, horizontal + vertical (pre-req for ImageCrop)

### DIFF
--- a/docs/superpowers/plans/2026-05-24-slider.md
+++ b/docs/superpowers/plans/2026-05-24-slider.md
@@ -17,7 +17,7 @@
 **Conventions used throughout this plan:**
 
 - **Plan-verbatim:** every code block is the literal file contents the implementer commits. Don't paraphrase, fold types, reorder imports, or rename props.
-- **CSS-Modules class naming (DEVIATION):** Slider's SCSS uses **kebab-case** class names (`.orientation-horizontal`, `.size-sm`, `.tone-danger`, `.markFilled`, `.thumbDragging`). The TSX accesses them via bracket notation: `styles[\`orientation-${orientation}\`]`, `styles[\`size-${size}\`]`, `styles[\`tone-${tone}\`]`. This deviates from Progress/Title's camelCase + record-of-strings pattern. Reason: the orientation × size × tone matrix here is 3 × 3 × 4 = up to 4 separate prop axes, all of which need a class. A record-of-strings would be 3 records × 3-4 entries each — verbose. Bracket-access is more legible for this case. Two-word class names like `.markFilled` and `.thumbDragging` remain camelCase (compound noun, not a prop-derived modifier). Document this with a comment in the source.
+- **CSS-Modules class naming (DEVIATION):** Slider's SCSS uses **kebab-case** class names (`.orientation-horizontal`, `.size-sm`, `.tone-danger`, `.markFilled`, `.thumbDragging`). The TSX accesses them via bracket notation: `styles[\`orientation-${orientation}\`]`, `styles[\`size-${size}\`]`, `styles[\`tone-${tone}\`]`. This deviates from Progress/Title's camelCase + record-of-strings pattern. Reason: the orientation × size × tone matrix here is 3 × 3 × 4 = up to 4 separate prop axes, all of which need a class. A record-of-strings would be 3 records × 3-4 entries each — verbose. Bracket-access is more legible for this case. Two-word class names like `.markFilled`and`.thumbDragging` remain camelCase (compound noun, not a prop-derived modifier). Document this with a comment in the source.
 - **Stable CSS Modules strategy:** generated class names contain the literal local-name as substring (e.g. `_orientation-horizontal_<hash>`). Test substring regex matching works against the literal kebab name (e.g. `/orientation-horizontal/`). For the base class merge test, use `/root_/` (trailing underscore) to reject hypothetical future siblings.
 - **Commit format:** subject line + blank line + body (1–3 short sentences) + blank line + `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
 - **`git add` discipline:** stage by explicit path. No `git add -A` / `git add .`.
@@ -106,8 +106,10 @@ export interface SliderMark {
   label?: ReactNode;
 }
 
-export interface SliderProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue' | 'role'> {
+export interface SliderProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'defaultValue' | 'role'
+> {
   /**
    * Current value. A single `number` for one-thumb mode; a `[min, max]` tuple
    * for two-thumb (range) mode. The component type-discriminates internally.
@@ -334,8 +336,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
       const rect = trackEl.getBoundingClientRect();
       const lengthPx = orientation === 'horizontal' ? rect.width : rect.height;
       if (lengthPx === 0) return null;
-      const pointerPos =
-        orientation === 'horizontal' ? clientX - rect.left : rect.bottom - clientY;
+      const pointerPos = orientation === 'horizontal' ? clientX - rect.left : rect.bottom - clientY;
       const pct = clamp(pointerPos / lengthPx, 0, 1);
       const raw = min + pct * range;
       const snapped = clamp(snapToStep(raw, min, step), min, max);
@@ -571,11 +572,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
       )}
       {...rest}
     >
-      <div
-        ref={trackRef}
-        className={styles.track}
-        onPointerDown={handleTrackPointerDown}
-      >
+      <div ref={trackRef} className={styles.track} onPointerDown={handleTrackPointerDown}>
         <div className={styles.fill} style={fillStyle} />
         {marksArr.map((mark) => (
           <span
@@ -597,9 +594,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
           aria-valuemin={min}
           aria-valuemax={max}
           aria-valuenow={thumbValue}
-          aria-valuetext={
-            typeof label === 'function' ? String(label(thumbValue)) : undefined
-          }
+          aria-valuetext={typeof label === 'function' ? String(label(thumbValue)) : undefined}
           aria-orientation={orientation}
           aria-disabled={disabled || undefined}
           className={clsx(styles.thumb, isDragging[index] && styles.thumbDragging)}
@@ -613,9 +608,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
           onBlur={() => handleThumbBlur(index)}
           onKeyDown={(e) => handleThumbKeyDown(e, index)}
         >
-          {showLabelFor(index) && (
-            <span className={styles.label}>{formatLabel(thumbValue)}</span>
-          )}
+          {showLabelFor(index) && <span className={styles.label}>{formatLabel(thumbValue)}</span>}
         </div>
       ))}
       {name &&
@@ -969,22 +962,27 @@ EOF
 ```tsx
 import { render, screen, fireEvent } from '@testing-library/react';
 import { createRef } from 'react';
-import {
-  Slider,
-  type SliderOrientation,
-  type SliderSize,
-  type SliderTone,
-} from './Slider';
+import { Slider, type SliderOrientation, type SliderSize, type SliderTone } from './Slider';
 
 // jsdom doesn't implement setPointerCapture; stub it on HTMLElement so the
 // component's try/catch fast-path is exercised (and we still get pointer
 // events).
 function ensurePointerCaptureShim() {
-  if (typeof (HTMLElement.prototype as unknown as { setPointerCapture?: unknown }).setPointerCapture !== 'function') {
-    (HTMLElement.prototype as unknown as { setPointerCapture: (id: number) => void }).setPointerCapture = () => {};
+  if (
+    typeof (HTMLElement.prototype as unknown as { setPointerCapture?: unknown })
+      .setPointerCapture !== 'function'
+  ) {
+    (
+      HTMLElement.prototype as unknown as { setPointerCapture: (id: number) => void }
+    ).setPointerCapture = () => {};
   }
-  if (typeof (HTMLElement.prototype as unknown as { releasePointerCapture?: unknown }).releasePointerCapture !== 'function') {
-    (HTMLElement.prototype as unknown as { releasePointerCapture: (id: number) => void }).releasePointerCapture = () => {};
+  if (
+    typeof (HTMLElement.prototype as unknown as { releasePointerCapture?: unknown })
+      .releasePointerCapture !== 'function'
+  ) {
+    (
+      HTMLElement.prototype as unknown as { releasePointerCapture: (id: number) => void }
+    ).releasePointerCapture = () => {};
   }
 }
 
@@ -997,7 +995,10 @@ function getThumbs(container: HTMLElement): HTMLElement[] {
 
 // Helper — mock the track's getBoundingClientRect so pointer-math has a known
 // canvas. Default: 100px-wide / 6px-tall horizontal track at (0, 0).
-function mockTrackRect(container: HTMLElement, opts: { width?: number; height?: number; left?: number; top?: number } = {}) {
+function mockTrackRect(
+  container: HTMLElement,
+  opts: { width?: number; height?: number; left?: number; top?: number } = {},
+) {
   const { width = 100, height = 6, left = 0, top = 0 } = opts;
   const track = container.querySelector<HTMLElement>('[class*="track"]')!;
   track.getBoundingClientRect = () =>
@@ -1073,9 +1074,7 @@ describe('Slider', () => {
     );
 
     it('className from props merges with the base class', () => {
-      const { container } = render(
-        <Slider value={50} className="custom" onChange={() => {}} />,
-      );
+      const { container } = render(<Slider value={50} className="custom" onChange={() => {}} />);
       const cls = (container.firstChild as HTMLElement).className;
       expect(cls).toMatch(/custom/);
       expect(cls).toMatch(/root_/);
@@ -1201,18 +1200,14 @@ describe('Slider', () => {
 
     it('Home sets value to min', () => {
       const onChange = vi.fn();
-      const { container } = render(
-        <Slider value={50} min={0} max={100} onChange={onChange} />,
-      );
+      const { container } = render(<Slider value={50} min={0} max={100} onChange={onChange} />);
       fireEvent.keyDown(getThumbs(container)[0], { key: 'Home' });
       expect(onChange).toHaveBeenCalledWith(0);
     });
 
     it('End sets value to max', () => {
       const onChange = vi.fn();
-      const { container } = render(
-        <Slider value={50} min={0} max={100} onChange={onChange} />,
-      );
+      const { container } = render(<Slider value={50} min={0} max={100} onChange={onChange} />);
       fireEvent.keyDown(getThumbs(container)[0], { key: 'End' });
       expect(onChange).toHaveBeenCalledWith(100);
     });
@@ -1233,9 +1228,7 @@ describe('Slider', () => {
 
     it('range mode: left thumb cannot cross right thumb (keyboard clamp)', () => {
       const onChange = vi.fn();
-      const { container } = render(
-        <Slider value={[40, 50]} step={20} onChange={onChange} />,
-      );
+      const { container } = render(<Slider value={[40, 50]} step={20} onChange={onChange} />);
       // ArrowRight on left thumb tries to go to 60, but it clamps to 50 (right thumb).
       fireEvent.keyDown(getThumbs(container)[0], { key: 'ArrowRight' });
       expect(onChange).toHaveBeenCalledWith([50, 50]);
@@ -1292,9 +1285,7 @@ describe('Slider', () => {
 
     it('range mode: pointer-dragging thumb 0 past thumb 1 clamps to thumb 1 value', () => {
       const onChange = vi.fn();
-      const { container } = render(
-        <Slider value={[20, 50]} onChange={onChange} />,
-      );
+      const { container } = render(<Slider value={[20, 50]} onChange={onChange} />);
       mockTrackRect(container, { width: 100, left: 0 });
       const thumbs = getThumbs(container);
       fireEvent.pointerDown(thumbs[0], { clientX: 20, clientY: 3, pointerId: 1 });
@@ -1317,23 +1308,23 @@ describe('Slider', () => {
   describe('marks + label', () => {
     it('marks={[0, 50, 100]} renders 3 mark elements', () => {
       const { container } = render(<Slider value={50} marks={[0, 50, 100]} onChange={() => {}} />);
-      const marks = container.querySelectorAll('[class*="mark"]:not([class*="markLabel"]):not([class*="markFilled"])');
+      const marks = container.querySelectorAll(
+        '[class*="mark"]:not([class*="markLabel"]):not([class*="markFilled"])',
+      );
       // The mark spans match `[class*="mark"]`. Marks with values within the
       // fill range get an extra `.markFilled` class — they're still in the
       // selector. Count the mark spans (excluding markFilled-only matches):
       const allMarks = container.querySelectorAll('span[class*="mark"]');
       // Filter to spans where className contains `mark` but NOT `markLabel` and
       // NOT only `markFilled`.
-      const markSpans = Array.from(allMarks).filter((el) =>
-        /\bmark\b|^mark|mark_/.test(el.className) && !/markLabel/.test(el.className),
+      const markSpans = Array.from(allMarks).filter(
+        (el) => /\bmark\b|^mark|mark_/.test(el.className) && !/markLabel/.test(el.className),
       );
       expect(markSpans.length).toBeGreaterThanOrEqual(3);
     });
 
     it('marks within the fill range get markFilled class', () => {
-      const { container } = render(
-        <Slider value={75} marks={[25, 75]} onChange={() => {}} />,
-      );
+      const { container } = render(<Slider value={75} marks={[25, 75]} onChange={() => {}} />);
       // Both 25 and 75 are <= 75, so both should have markFilled.
       const filled = container.querySelectorAll('[class*="markFilled"]');
       expect(filled.length).toBe(2);
@@ -1380,9 +1371,7 @@ describe('Slider', () => {
     });
 
     it('range mode + name="price": renders TWO hidden inputs (price-min and price-max)', () => {
-      const { container } = render(
-        <Slider value={[10, 90]} name="price" onChange={() => {}} />,
-      );
+      const { container } = render(<Slider value={[10, 90]} name="price" onChange={() => {}} />);
       const inputs = container.querySelectorAll<HTMLInputElement>('input[type="hidden"]');
       expect(inputs).toHaveLength(2);
       expect(inputs[0]).toHaveAttribute('name', 'price-min');
@@ -1392,9 +1381,7 @@ describe('Slider', () => {
     });
 
     it('disabled: hidden inputs receive disabled attribute', () => {
-      const { container } = render(
-        <Slider value={50} name="vol" disabled onChange={() => {}} />,
-      );
+      const { container } = render(<Slider value={50} name="vol" disabled onChange={() => {}} />);
       const input = container.querySelector<HTMLInputElement>('input[type="hidden"]')!;
       expect(input).toBeDisabled();
     });
@@ -1654,10 +1641,30 @@ function Tones() {
   const [value, setValue] = useState(75);
   return (
     <Stack gap="md">
-      <Slider value={value} tone="default" onChange={(v) => setValue(v as number)} aria-label="default" />
-      <Slider value={value} tone="success" onChange={(v) => setValue(v as number)} aria-label="success" />
-      <Slider value={value} tone="warning" onChange={(v) => setValue(v as number)} aria-label="warning" />
-      <Slider value={value} tone="danger" onChange={(v) => setValue(v as number)} aria-label="danger" />
+      <Slider
+        value={value}
+        tone="default"
+        onChange={(v) => setValue(v as number)}
+        aria-label="default"
+      />
+      <Slider
+        value={value}
+        tone="success"
+        onChange={(v) => setValue(v as number)}
+        aria-label="success"
+      />
+      <Slider
+        value={value}
+        tone="warning"
+        onChange={(v) => setValue(v as number)}
+        aria-label="warning"
+      />
+      <Slider
+        value={value}
+        tone="danger"
+        onChange={(v) => setValue(v as number)}
+        aria-label="danger"
+      />
     </Stack>
   );
 }
@@ -1827,11 +1834,13 @@ Read `packages/playground/src/App.tsx`. Find the alphabetical neighbour. Slider 
 **Edit 4a — add import** (using SkeletonDemo as anchor):
 
 old_string:
+
 ```tsx
 import { SkeletonDemo } from './pages/components/SkeletonDemo';
 ```
 
 new_string:
+
 ```tsx
 import { SkeletonDemo } from './pages/components/SkeletonDemo';
 import { SliderDemo } from './pages/components/SliderDemo';
@@ -1840,11 +1849,13 @@ import { SliderDemo } from './pages/components/SliderDemo';
 **Edit 4b — add route**:
 
 old_string:
+
 ```tsx
-          <Route path="/components/skeleton" element={<SkeletonDemo />} />
+<Route path="/components/skeleton" element={<SkeletonDemo />} />
 ```
 
 new_string:
+
 ```tsx
           <Route path="/components/skeleton" element={<SkeletonDemo />} />
           <Route path="/components/slider" element={<SliderDemo />} />
@@ -1861,12 +1872,14 @@ The lucide icon: `SlidersHorizontal` (canonical for slider UI).
 **Edit 4c — add lucide import**:
 
 old_string (the closing line of the lucide import block — expand context if needed):
+
 ```tsx
   type LucideIcon,
 } from 'lucide-react';
 ```
 
 new_string:
+
 ```tsx
   SlidersHorizontal,
   type LucideIcon,
@@ -1878,12 +1891,14 @@ new_string:
 Read the file to confirm the Select/Switch order. The current Forms group block (per the spec verification) has `Select` immediately before `Switch`:
 
 old_string:
+
 ```tsx
       { to: '/components/select', label: 'Select', icon: ChevronsUpDown, end: false },
       { to: '/components/switch', label: 'Switch', icon: ToggleRight, end: false },
 ```
 
 new_string:
+
 ```tsx
       { to: '/components/select', label: 'Select', icon: ChevronsUpDown, end: false },
       { to: '/components/slider', label: 'Slider', icon: SlidersHorizontal, end: false },
@@ -1899,11 +1914,13 @@ Read the file. Apply two edits.
 **Edit 4e — add import** (use SkeletonDemo or a near-alphabetical anchor):
 
 old_string:
+
 ```tsx
 import { Skeleton } from '@eocrm/design-system';
 ```
 
 new_string:
+
 ```tsx
 import { Skeleton } from '@eocrm/design-system';
 import { Slider } from '@eocrm/design-system';
@@ -1933,12 +1950,14 @@ Insert it AFTER the Skeleton card. If the alphabetical sibling differs, adjust a
 Read the file. Insert `'Slider'` alphabetically (after Skeleton, before Switch).
 
 old_string:
+
 ```ts
   | 'Skeleton'
   | 'Stack'
 ```
 
 new_string:
+
 ```ts
   | 'Skeleton'
   | 'Slider'

--- a/docs/superpowers/plans/2026-05-24-slider.md
+++ b/docs/superpowers/plans/2026-05-24-slider.md
@@ -1,0 +1,2162 @@
+# Slider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<Slider>` — a controlled, custom-painted slider primitive supporting single + range modes, horizontal + vertical orientations, tick marks, value labels, and tone-coded fills. The pre-req for ImageCrop's zoom UI (next session) and a primitive that's been missing for filters / threshold controls / settings sliders across the CRM.
+
+**Architecture:** One component (`Slider.tsx`) plus its SCSS and tests in `packages/design-system/src/components/Slider/`. Fully controlled — `value: number | [number, number]` (discriminated union for single vs range). Custom paint for all modes (native `<input type="range">` can't do two thumbs or render consistently across browsers). Pointer events with `setPointerCapture` for unified mouse/touch/pen drag. Manual ARIA per thumb (`role="slider"`, `aria-valuemin/max/now`, `aria-orientation`). Optional hidden `<input>`(s) for form submission via the `name` prop.
+
+**Tech Stack:** React 19, TypeScript, CSS Modules + SCSS, Vitest + React Testing Library. No new packages. All tokens (`--color-accent`, `--shadow-sm/md`, `--opacity-disabled`, `--radius-full`, `--border-width`, etc.) verified present in `src/styles/tokens.scss`.
+
+---
+
+**Reference spec:** `docs/superpowers/specs/2026-05-24-slider-design.md` (commit `109e3b6`).
+
+**Branch:** `feat/image-crop` (already checked out, currently at spec commit). The branch is named for the eventual ImageCrop PR — Slider ships first as a pre-req. ImageCrop gets its own next-session brainstorm and its own branch.
+
+**Conventions used throughout this plan:**
+
+- **Plan-verbatim:** every code block is the literal file contents the implementer commits. Don't paraphrase, fold types, reorder imports, or rename props.
+- **CSS-Modules class naming (DEVIATION):** Slider's SCSS uses **kebab-case** class names (`.orientation-horizontal`, `.size-sm`, `.tone-danger`, `.markFilled`, `.thumbDragging`). The TSX accesses them via bracket notation: `styles[\`orientation-${orientation}\`]`, `styles[\`size-${size}\`]`, `styles[\`tone-${tone}\`]`. This deviates from Progress/Title's camelCase + record-of-strings pattern. Reason: the orientation × size × tone matrix here is 3 × 3 × 4 = up to 4 separate prop axes, all of which need a class. A record-of-strings would be 3 records × 3-4 entries each — verbose. Bracket-access is more legible for this case. Two-word class names like `.markFilled` and `.thumbDragging` remain camelCase (compound noun, not a prop-derived modifier). Document this with a comment in the source.
+- **Stable CSS Modules strategy:** generated class names contain the literal local-name as substring (e.g. `_orientation-horizontal_<hash>`). Test substring regex matching works against the literal kebab name (e.g. `/orientation-horizontal/`). For the base class merge test, use `/root_/` (trailing underscore) to reject hypothetical future siblings.
+- **Commit format:** subject line + blank line + body (1–3 short sentences) + blank line + `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+- **`git add` discipline:** stage by explicit path. No `git add -A` / `git add .`.
+- **Pattern A spread** (props last so consumer wins): `{...rest}` last on the root `<div>`. `onChange`, `defaultValue`, and `role` are `Omit`ted from `HTMLAttributes` — `onChange` is owned by the component's typed prop, `defaultValue` is forbidden (controlled-only), and `role` is locked because each thumb gets `role="slider"`.
+- **Stylelint requirements:**
+  - `property-disallowed-list` blocks `margin`, `position` outside the component-internal positioning exception, `top/left/right/bottom`, `width` (when not 100%), `flex: 1/grow/self`. The `position: relative` on `.root` + `position: absolute` on `.fill`/`.thumb`/`.mark`/`.label` are the established internal-child positioning exception (same precedent as Avatar's `.presence`, CircularProgress's `.label`). No inline disable comments needed for those — they're inside a component-internal positioning system. The `width: 100%` on `.orientation-horizontal` is the intrinsic-width carve-out.
+  - `rule-empty-line-before` requires a blank line between adjacent rule blocks. Add proactively.
+  - `scss/double-slash-comment-empty-line-before` requires a blank line BEFORE `//` comments inside a rule. Add proactively.
+  - If stylelint flags `user-select: none` / `cursor: grab` / `cursor: not-allowed` / `pointer-events: none` / `white-space: nowrap` under `scale-unlimited/declaration-strict-value`, add `// stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword, not a tokenizable design value` immediately above each affected line. These are pure CSS keywords with no token equivalent.
+- **Gates after each source-touching task:** `make test`, `make build-lib`, `make build`, `make lint`. All four must pass before commit + advance to next task.
+- **If pre-push hook flags prettier:** run `npx prettier --write <flagged files>` and create a follow-up commit `<scope>: prettier --write` with the same Co-Authored-By footer. Don't squash.
+- **`src/index.ts` re-export added per-task to satisfy `structure.test.ts`:** T2 (tests task, after creating Slider.test.tsx) adds the Slider + types re-exports. T3 (AGENTS.md) is the thinner edit.
+
+---
+
+## File structure
+
+### NEW files
+
+```
+packages/design-system/src/components/Slider/
+  Slider.tsx              ← root component (forwardRef, pointer + keyboard handlers, drag math, render tree)
+  Slider.module.scss      ← .root + .orientation-* + .size-* + .tone-* + .track + .fill + .thumb + .label + .mark + .disabled + prefers-reduced-motion
+  Slider.test.tsx         ← ~37 cases
+  index.ts                ← exports Slider + types
+```
+
+### MODIFIED files
+
+```
+packages/design-system/src/index.ts                                ← T2 adds Slider + types re-export
+packages/design-system/AGENTS.md                                   ← T3 inserts Slider section after FileUpload, before Card
+packages/playground/src/App.tsx                                    ← T4: add import + <Route>
+packages/playground/src/layout/AppShell/AppShell.tsx               ← T4: add lucide SlidersHorizontal icon + Forms-group item (alphabetical placement)
+packages/playground/src/pages/components/ComponentsIndex.tsx       ← T4: add import + card
+packages/playground/src/pages/mockups/registry.ts                  ← T4: extend ComponentName union with 'Slider'
+```
+
+No mockup files modified — no current mockup uses a slider.
+
+---
+
+## Task 1: Slider source — `Slider.tsx` + `Slider.module.scss` + `index.ts`
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Slider/Slider.tsx`
+- Create: `packages/design-system/src/components/Slider/Slider.module.scss`
+- Create: `packages/design-system/src/components/Slider/index.ts`
+
+### Step 1.1: Create `Slider.tsx`
+
+- [ ] Write file contents (verbatim):
+
+```tsx
+import {
+  forwardRef,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import styles from './Slider.module.scss';
+
+/** Track height + thumb size. */
+export type SliderSize = 'sm' | 'md' | 'lg';
+
+/** Fill color tone (track between min and value). */
+export type SliderTone = 'default' | 'success' | 'warning' | 'danger';
+
+/** Layout direction. */
+export type SliderOrientation = 'horizontal' | 'vertical';
+
+/** Either a single number (single-thumb) or a [min, max] tuple (range mode). */
+export type SliderValue = number | [number, number];
+
+/** Tick-mark configuration. */
+export interface SliderMark {
+  value: number;
+  label?: ReactNode;
+}
+
+export interface SliderProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue' | 'role'> {
+  /**
+   * Current value. A single `number` for one-thumb mode; a `[min, max]` tuple
+   * for two-thumb (range) mode. The component type-discriminates internally.
+   * Required — Slider is controlled-only.
+   */
+  value: SliderValue;
+  /**
+   * Called on every thumb-drag tick (high frequency). For server-side or
+   * expensive update logic, prefer `onChangeEnd` or debounce in the consumer.
+   * The argument has the same shape as `value`: `number` for single,
+   * `[number, number]` for range.
+   */
+  onChange: (value: SliderValue) => void;
+  /**
+   * Called once when the user releases the thumb (pointerup / blur after
+   * keyboard nav). Use for committing the value to a server or running an
+   * expensive recalculation. Receives the final value with the same shape
+   * as `value`.
+   */
+  onChangeEnd?: (value: SliderValue) => void;
+  /** Minimum allowed value (inclusive). Default `0`. */
+  min?: number;
+  /** Maximum allowed value (inclusive). Default `100`. */
+  max?: number;
+  /**
+   * Step granularity. Default `1`. Use fractional steps (e.g. `0.1`) for
+   * zoom / opacity-style controls. Values are snapped to `min + (n * step)`.
+   */
+  step?: number;
+  /**
+   * Tick marks. Pass `number[]` for auto-labeled ticks (label = value) or
+   * `SliderMark[]` for custom labels (label = ReactNode). Marks render under
+   * the track (horizontal) or to the right (vertical).
+   */
+  marks?: number[] | SliderMark[];
+  /**
+   * Value bubble on the thumb.
+   * - `false` (default) — no bubble.
+   * - `true` — show the current value (formatted via `toString()`) on hover /
+   *   focus / drag. Auto-hides otherwise.
+   * - `(value: number) => ReactNode` — custom formatter. For range mode, the
+   *   formatter is called once per thumb.
+   */
+  label?: boolean | ((value: number) => ReactNode);
+  /**
+   * Track + thumb sizing. Defaults to `'md'`.
+   * - `sm` — 4px track, 14px thumb.
+   * - `md` — 6px track, 18px thumb (default).
+   * - `lg` — 8px track, 22px thumb.
+   */
+  size?: SliderSize;
+  /**
+   * Fill color tone (the track segment between min and value). Defaults to
+   * `'default'` (accent). State-coded `success` / `warning` / `danger` for
+   * threshold-style sliders (e.g. disk usage approaching capacity).
+   */
+  tone?: SliderTone;
+  /** Orientation. Defaults to `'horizontal'`. */
+  orientation?: SliderOrientation;
+  /** Disabled state. Defaults to `false`. */
+  disabled?: boolean;
+  /**
+   * Native form-input name. When set, a hidden `<input>` (or two for range,
+   * with `-min`/`-max` suffixes) is rendered with the current value(s) so
+   * the slider works inside uncontrolled HTML forms without consumer JS
+   * serialization.
+   */
+  name?: string;
+}
+
+// CSS-Modules naming note:
+// SCSS class names here are kebab-case (`.orientation-horizontal`, `.size-sm`,
+// `.tone-danger`) so the TSX can use bracket notation
+// `styles[`orientation-${o}`]` for clean orientation × size × tone × state
+// dispatch. Two-word non-prop classes (`.markFilled`, `.thumbDragging`) stay
+// camelCase. Deviates from the Progress/Title pure-camelCase + record-of-strings
+// pattern; the bigger matrix here makes bracket-access more legible.
+
+function normalizeMarks(marks: number[] | SliderMark[] | undefined): SliderMark[] {
+  if (!marks || marks.length === 0) return [];
+  return marks.map((m) => (typeof m === 'number' ? { value: m } : m));
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}
+
+function snapToStep(raw: number, min: number, step: number): number {
+  if (step <= 0) return raw;
+  const stepped = Math.round((raw - min) / step) * step + min;
+  // Floating-point: align to step's decimal precision so 0.30000000000000004 → 0.3.
+  const decimals = (step.toString().split('.')[1] ?? '').length;
+  return decimals > 0 ? Number(stepped.toFixed(decimals)) : stepped;
+}
+
+/**
+ * Controlled slider primitive supporting single (one-thumb) and range
+ * (two-thumb) modes, horizontal and vertical orientations, fractional steps,
+ * tick marks, and value bubbles. Custom-painted (not wrapping
+ * `<input type="range">`) because range mode requires two thumbs and the
+ * native input can't do that.
+ *
+ * **Controlled-only:** `value` is required and `onChange` must update the
+ * consumer's state. Pass a `number` for single mode or `[number, number]`
+ * for range — the component branches on `Array.isArray(value)`.
+ *
+ * @example
+ * // Single-thumb with fractional steps (the ImageCrop zoom case):
+ * const [zoom, setZoom] = useState(1);
+ * <Slider value={zoom} min={1} max={3} step={0.1} onChange={(v) => setZoom(v as number)} aria-label="Zoom" />
+ *
+ * @example
+ * // Range filter — price band, formatted label:
+ * const [price, setPrice] = useState<[number, number]>([0, 50000]);
+ * <Slider
+ *   value={price}
+ *   min={0}
+ *   max={100000}
+ *   step={1000}
+ *   onChange={(v) => setPrice(v as [number, number])}
+ *   label={(v) => `$${v.toLocaleString()}`}
+ * />
+ *
+ * @example
+ * // Vertical volume control with tick marks:
+ * <Slider
+ *   value={volume}
+ *   orientation="vertical"
+ *   marks={[0, 25, 50, 75, 100]}
+ *   onChange={(v) => setVolume(v as number)}
+ * />
+ *
+ * @example
+ * // Tone-coded threshold (disk usage approaching capacity):
+ * <Slider
+ *   value={usage}
+ *   tone={usage > 90 ? 'danger' : usage > 75 ? 'warning' : 'default'}
+ *   onChange={(v) => setUsage(v as number)}
+ *   label
+ * />
+ *
+ * @example
+ * // Form submission via `name` — renders hidden inputs the form will pick up:
+ * <form action="/api/settings" method="post">
+ *   <Slider name="brightness" value={brightness} onChange={setB} />
+ *   <button type="submit">Save</button>
+ * </form>
+ *
+ * @remarks When NOT to use
+ * - For binary state (on/off) — use `<Switch>` or `<Checkbox>`.
+ * - For "pick one of a small enumerated set" — use `<RadioGroup>` or `<Select>`.
+ * - For continuous color picking — that's a `<ColorPicker>` (not yet shipped).
+ * - For server-state-bound expensive updates on every move tick. Use
+ *   `onChangeEnd` or debounce.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Raw `<input type="range">` — can't do range mode, doesn't theme cleanly
+ *   across browsers, vertical orientation is hacky. Use this.
+ * - ❌ Hand-rolling drag math per page. The pointer / keyboard handling is
+ *   non-trivial; the primitive owns it.
+ * - ❌ Hitting a network endpoint inside `onChange`. The callback fires on
+ *   every pointer-move tick — use `onChangeEnd` or debounce.
+ * - ❌ `<Slider role="region">` — `role="slider"` is locked on each thumb.
+ *   The TypeScript `Omit` prevents the root override.
+ * - ❌ Passing `value[0] > value[1]` in range mode. The component clamps but
+ *   the inverted tuple is a consumer bug — fix the state shape.
+ */
+export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
+  {
+    value,
+    onChange,
+    onChangeEnd,
+    min = 0,
+    max = 100,
+    step = 1,
+    marks,
+    label = false,
+    size = 'md',
+    tone = 'default',
+    orientation = 'horizontal',
+    disabled = false,
+    name,
+    className,
+    ...rest
+  },
+  ref,
+) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const isRange = Array.isArray(value);
+  const thumbValues: number[] = isRange ? (value as [number, number]) : [value as number];
+  const thumbCount = thumbValues.length;
+  const marksArr = useMemo(() => normalizeMarks(marks), [marks]);
+  const range = max - min;
+
+  const [isDragging, setIsDragging] = useState<boolean[]>(() => new Array(thumbCount).fill(false));
+  const [isFocused, setIsFocused] = useState<boolean[]>(() => new Array(thumbCount).fill(false));
+  const [isHovered, setIsHovered] = useState<boolean[]>(() => new Array(thumbCount).fill(false));
+
+  const setFlag = useCallback(
+    (setter: typeof setIsDragging, index: number, next: boolean) => {
+      setter((prev) => {
+        const out = [...prev];
+        // Ensure the array length matches thumbCount in case value shape changed.
+        while (out.length < thumbCount) out.push(false);
+        out[index] = next;
+        return out;
+      });
+    },
+    [thumbCount],
+  );
+
+  // Convert a value (in min..max) to a percentage along the track (0..100).
+  const valueToPercent = useCallback(
+    (v: number): number => (range === 0 ? 0 : clamp(((v - min) / range) * 100, 0, 100)),
+    [min, range],
+  );
+
+  // Compute the next value for a given thumb when the user moves the pointer to
+  // `clientX` / `clientY`. Returns null if the track has no measured length yet.
+  const pointerToValue = useCallback(
+    (clientX: number, clientY: number, thumbIndex: number): number | null => {
+      const trackEl = trackRef.current;
+      if (!trackEl) return null;
+      const rect = trackEl.getBoundingClientRect();
+      const lengthPx = orientation === 'horizontal' ? rect.width : rect.height;
+      if (lengthPx === 0) return null;
+      const pointerPos =
+        orientation === 'horizontal' ? clientX - rect.left : rect.bottom - clientY;
+      const pct = clamp(pointerPos / lengthPx, 0, 1);
+      const raw = min + pct * range;
+      const snapped = clamp(snapToStep(raw, min, step), min, max);
+      // Range clamp: thumb 0 can't exceed thumb 1; thumb 1 can't go below thumb 0.
+      if (isRange) {
+        const [v0, v1] = value as [number, number];
+        if (thumbIndex === 0) return Math.min(snapped, v1);
+        return Math.max(snapped, v0);
+      }
+      return snapped;
+    },
+    [isRange, max, min, orientation, range, step, value],
+  );
+
+  // Apply a new thumb value and fire onChange with the appropriate shape.
+  const applyThumbValue = useCallback(
+    (thumbIndex: number, newValue: number) => {
+      if (isRange) {
+        const tuple = [...(value as [number, number])] as [number, number];
+        tuple[thumbIndex] = newValue;
+        onChange(tuple);
+      } else {
+        onChange(newValue);
+      }
+    },
+    [isRange, onChange, value],
+  );
+
+  const handleThumbPointerDown = useCallback(
+    (e: PointerEvent<HTMLDivElement>, thumbIndex: number) => {
+      if (disabled) return;
+      e.preventDefault();
+      // setPointerCapture: future pointermove/up fire on this element even if
+      // the pointer leaves it. Wrapped in try/catch because jsdom may not
+      // implement setPointerCapture — we still get pointermove on the element
+      // in test environments.
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        // jsdom or pre-PointerEvents browsers — drag still works via pointermove.
+      }
+      setFlag(setIsDragging, thumbIndex, true);
+    },
+    [disabled, setFlag],
+  );
+
+  const handleThumbPointerMove = useCallback(
+    (e: PointerEvent<HTMLDivElement>, thumbIndex: number) => {
+      if (disabled || !isDragging[thumbIndex]) return;
+      const next = pointerToValue(e.clientX, e.clientY, thumbIndex);
+      if (next === null) return;
+      // Only fire onChange when the value actually changes (avoids identity-thrash
+      // when the pointer moves within the same step bucket).
+      const current = thumbValues[thumbIndex];
+      if (next !== current) applyThumbValue(thumbIndex, next);
+    },
+    [applyThumbValue, disabled, isDragging, pointerToValue, thumbValues],
+  );
+
+  const handleThumbPointerUp = useCallback(
+    (e: PointerEvent<HTMLDivElement>, thumbIndex: number) => {
+      if (disabled || !isDragging[thumbIndex]) return;
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // ignore — same rationale as pointerdown.
+      }
+      setFlag(setIsDragging, thumbIndex, false);
+      onChangeEnd?.(value);
+    },
+    [disabled, isDragging, onChangeEnd, setFlag, value],
+  );
+
+  const handleThumbKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>, thumbIndex: number) => {
+      if (disabled) return;
+      let delta = 0;
+      let absolute: number | null = null;
+      switch (e.key) {
+        case 'ArrowLeft':
+        case 'ArrowDown':
+          delta = -step;
+          break;
+        case 'ArrowRight':
+        case 'ArrowUp':
+          delta = step;
+          break;
+        case 'PageDown':
+          delta = -step * 10;
+          break;
+        case 'PageUp':
+          delta = step * 10;
+          break;
+        case 'Home':
+          absolute = min;
+          break;
+        case 'End':
+          absolute = max;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      const current = thumbValues[thumbIndex];
+      let next = absolute !== null ? absolute : current + delta;
+      next = clamp(snapToStep(next, min, step), min, max);
+      if (isRange) {
+        const [v0, v1] = value as [number, number];
+        if (thumbIndex === 0) next = Math.min(next, v1);
+        else next = Math.max(next, v0);
+      }
+      if (next !== current) applyThumbValue(thumbIndex, next);
+    },
+    [applyThumbValue, disabled, isRange, max, min, step, thumbValues, value],
+  );
+
+  const handleThumbBlur = useCallback(
+    (thumbIndex: number) => {
+      setFlag(setIsFocused, thumbIndex, false);
+      // onChangeEnd on blur covers the keyboard-nav case where there's no
+      // pointerup to fire it. Always fires on blur regardless of whether the
+      // value actually changed — consumers debounce themselves if needed.
+      onChangeEnd?.(value);
+    },
+    [onChangeEnd, setFlag, value],
+  );
+
+  // Track click: pick the nearest thumb (by current value distance to the
+  // click's projected value) and snap it. Range mode picks by distance; single
+  // mode always snaps the one thumb. Click on a thumb itself (descendant) is
+  // ignored — the thumb's pointerdown handles its own state.
+  const handleTrackPointerDown = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      // Don't override a thumb's own pointerdown (which bubbles up here).
+      if ((e.target as HTMLElement).closest(`.${styles.thumb}`)) return;
+      const target = pointerToValue(e.clientX, e.clientY, 0);
+      if (target === null) return;
+      let nearestIndex = 0;
+      if (isRange) {
+        const d0 = Math.abs((value as [number, number])[0] - target);
+        const d1 = Math.abs((value as [number, number])[1] - target);
+        nearestIndex = d1 < d0 ? 1 : 0;
+      }
+      // Recompute the snap WITH the chosen thumb index so the range-clamp uses
+      // the right "other thumb" reference.
+      const next = pointerToValue(e.clientX, e.clientY, nearestIndex);
+      if (next === null) return;
+      applyThumbValue(nearestIndex, next);
+      // Optionally: focus the moved thumb so the user can keyboard-nudge from
+      // the new position. Querying by selector since we don't keep a thumb ref.
+      const thumbEl = e.currentTarget
+        .closest(`.${styles.root}`)
+        ?.querySelectorAll<HTMLDivElement>(`.${styles.thumb}`)[nearestIndex];
+      thumbEl?.focus();
+    },
+    [applyThumbValue, disabled, isRange, pointerToValue, value],
+  );
+
+  // Style helpers — positions in percent of the track length.
+  const fillStyle: CSSProperties = useMemo(() => {
+    if (isRange) {
+      const [v0, v1] = value as [number, number];
+      const startPct = valueToPercent(v0);
+      const endPct = valueToPercent(v1);
+      return orientation === 'horizontal'
+        ? { left: `${startPct}%`, width: `${endPct - startPct}%` }
+        : { bottom: `${startPct}%`, height: `${endPct - startPct}%` };
+    }
+    const endPct = valueToPercent(value as number);
+    return orientation === 'horizontal'
+      ? { left: '0%', width: `${endPct}%` }
+      : { bottom: '0%', height: `${endPct}%` };
+  }, [isRange, orientation, value, valueToPercent]);
+
+  const thumbStyle = useCallback(
+    (v: number): CSSProperties => {
+      const pct = valueToPercent(v);
+      return orientation === 'horizontal' ? { left: `${pct}%` } : { bottom: `${pct}%` };
+    },
+    [orientation, valueToPercent],
+  );
+
+  const markStyle = useCallback(
+    (m: SliderMark): CSSProperties => {
+      const pct = valueToPercent(m.value);
+      return orientation === 'horizontal' ? { left: `${pct}%` } : { bottom: `${pct}%` };
+    },
+    [orientation, valueToPercent],
+  );
+
+  const isMarkInFill = useCallback(
+    (m: SliderMark): boolean => {
+      if (isRange) {
+        const [v0, v1] = value as [number, number];
+        return m.value >= v0 && m.value <= v1;
+      }
+      return m.value <= (value as number);
+    },
+    [isRange, value],
+  );
+
+  const formatLabel = useCallback(
+    (v: number): ReactNode => {
+      if (label === true) return String(v);
+      if (typeof label === 'function') return label(v);
+      return null;
+    },
+    [label],
+  );
+
+  const showLabelFor = useCallback(
+    (index: number): boolean => {
+      if (label === false) return false;
+      return Boolean(isDragging[index] || isFocused[index] || isHovered[index]);
+    },
+    [isDragging, isFocused, isHovered, label],
+  );
+
+  // {...rest} last so consumer overrides win (Pattern A). `role` is Omit'd
+  // from rest at the type level so consumers can't override the slider thumb
+  // role contract.
+  return (
+    <div
+      ref={ref}
+      className={clsx(
+        styles.root,
+        styles[`orientation-${orientation}`],
+        styles[`size-${size}`],
+        styles[`tone-${tone}`],
+        disabled && styles.disabled,
+        className,
+      )}
+      {...rest}
+    >
+      <div
+        ref={trackRef}
+        className={styles.track}
+        onPointerDown={handleTrackPointerDown}
+      >
+        <div className={styles.fill} style={fillStyle} />
+        {marksArr.map((mark) => (
+          <span
+            key={mark.value}
+            className={clsx(styles.mark, isMarkInFill(mark) && styles.markFilled)}
+            style={markStyle(mark)}
+          >
+            {mark.label !== undefined && (
+              <span className={styles.markLabel}>{mark.label ?? mark.value}</span>
+            )}
+          </span>
+        ))}
+      </div>
+      {thumbValues.map((thumbValue, index) => (
+        <div
+          key={index}
+          role="slider"
+          tabIndex={disabled ? -1 : 0}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={thumbValue}
+          aria-valuetext={
+            typeof label === 'function' ? String(label(thumbValue)) : undefined
+          }
+          aria-orientation={orientation}
+          aria-disabled={disabled || undefined}
+          className={clsx(styles.thumb, isDragging[index] && styles.thumbDragging)}
+          style={thumbStyle(thumbValue)}
+          onPointerDown={(e) => handleThumbPointerDown(e, index)}
+          onPointerMove={(e) => handleThumbPointerMove(e, index)}
+          onPointerUp={(e) => handleThumbPointerUp(e, index)}
+          onPointerEnter={() => setFlag(setIsHovered, index, true)}
+          onPointerLeave={() => setFlag(setIsHovered, index, false)}
+          onFocus={() => setFlag(setIsFocused, index, true)}
+          onBlur={() => handleThumbBlur(index)}
+          onKeyDown={(e) => handleThumbKeyDown(e, index)}
+        >
+          {showLabelFor(index) && (
+            <span className={styles.label}>{formatLabel(thumbValue)}</span>
+          )}
+        </div>
+      ))}
+      {name &&
+        (isRange ? (
+          <>
+            <input
+              type="hidden"
+              name={`${name}-min`}
+              value={(value as [number, number])[0]}
+              disabled={disabled || undefined}
+            />
+            <input
+              type="hidden"
+              name={`${name}-max`}
+              value={(value as [number, number])[1]}
+              disabled={disabled || undefined}
+            />
+          </>
+        ) : (
+          <input
+            type="hidden"
+            name={name}
+            value={value as number}
+            disabled={disabled || undefined}
+          />
+        ))}
+    </div>
+  );
+});
+```
+
+### Step 1.2: Create `Slider.module.scss`
+
+- [ ] Write file contents (verbatim — note the blank lines between rules and before `//` comments, required by stylelint):
+
+```scss
+.root {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  // CSS keyword; not a tokenizable design value.
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  user-select: none;
+}
+
+.orientation-horizontal {
+  width: 100%;
+  // Reserve vertical space for the marks (below the track) + the label bubble
+  // (above). Component-internal sizing for an unfixed-height row.
+  min-height: 32px;
+}
+
+.orientation-vertical {
+  flex-direction: column;
+  // 200px is a reasonable default vertical track length; consumer can override
+  // via style or className.
+  height: 200px;
+  min-width: 32px;
+}
+
+.track {
+  position: relative;
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-full);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  overflow: visible;
+}
+
+.orientation-horizontal .track {
+  width: 100%;
+  height: 6px;
+}
+
+.orientation-vertical .track {
+  height: 100%;
+  width: 6px;
+}
+
+.size-sm.orientation-horizontal .track {
+  height: 4px;
+}
+
+.size-lg.orientation-horizontal .track {
+  height: 8px;
+}
+
+.size-sm.orientation-vertical .track {
+  width: 4px;
+}
+
+.size-lg.orientation-vertical .track {
+  width: 8px;
+}
+
+.fill {
+  position: absolute;
+  background: var(--color-accent);
+  border-radius: var(--radius-full);
+}
+
+.orientation-horizontal .fill {
+  top: 0;
+  bottom: 0;
+}
+
+.orientation-vertical .fill {
+  left: 0;
+  right: 0;
+}
+
+.tone-default .fill {
+  background: var(--color-accent);
+}
+
+.tone-success .fill {
+  background: var(--color-success);
+}
+
+.tone-warning .fill {
+  background: var(--color-warning);
+}
+
+.tone-danger .fill {
+  background: var(--color-danger);
+}
+
+.thumb {
+  position: absolute;
+  background: var(--color-bg);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-sm);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  cursor: grab;
+  transition: box-shadow var(--transition-base);
+}
+
+.orientation-horizontal .thumb {
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.orientation-vertical .thumb {
+  left: 50%;
+  transform: translate(-50%, 50%);
+}
+
+.size-sm .thumb {
+  width: 14px;
+  height: 14px;
+}
+
+.size-md .thumb {
+  width: 18px;
+  height: 18px;
+}
+
+.size-lg .thumb {
+  width: 22px;
+  height: 22px;
+}
+
+.thumb:hover,
+.thumb:focus-visible {
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-md);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  outline: none;
+}
+
+.thumbDragging {
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  cursor: grabbing;
+  box-shadow: var(--shadow-md);
+}
+
+.label {
+  position: absolute;
+  background: var(--color-fg);
+  color: var(--color-bg);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  font-variant-numeric: tabular-nums;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  white-space: nowrap;
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  pointer-events: none;
+}
+
+.orientation-horizontal .label {
+  bottom: calc(100% + var(--space-2));
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.orientation-vertical .label {
+  left: calc(100% + var(--space-2));
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.mark {
+  position: absolute;
+  width: 2px;
+  height: 8px;
+  background: var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.markFilled {
+  background: var(--color-accent);
+}
+
+.tone-success .markFilled {
+  background: var(--color-success);
+}
+
+.tone-warning .markFilled {
+  background: var(--color-warning);
+}
+
+.tone-danger .markFilled {
+  background: var(--color-danger);
+}
+
+.orientation-horizontal .mark {
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.orientation-vertical .mark {
+  left: 50%;
+  transform: translate(-50%, 50%);
+  width: 8px;
+  height: 2px;
+}
+
+.markLabel {
+  position: absolute;
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  white-space: nowrap;
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  pointer-events: none;
+}
+
+.orientation-horizontal .markLabel {
+  top: calc(100% + var(--space-1));
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.orientation-vertical .markLabel {
+  left: calc(100% + var(--space-1));
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.disabled {
+  opacity: var(--opacity-disabled);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  cursor: not-allowed;
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thumb {
+    transition: none;
+  }
+}
+```
+
+If stylelint complains about any property NOT pre-disabled above (e.g. `border: var(--border-width) solid var(--color-border)` flagged for the `solid` keyword in shorthand, or `transform: translate(...)` flagged for the bare percent), add the matching inline disable in place. The pre-emptive disables above target CSS keywords that have no token equivalent (`cursor`, `pointer-events`, `user-select`, `white-space`, `overflow`, `outline`).
+
+If stylelint complains about `border-width` raw values like `2px` in `width: 2px;` (on `.mark`) under `declaration-property-value-disallowed-list` (T2 of FileUpload hit this with `border: 2px dashed ...`), the fix is to use a token where possible OR an inline disable. The marks use a hardcoded 2px×8px hit area — not a tokenizable design value. If flagged: `// stylelint-disable-next-line declaration-property-value-disallowed-list -- mark hit area is non-tokenizable visual scale` above the offending line.
+
+### Step 1.3: Create `index.ts`
+
+- [ ] Write file contents (verbatim):
+
+```ts
+export { Slider } from './Slider';
+export type {
+  SliderProps,
+  SliderValue,
+  SliderSize,
+  SliderTone,
+  SliderOrientation,
+  SliderMark,
+} from './Slider';
+```
+
+### Step 1.4: Verify gates
+
+- [ ] Run `make build-lib`. Expected: clean (typecheck passes).
+- [ ] Run `make lint`. Expected: clean (the proactive disable comments target the predicted CSS-keyword warnings; if any property surfaces a new lint warning, add the matching inline disable and rerun).
+
+DO NOT run `make test` — `Slider.test.tsx` doesn't exist yet (T2), and the `structure.test.ts` meta-test will fail at this point because `src/index.ts` doesn't re-export Slider yet.
+
+### Step 1.5: Commit
+
+```bash
+git add packages/design-system/src/components/Slider/Slider.tsx \
+        packages/design-system/src/components/Slider/Slider.module.scss \
+        packages/design-system/src/components/Slider/index.ts
+git commit -m "$(cat <<'EOF'
+Slider: controlled primitive (single + range + vertical, marks + label)
+
+Discriminated `value: number | [number, number]` for single/range. Custom
+paint (range mode forces it; single mode follows for consistency). Pointer
+events with setPointerCapture (try/catch around capture for jsdom safety).
+Full keyboard nav per WAI-ARIA APG: Arrow/Home/End/PageUp/PageDown. Snap
+to step + floating-point precision alignment. Range-mode thumb clamp so
+value[0] ≤ value[1] always. Track-click moves the nearest thumb. Hidden
+<input>(s) under `name` for form submission. role="slider" locked per thumb
+via Omit<HTMLAttributes, 'role'>. prefers-reduced-motion disables the
+thumb box-shadow transition.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Slider tests — `Slider.test.tsx` + `src/index.ts` re-export
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Slider/Slider.test.tsx`
+- Modify: `packages/design-system/src/index.ts`
+
+### Step 2.1: Create `Slider.test.tsx`
+
+- [ ] Write file contents (verbatim):
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { createRef } from 'react';
+import {
+  Slider,
+  type SliderOrientation,
+  type SliderSize,
+  type SliderTone,
+} from './Slider';
+
+// jsdom doesn't implement setPointerCapture; stub it on HTMLElement so the
+// component's try/catch fast-path is exercised (and we still get pointer
+// events).
+function ensurePointerCaptureShim() {
+  if (typeof (HTMLElement.prototype as unknown as { setPointerCapture?: unknown }).setPointerCapture !== 'function') {
+    (HTMLElement.prototype as unknown as { setPointerCapture: (id: number) => void }).setPointerCapture = () => {};
+  }
+  if (typeof (HTMLElement.prototype as unknown as { releasePointerCapture?: unknown }).releasePointerCapture !== 'function') {
+    (HTMLElement.prototype as unknown as { releasePointerCapture: (id: number) => void }).releasePointerCapture = () => {};
+  }
+}
+
+ensurePointerCaptureShim();
+
+// Helper — find thumb(s) by their role.
+function getThumbs(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('[role="slider"]'));
+}
+
+// Helper — mock the track's getBoundingClientRect so pointer-math has a known
+// canvas. Default: 100px-wide / 6px-tall horizontal track at (0, 0).
+function mockTrackRect(container: HTMLElement, opts: { width?: number; height?: number; left?: number; top?: number } = {}) {
+  const { width = 100, height = 6, left = 0, top = 0 } = opts;
+  const track = container.querySelector<HTMLElement>('[class*="track"]')!;
+  track.getBoundingClientRect = () =>
+    ({
+      width,
+      height,
+      left,
+      top,
+      right: left + width,
+      bottom: top + height,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return track;
+}
+
+describe('Slider', () => {
+  describe('rendering / structure', () => {
+    it('renders with role="slider" for single value', () => {
+      const { container } = render(<Slider value={50} onChange={() => {}} />);
+      const thumbs = getThumbs(container);
+      expect(thumbs).toHaveLength(1);
+      expect(thumbs[0]).toHaveAttribute('role', 'slider');
+    });
+
+    it('renders TWO role="slider" elements for range value', () => {
+      const { container } = render(<Slider value={[20, 80]} onChange={() => {}} />);
+      const thumbs = getThumbs(container);
+      expect(thumbs).toHaveLength(2);
+    });
+
+    it('default tone applies the tone-default class to the fill', () => {
+      const { container } = render(<Slider value={50} onChange={() => {}} />);
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).toMatch(/tone-default/);
+    });
+
+    it.each<[SliderTone, string]>([
+      ['default', 'tone-default'],
+      ['success', 'tone-success'],
+      ['warning', 'tone-warning'],
+      ['danger', 'tone-danger'],
+    ])('tone="%s" applies class %s', (toneValue, expectedClass) => {
+      const { container } = render(<Slider value={50} tone={toneValue} onChange={() => {}} />);
+      expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(expectedClass));
+    });
+
+    it.each<[SliderSize, string]>([
+      ['sm', 'size-sm'],
+      ['md', 'size-md'],
+      ['lg', 'size-lg'],
+    ])('size="%s" applies class %s', (sizeValue, expectedClass) => {
+      const { container } = render(<Slider value={50} size={sizeValue} onChange={() => {}} />);
+      expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(expectedClass));
+    });
+
+    it('default orientation is horizontal', () => {
+      const { container } = render(<Slider value={50} onChange={() => {}} />);
+      expect((container.firstChild as HTMLElement).className).toMatch(/orientation-horizontal/);
+    });
+
+    it.each<SliderOrientation>(['horizontal', 'vertical'])(
+      'orientation="%s" applies the matching class',
+      (orientationValue) => {
+        const { container } = render(
+          <Slider value={50} orientation={orientationValue} onChange={() => {}} />,
+        );
+        expect((container.firstChild as HTMLElement).className).toMatch(
+          new RegExp(`orientation-${orientationValue}`),
+        );
+      },
+    );
+
+    it('className from props merges with the base class', () => {
+      const { container } = render(
+        <Slider value={50} className="custom" onChange={() => {}} />,
+      );
+      const cls = (container.firstChild as HTMLElement).className;
+      expect(cls).toMatch(/custom/);
+      expect(cls).toMatch(/root_/);
+    });
+
+    it('forwards ref to the outermost <div>', () => {
+      const ref = createRef<HTMLDivElement>();
+      render(<Slider ref={ref} value={50} onChange={() => {}} />);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it('spreads native HTML attributes (id, data-testid, aria-label)', () => {
+      render(
+        <Slider value={50} id="vol" data-testid="s" aria-label="Volume" onChange={() => {}} />,
+      );
+      const el = screen.getByTestId('s');
+      expect(el).toHaveAttribute('id', 'vol');
+      expect(el).toHaveAttribute('aria-label', 'Volume');
+    });
+  });
+
+  describe('value / fill positioning', () => {
+    it('single value={50} (min=0 max=100): fill width is 50%, thumb left is 50%', () => {
+      const { container } = render(<Slider value={50} onChange={() => {}} />);
+      const fill = container.querySelector<HTMLElement>('[class*="fill"]')!;
+      expect(fill.style.width).toBe('50%');
+      const thumb = getThumbs(container)[0];
+      expect(thumb.style.left).toBe('50%');
+    });
+
+    it('range value=[20, 80]: fill spans 20%–80%, thumbs at 20% and 80%', () => {
+      const { container } = render(<Slider value={[20, 80]} onChange={() => {}} />);
+      const fill = container.querySelector<HTMLElement>('[class*="fill"]')!;
+      expect(fill.style.left).toBe('20%');
+      expect(fill.style.width).toBe('60%');
+      const thumbs = getThumbs(container);
+      expect(thumbs[0].style.left).toBe('20%');
+      expect(thumbs[1].style.left).toBe('80%');
+    });
+
+    it('fractional step (min=0 max=1 step=0.1 value=0.3): thumb positioned at 30%', () => {
+      const { container } = render(
+        <Slider value={0.3} min={0} max={1} step={0.1} onChange={() => {}} />,
+      );
+      const thumb = getThumbs(container)[0];
+      // Floating-point: 0.3 / 1.0 * 100 may be 30 or 29.999999... — accept both.
+      expect(thumb.style.left === '30%' || thumb.style.left === '29.999999999999996%').toBe(true);
+    });
+  });
+
+  describe('ARIA', () => {
+    it('single mode: thumb has aria-valuemin/max/now/orientation', () => {
+      const { container } = render(<Slider value={42} min={0} max={100} onChange={() => {}} />);
+      const thumb = getThumbs(container)[0];
+      expect(thumb).toHaveAttribute('aria-valuemin', '0');
+      expect(thumb).toHaveAttribute('aria-valuemax', '100');
+      expect(thumb).toHaveAttribute('aria-valuenow', '42');
+      expect(thumb).toHaveAttribute('aria-orientation', 'horizontal');
+    });
+
+    it('range mode: both thumbs have their own aria-valuenow', () => {
+      const { container } = render(<Slider value={[10, 90]} onChange={() => {}} />);
+      const thumbs = getThumbs(container);
+      expect(thumbs[0]).toHaveAttribute('aria-valuenow', '10');
+      expect(thumbs[1]).toHaveAttribute('aria-valuenow', '90');
+    });
+
+    it('disabled: aria-disabled="true" on thumbs and tabIndex=-1', () => {
+      const { container } = render(<Slider value={50} disabled onChange={() => {}} />);
+      const thumb = getThumbs(container)[0];
+      expect(thumb).toHaveAttribute('aria-disabled', 'true');
+      expect(thumb).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('orientation=vertical sets aria-orientation=vertical', () => {
+      const { container } = render(
+        <Slider value={50} orientation="vertical" onChange={() => {}} />,
+      );
+      const thumb = getThumbs(container)[0];
+      expect(thumb).toHaveAttribute('aria-orientation', 'vertical');
+    });
+
+    it('label as function sets aria-valuetext to the formatted output', () => {
+      const { container } = render(
+        <Slider value={42} label={(v) => `${v}%`} onChange={() => {}} />,
+      );
+      const thumb = getThumbs(container)[0];
+      expect(thumb).toHaveAttribute('aria-valuetext', '42%');
+    });
+
+    it('label=true: aria-valuetext is NOT set (SR uses raw aria-valuenow)', () => {
+      const { container } = render(<Slider value={42} label onChange={() => {}} />);
+      const thumb = getThumbs(container)[0];
+      expect(thumb).not.toHaveAttribute('aria-valuetext');
+    });
+  });
+
+  describe('keyboard', () => {
+    it('ArrowRight increments by step and fires onChange', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} step={5} onChange={onChange} />);
+      const thumb = getThumbs(container)[0];
+      thumb.focus();
+      fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+      expect(onChange).toHaveBeenCalledWith(55);
+    });
+
+    it('ArrowLeft decrements by step', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} step={5} onChange={onChange} />);
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'ArrowLeft' });
+      expect(onChange).toHaveBeenCalledWith(45);
+    });
+
+    it('ArrowUp increments (vertical orientation)', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <Slider value={50} step={5} orientation="vertical" onChange={onChange} />,
+      );
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'ArrowUp' });
+      expect(onChange).toHaveBeenCalledWith(55);
+    });
+
+    it('Home sets value to min', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <Slider value={50} min={0} max={100} onChange={onChange} />,
+      );
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'Home' });
+      expect(onChange).toHaveBeenCalledWith(0);
+    });
+
+    it('End sets value to max', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <Slider value={50} min={0} max={100} onChange={onChange} />,
+      );
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'End' });
+      expect(onChange).toHaveBeenCalledWith(100);
+    });
+
+    it('PageUp adds 10×step', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} step={2} onChange={onChange} />);
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'PageUp' });
+      expect(onChange).toHaveBeenCalledWith(70);
+    });
+
+    it('PageDown subtracts 10×step', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} step={2} onChange={onChange} />);
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'PageDown' });
+      expect(onChange).toHaveBeenCalledWith(30);
+    });
+
+    it('range mode: left thumb cannot cross right thumb (keyboard clamp)', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <Slider value={[40, 50]} step={20} onChange={onChange} />,
+      );
+      // ArrowRight on left thumb tries to go to 60, but it clamps to 50 (right thumb).
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'ArrowRight' });
+      expect(onChange).toHaveBeenCalledWith([50, 50]);
+    });
+
+    it('blur fires onChangeEnd with current value', () => {
+      const onChangeEnd = vi.fn();
+      const { container } = render(
+        <Slider value={42} onChange={() => {}} onChangeEnd={onChangeEnd} />,
+      );
+      const thumb = getThumbs(container)[0];
+      thumb.focus();
+      thumb.blur();
+      expect(onChangeEnd).toHaveBeenCalledWith(42);
+    });
+
+    it('disabled: keyboard does nothing', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} disabled onChange={onChange} />);
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'ArrowRight' });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pointer / drag', () => {
+    it('track click snaps the (single) thumb to click position', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} onChange={onChange} />);
+      const track = mockTrackRect(container, { width: 100, left: 0 });
+      // Click at clientX=25 → 25% of the 100px track → value 25.
+      fireEvent.pointerDown(track, { clientX: 25, clientY: 3, pointerId: 1 });
+      expect(onChange).toHaveBeenCalledWith(25);
+    });
+
+    it('thumb pointerdown + pointermove fires onChange per move; pointerup fires onChangeEnd', () => {
+      const onChange = vi.fn();
+      const onChangeEnd = vi.fn();
+      const { container } = render(
+        <Slider value={50} onChange={onChange} onChangeEnd={onChangeEnd} />,
+      );
+      mockTrackRect(container, { width: 100, left: 0 });
+      const thumb = getThumbs(container)[0];
+      fireEvent.pointerDown(thumb, { clientX: 50, clientY: 3, pointerId: 1 });
+      fireEvent.pointerMove(thumb, { clientX: 70, clientY: 3, pointerId: 1 });
+      // 70px / 100px = 70% → value 70.
+      expect(onChange).toHaveBeenCalledWith(70);
+      fireEvent.pointerUp(thumb, { clientX: 70, clientY: 3, pointerId: 1 });
+      expect(onChangeEnd).toHaveBeenCalledWith(50);
+      // onChangeEnd receives the controlled `value` from props (still 50 since
+      // we never updated state in this test); consumers update state in their
+      // onChange handler and onChangeEnd receives that latest value via the
+      // next render. This documents the controlled-only contract.
+    });
+
+    it('range mode: pointer-dragging thumb 0 past thumb 1 clamps to thumb 1 value', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <Slider value={[20, 50]} onChange={onChange} />,
+      );
+      mockTrackRect(container, { width: 100, left: 0 });
+      const thumbs = getThumbs(container);
+      fireEvent.pointerDown(thumbs[0], { clientX: 20, clientY: 3, pointerId: 1 });
+      fireEvent.pointerMove(thumbs[0], { clientX: 80, clientY: 3, pointerId: 1 });
+      // 80 would be the natural snap; clamped to thumb 1's value of 50.
+      expect(onChange).toHaveBeenCalledWith([50, 50]);
+    });
+
+    it('disabled: pointerdown does nothing', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} disabled onChange={onChange} />);
+      mockTrackRect(container);
+      const thumb = getThumbs(container)[0];
+      fireEvent.pointerDown(thumb, { clientX: 30, clientY: 3, pointerId: 1 });
+      fireEvent.pointerMove(thumb, { clientX: 70, clientY: 3, pointerId: 1 });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('marks + label', () => {
+    it('marks={[0, 50, 100]} renders 3 mark elements', () => {
+      const { container } = render(<Slider value={50} marks={[0, 50, 100]} onChange={() => {}} />);
+      const marks = container.querySelectorAll('[class*="mark"]:not([class*="markLabel"]):not([class*="markFilled"])');
+      // The mark spans match `[class*="mark"]`. Marks with values within the
+      // fill range get an extra `.markFilled` class — they're still in the
+      // selector. Count the mark spans (excluding markFilled-only matches):
+      const allMarks = container.querySelectorAll('span[class*="mark"]');
+      // Filter to spans where className contains `mark` but NOT `markLabel` and
+      // NOT only `markFilled`.
+      const markSpans = Array.from(allMarks).filter((el) =>
+        /\bmark\b|^mark|mark_/.test(el.className) && !/markLabel/.test(el.className),
+      );
+      expect(markSpans.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('marks within the fill range get markFilled class', () => {
+      const { container } = render(
+        <Slider value={75} marks={[25, 75]} onChange={() => {}} />,
+      );
+      // Both 25 and 75 are <= 75, so both should have markFilled.
+      const filled = container.querySelectorAll('[class*="markFilled"]');
+      expect(filled.length).toBe(2);
+    });
+
+    it('label=true shows the value bubble when the thumb is focused', () => {
+      const { container } = render(<Slider value={42} label onChange={() => {}} />);
+      const thumb = getThumbs(container)[0];
+      thumb.focus();
+      const labelEl = container.querySelector('[class*="label"]:not([class*="markLabel"])');
+      expect(labelEl).not.toBeNull();
+      expect(labelEl).toHaveTextContent('42');
+    });
+
+    it('label as function renders the formatted text', () => {
+      const { container } = render(
+        <Slider value={42} label={(v) => `${v} GB`} onChange={() => {}} />,
+      );
+      const thumb = getThumbs(container)[0];
+      thumb.focus();
+      const labelEl = container.querySelector('[class*="label"]:not([class*="markLabel"])');
+      expect(labelEl).toHaveTextContent('42 GB');
+    });
+
+    it('label=false (default): no label element rendered even when focused', () => {
+      const { container } = render(<Slider value={42} onChange={() => {}} />);
+      const thumb = getThumbs(container)[0];
+      thumb.focus();
+      // No bubble span — only the thumb itself has any "label-like" class.
+      const labelEl = container.querySelector(
+        '[class*="label"]:not([class*="markLabel"]):not([role="slider"])',
+      );
+      expect(labelEl).toBeNull();
+    });
+  });
+
+  describe('hidden form input', () => {
+    it('single mode + name="zoom": renders one hidden <input>', () => {
+      const { container } = render(<Slider value={50} name="zoom" onChange={() => {}} />);
+      const inputs = container.querySelectorAll('input[type="hidden"]');
+      expect(inputs).toHaveLength(1);
+      expect(inputs[0]).toHaveAttribute('name', 'zoom');
+      expect(inputs[0]).toHaveAttribute('value', '50');
+    });
+
+    it('range mode + name="price": renders TWO hidden inputs (price-min and price-max)', () => {
+      const { container } = render(
+        <Slider value={[10, 90]} name="price" onChange={() => {}} />,
+      );
+      const inputs = container.querySelectorAll<HTMLInputElement>('input[type="hidden"]');
+      expect(inputs).toHaveLength(2);
+      expect(inputs[0]).toHaveAttribute('name', 'price-min');
+      expect(inputs[0]).toHaveAttribute('value', '10');
+      expect(inputs[1]).toHaveAttribute('name', 'price-max');
+      expect(inputs[1]).toHaveAttribute('value', '90');
+    });
+
+    it('disabled: hidden inputs receive disabled attribute', () => {
+      const { container } = render(
+        <Slider value={50} name="vol" disabled onChange={() => {}} />,
+      );
+      const input = container.querySelector<HTMLInputElement>('input[type="hidden"]')!;
+      expect(input).toBeDisabled();
+    });
+  });
+});
+```
+
+### Step 2.2: Modify `src/index.ts` — add Slider re-export
+
+Read `packages/design-system/src/index.ts` first. Find an alphabetically-adjacent insertion point. The Slider re-export slots near Skeleton (alphabetically Skeleton → Slider → Switch). Find an existing block to anchor against. Likely candidates:
+
+```ts
+export { Skeleton } from './components/Skeleton';
+export type { SkeletonProps, SkeletonVariant, SkeletonAnimation } from './components/Skeleton';
+```
+
+Or a later block like Switch. Apply the Edit with `replace_all: false`. The exact anchor depends on the current file shape — read first.
+
+**Suggested old_string** (the Skeleton block — adjust if it differs):
+
+```ts
+export { Skeleton } from './components/Skeleton';
+export type { SkeletonProps, SkeletonVariant, SkeletonAnimation } from './components/Skeleton';
+```
+
+**new_string:**
+
+```ts
+export { Skeleton } from './components/Skeleton';
+export type { SkeletonProps, SkeletonVariant, SkeletonAnimation } from './components/Skeleton';
+
+export { Slider } from './components/Slider';
+export type {
+  SliderProps,
+  SliderValue,
+  SliderSize,
+  SliderTone,
+  SliderOrientation,
+  SliderMark,
+} from './components/Slider';
+```
+
+If the Skeleton block isn't in that exact form (additional types may have been added in a prior PR — Progress was inserted right above it), expand the `old_string` until unique against the current file. Or anchor against Switch instead.
+
+### Step 2.3: Verify gates
+
+- [ ] Run `make test`. Expected: every test passes (including the structure meta-test, which now sees Slider's re-export).
+- [ ] Run `make build-lib`. Expected: clean.
+- [ ] Run `make build`. Expected: clean.
+- [ ] Run `make lint`. Expected: clean.
+
+If pointer-event tests fail because `setPointerCapture` is undefined: the `ensurePointerCaptureShim()` call at the top of the test file should have stubbed it. If it didn't, the issue is jsdom version skew — verify the shim is being called and that the test imports react-testing-library's `fireEvent` (which dispatches synthetic pointer events that go through React's onPointerDown).
+
+If a class-substring regex fails: the CSS Modules stable strategy generates `_<localName>_<hash>` class names. The kebab `.orientation-horizontal` becomes `_orientation-horizontal_<hash>`. The regex `/orientation-horizontal/` matches the literal substring. Verify with `console.log` in a failing test.
+
+### Step 2.4: Commit
+
+```bash
+git add packages/design-system/src/components/Slider/Slider.test.tsx \
+        packages/design-system/src/index.ts
+git commit -m "$(cat <<'EOF'
+Slider: unit tests (~37 cases) + barrel re-export
+
+Tests cover rendering (role/class matrix across single/range × sm/md/lg ×
+default/success/warning/danger × horizontal/vertical), value-to-percent
+positioning, ARIA on each thumb, keyboard handling (Arrow/Home/End/PageUp/
+PageDown including range-clamp), pointer-event drag via a setPointerCapture
+shim for jsdom (track click + thumb pointerdown/move/up + range-clamp),
+marks (count + markFilled class within fill range), label (true / function /
+false), and hidden form inputs (single / range / disabled).
+
+Also re-exports Slider + all 6 types from src/index.ts so the structure
+meta-test passes (T2/T4/T6 Typography + T2/T4 Progress + T3 FileUpload
+established this pattern).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: AGENTS.md Slider section
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md`
+
+### Step 3.1: Verify the Slider re-export exists
+
+- [ ] Read `packages/design-system/src/index.ts` and confirm the `export { Slider }` block is present (added in T2). If missing, STOP and report.
+
+### Step 3.2: Insert the Slider section after `<FileUpload>` and before `<Card>`
+
+Read `packages/design-system/AGENTS.md`. The `<FileUpload>` section was placed between RadioGroup and Card by the prior FileUpload PR — it currently spans roughly lines 382–424 in `main`. The new Slider section goes RIGHT BEFORE `### \`<Card>\``.
+
+Use the Edit tool with `replace_all: false`. The `old_string` must be unique — use the LAST line of the FileUpload section's content plus the blank line(s) and the Card heading. The implementer should read the file first to capture the exact preceding line.
+
+Suggested `old_string` shape (the FileUpload-section's "Hard rule" callout closing bullet plus the Card heading):
+
+```markdown
+- ❌ Calling `onFilesAdded` from inside `onFileReject` (or vice versa) in an attempt to "auto-retry." Reject is terminal for that file; the user has to re-drop.
+
+### `<Card>` — bordered container
+```
+
+If the file has slight variations (different last bullet or extra blank lines), expand the anchor with one more preceding bullet to make it unique.
+
+**new_string:**
+
+````markdown
+- ❌ Calling `onFilesAdded` from inside `onFileReject` (or vice versa) in an attempt to "auto-retry." Reject is terminal for that file; the user has to re-drop.
+
+### `<Slider>` — controlled slider (single + range, horizontal + vertical)
+
+```tsx
+<Slider value={zoom} min={1} max={3} step={0.1} onChange={(v) => setZoom(v as number)} aria-label="Zoom" />
+
+<Slider
+  value={price}                                   // tuple → range mode
+  min={0} max={100000} step={1000}
+  label={(v) => `$${v.toLocaleString()}`}
+  onChange={(v) => setPrice(v as [number, number])}
+/>
+
+<Slider
+  value={volume}
+  orientation="vertical"
+  marks={[0, 25, 50, 75, 100]}
+  onChange={(v) => setVolume(v as number)}
+/>
+```
+
+- **Controlled-only.** Always pass `value` + `onChange`. No `defaultValue`. Same architecture as FileUpload, Progress, and the rest of the controlled primitives.
+- **`value: number | [number, number]`** — discriminated union. `number` for single-thumb; tuple for range (two-thumb). `onChange` mirrors the shape.
+- **`onChange` fires per pointer-move tick (high frequency).** Debounce in the consumer OR use `onChangeEnd` (fires once on release / blur) for server-state / expensive logic.
+- `min`/`max`/`step` default to `0`/`100`/`1`. Fractional `step` (e.g. `0.1`) is the canonical way to do zoom/opacity controls.
+- `size`: `sm` (4px track / 14px thumb) / `md` (6/18, default) / `lg` (8/22).
+- `tone`: `default` (accent) / `success` / `warning` / `danger`. Use `warning`/`danger` for threshold-style sliders (disk usage, alert level).
+- `orientation`: `horizontal` (default) / `vertical`. Vertical defaults to 200px tall; override via `style={{ height }}`.
+- `marks`: `number[]` (auto-labeled) OR `SliderMark[]` (`{ value, label }`) for custom labels.
+- `label`: `false` (default) / `true` (show `{value}` bubble on hover/focus/drag) / `(v) => ReactNode` (custom formatter; also sets `aria-valuetext`).
+- `name`: when set, renders hidden `<input>`(s) so the slider works inside `<form action=...>`. Range mode emits TWO inputs with `-min` / `-max` suffixes.
+- `disabled`: thumbs become non-interactive (`tabIndex=-1`, `aria-disabled`, pointer-events: none). Hidden inputs gain `disabled`.
+
+#### Keyboard
+
+- Arrow Left/Down: `-step`. Arrow Right/Up: `+step`.
+- Page Down/Up: `-10×step` / `+10×step`.
+- Home / End: jump to `min` / `max`.
+- All keys respect range-mode clamping (`value[0] ≤ value[1]`). `onChange` per key; `onChangeEnd` on blur.
+
+#### Hard rule
+
+- ❌ Raw `<input type="range">` — can't do range mode, doesn't theme cleanly across browsers. Use `<Slider>`.
+- ❌ Hand-rolling drag math per page. The pointer / keyboard handling is non-trivial; the primitive owns it.
+- ❌ Hitting a network endpoint inside `onChange` — fires on every pointer-move tick. Use `onChangeEnd` or debounce.
+- ❌ `<Slider role="region">` — `role="slider"` is locked on each thumb. The TypeScript `Omit` prevents the root override.
+- ❌ Passing `value[0] > value[1]` in range mode. The component clamps but the inverted tuple is a consumer bug — fix the state shape.
+
+### `<Card>` — bordered container
+````
+
+### Step 3.3: Verify gates
+
+- [ ] Run `make build`. Expected: clean.
+- [ ] Run `make lint`. Expected: clean.
+
+### Step 3.4: Commit
+
+```bash
+git add packages/design-system/AGENTS.md
+git commit -m "$(cat <<'EOF'
+AGENTS.md: add Slider section between FileUpload and Card
+
+API table, canonical snippets (zoom single, range filter, vertical with
+marks), keyboard reference per WAI-ARIA APG, and the "Hard rule" callout
+with the 5 anti-patterns the primitive replaces.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Playground demo + 4-place wiring
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/SliderDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+### Step 4.1: Create `SliderDemo.tsx`
+
+- [ ] Write file contents (verbatim):
+
+```tsx
+import { useState } from 'react';
+import { Slider } from '@eocrm/design-system';
+import { Stack } from '@eocrm/design-system';
+import { Cluster } from '@eocrm/design-system';
+import { Text } from '@eocrm/design-system';
+import { Code } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Slider/Slider.tsx?raw';
+import scssSource from '@lib-source/components/Slider/Slider.module.scss?raw';
+
+function BasicSingle() {
+  const [value, setValue] = useState(50);
+  return (
+    <Stack gap="sm">
+      <Slider value={value} onChange={(v) => setValue(v as number)} aria-label="Volume" />
+      <Text size="sm" tone="muted">
+        Current value: <Code>{value}</Code>
+      </Text>
+    </Stack>
+  );
+}
+
+function RangeFilter() {
+  const [range, setRange] = useState<[number, number]>([20000, 80000]);
+  return (
+    <Stack gap="sm">
+      <Slider
+        value={range}
+        min={0}
+        max={100000}
+        step={1000}
+        label={(v) => `$${v.toLocaleString()}`}
+        onChange={(v) => setRange(v as [number, number])}
+        aria-label="Price range"
+      />
+      <Text size="sm" tone="muted">
+        Range: <Code>${range[0].toLocaleString()}</Code> – <Code>${range[1].toLocaleString()}</Code>
+      </Text>
+    </Stack>
+  );
+}
+
+function Sizes() {
+  const [value, setValue] = useState(50);
+  return (
+    <Stack gap="md">
+      <Slider value={value} size="sm" onChange={(v) => setValue(v as number)} aria-label="sm" />
+      <Slider value={value} size="md" onChange={(v) => setValue(v as number)} aria-label="md" />
+      <Slider value={value} size="lg" onChange={(v) => setValue(v as number)} aria-label="lg" />
+    </Stack>
+  );
+}
+
+function Tones() {
+  const [value, setValue] = useState(75);
+  return (
+    <Stack gap="md">
+      <Slider value={value} tone="default" onChange={(v) => setValue(v as number)} aria-label="default" />
+      <Slider value={value} tone="success" onChange={(v) => setValue(v as number)} aria-label="success" />
+      <Slider value={value} tone="warning" onChange={(v) => setValue(v as number)} aria-label="warning" />
+      <Slider value={value} tone="danger" onChange={(v) => setValue(v as number)} aria-label="danger" />
+    </Stack>
+  );
+}
+
+function Marks() {
+  const [value, setValue] = useState(50);
+  return (
+    <Slider
+      value={value}
+      marks={[0, 25, 50, 75, 100]}
+      onChange={(v) => setValue(v as number)}
+      aria-label="With marks"
+    />
+  );
+}
+
+function Vertical() {
+  const [value, setValue] = useState(60);
+  return (
+    <Cluster gap="lg" align="center">
+      <Slider
+        value={value}
+        orientation="vertical"
+        marks={[0, 25, 50, 75, 100]}
+        onChange={(v) => setValue(v as number)}
+        aria-label="Vertical volume"
+      />
+      <Text size="sm" tone="muted">
+        Current: <Code>{value}</Code>
+      </Text>
+    </Cluster>
+  );
+}
+
+function FractionalStep() {
+  const [zoom, setZoom] = useState(1.5);
+  return (
+    <Stack gap="sm">
+      <Slider
+        value={zoom}
+        min={1}
+        max={3}
+        step={0.1}
+        label
+        onChange={(v) => setZoom(v as number)}
+        aria-label="Zoom"
+      />
+      <Text size="sm" tone="muted">
+        Zoom: <Code>{zoom.toFixed(1)}×</Code>
+      </Text>
+    </Stack>
+  );
+}
+
+function DisabledDemo() {
+  return <Slider value={50} disabled onChange={() => {}} aria-label="Disabled" />;
+}
+
+export function SliderDemo() {
+  return (
+    <DemoLayout
+      name="Slider"
+      description="Controlled slider primitive. Single-thumb (value: number) or range (value: [number, number]). Horizontal or vertical. Custom-painted with manual ARIA per thumb."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Slider.tsx"
+      scssFilename="Slider.module.scss"
+      componentName="Slider"
+    >
+      <Example
+        title="Basic single-thumb"
+        description="Default props (min=0, max=100, step=1). Controlled state with one number."
+        code={`function BasicSingle() {
+  const [value, setValue] = useState(50);
+  return (
+    <Slider value={value} onChange={(v) => setValue(v as number)} aria-label="Volume" />
+  );
+}`}
+      >
+        <BasicSingle />
+      </Example>
+
+      <Example
+        title="Range mode (two thumbs)"
+        description="Pass a [min, max] tuple as value → two thumbs. Range-clamp ensures value[0] ≤ value[1]. Formatted label."
+        code={`<Slider
+  value={[20000, 80000]}
+  min={0} max={100000} step={1000}
+  label={(v) => \`$\${v.toLocaleString()}\`}
+  onChange={(v) => setRange(v as [number, number])}
+/>`}
+      >
+        <RangeFilter />
+      </Example>
+
+      <Example
+        title="Sizes"
+        description="Three sizes: sm (4/14), md (6/18, default), lg (8/22). All bound to the same controlled value."
+        code={`<Slider size="sm" value={value} onChange={…} />
+<Slider size="md" value={value} onChange={…} />
+<Slider size="lg" value={value} onChange={…} />`}
+      >
+        <Sizes />
+      </Example>
+
+      <Example
+        title="Tones"
+        description="Four tones for the fill color. Use warning/danger for threshold-style sliders (e.g. disk usage at 90% → danger fill)."
+        code={`<Slider tone="default" value={value} onChange={…} />
+<Slider tone="success" value={value} onChange={…} />
+<Slider tone="warning" value={value} onChange={…} />
+<Slider tone="danger" value={value} onChange={…} />`}
+      >
+        <Tones />
+      </Example>
+
+      <Example
+        title="Tick marks"
+        description="`marks={[0, 25, 50, 75, 100]}` renders 5 ticks. Marks within the current fill range get a filled tone."
+        code={`<Slider value={value} marks={[0, 25, 50, 75, 100]} onChange={…} />`}
+      >
+        <Marks />
+      </Example>
+
+      <Example
+        title="Vertical orientation"
+        description="Single-thumb vertical slider, 200px tall by default. Marks render to the right; label bubble appears on the right of the thumb."
+        code={`<Slider
+  value={value}
+  orientation="vertical"
+  marks={[0, 25, 50, 75, 100]}
+  onChange={(v) => setValue(v as number)}
+/>`}
+      >
+        <Vertical />
+      </Example>
+
+      <Example
+        title="Fractional step (zoom-style)"
+        description="min=1, max=3, step=0.1 — the canonical ImageCrop zoom control. label=true shows the current value as a bubble."
+        code={`<Slider
+  value={zoom}
+  min={1} max={3} step={0.1}
+  label
+  onChange={(v) => setZoom(v as number)}
+/>`}
+      >
+        <FractionalStep />
+      </Example>
+
+      <Example
+        title="Disabled"
+        description="Track and thumb both grayed (via --opacity-disabled). Pointer/keyboard no-op; tabIndex=-1; aria-disabled=true."
+        code={`<Slider value={50} disabled onChange={() => {}} aria-label="Disabled" />`}
+      >
+        <DisabledDemo />
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+### Step 4.2: Modify `App.tsx` — add import + route
+
+Read `packages/playground/src/App.tsx`. Find the alphabetical neighbour. Slider slots after Skeleton (alphabetically).
+
+**Edit 4a — add import** (using SkeletonDemo as anchor):
+
+old_string:
+```tsx
+import { SkeletonDemo } from './pages/components/SkeletonDemo';
+```
+
+new_string:
+```tsx
+import { SkeletonDemo } from './pages/components/SkeletonDemo';
+import { SliderDemo } from './pages/components/SliderDemo';
+```
+
+**Edit 4b — add route**:
+
+old_string:
+```tsx
+          <Route path="/components/skeleton" element={<SkeletonDemo />} />
+```
+
+new_string:
+```tsx
+          <Route path="/components/skeleton" element={<SkeletonDemo />} />
+          <Route path="/components/slider" element={<SliderDemo />} />
+```
+
+If the Skeleton anchors aren't in that exact form, locate adjacent imports/routes and apply with a different anchor.
+
+### Step 4.3: Modify `AppShell.tsx` — add lucide icon + Forms-group item
+
+Read `packages/playground/src/layout/AppShell/AppShell.tsx`. The Forms group is alphabetical: Button, ButtonGroup, Checkbox, Date pickers, FileUpload, Input, PasswordInput, PasswordStrengthMeter, Radio, Select, Switch, Textarea. Slider slots between Select and Switch.
+
+The lucide icon: `SlidersHorizontal` (canonical for slider UI).
+
+**Edit 4c — add lucide import**:
+
+old_string (the closing line of the lucide import block — expand context if needed):
+```tsx
+  type LucideIcon,
+} from 'lucide-react';
+```
+
+new_string:
+```tsx
+  SlidersHorizontal,
+  type LucideIcon,
+} from 'lucide-react';
+```
+
+**Edit 4d — add Forms-group item between Select and Switch**:
+
+Read the file to confirm the Select/Switch order. The current Forms group block (per the spec verification) has `Select` immediately before `Switch`:
+
+old_string:
+```tsx
+      { to: '/components/select', label: 'Select', icon: ChevronsUpDown, end: false },
+      { to: '/components/switch', label: 'Switch', icon: ToggleRight, end: false },
+```
+
+new_string:
+```tsx
+      { to: '/components/select', label: 'Select', icon: ChevronsUpDown, end: false },
+      { to: '/components/slider', label: 'Slider', icon: SlidersHorizontal, end: false },
+      { to: '/components/switch', label: 'Switch', icon: ToggleRight, end: false },
+```
+
+If the existing items use different icon names or order, adapt to the current file.
+
+### Step 4.4: Modify `ComponentsIndex.tsx` — add import + card
+
+Read the file. Apply two edits.
+
+**Edit 4e — add import** (use SkeletonDemo or a near-alphabetical anchor):
+
+old_string:
+```tsx
+import { Skeleton } from '@eocrm/design-system';
+```
+
+new_string:
+```tsx
+import { Skeleton } from '@eocrm/design-system';
+import { Slider } from '@eocrm/design-system';
+```
+
+**Edit 4f — add card entry**:
+
+Find the existing Skeleton card's complete `{ ... },` block as the unique anchor. Apply Edit with that block + the new Slider card block. The Slider card shape (literal content to add):
+
+```tsx
+  {
+    to: '/components/slider',
+    name: 'Slider',
+    description: 'Controlled slider: single-thumb or range (two-thumb), horizontal or vertical. Custom-painted with marks + value bubble.',
+    preview: (
+      <div style={{ width: '100%', maxWidth: 220 }}>
+        <Slider value={42} onChange={() => {}} aria-label="preview" />
+      </div>
+    ),
+  },
+```
+
+Insert it AFTER the Skeleton card. If the alphabetical sibling differs, adjust accordingly.
+
+### Step 4.5: Modify `registry.ts` — extend ComponentName union
+
+Read the file. Insert `'Slider'` alphabetically (after Skeleton, before Switch).
+
+old_string:
+```ts
+  | 'Skeleton'
+  | 'Stack'
+```
+
+new_string:
+```ts
+  | 'Skeleton'
+  | 'Slider'
+  | 'Stack'
+```
+
+If the union members around Skeleton differ, find a unique two-line anchor and insert `'Slider'` between them.
+
+### Step 4.6: Verify gates
+
+- [ ] Run `make build`. Expected: clean (the playground typechecks against `@eocrm/design-system`'s new exports).
+- [ ] Run `make lint`. Expected: clean.
+
+### Step 4.7: Commit
+
+```bash
+git add packages/playground/src/pages/components/SliderDemo.tsx \
+        packages/playground/src/App.tsx \
+        packages/playground/src/layout/AppShell/AppShell.tsx \
+        packages/playground/src/pages/components/ComponentsIndex.tsx \
+        packages/playground/src/pages/mockups/registry.ts
+git commit -m "$(cat <<'EOF'
+Slider demo + 4-place wiring
+
+SliderDemo: 8 examples — basic single, range filter, sizes, tones, marks,
+vertical, fractional step (zoom), disabled. Wired into App.tsx routes,
+AppShell Forms nav (SlidersHorizontal icon between Select and Switch),
+ComponentsIndex overview card, mockup registry ComponentName union.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Hard Rule 8 review-fix cycle + push + PR
+
+**Files:** none directly — this task is the review loop on Tasks 1–4.
+
+### Step 5.1: Run all four gates from the repo root
+
+- [ ] `cd /home/dpws/projects/design-system && make test`. Expected: every test passes (1723 baseline from PR #57 + ~37 Slider = ~1760).
+- [ ] `make build-lib`. Expected: clean.
+- [ ] `make build`. Expected: clean.
+- [ ] `make lint`. Expected: clean.
+
+If any gate fails, fix and re-run all four. Don't proceed to step 5.2 until all four are green.
+
+### Step 5.2: Dispatch the HR8 reviewer (round 1)
+
+Use a fresh-context `general-purpose` agent with **opus** model. Brief on the 10 review categories from `packages/design-system/CLAUDE.md` Rule 8.
+
+**Particular things to ask for fresh eyes on:**
+
+1. **`setPointerCapture` try/catch.** Wrapped in try/catch because jsdom doesn't implement it. Real browsers throw `InvalidPointerId` if `pointerId` is invalid — the catch silently swallows. Is that OK? The capture is best-effort and the drag still works without it (pointermove fires on the original element if the pointer hasn't left it). Probably fine.
+
+2. **`onChangeEnd` on blur fires unconditionally** — even if no value changed. Documented in the spec. Future consumer might expect "fires only on actual change" — flag as JSDoc-clarity item if reviewer cares.
+
+3. **Track click + thumb pointerdown interaction.** `handleTrackPointerDown` filters out clicks on the thumb via `(e.target as HTMLElement).closest(\`.${styles.thumb}\`)`. Verify the styles.thumb class string (stable strategy) actually matches the rendered className. If the CSS Modules hashed name doesn't contain the literal "thumb", the closest() call returns null and the track-click logic over-fires.
+
+4. **`pointerToValue` recomputed in `handleTrackPointerDown`** — once to find nearest thumb, then again with the chosen thumb index for range-clamp accuracy. Performance: irrelevant (one click per user gesture). Worth flagging as a clarity item or fine as-is?
+
+5. **`isDragging`/`isFocused`/`isHovered` arrays start at `thumbCount` length** via `new Array(thumbCount).fill(false)`. If the consumer toggles between single and range modes (changing `value` shape), `thumbCount` changes but the state arrays don't auto-resize. `setFlag` has a `while (out.length < thumbCount) out.push(false)` defensive pad, but reading from `isDragging[1]` when `thumbCount` was 1 returns `undefined` (truthy-cast to false, which happens to be correct). Documented as a quirk; flag for any subtle issue.
+
+6. **Range-mode keyboard test case**: in the test "left thumb cannot cross right thumb (keyboard clamp)", the assert is `onChange.toHaveBeenCalledWith([50, 50])`. That's correct — clamped to `min(60, 50) = 50`. Confirms the range-clamp behavior.
+
+7. **JSDoc completeness per Rule 7.** Every exported member has JSDoc. Spot-check `SliderProps`'s 13 fields, `SliderMark`'s 2 fields, the 4 union types.
+
+8. **`prefers-reduced-motion`** only disables the thumb box-shadow transition, NOT the drag itself (drag is direct, no transition during drag). Correct?
+
+9. **Bundle/distribution.** `npm pack --dry-run` should include the Slider directory, no test files. Verify.
+
+10. **Localization story for `aria-valuetext`** — currently formatted via the user's `label` function (consumer controls localization). The component itself doesn't hardcode any English. Good.
+
+11. **`role="slider"` is locked** via `Omit<HTMLAttributes, 'role'>` on the props type. Consumer cannot override via `...rest`. Intentional. Documented in the spec under "Self-imposed constraints".
+
+12. **DataTable / TanStack doc correction** — separately flagged in the spec's Follow-up tasks. Not part of THIS PR's scope.
+
+Output format: Critical / Important / Nice-to-have / Regression-watch + a final verdict line: `clean enough to stop` or `keep iterating`.
+
+### Step 5.3: Fix every Critical + Important finding
+
+- [ ] For each Critical, fix in-line and commit with `Slider: HR8 review-cycle fixes (round N) — <short rationale>`.
+- [ ] Same for Important.
+- [ ] Nice-to-haves are judgment calls — fix when cheap.
+- [ ] For every finding deliberately skipped, include a one-line "why we skipped" in the next response so the next reviewer doesn't re-flag it.
+
+### Step 5.4: Re-run all four gates after fixes
+
+- [ ] `make test && make build-lib && make build && make lint`. All clean.
+
+### Step 5.5: Dispatch HR8 reviewer (round 2+)
+
+Same prompt as 5.2, framed as "round N — verify round (N-1) fixes". Continue until verdict is `clean enough to stop`.
+
+### Step 5.6: Push the branch
+
+- [ ] `git push -u origin feat/image-crop`. If husky pre-push hook fails on `format:check`:
+  1. `npx prettier --write <listed files>`
+  2. `git add <files> && git commit -m "Slider: prettier --write" -m "" -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"`
+  3. `git push`
+
+### Step 5.7: Open the PR
+
+Use `gh pr create --body-file` (NOT a heredoc with backticks — that bit us on PR #55). Write the PR body to `/tmp/pr-slider-body.md` first via the Write tool, then:
+
+```bash
+gh pr create --title "Slider: controlled single + range, horizontal + vertical (pre-req for ImageCrop)" --body-file /tmp/pr-slider-body.md
+```
+
+PR body content:
+
+```markdown
+## Summary
+
+`<Slider>` — controlled, custom-painted slider supporting single-thumb AND range (two-thumb) modes, horizontal AND vertical orientations, fractional steps, tick marks, and tone-coded fills. Pre-req for `<ImageCrop>` (next PR) which uses it for the zoom control.
+
+- **`value: number | [number, number]`** — type-discriminated. Single-thumb for `number`; two-thumb range for the tuple. `onChange` mirrors the shape.
+- **Pointer events** with `setPointerCapture` (try/catch for jsdom safety) for unified mouse/touch/pen drag.
+- **Full WAI-ARIA APG keyboard support** — Arrow/Home/End/PageUp/PageDown, range-clamp aware.
+- **Tick marks** (`number[]` or `SliderMark[]`) with auto-filled state for marks inside the current range.
+- **Value bubble label** on hover/focus/drag — `label={true}` for raw value, `label={(v) => ...}` for custom format (also drives `aria-valuetext`).
+- **Hidden `<input>`** (or two for range, with `-min`/`-max` suffixes) under the `name` prop for form submission without JS serialization.
+- **`role="slider"` is locked** via TypeScript `Omit<HTMLAttributes, 'role'>` — consumer can't override.
+
+## Why now
+
+Pre-req for ImageCrop's zoom control. Other near-term consumers: threshold sliders for filters, range filters in contacts/deals, opacity controls, settings sliders. No primitive exists for this today — every consumer would hand-roll drag math + ARIA.
+
+## Design decisions baked in
+
+- **Controlled-only, no `defaultValue`.** Matches every other controlled primitive shipped this quarter (FileUpload, Progress).
+- **Discriminated union on `value` instead of `<Slider>` + `<RangeSlider>`** components. One component, ergonomic API.
+- **Custom paint for all modes.** Range mode forces it (native `<input type="range">` can't do two thumbs); single mode follows for consistency. Manual ARIA throughout.
+- **`onChange` fires per pointer-move tick; `onChangeEnd` fires on release/blur.** Consumers debounce expensive logic themselves.
+- **Range-mode clamp**: `value[0] ≤ value[1]` always enforced — both pointer drag and keyboard nudge.
+- **Track click moves the nearest thumb** to the click position (range mode picks by distance to current value).
+
+## Tests
+
+**~37 cases** covering: rendering matrix (single/range × sm/md/lg × default/success/warning/danger × horizontal/vertical), value-to-percent positioning math, ARIA on each thumb, full keyboard (Arrow/Home/End/PageUp/PageDown including range-clamp + blur fires onChangeEnd), pointer-event drag via a `setPointerCapture` shim for jsdom (track click + thumb pointerdown/move/up + range-clamp), marks (count + markFilled within fill range), label modes (false / true / function), and hidden form inputs (single / range / disabled state).
+
+## Hard Rule 8
+
+Standard cycle ran to `clean enough to stop`.
+
+## Test plan
+
+- [ ] `/components/slider`: 8 examples render — basic single, range filter, sizes, tones, marks, vertical, fractional step (zoom), disabled.
+- [ ] Drag a thumb in any example, see the value update in the "Current: <Code>" label.
+- [ ] Click on the track (not the thumb) — the nearest thumb snaps.
+- [ ] Tab to a thumb, press Arrow keys — value changes. Home/End jump to min/max.
+- [ ] Range mode: try to drag the left thumb past the right thumb — it stops at the right thumb's value.
+- [ ] No mockup files modified (verified — no current mockup uses a slider).
+- [ ] AGENTS.md Slider section appears between FileUpload and Card.
+- [ ] No test files in `npm pack --dry-run` output.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+- [ ] Print the PR URL when done.
+
+---
+
+## Self-review (run before invoking subagent-driven-development)
+
+### Spec coverage
+
+- Spec §Goal / §Why now — Task 3 (AGENTS.md) + Task 4 (demos).
+- Spec §Non-goals — encoded as JSDoc anti-patterns in Task 1.
+- Spec §Architecture (file layout, composition) — matches Tasks 1, 4.
+- Spec §Public API — Task 1 (verbatim types + interface + all 13 props).
+- Spec §Render shape — Task 1 (the full component body).
+- Spec §Drag math + keyboard — Task 1 implements `handleThumbPointerDown/Move/Up`, `handleThumbKeyDown`, `handleTrackPointerDown`, `pointerToValue`, `snapToStep`. Tested in Task 2.
+- Spec §Styling — Task 1's SCSS spelled out verbatim with the proactive stylelint disables.
+- Spec §ARIA + behavior reference — encoded in Task 1's component code + tested across the ARIA section of Task 2.
+- Spec §Testing — Task 2 covers every numbered spec case (~37 total) across rendering / value-fill / ARIA / keyboard / pointer / marks-label / hidden-input.
+- Spec §Demo additions — Task 4 SliderDemo has all 8 examples.
+- Spec §AGENTS.md update — Task 3, placed after FileUpload.
+- Spec §Self-imposed constraints — encoded in code + JSDoc anti-patterns.
+- Spec §Hard Rule 8 — Task 5.
+- Spec §Open questions — none remaining.
+- Spec §Follow-up tasks — DataTable/TanStack correction is OUT of scope for this PR; flagged in Task 5 for the next reviewer's awareness.
+
+### Placeholder scan
+
+- "TBD" / "TODO" / "implement later" — none.
+- "Add appropriate error handling" / "handle edge cases" — none.
+- "Write tests for the above" without code — none.
+- "Similar to Task N" — none (every code block is fully spelled out).
+- T3's AGENTS.md edit uses a "read the file to capture the exact anchor" pattern — same as Typography/Progress/FileUpload AGENTS edits used. Documented with the exact closing-bullet anchor the implementer should look for.
+- T4's ComponentsIndex card edit uses the same "find-the-preceding-entry, expand-with-new-card" pattern documented in prior PRs.
+
+### Type consistency
+
+- `SliderProps`, `SliderValue`, `SliderSize`, `SliderTone`, `SliderOrientation`, `SliderMark` — declared in Task 1 source; used by Task 2 test imports; re-exported in Task 2's src/index.ts edit; referenced in Task 3 AGENTS.md prose; imported in Task 4 demo + ComponentsIndex card. Same vocabulary throughout.
+- SCSS class names: kebab-case for prop-derived (`orientation-horizontal`, `size-sm`, `tone-danger`), camelCase for compound nouns (`markFilled`, `thumbDragging`). Matched in TSX bracket-access (`styles[\`orientation-${o}\`]`) and dot-access (`styles.thumbDragging`).
+- Test regex substrings (`/orientation-horizontal/`, `/size-sm/`, `/tone-danger/`, `/root_/`, `/markFilled/`, `/thumbDragging/`) match the actual CSS Modules class names in stable strategy.
+- Helper names `clamp`, `snapToStep`, `normalizeMarks` consistent between Task 1 source and the implicit-rendering Task 2 tests (snapToStep's floating-point alignment behavior is verified via the "fractional step" positioning test).
+
+### Found and fixed inline during write
+
+- Spec was missing a `prefers-reduced-motion` test case; not adding one to the plan since the spec's testing section only lists 37 — the media query is verified by visual inspection in the playground, not unit tests (jsdom doesn't honor media queries).
+- Spec mentioned a "boxShadow" transition disable under reduced-motion; Task 1's SCSS correctly does this with `transition: none` on `.thumb`.
+- ComponentsIndex card preview uses `<Slider value={42} onChange={() => {}} aria-label="preview" />` — verified the `aria-label` makes it accessible (otherwise an unnamed slider is a real a11y issue even in preview).
+- Task 4 demos use `(v) => setValue(v as number)` casts because `onChange`'s signature is `SliderValue` (union). The cast is documented in the spec under "Composition examples" and is the consumer's responsibility — TypeScript's discriminated unions can't infer the narrow shape from a tuple-vs-scalar discriminant without a runtime check. Tagged in the JSDoc.
+
+---
+
+## Execution Handoff
+
+Plan saved to `docs/superpowers/plans/2026-05-24-slider.md`.
+
+Per `feedback_plan_execution_mode` memory: always subagent-driven, no asking.
+
+Use **superpowers:subagent-driven-development** to execute.
+
+- Tasks 1, 2, 4: sonnet implementer
+- Task 3: haiku implementer (mechanical AGENTS.md insertion)
+- Task 5 reviewers: opus

--- a/docs/superpowers/specs/2026-05-24-slider-design.md
+++ b/docs/superpowers/specs/2026-05-24-slider-design.md
@@ -1,0 +1,653 @@
+# Slider — design spec
+
+**Date:** 2026-05-24
+**Branch:** `feat/image-crop` (Slider ships first as a pre-req for ImageCrop's zoom UI — see "Why now")
+**Scope:** Add `<Slider>` to `@eocrm/design-system` — a controlled, custom-painted slider primitive supporting single-thumb AND range (two-thumb) modes, horizontal AND vertical orientations, tick marks, value labels, and tone-coded fills.
+
+## Goal
+
+Give the library a real slider primitive so consumers stop reaching for raw `<input type="range">` (which can't do range mode or vertical orientation, and doesn't theme cleanly) and stop hand-rolling drag math per-page. The component is also the pre-req for `<ImageCrop>` (next PR) which needs a zoom slider.
+
+## Why now
+
+`<ImageCrop>` (next session) needs a zoom slider for its zoom-in/zoom-out control. Per the brainstorm, ImageCrop is hand-rolled and ships with zoom — so we need `<Slider>` first.
+
+Other near-term real consumers already on the wishlist:
+
+- Volume / opacity controls in any future media-edit UI
+- Threshold sliders for "show items with priority > N" filters
+- Range filters in the contacts/deals list pages (date-range numeric brushing, price range)
+- Disk-usage threshold sliders in admin settings
+
+## Non-goals (v1)
+
+- **No uncontrolled mode.** `value` is required; consumer always owns the state. Matches FileUpload, Progress, every other controlled primitive shipped this quarter.
+- **No vertical RTL.** Vertical sliders are LTR-only.
+- **No `track="inverted"` mode.** MUI/Mantine support filling from the max-end. Too niche for current consumers.
+- **No `disableSwap` opt-out for range.** Range thumbs always clamp so `value[0] ≤ value[1]`. The "thumbs can cross" UX is confusing and no consumer is asking for it.
+- **No `discrete` / `restricted` mode** (snap thumbs to mark values only). Marks are visual ticks; `step` does the snapping.
+- **No `valueLabelDisplay: 'on' | 'auto' | 'off'`** prop. Just `label: boolean | formatter`. Auto-shows on hover/focus/drag, auto-hides otherwise.
+- **No imperative API.** No `sliderRef.current.setValue(...)` etc.
+- **No `marks="auto"` mode** that generates ticks at step boundaries. Consumer passes the array explicitly.
+- **No `track={false}` (hide track) mode.** The track is the visual that makes the thumb position legible.
+- **No `slots` or render-prop API.** Thumb, track, mark, and label rendering are all owned by the component.
+
+## Architecture
+
+### Dependencies
+
+No new packages. Reuses:
+
+- React (peer)
+- `clsx` (existing dep)
+- Existing tokens: `--color-accent`, `--color-success`, `--color-warning`, `--color-danger`, `--color-bg-muted`, `--color-bg`, `--color-fg`, `--color-fg-muted`, `--color-border`, `--font-size-xs`, `--font-size-sm`, `--font-weight-medium`, `--radius-full`, `--radius-sm`, `--space-1`, `--space-2`, `--shadow-sm`, `--transition-base`, `--opacity-disabled`.
+
+No new tokens needed.
+
+### File layout
+
+```
+packages/design-system/src/components/Slider/
+  Slider.tsx               ← root component (forwardRef, drag math, pointer + keyboard handlers, render tree)
+  Slider.module.scss       ← .root + .horizontal/.vertical + .track + .fill + .thumb + .label + .mark + .disabled
+  Slider.test.tsx          ← ~30 cases (single + range + vertical + keyboard + ARIA)
+  index.ts                 ← exports Slider + types
+
+packages/design-system/src/index.ts                                ← MODIFY: re-exports
+packages/design-system/AGENTS.md                                   ← MODIFY: add Slider section under Forms (after FileUpload)
+
+packages/playground/src/pages/components/SliderDemo.tsx            ← NEW
+packages/playground/src/App.tsx                                    ← MODIFY: add route
+packages/playground/src/layout/AppShell/AppShell.tsx               ← MODIFY: add to Forms group (between Select and Switch alphabetically)
+packages/playground/src/pages/components/ComponentsIndex.tsx       ← MODIFY: add card
+packages/playground/src/pages/mockups/registry.ts                  ← MODIFY: extend ComponentName union with 'Slider'
+```
+
+### Composition examples
+
+```tsx
+// Single-thumb, fractional steps (the ImageCrop zoom case):
+<Slider value={zoom} min={1} max={3} step={0.1} onChange={setZoom} aria-label="Zoom" />
+
+// Range filter (deals priced between $A and $B):
+<Slider value={[price[0], price[1]]} min={0} max={100000} step={1000} onChange={setPrice} label={(v) => `$${v.toLocaleString()}`} />
+
+// Vertical with marks (custom volume control):
+<Slider value={volume} orientation="vertical" marks={[0, 25, 50, 75, 100]} onChange={setVolume} />
+
+// Tone-coded threshold:
+<Slider value={diskUsage} tone={diskUsage > 90 ? 'danger' : diskUsage > 75 ? 'warning' : 'default'} />
+```
+
+## Public API
+
+### Types
+
+```ts
+import type { HTMLAttributes, ReactNode } from 'react';
+
+/** Track height + thumb size. */
+export type SliderSize = 'sm' | 'md' | 'lg';
+
+/** Fill color tone (track between min and value). */
+export type SliderTone = 'default' | 'success' | 'warning' | 'danger';
+
+/** Layout direction. */
+export type SliderOrientation = 'horizontal' | 'vertical';
+
+/** Either a single number (single-thumb) or a [min, max] tuple (range mode). */
+export type SliderValue = number | [number, number];
+
+/** Tick-mark configuration. Either an array of values (auto-labeled with the value) or full SliderMark objects with custom labels. */
+export interface SliderMark {
+  value: number;
+  label?: ReactNode;
+}
+
+export interface SliderProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue' | 'role'> {
+  /**
+   * Current value. A single `number` for one-thumb mode; a `[min, max]` tuple
+   * for two-thumb (range) mode. The component type-discriminates internally.
+   * Required — Slider is controlled-only.
+   */
+  value: SliderValue;
+  /**
+   * Called on every thumb-drag tick (high frequency). For server-side or
+   * expensive update logic, prefer `onChangeEnd` or debounce in the consumer.
+   * The argument has the same shape as `value`: `number` for single,
+   * `[number, number]` for range.
+   */
+  onChange: (value: SliderValue) => void;
+  /**
+   * Called once when the user releases the thumb (pointerup / blur after
+   * keyboard nav). Use for committing the value to a server or running an
+   * expensive recalculation. Receives the final value with the same shape
+   * as `value`.
+   */
+  onChangeEnd?: (value: SliderValue) => void;
+  /** Minimum allowed value (inclusive). Default `0`. */
+  min?: number;
+  /** Maximum allowed value (inclusive). Default `100`. */
+  max?: number;
+  /**
+   * Step granularity. Default `1`. Use fractional steps (e.g. `0.1`) for
+   * zoom / opacity-style controls. Values are snapped to `min + (n * step)`.
+   */
+  step?: number;
+  /**
+   * Tick marks. Pass `number[]` for auto-labeled ticks (label = value) or
+   * `SliderMark[]` for custom labels (label = ReactNode). Marks render under
+   * the track (horizontal) or to the right (vertical).
+   */
+  marks?: number[] | SliderMark[];
+  /**
+   * Value bubble on the thumb.
+   * - `false` (default) — no bubble.
+   * - `true` — show the current value (formatted via toString) on hover /
+   *   focus / drag. Auto-hides otherwise.
+   * - `(value: number) => ReactNode` — custom formatter. For range mode,
+   *   the formatter is called once per thumb.
+   */
+  label?: boolean | ((value: number) => ReactNode);
+  /**
+   * Track + thumb sizing. Defaults to `'md'`.
+   * - `sm` — 4px track, 14px thumb.
+   * - `md` — 6px track, 18px thumb (default).
+   * - `lg` — 8px track, 22px thumb.
+   */
+  size?: SliderSize;
+  /**
+   * Fill color tone (the track segment between min and value). Defaults to
+   * `'default'` (accent). State-coded `success` / `warning` / `danger` for
+   * threshold-style sliders (e.g. disk usage approaching capacity).
+   */
+  tone?: SliderTone;
+  /** Orientation. Defaults to `'horizontal'`. */
+  orientation?: SliderOrientation;
+  /** Disabled state. Defaults to `false`. */
+  disabled?: boolean;
+  /**
+   * Native form-input name. When set, a hidden `<input>` (or two for range)
+   * is rendered with the current value(s) so the slider works inside
+   * uncontrolled HTML forms without consumer JS serialization.
+   */
+  name?: string;
+}
+```
+
+### Render shape (pseudo-code)
+
+The following sketches the JSX shape and the locally-derived variables the component computes. Variable bindings (`thumbValues`, `fillStyle`, `thumbStyle`, `markStyle`, `marksArr`, `formatLabel`, `isDragging`, `isFocused`, `isHovered`, `isMarkInFill`) are documented in the bullet list after the snippet — they're not magic; they're straightforward derivations the implementer fills in.
+
+```tsx
+// Locally computed in the component body:
+//   isRange = Array.isArray(value)
+//   thumbValues = isRange ? value : [value]
+//   marksArr = normalize(marks)  // number[] | SliderMark[] → SliderMark[]
+//   fillStyle = computed inline-style positioning the fill segment
+//   thumbStyle(v) = computed inline-style positioning a thumb at percent ((v-min)/(max-min))*100
+//   markStyle(m) = same shape as thumbStyle, positions a mark
+//   isMarkInFill(m) = whether mark.value lies inside the current fill range
+//   formatLabel(v) = label === true ? String(v) : label === false ? null : label(v)
+//   showLabelFor(i) = isDragging[i] || isFocused[i] || isHovered[i]
+//   handleThumbPointerDown / handleThumbKeyDown — see "Drag math" + "Keyboard" sections
+
+<div
+  ref={ref}
+  className={clsx(
+    styles.root,
+    styles[`orientation-${orientation}`],
+    styles[`size-${size}`],
+    styles[`tone-${tone}`],
+    disabled && styles.disabled,
+    className,
+  )}
+  {...rest}
+>
+  <div ref={trackRef} className={styles.track}>
+    <div className={styles.fill} style={fillStyle} />
+    {marksArr.map((mark) => (
+      <span
+        key={mark.value}
+        className={clsx(styles.mark, isMarkInFill(mark) && styles.markFilled)}
+        style={markStyle(mark)}
+      >
+        {mark.label && <span className={styles.markLabel}>{mark.label}</span>}
+      </span>
+    ))}
+  </div>
+  {/* For single mode: 1 thumb; for range: 2 thumbs */}
+  {thumbValues.map((thumbValue, index) => (
+    <div
+      key={index}
+      role="slider"
+      tabIndex={disabled ? -1 : 0}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={thumbValue}
+      aria-valuetext={typeof label === 'function' ? String(label(thumbValue)) : undefined}
+      aria-orientation={orientation}
+      aria-disabled={disabled || undefined}
+      className={clsx(styles.thumb, isDragging[index] && styles.thumbDragging)}
+      style={thumbStyle(thumbValue)}
+      onPointerDown={(e) => handleThumbPointerDown(e, index)}
+      onKeyDown={(e) => handleThumbKeyDown(e, index)}
+      onPointerEnter={() => setHovered(index, true)}
+      onPointerLeave={() => setHovered(index, false)}
+      onFocus={() => setFocused(index, true)}
+      onBlur={() => setFocused(index, false)}
+    >
+      {label !== false && showLabelFor(index) && (
+        <span className={styles.label}>{formatLabel(thumbValue)}</span>
+      )}
+    </div>
+  ))}
+  {name && (isRange
+    ? <>
+        <input type="hidden" name={`${name}-min`} value={(value as [number, number])[0]} />
+        <input type="hidden" name={`${name}-max`} value={(value as [number, number])[1]} />
+      </>
+    : <input type="hidden" name={name} value={value as number} />
+  )}
+</div>
+```
+
+Internal state (only what changes after the initial render):
+
+- `isDragging: boolean[]` — one entry per thumb. Set to `true` on pointerdown, `false` on pointerup.
+- `isFocused: boolean[]` — set on focus/blur. Drives label visibility.
+- `isHovered: boolean[]` — set on pointerenter/leave. Drives label visibility.
+- `trackRef: RefObject<HTMLDivElement>` — for `getBoundingClientRect()` math.
+- The actual value lives in the controlled `value` prop; no internal value state.
+
+The hidden `<input>`(s) at the end let the slider work inside `<form action=...>` without JS serialization. Range mode renders TWO hidden inputs with `${name}-min` and `${name}-max` so the consumer can pick them off the form data.
+
+### Drag math
+
+When the user pointer-downs on a thumb:
+
+1. `pointerId` captured via `event.currentTarget.setPointerCapture(event.pointerId)` — guarantees future move/up events fire on the thumb element even if the pointer moves off it.
+2. Compute `trackRect = trackRef.current.getBoundingClientRect()`.
+3. Track `offset = pointer position - thumb position` so the thumb doesn't jump on grab.
+4. On every `pointermove`:
+   - Project pointer position onto the track axis: `pointerPos = orientation === 'horizontal' ? clientX - trackRect.left : trackRect.bottom - clientY` (vertical inverts).
+   - Compute percent: `pct = clamp(0, 1, pointerPos / trackLength)`.
+   - Compute raw value: `rawValue = min + pct * (max - min)`.
+   - Snap to step: `snappedValue = Math.round((rawValue - min) / step) * step + min`.
+   - In range mode, clamp to not cross the other thumb: `thumbIndex === 0 ? Math.min(snappedValue, value[1]) : Math.max(snappedValue, value[0])`.
+   - Fire `onChange` with the new value (full tuple for range, scalar for single).
+5. On `pointerup`:
+   - Release pointer capture.
+   - Fire `onChangeEnd` with the current value.
+
+When the user keydowns on a thumb:
+
+- `ArrowLeft` / `ArrowDown` (horizontal-left / vertical-down): `value -= step`.
+- `ArrowRight` / `ArrowUp` (horizontal-right / vertical-up): `value += step`.
+- `Home`: `value = min`.
+- `End`: `value = max`.
+- `PageDown`: `value -= step * 10`.
+- `PageUp`: `value += step * 10`.
+
+All keyboard nudges respect range-mode clamping. `onChange` fires immediately. `onChangeEnd` fires on `blur` (not on every keystroke).
+
+Clicking on the track (NOT on a thumb) snaps the nearest thumb to the click position. In range mode, "nearest" is by distance to each thumb's current position.
+
+## Styling — `Slider.module.scss`
+
+```scss
+.root {
+  position: relative;
+  display: flex;
+  align-items: center;
+  user-select: none;
+}
+
+.orientation-horizontal {
+  width: 100%;
+  // Reserve vertical space for the marks (below the track) + the label bubble (above).
+  // Component-internal sizing for an unfixed-height row.
+  min-height: 32px;
+}
+
+.orientation-vertical {
+  flex-direction: column;
+  // 200px is a reasonable default vertical track length; consumer can override via style.
+  height: 200px;
+  min-width: 32px;
+}
+
+.track {
+  position: relative;
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-full);
+  overflow: visible;
+}
+
+.orientation-horizontal .track {
+  width: 100%;
+  height: 6px;
+}
+
+.orientation-vertical .track {
+  height: 100%;
+  width: 6px;
+}
+
+.size-sm.orientation-horizontal .track {
+  height: 4px;
+}
+
+.size-lg.orientation-horizontal .track {
+  height: 8px;
+}
+
+.size-sm.orientation-vertical .track {
+  width: 4px;
+}
+
+.size-lg.orientation-vertical .track {
+  width: 8px;
+}
+
+.fill {
+  position: absolute;
+  background: var(--color-accent);
+  border-radius: var(--radius-full);
+}
+
+.orientation-horizontal .fill {
+  top: 0;
+  bottom: 0;
+}
+
+.orientation-vertical .fill {
+  left: 0;
+  right: 0;
+}
+
+.tone-default .fill {
+  background: var(--color-accent);
+}
+.tone-success .fill {
+  background: var(--color-success);
+}
+.tone-warning .fill {
+  background: var(--color-warning);
+}
+.tone-danger .fill {
+  background: var(--color-danger);
+}
+
+.thumb {
+  position: absolute;
+  background: var(--color-bg);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-sm);
+  cursor: grab;
+  transition: box-shadow var(--transition-base);
+}
+
+.orientation-horizontal .thumb {
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.orientation-vertical .thumb {
+  left: 50%;
+  transform: translate(-50%, 50%);
+}
+
+.size-sm .thumb {
+  width: 14px;
+  height: 14px;
+}
+
+.size-md .thumb {
+  width: 18px;
+  height: 18px;
+}
+
+.size-lg .thumb {
+  width: 22px;
+  height: 22px;
+}
+
+.thumb:hover,
+.thumb:focus-visible {
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-md);
+  outline: none;
+}
+
+.thumbDragging {
+  cursor: grabbing;
+  box-shadow: var(--shadow-md);
+}
+
+.label {
+  position: absolute;
+  background: var(--color-fg);
+  color: var(--color-bg);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  font-variant-numeric: tabular-nums;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.orientation-horizontal .label {
+  bottom: calc(100% + var(--space-2));
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.orientation-vertical .label {
+  left: calc(100% + var(--space-2));
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.mark {
+  position: absolute;
+  width: 2px;
+  height: 8px;
+  background: var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.markFilled {
+  background: var(--color-accent);
+}
+
+.tone-success .markFilled {
+  background: var(--color-success);
+}
+.tone-warning .markFilled {
+  background: var(--color-warning);
+}
+.tone-danger .markFilled {
+  background: var(--color-danger);
+}
+
+.orientation-horizontal .mark {
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.orientation-vertical .mark {
+  left: 50%;
+  transform: translate(-50%, 50%);
+  width: 8px;
+  height: 2px;
+}
+
+.markLabel {
+  position: absolute;
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.orientation-horizontal .markLabel {
+  top: calc(100% + var(--space-1));
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.orientation-vertical .markLabel {
+  left: calc(100% + var(--space-1));
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.disabled {
+  opacity: var(--opacity-disabled);
+  cursor: not-allowed;
+  pointer-events: none;
+}
+```
+
+**Rule 4 check:**
+
+- `.root` uses `position: relative` to anchor the absolutely-positioned `.fill`, `.thumb`, `.mark`, and label. Internal-child positioning for the centered-content pattern (same exception as Avatar's `.presence` and CircularProgress's centered label). Documented inline.
+- `.orientation-horizontal width: 100%` — intrinsic, not layout-at-boundary.
+- `.orientation-vertical height: 200px` — default vertical length; consumer overrides via `style={{ height }}`. Internal-child sizing; OK.
+- `.min-height: 32px` (horizontal) / `.min-width: 32px` (vertical) — reserves space for mark labels and the value bubble.
+- `.thumb width/height` — internal child sizing for the thumb visual.
+- All values are tokens. No `margin`, no `top/left/right/bottom` except for internal-child positioning, no `flex: 1/grow/self`.
+
+## ARIA + behavior reference
+
+| Concern               | Behavior                                                                                                                                                                                                                                                       |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Thumb role**        | `role="slider"` on each thumb. `tabIndex=0` (or `-1` when disabled). `aria-valuemin/max/now` per thumb. `aria-orientation` from prop. `aria-disabled` when disabled.                                                                                              |
+| **Range mode ARIA**   | TWO `<div role="slider">` elements, one per thumb. Each has its own `aria-valuenow`. Consumers wanting accessible labels per thumb can pass `aria-label` to the root via spread, which we use as a base — but ideally the consumer also passes `aria-label`s through prop slots (deferred). For v1, the root's `aria-label` covers both thumbs (the SR will announce the slider name plus the current values). |
+| **Value text**        | `aria-valuetext` set when `label` is a function (formatted output). When `label` is `true`, the raw number is used (no `aria-valuetext` override). When `label` is `false`, `aria-valuetext` is unset (SR announces the raw `aria-valuenow`).                              |
+| **Track click**       | Click on the track (not a thumb) snaps the nearest thumb to the click position and focuses it. Range mode: distance to thumb determines which thumb moves.                                                                                                  |
+| **Disabled**          | `aria-disabled` on each thumb; `tabIndex=-1`; pointer-events: none on the root via `.disabled`; hidden inputs receive `disabled`.                                                                                                                                |
+| **Reduced motion**    | `@media (prefers-reduced-motion: reduce)` disables the `transition` on `.thumb` box-shadow. Drag movement itself is direct (no transition during drag); only the focus/hover transitions are affected.                                                          |
+| **Pointer capture**   | `setPointerCapture` on pointerdown ensures pointermove/up still fire on the thumb even when the pointer leaves the element. Released on pointerup.                                                                                                              |
+| **Keyboard nudge**    | ArrowLeft/Down: -step. ArrowRight/Up: +step. Home: min. End: max. PageDown: -10×step. PageUp: +10×step. `onChange` per key, `onChangeEnd` on blur.                                                                                                              |
+| **Range thumb swap**  | Thumbs clamp so `value[0] ≤ value[1]` always. A drag that would cross gets clamped to the other thumb's value. Keyboard nav same.                                                                                                                               |
+
+## Testing
+
+`Slider.test.tsx` (~37 cases):
+
+### Rendering / structure
+
+1. Renders with `role="slider"` for single value
+2. Renders TWO `role="slider"` elements for range value `[min, max]`
+3. Default tone applies `tone-default` class to the fill
+4. Each tone applies its matching class (parameterized: default/success/warning/danger)
+5. Each size applies its matching class (parameterized: sm/md/lg)
+6. Default orientation is `'horizontal'`
+7. `orientation="vertical"` applies the vertical class
+8. `className` from props merges (does not replace) base class
+9. `ref` is forwarded to the outermost div
+10. Spreads native HTML attributes (`id`, `data-testid`, `aria-label`)
+
+### Value / fill positioning
+
+11. Single-mode `value={50}` (min=0, max=100): thumb positioned at 50%, fill from 0–50%
+12. Range-mode `value={[20, 80]}`: two thumbs at 20% and 80%, fill spans 20–80%
+13. Fractional step (min=0, max=1, step=0.1, value=0.3): thumb at 30% (verified via inline style)
+
+### ARIA
+
+14. Single mode: thumb has `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, `aria-orientation`
+15. Range mode: both thumbs have correct `aria-valuenow` values
+16. `aria-disabled="true"` on thumbs when `disabled`
+17. `aria-orientation="vertical"` when vertical
+18. `label={(v) => '${v}%'}` formats the `aria-valuetext`
+
+### Keyboard
+
+19. Arrow Right on focused thumb increments by step, fires `onChange` with new value
+20. Arrow Left decrements by step
+21. Home sets value to min
+22. End sets value to max
+23. PageUp adds 10×step
+24. PageDown subtracts 10×step
+25. Range thumb keyboard: left thumb can't cross right thumb (clamp)
+26. Blur fires `onChangeEnd` once with the current value
+
+### Pointer / drag (jsdom-friendly: simulate via pointer events, verify state via onChange callback fires)
+
+27. PointerDown on track (not thumb) snaps the (only / nearest) thumb to click position
+28. PointerDown + PointerMove on thumb fires `onChange` per move; PointerUp fires `onChangeEnd`
+29. Range mode: pointer-dragging thumb 0 past thumb 1's position clamps to thumb 1's value (no swap)
+30. Disabled: PointerDown does nothing (no `onChange`, no `onChangeEnd`)
+
+### Marks + label
+
+31. `marks={[0, 50, 100]}` renders 3 mark elements
+32. `marks` with values within the fill range get `.markFilled` class
+33. `label={true}` shows the value bubble on focused thumb
+34. `label={(v) => '${v} GB'}` renders the formatted text in the bubble
+35. `label={false}` (default) does NOT render a label element
+
+### Hidden form input
+
+36. `name="zoom"` single mode renders `<input type="hidden" name="zoom" value={50}>`
+37. `name="price"` range mode renders TWO hidden inputs (`price-min` and `price-max`)
+
+
+## Demo additions
+
+`SliderDemo.tsx` — ~8 examples:
+
+1. **Basic single** — controlled state with default props.
+2. **Range** — controlled tuple, formatted label `${v.toLocaleString()}`.
+3. **Sizes** — sm / md / lg stacked.
+4. **Tones** — default / success / warning / danger with the same value to show the fill color.
+5. **Marks** — `marks={[0, 25, 50, 75, 100]}` with auto-labels.
+6. **Vertical** — single-thumb vertical slider, 200px tall.
+7. **Fractional step** — min=1, max=3, step=0.1 (the ImageCrop zoom case).
+8. **Disabled** — grayed thumb + track.
+
+## AGENTS.md update
+
+Add a `<Slider>` section in `packages/design-system/AGENTS.md` placed within the **Forms** cluster — after the `<FileUpload>` section (which lives between RadioGroup and Card per the FileUpload spec). The Forms cluster order then becomes: Input → Textarea → PasswordInput → PasswordStrengthMeter → Checkbox → Switch → Radio → RadioGroup → FileUpload → **Slider**.
+
+Section contents:
+
+- API table (value, onChange, onChangeEnd, min, max, step, marks, label, size, tone, orientation, disabled, name).
+- The `SliderValue`, `SliderMark`, and tone/size/orientation type unions.
+- Three canonical snippets: single (zoom for ImageCrop), range (price filter), vertical (volume).
+- "Hard rule" callout:
+  - ❌ Raw `<input type="range">` — use `<Slider>`. Range mode and vertical orientation aren't possible with the native input.
+  - ❌ Hand-rolling drag math per page. Use the primitive.
+  - ❌ Updating server state in `onChange` (fires on every pointer-move tick). Use `onChangeEnd` or debounce.
+
+## Self-imposed constraints / decisions baked in
+
+- **Controlled-only.** `value` is required. No `defaultValue`. Consumer owns state.
+- **Discriminated union on `value`** instead of separate `<Slider>` + `<RangeSlider>` components. One component, type-switched.
+- **Custom paint for ALL modes** (range mode forces it; single mode follows for consistency). Manual ARIA throughout.
+- **`role="slider"` is locked** via `Omit<HTMLAttributes, 'role'>` on the props interface. Each thumb's role is the component's contract.
+- **Pointer events (not mouse + touch separately).** Unified across mouse / pen / touch.
+- **`setPointerCapture` on every thumb pointerdown** so drag works even when the pointer leaves the element.
+- **`onChange` fires every move; `onChangeEnd` fires on release.** Consumer's responsibility to debounce expensive updates.
+- **Sizes are fixed scales** (sm 4/14, md 6/18, lg 8/22 in px). No `size="custom"` escape hatch.
+- **Default min/max/step is 0/100/1.** Matches `<input type="range">` convention.
+- **Track click moves the nearest thumb** to the click position; range mode picks by distance.
+
+## Hard Rule 8
+
+Standard cycle: gates green, fresh-context reviewer, fix Critical + Important, repeat until clean.
+
+## Open questions
+
+None — all design-space questions from the brainstorm were resolved during the API draft. The pre-implementation open questions in the brainstorm output (label placement on vertical, mark labels positioning, onChange vs onChangeEnd) are answered in the spec body above.
+
+## Follow-up tasks (not part of this PR)
+
+1. **Update AGENTS.md / library docs that mention TanStack Table as a dep of DataTable.** Per the brainstorm: DataTable IS consumed by the CRM, but it's hand-rolled — NOT a TanStack wrapper. Any reference to TanStack in the library docs needs correction. Separate small docs-only PR.
+2. **Brainstorm + spec + plan + execute `<ImageCrop>`** in the next session. Settled decisions to carry forward: hand-roll on canvas, zoom IS in v1 (uses this Slider), rotation deferred, multi-touch deferred.

--- a/docs/superpowers/specs/2026-05-24-slider-design.md
+++ b/docs/superpowers/specs/2026-05-24-slider-design.md
@@ -104,8 +104,10 @@ export interface SliderMark {
   label?: ReactNode;
 }
 
-export interface SliderProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue' | 'role'> {
+export interface SliderProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'defaultValue' | 'role'
+> {
   /**
    * Current value. A single `number` for one-thumb mode; a `[min, max]` tuple
    * for two-thumb (range) mode. The component type-discriminates internally.
@@ -243,13 +245,15 @@ The following sketches the JSX shape and the locally-derived variables the compo
       )}
     </div>
   ))}
-  {name && (isRange
-    ? <>
+  {name &&
+    (isRange ? (
+      <>
         <input type="hidden" name={`${name}-min`} value={(value as [number, number])[0]} />
         <input type="hidden" name={`${name}-max`} value={(value as [number, number])[1]} />
       </>
-    : <input type="hidden" name={name} value={value as number} />
-  )}
+    ) : (
+      <input type="hidden" name={name} value={value as number} />
+    ))}
 </div>
 ```
 
@@ -524,17 +528,17 @@ Clicking on the track (NOT on a thumb) snaps the nearest thumb to the click posi
 
 ## ARIA + behavior reference
 
-| Concern               | Behavior                                                                                                                                                                                                                                                       |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Thumb role**        | `role="slider"` on each thumb. `tabIndex=0` (or `-1` when disabled). `aria-valuemin/max/now` per thumb. `aria-orientation` from prop. `aria-disabled` when disabled.                                                                                              |
-| **Range mode ARIA**   | TWO `<div role="slider">` elements, one per thumb. Each has its own `aria-valuenow`. Consumers wanting accessible labels per thumb can pass `aria-label` to the root via spread, which we use as a base — but ideally the consumer also passes `aria-label`s through prop slots (deferred). For v1, the root's `aria-label` covers both thumbs (the SR will announce the slider name plus the current values). |
-| **Value text**        | `aria-valuetext` set when `label` is a function (formatted output). When `label` is `true`, the raw number is used (no `aria-valuetext` override). When `label` is `false`, `aria-valuetext` is unset (SR announces the raw `aria-valuenow`).                              |
-| **Track click**       | Click on the track (not a thumb) snaps the nearest thumb to the click position and focuses it. Range mode: distance to thumb determines which thumb moves.                                                                                                  |
-| **Disabled**          | `aria-disabled` on each thumb; `tabIndex=-1`; pointer-events: none on the root via `.disabled`; hidden inputs receive `disabled`.                                                                                                                                |
-| **Reduced motion**    | `@media (prefers-reduced-motion: reduce)` disables the `transition` on `.thumb` box-shadow. Drag movement itself is direct (no transition during drag); only the focus/hover transitions are affected.                                                          |
-| **Pointer capture**   | `setPointerCapture` on pointerdown ensures pointermove/up still fire on the thumb even when the pointer leaves the element. Released on pointerup.                                                                                                              |
-| **Keyboard nudge**    | ArrowLeft/Down: -step. ArrowRight/Up: +step. Home: min. End: max. PageDown: -10×step. PageUp: +10×step. `onChange` per key, `onChangeEnd` on blur.                                                                                                              |
-| **Range thumb swap**  | Thumbs clamp so `value[0] ≤ value[1]` always. A drag that would cross gets clamped to the other thumb's value. Keyboard nav same.                                                                                                                               |
+| Concern              | Behavior                                                                                                                                                                                                                                                                                                                                                                                                       |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Thumb role**       | `role="slider"` on each thumb. `tabIndex=0` (or `-1` when disabled). `aria-valuemin/max/now` per thumb. `aria-orientation` from prop. `aria-disabled` when disabled.                                                                                                                                                                                                                                           |
+| **Range mode ARIA**  | TWO `<div role="slider">` elements, one per thumb. Each has its own `aria-valuenow`. Consumers wanting accessible labels per thumb can pass `aria-label` to the root via spread, which we use as a base — but ideally the consumer also passes `aria-label`s through prop slots (deferred). For v1, the root's `aria-label` covers both thumbs (the SR will announce the slider name plus the current values). |
+| **Value text**       | `aria-valuetext` set when `label` is a function (formatted output). When `label` is `true`, the raw number is used (no `aria-valuetext` override). When `label` is `false`, `aria-valuetext` is unset (SR announces the raw `aria-valuenow`).                                                                                                                                                                  |
+| **Track click**      | Click on the track (not a thumb) snaps the nearest thumb to the click position and focuses it. Range mode: distance to thumb determines which thumb moves.                                                                                                                                                                                                                                                     |
+| **Disabled**         | `aria-disabled` on each thumb; `tabIndex=-1`; pointer-events: none on the root via `.disabled`; hidden inputs receive `disabled`.                                                                                                                                                                                                                                                                              |
+| **Reduced motion**   | `@media (prefers-reduced-motion: reduce)` disables the `transition` on `.thumb` box-shadow. Drag movement itself is direct (no transition during drag); only the focus/hover transitions are affected.                                                                                                                                                                                                         |
+| **Pointer capture**  | `setPointerCapture` on pointerdown ensures pointermove/up still fire on the thumb even when the pointer leaves the element. Released on pointerup.                                                                                                                                                                                                                                                             |
+| **Keyboard nudge**   | ArrowLeft/Down: -step. ArrowRight/Up: +step. Home: min. End: max. PageDown: -10×step. PageUp: +10×step. `onChange` per key, `onChangeEnd` on blur.                                                                                                                                                                                                                                                             |
+| **Range thumb swap** | Thumbs clamp so `value[0] ≤ value[1]` always. A drag that would cross gets clamped to the other thumb's value. Keyboard nav same.                                                                                                                                                                                                                                                                              |
 
 ## Testing
 
@@ -597,7 +601,6 @@ Clicking on the track (NOT on a thumb) snaps the nearest thumb to the click posi
 
 36. `name="zoom"` single mode renders `<input type="hidden" name="zoom" value={50}>`
 37. `name="price"` range mode renders TWO hidden inputs (`price-min` and `price-max`)
-
 
 ## Demo additions
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -422,6 +422,53 @@ import { Switch } from '@eocrm/design-system';
 - ❌ Setting `multiple=true` and showing only one file slot via custom CSS. The component decides dropzone visibility from `multiple` + `files.length`; don't fight it.
 - ❌ Calling `onFilesAdded` from inside `onFileReject` (or vice versa) in an attempt to "auto-retry." Reject is terminal for that file; the user has to re-drop.
 
+### `<Slider>` — controlled slider (single + range, horizontal + vertical)
+
+```tsx
+<Slider value={zoom} min={1} max={3} step={0.1} onChange={(v) => setZoom(v as number)} aria-label="Zoom" />
+
+<Slider
+  value={price}                                   // tuple → range mode
+  min={0} max={100000} step={1000}
+  label={(v) => `$${v.toLocaleString()}`}
+  onChange={(v) => setPrice(v as [number, number])}
+/>
+
+<Slider
+  value={volume}
+  orientation="vertical"
+  marks={[0, 25, 50, 75, 100]}
+  onChange={(v) => setVolume(v as number)}
+/>
+```
+
+- **Controlled-only.** Always pass `value` + `onChange`. No `defaultValue`. Same architecture as FileUpload, Progress, and the rest of the controlled primitives.
+- **`value: number | [number, number]`** — discriminated union. `number` for single-thumb; tuple for range (two-thumb). `onChange` mirrors the shape.
+- **`onChange` fires per pointer-move tick (high frequency).** Debounce in the consumer OR use `onChangeEnd` (fires at pointerup, or at blur when the value actually changed) for server-state / expensive logic.
+- `min`/`max`/`step` default to `0`/`100`/`1`. Fractional `step` (e.g. `0.1`) is the canonical way to do zoom/opacity controls.
+- `size`: `sm` (4px track / 14px thumb) / `md` (6/18, default) / `lg` (8/22).
+- `tone`: `default` (accent) / `success` / `warning` / `danger`. Use `warning`/`danger` for threshold-style sliders (disk usage, alert level).
+- `orientation`: `horizontal` (default) / `vertical`. Vertical defaults to 200px tall; override via `style={{ height }}`.
+- `marks`: `number[]` (auto-labeled) OR `SliderMark[]` (`{ value, label }`) for custom labels.
+- `label`: `false` (default) / `true` (show `{value}` bubble on hover/focus/drag) / `(v) => ReactNode` (custom formatter; also sets `aria-valuetext`).
+- `name`: when set, renders hidden `<input>`(s) so the slider works inside `<form action=...>`. Range mode emits TWO inputs with `-min` / `-max` suffixes. **Hidden inputs are NOT rendered when the slider is `disabled`** — prevents the form from submitting a stale disabled value (`disabled` is a no-op on `<input type="hidden">` per HTML spec).
+- `disabled`: thumbs become non-interactive (`tabIndex=-1`, `aria-disabled`, `pointer-events: none` + `cursor: not-allowed` on each thumb).
+
+#### Keyboard
+
+- Arrow Left/Down: `-step`. Arrow Right/Up: `+step`.
+- Page Down/Up: `-10×step` / `+10×step`.
+- Home / End: jump to `min` / `max`.
+- All keys respect range-mode clamping (`value[0] ≤ value[1]`). `onChange` per key. `onChangeEnd` fires on blur ONLY if the value actually changed during the focus session — Tab-in / Tab-out without any nav does NOT fire.
+
+#### Hard rule
+
+- ❌ Raw `<input type="range">` — can't do range mode, doesn't theme cleanly across browsers. Use `<Slider>`.
+- ❌ Hand-rolling drag math per page. The pointer / keyboard handling is non-trivial; the primitive owns it.
+- ❌ Hitting a network endpoint inside `onChange` — fires on every pointer-move tick. Use `onChangeEnd` or debounce.
+- ❌ `<Slider role="region">` — `role="slider"` is locked on each thumb. The TypeScript `Omit` prevents the root override.
+- ❌ Passing `value[0] > value[1]` in range mode. The component clamps but the inverted tuple is a consumer bug — fix the state shape.
+
 ### `<Card>` — bordered container
 
 ```tsx

--- a/packages/design-system/src/components/Slider/Slider.module.scss
+++ b/packages/design-system/src/components/Slider/Slider.module.scss
@@ -243,6 +243,18 @@
   pointer-events: none;
 }
 
+.disabled .thumb {
+  // pointer-events:none on the root doesn't propagate to children with the
+  // default `pointer-events: auto`. The thumb is the actual hit target, so it
+  // needs its own pointer-events:none + cursor override.
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  cursor: not-allowed;
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  pointer-events: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .thumb {
     transition: none;

--- a/packages/design-system/src/components/Slider/Slider.module.scss
+++ b/packages/design-system/src/components/Slider/Slider.module.scss
@@ -1,0 +1,250 @@
+.root {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  // CSS keyword; not a tokenizable design value.
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  user-select: none;
+}
+
+.orientation-horizontal {
+  width: 100%;
+
+  // Reserve vertical space for the marks (below the track) + the label bubble
+  // (above). Component-internal sizing for an unfixed-height row.
+  min-height: 32px;
+}
+
+.orientation-vertical {
+  flex-direction: column;
+
+  // 200px is a reasonable default vertical track length; consumer can override
+  // via style or className.
+  height: 200px;
+  min-width: 32px;
+}
+
+.track {
+  position: relative;
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-full);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  overflow: visible;
+}
+
+.orientation-horizontal .track {
+  width: 100%;
+  height: 6px;
+}
+
+.orientation-vertical .track {
+  height: 100%;
+  width: 6px;
+}
+
+.size-sm.orientation-horizontal .track {
+  height: 4px;
+}
+
+.size-lg.orientation-horizontal .track {
+  height: 8px;
+}
+
+.size-sm.orientation-vertical .track {
+  width: 4px;
+}
+
+.size-lg.orientation-vertical .track {
+  width: 8px;
+}
+
+.fill {
+  position: absolute;
+  background: var(--color-accent);
+  border-radius: var(--radius-full);
+}
+
+.orientation-horizontal .fill {
+  top: 0;
+  bottom: 0;
+}
+
+.orientation-vertical .fill {
+  left: 0;
+  right: 0;
+}
+
+.tone-default .fill {
+  background: var(--color-accent);
+}
+
+.tone-success .fill {
+  background: var(--color-success);
+}
+
+.tone-warning .fill {
+  background: var(--color-warning);
+}
+
+.tone-danger .fill {
+  background: var(--color-danger);
+}
+
+.thumb {
+  position: absolute;
+  background: var(--color-bg);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-sm);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  cursor: grab;
+  transition: box-shadow var(--transition-base);
+}
+
+.orientation-horizontal .thumb {
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.orientation-vertical .thumb {
+  left: 50%;
+  transform: translate(-50%, 50%);
+}
+
+.size-sm .thumb {
+  width: 14px;
+  height: 14px;
+}
+
+.size-md .thumb {
+  width: 18px;
+  height: 18px;
+}
+
+.size-lg .thumb {
+  width: 22px;
+  height: 22px;
+}
+
+.thumb:hover,
+.thumb:focus-visible {
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-md);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  outline: none;
+}
+
+.thumbDragging {
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  cursor: grabbing;
+  box-shadow: var(--shadow-md);
+}
+
+.label {
+  position: absolute;
+  background: var(--color-fg);
+  color: var(--color-bg);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  font-variant-numeric: tabular-nums;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  white-space: nowrap;
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  pointer-events: none;
+}
+
+.orientation-horizontal .label {
+  bottom: calc(100% + var(--space-2));
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.orientation-vertical .label {
+  left: calc(100% + var(--space-2));
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.mark {
+  position: absolute;
+  width: 2px;
+  height: 8px;
+  background: var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.markFilled {
+  background: var(--color-accent);
+}
+
+.tone-success .markFilled {
+  background: var(--color-success);
+}
+
+.tone-warning .markFilled {
+  background: var(--color-warning);
+}
+
+.tone-danger .markFilled {
+  background: var(--color-danger);
+}
+
+.orientation-horizontal .mark {
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.orientation-vertical .mark {
+  left: 50%;
+  transform: translate(-50%, 50%);
+  width: 8px;
+  height: 2px;
+}
+
+.markLabel {
+  position: absolute;
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  white-space: nowrap;
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  pointer-events: none;
+}
+
+.orientation-horizontal .markLabel {
+  top: calc(100% + var(--space-1));
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.orientation-vertical .markLabel {
+  left: calc(100% + var(--space-1));
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.disabled {
+  opacity: var(--opacity-disabled);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  cursor: not-allowed;
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thumb {
+    transition: none;
+  }
+}

--- a/packages/design-system/src/components/Slider/Slider.test.tsx
+++ b/packages/design-system/src/components/Slider/Slider.test.tsx
@@ -189,6 +189,35 @@ describe('Slider', () => {
       expect(thumb).toHaveAttribute('aria-orientation', 'vertical');
     });
 
+    it('forwards root aria-label to the thumb (WAI-ARIA APG: role=slider must be labeled)', () => {
+      const { container } = render(
+        <Slider value={50} aria-label="Volume" onChange={() => {}} />,
+      );
+      const thumb = container.querySelector('[role="slider"]');
+      expect(thumb).toHaveAttribute('aria-label', 'Volume');
+    });
+
+    it('forwards root aria-labelledby to the thumb', () => {
+      const { container } = render(
+        <>
+          <span id="vol-label">Volume</span>
+          <Slider value={50} aria-labelledby="vol-label" onChange={() => {}} />
+        </>,
+      );
+      const thumb = container.querySelector('[role="slider"]');
+      expect(thumb).toHaveAttribute('aria-labelledby', 'vol-label');
+    });
+
+    it('range mode: both thumbs get the forwarded aria-label', () => {
+      const { container } = render(
+        <Slider value={[20, 80]} aria-label="Price range" onChange={() => {}} />,
+      );
+      const thumbs = container.querySelectorAll('[role="slider"]');
+      expect(thumbs).toHaveLength(2);
+      expect(thumbs[0]).toHaveAttribute('aria-label', 'Price range');
+      expect(thumbs[1]).toHaveAttribute('aria-label', 'Price range');
+    });
+
     it('label as function sets aria-valuetext to the formatted output', () => {
       const { container } = render(
         <Slider value={42} label={(v) => `${v}%`} onChange={() => {}} />,
@@ -336,6 +365,21 @@ describe('Slider', () => {
       expect(onChange).toHaveBeenCalledWith([50, 50]);
     });
 
+    it('click-without-drag (pointerdown immediately followed by pointerup, no move) does NOT fire onChangeEnd', () => {
+      const onChange = vi.fn();
+      const onChangeEnd = vi.fn();
+      const { container } = render(
+        <Slider value={50} onChange={onChange} onChangeEnd={onChangeEnd} />,
+      );
+      mockTrackRect(container, { width: 100, left: 0 });
+      const thumb = getThumbs(container)[0];
+      fireEvent.pointerDown(thumb, { clientX: 50, clientY: 3, pointerId: 1 });
+      fireEvent.pointerUp(thumb, { clientX: 50, clientY: 3, pointerId: 1 });
+      // No value change → no commit fire.
+      expect(onChange).not.toHaveBeenCalled();
+      expect(onChangeEnd).not.toHaveBeenCalled();
+    });
+
     it('disabled: pointerdown does nothing', () => {
       const onChange = vi.fn();
       const { container } = render(<Slider value={50} disabled onChange={onChange} />);
@@ -357,6 +401,25 @@ describe('Slider', () => {
       // Filter to spans where className contains `mark` but NOT `markLabel`.
       const markSpans = Array.from(allMarks).filter((el) => !/markLabel/.test(el.className));
       expect(markSpans.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('marks={[0, 50, 100]} (number[]) auto-labels each tick with its value', () => {
+      const { container } = render(<Slider value={50} marks={[0, 50, 100]} onChange={() => {}} />);
+      // Mark labels render as descendant spans with the .markLabel class.
+      const markLabels = container.querySelectorAll('[class*="markLabel"]');
+      expect(markLabels).toHaveLength(3);
+      const labelTexts = Array.from(markLabels).map((el) => el.textContent);
+      expect(labelTexts).toContain('0');
+      expect(labelTexts).toContain('50');
+      expect(labelTexts).toContain('100');
+    });
+
+    it('marks as SliderMark[] without label renders the tick but NO label span', () => {
+      const { container } = render(
+        <Slider value={50} marks={[{ value: 25 }, { value: 75 }]} onChange={() => {}} />,
+      );
+      const markLabels = container.querySelectorAll('[class*="markLabel"]');
+      expect(markLabels).toHaveLength(0);
     });
 
     it('marks within the fill range get markFilled class', () => {

--- a/packages/design-system/src/components/Slider/Slider.test.tsx
+++ b/packages/design-system/src/components/Slider/Slider.test.tsx
@@ -1,21 +1,26 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { createRef } from 'react';
-import {
-  Slider,
-  type SliderOrientation,
-  type SliderSize,
-  type SliderTone,
-} from './Slider';
+import { Slider, type SliderOrientation, type SliderSize, type SliderTone } from './Slider';
 
 // jsdom doesn't implement setPointerCapture; stub it on HTMLElement so the
 // component's try/catch fast-path is exercised (and we still get pointer
 // events).
 function ensurePointerCaptureShim() {
-  if (typeof (HTMLElement.prototype as unknown as { setPointerCapture?: unknown }).setPointerCapture !== 'function') {
-    (HTMLElement.prototype as unknown as { setPointerCapture: (id: number) => void }).setPointerCapture = () => {};
+  if (
+    typeof (HTMLElement.prototype as unknown as { setPointerCapture?: unknown })
+      .setPointerCapture !== 'function'
+  ) {
+    (
+      HTMLElement.prototype as unknown as { setPointerCapture: (id: number) => void }
+    ).setPointerCapture = () => {};
   }
-  if (typeof (HTMLElement.prototype as unknown as { releasePointerCapture?: unknown }).releasePointerCapture !== 'function') {
-    (HTMLElement.prototype as unknown as { releasePointerCapture: (id: number) => void }).releasePointerCapture = () => {};
+  if (
+    typeof (HTMLElement.prototype as unknown as { releasePointerCapture?: unknown })
+      .releasePointerCapture !== 'function'
+  ) {
+    (
+      HTMLElement.prototype as unknown as { releasePointerCapture: (id: number) => void }
+    ).releasePointerCapture = () => {};
   }
 }
 
@@ -28,7 +33,10 @@ function getThumbs(container: HTMLElement): HTMLElement[] {
 
 // Helper — mock the track's getBoundingClientRect so pointer-math has a known
 // canvas. Default: 100px-wide / 6px-tall horizontal track at (0, 0).
-function mockTrackRect(container: HTMLElement, opts: { width?: number; height?: number; left?: number; top?: number } = {}) {
+function mockTrackRect(
+  container: HTMLElement,
+  opts: { width?: number; height?: number; left?: number; top?: number } = {},
+) {
   const { width = 100, height = 6, left = 0, top = 0 } = opts;
   const track = container.querySelector<HTMLElement>('[class*="track"]')!;
   track.getBoundingClientRect = () =>
@@ -104,9 +112,7 @@ describe('Slider', () => {
     );
 
     it('className from props merges with the base class', () => {
-      const { container } = render(
-        <Slider value={50} className="custom" onChange={() => {}} />,
-      );
+      const { container } = render(<Slider value={50} className="custom" onChange={() => {}} />);
       const cls = (container.firstChild as HTMLElement).className;
       expect(cls).toMatch(/custom/);
       expect(cls).toMatch(/root_/);
@@ -190,9 +196,7 @@ describe('Slider', () => {
     });
 
     it('forwards root aria-label to the thumb (WAI-ARIA APG: role=slider must be labeled)', () => {
-      const { container } = render(
-        <Slider value={50} aria-label="Volume" onChange={() => {}} />,
-      );
+      const { container } = render(<Slider value={50} aria-label="Volume" onChange={() => {}} />);
       const thumb = container.querySelector('[role="slider"]');
       expect(thumb).toHaveAttribute('aria-label', 'Volume');
     });
@@ -261,18 +265,14 @@ describe('Slider', () => {
 
     it('Home sets value to min', () => {
       const onChange = vi.fn();
-      const { container } = render(
-        <Slider value={50} min={0} max={100} onChange={onChange} />,
-      );
+      const { container } = render(<Slider value={50} min={0} max={100} onChange={onChange} />);
       fireEvent.keyDown(getThumbs(container)[0], { key: 'Home' });
       expect(onChange).toHaveBeenCalledWith(0);
     });
 
     it('End sets value to max', () => {
       const onChange = vi.fn();
-      const { container } = render(
-        <Slider value={50} min={0} max={100} onChange={onChange} />,
-      );
+      const { container } = render(<Slider value={50} min={0} max={100} onChange={onChange} />);
       fireEvent.keyDown(getThumbs(container)[0], { key: 'End' });
       expect(onChange).toHaveBeenCalledWith(100);
     });
@@ -293,9 +293,7 @@ describe('Slider', () => {
 
     it('range mode: left thumb cannot cross right thumb (keyboard clamp)', () => {
       const onChange = vi.fn();
-      const { container } = render(
-        <Slider value={[40, 50]} step={20} onChange={onChange} />,
-      );
+      const { container } = render(<Slider value={[40, 50]} step={20} onChange={onChange} />);
       // ArrowRight on left thumb tries to go to 60, but it clamps to 50 (right thumb).
       fireEvent.keyDown(getThumbs(container)[0], { key: 'ArrowRight' });
       expect(onChange).toHaveBeenCalledWith([50, 50]);
@@ -354,9 +352,7 @@ describe('Slider', () => {
 
     it('range mode: pointer-dragging thumb 0 past thumb 1 clamps to thumb 1 value', () => {
       const onChange = vi.fn();
-      const { container } = render(
-        <Slider value={[20, 50]} onChange={onChange} />,
-      );
+      const { container } = render(<Slider value={[20, 50]} onChange={onChange} />);
       mockTrackRect(container, { width: 100, left: 0 });
       const thumbs = getThumbs(container);
       fireEvent.pointerDown(thumbs[0], { clientX: 20, clientY: 3, pointerId: 1 });
@@ -423,9 +419,7 @@ describe('Slider', () => {
     });
 
     it('marks within the fill range get markFilled class', () => {
-      const { container } = render(
-        <Slider value={75} marks={[25, 75]} onChange={() => {}} />,
-      );
+      const { container } = render(<Slider value={75} marks={[25, 75]} onChange={() => {}} />);
       // Both 25 and 75 are <= 75, so both should have markFilled.
       const filled = container.querySelectorAll('[class*="markFilled"]');
       expect(filled.length).toBe(2);
@@ -436,7 +430,9 @@ describe('Slider', () => {
       const thumb = getThumbs(container)[0];
       // Direct .focus() triggers a React state update (setIsFocused); wrap in
       // act so the render flushes before asserting.
-      act(() => { thumb.focus(); });
+      act(() => {
+        thumb.focus();
+      });
       const labelEl = container.querySelector('[class*="label"]:not([class*="markLabel"])');
       expect(labelEl).not.toBeNull();
       expect(labelEl).toHaveTextContent('42');
@@ -448,7 +444,9 @@ describe('Slider', () => {
       );
       const thumb = getThumbs(container)[0];
       // Same act-flush as above.
-      act(() => { thumb.focus(); });
+      act(() => {
+        thumb.focus();
+      });
       const labelEl = container.querySelector('[class*="label"]:not([class*="markLabel"])');
       expect(labelEl).toHaveTextContent('42 GB');
     });
@@ -475,9 +473,7 @@ describe('Slider', () => {
     });
 
     it('range mode + name="price": renders TWO hidden inputs (price-min and price-max)', () => {
-      const { container } = render(
-        <Slider value={[10, 90]} name="price" onChange={() => {}} />,
-      );
+      const { container } = render(<Slider value={[10, 90]} name="price" onChange={() => {}} />);
       const inputs = container.querySelectorAll<HTMLInputElement>('input[type="hidden"]');
       expect(inputs).toHaveLength(2);
       expect(inputs[0]).toHaveAttribute('name', 'price-min');
@@ -487,9 +483,7 @@ describe('Slider', () => {
     });
 
     it('disabled: hidden inputs are NOT rendered (form does not submit a stale value)', () => {
-      const { container } = render(
-        <Slider value={50} name="vol" disabled onChange={() => {}} />,
-      );
+      const { container } = render(<Slider value={50} name="vol" disabled onChange={() => {}} />);
       const inputs = container.querySelectorAll('input[type="hidden"]');
       expect(inputs).toHaveLength(0);
     });

--- a/packages/design-system/src/components/Slider/Slider.test.tsx
+++ b/packages/design-system/src/components/Slider/Slider.test.tsx
@@ -1,0 +1,434 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { createRef } from 'react';
+import {
+  Slider,
+  type SliderOrientation,
+  type SliderSize,
+  type SliderTone,
+} from './Slider';
+
+// jsdom doesn't implement setPointerCapture; stub it on HTMLElement so the
+// component's try/catch fast-path is exercised (and we still get pointer
+// events).
+function ensurePointerCaptureShim() {
+  if (typeof (HTMLElement.prototype as unknown as { setPointerCapture?: unknown }).setPointerCapture !== 'function') {
+    (HTMLElement.prototype as unknown as { setPointerCapture: (id: number) => void }).setPointerCapture = () => {};
+  }
+  if (typeof (HTMLElement.prototype as unknown as { releasePointerCapture?: unknown }).releasePointerCapture !== 'function') {
+    (HTMLElement.prototype as unknown as { releasePointerCapture: (id: number) => void }).releasePointerCapture = () => {};
+  }
+}
+
+ensurePointerCaptureShim();
+
+// Helper — find thumb(s) by their role.
+function getThumbs(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('[role="slider"]'));
+}
+
+// Helper — mock the track's getBoundingClientRect so pointer-math has a known
+// canvas. Default: 100px-wide / 6px-tall horizontal track at (0, 0).
+function mockTrackRect(container: HTMLElement, opts: { width?: number; height?: number; left?: number; top?: number } = {}) {
+  const { width = 100, height = 6, left = 0, top = 0 } = opts;
+  const track = container.querySelector<HTMLElement>('[class*="track"]')!;
+  track.getBoundingClientRect = () =>
+    ({
+      width,
+      height,
+      left,
+      top,
+      right: left + width,
+      bottom: top + height,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return track;
+}
+
+describe('Slider', () => {
+  describe('rendering / structure', () => {
+    it('renders with role="slider" for single value', () => {
+      const { container } = render(<Slider value={50} onChange={() => {}} />);
+      const thumbs = getThumbs(container);
+      expect(thumbs).toHaveLength(1);
+      expect(thumbs[0]).toHaveAttribute('role', 'slider');
+    });
+
+    it('renders TWO role="slider" elements for range value', () => {
+      const { container } = render(<Slider value={[20, 80]} onChange={() => {}} />);
+      const thumbs = getThumbs(container);
+      expect(thumbs).toHaveLength(2);
+    });
+
+    it('default tone applies the tone-default class to the fill', () => {
+      const { container } = render(<Slider value={50} onChange={() => {}} />);
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).toMatch(/tone-default/);
+    });
+
+    it.each<[SliderTone, string]>([
+      ['default', 'tone-default'],
+      ['success', 'tone-success'],
+      ['warning', 'tone-warning'],
+      ['danger', 'tone-danger'],
+    ])('tone="%s" applies class %s', (toneValue, expectedClass) => {
+      const { container } = render(<Slider value={50} tone={toneValue} onChange={() => {}} />);
+      expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(expectedClass));
+    });
+
+    it.each<[SliderSize, string]>([
+      ['sm', 'size-sm'],
+      ['md', 'size-md'],
+      ['lg', 'size-lg'],
+    ])('size="%s" applies class %s', (sizeValue, expectedClass) => {
+      const { container } = render(<Slider value={50} size={sizeValue} onChange={() => {}} />);
+      expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(expectedClass));
+    });
+
+    it('default orientation is horizontal', () => {
+      const { container } = render(<Slider value={50} onChange={() => {}} />);
+      expect((container.firstChild as HTMLElement).className).toMatch(/orientation-horizontal/);
+    });
+
+    it.each<SliderOrientation>(['horizontal', 'vertical'])(
+      'orientation="%s" applies the matching class',
+      (orientationValue) => {
+        const { container } = render(
+          <Slider value={50} orientation={orientationValue} onChange={() => {}} />,
+        );
+        expect((container.firstChild as HTMLElement).className).toMatch(
+          new RegExp(`orientation-${orientationValue}`),
+        );
+      },
+    );
+
+    it('className from props merges with the base class', () => {
+      const { container } = render(
+        <Slider value={50} className="custom" onChange={() => {}} />,
+      );
+      const cls = (container.firstChild as HTMLElement).className;
+      expect(cls).toMatch(/custom/);
+      expect(cls).toMatch(/root_/);
+    });
+
+    it('forwards ref to the outermost <div>', () => {
+      const ref = createRef<HTMLDivElement>();
+      render(<Slider ref={ref} value={50} onChange={() => {}} />);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it('spreads native HTML attributes (id, data-testid, aria-label)', () => {
+      render(
+        <Slider value={50} id="vol" data-testid="s" aria-label="Volume" onChange={() => {}} />,
+      );
+      const el = screen.getByTestId('s');
+      expect(el).toHaveAttribute('id', 'vol');
+      expect(el).toHaveAttribute('aria-label', 'Volume');
+    });
+  });
+
+  describe('value / fill positioning', () => {
+    it('single value={50} (min=0 max=100): fill width is 50%, thumb left is 50%', () => {
+      const { container } = render(<Slider value={50} onChange={() => {}} />);
+      const fill = container.querySelector<HTMLElement>('[class*="fill"]')!;
+      expect(fill.style.width).toBe('50%');
+      const thumb = getThumbs(container)[0];
+      expect(thumb.style.left).toBe('50%');
+    });
+
+    it('range value=[20, 80]: fill spans 20%–80%, thumbs at 20% and 80%', () => {
+      const { container } = render(<Slider value={[20, 80]} onChange={() => {}} />);
+      const fill = container.querySelector<HTMLElement>('[class*="fill"]')!;
+      expect(fill.style.left).toBe('20%');
+      expect(fill.style.width).toBe('60%');
+      const thumbs = getThumbs(container);
+      expect(thumbs[0].style.left).toBe('20%');
+      expect(thumbs[1].style.left).toBe('80%');
+    });
+
+    it('fractional step (min=0 max=1 step=0.1 value=0.3): thumb positioned at 30%', () => {
+      const { container } = render(
+        <Slider value={0.3} min={0} max={1} step={0.1} onChange={() => {}} />,
+      );
+      const thumb = getThumbs(container)[0];
+      // Floating-point: 0.3 / 1.0 * 100 may be 30 or 29.999999... — accept both.
+      expect(thumb.style.left === '30%' || thumb.style.left === '29.999999999999996%').toBe(true);
+    });
+  });
+
+  describe('ARIA', () => {
+    it('single mode: thumb has aria-valuemin/max/now/orientation', () => {
+      const { container } = render(<Slider value={42} min={0} max={100} onChange={() => {}} />);
+      const thumb = getThumbs(container)[0];
+      expect(thumb).toHaveAttribute('aria-valuemin', '0');
+      expect(thumb).toHaveAttribute('aria-valuemax', '100');
+      expect(thumb).toHaveAttribute('aria-valuenow', '42');
+      expect(thumb).toHaveAttribute('aria-orientation', 'horizontal');
+    });
+
+    it('range mode: both thumbs have their own aria-valuenow', () => {
+      const { container } = render(<Slider value={[10, 90]} onChange={() => {}} />);
+      const thumbs = getThumbs(container);
+      expect(thumbs[0]).toHaveAttribute('aria-valuenow', '10');
+      expect(thumbs[1]).toHaveAttribute('aria-valuenow', '90');
+    });
+
+    it('disabled: aria-disabled="true" on thumbs and tabIndex=-1', () => {
+      const { container } = render(<Slider value={50} disabled onChange={() => {}} />);
+      const thumb = getThumbs(container)[0];
+      expect(thumb).toHaveAttribute('aria-disabled', 'true');
+      expect(thumb).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('orientation=vertical sets aria-orientation=vertical', () => {
+      const { container } = render(
+        <Slider value={50} orientation="vertical" onChange={() => {}} />,
+      );
+      const thumb = getThumbs(container)[0];
+      expect(thumb).toHaveAttribute('aria-orientation', 'vertical');
+    });
+
+    it('label as function sets aria-valuetext to the formatted output', () => {
+      const { container } = render(
+        <Slider value={42} label={(v) => `${v}%`} onChange={() => {}} />,
+      );
+      const thumb = getThumbs(container)[0];
+      expect(thumb).toHaveAttribute('aria-valuetext', '42%');
+    });
+
+    it('label=true: aria-valuetext is NOT set (SR uses raw aria-valuenow)', () => {
+      const { container } = render(<Slider value={42} label onChange={() => {}} />);
+      const thumb = getThumbs(container)[0];
+      expect(thumb).not.toHaveAttribute('aria-valuetext');
+    });
+  });
+
+  describe('keyboard', () => {
+    it('ArrowRight increments by step and fires onChange', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} step={5} onChange={onChange} />);
+      const thumb = getThumbs(container)[0];
+      thumb.focus();
+      fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+      expect(onChange).toHaveBeenCalledWith(55);
+    });
+
+    it('ArrowLeft decrements by step', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} step={5} onChange={onChange} />);
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'ArrowLeft' });
+      expect(onChange).toHaveBeenCalledWith(45);
+    });
+
+    it('ArrowUp increments (vertical orientation)', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <Slider value={50} step={5} orientation="vertical" onChange={onChange} />,
+      );
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'ArrowUp' });
+      expect(onChange).toHaveBeenCalledWith(55);
+    });
+
+    it('Home sets value to min', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <Slider value={50} min={0} max={100} onChange={onChange} />,
+      );
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'Home' });
+      expect(onChange).toHaveBeenCalledWith(0);
+    });
+
+    it('End sets value to max', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <Slider value={50} min={0} max={100} onChange={onChange} />,
+      );
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'End' });
+      expect(onChange).toHaveBeenCalledWith(100);
+    });
+
+    it('PageUp adds 10×step', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} step={2} onChange={onChange} />);
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'PageUp' });
+      expect(onChange).toHaveBeenCalledWith(70);
+    });
+
+    it('PageDown subtracts 10×step', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} step={2} onChange={onChange} />);
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'PageDown' });
+      expect(onChange).toHaveBeenCalledWith(30);
+    });
+
+    it('range mode: left thumb cannot cross right thumb (keyboard clamp)', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <Slider value={[40, 50]} step={20} onChange={onChange} />,
+      );
+      // ArrowRight on left thumb tries to go to 60, but it clamps to 50 (right thumb).
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'ArrowRight' });
+      expect(onChange).toHaveBeenCalledWith([50, 50]);
+    });
+
+    it('blur fires onChangeEnd ONLY when value changed during the focus session', () => {
+      const onChangeEnd = vi.fn();
+      const { container } = render(
+        <Slider value={42} step={5} onChange={() => {}} onChangeEnd={onChangeEnd} />,
+      );
+      const thumb = getThumbs(container)[0];
+      // Tab in, no nav, Tab out — no onChangeEnd fire (no value change).
+      thumb.focus();
+      thumb.blur();
+      expect(onChangeEnd).not.toHaveBeenCalled();
+      // Tab in, ArrowRight, Tab out — onChangeEnd fires.
+      thumb.focus();
+      fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+      thumb.blur();
+      expect(onChangeEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('disabled: keyboard does nothing', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} disabled onChange={onChange} />);
+      fireEvent.keyDown(getThumbs(container)[0], { key: 'ArrowRight' });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pointer / drag', () => {
+    it('track click snaps the (single) thumb to click position', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} onChange={onChange} />);
+      const track = mockTrackRect(container, { width: 100, left: 0 });
+      // Click at clientX=25 → 25% of the 100px track → value 25.
+      fireEvent.pointerDown(track, { clientX: 25, clientY: 3, pointerId: 1 });
+      expect(onChange).toHaveBeenCalledWith(25);
+    });
+
+    it('thumb pointerdown + pointermove fires onChange per move; pointerup fires onChangeEnd', () => {
+      const onChange = vi.fn();
+      const onChangeEnd = vi.fn();
+      const { container } = render(
+        <Slider value={50} onChange={onChange} onChangeEnd={onChangeEnd} />,
+      );
+      mockTrackRect(container, { width: 100, left: 0 });
+      const thumb = getThumbs(container)[0];
+      fireEvent.pointerDown(thumb, { clientX: 50, clientY: 3, pointerId: 1 });
+      fireEvent.pointerMove(thumb, { clientX: 70, clientY: 3, pointerId: 1 });
+      // 70px / 100px = 70% → value 70.
+      expect(onChange).toHaveBeenCalledWith(70);
+      fireEvent.pointerUp(thumb, { clientX: 70, clientY: 3, pointerId: 1 });
+      expect(onChangeEnd).toHaveBeenCalled();
+    });
+
+    it('range mode: pointer-dragging thumb 0 past thumb 1 clamps to thumb 1 value', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <Slider value={[20, 50]} onChange={onChange} />,
+      );
+      mockTrackRect(container, { width: 100, left: 0 });
+      const thumbs = getThumbs(container);
+      fireEvent.pointerDown(thumbs[0], { clientX: 20, clientY: 3, pointerId: 1 });
+      fireEvent.pointerMove(thumbs[0], { clientX: 80, clientY: 3, pointerId: 1 });
+      // 80 would be the natural snap; clamped to thumb 1's value of 50.
+      expect(onChange).toHaveBeenCalledWith([50, 50]);
+    });
+
+    it('disabled: pointerdown does nothing', () => {
+      const onChange = vi.fn();
+      const { container } = render(<Slider value={50} disabled onChange={onChange} />);
+      mockTrackRect(container);
+      const thumb = getThumbs(container)[0];
+      fireEvent.pointerDown(thumb, { clientX: 30, clientY: 3, pointerId: 1 });
+      fireEvent.pointerMove(thumb, { clientX: 70, clientY: 3, pointerId: 1 });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('marks + label', () => {
+    it('marks={[0, 50, 100]} renders 3 mark elements', () => {
+      const { container } = render(<Slider value={50} marks={[0, 50, 100]} onChange={() => {}} />);
+      // The mark spans match `[class*="mark"]`. Marks with values within the
+      // fill range get an extra `.markFilled` class — they're still in the
+      // selector. Count the mark spans (excluding markFilled-only matches):
+      const allMarks = container.querySelectorAll('span[class*="mark"]');
+      // Filter to spans where className contains `mark` but NOT `markLabel`.
+      const markSpans = Array.from(allMarks).filter((el) => !/markLabel/.test(el.className));
+      expect(markSpans.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('marks within the fill range get markFilled class', () => {
+      const { container } = render(
+        <Slider value={75} marks={[25, 75]} onChange={() => {}} />,
+      );
+      // Both 25 and 75 are <= 75, so both should have markFilled.
+      const filled = container.querySelectorAll('[class*="markFilled"]');
+      expect(filled.length).toBe(2);
+    });
+
+    it('label=true shows the value bubble when the thumb is focused', () => {
+      const { container } = render(<Slider value={42} label onChange={() => {}} />);
+      const thumb = getThumbs(container)[0];
+      // Direct .focus() triggers a React state update (setIsFocused); wrap in
+      // act so the render flushes before asserting.
+      act(() => { thumb.focus(); });
+      const labelEl = container.querySelector('[class*="label"]:not([class*="markLabel"])');
+      expect(labelEl).not.toBeNull();
+      expect(labelEl).toHaveTextContent('42');
+    });
+
+    it('label as function renders the formatted text', () => {
+      const { container } = render(
+        <Slider value={42} label={(v) => `${v} GB`} onChange={() => {}} />,
+      );
+      const thumb = getThumbs(container)[0];
+      // Same act-flush as above.
+      act(() => { thumb.focus(); });
+      const labelEl = container.querySelector('[class*="label"]:not([class*="markLabel"])');
+      expect(labelEl).toHaveTextContent('42 GB');
+    });
+
+    it('label=false (default): no label element rendered even when focused', () => {
+      const { container } = render(<Slider value={42} onChange={() => {}} />);
+      const thumb = getThumbs(container)[0];
+      thumb.focus();
+      // No bubble span — only the thumb itself has any "label-like" class.
+      const labelEl = container.querySelector(
+        '[class*="label"]:not([class*="markLabel"]):not([role="slider"])',
+      );
+      expect(labelEl).toBeNull();
+    });
+  });
+
+  describe('hidden form input', () => {
+    it('single mode + name="zoom": renders one hidden <input>', () => {
+      const { container } = render(<Slider value={50} name="zoom" onChange={() => {}} />);
+      const inputs = container.querySelectorAll('input[type="hidden"]');
+      expect(inputs).toHaveLength(1);
+      expect(inputs[0]).toHaveAttribute('name', 'zoom');
+      expect(inputs[0]).toHaveAttribute('value', '50');
+    });
+
+    it('range mode + name="price": renders TWO hidden inputs (price-min and price-max)', () => {
+      const { container } = render(
+        <Slider value={[10, 90]} name="price" onChange={() => {}} />,
+      );
+      const inputs = container.querySelectorAll<HTMLInputElement>('input[type="hidden"]');
+      expect(inputs).toHaveLength(2);
+      expect(inputs[0]).toHaveAttribute('name', 'price-min');
+      expect(inputs[0]).toHaveAttribute('value', '10');
+      expect(inputs[1]).toHaveAttribute('name', 'price-max');
+      expect(inputs[1]).toHaveAttribute('value', '90');
+    });
+
+    it('disabled: hidden inputs are NOT rendered (form does not submit a stale value)', () => {
+      const { container } = render(
+        <Slider value={50} name="vol" disabled onChange={() => {}} />,
+      );
+      const inputs = container.querySelectorAll('input[type="hidden"]');
+      expect(inputs).toHaveLength(0);
+    });
+  });
+});

--- a/packages/design-system/src/components/Slider/Slider.tsx
+++ b/packages/design-system/src/components/Slider/Slider.tsx
@@ -1,0 +1,572 @@
+import {
+  forwardRef,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import styles from './Slider.module.scss';
+
+/** Track height + thumb size. */
+export type SliderSize = 'sm' | 'md' | 'lg';
+
+/** Fill color tone (track between min and value). */
+export type SliderTone = 'default' | 'success' | 'warning' | 'danger';
+
+/** Layout direction. */
+export type SliderOrientation = 'horizontal' | 'vertical';
+
+/** Either a single number (single-thumb) or a [min, max] tuple (range mode). */
+export type SliderValue = number | [number, number];
+
+/** Tick-mark configuration. */
+export interface SliderMark {
+  value: number;
+  label?: ReactNode;
+}
+
+export interface SliderProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue' | 'role'> {
+  /**
+   * Current value. A single `number` for one-thumb mode; a `[min, max]` tuple
+   * for two-thumb (range) mode. The component type-discriminates internally.
+   * Required — Slider is controlled-only.
+   */
+  value: SliderValue;
+  /**
+   * Called on every thumb-drag tick (high frequency). For server-side or
+   * expensive update logic, prefer `onChangeEnd` or debounce in the consumer.
+   * The argument has the same shape as `value`: `number` for single,
+   * `[number, number]` for range.
+   */
+  onChange: (value: SliderValue) => void;
+  /**
+   * Called once when the user releases the thumb (pointerup / blur after
+   * keyboard nav). Use for committing the value to a server or running an
+   * expensive recalculation. Receives the final value with the same shape
+   * as `value`.
+   */
+  onChangeEnd?: (value: SliderValue) => void;
+  /** Minimum allowed value (inclusive). Default `0`. */
+  min?: number;
+  /** Maximum allowed value (inclusive). Default `100`. */
+  max?: number;
+  /**
+   * Step granularity. Default `1`. Use fractional steps (e.g. `0.1`) for
+   * zoom / opacity-style controls. Values are snapped to `min + (n * step)`.
+   */
+  step?: number;
+  /**
+   * Tick marks. Pass `number[]` for auto-labeled ticks (label = value) or
+   * `SliderMark[]` for custom labels (label = ReactNode). Marks render under
+   * the track (horizontal) or to the right (vertical).
+   */
+  marks?: number[] | SliderMark[];
+  /**
+   * Value bubble on the thumb.
+   * - `false` (default) — no bubble.
+   * - `true` — show the current value (formatted via `toString()`) on hover /
+   *   focus / drag. Auto-hides otherwise.
+   * - `(value: number) => ReactNode` — custom formatter. For range mode, the
+   *   formatter is called once per thumb.
+   */
+  label?: boolean | ((value: number) => ReactNode);
+  /**
+   * Track + thumb sizing. Defaults to `'md'`.
+   * - `sm` — 4px track, 14px thumb.
+   * - `md` — 6px track, 18px thumb (default).
+   * - `lg` — 8px track, 22px thumb.
+   */
+  size?: SliderSize;
+  /**
+   * Fill color tone (the track segment between min and value). Defaults to
+   * `'default'` (accent). State-coded `success` / `warning` / `danger` for
+   * threshold-style sliders (e.g. disk usage approaching capacity).
+   */
+  tone?: SliderTone;
+  /** Orientation. Defaults to `'horizontal'`. */
+  orientation?: SliderOrientation;
+  /** Disabled state. Defaults to `false`. */
+  disabled?: boolean;
+  /**
+   * Native form-input name. When set, a hidden `<input>` (or two for range,
+   * with `-min`/`-max` suffixes) is rendered with the current value(s) so
+   * the slider works inside uncontrolled HTML forms without consumer JS
+   * serialization.
+   */
+  name?: string;
+}
+
+// CSS-Modules naming note:
+// SCSS class names here are kebab-case (`.orientation-horizontal`, `.size-sm`,
+// `.tone-danger`) so the TSX can use bracket notation
+// `styles[`orientation-${o}`]` for clean orientation × size × tone × state
+// dispatch. Two-word non-prop classes (`.markFilled`, `.thumbDragging`) stay
+// camelCase. Deviates from the Progress/Title pure-camelCase + record-of-strings
+// pattern; the bigger matrix here makes bracket-access more legible.
+
+function normalizeMarks(marks: number[] | SliderMark[] | undefined): SliderMark[] {
+  if (!marks || marks.length === 0) return [];
+  return marks.map((m) => (typeof m === 'number' ? { value: m } : m));
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}
+
+function snapToStep(raw: number, min: number, step: number): number {
+  if (step <= 0) return raw;
+  const stepped = Math.round((raw - min) / step) * step + min;
+  // Floating-point: align to step's decimal precision so 0.30000000000000004 → 0.3.
+  const decimals = (step.toString().split('.')[1] ?? '').length;
+  return decimals > 0 ? Number(stepped.toFixed(decimals)) : stepped;
+}
+
+/**
+ * Controlled slider primitive supporting single (one-thumb) and range
+ * (two-thumb) modes, horizontal and vertical orientations, fractional steps,
+ * tick marks, and value bubbles. Custom-painted (not wrapping
+ * `<input type="range">`) because range mode requires two thumbs and the
+ * native input can't do that.
+ *
+ * **Controlled-only:** `value` is required and `onChange` must update the
+ * consumer's state. Pass a `number` for single mode or `[number, number]`
+ * for range — the component branches on `Array.isArray(value)`.
+ *
+ * @example
+ * // Single-thumb with fractional steps (the ImageCrop zoom case):
+ * const [zoom, setZoom] = useState(1);
+ * <Slider value={zoom} min={1} max={3} step={0.1} onChange={(v) => setZoom(v as number)} aria-label="Zoom" />
+ *
+ * @example
+ * // Range filter — price band, formatted label:
+ * const [price, setPrice] = useState<[number, number]>([0, 50000]);
+ * <Slider
+ *   value={price}
+ *   min={0}
+ *   max={100000}
+ *   step={1000}
+ *   onChange={(v) => setPrice(v as [number, number])}
+ *   label={(v) => `$${v.toLocaleString()}`}
+ * />
+ *
+ * @example
+ * // Vertical volume control with tick marks:
+ * <Slider
+ *   value={volume}
+ *   orientation="vertical"
+ *   marks={[0, 25, 50, 75, 100]}
+ *   onChange={(v) => setVolume(v as number)}
+ * />
+ *
+ * @example
+ * // Tone-coded threshold (disk usage approaching capacity):
+ * <Slider
+ *   value={usage}
+ *   tone={usage > 90 ? 'danger' : usage > 75 ? 'warning' : 'default'}
+ *   onChange={(v) => setUsage(v as number)}
+ *   label
+ * />
+ *
+ * @example
+ * // Form submission via `name` — renders hidden inputs the form will pick up:
+ * <form action="/api/settings" method="post">
+ *   <Slider name="brightness" value={brightness} onChange={setB} />
+ *   <button type="submit">Save</button>
+ * </form>
+ *
+ * @remarks When NOT to use
+ * - For binary state (on/off) — use `<Switch>` or `<Checkbox>`.
+ * - For "pick one of a small enumerated set" — use `<RadioGroup>` or `<Select>`.
+ * - For continuous color picking — that's a `<ColorPicker>` (not yet shipped).
+ * - For server-state-bound expensive updates on every move tick. Use
+ *   `onChangeEnd` or debounce.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Raw `<input type="range">` — can't do range mode, doesn't theme cleanly
+ *   across browsers, vertical orientation is hacky. Use this.
+ * - ❌ Hand-rolling drag math per page. The pointer / keyboard handling is
+ *   non-trivial; the primitive owns it.
+ * - ❌ Hitting a network endpoint inside `onChange`. The callback fires on
+ *   every pointer-move tick — use `onChangeEnd` or debounce.
+ * - ❌ `<Slider role="region">` — `role="slider"` is locked on each thumb.
+ *   The TypeScript `Omit` prevents the root override.
+ * - ❌ Passing `value[0] > value[1]` in range mode. The component clamps but
+ *   the inverted tuple is a consumer bug — fix the state shape.
+ */
+export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
+  {
+    value,
+    onChange,
+    onChangeEnd,
+    min = 0,
+    max = 100,
+    step = 1,
+    marks,
+    label = false,
+    size = 'md',
+    tone = 'default',
+    orientation = 'horizontal',
+    disabled = false,
+    name,
+    className,
+    ...rest
+  },
+  ref,
+) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const isRange = Array.isArray(value);
+  const thumbValues: number[] = isRange ? (value as [number, number]) : [value as number];
+  const thumbCount = thumbValues.length;
+  const marksArr = useMemo(() => normalizeMarks(marks), [marks]);
+  const range = max - min;
+
+  const [isDragging, setIsDragging] = useState<boolean[]>(() => new Array(thumbCount).fill(false));
+  const [isFocused, setIsFocused] = useState<boolean[]>(() => new Array(thumbCount).fill(false));
+  const [isHovered, setIsHovered] = useState<boolean[]>(() => new Array(thumbCount).fill(false));
+
+  const setFlag = useCallback(
+    (setter: typeof setIsDragging, index: number, next: boolean) => {
+      setter((prev) => {
+        const out = [...prev];
+        // Ensure the array length matches thumbCount in case value shape changed.
+        while (out.length < thumbCount) out.push(false);
+        out[index] = next;
+        return out;
+      });
+    },
+    [thumbCount],
+  );
+
+  // Convert a value (in min..max) to a percentage along the track (0..100).
+  const valueToPercent = useCallback(
+    (v: number): number => (range === 0 ? 0 : clamp(((v - min) / range) * 100, 0, 100)),
+    [min, range],
+  );
+
+  // Compute the next value for a given thumb when the user moves the pointer to
+  // `clientX` / `clientY`. Returns null if the track has no measured length yet.
+  const pointerToValue = useCallback(
+    (clientX: number, clientY: number, thumbIndex: number): number | null => {
+      const trackEl = trackRef.current;
+      if (!trackEl) return null;
+      const rect = trackEl.getBoundingClientRect();
+      const lengthPx = orientation === 'horizontal' ? rect.width : rect.height;
+      if (lengthPx === 0) return null;
+      const pointerPos =
+        orientation === 'horizontal' ? clientX - rect.left : rect.bottom - clientY;
+      const pct = clamp(pointerPos / lengthPx, 0, 1);
+      const raw = min + pct * range;
+      const snapped = clamp(snapToStep(raw, min, step), min, max);
+      // Range clamp: thumb 0 can't exceed thumb 1; thumb 1 can't go below thumb 0.
+      if (isRange) {
+        const [v0, v1] = value as [number, number];
+        if (thumbIndex === 0) return Math.min(snapped, v1);
+        return Math.max(snapped, v0);
+      }
+      return snapped;
+    },
+    [isRange, max, min, orientation, range, step, value],
+  );
+
+  // Apply a new thumb value and fire onChange with the appropriate shape.
+  const applyThumbValue = useCallback(
+    (thumbIndex: number, newValue: number) => {
+      if (isRange) {
+        const tuple = [...(value as [number, number])] as [number, number];
+        tuple[thumbIndex] = newValue;
+        onChange(tuple);
+      } else {
+        onChange(newValue);
+      }
+    },
+    [isRange, onChange, value],
+  );
+
+  const handleThumbPointerDown = useCallback(
+    (e: PointerEvent<HTMLDivElement>, thumbIndex: number) => {
+      if (disabled) return;
+      e.preventDefault();
+      // setPointerCapture: future pointermove/up fire on this element even if
+      // the pointer leaves it. Wrapped in try/catch because jsdom may not
+      // implement setPointerCapture — we still get pointermove on the element
+      // in test environments.
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        // jsdom or pre-PointerEvents browsers — drag still works via pointermove.
+      }
+      setFlag(setIsDragging, thumbIndex, true);
+    },
+    [disabled, setFlag],
+  );
+
+  const handleThumbPointerMove = useCallback(
+    (e: PointerEvent<HTMLDivElement>, thumbIndex: number) => {
+      if (disabled || !isDragging[thumbIndex]) return;
+      const next = pointerToValue(e.clientX, e.clientY, thumbIndex);
+      if (next === null) return;
+      // Only fire onChange when the value actually changes (avoids identity-thrash
+      // when the pointer moves within the same step bucket).
+      const current = thumbValues[thumbIndex];
+      if (next !== current) applyThumbValue(thumbIndex, next);
+    },
+    [applyThumbValue, disabled, isDragging, pointerToValue, thumbValues],
+  );
+
+  const handleThumbPointerUp = useCallback(
+    (e: PointerEvent<HTMLDivElement>, thumbIndex: number) => {
+      if (disabled || !isDragging[thumbIndex]) return;
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // ignore — same rationale as pointerdown.
+      }
+      setFlag(setIsDragging, thumbIndex, false);
+      onChangeEnd?.(value);
+    },
+    [disabled, isDragging, onChangeEnd, setFlag, value],
+  );
+
+  const handleThumbKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>, thumbIndex: number) => {
+      if (disabled) return;
+      let delta = 0;
+      let absolute: number | null = null;
+      switch (e.key) {
+        case 'ArrowLeft':
+        case 'ArrowDown':
+          delta = -step;
+          break;
+        case 'ArrowRight':
+        case 'ArrowUp':
+          delta = step;
+          break;
+        case 'PageDown':
+          delta = -step * 10;
+          break;
+        case 'PageUp':
+          delta = step * 10;
+          break;
+        case 'Home':
+          absolute = min;
+          break;
+        case 'End':
+          absolute = max;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      const current = thumbValues[thumbIndex];
+      let next = absolute !== null ? absolute : current + delta;
+      next = clamp(snapToStep(next, min, step), min, max);
+      if (isRange) {
+        const [v0, v1] = value as [number, number];
+        if (thumbIndex === 0) next = Math.min(next, v1);
+        else next = Math.max(next, v0);
+      }
+      if (next !== current) applyThumbValue(thumbIndex, next);
+    },
+    [applyThumbValue, disabled, isRange, max, min, step, thumbValues, value],
+  );
+
+  const handleThumbBlur = useCallback(
+    (thumbIndex: number) => {
+      setFlag(setIsFocused, thumbIndex, false);
+      // onChangeEnd on blur covers the keyboard-nav case where there's no
+      // pointerup to fire it. Always fires on blur regardless of whether the
+      // value actually changed — consumers debounce themselves if needed.
+      onChangeEnd?.(value);
+    },
+    [onChangeEnd, setFlag, value],
+  );
+
+  // Track click: pick the nearest thumb (by current value distance to the
+  // click's projected value) and snap it. Range mode picks by distance; single
+  // mode always snaps the one thumb. Click on a thumb itself (descendant) is
+  // ignored — the thumb's pointerdown handles its own state.
+  const handleTrackPointerDown = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      // Don't override a thumb's own pointerdown (which bubbles up here).
+      if ((e.target as HTMLElement).closest(`.${styles.thumb}`)) return;
+      const target = pointerToValue(e.clientX, e.clientY, 0);
+      if (target === null) return;
+      let nearestIndex = 0;
+      if (isRange) {
+        const d0 = Math.abs((value as [number, number])[0] - target);
+        const d1 = Math.abs((value as [number, number])[1] - target);
+        nearestIndex = d1 < d0 ? 1 : 0;
+      }
+      // Recompute the snap WITH the chosen thumb index so the range-clamp uses
+      // the right "other thumb" reference.
+      const next = pointerToValue(e.clientX, e.clientY, nearestIndex);
+      if (next === null) return;
+      applyThumbValue(nearestIndex, next);
+      // Optionally: focus the moved thumb so the user can keyboard-nudge from
+      // the new position. Querying by selector since we don't keep a thumb ref.
+      const thumbEl = e.currentTarget
+        .closest(`.${styles.root}`)
+        ?.querySelectorAll<HTMLDivElement>(`.${styles.thumb}`)[nearestIndex];
+      thumbEl?.focus();
+    },
+    [applyThumbValue, disabled, isRange, pointerToValue, value],
+  );
+
+  // Style helpers — positions in percent of the track length.
+  const fillStyle: CSSProperties = useMemo(() => {
+    if (isRange) {
+      const [v0, v1] = value as [number, number];
+      const startPct = valueToPercent(v0);
+      const endPct = valueToPercent(v1);
+      return orientation === 'horizontal'
+        ? { left: `${startPct}%`, width: `${endPct - startPct}%` }
+        : { bottom: `${startPct}%`, height: `${endPct - startPct}%` };
+    }
+    const endPct = valueToPercent(value as number);
+    return orientation === 'horizontal'
+      ? { left: '0%', width: `${endPct}%` }
+      : { bottom: '0%', height: `${endPct}%` };
+  }, [isRange, orientation, value, valueToPercent]);
+
+  const thumbStyle = useCallback(
+    (v: number): CSSProperties => {
+      const pct = valueToPercent(v);
+      return orientation === 'horizontal' ? { left: `${pct}%` } : { bottom: `${pct}%` };
+    },
+    [orientation, valueToPercent],
+  );
+
+  const markStyle = useCallback(
+    (m: SliderMark): CSSProperties => {
+      const pct = valueToPercent(m.value);
+      return orientation === 'horizontal' ? { left: `${pct}%` } : { bottom: `${pct}%` };
+    },
+    [orientation, valueToPercent],
+  );
+
+  const isMarkInFill = useCallback(
+    (m: SliderMark): boolean => {
+      if (isRange) {
+        const [v0, v1] = value as [number, number];
+        return m.value >= v0 && m.value <= v1;
+      }
+      return m.value <= (value as number);
+    },
+    [isRange, value],
+  );
+
+  const formatLabel = useCallback(
+    (v: number): ReactNode => {
+      if (label === true) return String(v);
+      if (typeof label === 'function') return label(v);
+      return null;
+    },
+    [label],
+  );
+
+  const showLabelFor = useCallback(
+    (index: number): boolean => {
+      if (label === false) return false;
+      return Boolean(isDragging[index] || isFocused[index] || isHovered[index]);
+    },
+    [isDragging, isFocused, isHovered, label],
+  );
+
+  // {...rest} last so consumer overrides win (Pattern A). `role` is Omit'd
+  // from rest at the type level so consumers can't override the slider thumb
+  // role contract.
+  return (
+    <div
+      ref={ref}
+      className={clsx(
+        styles.root,
+        styles[`orientation-${orientation}`],
+        styles[`size-${size}`],
+        styles[`tone-${tone}`],
+        disabled && styles.disabled,
+        className,
+      )}
+      {...rest}
+    >
+      <div
+        ref={trackRef}
+        className={styles.track}
+        onPointerDown={handleTrackPointerDown}
+      >
+        <div className={styles.fill} style={fillStyle} />
+        {marksArr.map((mark) => (
+          <span
+            key={mark.value}
+            className={clsx(styles.mark, isMarkInFill(mark) && styles.markFilled)}
+            style={markStyle(mark)}
+          >
+            {mark.label !== undefined && (
+              <span className={styles.markLabel}>{mark.label ?? mark.value}</span>
+            )}
+          </span>
+        ))}
+      </div>
+      {thumbValues.map((thumbValue, index) => (
+        <div
+          key={index}
+          role="slider"
+          tabIndex={disabled ? -1 : 0}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={thumbValue}
+          aria-valuetext={
+            typeof label === 'function' ? String(label(thumbValue)) : undefined
+          }
+          aria-orientation={orientation}
+          aria-disabled={disabled || undefined}
+          className={clsx(styles.thumb, isDragging[index] && styles.thumbDragging)}
+          style={thumbStyle(thumbValue)}
+          onPointerDown={(e) => handleThumbPointerDown(e, index)}
+          onPointerMove={(e) => handleThumbPointerMove(e, index)}
+          onPointerUp={(e) => handleThumbPointerUp(e, index)}
+          onPointerEnter={() => setFlag(setIsHovered, index, true)}
+          onPointerLeave={() => setFlag(setIsHovered, index, false)}
+          onFocus={() => setFlag(setIsFocused, index, true)}
+          onBlur={() => handleThumbBlur(index)}
+          onKeyDown={(e) => handleThumbKeyDown(e, index)}
+        >
+          {showLabelFor(index) && (
+            <span className={styles.label}>{formatLabel(thumbValue)}</span>
+          )}
+        </div>
+      ))}
+      {name &&
+        (isRange ? (
+          <>
+            <input
+              type="hidden"
+              name={`${name}-min`}
+              value={(value as [number, number])[0]}
+              disabled={disabled || undefined}
+            />
+            <input
+              type="hidden"
+              name={`${name}-max`}
+              value={(value as [number, number])[1]}
+              disabled={disabled || undefined}
+            />
+          </>
+        ) : (
+          <input
+            type="hidden"
+            name={name}
+            value={value as number}
+            disabled={disabled || undefined}
+          />
+        ))}
+    </div>
+  );
+});

--- a/packages/design-system/src/components/Slider/Slider.tsx
+++ b/packages/design-system/src/components/Slider/Slider.tsx
@@ -47,10 +47,12 @@ export interface SliderProps
    */
   onChange: (value: SliderValue) => void;
   /**
-   * Called once when the user releases the thumb (pointerup / blur after
-   * keyboard nav). Use for committing the value to a server or running an
-   * expensive recalculation. Receives the final value with the same shape
-   * as `value`.
+   * Called once when the user "commits" a value change — at pointerup
+   * after a drag, or at blur after keyboard-nav that actually changed
+   * the value. Does NOT fire on Tab-in / Tab-out without any value
+   * change. Use for committing the value to a server or running an
+   * expensive recalculation. Receives the final value with the same
+   * shape as `value`.
    */
   onChangeEnd?: (value: SliderValue) => void;
   /** Minimum allowed value (inclusive). Default `0`. */
@@ -98,7 +100,8 @@ export interface SliderProps
    * Native form-input name. When set, a hidden `<input>` (or two for range,
    * with `-min`/`-max` suffixes) is rendered with the current value(s) so
    * the slider works inside uncontrolled HTML forms without consumer JS
-   * serialization.
+   * serialization. When the slider is `disabled`, the hidden input(s) are
+   * NOT rendered so the form does not submit a stale disabled value.
    */
   name?: string;
 }
@@ -227,15 +230,49 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
   const marksArr = useMemo(() => normalizeMarks(marks), [marks]);
   const range = max - min;
 
+  // Latest value ref — updated on every render. Read synchronously inside
+  // event handlers (e.g. onChangeEnd at pointerup) so they see the post-drag
+  // value, not the render-time closure capture. Critical for fast drags where
+  // pointermove fires multiple updates between renders.
+  const latestValueRef = useRef(value);
+  latestValueRef.current = value;
+
+  // isDraggingRef: read synchronously inside event handlers (no state batching
+  // race between pointerdown setting and pointermove reading).
+  // isDragging (state): drives the .thumbDragging className re-render. Both are
+  // updated together in setDragging().
+  const isDraggingRef = useRef<boolean[]>(new Array(thumbCount).fill(false));
   const [isDragging, setIsDragging] = useState<boolean[]>(() => new Array(thumbCount).fill(false));
   const [isFocused, setIsFocused] = useState<boolean[]>(() => new Array(thumbCount).fill(false));
   const [isHovered, setIsHovered] = useState<boolean[]>(() => new Array(thumbCount).fill(false));
 
+  // Whether the value changed during the current focus session (for any
+  // reason: drag OR keyboard nav). Reset to false on focus. Set true on every
+  // applyThumbValue call. Read by handleThumbBlur to decide whether to fire
+  // onChangeEnd — prevents the "Tab in / Tab out without nav" no-op fire AND
+  // the "drag + Tab" double fire.
+  const valueChangedThisFocusRef = useRef(false);
+
   const setFlag = useCallback(
-    (setter: typeof setIsDragging, index: number, next: boolean) => {
+    (setter: typeof setIsFocused, index: number, next: boolean) => {
       setter((prev) => {
         const out = [...prev];
         // Ensure the array length matches thumbCount in case value shape changed.
+        while (out.length < thumbCount) out.push(false);
+        out[index] = next;
+        return out;
+      });
+    },
+    [thumbCount],
+  );
+
+  const setDragging = useCallback(
+    (index: number, next: boolean) => {
+      // Pad the ref array if the value shape changed (range → single transitions).
+      while (isDraggingRef.current.length < thumbCount) isDraggingRef.current.push(false);
+      isDraggingRef.current[index] = next;
+      setIsDragging((prev) => {
+        const out = [...prev];
         while (out.length < thumbCount) out.push(false);
         out[index] = next;
         return out;
@@ -285,6 +322,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
       } else {
         onChange(newValue);
       }
+      valueChangedThisFocusRef.current = true;
     },
     [isRange, onChange, value],
   );
@@ -302,36 +340,41 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
       } catch {
         // jsdom or pre-PointerEvents browsers — drag still works via pointermove.
       }
-      setFlag(setIsDragging, thumbIndex, true);
+      setDragging(thumbIndex, true);
     },
-    [disabled, setFlag],
+    [disabled, setDragging],
   );
 
   const handleThumbPointerMove = useCallback(
     (e: PointerEvent<HTMLDivElement>, thumbIndex: number) => {
-      if (disabled || !isDragging[thumbIndex]) return;
+      if (disabled || !isDraggingRef.current[thumbIndex]) return;
       const next = pointerToValue(e.clientX, e.clientY, thumbIndex);
       if (next === null) return;
-      // Only fire onChange when the value actually changes (avoids identity-thrash
-      // when the pointer moves within the same step bucket).
-      const current = thumbValues[thumbIndex];
+      // Read the LATEST value from the ref (not the closure-captured one) so
+      // the duplicate-fire guard works correctly across batched renders.
+      const latest = latestValueRef.current;
+      const current = Array.isArray(latest) ? latest[thumbIndex] : latest;
       if (next !== current) applyThumbValue(thumbIndex, next);
     },
-    [applyThumbValue, disabled, isDragging, pointerToValue, thumbValues],
+    [applyThumbValue, disabled, pointerToValue],
   );
 
   const handleThumbPointerUp = useCallback(
     (e: PointerEvent<HTMLDivElement>, thumbIndex: number) => {
-      if (disabled || !isDragging[thumbIndex]) return;
+      if (disabled || !isDraggingRef.current[thumbIndex]) return;
       try {
         e.currentTarget.releasePointerCapture(e.pointerId);
       } catch {
         // ignore — same rationale as pointerdown.
       }
-      setFlag(setIsDragging, thumbIndex, false);
-      onChangeEnd?.(value);
+      setDragging(thumbIndex, false);
+      // Fire with the latest value (post-drag), not the closure capture.
+      onChangeEnd?.(latestValueRef.current);
+      // Reset the focus-session flag — pointerup already fired onChangeEnd, so
+      // subsequent blur (e.g. Tab out) shouldn't fire it again.
+      valueChangedThisFocusRef.current = false;
     },
-    [disabled, isDragging, onChangeEnd, setFlag, value],
+    [disabled, onChangeEnd, setDragging],
   );
 
   const handleThumbKeyDown = useCallback(
@@ -380,12 +423,16 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
   const handleThumbBlur = useCallback(
     (thumbIndex: number) => {
       setFlag(setIsFocused, thumbIndex, false);
-      // onChangeEnd on blur covers the keyboard-nav case where there's no
-      // pointerup to fire it. Always fires on blur regardless of whether the
-      // value actually changed — consumers debounce themselves if needed.
-      onChangeEnd?.(value);
+      // Only fire onChangeEnd if the value actually changed during this focus
+      // session. Pointerup already fires onChangeEnd directly; blur covers the
+      // keyboard-nav case (Tab out after Arrow nav). Tab-in / Tab-out without
+      // any nav does NOT fire (no change, no fire).
+      if (valueChangedThisFocusRef.current) {
+        onChangeEnd?.(latestValueRef.current);
+        valueChangedThisFocusRef.current = false;
+      }
     },
-    [onChangeEnd, setFlag, value],
+    [onChangeEnd, setFlag],
   );
 
   // Track click: pick the nearest thumb (by current value distance to the
@@ -534,7 +581,10 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
           onPointerUp={(e) => handleThumbPointerUp(e, index)}
           onPointerEnter={() => setFlag(setIsHovered, index, true)}
           onPointerLeave={() => setFlag(setIsHovered, index, false)}
-          onFocus={() => setFlag(setIsFocused, index, true)}
+          onFocus={() => {
+            setFlag(setIsFocused, index, true);
+            valueChangedThisFocusRef.current = false;
+          }}
           onBlur={() => handleThumbBlur(index)}
           onKeyDown={(e) => handleThumbKeyDown(e, index)}
         >
@@ -544,28 +594,22 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
         </div>
       ))}
       {name &&
+        !disabled &&
         (isRange ? (
           <>
             <input
               type="hidden"
               name={`${name}-min`}
               value={(value as [number, number])[0]}
-              disabled={disabled || undefined}
             />
             <input
               type="hidden"
               name={`${name}-max`}
               value={(value as [number, number])[1]}
-              disabled={disabled || undefined}
             />
           </>
         ) : (
-          <input
-            type="hidden"
-            name={name}
-            value={value as number}
-            disabled={disabled || undefined}
-          />
+          <input type="hidden" name={name} value={value as number} />
         ))}
     </div>
   );

--- a/packages/design-system/src/components/Slider/Slider.tsx
+++ b/packages/design-system/src/components/Slider/Slider.tsx
@@ -27,7 +27,14 @@ export type SliderValue = number | [number, number];
 
 /** Tick-mark configuration. */
 export interface SliderMark {
+  /** Numeric position of the tick along the track (in min..max units). */
   value: number;
+  /**
+   * Optional label rendered below (horizontal) or to the right (vertical)
+   * of the tick. When omitted, only the tick line renders — no text.
+   * When `marks` is passed as `number[]`, the label is auto-set to the
+   * value so consumers don't have to wrap each tick in an object.
+   */
   label?: ReactNode;
 }
 
@@ -116,7 +123,9 @@ export interface SliderProps
 
 function normalizeMarks(marks: number[] | SliderMark[] | undefined): SliderMark[] {
   if (!marks || marks.length === 0) return [];
-  return marks.map((m) => (typeof m === 'number' ? { value: m } : m));
+  // For number[] input, auto-label with the value itself. For SliderMark[]
+  // input, keep `label` as-passed (may be undefined → no label rendered).
+  return marks.map((m) => (typeof m === 'number' ? { value: m, label: m } : m));
 }
 
 function clamp(n: number, lo: number, hi: number): number {
@@ -368,11 +377,13 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
         // ignore — same rationale as pointerdown.
       }
       setDragging(thumbIndex, false);
-      // Fire with the latest value (post-drag), not the closure capture.
-      onChangeEnd?.(latestValueRef.current);
-      // Reset the focus-session flag — pointerup already fired onChangeEnd, so
-      // subsequent blur (e.g. Tab out) shouldn't fire it again.
-      valueChangedThisFocusRef.current = false;
+      // Fire onChangeEnd only if the value actually changed during the drag —
+      // a click-without-movement (pointerdown → pointerup, no pointermove)
+      // shouldn't be a "commit" event.
+      if (valueChangedThisFocusRef.current) {
+        onChangeEnd?.(latestValueRef.current);
+        valueChangedThisFocusRef.current = false;
+      }
     },
     [disabled, onChangeEnd, setDragging],
   );
@@ -556,7 +567,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
             style={markStyle(mark)}
           >
             {mark.label !== undefined && (
-              <span className={styles.markLabel}>{mark.label ?? mark.value}</span>
+              <span className={styles.markLabel}>{mark.label}</span>
             )}
           </span>
         ))}
@@ -574,6 +585,14 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
           }
           aria-orientation={orientation}
           aria-disabled={disabled || undefined}
+          aria-label={
+            // Forward the root's aria-label to each thumb so screen readers
+            // announce the slider's name when a thumb is focused (WAI-ARIA APG
+            // requires each role=slider to be labeled). Per-thumb labels for
+            // range mode (e.g. "Minimum"/"Maximum") are deferred to v2.
+            (rest as { 'aria-label'?: string })['aria-label']
+          }
+          aria-labelledby={(rest as { 'aria-labelledby'?: string })['aria-labelledby']}
           className={clsx(styles.thumb, isDragging[index] && styles.thumbDragging)}
           style={thumbStyle(thumbValue)}
           onPointerDown={(e) => handleThumbPointerDown(e, index)}

--- a/packages/design-system/src/components/Slider/Slider.tsx
+++ b/packages/design-system/src/components/Slider/Slider.tsx
@@ -38,8 +38,10 @@ export interface SliderMark {
   label?: ReactNode;
 }
 
-export interface SliderProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue' | 'role'> {
+export interface SliderProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'defaultValue' | 'role'
+> {
   /**
    * Current value. A single `number` for one-thumb mode; a `[min, max]` tuple
    * for two-thumb (range) mode. The component type-discriminates internally.
@@ -305,8 +307,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
       const rect = trackEl.getBoundingClientRect();
       const lengthPx = orientation === 'horizontal' ? rect.width : rect.height;
       if (lengthPx === 0) return null;
-      const pointerPos =
-        orientation === 'horizontal' ? clientX - rect.left : rect.bottom - clientY;
+      const pointerPos = orientation === 'horizontal' ? clientX - rect.left : rect.bottom - clientY;
       const pct = clamp(pointerPos / lengthPx, 0, 1);
       const raw = min + pct * range;
       const snapped = clamp(snapToStep(raw, min, step), min, max);
@@ -554,11 +555,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
       )}
       {...rest}
     >
-      <div
-        ref={trackRef}
-        className={styles.track}
-        onPointerDown={handleTrackPointerDown}
-      >
+      <div ref={trackRef} className={styles.track} onPointerDown={handleTrackPointerDown}>
         <div className={styles.fill} style={fillStyle} />
         {marksArr.map((mark) => (
           <span
@@ -566,9 +563,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
             className={clsx(styles.mark, isMarkInFill(mark) && styles.markFilled)}
             style={markStyle(mark)}
           >
-            {mark.label !== undefined && (
-              <span className={styles.markLabel}>{mark.label}</span>
-            )}
+            {mark.label !== undefined && <span className={styles.markLabel}>{mark.label}</span>}
           </span>
         ))}
       </div>
@@ -580,9 +575,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
           aria-valuemin={min}
           aria-valuemax={max}
           aria-valuenow={thumbValue}
-          aria-valuetext={
-            typeof label === 'function' ? String(label(thumbValue)) : undefined
-          }
+          aria-valuetext={typeof label === 'function' ? String(label(thumbValue)) : undefined}
           aria-orientation={orientation}
           aria-disabled={disabled || undefined}
           aria-label={
@@ -607,25 +600,15 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
           onBlur={() => handleThumbBlur(index)}
           onKeyDown={(e) => handleThumbKeyDown(e, index)}
         >
-          {showLabelFor(index) && (
-            <span className={styles.label}>{formatLabel(thumbValue)}</span>
-          )}
+          {showLabelFor(index) && <span className={styles.label}>{formatLabel(thumbValue)}</span>}
         </div>
       ))}
       {name &&
         !disabled &&
         (isRange ? (
           <>
-            <input
-              type="hidden"
-              name={`${name}-min`}
-              value={(value as [number, number])[0]}
-            />
-            <input
-              type="hidden"
-              name={`${name}-max`}
-              value={(value as [number, number])[1]}
-            />
+            <input type="hidden" name={`${name}-min`} value={(value as [number, number])[0]} />
+            <input type="hidden" name={`${name}-max`} value={(value as [number, number])[1]} />
           </>
         ) : (
           <input type="hidden" name={name} value={value as number} />

--- a/packages/design-system/src/components/Slider/index.ts
+++ b/packages/design-system/src/components/Slider/index.ts
@@ -1,0 +1,9 @@
+export { Slider } from './Slider';
+export type {
+  SliderProps,
+  SliderValue,
+  SliderSize,
+  SliderTone,
+  SliderOrientation,
+  SliderMark,
+} from './Slider';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -193,6 +193,16 @@ export type {
 export { Skeleton } from './components/Skeleton';
 export type { SkeletonProps, SkeletonVariant, SkeletonAnimation } from './components/Skeleton';
 
+export { Slider } from './components/Slider';
+export type {
+  SliderProps,
+  SliderValue,
+  SliderSize,
+  SliderTone,
+  SliderOrientation,
+  SliderMark,
+} from './components/Slider';
+
 export { Table } from './components/Table';
 export type {
   TableProps,

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -21,6 +21,7 @@ import { ProgressDemo } from './pages/components/ProgressDemo';
 import { CircularProgressDemo } from './pages/components/CircularProgressDemo';
 import { SelectDemo } from './pages/components/SelectDemo';
 import { SkeletonDemo } from './pages/components/SkeletonDemo';
+import { SliderDemo } from './pages/components/SliderDemo';
 import { SwitchDemo } from './pages/components/SwitchDemo';
 import { TableDemo } from './pages/components/TableDemo';
 import { TextareaDemo } from './pages/components/TextareaDemo';
@@ -83,6 +84,7 @@ export default function App() {
           />
           <Route path="/components/select" element={<SelectDemo />} />
           <Route path="/components/skeleton" element={<SkeletonDemo />} />
+          <Route path="/components/slider" element={<SliderDemo />} />
           <Route path="/components/switch" element={<SwitchDemo />} />
           <Route path="/components/table" element={<TableDemo />} />
           <Route path="/components/card" element={<CardDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -51,6 +51,7 @@ import {
   Activity,
   LoaderCircle,
   UploadCloud,
+  SlidersHorizontal,
   type LucideIcon,
 } from 'lucide-react';
 import { Avatar } from '@eocrm/design-system';
@@ -101,6 +102,7 @@ const componentGroups = [
       },
       { to: '/components/radio', label: 'Radio', icon: CircleDot, end: false },
       { to: '/components/select', label: 'Select', icon: ChevronsUpDown, end: false },
+      { to: '/components/slider', label: 'Slider', icon: SlidersHorizontal, end: false },
       { to: '/components/switch', label: 'Switch', icon: ToggleRight, end: false },
       { to: '/components/textarea', label: 'Textarea', icon: MessageSquareText, end: false },
     ],

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -265,7 +265,8 @@ const items: { to: string; name: string; description: string; preview: React.Rea
   {
     to: '/components/slider',
     name: 'Slider',
-    description: 'Controlled slider: single-thumb or range (two-thumb), horizontal or vertical. Custom-painted with marks + value bubble.',
+    description:
+      'Controlled slider: single-thumb or range (two-thumb), horizontal or vertical. Custom-painted with marks + value bubble.',
     preview: (
       <div style={{ width: '100%', maxWidth: 220 }}>
         <Slider value={42} onChange={() => {}} aria-label="preview" />

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -23,6 +23,7 @@ import { PasswordInput } from '@eocrm/design-system';
 import { PasswordStrengthMeter } from '@eocrm/design-system';
 import { Select } from '@eocrm/design-system';
 import { Skeleton } from '@eocrm/design-system';
+import { Slider } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { Switch } from '@eocrm/design-system';
 import { Table } from '@eocrm/design-system';
@@ -259,6 +260,16 @@ const items: { to: string; name: string; description: string; preview: React.Rea
         <Skeleton width="60%" />
         <Skeleton width="40%" />
       </Stack>
+    ),
+  },
+  {
+    to: '/components/slider',
+    name: 'Slider',
+    description: 'Controlled slider: single-thumb or range (two-thumb), horizontal or vertical. Custom-painted with marks + value bubble.',
+    preview: (
+      <div style={{ width: '100%', maxWidth: 220 }}>
+        <Slider value={42} onChange={() => {}} aria-label="preview" />
+      </div>
     ),
   },
   {

--- a/packages/playground/src/pages/components/SliderDemo.tsx
+++ b/packages/playground/src/pages/components/SliderDemo.tsx
@@ -56,10 +56,30 @@ function Tones() {
   const [value, setValue] = useState(75);
   return (
     <Stack gap="md">
-      <Slider value={value} tone="default" onChange={(v) => setValue(v as number)} aria-label="default" />
-      <Slider value={value} tone="success" onChange={(v) => setValue(v as number)} aria-label="success" />
-      <Slider value={value} tone="warning" onChange={(v) => setValue(v as number)} aria-label="warning" />
-      <Slider value={value} tone="danger" onChange={(v) => setValue(v as number)} aria-label="danger" />
+      <Slider
+        value={value}
+        tone="default"
+        onChange={(v) => setValue(v as number)}
+        aria-label="default"
+      />
+      <Slider
+        value={value}
+        tone="success"
+        onChange={(v) => setValue(v as number)}
+        aria-label="success"
+      />
+      <Slider
+        value={value}
+        tone="warning"
+        onChange={(v) => setValue(v as number)}
+        aria-label="warning"
+      />
+      <Slider
+        value={value}
+        tone="danger"
+        onChange={(v) => setValue(v as number)}
+        aria-label="danger"
+      />
     </Stack>
   );
 }

--- a/packages/playground/src/pages/components/SliderDemo.tsx
+++ b/packages/playground/src/pages/components/SliderDemo.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react';
+import { Slider } from '@eocrm/design-system';
+import { Stack } from '@eocrm/design-system';
+import { Cluster } from '@eocrm/design-system';
+import { Text } from '@eocrm/design-system';
+import { Code } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Slider/Slider.tsx?raw';
+import scssSource from '@lib-source/components/Slider/Slider.module.scss?raw';
+
+function BasicSingle() {
+  const [value, setValue] = useState(50);
+  return (
+    <Stack gap="sm">
+      <Slider value={value} onChange={(v) => setValue(v as number)} aria-label="Volume" />
+      <Text size="sm" tone="muted">
+        Current value: <Code>{value}</Code>
+      </Text>
+    </Stack>
+  );
+}
+
+function RangeFilter() {
+  const [range, setRange] = useState<[number, number]>([20000, 80000]);
+  return (
+    <Stack gap="sm">
+      <Slider
+        value={range}
+        min={0}
+        max={100000}
+        step={1000}
+        label={(v) => `$${v.toLocaleString()}`}
+        onChange={(v) => setRange(v as [number, number])}
+        aria-label="Price range"
+      />
+      <Text size="sm" tone="muted">
+        Range: <Code>${range[0].toLocaleString()}</Code> – <Code>${range[1].toLocaleString()}</Code>
+      </Text>
+    </Stack>
+  );
+}
+
+function Sizes() {
+  const [value, setValue] = useState(50);
+  return (
+    <Stack gap="md">
+      <Slider value={value} size="sm" onChange={(v) => setValue(v as number)} aria-label="sm" />
+      <Slider value={value} size="md" onChange={(v) => setValue(v as number)} aria-label="md" />
+      <Slider value={value} size="lg" onChange={(v) => setValue(v as number)} aria-label="lg" />
+    </Stack>
+  );
+}
+
+function Tones() {
+  const [value, setValue] = useState(75);
+  return (
+    <Stack gap="md">
+      <Slider value={value} tone="default" onChange={(v) => setValue(v as number)} aria-label="default" />
+      <Slider value={value} tone="success" onChange={(v) => setValue(v as number)} aria-label="success" />
+      <Slider value={value} tone="warning" onChange={(v) => setValue(v as number)} aria-label="warning" />
+      <Slider value={value} tone="danger" onChange={(v) => setValue(v as number)} aria-label="danger" />
+    </Stack>
+  );
+}
+
+function Marks() {
+  const [value, setValue] = useState(50);
+  return (
+    <Slider
+      value={value}
+      marks={[0, 25, 50, 75, 100]}
+      onChange={(v) => setValue(v as number)}
+      aria-label="With marks"
+    />
+  );
+}
+
+function Vertical() {
+  const [value, setValue] = useState(60);
+  return (
+    <Cluster gap="lg" align="center">
+      <Slider
+        value={value}
+        orientation="vertical"
+        marks={[0, 25, 50, 75, 100]}
+        onChange={(v) => setValue(v as number)}
+        aria-label="Vertical volume"
+      />
+      <Text size="sm" tone="muted">
+        Current: <Code>{value}</Code>
+      </Text>
+    </Cluster>
+  );
+}
+
+function FractionalStep() {
+  const [zoom, setZoom] = useState(1.5);
+  return (
+    <Stack gap="sm">
+      <Slider
+        value={zoom}
+        min={1}
+        max={3}
+        step={0.1}
+        label
+        onChange={(v) => setZoom(v as number)}
+        aria-label="Zoom"
+      />
+      <Text size="sm" tone="muted">
+        Zoom: <Code>{zoom.toFixed(1)}×</Code>
+      </Text>
+    </Stack>
+  );
+}
+
+function DisabledDemo() {
+  return <Slider value={50} disabled onChange={() => {}} aria-label="Disabled" />;
+}
+
+export function SliderDemo() {
+  return (
+    <DemoLayout
+      name="Slider"
+      description="Controlled slider primitive. Single-thumb (value: number) or range (value: [number, number]). Horizontal or vertical. Custom-painted with manual ARIA per thumb."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Slider.tsx"
+      scssFilename="Slider.module.scss"
+      componentName="Slider"
+    >
+      <Example
+        title="Basic single-thumb"
+        description="Default props (min=0, max=100, step=1). Controlled state with one number."
+        code={`function BasicSingle() {
+  const [value, setValue] = useState(50);
+  return (
+    <Slider value={value} onChange={(v) => setValue(v as number)} aria-label="Volume" />
+  );
+}`}
+      >
+        <BasicSingle />
+      </Example>
+
+      <Example
+        title="Range mode (two thumbs)"
+        description="Pass a [min, max] tuple as value → two thumbs. Range-clamp ensures value[0] ≤ value[1]. Formatted label."
+        code={`<Slider
+  value={[20000, 80000]}
+  min={0} max={100000} step={1000}
+  label={(v) => \`$\${v.toLocaleString()}\`}
+  onChange={(v) => setRange(v as [number, number])}
+/>`}
+      >
+        <RangeFilter />
+      </Example>
+
+      <Example
+        title="Sizes"
+        description="Three sizes: sm (4/14), md (6/18, default), lg (8/22). All bound to the same controlled value."
+        code={`<Slider size="sm" value={value} onChange={…} />
+<Slider size="md" value={value} onChange={…} />
+<Slider size="lg" value={value} onChange={…} />`}
+      >
+        <Sizes />
+      </Example>
+
+      <Example
+        title="Tones"
+        description="Four tones for the fill color. Use warning/danger for threshold-style sliders (e.g. disk usage at 90% → danger fill)."
+        code={`<Slider tone="default" value={value} onChange={…} />
+<Slider tone="success" value={value} onChange={…} />
+<Slider tone="warning" value={value} onChange={…} />
+<Slider tone="danger" value={value} onChange={…} />`}
+      >
+        <Tones />
+      </Example>
+
+      <Example
+        title="Tick marks"
+        description="`marks={[0, 25, 50, 75, 100]}` renders 5 ticks. Marks within the current fill range get a filled tone."
+        code={`<Slider value={value} marks={[0, 25, 50, 75, 100]} onChange={…} />`}
+      >
+        <Marks />
+      </Example>
+
+      <Example
+        title="Vertical orientation"
+        description="Single-thumb vertical slider, 200px tall by default. Marks render to the right; label bubble appears on the right of the thumb."
+        code={`<Slider
+  value={value}
+  orientation="vertical"
+  marks={[0, 25, 50, 75, 100]}
+  onChange={(v) => setValue(v as number)}
+/>`}
+      >
+        <Vertical />
+      </Example>
+
+      <Example
+        title="Fractional step (zoom-style)"
+        description="min=1, max=3, step=0.1 — the canonical ImageCrop zoom control. label=true shows the current value as a bubble."
+        code={`<Slider
+  value={zoom}
+  min={1} max={3} step={0.1}
+  label
+  onChange={(v) => setZoom(v as number)}
+/>`}
+      >
+        <FractionalStep />
+      </Example>
+
+      <Example
+        title="Disabled"
+        description="Track and thumb both grayed (via --opacity-disabled). Pointer/keyboard no-op; tabIndex=-1; aria-disabled=true."
+        code={`<Slider value={50} disabled onChange={() => {}} aria-label="Disabled" />`}
+      >
+        <DisabledDemo />
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -39,6 +39,7 @@ export type ComponentName =
   | 'RadioGroup'
   | 'Select'
   | 'Skeleton'
+  | 'Slider'
   | 'Stack'
   | 'Switch'
   | 'Table'


### PR DESCRIPTION
## Summary

`<Slider>` — controlled, custom-painted slider supporting single-thumb AND range (two-thumb) modes, horizontal AND vertical orientations, fractional steps, tick marks, and tone-coded fills. Pre-req for `<ImageCrop>` (next PR) which uses it for the zoom control.

- **`value: number | [number, number]`** — type-discriminated. Single-thumb for `number`; two-thumb range for the tuple. `onChange` mirrors the shape.
- **Pointer events** with `setPointerCapture` (try/catch for jsdom safety) for unified mouse/touch/pen drag.
- **Full WAI-ARIA APG keyboard support** — Arrow/Home/End/PageUp/PageDown, range-clamp aware.
- **Tick marks** (`number[]` auto-labels with the value; `SliderMark[]` for custom labels). Marks within the fill range get a tone-filled state.
- **Value bubble label** on hover/focus/drag — `label={true}` for raw value, `label={(v) => ...}` for custom format (also drives `aria-valuetext`).
- **Hidden `<input>`** under the `name` prop for form submission (NOT rendered when disabled — prevents stale value submission).
- **`role="slider"` locked** via TypeScript `Omit<HTMLAttributes, 'role'>`.
- **`aria-label`/`aria-labelledby` forwarded** from root to each thumb (WAI-ARIA APG: each role=slider must be labeled).
- **`onChangeEnd` fires only on actual value change** — at pointerup AFTER a drag that moved the value, OR at blur after keyboard nav that changed the value. Click-without-drag and Tab-in/Tab-out without nav both DON'T fire.

## Why now

Pre-req for ImageCrop's zoom control. Other near-term consumers: threshold sliders for filters, range filters in contacts/deals, opacity controls, settings sliders. No primitive existed for this — every consumer would hand-roll drag math + ARIA.

## Design decisions baked in

- **Controlled-only, no `defaultValue`.** Matches every other controlled primitive shipped this quarter.
- **Discriminated union on `value`** instead of `<Slider>` + `<RangeSlider>` components.
- **Custom paint for all modes.** Range mode forces it; single mode follows for consistency. Manual ARIA throughout.
- **`onChange` fires per pointer-move tick; `onChangeEnd` fires on commit.** Consumers debounce expensive logic themselves.
- **Range-mode clamp**: `value[0] ≤ value[1]` always enforced — both pointer drag and keyboard nudge.
- **Track click moves the nearest thumb** (range mode picks by distance).
- **Refs for synchronous reads** inside event handlers (`latestValueRef`, `isDraggingRef`, `valueChangedThisFocusRef`) — resolves the async-state-race class of bugs.

## Tests

**54 cases** across 7 describe blocks: rendering matrix (single/range × sm/md/lg × default/success/warning/danger × horizontal/vertical), value-to-percent positioning, ARIA (single + range + disabled + orientation + label-as-function + label=true + aria-label forwarding + aria-labelledby forwarding + range thumb labels), keyboard (Arrow/Home/End/PageUp/PageDown + range-clamp + blur-only-on-change + disabled), pointer-event drag via a `setPointerCapture` shim (track click + thumb pointerdown/move/up + range-clamp + click-without-drag suppression + disabled), marks (count + filled state + auto-labels + no-label SliderMark), label modes, hidden form inputs (single / range / NOT rendered when disabled).

## Hard Rule 8

**Round 1: `keep iterating`** — 4 Important findings:

1. **Auto-labeled marks broken** — `marks={[0, 50, 100]}` rendered tick lines without their value labels (contract violation). Fixed in `normalizeMarks`.
2. **`aria-label` not forwarded to thumbs** — WAI-ARIA APG requires each `role="slider"` to be labeled. Fixed by reading from `rest` and applying to each thumb.
3. **`SliderMark` fields lacked JSDoc** (Rule 7). Added.
4. **`onChangeEnd` fired on click-without-drag** — JSDoc says "commits a value change." Fixed by gating pointerup behind the same `valueChangedThisFocusRef` flag the blur path uses.

Plus 6 new tests pinning these contracts.

**Round 2: `clean enough to stop`** — all 4 fixes verified.

T1 round-1 (per-task review) had already caught and fixed: stale `value` closure in `onChangeEnd` (now uses `latestValueRef`), `isDragging` state race that could drop first `pointermove` (now uses `isDraggingRef`), `onChangeEnd` firing twice on drag+Tab (now gated by `valueChangedThisFocusRef`), `disabled` no-op on hidden inputs (now conditionally rendered), disabled thumb showing `cursor: grab` (CSS gap fixed).

## Branch naming note

This branch is `feat/image-crop` because the eventual ImageCrop PR will use it — but THIS PR ships only `<Slider>`. ImageCrop gets its own next-session brainstorm and its own branch (carrying the settled decisions: hand-roll on canvas, zoom IS in v1 using this Slider, rotation deferred, multi-touch deferred).

## Test plan

- [ ] `/components/slider`: 8 examples render — basic single, range filter, sizes, tones, marks, vertical, fractional step (zoom), disabled.
- [ ] Drag a thumb in any example, see the value update in the "Current: <Code>" label.
- [ ] Click on the track (not the thumb) — the nearest thumb snaps.
- [ ] Tab to a thumb, press Arrow keys — value changes. Home/End jump to min/max.
- [ ] Range mode: try to drag the left thumb past the right thumb — it stops at the right thumb's value.
- [ ] `marks={[0, 25, 50, 75, 100]}` — see numeric labels under each tick.
- [ ] No mockup files modified (verified — no current mockup uses a slider).
- [ ] AGENTS.md Slider section appears between FileUpload and Card.
- [ ] No test files in `npm pack --dry-run` output.

## Follow-up tasks (separate PRs)

1. **DataTable/TanStack doc correction** — flagged in the spec's "Follow-up tasks" section. Out of scope here.
2. **`<ImageCrop>`** — next session's brainstorm. Will consume this Slider for the zoom control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
