### PR TITLE
TopBar: sticky application top-bar primitive (Search + IconButton + indicator dot)

### DIFF
--- a/docs/superpowers/plans/2026-05-28-topbar-component.md
+++ b/docs/superpowers/plans/2026-05-28-topbar-component.md
@@ -1,0 +1,412 @@
+# `<TopBar>` component — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Build a new library primitive `<TopBar>` matching the existing playground topbar design (search input + icon buttons with notification dots + avatar). Per spec at `docs/superpowers/specs/2026-05-28-topbar-design.md`.
+
+**Branch:** `feat/topbar-component` (already checked out off main).
+
+**Locked-in design (from brainstorm):** compound API (`<TopBar>`, `<TopBar.Start>`, `<TopBar.End>`, `<TopBar.Search>`, `<TopBar.IconButton>`); sticky-top positioning by default; minimal search input (no command-palette).
+
+---
+
+## Task 1: tokens + i18n keys
+
+**Files:**
+- Create: `packages/design-system/src/components/TopBar/TopBar.tokens.scss`
+- Modify: `packages/design-system/src/i18n/messages.ts` — add `topBar` namespace
+- Modify: `packages/design-system/src/i18n/en.ts` — `topBar.label`, `topBar.search`
+- Modify: `packages/design-system/src/i18n/ru.ts` — same
+
+Token values: copy verbatim from the spec's "Tokens" section.
+
+i18n mapping:
+- `topBar.label`: `Application top bar` / `Верхняя панель приложения`
+- `topBar.search`: `Search` / `Поиск`
+
+- [ ] Commit `TopBar: tokens + i18n`.
+
+---
+
+## Task 2: Root + Start + End
+
+**Files:**
+- Create: `packages/design-system/src/components/TopBar/TopBar.tsx`
+- Create: `packages/design-system/src/components/TopBar/TopBarStart.tsx`
+- Create: `packages/design-system/src/components/TopBar/TopBarEnd.tsx`
+- Create: `packages/design-system/src/components/TopBar/TopBar.module.scss`
+- Create: `packages/design-system/src/components/TopBar/index.ts`
+
+### `TopBar.tsx`
+
+```tsx
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { useTranslation } from '../../i18n';
+import { TopBarStart } from './TopBarStart';
+import { TopBarEnd } from './TopBarEnd';
+import { TopBarSearch } from './TopBarSearch';
+import { TopBarIconButton } from './TopBarIconButton';
+import styles from './TopBar.module.scss';
+
+export type TopBarElement = 'header' | 'div';
+
+export interface TopBarProps extends Omit<HTMLAttributes<HTMLElement>, 'aria-label'> {
+  /** Defaults to `'header'`. Use `'div'` for nested toolbars where a banner element would be wrong. */
+  as?: TopBarElement;
+  /** Accessible label. Defaults to `t('topBar.label')`. */
+  'aria-label'?: string;
+  children?: ReactNode;
+}
+
+const TopBarRoot = forwardRef<HTMLElement, TopBarProps>(function TopBar(
+  { as = 'header', 'aria-label': ariaLabel, className, children, ...props },
+  ref,
+) {
+  const t = useTranslation();
+  const Comp = as as 'header';
+  return (
+    <Comp
+      ref={ref as never}
+      aria-label={ariaLabel ?? t('topBar.label')}
+      className={clsx(styles.topBar, className)}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});
+
+export const TopBar = Object.assign(TopBarRoot, {
+  Start: TopBarStart,
+  End: TopBarEnd,
+  Search: TopBarSearch,
+  IconButton: TopBarIconButton,
+});
+```
+
+### `TopBarStart.tsx` and `TopBarEnd.tsx`
+
+Trivial flex wrappers:
+
+```tsx
+export const TopBarStart = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  function TopBarStart({ className, ...props }, ref) {
+    return <div ref={ref} className={clsx(styles.start, className)} {...props} />;
+  },
+);
+// Same shape for TopBarEnd, swapping the class.
+```
+
+### `TopBar.module.scss` (root + start + end only)
+
+```scss
+@use './TopBar.tokens';
+
+// Layout-owning primitive (Hard rule 4 exception): TopBar owns its
+// own height + padding + sticky positioning because that IS its job.
+// Same justification as <Rail>, <Modal>, <Drawer>, <Page>.
+// stylelint-disable property-disallowed-list -- layout-owning primitive
+.topBar {
+  position: sticky;
+  top: 0;
+  z-index: var(--topbar-z-index);
+  height: var(--topbar-height);
+  padding: 0 var(--topbar-padding-x);
+  background: var(--topbar-bg);
+  border-bottom: var(--topbar-border-width) solid var(--topbar-border-color);
+  display: flex;
+  align-items: center;
+  gap: var(--topbar-gap);
+}
+// stylelint-enable property-disallowed-list
+
+.start {
+  display: flex;
+  align-items: center;
+  gap: var(--topbar-gap);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.end {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+```
+
+- [ ] Commit `TopBar: root + Start + End`.
+
+---
+
+## Task 3: TopBar.Search
+
+**File:** `packages/design-system/src/components/TopBar/TopBarSearch.tsx`
+
+```tsx
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from 'react';
+import { Search } from 'lucide-react';
+import clsx from 'clsx';
+import { useTranslation } from '../../i18n';
+import styles from './TopBar.module.scss';
+
+export interface TopBarSearchProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  /** Optional `<kbd>` hint shown after the input — e.g. '⌘K'. */
+  hotkey?: ReactNode;
+  /** Forwarded to the wrapper div. */
+  className?: string;
+}
+
+export const TopBarSearch = forwardRef<HTMLInputElement, TopBarSearchProps>(function TopBarSearch(
+  { hotkey, placeholder, className, 'aria-label': ariaLabel, ...inputProps },
+  ref,
+) {
+  const t = useTranslation();
+  return (
+    <div className={clsx(styles.search, className)}>
+      <Search aria-hidden className={styles.searchIcon} />
+      <input
+        ref={ref}
+        type="search"
+        placeholder={placeholder}
+        aria-label={ariaLabel ?? placeholder ?? t('topBar.search')}
+        className={styles.searchInput}
+        // Password managers (1Password, Bitwarden) and browser autofill
+        // shouldn't try to fill a free-text search box.
+        autoComplete="off"
+        data-1p-ignore
+        data-lpignore="true"
+        data-form-type="other"
+        {...inputProps}
+      />
+      {hotkey != null && (
+        <kbd aria-hidden className={styles.searchKbd}>
+          {hotkey}
+        </kbd>
+      )}
+    </div>
+  );
+});
+```
+
+### SCSS additions for `.search`
+
+```scss
+.search {
+  display: flex;
+  align-items: center;
+  gap: var(--topbar-search-gap);
+  height: var(--topbar-search-height);
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- search field gets a max width so wide viewports don't yield a huge bar
+  width: 100%;
+  max-width: var(--topbar-search-max-width);
+  min-width: 0; // allow Start's flex-1 to shrink the search
+  padding: 0 var(--topbar-search-padding-x);
+  background: var(--topbar-search-bg);
+  border-radius: var(--topbar-search-radius);
+}
+
+.search:focus-within {
+  outline: var(--ring-width) solid var(--topbar-search-ring-focus);
+  outline-offset: -1px;
+}
+
+.searchIcon {
+  width: var(--topbar-search-icon-size);
+  height: var(--topbar-search-icon-size);
+  color: var(--topbar-search-icon-fg);
+  flex-shrink: 0;
+}
+
+.searchInput {
+  flex: 1 1 auto;
+  min-width: 0;
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- transparent so the wrapper's bg shows
+  background: transparent;
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- native input border reset
+  border: 0;
+  color: var(--topbar-search-fg);
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- inherit page font sizing
+  font: inherit;
+}
+
+.searchInput:focus {
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- the wrapper handles the visible focus ring
+  outline: none;
+}
+
+.searchInput::placeholder {
+  color: var(--topbar-search-placeholder-fg);
+}
+
+.searchKbd {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 var(--topbar-search-kbd-padding-x);
+  background: var(--topbar-search-kbd-bg);
+  color: var(--topbar-search-kbd-fg);
+  font-size: var(--topbar-search-kbd-font-size);
+  border-radius: var(--topbar-search-kbd-radius);
+  font-family: var(--font-family-sans);
+  flex-shrink: 0;
+}
+```
+
+- [ ] Commit `TopBar: Search subcomponent`.
+
+---
+
+## Task 4: TopBar.IconButton
+
+**File:** `packages/design-system/src/components/TopBar/TopBarIconButton.tsx`
+
+```tsx
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { Button } from '../Button';
+import styles from './TopBar.module.scss';
+
+export type TopBarIndicatorTone = 'danger' | 'warning' | 'info' | 'accent';
+
+export interface TopBarIconButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  children: ReactNode;
+  indicator?: boolean;
+  indicatorTone?: TopBarIndicatorTone;
+  'aria-label': string;  // REQUIRED for icon-only buttons
+}
+
+const TONE_CLASS: Record<TopBarIndicatorTone, string> = {
+  danger: styles.indicatorDanger,
+  warning: styles.indicatorWarning,
+  info: styles.indicatorInfo,
+  accent: styles.indicatorAccent,
+};
+
+export const TopBarIconButton = forwardRef<HTMLButtonElement, TopBarIconButtonProps>(
+  function TopBarIconButton(
+    { children, indicator = false, indicatorTone = 'danger', className, ...props },
+    ref,
+  ) {
+    return (
+      <Button
+        ref={ref}
+        variant="ghost"
+        size="sm"
+        iconOnly
+        className={clsx(styles.iconButton, className)}
+        {...props}
+      >
+        {children}
+        {indicator && <span aria-hidden className={clsx(styles.indicator, TONE_CLASS[indicatorTone])} />}
+      </Button>
+    );
+  },
+);
+```
+
+### SCSS additions for `.iconButton` and `.indicator`
+
+```scss
+.iconButton {
+  // The base ghost Button is square via `iconOnly`; topbar variant uses
+  // a slightly larger touch target to feel right in the bar.
+  width: var(--topbar-icon-button-size);
+  height: var(--topbar-icon-button-size);
+  border-radius: var(--topbar-icon-button-radius);
+  position: relative;
+}
+
+.indicator {
+  position: absolute;
+  top: var(--topbar-indicator-offset-top);
+  right: var(--topbar-indicator-offset-right);
+  width: var(--topbar-indicator-size);
+  height: var(--topbar-indicator-size);
+  border-radius: var(--radius-full);
+  border: var(--topbar-indicator-border-width) solid var(--topbar-indicator-border-color);
+  pointer-events: none;
+}
+
+.indicatorDanger  { background: var(--topbar-indicator-bg-danger); }
+.indicatorWarning { background: var(--topbar-indicator-bg-warning); }
+.indicatorInfo    { background: var(--topbar-indicator-bg-info); }
+.indicatorAccent  { background: var(--topbar-indicator-bg-accent); }
+```
+
+- [ ] Commit `TopBar: IconButton with notification indicator`.
+
+---
+
+## Task 5: Public exports + manifest
+
+- `packages/design-system/src/components/TopBar/index.ts` — re-export Root + subcomponents + types.
+- `packages/design-system/src/index.ts` — re-export `TopBar` + `TopBarProps`, `TopBarSearchProps`, `TopBarIconButtonProps`, `TopBarIndicatorTone`, `TopBarElement`.
+- Add `'TopBar'` to `packages/playground/src/pages/mockups/registry.ts`'s `ComponentName` union.
+- Re-generate manifest via `node scripts/generate-manifest.mjs` (or whatever the script is); register under cluster `Navigation` (alongside Rail).
+
+- [ ] Commit `TopBar: barrel + manifest`.
+
+---
+
+## Task 6: Tests
+
+**File:** `packages/design-system/src/components/TopBar/TopBar.test.tsx`
+
+Cover the test list from the spec's "Tests" section. Vitest globals, RTL `render`/`screen`.
+
+- [ ] Commit `TopBar: unit tests`.
+
+---
+
+## Task 7: Demo page
+
+**Files:**
+- Create: `packages/playground/src/pages/components/TopBarDemo.tsx`
+- Modify: `packages/playground/src/App.tsx` — route `/components/topbar`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx` — add the nav item
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx` — add the overview card
+
+The demo has 3-4 examples per spec.
+
+- [ ] Commit `TopBar: playground demo + nav`.
+
+---
+
+## Task 8: AppShell migration
+
+Replace the hand-rolled `<header className={styles.topbar}>` block in `AppShell.tsx` with the new `<TopBar>` + `<TopBar.Search>` + `<TopBar.IconButton>`.
+
+Remove the now-dead SCSS classes from `AppShell.module.scss` (`.topbar`, `.searchWrap`, `.searchIcon`, `.search`, `.searchKbd`, `.iconBtn`, `.notifDot`). Keep the `.shell` grid + `--topbar-height` token (the grid still references it).
+
+Verify in Playwright that the migrated topbar visually matches the previous one (search input, two icon buttons with the bell having a red dot, avatar).
+
+- [ ] Commit `Playground AppShell: adopt the new TopBar`.
+
+---
+
+## Task 9: Docs
+
+`packages/design-system/AGENTS.md` — add a TopBar catalog entry after Rail.
+
+- [ ] Commit `Docs: TopBar in AGENTS.md`.
+
+---
+
+## Task 10: Library hr8 review-fix loop
+
+Standard hr8 cycle per `CLAUDE.md` Rule 8.
+
+- [ ] Step 1: full gate sweep (test / typecheck / lint / build / npm pack --dry-run)
+- [ ] Step 2: fresh-context reviewer on the 10 categories. Specifically probe: polymorphic `as` for the root element type-soundness; indicator dot a11y (aria-hidden on the visual marker, consumer responsible for screen-reader text); sticky-top positioning works without consumer setting up specific layout; demo + AppShell adoption are visually identical.
+- [ ] Step 3: fix Critical + Important findings.
+- [ ] Step 4: re-run + re-spawn until `clean enough to stop`.
+
+---
+
+## Task 11: Push + PR
+
+Title: `TopBar: sticky application top-bar primitive (Search + IconButton + indicator dot)`.

--- a/docs/superpowers/plans/2026-05-28-topbar-component.md
+++ b/docs/superpowers/plans/2026-05-28-topbar-component.md
@@ -13,6 +13,7 @@
 ## Task 1: tokens + i18n keys
 
 **Files:**
+
 - Create: `packages/design-system/src/components/TopBar/TopBar.tokens.scss`
 - Modify: `packages/design-system/src/i18n/messages.ts` — add `topBar` namespace
 - Modify: `packages/design-system/src/i18n/en.ts` — `topBar.label`, `topBar.search`
@@ -21,6 +22,7 @@
 Token values: copy verbatim from the spec's "Tokens" section.
 
 i18n mapping:
+
 - `topBar.label`: `Application top bar` / `Верхняя панель приложения`
 - `topBar.search`: `Search` / `Поиск`
 
@@ -31,6 +33,7 @@ i18n mapping:
 ## Task 2: Root + Start + End
 
 **Files:**
+
 - Create: `packages/design-system/src/components/TopBar/TopBar.tsx`
 - Create: `packages/design-system/src/components/TopBar/TopBarStart.tsx`
 - Create: `packages/design-system/src/components/TopBar/TopBarEnd.tsx`
@@ -271,12 +274,14 @@ import styles from './TopBar.module.scss';
 
 export type TopBarIndicatorTone = 'danger' | 'warning' | 'info' | 'accent';
 
-export interface TopBarIconButtonProps
-  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+export interface TopBarIconButtonProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children'
+> {
   children: ReactNode;
   indicator?: boolean;
   indicatorTone?: TopBarIndicatorTone;
-  'aria-label': string;  // REQUIRED for icon-only buttons
+  'aria-label': string; // REQUIRED for icon-only buttons
 }
 
 const TONE_CLASS: Record<TopBarIndicatorTone, string> = {
@@ -301,7 +306,9 @@ export const TopBarIconButton = forwardRef<HTMLButtonElement, TopBarIconButtonPr
         {...props}
       >
         {children}
-        {indicator && <span aria-hidden className={clsx(styles.indicator, TONE_CLASS[indicatorTone])} />}
+        {indicator && (
+          <span aria-hidden className={clsx(styles.indicator, TONE_CLASS[indicatorTone])} />
+        )}
       </Button>
     );
   },
@@ -331,10 +338,18 @@ export const TopBarIconButton = forwardRef<HTMLButtonElement, TopBarIconButtonPr
   pointer-events: none;
 }
 
-.indicatorDanger  { background: var(--topbar-indicator-bg-danger); }
-.indicatorWarning { background: var(--topbar-indicator-bg-warning); }
-.indicatorInfo    { background: var(--topbar-indicator-bg-info); }
-.indicatorAccent  { background: var(--topbar-indicator-bg-accent); }
+.indicatorDanger {
+  background: var(--topbar-indicator-bg-danger);
+}
+.indicatorWarning {
+  background: var(--topbar-indicator-bg-warning);
+}
+.indicatorInfo {
+  background: var(--topbar-indicator-bg-info);
+}
+.indicatorAccent {
+  background: var(--topbar-indicator-bg-accent);
+}
 ```
 
 - [ ] Commit `TopBar: IconButton with notification indicator`.
@@ -365,6 +380,7 @@ Cover the test list from the spec's "Tests" section. Vitest globals, RTL `render
 ## Task 7: Demo page
 
 **Files:**
+
 - Create: `packages/playground/src/pages/components/TopBarDemo.tsx`
 - Modify: `packages/playground/src/App.tsx` — route `/components/topbar`
 - Modify: `packages/playground/src/layout/AppShell/AppShell.tsx` — add the nav item

--- a/docs/superpowers/specs/2026-05-28-topbar-design.md
+++ b/docs/superpowers/specs/2026-05-28-topbar-design.md
@@ -1,0 +1,225 @@
+# `<TopBar>` — sticky application top bar primitive
+
+## Goal
+
+Take the styled topbar that lives in the playground's `AppShell` today and lift it into the library as a reusable primitive. Visual fidelity must match the playground exactly (the user said "use the same design we currently have"). Consumers should be able to drop a TopBar into any layout — most often paired with a `<Rail>` sidebar in a CSS-grid app shell — and get the same chrome without re-implementing it.
+
+The current playground topbar:
+
+- Sticky to the top of the viewport (`position: sticky; top: 0`).
+- 56px tall, light background, subtle bottom border, padded inline.
+- Two visual clusters: a left side (currently just a styled search input with leading icon + `⌘K` kbd hint), and a right side (icon buttons for "create" / "notifications" + a small avatar).
+- One of the icon buttons has a tiny accent-colored dot in the upper-right to indicate unread notifications.
+
+## Locked-in design decisions (brainstorm)
+
+1. **Scope:** the bar's chrome + a `Search` subcomponent + an `IconButton` subcomponent. Avatar stays a separate primitive (already exists).
+2. **Positioning:** sticky-top within a CSS grid. Same as the AppShell.
+3. **Search:** minimal — a real `<input>` with leading icon and an optional kbd hint. Consumer wires `value`/`onChange`/etc. through prop spread. No command-palette behavior in v1.
+
+## Architecture
+
+Compound API. Three subcomponents under the root:
+
+```tsx
+<TopBar aria-label="Application top bar">
+  <TopBar.Start>
+    <TopBar.Search placeholder="Search contacts, deals…" hotkey="⌘K" />
+  </TopBar.Start>
+  <TopBar.End>
+    <TopBar.IconButton aria-label="Create new">
+      <Plus size={16} />
+    </TopBar.IconButton>
+    <TopBar.IconButton aria-label="Notifications" indicator>
+      <Bell size={16} />
+    </TopBar.IconButton>
+    <Avatar name="Alex Rivera" size="sm" />
+  </TopBar.End>
+</TopBar>
+```
+
+The root renders a `<header>` (implicit `banner` role when a direct child of `body`, override-able via `as`). Inside the header is a flex row with `Start` on the left and `End` pushed to the right (`Start` has `flex: 1` to take the remaining space; `End` shrinks to its content).
+
+## Subcomponent specs
+
+### `<TopBar>`
+
+Props:
+
+- `aria-label?: string` — accessible name for the bar. Defaults via i18n (`t('topBar.label')`).
+- `className?: string`
+- Children: typically `<TopBar.Start>` + `<TopBar.End>`, but the children area is open — a consumer who wants a single-cluster bar (just on the right, say) can pass only one slot or arbitrary children.
+- `as?: 'header' | 'div'` — default `'header'`. `'div'` for the rare nested-bar case.
+
+Renders an inline-padded, sticky-top horizontal bar with a bottom border. Owns its own `height`, `padding-x`, `background`, `border-bottom` — Hard rule 4 exception, justified inline (same as `<Modal>`, `<Drawer>`, `<Rail>`, `<Page>`).
+
+### `<TopBar.Start>` and `<TopBar.End>`
+
+Both render a flex row of children with `Cluster`-like gap. `Start` has `flex: 1` so it expands; `End` shrinks. The bar's children space stays between them.
+
+Props (both): `className?`, `children`, plus HTMLAttributes.
+
+### `<TopBar.Search>`
+
+Props:
+
+- `placeholder?: string` — visible placeholder text. No default (consumer-controlled — varies by app context).
+- `hotkey?: ReactNode` — content of the trailing `<kbd>` hint. Pass `'⌘K'`, `'Ctrl+K'`, or any node. Omit for no hint.
+- `value?: string`, `defaultValue?: string`, `onChange?` — standard text-input controls. Spread through to the underlying `<input>`.
+- `aria-label?: string` — defaults to placeholder or to `t('topBar.search')` if both are unset.
+- All other props (HTMLAttributes minus `type`) pass through to the input.
+
+Renders a 32px-tall pill-shaped surface with:
+
+- Leading `Search` icon from lucide-react at `--topbar-search-icon-fg`.
+- The `<input type="search">` (transparent bg, no border — the surface chrome is on the wrapper).
+- Optional trailing `<kbd>` with the hotkey copy, styled muted with a faint background.
+
+The input does NOT implement keyboard-shortcut focus behavior (e.g. ⌘K → focus the input). That's a consumer concern — the library doesn't dictate which shortcuts bind to which UI. The `hotkey` prop is purely a visual hint.
+
+### `<TopBar.IconButton>`
+
+A thin wrapper over the existing `<Button iconOnly variant="ghost" size="sm">` with one addition: an `indicator?: boolean` prop that overlays a small dot in the button's upper-right corner (for "new notifications", "updates available", etc.).
+
+Props:
+
+- `children: ReactNode` — typically a lucide icon.
+- `indicator?: boolean` — show the dot.
+- `indicatorTone?: 'danger' | 'warning' | 'info' | 'accent'` — default `'danger'`. The notification color.
+- `aria-label: string` — REQUIRED (icon-only button).
+- Plus `ButtonHTMLAttributes` via spread.
+
+Renders the Button with `position: relative` so the dot can absolute-position to top-right.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `packages/design-system/src/components/TopBar/TopBar.tsx` (NEW) | Root + context (likely no context needed — pure layout) + compose subcomponents |
+| `packages/design-system/src/components/TopBar/TopBarStart.tsx` (NEW) | `<div className="start">` flex region |
+| `packages/design-system/src/components/TopBar/TopBarEnd.tsx` (NEW) | `<div className="end">` flex region |
+| `packages/design-system/src/components/TopBar/TopBarSearch.tsx` (NEW) | Styled search input |
+| `packages/design-system/src/components/TopBar/TopBarIconButton.tsx` (NEW) | Icon button + optional indicator dot |
+| `packages/design-system/src/components/TopBar/TopBar.module.scss` (NEW) | All visual styles |
+| `packages/design-system/src/components/TopBar/TopBar.tokens.scss` (NEW) | Component tokens |
+| `packages/design-system/src/components/TopBar/TopBar.test.tsx` (NEW) | Unit tests |
+| `packages/design-system/src/components/TopBar/index.ts` (NEW) | Public exports |
+| `packages/design-system/src/i18n/messages.ts` (MODIFY) | Add `topBar.label`, `topBar.search` keys |
+| `packages/design-system/src/i18n/en.ts` (MODIFY) | en values |
+| `packages/design-system/src/i18n/ru.ts` (MODIFY) | ru values |
+| `packages/design-system/src/index.ts` (MODIFY) | Re-export |
+| `packages/design-system/AGENTS.md` (MODIFY) | TopBar catalog entry |
+| `packages/playground/src/pages/components/TopBarDemo.tsx` (NEW) | Demo page |
+| `packages/playground/src/App.tsx` (MODIFY) | Route |
+| `packages/playground/src/layout/AppShell/AppShell.tsx` (MODIFY) | Adopt the new TopBar; remove hand-rolled markup |
+| `packages/playground/src/layout/AppShell/AppShell.module.scss` (MODIFY) | Remove now-dead `.topbar`/`.searchWrap`/`.iconBtn` etc. styles |
+| `packages/playground/src/pages/mockups/registry.ts` (MODIFY) | Add `TopBar` to the ComponentName union |
+| `packages/playground/src/pages/components/ComponentsIndex.tsx` (MODIFY) | Add card |
+| `packages/design-system/src/components.manifest.json` (regen via script) | New component metadata |
+
+## Tokens
+
+```scss
+:root {
+  // Bar chrome
+  --topbar-height: 56px;
+  --topbar-bg: var(--color-bg);
+  --topbar-border-color: var(--color-border);
+  --topbar-border-width: var(--border-width);
+  --topbar-padding-x: var(--space-4);
+  --topbar-gap: var(--space-md, var(--space-3));
+  --topbar-z-index: 5;
+
+  // Search
+  --topbar-search-min-width: 280px;
+  --topbar-search-max-width: 420px;
+  --topbar-search-height: 32px;
+  --topbar-search-bg: var(--color-bg-subtle);
+  --topbar-search-fg: var(--color-fg);
+  --topbar-search-placeholder-fg: var(--color-fg-muted);
+  --topbar-search-radius: var(--radius-md);
+  --topbar-search-padding-x: var(--space-3);
+  --topbar-search-gap: var(--space-2);
+  --topbar-search-icon-fg: var(--color-fg-muted);
+  --topbar-search-icon-size: 14px;
+  --topbar-search-kbd-bg: var(--color-bg-muted);
+  --topbar-search-kbd-fg: var(--color-fg-muted);
+  --topbar-search-kbd-radius: var(--radius-sm);
+  --topbar-search-kbd-padding-x: var(--space-1);
+  --topbar-search-kbd-font-size: var(--font-size-xs);
+  --topbar-search-ring-focus: var(--ring-accent);
+
+  // Icon button
+  --topbar-icon-button-size: 32px;
+  --topbar-icon-button-radius: var(--radius-md);
+
+  // Notification dot
+  --topbar-indicator-size: 8px;
+  --topbar-indicator-offset-top: 6px;
+  --topbar-indicator-offset-right: 6px;
+  --topbar-indicator-bg-danger: var(--color-danger);
+  --topbar-indicator-bg-warning: var(--color-warning);
+  --topbar-indicator-bg-info: var(--color-info);
+  --topbar-indicator-bg-accent: var(--color-accent);
+  --topbar-indicator-border-color: var(--topbar-bg); // same as bar bg so the ring around the dot reads as a tiny halo
+  --topbar-indicator-border-width: 1.5px;
+}
+```
+
+## i18n keys
+
+```ts
+topBar: {
+  label: string;   // default aria-label for the bar
+  search: string;  // default aria-label for the search input
+};
+```
+
+| Key | en | ru |
+| --- | --- | --- |
+| `topBar.label` | `Application top bar` | `Верхняя панель приложения` |
+| `topBar.search` | `Search` | `Поиск` |
+
+## Accessibility
+
+- `<header>` element. When the consumer renders it inside the page body, the implicit `banner` role applies. Override with `as="div"` for nested bars (a secondary toolbar inside a main page area where `<header>` isn't appropriate).
+- `<TopBar.Search>` is a real `<input type="search">`. Browsers expose `role="searchbox"` automatically. The leading icon is `aria-hidden`. The trailing kbd hint is `aria-hidden` (it's a visual reminder, not announced).
+- `<TopBar.IconButton>` requires `aria-label` (extends `<Button iconOnly>`). The indicator dot has no role — it's a visual cue. Consumer is responsible for an additional accessible note ("3 unread notifications") via either the `aria-label` text or a hidden span.
+
+## Tests
+
+Per Rule 1, `TopBar.test.tsx` covers:
+
+- Root renders as `<header>` by default; `as="div"` renders a `<div>`.
+- aria-label defaults to `t('topBar.label')`; consumer override wins.
+- Start/End slot positions: Start has `flex: 1`, End shrinks. (Assert via class application — actual flex math is jsdom-untestable.)
+- TopBar.Search renders icon, input, and (when provided) kbd hint.
+- TopBar.Search input forwards arbitrary HTML props (`onChange`, `value`, etc.).
+- TopBar.IconButton renders without indicator by default; `indicator` prop adds the dot element.
+- All subcomponents `forwardRef` (Rule 6).
+
+## Demo + playground
+
+A new `RailDemo`-shaped demo page at `/components/topbar` with examples:
+
+1. Default — Start has Search, End has IconButtons + Avatar (matches the existing playground topbar).
+2. No search — End-only with brand on the Start side.
+3. Custom indicator tone — show `indicatorTone="warning"` for a maintenance-banner kind of cue.
+4. Inside a layout — wrap a `<TopBar>` in a small mock app shell to show the sticky behavior.
+
+After the primitive ships, adopt it inside the playground's `AppShell.tsx` to remove the hand-rolled markup (search input, icon buttons, notification dot, etc.). Drop the now-orphaned classes from `AppShell.module.scss`.
+
+## Out of scope (deliberate)
+
+- Command-palette behavior (typing-to-search, keyboard shortcut to focus the input, result list). The `hotkey` prop is visual only.
+- A built-in "user menu" or "create menu" — consumers compose those with existing primitives (`<DropdownMenu>` + `<Avatar>` etc.).
+- Theming variants (dark TopBar inside a light app, or transparent over a hero image). The default light-on-light look matches the playground; consumers retheme via the tokens.
+- A right-aligned brand or logo slot. The brand lives in `<Rail.Header>` per the AppShell pattern; TopBar is search + actions.
+
+## File layout invariants
+
+- All values in `TopBar.module.scss` via `var(--topbar-*)` tokens declared in `TopBar.tokens.scss`.
+- The TopBar owns its height/padding/border-bottom because it IS a layout primitive — same Rule 4 exception as Rail/Modal/Page. Documented inline.
+- All public types re-exported from `src/index.ts`.
+- `forwardRef` + JSDoc on every exported member.
+- Every user-facing string flows through `useTranslation` (Rule 9).

--- a/docs/superpowers/specs/2026-05-28-topbar-design.md
+++ b/docs/superpowers/specs/2026-05-28-topbar-design.md
@@ -93,29 +93,29 @@ Renders the Button with `position: relative` so the dot can absolute-position to
 
 ## Files
 
-| File | Role |
-| --- | --- |
-| `packages/design-system/src/components/TopBar/TopBar.tsx` (NEW) | Root + context (likely no context needed — pure layout) + compose subcomponents |
-| `packages/design-system/src/components/TopBar/TopBarStart.tsx` (NEW) | `<div className="start">` flex region |
-| `packages/design-system/src/components/TopBar/TopBarEnd.tsx` (NEW) | `<div className="end">` flex region |
-| `packages/design-system/src/components/TopBar/TopBarSearch.tsx` (NEW) | Styled search input |
-| `packages/design-system/src/components/TopBar/TopBarIconButton.tsx` (NEW) | Icon button + optional indicator dot |
-| `packages/design-system/src/components/TopBar/TopBar.module.scss` (NEW) | All visual styles |
-| `packages/design-system/src/components/TopBar/TopBar.tokens.scss` (NEW) | Component tokens |
-| `packages/design-system/src/components/TopBar/TopBar.test.tsx` (NEW) | Unit tests |
-| `packages/design-system/src/components/TopBar/index.ts` (NEW) | Public exports |
-| `packages/design-system/src/i18n/messages.ts` (MODIFY) | Add `topBar.label`, `topBar.search` keys |
-| `packages/design-system/src/i18n/en.ts` (MODIFY) | en values |
-| `packages/design-system/src/i18n/ru.ts` (MODIFY) | ru values |
-| `packages/design-system/src/index.ts` (MODIFY) | Re-export |
-| `packages/design-system/AGENTS.md` (MODIFY) | TopBar catalog entry |
-| `packages/playground/src/pages/components/TopBarDemo.tsx` (NEW) | Demo page |
-| `packages/playground/src/App.tsx` (MODIFY) | Route |
-| `packages/playground/src/layout/AppShell/AppShell.tsx` (MODIFY) | Adopt the new TopBar; remove hand-rolled markup |
-| `packages/playground/src/layout/AppShell/AppShell.module.scss` (MODIFY) | Remove now-dead `.topbar`/`.searchWrap`/`.iconBtn` etc. styles |
-| `packages/playground/src/pages/mockups/registry.ts` (MODIFY) | Add `TopBar` to the ComponentName union |
-| `packages/playground/src/pages/components/ComponentsIndex.tsx` (MODIFY) | Add card |
-| `packages/design-system/src/components.manifest.json` (regen via script) | New component metadata |
+| File                                                                      | Role                                                                            |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `packages/design-system/src/components/TopBar/TopBar.tsx` (NEW)           | Root + context (likely no context needed — pure layout) + compose subcomponents |
+| `packages/design-system/src/components/TopBar/TopBarStart.tsx` (NEW)      | `<div className="start">` flex region                                           |
+| `packages/design-system/src/components/TopBar/TopBarEnd.tsx` (NEW)        | `<div className="end">` flex region                                             |
+| `packages/design-system/src/components/TopBar/TopBarSearch.tsx` (NEW)     | Styled search input                                                             |
+| `packages/design-system/src/components/TopBar/TopBarIconButton.tsx` (NEW) | Icon button + optional indicator dot                                            |
+| `packages/design-system/src/components/TopBar/TopBar.module.scss` (NEW)   | All visual styles                                                               |
+| `packages/design-system/src/components/TopBar/TopBar.tokens.scss` (NEW)   | Component tokens                                                                |
+| `packages/design-system/src/components/TopBar/TopBar.test.tsx` (NEW)      | Unit tests                                                                      |
+| `packages/design-system/src/components/TopBar/index.ts` (NEW)             | Public exports                                                                  |
+| `packages/design-system/src/i18n/messages.ts` (MODIFY)                    | Add `topBar.label`, `topBar.search` keys                                        |
+| `packages/design-system/src/i18n/en.ts` (MODIFY)                          | en values                                                                       |
+| `packages/design-system/src/i18n/ru.ts` (MODIFY)                          | ru values                                                                       |
+| `packages/design-system/src/index.ts` (MODIFY)                            | Re-export                                                                       |
+| `packages/design-system/AGENTS.md` (MODIFY)                               | TopBar catalog entry                                                            |
+| `packages/playground/src/pages/components/TopBarDemo.tsx` (NEW)           | Demo page                                                                       |
+| `packages/playground/src/App.tsx` (MODIFY)                                | Route                                                                           |
+| `packages/playground/src/layout/AppShell/AppShell.tsx` (MODIFY)           | Adopt the new TopBar; remove hand-rolled markup                                 |
+| `packages/playground/src/layout/AppShell/AppShell.module.scss` (MODIFY)   | Remove now-dead `.topbar`/`.searchWrap`/`.iconBtn` etc. styles                  |
+| `packages/playground/src/pages/mockups/registry.ts` (MODIFY)              | Add `TopBar` to the ComponentName union                                         |
+| `packages/playground/src/pages/components/ComponentsIndex.tsx` (MODIFY)   | Add card                                                                        |
+| `packages/design-system/src/components.manifest.json` (regen via script)  | New component metadata                                                          |
 
 ## Tokens
 
@@ -161,7 +161,9 @@ Renders the Button with `position: relative` so the dot can absolute-position to
   --topbar-indicator-bg-warning: var(--color-warning);
   --topbar-indicator-bg-info: var(--color-info);
   --topbar-indicator-bg-accent: var(--color-accent);
-  --topbar-indicator-border-color: var(--topbar-bg); // same as bar bg so the ring around the dot reads as a tiny halo
+  --topbar-indicator-border-color: var(
+    --topbar-bg
+  ); // same as bar bg so the ring around the dot reads as a tiny halo
   --topbar-indicator-border-width: 1.5px;
 }
 ```
@@ -170,15 +172,15 @@ Renders the Button with `position: relative` so the dot can absolute-position to
 
 ```ts
 topBar: {
-  label: string;   // default aria-label for the bar
-  search: string;  // default aria-label for the search input
-};
+  label: string; // default aria-label for the bar
+  search: string; // default aria-label for the search input
+}
 ```
 
-| Key | en | ru |
-| --- | --- | --- |
-| `topBar.label` | `Application top bar` | `Верхняя панель приложения` |
-| `topBar.search` | `Search` | `Поиск` |
+| Key             | en                    | ru                          |
+| --------------- | --------------------- | --------------------------- |
+| `topBar.label`  | `Application top bar` | `Верхняя панель приложения` |
+| `topBar.search` | `Search`              | `Поиск`                     |
 
 ## Accessibility
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1362,6 +1362,53 @@ import { Home, Users, Settings } from 'lucide-react';
 - ❌ Multi-level group nesting (groups inside groups). v1 supports one level only.
 - ❌ Putting an icon-less top-level item directly inside a section — when the rail collapses there's nothing visible. Items without icons belong inside a `<Rail.Group>`.
 
+### `<TopBar>` — sticky application top bar
+
+Horizontal app-chrome bar pinned to the top of the viewport. Compound API: `<TopBar.Start>` + `<TopBar.End>` for the two horizontal clusters, plus `<TopBar.Search>` (styled `<input type="search">` with a leading icon and an optional `<kbd>` hotkey hint) and `<TopBar.IconButton>` (icon-only ghost button with an optional notification-dot indicator).
+
+```tsx
+import { Avatar, TopBar } from '@eocrm/design-system';
+import { Bell, Plus } from 'lucide-react';
+
+<TopBar>
+  <TopBar.Start>
+    <TopBar.Search placeholder="Search contacts, deals…" hotkey="⌘K" />
+  </TopBar.Start>
+  <TopBar.End>
+    <TopBar.IconButton aria-label="Create new">
+      <Plus size={16} />
+    </TopBar.IconButton>
+    <TopBar.IconButton aria-label="Notifications, 3 unread" indicator>
+      <Bell size={16} />
+    </TopBar.IconButton>
+    <Avatar name="Alex Rivera" size="sm" />
+  </TopBar.End>
+</TopBar>;
+```
+
+- **Compound API** — `TopBar.Start` / `TopBar.End` / `TopBar.Search` / `TopBar.IconButton`.
+- **Layout-owning primitive (Hard rule 4 exception)** — like `<Modal>`, `<Drawer>`, `<Page>`, `<Rail>`, the bar owns its own height (56px), sticky positioning, padding, background, and bottom border because that IS its job as a top-bar chrome.
+- **`as` prop** — `'header'` (default, carries the implicit `banner` landmark) or `'div'` (for nested toolbars where stacking two `<header>` landmarks would be wrong).
+- **`<TopBar.Start>`** — flex-grows (`flex: 1`) so a sibling `<TopBar.End>` is pushed to the right edge with no spacer needed.
+- **`<TopBar.End>`** — shrinks to its content. Use for trailing actions + avatar.
+- **`<TopBar.Search>`** — a real `<input type="search">` (browsers expose `role="searchbox"`). `placeholder` is consumer-controlled. `aria-label` defaults to the placeholder, then to `t('topBar.search')`. The `hotkey` prop renders a trailing `<kbd>` hint — purely **visual**; binding ⌘K to focus is the consumer's responsibility. Spread `value` / `onChange` through normally — they reach the underlying input. The component sets `autoComplete="off"` plus `data-1p-ignore` / `data-lpignore` / `data-form-type="other"` so password managers and browser autofill skip it.
+- **`<TopBar.IconButton>`** — wraps `<Button iconOnly variant="ghost" size="sm">` sized for the bar (32×32) plus an optional `indicator` boolean. The dot tone is `'danger'` by default; pick `'warning'` / `'info'` / `'accent'` for softer cues. **`aria-label` is required** — include count info there (`'Notifications, 3 unread'`); the dot itself is `aria-hidden`.
+- **i18n**: `topBar.label` (default `<header>` aria-label), `topBar.search` (default `<input>` aria-label fallback).
+
+#### When NOT to use
+
+- ❌ Left-side navigation column — use `<Rail>`.
+- ❌ Page-local heading + actions — use `<PageHeader>`, not a TopBar.
+- ❌ Action toolbar attached to a specific section — use a `<Cluster>` inside that section; TopBar is for the application's top chrome.
+- ❌ Command-palette experience — `<TopBar.Search>` is a plain text input. Compose `<Popover>` + `<OptionsPicker>` for typeahead / result lists.
+
+#### Anti-patterns
+
+- ❌ Wrapping the bar in another `position: sticky` container — the bar already sticks. Layered sticky parents stack at the wrong offset.
+- ❌ Reaching for `<TopBar.IconButton>` outside the bar — it's a topbar-scoped size + indicator pattern. Use `<Button iconOnly variant="ghost">` for general icon buttons.
+- ❌ Putting a `<Button variant="primary">` inside the bar — primary actions belong in the page body where they're discoverable; the topbar is for navigation, search, and global ambient actions only.
+- ❌ Relying on the indicator dot to communicate count to assistive tech — the dot is decorative (`aria-hidden`); put the count in the `aria-label` instead.
+
 ### `<DropdownMenu>` — action menus from a trigger
 
 ```tsx

--- a/packages/design-system/scripts/generate-manifest.mjs
+++ b/packages/design-system/scripts/generate-manifest.mjs
@@ -79,6 +79,7 @@ const CLUSTERS = {
   Link: 'Navigation',
   Rail: 'Navigation',
   Tabs: 'Navigation',
+  TopBar: 'Navigation',
 
   // Overlays
   ConfirmationPopover: 'Overlays',

--- a/packages/design-system/src/_meta/manifest.ts
+++ b/packages/design-system/src/_meta/manifest.ts
@@ -101,6 +101,7 @@ const CLUSTERS: Record<string, string> = {
   Link: 'Navigation',
   Rail: 'Navigation',
   Tabs: 'Navigation',
+  TopBar: 'Navigation',
 
   // Overlays
   ConfirmationPopover: 'Overlays',

--- a/packages/design-system/src/components.manifest.json
+++ b/packages/design-system/src/components.manifest.json
@@ -56,7 +56,8 @@
       "OptionsPicker",
       "PasswordInput",
       "Rail",
-      "Toast"
+      "Toast",
+      "TopBar"
     ]
   },
   "ButtonGroup": {
@@ -480,5 +481,13 @@
       "PasswordInput",
       "Rail"
     ]
+  },
+  "TopBar": {
+    "tier": "composition",
+    "cluster": "Navigation",
+    "composes": [
+      "Button"
+    ],
+    "composedBy": []
   }
 }

--- a/packages/design-system/src/components/TopBar/TopBar.module.scss
+++ b/packages/design-system/src/components/TopBar/TopBar.module.scss
@@ -1,0 +1,42 @@
+@use './TopBar.tokens';
+
+// ─── Root ───────────────────────────────────────────────────────────────
+// stylelint-disable property-disallowed-list -- TopBar is a layout-owning
+// primitive (Hard rule 4 exception). Like <Modal>, <Drawer>, <Page>, <Rail>,
+// the top bar owns its OWN height + padding + sticky positioning because
+// that IS its job as a top-bar chrome. The consumer chooses WHERE the bar
+// lives (typically a CSS-grid app shell) by styling its parent; the bar
+// itself fills the available inline space.
+.topBar {
+  position: sticky;
+  top: 0;
+  z-index: var(--topbar-z-index);
+  height: var(--topbar-height);
+  padding: 0 var(--topbar-padding-x);
+  background: var(--topbar-bg);
+  border-bottom: var(--topbar-border-width) solid var(--topbar-border-color);
+  display: flex;
+  align-items: center;
+  gap: var(--topbar-gap);
+}
+// stylelint-enable property-disallowed-list
+
+// ─── Start / End clusters ───────────────────────────────────────────────
+// stylelint-disable property-disallowed-list -- Start/End are TopBar's
+// internal layout regions: Start flex-grows so End is pushed to the right
+// edge with no spacer. Same rule-4 exception as the bar itself.
+.start {
+  display: flex;
+  align-items: center;
+  gap: var(--topbar-gap);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.end {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+// stylelint-enable property-disallowed-list

--- a/packages/design-system/src/components/TopBar/TopBar.module.scss
+++ b/packages/design-system/src/components/TopBar/TopBar.module.scss
@@ -111,3 +111,46 @@
   font-family: var(--font-family-sans);
   flex-shrink: 0;
 }
+
+// ─── IconButton + notification indicator ────────────────────────────────
+// stylelint-disable property-disallowed-list -- icon button needs an
+// explicit width + position:relative so the indicator dot (absolute-
+// positioned in its upper-right) has an anchor. The dot itself is
+// absolutely positioned, which Rule 4 normally bans on components — but
+// it's a topbar-scoped visual marker, not a layout container, so the
+// exception is justified inline.
+.iconButton {
+  width: var(--topbar-icon-button-size);
+  height: var(--topbar-icon-button-size);
+  border-radius: var(--topbar-icon-button-radius);
+  position: relative;
+}
+
+.indicator {
+  position: absolute;
+  top: var(--topbar-indicator-offset-top);
+  right: var(--topbar-indicator-offset-right);
+  width: var(--topbar-indicator-size);
+  height: var(--topbar-indicator-size);
+  border-radius: var(--radius-full);
+  border: var(--topbar-indicator-border-width) solid var(--topbar-indicator-border-color);
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- the dot is decorative; clicks pass through to the button beneath
+  pointer-events: none;
+}
+// stylelint-enable property-disallowed-list
+
+.indicatorDanger {
+  background: var(--topbar-indicator-bg-danger);
+}
+
+.indicatorWarning {
+  background: var(--topbar-indicator-bg-warning);
+}
+
+.indicatorInfo {
+  background: var(--topbar-indicator-bg-info);
+}
+
+.indicatorAccent {
+  background: var(--topbar-indicator-bg-accent);
+}

--- a/packages/design-system/src/components/TopBar/TopBar.module.scss
+++ b/packages/design-system/src/components/TopBar/TopBar.module.scss
@@ -40,3 +40,74 @@
   flex-shrink: 0;
 }
 // stylelint-enable property-disallowed-list
+
+// ─── Search ─────────────────────────────────────────────────────────────
+// stylelint-disable property-disallowed-list -- search field needs a max
+// width so it doesn't stretch across an entire wide viewport, and a
+// min-width: 0 so it can shrink inside the Start cluster's flex row.
+.search {
+  display: flex;
+  align-items: center;
+  gap: var(--topbar-search-gap);
+  height: var(--topbar-search-height);
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- intrinsic 100% of the available column
+  width: 100%;
+  max-width: var(--topbar-search-max-width);
+  min-width: 0;
+  padding: 0 var(--topbar-search-padding-x);
+  background: var(--topbar-search-bg);
+  border-radius: var(--topbar-search-radius);
+}
+// stylelint-enable property-disallowed-list
+
+.search:focus-within {
+  outline: var(--ring-width) solid var(--topbar-search-ring-focus);
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- pull the focus ring inward by 1px so it sits ON the surface edge instead of outside it
+  outline-offset: -1px;
+}
+
+.searchIcon {
+  width: var(--topbar-search-icon-size);
+  height: var(--topbar-search-icon-size);
+  color: var(--topbar-search-icon-fg);
+  flex-shrink: 0;
+}
+
+// stylelint-disable property-disallowed-list -- the input needs flex:1 so it
+// fills the remaining width inside the .search wrapper between the icon and
+// the kbd hint. It is NOT a layout-owning region — it is the inner content
+// of the search pill.
+.searchInput {
+  flex: 1 1 auto;
+  min-width: 0;
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- transparent so the wrapper's bg shows through
+  background: transparent;
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- native input border reset; the wrapper provides chrome
+  border: 0;
+  color: var(--topbar-search-fg);
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- inherit page font sizing
+  font: inherit;
+}
+// stylelint-enable property-disallowed-list
+
+.searchInput:focus {
+  // stylelint-disable-next-line declaration-property-value-disallowed-list -- the wrapper handles the visible focus ring (focus-within)
+  outline: none;
+}
+
+.searchInput::placeholder {
+  color: var(--topbar-search-placeholder-fg);
+}
+
+.searchKbd {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 var(--topbar-search-kbd-padding-x);
+  background: var(--topbar-search-kbd-bg);
+  color: var(--topbar-search-kbd-fg);
+  font-size: var(--topbar-search-kbd-font-size);
+  border-radius: var(--topbar-search-kbd-radius);
+  font-family: var(--font-family-sans);
+  flex-shrink: 0;
+}

--- a/packages/design-system/src/components/TopBar/TopBar.test.tsx
+++ b/packages/design-system/src/components/TopBar/TopBar.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { TopBar } from './TopBar';
+
+describe('TopBar (smoke)', () => {
+  it('renders without crashing', () => {
+    render(<TopBar aria-label="bar" />);
+    expect(screen.getByRole('banner', { name: 'bar' })).toBeInTheDocument();
+  });
+});

--- a/packages/design-system/src/components/TopBar/TopBar.test.tsx
+++ b/packages/design-system/src/components/TopBar/TopBar.test.tsx
@@ -30,9 +30,7 @@ describe('TopBar', () => {
         <TopBar />
       </I18nProvider>,
     );
-    expect(
-      screen.getByRole('banner', { name: 'Верхняя панель приложения' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('banner', { name: 'Верхняя панель приложения' })).toBeInTheDocument();
   });
 
   it('merges consumer className with the internal class instead of replacing it', () => {
@@ -207,9 +205,9 @@ describe('TopBar', () => {
             </TopBar.End>
           </TopBar>,
         );
-        const dot = screen.getByRole('button', { name: `btn-${tone}` }).querySelector(
-          'span[aria-hidden]',
-        );
+        const dot = screen
+          .getByRole('button', { name: `btn-${tone}` })
+          .querySelector('span[aria-hidden]');
         expect(dot).not.toBeNull();
         // The class list should contain something that ends in the tone (the
         // CSS module hashes the class but keeps the readable suffix).

--- a/packages/design-system/src/components/TopBar/TopBar.test.tsx
+++ b/packages/design-system/src/components/TopBar/TopBar.test.tsx
@@ -1,9 +1,258 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nProvider } from '../../i18n/I18nProvider';
 import { TopBar } from './TopBar';
 
-describe('TopBar (smoke)', () => {
-  it('renders without crashing', () => {
-    render(<TopBar aria-label="bar" />);
-    expect(screen.getByRole('banner', { name: 'bar' })).toBeInTheDocument();
+describe('TopBar', () => {
+  it('renders as a <header> banner landmark by default with the default aria-label', () => {
+    render(<TopBar />);
+    const bar = screen.getByRole('banner', { name: 'Application top bar' });
+    expect(bar.tagName).toBe('HEADER');
+  });
+
+  it('honors the aria-label prop override', () => {
+    render(<TopBar aria-label="Custom bar" />);
+    expect(screen.getByRole('banner', { name: 'Custom bar' })).toBeInTheDocument();
+  });
+
+  it('renders as a <div> (no banner role) when as="div" is passed', () => {
+    const { container } = render(<TopBar as="div" aria-label="Nested" />);
+    expect(screen.queryByRole('banner')).not.toBeInTheDocument();
+    const root = container.firstElementChild;
+    expect(root?.tagName).toBe('DIV');
+    expect(root?.getAttribute('aria-label')).toBe('Nested');
+  });
+
+  it('uses ru locale for the default aria-label when I18nProvider locale="ru"', () => {
+    render(
+      <I18nProvider locale="ru">
+        <TopBar />
+      </I18nProvider>,
+    );
+    expect(
+      screen.getByRole('banner', { name: 'Верхняя панель приложения' }),
+    ).toBeInTheDocument();
+  });
+
+  it('merges consumer className with the internal class instead of replacing it', () => {
+    render(<TopBar aria-label="bar" className="custom-class" />);
+    const bar = screen.getByRole('banner');
+    expect(bar.className).toContain('custom-class');
+    // The internal layout class must still be present so the bar keeps its
+    // sticky-top + flex chrome — `className` is merge, not replace.
+    expect(bar.className.split(' ').length).toBeGreaterThan(1);
+  });
+
+  it('forwards refs on the root and every subcomponent', () => {
+    const rootRef = createRef<HTMLElement>();
+    const startRef = createRef<HTMLDivElement>();
+    const endRef = createRef<HTMLDivElement>();
+    const searchRef = createRef<HTMLInputElement>();
+    const buttonRef = createRef<HTMLButtonElement>();
+    render(
+      <TopBar ref={rootRef} aria-label="bar">
+        <TopBar.Start ref={startRef}>
+          <TopBar.Search ref={searchRef} placeholder="search" />
+        </TopBar.Start>
+        <TopBar.End ref={endRef}>
+          <TopBar.IconButton ref={buttonRef} aria-label="act">
+            <span>i</span>
+          </TopBar.IconButton>
+        </TopBar.End>
+      </TopBar>,
+    );
+    expect(rootRef.current?.tagName).toBe('HEADER');
+    expect(startRef.current?.tagName).toBe('DIV');
+    expect(endRef.current?.tagName).toBe('DIV');
+    expect(searchRef.current?.tagName).toBe('INPUT');
+    expect(buttonRef.current?.tagName).toBe('BUTTON');
+  });
+
+  describe('Search', () => {
+    it('renders a <input type="search"> with the placeholder as the aria-label fallback', () => {
+      render(
+        <TopBar aria-label="bar">
+          <TopBar.Start>
+            <TopBar.Search placeholder="Search contacts" />
+          </TopBar.Start>
+        </TopBar>,
+      );
+      const input = screen.getByRole('searchbox', { name: 'Search contacts' });
+      expect(input).toHaveAttribute('type', 'search');
+      expect(input).toHaveAttribute('placeholder', 'Search contacts');
+    });
+
+    it('uses t("topBar.search") as aria-label when neither placeholder nor aria-label is set', () => {
+      render(
+        <TopBar aria-label="bar">
+          <TopBar.Start>
+            <TopBar.Search />
+          </TopBar.Start>
+        </TopBar>,
+      );
+      expect(screen.getByRole('searchbox', { name: 'Search' })).toBeInTheDocument();
+    });
+
+    it('explicit aria-label wins over both placeholder and the i18n default', () => {
+      render(
+        <TopBar aria-label="bar">
+          <TopBar.Start>
+            <TopBar.Search placeholder="placeholder" aria-label="Find" />
+          </TopBar.Start>
+        </TopBar>,
+      );
+      expect(screen.getByRole('searchbox', { name: 'Find' })).toBeInTheDocument();
+    });
+
+    it('renders the optional <kbd> hotkey hint when `hotkey` is provided', () => {
+      render(
+        <TopBar aria-label="bar">
+          <TopBar.Start>
+            <TopBar.Search placeholder="search" hotkey="⌘K" />
+          </TopBar.Start>
+        </TopBar>,
+      );
+      // The kbd is aria-hidden, so we query the DOM directly.
+      const kbd = document.querySelector('kbd');
+      expect(kbd).not.toBeNull();
+      expect(kbd?.textContent).toBe('⌘K');
+      expect(kbd?.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('omits the kbd hint when `hotkey` is not provided', () => {
+      render(
+        <TopBar aria-label="bar">
+          <TopBar.Start>
+            <TopBar.Search placeholder="search" />
+          </TopBar.Start>
+        </TopBar>,
+      );
+      expect(document.querySelector('kbd')).toBeNull();
+    });
+
+    it('forwards `value` / `onChange` through to the underlying input', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <TopBar aria-label="bar">
+          <TopBar.Start>
+            <TopBar.Search placeholder="search" value="hi" onChange={onChange} />
+          </TopBar.Start>
+        </TopBar>,
+      );
+      const input = screen.getByRole('searchbox');
+      expect(input).toHaveValue('hi');
+      await user.type(input, 'x');
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('sets the password-manager and autofill ignore attributes on the input', () => {
+      render(
+        <TopBar aria-label="bar">
+          <TopBar.Start>
+            <TopBar.Search placeholder="search" />
+          </TopBar.Start>
+        </TopBar>,
+      );
+      const input = screen.getByRole('searchbox');
+      expect(input).toHaveAttribute('autocomplete', 'off');
+      expect(input).toHaveAttribute('data-1p-ignore');
+      expect(input).toHaveAttribute('data-lpignore', 'true');
+      expect(input).toHaveAttribute('data-form-type', 'other');
+    });
+  });
+
+  describe('IconButton', () => {
+    it('renders a <button> with the given aria-label and no indicator dot by default', () => {
+      render(
+        <TopBar aria-label="bar">
+          <TopBar.End>
+            <TopBar.IconButton aria-label="Create new">
+              <span data-testid="icon">+</span>
+            </TopBar.IconButton>
+          </TopBar.End>
+        </TopBar>,
+      );
+      const button = screen.getByRole('button', { name: 'Create new' });
+      expect(button.tagName).toBe('BUTTON');
+      // No indicator span when `indicator` is omitted.
+      expect(button.querySelector('span[aria-hidden]')).toBeNull();
+    });
+
+    it('renders the indicator dot when `indicator` is set', () => {
+      render(
+        <TopBar aria-label="bar">
+          <TopBar.End>
+            <TopBar.IconButton aria-label="Notifications" indicator>
+              <span>b</span>
+            </TopBar.IconButton>
+          </TopBar.End>
+        </TopBar>,
+      );
+      const button = screen.getByRole('button', { name: 'Notifications' });
+      const dot = button.querySelector('span[aria-hidden]');
+      expect(dot).not.toBeNull();
+    });
+
+    it('applies the correct tone class for each indicatorTone option', () => {
+      const tones = ['danger', 'warning', 'info', 'accent'] as const;
+      for (const tone of tones) {
+        const { unmount } = render(
+          <TopBar aria-label={`bar-${tone}`}>
+            <TopBar.End>
+              <TopBar.IconButton aria-label={`btn-${tone}`} indicator indicatorTone={tone}>
+                <span>i</span>
+              </TopBar.IconButton>
+            </TopBar.End>
+          </TopBar>,
+        );
+        const dot = screen.getByRole('button', { name: `btn-${tone}` }).querySelector(
+          'span[aria-hidden]',
+        );
+        expect(dot).not.toBeNull();
+        // The class list should contain something that ends in the tone (the
+        // CSS module hashes the class but keeps the readable suffix).
+        expect(dot?.className.toLowerCase()).toContain(tone);
+        unmount();
+      }
+    });
+
+    it('forwards click handlers and other button props through the wrapping Button', async () => {
+      const user = userEvent.setup();
+      const onClick = vi.fn();
+      render(
+        <TopBar aria-label="bar">
+          <TopBar.End>
+            <TopBar.IconButton aria-label="act" onClick={onClick} data-testid="btn">
+              <span>i</span>
+            </TopBar.IconButton>
+          </TopBar.End>
+        </TopBar>,
+      );
+      const button = screen.getByTestId('btn');
+      await user.click(button);
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Start / End', () => {
+    it('Start and End are distinct DOM elements with their own classes', () => {
+      render(
+        <TopBar aria-label="bar">
+          <TopBar.Start data-testid="start">
+            <span>start</span>
+          </TopBar.Start>
+          <TopBar.End data-testid="end">
+            <span>end</span>
+          </TopBar.End>
+        </TopBar>,
+      );
+      const start = screen.getByTestId('start');
+      const end = screen.getByTestId('end');
+      expect(start.tagName).toBe('DIV');
+      expect(end.tagName).toBe('DIV');
+      expect(start.className).not.toBe(end.className);
+    });
   });
 });

--- a/packages/design-system/src/components/TopBar/TopBar.tokens.scss
+++ b/packages/design-system/src/components/TopBar/TopBar.tokens.scss
@@ -14,7 +14,6 @@
   --topbar-z-index: 5;
 
   // ─── Search ───────────────────────────────────────────────────────────
-  --topbar-search-min-width: 280px;
   --topbar-search-max-width: 420px;
   --topbar-search-height: 32px;
   --topbar-search-bg: var(--color-bg-subtle);

--- a/packages/design-system/src/components/TopBar/TopBar.tokens.scss
+++ b/packages/design-system/src/components/TopBar/TopBar.tokens.scss
@@ -1,0 +1,52 @@
+// TopBar.tokens.scss — Component-scoped tokens for <TopBar>. Each token
+// defaults to the primitive that the SCSS would otherwise use directly.
+// Consumers can rebind any of these at a higher level
+// (`.theme-foo :root { --topbar-bg: … }`) to retheme the bar without
+// forking its module.scss.
+:root {
+  // ─── Bar chrome ───────────────────────────────────────────────────────
+  --topbar-height: 56px;
+  --topbar-bg: var(--color-bg);
+  --topbar-border-color: var(--color-border);
+  --topbar-border-width: var(--border-width);
+  --topbar-padding-x: var(--space-4);
+  --topbar-gap: var(--space-3);
+  --topbar-z-index: 5;
+
+  // ─── Search ───────────────────────────────────────────────────────────
+  --topbar-search-min-width: 280px;
+  --topbar-search-max-width: 420px;
+  --topbar-search-height: 32px;
+  --topbar-search-bg: var(--color-bg-subtle);
+  --topbar-search-fg: var(--color-fg);
+  --topbar-search-placeholder-fg: var(--color-fg-muted);
+  --topbar-search-radius: var(--radius-md);
+  --topbar-search-padding-x: var(--space-3);
+  --topbar-search-gap: var(--space-2);
+  --topbar-search-icon-fg: var(--color-fg-muted);
+  --topbar-search-icon-size: 14px;
+  --topbar-search-kbd-bg: var(--color-bg-muted);
+  --topbar-search-kbd-fg: var(--color-fg-muted);
+  --topbar-search-kbd-radius: var(--radius-sm);
+  --topbar-search-kbd-padding-x: var(--space-1);
+  --topbar-search-kbd-font-size: var(--font-size-xs);
+  --topbar-search-ring-focus: var(--ring-accent);
+
+  // ─── Icon button ──────────────────────────────────────────────────────
+  --topbar-icon-button-size: 32px;
+  --topbar-icon-button-radius: var(--radius-md);
+
+  // ─── Notification dot ─────────────────────────────────────────────────
+  --topbar-indicator-size: 8px;
+  --topbar-indicator-offset-top: 6px;
+  --topbar-indicator-offset-right: 6px;
+  --topbar-indicator-bg-danger: var(--color-danger);
+  --topbar-indicator-bg-warning: var(--color-warning);
+  --topbar-indicator-bg-info: var(--color-info);
+  --topbar-indicator-bg-accent: var(--color-accent);
+
+  // Same as bar bg so the ring around the dot reads as a tiny halo
+  // separating it from the icon underneath.
+  --topbar-indicator-border-color: var(--topbar-bg);
+  --topbar-indicator-border-width: 1.5px;
+}

--- a/packages/design-system/src/components/TopBar/TopBar.tsx
+++ b/packages/design-system/src/components/TopBar/TopBar.tsx
@@ -3,6 +3,8 @@ import clsx from 'clsx';
 import { useTranslation } from '../../i18n';
 import { TopBarStart } from './TopBarStart';
 import { TopBarEnd } from './TopBarEnd';
+import { TopBarSearch } from './TopBarSearch';
+import { TopBarIconButton } from './TopBarIconButton';
 import styles from './TopBar.module.scss';
 
 /**
@@ -142,9 +144,9 @@ const TopBarRoot = forwardRef<HTMLElement, TopBarProps>(function TopBar(
  * attached to the root via `Object.assign` (the canonical compound pattern
  * used by `<Card>`, `<Rail>`, `<DropdownMenu>`, etc.).
  */
-// NOTE: Search and IconButton are attached in Task 5 once their modules
-// exist. This file's compose is updated then.
 export const TopBar = Object.assign(TopBarRoot, {
   Start: TopBarStart,
   End: TopBarEnd,
+  Search: TopBarSearch,
+  IconButton: TopBarIconButton,
 });

--- a/packages/design-system/src/components/TopBar/TopBar.tsx
+++ b/packages/design-system/src/components/TopBar/TopBar.tsx
@@ -1,0 +1,150 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { useTranslation } from '../../i18n';
+import { TopBarStart } from './TopBarStart';
+import { TopBarEnd } from './TopBarEnd';
+import styles from './TopBar.module.scss';
+
+/**
+ * Element type the root renders as. `'header'` (default) is the right choice
+ * for the application's primary top bar — it carries the implicit `banner`
+ * landmark when placed as a direct child of `<body>`. Use `'div'` for the
+ * rare case of a nested toolbar inside a main content area where another
+ * `<header>` element would be semantically wrong.
+ */
+export type TopBarElement = 'header' | 'div';
+
+/**
+ * Props for `<TopBar>` — the application top-bar primitive.
+ *
+ * Composes via `<TopBar.Start>` + `<TopBar.End>` for the two horizontal
+ * clusters, plus `<TopBar.Search>` and `<TopBar.IconButton>` for the most
+ * common children. Any other children are accepted — the root is just a
+ * flex row that owns its own height, padding, sticky positioning, and
+ * bottom border.
+ */
+export interface TopBarProps extends Omit<HTMLAttributes<HTMLElement>, 'aria-label'> {
+  /**
+   * Element to render. Defaults to `'header'`. Pick `'div'` when the bar is
+   * nested inside another content area where a second `<header>` landmark
+   * would conflict with page semantics.
+   */
+  as?: TopBarElement;
+  /**
+   * Accessible label for the bar's landmark. Defaults to `t('topBar.label')`
+   * so screen readers always announce a name for the region. Override when a
+   * page has multiple bars to disambiguate them.
+   */
+  'aria-label'?: string;
+  /**
+   * Children of the bar — typically `<TopBar.Start>` + `<TopBar.End>`. The
+   * children area is open so consumers can render a single cluster, a
+   * single trailing element, or any other arrangement they need.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Sticky application top-bar primitive. Renders an inline-padded horizontal
+ * bar pinned to the top of its scroll container with a subtle bottom border.
+ *
+ * **Layout-owning primitive (Hard rule 4 exception).** Like `<Modal>`,
+ * `<Drawer>`, `<Page>`, and `<Rail>`, `<TopBar>` is a layout container by
+ * design — it owns its own height, sticky positioning, padding, and
+ * background because that IS its job as a top-bar chrome. The consumer
+ * chooses where to place the bar by styling its parent (typically a CSS
+ * grid app shell); the bar itself fills the available inline space.
+ *
+ * Compound API — combine the subcomponents to build the bar you need:
+ *
+ * - `<TopBar.Start>` — the left cluster. Flex-grows to take remaining space.
+ * - `<TopBar.End>` — the right cluster. Shrinks to its content.
+ * - `<TopBar.Search>` — a styled `<input type="search">` with leading icon
+ *   and optional trailing `<kbd>` hint.
+ * - `<TopBar.IconButton>` — a thin `<Button iconOnly variant="ghost">` with
+ *   an optional notification-dot indicator.
+ *
+ * @example
+ * // Canonical app-shell pattern: Start has the search, End has the actions.
+ * <TopBar>
+ *   <TopBar.Start>
+ *     <TopBar.Search placeholder="Search contacts, deals…" hotkey="⌘K" />
+ *   </TopBar.Start>
+ *   <TopBar.End>
+ *     <TopBar.IconButton aria-label="Create new"><Plus size={16} /></TopBar.IconButton>
+ *     <TopBar.IconButton aria-label="Notifications" indicator>
+ *       <Bell size={16} />
+ *     </TopBar.IconButton>
+ *     <Avatar name="Alex Rivera" size="sm" />
+ *   </TopBar.End>
+ * </TopBar>
+ *
+ * @example
+ * // Right-aligned actions only — Start can be omitted; End still shrinks to
+ * // the right because the flex row has no growing sibling to push it.
+ * <TopBar>
+ *   <TopBar.End>
+ *     <TopBar.IconButton aria-label="Settings"><Settings size={16} /></TopBar.IconButton>
+ *   </TopBar.End>
+ * </TopBar>
+ *
+ * @example
+ * // Nested secondary toolbar — use `as="div"` to avoid stacking two
+ * // `<header>` landmarks on the page.
+ * <TopBar as="div" aria-label="Filters">
+ *   <TopBar.Start>…</TopBar.Start>
+ * </TopBar>
+ *
+ * @remarks When NOT to use
+ * - For a left-side navigation column → use `<Rail>`.
+ * - For a page-local heading + actions → use `<PageHeader>`, not a TopBar.
+ * - For an action toolbar attached to a specific section → use a `<Cluster>`
+ *   inside that section; TopBar is for the application's top chrome.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Wrapping the bar in additional `position: sticky` containers — the
+ *   bar already sticks. Layered sticky parents stack the bar at the wrong
+ *   offset.
+ * - ❌ Reaching for `<TopBar.IconButton>` outside the bar. It's a
+ *   topbar-specific size + indicator pattern; for general icon buttons use
+ *   `<Button iconOnly variant="ghost">`.
+ * - ❌ Putting a `<Button variant="primary">` inside the bar. Primary
+ *   actions belong inside the page body where they're discoverable; the
+ *   topbar is for navigation, search, and global ambient actions only.
+ */
+const TopBarRoot = forwardRef<HTMLElement, TopBarProps>(function TopBar(
+  { as = 'header', 'aria-label': ariaLabel, className, children, ...props },
+  ref,
+) {
+  const t = useTranslation();
+  // The `as` union is narrow (`'header' | 'div'`), so a single cast is
+  // enough — both elements accept the same HTMLAttributes<HTMLElement>
+  // surface used by the props interface. The forwarded ref is typed to
+  // HTMLElement (the common supertype) so the same ref works for either
+  // rendered element without leaking a generic into the public type.
+  const Comp = as as 'header';
+  return (
+    <Comp
+      ref={ref as never}
+      aria-label={ariaLabel ?? t('topBar.label')}
+      className={clsx(styles.topBar, className)}
+      // {...props} last so consumer overrides win (Pattern A).
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});
+
+/**
+ * `<TopBar>` — sticky application top-bar primitive. See `TopBarRoot` JSDoc
+ * for the full per-prop and per-subcomponent contract. Subcomponents are
+ * attached to the root via `Object.assign` (the canonical compound pattern
+ * used by `<Card>`, `<Rail>`, `<DropdownMenu>`, etc.).
+ */
+// NOTE: Search and IconButton are attached in Task 5 once their modules
+// exist. This file's compose is updated then.
+export const TopBar = Object.assign(TopBarRoot, {
+  Start: TopBarStart,
+  End: TopBarEnd,
+});

--- a/packages/design-system/src/components/TopBar/TopBarEnd.tsx
+++ b/packages/design-system/src/components/TopBar/TopBarEnd.tsx
@@ -1,0 +1,31 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './TopBar.module.scss';
+
+/**
+ * Props for `<TopBar.End>`. Inherits the full `<div>` HTML attribute set;
+ * use the standard `className` / `style` / event-handler props as usual.
+ */
+export type TopBarEndProps = HTMLAttributes<HTMLDivElement>;
+
+/**
+ * Right-side cluster of a `<TopBar>`. Renders a flex row that shrinks to its
+ * intrinsic content width — paired with `<TopBar.Start>` (which flex-grows),
+ * `End` is naturally pushed to the right edge of the bar.
+ *
+ * Typically holds `<TopBar.IconButton>` action buttons and a trailing
+ * `<Avatar>` for the user menu.
+ *
+ * @example
+ * <TopBar.End>
+ *   <TopBar.IconButton aria-label="Create new"><Plus size={16} /></TopBar.IconButton>
+ *   <TopBar.IconButton aria-label="Notifications" indicator><Bell size={16} /></TopBar.IconButton>
+ *   <Avatar name="Alex Rivera" size="sm" />
+ * </TopBar.End>
+ */
+export const TopBarEnd = forwardRef<HTMLDivElement, TopBarEndProps>(function TopBarEnd(
+  { className, ...props },
+  ref,
+) {
+  return <div ref={ref} className={clsx(styles.end, className)} {...props} />;
+});

--- a/packages/design-system/src/components/TopBar/TopBarIconButton.tsx
+++ b/packages/design-system/src/components/TopBar/TopBarIconButton.tsx
@@ -1,0 +1,130 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { Button } from '../Button';
+import styles from './TopBar.module.scss';
+
+/**
+ * Tone of the optional notification-indicator dot. Selects the dot color.
+ * - `'danger'` (default) — red, for unread / urgent notifications.
+ * - `'warning'` — amber, for soft-warning cues (maintenance banner, etc.).
+ * - `'info'` — blue, for informational badges.
+ * - `'accent'` — accent color, for "new content" cues.
+ */
+export type TopBarIndicatorTone = 'danger' | 'warning' | 'info' | 'accent';
+
+/**
+ * Props for `<TopBar.IconButton>` — a thin wrapper over `<Button iconOnly
+ * variant="ghost" size="sm">` sized for the bar with one addition: an
+ * optional notification-indicator dot positioned in the upper-right corner.
+ */
+export interface TopBarIconButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  /**
+   * Icon to render inside the button. Typically a single lucide icon
+   * (e.g. `<Bell size={16} />`). The wrapping button supplies the
+   * accessible name via `aria-label` — the icon itself is decorative.
+   */
+  children: ReactNode;
+  /**
+   * Show a small dot in the upper-right corner of the button. Useful for
+   * "unread notifications", "pending updates", etc. The dot is purely
+   * visual (`aria-hidden`); the consumer is responsible for surfacing
+   * count / status text to assistive tech, typically via the button's
+   * `aria-label` or a hidden span.
+   */
+  indicator?: boolean;
+  /**
+   * Dot color. Defaults to `'danger'` (red). See `TopBarIndicatorTone` for
+   * the full option set.
+   */
+  indicatorTone?: TopBarIndicatorTone;
+  /**
+   * **Required.** Accessible name for the icon-only button — without it,
+   * screen readers announce nothing. Phrase as an action (`'Notifications'`,
+   * `'Create new'`). Include count info here when the indicator is on
+   * (e.g. `'Notifications, 3 unread'`).
+   */
+  'aria-label': string;
+}
+
+/** Per-tone CSS class lookup. Kept as a record so adding a tone is one edit. */
+const TONE_CLASS: Record<TopBarIndicatorTone, string> = {
+  danger: styles.indicatorDanger,
+  warning: styles.indicatorWarning,
+  info: styles.indicatorInfo,
+  accent: styles.indicatorAccent,
+};
+
+/**
+ * Icon button subcomponent for `<TopBar>`. Wraps the design system's
+ * `<Button iconOnly variant="ghost" size="sm">` and adds the optional
+ * notification-indicator dot in the upper-right corner.
+ *
+ * Two reasons to reach for this instead of using `<Button>` directly:
+ *
+ * 1. The bar uses a specific 32×32 size + radius pair that the base
+ *    Button doesn't expose as a single prop. Keeping it as a separate
+ *    subcomponent means consumers don't have to remember the exact
+ *    classes / sizes.
+ * 2. The `indicator` dot is topbar-specific — outside the bar it would
+ *    overlap with the layout in odd ways. Scoping it to the topbar
+ *    keeps the API surface tight.
+ *
+ * @example
+ * <TopBar.IconButton aria-label="Create new">
+ *   <Plus size={16} />
+ * </TopBar.IconButton>
+ *
+ * @example
+ * // With a notification dot.
+ * <TopBar.IconButton aria-label="Notifications, 3 unread" indicator>
+ *   <Bell size={16} />
+ * </TopBar.IconButton>
+ *
+ * @example
+ * // Custom indicator tone for a soft cue (maintenance banner trigger).
+ * <TopBar.IconButton
+ *   aria-label="Maintenance scheduled"
+ *   indicator
+ *   indicatorTone="warning"
+ * >
+ *   <Wrench size={16} />
+ * </TopBar.IconButton>
+ *
+ * @remarks When NOT to use
+ * - For an icon-only button outside the topbar → use
+ *   `<Button iconOnly variant="ghost">` directly. The TopBar variant has
+ *   indicator-dot styling that only makes sense inside the bar.
+ * - For a labeled action ("Create new" with both icon + text) → use a
+ *   regular `<Button>`; this subcomponent is icon-only.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Forgetting `aria-label`. The button is icon-only — without a label
+ *   screen readers announce nothing. TypeScript requires it.
+ * - ❌ Relying on the indicator dot to communicate the count to assistive
+ *   tech. The dot is `aria-hidden`; put the count text in the
+ *   `aria-label` (`'Notifications, 3 unread'`) instead.
+ */
+export const TopBarIconButton = forwardRef<HTMLButtonElement, TopBarIconButtonProps>(
+  function TopBarIconButton(
+    { children, indicator = false, indicatorTone = 'danger', className, ...props },
+    ref,
+  ) {
+    return (
+      <Button
+        ref={ref}
+        variant="ghost"
+        size="sm"
+        iconOnly
+        className={clsx(styles.iconButton, className)}
+        // {...props} last so consumer overrides win (Pattern A).
+        {...props}
+      >
+        {children}
+        {indicator && (
+          <span aria-hidden className={clsx(styles.indicator, TONE_CLASS[indicatorTone])} />
+        )}
+      </Button>
+    );
+  },
+);

--- a/packages/design-system/src/components/TopBar/TopBarIconButton.tsx
+++ b/packages/design-system/src/components/TopBar/TopBarIconButton.tsx
@@ -17,8 +17,10 @@ export type TopBarIndicatorTone = 'danger' | 'warning' | 'info' | 'accent';
  * variant="ghost" size="sm">` sized for the bar with one addition: an
  * optional notification-indicator dot positioned in the upper-right corner.
  */
-export interface TopBarIconButtonProps
-  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+export interface TopBarIconButtonProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children'
+> {
   /**
    * Icon to render inside the button. Typically a single lucide icon
    * (e.g. `<Bell size={16} />`). The wrapping button supplies the

--- a/packages/design-system/src/components/TopBar/TopBarSearch.tsx
+++ b/packages/design-system/src/components/TopBar/TopBarSearch.tsx
@@ -1,0 +1,112 @@
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from 'react';
+import { Search } from 'lucide-react';
+import clsx from 'clsx';
+import { useTranslation } from '../../i18n';
+import styles from './TopBar.module.scss';
+
+/**
+ * Props for `<TopBar.Search>` — a styled `<input type="search">` with a
+ * leading magnifying-glass icon and an optional trailing `<kbd>` hint.
+ *
+ * Inherits the standard `<input>` HTML attribute surface (minus `type`,
+ * which is fixed to `'search'`). Spread your `value` / `defaultValue` /
+ * `onChange` / `name` / `id` props through normally — they reach the
+ * underlying input.
+ */
+export interface TopBarSearchProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  /**
+   * Optional `<kbd>` hint shown after the input — typically a hotkey copy
+   * (e.g. `'⌘K'`, `'Ctrl+K'`). The hint is **visual only**; the library
+   * does not bind any keyboard shortcut to it. Omit for no hint.
+   */
+  hotkey?: ReactNode;
+  /**
+   * `className` for the wrapping `<div>` (the search surface itself).
+   * The input's own className lives on the underlying `<input>` via the
+   * spread input-props (use the standard `inputClassName` pattern if you
+   * need to target the inner element specifically — not exposed in v1).
+   */
+  className?: string;
+}
+
+/**
+ * Search input subcomponent for `<TopBar>`. Renders a 32px-tall pill with
+ * a leading lucide `Search` icon, a real `<input type="search">`, and an
+ * optional trailing `<kbd>` hotkey hint.
+ *
+ * The native `type="search"` lets the browser expose `role="searchbox"`
+ * automatically and gives users the standard clear-button affordance. The
+ * input is wired with `autoComplete="off"` plus the password-manager
+ * ignore data attributes (`data-1p-ignore`, `data-lpignore`, `data-form-
+ * type="other"`) so 1Password / Bitwarden / Chrome autofill don't try to
+ * fill it as a username field — a free-text search box has no business
+ * receiving credentials.
+ *
+ * The `hotkey` prop is a **visual hint only** — the component does not
+ * implement keyboard-shortcut focus behavior. Binding ⌘K (or anything
+ * else) to focus the input is the consumer's responsibility; the library
+ * doesn't dictate which shortcuts a host app uses.
+ *
+ * @example
+ * <TopBar.Search placeholder="Search contacts, deals…" hotkey="⌘K" />
+ *
+ * @example
+ * // Controlled — round-trip value through state.
+ * const [q, setQ] = useState('');
+ * <TopBar.Search
+ *   placeholder="Search…"
+ *   value={q}
+ *   onChange={(e) => setQ(e.target.value)}
+ * />
+ *
+ * @example
+ * // No hotkey hint — omit the prop entirely.
+ * <TopBar.Search placeholder="Filter…" />
+ *
+ * @remarks When NOT to use
+ * - For a command-palette experience (typing → result list → keyboard
+ *   nav) → use a `<Popover>` + `<OptionsPicker>` combination; the topbar
+ *   search is a plain text input.
+ * - For a form's search field → use `<Input>` directly. The topbar search
+ *   styling (pill + leading icon) is specific to the bar.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Putting a submit button inside the search wrapper. The input is
+ *   `type="search"` — on Enter, the consumer reads the value from the
+ *   input's `onKeyDown` / `onChange`. Adding a button changes the shape.
+ * - ❌ Setting `placeholder` and `aria-label` to different strings. The
+ *   default aria-label IS the placeholder; only override when the visible
+ *   placeholder is too terse to stand on its own.
+ */
+export const TopBarSearch = forwardRef<HTMLInputElement, TopBarSearchProps>(function TopBarSearch(
+  { hotkey, placeholder, className, 'aria-label': ariaLabel, ...inputProps },
+  ref,
+) {
+  const t = useTranslation();
+  return (
+    <div className={clsx(styles.search, className)}>
+      <Search aria-hidden className={styles.searchIcon} />
+      <input
+        ref={ref}
+        type="search"
+        placeholder={placeholder}
+        aria-label={ariaLabel ?? placeholder ?? t('topBar.search')}
+        className={styles.searchInput}
+        // Password managers (1Password, Bitwarden) and browser autofill
+        // shouldn't try to fill a free-text search box. The data attrs
+        // cover 1P and LP; `autoComplete="off"` covers Chrome / Safari.
+        autoComplete="off"
+        data-1p-ignore
+        data-lpignore="true"
+        data-form-type="other"
+        // {...inputProps} last so consumer overrides win (Pattern A).
+        {...inputProps}
+      />
+      {hotkey != null && (
+        <kbd aria-hidden className={styles.searchKbd}>
+          {hotkey}
+        </kbd>
+      )}
+    </div>
+  );
+});

--- a/packages/design-system/src/components/TopBar/TopBarStart.tsx
+++ b/packages/design-system/src/components/TopBar/TopBarStart.tsx
@@ -1,0 +1,36 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './TopBar.module.scss';
+
+/**
+ * Props for `<TopBar.Start>`. Inherits the full `<div>` HTML attribute set;
+ * use the standard `className` / `style` / event-handler props as usual.
+ */
+export type TopBarStartProps = HTMLAttributes<HTMLDivElement>;
+
+/**
+ * Left-side cluster of a `<TopBar>`. Renders a flex row that occupies the
+ * remaining bar width (`flex: 1`) — so a sibling `<TopBar.End>` gets pushed
+ * to the right edge with no extra spacer needed.
+ *
+ * Typically holds a brand mark, a workspace switcher, and/or `<TopBar.Search>`.
+ * Children are laid out horizontally with the bar's standard gap.
+ *
+ * @example
+ * <TopBar>
+ *   <TopBar.Start>
+ *     <TopBar.Search placeholder="Search…" hotkey="⌘K" />
+ *   </TopBar.Start>
+ *   <TopBar.End>
+ *     <TopBar.IconButton aria-label="Notifications" indicator>
+ *       <Bell size={16} />
+ *     </TopBar.IconButton>
+ *   </TopBar.End>
+ * </TopBar>
+ */
+export const TopBarStart = forwardRef<HTMLDivElement, TopBarStartProps>(function TopBarStart(
+  { className, ...props },
+  ref,
+) {
+  return <div ref={ref} className={clsx(styles.start, className)} {...props} />;
+});

--- a/packages/design-system/src/components/TopBar/index.ts
+++ b/packages/design-system/src/components/TopBar/index.ts
@@ -2,3 +2,8 @@ export { TopBar } from './TopBar';
 export type { TopBarProps, TopBarElement } from './TopBar';
 export type { TopBarStartProps } from './TopBarStart';
 export type { TopBarEndProps } from './TopBarEnd';
+export type { TopBarSearchProps } from './TopBarSearch';
+export type {
+  TopBarIconButtonProps,
+  TopBarIndicatorTone,
+} from './TopBarIconButton';

--- a/packages/design-system/src/components/TopBar/index.ts
+++ b/packages/design-system/src/components/TopBar/index.ts
@@ -3,7 +3,4 @@ export type { TopBarProps, TopBarElement } from './TopBar';
 export type { TopBarStartProps } from './TopBarStart';
 export type { TopBarEndProps } from './TopBarEnd';
 export type { TopBarSearchProps } from './TopBarSearch';
-export type {
-  TopBarIconButtonProps,
-  TopBarIndicatorTone,
-} from './TopBarIconButton';
+export type { TopBarIconButtonProps, TopBarIndicatorTone } from './TopBarIconButton';

--- a/packages/design-system/src/components/TopBar/index.ts
+++ b/packages/design-system/src/components/TopBar/index.ts
@@ -1,0 +1,4 @@
+export { TopBar } from './TopBar';
+export type { TopBarProps, TopBarElement } from './TopBar';
+export type { TopBarStartProps } from './TopBarStart';
+export type { TopBarEndProps } from './TopBarEnd';

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -137,4 +137,8 @@ export const en: Messages = {
     collapse: 'Collapse navigation',
     navigation: 'Main navigation',
   },
+  topBar: {
+    label: 'Application top bar',
+    search: 'Search',
+  },
 };

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -216,6 +216,12 @@ export interface Messages {
     /** Default aria-label on the rail's wrapping `<nav>` landmark. */
     navigation: string;
   };
+  topBar: {
+    /** Default aria-label on the wrapping `<header>` landmark. */
+    label: string;
+    /** Default aria-label on the `<TopBar.Search>` input when neither `aria-label` nor `placeholder` is set. */
+    search: string;
+  };
 }
 
 /** Supported locale codes. v1 ships English and Russian. */

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -139,4 +139,8 @@ export const ru: Messages = {
     collapse: 'Свернуть навигацию',
     navigation: 'Главная навигация',
   },
+  topBar: {
+    label: 'Верхняя панель приложения',
+    search: 'Поиск',
+  },
 };

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -371,6 +371,17 @@ export type {
   RailGroupProps,
 } from './components/Rail';
 
+export { TopBar } from './components/TopBar';
+export type {
+  TopBarProps,
+  TopBarElement,
+  TopBarStartProps,
+  TopBarEndProps,
+  TopBarSearchProps,
+  TopBarIconButtonProps,
+  TopBarIndicatorTone,
+} from './components/TopBar';
+
 export { Code } from './components/Code';
 export type { CodeProps, CodeTone } from './components/Code';
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -68,6 +68,7 @@ import { GridDemo } from './pages/components/GridDemo';
 import { LinkDemo } from './pages/components/LinkDemo';
 import { RailDemo } from './pages/components/RailDemo';
 import { ToastDemo } from './pages/components/ToastDemo';
+import { TopBarDemo } from './pages/components/TopBarDemo';
 import { I18nProvider, ToastViewport } from '@eocrm/design-system';
 
 export default function App() {
@@ -148,6 +149,7 @@ export default function App() {
             <Route path="/components/grid" element={<GridDemo />} />
             <Route path="/components/link" element={<LinkDemo />} />
             <Route path="/components/rail" element={<RailDemo />} />
+            <Route path="/components/topbar" element={<TopBarDemo />} />
             <Route path="/components/textarea" element={<TextareaDemo />} />
             <Route path="/components/toast" element={<ToastDemo />} />
           </Routes>

--- a/packages/playground/src/layout/AppShell/AppShell.module.scss
+++ b/packages/playground/src/layout/AppShell/AppShell.module.scss
@@ -143,117 +143,13 @@
   }
 }
 
-// Topbar
-.topbar {
+// Topbar — wrapper that places the <TopBar> primitive into the shell grid.
+// The bar's chrome (height, background, sticky positioning) is owned by the
+// library component; this wrapper only positions it in the grid cell and
+// supplies the higher z-index so the sticky bar overlays page content.
+.topbarWrap {
   grid-area: topbar;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-4);
-  padding: 0 var(--space-5);
-  background: var(--color-bg);
-  border-bottom: var(--border-width) solid var(--color-border);
-  position: sticky;
-  top: 0;
   z-index: var(--z-topbar);
-}
-
-.searchWrap {
-  position: relative;
-  display: flex;
-  align-items: center;
-  width: 360px;
-  max-width: 100%;
-}
-
-.searchIcon {
-  position: absolute;
-  left: var(--space-2);
-  color: var(--color-fg-subtle);
-  pointer-events: none;
-}
-
-.search {
-  width: 100%;
-  height: var(--size-md);
-  padding: 0 56px 0 var(--space-6);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-bg-muted);
-  color: var(--color-fg);
-  font-size: var(--font-size-md);
-  transition:
-    background var(--transition-fast),
-    border-color var(--transition-fast);
-
-  &::placeholder {
-    color: var(--color-fg-subtle);
-  }
-
-  &:hover {
-    background: var(--color-bg-sunken);
-  }
-
-  &:focus {
-    outline: none;
-    background: var(--color-bg);
-    border-color: var(--color-accent);
-    box-shadow: 0 0 0 var(--ring-width) var(--ring-accent);
-  }
-}
-
-.searchKbd {
-  position: absolute;
-  right: var(--space-2);
-  display: inline-flex;
-  align-items: center;
-  height: 18px;
-  padding: 0 var(--space-1);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-bg);
-  color: var(--color-fg-subtle);
-  font-family: inherit;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-medium);
-  pointer-events: none;
-}
-
-.iconBtn {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--size-md);
-  height: var(--size-md);
-  border: none;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--color-fg-muted);
-  cursor: pointer;
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast);
-
-  &:hover {
-    background: var(--color-bg-muted);
-    color: var(--color-fg);
-  }
-
-  &:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 var(--ring-width) var(--ring-accent);
-  }
-}
-
-.notifDot {
-  position: absolute;
-  top: 6px;
-  right: 8px;
-  width: 6px;
-  height: 6px;
-  border-radius: var(--radius-full);
-  background: var(--color-danger);
 }
 
 .navFooter {

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -188,6 +188,7 @@ const componentGroups = [
       { to: '/components/link', label: 'Link', icon: ExternalLink, end: false },
       { to: '/components/rail', label: 'Rail', icon: Sidebar, end: false },
       { to: '/components/tabs', label: 'Tabs', icon: PanelTop, end: false },
+      { to: '/components/topbar', label: 'TopBar', icon: LayoutPanelTop, end: false },
     ],
   },
   {

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -8,7 +8,6 @@ import {
   Users,
   UserCog,
   UserSquare,
-  Search,
   Bell,
   Plus,
   Component,
@@ -67,8 +66,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import { useState, useEffect } from 'react';
-import { Avatar, Rail, useRail } from '@eocrm/design-system';
-import { Cluster } from '@eocrm/design-system';
+import { Avatar, Rail, TopBar, useRail } from '@eocrm/design-system';
 import styles from './AppShell.module.scss';
 
 const SIDEBAR_COLLAPSED_KEY = 'eocrm-playground-sidebar-collapsed';
@@ -306,37 +304,22 @@ export function AppShell({ children }: { children: ReactNode }) {
         </Rail>
       </div>
 
-      <header className={styles.topbar}>
-        <Cluster gap="md" align="center" wrap={false}>
-          <div className={styles.searchWrap}>
-            <Search size={14} className={styles.searchIcon} aria-hidden />
-            <input
-              type="search"
-              placeholder="Search contacts, deals…"
-              className={styles.search}
-              aria-label="Search"
-              // Tell password managers (1Password, Bitwarden) and browser autofill
-              // to leave this alone — it's a free-text search, not a username field.
-              autoComplete="off"
-              data-1p-ignore
-              data-lpignore="true"
-              data-form-type="other"
-            />
-            <kbd className={styles.searchKbd}>⌘K</kbd>
-          </div>
-        </Cluster>
-
-        <Cluster gap="sm" align="center" wrap={false}>
-          <button className={styles.iconBtn} aria-label="Create new">
-            <Plus size={16} />
-          </button>
-          <button className={styles.iconBtn} aria-label="Notifications">
-            <Bell size={16} />
-            <span className={styles.notifDot} aria-hidden />
-          </button>
-          <Avatar name="Alex Rivera" size="sm" />
-        </Cluster>
-      </header>
+      <div className={styles.topbarWrap}>
+        <TopBar>
+          <TopBar.Start>
+            <TopBar.Search placeholder="Search contacts, deals…" hotkey="⌘K" />
+          </TopBar.Start>
+          <TopBar.End>
+            <TopBar.IconButton aria-label="Create new">
+              <Plus size={16} />
+            </TopBar.IconButton>
+            <TopBar.IconButton aria-label="Notifications" indicator>
+              <Bell size={16} />
+            </TopBar.IconButton>
+            <Avatar name="Alex Rivera" size="sm" />
+          </TopBar.End>
+        </TopBar>
+      </div>
 
       <main className={styles.content}>{children}</main>
     </div>

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { ArrowRight, Home, Inbox, Settings as SettingsIcon, Users } from 'lucide-react';
+import { ArrowRight, Bell, Home, Inbox, Settings as SettingsIcon, Users } from 'lucide-react';
 import { Accordion } from '@eocrm/design-system';
 import { Alert } from '@eocrm/design-system';
 import { Avatar } from '@eocrm/design-system';
@@ -27,6 +27,7 @@ import { Skeleton } from '@eocrm/design-system';
 import { Slider } from '@eocrm/design-system';
 import { Kanban } from '@eocrm/design-system';
 import { Rail } from '@eocrm/design-system';
+import { TopBar } from '@eocrm/design-system';
 import { Sortable } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { Switch } from '@eocrm/design-system';
@@ -624,6 +625,36 @@ const items: { to: string; name: string; description: string; preview: React.Rea
             </Rail.Item>
           </Rail.Section>
         </Rail>
+      </div>
+    ),
+  },
+  {
+    to: '/components/topbar',
+    name: 'TopBar',
+    description:
+      'Sticky application top-bar primitive. Compound API with Start/End clusters, a styled Search input, and an IconButton with optional notification dot.',
+    preview: (
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 360,
+          height: 80,
+          overflow: 'hidden',
+          pointerEvents: 'none',
+          borderRadius: 'var(--radius-md)',
+          border: 'var(--border-width) solid var(--color-border)',
+        }}
+      >
+        <TopBar>
+          <TopBar.Start>
+            <TopBar.Search placeholder="Search…" hotkey="⌘K" />
+          </TopBar.Start>
+          <TopBar.End>
+            <TopBar.IconButton aria-label="Notifications" indicator>
+              <Bell size={14} />
+            </TopBar.IconButton>
+          </TopBar.End>
+        </TopBar>
       </div>
     ),
   },

--- a/packages/playground/src/pages/components/TopBarDemo.tsx
+++ b/packages/playground/src/pages/components/TopBarDemo.tsx
@@ -1,0 +1,224 @@
+import { useState } from 'react';
+import { Bell, HelpCircle, Plus, Settings as SettingsIcon, Wrench } from 'lucide-react';
+import { Avatar, Text, TopBar } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import { getComponentFiles } from '../../lib/componentFiles';
+
+/**
+ * Bordered preview frame that lets the sticky-top TopBar sit at the
+ * top of a believable layout column. The TopBar's `position: sticky`
+ * needs a scrollable parent to anchor against — without the frame it
+ * would stick to the page-level scroller and visually escape the demo.
+ */
+function TopBarStage({ children, height = 220 }: { children: React.ReactNode; height?: number }) {
+  return (
+    <div
+      style={{
+        height,
+        overflow: 'auto',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+        background: 'var(--color-bg-subtle)',
+      }}
+    >
+      {children}
+      <div style={{ padding: 'var(--space-4)' }}>
+        <Text tone="muted">
+          Scroll this box — the bar pins to the top. Page content goes here in a real app.
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+/** Brand mark used by the right-aligned example. */
+function BrandMark() {
+  return (
+    <div
+      aria-hidden
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 'var(--space-2)',
+        fontWeight: 'var(--font-weight-semibold)',
+        color: 'var(--color-fg)',
+      }}
+    >
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 24,
+          height: 24,
+          borderRadius: 'var(--radius-md)',
+          background: 'var(--color-accent)',
+          color: 'var(--color-accent-fg)',
+          fontSize: 'var(--font-size-xs)',
+        }}
+      >
+        OC
+      </span>
+      Orbit CRM
+    </div>
+  );
+}
+
+export function TopBarDemo() {
+  // Example 1: controlled search input so consumers see the round-trip pattern.
+  const [query, setQuery] = useState('');
+
+  return (
+    <DemoLayout
+      name="TopBar"
+      componentName="TopBar"
+      description="Sticky application top-bar primitive. Compound API: TopBar.Start + TopBar.End for the two horizontal clusters, plus TopBar.Search (styled search input with a leading icon and optional hotkey hint) and TopBar.IconButton (icon-only ghost button with an optional notification-dot indicator)."
+      files={getComponentFiles('TopBar')}
+    >
+      <Example
+        title="Default — search on the left, actions + avatar on the right"
+        description="The canonical app-shell pattern: TopBar.Start holds TopBar.Search (with an optional ⌘K hint), TopBar.End holds two TopBar.IconButton actions and a trailing Avatar. The Bell button is `indicator` to surface unread notifications."
+        code={`const [query, setQuery] = useState('');
+
+<TopBar>
+  <TopBar.Start>
+    <TopBar.Search
+      placeholder="Search contacts, deals…"
+      hotkey="⌘K"
+      value={query}
+      onChange={(e) => setQuery(e.target.value)}
+    />
+  </TopBar.Start>
+  <TopBar.End>
+    <TopBar.IconButton aria-label="Create new">
+      <Plus size={16} />
+    </TopBar.IconButton>
+    <TopBar.IconButton aria-label="Notifications, 3 unread" indicator>
+      <Bell size={16} />
+    </TopBar.IconButton>
+    <Avatar name="Alex Rivera" size="sm" />
+  </TopBar.End>
+</TopBar>`}
+      >
+        <TopBarStage>
+          <TopBar>
+            <TopBar.Start>
+              <TopBar.Search
+                placeholder="Search contacts, deals…"
+                hotkey="⌘K"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
+            </TopBar.Start>
+            <TopBar.End>
+              <TopBar.IconButton aria-label="Create new">
+                <Plus size={16} />
+              </TopBar.IconButton>
+              <TopBar.IconButton aria-label="Notifications, 3 unread" indicator>
+                <Bell size={16} />
+              </TopBar.IconButton>
+              <Avatar name="Alex Rivera" size="sm" />
+            </TopBar.End>
+          </TopBar>
+        </TopBarStage>
+      </Example>
+
+      <Example
+        title="Brand on the left, no search"
+        description="The Start cluster can hold anything — drop the search and use it for a brand mark when the bar is part of a marketing surface or a docs site. End-only is also valid: a single trailing cluster works because Start defaults to no content."
+        code={`<TopBar>
+  <TopBar.Start>
+    <BrandMark />
+  </TopBar.Start>
+  <TopBar.End>
+    <TopBar.IconButton aria-label="Help">
+      <HelpCircle size={16} />
+    </TopBar.IconButton>
+    <TopBar.IconButton aria-label="Settings">
+      <SettingsIcon size={16} />
+    </TopBar.IconButton>
+    <Avatar name="Sam Chen" size="sm" />
+  </TopBar.End>
+</TopBar>`}
+      >
+        <TopBarStage>
+          <TopBar>
+            <TopBar.Start>
+              <BrandMark />
+            </TopBar.Start>
+            <TopBar.End>
+              <TopBar.IconButton aria-label="Help">
+                <HelpCircle size={16} />
+              </TopBar.IconButton>
+              <TopBar.IconButton aria-label="Settings">
+                <SettingsIcon size={16} />
+              </TopBar.IconButton>
+              <Avatar name="Sam Chen" size="sm" />
+            </TopBar.End>
+          </TopBar>
+        </TopBarStage>
+      </Example>
+
+      <Example
+        title="Custom indicator tone"
+        description="`indicatorTone` selects the dot color. Use `warning` for soft cues (a scheduled maintenance reminder), `info` for informational pings, `accent` for new-feature highlights. The default is `danger`."
+        code={`<TopBar>
+  <TopBar.End>
+    <TopBar.IconButton aria-label="Maintenance scheduled" indicator indicatorTone="warning">
+      <Wrench size={16} />
+    </TopBar.IconButton>
+    <TopBar.IconButton aria-label="What's new" indicator indicatorTone="accent">
+      <Bell size={16} />
+    </TopBar.IconButton>
+  </TopBar.End>
+</TopBar>`}
+      >
+        <TopBarStage>
+          <TopBar>
+            <TopBar.End>
+              <TopBar.IconButton
+                aria-label="Maintenance scheduled"
+                indicator
+                indicatorTone="warning"
+              >
+                <Wrench size={16} />
+              </TopBar.IconButton>
+              <TopBar.IconButton aria-label="What's new" indicator indicatorTone="accent">
+                <Bell size={16} />
+              </TopBar.IconButton>
+            </TopBar.End>
+          </TopBar>
+        </TopBarStage>
+      </Example>
+
+      <Example
+        title='Nested toolbar with as="div"'
+        description='When the bar appears inside another content area where a second header landmark would be wrong (e.g. a secondary filters toolbar inside a main page), pass `as="div"` to render the same chrome without the banner role.'
+        code={`<TopBar as="div" aria-label="Filters toolbar">
+  <TopBar.Start>
+    <Text weight="medium">Filters</Text>
+  </TopBar.Start>
+  <TopBar.End>
+    <TopBar.IconButton aria-label="Reset filters">
+      <Wrench size={16} />
+    </TopBar.IconButton>
+  </TopBar.End>
+</TopBar>`}
+      >
+        <TopBarStage>
+          <TopBar as="div" aria-label="Filters toolbar">
+            <TopBar.Start>
+              <Text weight="medium">Filters</Text>
+            </TopBar.Start>
+            <TopBar.End>
+              <TopBar.IconButton aria-label="Reset filters">
+                <Wrench size={16} />
+              </TopBar.IconButton>
+            </TopBar.End>
+          </TopBar>
+        </TopBarStage>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -60,7 +60,8 @@ export type ComponentName =
   | 'Textarea'
   | 'Title'
   | 'Toast'
-  | 'Tooltip';
+  | 'Tooltip'
+  | 'TopBar';
 
 export interface MockupEntry {
   slug: string;


### PR DESCRIPTION
## Summary

- New library primitive `<TopBar>` — sticky-top app-shell chrome with compound API: `TopBar.Start`, `TopBar.End`, `TopBar.Search`, `TopBar.IconButton`. Lifted verbatim from the playground's hand-rolled topbar so consumers stop re-implementing it.
- `TopBar.IconButton` adds an `indicator` + `indicatorTone` prop (small absolute-positioned dot in the upper-right, decorative — consumer supplies the accessible "N unread" text via `aria-label`).
- `TopBar.Search` renders a real `<input type="search">` with leading lucide icon + optional `<kbd>` hotkey hint; password-manager opt-out attributes are wired so 1Password/Bitwarden/LastPass don't try to autofill the search box.
- AppShell now consumes `<TopBar>` from `@eocrm/design-system` — the hand-rolled `.topbar` / `.searchWrap` / `.iconBtn` / `.notifDot` styles are deleted; AppShell keeps only the grid-area wrapper.

## Implementation notes

- TopBar is a layout-owning primitive (Hard rule 4 exception, justified inline like Modal/Drawer/Rail/Page): it owns its own height, padding-x, sticky positioning, and bottom border because that IS its job.
- All visual values come from `TopBar.tokens.scss` — no raw values, no hardcoded colors.
- i18n keys: `topBar.label`, `topBar.search` (en + ru).
- 18 new unit tests (2150/2150 library tests total).
- hr8 review pass 1 verdict: clean enough to stop. Pass 1 dropped an unused `--topbar-search-min-width` token (the only Important finding).

## Test plan

- [x] `make test` — 2150/2150 passing
- [x] `make build` — typecheck + bundle green
- [x] `make lint` — stylelint clean
- [x] `npm pack --dry-run -w @eocrm/design-system` — tarball clean
- [x] Visual smoke: playground TopBarDemo renders at `/components/topbar` (4 examples)
- [x] Visual smoke: AppShell topbar is pixel-equivalent to pre-migration (search + plus + bell-with-red-dot + AR avatar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)