### PR TITLE
OptionsPicker: group palette color (header dot + checkboxes)

### DIFF
--- a/packages/design-system/src/components/OptionsPicker/OptionsPicker.module.scss
+++ b/packages/design-system/src/components/OptionsPicker/OptionsPicker.module.scss
@@ -98,6 +98,17 @@
   font-family: var(--font-family-mono);
 }
 
+// Group-header dot. Used by the palette-colored variant (when group.color
+// is set, GroupDot renders a <span> with this class). The Badge-tone path
+// applies the same class to the Badge wrapper — the size is identical so
+// both rendering branches land at the same visual size.
+.groupDot {
+  width: var(--size-badge-dot);
+  height: var(--size-badge-dot);
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
 // Indent options that live inside a group so they read as nested under
 // the group header (the header's dot + label is the "outdent" anchor).
 .group .row {

--- a/packages/design-system/src/components/OptionsPicker/OptionsPicker.tsx
+++ b/packages/design-system/src/components/OptionsPicker/OptionsPicker.tsx
@@ -26,6 +26,7 @@ import { Radio } from '../Radio';
 import { Cluster } from '../Cluster';
 import { Input } from '../Input';
 import { Badge, type BadgeTone } from '../Badge';
+import { type PaletteColor } from '../../palette';
 import { Text } from '../Text';
 import styles from './OptionsPicker.module.scss';
 
@@ -52,6 +53,14 @@ export interface OptionsPickerGroup {
   options: OptionsPickerOption[];
   /** Colored dot tone for the group header. Default `'neutral'`. */
   tone?: BadgeTone;
+  /**
+   * Categorical palette color. When set, takes precedence over `tone`:
+   * the group header dot uses the palette color, AND every option's
+   * Checkbox in this group adopts the same palette color for its
+   * checked / indeterminate fill. Use to give each namespace its own
+   * visual identity (e.g., auth.* = blue, role.* = amber).
+   */
+  color?: PaletteColor;
   /** Right-side hint label (e.g., `"auth.*"`). Omitted → no hint renders. */
   hint?: string;
 }
@@ -570,12 +579,7 @@ const OptionsPickerContent = forwardRef<HTMLDivElement, OptionsPickerContentProp
                       aria-controls={g.options.map((o) => `${contentId}-opt-${o.value}`).join(' ')}
                       onClick={() => toggleGroup(g.options)}
                     >
-                      <Badge
-                        tone={g.tone ?? 'neutral'}
-                        dot="start"
-                        size="sm"
-                        className={styles.groupDot}
-                      />
+                      <GroupDot color={g.color} tone={g.tone} />
                       <Text size="xs" weight="semibold" className={styles.groupLabel}>
                         {g.label}
                       </Text>
@@ -587,12 +591,7 @@ const OptionsPickerContent = forwardRef<HTMLDivElement, OptionsPickerContentProp
                     </button>
                   ) : (
                     <div className={styles.groupHeader} role="presentation">
-                      <Badge
-                        tone={g.tone ?? 'neutral'}
-                        dot="start"
-                        size="sm"
-                        className={styles.groupDot}
-                      />
+                      <GroupDot color={g.color} tone={g.tone} />
                       <Text size="xs" weight="semibold" className={styles.groupLabel}>
                         {g.label}
                       </Text>
@@ -612,6 +611,7 @@ const OptionsPickerContent = forwardRef<HTMLDivElement, OptionsPickerContentProp
                       rowId={`${contentId}-opt-${opt.value}`}
                       focused={focusedValue === opt.value}
                       onToggle={toggle}
+                      color={g.color}
                     />
                   ))}
                 </div>
@@ -659,6 +659,27 @@ const OptionsPickerContent = forwardRef<HTMLDivElement, OptionsPickerContentProp
   },
 );
 
+/**
+ * Group-header dot. Default path uses `<Badge tone>` (the legacy
+ * semantic-tone behavior). When a palette `color` is set on the group,
+ * render a custom palette-colored dot instead — the same saturated
+ * `--color-palette-<name>-fg` token used by the group's Checkboxes,
+ * so the header and the row fills match exactly.
+ */
+function GroupDot({ color, tone }: { color?: PaletteColor; tone?: BadgeTone }) {
+  if (color) {
+    return (
+      <span
+        aria-hidden="true"
+        className={styles.groupDot}
+        style={{ background: `var(--color-palette-${color}-fg)` }}
+        data-palette={color}
+      />
+    );
+  }
+  return <Badge tone={tone ?? 'neutral'} dot="start" size="sm" className={styles.groupDot} />;
+}
+
 interface OptionRowProps {
   option: OptionsPickerOption;
   checked: boolean;
@@ -666,9 +687,10 @@ interface OptionRowProps {
   rowId: string;
   focused: boolean;
   onToggle: (value: string) => void;
+  color?: PaletteColor;
 }
 
-function OptionRow({ option, checked, mode, rowId, focused, onToggle }: OptionRowProps) {
+function OptionRow({ option, checked, mode, rowId, focused, onToggle, color }: OptionRowProps) {
   const checkboxOnChange = useCallback(() => onToggle(option.value), [onToggle, option.value]);
   const radioOnChange = useCallback(() => onToggle(option.value), [onToggle, option.value]);
   // Click anywhere inside the row toggles — the inner Checkbox/Radio handles
@@ -694,6 +716,7 @@ function OptionRow({ option, checked, mode, rowId, focused, onToggle }: OptionRo
           checked={checked}
           onChange={checkboxOnChange}
           label={<Text size="sm">{option.label}</Text>}
+          color={color}
         />
       ) : (
         <Radio

--- a/packages/playground/src/pages/components/OptionsPickerDemo.tsx
+++ b/packages/playground/src/pages/components/OptionsPickerDemo.tsx
@@ -19,7 +19,7 @@ const groupedOptions = [
   {
     id: 'auth',
     label: 'Authentication',
-    tone: 'success' as const,
+    color: 'blue' as const,
     hint: 'auth.*',
     options: [
       { value: 'auth.login_succeeded', label: 'login_succeeded' },
@@ -31,7 +31,7 @@ const groupedOptions = [
   {
     id: 'role',
     label: 'Roles',
-    tone: 'info' as const,
+    color: 'violet' as const,
     hint: 'role.*',
     options: [
       { value: 'role.assigned', label: 'assigned' },
@@ -42,7 +42,7 @@ const groupedOptions = [
   {
     id: 'invitation',
     label: 'Invitations',
-    tone: 'warning' as const,
+    color: 'amber' as const,
     hint: 'invitation.*',
     options: [
       { value: 'invitation.sent', label: 'sent' },


### PR DESCRIPTION
## Summary

`OptionsPickerGroup` gains an optional `color?: PaletteColor`. When set:

- The group **header dot** renders the palette `fg` color (sized via the same `--size-badge-dot` token the existing Badge dot used).
- Every option **Checkbox** in the group inherits that color via Checkbox's new `color` prop — so the checked / indeterminate fills match the header dot exactly.

The existing `tone?: BadgeTone` path is untouched for backward compatibility; `color` takes precedence when both are provided.

The OptionsPicker demo's grouped example switches from semantic tones (success / info / warning) to palette colors (blue / violet / amber) — each namespace now reads as its own visual identity:

- `AUTHENTICATION` → blue
- `ROLES` → violet
- `INVITATIONS` → amber

## Test plan

- [x] Tests, typecheck, lint, build — all green (2071/2071 passing)
- [x] Playwright check — opened the grouped picker, confirmed:
  - 3 group dots render with palette fg colors (blue / violet / amber)
  - All 10 checkboxes inherit their group's `--checkbox-color` CSS variable
  - First checkbox of each group (pre-checked in the demo's initial state) renders with the matching palette fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)