### PR TITLE
Add eocrm full-screen login mockup

### DIFF
--- a/docs/superpowers/plans/2026-05-29-login-mockup.md
+++ b/docs/superpowers/plans/2026-05-29-login-mockup.md
@@ -1,0 +1,522 @@
+# Login Screen Mockup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a full-screen `eocrm` sign-in mockup at `/mockups/login` in the playground, built from `@eocrm/design-system` primitives (Direction C: elevated card on a token-tinted backdrop).
+
+**Architecture:** A new `Login.tsx` under `packages/playground/src/pages/mockups/Login/`, composed entirely of library primitives. Two contained, token-based **inline-mock escape hatches** (per playground Hard rule 6 — the same idiom `Dashboard.tsx` uses): the `<AuthScreen>` page-chrome wrapper (full-viewport centering + tinted radial backdrop) and the multi-color Google "G" mark. Full-screen behavior comes from a one-line guard in `AppShell.tsx` that renders the login route without the Rail/TopBar chrome. Wired via `App.tsx` route, `AppShell` sidebar entry, and the mockup `registry.ts`. Verified by `make build` + `make lint` + a visual check + the Hard-rule-7 mockup review loop (the playground has **no** unit tests — 0 `*.test.tsx` files — so there is no TDD step for a mockup).
+
+**Tech Stack:** React 18 + TypeScript, `react-router-dom` (playground-only dep), `@eocrm/design-system`, `lucide-react` (demo-only icons), Vite. Branch: `feat/login-mockup`.
+
+**Brand note (locked):** the wordmark is **`eocrm`** (user's explicit choice — matches the approved mockup + the eocrm reference signin). This deliberately differs from AppShell's "Orbit CRM" demo brand; do **not** "fix" it to Orbit CRM during review.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-login-mockup-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `packages/playground/src/pages/mockups/Login/Login.tsx` | **NEW** — the entire mockup: composition + interactive validation/error behavior + the two escape-hatch mocks |
+| `packages/playground/src/App.tsx` | MODIFY — import `Login`, add `/mockups/login` route |
+| `packages/playground/src/layout/AppShell/AppShell.tsx` | MODIFY — full-bleed guard for the login route + a "Login" entry in `mockupItems` + `LogIn` icon import |
+| `packages/playground/src/pages/mockups/registry.ts` | MODIFY — add the `login` mockup entry (no `ComponentName` union change needed) |
+| `packages/design-system/src/components/TODO.md` | MODIFY — add `<AuthScreen>` and brand-icon gap entries |
+
+`MockupsIndex.tsx` is **not** edited — it renders every non-parameterized `registry.ts` entry automatically (verified: `MOCKUPS.filter((m) => !m.path.includes(':'))`).
+
+---
+
+## Task 1: File the two escape-hatch gaps in TODO.md
+
+Do this first so the inline-mock `{/* TODO… */}` comments in `Login.tsx` reference real entries.
+
+**Files:**
+- Modify: `packages/design-system/src/components/TODO.md`
+
+- [ ] **Step 1: Add both entries under the `## Open` section**
+
+Insert these two entries immediately after the `## Open` line (before the existing `<StatTile>` entry), matching the file's existing entry format:
+
+````markdown
+### [ ] `<AuthScreen>` (or `<AuthLayout>`) — full-viewport centered surface with a tinted backdrop for auth pages
+
+**Filed:** 2026-05-29
+**Mocked in:**
+
+- `packages/playground/src/pages/mockups/Login/Login.tsx` — the outer page wrapper (full-bleed gradient backdrop, vertical layout) and the inner region that centers the card in the remaining viewport height.
+
+**What's needed:**
+A page-level layout primitive for sign-in / forgot-password / accept-invite screens: takes over the full viewport (`min-height: 100vh`), paints a subtle token-based backdrop (default a soft accent wash), and lays out three slots — an optional top bar (back-link / brand), a vertically + horizontally centered main slot (the auth card), and an optional footer (legal links). Props sketch: `backdrop?: 'plain' | 'tinted'`, plus `header` / `footer` slots and `children` (the centered content). No interactive state. The real eocrm app has an `AuthCardLayout` serving exactly this role, so the CRM will want it too.
+
+**Current workaround:**
+Two raw `<div style={{…}}>` at the exact mock site, token-only values: the outer wrapper (`min-height: 100vh; display: flex; flex-direction: column; padding: var(--space-6); background: radial-gradient(120% 90% at 50% -8%, var(--color-accent-subtle-bg) 0%, var(--color-bg-subtle) 52%)`) and the centering region (`flex: 1; display: grid; place-items: center`). Marked with the standard TODO comment.
+
+**When this ships:** refactor the Login mockup's two wrapper `<div>`s to use the primitive, then tick this checkbox.
+
+### [ ] `<BrandIcon>` / social-login icon set — multi-color brand marks (Google, Microsoft, Apple…)
+
+**Filed:** 2026-05-29
+**Mocked in:**
+
+- `packages/playground/src/pages/mockups/Login/Login.tsx` — the Google "G" inside the "Continue with Google" SSO button.
+
+**What's needed:**
+A small set of brand / social-provider marks for SSO buttons. These are multi-color, fixed-brand-color assets (Google's 4-color "G", etc.) that intentionally do **not** map to design tokens — brand guidelines mandate the exact colors. `lucide-react` (the demo icon set) has no brand logos. Could ship as a tiny `<GoogleIcon>` / `<BrandIcon name="google">` component or an assets module.
+
+**Current workaround:**
+A hand-authored inline `<svg viewBox="0 0 48 48">` with four `<path fill="#…">` brand-hex colors at the exact mock site, `aria-hidden="true"`. Marked with the standard TODO comment. (Note: brand hex is correct here — this is the documented exception to token-only color.)
+
+**When this ships:** refactor the Login SSO button to use the brand icon, then tick this checkbox.
+````
+
+- [ ] **Step 2: Verify the file still reads cleanly**
+
+Run: `sed -n '28,40p' packages/design-system/src/components/TODO.md`
+Expected: the `## Open` heading followed by the new `<AuthScreen>` entry.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/TODO.md
+git commit -m "docs(todo): file <AuthScreen> + brand-icon gaps for login mockup"
+```
+
+---
+
+## Task 2: Build the Login mockup
+
+**Files:**
+- Create: `packages/playground/src/pages/mockups/Login/Login.tsx`
+
+- [ ] **Step 1: Create `Login.tsx` with the full implementation**
+
+Create `packages/playground/src/pages/mockups/Login/Login.tsx` with exactly this content:
+
+```tsx
+import { useState, type KeyboardEvent } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  Alert,
+  Button,
+  Card,
+  Checkbox,
+  Cluster,
+  Divider,
+  Input,
+  Link,
+  PasswordInput,
+  Stack,
+  Text,
+  Title,
+} from '@eocrm/design-system';
+
+// Loose client-side shape check only — real validation is server-side.
+const EMAIL_RE = /.+@.+\..+/;
+
+export function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  function submit() {
+    const nextEmailError = EMAIL_RE.test(email) ? null : 'Enter a valid email address.';
+    const nextPasswordError =
+      password.length >= 6 ? null : 'Password must be at least 6 characters.';
+    setEmailError(nextEmailError);
+    setPasswordError(nextPasswordError);
+    if (nextEmailError || nextPasswordError) {
+      setFormError(null);
+      return;
+    }
+    // No backend in a mockup — simulate an auth failure so the error Alert
+    // (the "error-state demo") is always reachable for stakeholders.
+    setFormError('Invalid email or password.');
+  }
+
+  function onEnter(e: KeyboardEvent) {
+    if (e.key === 'Enter') submit();
+  }
+
+  return (
+    /* TODO: replace when <AuthScreen> ships — see components/TODO.md.
+       Full-viewport centered auth layout with a tinted backdrop is page
+       chrome no current primitive expresses. Inline style uses tokens only. */
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        padding: 'var(--space-6)',
+        background:
+          'radial-gradient(120% 90% at 50% -8%, var(--color-accent-subtle-bg) 0%, var(--color-bg-subtle) 52%)',
+      }}
+    >
+      <Cluster justify="start">
+        <Link as={RouterLink} to="/mockups" variant="muted">
+          ← Back to mockups
+        </Link>
+      </Cluster>
+
+      {/* TODO: replace when <AuthScreen> ships — see components/TODO.md.
+          Centers the card in the remaining viewport height (same gap). */}
+      <div style={{ flex: 1, display: 'grid', placeItems: 'center' }}>
+        <Stack gap="lg" align="center">
+          <Text as="span" size="xl" weight="bold">
+            eocrm
+          </Text>
+
+          <Card padding="lg">
+            <Stack gap="lg">
+              <Stack gap="xs">
+                <Title order={1} size="lg">
+                  Sign in
+                </Title>
+                <Text size="sm" tone="muted">
+                  Welcome back. Enter your email to continue to your workspace.
+                </Text>
+              </Stack>
+
+              <Button variant="secondary">
+                {/* TODO: replace when a brand/social icon set ships — see components/TODO.md.
+                    Multi-color Google "G"; not in lucide. Brand hex is intentional. */}
+                <svg width="16" height="16" viewBox="0 0 48 48" aria-hidden="true">
+                  <path
+                    fill="#EA4335"
+                    d="M24 9.5c3.5 0 6.6 1.2 9 3.6l6.7-6.7C35.6 2.4 30.1 0 24 0 14.6 0 6.4 5.4 2.6 13.2l7.8 6.1C12.2 13.3 17.6 9.5 24 9.5z"
+                  />
+                  <path
+                    fill="#4285F4"
+                    d="M46.1 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.4c-.5 2.9-2.1 5.3-4.6 7l7.1 5.5c4.2-3.9 6.6-9.6 6.6-16.5z"
+                  />
+                  <path
+                    fill="#FBBC05"
+                    d="M10.4 28.3c-.5-1.4-.8-3-.8-4.3s.3-2.9.8-4.3l-7.8-6.1C1 16.8 0 20.3 0 24s1 7.2 2.6 10.4l7.8-6.1z"
+                  />
+                  <path
+                    fill="#34A853"
+                    d="M24 48c6.5 0 11.9-2.1 15.9-5.8l-7.1-5.5c-2 1.3-4.5 2.1-8.8 2.1-6.4 0-11.8-3.8-13.6-9.1l-7.8 6.1C6.4 42.6 14.6 48 24 48z"
+                  />
+                </svg>
+                Continue with Google
+              </Button>
+
+              <Divider>OR</Divider>
+
+              {formError && (
+                <Alert tone="error" title="Couldn't sign you in">
+                  {formError}
+                </Alert>
+              )}
+
+              <Stack gap="md">
+                <Stack gap="xs">
+                  <Text as="label" htmlFor="login-email" weight="medium" size="sm">
+                    Email
+                  </Text>
+                  <Input
+                    id="login-email"
+                    type="email"
+                    autoComplete="email"
+                    placeholder="you@company.com"
+                    value={email}
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                      if (emailError) setEmailError(null);
+                    }}
+                    onKeyDown={onEnter}
+                    invalid={!!emailError}
+                    aria-describedby={emailError ? 'login-email-error' : undefined}
+                  />
+                  {emailError && (
+                    <Text id="login-email-error" size="sm" tone="danger">
+                      {emailError}
+                    </Text>
+                  )}
+                </Stack>
+
+                <Stack gap="xs">
+                  <Cluster justify="between" align="baseline">
+                    <Text as="label" htmlFor="login-password" weight="medium" size="sm">
+                      Password
+                    </Text>
+                    <Link href="/forgot-password" variant="default">
+                      Forgot?
+                    </Link>
+                  </Cluster>
+                  <PasswordInput
+                    id="login-password"
+                    autoComplete="current-password"
+                    placeholder="••••••••"
+                    capsLockWarning
+                    value={password}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                      if (passwordError) setPasswordError(null);
+                    }}
+                    onKeyDown={onEnter}
+                    invalid={!!passwordError}
+                    aria-describedby={passwordError ? 'login-password-error' : undefined}
+                  />
+                  {passwordError && (
+                    <Text id="login-password-error" size="sm" tone="danger">
+                      {passwordError}
+                    </Text>
+                  )}
+                </Stack>
+              </Stack>
+
+              <Checkbox label="Keep me signed in" defaultChecked />
+
+              <Button variant="primary" onClick={submit}>
+                Sign in
+              </Button>
+            </Stack>
+          </Card>
+        </Stack>
+      </div>
+
+      <Cluster justify="center" gap="lg">
+        <Link href="/legal/privacy" variant="muted">
+          Privacy
+        </Link>
+        <Link href="/legal/terms" variant="muted">
+          Terms
+        </Link>
+        <Link href="/status" variant="muted">
+          Status
+        </Link>
+      </Cluster>
+    </div>
+  );
+}
+```
+
+Notes for the implementer (do not add as code comments beyond those already shown):
+- **No `<form>`** (Hard rule 6 forbids raw `<form>`). Submit fires via the primary Button's `onClick` and an Enter-key handler on both inputs.
+- **Buttons full-width:** they sit in a `Stack`, whose default `align="stretch"` stretches children to the card width. Confirm visually in Task 4; if a Button caps its own width, that is a contained tweak inside the AuthScreen escape hatch, not a new one.
+- **Inert links:** `Forgot?` / footer links use plausible `href` paths (not `href="#"`, which the Link JSDoc flags as an anti-pattern). They don't resolve inside the playground SPA — that's acceptable for a static mockup; note it for the reviewer.
+- **`eocrm` wordmark** is `Text` (not a heading) so the page's single `<h1>` is "Sign in" (`Title order={1}`).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/playground/src/pages/mockups/Login/Login.tsx
+git commit -m "feat(mockup): add eocrm full-screen login screen"
+```
+
+---
+
+## Task 3: Wire the mockup (route + shell guard + nav + registry)
+
+**Files:**
+- Modify: `packages/playground/src/App.tsx`
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
+- Modify: `packages/playground/src/pages/mockups/registry.ts`
+
+- [ ] **Step 1: Add the import + route in `App.tsx`**
+
+Add the import alongside the other mockup imports (after the `Settings` import on line 12):
+
+```tsx
+import { Settings } from './pages/mockups/Settings/Settings';
+import { Login } from './pages/mockups/Login/Login';
+```
+
+Add the route inside the mockups group (after the `/mockups/audit` route, currently line 93):
+
+```tsx
+            <Route path="/mockups/audit" element={<Audit />} />
+            <Route path="/mockups/login" element={<Login />} />
+```
+
+- [ ] **Step 2: Add the full-bleed guard + nav entry + icon in `AppShell.tsx`**
+
+Add `LogIn` to the `lucide-react` import block (e.g., next to `Activity`):
+
+```tsx
+  Activity,
+  LogIn,
+```
+
+Add a "Login" entry to `mockupItems` (after the `system-settings` item, currently line 84):
+
+```tsx
+  { to: '/mockups/system-settings', label: 'System settings', icon: SettingsIcon, end: false },
+  { to: '/mockups/login', label: 'Login', icon: LogIn, end: false },
+```
+
+Add the full-bleed guard as the first statement in the `AppShell` function body. Change:
+
+```tsx
+export function AppShell({ children }: { children: ReactNode }) {
+  const { pathname } = useLocation();
+  const inComponents = pathname.startsWith('/components');
+```
+
+to:
+
+```tsx
+export function AppShell({ children }: { children: ReactNode }) {
+  const { pathname } = useLocation();
+
+  // Full-bleed routes render outside the shell chrome (no Rail / TopBar) so a
+  // login screen reads like a real auth page, not a page inside the CRM.
+  if (pathname === '/mockups/login') {
+    return <>{children}</>;
+  }
+
+  const inComponents = pathname.startsWith('/components');
+```
+
+- [ ] **Step 3: Add the registry entry in `registry.ts`**
+
+Add this entry to the `MOCKUPS` array (after the `system-settings` entry, before the closing `]`):
+
+```ts
+  {
+    slug: 'login',
+    title: 'Login',
+    path: '/mockups/login',
+    blurb: 'Full-screen eocrm sign-in — branded card, email/password, Google SSO, error states.',
+    usesComponents: [
+      'Alert',
+      'Button',
+      'Card',
+      'Checkbox',
+      'Cluster',
+      'Divider',
+      'Input',
+      'Link',
+      'PasswordInput',
+      'Stack',
+      'Text',
+      'Title',
+    ],
+  },
+```
+
+(No `ComponentName` union change — all twelve names already exist in the union.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/playground/src/App.tsx packages/playground/src/layout/AppShell/AppShell.tsx packages/playground/src/pages/mockups/registry.ts
+git commit -m "feat(mockup): wire login route, full-bleed shell guard, nav + registry"
+```
+
+---
+
+## Task 4: Gates — typecheck, build, lint
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck + build the playground**
+
+Run: `make build`
+Expected: completes with no TypeScript errors and a successful Vite bundle. If TS complains about a prop, re-check it against the component source (the props used here are verified against the v-current source: `Input.invalid`, `PasswordInput.capsLockWarning`, `Checkbox.label/defaultChecked`, `Alert.tone/title`, `Divider` children, `Title.order/size`, `Text.as/htmlFor/size/weight/tone`, `Link.as/href/variant`, `Cluster.justify/align`, `Stack.gap/align`).
+
+- [ ] **Step 2: Lint both packages**
+
+Run: `make lint`
+Expected: passes. (Stylelint targets `.scss`; `Login.tsx` ships no SCSS, so this mainly confirms nothing else regressed.)
+
+- [ ] **Step 3: Visual smoke (manual, fast)**
+
+Run: `make dev` (starts the playground on http://localhost:8080 without opening a browser; run in the background).
+Then drive a browser (Playwright MCP `browser_navigate` → `browser_take_screenshot`, or open it yourself) to `http://localhost:8080/mockups/login` and confirm:
+1. **No sidebar / topbar** — the login owns the full viewport.
+2. Tinted radial backdrop (light blue at top fading to near-white), `eocrm` wordmark centered above a white elevated card.
+3. Card: "Sign in" + subtitle, full-width "Continue with Google" (with the 4-color G), an "OR" divider, Email + Password (with "Forgot?" on the label row + reveal eye), "Keep me signed in" (checked), full-width primary "Sign in".
+4. Footer row: Privacy · Terms · Status; top-left "← Back to mockups".
+5. **Error-state demo:** click "Sign in" with empty fields → inline red errors under Email + Password. Type a valid email + a 6+ char password → click "Sign in" → the red `Alert` "Couldn't sign you in / Invalid email or password." appears above the fields.
+6. Buttons are full-width (Task 2 note). If not, fix inside the AuthScreen mock and re-screenshot.
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(mockup): login visual + typecheck fixes"
+```
+(Skip if Steps 1–3 needed no changes.)
+
+---
+
+## Task 5: Hard-rule-7 mockup review loop
+
+This is **mandatory** — the change touches `packages/playground/src/pages/mockups/**` and `registry.ts`. (It does **not** require the library review loop: the only `packages/design-system/**` change is the `TODO.md` docs edit, which is a docs-only, no-regression change.)
+
+**Files:** none directly (review → fix → re-verify)
+
+- [ ] **Step 1: Confirm gates are green** (Task 4 must pass before review — Rule 7 step 1).
+
+- [ ] **Step 2: Spawn a fresh-context reviewer** (`general-purpose` agent) targeted at `packages/playground/src/pages/mockups/Login/Login.tsx`, `App.tsx`, `AppShell.tsx`, `registry.ts`, and the two new `TODO.md` entries. Brief it on the 10 Rule-7 categories from `packages/playground/CLAUDE.md`:
+  1. Hard rule 6 compliance — no stray inline `style`/raw HTML outside the two TODO'd escape-hatch sites; each escape hatch has a matching `TODO.md` entry **and** inline `{/* TODO… */}` comment.
+  2. Registry sync — every component used is listed in `usesComponents`; no stale names.
+  3. Imports — only from `@eocrm/design-system` (+ `react-router-dom` / `lucide-react` demo deps); no relative paths into the library.
+  4. Realism — believable copy, plausible behavior.
+  5. Accessibility — one `<h1>` (Sign in), labels associated via `htmlFor`/`id`, inputs wired to error text via `aria-describedby`, the Google `<svg>` is `aria-hidden`, error `Alert` uses `tone="error"` (role="alert").
+  6. Keyboard / focus — Tab order matches visual order; Enter submits; password reveal reachable.
+  7. Layout discipline — spacing via `Stack`/`Cluster` `gap`, not ad-hoc margins.
+  8. Component coverage — uses `Divider` (label), `PasswordInput`, `Alert`, etc. rather than hand-rolling.
+  9. State realism — clean + inline-error + Alert states all reachable.
+  10. No stale TODOs — both new `TODO.md` entries are open with matching inline comments.
+
+  **Tell the reviewer explicitly:** the `eocrm` wordmark (vs AppShell's "Orbit CRM") and the non-resolving `Forgot?`/footer hrefs are intentional, approved decisions — do not flag them. Ask for output as Critical / Important / Nice-to-have / Regression-watch + a verdict line (`clean enough to stop` or `keep iterating`).
+
+- [ ] **Step 3: Fix every Critical and Important finding.** Document any deliberately-skipped finding in one line.
+
+- [ ] **Step 4: Re-run gates** (`make build`, `make lint`) after fixes.
+
+- [ ] **Step 5: Spawn another reviewer** with the same brief. **Repeat Steps 3–5** until the verdict is `clean enough to stop` with 0 Critical / 0 Important.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "fix(mockup): address login review findings"
+```
+(Skip if no changes.)
+
+---
+
+## Task 6: Open the PR
+
+**Files:** none
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin feat/login-mockup`
+Expected: the pre-push hook (prettier + stylelint + typecheck) passes, then the branch pushes. If the hook fails, fix the reported issue — do **not** use `--no-verify`.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --base main --title "Add eocrm full-screen login mockup" --body "$(cat <<'EOF'
+Full-screen `eocrm` sign-in mockup at `/mockups/login` (Direction C: elevated card on a token-tinted backdrop), built from `@eocrm/design-system` primitives.
+
+- Page chrome via the token-based inline-mock escape hatch (no module.scss) — two gaps filed in `TODO.md`: `<AuthScreen>` and a brand-icon set.
+- `Divider` label (`<Divider>OR</Divider>`) used for the SSO separator.
+- Full-screen via an `AppShell` guard (no Rail/TopBar on the login route).
+- Interactive error-state demo: inline validation + an `Alert` on failed submit.
+
+Spec: `docs/superpowers/specs/2026-05-29-login-mockup-design.md`
+Plan: `docs/superpowers/plans/2026-05-29-login-mockup.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for the `Quality / check` status check to pass**, then the change is ready to merge (squash or merge commit — caller's choice).
+
+---
+
+## Self-review checklist (run before executing)
+
+1. **Spec coverage:** centered card on tinted backdrop ✓ (Task 2 AuthScreen mock + token gradient); full-screen ✓ (Task 3 guard); Google SSO + OR divider ✓ (Task 2); footer links ✓; error-state demo ✓; "Keep me signed in" default-checked ✓; no "Create an account" ✓; copy grounded in reference ✓; registry/route/nav wiring ✓ (Task 3); escape hatches TODO'd ✓ (Task 1); Rule-7 review ✓ (Task 5).
+2. **Placeholders:** none — full `Login.tsx` source, exact wiring diffs, exact `TODO.md` text, exact commands.
+3. **Type/name consistency:** `submit`, `onEnter`, `emailError`/`passwordError`/`formError`, ids `login-email`/`login-email-error`/`login-password`/`login-password-error` used consistently across the component; prop names verified against component source.

--- a/docs/superpowers/plans/2026-05-29-login-mockup.md
+++ b/docs/superpowers/plans/2026-05-29-login-mockup.md
@@ -16,13 +16,13 @@
 
 ## File Structure
 
-| File | Responsibility |
-| --- | --- |
+| File                                                    | Responsibility                                                                                                |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `packages/playground/src/pages/mockups/Login/Login.tsx` | **NEW** — the entire mockup: composition + interactive validation/error behavior + the two escape-hatch mocks |
-| `packages/playground/src/App.tsx` | MODIFY — import `Login`, add `/mockups/login` route |
-| `packages/playground/src/layout/AppShell/AppShell.tsx` | MODIFY — full-bleed guard for the login route + a "Login" entry in `mockupItems` + `LogIn` icon import |
-| `packages/playground/src/pages/mockups/registry.ts` | MODIFY — add the `login` mockup entry (no `ComponentName` union change needed) |
-| `packages/design-system/src/components/TODO.md` | MODIFY — add `<AuthScreen>` and brand-icon gap entries |
+| `packages/playground/src/App.tsx`                       | MODIFY — import `Login`, add `/mockups/login` route                                                           |
+| `packages/playground/src/layout/AppShell/AppShell.tsx`  | MODIFY — full-bleed guard for the login route + a "Login" entry in `mockupItems` + `LogIn` icon import        |
+| `packages/playground/src/pages/mockups/registry.ts`     | MODIFY — add the `login` mockup entry (no `ComponentName` union change needed)                                |
+| `packages/design-system/src/components/TODO.md`         | MODIFY — add `<AuthScreen>` and brand-icon gap entries                                                        |
 
 `MockupsIndex.tsx` is **not** edited — it renders every non-parameterized `registry.ts` entry automatically (verified: `MOCKUPS.filter((m) => !m.path.includes(':'))`).
 
@@ -33,13 +33,14 @@
 Do this first so the inline-mock `{/* TODO… */}` comments in `Login.tsx` reference real entries.
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/TODO.md`
 
 - [ ] **Step 1: Add both entries under the `## Open` section**
 
 Insert these two entries immediately after the `## Open` line (before the existing `<StatTile>` entry), matching the file's existing entry format:
 
-````markdown
+```markdown
 ### [ ] `<AuthScreen>` (or `<AuthLayout>`) — full-viewport centered surface with a tinted backdrop for auth pages
 
 **Filed:** 2026-05-29
@@ -69,7 +70,7 @@ A small set of brand / social-provider marks for SSO buttons. These are multi-co
 A hand-authored inline `<svg viewBox="0 0 48 48">` with four `<path fill="#…">` brand-hex colors at the exact mock site, `aria-hidden="true"`. Marked with the standard TODO comment. (Note: brand hex is correct here — this is the documented exception to token-only color.)
 
 **When this ships:** refactor the Login SSO button to use the brand icon, then tick this checkbox.
-````
+```
 
 - [ ] **Step 2: Verify the file still reads cleanly**
 
@@ -88,6 +89,7 @@ git commit -m "docs(todo): file <AuthScreen> + brand-icon gaps for login mockup"
 ## Task 2: Build the Login mockup
 
 **Files:**
+
 - Create: `packages/playground/src/pages/mockups/Login/Login.tsx`
 
 - [ ] **Step 1: Create `Login.tsx` with the full implementation**
@@ -296,6 +298,7 @@ export function Login() {
 ```
 
 Notes for the implementer (do not add as code comments beyond those already shown):
+
 - **No `<form>`** (Hard rule 6 forbids raw `<form>`). Submit fires via the primary Button's `onClick` and an Enter-key handler on both inputs.
 - **Buttons full-width:** they sit in a `Stack`, whose default `align="stretch"` stretches children to the card width. Confirm visually in Task 4; if a Button caps its own width, that is a contained tweak inside the AuthScreen escape hatch, not a new one.
 - **Inert links:** `Forgot?` / footer links use plausible `href` paths (not `href="#"`, which the Link JSDoc flags as an anti-pattern). They don't resolve inside the playground SPA — that's acceptable for a static mockup; note it for the reviewer.
@@ -313,6 +316,7 @@ git commit -m "feat(mockup): add eocrm full-screen login screen"
 ## Task 3: Wire the mockup (route + shell guard + nav + registry)
 
 **Files:**
+
 - Modify: `packages/playground/src/App.tsx`
 - Modify: `packages/playground/src/layout/AppShell/AppShell.tsx`
 - Modify: `packages/playground/src/pages/mockups/registry.ts`
@@ -428,6 +432,7 @@ Expected: passes. (Stylelint targets `.scss`; `Login.tsx` ships no SCSS, so this
 
 Run: `make dev` (starts the playground on http://localhost:8080 without opening a browser; run in the background).
 Then drive a browser (Playwright MCP `browser_navigate` → `browser_take_screenshot`, or open it yourself) to `http://localhost:8080/mockups/login` and confirm:
+
 1. **No sidebar / topbar** — the login owns the full viewport.
 2. Tinted radial backdrop (light blue at top fading to near-white), `eocrm` wordmark centered above a white elevated card.
 3. Card: "Sign in" + subtitle, full-width "Continue with Google" (with the 4-color G), an "OR" divider, Email + Password (with "Forgot?" on the label row + reveal eye), "Keep me signed in" (checked), full-width primary "Sign in".
@@ -441,6 +446,7 @@ Then drive a browser (Playwright MCP `browser_navigate` → `browser_take_screen
 git add -A
 git commit -m "fix(mockup): login visual + typecheck fixes"
 ```
+
 (Skip if Steps 1–3 needed no changes.)
 
 ---
@@ -479,6 +485,7 @@ This is **mandatory** — the change touches `packages/playground/src/pages/mock
 git add -A
 git commit -m "fix(mockup): address login review findings"
 ```
+
 (Skip if no changes.)
 
 ---

--- a/docs/superpowers/specs/2026-05-29-login-mockup-design.md
+++ b/docs/superpowers/specs/2026-05-29-login-mockup-design.md
@@ -1,0 +1,182 @@
+# Login screen — playground mockup
+
+## Goal
+
+A believable, full-screen **eocrm sign-in** screen in the playground's mockups section
+(`/mockups/login`), built from `@eocrm/design-system` primitives. It dogfoods the form
+surface (Input, PasswordInput, Checkbox, Button, Alert, Link) in a realistic composition and
+gives stakeholders/agents a reference for what an auth screen looks like on this design system.
+
+Grounded in the canonical eocrm signin design
+(`/Users/dpws/projects/eocrm/docs/design/2026-04-28-elevated-direction/signin.jsx`).
+
+This is a **mockup, not a library component** — no tests/exports/AGENTS.md entry. It "exists"
+when it's routed, in the sidebar, and in the registry, and it passes the Rule-7 review loop.
+
+## Locked-in decisions (brainstorm)
+
+1. **Artifact:** playground mockup under `src/pages/mockups/Login/Login.tsx`.
+2. **Layout — "Direction C":** an elevated `Card` floating on a soft, tinted radial backdrop;
+   `eocrm` wordmark centered above the card.
+3. **Chrome:** **full-screen** — the login owns the viewport, no CRM sidebar/topbar behind it.
+4. **Included blocks:** Continue with Google (+ "OR" divider), footer links (Privacy · Terms ·
+   Status), and an **error-state demo** (inline field validation + an `Alert` on failed submit).
+   Always present: Email, Password (with "Forgot?"), "Keep me signed in" (checked by default),
+   primary "Sign in".
+5. **Omitted:** "Create an account" link (kept minimal — invite-only CRM feel).
+6. **Copy** is grounded in the reference and hardcoded in English (mockups don't use i18n; cf.
+   Dashboard): title "Sign in"; subtitle "Welcome back. Enter your email to continue to your
+   workspace."; email placeholder "you@company.com"; password placeholder "••••••••"; error
+   "Invalid email or password.".
+
+## Correction to the verbal design
+
+The verbal design mentioned a `Login.module.scss` for page chrome. **That is forbidden** by
+playground Hard rule 6 — mockups may not use co-located `*.module.scss`, inline `style={}`, or
+raw HTML tags. Page chrome is instead handled with the repo's established **token-based
+inline-mock escape hatch** (the exact idiom `Dashboard.tsx` uses for its `StatTile` mock,
+lines 95–108): a raw element with inline `style` whose values are **design tokens**
+(`var(--color-…)`, `var(--space-…)`, `var(--radius-…)`) — never raw hex — preceded by a
+`{/* TODO: replace when <X> ships — see components/TODO.md */}` comment and backed by a
+`TODO.md` entry. The "Direction C" gradient is composed from existing color tokens, so the look
+survives the rules.
+
+## Composition (primitives)
+
+Inside the card, everything is a library primitive:
+
+```
+Card (padding="lg")
+└─ Stack (gap="lg")
+   ├─ Stack (gap="xs")
+   │   ├─ Title order={1} size="lg"        "Sign in"
+   │   └─ Text size="sm" tone="muted"       welcome subtitle
+   ├─ Button variant="secondary"            ⟨G⟩ Continue with Google   (full-width)
+   ├─ «OR divider»                          (escape hatch — see Gap 2)
+   ├─ [Alert tone="error"]                  shown only after a failed submit (Gap: error demo)
+   ├─ Stack (gap="md")  // fields
+   │   ├─ Stack (gap="xs")
+   │   │   ├─ Text as="label" htmlFor="login-email" weight="medium"   "Email"
+   │   │   ├─ Input id="login-email" type="email" autoComplete="email"
+   │   │   │        placeholder="you@company.com" invalid={…} aria-describedby={…}
+   │   │   └─ Text id="login-email-err" size="sm" tone="danger"        (conditional)
+   │   └─ Stack (gap="xs")
+   │       ├─ Cluster justify="between" align="baseline"
+   │       │   ├─ Text as="label" htmlFor="login-password" weight="medium"   "Password"
+   │       │   └─ Link href="#"                                              "Forgot?"
+   │       ├─ PasswordInput id="login-password" autoComplete="current-password"
+   │       │        placeholder="••••••••" capsLockWarning revealable
+   │       │        invalid={…} aria-describedby={…}
+   │       └─ Text id="login-password-err" size="sm" tone="danger"           (conditional)
+   ├─ Checkbox label="Keep me signed in" defaultChecked
+   └─ Button variant="primary" type="submit" onClick={submit}                "Sign in" (full-width)
+```
+
+- **Full-width buttons:** the buttons sit directly in a `Stack`, whose default `align="stretch"`
+  stretches children to the card width — so both buttons span full-width with no extra mock.
+  Verify visually in the playground; if a Button caps its own width, that's a contained tweak
+  inside the auth-screen escape hatch, **not** a new one.
+- **Icons:** `lucide-react` is a demo-only dep already used by mockups (Dashboard). The
+  Google brand "G" is *not* in lucide and is multi-color → Gap 3.
+
+## Escape-hatch gaps (each gets a TODO.md entry + inline `{/* TODO… */}` comment)
+
+These are genuine library gaps the mockup surfaces — mockups are the "canary for missing
+primitives." Each inline mock is token-based and contained to the smallest block.
+
+**Gap 1 — `<AuthScreen>` (full-viewport centered backdrop).** No primitive paints a page-level
+gradient or centers content in the viewport. One outer mock element owns the full-bleed layout:
+a viewport-height grid with three rows — a top-left "← Back to mockups" `Link` (demo affordance),
+a centered middle holding the wordmark + card, and a bottom footer row of `Link`s. The inline
+`style` is confined to the outer grid **container** (rows template, `min-height: 100vh`, backdrop,
+padding); each row's contents use `Stack` / `Cluster` / `Link` / `Text` primitives. Backdrop:
+`radial-gradient(120% 90% at 50% -8%, var(--color-accent-subtle-bg) 0%, var(--color-bg-subtle) 52%)`
+(token stops — exact token names confirmed in planning; the real eocrm has an `AuthCardLayout`,
+so this is a real CRM gap). The `eocrm` wordmark renders via `Text`/`Title` (no extra hatch).
+
+**Gap 2 — `Divider` with a centered "OR" label.** `Divider` exposes only
+orientation/variant/size — no label slot, and flanking rules need `flex: 1` which components
+don't own. Inline-mock a row of two token-bordered rules + a `Text size="xs" tone="subtle"` "OR".
+TODO: add label support to `Divider`.
+
+**Gap 3 — Google brand mark.** No colored brand icon in the library or lucide. Inline-mock the
+official 4-color "G" `<svg>` at the SSO button's left. TODO: a brand-icon/asset entry.
+
+No `<form>` element (Hard rule 6): submission is wired via the primary `Button`'s `onClick` plus
+an Enter-key handler on the password field — not a raw `<form>`.
+
+## Full-screen mechanism (App.tsx + AppShell)
+
+`App.tsx` wraps every route in `<AppShell>`. To make `/mockups/login` full-bleed:
+
+1. `App.tsx` (MODIFY): add `<Route path="/mockups/login" element={<Login />} />` to the existing
+   `<Routes>`.
+2. `AppShell.tsx` (MODIFY): early-return `children` full-bleed (skip the Rail + TopBar grid) when
+   `useLocation().pathname` is the login route. AppShell already reads the location to switch
+   sidebar sections, so this is a small, contained guard. (Equivalent to "render outside the
+   shell"; chosen over nested `<Routes>` to avoid React-Router splat-path subtlety.)
+
+`App.tsx` / `AppShell.tsx` are playground tooling — Hard rule 6 and the Rule-7 mockup review
+loop do **not** apply to them; they push through the normal PR flow.
+
+## Behavior & states (interactive mockup)
+
+Local `useState` only — no network. The inputs are real (typeable, password reveal, caps-lock
+warning, checkbox toggles).
+
+- **On "Sign in" (click or Enter in password):**
+  - Email fails a simple format check (`/.+@.+\..+/`) → inline `Text tone="danger"` "Enter a
+    valid email address." + `Input invalid` + `aria-describedby`.
+  - Password < 6 chars → inline "Password must be at least 6 characters." + `PasswordInput invalid`.
+  - If both pass → simulate auth failure: render `Alert tone="error" title="Couldn't sign you in"`
+    with body "Invalid email or password." above the fields. Deterministic (no timers), so the
+    error state is always reachable for the demo.
+- Errors clear on edit of the offending field.
+- Default render = clean state (the hero). The Alert + invalid borders are the error-state demo.
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `packages/playground/src/pages/mockups/Login/Login.tsx` | **NEW** — the mockup |
+| `packages/playground/src/App.tsx` | MODIFY — add `/mockups/login` route |
+| `packages/playground/src/layout/AppShell/AppShell.tsx` | MODIFY — full-bleed guard for login + Mockups sidebar nav entry |
+| `packages/playground/src/pages/mockups/registry.ts` | MODIFY — add `login` entry (all `usesComponents` already in the `ComponentName` union) |
+| `packages/playground/src/pages/mockups/MockupsIndex.tsx` | VERIFY — auto-renders from registry; edit only if it does not |
+| `packages/design-system/src/components/TODO.md` | MODIFY — add Gap 1/2/3 entries |
+| `docs/superpowers/specs/2026-05-29-login-mockup-design.md` | this spec |
+
+`registry.ts` entry:
+
+```ts
+{
+  slug: 'login',
+  title: 'Login',
+  path: '/mockups/login',
+  blurb: 'Full-screen sign-in — branded card, email/password, Google SSO, error states.',
+  usesComponents: [
+    'Alert', 'Button', 'Card', 'Checkbox', 'Cluster',
+    'Divider', 'Input', 'Link', 'PasswordInput', 'Stack', 'Text', 'Title',
+  ],
+}
+```
+
+No in-page `<CrossLinks>` footer (it would break the full-bleed illusion); the registry entry
+still powers the component-demo → mockup "Seen in" links. Note this deviation for the reviewer.
+
+## Wiring & review (definition of done)
+
+1. Route (`App.tsx`) + full-bleed guard & sidebar entry (`AppShell.tsx`) + registry entry +
+   MockupsIndex shows it.
+2. Each escape-hatch mock has a matching `TODO.md` entry and inline `{/* TODO… */}` comment.
+3. Gates green: `make test`, `make build`, `make lint`.
+4. **Rule-7 review loop** (mockup change): spawn a fresh-context reviewer against the 10
+   categories, fix every Critical/Important, re-run gates, repeat until "clean enough to stop".
+5. PR off `feat/login-mockup` → wait for `Quality / check` → merge.
+
+## Out of scope
+
+- Real authentication, OAuth, forgot-password / create-account pages, post-login routing.
+- Building the `<AuthScreen>`, `Divider` label support, or a brand-icon primitive (filed as
+  TODOs only — the mockup inline-mocks them).
+- Dark mode, i18n of the mockup's own copy, "remember me" session semantics.

--- a/docs/superpowers/specs/2026-05-29-login-mockup-design.md
+++ b/docs/superpowers/specs/2026-05-29-login-mockup-design.md
@@ -77,7 +77,7 @@ Card (padding="lg")
   Verify visually in the playground; if a Button caps its own width, that's a contained tweak
   inside the auth-screen escape hatch, **not** a new one.
 - **Icons:** `lucide-react` is a demo-only dep already used by mockups (Dashboard). The
-  Google brand "G" is *not* in lucide and is multi-color → Gap 3.
+  Google brand "G" is _not_ in lucide and is multi-color → Gap 3.
 
 ## Escape-hatch gaps (each gets a TODO.md entry + inline `{/* TODO… */}` comment)
 
@@ -136,15 +136,15 @@ warning, checkbox toggles).
 
 ## Files
 
-| File | Change |
-| --- | --- |
-| `packages/playground/src/pages/mockups/Login/Login.tsx` | **NEW** — the mockup |
-| `packages/playground/src/App.tsx` | MODIFY — add `/mockups/login` route |
-| `packages/playground/src/layout/AppShell/AppShell.tsx` | MODIFY — full-bleed guard for login + Mockups sidebar nav entry |
-| `packages/playground/src/pages/mockups/registry.ts` | MODIFY — add `login` entry (all `usesComponents` already in the `ComponentName` union) |
-| `packages/playground/src/pages/mockups/MockupsIndex.tsx` | VERIFY — auto-renders from registry; edit only if it does not |
-| `packages/design-system/src/components/TODO.md` | MODIFY — add Gap 1/2/3 entries |
-| `docs/superpowers/specs/2026-05-29-login-mockup-design.md` | this spec |
+| File                                                       | Change                                                                                 |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `packages/playground/src/pages/mockups/Login/Login.tsx`    | **NEW** — the mockup                                                                   |
+| `packages/playground/src/App.tsx`                          | MODIFY — add `/mockups/login` route                                                    |
+| `packages/playground/src/layout/AppShell/AppShell.tsx`     | MODIFY — full-bleed guard for login + Mockups sidebar nav entry                        |
+| `packages/playground/src/pages/mockups/registry.ts`        | MODIFY — add `login` entry (all `usesComponents` already in the `ComponentName` union) |
+| `packages/playground/src/pages/mockups/MockupsIndex.tsx`   | VERIFY — auto-renders from registry; edit only if it does not                          |
+| `packages/design-system/src/components/TODO.md`            | MODIFY — add Gap 1/2/3 entries                                                         |
+| `docs/superpowers/specs/2026-05-29-login-mockup-design.md` | this spec                                                                              |
 
 `registry.ts` entry:
 

--- a/packages/design-system/src/components/TODO.md
+++ b/packages/design-system/src/components/TODO.md
@@ -27,6 +27,36 @@ Keep entries terse but specific. The "Mocked in" path is load-bearing — the im
 
 ## Open
 
+### [ ] `<AuthScreen>` (or `<AuthLayout>`) — full-viewport centered surface with a tinted backdrop for auth pages
+
+**Filed:** 2026-05-29
+**Mocked in:**
+
+- `packages/playground/src/pages/mockups/Login/Login.tsx` — the outer page wrapper (full-bleed gradient backdrop, vertical layout) and the inner region that centers the card in the remaining viewport height.
+
+**What's needed:**
+A page-level layout primitive for sign-in / forgot-password / accept-invite screens: takes over the full viewport (`min-height: 100vh`), paints a subtle token-based backdrop (default a soft accent wash), and lays out three slots — an optional top bar (back-link / brand), a vertically + horizontally centered main slot (the auth card), and an optional footer (legal links). Props sketch: `backdrop?: 'plain' | 'tinted'`, plus `header` / `footer` slots and `children` (the centered content). No interactive state. The real eocrm app has an `AuthCardLayout` serving exactly this role, so the CRM will want it too.
+
+**Current workaround:**
+Two raw `<div style={{…}}>` at the exact mock site, token-only values: the outer wrapper (`min-height: 100vh; display: flex; flex-direction: column; padding: var(--space-6); background: radial-gradient(120% 90% at 50% -8%, var(--color-accent-subtle-bg) 0%, var(--color-bg-subtle) 52%)`) and the centering region (`flex: 1; display: grid; place-items: center`). Marked with the standard TODO comment.
+
+**When this ships:** refactor the Login mockup's two wrapper `<div>`s to use the primitive, then tick this checkbox.
+
+### [ ] `<BrandIcon>` / social-login icon set — multi-color brand marks (Google, Microsoft, Apple…)
+
+**Filed:** 2026-05-29
+**Mocked in:**
+
+- `packages/playground/src/pages/mockups/Login/Login.tsx` — the Google "G" inside the "Continue with Google" SSO button.
+
+**What's needed:**
+A small set of brand / social-provider marks for SSO buttons. These are multi-color, fixed-brand-color assets (Google's 4-color "G", etc.) that intentionally do **not** map to design tokens — brand guidelines mandate the exact colors. `lucide-react` (the demo icon set) has no brand logos. Could ship as a tiny `<GoogleIcon>` / `<BrandIcon name="google">` component or an assets module.
+
+**Current workaround:**
+A hand-authored inline `<svg viewBox="0 0 48 48">` with four `<path fill="#…">` brand-hex colors at the exact mock site, `aria-hidden="true"`. Marked with the standard TODO comment. (Note: brand hex is correct here — this is the documented exception to token-only color.)
+
+**When this ships:** refactor the Login SSO button to use the brand icon, then tick this checkbox.
+
 ### [ ] `<StatTile>` (or `<IconTile>`) — tinted square (or circle) containing a centered icon
 
 **Filed:** 2026-05-25

--- a/packages/design-system/src/components/TODO.md
+++ b/packages/design-system/src/components/TODO.md
@@ -32,7 +32,8 @@ Keep entries terse but specific. The "Mocked in" path is load-bearing — the im
 **Filed:** 2026-05-29
 **Mocked in:**
 
-- `packages/playground/src/pages/mockups/Login/Login.tsx` — the outer page wrapper (full-bleed gradient backdrop, vertical layout) and the inner region that centers the card in the remaining viewport height.
+- `packages/playground/src/pages/mockups/Login/Login.tsx:51` — outer full-bleed wrapper (gradient backdrop, flex column, full viewport height)
+- `packages/playground/src/pages/mockups/Login/Login.tsx:69` — card-centering region (flex: 1, grid place-items center)
 
 **What's needed:**
 A page-level layout primitive for sign-in / forgot-password / accept-invite screens: takes over the full viewport (`min-height: 100vh`), paints a subtle token-based backdrop (default a soft accent wash), and lays out three slots — an optional top bar (back-link / brand), a vertically + horizontally centered main slot (the auth card), and an optional footer (legal links). Props sketch: `backdrop?: 'plain' | 'tinted'`, plus `header` / `footer` slots and `children` (the centered content). No interactive state. The real eocrm app has an `AuthCardLayout` serving exactly this role, so the CRM will want it too.
@@ -47,7 +48,7 @@ Two raw `<div style={{…}}>` at the exact mock site, token-only values: the out
 **Filed:** 2026-05-29
 **Mocked in:**
 
-- `packages/playground/src/pages/mockups/Login/Login.tsx` — the Google "G" inside the "Continue with Google" SSO button.
+- `packages/playground/src/pages/mockups/Login/Login.tsx:89` — the Google "G" inside the "Continue with Google" SSO button.
 
 **What's needed:**
 A small set of brand / social-provider marks for SSO buttons. These are multi-color, fixed-brand-color assets (Google's 4-color "G", etc.) that intentionally do **not** map to design tokens — brand guidelines mandate the exact colors. `lucide-react` (the demo icon set) has no brand logos. Could ship as a tiny `<GoogleIcon>` / `<BrandIcon name="google">` component or an assets module.

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -10,6 +10,7 @@ import { Members } from './pages/mockups/Members/Members';
 import { Tenants } from './pages/mockups/Tenants/Tenants';
 import { TenantDetail } from './pages/mockups/Tenants/TenantDetail';
 import { Settings } from './pages/mockups/Settings/Settings';
+import { Login } from './pages/mockups/Login/Login';
 import { ComponentsIndex } from './pages/components/ComponentsIndex';
 import { TokensPage } from './pages/Tokens/TokensPage';
 import { ArchitecturePage } from './pages/Architecture/ArchitecturePage';
@@ -91,6 +92,7 @@ export default function App() {
             <Route path="/mockups/tenants/:slug" element={<TenantDetail />} />
             <Route path="/mockups/system-settings" element={<Settings />} />
             <Route path="/mockups/audit" element={<Audit />} />
+            <Route path="/mockups/login" element={<Login />} />
 
             <Route path="/components" element={<ComponentsIndex />} />
             <Route path="/components/tokens" element={<TokensPage />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -250,6 +250,16 @@ function BrandMark() {
 export function AppShell({ children }: { children: ReactNode }) {
   const { pathname } = useLocation();
 
+  // Persisted collapsed state — survives reload, syncs across tabs.
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === '1';
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? '1' : '0');
+  }, [collapsed]);
+
   // Full-bleed routes render outside the shell chrome (no Rail / TopBar) so a
   // login screen reads like a real auth page, not a page inside the CRM.
   if (pathname === '/mockups/login') {
@@ -261,16 +271,6 @@ export function AppShell({ children }: { children: ReactNode }) {
   const switchLink = inComponents
     ? { to: '/mockups', label: 'Mockups', icon: Layers }
     : { to: '/components', label: 'Components', icon: Component };
-
-  // Persisted collapsed state — survives reload, syncs across tabs.
-  const [collapsed, setCollapsed] = useState<boolean>(() => {
-    if (typeof window === 'undefined') return false;
-    return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === '1';
-  });
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? '1' : '0');
-  }, [collapsed]);
 
   return (
     <div className={styles.shell} data-rail-collapsed={collapsed || undefined}>

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -59,6 +59,7 @@ import {
   Type,
   Code as CodeIcon,
   Activity,
+  LogIn,
   LoaderCircle,
   UploadCloud,
   SlidersHorizontal,
@@ -82,6 +83,7 @@ const mockupItems = [
   { to: '/mockups/tenants', label: 'Tenants', icon: Building2, end: false },
   { to: '/mockups/audit', label: 'Audit log', icon: Activity, end: false },
   { to: '/mockups/system-settings', label: 'System settings', icon: SettingsIcon, end: false },
+  { to: '/mockups/login', label: 'Login', icon: LogIn, end: false },
 ];
 
 const componentOverview = {
@@ -247,6 +249,13 @@ function BrandMark() {
 
 export function AppShell({ children }: { children: ReactNode }) {
   const { pathname } = useLocation();
+
+  // Full-bleed routes render outside the shell chrome (no Rail / TopBar) so a
+  // login screen reads like a real auth page, not a page inside the CRM.
+  if (pathname === '/mockups/login') {
+    return <>{children}</>;
+  }
+
   const inComponents = pathname.startsWith('/components');
 
   const switchLink = inComponents

--- a/packages/playground/src/pages/mockups/Login/Login.tsx
+++ b/packages/playground/src/pages/mockups/Login/Login.tsx
@@ -129,6 +129,7 @@ export function Login() {
                     onChange={(e) => {
                       setEmail(e.target.value);
                       if (emailError) setEmailError(null);
+                      if (formError) setFormError(null);
                     }}
                     onKeyDown={onEnter}
                     invalid={!!emailError}
@@ -159,6 +160,7 @@ export function Login() {
                     onChange={(e) => {
                       setPassword(e.target.value);
                       if (passwordError) setPasswordError(null);
+                      if (formError) setFormError(null);
                     }}
                     onKeyDown={onEnter}
                     invalid={!!passwordError}

--- a/packages/playground/src/pages/mockups/Login/Login.tsx
+++ b/packages/playground/src/pages/mockups/Login/Login.tsx
@@ -1,0 +1,198 @@
+import { useState, type KeyboardEvent } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  Alert,
+  Button,
+  Card,
+  Checkbox,
+  Cluster,
+  Divider,
+  Input,
+  Link,
+  PasswordInput,
+  Stack,
+  Text,
+  Title,
+} from '@eocrm/design-system';
+
+// Loose client-side shape check only — real validation is server-side.
+const EMAIL_RE = /.+@.+\..+/;
+
+export function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  function submit() {
+    const nextEmailError = EMAIL_RE.test(email) ? null : 'Enter a valid email address.';
+    const nextPasswordError =
+      password.length >= 6 ? null : 'Password must be at least 6 characters.';
+    setEmailError(nextEmailError);
+    setPasswordError(nextPasswordError);
+    if (nextEmailError || nextPasswordError) {
+      setFormError(null);
+      return;
+    }
+    // No backend in a mockup — simulate an auth failure so the error Alert
+    // (the "error-state demo") is always reachable for stakeholders.
+    setFormError('Invalid email or password.');
+  }
+
+  function onEnter(e: KeyboardEvent) {
+    if (e.key === 'Enter') submit();
+  }
+
+  return (
+    /* TODO: replace when <AuthScreen> ships — see components/TODO.md.
+       Full-viewport centered auth layout with a tinted backdrop is page
+       chrome no current primitive expresses. Inline style uses tokens only. */
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        padding: 'var(--space-6)',
+        background:
+          'radial-gradient(120% 90% at 50% -8%, var(--color-accent-subtle-bg) 0%, var(--color-bg-subtle) 52%)',
+      }}
+    >
+      <Cluster justify="start">
+        <Link as={RouterLink} to="/mockups" variant="muted">
+          ← Back to mockups
+        </Link>
+      </Cluster>
+
+      {/* TODO: replace when <AuthScreen> ships — see components/TODO.md.
+          Centers the card in the remaining viewport height (same gap). */}
+      <div style={{ flex: 1, display: 'grid', placeItems: 'center' }}>
+        <Stack gap="lg" align="center">
+          <Text as="span" size="xl" weight="bold">
+            eocrm
+          </Text>
+
+          <Card padding="lg">
+            <Stack gap="lg">
+              <Stack gap="xs">
+                <Title order={1} size="lg">
+                  Sign in
+                </Title>
+                <Text size="sm" tone="muted">
+                  Welcome back. Enter your email to continue to your workspace.
+                </Text>
+              </Stack>
+
+              <Button variant="secondary">
+                {/* TODO: replace when a brand/social icon set ships — see components/TODO.md.
+                    Multi-color Google "G"; not in lucide. Brand hex is intentional. */}
+                <svg width="16" height="16" viewBox="0 0 48 48" aria-hidden="true">
+                  <path
+                    fill="#EA4335"
+                    d="M24 9.5c3.5 0 6.6 1.2 9 3.6l6.7-6.7C35.6 2.4 30.1 0 24 0 14.6 0 6.4 5.4 2.6 13.2l7.8 6.1C12.2 13.3 17.6 9.5 24 9.5z"
+                  />
+                  <path
+                    fill="#4285F4"
+                    d="M46.1 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.4c-.5 2.9-2.1 5.3-4.6 7l7.1 5.5c4.2-3.9 6.6-9.6 6.6-16.5z"
+                  />
+                  <path
+                    fill="#FBBC05"
+                    d="M10.4 28.3c-.5-1.4-.8-3-.8-4.3s.3-2.9.8-4.3l-7.8-6.1C1 16.8 0 20.3 0 24s1 7.2 2.6 10.4l7.8-6.1z"
+                  />
+                  <path
+                    fill="#34A853"
+                    d="M24 48c6.5 0 11.9-2.1 15.9-5.8l-7.1-5.5c-2 1.3-4.5 2.1-8.8 2.1-6.4 0-11.8-3.8-13.6-9.1l-7.8 6.1C6.4 42.6 14.6 48 24 48z"
+                  />
+                </svg>
+                Continue with Google
+              </Button>
+
+              <Divider>OR</Divider>
+
+              {formError && (
+                <Alert tone="error" title="Couldn't sign you in">
+                  {formError}
+                </Alert>
+              )}
+
+              <Stack gap="md">
+                <Stack gap="xs">
+                  <Text as="label" htmlFor="login-email" weight="medium" size="sm">
+                    Email
+                  </Text>
+                  <Input
+                    id="login-email"
+                    type="email"
+                    autoComplete="email"
+                    placeholder="you@company.com"
+                    value={email}
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                      if (emailError) setEmailError(null);
+                    }}
+                    onKeyDown={onEnter}
+                    invalid={!!emailError}
+                    aria-describedby={emailError ? 'login-email-error' : undefined}
+                  />
+                  {emailError && (
+                    <Text id="login-email-error" size="sm" tone="danger">
+                      {emailError}
+                    </Text>
+                  )}
+                </Stack>
+
+                <Stack gap="xs">
+                  <Cluster justify="between" align="baseline">
+                    <Text as="label" htmlFor="login-password" weight="medium" size="sm">
+                      Password
+                    </Text>
+                    <Link href="/forgot-password" variant="default">
+                      Forgot?
+                    </Link>
+                  </Cluster>
+                  <PasswordInput
+                    id="login-password"
+                    autoComplete="current-password"
+                    placeholder="••••••••"
+                    capsLockWarning
+                    value={password}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                      if (passwordError) setPasswordError(null);
+                    }}
+                    onKeyDown={onEnter}
+                    invalid={!!passwordError}
+                    aria-describedby={passwordError ? 'login-password-error' : undefined}
+                  />
+                  {passwordError && (
+                    <Text id="login-password-error" size="sm" tone="danger">
+                      {passwordError}
+                    </Text>
+                  )}
+                </Stack>
+              </Stack>
+
+              <Checkbox label="Keep me signed in" defaultChecked />
+
+              <Button variant="primary" onClick={submit}>
+                Sign in
+              </Button>
+            </Stack>
+          </Card>
+        </Stack>
+      </div>
+
+      <Cluster justify="center" gap="lg">
+        <Link href="/legal/privacy" variant="muted">
+          Privacy
+        </Link>
+        <Link href="/legal/terms" variant="muted">
+          Terms
+        </Link>
+        <Link href="/status" variant="muted">
+          Status
+        </Link>
+      </Cluster>
+    </div>
+  );
+}

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -290,6 +290,26 @@ export const MOCKUPS = [
       'Tooltip',
     ],
   },
+  {
+    slug: 'login',
+    title: 'Login',
+    path: '/mockups/login',
+    blurb: 'Full-screen eocrm sign-in — branded card, email/password, Google SSO, error states.',
+    usesComponents: [
+      'Alert',
+      'Button',
+      'Card',
+      'Checkbox',
+      'Cluster',
+      'Divider',
+      'Input',
+      'Link',
+      'PasswordInput',
+      'Stack',
+      'Text',
+      'Title',
+    ],
+  },
 ] as const satisfies readonly MockupEntry[];
 
 export type MockupSlug = (typeof MOCKUPS)[number]['slug'];


### PR DESCRIPTION
## Summary

A full-screen `eocrm` sign-in **mockup** at `/mockups/login` (Direction C: an elevated card on a token-tinted radial backdrop), built entirely from `@eocrm/design-system` primitives.

- **Composition:** `Card` + `Stack`/`Cluster` + `Title`/`Text` + `Input` + `PasswordInput` (caps-lock warning + reveal) + `Checkbox` + `Button` + `Alert` + `Link`, with `<Divider>OR</Divider>` for the SSO separator.
- **Full-screen:** a one-line `AppShell` guard renders the login route without the Rail/TopBar (all hooks run before the early return — Rules of Hooks respected).
- **Error-state demo:** inline field validation (`invalid` + `aria-describedby`) plus an `Alert tone="error"` simulated auth failure; errors clear on edit; Enter submits.
- **Hard rule 6:** no `module.scss` / stray inline styles / raw HTML — only two token-based inline-mock escape hatches (the `<AuthScreen>` page-chrome wrapper + the multi-color Google "G"), each with a `{/* TODO… */}` comment and a matching `TODO.md` entry (`<AuthScreen>` + brand-icon gaps filed).
- **Wired:** route (`App.tsx`), sidebar nav + full-bleed guard (`AppShell.tsx`), mockup `registry.ts` (auto-appears in `MockupsIndex`).
- **Brand:** wordmark is `eocrm` (deliberate — differs from AppShell's "Orbit CRM" demo brand).

Spec: `docs/superpowers/specs/2026-05-29-login-mockup-design.md`
Plan: `docs/superpowers/plans/2026-05-29-login-mockup.md`

## Test Plan

- [x] `make build` (typecheck + bundle) green
- [x] `make lint` green
- [x] `make test` — 2343 library tests pass (mockups have no unit tests by design)
- [x] Hard-rule-7 mockup review loop: 0 Critical / 0 Important → "clean enough to stop"
- [x] Visual check in the live playground: clean state, inline-error state, and auth-failure Alert all verified at `/mockups/login`
- [ ] CI `Quality / check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)