### PR TITLE
Toast: vertically center icon + close button against the body

### DIFF
--- a/packages/design-system/src/components/Toast/Toast.module.scss
+++ b/packages/design-system/src/components/Toast/Toast.module.scss
@@ -93,7 +93,13 @@
   display: grid;
   grid-template-columns: auto 1fr auto;
   gap: var(--space-2);
-  align-items: start;
+
+  // Centers the icon and close button against the body (vs. top-aligned
+  // start, which left the leading visually high relative to the message's
+  // line-height: 1.4 baseline). For 2-line toasts (message + description)
+  // the icon centers between the two lines — same pattern as Sonner /
+  // react-hot-toast.
+  align-items: center;
   padding: var(--space-3);
   background: var(--color-bg);
   border-radius: var(--radius-md);


### PR DESCRIPTION
## Summary

`.toast`'s grid had `align-items: start`, which pinned the leading icon and trailing close button to the top of their grid row. With the message's `line-height: 1.4`, both elements visually sat above the text baseline on single-line toasts.

## Fix

One line: `align-items: start` → `align-items: center` on `.toast` in `Toast.module.scss`.

## Verified

Measured both cases in the browser:

| Case | Icon center Y | Close center Y | Body center Y | Toast center Y |
| --- | --- | --- | --- | --- |
| Single-line | 1885.20 | 1885.20 | 1885.20 | 1885.20 |
| 2-line (message + description) | 1823.03 | 1823.03 | — | 1823.04 |

Single-line: all three elements share the toast's vertical midline.
2-line: icon + close center vertically between the message and description lines — same pattern as Sonner / react-hot-toast.

## Test plan

- [ ] `/components/toast`: fire any single-line toast (info / success / warning / error) — icon and close button line up visually with the message text baseline.
- [ ] Fire the "with description" toast — icon and close sit between the two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)