### PR TITLE
Mockup: superadmin System settings page

### DIFF
--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -395,12 +395,18 @@
 // `:not(.triggerChips)` keeps the vertical padding of chips triggers intact
 // (chips wrap onto multiple lines and need the existing `--space-1` Y-padding
 // instead of a flat `0`); height-bearing `min-height` still applies.
+// Per-size padding: explicitly set padding-block (top/bottom) and
+// padding-left only. The `padding` shorthand would clobber the
+// padding-right reservation set by `.triggerButton` / `.triggerInput`,
+// which is what reserves space for the absolute-positioned chevron + ✕
+// overlays. Setting padding-left alone preserves that reservation.
 .size-sm .trigger {
   min-height: var(--select-trigger-height-sm);
   font-size: var(--select-trigger-font-size-sm);
 
   &:not(.triggerChips) {
-    padding: 0 var(--select-trigger-padding-x-sm);
+    padding-block: 0;
+    padding-left: var(--select-trigger-padding-x-sm);
   }
 }
 
@@ -409,7 +415,8 @@
   font-size: var(--select-trigger-font-size-md);
 
   &:not(.triggerChips) {
-    padding: 0 var(--select-trigger-padding-x-md);
+    padding-block: 0;
+    padding-left: var(--select-trigger-padding-x-md);
   }
 }
 
@@ -418,7 +425,8 @@
   font-size: var(--select-trigger-font-size-lg);
 
   &:not(.triggerChips) {
-    padding: 0 var(--select-trigger-padding-x-lg);
+    padding-block: 0;
+    padding-left: var(--select-trigger-padding-x-lg);
   }
 }
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -9,6 +9,7 @@ import { ContactDetail } from './pages/mockups/ContactDetail/ContactDetail';
 import { Members } from './pages/mockups/Members/Members';
 import { Tenants } from './pages/mockups/Tenants/Tenants';
 import { TenantDetail } from './pages/mockups/Tenants/TenantDetail';
+import { Settings } from './pages/mockups/Settings/Settings';
 import { ComponentsIndex } from './pages/components/ComponentsIndex';
 import { TokensPage } from './pages/Tokens/TokensPage';
 import { ArchitecturePage } from './pages/Architecture/ArchitecturePage';
@@ -83,6 +84,7 @@ export default function App() {
           <Route path="/mockups/members" element={<Members />} />
           <Route path="/mockups/tenants" element={<Tenants />} />
           <Route path="/mockups/tenants/:slug" element={<TenantDetail />} />
+          <Route path="/mockups/system-settings" element={<Settings />} />
           <Route path="/mockups/audit" element={<Audit />} />
 
           <Route path="/components" element={<ComponentsIndex />} />

--- a/packages/playground/src/data/systemSettings.ts
+++ b/packages/playground/src/data/systemSettings.ts
@@ -1,0 +1,221 @@
+// System-level settings for the EOCRM platform. Two real keys come from
+// EOCRM (audit.retention_days, notification.retention_days — see
+// `/Users/dpws/projects/eocrm/api/app/Modules/Platform/Settings/Services/DefaultSettings.php`);
+// the rest are plausible additions for a richer superadmin mockup.
+
+export interface NumberSetting {
+  key: string;
+  label: string;
+  description: string;
+  type: 'number';
+  defaultValue: number;
+  currentValue: number;
+  unit?: string;
+  min?: number;
+  max?: number;
+}
+
+export interface BooleanSetting {
+  key: string;
+  label: string;
+  description: string;
+  type: 'boolean';
+  defaultValue: boolean;
+  currentValue: boolean;
+}
+
+export interface StringSetting {
+  key: string;
+  label: string;
+  description: string;
+  type: 'string';
+  defaultValue: string;
+  currentValue: string;
+  placeholder?: string;
+}
+
+export interface SelectSetting {
+  key: string;
+  label: string;
+  description: string;
+  type: 'select';
+  defaultValue: string;
+  currentValue: string;
+  options: { value: string; label: string }[];
+}
+
+export type SettingDef = NumberSetting | BooleanSetting | StringSetting | SelectSetting;
+
+export interface SettingsSection {
+  id: string;
+  title: string;
+  description: string;
+  settings: SettingDef[];
+}
+
+export const settingsSections: SettingsSection[] = [
+  {
+    id: 'retention',
+    title: 'Data retention',
+    description:
+      'How long the platform keeps logs and notifications before nightly cleanup deletes them.',
+    settings: [
+      {
+        key: 'audit.retention_days',
+        label: 'Audit log retention',
+        description:
+          'Days to retain audit log entries. Cleanup runs nightly at 03:00 UTC. Minimum 7 days, maximum 10 years.',
+        type: 'number',
+        defaultValue: 180,
+        currentValue: 365,
+        unit: 'days',
+        min: 7,
+        max: 3650,
+      },
+      {
+        key: 'notification.retention_days',
+        label: 'Notification retention',
+        description: 'Days to retain delivered in-app notifications before they’re purged.',
+        type: 'number',
+        defaultValue: 90,
+        currentValue: 90,
+        unit: 'days',
+        min: 7,
+        max: 3650,
+      },
+      {
+        key: 'tenant.archive_grace_days',
+        label: 'Tenant archive grace period',
+        description:
+          'When a tenant is archived, this many days must pass before its database is permanently destroyed.',
+        type: 'number',
+        defaultValue: 30,
+        currentValue: 60,
+        unit: 'days',
+        min: 7,
+        max: 180,
+      },
+    ],
+  },
+  {
+    id: 'provisioning',
+    title: 'Tenant provisioning defaults',
+    description: 'Applied to new tenants at creation time. Existing tenants are unaffected.',
+    settings: [
+      {
+        key: 'tenant.default_db_quota_gb',
+        label: 'Default DB quota',
+        description: 'Starting database quota for newly provisioned tenants.',
+        type: 'number',
+        defaultValue: 5,
+        currentValue: 10,
+        unit: 'GB',
+        min: 1,
+        max: 500,
+      },
+      {
+        key: 'tenant.default_seat_limit',
+        label: 'Default seat limit',
+        description: 'Maximum active members included in the default plan.',
+        type: 'number',
+        defaultValue: 10,
+        currentValue: 25,
+        unit: 'seats',
+        min: 1,
+        max: 10000,
+      },
+      {
+        key: 'tenant.auto_approve_provisioning',
+        label: 'Auto-approve new tenants',
+        description:
+          'When enabled, provisioning starts immediately after signup. When disabled, a superadmin must manually approve each tenant.',
+        type: 'boolean',
+        defaultValue: true,
+        currentValue: true,
+      },
+      {
+        key: 'tenant.default_region',
+        label: 'Default data region',
+        description: 'Which regional cluster new tenants are provisioned into by default.',
+        type: 'select',
+        defaultValue: 'eu-west-1',
+        currentValue: 'eu-west-1',
+        options: [
+          { value: 'eu-west-1', label: 'Europe (Ireland)' },
+          { value: 'eu-central-1', label: 'Europe (Frankfurt)' },
+          { value: 'us-east-1', label: 'US East (Virginia)' },
+          { value: 'us-west-2', label: 'US West (Oregon)' },
+          { value: 'ap-southeast-2', label: 'Asia Pacific (Sydney)' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'security',
+    title: 'Security',
+    description: 'Authentication, session, and password policy applied across all tenants.',
+    settings: [
+      {
+        key: 'security.session_timeout_minutes',
+        label: 'Session timeout',
+        description: 'Idle minutes before an authenticated session is invalidated.',
+        type: 'number',
+        defaultValue: 60,
+        currentValue: 30,
+        unit: 'minutes',
+        min: 5,
+        max: 1440,
+      },
+      {
+        key: 'security.password_min_length',
+        label: 'Password minimum length',
+        description:
+          'Enforced on signup and password change. Existing passwords are not re-validated until next change.',
+        type: 'number',
+        defaultValue: 8,
+        currentValue: 12,
+        unit: 'characters',
+        min: 8,
+        max: 64,
+      },
+      {
+        key: 'security.enforce_mfa_owners',
+        label: 'Enforce MFA for tenant owners',
+        description:
+          'When enabled, tenant owners must enroll an authenticator app before accessing their workspace. Other members are unaffected.',
+        type: 'boolean',
+        defaultValue: false,
+        currentValue: true,
+      },
+    ],
+  },
+  {
+    id: 'maintenance',
+    title: 'Maintenance & notifications',
+    description: 'Platform-wide operational toggles and the sender identity used for system email.',
+    settings: [
+      {
+        key: 'maintenance.read_only',
+        label: 'Read-only mode',
+        description:
+          'When enabled, every tenant is forced into read-only state regardless of plan. Use during major migrations or incidents. Tenant users see a banner explaining the freeze.',
+        type: 'boolean',
+        defaultValue: false,
+        currentValue: false,
+      },
+      {
+        key: 'notification.sender_email',
+        label: 'Notification sender',
+        description:
+          'From-address used for system email (invitations, password resets, provisioning notifications).',
+        type: 'string',
+        defaultValue: 'noreply@eocrm.example',
+        currentValue: 'platform@eocrm.example',
+        placeholder: 'noreply@example.com',
+      },
+    ],
+  },
+];
+
+export const lastUpdatedBy = 'Olivia Chen';
+export const lastUpdatedAt = '2026-05-23T14:22:00Z';

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -63,6 +63,7 @@ import {
   SlidersHorizontal,
   Crop,
   Palette,
+  Settings as SettingsIcon,
   type LucideIcon,
 } from 'lucide-react';
 import { Avatar } from '@eocrm/design-system';
@@ -77,6 +78,7 @@ const mockupItems = [
   { to: '/mockups/members', label: 'Members', icon: UserCog, end: false },
   { to: '/mockups/tenants', label: 'Tenants', icon: Building2, end: false },
   { to: '/mockups/audit', label: 'Audit log', icon: Activity, end: false },
+  { to: '/mockups/system-settings', label: 'System settings', icon: SettingsIcon, end: false },
 ];
 
 const componentOverview = {

--- a/packages/playground/src/pages/mockups/Settings/Settings.tsx
+++ b/packages/playground/src/pages/mockups/Settings/Settings.tsx
@@ -1,0 +1,213 @@
+import { useState, type ReactNode } from 'react';
+import { RotateCcw, ScrollText } from 'lucide-react';
+import {
+  Badge,
+  Button,
+  Card,
+  Cluster,
+  Code,
+  Divider,
+  Input,
+  Page,
+  PageHeader,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  Title,
+  Tooltip,
+} from '@eocrm/design-system';
+import {
+  lastUpdatedAt,
+  lastUpdatedBy,
+  settingsSections,
+  type SettingDef,
+} from '../../../data/systemSettings';
+import { CrossLinks } from '../../shared/CrossLinks';
+
+function formatLastUpdated(iso: string): string {
+  return new Date(iso).toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  });
+}
+
+function isModified(setting: SettingDef, currentValue: unknown): boolean {
+  return String(currentValue) !== String(setting.defaultValue);
+}
+
+interface SettingRowProps {
+  setting: SettingDef;
+  value: unknown;
+  onChange: (next: unknown) => void;
+  onReset: () => void;
+}
+
+function SettingRow({ setting, value, onChange, onReset }: SettingRowProps) {
+  const modified = isModified(setting, value);
+
+  // Right-hand control varies by type.
+  let control: ReactNode = null;
+  switch (setting.type) {
+    case 'number':
+      control = (
+        <Cluster gap="sm" align="center" wrap={false}>
+          <Input
+            type="number"
+            value={String(value)}
+            min={setting.min}
+            max={setting.max}
+            onChange={(e) => onChange(Number(e.target.value))}
+            aria-label={setting.label}
+          />
+          {setting.unit && (
+            <Text as="span" size="sm" tone="muted">
+              {setting.unit}
+            </Text>
+          )}
+        </Cluster>
+      );
+      break;
+    case 'boolean':
+      control = (
+        <Switch
+          checked={Boolean(value)}
+          onChange={(next) => onChange(next)}
+          aria-label={setting.label}
+        />
+      );
+      break;
+    case 'string':
+      control = (
+        <Input
+          type="text"
+          value={String(value)}
+          placeholder={setting.placeholder}
+          onChange={(e) => onChange(e.target.value)}
+          aria-label={setting.label}
+        />
+      );
+      break;
+    case 'select':
+      control = (
+        <Select
+          options={setting.options}
+          value={String(value)}
+          onChange={(next) => onChange(next)}
+          aria-label={setting.label}
+        />
+      );
+      break;
+  }
+
+  return (
+    <Cluster justify="between" align="start" gap="lg" wrap={false}>
+      <Stack gap="xs">
+        <Cluster gap="sm" align="center">
+          <Text as="span" weight="semibold">
+            {setting.label}
+          </Text>
+          {modified && (
+            <Tooltip content={`Default: ${String(setting.defaultValue)}`}>
+              <Badge tone="info" size="sm">
+                Modified
+              </Badge>
+            </Tooltip>
+          )}
+          <Code tone="muted">{setting.key}</Code>
+        </Cluster>
+        <Text size="sm" tone="muted">
+          {setting.description}
+        </Text>
+      </Stack>
+      <Cluster gap="sm" align="center" wrap={false}>
+        {control}
+        {modified && (
+          <Tooltip content={`Reset to ${String(setting.defaultValue)}`}>
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label={`Reset ${setting.label} to default`}
+              onClick={onReset}
+            >
+              <RotateCcw size={14} />
+            </Button>
+          </Tooltip>
+        )}
+      </Cluster>
+    </Cluster>
+  );
+}
+
+function SectionCard({ section }: { section: (typeof settingsSections)[number] }) {
+  // Per-section local state seeded from the data file. Each setting tracks
+  // its own value; reset rewrites just that one back to its default.
+  const [values, setValues] = useState<Record<string, unknown>>(() =>
+    Object.fromEntries(section.settings.map((s) => [s.key, s.currentValue])),
+  );
+
+  return (
+    <Card padding="md">
+      <Stack gap="md">
+        <Stack gap="xs">
+          <Title order={2} size="md">
+            {section.title}
+          </Title>
+          <Text size="sm" tone="muted">
+            {section.description}
+          </Text>
+        </Stack>
+        <Stack gap="md">
+          {section.settings.map((setting, i) => (
+            <Stack key={setting.key} gap="md">
+              {i > 0 && <Divider />}
+              <SettingRow
+                setting={setting}
+                value={values[setting.key]}
+                onChange={(next) => setValues((prev) => ({ ...prev, [setting.key]: next }))}
+                onReset={() =>
+                  setValues((prev) => ({ ...prev, [setting.key]: setting.defaultValue }))
+                }
+              />
+            </Stack>
+          ))}
+        </Stack>
+      </Stack>
+    </Card>
+  );
+}
+
+export function Settings() {
+  return (
+    <Page>
+      <PageHeader>
+        <PageHeader.Title>System settings</PageHeader.Title>
+        <PageHeader.Subtitle>
+          Global configuration for the EOCRM platform. Changes apply to every tenant — adjust with
+          care.
+        </PageHeader.Subtitle>
+        <PageHeader.Meta>
+          <Text size="sm" tone="muted">
+            Last changed by {lastUpdatedBy} · {formatLastUpdated(lastUpdatedAt)}
+          </Text>
+        </PageHeader.Meta>
+        <PageHeader.Actions>
+          <Button variant="secondary">
+            <ScrollText size={14} /> View audit log
+          </Button>
+        </PageHeader.Actions>
+      </PageHeader>
+
+      {settingsSections.map((section) => (
+        <SectionCard key={section.id} section={section} />
+      ))}
+
+      <CrossLinks kind="mockup" slug="system-settings" />
+    </Page>
+  );
+}

--- a/packages/playground/src/pages/mockups/Settings/Settings.tsx
+++ b/packages/playground/src/pages/mockups/Settings/Settings.tsx
@@ -98,6 +98,7 @@ function SettingRow({ setting, value, onChange, onReset }: SettingRowProps) {
           options={setting.options}
           value={String(value)}
           onChange={(next) => onChange(next)}
+          clearable={false}
           aria-label={setting.label}
         />
       );

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -262,6 +262,30 @@ export const MOCKUPS = [
       'Tooltip',
     ],
   },
+  {
+    slug: 'system-settings',
+    title: 'System settings',
+    path: '/mockups/system-settings',
+    blurb:
+      'Superadmin global settings — data retention, tenant provisioning defaults, security policy, maintenance toggles.',
+    usesComponents: [
+      'Badge',
+      'Button',
+      'Card',
+      'Cluster',
+      'Code',
+      'Divider',
+      'Input',
+      'Page',
+      'PageHeader',
+      'Select',
+      'Stack',
+      'Switch',
+      'Text',
+      'Title',
+      'Tooltip',
+    ],
+  },
 ] as const satisfies readonly MockupEntry[];
 
 export type MockupSlug = (typeof MOCKUPS)[number]['slug'];


### PR DESCRIPTION
## Summary

New mockup at \`/mockups/system-settings\`. Global platform-level configuration the way a superadmin would expect to manage it. Four sections × 11 settings.

- **Data retention** — audit log retention (default 180d), notification retention (90d), tenant archive grace period (30d). The first two mirror the real EOCRM Settings keys from \`Modules/Platform/Settings\`.
- **Tenant provisioning defaults** — default DB quota, default seat limit, auto-approve toggle, default data region (eu / us / ap).
- **Security** — session timeout, password minimum length, MFA enforcement for tenant owners.
- **Maintenance & notifications** — read-only mode toggle, sender email.

Per-setting affordances:
- "Modified" Badge appears when the current value differs from the default; Tooltip on the badge shows the default value
- Reset-to-default ghost button next to modified rows
- Setting key (\`audit.retention_days\` etc.) rendered as a small \`<Code>\` chip so the operator can map each row to the API surface

Page is interactive but no real API — values reset on reload.

## Discipline

- Hard rule 6 clean: zero inline styles, zero raw HTML, no co-located SCSS in the new mockup
- Registry sync verified: 15 imports === 15 \`usesComponents\` entries
- hr7 review pass 1: \`clean enough to stop\` (0 Critical, 0 Important)

## Test plan

- [x] \`make build\`, \`make lint\`, \`make test\` (2078/2078) — clean
- [x] Page renders at /mockups/system-settings; controls interactive
- [ ] Visual sanity-check on narrow viewports (~1024px) — Cluster wrap=false on the row may pinch on dense descriptions; current shape is mockup-acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)