### PR TITLE
Kanban: multi-column drag-to-reorder with live cross-column re-insertion

### DIFF
--- a/docs/superpowers/plans/2026-05-26-kanban.md
+++ b/docs/superpowers/plans/2026-05-26-kanban.md
@@ -1,0 +1,116 @@
+# Kanban Implementation Plan (v1 with live cross-column re-insertion)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Ship `<Kanban>` — multi-column board UI with cross-column drag, built on `@dnd-kit/sortable`. Ships WITH live cross-column re-insertion from the start (the previously-deferred behavior). Internal items state mutates mid-drag; consumer's `onMove` fires once on drop. Closes the `<MutedBox>` TODO entry by absorbing the kanban-column styling.
+
+**Architecture:** see `docs/superpowers/specs/2026-05-26-kanban-live-reinsertion-design.md` for the full design. Summary: Kanban Root extracts column order + cards per column + card-id → ReactElement mapping from `children` via `useMemo`. Internal `liveItems` state (Map<columnId, cardId[]>) is null when idle, populated from the children-derived `initialItems` on `dragStart`, mutated on `dragOver` (cross-column only), and reset on `dragEnd`/`dragCancel`. Render uses `liveItems ?? initialItems` to look up each card's ReactElement from the mapping. Consumer's `onMove` fires once on `dragEnd` with the diff between final and initial.
+
+**Tech Stack:** React 19, TypeScript, CSS Modules + SCSS, `@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities` (already sanctioned deps), Vitest + RTL.
+
+**Spec:** `docs/superpowers/specs/2026-05-26-kanban-design.md` (v1 spec) + `docs/superpowers/specs/2026-05-26-kanban-live-reinsertion-design.md` (live-reinsertion architecture). Both apply together; this PR ships both.
+
+**Branch:** `feat/kanban-live-reinsertion` (already created from fresh main at `a4db3ca`).
+
+---
+
+## File structure
+
+| Path | Created / Modified | Responsibility |
+| --- | --- | --- |
+| `packages/design-system/src/components/Kanban/Kanban.tsx` | Create | Root + Column + Card + Handle re-export + live-items state machine |
+| `packages/design-system/src/components/Kanban/Kanban.module.scss` | Create | board / column / card styles |
+| `packages/design-system/src/components/Kanban/Kanban.test.tsx` | Create | ~10 cases (structure-focused; drag interaction via dnd-kit) |
+| `packages/design-system/src/components/Kanban/index.ts` | Create | Barrel |
+| `packages/design-system/src/index.ts` | Modify | Public re-export after Input |
+| `packages/design-system/src/_meta/manifest.ts` | Modify | `Kanban: 'Forms'` |
+| `packages/design-system/scripts/generate-manifest.mjs` | Modify | mirror |
+| `packages/design-system/src/components.manifest.json` | Modify | regenerated |
+| `packages/design-system/AGENTS.md` | Modify | TL;DR section after `<Sortable>` |
+| `packages/design-system/src/components/TODO.md` | Modify | Close `<MutedBox>` entry |
+| `packages/playground/src/pages/components/KanbanDemo.tsx` | Create | 2 examples |
+| `packages/playground/src/App.tsx` | Modify | Route |
+| `packages/playground/src/layout/AppShell/AppShell.tsx` | Modify | Forms cluster nav + `KanbanSquare` lucide |
+| `packages/playground/src/pages/components/ComponentsIndex.tsx` | Modify | Overview card |
+| `packages/playground/src/pages/mockups/Deals/Deals.tsx` | Modify | Migrate from Grid + inline-styled `<div>` to `<Kanban>` |
+| `packages/playground/src/pages/mockups/registry.ts` | Modify | `'Kanban'` to ComponentName union + deals' usesComponents |
+
+---
+
+## Task 1: Kanban source + tests + manifest
+
+Implements the full primitive WITH live re-insertion architecture. Imports `SortableHandle` + `SortableItemContext` + `SortableItemContextValue` from the existing Sortable module (already a public export per Sortable v2 ship).
+
+See the spec for the complete Kanban.tsx code; the implementer should follow the spec's "Implementation outline" section verbatim, with these additions for code completeness:
+
+- **All TypeScript imports** from `react` + `@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities` + `clsx` + `../Sortable/Sortable` + `./Kanban.module.scss`.
+- **All exported types**: `KanbanProps`, `KanbanColumnProps`, `KanbanCardProps`, `KanbanMoveEvent`.
+- **`containsHandle` helper** (same as Sortable's) — walks children for `SortableHandle` recursively to drive Card's hybrid-Handle drag origin.
+- **`KanbanColumn`** uses `useDroppable({ id })` to register as a drop target. Wraps its children in `<SortableContext items={cardIdsInColumn} strategy={verticalListSortingStrategy}>`. The `cardIdsInColumn` is the cards array from the parent Kanban Root's effective items (passed via Context).
+- **`KanbanCard`** uses `useSortable({ id })`. Renders `<div role="article">` (only when a Sortable.Handle is present in subtree, per Sortable's anti-pattern; otherwise no role override and dnd-kit's `role="button"` applies). Wraps children in `<SortableItemContext.Provider>` so the Handle reads the right context.
+- **`Object.assign`** compound exposing `Item: KanbanCard` (alias)... wait, no. Use `Column` and `Card` as named sub-components, not `Item`. `Handle: SortableHandle` re-exported.
+
+The Root's render path needs the **column-children splitter**: for each `<Kanban.Column>` in `children`, walk its `children` once and split into `{ before: ReactNode[], cards: ReactElement<KanbanCardProps>[], after: ReactNode[] }`. Cards are collected by their `KanbanCard` type check; everything BEFORE the first card goes into `before`, everything AFTER the last card goes into `after`. At render, the Root recomposes each column with `[...before, ...cards-in-effective-order, ...after]`.
+
+**Passing per-column items down to KanbanColumn**: the simplest way is a Context. Define `KanbanColumnContext` providing `{ effectiveCardIds: (string | number)[] }`. Wrap each rendered column in this context's Provider, passing the effective card-ids array for that column. KanbanColumn reads this context to populate its SortableContext's `items` prop. Falls back to deriving from children (for the "Kanban.Column used outside Kanban" case, which should never happen but be defensive).
+
+**Files to create/modify** per the table above. Includes:
+- The CLAUDE.md dep-policy update (the @dnd-kit allowlist) is ALREADY in place from PR #70 — no edit needed.
+- The `_meta/manifest.ts` and `generate-manifest.mjs` need `Kanban: 'Forms'` added; the JSON gets regenerated.
+
+**Tests** — 10 cases per the spec, plus:
+- `onMove` fires exactly once at the end of a simulated drag (use a wrapper component that exposes state to verify the consumer's setState semantics).
+- Live re-insertion is NOT unit-tested (jsdom can't simulate cross-column drag with real layout); manual verification in the playground demo.
+
+---
+
+## Task 2: AGENTS.md + Demo + 4-place wiring + Deals migration + close MutedBox TODO
+
+Combined task (all are mechanical inserts / migrations):
+
+1. **AGENTS.md**: insert Kanban TL;DR after `<Sortable>`. Use the v1 spec's drafted text but update the "cross-column drag" paragraph to describe live re-insertion (cards reflow as the dragged card crosses columns; `onMove` fires once on drop). Drop the "no live re-insertion" anti-pattern bullet.
+
+2. **KanbanDemo.tsx**: 2 examples (basic 3-column, cards with Handle + DropdownMenu) + 2 independent state instances (boardA, boardB) so the two examples don't share state. Use `arrayMove` from `@dnd-kit/sortable` for the move logic + a `moveBetween` helper for cross-column splice.
+
+3. **4-place wiring**:
+   - `App.tsx`: import + route `/components/kanban`, alphabetical (between K-named and L-named).
+   - `AppShell.tsx`: Forms cluster entry between Slider and Switch... no, alphabetical means `Kanban` goes before `Slider` actually (K < S). Confirm. Lucide icon `KanbanSquare` (already imported for the Deals mockup nav).
+   - `ComponentsIndex.tsx`: overview card with mini preview.
+   - `registry.ts`: add `'Kanban'` to the `ComponentName` union.
+
+4. **Deals migration**:
+   - Read `packages/playground/src/pages/mockups/Deals/Deals.tsx`.
+   - Replace the `<Grid columns={4}>` + inline-styled `<div>` kanban-column escape hatches with `<Kanban>` + `<Kanban.Column>` + `<Kanban.Card>`.
+   - Add `useState` for the deals-by-stage state. Initialize by grouping the flat `deals` array by `stage`. Apply the splice-out + splice-in pattern in the `onMove` handler.
+   - Remove `Grid` import + the inline-style escape hatches + the `{/* TODO: replace when <MutedBox> ships */}` comment.
+   - Update `registry.ts` deals' `usesComponents`: add `'Kanban'`, remove `'Grid'` if no longer imported.
+
+5. **Close `<MutedBox>` TODO** entry: move from Open to Closed in `packages/design-system/src/components/TODO.md`. Mark `[x]`. Append resolution note pointing to this PR.
+
+---
+
+## Task 3: HR8 review cycle + push + PR
+
+Two rounds of fresh-context Opus reviewers. Fix Critical + Important. Push branch. Open PR titled "Kanban: multi-column drag-to-reorder with live cross-column re-insertion".
+
+PR description summary:
+- Compound primitive `<Kanban>` + Column + Card + Handle. Thin layer over `@dnd-kit/sortable` with internal items state for live cross-column re-insertion.
+- `onMove` fires once on drop with `{from: {columnId, index}, to: {columnId, index}, cardId}`.
+- Closes the `<MutedBox>` TODO entry — `<Kanban.Column>`'s built-in muted background absorbs that gap.
+- Deals mockup migrated; cards are now actually draggable (previously static).
+- Limitations (anti-patterns documented): no column reordering, no cross-column keyboard reorder (per-`SortableContext` `coordinateGetter` limitation), cards must be contiguous within a column's children.
+
+---
+
+## Risks
+
+- The `cloneElement`-based render of columns is the most subtle piece. If a consumer wraps `<Kanban.Card>` inside another component, the `containsHandle` walk + the card-children extraction both miss it.
+- The `initialItemsKey` reconciliation: if a consumer mutates state mid-drag, we reset `liveItems` and the drag continues from the new "truth". Edge case but real.
+- Performance: every cursor-crossing-columns triggers a Kanban setState + subtree re-render. For 100+ cards this might lag. Same constraint as Sortable.
+
+## Out of scope
+
+- Cross-column keyboard reorder (custom coordinate-getter needed).
+- Column reordering.
+- DragOverlay portal.
+- `canDrop` validation.

--- a/docs/superpowers/plans/2026-05-26-kanban.md
+++ b/docs/superpowers/plans/2026-05-26-kanban.md
@@ -16,24 +16,24 @@
 
 ## File structure
 
-| Path | Created / Modified | Responsibility |
-| --- | --- | --- |
-| `packages/design-system/src/components/Kanban/Kanban.tsx` | Create | Root + Column + Card + Handle re-export + live-items state machine |
-| `packages/design-system/src/components/Kanban/Kanban.module.scss` | Create | board / column / card styles |
-| `packages/design-system/src/components/Kanban/Kanban.test.tsx` | Create | ~10 cases (structure-focused; drag interaction via dnd-kit) |
-| `packages/design-system/src/components/Kanban/index.ts` | Create | Barrel |
-| `packages/design-system/src/index.ts` | Modify | Public re-export after Input |
-| `packages/design-system/src/_meta/manifest.ts` | Modify | `Kanban: 'Forms'` |
-| `packages/design-system/scripts/generate-manifest.mjs` | Modify | mirror |
-| `packages/design-system/src/components.manifest.json` | Modify | regenerated |
-| `packages/design-system/AGENTS.md` | Modify | TL;DR section after `<Sortable>` |
-| `packages/design-system/src/components/TODO.md` | Modify | Close `<MutedBox>` entry |
-| `packages/playground/src/pages/components/KanbanDemo.tsx` | Create | 2 examples |
-| `packages/playground/src/App.tsx` | Modify | Route |
-| `packages/playground/src/layout/AppShell/AppShell.tsx` | Modify | Forms cluster nav + `KanbanSquare` lucide |
-| `packages/playground/src/pages/components/ComponentsIndex.tsx` | Modify | Overview card |
-| `packages/playground/src/pages/mockups/Deals/Deals.tsx` | Modify | Migrate from Grid + inline-styled `<div>` to `<Kanban>` |
-| `packages/playground/src/pages/mockups/registry.ts` | Modify | `'Kanban'` to ComponentName union + deals' usesComponents |
+| Path                                                              | Created / Modified | Responsibility                                                     |
+| ----------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------ |
+| `packages/design-system/src/components/Kanban/Kanban.tsx`         | Create             | Root + Column + Card + Handle re-export + live-items state machine |
+| `packages/design-system/src/components/Kanban/Kanban.module.scss` | Create             | board / column / card styles                                       |
+| `packages/design-system/src/components/Kanban/Kanban.test.tsx`    | Create             | ~10 cases (structure-focused; drag interaction via dnd-kit)        |
+| `packages/design-system/src/components/Kanban/index.ts`           | Create             | Barrel                                                             |
+| `packages/design-system/src/index.ts`                             | Modify             | Public re-export after Input                                       |
+| `packages/design-system/src/_meta/manifest.ts`                    | Modify             | `Kanban: 'Forms'`                                                  |
+| `packages/design-system/scripts/generate-manifest.mjs`            | Modify             | mirror                                                             |
+| `packages/design-system/src/components.manifest.json`             | Modify             | regenerated                                                        |
+| `packages/design-system/AGENTS.md`                                | Modify             | TL;DR section after `<Sortable>`                                   |
+| `packages/design-system/src/components/TODO.md`                   | Modify             | Close `<MutedBox>` entry                                           |
+| `packages/playground/src/pages/components/KanbanDemo.tsx`         | Create             | 2 examples                                                         |
+| `packages/playground/src/App.tsx`                                 | Modify             | Route                                                              |
+| `packages/playground/src/layout/AppShell/AppShell.tsx`            | Modify             | Forms cluster nav + `KanbanSquare` lucide                          |
+| `packages/playground/src/pages/components/ComponentsIndex.tsx`    | Modify             | Overview card                                                      |
+| `packages/playground/src/pages/mockups/Deals/Deals.tsx`           | Modify             | Migrate from Grid + inline-styled `<div>` to `<Kanban>`            |
+| `packages/playground/src/pages/mockups/registry.ts`               | Modify             | `'Kanban'` to ComponentName union + deals' usesComponents          |
 
 ---
 
@@ -55,10 +55,12 @@ The Root's render path needs the **column-children splitter**: for each `<Kanban
 **Passing per-column items down to KanbanColumn**: the simplest way is a Context. Define `KanbanColumnContext` providing `{ effectiveCardIds: (string | number)[] }`. Wrap each rendered column in this context's Provider, passing the effective card-ids array for that column. KanbanColumn reads this context to populate its SortableContext's `items` prop. Falls back to deriving from children (for the "Kanban.Column used outside Kanban" case, which should never happen but be defensive).
 
 **Files to create/modify** per the table above. Includes:
+
 - The CLAUDE.md dep-policy update (the @dnd-kit allowlist) is ALREADY in place from PR #70 — no edit needed.
 - The `_meta/manifest.ts` and `generate-manifest.mjs` need `Kanban: 'Forms'` added; the JSON gets regenerated.
 
 **Tests** — 10 cases per the spec, plus:
+
 - `onMove` fires exactly once at the end of a simulated drag (use a wrapper component that exposes state to verify the consumer's setState semantics).
 - Live re-insertion is NOT unit-tested (jsdom can't simulate cross-column drag with real layout); manual verification in the playground demo.
 
@@ -94,6 +96,7 @@ Combined task (all are mechanical inserts / migrations):
 Two rounds of fresh-context Opus reviewers. Fix Critical + Important. Push branch. Open PR titled "Kanban: multi-column drag-to-reorder with live cross-column re-insertion".
 
 PR description summary:
+
 - Compound primitive `<Kanban>` + Column + Card + Handle. Thin layer over `@dnd-kit/sortable` with internal items state for live cross-column re-insertion.
 - `onMove` fires once on drop with `{from: {columnId, index}, to: {columnId, index}, cardId}`.
 - Closes the `<MutedBox>` TODO entry — `<Kanban.Column>`'s built-in muted background absorbs that gap.

--- a/docs/superpowers/specs/2026-05-26-kanban-live-reinsertion-design.md
+++ b/docs/superpowers/specs/2026-05-26-kanban-live-reinsertion-design.md
@@ -1,0 +1,282 @@
+# Kanban live cross-column re-insertion — v2 design
+
+**Date:** 2026-05-26
+**Component:** `<Kanban>` (enhancement, not new component)
+**Motivation:** PR #70 (commits `a4db3ca`) shipped Kanban v1 with `commit-on-drop` behavior — the dragged card follows the cursor but other cards don't reflow until release. v2 adds live cross-column re-insertion: cards in the target column shift to make room as the dragged card crosses in, matching Trello/Jira UX.
+
+**Supersedes:** the "commit-on-drop only" v1 limitation documented in `2026-05-26-kanban-design.md`. A prior attempt (PR #70 commit `464ab75`) added live re-insertion via consumer-state mutation in `onDragOver`; this caused an infinite `measureRect → setState → re-render → measureRect` loop in dnd-kit. The loop was the consumer-state-mutation approach being wrong — the right approach is to keep the live-reorder state INTERNAL to Kanban (per dnd-kit's official `MultipleContainers` storybook).
+
+## Why the v1 approach failed
+
+`v1.5` (commit `464ab75`, reverted): updated **consumer state** mid-drag in `onDragOver`. Consumer's `setState` triggered a re-render of the parent component holding the children. dnd-kit's internal resize observer fired for every layout shift. The dragged card's DOM node remounted across columns. dnd-kit dispatched a setState in its `measureRect` layout-effect. That setState scheduled another render. Cascade.
+
+`v2`: update **internal state in Kanban** mid-drag. Only Kanban's subtree re-renders. Consumer state is untouched until drop. dnd-kit's reconciliation works as designed (this is the pattern its official kanban storybook ships).
+
+## Architecture
+
+```
+Consumer's JSX (unchanged)
+       │
+       ▼
+  <Kanban>
+       │
+       │  useMemo over children → extract:
+       │  • columnOrder: columnId[]
+       │  • initialItems: Map<columnId, cardId[]>
+       │  • cardElements: Map<cardId, ReactElement<KanbanCardProps>>
+       │  • columnNonCardChildren: Map<columnId, ReactNode[]>
+       │
+       ▼
+  liveItems: Map<columnId, cardId[]> | null
+  (null when idle; populated from initialItems on drag start)
+       │
+       ▼
+  effectiveItems = liveItems ?? initialItems
+       │
+       ▼
+  Render each column from effectiveItems[columnId], looking up
+  each cardId in cardElements to get its React element. Non-card
+  children (header, etc.) render BEFORE the cards in the order
+  the consumer wrote them.
+```
+
+### Drag lifecycle
+
+```
+idle:           liveItems = null, render from initialItems (= children's natural order)
+
+onDragStart:    setLiveItems(new Map(initialItems))  ← snapshot
+
+onDragOver:     if (active card's container ≠ over target's container):
+                  setLiveItems(prev => move active to new container at over's index)
+                else: no-op (within-column reorder happens automatically via dnd-kit's
+                                 verticalListSortingStrategy + useSortable transforms)
+
+onDragEnd:      compute (from, to, cardId) by diffing liveItems against initialItems
+                fire onMove?.(...)  once
+                setLiveItems(null)  ← reset
+
+onDragCancel:   setLiveItems(null)  ← discard
+```
+
+### Reconciling consumer state changes
+
+If the consumer mutates state mid-drag (rare but possible), `children` changes → `useMemo` recomputes `initialItems`. The current `liveItems` may reference cardIds that no longer exist or miss new ones. v2 detects this via:
+
+```ts
+useEffect(() => {
+  // When initialItems changes (consumer state mutation), reset liveItems.
+  // If a drag is in flight, this cancels the live overlay; dnd-kit's
+  // onDragEnd will still fire and fire onMove with whatever final
+  // state it had — consumer should expect this.
+  setLiveItems(null);
+}, [initialItemsKey]); // serialized signature of initialItems
+```
+
+`initialItemsKey` is a stable string serialization of `initialItems` (e.g. `JSON.stringify([...initialItems])`). It changes only when the underlying card→column assignment changes.
+
+This means: if the consumer adds/removes a card during a drag, the live overlay resets to the new "truth" from children, and the drag continues from there. Conservative.
+
+## Public API impact
+
+**Zero.** Same `<Kanban onMove={...}><Kanban.Column id=...><Kanban.Card id=...>...</Kanban.Card></Kanban.Column></Kanban>` shape. `onMove` still fires exactly once per drag (on drop), with the same `{from, to, cardId}` payload.
+
+The JSDoc / AGENTS.md "anti-patterns" bullet that documented the v1 commit-on-drop limitation gets removed. Replaced with a note that cards reflow live as the dragged card crosses columns.
+
+## Render rule: cards must be contiguous within a column's children
+
+To re-arrange cards via internal state, Kanban needs to know WHERE in the column's child list to insert the reordered cards. The implementation assumes: **a `<Kanban.Column>`'s `<Kanban.Card>` children are a contiguous block** (typically after a header / before a footer).
+
+Concretely, when extracting column children at memo time:
+- Split each column's children into `[beforeCards, ...cards, afterCards]`.
+- `beforeCards` = all non-card children before the first card.
+- `cards` = the contiguous block of `KanbanCard` children.
+- `afterCards` = all non-card children after the last card.
+- Render: `[...beforeCards, ...reorderedCards, ...afterCards]`.
+
+If a consumer interleaves non-cards within the cards (e.g. `<Card><Header><Card>`), the reorder still works but the non-card lands in a weird position. Document as anti-pattern: keep header(s) before cards, footer(s) after.
+
+## Implementation outline (Kanban.tsx)
+
+```tsx
+const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
+  { onMove, className, children, ...rest },
+  ref,
+) {
+  // Extract from children
+  const { columnOrder, initialItems, cardElements, columnNonCardChildren } = useMemo(() => {
+    // walk children, build all four
+  }, [children]);
+
+  const initialItemsKey = useMemo(
+    () => JSON.stringify([...initialItems].map(([col, cards]) => [col, [...cards]])),
+    [initialItems],
+  );
+
+  const [liveItems, setLiveItems] = useState<Map<string | number, (string | number)[]> | null>(null);
+
+  // Reset live items when consumer state mutates
+  useEffect(() => {
+    setLiveItems(null);
+  }, [initialItemsKey]);
+
+  const effectiveItems = liveItems ?? initialItems;
+
+  const findContainer = (id: string | number): string | number | null => {
+    if (effectiveItems.has(id)) return id; // dropped on column itself
+    for (const [colId, cards] of effectiveItems) {
+      if (cards.includes(id)) return colId;
+    }
+    return null;
+  };
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setLiveItems(new Map([...initialItems].map(([col, cards]) => [col, [...cards]])));
+  }, [initialItems]);
+
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    const { active, over } = event;
+    if (!over || !liveItems) return;
+    const activeId = active.id as string | number;
+    const overId = over.id as string | number;
+
+    const activeContainer = findContainer(activeId);
+    const overContainer = findContainer(overId);
+    if (activeContainer == null || overContainer == null) return;
+    if (activeContainer === overContainer) return;
+
+    setLiveItems((prev) => {
+      if (!prev) return prev;
+      const activeItems = prev.get(activeContainer) ?? [];
+      const overItems = prev.get(overContainer) ?? [];
+      const activeIdx = activeItems.indexOf(activeId);
+      if (activeIdx < 0) return prev;
+
+      // Insertion index: where in overContainer to place the active card.
+      // If over.id is a card in overContainer → insert at its position.
+      // If over.id is the column itself (empty drop) → append.
+      let insertAt: number;
+      if (overItems.includes(overId)) {
+        insertAt = overItems.indexOf(overId);
+      } else {
+        insertAt = overItems.length;
+      }
+
+      const next = new Map(prev);
+      next.set(activeContainer, activeItems.filter((id) => id !== activeId));
+      const newOverItems = [...overItems];
+      newOverItems.splice(insertAt, 0, activeId);
+      next.set(overContainer, newOverItems);
+      return next;
+    });
+  }, [liveItems, findContainer]);
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    const activeId = active.id as string | number;
+
+    // Compute the from-position from initialItems and to-position from liveItems
+    const final = liveItems ?? initialItems;
+    let toColumn: string | number | null = null;
+    let toIndex = -1;
+    for (const [colId, cards] of final) {
+      const idx = cards.indexOf(activeId);
+      if (idx >= 0) {
+        toColumn = colId;
+        toIndex = idx;
+        break;
+      }
+    }
+
+    let fromColumn: string | number | null = null;
+    let fromIndex = -1;
+    for (const [colId, cards] of initialItems) {
+      const idx = cards.indexOf(activeId);
+      if (idx >= 0) {
+        fromColumn = colId;
+        fromIndex = idx;
+        break;
+      }
+    }
+
+    setLiveItems(null);
+
+    if (fromColumn == null || toColumn == null) return;
+    // Within-column reorder finalization: use dnd-kit's arrayMove on the
+    // initial items if active and over are in the same column
+    if (over && fromColumn === toColumn) {
+      const overId = over.id as string | number;
+      const containerItems = initialItems.get(fromColumn) ?? [];
+      const overIdx = containerItems.indexOf(overId);
+      if (overIdx >= 0 && overIdx !== fromIndex) {
+        // Final position is the overIdx (or its neighbor)
+        toIndex = overIdx;
+      } else {
+        // No move
+        return;
+      }
+    }
+
+    if (fromColumn === toColumn && fromIndex === toIndex) return;
+
+    onMove?.({
+      from: { columnId: fromColumn, index: fromIndex },
+      to: { columnId: toColumn, index: toIndex },
+      cardId: activeId,
+    });
+  }, [liveItems, initialItems, onMove]);
+
+  const handleDragCancel = useCallback(() => {
+    setLiveItems(null);
+  }, []);
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <div ref={ref} role="region" aria-label="Kanban board" className={clsx(styles.board, className)} {...rest}>
+        {columnOrder.map((colId) => {
+          const columnElement = Children.toArray(children).find(
+            (c): c is ReactElement<KanbanColumnProps> => isValidElement(c) && c.type === KanbanColumn && (c.props as KanbanColumnProps).id === colId,
+          );
+          if (!columnElement) return null;
+          const cardIds = effectiveItems.get(colId) ?? [];
+          const cards = cardIds.map((id) => cardElements.get(id)).filter((c): c is ReactElement => c != null);
+          const { before, after } = columnNonCardChildren.get(colId) ?? { before: [], after: [] };
+          return cloneElement(columnElement, {}, ...before, ...cards, ...after);
+        })}
+      </div>
+    </DndContext>
+  );
+});
+```
+
+## Tests
+
+Same shape as v1 — drag interaction is not unit-tested (dnd-kit covers it). The v1 test file's 10 cases still apply (they test structure, ref forwarding, classes, ids, etc.). Add 2 new cases:
+
+- `onMove` fires once at end of drag (not multiple times during).
+- Re-arrange children mid-drag doesn't crash (state reset on initialItems change).
+
+## Risks
+
+- **Cards-must-be-contiguous assumption** is new. If a real consumer interleaves, they get a layout glitch. Documented anti-pattern.
+- **Reconcile on consumer state mutation** is conservative — cancels the live overlay. If a consumer mutates state on every cursor move (unlikely), live re-insertion gets jittery.
+- **Performance**: every `liveItems` setState during drag re-renders the entire Kanban subtree. For 100+ cards this might lag. Same constraint as v1.
+
+## Out of scope (still deferred to v3)
+
+- Cross-column keyboard reorder (dnd-kit's stock `sortableKeyboardCoordinates` is per-`SortableContext`).
+- Column reordering.
+- Custom `canDrop` validation.
+- DragOverlay (portal-rendered cursor-following ghost).

--- a/docs/superpowers/specs/2026-05-26-kanban-live-reinsertion-design.md
+++ b/docs/superpowers/specs/2026-05-26-kanban-live-reinsertion-design.md
@@ -88,6 +88,7 @@ The JSDoc / AGENTS.md "anti-patterns" bullet that documented the v1 commit-on-dr
 To re-arrange cards via internal state, Kanban needs to know WHERE in the column's child list to insert the reordered cards. The implementation assumes: **a `<Kanban.Column>`'s `<Kanban.Card>` children are a contiguous block** (typically after a header / before a footer).
 
 Concretely, when extracting column children at memo time:
+
 - Split each column's children into `[beforeCards, ...cards, afterCards]`.
 - `beforeCards` = all non-card children before the first card.
 - `cards` = the contiguous block of `KanbanCard` children.
@@ -113,7 +114,9 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
     [initialItems],
   );
 
-  const [liveItems, setLiveItems] = useState<Map<string | number, (string | number)[]> | null>(null);
+  const [liveItems, setLiveItems] = useState<Map<string | number, (string | number)[]> | null>(
+    null,
+  );
 
   // Reset live items when consumer state mutates
   useEffect(() => {
@@ -135,101 +138,113 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
-  const handleDragStart = useCallback((event: DragStartEvent) => {
-    setLiveItems(new Map([...initialItems].map(([col, cards]) => [col, [...cards]])));
-  }, [initialItems]);
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      setLiveItems(new Map([...initialItems].map(([col, cards]) => [col, [...cards]])));
+    },
+    [initialItems],
+  );
 
-  const handleDragOver = useCallback((event: DragOverEvent) => {
-    const { active, over } = event;
-    if (!over || !liveItems) return;
-    const activeId = active.id as string | number;
-    const overId = over.id as string | number;
-
-    const activeContainer = findContainer(activeId);
-    const overContainer = findContainer(overId);
-    if (activeContainer == null || overContainer == null) return;
-    if (activeContainer === overContainer) return;
-
-    setLiveItems((prev) => {
-      if (!prev) return prev;
-      const activeItems = prev.get(activeContainer) ?? [];
-      const overItems = prev.get(overContainer) ?? [];
-      const activeIdx = activeItems.indexOf(activeId);
-      if (activeIdx < 0) return prev;
-
-      // Insertion index: where in overContainer to place the active card.
-      // If over.id is a card in overContainer → insert at its position.
-      // If over.id is the column itself (empty drop) → append.
-      let insertAt: number;
-      if (overItems.includes(overId)) {
-        insertAt = overItems.indexOf(overId);
-      } else {
-        insertAt = overItems.length;
-      }
-
-      const next = new Map(prev);
-      next.set(activeContainer, activeItems.filter((id) => id !== activeId));
-      const newOverItems = [...overItems];
-      newOverItems.splice(insertAt, 0, activeId);
-      next.set(overContainer, newOverItems);
-      return next;
-    });
-  }, [liveItems, findContainer]);
-
-  const handleDragEnd = useCallback((event: DragEndEvent) => {
-    const { active, over } = event;
-    const activeId = active.id as string | number;
-
-    // Compute the from-position from initialItems and to-position from liveItems
-    const final = liveItems ?? initialItems;
-    let toColumn: string | number | null = null;
-    let toIndex = -1;
-    for (const [colId, cards] of final) {
-      const idx = cards.indexOf(activeId);
-      if (idx >= 0) {
-        toColumn = colId;
-        toIndex = idx;
-        break;
-      }
-    }
-
-    let fromColumn: string | number | null = null;
-    let fromIndex = -1;
-    for (const [colId, cards] of initialItems) {
-      const idx = cards.indexOf(activeId);
-      if (idx >= 0) {
-        fromColumn = colId;
-        fromIndex = idx;
-        break;
-      }
-    }
-
-    setLiveItems(null);
-
-    if (fromColumn == null || toColumn == null) return;
-    // Within-column reorder finalization: use dnd-kit's arrayMove on the
-    // initial items if active and over are in the same column
-    if (over && fromColumn === toColumn) {
+  const handleDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const { active, over } = event;
+      if (!over || !liveItems) return;
+      const activeId = active.id as string | number;
       const overId = over.id as string | number;
-      const containerItems = initialItems.get(fromColumn) ?? [];
-      const overIdx = containerItems.indexOf(overId);
-      if (overIdx >= 0 && overIdx !== fromIndex) {
-        // Final position is the overIdx (or its neighbor)
-        toIndex = overIdx;
-      } else {
-        // No move
-        return;
+
+      const activeContainer = findContainer(activeId);
+      const overContainer = findContainer(overId);
+      if (activeContainer == null || overContainer == null) return;
+      if (activeContainer === overContainer) return;
+
+      setLiveItems((prev) => {
+        if (!prev) return prev;
+        const activeItems = prev.get(activeContainer) ?? [];
+        const overItems = prev.get(overContainer) ?? [];
+        const activeIdx = activeItems.indexOf(activeId);
+        if (activeIdx < 0) return prev;
+
+        // Insertion index: where in overContainer to place the active card.
+        // If over.id is a card in overContainer → insert at its position.
+        // If over.id is the column itself (empty drop) → append.
+        let insertAt: number;
+        if (overItems.includes(overId)) {
+          insertAt = overItems.indexOf(overId);
+        } else {
+          insertAt = overItems.length;
+        }
+
+        const next = new Map(prev);
+        next.set(
+          activeContainer,
+          activeItems.filter((id) => id !== activeId),
+        );
+        const newOverItems = [...overItems];
+        newOverItems.splice(insertAt, 0, activeId);
+        next.set(overContainer, newOverItems);
+        return next;
+      });
+    },
+    [liveItems, findContainer],
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      const activeId = active.id as string | number;
+
+      // Compute the from-position from initialItems and to-position from liveItems
+      const final = liveItems ?? initialItems;
+      let toColumn: string | number | null = null;
+      let toIndex = -1;
+      for (const [colId, cards] of final) {
+        const idx = cards.indexOf(activeId);
+        if (idx >= 0) {
+          toColumn = colId;
+          toIndex = idx;
+          break;
+        }
       }
-    }
 
-    if (fromColumn === toColumn && fromIndex === toIndex) return;
+      let fromColumn: string | number | null = null;
+      let fromIndex = -1;
+      for (const [colId, cards] of initialItems) {
+        const idx = cards.indexOf(activeId);
+        if (idx >= 0) {
+          fromColumn = colId;
+          fromIndex = idx;
+          break;
+        }
+      }
 
-    onMove?.({
-      from: { columnId: fromColumn, index: fromIndex },
-      to: { columnId: toColumn, index: toIndex },
-      cardId: activeId,
-    });
-  }, [liveItems, initialItems, onMove]);
+      setLiveItems(null);
+
+      if (fromColumn == null || toColumn == null) return;
+      // Within-column reorder finalization: use dnd-kit's arrayMove on the
+      // initial items if active and over are in the same column
+      if (over && fromColumn === toColumn) {
+        const overId = over.id as string | number;
+        const containerItems = initialItems.get(fromColumn) ?? [];
+        const overIdx = containerItems.indexOf(overId);
+        if (overIdx >= 0 && overIdx !== fromIndex) {
+          // Final position is the overIdx (or its neighbor)
+          toIndex = overIdx;
+        } else {
+          // No move
+          return;
+        }
+      }
+
+      if (fromColumn === toColumn && fromIndex === toIndex) return;
+
+      onMove?.({
+        from: { columnId: fromColumn, index: fromIndex },
+        to: { columnId: toColumn, index: toIndex },
+        cardId: activeId,
+      });
+    },
+    [liveItems, initialItems, onMove],
+  );
 
   const handleDragCancel = useCallback(() => {
     setLiveItems(null);
@@ -244,14 +259,25 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      <div ref={ref} role="region" aria-label="Kanban board" className={clsx(styles.board, className)} {...rest}>
+      <div
+        ref={ref}
+        role="region"
+        aria-label="Kanban board"
+        className={clsx(styles.board, className)}
+        {...rest}
+      >
         {columnOrder.map((colId) => {
           const columnElement = Children.toArray(children).find(
-            (c): c is ReactElement<KanbanColumnProps> => isValidElement(c) && c.type === KanbanColumn && (c.props as KanbanColumnProps).id === colId,
+            (c): c is ReactElement<KanbanColumnProps> =>
+              isValidElement(c) &&
+              c.type === KanbanColumn &&
+              (c.props as KanbanColumnProps).id === colId,
           );
           if (!columnElement) return null;
           const cardIds = effectiveItems.get(colId) ?? [];
-          const cards = cardIds.map((id) => cardElements.get(id)).filter((c): c is ReactElement => c != null);
+          const cards = cardIds
+            .map((id) => cardElements.get(id))
+            .filter((c): c is ReactElement => c != null);
           const { before, after } = columnNonCardChildren.get(colId) ?? { before: [], after: [] };
           return cloneElement(columnElement, {}, ...before, ...cards, ...after);
         })}

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -585,9 +585,8 @@ function handleMove(event: KanbanMoveEvent) {
     const source = [...next[from.columnId as keyof typeof curr]];
     const [moved] = source.splice(from.index, 1);
     next[from.columnId as keyof typeof curr] = source;
-    const target = from.columnId === to.columnId
-      ? source
-      : [...(next[to.columnId as keyof typeof curr] ?? [])];
+    const target =
+      from.columnId === to.columnId ? source : [...(next[to.columnId as keyof typeof curr] ?? [])];
     target.splice(to.index, 0, moved);
     next[to.columnId as keyof typeof curr] = target;
     return next;
@@ -605,7 +604,7 @@ function handleMove(event: KanbanMoveEvent) {
       ))}
     </Kanban.Column>
   ))}
-</Kanban>
+</Kanban>;
 ```
 
 Props on the root: `onMove?: (event: KanbanMoveEvent) => void` — fires once per drop with the diff between the initial layout and the final layout. Consumer applies the move (immutable splice in/out). Columns and Cards both need stable `id` props (`string | number`).

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -565,6 +565,65 @@ Props on the root: `onReorder?: ({ from, to, id }) => void` — fires only when 
 - ❌ Wrapping non-`Sortable.Item` content inside `<Sortable>`. dnd-kit's `SortableContext` only tracks the ids you pass it; arbitrary children render but won't be reorderable.
 - ❌ Relying on whole-item drag (no Handle) for screen-reader-accessible lists. Without a Handle, dnd-kit puts `role="button"` on the `<li>` and the listitem semantics are lost — screen readers stop announcing "item N of M." For accessible lists, always include a `<Sortable.Handle>`.
 
+### `<Kanban>` — multi-column board (drag-to-reorder + cross-column drag with live reflow)
+
+Trello/Jira-style board UI. Compound: `Kanban`, `Kanban.Column`, `Kanban.Card`, `Kanban.Handle` (re-exported `Sortable.Handle`). Built on the same `@dnd-kit/sortable` plumbing as `<Sortable>` with internal items state that re-arranges cards live as the dragged card crosses column boundaries.
+
+```tsx
+import { Kanban, type KanbanMoveEvent } from '@eocrm/design-system';
+
+const [board, setBoard] = useState({
+  todo: [{ id: 'a', title: 'Buy milk' }],
+  doing: [{ id: 'b', title: 'Write spec' }],
+  done: [{ id: 'c', title: 'Ship Sortable' }],
+});
+
+function handleMove(event: KanbanMoveEvent) {
+  const { from, to, cardId } = event;
+  setBoard((curr) => {
+    const next = { ...curr };
+    const source = [...next[from.columnId as keyof typeof curr]];
+    const [moved] = source.splice(from.index, 1);
+    next[from.columnId as keyof typeof curr] = source;
+    const target = from.columnId === to.columnId
+      ? source
+      : [...(next[to.columnId as keyof typeof curr] ?? [])];
+    target.splice(to.index, 0, moved);
+    next[to.columnId as keyof typeof curr] = target;
+    return next;
+  });
+}
+
+<Kanban onMove={handleMove}>
+  {(['todo', 'doing', 'done'] as const).map((colId) => (
+    <Kanban.Column key={colId} id={colId}>
+      <Title order={3}>{colId}</Title>
+      {board[colId].map((c) => (
+        <Kanban.Card key={c.id} id={c.id}>
+          <Card>{c.title}</Card>
+        </Kanban.Card>
+      ))}
+    </Kanban.Column>
+  ))}
+</Kanban>
+```
+
+Props on the root: `onMove?: (event: KanbanMoveEvent) => void` — fires once per drop with the diff between the initial layout and the final layout. Consumer applies the move (immutable splice in/out). Columns and Cards both need stable `id` props (`string | number`).
+
+**Drag origin** (hybrid): `<Kanban.Handle>` inside a Card restricts drag origin to the Handle. Without a Handle, the whole Card is draggable (and dnd-kit assigns it `role="button"`).
+
+**Cross-column drag is LIVE**: as the dragged card crosses into a new column, cards in the target column shift to make room in real time. `onMove` still fires only once on release. This is driven by internal Kanban state — consumer's state is untouched until drop, so re-renders are scoped to the Kanban subtree (avoids the measureRect cascade that would happen if mid-drag mutations went through consumer setState).
+
+**Keyboard reorder** works WITHIN a column (Tab to Card/Handle, Space pick up, Arrow keys move, Space drop). Cross-column keyboard moves are NOT supported in v1.
+
+**Anti-patterns**
+
+- ❌ Expecting cross-column keyboard reorder. dnd-kit's stock coordinate-getter is per-`SortableContext`. v2 will ship a custom getter that bridges columns.
+- ❌ Interleaving non-`Kanban.Card` children with cards inside a `<Kanban.Column>`. The Root walks each column's children to extract a contiguous card block; if non-cards appear between cards, the rendering re-arranges them awkwardly. Keep header / count badges BEFORE the cards, footer / "Add card" buttons AFTER.
+- ❌ Wrapping `<Kanban.Card>` inside a custom component. The Root walks direct descendants of `<Kanban.Column>` to find cards; nested cards are invisible to it.
+- ❌ Non-stable column / card ids (e.g. array indices). Both must persist across reorders.
+- ❌ Mutating board state in place inside `onMove`. Always return a new object/array reference.
+
 ### `<ImageCrop>` — controlled image cropper
 
 ```tsx

--- a/packages/design-system/scripts/generate-manifest.mjs
+++ b/packages/design-system/scripts/generate-manifest.mjs
@@ -38,6 +38,7 @@ const CLUSTERS = {
   FileUpload: 'Forms',
   ImageCrop: 'Forms',
   Input: 'Forms',
+  Kanban: 'Forms',
   PasswordInput: 'Forms',
   PasswordStrengthMeter: 'Forms',
   Radio: 'Forms',

--- a/packages/design-system/src/_meta/manifest.ts
+++ b/packages/design-system/src/_meta/manifest.ts
@@ -60,6 +60,7 @@ const CLUSTERS: Record<string, string> = {
   FileUpload: 'Forms',
   ImageCrop: 'Forms',
   Input: 'Forms',
+  Kanban: 'Forms',
   PasswordInput: 'Forms',
   PasswordStrengthMeter: 'Forms',
   Radio: 'Forms',

--- a/packages/design-system/src/components.manifest.json
+++ b/packages/design-system/src/components.manifest.json
@@ -232,6 +232,14 @@
       "ColorPicker"
     ]
   },
+  "Kanban": {
+    "tier": "composition",
+    "cluster": "Forms",
+    "composes": [
+      "Sortable"
+    ],
+    "composedBy": []
+  },
   "Link": {
     "tier": "primitive",
     "cluster": "Navigation",
@@ -330,7 +338,9 @@
     "tier": "primitive",
     "cluster": "Forms",
     "composes": [],
-    "composedBy": []
+    "composedBy": [
+      "Kanban"
+    ]
   },
   "Stack": {
     "tier": "primitive",

--- a/packages/design-system/src/components/Kanban/Kanban.module.scss
+++ b/packages/design-system/src/components/Kanban/Kanban.module.scss
@@ -1,0 +1,37 @@
+.board {
+  display: flex;
+  flex-direction: row;
+  gap: var(--space-3);
+  overflow-x: auto;
+  padding-block: var(--space-1);
+}
+
+.column {
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 260px;
+  flex-shrink: 0;
+  min-height: 80px;
+}
+
+.card {
+  position: relative;
+  cursor: grab;
+  touch-action: none;
+}
+
+.card[data-dragging='true'] {
+  cursor: grabbing;
+  box-shadow: var(--shadow-lg);
+  z-index: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none !important; // stylelint-disable-line declaration-no-important -- override dnd-kit's inline transition
+  }
+}

--- a/packages/design-system/src/components/Kanban/Kanban.test.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.test.tsx
@@ -1,0 +1,169 @@
+import { createRef } from 'react';
+import { render } from '@testing-library/react';
+import { Kanban } from './Kanban';
+import { SortableHandle } from '../Sortable/Sortable';
+
+describe('Kanban', () => {
+  it('renders a board region with columns and cards (role="article" only when Handle is present)', () => {
+    const { container } = render(
+      <Kanban>
+        <Kanban.Column id="col-a">
+          <Kanban.Card id="card-1">
+            <Kanban.Handle aria-label="Drag card 1" />
+            Card One
+          </Kanban.Card>
+          <Kanban.Card id="card-2">Card Two (no handle)</Kanban.Card>
+        </Kanban.Column>
+      </Kanban>,
+    );
+
+    // Root is a region
+    const region = container.querySelector('[role="region"]');
+    expect(region).not.toBeNull();
+
+    // Card with Handle gets role="article"
+    const articles = container.querySelectorAll('[role="article"]');
+    expect(articles).toHaveLength(1);
+
+    // Card without Handle does NOT get role="article" (dnd-kit applies role="button")
+    const buttons = container.querySelectorAll('[role="button"]');
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('forwards ref to root <div> with role="region"', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <Kanban ref={ref}>
+        <Kanban.Column id="col-a">
+          <Kanban.Card id="card-1">A</Kanban.Card>
+        </Kanban.Column>
+      </Kanban>,
+    );
+    expect(ref.current?.tagName).toBe('DIV');
+    expect(ref.current?.getAttribute('role')).toBe('region');
+  });
+
+  it('Column forwards ref to its <div>', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <Kanban>
+        <Kanban.Column ref={ref} id="col-a">
+          <Kanban.Card id="card-1">A</Kanban.Card>
+        </Kanban.Column>
+      </Kanban>,
+    );
+    expect(ref.current?.tagName).toBe('DIV');
+  });
+
+  it('Card forwards ref to its <div>; role="article" when Handle is present', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <Kanban>
+        <Kanban.Column id="col-a">
+          <Kanban.Card ref={ref} id="card-1">
+            <Kanban.Handle aria-label="Drag" />
+            Content
+          </Kanban.Card>
+        </Kanban.Column>
+      </Kanban>,
+    );
+    expect(ref.current?.tagName).toBe('DIV');
+    expect(ref.current?.getAttribute('role')).toBe('article');
+  });
+
+  it('merges consumer className on root, Column, and Card', () => {
+    const { container } = render(
+      <Kanban className="custom-board">
+        <Kanban.Column id="col-a" className="custom-col">
+          <Kanban.Card id="card-1" className="custom-card">
+            A
+          </Kanban.Card>
+        </Kanban.Column>
+      </Kanban>,
+    );
+    expect(container.querySelector('[role="region"]')?.className).toContain('custom-board');
+    // Column div
+    const allDivs = container.querySelectorAll('div');
+    const colDiv = Array.from(allDivs).find((d) => d.className.includes('custom-col'));
+    expect(colDiv).not.toBeNull();
+    // Card div
+    const cardDiv = Array.from(allDivs).find((d) => d.className.includes('custom-card'));
+    expect(cardDiv).not.toBeNull();
+  });
+
+  it('Column and Card ids accept both string and number', () => {
+    const { container } = render(
+      <Kanban>
+        <Kanban.Column id="string-col">
+          <Kanban.Card id="string-card">String id</Kanban.Card>
+        </Kanban.Column>
+        <Kanban.Column id={42}>
+          <Kanban.Card id={99}>Number id</Kanban.Card>
+        </Kanban.Column>
+      </Kanban>,
+    );
+    // Both columns render — there should be at least 2 column divs inside the region
+    const region = container.querySelector('[role="region"]')!;
+    expect(region.children.length).toBe(2);
+  });
+
+  it('renders an empty Column without crashing', () => {
+    const { container } = render(
+      <Kanban>
+        <Kanban.Column id="empty" />
+      </Kanban>,
+    );
+    expect(container.querySelector('[role="region"]')).not.toBeNull();
+  });
+
+  it('renders multiple Columns in source order', () => {
+    const { container } = render(
+      <Kanban>
+        <Kanban.Column id="first">
+          <Kanban.Card id="a">A</Kanban.Card>
+        </Kanban.Column>
+        <Kanban.Column id="second">
+          <Kanban.Card id="b">B</Kanban.Card>
+        </Kanban.Column>
+        <Kanban.Column id="third">
+          <Kanban.Card id="c">C</Kanban.Card>
+        </Kanban.Column>
+      </Kanban>,
+    );
+    const region = container.querySelector('[role="region"]')!;
+    expect(region.children).toHaveLength(3);
+  });
+
+  it('Kanban.Handle is the same reference as SortableHandle', () => {
+    expect(Kanban.Handle).toBe(SortableHandle);
+  });
+
+  it('renders without console warnings under default props with Handles', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <Kanban>
+        <Kanban.Column id="col-a">
+          <Kanban.Card id="card-1">
+            <Kanban.Handle aria-label="Drag card 1" />
+            Card One
+          </Kanban.Card>
+          <Kanban.Card id="card-2">
+            <Kanban.Handle aria-label="Drag card 2" />
+            Card Two
+          </Kanban.Card>
+        </Kanban.Column>
+        <Kanban.Column id="col-b">
+          <Kanban.Card id="card-3">
+            <Kanban.Handle aria-label="Drag card 3" />
+            Card Three
+          </Kanban.Card>
+        </Kanban.Column>
+      </Kanban>,
+    );
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+    consoleWarn.mockRestore();
+  });
+});

--- a/packages/design-system/src/components/Kanban/Kanban.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.tsx
@@ -1,0 +1,604 @@
+import {
+  Children,
+  cloneElement,
+  createContext,
+  forwardRef,
+  isValidElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type HTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import {
+  closestCorners,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import clsx from 'clsx';
+import {
+  SortableHandle,
+  SortableItemContext,
+  type SortableItemContextValue,
+} from '../Sortable/Sortable';
+import styles from './Kanban.module.scss';
+
+// ---------------------------------------------------------------------------
+// Internal context: Root → Column, passes effective cardIds for SortableContext
+// ---------------------------------------------------------------------------
+
+const KanbanColumnItemsContext = createContext<readonly (string | number)[] | null>(null);
+
+// ---------------------------------------------------------------------------
+// Public interfaces
+// ---------------------------------------------------------------------------
+
+/**
+ * Payload fired by `onMove` after a successful drag-drop across or within
+ * a column. Consumer applies the move by updating their items state.
+ */
+export interface KanbanMoveEvent {
+  /** Source position — where the card was before the drag. */
+  from: { columnId: string | number; index: number };
+  /** Destination position — where the card landed after the drop. */
+  to: { columnId: string | number; index: number };
+  /** The id of the card that was dragged. */
+  cardId: string | number;
+}
+
+export interface KanbanProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Fires once per drag (on drop) with the from/to positions and the cardId.
+   * NOT fired on drag cancel. NOT fired when from === to (no-op drop).
+   *
+   * Consumer should update their items state immutably, e.g.:
+   * ```ts
+   * const [cols, setCols] = useState({ todo: ['a', 'b'], done: ['c'] });
+   * const handleMove = ({ from, to, cardId }) => {
+   *   setCols((prev) => {
+   *     const next = { ...prev };
+   *     next[from.columnId] = [...prev[from.columnId]];
+   *     next[from.columnId].splice(from.index, 1);
+   *     next[to.columnId] = [...prev[to.columnId]];
+   *     next[to.columnId].splice(to.index, 0, cardId);
+   *     return next;
+   *   });
+   * };
+   * ```
+   */
+  onMove?: (event: KanbanMoveEvent) => void;
+}
+
+export interface KanbanColumnProps extends Omit<HTMLAttributes<HTMLDivElement>, 'id'> {
+  /**
+   * Stable identifier for this column. Must be unique within a `<Kanban>`.
+   * Used internally to track which cards belong to which column.
+   */
+  id: string | number;
+  children?: ReactNode;
+}
+
+export interface KanbanCardProps extends Omit<HTMLAttributes<HTMLDivElement>, 'id'> {
+  /**
+   * Stable identifier for this card. Must be unique across ALL columns in
+   * the `<Kanban>`. Used by dnd-kit to track the card during drag.
+   */
+  id: string | number;
+  children: ReactNode;
+}
+
+// ---------------------------------------------------------------------------
+// containsHandle — mirrors Sortable's implementation; checks for KanbanHandle
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively walk the children subtree looking for a `Kanban.Handle`
+ * (`SortableHandle`). Mirrors Sortable's `containsHandle` function.
+ *
+ * Limitation: only walks `React.Children` and `props.children` — a Handle
+ * wrapped inside a custom component is invisible to this walk.
+ */
+function containsHandle(children: ReactNode): boolean {
+  let found = false;
+  function walk(node: ReactNode) {
+    if (found) return;
+    if (!isValidElement(node)) return;
+    if (node.type === SortableHandle) {
+      found = true;
+      return;
+    }
+    const { children: nested } = node.props as { children?: ReactNode };
+    if (nested != null) Children.forEach(nested, walk);
+  }
+  Children.forEach(children, walk);
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// KanbanCard
+// ---------------------------------------------------------------------------
+
+/**
+ * One draggable card inside a `<Kanban.Column>`. Renders a `<div>` with
+ * the consumer's children. Must have a stable `id` prop.
+ *
+ * If the children subtree contains a `<Kanban.Handle>`, only the Handle
+ * initiates drag (the card div gets `role="article"`). Otherwise the whole
+ * card is draggable (dnd-kit applies `role="button"`).
+ */
+export const KanbanCard = forwardRef<HTMLDivElement, KanbanCardProps>(function KanbanCard(
+  { id, className, children, ...rest },
+  ref,
+) {
+  const { setNodeRef, setActivatorNodeRef, listeners, attributes, transform, transition, isDragging } =
+    useSortable({ id });
+
+  const hasHandle = useMemo(() => containsHandle(children), [children]);
+
+  const ctxValue = useMemo<SortableItemContextValue>(
+    () => ({ listeners, attributes, setActivatorNodeRef }),
+    [listeners, attributes, setActivatorNodeRef],
+  );
+
+  const setRef = (node: HTMLDivElement | null) => {
+    setNodeRef(node);
+    // When no Handle is present, the Card itself is the drag activator.
+    if (!hasHandle) setActivatorNodeRef(node);
+    if (typeof ref === 'function') ref(node);
+    else if (ref) ref.current = node;
+  };
+
+  return (
+    <SortableItemContext.Provider value={ctxValue}>
+      <div
+        ref={setRef}
+        style={{ transform: CSS.Transform.toString(transform), transition }}
+        data-dragging={isDragging ? 'true' : undefined}
+        className={clsx(styles.card, className)}
+        // dnd-kit drag attrs BEFORE {...rest} so consumer rest wins.
+        {...(hasHandle ? {} : listeners)}
+        {...(hasHandle ? {} : attributes)}
+        {...rest}
+        // role="article" AFTER {...rest} so it wins, but only when a Handle
+        // is present. Without a Handle, dnd-kit's role="button" is correct
+        // (Card IS the drag activator).
+        {...(hasHandle ? { role: 'article' } : {})}
+      >
+        {children}
+      </div>
+    </SortableItemContext.Provider>
+  );
+});
+KanbanCard.displayName = 'KanbanCard';
+
+// ---------------------------------------------------------------------------
+// KanbanColumn
+// ---------------------------------------------------------------------------
+
+/**
+ * One swimlane in a `<Kanban>`. Renders a droppable `<div>` wrapping a
+ * `SortableContext` so cards within it can reorder. Must have a stable `id`.
+ *
+ * Column layout (header, footer) goes before / after `<Kanban.Card>` children
+ * — keep cards as a contiguous block.
+ */
+export const KanbanColumn = forwardRef<HTMLDivElement, KanbanColumnProps>(function KanbanColumn(
+  { id, className, children, ...rest },
+  ref,
+) {
+  const { setNodeRef } = useDroppable({ id });
+
+  // Effective card ids are injected by KanbanRoot via context so that this
+  // column's SortableContext sees the live-reordered order.
+  const ctxCardIds = useContext(KanbanColumnItemsContext);
+
+  // Fallback: derive card ids from children if not in context (standalone use).
+  const fallbackCardIds = useMemo(() => {
+    if (ctxCardIds !== null) return null; // skip computation
+    const ids: (string | number)[] = [];
+    Children.forEach(children, (card) => {
+      if (!isValidElement(card) || card.type !== KanbanCard) return;
+      ids.push((card.props as KanbanCardProps).id);
+    });
+    return ids;
+  }, [children, ctxCardIds]);
+
+  const cardIds = ctxCardIds ?? fallbackCardIds ?? [];
+
+  const setRef = (node: HTMLDivElement | null) => {
+    setNodeRef(node);
+    if (typeof ref === 'function') ref(node);
+    else if (ref) ref.current = node;
+  };
+
+  return (
+    <div ref={setRef} className={clsx(styles.column, className)} {...rest}>
+      <SortableContext items={cardIds as (string | number)[]} strategy={verticalListSortingStrategy}>
+        {children}
+      </SortableContext>
+    </div>
+  );
+});
+KanbanColumn.displayName = 'KanbanColumn';
+
+// ---------------------------------------------------------------------------
+// KanbanRoot
+// ---------------------------------------------------------------------------
+
+/**
+ * Multi-column drag-and-drop board. Compound API: `Kanban`, `Kanban.Column`,
+ * `Kanban.Card`, `Kanban.Handle`. Built on `@dnd-kit/sortable`.
+ *
+ * Cards reflow live as the dragged card crosses column boundaries — the
+ * target column shifts to make room in real time (matching Trello / Jira
+ * UX). Internal `liveItems` state drives the live reflow; consumer state is
+ * untouched until `onMove` fires on drop.
+ *
+ * Controlled-only: consumer holds their items state and applies the move in
+ * `onMove`, then re-renders. `onMove` fires exactly once per drag (on drop),
+ * never during drag.
+ *
+ * @example
+ * // Basic Kanban with two columns and a Handle per card.
+ * const [cols, setCols] = useState({
+ *   todo: [{ id: 'a', title: 'Write tests' }, { id: 'b', title: 'Fix bug' }],
+ *   done: [{ id: 'c', title: 'Ship it' }],
+ * });
+ *
+ * const handleMove = ({ from, to, cardId }) => {
+ *   setCols((prev) => {
+ *     const fromCards = [...prev[from.columnId]];
+ *     const [moved] = fromCards.splice(from.index, 1);
+ *     const toCards = prev.to === prev.from
+ *       ? fromCards
+ *       : [...prev[to.columnId]];
+ *     toCards.splice(to.index, 0, moved);
+ *     return {
+ *       ...prev,
+ *       [from.columnId]: fromCards,
+ *       [to.columnId]: toCards,
+ *     };
+ *   });
+ * };
+ *
+ * <Kanban onMove={handleMove}>
+ *   {Object.entries(cols).map(([colId, cards]) => (
+ *     <Kanban.Column key={colId} id={colId}>
+ *       <h3>{colId}</h3>
+ *       {cards.map((card) => (
+ *         <Kanban.Card key={card.id} id={card.id}>
+ *           <Cluster justify="between">
+ *             <span>{card.title}</span>
+ *             <Kanban.Handle aria-label={`Drag ${card.title}`} />
+ *           </Cluster>
+ *         </Kanban.Card>
+ *       ))}
+ *     </Kanban.Column>
+ *   ))}
+ * </Kanban>
+ *
+ * @remarks When NOT to use
+ * - Single-column drag-to-reorder — use `<Sortable>` instead. It's simpler
+ *   and doesn't carry the multi-column DndContext overhead.
+ * - Pure display boards with no drag (read-only lists) — use `<Stack>` +
+ *   `<Card>`. No need for dnd-kit wiring.
+ * - Column reordering — not supported; columns render in source JSX order.
+ * - Cross-column keyboard reorder — dnd-kit's `sortableKeyboardCoordinates`
+ *   is scoped per `SortableContext` (i.e., per column). Keyboard drag works
+ *   within a column only.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Expecting cross-column keyboard reorder. dnd-kit's keyboard
+ *   coordinator is per-SortableContext. Cards keyboard-reorder within their
+ *   column; cross-column keyboard move is out of scope.
+ * - ❌ Non-contiguous cards within a column's children. The live-reinsertion
+ *   architecture splits each column's children into [before-cards, cards,
+ *   after-cards]. If you interleave non-card elements within the card block
+ *   (e.g. `<Card><Divider><Card>`), the non-card ends up in an unexpected
+ *   position after a reorder. Keep headers/footers strictly before/after the
+ *   card block.
+ * - ❌ Wrapping `<Kanban.Card>` inside a custom component. Both
+ *   `containsHandle` and the card-extraction walk direct children only. A
+ *   card wrapped in `<MyRow>` won't be extracted — it renders but won't be
+ *   reorderable via live-reinsertion.
+ * - ❌ Non-stable column / card ids. Ids must be stable across renders.
+ *   Using array indices breaks dnd-kit's reconciliation during drag.
+ * - ❌ Mutating state in place inside `onMove`. Always produce a new array /
+ *   object — React needs a fresh reference to schedule a re-render.
+ */
+const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
+  { onMove, className, children, ...rest },
+  ref,
+) {
+  // ------------------------------------------------------------------
+  // Parse children: extract column order, initial items, card elements,
+  // and the before/after non-card slices for each column.
+  // ------------------------------------------------------------------
+  const { columnOrder, initialItems, cardElements, columnChildrenSlices } = useMemo(() => {
+    const colOrder: (string | number)[] = [];
+    const initItems = new Map<string | number, (string | number)[]>();
+    const cardElems = new Map<string | number, ReactElement<KanbanCardProps>>();
+    const colSlices = new Map<string | number, { before: ReactNode[]; after: ReactNode[] }>();
+
+    Children.forEach(children, (child) => {
+      if (!isValidElement(child) || child.type !== KanbanColumn) return;
+      const colProps = child.props as KanbanColumnProps;
+      const colId = colProps.id;
+      colOrder.push(colId);
+
+      const colCardIds: (string | number)[] = [];
+      let firstCardIdx = -1;
+      let lastCardIdx = -1;
+      const colChildren = Children.toArray(colProps.children);
+
+      colChildren.forEach((grandchild, idx) => {
+        if (!isValidElement(grandchild) || grandchild.type !== KanbanCard) return;
+        const cardProps = grandchild.props as KanbanCardProps;
+        colCardIds.push(cardProps.id);
+        cardElems.set(cardProps.id, grandchild as ReactElement<KanbanCardProps>);
+        if (firstCardIdx < 0) firstCardIdx = idx;
+        lastCardIdx = idx;
+      });
+
+      // Split into before/after slices (non-card children outside the card block).
+      const before: ReactNode[] = firstCardIdx >= 0 ? colChildren.slice(0, firstCardIdx) : colChildren;
+      const after: ReactNode[] = lastCardIdx >= 0 ? colChildren.slice(lastCardIdx + 1) : [];
+
+      initItems.set(colId, colCardIds);
+      colSlices.set(colId, { before, after });
+    });
+
+    return {
+      columnOrder: colOrder,
+      initialItems: initItems,
+      cardElements: cardElems,
+      columnChildrenSlices: colSlices,
+    };
+  }, [children]);
+
+  // ------------------------------------------------------------------
+  // Stable serialization of initialItems to detect consumer state changes
+  // ------------------------------------------------------------------
+  const initialItemsKey = useMemo(() => {
+    const parts: string[] = [];
+    for (const [colId, cards] of initialItems) {
+      parts.push(`${colId}:${cards.join(',')}`);
+    }
+    return parts.join('|');
+  }, [initialItems]);
+
+  // ------------------------------------------------------------------
+  // Internal drag state: null when idle, populated on drag start
+  // ------------------------------------------------------------------
+  const [liveItems, setLiveItems] = useState<Map<string | number, (string | number)[]> | null>(null);
+
+  // Reset live items when consumer state mutates (e.g. external update mid-drag).
+  useEffect(() => {
+    setLiveItems(null);
+  }, [initialItemsKey]);
+
+  const effectiveItems = liveItems ?? initialItems;
+
+  // ------------------------------------------------------------------
+  // Sensors
+  // ------------------------------------------------------------------
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  // ------------------------------------------------------------------
+  // Container lookup: given an id (card or column), find which column owns it
+  // ------------------------------------------------------------------
+  const findContainer = useCallback(
+    (
+      id: string | number,
+      items: Map<string | number, (string | number)[]>,
+    ): string | number | null => {
+      if (items.has(id)) return id; // id is a column id itself (drop on empty column)
+      for (const [colId, cards] of items) {
+        if (cards.includes(id)) return colId;
+      }
+      return null;
+    },
+    [],
+  );
+
+  // ------------------------------------------------------------------
+  // Drag handlers
+  // ------------------------------------------------------------------
+  const handleDragStart = useCallback(
+    (_event: DragStartEvent) => {
+      // Snapshot: shallow-copy each cards array so mutations don't leak into initialItems.
+      const snapshot = new Map<string | number, (string | number)[]>();
+      for (const [colId, cards] of initialItems) snapshot.set(colId, [...cards]);
+      setLiveItems(snapshot);
+    },
+    [initialItems],
+  );
+
+  const handleDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const { active, over } = event;
+      if (!over) return;
+      const activeId = active.id as string | number;
+      const overId = over.id as string | number;
+
+      setLiveItems((prev) => {
+        if (!prev) return prev;
+        const activeContainer = findContainer(activeId, prev);
+        const overContainer = findContainer(overId, prev);
+        if (activeContainer == null || overContainer == null) return prev;
+        // Within-column reorder: useSortable's transforms handle it — no state update needed.
+        if (activeContainer === overContainer) return prev;
+
+        const activeCards = prev.get(activeContainer) ?? [];
+        const overCards = prev.get(overContainer) ?? [];
+        if (!activeCards.includes(activeId)) return prev;
+
+        // Insertion position: if over.id is a card in the target column, insert at its index;
+        // if over.id is the column itself (empty drop), append.
+        let insertAt: number;
+        if (overCards.includes(overId)) {
+          insertAt = overCards.indexOf(overId);
+        } else {
+          insertAt = overCards.length;
+        }
+
+        const next = new Map(prev);
+        next.set(activeContainer, activeCards.filter((id) => id !== activeId));
+        const newOver = [...overCards];
+        newOver.splice(insertAt, 0, activeId);
+        next.set(overContainer, newOver);
+        return next;
+      });
+    },
+    [findContainer],
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      const activeId = active.id as string | number;
+      const finalItems = liveItems ?? initialItems;
+
+      // Locate card in initialItems (from-position).
+      let fromColumn: string | number | null = null;
+      let fromIndex = -1;
+      for (const [colId, cards] of initialItems) {
+        const idx = cards.indexOf(activeId);
+        if (idx >= 0) {
+          fromColumn = colId;
+          fromIndex = idx;
+          break;
+        }
+      }
+
+      // Locate card in finalItems (to-position).
+      let toColumn: string | number | null = null;
+      let toIndex = -1;
+      for (const [colId, cards] of finalItems) {
+        const idx = cards.indexOf(activeId);
+        if (idx >= 0) {
+          toColumn = colId;
+          toIndex = idx;
+          break;
+        }
+      }
+
+      setLiveItems(null);
+
+      if (fromColumn == null || toColumn == null) return;
+
+      // Within-column reorder finalization: liveItems won't have been updated
+      // by handleDragOver (which no-ops for same-column). Use over.id to
+      // compute the final position from the initial items array.
+      if (over && fromColumn === toColumn) {
+        const overId = over.id as string | number;
+        const cards = initialItems.get(fromColumn) ?? [];
+        const overIdx = cards.indexOf(overId);
+        if (overIdx >= 0) {
+          toIndex = overIdx;
+        } else {
+          // over.id is the column itself (dropped back on original column with no card target) — no move.
+          return;
+        }
+      }
+
+      if (fromColumn === toColumn && fromIndex === toIndex) return;
+
+      onMove?.({
+        from: { columnId: fromColumn, index: fromIndex },
+        to: { columnId: toColumn, index: toIndex },
+        cardId: activeId,
+      });
+    },
+    [liveItems, initialItems, onMove],
+  );
+
+  const handleDragCancel = useCallback(() => {
+    setLiveItems(null);
+  }, []);
+
+  // ------------------------------------------------------------------
+  // Render
+  // ------------------------------------------------------------------
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      {/* {...rest} before role/aria-label so our semantics win */}
+      <div
+        ref={ref}
+        className={clsx(styles.board, className)}
+        {...rest}
+        role="region"
+        aria-label="Kanban board"
+      >
+        {columnOrder.map((colId) => {
+          const columnElement = Children.toArray(children).find(
+            (c): c is ReactElement<KanbanColumnProps> =>
+              isValidElement(c) &&
+              c.type === KanbanColumn &&
+              (c.props as KanbanColumnProps).id === colId,
+          );
+          if (!columnElement) return null;
+
+          const cardIds = effectiveItems.get(colId) ?? [];
+          const cards = cardIds
+            .map((id) => cardElements.get(id))
+            .filter((c): c is ReactElement<KanbanCardProps> => c != null);
+
+          const slice = columnChildrenSlices.get(colId) ?? { before: [], after: [] };
+
+          // Re-clone the column with re-arranged children. KanbanColumn reads
+          // cardIds via KanbanColumnItemsContext so its SortableContext.items
+          // matches what's rendered.
+          return (
+            <KanbanColumnItemsContext.Provider key={colId} value={cardIds}>
+              {cloneElement(columnElement, {}, ...slice.before, ...cards, ...slice.after)}
+            </KanbanColumnItemsContext.Provider>
+          );
+        })}
+      </div>
+    </DndContext>
+  );
+});
+KanbanRoot.displayName = 'Kanban';
+
+// ---------------------------------------------------------------------------
+// Compound export
+// ---------------------------------------------------------------------------
+
+export const Kanban = Object.assign(KanbanRoot, {
+  Column: KanbanColumn,
+  Card: KanbanCard,
+  /**
+   * Re-exported from `<Sortable.Handle>`. Attaches drag listeners when placed
+   * inside a `<Kanban.Card>`. When present, only the Handle initiates drag
+   * (the Card div gets `role="article"`).
+   */
+  Handle: SortableHandle,
+});

--- a/packages/design-system/src/components/Kanban/Kanban.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.tsx
@@ -330,18 +330,23 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
   // ------------------------------------------------------------------
   // Parse children: extract column order, initial items, card elements,
   // and the before/after non-card slices for each column.
+  // columnElements is built in the same pass so render-time lookup is O(1)
+  // instead of O(N) per column (i.e., O(N²) total per render).
   // ------------------------------------------------------------------
-  const { columnOrder, initialItems, cardElements, columnChildrenSlices } = useMemo(() => {
+  const { columnOrder, columnElements, initialItems, cardElements, columnChildrenSlices } = useMemo(() => {
     const colOrder: (string | number)[] = [];
+    const colElems = new Map<string | number, ReactElement<KanbanColumnProps>>();
     const initItems = new Map<string | number, (string | number)[]>();
     const cardElems = new Map<string | number, ReactElement<KanbanCardProps>>();
     const colSlices = new Map<string | number, { before: ReactNode[]; after: ReactNode[] }>();
 
     Children.forEach(children, (child) => {
       if (!isValidElement(child) || child.type !== KanbanColumn) return;
-      const colProps = child.props as KanbanColumnProps;
+      const columnElement = child as ReactElement<KanbanColumnProps>;
+      const colProps = columnElement.props;
       const colId = colProps.id;
       colOrder.push(colId);
+      colElems.set(colId, columnElement);
 
       const colCardIds: (string | number)[] = [];
       let firstCardIdx = -1;
@@ -367,6 +372,7 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
 
     return {
       columnOrder: colOrder,
+      columnElements: colElems,
       initialItems: initItems,
       cardElements: cardElems,
       columnChildrenSlices: colSlices,
@@ -374,15 +380,14 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
   }, [children]);
 
   // ------------------------------------------------------------------
-  // Stable serialization of initialItems to detect consumer state changes
+  // Stable serialization of initialItems to detect consumer state changes.
+  // JSON.stringify is robust against ids that contain `:` or `,` characters,
+  // unlike a hand-rolled delimiter-join.
   // ------------------------------------------------------------------
-  const initialItemsKey = useMemo(() => {
-    const parts: string[] = [];
-    for (const [colId, cards] of initialItems) {
-      parts.push(`${colId}:${cards.join(',')}`);
-    }
-    return parts.join('|');
-  }, [initialItems]);
+  const initialItemsKey = useMemo(
+    () => JSON.stringify(Array.from(initialItems.entries())),
+    [initialItems],
+  );
 
   // ------------------------------------------------------------------
   // Internal drag state: null when idle, populated on drag start
@@ -477,6 +482,16 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
     (event: DragEndEvent) => {
       const { active, over } = event;
       const activeId = active.id as string | number;
+
+      // Release outside any droppable → cancel + snap back. dnd-kit fires
+      // onDragEnd with over=null when the cursor leaves all droppable areas
+      // before release. Treat that as a cancellation (matches Sortable
+      // semantics and Trello convention).
+      if (!over) {
+        setLiveItems(null);
+        return;
+      }
+
       const finalItems = liveItems ?? initialItems;
 
       // Locate card in initialItems (from-position).
@@ -507,19 +522,28 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
 
       if (fromColumn == null || toColumn == null) return;
 
-      // Within-column reorder finalization: liveItems won't have been updated
-      // by handleDragOver (which no-ops for same-column). Use over.id to
-      // compute the final position from the initial items array.
-      if (over && fromColumn === toColumn) {
-        const overId = over.id as string | number;
-        const cards = initialItems.get(fromColumn) ?? [];
-        const overIdx = cards.indexOf(overId);
-        if (overIdx >= 0) {
-          toIndex = overIdx;
-        } else {
-          // over.id is the column itself (dropped back on original column with no card target) — no move.
-          return;
+      // Within-column reorder finalization: use over.id semantics to pick the
+      // final index, but ONLY when the card never left this column during the
+      // drag. If it transited away and came back, the live-state diff already
+      // gave us the correct toIndex — don't overwrite it (would corrupt the
+      // drop position; cf. HR8 round-1 critical finding).
+      if (fromColumn === toColumn) {
+        const liveCol = finalItems.get(fromColumn) ?? [];
+        const livePosition = liveCol.indexOf(activeId);
+        if (livePosition === fromIndex) {
+          // Pure within-column reorder, no cross-column transit. dnd-kit's
+          // over.id is a sibling card or the column itself.
+          const overId = over.id as string | number;
+          const overIdx = liveCol.indexOf(overId);
+          if (overIdx >= 0) {
+            toIndex = overIdx;
+          } else {
+            // over.id is the column itself (no card target) — no move.
+            return;
+          }
         }
+        // else: card transited away and came back; toIndex from the live
+        // diff is already correct, don't touch it.
       }
 
       if (fromColumn === toColumn && fromIndex === toIndex) return;
@@ -549,21 +573,21 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      {/* {...rest} before role/aria-label so our semantics win */}
+      {/*
+        aria-label BEFORE {...rest} so consumer can pass a more specific
+        label (e.g. "Q3 sales pipeline") and have it win.
+        role="region" AFTER {...rest} so it stays locked — non-overridable
+        semantic guarantee.
+      */}
       <div
         ref={ref}
+        aria-label="Kanban board"
         className={clsx(styles.board, className)}
         {...rest}
         role="region"
-        aria-label="Kanban board"
       >
         {columnOrder.map((colId) => {
-          const columnElement = Children.toArray(children).find(
-            (c): c is ReactElement<KanbanColumnProps> =>
-              isValidElement(c) &&
-              c.type === KanbanColumn &&
-              (c.props as KanbanColumnProps).id === colId,
-          );
+          const columnElement = columnElements.get(colId);
           if (!columnElement) return null;
 
           const cardIds = effectiveItems.get(colId) ?? [];

--- a/packages/design-system/src/components/Kanban/Kanban.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.tsx
@@ -147,8 +147,15 @@ export const KanbanCard = forwardRef<HTMLDivElement, KanbanCardProps>(function K
   { id, className, children, ...rest },
   ref,
 ) {
-  const { setNodeRef, setActivatorNodeRef, listeners, attributes, transform, transition, isDragging } =
-    useSortable({ id });
+  const {
+    setNodeRef,
+    setActivatorNodeRef,
+    listeners,
+    attributes,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
 
   const hasHandle = useMemo(() => containsHandle(children), [children]);
 
@@ -230,7 +237,10 @@ export const KanbanColumn = forwardRef<HTMLDivElement, KanbanColumnProps>(functi
 
   return (
     <div ref={setRef} className={clsx(styles.column, className)} {...rest}>
-      <SortableContext items={cardIds as (string | number)[]} strategy={verticalListSortingStrategy}>
+      <SortableContext
+        items={cardIds as (string | number)[]}
+        strategy={verticalListSortingStrategy}
+      >
         {children}
       </SortableContext>
     </div>
@@ -333,51 +343,53 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
   // columnElements is built in the same pass so render-time lookup is O(1)
   // instead of O(N) per column (i.e., O(N²) total per render).
   // ------------------------------------------------------------------
-  const { columnOrder, columnElements, initialItems, cardElements, columnChildrenSlices } = useMemo(() => {
-    const colOrder: (string | number)[] = [];
-    const colElems = new Map<string | number, ReactElement<KanbanColumnProps>>();
-    const initItems = new Map<string | number, (string | number)[]>();
-    const cardElems = new Map<string | number, ReactElement<KanbanCardProps>>();
-    const colSlices = new Map<string | number, { before: ReactNode[]; after: ReactNode[] }>();
+  const { columnOrder, columnElements, initialItems, cardElements, columnChildrenSlices } =
+    useMemo(() => {
+      const colOrder: (string | number)[] = [];
+      const colElems = new Map<string | number, ReactElement<KanbanColumnProps>>();
+      const initItems = new Map<string | number, (string | number)[]>();
+      const cardElems = new Map<string | number, ReactElement<KanbanCardProps>>();
+      const colSlices = new Map<string | number, { before: ReactNode[]; after: ReactNode[] }>();
 
-    Children.forEach(children, (child) => {
-      if (!isValidElement(child) || child.type !== KanbanColumn) return;
-      const columnElement = child as ReactElement<KanbanColumnProps>;
-      const colProps = columnElement.props;
-      const colId = colProps.id;
-      colOrder.push(colId);
-      colElems.set(colId, columnElement);
+      Children.forEach(children, (child) => {
+        if (!isValidElement(child) || child.type !== KanbanColumn) return;
+        const columnElement = child as ReactElement<KanbanColumnProps>;
+        const colProps = columnElement.props;
+        const colId = colProps.id;
+        colOrder.push(colId);
+        colElems.set(colId, columnElement);
 
-      const colCardIds: (string | number)[] = [];
-      let firstCardIdx = -1;
-      let lastCardIdx = -1;
-      const colChildren = Children.toArray(colProps.children);
+        const colCardIds: (string | number)[] = [];
+        let firstCardIdx = -1;
+        let lastCardIdx = -1;
+        const colChildren = Children.toArray(colProps.children);
 
-      colChildren.forEach((grandchild, idx) => {
-        if (!isValidElement(grandchild) || grandchild.type !== KanbanCard) return;
-        const cardProps = grandchild.props as KanbanCardProps;
-        colCardIds.push(cardProps.id);
-        cardElems.set(cardProps.id, grandchild as ReactElement<KanbanCardProps>);
-        if (firstCardIdx < 0) firstCardIdx = idx;
-        lastCardIdx = idx;
+        colChildren.forEach((grandchild, idx) => {
+          if (!isValidElement(grandchild) || grandchild.type !== KanbanCard) return;
+          const cardProps = grandchild.props as KanbanCardProps;
+          colCardIds.push(cardProps.id);
+          cardElems.set(cardProps.id, grandchild as ReactElement<KanbanCardProps>);
+          if (firstCardIdx < 0) firstCardIdx = idx;
+          lastCardIdx = idx;
+        });
+
+        // Split into before/after slices (non-card children outside the card block).
+        const before: ReactNode[] =
+          firstCardIdx >= 0 ? colChildren.slice(0, firstCardIdx) : colChildren;
+        const after: ReactNode[] = lastCardIdx >= 0 ? colChildren.slice(lastCardIdx + 1) : [];
+
+        initItems.set(colId, colCardIds);
+        colSlices.set(colId, { before, after });
       });
 
-      // Split into before/after slices (non-card children outside the card block).
-      const before: ReactNode[] = firstCardIdx >= 0 ? colChildren.slice(0, firstCardIdx) : colChildren;
-      const after: ReactNode[] = lastCardIdx >= 0 ? colChildren.slice(lastCardIdx + 1) : [];
-
-      initItems.set(colId, colCardIds);
-      colSlices.set(colId, { before, after });
-    });
-
-    return {
-      columnOrder: colOrder,
-      columnElements: colElems,
-      initialItems: initItems,
-      cardElements: cardElems,
-      columnChildrenSlices: colSlices,
-    };
-  }, [children]);
+      return {
+        columnOrder: colOrder,
+        columnElements: colElems,
+        initialItems: initItems,
+        cardElements: cardElems,
+        columnChildrenSlices: colSlices,
+      };
+    }, [children]);
 
   // ------------------------------------------------------------------
   // Stable serialization of initialItems to detect consumer state changes.
@@ -392,7 +404,9 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
   // ------------------------------------------------------------------
   // Internal drag state: null when idle, populated on drag start
   // ------------------------------------------------------------------
-  const [liveItems, setLiveItems] = useState<Map<string | number, (string | number)[]> | null>(null);
+  const [liveItems, setLiveItems] = useState<Map<string | number, (string | number)[]> | null>(
+    null,
+  );
 
   // Reset live items when consumer state mutates (e.g. external update mid-drag).
   useEffect(() => {
@@ -468,7 +482,10 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
         }
 
         const next = new Map(prev);
-        next.set(activeContainer, activeCards.filter((id) => id !== activeId));
+        next.set(
+          activeContainer,
+          activeCards.filter((id) => id !== activeId),
+        );
         const newOver = [...overCards];
         newOver.splice(insertAt, 0, activeId);
         next.set(overContainer, newOver);

--- a/packages/design-system/src/components/Kanban/index.ts
+++ b/packages/design-system/src/components/Kanban/index.ts
@@ -1,0 +1,7 @@
+export {
+  Kanban,
+  type KanbanProps,
+  type KanbanColumnProps,
+  type KanbanCardProps,
+  type KanbanMoveEvent,
+} from './Kanban';

--- a/packages/design-system/src/components/Sortable/Sortable.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.tsx
@@ -67,13 +67,13 @@ export interface SortableHandleProps extends ButtonHTMLAttributes<HTMLButtonElem
   children?: ReactNode;
 }
 
-interface SortableItemContextValue {
+export interface SortableItemContextValue {
   listeners: ReturnType<typeof useSortable>['listeners'];
   attributes: ReturnType<typeof useSortable>['attributes'];
   setActivatorNodeRef: ReturnType<typeof useSortable>['setActivatorNodeRef'];
 }
 
-const SortableItemContext = createContext<SortableItemContextValue | null>(null);
+export const SortableItemContext = createContext<SortableItemContextValue | null>(null);
 
 /**
  * Recursively check whether the children subtree contains a `Sortable.Handle`.

--- a/packages/design-system/src/components/Sortable/index.ts
+++ b/packages/design-system/src/components/Sortable/index.ts
@@ -1,7 +1,11 @@
 export {
   Sortable,
+  SortableHandle,
+  SortableItem,
+  SortableItemContext,
   type SortableProps,
   type SortableItemProps,
   type SortableHandleProps,
   type SortableReorderEvent,
+  type SortableItemContextValue,
 } from './Sortable';

--- a/packages/design-system/src/components/TODO.md
+++ b/packages/design-system/src/components/TODO.md
@@ -85,7 +85,9 @@ A raw `<div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)
 
 **When this ships:** refactor the Members seats card and re-evaluate the search-input constraints across mockups, then tick this checkbox.
 
-### [ ] `<MutedBox>` — non-Card subdued-background container
+## Closed
+
+### [x] `<MutedBox>` — non-Card subdued-background container
 
 **Filed:** 2026-05-25
 **Mocked in:**
@@ -102,6 +104,4 @@ Inline `style={{ background: 'var(--color-bg-muted)', borderRadius: 'var(--radiu
 
 **When this ships:** refactor the Deals mockup column-wrapper sites, then tick this checkbox.
 
-## Closed
-
-_(filled as entries are resolved.)_
+**Resolved:** absorbed by `<Kanban.Column>`'s built-in muted-background styling (commit `08853a3`). Deals mockup migrated to use `<Kanban>` in the same PR.

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -13,6 +13,14 @@ export type {
 export { Input } from './components/Input';
 export type { InputProps, InputSize } from './components/Input';
 
+export { Kanban } from './components/Kanban';
+export type {
+  KanbanProps,
+  KanbanColumnProps,
+  KanbanCardProps,
+  KanbanMoveEvent,
+} from './components/Kanban';
+
 export { Card } from './components/Card';
 export type { CardProps, CardPadding, CardTone } from './components/Card';
 export type { CardHeaderProps, CardHeaderLevel } from './components/Card';

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -16,6 +16,7 @@ import { ButtonDemo } from './pages/components/ButtonDemo';
 import { ButtonGroupDemo } from './pages/components/ButtonGroupDemo';
 import { DatePickersDemo } from './pages/components/DatePickersDemo';
 import { InputDemo } from './pages/components/InputDemo';
+import { KanbanDemo } from './pages/components/KanbanDemo';
 import { PasswordInputDemo } from './pages/components/PasswordInputDemo';
 import { PasswordStrengthMeterDemo } from './pages/components/PasswordStrengthMeterDemo';
 import { PaginationDemo } from './pages/components/PaginationDemo';
@@ -83,6 +84,7 @@ export default function App() {
           <Route path="/components/button-group" element={<ButtonGroupDemo />} />
           <Route path="/components/datepickers" element={<DatePickersDemo />} />
           <Route path="/components/input" element={<InputDemo />} />
+          <Route path="/components/kanban" element={<KanbanDemo />} />
           <Route path="/components/pagination" element={<PaginationDemo />} />
           <Route path="/components/progress" element={<ProgressDemo />} />
           <Route path="/components/circular-progress" element={<CircularProgressDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -126,6 +126,7 @@ const componentGroups = [
       { to: '/components/radio', label: 'Radio', icon: CircleDot, end: false },
       { to: '/components/select', label: 'Select', icon: ChevronsUpDown, end: false },
       { to: '/components/slider', label: 'Slider', icon: SlidersHorizontal, end: false },
+      { to: '/components/kanban', label: 'Kanban', icon: KanbanSquare, end: false },
       { to: '/components/sortable', label: 'Sortable', icon: GripVertical, end: false },
       { to: '/components/switch', label: 'Switch', icon: ToggleRight, end: false },
       { to: '/components/textarea', label: 'Textarea', icon: MessageSquareText, end: false },

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -25,6 +25,7 @@ import { PasswordStrengthMeter } from '@eocrm/design-system';
 import { Select } from '@eocrm/design-system';
 import { Skeleton } from '@eocrm/design-system';
 import { Slider } from '@eocrm/design-system';
+import { Kanban } from '@eocrm/design-system';
 import { Sortable } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { Switch } from '@eocrm/design-system';
@@ -301,6 +302,27 @@ const items: { to: string; name: string; description: string; preview: React.Rea
     preview: (
       <div style={{ width: '100%', maxWidth: 220 }}>
         <Slider value={42} onChange={() => {}} aria-label="preview" />
+      </div>
+    ),
+  },
+  {
+    to: '/components/kanban',
+    name: 'Kanban',
+    description: 'Multi-column board with live cross-column drag.',
+    preview: (
+      <div style={{ width: '100%', maxWidth: 220, pointerEvents: 'none' }}>
+        <Kanban>
+          <Kanban.Column id="a">
+            <Kanban.Card id="card-a">
+              <Card padding="sm">A</Card>
+            </Kanban.Card>
+          </Kanban.Column>
+          <Kanban.Column id="b">
+            <Kanban.Card id="card-b">
+              <Card padding="sm">B</Card>
+            </Kanban.Card>
+          </Kanban.Column>
+        </Kanban>
       </div>
     ),
   },

--- a/packages/playground/src/pages/components/KanbanDemo.tsx
+++ b/packages/playground/src/pages/components/KanbanDemo.tsx
@@ -1,0 +1,224 @@
+import { useCallback, useState } from 'react';
+import { GripVertical, MoreHorizontal } from 'lucide-react';
+import {
+  Badge,
+  Button,
+  Card,
+  Cluster,
+  DropdownMenu,
+  Kanban,
+  Stack,
+  Text,
+  Title,
+  type KanbanMoveEvent,
+} from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import tsxSource from '@lib-source/components/Kanban/Kanban.tsx?raw';
+import scssSource from '@lib-source/components/Kanban/Kanban.module.scss?raw';
+
+type ColId = 'todo' | 'doing' | 'done';
+
+interface CardData {
+  id: string;
+  title: string;
+}
+
+const COL_TITLES: Record<ColId, string> = {
+  todo: 'To do',
+  doing: 'In progress',
+  done: 'Done',
+};
+
+const INITIAL_BOARD: Record<ColId, CardData[]> = {
+  todo: [
+    { id: 'task-1', title: 'Draft Q3 OKRs' },
+    { id: 'task-2', title: 'Review pricing page mocks' },
+    { id: 'task-3', title: 'Schedule retro' },
+  ],
+  doing: [
+    { id: 'task-4', title: 'Refactor billing service' },
+    { id: 'task-5', title: 'Customer interview notes' },
+  ],
+  done: [
+    { id: 'task-6', title: 'Ship onboarding email' },
+    { id: 'task-7', title: 'Migrate logs to OTLP' },
+  ],
+};
+
+function makeMoveHandler(
+  setter: React.Dispatch<React.SetStateAction<Record<ColId, CardData[]>>>,
+) {
+  return (event: KanbanMoveEvent) => {
+    const { from, to, cardId } = event;
+    setter((curr) => {
+      const fromCol = from.columnId as ColId;
+      const toCol = to.columnId as ColId;
+      const next: Record<ColId, CardData[]> = {
+        todo: [...curr.todo],
+        doing: [...curr.doing],
+        done: [...curr.done],
+      };
+      const sourceArr = next[fromCol];
+      const idx = sourceArr.findIndex((c) => c.id === cardId);
+      if (idx < 0) return curr;
+      const [moved] = sourceArr.splice(idx, 1);
+      const targetArr = fromCol === toCol ? sourceArr : next[toCol];
+      const insertAt = Math.min(to.index, targetArr.length);
+      targetArr.splice(insertAt, 0, moved);
+      return next;
+    });
+  };
+}
+
+export function KanbanDemo() {
+  const [boardA, setBoardA] = useState<Record<ColId, CardData[]>>(INITIAL_BOARD);
+  const [boardB, setBoardB] = useState<Record<ColId, CardData[]>>(INITIAL_BOARD);
+  const handleMoveA = useCallback(makeMoveHandler(setBoardA), [setBoardA]);
+  const handleMoveB = useCallback(makeMoveHandler(setBoardB), [setBoardB]);
+
+  return (
+    <DemoLayout
+      name="Kanban"
+      componentName="Kanban"
+      description="Multi-column board with live cross-column drag. Cards reflow into the target column as the dragged card crosses in — internal state, consumer's onMove fires once on drop."
+      tsxSource={tsxSource}
+      scssSource={scssSource}
+      tsxFilename="Kanban.tsx"
+      scssFilename="Kanban.module.scss"
+    >
+      <Example
+        title="Basic board (3 columns)"
+        description="Drag cards within and across columns. Empty columns are still drop targets. Watch the target column reflow as the dragged card crosses in."
+        code={`<Kanban onMove={handleMove}>
+  {(['todo', 'doing', 'done'] as const).map((colId) => (
+    <Kanban.Column key={colId} id={colId}>
+      <Cluster justify="between" align="center">
+        <Title order={3} size="sm">{COL_TITLES[colId]}</Title>
+        <Badge tone="neutral" size="sm">{board[colId].length}</Badge>
+      </Cluster>
+      {board[colId].map((card) => (
+        <Kanban.Card key={card.id} id={card.id}>
+          <Card padding="sm">{card.title}</Card>
+        </Kanban.Card>
+      ))}
+    </Kanban.Column>
+  ))}
+</Kanban>`}
+      >
+        <Kanban onMove={handleMoveA}>
+          {(['todo', 'doing', 'done'] as const).map((colId) => (
+            <Kanban.Column key={colId} id={colId}>
+              <Cluster justify="between" align="center">
+                <Title order={3} size="sm">
+                  {COL_TITLES[colId]}
+                </Title>
+                <Badge tone="neutral" size="sm">
+                  {boardA[colId].length}
+                </Badge>
+              </Cluster>
+              {boardA[colId].map((card) => (
+                <Kanban.Card key={card.id} id={card.id}>
+                  <Card padding="sm">{card.title}</Card>
+                </Kanban.Card>
+              ))}
+            </Kanban.Column>
+          ))}
+        </Kanban>
+      </Example>
+
+      <Example
+        title="Cards with Handle + DropdownMenu"
+        description="Use Kanban.Handle when cards contain interactive elements. The grip is the only drag-initiator; the internal menu stays clickable."
+        code={`<Kanban onMove={handleMove}>
+  {(['todo', 'doing', 'done'] as const).map((colId) => (
+    <Kanban.Column key={colId} id={colId}>
+      <Cluster justify="between" align="center">
+        <Title order={3} size="sm">{COL_TITLES[colId]}</Title>
+        <Badge tone="neutral" size="sm">{board[colId].length}</Badge>
+      </Cluster>
+      {board[colId].map((card) => (
+        <Kanban.Card key={card.id} id={card.id}>
+          <Card padding="sm">
+            <Cluster justify="between" align="center">
+              <Cluster gap="sm" align="center">
+                <Kanban.Handle aria-label={\`Reorder \${card.title}\`}>
+                  <GripVertical size={14} />
+                </Kanban.Handle>
+                <Text weight="medium">{card.title}</Text>
+              </Cluster>
+              <DropdownMenu>
+                <DropdownMenu.Trigger>
+                  <Button variant="ghost" size="sm" iconOnly aria-label="More">
+                    <MoreHorizontal size={14} />
+                  </Button>
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Content align="end">
+                  <DropdownMenu.Item onSelect={() => {}}>View</DropdownMenu.Item>
+                  <DropdownMenu.Item onSelect={() => {}}>Archive</DropdownMenu.Item>
+                </DropdownMenu.Content>
+              </DropdownMenu>
+            </Cluster>
+          </Card>
+        </Kanban.Card>
+      ))}
+    </Kanban.Column>
+  ))}
+</Kanban>`}
+      >
+        <Kanban onMove={handleMoveB}>
+          {(['todo', 'doing', 'done'] as const).map((colId) => (
+            <Kanban.Column key={colId} id={colId}>
+              <Cluster justify="between" align="center">
+                <Title order={3} size="sm">
+                  {COL_TITLES[colId]}
+                </Title>
+                <Badge tone="neutral" size="sm">
+                  {boardB[colId].length}
+                </Badge>
+              </Cluster>
+              {boardB[colId].map((card) => (
+                <Kanban.Card key={card.id} id={card.id}>
+                  <Card padding="sm">
+                    <Cluster justify="between" align="center">
+                      <Cluster gap="sm" align="center">
+                        <Kanban.Handle aria-label={`Reorder ${card.title}`}>
+                          <GripVertical size={14} />
+                        </Kanban.Handle>
+                        <Text weight="medium">{card.title}</Text>
+                      </Cluster>
+                      <DropdownMenu>
+                        <DropdownMenu.Trigger>
+                          <Button variant="ghost" size="sm" iconOnly aria-label="More">
+                            <MoreHorizontal size={14} />
+                          </Button>
+                        </DropdownMenu.Trigger>
+                        <DropdownMenu.Content align="end">
+                          <DropdownMenu.Item onSelect={() => {}}>View</DropdownMenu.Item>
+                          <DropdownMenu.Item onSelect={() => {}}>Archive</DropdownMenu.Item>
+                        </DropdownMenu.Content>
+                      </DropdownMenu>
+                    </Cluster>
+                  </Card>
+                </Kanban.Card>
+              ))}
+            </Kanban.Column>
+          ))}
+        </Kanban>
+      </Example>
+
+      <Stack gap="xs">
+        <Title order={3} size="md">
+          Implementation notes
+        </Title>
+        <Text size="sm" tone="muted">
+          Each Column is a SortableContext; the Root provides a single shared DndContext
+          spanning all columns. Cards reflow live during cross-column drag — internal
+          Kanban state mutates on dragOver; consumer's onMove fires once on drop with
+          the diff. Keyboard reorder works within a column only (dnd-kit's stock
+          coordinateGetter is per-SortableContext).
+        </Text>
+      </Stack>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/components/KanbanDemo.tsx
+++ b/packages/playground/src/pages/components/KanbanDemo.tsx
@@ -46,9 +46,7 @@ const INITIAL_BOARD: Record<ColId, CardData[]> = {
   ],
 };
 
-function makeMoveHandler(
-  setter: React.Dispatch<React.SetStateAction<Record<ColId, CardData[]>>>,
-) {
+function makeMoveHandler(setter: React.Dispatch<React.SetStateAction<Record<ColId, CardData[]>>>) {
   return (event: KanbanMoveEvent) => {
     const { from, to, cardId } = event;
     setter((curr) => {
@@ -212,11 +210,10 @@ export function KanbanDemo() {
           Implementation notes
         </Title>
         <Text size="sm" tone="muted">
-          Each Column is a SortableContext; the Root provides a single shared DndContext
-          spanning all columns. Cards reflow live during cross-column drag — internal
-          Kanban state mutates on dragOver; consumer's onMove fires once on drop with
-          the diff. Keyboard reorder works within a column only (dnd-kit's stock
-          coordinateGetter is per-SortableContext).
+          Each Column is a SortableContext; the Root provides a single shared DndContext spanning
+          all columns. Cards reflow live during cross-column drag — internal Kanban state mutates on
+          dragOver; consumer's onMove fires once on drop with the diff. Keyboard reorder works
+          within a column only (dnd-kit's stock coordinateGetter is per-SortableContext).
         </Text>
       </Stack>
     </DemoLayout>

--- a/packages/playground/src/pages/mockups/Deals/Deals.tsx
+++ b/packages/playground/src/pages/mockups/Deals/Deals.tsx
@@ -34,9 +34,7 @@ function groupByStage(dealList: Deal[]): Record<DealStage, Deal[]> {
 }
 
 export function Deals() {
-  const [dealsByStage, setDealsByStage] = useState<Record<DealStage, Deal[]>>(
-    groupByStage(deals),
-  );
+  const [dealsByStage, setDealsByStage] = useState<Record<DealStage, Deal[]>>(groupByStage(deals));
 
   function handleMove(event: KanbanMoveEvent) {
     const { from, to, cardId } = event;

--- a/packages/playground/src/pages/mockups/Deals/Deals.tsx
+++ b/packages/playground/src/pages/mockups/Deals/Deals.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { MoreHorizontal, Plus, Filter } from 'lucide-react';
 import {
   Avatar,
@@ -7,12 +8,13 @@ import {
   Cluster,
   Code,
   DropdownMenu,
-  Grid,
+  Kanban,
   Stack,
   Text,
   Title,
+  type KanbanMoveEvent,
 } from '@eocrm/design-system';
-import { dealStages, deals, type DealStage } from '../../../data/mock';
+import { dealStages, deals, type Deal, type DealStage } from '../../../data/mock';
 import { CrossLinks } from '../../shared/CrossLinks';
 
 const stageTone: Record<DealStage, 'neutral' | 'info' | 'warning' | 'success'> = {
@@ -22,13 +24,51 @@ const stageTone: Record<DealStage, 'neutral' | 'info' | 'warning' | 'success'> =
   won: 'success',
 };
 
+function groupByStage(dealList: Deal[]): Record<DealStage, Deal[]> {
+  return {
+    lead: dealList.filter((d) => d.stage === 'lead'),
+    qualified: dealList.filter((d) => d.stage === 'qualified'),
+    proposal: dealList.filter((d) => d.stage === 'proposal'),
+    won: dealList.filter((d) => d.stage === 'won'),
+  };
+}
+
 export function Deals() {
+  const [dealsByStage, setDealsByStage] = useState<Record<DealStage, Deal[]>>(
+    groupByStage(deals),
+  );
+
+  function handleMove(event: KanbanMoveEvent) {
+    const { from, to, cardId } = event;
+    setDealsByStage((curr) => {
+      const fromCol = from.columnId as DealStage;
+      const toCol = to.columnId as DealStage;
+      const next: Record<DealStage, Deal[]> = {
+        lead: [...curr.lead],
+        qualified: [...curr.qualified],
+        proposal: [...curr.proposal],
+        won: [...curr.won],
+      };
+      const sourceArr = next[fromCol];
+      const idx = sourceArr.findIndex((d) => d.id === cardId);
+      if (idx < 0) return curr;
+      const [moved] = sourceArr.splice(idx, 1);
+      const movedWithStage = { ...moved, stage: toCol };
+      const targetArr = fromCol === toCol ? sourceArr : next[toCol];
+      const insertAt = Math.min(to.index, targetArr.length);
+      targetArr.splice(insertAt, 0, movedWithStage);
+      return next;
+    });
+  }
+
+  const totalDeals = Object.values(dealsByStage).reduce((sum, arr) => sum + arr.length, 0);
+
   return (
     <Stack gap="lg">
       <Cluster justify="between" align="end" gap="md">
         <Stack gap="xs">
           <Title order={1}>Deals</Title>
-          <Text tone="muted">{deals.length} active deals across 4 stages</Text>
+          <Text tone="muted">{totalDeals} active deals across 4 stages</Text>
         </Stack>
         <Cluster gap="sm">
           <Button variant="secondary">
@@ -40,106 +80,95 @@ export function Deals() {
         </Cluster>
       </Cluster>
 
-      <Grid columns={4} gap="sm">
+      <Kanban onMove={handleMove}>
         {dealStages.map((stage) => {
-          const stageDeals = deals.filter((d) => d.stage === stage.id);
+          const stageDeals = dealsByStage[stage.id];
           const total = stageDeals.reduce((sum, d) => sum + d.amount, 0);
           return (
-            /* TODO: replace when <MutedBox> ships — see components/TODO.md.
-               Each kanban column needs --color-bg-muted to read as a distinct
-               lane against the white page; Card has the wrong default surface. */
-            <div
-              key={stage.id}
-              style={{
-                background: 'var(--color-bg-muted)',
-                borderRadius: 'var(--radius-md)',
-                padding: 'var(--space-3)',
-              }}
-            >
-              <Stack gap="md">
-                <Cluster justify="between" align="center" gap="sm">
-                  <Cluster gap="sm" align="center">
-                    <Badge tone={stageTone[stage.id]} dot="start" size="sm">
-                      {stage.label}
-                    </Badge>
-                    <Badge tone="neutral" size="sm">
-                      {stageDeals.length}
-                    </Badge>
-                  </Cluster>
-                  <Text as="span" size="xs" tone="subtle">
-                    ${total.toLocaleString()}
-                  </Text>
+            <Kanban.Column key={stage.id} id={stage.id}>
+              <Cluster justify="between" align="center" gap="sm">
+                <Cluster gap="sm" align="center">
+                  <Badge tone={stageTone[stage.id]} dot="start" size="sm">
+                    {stage.label}
+                  </Badge>
+                  <Badge tone="neutral" size="sm">
+                    {stageDeals.length}
+                  </Badge>
                 </Cluster>
+                <Text as="span" size="xs" tone="subtle">
+                  ${total.toLocaleString()}
+                </Text>
+              </Cluster>
 
-                <Stack gap="sm">
-                  {stageDeals.map((d) => (
-                    <Card key={d.id} padding="md">
-                      <Stack gap="sm">
-                        <Cluster justify="between" align="start" gap="sm" wrap={false}>
-                          <Code tone="muted">{d.id}</Code>
-                          <DropdownMenu>
-                            <DropdownMenu.Trigger>
-                              <Button variant="ghost" size="sm" iconOnly aria-label="More">
-                                <MoreHorizontal size={14} />
-                              </Button>
-                            </DropdownMenu.Trigger>
-                            <DropdownMenu.Content align="end">
-                              <DropdownMenu.Item onSelect={() => {}}>Open</DropdownMenu.Item>
-                              <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-                              <DropdownMenu.Sub>
-                                <DropdownMenu.SubTrigger>Move to stage</DropdownMenu.SubTrigger>
-                                <DropdownMenu.SubContent>
-                                  {dealStages
-                                    .filter((s) => s.id !== stage.id)
-                                    .map((s) => (
-                                      <DropdownMenu.Item key={s.id} onSelect={() => {}}>
-                                        {s.label}
-                                      </DropdownMenu.Item>
-                                    ))}
-                                </DropdownMenu.SubContent>
-                              </DropdownMenu.Sub>
-                              <DropdownMenu.Separator />
-                              <DropdownMenu.Item onSelect={() => {}} tone="danger">
-                                Delete
-                              </DropdownMenu.Item>
-                            </DropdownMenu.Content>
-                          </DropdownMenu>
-                        </Cluster>
-                        <Stack gap="xs">
-                          <Title order={3} size="md">
-                            {d.title}
-                          </Title>
-                          <Text as="span" size="sm" tone="muted">
-                            {d.company}
-                          </Text>
-                        </Stack>
-                        {d.tags.length > 0 && (
-                          <Cluster gap="xs">
-                            {d.tags.map((t) => (
-                              <Badge key={t.label} tone={t.tone}>
-                                {t.label}
-                              </Badge>
-                            ))}
-                          </Cluster>
-                        )}
-                        <Cluster justify="between" align="center" gap="sm">
-                          <Text as="span" weight="semibold">
-                            ${d.amount.toLocaleString()}
-                          </Text>
-                          <Avatar name={d.owner} size="sm" />
-                        </Cluster>
+              {stageDeals.map((d) => (
+                <Kanban.Card key={d.id} id={d.id}>
+                  <Card padding="md">
+                    <Stack gap="sm">
+                      <Cluster justify="between" align="start" gap="sm" wrap={false}>
+                        <Code tone="muted">{d.id}</Code>
+                        <DropdownMenu>
+                          <DropdownMenu.Trigger>
+                            <Button variant="ghost" size="sm" iconOnly aria-label="More">
+                              <MoreHorizontal size={14} />
+                            </Button>
+                          </DropdownMenu.Trigger>
+                          <DropdownMenu.Content align="end">
+                            <DropdownMenu.Item onSelect={() => {}}>Open</DropdownMenu.Item>
+                            <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+                            <DropdownMenu.Sub>
+                              <DropdownMenu.SubTrigger>Move to stage</DropdownMenu.SubTrigger>
+                              <DropdownMenu.SubContent>
+                                {dealStages
+                                  .filter((s) => s.id !== stage.id)
+                                  .map((s) => (
+                                    <DropdownMenu.Item key={s.id} onSelect={() => {}}>
+                                      {s.label}
+                                    </DropdownMenu.Item>
+                                  ))}
+                              </DropdownMenu.SubContent>
+                            </DropdownMenu.Sub>
+                            <DropdownMenu.Separator />
+                            <DropdownMenu.Item onSelect={() => {}} tone="danger">
+                              Delete
+                            </DropdownMenu.Item>
+                          </DropdownMenu.Content>
+                        </DropdownMenu>
+                      </Cluster>
+                      <Stack gap="xs">
+                        <Title order={3} size="md">
+                          {d.title}
+                        </Title>
+                        <Text as="span" size="sm" tone="muted">
+                          {d.company}
+                        </Text>
                       </Stack>
-                    </Card>
-                  ))}
-                  <Button variant="ghost" size="sm">
-                    <Plus size={14} /> Add deal
-                  </Button>
-                </Stack>
-              </Stack>
-            </div>
+                      {d.tags.length > 0 && (
+                        <Cluster gap="xs">
+                          {d.tags.map((t) => (
+                            <Badge key={t.label} tone={t.tone}>
+                              {t.label}
+                            </Badge>
+                          ))}
+                        </Cluster>
+                      )}
+                      <Cluster justify="between" align="center" gap="sm">
+                        <Text as="span" weight="semibold">
+                          ${d.amount.toLocaleString()}
+                        </Text>
+                        <Avatar name={d.owner} size="sm" />
+                      </Cluster>
+                    </Stack>
+                  </Card>
+                </Kanban.Card>
+              ))}
+
+              <Button variant="ghost" size="sm">
+                <Plus size={14} /> Add deal
+              </Button>
+            </Kanban.Column>
           );
         })}
-      </Grid>
+      </Kanban>
 
       <CrossLinks kind="mockup" slug="deals" />
     </Stack>

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -31,6 +31,7 @@ export type ComponentName =
   | 'InlineDatePicker'
   | 'InlineDateRangePicker'
   | 'Input'
+  | 'Kanban'
   | 'Link'
   | 'Modal'
   | 'PageHeader'
@@ -95,7 +96,7 @@ export const MOCKUPS = [
       'Cluster',
       'Code',
       'DropdownMenu',
-      'Grid',
+      'Kanban',
       'Stack',
       'Text',
       'Title',


### PR DESCRIPTION
## Summary

New compound primitive `<Kanban>` with `Column` + `Card` + `Handle` (re-exported `Sortable.Handle`). Trello/Jira-style board UI built on the same `@dnd-kit/sortable` plumbing as the merged `<Sortable>`.

**Live cross-column re-insertion**: as the dragged card crosses into a new column, cards in the target column shift in real time to make room. Consumer's `onMove` fires once on drop with `{ from: {columnId, index}, to: {columnId, index}, cardId }`. The trick: internal `liveItems` state mutates mid-drag (snapshot at `dragStart`, mutate at `dragOver` for cross-column moves, reset at `dragEnd`/`dragCancel`). Re-renders are scoped to the Kanban subtree only — consumer state stays untouched until drop, avoiding the `measureRect → setState` cascade that broke an earlier attempt.

**Closes the `<MutedBox>` TODO** in `packages/design-system/src/components/TODO.md` — `<Kanban.Column>`'s built-in muted background absorbs that gap. **Deals mockup migrated** from `<Grid columns={4}>` + inline-styled `<div>` escape hatches to `<Kanban>`; cards are now actually draggable (previously static).

### Specs / plan

- `docs/superpowers/specs/2026-05-26-kanban-design.md` — v1 API
- `docs/superpowers/specs/2026-05-26-kanban-live-reinsertion-design.md` — internal-state architecture
- `docs/superpowers/plans/2026-05-26-kanban.md` — 3-task execution plan

### History

A prior attempt to add live re-insertion to PR #70's Kanban additions mutated consumer state mid-drag in `onDragOver` and hit an infinite `measureRect → setState → re-render → measureRect` loop. The Kanban portion of PR #70 was reverted and dropped from the merge (Sortable shipped alone). This PR ships Kanban from scratch with the correct internal-state architecture.

### v1 limitations (documented anti-patterns)

- **No cross-column keyboard reorder** — dnd-kit's stock `sortableKeyboardCoordinates` is per-`SortableContext`. Keyboard reorder works within a column only.
- **No column reordering** — only cards move.
- **Cards must be contiguous within a column's children** — non-card children (header, count badge) go BEFORE the cards; footer (Add card button) goes AFTER. Interleaved non-cards land awkwardly after a reorder.
- **`<Kanban.Card>` must be a direct child of `<Kanban.Column>`** — the Root walks direct descendants only.

### Files

- New library: `packages/design-system/src/components/Kanban/` (4 files)
- New playground: `packages/playground/src/pages/components/KanbanDemo.tsx` (2 examples, independent state)
- Modified library: `src/index.ts`, `AGENTS.md`, `_meta/manifest.ts`, `scripts/generate-manifest.mjs`, `components.manifest.json`, `components/TODO.md`, `components/Sortable/Sortable.tsx` (export-promotion: `SortableItemContext`, `SortableItemContextValue`, `SortableHandle`, `SortableItem` — public API stays backward-compatible), `components/Sortable/index.ts`
- Modified playground: `App.tsx`, `AppShell.tsx`, `ComponentsIndex.tsx`, `mockups/registry.ts`, `mockups/Deals/Deals.tsx`

### HR8 review cycle

Two rounds of fresh-context Opus reviewers.

- **Round 1** — 1 Critical (same-column override corrupted drops after cross-column transit) + 2 Important (no null-`over` bail in `handleDragEnd`; consumer couldn't override `aria-label`) + 2 worth-applying NTHs (O(N²) column lookup; unsafe `:` / `,` separators in `initialItemsKey`). Fixed at `769db90`.
- **Round 2** — verdict: `clean enough to stop`. 0 Critical, 0 Important.

## Test plan

- [x] `make test` — 1976/1976 passing (10 new Kanban cases; structure-focused per Sortable / DataTable precedent — drag interaction not unit-testable in jsdom)
- [x] `make build-lib` — typecheck clean
- [x] `make build` — playground bundle clean
- [x] `make lint` — clean
- [x] `npm pack --dry-run -w @eocrm/design-system` — `Kanban.tsx` (22.3KB) + `Kanban.module.scss` (716B) + `index.ts` (132B) in tarball; test file excluded
- [x] Manually verify Deals mockup (`/mockups/deals`) drag-reorders cards within and across columns
- [x] Manually verify KanbanDemo (`/components/kanban`) — both examples have independent state
- [x] HR8 review cycle round 2: clean enough to stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)