### PR TITLE
Accordion: stop inner padding from snapping during collapse

### DIFF
--- a/packages/design-system/src/components/Accordion/Accordion.module.scss
+++ b/packages/design-system/src/components/Accordion/Accordion.module.scss
@@ -104,8 +104,14 @@
   grid-template-rows: 1fr;
 }
 
+// The grid track from .content (0fr↔1fr) drives the height. .inner is
+// the grid item — overflow: hidden so the body inside clips during
+// collapse, min-height: 0 so the grid track's 0fr fully collapses (without
+// this, grid item's min-content baseline would keep the row at the
+// body's padding sum even when closed).
 .inner {
   overflow: hidden;
+  min-height: 0;
 
   // Promote to its own compositor layer. Combined with the parent's
   // will-change + contain hints, this keeps the row-resize animation off
@@ -113,9 +119,15 @@
   transform: translateZ(0);
 }
 
-.content[data-state='open'] .inner {
-  // Default content padding belongs to size='md'; the per-size rules below
-  // override.
+// The padded surface where children render. Padding lives HERE — not on
+// .inner — so it persists across the collapse transition. If the padding
+// were on .inner (the grid item), grid auto-sizing would keep the closed
+// row at min-content (padding sum) instead of zero. With padding on a
+// child .body inside .inner, the .inner can collapse to 0 cleanly, and
+// .body's padding only ever clips visually via overflow:hidden, never
+// snaps in or out — which is what causes the "content jumps" feel.
+// Default belongs to size='md'; the per-size rules below override.
+.body {
   padding: var(--accordion-content-padding-y-md) var(--accordion-content-padding-x-md);
 }
 
@@ -133,7 +145,7 @@
   font-size: var(--accordion-trigger-font-size-sm);
 }
 
-.accordion[data-size='sm'] .content[data-state='open'] .inner {
+.accordion[data-size='sm'] .body {
   padding: var(--accordion-content-padding-y-sm) var(--accordion-content-padding-x-sm);
   font-size: var(--accordion-content-font-size-sm);
 }
@@ -147,7 +159,7 @@
   font-size: var(--accordion-trigger-font-size-md);
 }
 
-.accordion[data-size='md'] .content[data-state='open'] .inner {
+.accordion[data-size='md'] .body {
   padding: var(--accordion-content-padding-y-md) var(--accordion-content-padding-x-md);
 }
 
@@ -160,7 +172,7 @@
   font-size: var(--accordion-trigger-font-size-lg);
 }
 
-.accordion[data-size='lg'] .content[data-state='open'] .inner {
+.accordion[data-size='lg'] .body {
   padding: var(--accordion-content-padding-y-lg) var(--accordion-content-padding-x-lg);
   font-size: var(--accordion-content-font-size-lg);
 }

--- a/packages/design-system/src/components/Accordion/AccordionContent.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionContent.tsx
@@ -27,7 +27,9 @@ export const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps
         data-state={isOpen ? 'open' : 'closed'}
         className={clsx(styles.content, className)}
       >
-        <div className={styles.inner}>{children}</div>
+        <div className={styles.inner}>
+          <div className={styles.body}>{children}</div>
+        </div>
       </div>
     );
   },


### PR DESCRIPTION
## Summary

Closing the accordion produced a visible vertical jump: data-state flipped to \`closed\` instantly, the inner padding (gated on \`[data-state='open']\`) dropped to 0, the content snapped shorter, and THEN the \`grid-template-rows: 0fr ↔ 1fr\` transition played from that already-shorter starting state. Symmetric snap on opening too.

## Fix

Structural — add a \`.body\` wrapper inside the grid item, move padding there.

- \`AccordionContent.tsx\` — wrap children in \`<div className={styles.body}>\` inside \`<div className={styles.inner}>\`. DOM: \`.content > .inner > .body > {children}\` (added one div).
- \`Accordion.module.scss\`:
  - \`.inner\` gets \`min-height: 0\` so the grid track's \`0fr\` can fully collapse the row (without it, the grid auto-sizing keeps the row at \`.body\`'s min-content height = padding sum, ~24px of residual visible band).
  - \`.body\` now carries the padding, **unconditional** — no \`[data-state='open']\` qualifier. The padding never snaps in/out; \`.inner\`'s \`overflow: hidden\` clips it visually during the collapse.
  - Per-size rules (\`.accordion[data-size='sm/md/lg'] .content[data-state='open'] .inner\` → \`.accordion[data-size='sm/md/lg'] .body\`) drop the state qualifier consistently across sm/md/lg.

## Verified in Playwright on \`/components/accordion\`

| state | contentH | innerH | bodyH | body.padding |
| --- | --- | --- | --- | --- |
| closed | 0 | 0 | 44 (intrinsic, clipped) | 12px 16px ✓ |
| open | 44 | 44 | 44 | 12px 16px ✓ |

Body padding string is identical before/after a close click — no snap.

## Test plan

- [x] \`npm test\`: 39/39 Accordion tests still pass (assertions query by role/aria — the extra \`<div>\` is transparent)
- [x] \`make lint\`, \`make build\` clean
- [x] hr8 review: \`clean enough to stop\` on pass 1 (0 Critical, 0 Important)

🤖 Generated with [Claude Code](https://claude.com/claude-code)