### PR TITLE
Tooltip: arrow z-index: -1 (stop arrow from poking through nearby content)

### DIFF
--- a/packages/design-system/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/design-system/src/components/Tooltip/Tooltip.module.scss
@@ -46,6 +46,14 @@
   // straight at the trigger.
   transform: rotate(45deg);
   pointer-events: none;
+
+  // Sit BEHIND .content's background so the half of the rotated square that
+  // overlaps the tooltip body (the upper half, given `bottom: -4px`-style
+  // positioning) is hidden by the panel bg. Only the corner poking outside
+  // the panel stays visible — which is the arrow we actually want to show.
+  // Without this the arrow peeks up through nearby content (e.g., a Kbd
+  // chip near the tooltip's edge). Standard Floating UI arrow pattern.
+  z-index: -1;
 }
 
 // --- Open-only entrance: per-side origin + starting transform -----------


### PR DESCRIPTION
## Summary

The Tooltip arrow's rotated-square is positioned with `bottom: -4px` (or the equivalent on other sides), so the upper half of the 8px diamond sits *inside* the tooltip body. The arrow was the last DOM child of \`.content\` and carried no \`z-index\` — so it stacked above content in DOM order, visibly peeking up through anything near the tooltip's edge.

Most visible on the upcoming Kbd PR (#95): a \`<Tooltip>\` containing a \`<Kbd>\` chip (light bg on dark tooltip) shows the dark arrow square poking up through the chip.

Standard Floating UI arrow pattern: \`z-index: -1\` puts the arrow behind \`.content\`'s background. The half outside the panel stays visible (it's outside the bg box); the half overlapping content hides behind the bg.

## Test plan

- [x] All 29 existing Tooltip unit tests still pass
- [x] Full library suite: 2150/2150
- [x] \`make lint\` clean
- [x] Visual smoke at \`/components/tooltip\` Rich-content example — arrow renders cleanly below the tooltip with no upward intrusion into the body

🤖 Generated with [Claude Code](https://claude.com/claude-code)