### PR TITLE
Badge palette color + Audit/OptionsPicker namespace unification

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1056,11 +1056,17 @@ import { Divider } from '@eocrm/design-system';
 // Stripe variant — rectangular category marker with left stripe:
 <Badge variant="stripe" tone="info">Lead</Badge>
 <Badge variant="stripe" tone="warning">Renewal due</Badge>
+
+// Categorical palette color (non-semantic) — for tag-like labels:
+<Badge color="amber">Marketing</Badge>
+<Badge color="teal">Engineering</Badge>
+<Badge variant="stripe" color="violet">Design</Badge>
 ```
 
-- `tone`: `neutral` (default) / `info` / `success` / `warning` / `danger` / `purple`
+- `tone`: `neutral` (default) / `info` / `success` / `warning` / `danger` / `purple`. Semantic. Use for status (Active / Won / Churned / Lead / Enterprise).
+- `color`: optional `PaletteColor` (30 named colors). Categorical — no semantic meaning. Use for tag-like labels where the 6 tones aren't enough (audit event namespaces, team tags, project labels). Takes precedence over `tone` when both are set. Works for both `filled` and `stripe` variants (stripe's left border picks up the palette fg).
 - `size`: `md` (20, default) / `sm` (16). `md` is the uppercase tracked "loud label" pill. `sm` drops the uppercase + tracking and renders case as-typed — use it for dense table cells, compact toolbars, or anywhere the uppercase treatment shouts next to body copy.
-- `variant`: `filled` (default) / `stripe`. `filled` is the standard pill. `stripe` renders a rectangular block with a tone-colored 3px left stripe and a softly tinted body — no uppercase or letter-spacing. Use for category markers or sidebar labels where pill emphasis is too loud. Composes with all six existing tones.
+- `variant`: `filled` (default) / `stripe`. `filled` is the standard pill. `stripe` renders a rectangular block with a tone-colored 3px left stripe and a softly tinted body — no uppercase or letter-spacing. Use for category markers or sidebar labels where pill emphasis is too loud. Composes with both `tone` (6 semantic) and `color` (30 palette).
 - `dot`: `start` / `end` — adds a small filled circle in the badge's text color before or after the content. Use for Slack/GitHub-style status indicators (`<Badge tone="success" dot="start">Online</Badge>`). Decorative only (`aria-hidden`); the text is still the accessible label.
 - **Non-interactive.** If it's clickable, use `<Button>` instead.
 - Doesn't auto-add `role="status"`. Wrap in `aria-live` if a state change should be announced.

--- a/packages/design-system/src/components/Badge/Badge.test.tsx
+++ b/packages/design-system/src/components/Badge/Badge.test.tsx
@@ -118,4 +118,40 @@ describe('Badge', () => {
       expect(container.firstElementChild!.className).toMatch(new RegExp(size));
     },
   );
+
+  it('color="amber" sets inline bg + color using palette tokens (filled)', () => {
+    const { container } = render(<Badge color="amber">Tag</Badge>);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.background).toBe('var(--color-palette-amber-bg)');
+    expect(root.style.color).toBe('var(--color-palette-amber-fg)');
+    expect(root.style.borderLeftColor).toBe('');
+  });
+
+  it('color="violet" on stripe variant also sets borderLeftColor', () => {
+    const { container } = render(
+      <Badge variant="stripe" color="violet">
+        Tag
+      </Badge>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.background).toBe('var(--color-palette-violet-bg)');
+    expect(root.style.color).toBe('var(--color-palette-violet-fg)');
+    expect(root.style.borderLeftColor).toBe('var(--color-palette-violet-fg)');
+  });
+
+  it('no color prop means no palette inline style is set', () => {
+    const { container } = render(<Badge tone="success">Active</Badge>);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.background).toBe('');
+    expect(root.style.color).toBe('');
+  });
+
+  it('consumer style merges on top of palette style (consumer override wins)', () => {
+    const { container } = render(
+      <Badge color="amber" style={{ background: 'red' }}>
+        Tag
+      </Badge>,
+    );
+    expect((container.firstElementChild as HTMLElement).style.background).toBe('red');
+  });
 });

--- a/packages/design-system/src/components/Badge/Badge.tsx
+++ b/packages/design-system/src/components/Badge/Badge.tsx
@@ -1,5 +1,6 @@
-import { forwardRef, type HTMLAttributes } from 'react';
+import { forwardRef, type CSSProperties, type HTMLAttributes } from 'react';
 import clsx from 'clsx';
+import { type PaletteColor } from '../../palette';
 import styles from './Badge.module.scss';
 
 /** Semantic tone. Use consistently across pages — `success` should never mean "bad". */
@@ -63,6 +64,16 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
    *   Use for category markers or sidebar labels where pill emphasis is too loud.
    */
   variant?: BadgeVariant;
+  /**
+   * Optional categorical palette color. When set, takes precedence over
+   * `tone`: the badge fills with the matching `--color-palette-<name>-bg/fg`
+   * tokens. Use for non-semantic categorical labels (e.g., audit event
+   * namespaces, tag colors) where the 6 semantic tones aren't enough.
+   *
+   * Both filled and stripe variants are supported; for stripe the
+   * left-border picks up the palette `fg` token.
+   */
+  color?: PaletteColor;
 }
 
 const toneClass: Record<BadgeTone, string> = {
@@ -119,6 +130,12 @@ const sizeClass: Record<BadgeSize, string> = {
  *   a `Button` or `Link`.
  * - For long-form text. Badges should be 1-2 words max.
  *
+ * @example
+ * // Categorical palette color (not a semantic tone) — for tag-like labels
+ * <Badge color="amber">Marketing</Badge>
+ * <Badge color="teal">Engineering</Badge>
+ * <Badge variant="stripe" color="violet">Design</Badge>
+ *
  * @remarks Anti-patterns
  * - ❌ Mixing tone meanings across pages. If `success` means "Won" on Deals
  *   and "Active" on Contacts, that's fine — but never use `success` for
@@ -127,11 +144,45 @@ const sizeClass: Record<BadgeSize, string> = {
  *   design problem is information density, not the badge.
  * - ❌ Wrapping a Badge in a `<button>` to make it clickable. Use a `Button`
  *   with an appropriate variant instead.
+ * - ❌ Using `color` (palette) for status. Use `tone` (semantic) for status;
+ *   palette colors carry no built-in meaning and consumers might shift the
+ *   mapping over time.
  */
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
-  { tone = 'neutral', size = 'md', dot, variant = 'filled', className, children, ...props },
+  {
+    tone = 'neutral',
+    size = 'md',
+    dot,
+    variant = 'filled',
+    color,
+    className,
+    children,
+    style,
+    ...props
+  },
   ref,
 ) {
+  // When a palette color is set, inject inline bg/fg/border-left-color
+  // values that override the tone class's CSS rules (inline beats class
+  // by specificity). When color is undefined, the tone class wins
+  // unchanged — defaults are byte-identical to today.
+  const colorStyle: CSSProperties | undefined = color
+    ? variant === 'stripe'
+      ? {
+          background: `var(--color-palette-${color}-bg)`,
+          color: `var(--color-palette-${color}-fg)`,
+          borderLeftColor: `var(--color-palette-${color}-fg)`,
+        }
+      : {
+          background: `var(--color-palette-${color}-bg)`,
+          color: `var(--color-palette-${color}-fg)`,
+        }
+    : undefined;
+
+  // Merge consumer-supplied style on top of the palette style so consumer
+  // overrides still win.
+  const mergedStyle = colorStyle || style ? { ...colorStyle, ...style } : undefined;
+
   // {...props} last so consumer overrides win (Pattern A).
   return (
     <span
@@ -143,6 +194,7 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
         variant === 'stripe' && styles.stripe,
         className,
       )}
+      style={mergedStyle}
       {...props}
     >
       {dot === 'start' && <span aria-hidden="true" className={styles.dot} />}

--- a/packages/design-system/src/components/OptionsPicker/OptionsPicker.module.scss
+++ b/packages/design-system/src/components/OptionsPicker/OptionsPicker.module.scss
@@ -88,6 +88,23 @@
   padding: var(--space-3) var(--space-2);
 }
 
+// Bottom border in the namespace's palette color. The width + style come
+// from these rules; the actual `border-bottom-color` is injected inline
+// from the React layer (using --color-palette-<name>-fg). Applied only
+// when the group has a `color` prop set, so legacy `tone`-only groups
+// stay borderless.
+// The `button.groupHeader { border: none }` rule below (multi-mode
+// button reset) is more specific than `.groupHeaderWithBorder` on its
+// own, so we need separate selectors for the div + button branches
+// that match or beat its specificity.
+.groupHeaderWithBorder {
+  border-bottom: var(--border-width) solid transparent;
+}
+
+button.groupHeader.groupHeaderWithBorder {
+  border-bottom: var(--border-width) solid transparent;
+}
+
 .groupLabel {
   text-transform: uppercase;
   letter-spacing: 0.04em;

--- a/packages/design-system/src/components/OptionsPicker/OptionsPicker.module.scss
+++ b/packages/design-system/src/components/OptionsPicker/OptionsPicker.module.scss
@@ -86,6 +86,7 @@
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-3) var(--space-2);
+  background: var(--color-bg-muted);
 }
 
 // Bottom border in the namespace's palette color. The width + style come
@@ -98,11 +99,11 @@
 // own, so we need separate selectors for the div + button branches
 // that match or beat its specificity.
 .groupHeaderWithBorder {
-  border-bottom: var(--border-width) solid transparent;
+  border-bottom: var(--border-width-emphasis) solid transparent;
 }
 
 button.groupHeader.groupHeaderWithBorder {
-  border-bottom: var(--border-width) solid transparent;
+  border-bottom: var(--border-width-emphasis) solid transparent;
 }
 
 .groupLabel {
@@ -138,14 +139,13 @@ button.groupHeader.groupHeaderWithBorder {
 }
 
 button.groupHeader {
-  background: transparent;
   border: none;
   cursor: pointer;
   width: 100%;
   text-align: left;
 
   &:hover {
-    background: var(--color-bg-muted);
+    background: var(--color-bg-subtle);
   }
 
   &:focus-visible {

--- a/packages/design-system/src/components/OptionsPicker/OptionsPicker.tsx
+++ b/packages/design-system/src/components/OptionsPicker/OptionsPicker.tsx
@@ -565,57 +565,73 @@ const OptionsPickerContent = forwardRef<HTMLDivElement, OptionsPickerContentProp
             )}
             {hasAnyVisible &&
               isGrouped(props) &&
-              visibleGroups.map((g) => (
-                <div key={g.id} className={styles.group}>
-                  {ctx.mode === 'multi' ? (
-                    <button
-                      type="button"
-                      className={styles.groupHeader}
-                      aria-pressed={tristate(
-                        g.options.map((o) => o.value),
-                        draft,
-                      )}
-                      aria-label={`Toggle group ${g.label}`}
-                      aria-controls={g.options.map((o) => `${contentId}-opt-${o.value}`).join(' ')}
-                      onClick={() => toggleGroup(g.options)}
-                    >
-                      <GroupDot color={g.color} tone={g.tone} />
-                      <Text size="xs" weight="semibold" className={styles.groupLabel}>
-                        {g.label}
-                      </Text>
-                      {g.hint && (
-                        <Text size="xs" tone="subtle" className={styles.groupHint}>
-                          {g.hint}
+              visibleGroups.map((g) => {
+                // When the group has a palette color, draw a 1px bottom
+                // border on the header in that color — visually carries
+                // the namespace identity from the dot across the full
+                // header width, separating each group's options.
+                const headerClassName = clsx(
+                  styles.groupHeader,
+                  g.color && styles.groupHeaderWithBorder,
+                );
+                const headerStyle = g.color
+                  ? { borderBottomColor: `var(--color-palette-${g.color}-fg)` }
+                  : undefined;
+                return (
+                  <div key={g.id} className={styles.group}>
+                    {ctx.mode === 'multi' ? (
+                      <button
+                        type="button"
+                        className={headerClassName}
+                        style={headerStyle}
+                        aria-pressed={tristate(
+                          g.options.map((o) => o.value),
+                          draft,
+                        )}
+                        aria-label={`Toggle group ${g.label}`}
+                        aria-controls={g.options
+                          .map((o) => `${contentId}-opt-${o.value}`)
+                          .join(' ')}
+                        onClick={() => toggleGroup(g.options)}
+                      >
+                        <GroupDot color={g.color} tone={g.tone} />
+                        <Text size="xs" weight="semibold" className={styles.groupLabel}>
+                          {g.label}
                         </Text>
-                      )}
-                    </button>
-                  ) : (
-                    <div className={styles.groupHeader} role="presentation">
-                      <GroupDot color={g.color} tone={g.tone} />
-                      <Text size="xs" weight="semibold" className={styles.groupLabel}>
-                        {g.label}
-                      </Text>
-                      {g.hint && (
-                        <Text size="xs" tone="subtle" className={styles.groupHint}>
-                          {g.hint}
+                        {g.hint && (
+                          <Text size="xs" tone="subtle" className={styles.groupHint}>
+                            {g.hint}
+                          </Text>
+                        )}
+                      </button>
+                    ) : (
+                      <div className={headerClassName} style={headerStyle} role="presentation">
+                        <GroupDot color={g.color} tone={g.tone} />
+                        <Text size="xs" weight="semibold" className={styles.groupLabel}>
+                          {g.label}
                         </Text>
-                      )}
-                    </div>
-                  )}
-                  {g.visibleOptions.map((opt) => (
-                    <OptionRow
-                      key={opt.value}
-                      option={opt}
-                      checked={draft.includes(opt.value)}
-                      mode={ctx.mode}
-                      rowId={`${contentId}-opt-${opt.value}`}
-                      focused={focusedValue === opt.value}
-                      onToggle={toggle}
-                      color={g.color}
-                    />
-                  ))}
-                </div>
-              ))}
+                        {g.hint && (
+                          <Text size="xs" tone="subtle" className={styles.groupHint}>
+                            {g.hint}
+                          </Text>
+                        )}
+                      </div>
+                    )}
+                    {g.visibleOptions.map((opt) => (
+                      <OptionRow
+                        key={opt.value}
+                        option={opt}
+                        checked={draft.includes(opt.value)}
+                        mode={ctx.mode}
+                        rowId={`${contentId}-opt-${opt.value}`}
+                        focused={focusedValue === opt.value}
+                        onToggle={toggle}
+                        color={g.color}
+                      />
+                    ))}
+                  </div>
+                );
+              })}
             {hasAnyVisible &&
               !isGrouped(props) &&
               visibleFlat.map((opt) => (

--- a/packages/playground/src/data/audit.ts
+++ b/packages/playground/src/data/audit.ts
@@ -192,11 +192,11 @@ import type { OptionsPickerGroup, OptionsPickerOption } from '@eocrm/design-syst
  */
 export const EVENT_NAMESPACE_COLOR: Record<string, PaletteColor> = {
   auth: 'blue',
-  role: 'violet',
+  role: 'fuchsia',
   user: 'teal',
   invitation: 'amber',
   contact: 'emerald',
-  deal: 'gold',
+  deal: 'rose',
   system_setting: 'slate',
 };
 

--- a/packages/playground/src/data/audit.ts
+++ b/packages/playground/src/data/audit.ts
@@ -1,4 +1,4 @@
-import type { BadgeTone } from '@eocrm/design-system';
+import type { PaletteColor } from '@eocrm/design-system';
 
 export type AuditActorRef = { id: string; name: string; email: string };
 export type AuditTenantRef = { id: string; slug: string; name: string };
@@ -183,11 +183,40 @@ import type { OptionsPickerGroup, OptionsPickerOption } from '@eocrm/design-syst
  * namespaces present in `auditEntries` plus a couple of common siblings to
  * make the picker feel populated.
  */
+/**
+ * Single source of truth: event namespace → palette color. Used in BOTH
+ * the Event-filter OptionsPicker (group header dot + checkbox fills) AND
+ * the DataTable Event-column badges (stripe color), so a given namespace
+ * reads as the same color everywhere on the page. Add a new namespace
+ * here when introducing new events.
+ */
+export const EVENT_NAMESPACE_COLOR: Record<string, PaletteColor> = {
+  auth: 'blue',
+  role: 'violet',
+  user: 'teal',
+  invitation: 'amber',
+  contact: 'emerald',
+  deal: 'gold',
+  system_setting: 'slate',
+};
+
+/**
+ * Looks up the palette color for an event name (`auth.login_succeeded` →
+ * `'blue'`). Falls back to `stone` for unknown namespaces so the badge
+ * still renders something legible. Replaces the older tone-based
+ * `eventTone()` — per-event tone variation traded for cross-page
+ * namespace consistency.
+ */
+export function eventColor(event: string): PaletteColor {
+  const namespace = event.split('.')[0] ?? '';
+  return EVENT_NAMESPACE_COLOR[namespace] ?? 'stone';
+}
+
 export const eventCatalog: OptionsPickerGroup[] = [
   {
     id: 'auth',
     label: 'Authentication',
-    tone: 'success',
+    color: EVENT_NAMESPACE_COLOR.auth,
     hint: 'auth.*',
     options: [
       { value: 'auth.login_succeeded', label: 'login_succeeded' },
@@ -202,7 +231,7 @@ export const eventCatalog: OptionsPickerGroup[] = [
   {
     id: 'role',
     label: 'Roles',
-    tone: 'info',
+    color: EVENT_NAMESPACE_COLOR.role,
     hint: 'role.*',
     options: [
       { value: 'role.assigned', label: 'assigned' },
@@ -213,7 +242,7 @@ export const eventCatalog: OptionsPickerGroup[] = [
   {
     id: 'user',
     label: 'Users',
-    tone: 'info',
+    color: EVENT_NAMESPACE_COLOR.user,
     hint: 'user.*',
     options: [
       { value: 'user.created', label: 'created' },
@@ -224,7 +253,7 @@ export const eventCatalog: OptionsPickerGroup[] = [
   {
     id: 'invitation',
     label: 'Invitations',
-    tone: 'warning',
+    color: EVENT_NAMESPACE_COLOR.invitation,
     hint: 'invitation.*',
     options: [
       { value: 'invitation.sent', label: 'sent' },
@@ -235,7 +264,7 @@ export const eventCatalog: OptionsPickerGroup[] = [
   {
     id: 'contact',
     label: 'Contacts',
-    tone: 'neutral',
+    color: EVENT_NAMESPACE_COLOR.contact,
     hint: 'contact.*',
     options: [
       { value: 'contact.created', label: 'created' },
@@ -246,7 +275,7 @@ export const eventCatalog: OptionsPickerGroup[] = [
   {
     id: 'deal',
     label: 'Deals',
-    tone: 'neutral',
+    color: EVENT_NAMESPACE_COLOR.deal,
     hint: 'deal.*',
     options: [
       { value: 'deal.created', label: 'created' },
@@ -258,7 +287,7 @@ export const eventCatalog: OptionsPickerGroup[] = [
   {
     id: 'system_setting',
     label: 'System settings',
-    tone: 'warning',
+    color: EVENT_NAMESPACE_COLOR.system_setting,
     hint: 'system_setting.*',
     options: [{ value: 'system_setting.updated', label: 'updated' }],
   },
@@ -270,20 +299,3 @@ export const tenantOptions: OptionsPickerOption[] = [
   { value: 'hooli', label: 'hooli' },
   { value: 'stark', label: 'stark' },
 ];
-
-/**
- * Maps an audit event name to a Badge tone. Namespace-driven so new events
- * inherit a sensible default without explicit listing.
- */
-export function eventTone(event: string): BadgeTone {
-  const head = event.split('.')[0] ?? '';
-  if (event.endsWith('.expired') || event.endsWith('.deleted') || event === 'auth.login_failed') {
-    return 'danger';
-  }
-  if (event === 'auth.login_succeeded' || event === 'auth.mfa_enabled' || event === 'deal.won') {
-    return 'success';
-  }
-  if (head === 'role' || head === 'user') return 'info';
-  if (head === 'invitation' || head === 'system_setting') return 'warning';
-  return 'neutral';
-}

--- a/packages/playground/src/pages/components/BadgeDemo.tsx
+++ b/packages/playground/src/pages/components/BadgeDemo.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@eocrm/design-system';
+import { Badge, PALETTE_COLORS } from '@eocrm/design-system';
 import { Cluster } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
@@ -257,6 +257,32 @@ export function BadgeDemo() {
               <Badge tone="danger">Lost</Badge>
             </Cluster>
           </div>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Palette colors (categorical)"
+        description="Optional `color` prop tints the badge with a categorical palette color — 30 named colors that carry no semantic meaning (use `tone` for status; `color` for tag-like categorical labels)."
+        code={`<Badge color="amber">Marketing</Badge>
+<Badge color="teal">Engineering</Badge>
+<Badge color="violet">Design</Badge>
+<Badge color="fuchsia" variant="stripe">Sales</Badge>`}
+      >
+        <Stack gap="sm">
+          <Cluster gap="xs" wrap>
+            {PALETTE_COLORS.map((color) => (
+              <Badge key={color} color={color}>
+                {color}
+              </Badge>
+            ))}
+          </Cluster>
+          <Cluster gap="xs" wrap>
+            {PALETTE_COLORS.slice(0, 10).map((color) => (
+              <Badge key={color} color={color} variant="stripe">
+                {color}
+              </Badge>
+            ))}
+          </Cluster>
         </Stack>
       </Example>
     </DemoLayout>

--- a/packages/playground/src/pages/components/OptionsPickerDemo.tsx
+++ b/packages/playground/src/pages/components/OptionsPickerDemo.tsx
@@ -31,7 +31,7 @@ const groupedOptions = [
   {
     id: 'role',
     label: 'Roles',
-    color: 'violet' as const,
+    color: 'emerald' as const,
     hint: 'role.*',
     options: [
       { value: 'role.assigned', label: 'assigned' },
@@ -42,7 +42,7 @@ const groupedOptions = [
   {
     id: 'invitation',
     label: 'Invitations',
-    color: 'amber' as const,
+    color: 'fuchsia' as const,
     hint: 'invitation.*',
     options: [
       { value: 'invitation.sent', label: 'sent' },

--- a/packages/playground/src/pages/mockups/Audit/Audit.tsx
+++ b/packages/playground/src/pages/mockups/Audit/Audit.tsx
@@ -24,7 +24,7 @@ import {
 import {
   auditEntries,
   eventCatalog,
-  eventTone,
+  eventColor,
   tenantOptions,
   type AuditEntry,
 } from '../../../data/audit';
@@ -219,7 +219,7 @@ export function Audit() {
         header: 'Event',
         size: 200,
         cell: (r) => (
-          <Badge variant="stripe" size="sm" tone={eventTone(r.event)}>
+          <Badge variant="stripe" size="sm" color={eventColor(r.event)}>
             {r.event}
           </Badge>
         ),

--- a/packages/playground/src/pages/mockups/Audit/Audit.tsx
+++ b/packages/playground/src/pages/mockups/Audit/Audit.tsx
@@ -219,7 +219,7 @@ export function Audit() {
         header: 'Event',
         size: 200,
         cell: (r) => (
-          <Badge tone={eventTone(r.event)} dot="start">
+          <Badge variant="stripe" size="sm" tone={eventTone(r.event)}>
             {r.event}
           </Badge>
         ),


### PR DESCRIPTION
## Summary

Builds on the palette PR (#82) by wiring palette colors through Badge, OptionsPicker, and the Audit mockup so every event namespace renders as a single distinct color across the page.

## Changes

**Library:**
- **Badge** gains `color?: PaletteColor`. When set, the badge fills with the matching `--color-palette-<name>-bg/-fg` tokens via inline style. Works for both `filled` and `stripe` variants; stripe's left border picks up the palette `fg`.
- **OptionsPicker** group header gains a colored bottom border (2px) in the namespace's palette color, and a muted gray background to visually distinguish headers from option rows.

**Audit mockup:**
- Event-column badges switch from `tone` + `dot="start"` to `variant="stripe" size="sm"` + palette `color`.
- New single source of truth in `data/audit.ts`: `EVENT_NAMESPACE_COLOR` + `eventColor(event)` — used by BOTH the OptionsPicker `groups` config AND the row badges, so each namespace reads as the same color in both places.
- 7 namespaces span distinct hue families: `auth=blue`, `role=fuchsia`, `user=teal`, `invitation=amber`, `contact=emerald`, `deal=rose`, `system_setting=slate`.

**OptionsPicker demo:**
- Grouped example uses `blue / emerald / fuchsia` — three hue families away from each other.

## Test plan

- [x] +4 Badge tests (filled / stripe / no-color / consumer-style override)
- [x] Full test suite — 2075/2075 passing
- [x] Typecheck, lint, build — all green
- [x] BadgeDemo "Palette colors (categorical)" example — 30 filled + 10 stripe badges all render correct palette tokens
- [x] Playwright on `/mockups/audit`:
  - All 7 namespace badges render with their assigned color
  - OptionsPicker dropdown shows the same colors on header dots + bottom border + checkboxes — colors match the row badges exactly
- [x] AGENTS.md Badge section updated to document `color`

🤖 Generated with [Claude Code](https://claude.com/claude-code)