### PR TITLE
ColorPicker: transparent fill on the hue slider

### DIFF
--- a/packages/design-system/src/components/ColorPicker/ColorPicker.module.scss
+++ b/packages/design-system/src/components/ColorPicker/ColorPicker.module.scss
@@ -110,6 +110,16 @@
       #ff0000
     ) !important;
   }
+
+  // Slider also renders a separate `.fill` overlay (the colored portion from
+  // min to the thumb, defaulting to --color-accent). For a hue picker there's
+  // no "filled" concept — the entire rainbow is meaningful, so the fill must
+  // be invisible to let the rainbow show through.
+  // stylelint-disable-next-line selector-pseudo-class-no-unknown -- CSS Modules :global() escape hatch
+  & :global([class*='fill']) {
+    // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- transparent override for hue picker; !important needed to defeat Slider's tone variants
+    background: transparent !important;
+  }
 }
 
 .hexInput {


### PR DESCRIPTION
## Summary

The ColorPicker's hue slider showed a blue (accent-colored) fill from min to the thumb, covering the left portion of the rainbow gradient.

Root cause: Slider renders two stacked elements — \`.track\` (full background bar) and \`.fill\` (the colored portion from min to the thumb, defaulting to \`--color-accent\`). The original SCSS only overrode \`.track\` with the rainbow gradient; the \`.fill\` kept painting blue.

## Fix

Added a second override inside \`.hueSlider\`:

\`\`\`scss
& :global([class*='fill']) {
  background: transparent !important;
}
\`\`\`

For a hue picker there's no \"filled vs unfilled\" concept — the entire rainbow is meaningful, so the fill is invisible to let the rainbow show through.

## Verified

\`getComputedStyle\` on every \`.fill\` inside \`[class*=\"hueSlider\"]\` returns \`rgba(0,0,0,0)\` and \`backgroundImage: none\`. All four gates green.

## Test plan

- [ ] \`/components/color-picker\`: open any inline panel example. The hue slider shows the full rainbow with no blue overlay on the left of the thumb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)