### PR TITLE
Playground: source-view shows every file per component

### DIFF
--- a/docs/superpowers/plans/2026-05-27-demo-all-component-files.md
+++ b/docs/superpowers/plans/2026-05-27-demo-all-component-files.md
@@ -181,7 +181,11 @@ export function DemoBody({ files, componentName, children }: DemoBodyProps) {
             />
             {active && (
               <div className={styles.sourceCode}>
-                <CodeBlock code={active.code} language={active.language} filename={active.filename} />
+                <CodeBlock
+                  code={active.code}
+                  language={active.language}
+                  filename={active.filename}
+                />
               </div>
             )}
           </div>
@@ -244,10 +248,10 @@ The migration per file:
 3. In the `<DemoLayout>` invocation, drop the four lines:
 
    ```tsx
-   tsxSource={tsxSource}
-   scssSource={scssSource}
-   tsxFilename="<X>.tsx"
-   scssFilename="<X>.module.scss"
+   tsxSource = { tsxSource };
+   scssSource = { scssSource };
+   tsxFilename = '<X>.tsx';
+   scssFilename = '<X>.module.scss';
    ```
 
 4. Add one line:

--- a/docs/superpowers/plans/2026-05-27-demo-all-component-files.md
+++ b/docs/superpowers/plans/2026-05-27-demo-all-component-files.md
@@ -1,0 +1,382 @@
+# Demo source-view: all files per component — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the two hard-coded `?raw` source imports per demo with a build-time directory scan, so every demo shows ALL public source files of its component (component + styles + tokens + index + any compound siblings).
+
+**Architecture:** One central `import.meta.glob('@lib-source/components/**/*.{tsx,ts,scss,css}', { query: '?raw', eager: true })` exposed via `getComponentFiles(name)`. `DemoBody` accepts an array of `{filename, code, language}` and renders one tab per file.
+
+**Spec:** `docs/superpowers/specs/2026-05-27-demo-all-component-files-design.md`
+
+**Branch:** `feat/demo-all-component-files` (already checked out off main)
+
+---
+
+## Task 1: Helper module
+
+**Files:**
+
+- Create: `packages/playground/src/lib/componentFiles.ts`
+
+- [ ] **Step 1: Write the helper**
+
+```ts
+const raw = import.meta.glob('@lib-source/components/**/*.{tsx,ts,scss,css}', {
+  query: '?raw',
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+export interface ComponentFile {
+  filename: string;
+  code: string;
+  language: 'tsx' | 'ts' | 'scss' | 'css';
+}
+
+const EXT_ORDER: Record<string, number> = {
+  tsx: 0,
+  scss: 1,
+  css: 1,
+  ts: 2,
+};
+
+function priority(name: string, component: string): [number, number, string] {
+  const ext = name.split('.').pop() ?? '';
+  const extRank = EXT_ORDER[ext] ?? 9;
+
+  // Within each extension family, the canonical files for the component
+  // come first.
+  let nameRank = 99;
+  if (name === `${component}.tsx`) nameRank = 0;
+  else if (ext === 'tsx') nameRank = 1;
+  else if (name === `${component}.module.scss`) nameRank = 0;
+  else if (name === `${component}.tokens.scss`) nameRank = 1;
+  else if (ext === 'scss' || ext === 'css') nameRank = 2;
+  else if (name === 'index.ts') nameRank = 99;
+  else if (ext === 'ts') nameRank = 50;
+
+  return [extRank, nameRank, name];
+}
+
+export function getComponentFiles(name: string): ComponentFile[] {
+  const dirMarker = `/components/${name}/`;
+
+  return Object.entries(raw)
+    .filter(([path]) => path.includes(dirMarker))
+    .filter(([path]) => {
+      const after = path.slice(path.indexOf(dirMarker) + dirMarker.length);
+      // Only files directly under the component dir, not nested children
+      // (none today, but safer).
+      if (after.includes('/')) return false;
+      return !after.includes('.test.');
+    })
+    .map(([path, code]) => {
+      const filename = path.slice(path.indexOf(dirMarker) + dirMarker.length);
+      const ext = filename.split('.').pop() as ComponentFile['language'];
+      return { filename, code, language: ext };
+    })
+    .sort((a, b) => {
+      const pa = priority(a.filename, name);
+      const pb = priority(b.filename, name);
+      if (pa[0] !== pb[0]) return pa[0] - pb[0];
+      if (pa[1] !== pb[1]) return pa[1] - pb[1];
+      return pa[2].localeCompare(pb[2]);
+    });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/playground/src/lib/componentFiles.ts
+git commit -m "Playground: getComponentFiles helper (build-time glob over component dirs)"
+```
+
+---
+
+## Task 2: DemoLayout / DemoBody accept the new prop shape
+
+**Files:**
+
+- Modify: `packages/playground/src/pages/components/DemoLayout.tsx`
+- Modify: `packages/playground/src/pages/components/DemoBody.tsx`
+
+- [ ] **Step 1: Update `DemoLayout`**
+
+Drop `tsxSource / scssSource / tsxFilename / scssFilename`. Add `files: ComponentFile[]`. Forward `files` to `DemoBody`.
+
+```tsx
+import { type ReactNode } from 'react';
+import { Stack } from '@eocrm/design-system';
+import { DemoBody } from './DemoBody';
+import type { ComponentName } from '../mockups/registry';
+import type { ComponentFile } from '../../lib/componentFiles';
+import styles from './DemoLayout.module.scss';
+
+export interface DemoLayoutProps {
+  name: string;
+  description: string;
+  files: ComponentFile[];
+  componentName?: ComponentName;
+  children: ReactNode;
+}
+
+export function DemoLayout({ name, description, files, componentName, children }: DemoLayoutProps) {
+  return (
+    <Stack gap="lg">
+      <header className={styles.header}>
+        <span className={styles.eyebrow}>Component</span>
+        <h1 className={styles.title}>{name}</h1>
+        <p className={styles.description}>{description}</p>
+      </header>
+
+      <DemoBody files={files} componentName={componentName}>
+        {children}
+      </DemoBody>
+    </Stack>
+  );
+}
+```
+
+- [ ] **Step 2: Update `DemoBody`**
+
+Replace the two-tab hard-code with a tab-per-file render. Active state defaults to `files[0].filename`. Render `<CodeBlock>` for the active file. Tab labels are the bare filenames.
+
+```tsx
+import { useState, type ReactNode } from 'react';
+import { ChevronDown, Code2 } from 'lucide-react';
+import { Card, Tabs } from '@eocrm/design-system';
+import { CodeBlock } from './CodeBlock';
+import { CrossLinks } from '../shared/CrossLinks';
+import type { ComponentName } from '../mockups/registry';
+import type { ComponentFile } from '../../lib/componentFiles';
+import styles from './DemoLayout.module.scss';
+
+export interface DemoBodyProps {
+  files: ComponentFile[];
+  componentName?: ComponentName;
+  children: ReactNode;
+}
+
+export function DemoBody({ files, componentName, children }: DemoBodyProps) {
+  const [activeId, setActiveId] = useState(files[0]?.filename ?? '');
+  const active = files.find((f) => f.filename === activeId) ?? files[0];
+
+  return (
+    <>
+      <Card padding="none">
+        <details className={styles.sourceDetails}>
+          <summary className={styles.sourceSummary}>
+            <span className={styles.summaryLabel}>
+              <Code2 size={14} />
+              View source code
+            </span>
+            <ChevronDown size={14} className={styles.chevron} />
+          </summary>
+          <div className={styles.sourceBody}>
+            <Tabs
+              items={files.map((f) => ({ id: f.filename, label: f.filename }))}
+              activeId={activeId}
+              onChange={setActiveId}
+            />
+            {active && (
+              <div className={styles.sourceCode}>
+                <CodeBlock code={active.code} language={active.language} filename={active.filename} />
+              </div>
+            )}
+          </div>
+        </details>
+      </Card>
+
+      <h2 className={styles.sectionTitle}>Examples</h2>
+      <div className={styles.examplesGrid}>{children}</div>
+
+      {componentName && <CrossLinks kind="component" name={componentName} />}
+    </>
+  );
+}
+```
+
+Note: `CodeBlock` already accepts `language: string` — confirm by reading `packages/playground/src/pages/components/CodeBlock.tsx`. If it accepts a narrower union, widen to include `'ts'` and `'css'`.
+
+- [ ] **Step 3: Build / typecheck**
+
+```bash
+make build
+```
+
+Fails if any demo still passes the old prop shape — that's fine, demos migrate in Task 3.
+
+To unblock typechecking in this commit, you can either (a) make the new props additionally accept the old shape behind a feature-flagged branch (don't), or (b) migrate at least one demo (e.g., `AlertDemo`) inline with this commit. Choose (b) — change `AlertDemo.tsx` to the new shape in the same commit so the build is green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/playground/src/pages/components/DemoLayout.tsx \
+        packages/playground/src/pages/components/DemoBody.tsx \
+        packages/playground/src/pages/components/AlertDemo.tsx
+git commit -m "Playground: DemoLayout/DemoBody take ComponentFile[] (one tab per file)"
+```
+
+---
+
+## Task 3: Migrate all 58 demo pages
+
+**Files:**
+
+- Modify: every `packages/playground/src/pages/components/*Demo.tsx` (except `AlertDemo.tsx` which was migrated in Task 2)
+
+The migration per file:
+
+1. Drop the two lines:
+
+   ```tsx
+   import tsxSource from '@lib-source/components/<X>/<X>.tsx?raw';
+   import scssSource from '@lib-source/components/<X>/<X>.module.scss?raw';
+   ```
+
+2. Add one line at the import block:
+
+   ```tsx
+   import { getComponentFiles } from '../../lib/componentFiles';
+   ```
+
+3. In the `<DemoLayout>` invocation, drop the four lines:
+
+   ```tsx
+   tsxSource={tsxSource}
+   scssSource={scssSource}
+   tsxFilename="<X>.tsx"
+   scssFilename="<X>.module.scss"
+   ```
+
+4. Add one line:
+
+   ```tsx
+   files={getComponentFiles('<X>')}
+   ```
+
+**The component-name string** passed to `getComponentFiles` is whatever the demo's `?raw` imports pointed at on `main`. Don't second-guess it — `grep '@lib-source/components/[A-Z]' packages/playground/src/pages/components/<X>Demo.tsx` shows the answer.
+
+- [ ] **Step 1: Migrate every demo**
+
+Do every `*Demo.tsx` in `packages/playground/src/pages/components/`. Skip files that don't `import @lib-source/...` (e.g., `ComponentsIndex.tsx`, `CodeBlock.tsx`).
+
+- [ ] **Step 2: Gates**
+
+```bash
+make build
+make lint
+```
+
+Both must be green.
+
+- [ ] **Step 3: Browser smoke-test**
+
+```bash
+make up
+```
+
+- Open http://localhost:8080/components/button — confirm three tabs (`Button.tsx`, `Button.module.scss`, `Button.tokens.scss`), each shows the right file.
+- Open `/components/dropdown-menu` — confirm 7-8 tabs including `DropdownMenu.tsx`, `Item.tsx`, `Radio.tsx`, `CheckboxItem.tsx`, `Trigger.tsx`, `DropdownMenu.module.scss`, `DropdownMenu.tokens.scss`, `index.ts`.
+- Open `/components/calendar` — confirm tabs include the calendar's many partials.
+- Open `/components/alert` — confirm Alert still works after Task 2's inline migration.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/playground/src/pages/components/
+git commit -m "Playground: migrate all 58 demos to files={getComponentFiles(...)}"
+```
+
+---
+
+## Task 4: Update playground CLAUDE.md
+
+**Files:**
+
+- Modify: `packages/playground/CLAUDE.md`
+
+- [ ] **Step 1: Replace Hard rule 3 example**
+
+In Hard rule 3, change the example block to show the new shape:
+
+```tsx
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import { getComponentFiles } from '../../lib/componentFiles';
+
+export function <Name>Demo() {
+  return (
+    <DemoLayout
+      name="<Name>"
+      componentName="<Name>"
+      description="One sentence on what it is and when to use it."
+      files={getComponentFiles('<Name>')}
+    >
+      <Example title="..." description="..." code={`...`}>
+        {/* live preview */}
+      </Example>
+      {/* more <Example> blocks for each variant / size / state */}
+    </DemoLayout>
+  );
+}
+```
+
+Add a sentence above the example: "The `files` prop is derived from a build-time scan of the component's directory — every `.tsx`, `.scss`, and `.ts` file (excluding `.test.tsx`) appears as a tab in the source-view, ordered: primary `.tsx` → other `.tsx` → `.module.scss` → `.tokens.scss` → `index.ts`."
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/playground/CLAUDE.md
+git commit -m "Playground CLAUDE.md: document files={getComponentFiles(...)} pattern"
+```
+
+---
+
+## Task 5: Push + PR
+
+- [ ] **Step 1: Final gate sweep**
+
+```bash
+make build
+make lint
+npm test -w @eocrm/design-system -- --run
+```
+
+All three green.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin feat/demo-all-component-files
+```
+
+If the pre-push hook flags prettier issues, run `npx prettier --write <files>`, add, commit, push again. Don't `--no-verify`.
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --title "Playground: source-view shows every file per component" --body "$(cat <<'EOF'
+## Summary
+
+The "View source code" panel on each component demo now shows ALL public source files in the component's directory — one tab per filename — instead of the hard-coded `Component.tsx` + `Component.module.scss` pair.
+
+Driven by a build-time `import.meta.glob` in a new helper (`packages/playground/src/lib/componentFiles.ts`); each demo replaces its two `?raw` imports + four prop lines with one `files={getComponentFiles('Component')}` prop.
+
+Visible improvements:
+
+- The `Component.tokens.scss` file added by the component-tokens migration is now visible per component.
+- Compound components (DropdownMenu, Calendar, DatePicker, DataTable) now show their sub-component sources.
+- The `index.ts` re-export manifest is visible.
+
+## Test plan
+
+- [x] `make build` / `make lint` clean
+- [x] Library tests still 2075/2075 (no library changes; smoke-check only)
+- [x] Browser: confirmed multi-tab source view on Button, DropdownMenu, Calendar, Alert
+EOF
+)"
+```
+
+Report the PR URL.

--- a/docs/superpowers/specs/2026-05-27-demo-all-component-files-design.md
+++ b/docs/superpowers/specs/2026-05-27-demo-all-component-files-design.md
@@ -1,0 +1,151 @@
+# Demo source-view: show all files per component
+
+## Problem
+
+Each component demo's "View source code" panel today shows two tabs hard-coded by the demo file:
+
+```tsx
+import tsxSource from '@lib-source/components/Alert/Alert.tsx?raw';
+import scssSource from '@lib-source/components/Alert/Alert.module.scss?raw';
+
+<DemoLayout
+  tsxSource={tsxSource}
+  scssSource={scssSource}
+  tsxFilename="Alert.tsx"
+  scssFilename="Alert.module.scss"
+  …
+/>
+```
+
+This worked when every component was exactly `<Name>.tsx` + `<Name>.module.scss`. The component-tokens migration just added a third file per component (`<Name>.tokens.scss`), and several components have always had more (compound components like `DropdownMenu` with `Item/Radio/CheckboxItem` siblings, `Calendar` with `View*`/`Day*` partials, `DatePicker` with inline/range variants). The source-view still shows only two files, so the rest is invisible to consumers reading the demo.
+
+## Goal
+
+The "View source code" panel shows **every public source file** in the component's directory — one tab per filename. The two-line manual wiring per demo is replaced with a single lookup.
+
+## Scope
+
+In scope:
+
+- A helper that reads the component's directory at build time and returns `{ filename, code, language }[]`.
+- `DemoBody` / `DemoLayout` accept `files: ComponentFile[]` and render N tabs (one per file).
+- All 58 demo pages migrated to the new API.
+- Playground `CLAUDE.md` Hard rule 3 example updated.
+
+Out of scope:
+
+- Library changes (none needed).
+- Test files in the tab strip. `<Name>.test.tsx` exists in every component dir but it's not what a consumer is looking at when they think "the component's source." They're filtered out.
+- Mockup pages. They don't use `DemoLayout`.
+
+## Design
+
+### File inclusion
+
+A file appears in the tab strip if it is inside `packages/design-system/src/components/<Name>/` AND its extension is `.tsx`, `.ts`, `.scss`, or `.css` AND it is NOT a test file (`.test.tsx`, `.test.ts`).
+
+`index.ts` IS included — consumers care which symbols are re-exported.
+
+### Tab order
+
+Files sort by a stable rule so the same component always shows the same order:
+
+1. `<Name>.tsx` first (the primary component file)
+2. Other `.tsx` files alphabetically (compound sub-components)
+3. `<Name>.module.scss`
+4. `<Name>.tokens.scss`
+5. Other `.scss` / `.css` files alphabetically
+6. `index.ts` last (the export manifest)
+7. Other `.ts` files alphabetically (rare)
+
+Rationale: humans read top-to-bottom by importance. The main component is what they came for; the export manifest is the bookkeeping they consult last.
+
+### Implementation
+
+New file: `packages/playground/src/lib/componentFiles.ts`.
+
+```ts
+const raw = import.meta.glob('@lib-source/components/**/*.{tsx,ts,scss,css}', {
+  query: '?raw',
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+export interface ComponentFile {
+  filename: string;
+  code: string;
+  language: 'tsx' | 'ts' | 'scss' | 'css';
+}
+
+export function getComponentFiles(name: string): ComponentFile[] { … }
+```
+
+`import.meta.glob` with `eager: true` and a literal-string pattern is statically analyzed by Vite: the matched files are bundled, the rest are not. Calling this function from each demo costs nothing extra — the bundle includes the same set of `?raw` source strings whether one file references them or fifty do.
+
+The filter inside `getComponentFiles`:
+
+1. Match path prefix `components/<name>/`.
+2. Reject any path containing `.test.`.
+3. Map to `{ filename: basename(path), code, language: extname(path).slice(1) }`.
+4. Sort by the order above.
+
+### DemoLayout / DemoBody API change
+
+The four props `tsxSource`, `scssSource`, `tsxFilename`, `scssFilename` collapse into one:
+
+```ts
+interface DemoLayoutProps {
+  name: string;
+  description: string;
+  files: ComponentFile[];
+  componentName?: ComponentName;
+  children: ReactNode;
+}
+```
+
+`DemoBody` renders the `<Tabs>` items from `files.map(f => ({ id: f.filename, label: f.filename }))` and the `<CodeBlock>` for the active file. The default active tab is `files[0]` (the primary `.tsx`).
+
+Edge case: if there are more than ~6 tabs, the Tabs component already handles horizontal overflow with its internal scroll behavior. No new UI is needed.
+
+### Per-demo migration
+
+Every demo loses two `?raw` imports and four prop lines, gains one helper import and one prop:
+
+```tsx
+// before
+import tsxSource from '@lib-source/components/Alert/Alert.tsx?raw';
+import scssSource from '@lib-source/components/Alert/Alert.module.scss?raw';
+
+<DemoLayout
+  name="Alert"
+  componentName="Alert"
+  description="…"
+  tsxSource={tsxSource}
+  scssSource={scssSource}
+  tsxFilename="Alert.tsx"
+  scssFilename="Alert.module.scss"
+>
+
+// after
+import { getComponentFiles } from '../../lib/componentFiles';
+
+<DemoLayout
+  name="Alert"
+  componentName="Alert"
+  description="…"
+  files={getComponentFiles('Alert')}
+>
+```
+
+This is mechanical for all 58 demos.
+
+## Risks
+
+- **Tab overflow on compound components.** `DropdownMenu` has 5 `.tsx` + 1 tokens + 1 module + 1 index = 8 tabs. `Calendar` has ~10. The existing `<Tabs>` primitive handles overflow but it's worth eyeballing in the browser.
+- **A demo whose component name differs from its dir.** Spot-check: e.g., `DatePickersDemo.tsx` covers `DatePicker` + `DateRangePicker` + inline variants. Currently it must point at one component's files; under the new helper it stays single-component. The demos call `getComponentFiles('DatePicker')` (or whatever they pointed at before), behavior unchanged.
+
+## Out of scope (deliberately deferred)
+
+- **Search across files** (find-in-source). Not asked for. Browser Cmd+F covers the displayed file.
+- **Highlight a token reference from one file to its definition in another.** Cool, lots of work, no signal anyone wants it.
+- **Show the demo `.tsx` itself as a tab.** The demo IS the page you're on; showing its own source is redundant.

--- a/packages/playground/CLAUDE.md
+++ b/packages/playground/CLAUDE.md
@@ -50,8 +50,7 @@ Every component demo:
 ```tsx
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/<Name>/<Name>.tsx?raw';
-import scssSource from '@lib-source/components/<Name>/<Name>.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function <Name>Demo() {
   return (
@@ -59,10 +58,7 @@ export function <Name>Demo() {
       name="<Name>"
       componentName="<Name>"
       description="One sentence on what it is and when to use it."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="<Name>.tsx"
-      scssFilename="<Name>.module.scss"
+      files={getComponentFiles('<Name>')}
     >
       <Example title="..." description="..." code={`...`}>
         {/* live preview */}
@@ -72,6 +68,10 @@ export function <Name>Demo() {
   );
 }
 ```
+
+The `files` prop is a build-time scan of the component's directory (`packages/playground/src/lib/componentFiles.ts`). Every `.tsx`, `.scss`, `.ts`, and `.css` file in `packages/design-system/src/components/<Name>/` becomes a tab in the source-view, excluding `.test.tsx`/`.test.ts`. Tab order: primary `<Name>.tsx` → other `.tsx` → `<Name>.module.scss` → `<Name>.tokens.scss` → other `.scss` → `index.ts` last.
+
+If your demo covers a component whose sources live outside `components/` (rare — `PaletteDemo` is the only example today), construct `files` as an inline `[{ filename, code, language }]` literal from explicit `?raw` imports.
 
 ### 4. Wire new demos into four places
 

--- a/packages/playground/src/lib/componentFiles.ts
+++ b/packages/playground/src/lib/componentFiles.ts
@@ -1,0 +1,62 @@
+const raw = import.meta.glob('@lib-source/components/**/*.{tsx,ts,scss,css}', {
+  query: '?raw',
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+export interface ComponentFile {
+  filename: string;
+  code: string;
+  language: 'tsx' | 'ts' | 'scss' | 'css';
+}
+
+const EXT_ORDER: Record<string, number> = {
+  tsx: 0,
+  scss: 1,
+  css: 1,
+  ts: 2,
+};
+
+function priority(name: string, component: string): [number, number, string] {
+  const ext = name.split('.').pop() ?? '';
+  const extRank = EXT_ORDER[ext] ?? 9;
+
+  // Within each extension family, the canonical files for the component
+  // come first.
+  let nameRank = 99;
+  if (name === `${component}.tsx`) nameRank = 0;
+  else if (ext === 'tsx') nameRank = 1;
+  else if (name === `${component}.module.scss`) nameRank = 0;
+  else if (name === `${component}.tokens.scss`) nameRank = 1;
+  else if (ext === 'scss' || ext === 'css') nameRank = 2;
+  else if (name === 'index.ts') nameRank = 99;
+  else if (ext === 'ts') nameRank = 50;
+
+  return [extRank, nameRank, name];
+}
+
+export function getComponentFiles(name: string): ComponentFile[] {
+  const dirMarker = `/components/${name}/`;
+
+  return Object.entries(raw)
+    .filter(([path]) => path.includes(dirMarker))
+    .filter(([path]) => {
+      const after = path.slice(path.indexOf(dirMarker) + dirMarker.length);
+      // Only files directly under the component dir, not nested children
+      // (none today, but safer).
+      if (after.includes('/')) return false;
+      return !after.includes('.test.');
+    })
+    .map(([path, code]) => {
+      const filename = path.slice(path.indexOf(dirMarker) + dirMarker.length);
+      const ext = filename.split('.').pop() as ComponentFile['language'];
+      return { filename, code, language: ext };
+    })
+    .sort((a, b) => {
+      const pa = priority(a.filename, name);
+      const pb = priority(b.filename, name);
+      if (pa[0] !== pb[0]) return pa[0] - pb[0];
+      if (pa[1] !== pb[1]) return pa[1] - pb[1];
+      return pa[2].localeCompare(pb[2]);
+    });
+}

--- a/packages/playground/src/pages/components/AccordionDemo.tsx
+++ b/packages/playground/src/pages/components/AccordionDemo.tsx
@@ -3,8 +3,7 @@ import { Plus } from 'lucide-react';
 import { Accordion, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Accordion/Accordion.tsx?raw';
-import scssSource from '@lib-source/components/Accordion/Accordion.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function AccordionDemo() {
   const [controlled, setControlled] = useState<string>('');
@@ -14,10 +13,7 @@ export function AccordionDemo() {
       name="Accordion"
       componentName="Accordion"
       description="Vertically-stacked collapsible panels. Compound component (Accordion.Item + Accordion.Trigger + Accordion.Content). Two modes: type='single' (one open at a time) or type='multiple' (any combination)."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Accordion.tsx"
-      scssFilename="Accordion.module.scss"
+      files={getComponentFiles('Accordion')}
     >
       <Example
         title="Single, collapsible (FAQ-style)"

--- a/packages/playground/src/pages/components/AlertDemo.tsx
+++ b/packages/playground/src/pages/components/AlertDemo.tsx
@@ -3,8 +3,7 @@ import { Bell } from 'lucide-react';
 import { Alert, Button, Cluster, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Alert/Alert.tsx?raw';
-import scssSource from '@lib-source/components/Alert/Alert.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function AlertDemo() {
   const [showSaved, setShowSaved] = useState(true);
@@ -14,10 +13,7 @@ export function AlertDemo() {
       name="Alert"
       componentName="Alert"
       description="Persistent in-flow notification. Four tones with tinted background + accent stripe. Optional title / description / icon / actions / dismiss. Use Toast for transient messages instead."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Alert.tsx"
-      scssFilename="Alert.module.scss"
+      files={getComponentFiles('Alert')}
     >
       <Example
         title="Four tones"

--- a/packages/playground/src/pages/components/AvatarDemo.tsx
+++ b/packages/playground/src/pages/components/AvatarDemo.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { Avatar, AvatarGroup, Cluster, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Avatar/Avatar.tsx?raw';
-import scssSource from '@lib-source/components/Avatar/Avatar.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 const TEAM = [
   'Alex Rivera',
@@ -38,10 +37,7 @@ export function AvatarDemo() {
     <DemoLayout
       name="Avatar"
       description="Circular profile element. Renders an image if src is provided, otherwise the person's initials on a deterministic color background — the same name always gets the same color."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Avatar.tsx"
-      scssFilename="Avatar.module.scss"
+      files={getComponentFiles('Avatar')}
       componentName="Avatar"
     >
       <Example

--- a/packages/playground/src/pages/components/BadgeDemo.tsx
+++ b/packages/playground/src/pages/components/BadgeDemo.tsx
@@ -3,18 +3,14 @@ import { Cluster } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Badge/Badge.tsx?raw';
-import scssSource from '@lib-source/components/Badge/Badge.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function BadgeDemo() {
   return (
     <DemoLayout
       name="Badge"
       description="Small inline pill for status, category, or count. Use semantic tones consistently — success means good, danger means problematic, etc."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Badge.tsx"
-      scssFilename="Badge.module.scss"
+      files={getComponentFiles('Badge')}
       componentName="Badge"
     >
       <Example

--- a/packages/playground/src/pages/components/BreadcrumbDemo.tsx
+++ b/packages/playground/src/pages/components/BreadcrumbDemo.tsx
@@ -3,8 +3,7 @@ import { Slash } from 'lucide-react';
 import { Breadcrumb } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Breadcrumb/Breadcrumb.tsx?raw';
-import scssSource from '@lib-source/components/Breadcrumb/Breadcrumb.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function BreadcrumbDemo() {
   return (
@@ -12,10 +11,7 @@ export function BreadcrumbDemo() {
       name="Breadcrumb"
       componentName="Breadcrumb"
       description="Compound navigation breadcrumb. Last child auto-marks as the current page. Default separator is a ChevronRight icon."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Breadcrumb.tsx"
-      scssFilename="Breadcrumb.module.scss"
+      files={getComponentFiles('Breadcrumb')}
     >
       <Example
         title="Basic — auto-current on last child"

--- a/packages/playground/src/pages/components/ButtonDemo.tsx
+++ b/packages/playground/src/pages/components/ButtonDemo.tsx
@@ -3,8 +3,7 @@ import { Check, Pencil, Plus, Search, Trash2, X } from 'lucide-react';
 import { Button, Cluster } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Button/Button.tsx?raw';
-import scssSource from '@lib-source/components/Button/Button.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 function SaveWithSuccessFlash() {
   const [saved, setSaved] = useState(false);
@@ -43,10 +42,7 @@ export function ButtonDemo() {
     <DemoLayout
       name="Button"
       description="Renders a <button>. The action element you reach for first — submit a form, open a modal, delete a row, navigate within the app."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Button.tsx"
-      scssFilename="Button.module.scss"
+      files={getComponentFiles('Button')}
       componentName="Button"
     >
       <Example

--- a/packages/playground/src/pages/components/ButtonGroupDemo.tsx
+++ b/packages/playground/src/pages/components/ButtonGroupDemo.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { Button, ButtonGroup, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/ButtonGroup/ButtonGroup.tsx?raw';
-import scssSource from '@lib-source/components/ButtonGroup/ButtonGroup.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function ButtonGroupDemo() {
   return (
@@ -11,10 +10,7 @@ export function ButtonGroupDemo() {
       name="ButtonGroup"
       componentName="ButtonGroup"
       description="Compound with two modes. Visual mode joins <Button> children into a single unit (toolbar actions). Segmented mode (value + onValueChange) is a single-select radiogroup with arrow-key navigation (view toggles, timeframe filters)."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="ButtonGroup.tsx"
-      scssFilename="ButtonGroup.module.scss"
+      files={getComponentFiles('ButtonGroup')}
     >
       <VisualSimpleExample />
       <VisualMixedVariantsExample />

--- a/packages/playground/src/pages/components/CalendarDemo.tsx
+++ b/packages/playground/src/pages/components/CalendarDemo.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { Calendar, type CalendarEvent, type CalendarView } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Calendar/Calendar.tsx?raw';
-import scssSource from '@lib-source/components/Calendar/Calendar.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 // ── Demo data ───────────────────────────────────────────────────────────────
 //
@@ -170,10 +169,7 @@ export function CalendarDemo() {
       name="Calendar"
       componentName="Calendar"
       description="Month view with continuous event bars. Multi-day events span across days; week boundaries split into separate bars with flattened edges."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Calendar.tsx"
-      scssFilename="Calendar.module.scss"
+      files={getComponentFiles('Calendar')}
     >
       <Example
         title="Default (empty)"

--- a/packages/playground/src/pages/components/CardDemo.tsx
+++ b/packages/playground/src/pages/components/CardDemo.tsx
@@ -7,18 +7,14 @@ import { Button } from '@eocrm/design-system';
 import { Link } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Card/Card.tsx?raw';
-import scssSource from '@lib-source/components/Card/Card.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function CardDemo() {
   return (
     <DemoLayout
       name="Card"
       description="A bordered container for grouping related content. Used for stat panels, list rows, info blocks. Do not nest cards inside cards."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Card.tsx"
-      scssFilename="Card.module.scss"
+      files={getComponentFiles('Card')}
       componentName="Card"
     >
       <Example

--- a/packages/playground/src/pages/components/CheckboxDemo.tsx
+++ b/packages/playground/src/pages/components/CheckboxDemo.tsx
@@ -3,8 +3,7 @@ import { Button, Checkbox, Stack, Text, type PaletteColor } from '@eocrm/design-
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/Checkbox/Checkbox.tsx?raw';
-import scssSource from '@lib-source/components/Checkbox/Checkbox.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 const TEAM = ['Alex', 'Priya', 'Tom', 'Sara', 'Jaden'];
 
@@ -136,10 +135,7 @@ export function CheckboxDemo() {
       name="Checkbox"
       componentName="Checkbox"
       description="Native `<input type='checkbox'>` visually hidden + custom-painted box. Supports controlled / uncontrolled state, indeterminate (mixed) state, sizes, label, disabled, invalid, and full native form integration."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Checkbox.tsx"
-      scssFilename="Checkbox.module.scss"
+      files={getComponentFiles('Checkbox')}
     >
       <Example
         title="Default"

--- a/packages/playground/src/pages/components/CircularProgressDemo.tsx
+++ b/packages/playground/src/pages/components/CircularProgressDemo.tsx
@@ -5,18 +5,14 @@ import { Cluster } from '@eocrm/design-system';
 import { Text } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/CircularProgress/CircularProgress.tsx?raw';
-import scssSource from '@lib-source/components/CircularProgress/CircularProgress.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function CircularProgressDemo() {
   return (
     <DemoLayout
       name="CircularProgress"
       description="Circular progress / loading spinner. Determinate via value/max draws a donut arc; indeterminate is the canonical inline 'Saving…' spinner. Same prop vocabulary as <Progress>."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="CircularProgress.tsx"
-      scssFilename="CircularProgress.module.scss"
+      files={getComponentFiles('CircularProgress')}
       componentName="CircularProgress"
     >
       <Example

--- a/packages/playground/src/pages/components/ClusterDemo.tsx
+++ b/packages/playground/src/pages/components/ClusterDemo.tsx
@@ -5,8 +5,7 @@ import { Badge } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import outlineStyles from './demoOutline.module.scss';
-import tsxSource from '@lib-source/components/Cluster/Cluster.tsx?raw';
-import scssSource from '@lib-source/components/Cluster/Cluster.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 const Block = ({ children }: { children: React.ReactNode }) => (
   <div
@@ -28,10 +27,7 @@ export function ClusterDemo() {
     <DemoLayout
       name="Cluster"
       description="Horizontal flex layout that wraps. Use for button rows, toolbars, tag lists, breadcrumbs. Replaces ad-hoc display: flex with flex-wrap."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Cluster.tsx"
-      scssFilename="Cluster.module.scss"
+      files={getComponentFiles('Cluster')}
       componentName="Cluster"
     >
       <Example

--- a/packages/playground/src/pages/components/CodeBlock.tsx
+++ b/packages/playground/src/pages/components/CodeBlock.tsx
@@ -7,7 +7,7 @@ import styles from './CodeBlock.module.scss';
 
 export interface CodeBlockProps {
   code: string;
-  language?: 'tsx' | 'scss' | 'css' | 'json';
+  language?: 'tsx' | 'ts' | 'scss' | 'css' | 'json';
   filename?: string;
   className?: string;
 }

--- a/packages/playground/src/pages/components/CodeDemo.tsx
+++ b/packages/playground/src/pages/components/CodeDemo.tsx
@@ -4,18 +4,14 @@ import { Stack } from '@eocrm/design-system';
 import { Cluster } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Code/Code.tsx?raw';
-import scssSource from '@lib-source/components/Code/Code.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function CodeDemo() {
   return (
     <DemoLayout
       name="Code"
       description="Inline <code> chip — monospace text with a subtle background. Inline only; block code with syntax highlighting lives in the playground's CodeBlock (Prism)."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Code.tsx"
-      scssFilename="Code.module.scss"
+      files={getComponentFiles('Code')}
       componentName="Code"
     >
       <Example

--- a/packages/playground/src/pages/components/ColorPickerDemo.tsx
+++ b/packages/playground/src/pages/components/ColorPickerDemo.tsx
@@ -7,8 +7,7 @@ import { Text } from '@eocrm/design-system';
 import { Code } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/ColorPicker/ColorPicker.tsx?raw';
-import scssSource from '@lib-source/components/ColorPicker/ColorPicker.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 const BRAND_PRESETS = [
   '#4F46E5',
@@ -88,10 +87,7 @@ export function ColorPickerDemo() {
     <DemoLayout
       name="ColorPicker"
       description="Controlled HEX color picker with two distribution shapes — compact popover trigger for form fields, and an inline <ColorPicker.Panel> for theme builders. Hand-rolled SV square + hue slider + HEX input. Consumer-supplied preset swatches."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="ColorPicker.tsx"
-      scssFilename="ColorPicker.module.scss"
+      files={getComponentFiles('ColorPicker')}
       componentName="ColorPicker"
     >
       <Example

--- a/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
+++ b/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { Button, Cluster, ConfirmationPopover, DropdownMenu } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/ConfirmationPopover/ConfirmationPopover.tsx?raw';
-import scssSource from '@lib-source/components/ConfirmationPopover/ConfirmationPopover.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 const fakeDelay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -16,10 +15,7 @@ export function ConfirmationPopoverDemo() {
       name="ConfirmationPopover"
       componentName="ConfirmationPopover"
       description="Opinionated 'Are you sure?' preset on top of Popover. Title + optional description + Cancel + Confirm. Initial focus on Cancel; async-aware onConfirm with pending state."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="ConfirmationPopover.tsx"
-      scssFilename="ConfirmationPopover.module.scss"
+      files={getComponentFiles('ConfirmationPopover')}
     >
       <Example
         title="Default variant — Archive"

--- a/packages/playground/src/pages/components/DataTableDemo.tsx
+++ b/packages/playground/src/pages/components/DataTableDemo.tsx
@@ -11,8 +11,7 @@ import {
 } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/DataTable/DataTable.tsx?raw';
-import scssSource from '@lib-source/components/DataTable/DataTable.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 type Deal = {
   id: string;
@@ -83,10 +82,7 @@ export function DataTableDemo() {
       name="DataTable"
       componentName="DataTable"
       description="Composition over the Table primitive with column ordering / sizing / visibility, row selection, row click, sortable headers, loading/empty states, plus left/right column pinning and pinned rows (Phase 2). Expandable rows ship in Phase 3."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="DataTable.tsx"
-      scssFilename="DataTable.module.scss"
+      files={getComponentFiles('DataTable')}
     >
       <BasicExample />
       <BorderedExample />

--- a/packages/playground/src/pages/components/DatePickerDemo.tsx
+++ b/packages/playground/src/pages/components/DatePickerDemo.tsx
@@ -47,10 +47,7 @@ function FormDemo() {
 
 export function DatePickerDemoPanel() {
   return (
-    <DemoBody
-      files={getComponentFiles('DatePicker')}
-      componentName="DatePicker"
-    >
+    <DemoBody files={getComponentFiles('DatePicker')} componentName="DatePicker">
       <Example
         title="Uncontrolled"
         description="No `value` / `onChange` — the picker owns state. Type a date, click in the grid, or use the clear button."

--- a/packages/playground/src/pages/components/DatePickerDemo.tsx
+++ b/packages/playground/src/pages/components/DatePickerDemo.tsx
@@ -3,8 +3,7 @@ import { Button, DatePicker, Stack, toDateKey } from '@eocrm/design-system';
 import { DemoBody } from './DemoBody';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/DatePicker/DatePicker.tsx?raw';
-import scssSource from '@lib-source/components/DatePicker/DatePicker.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 const TODAY = new Date();
 const IN_90_DAYS = new Date(TODAY.getFullYear(), TODAY.getMonth(), TODAY.getDate() + 90);
@@ -49,10 +48,7 @@ function FormDemo() {
 export function DatePickerDemoPanel() {
   return (
     <DemoBody
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="DatePicker.tsx"
-      scssFilename="DatePicker.module.scss"
+      files={getComponentFiles('DatePicker')}
       componentName="DatePicker"
     >
       <Example

--- a/packages/playground/src/pages/components/DateRangePickerDemo.tsx
+++ b/packages/playground/src/pages/components/DateRangePickerDemo.tsx
@@ -3,8 +3,7 @@ import { Button, DateRangePicker, Stack, toDateKey, type DateRange } from '@eocr
 import { DemoBody } from './DemoBody';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/DateRangePicker/DateRangePicker.tsx?raw';
-import scssSource from '@lib-source/components/DateRangePicker/DateRangePicker.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 const TODAY = new Date();
 const IN_14 = new Date(TODAY.getFullYear(), TODAY.getMonth(), TODAY.getDate() + 14);
@@ -62,10 +61,7 @@ function FormDemo() {
 export function DateRangePickerDemoPanel() {
   return (
     <DemoBody
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="DateRangePicker.tsx"
-      scssFilename="DateRangePicker.module.scss"
+      files={getComponentFiles('DateRangePicker')}
       componentName="DateRangePicker"
     >
       <Example

--- a/packages/playground/src/pages/components/DateRangePickerDemo.tsx
+++ b/packages/playground/src/pages/components/DateRangePickerDemo.tsx
@@ -60,10 +60,7 @@ function FormDemo() {
 
 export function DateRangePickerDemoPanel() {
   return (
-    <DemoBody
-      files={getComponentFiles('DateRangePicker')}
-      componentName="DateRangePicker"
-    >
+    <DemoBody files={getComponentFiles('DateRangePicker')} componentName="DateRangePicker">
       <Example
         title="Uncontrolled"
         description="No `value` / `onChange` — the picker owns state. Click the input or the calendar button to open; pick start then end."

--- a/packages/playground/src/pages/components/DefinitionListDemo.tsx
+++ b/packages/playground/src/pages/components/DefinitionListDemo.tsx
@@ -2,8 +2,7 @@ import { Mail, Phone, Building, MapPin, Globe, Briefcase, Cake, User } from 'luc
 import { Badge, Cluster, DefinitionList, Link, Stack, Text } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/DefinitionList/DefinitionList.tsx?raw';
-import scssSource from '@lib-source/components/DefinitionList/DefinitionList.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function DefinitionListDemo() {
   return (
@@ -11,10 +10,7 @@ export function DefinitionListDemo() {
       name="DefinitionList"
       componentName="DefinitionList"
       description="Semantic key/value pairs (dl/dt/dd) with optional leading icon on the description. Use this instead of Card.List when every row has a label."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="DefinitionList.tsx"
-      scssFilename="DefinitionList.module.scss"
+      files={getComponentFiles('DefinitionList')}
     >
       <Example
         title="Horizontal with icons"

--- a/packages/playground/src/pages/components/DemoBody.tsx
+++ b/packages/playground/src/pages/components/DemoBody.tsx
@@ -41,7 +41,11 @@ export function DemoBody({ files, componentName, children }: DemoBodyProps) {
             />
             {active && (
               <div className={styles.sourceCode}>
-                <CodeBlock code={active.code} language={active.language} filename={active.filename} />
+                <CodeBlock
+                  code={active.code}
+                  language={active.language}
+                  filename={active.filename}
+                />
               </div>
             )}
           </div>

--- a/packages/playground/src/pages/components/DemoBody.tsx
+++ b/packages/playground/src/pages/components/DemoBody.tsx
@@ -4,13 +4,11 @@ import { Card, Tabs } from '@eocrm/design-system';
 import { CodeBlock } from './CodeBlock';
 import { CrossLinks } from '../shared/CrossLinks';
 import type { ComponentName } from '../mockups/registry';
+import type { ComponentFile } from '../../lib/componentFiles';
 import styles from './DemoLayout.module.scss';
 
 export interface DemoBodyProps {
-  tsxSource: string;
-  scssSource: string;
-  tsxFilename: string;
-  scssFilename: string;
+  files: ComponentFile[];
   componentName?: ComponentName;
   children: ReactNode;
 }
@@ -20,15 +18,9 @@ export interface DemoBodyProps {
  * `<DemoLayout>` — reusable inside multi-variant pages where the page
  * header is rendered once and tabs swap the body.
  */
-export function DemoBody({
-  tsxSource,
-  scssSource,
-  tsxFilename,
-  scssFilename,
-  componentName,
-  children,
-}: DemoBodyProps) {
-  const [sourceTab, setSourceTab] = useState<'tsx' | 'scss'>('tsx');
+export function DemoBody({ files, componentName, children }: DemoBodyProps) {
+  const [activeId, setActiveId] = useState(files[0]?.filename ?? '');
+  const active = files.find((f) => f.filename === activeId) ?? files[0];
 
   return (
     <>
@@ -43,20 +35,15 @@ export function DemoBody({
           </summary>
           <div className={styles.sourceBody}>
             <Tabs
-              items={[
-                { id: 'tsx', label: 'Component' },
-                { id: 'scss', label: 'Styles' },
-              ]}
-              activeId={sourceTab}
-              onChange={(id) => setSourceTab(id as 'tsx' | 'scss')}
+              items={files.map((f) => ({ id: f.filename, label: f.filename }))}
+              activeId={activeId}
+              onChange={setActiveId}
             />
-            <div className={styles.sourceCode}>
-              {sourceTab === 'tsx' ? (
-                <CodeBlock code={tsxSource} language="tsx" filename={tsxFilename} />
-              ) : (
-                <CodeBlock code={scssSource} language="scss" filename={scssFilename} />
-              )}
-            </div>
+            {active && (
+              <div className={styles.sourceCode}>
+                <CodeBlock code={active.code} language={active.language} filename={active.filename} />
+              </div>
+            )}
           </div>
         </details>
       </Card>

--- a/packages/playground/src/pages/components/DemoLayout.tsx
+++ b/packages/playground/src/pages/components/DemoLayout.tsx
@@ -2,29 +2,18 @@ import { type ReactNode } from 'react';
 import { Stack } from '@eocrm/design-system';
 import { DemoBody } from './DemoBody';
 import type { ComponentName } from '../mockups/registry';
+import type { ComponentFile } from '../../lib/componentFiles';
 import styles from './DemoLayout.module.scss';
 
 export interface DemoLayoutProps {
   name: string;
   description: string;
-  tsxSource: string;
-  scssSource: string;
-  tsxFilename: string;
-  scssFilename: string;
+  files: ComponentFile[];
   componentName?: ComponentName;
   children: ReactNode;
 }
 
-export function DemoLayout({
-  name,
-  description,
-  tsxSource,
-  scssSource,
-  tsxFilename,
-  scssFilename,
-  componentName,
-  children,
-}: DemoLayoutProps) {
+export function DemoLayout({ name, description, files, componentName, children }: DemoLayoutProps) {
   return (
     <Stack gap="lg">
       <header className={styles.header}>
@@ -33,13 +22,7 @@ export function DemoLayout({
         <p className={styles.description}>{description}</p>
       </header>
 
-      <DemoBody
-        tsxSource={tsxSource}
-        scssSource={scssSource}
-        tsxFilename={tsxFilename}
-        scssFilename={scssFilename}
-        componentName={componentName}
-      >
+      <DemoBody files={files} componentName={componentName}>
         {children}
       </DemoBody>
     </Stack>

--- a/packages/playground/src/pages/components/DividerDemo.tsx
+++ b/packages/playground/src/pages/components/DividerDemo.tsx
@@ -1,8 +1,7 @@
 import { Button, Card, Cluster, Divider, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Divider/Divider.tsx?raw';
-import scssSource from '@lib-source/components/Divider/Divider.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function DividerDemo() {
   return (
@@ -10,10 +9,7 @@ export function DividerDemo() {
       name="Divider"
       componentName="Divider"
       description="Thin separator primitive. Horizontal or vertical, solid or dashed, three size tiers, optional centered label."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Divider.tsx"
-      scssFilename="Divider.module.scss"
+      files={getComponentFiles('Divider')}
     >
       <Example
         title="Horizontal default"

--- a/packages/playground/src/pages/components/DrawerDemo.tsx
+++ b/packages/playground/src/pages/components/DrawerDemo.tsx
@@ -2,8 +2,7 @@ import { useRef, useState } from 'react';
 import { Button, Cluster, Drawer, Input, Modal, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Drawer/DrawerRoot.tsx?raw';
-import scssSource from '@lib-source/components/Drawer/Drawer.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function DrawerDemo() {
   return (
@@ -11,10 +10,7 @@ export function DrawerDemo() {
       name="Drawer"
       componentName="Drawer"
       description="Edge-anchored slide-in panel. Four sides (left/right/top/bottom), three sizes, overlay variants, drag-to-close on mobile, and cross-component stacking with Modal."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="DrawerRoot.tsx"
-      scssFilename="Drawer.module.scss"
+      files={getComponentFiles('Drawer')}
     >
       <BasicExample />
       <SidesExample />

--- a/packages/playground/src/pages/components/DropdownMenuDemo.tsx
+++ b/packages/playground/src/pages/components/DropdownMenuDemo.tsx
@@ -6,8 +6,7 @@ import { DropdownMenu } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/DropdownMenu/DropdownMenu.tsx?raw';
-import scssSource from '@lib-source/components/DropdownMenu/DropdownMenu.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function DropdownMenuDemo() {
   return (
@@ -15,10 +14,7 @@ export function DropdownMenuDemo() {
       name="DropdownMenu"
       componentName="DropdownMenu"
       description="Action menu opened from a trigger. Compound API — pair Trigger / Content / Item / Separator. Portaled, Floating-UI-positioned, full WAI-ARIA menu keyboard behavior."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="DropdownMenu.tsx"
-      scssFilename="DropdownMenu.module.scss"
+      files={getComponentFiles('DropdownMenu')}
     >
       <Example
         title="Toolbar overflow"

--- a/packages/playground/src/pages/components/EmptyStateDemo.tsx
+++ b/packages/playground/src/pages/components/EmptyStateDemo.tsx
@@ -2,8 +2,7 @@ import { Button, Card, Cluster, EmptyState, Stack, Table } from '@eocrm/design-s
 import { Inbox, PackageOpen, Search, SearchX, Users } from 'lucide-react';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/EmptyState/EmptyState.tsx?raw';
-import scssSource from '@lib-source/components/EmptyState/EmptyState.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function EmptyStateDemo() {
   return (
@@ -11,10 +10,7 @@ export function EmptyStateDemo() {
       name="EmptyState"
       componentName="EmptyState"
       description="Opinionated 'nothing here' container — icon, title, description, actions. Three sizes for inline / card / hero use."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="EmptyState.tsx"
-      scssFilename="EmptyState.module.scss"
+      files={getComponentFiles('EmptyState')}
     >
       <Example
         title="Title only"

--- a/packages/playground/src/pages/components/FileUploadDemo.tsx
+++ b/packages/playground/src/pages/components/FileUploadDemo.tsx
@@ -7,8 +7,7 @@ import { Text } from '@eocrm/design-system';
 import { Code } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/FileUpload/FileUpload.tsx?raw';
-import scssSource from '@lib-source/components/FileUpload/FileUpload.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 function makeId() {
   // crypto.randomUUID exists in modern browsers; fall back to a counter for jsdom.
@@ -189,10 +188,7 @@ export function FileUploadDemo() {
     <DemoLayout
       name="FileUpload"
       description="Controlled, dropzone-style file picker. Pure UI shell — consumer owns the FileEntry[] state and the upload network code. Drop or click to add files; the component handles validation, drag-over feedback, per-row rendering, and the remove button."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="FileUpload.tsx"
-      scssFilename="FileUpload.module.scss"
+      files={getComponentFiles('FileUpload')}
       componentName="FileUpload"
     >
       <Example

--- a/packages/playground/src/pages/components/FilterChipDemo.tsx
+++ b/packages/playground/src/pages/components/FilterChipDemo.tsx
@@ -3,8 +3,7 @@ import { Cluster, FilterChip } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/FilterChip/FilterChip.tsx?raw';
-import scssSource from '@lib-source/components/FilterChip/FilterChip.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function FilterChipDemo() {
   const [chips, setChips] = useState<string[]>(['event', 'tenant']);
@@ -15,10 +14,7 @@ export function FilterChipDemo() {
       name="FilterChip"
       componentName="FilterChip"
       description='Dismissible "active filter" pill: Label + tone-dotted Value + auto-rendered × button when onDismiss is passed.'
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="FilterChip.tsx"
-      scssFilename="FilterChip.module.scss"
+      files={getComponentFiles('FilterChip')}
     >
       <Example
         title="Label + tone-dotted value + dismiss"

--- a/packages/playground/src/pages/components/GridDemo.tsx
+++ b/packages/playground/src/pages/components/GridDemo.tsx
@@ -1,8 +1,7 @@
 import { Card, Cluster, Grid, Input, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Grid/Grid.tsx?raw';
-import scssSource from '@lib-source/components/Grid/Grid.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function GridDemo() {
   return (
@@ -10,10 +9,7 @@ export function GridDemo() {
       name="Grid"
       componentName="Grid"
       description="2D layout primitive — CSS Grid wrapper. Use it when you need equal-width columns OR a responsive tile layout that reflows by container width (no breakpoints needed). Pair with Stack (vertical) and Cluster (horizontal-with-wrap)."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Grid.tsx"
-      scssFilename="Grid.module.scss"
+      files={getComponentFiles('Grid')}
     >
       <AutoFitExample />
       <FixedColumnsExample />

--- a/packages/playground/src/pages/components/ImageCropDemo.tsx
+++ b/packages/playground/src/pages/components/ImageCropDemo.tsx
@@ -14,8 +14,7 @@ import { Code } from '@eocrm/design-system';
 import { CircularProgress } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/ImageCrop/ImageCrop.tsx?raw';
-import scssSource from '@lib-source/components/ImageCrop/ImageCrop.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 // Public sample image used across all examples — a generic photo from picsum.
 // Using a fixed seed so the image is stable across page loads.
@@ -193,10 +192,7 @@ export function ImageCropDemo() {
     <DemoLayout
       name="ImageCrop"
       description="Controlled image-crop primitive. Pattern-A drag (crop box centered, image dragged, slider-controlled zoom). Hand-rolled on <canvas>. extractCropBlob utility for the consumer's Save handler."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="ImageCrop.tsx"
-      scssFilename="ImageCrop.module.scss"
+      files={getComponentFiles('ImageCrop')}
       componentName="ImageCrop"
     >
       <Example

--- a/packages/playground/src/pages/components/InlineDatePickerDemo.tsx
+++ b/packages/playground/src/pages/components/InlineDatePickerDemo.tsx
@@ -47,10 +47,7 @@ function FormDemo() {
 
 export function InlineDatePickerDemoPanel() {
   return (
-    <DemoBody
-      files={getComponentFiles('DatePicker')}
-      componentName="InlineDatePicker"
-    >
+    <DemoBody files={getComponentFiles('DatePicker')} componentName="InlineDatePicker">
       <Example
         title="Uncontrolled"
         description="No `value` / `onChange` — the picker owns state. Click a cell to set; use the chevrons or PageUp/PageDown to navigate."

--- a/packages/playground/src/pages/components/InlineDatePickerDemo.tsx
+++ b/packages/playground/src/pages/components/InlineDatePickerDemo.tsx
@@ -3,8 +3,7 @@ import { Button, InlineDatePicker, Stack, toDateKey } from '@eocrm/design-system
 import { DemoBody } from './DemoBody';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/DatePicker/InlineDatePicker.tsx?raw';
-import scssSource from '@lib-source/components/DatePicker/InlineDatePicker.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 const TODAY = new Date();
 const IN_90 = new Date(TODAY.getFullYear(), TODAY.getMonth(), TODAY.getDate() + 90);
@@ -49,10 +48,7 @@ function FormDemo() {
 export function InlineDatePickerDemoPanel() {
   return (
     <DemoBody
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="InlineDatePicker.tsx"
-      scssFilename="InlineDatePicker.module.scss"
+      files={getComponentFiles('DatePicker')}
       componentName="InlineDatePicker"
     >
       <Example

--- a/packages/playground/src/pages/components/InlineDateRangePickerDemo.tsx
+++ b/packages/playground/src/pages/components/InlineDateRangePickerDemo.tsx
@@ -63,10 +63,7 @@ function FormDemo() {
 
 export function InlineDateRangePickerDemoPanel() {
   return (
-    <DemoBody
-      files={getComponentFiles('DateRangePicker')}
-      componentName="InlineDateRangePicker"
-    >
+    <DemoBody files={getComponentFiles('DateRangePicker')} componentName="InlineDateRangePicker">
       <Example
         title="Uncontrolled"
         description="No `value` / `onChange` — the picker owns state. Click start then end; hover (or arrow-key) between clicks shows the preview range."

--- a/packages/playground/src/pages/components/InlineDateRangePickerDemo.tsx
+++ b/packages/playground/src/pages/components/InlineDateRangePickerDemo.tsx
@@ -9,8 +9,7 @@ import {
 import { DemoBody } from './DemoBody';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/DateRangePicker/InlineDateRangePicker.tsx?raw';
-import scssSource from '@lib-source/components/DateRangePicker/InlineDateRangePicker.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 const TODAY = new Date();
 const IN_14 = new Date(TODAY.getFullYear(), TODAY.getMonth(), TODAY.getDate() + 14);
@@ -65,10 +64,7 @@ function FormDemo() {
 export function InlineDateRangePickerDemoPanel() {
   return (
     <DemoBody
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="InlineDateRangePicker.tsx"
-      scssFilename="InlineDateRangePicker.module.scss"
+      files={getComponentFiles('DateRangePicker')}
       componentName="InlineDateRangePicker"
     >
       <Example

--- a/packages/playground/src/pages/components/InputDemo.tsx
+++ b/packages/playground/src/pages/components/InputDemo.tsx
@@ -3,8 +3,7 @@ import { Input, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/Input/Input.tsx?raw';
-import scssSource from '@lib-source/components/Input/Input.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function InputDemo() {
   const [value, setValue] = useState('priya@acme.com');
@@ -14,10 +13,7 @@ export function InputDemo() {
     <DemoLayout
       name="Input"
       description="A controlled single-line text field. Renders an <input> and forwards all native props. The component is deliberately dumb — validation logic lives in your form layer."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Input.tsx"
-      scssFilename="Input.module.scss"
+      files={getComponentFiles('Input')}
       componentName="Input"
     >
       <Example

--- a/packages/playground/src/pages/components/KanbanDemo.tsx
+++ b/packages/playground/src/pages/components/KanbanDemo.tsx
@@ -14,8 +14,7 @@ import {
 } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Kanban/Kanban.tsx?raw';
-import scssSource from '@lib-source/components/Kanban/Kanban.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 type ColId = 'todo' | 'doing' | 'done';
 
@@ -80,10 +79,7 @@ export function KanbanDemo() {
       name="Kanban"
       componentName="Kanban"
       description="Multi-column board with live cross-column drag. Cards reflow into the target column as the dragged card crosses in — internal state, consumer's onMove fires once on drop."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Kanban.tsx"
-      scssFilename="Kanban.module.scss"
+      files={getComponentFiles('Kanban')}
     >
       <Example
         title="Basic board (3 columns)"

--- a/packages/playground/src/pages/components/LinkDemo.tsx
+++ b/packages/playground/src/pages/components/LinkDemo.tsx
@@ -3,8 +3,7 @@ import { ExternalLink } from 'lucide-react';
 import { Cluster, Link, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Link/Link.tsx?raw';
-import scssSource from '@lib-source/components/Link/Link.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function LinkDemo() {
   return (
@@ -12,10 +11,7 @@ export function LinkDemo() {
       name="Link"
       componentName="Link"
       description="Polymorphic styled anchor. Default <a>; consumers pass `as={RouterLink}` for SPA navigation. Three visual variants cover inline CTA, muted nav, and subtle name-link patterns."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Link.tsx"
-      scssFilename="Link.module.scss"
+      files={getComponentFiles('Link')}
     >
       <Example
         title="Default — external link"

--- a/packages/playground/src/pages/components/ModalDemo.tsx
+++ b/packages/playground/src/pages/components/ModalDemo.tsx
@@ -2,8 +2,7 @@ import { useRef, useState } from 'react';
 import { Badge, Button, Cluster, Input, Modal, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Modal/ModalRoot.tsx?raw';
-import scssSource from '@lib-source/components/Modal/Modal.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function ModalDemo() {
   return (
@@ -11,10 +10,7 @@ export function ModalDemo() {
       name="Modal"
       componentName="Modal"
       description="Focus-locked, scroll-locked dialog with a compound API (Header / Body / Footer / Close). Three size presets, solid + blur overlay variants, fullscreen on mobile. Stacked-modal support: overlay mode (default) keeps the parent visible; replace mode hides it."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="ModalRoot.tsx"
-      scssFilename="Modal.module.scss"
+      files={getComponentFiles('Modal')}
     >
       <BasicExample />
       <SizesExample />

--- a/packages/playground/src/pages/components/OptionsPickerDemo.tsx
+++ b/packages/playground/src/pages/components/OptionsPickerDemo.tsx
@@ -4,8 +4,7 @@ import { Button, OptionsPicker, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/OptionsPicker/OptionsPicker.tsx?raw';
-import scssSource from '@lib-source/components/OptionsPicker/OptionsPicker.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 const flatOptions = [
   { value: 'lead', label: 'Lead' },
@@ -67,10 +66,7 @@ export function OptionsPickerDemo() {
       name="OptionsPicker"
       componentName="OptionsPicker"
       description="Filter-picker UX: popover with search, optional grouping, multi/single select, draft-then-Apply commit."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="OptionsPicker.tsx"
-      scssFilename="OptionsPicker.module.scss"
+      files={getComponentFiles('OptionsPicker')}
     >
       <Example
         title="Multi-select, flat options"

--- a/packages/playground/src/pages/components/PageDemo.tsx
+++ b/packages/playground/src/pages/components/PageDemo.tsx
@@ -2,8 +2,7 @@ import { Card, Page, Text } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/Page/Page.tsx?raw';
-import scssSource from '@lib-source/components/Page/Page.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 function Stand({ children }: { children: string }) {
   return (
@@ -19,10 +18,7 @@ export function PageDemo() {
       name="Page"
       componentName="Page"
       description="Page-root layout primitive. Wraps a CRM page's top-level sections with the canonical vertical rhythm (gap='lg'). Each example shows the same three sections under a different gap setting."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Page.tsx"
-      scssFilename="Page.module.scss"
+      files={getComponentFiles('Page')}
     >
       <Example
         title='Default — gap="lg"'

--- a/packages/playground/src/pages/components/PageHeaderDemo.tsx
+++ b/packages/playground/src/pages/components/PageHeaderDemo.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { PageHeader, Avatar, Badge, Button, Breadcrumb, Tabs, Text } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/PageHeader/PageHeader.tsx?raw';
-import scssSource from '@lib-source/components/PageHeader/PageHeader.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 function MinimalDemo() {
   return (
@@ -96,10 +95,7 @@ export function PageHeaderDemo() {
     <DemoLayout
       name="PageHeader"
       description="Compound layout primitive for top-of-page headers. Seven slots (Breadcrumb, BackButton, Aside, Title, Subtitle, Meta, Actions) attached via Object.assign. Missing slots collapse; unrecognized children are silently dropped."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="PageHeader.tsx"
-      scssFilename="PageHeader.module.scss"
+      files={getComponentFiles('PageHeader')}
       componentName="PageHeader"
     >
       <Example

--- a/packages/playground/src/pages/components/PaginationDemo.tsx
+++ b/packages/playground/src/pages/components/PaginationDemo.tsx
@@ -4,10 +4,7 @@ import { CursorPagination, Cluster, Pagination, Select, Stack, Tabs } from '@eoc
 import { DemoBody } from './DemoBody';
 import { Example } from './Example';
 import styles from './DemoLayout.module.scss';
-import paginationTsx from '@lib-source/components/Pagination/Pagination.tsx?raw';
-import paginationScss from '@lib-source/components/Pagination/Pagination.module.scss?raw';
-import cursorPaginationTsx from '@lib-source/components/CursorPagination/CursorPagination.tsx?raw';
-import cursorPaginationScss from '@lib-source/components/CursorPagination/CursorPagination.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 type Variant = 'pagination' | 'cursor-pagination';
 
@@ -29,13 +26,7 @@ function PaginationDemoPanel() {
   const pageSizeNum = Number(pageSize);
 
   return (
-    <DemoBody
-      tsxSource={paginationTsx}
-      scssSource={paginationScss}
-      tsxFilename="Pagination.tsx"
-      scssFilename="Pagination.module.scss"
-      componentName="Pagination"
-    >
+    <DemoBody files={getComponentFiles('Pagination')} componentName="Pagination">
       <Example
         title="Basic"
         description="Default md size. Click prev / next / a page number to update."
@@ -190,12 +181,7 @@ function CursorPaginationDemoPanel() {
   const hasNext = cursor < 5;
 
   return (
-    <DemoBody
-      tsxSource={cursorPaginationTsx}
-      scssSource={cursorPaginationScss}
-      tsxFilename="CursorPagination.tsx"
-      scssFilename="CursorPagination.module.scss"
-    >
+    <DemoBody files={getComponentFiles('CursorPagination')}>
       <Example
         title="Basic"
         description="Both buttons enabled — has both directions to navigate."

--- a/packages/playground/src/pages/components/PaletteDemo.tsx
+++ b/packages/playground/src/pages/components/PaletteDemo.tsx
@@ -72,10 +72,10 @@ export function PaletteDemo() {
       name="Palette"
       componentName="Palette"
       description="30 categorical bg + fg color pairs in the --color-palette-* namespace. Consumer-defined domain → color mapping; library Checkbox accepts palette colors out-of-the-box."
-      tsxSource={paletteSource}
-      scssSource={tokensSource}
-      tsxFilename="palette.ts"
-      scssFilename="tokens.scss"
+      files={[
+        { filename: 'palette.ts', code: paletteSource, language: 'ts' },
+        { filename: 'tokens.scss', code: tokensSource, language: 'scss' },
+      ]}
     >
       <Example
         title="All 30 colors"

--- a/packages/playground/src/pages/components/PasswordInputDemo.tsx
+++ b/packages/playground/src/pages/components/PasswordInputDemo.tsx
@@ -3,8 +3,7 @@ import { Button, PasswordInput, PasswordStrengthMeter, Stack } from '@eocrm/desi
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/PasswordInput/PasswordInput.tsx?raw';
-import scssSource from '@lib-source/components/PasswordInput/PasswordInput.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 function ControlledDemo() {
   const [revealed, setRevealed] = useState(false);
@@ -77,10 +76,7 @@ export function PasswordInputDemo() {
       name="PasswordInput"
       componentName="PasswordInput"
       description="Password text field with an eye toggle that reveals/hides the value. Optional caps-lock and wrong-keyboard-layout warnings. Pair with <PasswordStrengthMeter> for signup forms."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="PasswordInput.tsx"
-      scssFilename="PasswordInput.module.scss"
+      files={getComponentFiles('PasswordInput')}
     >
       <Example
         title="Default"

--- a/packages/playground/src/pages/components/PasswordStrengthMeterDemo.tsx
+++ b/packages/playground/src/pages/components/PasswordStrengthMeterDemo.tsx
@@ -8,8 +8,7 @@ import {
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/PasswordStrengthMeter/PasswordStrengthMeter.tsx?raw';
-import scssSource from '@lib-source/components/PasswordStrengthMeter/PasswordStrengthMeter.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 function LiveWithInputDemo() {
   const [pw, setPw] = useState('');
@@ -52,10 +51,7 @@ export function PasswordStrengthMeterDemo() {
       name="PasswordStrengthMeter"
       componentName="PasswordStrengthMeter"
       description="4-segment password-strength visualization. The default heuristic (length + character classes) is suitable for prototypes — pass `score` from zxcvbn or server-side scoring for production."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="PasswordStrengthMeter.tsx"
-      scssFilename="PasswordStrengthMeter.module.scss"
+      files={getComponentFiles('PasswordStrengthMeter')}
     >
       <Example
         title="Live with PasswordInput"

--- a/packages/playground/src/pages/components/PersonDisplayDemo.tsx
+++ b/packages/playground/src/pages/components/PersonDisplayDemo.tsx
@@ -2,8 +2,7 @@ import { Badge, PersonDisplay, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/PersonDisplay/PersonDisplay.tsx?raw';
-import scssSource from '@lib-source/components/PersonDisplay/PersonDisplay.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function PersonDisplayDemo() {
   return (
@@ -11,10 +10,7 @@ export function PersonDisplayDemo() {
       name="PersonDisplay"
       componentName="PersonDisplay"
       description="Avatar + name (+ optional description lines) — the canonical person-row composition. Three sizes (sm / md / lg) drive Avatar + Text scales."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="PersonDisplay.tsx"
-      scssFilename="PersonDisplay.module.scss"
+      files={getComponentFiles('PersonDisplay')}
     >
       <Example
         title="All three sizes"

--- a/packages/playground/src/pages/components/PopoverDemo.tsx
+++ b/packages/playground/src/pages/components/PopoverDemo.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { Button, Cluster, DropdownMenu, Popover, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Popover/Popover.tsx?raw';
-import scssSource from '@lib-source/components/Popover/Popover.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function PopoverDemo() {
   return (
@@ -11,10 +10,7 @@ export function PopoverDemo() {
       name="Popover"
       componentName="Popover"
       description="Non-modal floating panel for arbitrary small surfaces. Compound API — pair Trigger / Content / optionally Heading / Close. Focus moves to the panel on open; Tab traverses out; click-outside or Escape dismisses."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Popover.tsx"
-      scssFilename="Popover.module.scss"
+      files={getComponentFiles('Popover')}
     >
       <Example
         title="Default — filter panel"

--- a/packages/playground/src/pages/components/ProgressDemo.tsx
+++ b/packages/playground/src/pages/components/ProgressDemo.tsx
@@ -7,8 +7,7 @@ import { Title } from '@eocrm/design-system';
 import { Text } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Progress/Progress.tsx?raw';
-import scssSource from '@lib-source/components/Progress/Progress.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 function LiveProgress() {
   const [value, setValue] = useState(45);
@@ -33,10 +32,7 @@ export function ProgressDemo() {
     <DemoLayout
       name="Progress"
       description="Linear progress bar — determinate via value/max, or indeterminate when value is omitted. Use for tracked progress (file upload, wizard step, disk usage). For inline 'loading' spinners next to a button, use <CircularProgress> instead."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Progress.tsx"
-      scssFilename="Progress.module.scss"
+      files={getComponentFiles('Progress')}
       componentName="Progress"
     >
       <Example

--- a/packages/playground/src/pages/components/RadioDemo.tsx
+++ b/packages/playground/src/pages/components/RadioDemo.tsx
@@ -3,8 +3,7 @@ import { Button, Radio, RadioGroup, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/Radio/Radio.tsx?raw';
-import scssSource from '@lib-source/components/Radio/Radio.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 function ControlledDemo() {
   const [plan, setPlan] = useState('free');
@@ -57,10 +56,7 @@ export function RadioDemo() {
       name="Radio"
       componentName="Radio"
       description="Native `<input type='radio'>` visually hidden + custom-painted ring + dot. Pair with `<RadioGroup>` for proper a11y grouping (fieldset/legend), shared name, and centralized state."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Radio.tsx"
-      scssFilename="Radio.module.scss"
+      files={getComponentFiles('Radio')}
     >
       <Example
         title="Default — RadioGroup (preferred)"

--- a/packages/playground/src/pages/components/SelectDemo.tsx
+++ b/packages/playground/src/pages/components/SelectDemo.tsx
@@ -11,8 +11,7 @@ import {
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import tsxSource from '@lib-source/components/Select/Select.tsx?raw';
-import scssSource from '@lib-source/components/Select/Select.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 // ── Demo data ───────────────────────────────────────────────────────────────
 
@@ -85,10 +84,7 @@ export function SelectDemo() {
       name="Select"
       componentName="Select"
       description="Value picker — single, multi (chips and summary), searchable, async, creatable. The generalist."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Select.tsx"
-      scssFilename="Select.module.scss"
+      files={getComponentFiles('Select')}
     >
       <Example
         title="Status — single, non-searchable"

--- a/packages/playground/src/pages/components/SkeletonDemo.tsx
+++ b/packages/playground/src/pages/components/SkeletonDemo.tsx
@@ -1,8 +1,7 @@
 import { Card, Cluster, Skeleton, Stack, Table } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Skeleton/Skeleton.tsx?raw';
-import scssSource from '@lib-source/components/Skeleton/Skeleton.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function SkeletonDemo() {
   return (
@@ -10,10 +9,7 @@ export function SkeletonDemo() {
       name="Skeleton"
       componentName="Skeleton"
       description="Placeholder rectangle for loading states. Three variants (text / circular / rectangular), pulse animation respects prefers-reduced-motion."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Skeleton.tsx"
-      scssFilename="Skeleton.module.scss"
+      files={getComponentFiles('Skeleton')}
     >
       <Example
         title="Text — inline placeholder"

--- a/packages/playground/src/pages/components/SliderDemo.tsx
+++ b/packages/playground/src/pages/components/SliderDemo.tsx
@@ -6,8 +6,7 @@ import { Text } from '@eocrm/design-system';
 import { Code } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Slider/Slider.tsx?raw';
-import scssSource from '@lib-source/components/Slider/Slider.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 function BasicSingle() {
   const [value, setValue] = useState(50);
@@ -143,10 +142,7 @@ export function SliderDemo() {
     <DemoLayout
       name="Slider"
       description="Controlled slider primitive. Single-thumb (value: number) or range (value: [number, number]). Horizontal or vertical. Custom-painted with manual ARIA per thumb."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Slider.tsx"
-      scssFilename="Slider.module.scss"
+      files={getComponentFiles('Slider')}
       componentName="Slider"
     >
       <Example

--- a/packages/playground/src/pages/components/SortableDemo.tsx
+++ b/packages/playground/src/pages/components/SortableDemo.tsx
@@ -14,8 +14,7 @@ import {
 } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Sortable/Sortable.tsx?raw';
-import scssSource from '@lib-source/components/Sortable/Sortable.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function SortableDemo() {
   const [todos, setTodos] = useState([
@@ -48,10 +47,7 @@ export function SortableDemo() {
       name="Sortable"
       componentName="Sortable"
       description="Drag-to-reorder list (single column) built on @dnd-kit/sortable. Compound API with Sortable, Sortable.Item, and an optional Sortable.Handle for click-isolation + keyboard a11y."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Sortable.tsx"
-      scssFilename="Sortable.module.scss"
+      files={getComponentFiles('Sortable')}
     >
       <Example
         title="Plain text list (no Handle)"

--- a/packages/playground/src/pages/components/StackDemo.tsx
+++ b/packages/playground/src/pages/components/StackDemo.tsx
@@ -6,8 +6,7 @@ import { Badge } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import outlineStyles from './demoOutline.module.scss';
-import tsxSource from '@lib-source/components/Stack/Stack.tsx?raw';
-import scssSource from '@lib-source/components/Stack/Stack.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 const Block = ({ children }: { children: React.ReactNode }) => (
   <div
@@ -28,10 +27,7 @@ export function StackDemo() {
     <DemoLayout
       name="Stack"
       description="Vertical flex layout with consistent gap. The most-used layout primitive — form fields, page sections, sidebar contents. Replaces ad-hoc display: flex; flex-direction: column."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Stack.tsx"
-      scssFilename="Stack.module.scss"
+      files={getComponentFiles('Stack')}
       componentName="Stack"
     >
       <Example

--- a/packages/playground/src/pages/components/SwitchDemo.tsx
+++ b/packages/playground/src/pages/components/SwitchDemo.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { Cluster, Stack, Switch } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Switch/Switch.tsx?raw';
-import scssSource from '@lib-source/components/Switch/Switch.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function SwitchDemo() {
   const [controlled, setControlled] = useState(false);
@@ -23,10 +22,7 @@ export function SwitchDemo() {
       name="Switch"
       componentName="Switch"
       description="Binary on/off toggle. Native checkbox with switch role + sliding thumb. Three tones, loading state with thumb-spinner, invalid parity with Input/Textarea."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Switch.tsx"
-      scssFilename="Switch.module.scss"
+      files={getComponentFiles('Switch')}
     >
       <Example
         title="Default + with label"

--- a/packages/playground/src/pages/components/TableDemo.tsx
+++ b/packages/playground/src/pages/components/TableDemo.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { Table, Badge } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Table/Table.tsx?raw';
-import scssSource from '@lib-source/components/Table/Table.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 interface Row {
   id: string;
@@ -145,10 +144,7 @@ export function TableDemo() {
       name="Table"
       componentName="Table"
       description="Tabular data primitive — compound subcomponents (Table.Header, Table.Body, Table.Row, Table.Cell, Table.HeaderCell, Table.Caption, Table.Footer) over native HTML semantics. Density, hover, striped, sticky-header, and sort-indicator visuals; data behavior (sort/filter/pagination) is the consumer's job."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Table.tsx"
-      scssFilename="Table.module.scss"
+      files={getComponentFiles('Table')}
     >
       <Example
         title="Default"

--- a/packages/playground/src/pages/components/TabsDemo.tsx
+++ b/packages/playground/src/pages/components/TabsDemo.tsx
@@ -5,8 +5,7 @@ import { Card } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Tabs/Tabs.tsx?raw';
-import scssSource from '@lib-source/components/Tabs/Tabs.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function TabsDemo() {
   const [t1, setT1] = useState('overview');
@@ -18,10 +17,7 @@ export function TabsDemo() {
     <DemoLayout
       name="Tabs"
       description="Horizontal tab strip with optional count chips. Controlled by the caller: pass activeId and onChange. Best for switching between views of the same entity — not for cross-page navigation."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Tabs.tsx"
-      scssFilename="Tabs.module.scss"
+      files={getComponentFiles('Tabs')}
       componentName="Tabs"
     >
       <Example

--- a/packages/playground/src/pages/components/TextDemo.tsx
+++ b/packages/playground/src/pages/components/TextDemo.tsx
@@ -5,18 +5,14 @@ import { Cluster } from '@eocrm/design-system';
 import { Input } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Text/Text.tsx?raw';
-import scssSource from '@lib-source/components/Text/Text.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function TextDemo() {
   return (
     <DemoLayout
       name="Text"
       description="Body / inline text primitive. Constrained-as (p/span/div/label). Use for every non-heading run — stop reaching for raw <p> + style={{ fontSize: ... }}."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Text.tsx"
-      scssFilename="Text.module.scss"
+      files={getComponentFiles('Text')}
       componentName="Text"
     >
       <Example

--- a/packages/playground/src/pages/components/TextareaDemo.tsx
+++ b/packages/playground/src/pages/components/TextareaDemo.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { Cluster, Stack, Textarea } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Textarea/Textarea.tsx?raw';
-import scssSource from '@lib-source/components/Textarea/Textarea.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function TextareaDemo() {
   const [tweet, setTweet] = useState("What's happening?");
@@ -14,10 +13,7 @@ export function TextareaDemo() {
       name="Textarea"
       componentName="Textarea"
       description="Multi-line text input. Auto-grows by default, optional character counter, configurable resize handle."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Textarea.tsx"
-      scssFilename="Textarea.module.scss"
+      files={getComponentFiles('Textarea')}
     >
       <Example
         title="Default"

--- a/packages/playground/src/pages/components/TitleDemo.tsx
+++ b/packages/playground/src/pages/components/TitleDemo.tsx
@@ -3,18 +3,14 @@ import { Stack } from '@eocrm/design-system';
 import { Cluster } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Title/Title.tsx?raw';
-import scssSource from '@lib-source/components/Title/Title.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function TitleDemo() {
   return (
     <DemoLayout
       name="Title"
       description="Semantic heading primitive. Renders <h1>-<h6> from the required `order` prop. Use for every heading in your UI."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Title.tsx"
-      scssFilename="Title.module.scss"
+      files={getComponentFiles('Title')}
       componentName="Title"
     >
       <Example

--- a/packages/playground/src/pages/components/ToastDemo.tsx
+++ b/packages/playground/src/pages/components/ToastDemo.tsx
@@ -3,8 +3,7 @@ import { Button, Cluster, Stack, toast } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
-import apiSource from '@lib-source/components/Toast/api.ts?raw';
-import scssSource from '@lib-source/components/Toast/Toast.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function ToastDemo() {
   const [bursting, setBursting] = useState(false);
@@ -14,10 +13,7 @@ export function ToastDemo() {
       name="Toast"
       componentName="Toast"
       description="Imperative transient notifications. Singleton `toast` API + one `<ToastViewport>` mounted at app root."
-      tsxSource={apiSource}
-      scssSource={scssSource}
-      tsxFilename="api.ts"
-      scssFilename="Toast.module.scss"
+      files={getComponentFiles('Toast')}
     >
       <Example
         title="Tones"

--- a/packages/playground/src/pages/components/TooltipDemo.tsx
+++ b/packages/playground/src/pages/components/TooltipDemo.tsx
@@ -3,8 +3,7 @@ import { Sparkles } from 'lucide-react';
 import { Button, Cluster, DropdownMenu, Tooltip } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
-import tsxSource from '@lib-source/components/Tooltip/Tooltip.tsx?raw';
-import scssSource from '@lib-source/components/Tooltip/Tooltip.module.scss?raw';
+import { getComponentFiles } from '../../lib/componentFiles';
 
 export function TooltipDemo() {
   return (
@@ -12,10 +11,7 @@ export function TooltipDemo() {
       name="Tooltip"
       componentName="Tooltip"
       description="Small floating label that opens on hover or keyboard focus and points at its trigger. Hand-rolled on Floating UI; lightweight, no focus trap."
-      tsxSource={tsxSource}
-      scssSource={scssSource}
-      tsxFilename="Tooltip.tsx"
-      scssFilename="Tooltip.module.scss"
+      files={getComponentFiles('Tooltip')}
     >
       <Example
         title="Default — top + center"


### PR DESCRIPTION
## Summary

The "View source code" panel on each component demo now shows ALL public source files in the component's directory — one tab per filename — instead of the hard-coded `Component.tsx` + `Component.module.scss` pair.

Driven by a build-time `import.meta.glob` in a new helper (`packages/playground/src/lib/componentFiles.ts`); each demo replaces its two `?raw` imports + four prop lines with one `files={getComponentFiles('Component')}` prop.

Visible improvements:

- The `Component.tokens.scss` file added by the component-tokens migration is now visible per component.
- Compound components (DropdownMenu, Calendar, DatePicker, DataTable) now show their sub-component sources.
- The `index.ts` re-export manifest is visible.

Tab order is deterministic: primary `Component.tsx` → other `.tsx` → `Component.module.scss` → `Component.tokens.scss` → other `.scss` → `index.ts` last. Test files (`*.test.tsx`) are excluded.

## Notes

- Playground bundle grew ~78% (1,795 kB → 3,188 kB raw) because the glob inlines every source file as a `?raw` string. Acceptable: the playground is private (\`"private": true\`) and never publishes.
- Outliers handled: `PaginationDemo` (two `DemoBody` panels for Pagination + CursorPagination), `ToastDemo` (drops a bespoke `api.ts?raw` import; now picked up by the glob), `PaletteDemo` (constructs `files` inline because palette sources live outside `components/`), `DatePickersDemo` (wrapper page — never used `DemoLayout`).
- `packages/playground/CLAUDE.md` Hard rule 3 updated with the new canonical pattern.

## Test plan

- [x] \`make build\` clean, \`make lint\` clean
- [x] Library tests still 2075/2075 (no library changes)
- [x] Reviewed all 57 demo migrations + 4 outliers
- [ ] Visual smoke-test in browser (Button: 3 tabs, DropdownMenu: many tabs, Calendar: many tabs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)