### PR TITLE
Playground: Design tokens reference page

### DIFF
--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -7,6 +7,7 @@ import { Contacts } from './pages/mockups/Contacts/Contacts';
 import { ContactDetail } from './pages/mockups/ContactDetail/ContactDetail';
 import { Members } from './pages/mockups/Members/Members';
 import { ComponentsIndex } from './pages/components/ComponentsIndex';
+import { TokensPage } from './pages/Tokens/TokensPage';
 import { AccordionDemo } from './pages/components/AccordionDemo';
 import { AlertDemo } from './pages/components/AlertDemo';
 import { BreadcrumbDemo } from './pages/components/BreadcrumbDemo';
@@ -69,6 +70,7 @@ export default function App() {
           <Route path="/mockups/members" element={<Members />} />
 
           <Route path="/components" element={<ComponentsIndex />} />
+          <Route path="/components/tokens" element={<TokensPage />} />
           <Route path="/components/accordion" element={<AccordionDemo />} />
           <Route path="/components/alert" element={<AlertDemo />} />
           <Route path="/components/breadcrumb" element={<BreadcrumbDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -75,6 +75,13 @@ const componentOverview = {
   end: true,
 };
 
+const tokensReference = {
+  to: '/components/tokens',
+  label: 'Design tokens',
+  icon: Palette,
+  end: false,
+};
+
 const componentGroups = [
   {
     heading: 'Layout',
@@ -214,6 +221,7 @@ export function AppShell({ children }: { children: ReactNode }) {
           {inComponents ? (
             <>
               {renderItem(componentOverview)}
+              {renderItem(tokensReference)}
               {componentGroups.map(({ heading, items }) => (
                 <div key={heading} className={styles.navGroup}>
                   <div className={styles.navSection}>{heading}</div>

--- a/packages/playground/src/pages/Tokens/TokenPreview.tsx
+++ b/packages/playground/src/pages/Tokens/TokenPreview.tsx
@@ -96,9 +96,7 @@ export function TokenPreview({ category, name }: TokenPreviewProps) {
       );
 
     case 'border':
-      return (
-        <div className={styles.borderSwatch} style={{ borderWidth: cssVar }} aria-hidden />
-      );
+      return <div className={styles.borderSwatch} style={{ borderWidth: cssVar }} aria-hidden />;
 
     case 'line':
       return (

--- a/packages/playground/src/pages/Tokens/TokenPreview.tsx
+++ b/packages/playground/src/pages/Tokens/TokenPreview.tsx
@@ -1,0 +1,124 @@
+import styles from './TokensPage.module.scss';
+
+interface TokenPreviewProps {
+  category: string;
+  name: string;
+}
+
+/**
+ * Per-category visual preview of a token's effect. Falls back to a small
+ * dash for categories that don't have a meaningful visual representation
+ * (e.g., z-index, transition duration).
+ */
+export function TokenPreview({ category, name }: TokenPreviewProps) {
+  // All previews use `var(--token-name)` so they reflect the live computed
+  // value — that way theme overrides and consumer-set CSS variables show up
+  // visually instead of being hard-coded to the literal value in tokens.scss.
+  const cssVar = `var(--${name})`;
+
+  switch (category) {
+    case 'color':
+      return (
+        <div
+          className={styles.colorSwatch}
+          style={{ backgroundColor: cssVar }}
+          aria-label={`Color swatch for ${name}`}
+        />
+      );
+
+    case 'space':
+      return (
+        <div className={styles.spaceTrack}>
+          <div className={styles.spaceFill} style={{ width: cssVar }} />
+        </div>
+      );
+
+    case 'radius':
+      return <div className={styles.radiusSwatch} style={{ borderRadius: cssVar }} />;
+
+    case 'shadow':
+      return <div className={styles.shadowSwatch} style={{ boxShadow: cssVar }} />;
+
+    case 'font':
+      // The `font-*` group includes sizes, weights, families, and line-heights.
+      if (name.startsWith('font-size-')) {
+        return (
+          <span className={styles.fontSizeSample} style={{ fontSize: cssVar }}>
+            Aa
+          </span>
+        );
+      }
+      if (name.startsWith('font-weight-')) {
+        return (
+          <span className={styles.fontWeightSample} style={{ fontWeight: cssVar }}>
+            Aa
+          </span>
+        );
+      }
+      if (name.startsWith('font-family-')) {
+        return (
+          <span className={styles.fontFamilySample} style={{ fontFamily: cssVar }}>
+            Aa
+          </span>
+        );
+      }
+      return <span className={styles.dash}>—</span>;
+
+    case 'size':
+      // Component sizing — render a small bar at the token's width up to 64px.
+      return (
+        <div className={styles.sizeTrack}>
+          <div className={styles.sizeFill} style={{ width: cssVar }} />
+        </div>
+      );
+
+    case 'opacity':
+      return (
+        <div className={styles.opacityRow}>
+          <div className={styles.opacitySwatch} style={{ opacity: cssVar }} />
+        </div>
+      );
+
+    case 'ring':
+      if (name === 'ring-width') {
+        return (
+          <div className={styles.ringWidthSample}>
+            <div className={styles.ringWidthBox} style={{ borderWidth: cssVar }} />
+          </div>
+        );
+      }
+      // ring-accent / ring-danger / ring-success — render a focus-ring overlay.
+      return (
+        <div
+          className={styles.ringSwatch}
+          style={{ boxShadow: `0 0 0 var(--ring-width) ${cssVar}` }}
+        />
+      );
+
+    case 'border':
+      return (
+        <div className={styles.borderSwatch} style={{ borderWidth: cssVar }} aria-hidden />
+      );
+
+    case 'line':
+      return (
+        <div className={styles.lineHeightSample} style={{ lineHeight: cssVar }}>
+          One
+          <br />
+          Two
+        </div>
+      );
+
+    case 'letter':
+      return (
+        <span className={styles.letterSample} style={{ letterSpacing: cssVar }}>
+          TRACKING
+        </span>
+      );
+
+    case 'transition':
+    case 'z':
+    default:
+      return <span className={styles.dash}>—</span>;
+  }
+}

--- a/packages/playground/src/pages/Tokens/TokensPage.module.scss
+++ b/packages/playground/src/pages/Tokens/TokensPage.module.scss
@@ -167,16 +167,17 @@
   width: 48px;
   height: 32px;
   border-radius: var(--radius-sm);
-  background-image: linear-gradient(
-      45deg,
-      var(--color-bg-muted) 25%,
-      transparent 25%
-    ),
+  background-image:
+    linear-gradient(45deg, var(--color-bg-muted) 25%, transparent 25%),
     linear-gradient(-45deg, var(--color-bg-muted) 25%, transparent 25%),
     linear-gradient(45deg, transparent 75%, var(--color-bg-muted) 75%),
     linear-gradient(-45deg, transparent 75%, var(--color-bg-muted) 75%);
   background-size: 8px 8px;
-  background-position: 0 0, 0 4px, 4px -4px, -4px 0;
+  background-position:
+    0 0,
+    0 4px,
+    4px -4px,
+    -4px 0;
 }
 
 .opacitySwatch {

--- a/packages/playground/src/pages/Tokens/TokensPage.module.scss
+++ b/packages/playground/src/pages/Tokens/TokensPage.module.scss
@@ -1,0 +1,235 @@
+.page {
+  max-width: 1100px;
+}
+
+.eyebrow {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wide);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.tableWrap {
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-bg);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm);
+}
+
+.colPreview {
+  width: 80px;
+}
+
+.colName {
+  width: 30%;
+}
+
+.colValue {
+  width: 22%;
+}
+
+.colExplanation {
+  width: auto;
+}
+
+.table thead th {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-muted);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg-muted);
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.table tbody td {
+  padding: var(--space-3);
+  border-bottom: var(--border-width) solid var(--color-border);
+  vertical-align: middle;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.table tbody tr:hover {
+  background: var(--color-bg-subtle);
+}
+
+.copyButton {
+  display: inline-block;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  cursor: pointer;
+  text-align: left;
+}
+
+.copyButton:focus-visible {
+  outline: var(--border-width-emphasis) solid var(--color-accent);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- focus-ring offset, no token equivalent
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.value {
+  color: var(--color-fg);
+}
+
+// ─── Preview swatch variants ────────────────────────────────────────────
+
+.colorSwatch {
+  width: 48px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  border: var(--border-width) solid var(--color-border);
+  background-clip: padding-box;
+}
+
+.spaceTrack {
+  width: 64px;
+  height: 12px;
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.spaceFill {
+  height: 100%;
+  background: var(--color-accent);
+}
+
+.radiusSwatch {
+  width: 48px;
+  height: 32px;
+  background: var(--color-fg-muted);
+}
+
+.shadowSwatch {
+  width: 48px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  border: var(--border-width) solid var(--color-border);
+}
+
+.fontSizeSample,
+.fontWeightSample,
+.fontFamilySample {
+  display: inline-block;
+  color: var(--color-fg);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- intentional baseline override for the preview cell
+  line-height: 1;
+}
+
+.fontWeightSample {
+  font-size: var(--font-size-md);
+}
+
+.fontFamilySample {
+  font-size: var(--font-size-md);
+}
+
+.sizeTrack {
+  width: 80px;
+  height: 12px;
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.sizeFill {
+  height: 100%;
+  background: var(--color-fg-muted);
+}
+
+.opacityRow {
+  display: inline-flex;
+  align-items: center;
+  width: 48px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  background-image: linear-gradient(
+      45deg,
+      var(--color-bg-muted) 25%,
+      transparent 25%
+    ),
+    linear-gradient(-45deg, var(--color-bg-muted) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--color-bg-muted) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--color-bg-muted) 75%);
+  background-size: 8px 8px;
+  background-position: 0 0, 0 4px, 4px -4px, -4px 0;
+}
+
+.opacitySwatch {
+  width: 100%;
+  height: 100%;
+  background: var(--color-accent);
+  border-radius: var(--radius-sm);
+}
+
+.ringSwatch {
+  width: 32px;
+  height: 32px;
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
+
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- inner margin so the focus ring shadow is visible inside the cell
+  margin: 4px;
+}
+
+.ringWidthSample {
+  display: inline-flex;
+  align-items: center;
+}
+
+.ringWidthBox {
+  width: 32px;
+  height: 32px;
+  border-style: solid;
+  border-color: var(--color-accent);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+}
+
+.borderSwatch {
+  width: 48px;
+  height: 32px;
+  border-style: solid;
+  border-color: var(--color-fg-muted);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+}
+
+.lineHeightSample {
+  font-size: var(--font-size-sm);
+  color: var(--color-fg);
+}
+
+.letterSample {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg);
+}
+
+.dash {
+  color: var(--color-fg-muted);
+}

--- a/packages/playground/src/pages/Tokens/TokensPage.tsx
+++ b/packages/playground/src/pages/Tokens/TokensPage.tsx
@@ -42,8 +42,8 @@ export function TokensPage() {
           <Title order={1}>Design tokens</Title>
           <Text tone="muted">
             All {allTokens.length} CSS custom properties defined in{' '}
-            <Code>packages/design-system/src/styles/tokens.scss</Code>. Click a name to copy
-            its <Code>var(--…)</Code> reference.
+            <Code>packages/design-system/src/styles/tokens.scss</Code>. Click a name to copy its{' '}
+            <Code>var(--…)</Code> reference.
           </Text>
         </Stack>
       </header>
@@ -100,9 +100,7 @@ export function TokensPage() {
                           <button
                             type="button"
                             className={styles.copyButton}
-                            onClick={() =>
-                              navigator.clipboard?.writeText(`var(--${token.name})`)
-                            }
+                            onClick={() => navigator.clipboard?.writeText(`var(--${token.name})`)}
                             aria-label={`Copy var(--${token.name})`}
                             title="Click to copy var(--…)"
                           >

--- a/packages/playground/src/pages/Tokens/TokensPage.tsx
+++ b/packages/playground/src/pages/Tokens/TokensPage.tsx
@@ -1,0 +1,135 @@
+import { useMemo, useState } from 'react';
+import { Stack, Title, Text, Code, Input } from '@eocrm/design-system';
+import tokensSource from '@lib-source/styles/tokens.scss?raw';
+import {
+  parseTokens,
+  groupTokensByCategory,
+  CATEGORY_META,
+  CATEGORY_ORDER,
+  type ParsedToken,
+} from './parseTokens';
+import { TokenPreview } from './TokenPreview';
+import styles from './TokensPage.module.scss';
+
+/**
+ * Read-only reference page for every design token in `tokens.scss`. The
+ * source file is imported via Vite's `?raw` loader and parsed at render
+ * time — so adding a new token in the library automatically shows up here
+ * with no playground change required.
+ */
+export function TokensPage() {
+  const allTokens = useMemo(() => parseTokens(tokensSource), []);
+  const [filter, setFilter] = useState('');
+
+  const filtered = useMemo<ParsedToken[]>(() => {
+    const needle = filter.trim().toLowerCase();
+    if (!needle) return allTokens;
+    return allTokens.filter(
+      (t) =>
+        t.name.toLowerCase().includes(needle) ||
+        t.value.toLowerCase().includes(needle) ||
+        t.explanation?.toLowerCase().includes(needle),
+    );
+  }, [allTokens, filter]);
+
+  const grouped = useMemo(() => groupTokensByCategory(filtered), [filtered]);
+
+  return (
+    <Stack gap="lg" className={styles.page}>
+      <header>
+        <Stack gap="sm">
+          <div className={styles.eyebrow}>Reference</div>
+          <Title order={1}>Design tokens</Title>
+          <Text tone="muted">
+            All {allTokens.length} CSS custom properties defined in{' '}
+            <Code>packages/design-system/src/styles/tokens.scss</Code>. Click a name to copy
+            its <Code>var(--…)</Code> reference.
+          </Text>
+        </Stack>
+      </header>
+
+      <Input
+        type="search"
+        placeholder="Filter by name, value, or description…"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        aria-label="Filter tokens"
+      />
+
+      {filtered.length === 0 ? (
+        <Text tone="muted">No tokens match {JSON.stringify(filter)}.</Text>
+      ) : (
+        CATEGORY_ORDER.filter((cat) => grouped[cat]?.length).map((category) => {
+          const meta = CATEGORY_META[category];
+          const tokens = grouped[category];
+          return (
+            <section key={category} className={styles.section}>
+              <Stack gap="sm">
+                <Title order={2}>
+                  {meta?.label ?? category}{' '}
+                  <Text as="span" tone="muted" size="sm">
+                    ({tokens.length})
+                  </Text>
+                </Title>
+                {meta?.description && <Text tone="muted">{meta.description}</Text>}
+              </Stack>
+
+              <div className={styles.tableWrap}>
+                <table className={styles.table}>
+                  <colgroup>
+                    <col className={styles.colPreview} />
+                    <col className={styles.colName} />
+                    <col className={styles.colValue} />
+                    <col className={styles.colExplanation} />
+                  </colgroup>
+                  <thead>
+                    <tr>
+                      <th>Preview</th>
+                      <th>Name</th>
+                      <th>Value</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {tokens.map((token) => (
+                      <tr key={token.name}>
+                        <td>
+                          <TokenPreview category={token.category} name={token.name} />
+                        </td>
+                        <td>
+                          <button
+                            type="button"
+                            className={styles.copyButton}
+                            onClick={() =>
+                              navigator.clipboard?.writeText(`var(--${token.name})`)
+                            }
+                            aria-label={`Copy var(--${token.name})`}
+                            title="Click to copy var(--…)"
+                          >
+                            <Code>--{token.name}</Code>
+                          </button>
+                        </td>
+                        <td>
+                          <Code className={styles.value}>{token.value}</Code>
+                        </td>
+                        <td>
+                          {token.explanation ? (
+                            <Text size="sm">{token.explanation}</Text>
+                          ) : (
+                            <Text tone="muted" size="sm">
+                              —
+                            </Text>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          );
+        })
+      )}
+    </Stack>
+  );
+}

--- a/packages/playground/src/pages/Tokens/parseTokens.ts
+++ b/packages/playground/src/pages/Tokens/parseTokens.ts
@@ -16,8 +16,7 @@ export interface ParsedToken {
   category: string;
 }
 
-const TOKEN_LINE_RE =
-  /^--([a-z0-9-]+):\s*([^;]+?);(?:\s*(?:\/\/\s*|\/\*\s*)(.+?)(?:\s*\*\/)?)?$/;
+const TOKEN_LINE_RE = /^--([a-z0-9-]+):\s*([^;]+?);(?:\s*(?:\/\/\s*|\/\*\s*)(.+?)(?:\s*\*\/)?)?$/;
 const COMMENT_LINE_RE = /^\/\/\s?(.*)$/;
 
 /**
@@ -120,8 +119,7 @@ export const CATEGORY_META: Record<string, { label: string; description: string 
   },
   opacity: {
     label: 'Opacity',
-    description:
-      'Reusable opacity values for hover, disabled, overlay, and tinted-surface states.',
+    description: 'Reusable opacity values for hover, disabled, overlay, and tinted-surface states.',
   },
   z: {
     label: 'Z-index',

--- a/packages/playground/src/pages/Tokens/parseTokens.ts
+++ b/packages/playground/src/pages/Tokens/parseTokens.ts
@@ -1,0 +1,183 @@
+/**
+ * Parsed token record extracted from the library's `tokens.scss` file.
+ *
+ * The explanation is sourced from inline `//` comments in the SCSS — either
+ * a multi-line block immediately preceding the token declaration or a
+ * trailing `// …` after the value. Trailing wins when both exist.
+ */
+export interface ParsedToken {
+  /** Token name without the leading `--` (e.g., `color-accent`). */
+  name: string;
+  /** Raw value string from the SCSS (e.g., `#0052cc`, `4px`, `rgb(0 0 0 / 50%)`). */
+  value: string;
+  /** Inline comment from the SCSS, if any. */
+  explanation?: string;
+  /** Top-level category derived from the name prefix (e.g., `color`, `space`). */
+  category: string;
+}
+
+const TOKEN_LINE_RE =
+  /^--([a-z0-9-]+):\s*([^;]+?);(?:\s*(?:\/\/\s*|\/\*\s*)(.+?)(?:\s*\*\/)?)?$/;
+const COMMENT_LINE_RE = /^\/\/\s?(.*)$/;
+
+/**
+ * Collapse multi-line token declarations onto a single line so the line-by-
+ * line parser below sees them. Some tokens (e.g. `--font-family-sans`,
+ * `--color-bg-overlay-blur`) span multiple lines because their values are
+ * long lists / functions.
+ */
+function joinMultilineDeclarations(raw: string): string {
+  // Greedy match anything starting with `--name:` up to the first `;`,
+  // then collapse internal whitespace to single spaces.
+  return raw.replace(/(--[a-z0-9-]+:[^;]*;)/g, (match) => match.replace(/\s+/g, ' '));
+}
+
+/**
+ * Parse the raw text of `tokens.scss` into a structured list of tokens.
+ *
+ * Heuristic for explanations: contiguous `//` comment lines immediately
+ * above a token declaration are joined with spaces. Trailing inline
+ * comments on the same line as the declaration override the preceding
+ * block. A blank line, a non-comment line, or a different token resets
+ * the pending comment buffer.
+ *
+ * Section headings in the SCSS (single-line comments that head a run of
+ * tokens) are intentionally NOT extracted — we derive categories from the
+ * token name prefix instead, which is more stable and doesn't depend on
+ * comment placement.
+ */
+export function parseTokens(raw: string): ParsedToken[] {
+  const tokens: ParsedToken[] = [];
+  let pending: string[] = [];
+  const normalized = joinMultilineDeclarations(raw);
+
+  for (const rawLine of normalized.split('\n')) {
+    const line = rawLine.trim();
+
+    if (line === '' || line === '{' || line === '}' || line.startsWith(':root')) {
+      pending = [];
+      continue;
+    }
+
+    const tokenMatch = TOKEN_LINE_RE.exec(line);
+    if (tokenMatch) {
+      const [, name, value, trailing] = tokenMatch;
+      const explanation = trailing?.trim() || pending.join(' ').trim() || undefined;
+      tokens.push({
+        name,
+        value: value.trim(),
+        explanation,
+        category: name.split('-')[0],
+      });
+      pending = [];
+      continue;
+    }
+
+    const commentMatch = COMMENT_LINE_RE.exec(line);
+    if (commentMatch) {
+      pending.push(commentMatch[1].trim());
+      continue;
+    }
+
+    // Any other line (SCSS variable, mixin, etc.) breaks the comment-to-token
+    // adjacency.
+    pending = [];
+  }
+
+  return tokens;
+}
+
+/** Human-readable label + short description for each token category. */
+export const CATEGORY_META: Record<string, { label: string; description: string }> = {
+  color: {
+    label: 'Color',
+    description:
+      'Surface, foreground, accent, semantic, and badge palettes. All token values are literal hex / rgb — no aliases reference other tokens, so theming swaps are straightforward.',
+  },
+  space: {
+    label: 'Spacing',
+    description:
+      '4px baseline scale. `--space-05` is a half-step (2px) for tight internal padding; everything else steps by 4 from `--space-0` up.',
+  },
+  size: {
+    label: 'Size',
+    description:
+      'Component-level sizing tokens — icon dimensions, control heights, avatar diameters. Use these when a component needs a discrete size variant; otherwise prefer spacing tokens.',
+  },
+  font: {
+    label: 'Typography',
+    description:
+      'Font families, sizes, and weights. Sizes follow a typographic scale; use semantic names (`--font-size-sm`) rather than reaching for a specific pixel value.',
+  },
+  radius: {
+    label: 'Border radius',
+    description: 'Corner-rounding tokens — from sharp (sm) to fully circular (full).',
+  },
+  shadow: {
+    label: 'Shadow',
+    description:
+      'Elevation tokens. `xs`–`xl` map to roughly increasing perceived height; pick by intent (a Tooltip is `sm`, a Modal is `lg`).',
+  },
+  opacity: {
+    label: 'Opacity',
+    description:
+      'Reusable opacity values for hover, disabled, overlay, and tinted-surface states.',
+  },
+  z: {
+    label: 'Z-index',
+    description:
+      'Stacking layers. Use these instead of arbitrary numbers so the order is centralised and predictable.',
+  },
+  ring: {
+    label: 'Focus ring',
+    description: 'Focus-ring color + width tokens. Apply via the `@include focus-ring` mixin.',
+  },
+  border: {
+    label: 'Border',
+    description: 'Border-width tokens.',
+  },
+  line: {
+    label: 'Line height',
+    description: 'Line-height tokens — paired with `--font-size-*`.',
+  },
+  letter: {
+    label: 'Letter spacing',
+    description: 'Letter-spacing tokens — typically for headings and uppercase labels.',
+  },
+  transition: {
+    label: 'Transition',
+    description: 'Duration tokens for CSS transitions. Pair with an easing function.',
+  },
+  avatar: {
+    label: 'Avatar',
+    description:
+      'Component-specific tokens for the Avatar primitive (overlap offsets for stacked avatars).',
+  },
+};
+
+/** Stable display order for the categories. */
+export const CATEGORY_ORDER: string[] = [
+  'color',
+  'space',
+  'size',
+  'font',
+  'radius',
+  'border',
+  'shadow',
+  'opacity',
+  'ring',
+  'line',
+  'letter',
+  'transition',
+  'avatar',
+  'z',
+];
+
+/** Group an array of tokens by `category`, preserving the order they appeared in. */
+export function groupTokensByCategory(tokens: ParsedToken[]): Record<string, ParsedToken[]> {
+  const groups: Record<string, ParsedToken[]> = {};
+  for (const token of tokens) {
+    (groups[token.category] ??= []).push(token);
+  }
+  return groups;
+}


### PR DESCRIPTION
## Summary

New playground page at `/components/tokens` — a live reference for every CSS custom property defined in `packages/design-system/src/styles/tokens.scss`. Source-driven: the SCSS file is imported via Vite's `?raw` loader and parsed at render time, so any token added to the library shows up here automatically with no playground change required.

## What you see

For each token: a visual preview (per-category), the token name (click to copy `var(--…)`), the raw value, and the inline `//` SCSS comment as the description.

164 tokens across 14 categories — Color, Spacing, Size, Typography, Border radius, Border, Shadow, Opacity, Focus ring, Line height, Letter spacing, Transition, Avatar, Z-index. Filter input across name / value / description for quick lookup.

## Per-category previews

| Category | Preview |
| --- | --- |
| Color | 48×32 swatch with token's color as background |
| Spacing | Blue bar at the token's width inside a 64px gray track |
| Radius | 48×32 dark-gray block with the token's border-radius |
| Shadow | 48×32 white box with the token's box-shadow |
| Font (size/weight/family) | "Aa" sample rendered with the token applied |
| Size | Gray bar at the token's width inside an 80px track |
| Opacity | Checkerboard background with an accent-blue swatch at the token's opacity |
| Focus ring (color) | Small box with a focus-ring shadow using the token |
| Focus ring (width) | Box with the token as border-width |
| Border | Box with the token as border-width |
| Line height | Two-line "One / Two" sample at the token's line-height |
| Letter spacing | "TRACKING" sample with the letter-spacing applied |
| Avatar | Dash (no meaningful visual — `calc()`-based negative offsets) |
| Transition / Z-index | Dash |

## Architecture

- `parseTokens.ts` — joins multi-line declarations onto single lines, extracts name/value/comment via regex, derives category from name prefix. Pure functions; testable.
- `TokenPreview.tsx` — switch on category, render the appropriate visual using `var(--…)` so live theme overrides reflect immediately.
- `TokensPage.tsx` — table per category with filter input.
- `TokensPage.module.scss` — token-only styles (one inline disable per CSS keyword + one for a 4px margin).

## Wiring

- `/components/tokens` route in `App.tsx`.
- "Design tokens" sidebar link at the top of the Components nav, right under Overview (reuses the `Palette` lucide icon).

## Playground-only

No library code touched. No new tests required (this is documentation tooling, not a shipped component). All four gates green.

## Test plan

- [ ] `/components/tokens` loads with the "Design tokens" header and the filter input.
- [ ] All 14 category sections render with the count beside each heading.
- [ ] Color section: swatches show the token's color.
- [ ] Spacing section: blue bars grow from `--space-0` (none) to `--space-12` (full track).
- [ ] Filter input narrows the visible tokens across name / value / description.
- [ ] Click a `--token-name` button: clipboard contains `var(--token-name)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
