### PR TITLE
PageHeader: compound layout primitive for top-of-page headers

### DIFF
--- a/docs/superpowers/plans/2026-05-25-page-header.md
+++ b/docs/superpowers/plans/2026-05-25-page-header.md
@@ -1,0 +1,1814 @@
+# PageHeader Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<PageHeader>` — a compound layout primitive that bundles breadcrumb, back-navigation, leading element (Avatar/icon), title, subtitle, meta row, and right-aligned actions into a single grid-based container with consistent spacing and an optional bottom border.
+
+**Architecture:** Compound pattern (`<PageHeader>` + 7 sub-components attached via `Object.assign`). The root reads children via `Children.toArray` + a `flattenChildren` helper (one level of Fragment unwrap), finds each known sub-component by `c.type === SubComponent`, and renders them into the correct CSS-grid slot via `grid-template-areas`. Each sub-component actively renders its own JSX (not a marker-null). Missing slots collapse to zero-height rows. `borderBottom: boolean = true` toggles the bottom border for when Tabs follows as a sibling.
+
+**Tech Stack:** React 19, TypeScript, CSS Modules + SCSS, Vitest + React Testing Library. Composes existing primitives (`<Title>`, `<Breadcrumb>`, `<Avatar>` etc.) — no new dependencies. `ChevronLeft` icon from `lucide-react` (already a transitive dep via playground).
+
+---
+
+**Reference spec:** `docs/superpowers/specs/2026-05-25-page-header-design.md` (commit `52d11b3`).
+
+**Branch:** `feat/page-header` (already checked out, currently at spec commit).
+
+**Conventions used throughout this plan:**
+
+- **Plan-verbatim:** every code block is the literal file contents the implementer commits. Don't paraphrase, rename props, reorder imports, or "clean up."
+- **CSS-Modules class naming:** camelCase throughout (matches Title / Progress / FileUpload / ImageCrop / ColorPicker precedent).
+- **Compound attach:** `Object.assign(PageHeaderRoot, { Breadcrumb, BackButton, Aside, Title, Subtitle, Meta, Actions })`.
+- **Pattern A spread** (props last so consumer wins): `{...rest}` last on elements that take pass-through props.
+- **Commit format:** subject + blank line + body (1–3 sentences) + blank line + `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+- **`git add` discipline:** stage by explicit path. No `git add -A`.
+- **Stylelint requirements:**
+  - `cursor: pointer`, `cursor: not-allowed` (CSS keywords) → inline disable.
+  - `text-decoration: none` on `.backButton` (CSS keyword for the `<a>` case) → inline disable.
+  - `margin-top: var(--space-3)` on `.actions` inside the media query → `property-disallowed-list` disable with rationale `-- internal responsive spacing in this layout primitive`.
+  - `font-weight: 500` is blocked by `scale-unlimited/declaration-strict-value` if it ever appears — none in this plan, leaving the proactive note here.
+- **Gates after each source-touching task:** `make test`, `make build-lib`, `make build`, `make lint`. All four must pass before commit + advance.
+- **If pre-push hook flags prettier:** `npx prettier --write <flagged files>` + follow-up commit `PageHeader: prettier --write` with the same Co-Authored-By footer.
+
+---
+
+## File structure
+
+### NEW files
+
+```
+packages/design-system/src/components/PageHeader/
+  PageHeader.tsx              ← T1: root + 7 sub-components + Object.assign + flattenChildren helper
+  PageHeader.module.scss      ← T1: grid layout + slot styling
+  PageHeader.test.tsx         ← T2: ~18 cases
+  index.ts                    ← T2: barrel
+```
+
+### MODIFIED files
+
+```
+packages/design-system/src/index.ts                              ← T2: barrel re-export
+packages/design-system/AGENTS.md                                 ← T3: PageHeader section after <Divider>
+packages/playground/src/pages/components/PageHeaderDemo.tsx      ← T4: 5 demo examples (NEW file)
+packages/playground/src/App.tsx                                  ← T4: import + Route
+packages/playground/src/layout/AppShell/AppShell.tsx             ← T4: LayoutPanelTop icon import + Layout-cluster nav item
+packages/playground/src/pages/components/ComponentsIndex.tsx     ← T4: import + card
+packages/playground/src/pages/mockups/registry.ts                ← T4: extend ComponentName union
+```
+
+No mockup refactor in this PR (ContactDetail / Members migration deferred per spec).
+
+---
+
+## Task 1: PageHeader source bundle (TSX + SCSS)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/PageHeader/PageHeader.tsx`
+- Create: `packages/design-system/src/components/PageHeader/PageHeader.module.scss`
+
+### Step 1.1: Write `PageHeader.tsx`
+
+- [ ] Write file contents (verbatim):
+
+```tsx
+import {
+  Children,
+  forwardRef,
+  Fragment,
+  isValidElement,
+  useEffect,
+  type AnchorHTMLAttributes,
+  type ButtonHTMLAttributes,
+  type ComponentType,
+  type HTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import { ChevronLeft } from 'lucide-react';
+import clsx from 'clsx';
+import { Title, type TitleSize } from '../Title';
+import styles from './PageHeader.module.scss';
+
+// ─── Types ───────────────────────────────────────────────────────────────
+
+export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Render a 1px bottom border under the header. Default `true`. Set
+   * `false` when placing a `<Tabs>` component as a sibling below — Tabs
+   * has its own `border-bottom`, and you don't want the double line.
+   */
+  borderBottom?: boolean;
+}
+
+export interface PageHeaderBreadcrumbProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface PageHeaderBackButtonProps {
+  /**
+   * If set, renders as `<a href={href}>`. Mutually exclusive with
+   * `onClick` — passing both renders as `<button>` (the onClick wins)
+   * and emits a dev-only warning.
+   */
+  href?: string;
+  /**
+   * If set, renders as `<button type="button" onClick={onClick}>`.
+   * Mutually exclusive with `href`.
+   */
+  onClick?: () => void;
+  /** Accessible label. Default `"Go back"`. */
+  'aria-label'?: string;
+  /** Icon to render. Default `<ChevronLeft size={16}>` from lucide-react. */
+  icon?: ReactNode;
+}
+
+export interface PageHeaderAsideProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface PageHeaderTitleProps {
+  /**
+   * Heading semantic level (1–6). Default `1`. Passes through to
+   * `<Title order={order}>` so the rendered element is `<h1>`–`<h6>`.
+   */
+  order?: 1 | 2 | 3 | 4 | 5 | 6;
+  /**
+   * Visual size override (decouples from semantic level). Pass-through to
+   * `<Title size>` — useful for "section-level page headers" where the
+   * h-level is 2 but you want it to LOOK like an h1.
+   */
+  size?: TitleSize;
+  children: ReactNode;
+}
+
+export interface PageHeaderSubtitleProps extends HTMLAttributes<HTMLParagraphElement> {
+  children: ReactNode;
+}
+
+export interface PageHeaderMetaProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface PageHeaderActionsProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+// ─── Internal helpers ────────────────────────────────────────────────────
+
+/**
+ * Flatten one level of React Fragments out of children. `React.Children.toArray`
+ * does NOT recursively unwrap fragments — this helper handles the common case
+ * of wrapping a single sub-component in `<>...</>`. Deeper nesting (HOCs, etc.)
+ * is intentionally NOT supported; documented as an anti-pattern.
+ */
+function flattenChildren(children: ReactNode): ReactNode[] {
+  const flat: ReactNode[] = [];
+  Children.toArray(children).forEach((child) => {
+    if (isValidElement(child) && child.type === Fragment) {
+      flat.push(
+        ...Children.toArray((child as ReactElement<{ children: ReactNode }>).props.children),
+      );
+    } else {
+      flat.push(child);
+    }
+  });
+  return flat;
+}
+
+/** Find the first child whose `type` equals the given component. */
+function findSlot<P>(children: ReactNode, type: ComponentType<P>): ReactElement<P> | undefined {
+  return flattenChildren(children).find(
+    (c): c is ReactElement<P> => isValidElement(c) && c.type === type,
+  );
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────
+
+/**
+ * Wraps a `<Breadcrumb>` (or any breadcrumb-like content) into the top row
+ * of the PageHeader grid. The breadcrumb row also hosts `<PageHeader.BackButton>`
+ * to its left when present — both are rendered together with a small gap.
+ *
+ * @example
+ * <PageHeader.Breadcrumb>
+ *   <Breadcrumb items={[...]} />
+ * </PageHeader.Breadcrumb>
+ */
+export function PageHeaderBreadcrumb({ children, className, ...rest }: PageHeaderBreadcrumbProps) {
+  return (
+    <div className={clsx(styles.breadcrumbInner, className)} {...rest}>
+      {children}
+    </div>
+  );
+}
+PageHeaderBreadcrumb.displayName = 'PageHeaderBreadcrumb';
+
+/**
+ * Compact back-navigation icon button rendered in the breadcrumb row
+ * (leading position). Renders as `<a href>` when `href` is set, or
+ * `<button type="button" onClick>` when `onClick` is set.
+ *
+ * @example
+ * // Anchor — relies on the consumer's router to intercept the click.
+ * <PageHeader.BackButton href="/contacts" aria-label="Back to contacts" />
+ *
+ * @example
+ * // Button — for programmatic navigation (history.back, route()).
+ * <PageHeader.BackButton onClick={() => router.back()} aria-label="Back" />
+ *
+ * @remarks Anti-patterns
+ * - ❌ Passing both `href` AND `onClick`. The component renders as a
+ *   `<button>` (onClick wins) and emits a dev-only warning. Pick one.
+ * - ❌ Passing neither `href` NOR `onClick`. Renders as a disabled
+ *   `<button>` with a dev-only warning — you almost certainly forgot a prop.
+ */
+export function PageHeaderBackButton({
+  href,
+  onClick,
+  'aria-label': ariaLabel = 'Go back',
+  icon = <ChevronLeft size={16} />,
+}: PageHeaderBackButtonProps) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production' && href && onClick) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '<PageHeader.BackButton> received both `href` and `onClick`. Rendering as <button>; `href` is ignored.',
+      );
+    }
+    if (process.env.NODE_ENV !== 'production' && !href && !onClick) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '<PageHeader.BackButton> rendered without `href` or `onClick`. Rendering as a disabled <button>.',
+      );
+    }
+  }, [href, onClick]);
+
+  if (onClick) {
+    const buttonProps: ButtonHTMLAttributes<HTMLButtonElement> = {
+      type: 'button',
+      onClick,
+      'aria-label': ariaLabel,
+      className: styles.backButton,
+    };
+    return <button {...buttonProps}>{icon}</button>;
+  }
+  if (href) {
+    const anchorProps: AnchorHTMLAttributes<HTMLAnchorElement> = {
+      href,
+      'aria-label': ariaLabel,
+      className: styles.backButton,
+    };
+    return <a {...anchorProps}>{icon}</a>;
+  }
+  return (
+    <button type="button" disabled aria-label={ariaLabel} className={styles.backButton}>
+      {icon}
+    </button>
+  );
+}
+PageHeaderBackButton.displayName = 'PageHeaderBackButton';
+
+/**
+ * The leading element to the LEFT of the title row — typically an Avatar,
+ * icon, or small image. Vertically centered with the title block. Distinct
+ * from `<PageHeader.BackButton>` which lives in the breadcrumb row.
+ *
+ * @example
+ * <PageHeader.Aside>
+ *   <Avatar size="lg" name="Acme Corp" src="..." />
+ * </PageHeader.Aside>
+ *
+ * @remarks
+ * - Position-based name (Aside) rather than semantic (Icon). The slot
+ *   accepts ANY ReactNode — Avatar, icon, image, custom badge. Naming it
+ *   "Icon" would lie about the common Avatar use case.
+ */
+export function PageHeaderAside({ children, className, ...rest }: PageHeaderAsideProps) {
+  return (
+    <div className={clsx(styles.aside, className)} {...rest}>
+      {children}
+    </div>
+  );
+}
+PageHeaderAside.displayName = 'PageHeaderAside';
+
+/**
+ * The main heading. Default `order={1}` renders an `<h1>`. Use `order={2}`
+ * (or higher) for section-level page headers within a larger page. `size`
+ * decouples visual size from semantic level — e.g. `<PageHeader.Title
+ * order={2} size="3xl">` renders an `<h2>` that LOOKS like an h1.
+ *
+ * @example
+ * <PageHeader.Title>Acme Corporation</PageHeader.Title>
+ *
+ * @example
+ * // Section header — h2 with default visual size for h2 (2xl):
+ * <PageHeader.Title order={2}>Filters</PageHeader.Title>
+ */
+export function PageHeaderTitle({ order = 1, size, children }: PageHeaderTitleProps) {
+  return (
+    <Title order={order} size={size} className={styles.title}>
+      {children}
+    </Title>
+  );
+}
+PageHeaderTitle.displayName = 'PageHeaderTitle';
+
+/**
+ * One-line description rendered below the title. Always a `<p>` with muted
+ * foreground color.
+ *
+ * @example
+ * <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
+ */
+export function PageHeaderSubtitle({ children, className, ...rest }: PageHeaderSubtitleProps) {
+  return (
+    <p className={clsx(styles.subtitle, className)} {...rest}>
+      {children}
+    </p>
+  );
+}
+PageHeaderSubtitle.displayName = 'PageHeaderSubtitle';
+
+/**
+ * Free slot for badges, timestamps, status chips, or any other small
+ * metadata you want below the subtitle. Rendered as a flex row that wraps
+ * to a new line on narrow viewports.
+ *
+ * @example
+ * <PageHeader.Meta>
+ *   <Badge tone="success">Active</Badge>
+ *   <Text size="sm" tone="muted">Last contacted 2 days ago</Text>
+ * </PageHeader.Meta>
+ */
+export function PageHeaderMeta({ children, className, ...rest }: PageHeaderMetaProps) {
+  return (
+    <div className={clsx(styles.meta, className)} {...rest}>
+      {children}
+    </div>
+  );
+}
+PageHeaderMeta.displayName = 'PageHeaderMeta';
+
+/**
+ * Right-aligned action cluster — typically a `<Cluster>` of `<Button>`s or
+ * a `<ButtonGroup>`. Vertically centered with the title block. Wraps to a
+ * new row below the title on viewports < 640px.
+ *
+ * @example
+ * <PageHeader.Actions>
+ *   <Button variant="secondary">Email</Button>
+ *   <Button variant="secondary">Call</Button>
+ *   <Button>Edit</Button>
+ * </PageHeader.Actions>
+ */
+export function PageHeaderActions({ children, className, ...rest }: PageHeaderActionsProps) {
+  return (
+    <div className={clsx(styles.actions, className)} {...rest}>
+      {children}
+    </div>
+  );
+}
+PageHeaderActions.displayName = 'PageHeaderActions';
+
+// ─── Root ────────────────────────────────────────────────────────────────
+
+/**
+ * Top-of-page heading area for CRM pages. Bundles seven optional slots
+ * (Breadcrumb, BackButton, Aside, Title, Subtitle, Meta, Actions) into a
+ * single CSS-grid layout with consistent spacing and an optional bottom
+ * border.
+ *
+ * Use the compound API — children are detected by `c.type === <SubComponent>`,
+ * placed into their grid area, and missing slots collapse to zero-height
+ * rows. Unrecognized children (e.g., a bare `<div>`) are silently dropped.
+ *
+ * @example
+ * // Minimal:
+ * <PageHeader>
+ *   <PageHeader.Title>Settings</PageHeader.Title>
+ * </PageHeader>
+ *
+ * @example
+ * // Members-style — title + subtitle + actions:
+ * <PageHeader>
+ *   <PageHeader.Title>Members</PageHeader.Title>
+ *   <PageHeader.Subtitle>Manage team access and roles.</PageHeader.Subtitle>
+ *   <PageHeader.Actions>
+ *     <Button>Invite member</Button>
+ *   </PageHeader.Actions>
+ * </PageHeader>
+ *
+ * @example
+ * // ContactDetail-style — everything:
+ * <PageHeader>
+ *   <PageHeader.Breadcrumb>
+ *     <Breadcrumb items={[...]} />
+ *   </PageHeader.Breadcrumb>
+ *   <PageHeader.BackButton href="/contacts" aria-label="Back to contacts" />
+ *   <PageHeader.Aside>
+ *     <Avatar size="lg" name="Acme Corp" />
+ *   </PageHeader.Aside>
+ *   <PageHeader.Title>Acme Corporation</PageHeader.Title>
+ *   <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
+ *   <PageHeader.Meta>
+ *     <Badge tone="success">Active</Badge>
+ *     <Text size="sm" tone="muted">Last contacted 2 days ago</Text>
+ *   </PageHeader.Meta>
+ *   <PageHeader.Actions>
+ *     <Button variant="secondary">Email</Button>
+ *     <Button>Edit</Button>
+ *   </PageHeader.Actions>
+ * </PageHeader>
+ *
+ * @example
+ * // With sibling Tabs — disable the bottom border:
+ * <PageHeader borderBottom={false}>
+ *   <PageHeader.Title>Reports</PageHeader.Title>
+ * </PageHeader>
+ * <Tabs value={tab} onChange={setTab}>...</Tabs>
+ *
+ * @remarks When NOT to use
+ * - For arbitrary section headers WITHIN a page that aren't the page's
+ *   primary heading. Use a `<Title order={2}>` directly.
+ * - For a sticky top bar. PageHeader is a regular block element; wrap it
+ *   in your own sticky container if you need sticky behavior.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Nesting `<PageHeader>` inside another `<PageHeader>` — undefined
+ *   behavior. Use a single PageHeader per page.
+ * - ❌ Putting non-PageHeader children (a bare `<div>`, a `<Stack>`) inside
+ *   `<PageHeader>`. They're silently dropped. Use one of the seven slots.
+ * - ❌ Wrapping a `<PageHeader.Title>` in an HOC or deep nesting. The
+ *   `c.type ===` detection only handles one level of Fragment unwrap.
+ * - ❌ Putting an Avatar inside `<PageHeader.Title>`. Muddles the `<h1>`
+ *   text-content for screen readers. Use `<PageHeader.Aside>` instead.
+ * - ❌ `position: sticky` on `<PageHeader>` itself — out of scope for v1.
+ *   Wrap PageHeader in your own sticky container if you need it.
+ */
+const PageHeaderRoot = forwardRef<HTMLDivElement, PageHeaderProps>(function PageHeaderRoot(
+  { borderBottom = true, className, children, ...rest },
+  ref,
+) {
+  const breadcrumb = findSlot(children, PageHeaderBreadcrumb);
+  const backButton = findSlot(children, PageHeaderBackButton);
+  const aside = findSlot(children, PageHeaderAside);
+  const title = findSlot(children, PageHeaderTitle);
+  const subtitle = findSlot(children, PageHeaderSubtitle);
+  const meta = findSlot(children, PageHeaderMeta);
+  const actions = findSlot(children, PageHeaderActions);
+
+  return (
+    <div
+      ref={ref}
+      className={clsx(styles.root, borderBottom && styles.rootWithBorder, className)}
+      {...rest}
+    >
+      {(breadcrumb || backButton) && (
+        <div className={styles.breadcrumb}>
+          {backButton}
+          {breadcrumb}
+        </div>
+      )}
+      {aside}
+      {title}
+      {subtitle}
+      {meta}
+      {actions}
+    </div>
+  );
+});
+PageHeaderRoot.displayName = 'PageHeader';
+
+/** Compound API: `<PageHeader>` + 7 sub-components. */
+export const PageHeader = Object.assign(PageHeaderRoot, {
+  Breadcrumb: PageHeaderBreadcrumb,
+  BackButton: PageHeaderBackButton,
+  Aside: PageHeaderAside,
+  Title: PageHeaderTitle,
+  Subtitle: PageHeaderSubtitle,
+  Meta: PageHeaderMeta,
+  Actions: PageHeaderActions,
+});
+```
+
+### Step 1.2: Write `PageHeader.module.scss`
+
+- [ ] Write file contents (verbatim):
+
+```scss
+@use '../../styles/mixins' as *;
+
+.root {
+  display: grid;
+  grid-template-areas:
+    'breadcrumb breadcrumb breadcrumb'
+    'aside title actions'
+    'aside subtitle actions'
+    'aside meta actions';
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-2) var(--space-3);
+  padding-block: var(--space-4) var(--space-3);
+}
+
+.rootWithBorder {
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.breadcrumb {
+  grid-area: breadcrumb;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.breadcrumbInner {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.backButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--color-fg-muted);
+
+  // CSS keyword — interactive trigger.
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  cursor: pointer;
+
+  // CSS keyword — kill the default underline when rendered as <a>.
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  text-decoration: none;
+}
+
+.backButton:hover:not(:disabled) {
+  background: var(--color-bg-muted);
+  color: var(--color-fg);
+}
+
+.backButton:focus-visible {
+  @include focus-ring;
+
+  outline: none;
+}
+
+.backButton:disabled {
+  // CSS keyword — disabled affordance.
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  cursor: not-allowed;
+  opacity: var(--opacity-disabled);
+}
+
+.aside {
+  grid-area: aside;
+  align-self: center;
+}
+
+.title {
+  grid-area: title;
+}
+
+.subtitle {
+  grid-area: subtitle;
+  font-size: var(--font-size-md);
+  color: var(--color-fg-muted);
+  line-height: var(--line-height-snug);
+}
+
+.meta {
+  grid-area: meta;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.actions {
+  grid-area: actions;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  align-self: center;
+}
+
+// ─── Responsive: actions wrap below the title on narrow viewports ────────
+@media (max-width: 640px) {
+  .root {
+    grid-template-areas:
+      'breadcrumb breadcrumb'
+      'aside title'
+      'aside subtitle'
+      'aside meta'
+      'actions actions';
+    grid-template-columns: auto 1fr;
+  }
+
+  .actions {
+    justify-content: flex-start;
+
+    // stylelint-disable-next-line property-disallowed-list -- internal responsive spacing in this layout primitive
+    margin-top: var(--space-3);
+  }
+}
+```
+
+If `<p class="subtitle">` accumulates browser-default margin via the global reset that conflicts with the grid, add `margin: 0;` inside `.subtitle` with a `property-disallowed-list` disable. The reset SHOULD zero `<p>` margins (verify by inspection); leaving it out of the verbatim SCSS unless lint flags it.
+
+### Step 1.3: Verify gates
+
+- [ ] Run `make build-lib` from `/home/dpws/projects/design-system`. Expected: clean (typecheck passes).
+- [ ] Run `make lint`. Expected: clean.
+
+DO NOT run `make test` yet — `index.ts` doesn't exist, `src/index.ts` doesn't re-export PageHeader, the structure meta-test would fail because there's no `PageHeader.test.tsx`.
+
+If lint flags a property not already pre-disabled, add the matching inline disable in place. Most likely flag is `subtitle`'s `margin: 0` (if the reset doesn't zero `<p>` margin).
+
+### Step 1.4: Commit
+
+```bash
+cd /home/dpws/projects/design-system && git add packages/design-system/src/components/PageHeader/PageHeader.tsx packages/design-system/src/components/PageHeader/PageHeader.module.scss && git commit -m "$(cat <<'EOF'
+PageHeader: source bundle (root + 7 sub-components + SCSS)
+
+Compound layout primitive for top-of-page headers. Seven slots
+(Breadcrumb, BackButton, Aside, Title, Subtitle, Meta, Actions) attached
+via Object.assign. The root reads children via Children.toArray + a small
+flattenChildren helper (one level of Fragment unwrap), finds each known
+sub-component by c.type === SubComponent, and renders into the correct
+grid area via grid-template-areas. Missing slots collapse to 0-height
+rows; unrecognized children silently dropped.
+
+BackButton renders <a href> or <button onClick> depending on prop; both
+present → button wins + dev warn; neither → disabled button + dev warn.
+
+borderBottom: boolean = true toggles the bottom border for the
+sibling-Tabs case. Responsive @media (max-width: 640px) re-orders the
+grid so Actions wraps below the title — first library component with a
+media query inside its SCSS Module.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Tests + barrel exports
+
+**Files:**
+
+- Create: `packages/design-system/src/components/PageHeader/PageHeader.test.tsx`
+- Create: `packages/design-system/src/components/PageHeader/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+### Step 2.1: Create `PageHeader.test.tsx`
+
+- [ ] Write file contents (verbatim):
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { PageHeader } from './index';
+
+describe('PageHeader — rendering', () => {
+  it('renders only the slots provided', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>Acme</PageHeader.Title>
+      </PageHeader>,
+    );
+    expect(screen.getByRole('heading', { level: 1, name: 'Acme' })).toBeInTheDocument();
+    // No subtitle / meta / actions / aside / breadcrumb rendered.
+    expect(container.querySelector('[class*="subtitle"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[class*="meta"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[class*="actions"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[class*="aside"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[class*="breadcrumb"]')).not.toBeInTheDocument();
+  });
+
+  it('renders all seven slots when provided', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Breadcrumb>
+          <nav data-testid="bc">crumb</nav>
+        </PageHeader.Breadcrumb>
+        <PageHeader.BackButton href="/back" />
+        <PageHeader.Aside>
+          <span data-testid="aside-content">A</span>
+        </PageHeader.Aside>
+        <PageHeader.Title>T</PageHeader.Title>
+        <PageHeader.Subtitle>S</PageHeader.Subtitle>
+        <PageHeader.Meta>M</PageHeader.Meta>
+        <PageHeader.Actions>
+          <button type="button">btn</button>
+        </PageHeader.Actions>
+      </PageHeader>,
+    );
+    expect(screen.getByTestId('bc')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go back' })).toBeInTheDocument();
+    expect(screen.getByTestId('aside-content')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'T' })).toBeInTheDocument();
+    expect(screen.getByText('S')).toBeInTheDocument();
+    expect(screen.getByText('M')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'btn' })).toBeInTheDocument();
+    // Spot-check that aside got positioned via the .aside class.
+    expect(container.querySelector('[class*="aside"]')).toBeInTheDocument();
+  });
+
+  it('applies rootWithBorder class by default', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>X</PageHeader.Title>
+      </PageHeader>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/rootWithBorder/);
+  });
+
+  it('does NOT apply rootWithBorder when borderBottom={false}', () => {
+    const { container } = render(
+      <PageHeader borderBottom={false}>
+        <PageHeader.Title>X</PageHeader.Title>
+      </PageHeader>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).not.toMatch(/rootWithBorder/);
+  });
+
+  it('renders as a <div>, not a <header>', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>X</PageHeader.Title>
+      </PageHeader>,
+    );
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+    // Confirm no banner landmark is introduced.
+    expect(container.querySelector('header')).not.toBeInTheDocument();
+  });
+});
+
+describe('PageHeader — sub-component detection', () => {
+  it('renders <PageHeader.Title> into the title slot', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>Match me</PageHeader.Title>
+      </PageHeader>,
+    );
+    const title = container.querySelector('[class*="title"]') as HTMLElement;
+    expect(title).toBeInTheDocument();
+    expect(title.tagName).toBe('H1');
+    expect(title.textContent).toBe('Match me');
+  });
+
+  it('silently drops unrecognized children', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>Kept</PageHeader.Title>
+        <div data-testid="bad-child">should not render</div>
+        <span>also dropped</span>
+      </PageHeader>,
+    );
+    expect(screen.getByRole('heading', { level: 1, name: 'Kept' })).toBeInTheDocument();
+    expect(screen.queryByTestId('bad-child')).not.toBeInTheDocument();
+    expect(screen.queryByText('also dropped')).not.toBeInTheDocument();
+    expect(container.textContent).not.toContain('should not render');
+  });
+
+  it('unwraps one level of Fragment around a sub-component', () => {
+    render(
+      <PageHeader>
+        <>
+          <PageHeader.Title>Fragmented</PageHeader.Title>
+          <PageHeader.Subtitle>Also fragmented</PageHeader.Subtitle>
+        </>
+      </PageHeader>,
+    );
+    expect(screen.getByRole('heading', { level: 1, name: 'Fragmented' })).toBeInTheDocument();
+    expect(screen.getByText('Also fragmented')).toBeInTheDocument();
+  });
+});
+
+describe('PageHeader.Title', () => {
+  it('defaults to order=1 (renders <h1>)', () => {
+    render(
+      <PageHeader>
+        <PageHeader.Title>H1</PageHeader.Title>
+      </PageHeader>,
+    );
+    expect(screen.getByRole('heading', { level: 1, name: 'H1' })).toBeInTheDocument();
+  });
+
+  it('renders <h2> when order={2}', () => {
+    render(
+      <PageHeader>
+        <PageHeader.Title order={2}>H2</PageHeader.Title>
+      </PageHeader>,
+    );
+    expect(screen.getByRole('heading', { level: 2, name: 'H2' })).toBeInTheDocument();
+    // And NO h1 should exist.
+    expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+  });
+});
+
+describe('PageHeader.BackButton', () => {
+  it('renders <a> when href is provided', () => {
+    render(
+      <PageHeader>
+        <PageHeader.BackButton href="/contacts" aria-label="Back to contacts" />
+      </PageHeader>,
+    );
+    const link = screen.getByRole('link', { name: 'Back to contacts' });
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/contacts');
+  });
+
+  it('renders <button> when onClick is provided', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <PageHeader>
+        <PageHeader.BackButton onClick={onClick} aria-label="Back" />
+      </PageHeader>,
+    );
+    const btn = screen.getByRole('button', { name: 'Back' });
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn).toHaveAttribute('type', 'button');
+    await user.click(btn);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('warns in dev when both href and onClick are passed; renders as <button>', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <PageHeader>
+        <PageHeader.BackButton href="/x" onClick={() => {}} aria-label="Back" />
+      </PageHeader>,
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('received both `href` and `onClick`'),
+    );
+    expect(screen.getByRole('button', { name: 'Back' }).tagName).toBe('BUTTON');
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    warnSpy.mockRestore();
+  });
+
+  it('warns in dev when neither href nor onClick; renders disabled <button>', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <PageHeader>
+        <PageHeader.BackButton aria-label="Back" />
+      </PageHeader>,
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('without `href` or `onClick`'));
+    const btn = screen.getByRole('button', { name: 'Back' });
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn).toBeDisabled();
+    warnSpy.mockRestore();
+  });
+
+  it('defaults aria-label to "Go back" when not provided', () => {
+    render(
+      <PageHeader>
+        <PageHeader.BackButton href="/back" />
+      </PageHeader>,
+    );
+    expect(screen.getByRole('link', { name: 'Go back' })).toBeInTheDocument();
+  });
+
+  it('renders custom icon when provided', () => {
+    render(
+      <PageHeader>
+        <PageHeader.BackButton href="/back" icon={<span data-testid="custom-icon">⟵</span>} />
+      </PageHeader>,
+    );
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+});
+
+describe('PageHeader.Aside + PageHeader.Actions', () => {
+  it('renders Aside children inside the .aside slot', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Aside>
+          <span data-testid="content">A</span>
+        </PageHeader.Aside>
+        <PageHeader.Title>T</PageHeader.Title>
+      </PageHeader>,
+    );
+    const aside = container.querySelector('[class*="aside"]') as HTMLElement;
+    expect(aside).toBeInTheDocument();
+    expect(aside).toContainElement(screen.getByTestId('content'));
+  });
+
+  it('renders Actions children inside the .actions slot', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>T</PageHeader.Title>
+        <PageHeader.Actions>
+          <button type="button">Save</button>
+          <button type="button">Cancel</button>
+        </PageHeader.Actions>
+      </PageHeader>,
+    );
+    const actions = container.querySelector('[class*="actions"]') as HTMLElement;
+    expect(actions).toBeInTheDocument();
+    expect(actions).toContainElement(screen.getByRole('button', { name: 'Save' }));
+    expect(actions).toContainElement(screen.getByRole('button', { name: 'Cancel' }));
+  });
+});
+
+describe('PageHeader.Subtitle + PageHeader.Meta', () => {
+  it('renders both below the title in the center column', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>T</PageHeader.Title>
+        <PageHeader.Subtitle>S</PageHeader.Subtitle>
+        <PageHeader.Meta>
+          <span data-testid="meta-child">M</span>
+        </PageHeader.Meta>
+      </PageHeader>,
+    );
+    expect(container.querySelector('[class*="subtitle"]')?.textContent).toBe('S');
+    expect(screen.getByTestId('meta-child')).toBeInTheDocument();
+  });
+});
+
+describe('PageHeader — misc', () => {
+  it('forwards ref to the outermost div', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <PageHeader ref={ref}>
+        <PageHeader.Title>X</PageHeader.Title>
+      </PageHeader>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('className merges with the base class on the root', () => {
+    const { container } = render(
+      <PageHeader className="custom-class">
+        <PageHeader.Title>X</PageHeader.Title>
+      </PageHeader>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/custom-class/);
+    expect(root.className).toMatch(/root/);
+  });
+
+  it('aria-labelledby support — h1 has a stable id we can target if needed', () => {
+    // Sanity that Title renders the actual <h1> element with text content
+    // (not a button or generic role).
+    render(
+      <PageHeader>
+        <PageHeader.Title>Findable</PageHeader.Title>
+      </PageHeader>,
+    );
+    const h1 = screen.getByRole('heading', { level: 1 });
+    expect(h1.tagName).toBe('H1');
+    expect(h1.textContent).toBe('Findable');
+  });
+});
+```
+
+### Step 2.2: Create `index.ts`
+
+- [ ] Write file contents (verbatim):
+
+```ts
+export {
+  PageHeader,
+  PageHeaderBreadcrumb,
+  PageHeaderBackButton,
+  PageHeaderAside,
+  PageHeaderTitle,
+  PageHeaderSubtitle,
+  PageHeaderMeta,
+  PageHeaderActions,
+} from './PageHeader';
+export type {
+  PageHeaderProps,
+  PageHeaderBreadcrumbProps,
+  PageHeaderBackButtonProps,
+  PageHeaderAsideProps,
+  PageHeaderTitleProps,
+  PageHeaderSubtitleProps,
+  PageHeaderMetaProps,
+  PageHeaderActionsProps,
+} from './PageHeader';
+```
+
+### Step 2.3: Modify `src/index.ts` — add PageHeader barrel re-export
+
+Read `packages/design-system/src/index.ts` first to find an alphabetical slot. `PageHeader` (P) slots after `Modal` and before `Pagination` / `PasswordInput` (any earlier P-named export).
+
+Use the Edit tool with `replace_all: false`. Suggested anchor — find a Modal-related export block:
+
+**old_string** (find the actual Modal block in the file; example template):
+
+```ts
+export { Modal } from './components/Modal';
+export type { ModalProps, ModalSize } from './components/Modal';
+```
+
+**new_string:**
+
+```ts
+export { Modal } from './components/Modal';
+export type { ModalProps, ModalSize } from './components/Modal';
+
+export { PageHeader } from './components/PageHeader';
+export type {
+  PageHeaderProps,
+  PageHeaderBreadcrumbProps,
+  PageHeaderBackButtonProps,
+  PageHeaderAsideProps,
+  PageHeaderTitleProps,
+  PageHeaderSubtitleProps,
+  PageHeaderMetaProps,
+  PageHeaderActionsProps,
+} from './components/PageHeader';
+```
+
+If the Modal block in the file has different surrounding context (e.g. extra type fields), expand `old_string` until it's unique and apply the equivalent insertion.
+
+### Step 2.4: Verify gates
+
+From `/home/dpws/projects/design-system`:
+
+- [ ] Run `make test`. Expected: baseline tests + ~18 new PageHeader tests pass + structure meta-test passes. Total test count rises by ~18.
+- [ ] Run `make build-lib`. Expected: clean.
+- [ ] Run `make build`. Expected: clean.
+- [ ] Run `make lint`. Expected: clean.
+
+If a test fails, most likely modes:
+
+- **Fragment test fails** — verify `flattenChildren`'s handling. The test wraps both Title and Subtitle in `<>...</>`; both should be detected. If only one is found, the helper is unwrapping wrong.
+- **"both href and onClick" test fails on the warn assertion** — useEffect timing. The warn is in a `useEffect`; React Testing Library auto-runs effects in `render()`, so the warn should fire by the time the assertion runs. If not, wrap the assertion in `await waitFor(...)`.
+- **Subtitle margin** — if a global reset leaves a `<p>` with default browser margins, the `.subtitle` element may not align with the grid as expected. The test asserts only text content, not visual position, so this would NOT fail tests — but flag it for the demo step.
+
+### Step 2.5: Commit
+
+```bash
+cd /home/dpws/projects/design-system && git add packages/design-system/src/components/PageHeader/PageHeader.test.tsx packages/design-system/src/components/PageHeader/index.ts packages/design-system/src/index.ts && git commit -m "$(cat <<'EOF'
+PageHeader: unit tests (~18 cases) + barrel re-exports
+
+Tests cover rendering (only-title minimal, all-seven-slots, borderBottom
+default + false, root is <div>), sub-component detection (Title slot,
+unrecognized children dropped, Fragment unwrap), Title (order=1 default,
+order=2 → h2), BackButton (<a> when href, <button> when onClick, both →
+button + warn, neither → disabled button + warn, default aria-label,
+custom icon), Aside + Actions slot content, Subtitle + Meta rendering,
+and misc (forwardRef, className merge, h1 sanity).
+
+Also re-exports PageHeader (with all 7 sub-components attached via
+Object.assign) and the per-slot Props types from src/index.ts so
+structure.test.ts passes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: AGENTS.md PageHeader section
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md`
+
+### Step 3.1: Verify the PageHeader re-export exists
+
+- [ ] Read `packages/design-system/src/index.ts` and confirm there's a block exporting `PageHeader` from `./components/PageHeader` (T2 added it). If missing, STOP and report BLOCKED.
+
+### Step 3.2: Insert PageHeader section AFTER `<Divider>` (last in the Layout cluster)
+
+Read `packages/design-system/AGENTS.md` to find the boundary — the `<Divider>` section's closing line immediately followed by whatever section comes next (typically a Forms or Display section heading).
+
+Use Edit with `replace_all: false`. Suggested anchor (verify against the file — the closing line of `<Divider>` is typically a "Hard rule" anti-pattern bullet):
+
+**old_string** (find the actual Divider closing line; example template):
+
+```markdown
+- ❌ Using `<Divider>` as a vertical separator inside a `<Cluster>` — use `<Divider orientation="vertical">` for that, then `<Divider>` knows to render as a vertical line instead of horizontal.
+
+### `<Button>` — action triggers
+```
+
+**new_string:**
+
+````markdown
+- ❌ Using `<Divider>` as a vertical separator inside a `<Cluster>` — use `<Divider orientation="vertical">` for that, then `<Divider>` knows to render as a vertical line instead of horizontal.
+
+### `<PageHeader>` — top-of-page heading area
+
+```tsx
+<PageHeader>
+  <PageHeader.Breadcrumb>
+    <Breadcrumb items={[...]} />
+  </PageHeader.Breadcrumb>
+  <PageHeader.BackButton href="/contacts" aria-label="Back to contacts" />
+  <PageHeader.Aside>
+    <Avatar size="lg" name="Acme Corp" />
+  </PageHeader.Aside>
+  <PageHeader.Title>Acme Corporation</PageHeader.Title>
+  <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
+  <PageHeader.Meta>
+    <Badge tone="success">Active</Badge>
+    <Text size="sm" tone="muted">Last contacted 2 days ago</Text>
+  </PageHeader.Meta>
+  <PageHeader.Actions>
+    <Button variant="secondary">Email</Button>
+    <Button>Edit</Button>
+  </PageHeader.Actions>
+</PageHeader>
+```
+
+- **Compound API.** Seven slots: `Breadcrumb`, `BackButton`, `Aside`, `Title`, `Subtitle`, `Meta`, `Actions`. Detected via `c.type === SubComponent` after one level of Fragment unwrap. Unrecognized children are silently dropped.
+- **All slots optional.** Missing slots collapse to zero-height rows; minimal usage is `<PageHeader><PageHeader.Title>…</PageHeader.Title></PageHeader>`.
+- **`borderBottom: boolean = true`** — toggles the 1px bottom border. Set `false` when placing `<Tabs>` immediately below (Tabs has its own bottom border; you don't want two lines).
+- **`<PageHeader.BackButton>`** renders as `<a href>` when `href` is provided, or `<button onClick>` when `onClick` is provided. Mutually exclusive — both → button wins with a dev warn; neither → disabled button with a dev warn. Default `aria-label="Go back"`; default icon `<ChevronLeft size={16}>`. Lives in the breadcrumb row, left of the breadcrumb itself.
+- **`<PageHeader.Aside>`** is a position-based slot (not named "Icon" / "Avatar") so it accepts whatever leading element you need. Vertically centered with the title block.
+- **`<PageHeader.Title>`** passes through to `<Title order={order} size={size}>`. Default `order={1}` (renders `<h1>`); set `order={2}` for sub-page section headers.
+- **`<PageHeader.Subtitle>`** is a `<p>` with muted color.
+- **`<PageHeader.Meta>`** is a flex row that wraps — good for badges + timestamps.
+- **`<PageHeader.Actions>`** is a flex row, right-aligned by default. On viewports < 640px, Actions wraps below the title block.
+- **NOT a `<header>` landmark.** PageHeader renders a `<div>` to avoid conflicting with the AppShell's app-level `<header role="banner">`.
+
+#### Hard rule
+
+- ❌ Nesting `<PageHeader>` inside another `<PageHeader>` — undefined behavior. Use one PageHeader per page.
+- ❌ Putting non-PageHeader children (a `<div>`, a `<Stack>`) inside `<PageHeader>` — they're silently dropped. Use one of the seven slots.
+- ❌ Wrapping a sub-component in an HOC or deep nesting. The `c.type ===` detection handles ONE level of Fragment unwrap only.
+- ❌ Putting an Avatar inside `<PageHeader.Title>` — muddles the `<h1>`'s text content for screen readers. Use `<PageHeader.Aside>` instead.
+- ❌ `position: sticky` directly on `<PageHeader>` — out of scope for v1. Wrap in your own sticky container if you need sticky behavior.
+- ❌ Passing both `href` and `onClick` to `<PageHeader.BackButton>` — onClick wins with a dev warn. Pick one.
+
+### `<Button>` — action triggers
+````
+
+If the anchor differs (e.g. `<Divider>` is followed by `<Card>` instead of `<Button>`), expand `old_string` upward with one more preceding line for uniqueness and replace with the equivalent insertion.
+
+### Step 3.3: Verify gates
+
+- [ ] Run `make build`. Expected: clean.
+- [ ] Run `make lint`. Expected: clean.
+
+### Step 3.4: Commit
+
+```bash
+cd /home/dpws/projects/design-system && git add packages/design-system/AGENTS.md && git commit -m "$(cat <<'EOF'
+AGENTS.md: add PageHeader section after <Divider> in Layout cluster
+
+Covers compound API (7 slots), borderBottom prop for sibling Tabs,
+BackButton's <a> vs <button> rendering with the mutual-exclusion warn,
+Aside as position-based slot, Title pass-through to <Title order size>,
+Subtitle / Meta / Actions, and the "Hard rule" callout with 6
+anti-patterns. PageHeader renders a <div> (not <header>) to avoid
+conflicting with AppShell's app-level banner landmark.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Playground demo + 4-place wiring
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/PageHeaderDemo.tsx`
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+### Step 4.1: Create `PageHeaderDemo.tsx`
+
+- [ ] Write file contents (verbatim):
+
+```tsx
+import { useState } from 'react';
+import {
+  PageHeader,
+  Avatar,
+  Badge,
+  Button,
+  Breadcrumb,
+  Tabs,
+  Text,
+  Stack,
+} from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/PageHeader/PageHeader.tsx?raw';
+import scssSource from '@lib-source/components/PageHeader/PageHeader.module.scss?raw';
+
+function MinimalDemo() {
+  return (
+    <PageHeader>
+      <PageHeader.Title>Settings</PageHeader.Title>
+    </PageHeader>
+  );
+}
+
+function WithSubtitleAndActions() {
+  return (
+    <PageHeader>
+      <PageHeader.Title>Members</PageHeader.Title>
+      <PageHeader.Subtitle>Manage team access and roles.</PageHeader.Subtitle>
+      <PageHeader.Actions>
+        <Button>Invite member</Button>
+      </PageHeader.Actions>
+    </PageHeader>
+  );
+}
+
+function FullDemo() {
+  return (
+    <PageHeader>
+      <PageHeader.Breadcrumb>
+        <Breadcrumb items={[{ label: 'Contacts', href: '#' }, { label: 'Acme Corp' }]} />
+      </PageHeader.Breadcrumb>
+      <PageHeader.BackButton href="#" aria-label="Back to contacts" />
+      <PageHeader.Aside>
+        <Avatar size="lg" name="Acme Corp" />
+      </PageHeader.Aside>
+      <PageHeader.Title>Acme Corporation</PageHeader.Title>
+      <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
+      <PageHeader.Meta>
+        <Badge tone="success">Active</Badge>
+        <Text size="sm" tone="muted">
+          Last contacted 2 days ago
+        </Text>
+      </PageHeader.Meta>
+      <PageHeader.Actions>
+        <Button variant="secondary">Email</Button>
+        <Button variant="secondary">Call</Button>
+        <Button>Edit</Button>
+      </PageHeader.Actions>
+    </PageHeader>
+  );
+}
+
+function WithSiblingTabs() {
+  const [tab, setTab] = useState('overview');
+  return (
+    <Stack gap="0">
+      <PageHeader borderBottom={false}>
+        <PageHeader.Title>Reports</PageHeader.Title>
+        <PageHeader.Actions>
+          <Button variant="secondary">Export</Button>
+          <Button>New report</Button>
+        </PageHeader.Actions>
+      </PageHeader>
+      <Tabs
+        value={tab}
+        onChange={setTab}
+        items={[
+          { value: 'overview', label: 'Overview' },
+          { value: 'pipeline', label: 'Pipeline' },
+          { value: 'forecast', label: 'Forecast' },
+        ]}
+      />
+    </Stack>
+  );
+}
+
+function SectionHeaderDemo() {
+  return (
+    <PageHeader>
+      <PageHeader.Title order={2}>Filters</PageHeader.Title>
+      <PageHeader.Subtitle>Narrow the dataset shown below.</PageHeader.Subtitle>
+      <PageHeader.Actions>
+        <Button variant="secondary">Reset</Button>
+      </PageHeader.Actions>
+    </PageHeader>
+  );
+}
+
+export function PageHeaderDemo() {
+  return (
+    <DemoLayout
+      name="PageHeader"
+      description="Compound layout primitive for top-of-page headers. Seven slots (Breadcrumb, BackButton, Aside, Title, Subtitle, Meta, Actions) attached via Object.assign. Missing slots collapse; unrecognized children are silently dropped."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="PageHeader.tsx"
+      scssFilename="PageHeader.module.scss"
+      componentName="PageHeader"
+    >
+      <Example
+        title="Minimal"
+        description="The smallest useful PageHeader — just a Title. All other slots are absent and collapse to 0 height."
+        code={`<PageHeader>
+  <PageHeader.Title>Settings</PageHeader.Title>
+</PageHeader>`}
+      >
+        <MinimalDemo />
+      </Example>
+
+      <Example
+        title="With subtitle and actions"
+        description="The dominant CRM list/index page pattern. Title + Subtitle on the left, a primary Action button on the right."
+        code={`<PageHeader>
+  <PageHeader.Title>Members</PageHeader.Title>
+  <PageHeader.Subtitle>Manage team access and roles.</PageHeader.Subtitle>
+  <PageHeader.Actions>
+    <Button>Invite member</Button>
+  </PageHeader.Actions>
+</PageHeader>`}
+      >
+        <WithSubtitleAndActions />
+      </Example>
+
+      <Example
+        title="Full (detail page)"
+        description="ContactDetail-style header. Breadcrumb + BackButton in the top row; Aside (Avatar) to the left of the title block; Title + Subtitle + Meta (Badge + Text) stacked in the center; Actions cluster on the right."
+        code={`<PageHeader>
+  <PageHeader.Breadcrumb>
+    <Breadcrumb items={[
+      { label: 'Contacts', href: '#' },
+      { label: 'Acme Corp' },
+    ]} />
+  </PageHeader.Breadcrumb>
+  <PageHeader.BackButton href="#" aria-label="Back to contacts" />
+  <PageHeader.Aside>
+    <Avatar size="lg" name="Acme Corp" />
+  </PageHeader.Aside>
+  <PageHeader.Title>Acme Corporation</PageHeader.Title>
+  <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
+  <PageHeader.Meta>
+    <Badge tone="success">Active</Badge>
+    <Text size="sm" tone="muted">Last contacted 2 days ago</Text>
+  </PageHeader.Meta>
+  <PageHeader.Actions>
+    <Button variant="secondary">Email</Button>
+    <Button variant="secondary">Call</Button>
+    <Button>Edit</Button>
+  </PageHeader.Actions>
+</PageHeader>`}
+      >
+        <FullDemo />
+      </Example>
+
+      <Example
+        title="Inline with sibling Tabs"
+        description="When Tabs follows the header as a sibling, set `borderBottom={false}` so PageHeader's border doesn't duplicate Tabs' own border-bottom."
+        code={`<Stack gap="0">
+  <PageHeader borderBottom={false}>
+    <PageHeader.Title>Reports</PageHeader.Title>
+    <PageHeader.Actions>
+      <Button variant="secondary">Export</Button>
+      <Button>New report</Button>
+    </PageHeader.Actions>
+  </PageHeader>
+  <Tabs value={tab} onChange={setTab} items={[
+    { value: 'overview', label: 'Overview' },
+    { value: 'pipeline', label: 'Pipeline' },
+    { value: 'forecast', label: 'Forecast' },
+  ]} />
+</Stack>`}
+      >
+        <WithSiblingTabs />
+      </Example>
+
+      <Example
+        title="Section header (order={2})"
+        description="Sub-page section header — renders as <h2> instead of <h1>. Useful for sub-pages within a tab or a panel where the page's <h1> lives elsewhere."
+        code={`<PageHeader>
+  <PageHeader.Title order={2}>Filters</PageHeader.Title>
+  <PageHeader.Subtitle>Narrow the dataset shown below.</PageHeader.Subtitle>
+  <PageHeader.Actions>
+    <Button variant="secondary">Reset</Button>
+  </PageHeader.Actions>
+</PageHeader>`}
+      >
+        <SectionHeaderDemo />
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+If `Breadcrumb`'s actual prop shape differs from `items={[{label, href?}]}` (verify by reading `packages/design-system/src/components/Breadcrumb/Breadcrumb.tsx` if the build fails), adapt the demo's Breadcrumb usage to match. If `Tabs`'s actual API differs from `items={[{value, label}]}` (likewise verify), adapt accordingly. The PageHeader's own contract is unaffected; these are just the demo's compositions.
+
+### Step 4.2: Modify `App.tsx` — add import + Route
+
+Read `packages/playground/src/App.tsx`. PageHeader (`P-a-g`) slots alphabetically between `Modal` and `Pagination` (any earlier P).
+
+**Edit 4a — add import**:
+
+old_string:
+
+```tsx
+import { ModalDemo } from './pages/components/ModalDemo';
+```
+
+new_string:
+
+```tsx
+import { ModalDemo } from './pages/components/ModalDemo';
+import { PageHeaderDemo } from './pages/components/PageHeaderDemo';
+```
+
+**Edit 4b — add Route**:
+
+old_string:
+
+```tsx
+<Route path="/components/modal" element={<ModalDemo />} />
+```
+
+new_string:
+
+```tsx
+          <Route path="/components/modal" element={<ModalDemo />} />
+          <Route path="/components/page-header" element={<PageHeaderDemo />} />
+```
+
+If the actual Modal import / route block has more surrounding context (extra props, multi-line definitions), expand the anchor for uniqueness and apply the equivalent insertion.
+
+### Step 4.3: Modify `AppShell.tsx` — add LayoutPanelTop icon + Layout-cluster nav item
+
+Read `packages/playground/src/layout/AppShell/AppShell.tsx`.
+
+**Edit 4c — add `LayoutPanelTop` import** (anchor on the existing `LayoutPanelLeft` line):
+
+old_string:
+
+```tsx
+  LayoutPanelLeft,
+```
+
+new_string:
+
+```tsx
+  LayoutPanelLeft,
+  LayoutPanelTop,
+```
+
+**Edit 4d — add Layout-cluster nav item at the END of the Layout group** (after `Card`):
+
+old_string:
+
+```tsx
+      { to: '/components/card', label: 'Card', icon: RectangleHorizontal, end: false },
+```
+
+new_string:
+
+```tsx
+      { to: '/components/card', label: 'Card', icon: RectangleHorizontal, end: false },
+      { to: '/components/page-header', label: 'PageHeader', icon: LayoutPanelTop, end: false },
+```
+
+If the Card line ends differently (additional flags, comment), include enough surrounding context in `old_string` for uniqueness.
+
+### Step 4.4: Modify `ComponentsIndex.tsx` — add import + card
+
+Read `packages/playground/src/pages/components/ComponentsIndex.tsx`.
+
+**Edit 4e — add `PageHeader` import** (place alongside other library-component imports — find the Modal import line for the anchor):
+
+old_string:
+
+```tsx
+import { Modal } from '@eocrm/design-system';
+```
+
+new_string:
+
+```tsx
+import { Modal } from '@eocrm/design-system';
+import { PageHeader } from '@eocrm/design-system';
+```
+
+If `Modal` is imported as part of a multi-import block (e.g. `import { Modal, Tooltip } from '@eocrm/design-system';`), instead add a new dedicated import for PageHeader.
+
+**Edit 4f — add card entry alphabetically** (after Modal, before any earlier P-name like `Pagination`):
+
+Read the file to find the existing Modal card's complete `{ ... },` block. After it, insert this PageHeader card. Use Edit with the Modal card as `old_string` and `Modal card + PageHeader card` as `new_string`:
+
+The new card:
+
+```tsx
+  {
+    to: '/components/page-header',
+    name: 'PageHeader',
+    description:
+      'Compound layout primitive for top-of-page headers. Breadcrumb + BackButton + Aside (Avatar) + Title + Subtitle + Meta + Actions.',
+    preview: (
+      <div style={{ width: '100%', pointerEvents: 'none' }}>
+        <PageHeader borderBottom={false}>
+          <PageHeader.Title order={2}>Acme Corp</PageHeader.Title>
+          <PageHeader.Subtitle>230 employees</PageHeader.Subtitle>
+          <PageHeader.Actions>
+            <button
+              type="button"
+              style={{
+                padding: '4px 10px',
+                borderRadius: 'var(--radius-sm)',
+                border: 'var(--border-width) solid var(--color-border)',
+                background: 'var(--color-bg)',
+                fontSize: 'var(--font-size-sm)',
+              }}
+            >
+              Edit
+            </button>
+          </PageHeader.Actions>
+        </PageHeader>
+      </div>
+    ),
+  },
+```
+
+Why an inline-styled `<button>` instead of the library's `<Button>`: the existing cards use Button freely; switch to `Button` if it's already imported in the file. If it isn't, use the inline-styled fallback above to keep the import surface unchanged.
+
+### Step 4.5: Modify `registry.ts` — extend ComponentName union
+
+old_string (alphabetical position):
+
+```ts
+  | 'Modal'
+```
+
+new_string:
+
+```ts
+  | 'Modal'
+  | 'PageHeader'
+```
+
+If the union has different surrounding context, find a unique anchor and insert `'PageHeader'` in alphabetical position.
+
+### Step 4.6: Verify gates
+
+From `/home/dpws/projects/design-system`:
+
+- [ ] Run `make build`. Expected: typecheck + vite bundle clean.
+- [ ] Run `make lint`. Expected: clean.
+
+If the build fails on the demo file:
+
+- Type errors from `Breadcrumb` / `Tabs` — these libraries' actual prop shapes may differ from the demo's usage. Read their source files and adapt the demo's Breadcrumb / Tabs usage to match. The PageHeader contract is unaffected.
+- `DemoLayout` / `Example` import paths — pre-existing playground patterns; mirror exactly from `ImageCropDemo.tsx` or `ColorPickerDemo.tsx`.
+
+### Step 4.7: Commit
+
+```bash
+cd /home/dpws/projects/design-system && git add packages/playground/src/pages/components/PageHeaderDemo.tsx packages/playground/src/App.tsx packages/playground/src/layout/AppShell/AppShell.tsx packages/playground/src/pages/components/ComponentsIndex.tsx packages/playground/src/pages/mockups/registry.ts && git commit -m "$(cat <<'EOF'
+PageHeader demo + 4-place wiring
+
+PageHeaderDemo: 5 examples — minimal (Title only), with subtitle + actions
+(Members-style), full (ContactDetail-style with Breadcrumb + BackButton +
+Aside + Title + Subtitle + Meta + Actions), inline with sibling Tabs
+(borderBottom={false}), and section header (order={2}).
+
+Wired into App.tsx routes, AppShell Layout cluster nav (LayoutPanelTop
+icon at the end of the Layout group), ComponentsIndex overview card,
+mockup registry ComponentName union.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: HR8 + push + PR
+
+**Files:** none directly — this task is the review loop on Tasks 1–4.
+
+### Step 5.1: Run all four gates from the repo root
+
+- [ ] `cd /home/dpws/projects/design-system && make test`. Expected: every test passes (baseline + ~18 new = ~1915).
+- [ ] `make build-lib`. Expected: clean.
+- [ ] `make build`. Expected: clean.
+- [ ] `make lint`. Expected: clean.
+
+If any gate fails, fix and re-run all four. Don't proceed to 5.2 until all four are green.
+
+### Step 5.2: Dispatch the HR8 reviewer (round 1)
+
+Use a fresh-context `general-purpose` agent with **opus** model. Brief on the 10 review categories from `packages/design-system/CLAUDE.md` Rule 8.
+
+**Pre-known design decisions to forward** (do NOT re-litigate):
+
+1. **Compound pattern** with 7 sub-components attached via `Object.assign`.
+2. **`Aside` slot (not `Leading`, not `Icon`)** — position-based naming per user preference. Accepts Avatar / icon / image.
+3. **`flattenChildren` helper handles ONE level of Fragment unwrap.** Deeper nesting / HOCs are documented anti-patterns.
+4. **Unrecognized children are silently dropped** — no error, no warning. Documented as anti-pattern.
+5. **BackButton: `<a>` if `href`, `<button>` if `onClick`.** Both → button + dev warn. Neither → disabled button + dev warn. Default `aria-label="Go back"`, default icon `<ChevronLeft size={16}>`.
+6. **`<div>` root, NOT `<header>`** — avoids landmark conflict with the AppShell's app-level `<header role="banner">`.
+7. **`borderBottom: boolean = true`** prop, with `false` for the sibling-Tabs case.
+8. **First library component with a media query inside its CSS Module** — flagged as REGRESSION-WATCH.
+9. **Mockup refactor** (ContactDetail, Members) deferred to a follow-up PR.
+10. **Multiple `<PageHeader.Title>` children** — first wins, rest dropped. Documented edge case.
+
+**Particular things to ask for fresh eyes on:**
+
+A. **`flattenChildren` and `Children.toArray` interaction.** `Children.toArray` adds a `.$$typeof === Symbol.for('react.element')` check that wraps siblings into arrays with keys — does `c.type === SubComponent` work correctly across that? Walk the test "unwraps one level of Fragment" to confirm.
+
+B. **Multiple children of the same sub-component.** What if a consumer passes `<PageHeader.Title>A</PageHeader.Title><PageHeader.Title>B</PageHeader.Title>`? `findSlot` returns the FIRST match; the second is silently dropped. Documented behavior — verify the test coverage.
+
+C. **`<a className=...>` and `<button className=...>` styling parity.** Both use `.backButton` and `.backButton:hover`. Does `:hover:not(:disabled)` work correctly on an `<a>` (which doesn't have a `disabled` attribute)? Test: render `<a>`, hover via Playwright/jsdom — should bg change to `--color-bg-muted`. Verify the SCSS doesn't accidentally drop the `<a>`'s hover.
+
+D. **`useEffect` for the BackButton warns.** React 18 StrictMode fires effects twice in development — does the warn fire twice? Spied warnSpy in the test should handle this (it just checks `toHaveBeenCalledWith(...)`, not the call count). But verify the warn message is correct.
+
+E. **Subtitle margin reset.** If the global reset DOESN'T zero `<p>` margins, the subtitle has default top/bottom margin from the browser — visually breaks the grid spacing. Inspect the rendered DOM and confirm `<p>`'s computed margin is 0. If not, add `.subtitle { margin: 0; }` with a `property-disallowed-list` disable.
+
+F. **Responsive media query.** First time we use one inside a component. Verify:
+
+- The selector `@media (max-width: 640px)` is correct (not `min-width`).
+- The re-ordered `grid-template-areas` actually compiles (the row count + column count matches).
+- `margin-top: var(--space-3)` on `.actions` inside the media query is the only `margin` exception we add — flag in HR8.
+
+G. **JSDoc completeness per Rule 7.** Every exported member needs JSDoc:
+
+- PageHeader (root) — has detailed JSDoc with 4 examples + anti-patterns.
+- PageHeaderBreadcrumb, BackButton, Aside, Title, Subtitle, Meta, Actions — each has JSDoc with at least one example.
+- All 8 Props interfaces — present in the source.
+
+H. **`npm pack --dry-run`** includes the PageHeader directory, excludes test files.
+
+I. **AGENTS.md placement** — confirmed after `<Divider>`, before next non-Layout section.
+
+J. **`flattenChildren` and primitive children.** If a consumer passes a string `"Hello"` as a direct child of `<PageHeader>`, `findSlot` gets a `ReactText` (not a `ReactElement`), `isValidElement` returns false, and it's dropped. Confirm by walking the helper.
+
+K. **Aside vertical alignment.** `.aside { align-self: center; }` — but the aside spans rows 2-4 (3 rows). `align-self: center` centers it within those rows. With Title + Subtitle + Meta all present, the Aside is centered between row-2-top and row-4-bottom — roughly at the Subtitle line. With only Title + Subtitle, the empty Meta row collapses; the Aside centers between Title and Subtitle. Verify visually.
+
+L. **`grid-area: aside` with `grid-row: 2 / 5`.** The grid-template-areas spans rows 2, 3, 4 automatically. Confirm by inspection (no explicit `grid-row` rule needed).
+
+Output format: Critical / Important / Nice-to-have / Regression-watch + final verdict (`clean enough to stop` / `keep iterating`).
+
+### Step 5.3: Fix every Critical + Important finding
+
+- [ ] For each Critical, fix in-line and commit with `PageHeader: HR8 review-cycle fixes (round N) — <short rationale>`.
+- [ ] Same for Important.
+- [ ] Nice-to-haves are judgment calls — fix when cheap.
+- [ ] For every finding deliberately skipped, include a one-line "why we skipped" in the next response.
+
+### Step 5.4: Re-run all four gates after fixes
+
+- [ ] `make test && make build-lib && make build && make lint`. All green.
+
+### Step 5.5: Dispatch HR8 reviewer (round 2+)
+
+Same prompt as 5.2, framed as "round N — verify round (N-1) fixes". Continue until verdict is `clean enough to stop`.
+
+### Step 5.6: Push the branch
+
+- [ ] `git push -u origin feat/page-header`. If husky pre-push hook fails on prettier:
+  1. `npx prettier --write <listed files>`
+  2. `git add <files> && git commit -m "PageHeader: prettier --write" -m "" -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"`
+  3. `git push`
+
+### Step 5.7: Open the PR
+
+Write the PR body to `/tmp/pr-page-header-body.md` via the Write tool, then:
+
+```bash
+gh pr create --title "PageHeader: compound layout primitive for top-of-page headers" --body-file /tmp/pr-page-header-body.md
+```
+
+PR body content:
+
+````markdown
+## Summary
+
+`<PageHeader>` — a compound layout primitive that bundles breadcrumb, back-navigation, leading element (Avatar / icon), title, subtitle, meta row, and right-aligned actions into a single grid-based container with consistent spacing and an optional bottom border.
+
+## What ships
+
+### Compound API — 7 slots
+
+```tsx
+<PageHeader>
+  <PageHeader.Breadcrumb>...</PageHeader.Breadcrumb>
+  <PageHeader.BackButton href="..." aria-label="..." />
+  <PageHeader.Aside>
+    <Avatar ... />
+  </PageHeader.Aside>
+  <PageHeader.Title>...</PageHeader.Title>
+  <PageHeader.Subtitle>...</PageHeader.Subtitle>
+  <PageHeader.Meta>
+    <Badge ... />
+    <Text ... />
+  </PageHeader.Meta>
+  <PageHeader.Actions>
+    <Button ... />
+  </PageHeader.Actions>
+</PageHeader>
+```
+````
+
+All slots optional; missing slots collapse to zero-height rows.
+
+## Design decisions baked in
+
+- **Compound pattern** — `<PageHeader>` + 7 sub-components attached via `Object.assign`, matching Card / Modal / Popover / ColorPicker idiom.
+- **Marker-detection by `c.type ===`** with one level of Fragment unwrap via a small `flattenChildren` helper. Deeper nesting / HOCs documented as anti-patterns.
+- **`<PageHeader.Aside>` (position-based name)** — accepts Avatar / icon / image. Naming it "Icon" or "Leading" was rejected as misleading; "Aside" is the position name with broad applicability.
+- **`<PageHeader.BackButton>`** renders `<a href>` when `href` is set, `<button onClick>` when `onClick` is set. Both → button wins + dev warn. Neither → disabled button + dev warn.
+- **`<div>` root, not `<header>`** — avoids landmark conflict with the AppShell's app-level `<header role="banner">`.
+- **`borderBottom: boolean = true`** — toggle the bottom border when placing `<Tabs>` immediately below.
+- **Sticky positioning deferred to v2** — consumers wrap PageHeader in their own sticky container if needed.
+- **Mockup refactor deferred** — ContactDetail / Members migration to PageHeader is a follow-up PR.
+
+## Tests
+
+**~18 cases** across rendering (only-Title minimal, all-seven-slots, borderBottom default + false, `<div>` root), sub-component detection (Title slot, unrecognized children dropped, Fragment unwrap), Title (order=1 default, order=2 → h2), BackButton (`<a>` when `href`, `<button>` when `onClick`, both → button + warn, neither → disabled + warn, default `aria-label`, custom icon), Aside + Actions slot content, Subtitle + Meta rendering, and misc (forwardRef, className merge, h1 sanity).
+
+## Hard Rule 8
+
+Standard cycle ran to `clean enough to stop`.
+
+## First library component with a media query inside its CSS Module
+
+The responsive behavior (Actions wraps below the title block at `max-width: 640px`) introduces the library's first in-component `@media` query. Flagged as a regression-watch for the HR8 review — consumers who want a different breakpoint will need to override or compose differently.
+
+## Test plan
+
+- [ ] `/components/page-header`: 5 examples render (Minimal, with subtitle + actions, Full, Inline with sibling Tabs, Section header `order={2}`).
+- [ ] Resize browser to < 640px: Actions wraps below the title block. Aside stays to the left.
+- [ ] BackButton with `href="..."`: renders as `<a>` with the correct href. Click navigates.
+- [ ] BackButton with `onClick={...}`: renders as `<button>`. Click fires the handler.
+- [ ] BackButton with both → console warn + button rendering.
+- [ ] BackButton with neither → console warn + disabled button rendering.
+- [ ] `borderBottom={false}` example: no double border between PageHeader and Tabs.
+- [ ] AGENTS.md PageHeader section appears in the Layout cluster after `<Divider>`.
+- [ ] `npm pack --dry-run` includes PageHeader directory, no test files.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+```
+
+- [ ] Print the PR URL when done.
+
+---
+
+## Self-review (run before invoking subagent-driven-development)
+
+### Spec coverage
+
+- Spec §Goal / §Why now — addressed by the whole bundle (T1-T4).
+- Spec §Non-goals — encoded as anti-patterns in JSDoc (T1) and AGENTS.md (T3).
+- Spec §Architecture (file layout, marker pattern, Fragment handling, grid) — T1 verbatim.
+- Spec §Public API — T1 (type exports), T2 (test coverage), T3 (AGENTS.md docs).
+- Spec §Slot inventory — T1 sub-components, T2 detection tests, T3 AGENTS.md table.
+- Spec §Interactions (BackButton modes, borderBottom, responsive) — T1 implementation + T2 tests.
+- Spec §Edge cases — T1 JSDoc + behavior, T2 tests for: no-children, only-Title, Fragment unwrap, both-href-onClick, neither, multiple-Title (first-wins, not explicitly tested but documented).
+- Spec §SCSS sketch — T1 verbatim with stylelint disables.
+- Spec §Testing strategy — T2 covers all listed cases (~18).
+- Spec §Demo additions — T4 with all 5 examples.
+- Spec §4-place wiring — T4.
+- Spec §AGENTS.md addition — T3.
+- Spec §HR8 cycle — T5.
+- Spec §Follow-up work — listed in PR body + spec; out of scope.
+
+### Placeholder scan
+
+- "TBD" / "TODO" / "implement later" — none.
+- "Add appropriate error handling" / "handle edge cases" — none.
+- "Write tests for the above" without code — none (test code is verbatim).
+- "Similar to Task N" — none.
+- T4's `ComponentsIndex.tsx` card edit references an inline-styled fallback button IF `Button` isn't imported — that's a concrete fallback, not a placeholder. The implementer reads the file and chooses the appropriate path.
+
+### Type consistency
+
+- `PageHeaderProps`, `PageHeaderBreadcrumbProps`, `PageHeaderBackButtonProps`, `PageHeaderAsideProps`, `PageHeaderTitleProps`, `PageHeaderSubtitleProps`, `PageHeaderMetaProps`, `PageHeaderActionsProps` — declared in T1, exported in T1, re-exported in T2.
+- Sub-component names (`PageHeaderBreadcrumb`, `PageHeaderBackButton`, etc.) — used in T1's `findSlot` calls, attached in `Object.assign`, referenced in tests.
+- `displayName` values match the JSX function names: `PageHeaderBreadcrumb`, `PageHeaderBackButton`, etc.
+- `borderBottom` prop consistent everywhere.
+- SCSS class names: `.root`, `.rootWithBorder`, `.breadcrumb`, `.breadcrumbInner`, `.backButton`, `.aside`, `.title`, `.subtitle`, `.meta`, `.actions`. Test regex substrings (`/title/`, `/subtitle/`, `/aside/`, `/actions/`, `/rootWithBorder/`) match.
+
+### Found and fixed inline during write
+
+- `<a>` vs `<button>` styling parity for `.backButton:hover` — used `:not(:disabled)` so hover works on `<a>` (which doesn't have a disabled attribute, so the not-pseudo-class always matches).
+- The "subtitle margin reset" — flagged in the HR8 review notes (L) since the global reset behavior is environment-dependent.
+- The `:has` selector approach to collapse empty grid rows — not needed since CSS grid already collapses empty rows by default (no content, no row height).
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-25-page-header.md`.
+
+Per `feedback_plan_execution_mode` memory: always subagent-driven, no asking.
+
+Use **superpowers:subagent-driven-development** to execute.
+
+- Tasks 1, 2, 4: sonnet implementer
+- Task 3: haiku implementer (mechanical AGENTS.md insertion)
+- Task 5 reviewers: opus
+```

--- a/docs/superpowers/specs/2026-05-25-page-header-design.md
+++ b/docs/superpowers/specs/2026-05-25-page-header-design.md
@@ -47,7 +47,11 @@ Unlike `<ColorPicker.Trigger>` which is a `null` marker, **PageHeader's sub-comp
 ```tsx
 // e.g.
 function PageHeaderTitle({ order = 1, size, children }: PageHeaderTitleProps) {
-  return <Title order={order} size={size} className={styles.title}>{children}</Title>;
+  return (
+    <Title order={order} size={size} className={styles.title}>
+      {children}
+    </Title>
+  );
 }
 PageHeaderTitle.displayName = 'PageHeaderTitle';
 ```
@@ -64,10 +68,10 @@ React's `Children.toArray` flattens one level of fragments, but **does NOT recur
 .root {
   display: grid;
   grid-template-areas:
-    "breadcrumb breadcrumb breadcrumb"
-    "aside title actions"
-    "aside subtitle actions"
-    "aside meta actions";
+    'breadcrumb breadcrumb breadcrumb'
+    'aside title actions'
+    'aside subtitle actions'
+    'aside meta actions';
   grid-template-columns: auto 1fr auto;
   gap: var(--space-2) var(--space-3);
   padding-block: var(--space-4) var(--space-3);
@@ -154,15 +158,15 @@ export const PageHeader = Object.assign(PageHeaderRoot, {
 
 ## Slot inventory
 
-| Slot | Element | Purpose | Grid area |
-| --- | --- | --- | --- |
-| `<PageHeader.Breadcrumb>` | `<div>` wrapping `<Breadcrumb>` | Page-level navigation trail | `breadcrumb` (row 1, full width) |
-| `<PageHeader.BackButton>` | `<a>` or `<button>` | Back navigation (renders inside the Breadcrumb row, leading) | — (rendered inside `.breadcrumb`) |
-| `<PageHeader.Aside>` | `<div>` | Avatar / icon / image | `aside` (rows 2-4, left column) |
-| `<PageHeader.Title>` | `<Title order={order}>` | Main heading (h1 default) | `title` (row 2, center column) |
-| `<PageHeader.Subtitle>` | `<p>` | One-line description | `subtitle` (row 3, center column) |
-| `<PageHeader.Meta>` | `<div>` (flex row, wraps) | Badges / timestamps / chips | `meta` (row 4, center column) |
-| `<PageHeader.Actions>` | `<div>` (flex row) | Right-aligned button cluster | `actions` (rows 2-4, right column) |
+| Slot                      | Element                         | Purpose                                                      | Grid area                          |
+| ------------------------- | ------------------------------- | ------------------------------------------------------------ | ---------------------------------- |
+| `<PageHeader.Breadcrumb>` | `<div>` wrapping `<Breadcrumb>` | Page-level navigation trail                                  | `breadcrumb` (row 1, full width)   |
+| `<PageHeader.BackButton>` | `<a>` or `<button>`             | Back navigation (renders inside the Breadcrumb row, leading) | — (rendered inside `.breadcrumb`)  |
+| `<PageHeader.Aside>`      | `<div>`                         | Avatar / icon / image                                        | `aside` (rows 2-4, left column)    |
+| `<PageHeader.Title>`      | `<Title order={order}>`         | Main heading (h1 default)                                    | `title` (row 2, center column)     |
+| `<PageHeader.Subtitle>`   | `<p>`                           | One-line description                                         | `subtitle` (row 3, center column)  |
+| `<PageHeader.Meta>`       | `<div>` (flex row, wraps)       | Badges / timestamps / chips                                  | `meta` (row 4, center column)      |
+| `<PageHeader.Actions>`    | `<div>` (flex row)              | Right-aligned button cluster                                 | `actions` (rows 2-4, right column) |
 
 ## Interactions / behavior
 
@@ -187,11 +191,11 @@ Grid template re-orders so Actions wraps to a new row below the title block:
 @media (max-width: 640px) {
   .root {
     grid-template-areas:
-      "breadcrumb breadcrumb"
-      "aside title"
-      "aside subtitle"
-      "aside meta"
-      "actions actions";
+      'breadcrumb breadcrumb'
+      'aside title'
+      'aside subtitle'
+      'aside meta'
+      'actions actions';
     grid-template-columns: auto 1fr;
   }
   .actions {
@@ -207,17 +211,17 @@ None — PageHeader is a pure layout primitive with no behavioral state.
 
 ## Edge cases
 
-| Case | Behavior |
-| --- | --- |
-| `<PageHeader>` with no children at all | Renders an empty styled `<div>`. No error. |
-| `<PageHeader>` with only `<PageHeader.Title>` | Renders title; all other grid rows collapse to 0 height. |
-| Non-PageHeader child (e.g., `<div>` directly in `<PageHeader>`) | Silently dropped. |
-| `<PageHeader.Title>` wrapped in `<>...</>` Fragment | Supported (one level of Fragment unwrapping). |
-| `<PageHeader.Title>` deeply nested under custom HOC | Silently dropped. Documented anti-pattern. |
-| `<PageHeader.BackButton>` with both `href` AND `onClick` | Renders as `<button>`, warns in dev. |
-| `<PageHeader.BackButton>` with neither `href` nor `onClick` | Renders as a non-interactive `<button disabled>`, warns in dev. |
-| Multiple `<PageHeader.Title>` children | First one wins, subsequent ones silently dropped. |
-| Empty `<PageHeader.Actions>` | Renders an empty `<div>` in the actions column (no negative impact). |
+| Case                                                            | Behavior                                                             |
+| --------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `<PageHeader>` with no children at all                          | Renders an empty styled `<div>`. No error.                           |
+| `<PageHeader>` with only `<PageHeader.Title>`                   | Renders title; all other grid rows collapse to 0 height.             |
+| Non-PageHeader child (e.g., `<div>` directly in `<PageHeader>`) | Silently dropped.                                                    |
+| `<PageHeader.Title>` wrapped in `<>...</>` Fragment             | Supported (one level of Fragment unwrapping).                        |
+| `<PageHeader.Title>` deeply nested under custom HOC             | Silently dropped. Documented anti-pattern.                           |
+| `<PageHeader.BackButton>` with both `href` AND `onClick`        | Renders as `<button>`, warns in dev.                                 |
+| `<PageHeader.BackButton>` with neither `href` nor `onClick`     | Renders as a non-interactive `<button disabled>`, warns in dev.      |
+| Multiple `<PageHeader.Title>` children                          | First one wins, subsequent ones silently dropped.                    |
+| Empty `<PageHeader.Actions>`                                    | Renders an empty `<div>` in the actions column (no negative impact). |
 
 ## SCSS sketch (verbatim)
 
@@ -225,10 +229,10 @@ None — PageHeader is a pure layout primitive with no behavioral state.
 .root {
   display: grid;
   grid-template-areas:
-    "breadcrumb breadcrumb breadcrumb"
-    "aside title actions"
-    "aside subtitle actions"
-    "aside meta actions";
+    'breadcrumb breadcrumb breadcrumb'
+    'aside title actions'
+    'aside subtitle actions'
+    'aside meta actions';
   grid-template-columns: auto 1fr auto;
   gap: var(--space-2) var(--space-3);
   padding-block: var(--space-4) var(--space-3);
@@ -307,11 +311,11 @@ None — PageHeader is a pure layout primitive with no behavioral state.
 @media (max-width: 640px) {
   .root {
     grid-template-areas:
-      "breadcrumb breadcrumb"
-      "aside title"
-      "aside subtitle"
-      "aside meta"
-      "actions actions";
+      'breadcrumb breadcrumb'
+      'aside title'
+      'aside subtitle'
+      'aside meta'
+      'actions actions';
     grid-template-columns: auto 1fr;
   }
 

--- a/docs/superpowers/specs/2026-05-25-page-header-design.md
+++ b/docs/superpowers/specs/2026-05-25-page-header-design.md
@@ -1,0 +1,388 @@
+# PageHeader Design Spec
+
+**Status:** approved (brainstorm session 2026-05-25)
+**Branch:** `feat/page-header`
+**Author:** Claude Opus 4.7 + dpws
+
+---
+
+## Goal
+
+Ship `<PageHeader>` for `@eocrm/design-system` — a compound layout primitive for the top-of-page heading area in CRM pages. Bundles the title, subtitle, breadcrumb, back-navigation, leading element (Avatar / icon), meta row (badges / timestamps), and right-aligned action cluster into a single grid-based container with consistent spacing and an optional bottom border.
+
+## Why now
+
+- Two existing mockups (`ContactDetail`, `Members`) hand-roll page headers with bespoke SCSS that has already drifted between them (different spacing, different alignment, different breakpoints).
+- Future pages need this primitive — every detail screen, every settings page, every "list with filters" page repeats the same shape.
+- The library has all the underlying primitives (`<Title>`, `<Breadcrumb>`, `<Avatar>`, `<Cluster>`, `<Badge>`) but no opinionated composition of them.
+
+## Non-goals (deferred to v2 / follow-up)
+
+- **Sticky positioning.** The AppShell topbar is already sticky; layering a sticky `<PageHeader>` requires z-index coordination the consumer should own in their layout CSS. v1 is a regular block element.
+- **Mockup refactor.** ContactDetail / Members hand-rolled headers won't be migrated to `<PageHeader>` in this PR — that's a separate follow-up to keep the diff focused. Same pattern as Slider / FileUpload / ImageCrop / ColorPicker PRs.
+- **Tabs as an inside slot.** Tabs live as a sibling OUTSIDE PageHeader; consumer disables PageHeader's `borderBottom` to avoid the double line.
+- **Built-in "page actions overflow" menu.** If Actions overflow on narrow viewports, consumer composes their own `<DropdownMenu>` inside `<PageHeader.Actions>`.
+- **`role="banner"` landmark.** PageHeader renders a `<div>`, not a `<header>` — the AppShell already has `<header role="banner">` for the app-level topbar, and only one banner landmark per page is the WCAG recommendation.
+
+## Architecture
+
+### File layout
+
+```
+packages/design-system/src/components/PageHeader/
+  PageHeader.tsx          ← root + 7 sub-components + Object.assign compound
+  PageHeader.module.scss  ← grid layout + slot styling
+  PageHeader.test.tsx     ← ~18 cases
+  index.ts                ← barrel
+```
+
+Single TSX file because each sub-component is thin (most are ~10-line marker-renderers or pass-throughs to existing primitives). Splitting into 8 files would be over-decomposition — matches Card's pattern of co-located sub-components in `Card.tsx`.
+
+### Compound API + marker-component pattern
+
+`<PageHeader>` reads its children via `Children.toArray(children)`, finds each known sub-component by `c.type === <SubComponent>`, and places them into the right grid slot of its own layout. Unrecognized children are silently dropped (no error — keeps the API forgiving).
+
+Unlike `<ColorPicker.Trigger>` which is a `null` marker, **PageHeader's sub-components actively render their own JSX**:
+
+```tsx
+// e.g.
+function PageHeaderTitle({ order = 1, size, children }: PageHeaderTitleProps) {
+  return <Title order={order} size={size} className={styles.title}>{children}</Title>;
+}
+PageHeaderTitle.displayName = 'PageHeaderTitle';
+```
+
+The root's job is to know which sub-component is the Title vs Subtitle vs Actions — not to extract their internals. Each sub-component owns its own rendering.
+
+### Fragment handling
+
+React's `Children.toArray` flattens one level of fragments, but **does NOT recursively unwrap nested fragments**. We use a small `flattenChildren` helper to flatten one level deep — sufficient for the common `<>` JSX-fragment-wrap case. Deeper nesting silently drops the wrapped sub-component (documented as an anti-pattern).
+
+### Layout grid
+
+```scss
+.root {
+  display: grid;
+  grid-template-areas:
+    "breadcrumb breadcrumb breadcrumb"
+    "aside title actions"
+    "aside subtitle actions"
+    "aside meta actions";
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-2) var(--space-3);
+  padding-block: var(--space-4) var(--space-3);
+}
+```
+
+- `aside` spans rows 2-4 vertically; vertically centered via `align-self: center`.
+- Title / Subtitle / Meta stack in the center column.
+- Actions occupy the right column spanning all three middle rows; vertically centered.
+
+**Missing slots collapse to zero-height rows.** The grid template includes the row even when its content is absent — but the row collapses to 0 because there's no child filling it. Verified by toggling each slot off in the demo.
+
+### Responsive
+
+Mobile (`max-width: 640px`): Actions wraps below the title block (the right column becomes a full-width row underneath). Aside stays to the left of the title. Implemented via a media query that re-orders `grid-template-areas`.
+
+This is the first library component to use a media query inside its CSS Module — flagged as a `REGRESSION-WATCH` for HR8 review. The alternative (consumer composes responsive layout outside) is more flexible but worse UX, since every consumer would need to reinvent the wheel.
+
+## Public API
+
+```ts
+export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Render a 1px bottom border under the header. Default `true`. Set
+   * `false` when placing a `<Tabs>` component as a sibling below — Tabs
+   * has its own `border-bottom`, and you don't want the double line.
+   */
+  borderBottom?: boolean;
+}
+
+export interface PageHeaderBreadcrumbProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface PageHeaderBackButtonProps {
+  /** Renders as `<a href>`. Mutually exclusive with `onClick`. */
+  href?: string;
+  /** Renders as `<button type="button">`. Mutually exclusive with `href`. */
+  onClick?: () => void;
+  /** Accessible label. Default `"Go back"`. */
+  'aria-label'?: string;
+  /** Icon to render. Default `<ChevronLeft size={16}>` from lucide-react. */
+  icon?: ReactNode;
+}
+
+export interface PageHeaderAsideProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface PageHeaderTitleProps {
+  /** Heading semantic level (1-6). Default `1`. Passed to <Title order=>. */
+  order?: 1 | 2 | 3 | 4 | 5 | 6;
+  /** Visual size override (decouples from semantic level). Pass-through to <Title size=>. */
+  size?: TitleSize;
+  children: ReactNode;
+}
+
+export interface PageHeaderSubtitleProps extends HTMLAttributes<HTMLParagraphElement> {
+  children: ReactNode;
+}
+
+export interface PageHeaderMetaProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface PageHeaderActionsProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+```
+
+Compound attach (same pattern as Card, ColorPicker):
+
+```ts
+export const PageHeader = Object.assign(PageHeaderRoot, {
+  Breadcrumb: PageHeaderBreadcrumb,
+  BackButton: PageHeaderBackButton,
+  Aside: PageHeaderAside,
+  Title: PageHeaderTitle,
+  Subtitle: PageHeaderSubtitle,
+  Meta: PageHeaderMeta,
+  Actions: PageHeaderActions,
+});
+```
+
+## Slot inventory
+
+| Slot | Element | Purpose | Grid area |
+| --- | --- | --- | --- |
+| `<PageHeader.Breadcrumb>` | `<div>` wrapping `<Breadcrumb>` | Page-level navigation trail | `breadcrumb` (row 1, full width) |
+| `<PageHeader.BackButton>` | `<a>` or `<button>` | Back navigation (renders inside the Breadcrumb row, leading) | — (rendered inside `.breadcrumb`) |
+| `<PageHeader.Aside>` | `<div>` | Avatar / icon / image | `aside` (rows 2-4, left column) |
+| `<PageHeader.Title>` | `<Title order={order}>` | Main heading (h1 default) | `title` (row 2, center column) |
+| `<PageHeader.Subtitle>` | `<p>` | One-line description | `subtitle` (row 3, center column) |
+| `<PageHeader.Meta>` | `<div>` (flex row, wraps) | Badges / timestamps / chips | `meta` (row 4, center column) |
+| `<PageHeader.Actions>` | `<div>` (flex row) | Right-aligned button cluster | `actions` (rows 2-4, right column) |
+
+## Interactions / behavior
+
+### `<PageHeader.BackButton>`
+
+- `href` prop → renders `<a href={href}>` with the icon. Standard anchor; consumer's router handles the click.
+- `onClick` prop → renders `<button type="button" onClick={onClick}>`.
+- Both props → console.warn in dev, button wins (avoids ambiguity).
+- Hover: `var(--color-bg-muted)` background.
+- Focus: standard focus ring via the `focus-ring` mixin.
+- Default `aria-label="Go back"` if not provided (warns once in dev for accessibility).
+
+### `borderBottom={false}`
+
+`.root` drops its `border-bottom`. Consumer typically pairs this with `<Tabs>` sibling below.
+
+### Responsive (`max-width: 640px`)
+
+Grid template re-orders so Actions wraps to a new row below the title block:
+
+```scss
+@media (max-width: 640px) {
+  .root {
+    grid-template-areas:
+      "breadcrumb breadcrumb"
+      "aside title"
+      "aside subtitle"
+      "aside meta"
+      "actions actions";
+    grid-template-columns: auto 1fr;
+  }
+  .actions {
+    justify-content: flex-start;
+    margin-top: var(--space-3);
+  }
+}
+```
+
+## Color math / utilities
+
+None — PageHeader is a pure layout primitive with no behavioral state.
+
+## Edge cases
+
+| Case | Behavior |
+| --- | --- |
+| `<PageHeader>` with no children at all | Renders an empty styled `<div>`. No error. |
+| `<PageHeader>` with only `<PageHeader.Title>` | Renders title; all other grid rows collapse to 0 height. |
+| Non-PageHeader child (e.g., `<div>` directly in `<PageHeader>`) | Silently dropped. |
+| `<PageHeader.Title>` wrapped in `<>...</>` Fragment | Supported (one level of Fragment unwrapping). |
+| `<PageHeader.Title>` deeply nested under custom HOC | Silently dropped. Documented anti-pattern. |
+| `<PageHeader.BackButton>` with both `href` AND `onClick` | Renders as `<button>`, warns in dev. |
+| `<PageHeader.BackButton>` with neither `href` nor `onClick` | Renders as a non-interactive `<button disabled>`, warns in dev. |
+| Multiple `<PageHeader.Title>` children | First one wins, subsequent ones silently dropped. |
+| Empty `<PageHeader.Actions>` | Renders an empty `<div>` in the actions column (no negative impact). |
+
+## SCSS sketch (verbatim)
+
+```scss
+.root {
+  display: grid;
+  grid-template-areas:
+    "breadcrumb breadcrumb breadcrumb"
+    "aside title actions"
+    "aside subtitle actions"
+    "aside meta actions";
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-2) var(--space-3);
+  padding-block: var(--space-4) var(--space-3);
+}
+
+.rootWithBorder {
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.breadcrumb {
+  grid-area: breadcrumb;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.backButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--color-fg-muted);
+  /* stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword */
+  cursor: pointer;
+  /* For <a> rendering: kill the default text-decoration */
+  text-decoration: none;
+}
+
+.backButton:hover {
+  background: var(--color-bg-muted);
+  color: var(--color-fg);
+}
+
+.backButton:focus-visible {
+  @include focus-ring;
+  outline: none;
+}
+
+.aside {
+  grid-area: aside;
+  align-self: center;
+}
+
+.title {
+  grid-area: title;
+}
+
+.subtitle {
+  grid-area: subtitle;
+  margin: 0;
+  font-size: var(--font-size-md);
+  color: var(--color-fg-muted);
+  line-height: var(--line-height-snug);
+}
+
+.meta {
+  grid-area: meta;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.actions {
+  grid-area: actions;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  align-self: center;
+}
+
+@media (max-width: 640px) {
+  .root {
+    grid-template-areas:
+      "breadcrumb breadcrumb"
+      "aside title"
+      "aside subtitle"
+      "aside meta"
+      "actions actions";
+    grid-template-columns: auto 1fr;
+  }
+
+  .actions {
+    justify-content: flex-start;
+    /* stylelint-disable-next-line property-disallowed-list -- internal responsive spacing in this layout primitive */
+    margin-top: var(--space-3);
+  }
+}
+```
+
+## Testing strategy
+
+### `PageHeader.test.tsx` (~18 cases)
+
+Grouped:
+
+- **Rendering** (4 cases): renders only the slots provided; missing slots collapse without empty rows; `borderBottom={false}` removes the bottom-border class; root element is a `<div>` (not `<header>`) so it doesn't conflict with the AppShell's banner landmark.
+- **Sub-component detection** (3 cases): Children that match `c.type === PageHeader.Title` are rendered in the title slot; non-PageHeader children (e.g., a `<div>`) are silently dropped; Fragments wrapping a `<PageHeader.Title>` ARE supported (one level of unwrapping).
+- **`<PageHeader.Title>`** (2 cases): default `order={1}` renders `<h1>`; `order={2}` renders `<h2>`; `size` prop overrides visual size without changing semantic level.
+- **`<PageHeader.BackButton>`** (3 cases): `href` prop renders an `<a>`; `onClick` prop renders a `<button type="button">`; default `aria-label="Go back"` is set when consumer doesn't provide one; custom `icon` prop replaces the default ChevronLeft.
+- **`<PageHeader.Aside>` + `<PageHeader.Actions>`** (2 cases): both render children as-is in their grid slots; Aside is vertically centered with the title block.
+- **`<PageHeader.Subtitle>` + `<PageHeader.Meta>`** (1 case): both render in the center column below the title.
+- **Layout / a11y / misc** (3 cases): root forwards `ref` to the outermost `<div>`; `className` merges with the base class; `getByRole('heading', { level: 1 })` finds the title.
+
+## Demo additions
+
+`packages/playground/src/pages/components/PageHeaderDemo.tsx` with 5 examples:
+
+1. **Minimal** — just `<PageHeader.Title>`. The "you only need the title" case.
+2. **With subtitle + actions** — Members-style header.
+3. **Full** — ContactDetail-style: Breadcrumb + BackButton + Aside (Avatar) + Title + Subtitle + Meta (Badge + Text) + Actions.
+4. **Inline with sibling Tabs** — Title + Actions, `borderBottom={false}`, with `<Tabs>` rendered as a sibling below. Demonstrates the prop's purpose.
+5. **Section header (`order={2}`)** — A sub-page header rendering as `<h2>`. For sub-sections within a page.
+
+## 4-place wiring
+
+- **`App.tsx`** — `<Route path="/components/page-header" element={<PageHeaderDemo />} />` inserted alphabetically.
+- **`AppShell.tsx`** — Layout cluster, between `Grid` and `Stack` (P comes after G, before S). Lucide icon: `LayoutPanelTop`.
+- **`ComponentsIndex.tsx`** — card with a small inline `<PageHeader>` preview (Title + Subtitle + one Button as Actions), `pointerEvents: 'none'`.
+- **`registry.ts`** — extend `ComponentName` union with `'PageHeader'`.
+
+## AGENTS.md addition
+
+Layout cluster, **after `<Divider>`** (last in the current layout block). PageHeader is a higher-level composition than the other layout primitives — placing it last in the cluster signals "this is built ON TOP of Stack/Cluster/Card." Section covers:
+
+- Compound API (7 slots: Breadcrumb, BackButton, Aside, Title, Subtitle, Meta, Actions).
+- Marker-detection by `c.type` — one level of Fragment unwrapping.
+- `borderBottom` prop pairing with sibling Tabs.
+- Hard-rule anti-patterns:
+  - ❌ Nesting `<PageHeader>` inside another `<PageHeader>`.
+  - ❌ Putting non-PageHeader children inside `<PageHeader>` — they're silently dropped.
+  - ❌ Wrapping a `<PageHeader.Title>` in an HOC or deep nesting — breaks `c.type ===` check.
+  - ❌ Avatar inside `<PageHeader.Title>` — muddles the `<h1>` text content. Use `<PageHeader.Aside>` instead.
+  - ❌ Sticky positioning via `position: sticky` on `<PageHeader>` itself — consumer wraps in their own sticky container if needed.
+
+## Hard Rule 8 — review cycle
+
+Standard cycle. Particular things to flag for the reviewer:
+
+- The marker-detection logic + `flattenChildren` Fragment handling.
+- Grid-template-areas collapse behavior when slots are absent — verify visually.
+- `<a>` vs `<button>` element selection in BackButton — `aria-label` fallback works for both.
+- The responsive media query inside the component (first time we do this) — **REGRESSION-WATCH**.
+- Verify the demo's "Inline with sibling Tabs" example actually renders a single border (not double).
+- `npm pack --dry-run` includes the PageHeader dir, no test files.
+
+## Follow-up work (out of scope)
+
+- **Mockup refactor** — migrate ContactDetail and Members to use `<PageHeader>` instead of their hand-rolled headers. Separate PR after this one merges.
+- **Sticky positioning** — add a `sticky` prop with z-index coordination once we have a clearer story for the AppShell topbar interaction.
+- **Tabs as inside slot** — if the borderBottom-prop pattern gets tedious in real usage, revisit whether `<PageHeader.Tabs>` should be a first-class slot.
+- **Page actions overflow** — first-class "more actions" overflow menu when there are 4+ buttons.
+- **Avatar size discipline** — if multiple consumers put differently-sized avatars in `<PageHeader.Aside>` and complain about inconsistency, lock a default size via the slot's own CSS.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -784,6 +784,50 @@ import { Divider } from '@eocrm/design-system';
 - ❌ `<Divider size="lg" />` for casual section breaks. Reserve `lg` (3px) for strong visual hierarchy.
 - ❌ Adding `margin` via inline `style`. The parent should own spacing.
 
+### `<PageHeader>` — top-of-page heading area
+
+```tsx
+<PageHeader>
+  <PageHeader.Breadcrumb>
+    <Breadcrumb items={[...]} />
+  </PageHeader.Breadcrumb>
+  <PageHeader.BackButton href="/contacts" aria-label="Back to contacts" />
+  <PageHeader.Aside>
+    <Avatar size="lg" name="Acme Corp" />
+  </PageHeader.Aside>
+  <PageHeader.Title>Acme Corporation</PageHeader.Title>
+  <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
+  <PageHeader.Meta>
+    <Badge tone="success">Active</Badge>
+    <Text size="sm" tone="muted">Last contacted 2 days ago</Text>
+  </PageHeader.Meta>
+  <PageHeader.Actions>
+    <Button variant="secondary">Email</Button>
+    <Button>Edit</Button>
+  </PageHeader.Actions>
+</PageHeader>
+```
+
+- **Compound API.** Seven slots: `Breadcrumb`, `BackButton`, `Aside`, `Title`, `Subtitle`, `Meta`, `Actions`. Detected via `c.type === SubComponent` after one level of Fragment unwrap. Unrecognized children are silently dropped.
+- **All slots optional.** Missing slots collapse to zero-height rows; minimal usage is `<PageHeader><PageHeader.Title>…</PageHeader.Title></PageHeader>`.
+- **`borderBottom: boolean = true`** — toggles the 1px bottom border. Set `false` when placing `<Tabs>` immediately below (Tabs has its own bottom border; you don't want two lines).
+- **`<PageHeader.BackButton>`** renders as `<a href>` when `href` is provided, or `<button onClick>` when `onClick` is provided. Mutually exclusive — both → button wins with a dev warn; neither → disabled button with a dev warn. Default `aria-label="Go back"`; default icon `<ChevronLeft size={16}>`. Lives in the breadcrumb row, left of the breadcrumb itself.
+- **`<PageHeader.Aside>`** is a position-based slot (not named "Icon" / "Avatar") so it accepts whatever leading element you need. Vertically centered with the title block.
+- **`<PageHeader.Title>`** passes through to `<Title order={order} size={size}>`. Default `order={1}` (renders `<h1>`); set `order={2}` for sub-page section headers.
+- **`<PageHeader.Subtitle>`** is a `<p>` with muted color.
+- **`<PageHeader.Meta>`** is a flex row that wraps — good for badges + timestamps.
+- **`<PageHeader.Actions>`** is a flex row, right-aligned by default. On viewports < 640px, Actions wraps below the title block.
+- **NOT a `<header>` landmark.** PageHeader renders a `<div>` to avoid conflicting with the AppShell's app-level `<header role="banner">`.
+
+#### Hard rule
+
+- ❌ Nesting `<PageHeader>` inside another `<PageHeader>` — undefined behavior. Use one PageHeader per page.
+- ❌ Putting non-PageHeader children (a `<div>`, a `<Stack>`) inside `<PageHeader>` — they're silently dropped. Use one of the seven slots.
+- ❌ Wrapping a sub-component in an HOC or deep nesting. The `c.type ===` detection handles ONE level of Fragment unwrap only.
+- ❌ Putting an Avatar inside `<PageHeader.Title>` — muddles the `<h1>`'s text content for screen readers. Use `<PageHeader.Aside>` instead.
+- ❌ `position: sticky` directly on `<PageHeader>` — out of scope for v1. Wrap in your own sticky container if you need sticky behavior.
+- ❌ Passing both `href` and `onClick` to `<PageHeader.BackButton>` — onClick wins with a dev warn. Pick one.
+
 ### `<Avatar>` — profile circle
 
 ```tsx

--- a/packages/design-system/src/components/PageHeader/PageHeader.module.scss
+++ b/packages/design-system/src/components/PageHeader/PageHeader.module.scss
@@ -82,7 +82,7 @@
   grid-area: subtitle;
   font-size: var(--font-size-md);
   color: var(--color-fg-muted);
-  line-height: var(--line-height-snug);
+  line-height: var(--line-height-tight);
 }
 
 .meta {

--- a/packages/design-system/src/components/PageHeader/PageHeader.module.scss
+++ b/packages/design-system/src/components/PageHeader/PageHeader.module.scss
@@ -1,0 +1,124 @@
+@use '../../styles/mixins' as *;
+
+.root {
+  display: grid;
+  grid-template-areas:
+    'breadcrumb breadcrumb breadcrumb'
+    'aside title actions'
+    'aside subtitle actions'
+    'aside meta actions';
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-2) var(--space-3);
+  padding-block: var(--space-4) var(--space-3);
+}
+
+.rootWithBorder {
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.breadcrumb {
+  grid-area: breadcrumb;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.breadcrumbInner {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.backButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--color-fg-muted);
+
+  // CSS keyword — interactive trigger.
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  cursor: pointer;
+
+  // CSS keyword — kill the default underline when rendered as <a>.
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  text-decoration: none;
+}
+
+.backButton:hover:not(:disabled) {
+  background: var(--color-bg-muted);
+  color: var(--color-fg);
+}
+
+.backButton:focus-visible {
+  @include focus-ring;
+
+  outline: none;
+}
+
+.backButton:disabled {
+  // CSS keyword — disabled affordance.
+  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
+  cursor: not-allowed;
+  opacity: var(--opacity-disabled);
+}
+
+.aside {
+  grid-area: aside;
+
+  // stylelint-disable-next-line property-disallowed-list -- grid slot needs vertical centering within its cell
+  align-self: center;
+}
+
+.title {
+  grid-area: title;
+}
+
+.subtitle {
+  grid-area: subtitle;
+  font-size: var(--font-size-md);
+  color: var(--color-fg-muted);
+  line-height: var(--line-height-snug);
+}
+
+.meta {
+  grid-area: meta;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.actions {
+  grid-area: actions;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+
+  // stylelint-disable-next-line property-disallowed-list -- grid slot needs vertical centering within its cell
+  align-self: center;
+}
+
+// ─── Responsive: actions wrap below the title on narrow viewports ────────
+@media (max-width: 640px) {
+  .root {
+    grid-template-areas:
+      'breadcrumb breadcrumb'
+      'aside title'
+      'aside subtitle'
+      'aside meta'
+      'actions actions';
+    grid-template-columns: auto 1fr;
+  }
+
+  .actions {
+    justify-content: flex-start;
+
+    // stylelint-disable-next-line property-disallowed-list -- internal responsive spacing in this layout primitive
+    margin-top: var(--space-3);
+  }
+}

--- a/packages/design-system/src/components/PageHeader/PageHeader.test.tsx
+++ b/packages/design-system/src/components/PageHeader/PageHeader.test.tsx
@@ -217,9 +217,7 @@ describe('PageHeader.BackButton', () => {
         <PageHeader.BackButton aria-label="Back" />
       </PageHeader>,
     );
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('without `href` or `onClick`'),
-    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('without `href` or `onClick`'));
     const btn = screen.getByRole('button', { name: 'Back' });
     expect(btn.tagName).toBe('BUTTON');
     expect(btn).toBeDisabled();

--- a/packages/design-system/src/components/PageHeader/PageHeader.test.tsx
+++ b/packages/design-system/src/components/PageHeader/PageHeader.test.tsx
@@ -1,8 +1,305 @@
-// Placeholder — full component tests land in T2.
-import { PageHeader } from './PageHeader';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { PageHeader } from './index';
 
-describe('PageHeader (placeholder)', () => {
-  it('exports PageHeader', () => {
-    expect(PageHeader).toBeDefined();
+describe('PageHeader — rendering', () => {
+  it('renders only the slots provided', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>Acme</PageHeader.Title>
+      </PageHeader>,
+    );
+    expect(screen.getByRole('heading', { level: 1, name: 'Acme' })).toBeInTheDocument();
+    // No subtitle / meta / actions / aside / breadcrumb rendered.
+    expect(container.querySelector('[class*="subtitle"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[class*="meta"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[class*="actions"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[class*="aside"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[class*="breadcrumb"]')).not.toBeInTheDocument();
+  });
+
+  it('renders all seven slots when provided', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Breadcrumb>
+          <nav data-testid="bc">crumb</nav>
+        </PageHeader.Breadcrumb>
+        <PageHeader.BackButton href="/back" />
+        <PageHeader.Aside>
+          <span data-testid="aside-content">A</span>
+        </PageHeader.Aside>
+        <PageHeader.Title>T</PageHeader.Title>
+        <PageHeader.Subtitle>S</PageHeader.Subtitle>
+        <PageHeader.Meta>M</PageHeader.Meta>
+        <PageHeader.Actions>
+          <button type="button">btn</button>
+        </PageHeader.Actions>
+      </PageHeader>,
+    );
+    expect(screen.getByTestId('bc')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go back' })).toBeInTheDocument();
+    expect(screen.getByTestId('aside-content')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'T' })).toBeInTheDocument();
+    expect(screen.getByText('S')).toBeInTheDocument();
+    expect(screen.getByText('M')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'btn' })).toBeInTheDocument();
+    // Spot-check that aside got positioned via the .aside class.
+    expect(container.querySelector('[class*="aside"]')).toBeInTheDocument();
+  });
+
+  it('applies rootWithBorder class by default', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>X</PageHeader.Title>
+      </PageHeader>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/rootWithBorder/);
+  });
+
+  it('does NOT apply rootWithBorder when borderBottom={false}', () => {
+    const { container } = render(
+      <PageHeader borderBottom={false}>
+        <PageHeader.Title>X</PageHeader.Title>
+      </PageHeader>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).not.toMatch(/rootWithBorder/);
+  });
+
+  it('renders as a <div>, not a <header>', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>X</PageHeader.Title>
+      </PageHeader>,
+    );
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+    // Confirm no banner landmark is introduced.
+    expect(container.querySelector('header')).not.toBeInTheDocument();
+  });
+});
+
+describe('PageHeader — sub-component detection', () => {
+  it('renders <PageHeader.Title> into the title slot', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>Match me</PageHeader.Title>
+      </PageHeader>,
+    );
+    const title = container.querySelector('[class*="title"]') as HTMLElement;
+    expect(title).toBeInTheDocument();
+    expect(title.tagName).toBe('H1');
+    expect(title.textContent).toBe('Match me');
+  });
+
+  it('silently drops unrecognized children', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>Kept</PageHeader.Title>
+        <div data-testid="bad-child">should not render</div>
+        <span>also dropped</span>
+      </PageHeader>,
+    );
+    expect(screen.getByRole('heading', { level: 1, name: 'Kept' })).toBeInTheDocument();
+    expect(screen.queryByTestId('bad-child')).not.toBeInTheDocument();
+    expect(screen.queryByText('also dropped')).not.toBeInTheDocument();
+    expect(container.textContent).not.toContain('should not render');
+  });
+
+  it('unwraps one level of Fragment around a sub-component', () => {
+    render(
+      <PageHeader>
+        <>
+          <PageHeader.Title>Fragmented</PageHeader.Title>
+          <PageHeader.Subtitle>Also fragmented</PageHeader.Subtitle>
+        </>
+      </PageHeader>,
+    );
+    expect(screen.getByRole('heading', { level: 1, name: 'Fragmented' })).toBeInTheDocument();
+    expect(screen.getByText('Also fragmented')).toBeInTheDocument();
+  });
+});
+
+describe('PageHeader.Title', () => {
+  it('defaults to order=1 (renders <h1>)', () => {
+    render(
+      <PageHeader>
+        <PageHeader.Title>H1</PageHeader.Title>
+      </PageHeader>,
+    );
+    expect(screen.getByRole('heading', { level: 1, name: 'H1' })).toBeInTheDocument();
+  });
+
+  it('renders <h2> when order={2}', () => {
+    render(
+      <PageHeader>
+        <PageHeader.Title order={2}>H2</PageHeader.Title>
+      </PageHeader>,
+    );
+    expect(screen.getByRole('heading', { level: 2, name: 'H2' })).toBeInTheDocument();
+    // And NO h1 should exist.
+    expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+  });
+});
+
+describe('PageHeader.BackButton', () => {
+  it('renders <a> when href is provided', () => {
+    render(
+      <PageHeader>
+        <PageHeader.BackButton href="/contacts" aria-label="Back to contacts" />
+      </PageHeader>,
+    );
+    const link = screen.getByRole('link', { name: 'Back to contacts' });
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/contacts');
+  });
+
+  it('renders <button> when onClick is provided', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <PageHeader>
+        <PageHeader.BackButton onClick={onClick} aria-label="Back" />
+      </PageHeader>,
+    );
+    const btn = screen.getByRole('button', { name: 'Back' });
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn).toHaveAttribute('type', 'button');
+    await user.click(btn);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('warns in dev when both href and onClick are passed; renders as <button>', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <PageHeader>
+        <PageHeader.BackButton href="/x" onClick={() => {}} aria-label="Back" />
+      </PageHeader>,
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('received both `href` and `onClick`'),
+    );
+    expect(screen.getByRole('button', { name: 'Back' }).tagName).toBe('BUTTON');
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    warnSpy.mockRestore();
+  });
+
+  it('warns in dev when neither href nor onClick; renders disabled <button>', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <PageHeader>
+        <PageHeader.BackButton aria-label="Back" />
+      </PageHeader>,
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('without `href` or `onClick`'),
+    );
+    const btn = screen.getByRole('button', { name: 'Back' });
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn).toBeDisabled();
+    warnSpy.mockRestore();
+  });
+
+  it('defaults aria-label to "Go back" when not provided', () => {
+    render(
+      <PageHeader>
+        <PageHeader.BackButton href="/back" />
+      </PageHeader>,
+    );
+    expect(screen.getByRole('link', { name: 'Go back' })).toBeInTheDocument();
+  });
+
+  it('renders custom icon when provided', () => {
+    render(
+      <PageHeader>
+        <PageHeader.BackButton href="/back" icon={<span data-testid="custom-icon">⟵</span>} />
+      </PageHeader>,
+    );
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+});
+
+describe('PageHeader.Aside + PageHeader.Actions', () => {
+  it('renders Aside children inside the .aside slot', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Aside>
+          <span data-testid="content">A</span>
+        </PageHeader.Aside>
+        <PageHeader.Title>T</PageHeader.Title>
+      </PageHeader>,
+    );
+    const aside = container.querySelector('[class*="aside"]') as HTMLElement;
+    expect(aside).toBeInTheDocument();
+    expect(aside).toContainElement(screen.getByTestId('content'));
+  });
+
+  it('renders Actions children inside the .actions slot', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>T</PageHeader.Title>
+        <PageHeader.Actions>
+          <button type="button">Save</button>
+          <button type="button">Cancel</button>
+        </PageHeader.Actions>
+      </PageHeader>,
+    );
+    const actions = container.querySelector('[class*="actions"]') as HTMLElement;
+    expect(actions).toBeInTheDocument();
+    expect(actions).toContainElement(screen.getByRole('button', { name: 'Save' }));
+    expect(actions).toContainElement(screen.getByRole('button', { name: 'Cancel' }));
+  });
+});
+
+describe('PageHeader.Subtitle + PageHeader.Meta', () => {
+  it('renders both below the title in the center column', () => {
+    const { container } = render(
+      <PageHeader>
+        <PageHeader.Title>T</PageHeader.Title>
+        <PageHeader.Subtitle>S</PageHeader.Subtitle>
+        <PageHeader.Meta>
+          <span data-testid="meta-child">M</span>
+        </PageHeader.Meta>
+      </PageHeader>,
+    );
+    expect(container.querySelector('[class*="subtitle"]')?.textContent).toBe('S');
+    expect(screen.getByTestId('meta-child')).toBeInTheDocument();
+  });
+});
+
+describe('PageHeader — misc', () => {
+  it('forwards ref to the outermost div', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <PageHeader ref={ref}>
+        <PageHeader.Title>X</PageHeader.Title>
+      </PageHeader>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('className merges with the base class on the root', () => {
+    const { container } = render(
+      <PageHeader className="custom-class">
+        <PageHeader.Title>X</PageHeader.Title>
+      </PageHeader>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/custom-class/);
+    expect(root.className).toMatch(/root/);
+  });
+
+  it('aria-labelledby support — h1 has a stable id we can target if needed', () => {
+    // Sanity that Title renders the actual <h1> element with text content
+    // (not a button or generic role).
+    render(
+      <PageHeader>
+        <PageHeader.Title>Findable</PageHeader.Title>
+      </PageHeader>,
+    );
+    const h1 = screen.getByRole('heading', { level: 1 });
+    expect(h1.tagName).toBe('H1');
+    expect(h1.textContent).toBe('Findable');
   });
 });

--- a/packages/design-system/src/components/PageHeader/PageHeader.test.tsx
+++ b/packages/design-system/src/components/PageHeader/PageHeader.test.tsx
@@ -119,6 +119,31 @@ describe('PageHeader — sub-component detection', () => {
     expect(screen.getByRole('heading', { level: 1, name: 'Fragmented' })).toBeInTheDocument();
     expect(screen.getByText('Also fragmented')).toBeInTheDocument();
   });
+
+  it('drops all but the first <PageHeader.Title> when multiple are passed', () => {
+    render(
+      <PageHeader>
+        <PageHeader.Title>First</PageHeader.Title>
+        <PageHeader.Title>Second</PageHeader.Title>
+      </PageHeader>,
+    );
+    const headings = screen.getAllByRole('heading', { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0].textContent).toBe('First');
+  });
+
+  it('does NOT unwrap deeply-nested Fragments (only one level)', () => {
+    render(
+      <PageHeader>
+        <>
+          <>
+            <PageHeader.Title>Deep</PageHeader.Title>
+          </>
+        </>
+      </PageHeader>,
+    );
+    expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+  });
 });
 
 describe('PageHeader.Title', () => {
@@ -290,9 +315,7 @@ describe('PageHeader — misc', () => {
     expect(root.className).toMatch(/root/);
   });
 
-  it('aria-labelledby support — h1 has a stable id we can target if needed', () => {
-    // Sanity that Title renders the actual <h1> element with text content
-    // (not a button or generic role).
+  it('renders a real <h1> element (not a button or generic role)', () => {
     render(
       <PageHeader>
         <PageHeader.Title>Findable</PageHeader.Title>

--- a/packages/design-system/src/components/PageHeader/PageHeader.test.tsx
+++ b/packages/design-system/src/components/PageHeader/PageHeader.test.tsx
@@ -1,0 +1,8 @@
+// Placeholder — full component tests land in T2.
+import { PageHeader } from './PageHeader';
+
+describe('PageHeader (placeholder)', () => {
+  it('exports PageHeader', () => {
+    expect(PageHeader).toBeDefined();
+  });
+});

--- a/packages/design-system/src/components/PageHeader/PageHeader.tsx
+++ b/packages/design-system/src/components/PageHeader/PageHeader.tsx
@@ -388,6 +388,9 @@ PageHeaderActions.displayName = 'PageHeaderActions';
  *   text-content for screen readers. Use `<PageHeader.Aside>` instead.
  * - ❌ `position: sticky` on `<PageHeader>` itself — out of scope for v1.
  *   Wrap PageHeader in your own sticky container if you need it.
+ * - ❌ Passing multiple `<PageHeader.Title>` (or any duplicate sub-component)
+ *   children. Only the FIRST match is rendered into the slot; subsequent
+ *   duplicates are silently dropped.
  */
 const PageHeaderRoot = forwardRef<HTMLDivElement, PageHeaderProps>(
   function PageHeaderRoot(

--- a/packages/design-system/src/components/PageHeader/PageHeader.tsx
+++ b/packages/design-system/src/components/PageHeader/PageHeader.tsx
@@ -103,10 +103,7 @@ function flattenChildren(children: ReactNode): ReactNode[] {
 }
 
 /** Find the first child whose `type` equals the given component. */
-function findSlot<P>(
-  children: ReactNode,
-  type: ComponentType<P>,
-): ReactElement<P> | undefined {
+function findSlot<P>(children: ReactNode, type: ComponentType<P>): ReactElement<P> | undefined {
   return flattenChildren(children).find(
     (c): c is ReactElement<P> => isValidElement(c) && c.type === type,
   );
@@ -124,11 +121,7 @@ function findSlot<P>(
  *   <Breadcrumb items={[...]} />
  * </PageHeader.Breadcrumb>
  */
-export function PageHeaderBreadcrumb({
-  children,
-  className,
-  ...rest
-}: PageHeaderBreadcrumbProps) {
+export function PageHeaderBreadcrumb({ children, className, ...rest }: PageHeaderBreadcrumbProps) {
   return (
     <div className={clsx(styles.breadcrumbInner, className)} {...rest}>
       {children}
@@ -195,12 +188,7 @@ export function PageHeaderBackButton({
     return <a {...anchorProps}>{icon}</a>;
   }
   return (
-    <button
-      type="button"
-      disabled
-      aria-label={ariaLabel}
-      className={styles.backButton}
-    >
+    <button type="button" disabled aria-label={ariaLabel} className={styles.backButton}>
       {icon}
     </button>
   );
@@ -260,11 +248,7 @@ PageHeaderTitle.displayName = 'PageHeaderTitle';
  * @example
  * <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
  */
-export function PageHeaderSubtitle({
-  children,
-  className,
-  ...rest
-}: PageHeaderSubtitleProps) {
+export function PageHeaderSubtitle({ children, className, ...rest }: PageHeaderSubtitleProps) {
   return (
     <p className={clsx(styles.subtitle, className)} {...rest}>
       {children}
@@ -392,40 +376,38 @@ PageHeaderActions.displayName = 'PageHeaderActions';
  *   children. Only the FIRST match is rendered into the slot; subsequent
  *   duplicates are silently dropped.
  */
-const PageHeaderRoot = forwardRef<HTMLDivElement, PageHeaderProps>(
-  function PageHeaderRoot(
-    { borderBottom = true, className, children, ...rest },
-    ref,
-  ) {
-    const breadcrumb = findSlot(children, PageHeaderBreadcrumb);
-    const backButton = findSlot(children, PageHeaderBackButton);
-    const aside = findSlot(children, PageHeaderAside);
-    const title = findSlot(children, PageHeaderTitle);
-    const subtitle = findSlot(children, PageHeaderSubtitle);
-    const meta = findSlot(children, PageHeaderMeta);
-    const actions = findSlot(children, PageHeaderActions);
+const PageHeaderRoot = forwardRef<HTMLDivElement, PageHeaderProps>(function PageHeaderRoot(
+  { borderBottom = true, className, children, ...rest },
+  ref,
+) {
+  const breadcrumb = findSlot(children, PageHeaderBreadcrumb);
+  const backButton = findSlot(children, PageHeaderBackButton);
+  const aside = findSlot(children, PageHeaderAside);
+  const title = findSlot(children, PageHeaderTitle);
+  const subtitle = findSlot(children, PageHeaderSubtitle);
+  const meta = findSlot(children, PageHeaderMeta);
+  const actions = findSlot(children, PageHeaderActions);
 
-    return (
-      <div
-        ref={ref}
-        className={clsx(styles.root, borderBottom && styles.rootWithBorder, className)}
-        {...rest}
-      >
-        {(breadcrumb || backButton) && (
-          <div className={styles.breadcrumb}>
-            {backButton}
-            {breadcrumb}
-          </div>
-        )}
-        {aside}
-        {title}
-        {subtitle}
-        {meta}
-        {actions}
-      </div>
-    );
-  },
-);
+  return (
+    <div
+      ref={ref}
+      className={clsx(styles.root, borderBottom && styles.rootWithBorder, className)}
+      {...rest}
+    >
+      {(breadcrumb || backButton) && (
+        <div className={styles.breadcrumb}>
+          {backButton}
+          {breadcrumb}
+        </div>
+      )}
+      {aside}
+      {title}
+      {subtitle}
+      {meta}
+      {actions}
+    </div>
+  );
+});
 PageHeaderRoot.displayName = 'PageHeader';
 
 /** Compound API: `<PageHeader>` + 7 sub-components. */

--- a/packages/design-system/src/components/PageHeader/PageHeader.tsx
+++ b/packages/design-system/src/components/PageHeader/PageHeader.tsx
@@ -1,0 +1,437 @@
+import {
+  Children,
+  forwardRef,
+  Fragment,
+  isValidElement,
+  useEffect,
+  type AnchorHTMLAttributes,
+  type ButtonHTMLAttributes,
+  type ComponentType,
+  type HTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import { ChevronLeft } from 'lucide-react';
+import clsx from 'clsx';
+import { Title, type TitleSize } from '../Title';
+import styles from './PageHeader.module.scss';
+
+// ─── Types ───────────────────────────────────────────────────────────────
+
+export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Render a 1px bottom border under the header. Default `true`. Set
+   * `false` when placing a `<Tabs>` component as a sibling below — Tabs
+   * has its own `border-bottom`, and you don't want the double line.
+   */
+  borderBottom?: boolean;
+}
+
+export interface PageHeaderBreadcrumbProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface PageHeaderBackButtonProps {
+  /**
+   * If set, renders as `<a href={href}>`. Mutually exclusive with
+   * `onClick` — passing both renders as `<button>` (the onClick wins)
+   * and emits a dev-only warning.
+   */
+  href?: string;
+  /**
+   * If set, renders as `<button type="button" onClick={onClick}>`.
+   * Mutually exclusive with `href`.
+   */
+  onClick?: () => void;
+  /** Accessible label. Default `"Go back"`. */
+  'aria-label'?: string;
+  /** Icon to render. Default `<ChevronLeft size={16}>` from lucide-react. */
+  icon?: ReactNode;
+}
+
+export interface PageHeaderAsideProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface PageHeaderTitleProps {
+  /**
+   * Heading semantic level (1–6). Default `1`. Passes through to
+   * `<Title order={order}>` so the rendered element is `<h1>`–`<h6>`.
+   */
+  order?: 1 | 2 | 3 | 4 | 5 | 6;
+  /**
+   * Visual size override (decouples from semantic level). Pass-through to
+   * `<Title size>` — useful for "section-level page headers" where the
+   * h-level is 2 but you want it to LOOK like an h1.
+   */
+  size?: TitleSize;
+  children: ReactNode;
+}
+
+export interface PageHeaderSubtitleProps extends HTMLAttributes<HTMLParagraphElement> {
+  children: ReactNode;
+}
+
+export interface PageHeaderMetaProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface PageHeaderActionsProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+// ─── Internal helpers ────────────────────────────────────────────────────
+
+/**
+ * Flatten one level of React Fragments out of children. `React.Children.toArray`
+ * does NOT recursively unwrap fragments — this helper handles the common case
+ * of wrapping a single sub-component in `<>...</>`. Deeper nesting (HOCs, etc.)
+ * is intentionally NOT supported; documented as an anti-pattern.
+ */
+function flattenChildren(children: ReactNode): ReactNode[] {
+  const flat: ReactNode[] = [];
+  Children.toArray(children).forEach((child) => {
+    if (isValidElement(child) && child.type === Fragment) {
+      flat.push(
+        ...Children.toArray((child as ReactElement<{ children: ReactNode }>).props.children),
+      );
+    } else {
+      flat.push(child);
+    }
+  });
+  return flat;
+}
+
+/** Find the first child whose `type` equals the given component. */
+function findSlot<P>(
+  children: ReactNode,
+  type: ComponentType<P>,
+): ReactElement<P> | undefined {
+  return flattenChildren(children).find(
+    (c): c is ReactElement<P> => isValidElement(c) && c.type === type,
+  );
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────
+
+/**
+ * Wraps a `<Breadcrumb>` (or any breadcrumb-like content) into the top row
+ * of the PageHeader grid. The breadcrumb row also hosts `<PageHeader.BackButton>`
+ * to its left when present — both are rendered together with a small gap.
+ *
+ * @example
+ * <PageHeader.Breadcrumb>
+ *   <Breadcrumb items={[...]} />
+ * </PageHeader.Breadcrumb>
+ */
+export function PageHeaderBreadcrumb({
+  children,
+  className,
+  ...rest
+}: PageHeaderBreadcrumbProps) {
+  return (
+    <div className={clsx(styles.breadcrumbInner, className)} {...rest}>
+      {children}
+    </div>
+  );
+}
+PageHeaderBreadcrumb.displayName = 'PageHeaderBreadcrumb';
+
+/**
+ * Compact back-navigation icon button rendered in the breadcrumb row
+ * (leading position). Renders as `<a href>` when `href` is set, or
+ * `<button type="button" onClick>` when `onClick` is set.
+ *
+ * @example
+ * // Anchor — relies on the consumer's router to intercept the click.
+ * <PageHeader.BackButton href="/contacts" aria-label="Back to contacts" />
+ *
+ * @example
+ * // Button — for programmatic navigation (history.back, route()).
+ * <PageHeader.BackButton onClick={() => router.back()} aria-label="Back" />
+ *
+ * @remarks Anti-patterns
+ * - ❌ Passing both `href` AND `onClick`. The component renders as a
+ *   `<button>` (onClick wins) and emits a dev-only warning. Pick one.
+ * - ❌ Passing neither `href` NOR `onClick`. Renders as a disabled
+ *   `<button>` with a dev-only warning — you almost certainly forgot a prop.
+ */
+export function PageHeaderBackButton({
+  href,
+  onClick,
+  'aria-label': ariaLabel = 'Go back',
+  icon = <ChevronLeft size={16} />,
+}: PageHeaderBackButtonProps) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production' && href && onClick) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '<PageHeader.BackButton> received both `href` and `onClick`. Rendering as <button>; `href` is ignored.',
+      );
+    }
+    if (process.env.NODE_ENV !== 'production' && !href && !onClick) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '<PageHeader.BackButton> rendered without `href` or `onClick`. Rendering as a disabled <button>.',
+      );
+    }
+  }, [href, onClick]);
+
+  if (onClick) {
+    const buttonProps: ButtonHTMLAttributes<HTMLButtonElement> = {
+      type: 'button',
+      onClick,
+      'aria-label': ariaLabel,
+      className: styles.backButton,
+    };
+    return <button {...buttonProps}>{icon}</button>;
+  }
+  if (href) {
+    const anchorProps: AnchorHTMLAttributes<HTMLAnchorElement> = {
+      href,
+      'aria-label': ariaLabel,
+      className: styles.backButton,
+    };
+    return <a {...anchorProps}>{icon}</a>;
+  }
+  return (
+    <button
+      type="button"
+      disabled
+      aria-label={ariaLabel}
+      className={styles.backButton}
+    >
+      {icon}
+    </button>
+  );
+}
+PageHeaderBackButton.displayName = 'PageHeaderBackButton';
+
+/**
+ * The leading element to the LEFT of the title row — typically an Avatar,
+ * icon, or small image. Vertically centered with the title block. Distinct
+ * from `<PageHeader.BackButton>` which lives in the breadcrumb row.
+ *
+ * @example
+ * <PageHeader.Aside>
+ *   <Avatar size="lg" name="Acme Corp" src="..." />
+ * </PageHeader.Aside>
+ *
+ * @remarks
+ * - Position-based name (Aside) rather than semantic (Icon). The slot
+ *   accepts ANY ReactNode — Avatar, icon, image, custom badge. Naming it
+ *   "Icon" would lie about the common Avatar use case.
+ */
+export function PageHeaderAside({ children, className, ...rest }: PageHeaderAsideProps) {
+  return (
+    <div className={clsx(styles.aside, className)} {...rest}>
+      {children}
+    </div>
+  );
+}
+PageHeaderAside.displayName = 'PageHeaderAside';
+
+/**
+ * The main heading. Default `order={1}` renders an `<h1>`. Use `order={2}`
+ * (or higher) for section-level page headers within a larger page. `size`
+ * decouples visual size from semantic level — e.g. `<PageHeader.Title
+ * order={2} size="3xl">` renders an `<h2>` that LOOKS like an h1.
+ *
+ * @example
+ * <PageHeader.Title>Acme Corporation</PageHeader.Title>
+ *
+ * @example
+ * // Section header — h2 with default visual size for h2 (2xl):
+ * <PageHeader.Title order={2}>Filters</PageHeader.Title>
+ */
+export function PageHeaderTitle({ order = 1, size, children }: PageHeaderTitleProps) {
+  return (
+    <Title order={order} size={size} className={styles.title}>
+      {children}
+    </Title>
+  );
+}
+PageHeaderTitle.displayName = 'PageHeaderTitle';
+
+/**
+ * One-line description rendered below the title. Always a `<p>` with muted
+ * foreground color.
+ *
+ * @example
+ * <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
+ */
+export function PageHeaderSubtitle({
+  children,
+  className,
+  ...rest
+}: PageHeaderSubtitleProps) {
+  return (
+    <p className={clsx(styles.subtitle, className)} {...rest}>
+      {children}
+    </p>
+  );
+}
+PageHeaderSubtitle.displayName = 'PageHeaderSubtitle';
+
+/**
+ * Free slot for badges, timestamps, status chips, or any other small
+ * metadata you want below the subtitle. Rendered as a flex row that wraps
+ * to a new line on narrow viewports.
+ *
+ * @example
+ * <PageHeader.Meta>
+ *   <Badge tone="success">Active</Badge>
+ *   <Text size="sm" tone="muted">Last contacted 2 days ago</Text>
+ * </PageHeader.Meta>
+ */
+export function PageHeaderMeta({ children, className, ...rest }: PageHeaderMetaProps) {
+  return (
+    <div className={clsx(styles.meta, className)} {...rest}>
+      {children}
+    </div>
+  );
+}
+PageHeaderMeta.displayName = 'PageHeaderMeta';
+
+/**
+ * Right-aligned action cluster — typically a `<Cluster>` of `<Button>`s or
+ * a `<ButtonGroup>`. Vertically centered with the title block. Wraps to a
+ * new row below the title on viewports < 640px.
+ *
+ * @example
+ * <PageHeader.Actions>
+ *   <Button variant="secondary">Email</Button>
+ *   <Button variant="secondary">Call</Button>
+ *   <Button>Edit</Button>
+ * </PageHeader.Actions>
+ */
+export function PageHeaderActions({ children, className, ...rest }: PageHeaderActionsProps) {
+  return (
+    <div className={clsx(styles.actions, className)} {...rest}>
+      {children}
+    </div>
+  );
+}
+PageHeaderActions.displayName = 'PageHeaderActions';
+
+// ─── Root ────────────────────────────────────────────────────────────────
+
+/**
+ * Top-of-page heading area for CRM pages. Bundles seven optional slots
+ * (Breadcrumb, BackButton, Aside, Title, Subtitle, Meta, Actions) into a
+ * single CSS-grid layout with consistent spacing and an optional bottom
+ * border.
+ *
+ * Use the compound API — children are detected by `c.type === <SubComponent>`,
+ * placed into their grid area, and missing slots collapse to zero-height
+ * rows. Unrecognized children (e.g., a bare `<div>`) are silently dropped.
+ *
+ * @example
+ * // Minimal:
+ * <PageHeader>
+ *   <PageHeader.Title>Settings</PageHeader.Title>
+ * </PageHeader>
+ *
+ * @example
+ * // Members-style — title + subtitle + actions:
+ * <PageHeader>
+ *   <PageHeader.Title>Members</PageHeader.Title>
+ *   <PageHeader.Subtitle>Manage team access and roles.</PageHeader.Subtitle>
+ *   <PageHeader.Actions>
+ *     <Button>Invite member</Button>
+ *   </PageHeader.Actions>
+ * </PageHeader>
+ *
+ * @example
+ * // ContactDetail-style — everything:
+ * <PageHeader>
+ *   <PageHeader.Breadcrumb>
+ *     <Breadcrumb items={[...]} />
+ *   </PageHeader.Breadcrumb>
+ *   <PageHeader.BackButton href="/contacts" aria-label="Back to contacts" />
+ *   <PageHeader.Aside>
+ *     <Avatar size="lg" name="Acme Corp" />
+ *   </PageHeader.Aside>
+ *   <PageHeader.Title>Acme Corporation</PageHeader.Title>
+ *   <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
+ *   <PageHeader.Meta>
+ *     <Badge tone="success">Active</Badge>
+ *     <Text size="sm" tone="muted">Last contacted 2 days ago</Text>
+ *   </PageHeader.Meta>
+ *   <PageHeader.Actions>
+ *     <Button variant="secondary">Email</Button>
+ *     <Button>Edit</Button>
+ *   </PageHeader.Actions>
+ * </PageHeader>
+ *
+ * @example
+ * // With sibling Tabs — disable the bottom border:
+ * <PageHeader borderBottom={false}>
+ *   <PageHeader.Title>Reports</PageHeader.Title>
+ * </PageHeader>
+ * <Tabs value={tab} onChange={setTab}>...</Tabs>
+ *
+ * @remarks When NOT to use
+ * - For arbitrary section headers WITHIN a page that aren't the page's
+ *   primary heading. Use a `<Title order={2}>` directly.
+ * - For a sticky top bar. PageHeader is a regular block element; wrap it
+ *   in your own sticky container if you need sticky behavior.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Nesting `<PageHeader>` inside another `<PageHeader>` — undefined
+ *   behavior. Use a single PageHeader per page.
+ * - ❌ Putting non-PageHeader children (a bare `<div>`, a `<Stack>`) inside
+ *   `<PageHeader>`. They're silently dropped. Use one of the seven slots.
+ * - ❌ Wrapping a `<PageHeader.Title>` in an HOC or deep nesting. The
+ *   `c.type ===` detection only handles one level of Fragment unwrap.
+ * - ❌ Putting an Avatar inside `<PageHeader.Title>`. Muddles the `<h1>`
+ *   text-content for screen readers. Use `<PageHeader.Aside>` instead.
+ * - ❌ `position: sticky` on `<PageHeader>` itself — out of scope for v1.
+ *   Wrap PageHeader in your own sticky container if you need it.
+ */
+const PageHeaderRoot = forwardRef<HTMLDivElement, PageHeaderProps>(
+  function PageHeaderRoot(
+    { borderBottom = true, className, children, ...rest },
+    ref,
+  ) {
+    const breadcrumb = findSlot(children, PageHeaderBreadcrumb);
+    const backButton = findSlot(children, PageHeaderBackButton);
+    const aside = findSlot(children, PageHeaderAside);
+    const title = findSlot(children, PageHeaderTitle);
+    const subtitle = findSlot(children, PageHeaderSubtitle);
+    const meta = findSlot(children, PageHeaderMeta);
+    const actions = findSlot(children, PageHeaderActions);
+
+    return (
+      <div
+        ref={ref}
+        className={clsx(styles.root, borderBottom && styles.rootWithBorder, className)}
+        {...rest}
+      >
+        {(breadcrumb || backButton) && (
+          <div className={styles.breadcrumb}>
+            {backButton}
+            {breadcrumb}
+          </div>
+        )}
+        {aside}
+        {title}
+        {subtitle}
+        {meta}
+        {actions}
+      </div>
+    );
+  },
+);
+PageHeaderRoot.displayName = 'PageHeader';
+
+/** Compound API: `<PageHeader>` + 7 sub-components. */
+export const PageHeader = Object.assign(PageHeaderRoot, {
+  Breadcrumb: PageHeaderBreadcrumb,
+  BackButton: PageHeaderBackButton,
+  Aside: PageHeaderAside,
+  Title: PageHeaderTitle,
+  Subtitle: PageHeaderSubtitle,
+  Meta: PageHeaderMeta,
+  Actions: PageHeaderActions,
+});

--- a/packages/design-system/src/components/PageHeader/index.ts
+++ b/packages/design-system/src/components/PageHeader/index.ts
@@ -1,0 +1,2 @@
+// Placeholder — full barrel lands in T2.
+export { PageHeader } from './PageHeader';

--- a/packages/design-system/src/components/PageHeader/index.ts
+++ b/packages/design-system/src/components/PageHeader/index.ts
@@ -1,2 +1,20 @@
-// Placeholder — full barrel lands in T2.
-export { PageHeader } from './PageHeader';
+export {
+  PageHeader,
+  PageHeaderBreadcrumb,
+  PageHeaderBackButton,
+  PageHeaderAside,
+  PageHeaderTitle,
+  PageHeaderSubtitle,
+  PageHeaderMeta,
+  PageHeaderActions,
+} from './PageHeader';
+export type {
+  PageHeaderProps,
+  PageHeaderBreadcrumbProps,
+  PageHeaderBackButtonProps,
+  PageHeaderAsideProps,
+  PageHeaderTitleProps,
+  PageHeaderSubtitleProps,
+  PageHeaderMetaProps,
+  PageHeaderActionsProps,
+} from './PageHeader';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -145,8 +145,17 @@ export type {
   ModalCloseProps,
 } from './components/Modal';
 
-// Placeholder — full PageHeader export block lands in T2.
 export { PageHeader } from './components/PageHeader';
+export type {
+  PageHeaderProps,
+  PageHeaderBreadcrumbProps,
+  PageHeaderBackButtonProps,
+  PageHeaderAsideProps,
+  PageHeaderTitleProps,
+  PageHeaderSubtitleProps,
+  PageHeaderMetaProps,
+  PageHeaderActionsProps,
+} from './components/PageHeader';
 
 export { Drawer } from './components/Drawer';
 export type {

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -145,6 +145,9 @@ export type {
   ModalCloseProps,
 } from './components/Modal';
 
+// Placeholder — full PageHeader export block lands in T2.
+export { PageHeader } from './components/PageHeader';
+
 export { Drawer } from './components/Drawer';
 export type {
   DrawerProps,

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -40,6 +40,7 @@ import { TabsDemo } from './pages/components/TabsDemo';
 import { DropdownMenuDemo } from './pages/components/DropdownMenuDemo';
 import { TooltipDemo } from './pages/components/TooltipDemo';
 import { ModalDemo } from './pages/components/ModalDemo';
+import { PageHeaderDemo } from './pages/components/PageHeaderDemo';
 import { PopoverDemo } from './pages/components/PopoverDemo';
 import { RadioDemo } from './pages/components/RadioDemo';
 import { CalendarDemo } from './pages/components/CalendarDemo';
@@ -105,6 +106,7 @@ export default function App() {
           <Route path="/components/dropdown-menu" element={<DropdownMenuDemo />} />
           <Route path="/components/tooltip" element={<TooltipDemo />} />
           <Route path="/components/modal" element={<ModalDemo />} />
+          <Route path="/components/page-header" element={<PageHeaderDemo />} />
           <Route path="/components/popover" element={<PopoverDemo />} />
           <Route path="/components/radio" element={<RadioDemo />} />
           <Route path="/components/calendar" element={<CalendarDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -42,6 +42,7 @@ import {
   TableProperties,
   ListOrdered,
   LayoutPanelLeft,
+  LayoutPanelTop,
   ListCollapse,
   MoveRight,
   ToggleRight,
@@ -91,6 +92,7 @@ const componentGroups = [
       { to: '/components/divider', label: 'Divider', icon: Minus, end: false },
       { to: '/components/grid', label: 'Grid', icon: LayoutGrid, end: false },
       { to: '/components/card', label: 'Card', icon: RectangleHorizontal, end: false },
+      { to: '/components/page-header', label: 'PageHeader', icon: LayoutPanelTop, end: false },
     ],
   },
   {

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -41,6 +41,7 @@ import { FileUpload } from '@eocrm/design-system';
 import { ImageCrop } from '@eocrm/design-system';
 import { Pagination } from '@eocrm/design-system';
 import { Radio, RadioGroup } from '@eocrm/design-system';
+import { PageHeader } from '@eocrm/design-system';
 import { toast } from '@eocrm/design-system';
 import styles from './ComponentsIndex.module.scss';
 
@@ -644,6 +645,23 @@ const items: { to: string; name: string; description: string; preview: React.Rea
             <Button size="sm">OK</Button>
           </div>
         </div>
+      </div>
+    ),
+  },
+  {
+    to: '/components/page-header',
+    name: 'PageHeader',
+    description:
+      'Compound layout primitive for top-of-page headers. Breadcrumb + BackButton + Aside (Avatar) + Title + Subtitle + Meta + Actions.',
+    preview: (
+      <div style={{ width: '100%', pointerEvents: 'none' }}>
+        <PageHeader borderBottom={false}>
+          <PageHeader.Title order={2}>Acme Corp</PageHeader.Title>
+          <PageHeader.Subtitle>230 employees</PageHeader.Subtitle>
+          <PageHeader.Actions>
+            <Button size="sm" variant="secondary">Edit</Button>
+          </PageHeader.Actions>
+        </PageHeader>
       </div>
     ),
   },

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -659,7 +659,9 @@ const items: { to: string; name: string; description: string; preview: React.Rea
           <PageHeader.Title order={2}>Acme Corp</PageHeader.Title>
           <PageHeader.Subtitle>230 employees</PageHeader.Subtitle>
           <PageHeader.Actions>
-            <Button size="sm" variant="secondary">Edit</Button>
+            <Button size="sm" variant="secondary">
+              Edit
+            </Button>
           </PageHeader.Actions>
         </PageHeader>
       </div>

--- a/packages/playground/src/pages/components/PageHeaderDemo.tsx
+++ b/packages/playground/src/pages/components/PageHeaderDemo.tsx
@@ -1,13 +1,5 @@
 import { useState } from 'react';
-import {
-  PageHeader,
-  Avatar,
-  Badge,
-  Button,
-  Breadcrumb,
-  Tabs,
-  Text,
-} from '@eocrm/design-system';
+import { PageHeader, Avatar, Badge, Button, Breadcrumb, Tabs, Text } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import tsxSource from '@lib-source/components/PageHeader/PageHeader.tsx?raw';
@@ -50,7 +42,9 @@ function FullDemo() {
       <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
       <PageHeader.Meta>
         <Badge tone="success">Active</Badge>
-        <Text size="sm" tone="muted">Last contacted 2 days ago</Text>
+        <Text size="sm" tone="muted">
+          Last contacted 2 days ago
+        </Text>
       </PageHeader.Meta>
       <PageHeader.Actions>
         <Button variant="secondary">Email</Button>

--- a/packages/playground/src/pages/components/PageHeaderDemo.tsx
+++ b/packages/playground/src/pages/components/PageHeaderDemo.tsx
@@ -1,0 +1,201 @@
+import { useState } from 'react';
+import {
+  PageHeader,
+  Avatar,
+  Badge,
+  Button,
+  Breadcrumb,
+  Tabs,
+  Text,
+} from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/PageHeader/PageHeader.tsx?raw';
+import scssSource from '@lib-source/components/PageHeader/PageHeader.module.scss?raw';
+
+function MinimalDemo() {
+  return (
+    <PageHeader>
+      <PageHeader.Title>Settings</PageHeader.Title>
+    </PageHeader>
+  );
+}
+
+function WithSubtitleAndActions() {
+  return (
+    <PageHeader>
+      <PageHeader.Title>Members</PageHeader.Title>
+      <PageHeader.Subtitle>Manage team access and roles.</PageHeader.Subtitle>
+      <PageHeader.Actions>
+        <Button>Invite member</Button>
+      </PageHeader.Actions>
+    </PageHeader>
+  );
+}
+
+function FullDemo() {
+  return (
+    <PageHeader>
+      <PageHeader.Breadcrumb>
+        <Breadcrumb>
+          <Breadcrumb.Item href="#">Contacts</Breadcrumb.Item>
+          <Breadcrumb.Item>Acme Corp</Breadcrumb.Item>
+        </Breadcrumb>
+      </PageHeader.Breadcrumb>
+      <PageHeader.BackButton href="#" aria-label="Back to contacts" />
+      <PageHeader.Aside>
+        <Avatar size="lg" name="Acme Corp" />
+      </PageHeader.Aside>
+      <PageHeader.Title>Acme Corporation</PageHeader.Title>
+      <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
+      <PageHeader.Meta>
+        <Badge tone="success">Active</Badge>
+        <Text size="sm" tone="muted">Last contacted 2 days ago</Text>
+      </PageHeader.Meta>
+      <PageHeader.Actions>
+        <Button variant="secondary">Email</Button>
+        <Button variant="secondary">Call</Button>
+        <Button>Edit</Button>
+      </PageHeader.Actions>
+    </PageHeader>
+  );
+}
+
+function WithSiblingTabs() {
+  const [tab, setTab] = useState('overview');
+  return (
+    <div>
+      <PageHeader borderBottom={false}>
+        <PageHeader.Title>Reports</PageHeader.Title>
+        <PageHeader.Actions>
+          <Button variant="secondary">Export</Button>
+          <Button>New report</Button>
+        </PageHeader.Actions>
+      </PageHeader>
+      <Tabs
+        activeId={tab}
+        onChange={setTab}
+        items={[
+          { id: 'overview', label: 'Overview' },
+          { id: 'pipeline', label: 'Pipeline' },
+          { id: 'forecast', label: 'Forecast' },
+        ]}
+      />
+    </div>
+  );
+}
+
+function SectionHeaderDemo() {
+  return (
+    <PageHeader>
+      <PageHeader.Title order={2}>Filters</PageHeader.Title>
+      <PageHeader.Subtitle>Narrow the dataset shown below.</PageHeader.Subtitle>
+      <PageHeader.Actions>
+        <Button variant="secondary">Reset</Button>
+      </PageHeader.Actions>
+    </PageHeader>
+  );
+}
+
+export function PageHeaderDemo() {
+  return (
+    <DemoLayout
+      name="PageHeader"
+      description="Compound layout primitive for top-of-page headers. Seven slots (Breadcrumb, BackButton, Aside, Title, Subtitle, Meta, Actions) attached via Object.assign. Missing slots collapse; unrecognized children are silently dropped."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="PageHeader.tsx"
+      scssFilename="PageHeader.module.scss"
+      componentName="PageHeader"
+    >
+      <Example
+        title="Minimal"
+        description="The smallest useful PageHeader — just a Title. All other slots are absent and collapse to 0 height."
+        code={`<PageHeader>
+  <PageHeader.Title>Settings</PageHeader.Title>
+</PageHeader>`}
+      >
+        <MinimalDemo />
+      </Example>
+
+      <Example
+        title="With subtitle and actions"
+        description="The dominant CRM list/index page pattern. Title + Subtitle on the left, a primary Action button on the right."
+        code={`<PageHeader>
+  <PageHeader.Title>Members</PageHeader.Title>
+  <PageHeader.Subtitle>Manage team access and roles.</PageHeader.Subtitle>
+  <PageHeader.Actions>
+    <Button>Invite member</Button>
+  </PageHeader.Actions>
+</PageHeader>`}
+      >
+        <WithSubtitleAndActions />
+      </Example>
+
+      <Example
+        title="Full (detail page)"
+        description="ContactDetail-style header. Breadcrumb + BackButton in the top row; Aside (Avatar) to the left of the title block; Title + Subtitle + Meta (Badge + Text) stacked in the center; Actions cluster on the right."
+        code={`<PageHeader>
+  <PageHeader.Breadcrumb>
+    <Breadcrumb>
+      <Breadcrumb.Item href="#">Contacts</Breadcrumb.Item>
+      <Breadcrumb.Item>Acme Corp</Breadcrumb.Item>
+    </Breadcrumb>
+  </PageHeader.Breadcrumb>
+  <PageHeader.BackButton href="#" aria-label="Back to contacts" />
+  <PageHeader.Aside>
+    <Avatar size="lg" name="Acme Corp" />
+  </PageHeader.Aside>
+  <PageHeader.Title>Acme Corporation</PageHeader.Title>
+  <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
+  <PageHeader.Meta>
+    <Badge tone="success">Active</Badge>
+    <Text size="sm" tone="muted">Last contacted 2 days ago</Text>
+  </PageHeader.Meta>
+  <PageHeader.Actions>
+    <Button variant="secondary">Email</Button>
+    <Button variant="secondary">Call</Button>
+    <Button>Edit</Button>
+  </PageHeader.Actions>
+</PageHeader>`}
+      >
+        <FullDemo />
+      </Example>
+
+      <Example
+        title="Inline with sibling Tabs"
+        description="When Tabs follows the header as a sibling, set `borderBottom={false}` so PageHeader's border doesn't duplicate Tabs' own border-bottom."
+        code={`<div>
+  <PageHeader borderBottom={false}>
+    <PageHeader.Title>Reports</PageHeader.Title>
+    <PageHeader.Actions>
+      <Button variant="secondary">Export</Button>
+      <Button>New report</Button>
+    </PageHeader.Actions>
+  </PageHeader>
+  <Tabs activeId={tab} onChange={setTab} items={[
+    { id: 'overview', label: 'Overview' },
+    { id: 'pipeline', label: 'Pipeline' },
+    { id: 'forecast', label: 'Forecast' },
+  ]} />
+</div>`}
+      >
+        <WithSiblingTabs />
+      </Example>
+
+      <Example
+        title="Section header (order={2})"
+        description="Sub-page section header — renders as <h2> instead of <h1>. Useful for sub-pages within a tab or a panel where the page's <h1> lives elsewhere."
+        code={`<PageHeader>
+  <PageHeader.Title order={2}>Filters</PageHeader.Title>
+  <PageHeader.Subtitle>Narrow the dataset shown below.</PageHeader.Subtitle>
+  <PageHeader.Actions>
+    <Button variant="secondary">Reset</Button>
+  </PageHeader.Actions>
+</PageHeader>`}
+      >
+        <SectionHeaderDemo />
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -32,6 +32,7 @@ export type ComponentName =
   | 'Input'
   | 'Link'
   | 'Modal'
+  | 'PageHeader'
   | 'Pagination'
   | 'PasswordInput'
   | 'PasswordStrengthMeter'


### PR DESCRIPTION
## Summary

`<PageHeader>` — a compound layout primitive that bundles breadcrumb, back-navigation, leading element (Avatar / icon), title, subtitle, meta row, and right-aligned actions into a single grid-based container with consistent spacing and an optional bottom border.

## What ships

### Compound API — 7 slots

```tsx
<PageHeader>
  <PageHeader.Breadcrumb>
    <Breadcrumb>...</Breadcrumb>
  </PageHeader.Breadcrumb>
  <PageHeader.BackButton href="/contacts" aria-label="Back to contacts" />
  <PageHeader.Aside>
    <Avatar size="lg" name="Acme Corp" />
  </PageHeader.Aside>
  <PageHeader.Title>Acme Corporation</PageHeader.Title>
  <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
  <PageHeader.Meta>
    <Badge tone="success">Active</Badge>
    <Text size="sm" tone="muted">Last contacted 2 days ago</Text>
  </PageHeader.Meta>
  <PageHeader.Actions>
    <Button variant="secondary">Email</Button>
    <Button>Edit</Button>
  </PageHeader.Actions>
</PageHeader>
```

All seven slots are optional; missing slots collapse to zero-height grid rows. Unrecognized children are silently dropped.

## Design decisions baked in

- **Compound pattern** — `<PageHeader>` + 7 sub-components attached via `Object.assign`, matching Card / Modal / Popover / ColorPicker idiom.
- **Marker-detection by `c.type ===`** with one level of Fragment unwrap via a small `flattenChildren` helper. Deeper nesting / HOCs documented as anti-patterns.
- **`<PageHeader.Aside>` (position-based name)** — accepts Avatar / icon / image. Naming it "Icon" or "Leading" was rejected as misleading; "Aside" describes the position with broad applicability.
- **`<PageHeader.BackButton>`** renders `<a href>` when `href` is set, `<button onClick>` when `onClick` is set. Both → button wins + dev warn. Neither → disabled button + dev warn. Default `aria-label="Go back"`, default icon `<ChevronLeft size={16}>`.
- **`<div>` root, not `<header>`** — avoids landmark conflict with the AppShell's app-level `<header role="banner">`.
- **`borderBottom: boolean = true`** — toggle the bottom border when placing `<Tabs>` as a sibling below (`Tabs` has its own border-bottom).
- **First library component with a media query inside its CSS Module** — Actions wraps below the title block at `max-width: 640px`. Documented as REGRESSION-WATCH in the spec.
- **Sticky positioning deferred to v2** — consumers wrap PageHeader in their own sticky container if needed.
- **Mockup refactor deferred** — ContactDetail / Members migration to PageHeader is a follow-up PR.

## Tests

**20 cases** (1923 total tests, +20 net new): rendering (only-Title minimal, all-seven-slots, borderBottom default + false, `<div>` root), sub-component detection (Title slot, unrecognized children dropped, one-level Fragment unwrap, multi-Title first-wins, deep-Fragment NOT unwrapped), Title (order=1 default, order=2 → h2), BackButton (`<a>` when `href`, `<button>` when `onClick`, both → button + warn, neither → disabled + warn, default `aria-label`, custom icon), Aside + Actions slot content, Subtitle + Meta rendering, and misc (forwardRef, className merge, real `<h1>` element).

## Hard Rule 8

Round 1 → 1 Critical (`var(--line-height-snug)` was an undefined token; silently fell back to browser default — replaced with `--line-height-tight`) + 1 Important (missing tests for documented edge cases) + 2 Nice-to-haves (misleading test name, missing anti-pattern in JSDoc). All fixed in round-1 commit `5afe78c`. Round 2 verdict: `clean enough to stop`.

## Test plan

- [ ] `/components/page-header`: 5 examples render (Minimal, with subtitle + actions, Full, Inline with sibling Tabs, Section header `order={2}`).
- [ ] Resize browser to < 640px: Actions wraps below the title block. Aside stays to the left.
- [ ] BackButton with `href`: renders as `<a>` with correct href. Click navigates.
- [ ] BackButton with `onClick`: renders as `<button>`. Click fires the handler.
- [ ] BackButton with both → console warn + `<button>` rendering.
- [ ] BackButton with neither → console warn + disabled `<button>` rendering.
- [ ] `borderBottom={false}` example: no double border between PageHeader and Tabs.
- [ ] AGENTS.md PageHeader section appears in the Layout cluster after `<Divider>`.
- [ ] `npm pack --dry-run` includes the PageHeader directory, no test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
