### PR TITLE
DataTable: column reorder grip has dedicated space, no longer glued to label

### DIFF
--- a/packages/design-system/src/components/DataTable/DataTable.module.scss
+++ b/packages/design-system/src/components/DataTable/DataTable.module.scss
@@ -37,6 +37,16 @@
   white-space: nowrap;
 }
 
+// Reserve room in the cell's left padding for the column reorder grip. The
+// grip is absolute-positioned inside the header's padding zone; body cells
+// share the same padding-left so the header label aligns with the body
+// content below it. Doubled `.root` so this beats the Table primitive's
+// density-driven `.density-dense .td` rule (specificity 0,2,0) — without
+// the doubling, density would override us back to its default padding-x.
+.root.root :is(th, td) {
+  padding-left: var(--data-table-cell-padding-inline-start);
+}
+
 // Selection auto-column — fixed narrow width is set via inline <col width> in colgroup.
 .autoCell {
   // text-align center is set by <Table.Cell align="center" />

--- a/packages/design-system/src/components/DataTable/DataTable.module.scss
+++ b/packages/design-system/src/components/DataTable/DataTable.module.scss
@@ -40,11 +40,18 @@
 // Reserve room in the cell's left padding for the column reorder grip. The
 // grip is absolute-positioned inside the header's padding zone; body cells
 // share the same padding-left so the header label aligns with the body
-// content below it. Doubled `.root` so this beats the Table primitive's
-// density-driven `.density-dense .td` rule (specificity 0,2,0) — without
-// the doubling, density would override us back to its default padding-x.
-.root.root :is(th, td) {
-  padding-left: var(--data-table-cell-padding-inline-start);
+// content below it.
+// Doubled `.root` is deliberate: specificity 0,2,1 beats the Table primitive's
+// density-driven `.density-dense .th` / `.density-comfortable .td` rules
+// (0,2,0) which would otherwise reset padding-x via the density shorthand.
+// `:is(th, td)` over `:where(th, td)` is also deliberate — `:is()` preserves
+// the type-selector specificity bump (whereas `:where()` drops to 0,0,0).
+// Only padding-LEFT is overridden; the right side stays density-driven so
+// dense tables keep their tight trailing edge. The auto-select cell is
+// excluded so its centered checkbox stays centered (asymmetric L/R padding
+// would otherwise shift the checkbox right).
+.root.root :is(th, td):not(.autoCell) {
+  padding-left: var(--data-table-cell-padding-left);
 }
 
 // Selection auto-column — fixed narrow width is set via inline <col width> in colgroup.

--- a/packages/design-system/src/components/DataTable/DataTable.tokens.scss
+++ b/packages/design-system/src/components/DataTable/DataTable.tokens.scss
@@ -3,6 +3,12 @@
   // ── Root + cell defaults ─────────────────────────────────────────────────
   --data-table-clickable-row-radius: var(--radius-sm);
 
+  // Reserved left-padding on every DataTable cell so the absolutely-positioned
+  // header reorder grip sits in dedicated space without overlapping the column
+  // label. Applied uniformly to body cells too so the header label visually
+  // aligns with the column's body content.
+  --data-table-cell-padding-inline-start: var(--space-4);
+
   // ── Empty state ──────────────────────────────────────────────────────────
   --data-table-empty-padding: var(--space-6) var(--space-4);
   --data-table-empty-fg: var(--color-fg-muted);

--- a/packages/design-system/src/components/DataTable/DataTable.tokens.scss
+++ b/packages/design-system/src/components/DataTable/DataTable.tokens.scss
@@ -7,7 +7,7 @@
   // header reorder grip sits in dedicated space without overlapping the column
   // label. Applied uniformly to body cells too so the header label visually
   // aligns with the column's body content.
-  --data-table-cell-padding-inline-start: var(--space-4);
+  --data-table-cell-padding-left: var(--space-4);
 
   // ── Empty state ──────────────────────────────────────────────────────────
   --data-table-empty-padding: var(--space-6) var(--space-4);

--- a/packages/design-system/src/components/DataTable/HeaderCell.module.scss
+++ b/packages/design-system/src/components/DataTable/HeaderCell.module.scss
@@ -15,10 +15,12 @@
   user-select: none;
 }
 
-// Drag grip — absolutely positioned at the left edge of the cell, sized to
-// fit inside the cell's left padding area (var(--space-3) = 12px) so it
-// never overlaps the label and nothing has to shift on hover. Only the
-// grip's opacity toggles — no padding/layout animation.
+// Drag grip — absolutely positioned at the left edge of the cell. The cell's
+// left padding is reserved via `--data-table-cell-padding-left` (16px) on the
+// DataTable root (see DataTable.module.scss); the 12px grip sits in that
+// padding area with a small gap before the column label, and body cells share
+// the same padding-left so the header label stays aligned with body content.
+// Only the grip's opacity toggles on hover — no layout shift.
 .grip {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary

The column reorder grip on \`<DataTable>\` headers visually overlapped the column label — the 14px GripVertical icon poked past the cell's 8px density-driven left padding into the label area. Visually: \"⠿When\", \"⠿Event\", title and grip touching.

Fix: reserve a dedicated 16px left padding zone in every DataTable cell via a new \`--data-table-cell-padding-left\` token (\`var(--space-4)\`). The grip stays absolute-positioned at \`left: 0\` with its 12px width and now sits inside that padding with ~4px of gap before the label. Body cells share the same padding-left so header labels still align with the column's body content. The auto-select cell (\`.autoCell\`) is excluded so the centered checkbox stays centered.

## Implementation

- \`DataTable.tokens.scss\` — new token \`--data-table-cell-padding-left: var(--space-4)\`.
- \`DataTable.module.scss\` — \`.root.root :is(th, td):not(.autoCell) { padding-left: var(--data-table-cell-padding-left); }\`. Doubled \`.root\` for specificity 0,3,1 to beat the Table primitive's density rules.
- \`HeaderCell.module.scss\` — updated grip header comment to cite the new token.

## Test plan

- [x] \`npm test\`: 2078/2078 passing
- [x] \`make lint\`: clean
- [x] \`make build\`: clean
- [x] hr8 review cycle: pass 1 flagged 3 Important (token name, autoCell side-effect, stale comment) → all fixed in commit 519bc42; pass 2 verdict \`clean enough to stop\`
- [x] Visual verify via Playwright on audit demo: grip ends at x=325, label starts at x=329, body content at x=329 — gap restored, alignment preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)