### PR TITLE
ci: release @eocrm/design-system 0.1.0 (BUMP=minor)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ permissions:
   id-token: write # forwarded to the chained deploy-playground job
 
 env:
-  BUMP: patch
+  BUMP: minor
 
 jobs:
   quality:


### PR DESCRIPTION
## Summary

Bumps the **deployed** version of `@eocrm/design-system` to **0.1.0**.

There's no manual publish trigger by design — the `Release` workflow runs on pushes to `main` and computes the next version from the latest `v*` tag bumped by the `BUMP` env var. This sets `BUMP: patch → minor`. Latest tag is `v0.0.70`, so a minor bump = **0.1.0**.

**Merging this PR is the release:** it touches `release.yml` (a release-related workflow), so the workflow's publish job runs → `npm publish` `@eocrm/design-system@0.1.0`, tags `v0.1.0`, and re-deploys the playground. (Marks the milestone: TimeField v2, Image, Rail fix, login mockup, Masonry.)

## ⚠️ Follow-up: reset BUMP after this ships
`BUMP` persists. Once `0.1.0` is published, the **next** library-touching merge would be `0.2.0` unless `BUMP` is reset to `patch`. Open a small follow-up PR resetting `BUMP: minor → patch` to resume patch cadence — note that reset PR will itself publish `0.1.1` (it touches the release workflow). Sequence accordingly.

## Test Plan
- [x] One-line `env.BUMP` change; the workflow's own comment documents this exact "edit BUMP on a branch and merge" path
- [ ] Merge → `Release` workflow publishes `0.1.0` + tags `v0.1.0`
- [ ] Confirm `v0.1.0` on GitHub Packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)