### PR TITLE
Add BrandIcon component (Google, Yandex)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ permissions:
   id-token: write # forwarded to the chained deploy-playground job
 
 env:
-  BUMP: minor
+  BUMP: patch
 
 jobs:
   quality:

--- a/docs/superpowers/plans/2026-05-30-brand-icon-component.md
+++ b/docs/superpowers/plans/2026-05-30-brand-icon-component.md
@@ -1,0 +1,560 @@
+# BrandIcon Component Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `<BrandIcon name="google" | "yandex">` library primitive rendering full-color official brand marks, refactor the Login mockup's inline Google `<svg>` to use it, and update the TODO bookkeeping.
+
+**Architecture:** A `forwardRef` `<svg>` whose paths come from an internal `Record<BrandName, {viewBox, body}>` registry (compile-time-complete; brand hex is inline — the documented exception to token-only color). `size` (px, default 20) sets width/height; decorative by default (`aria-hidden`), a `title` prop opts into `role="img"` + `aria-label`. A minimal `.icon` class gives the svg sane inline placement (and satisfies the 4-file structure test). Display cluster, primitive tier, no i18n.
+
+**Tech Stack:** React 19 + TypeScript, `clsx`, SCSS module, Vitest (globals, jsdom, RTL). Branch: `feat/brand-icon` (already checked out).
+
+**Spec:** `docs/superpowers/specs/2026-05-30-brand-icon-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `packages/design-system/src/components/BrandIcon/BrandIcon.tsx` | NEW — component + `ICONS` registry |
+| `packages/design-system/src/components/BrandIcon/BrandIcon.module.scss` | NEW — `.icon` class |
+| `packages/design-system/src/components/BrandIcon/BrandIcon.test.tsx` | NEW — unit tests |
+| `packages/design-system/src/components/BrandIcon/index.ts` | NEW — exports |
+| `packages/design-system/src/index.ts` | MODIFY — re-export (after the Badge block) |
+| `packages/design-system/src/_meta/manifest.ts` | MODIFY — `BrandIcon: 'Display'` |
+| `packages/design-system/scripts/generate-manifest.mjs` | MODIFY — `BrandIcon: 'Display'` (kept in sync) |
+| `packages/design-system/src/components.manifest.json` | REGEN — `npm run build:manifest` |
+| `packages/design-system/src/components/TODO.md` | MODIFY — tick `<BrandIcon>`; annotate `<AuthScreen>` deferred |
+| `packages/design-system/AGENTS.md` | MODIFY — `<BrandIcon>` TL;DR (Display) |
+| `packages/playground/src/pages/mockups/Login/Login.tsx` | MODIFY — inline Google `<svg>` → `<BrandIcon>` |
+| `packages/playground/src/pages/components/BrandIconDemo.tsx` | NEW — demo |
+| `packages/playground/src/App.tsx` | MODIFY — `/components/brand-icon` route |
+| `packages/playground/src/layout/AppShell/AppShell.tsx` | MODIFY — Display nav entry + `Fingerprint` import |
+| `packages/playground/src/pages/components/ComponentsIndex.tsx` | MODIFY — overview card |
+
+---
+
+## Task 1: The `<BrandIcon>` component (TDD)
+
+**Files:** under `packages/design-system/src/components/BrandIcon/`.
+
+- [ ] **Step 1: Create `BrandIcon.module.scss`**
+
+```scss
+.icon {
+  display: inline-block;
+  vertical-align: middle;
+}
+```
+
+- [ ] **Step 2: Write the failing test** — `BrandIcon.test.tsx`
+
+```tsx
+import { createRef } from 'react';
+import { render } from '@testing-library/react';
+import { BrandIcon } from './BrandIcon';
+
+function svgOf(c: HTMLElement): SVGSVGElement {
+  return c.querySelector('svg') as SVGSVGElement;
+}
+
+describe('BrandIcon', () => {
+  it('renders the google mark (4 colored paths, 0 0 48 48)', () => {
+    const { container } = render(<BrandIcon name="google" />);
+    const svg = svgOf(container);
+    expect(svg).not.toBeNull();
+    expect(svg.querySelectorAll('path')).toHaveLength(4);
+    expect(svg.getAttribute('viewBox')).toBe('0 0 48 48');
+  });
+
+  it('renders the yandex mark (distinct viewBox + brand red)', () => {
+    const { container } = render(<BrandIcon name="yandex" />);
+    expect(svgOf(container).getAttribute('viewBox')).toBe('0 0 24 24');
+    expect(container.innerHTML).toMatch(/#FC3F1D/i);
+  });
+
+  it('renders every known brand without throwing', () => {
+    (['google', 'yandex'] as const).forEach((name) => {
+      expect(() => render(<BrandIcon name={name} />)).not.toThrow();
+    });
+  });
+
+  it('sizes the svg (default 20, overridable)', () => {
+    const { container, rerender } = render(<BrandIcon name="google" />);
+    expect(svgOf(container).getAttribute('width')).toBe('20');
+    expect(svgOf(container).getAttribute('height')).toBe('20');
+    rerender(<BrandIcon name="google" size={32} />);
+    expect(svgOf(container).getAttribute('width')).toBe('32');
+    expect(svgOf(container).getAttribute('height')).toBe('32');
+  });
+
+  it('is decorative by default (aria-hidden, no role)', () => {
+    const { container } = render(<BrandIcon name="google" />);
+    const svg = svgOf(container);
+    expect(svg.getAttribute('aria-hidden')).toBe('true');
+    expect(svg.getAttribute('role')).toBeNull();
+  });
+
+  it('title makes it a labeled image', () => {
+    const { container, getByTitle } = render(<BrandIcon name="yandex" title="Yandex" />);
+    const svg = svgOf(container);
+    expect(svg.getAttribute('role')).toBe('img');
+    expect(svg.getAttribute('aria-label')).toBe('Yandex');
+    expect(svg.getAttribute('aria-hidden')).toBeNull();
+    expect(getByTitle('Yandex')).toBeInTheDocument();
+  });
+
+  it('forwards ref to the svg, merges className, spreads attrs', () => {
+    const ref = createRef<SVGSVGElement>();
+    const { container } = render(
+      <BrandIcon name="google" ref={ref} className="custom" data-testid="bi" />,
+    );
+    expect(ref.current).toBe(svgOf(container));
+    expect(svgOf(container).getAttribute('class')).toMatch(/custom/);
+    expect(svgOf(container).getAttribute('data-testid')).toBe('bi');
+  });
+});
+```
+
+- [ ] **Step 3: Run the test — verify it FAILS**
+
+Run: `cd packages/design-system && npx vitest run src/components/BrandIcon/BrandIcon.test.tsx`
+Expected: FAIL — `Failed to resolve import "./BrandIcon"`.
+
+- [ ] **Step 4: Create `BrandIcon.tsx`**
+
+```tsx
+import { forwardRef, type ReactNode, type SVGAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './BrandIcon.module.scss';
+
+/** Brands shipped today. Extend the union + the `ICONS` registry to add more. */
+export type BrandName = 'google' | 'yandex';
+
+export interface BrandIconProps extends Omit<SVGAttributes<SVGSVGElement>, 'children'> {
+  /** Which brand mark to render. */
+  name: BrandName;
+  /** Square pixel size (width = height). Defaults to `20`. */
+  size?: number;
+  /**
+   * Accessible name. Omit (default) for a decorative icon beside a text label —
+   * the icon renders `aria-hidden`. Set it for a standalone icon (e.g. an
+   * icon-only button) → `role="img"` + `aria-label`.
+   */
+  title?: string;
+}
+
+type BrandSvg = { viewBox: string; body: ReactNode };
+
+// `Record<BrandName, …>` makes the registry complete at COMPILE time — adding a
+// brand to `BrandName` without art fails typecheck. Brand hex is inline (the
+// documented exception to token-only color; the colors are brand-mandated).
+const ICONS: Record<BrandName, BrandSvg> = {
+  google: {
+    viewBox: '0 0 48 48',
+    body: (
+      <>
+        <path
+          fill="#EA4335"
+          d="M24 9.5c3.5 0 6.6 1.2 9 3.6l6.7-6.7C35.6 2.4 30.1 0 24 0 14.6 0 6.4 5.4 2.6 13.2l7.8 6.1C12.2 13.3 17.6 9.5 24 9.5z"
+        />
+        <path
+          fill="#4285F4"
+          d="M46.1 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.4c-.5 2.9-2.1 5.3-4.6 7l7.1 5.5c4.2-3.9 6.6-9.6 6.6-16.5z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M10.4 28.3c-.5-1.4-.8-3-.8-4.3s.3-2.9.8-4.3l-7.8-6.1C1 16.8 0 20.3 0 24s1 7.2 2.6 10.4l7.8-6.1z"
+        />
+        <path
+          fill="#34A853"
+          d="M24 48c6.5 0 11.9-2.1 15.9-5.8l-7.1-5.5c-2 1.3-4.5 2.1-8.8 2.1-6.4 0-11.8-3.8-13.6-9.1l-7.8 6.1C6.4 42.6 14.6 48 24 48z"
+        />
+      </>
+    ),
+  },
+  yandex: {
+    viewBox: '0 0 24 24',
+    body: (
+      <>
+        <rect width="24" height="24" rx="5" fill="#FC3F1D" />
+        {/* v1 representation of the Yandex "Я" logomark; swap for official path art when sourced. */}
+        <text
+          x="12"
+          y="17.5"
+          textAnchor="middle"
+          fontFamily="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif"
+          fontWeight="700"
+          fontSize="16"
+          fill="#fff"
+        >
+          Я
+        </text>
+      </>
+    ),
+  },
+};
+
+/**
+ * Renders a third-party brand's official multi-color mark — for SSO buttons and
+ * brand chrome. Colors are brand-mandated (not themeable). Decorative by
+ * default; pass `title` for standalone, labeled use.
+ *
+ * @example
+ * // In an SSO button (decorative — the text carries the name):
+ * <Button variant="secondary">
+ *   <BrandIcon name="google" size={16} /> Continue with Google
+ * </Button>
+ *
+ * @example
+ * // Standalone, labeled:
+ * <BrandIcon name="yandex" title="Yandex" size={24} />
+ *
+ * @remarks When NOT to use
+ * - Generic UI glyphs (chevron, search, close) → use `lucide-react`. This is
+ *   only for third-party brand marks.
+ * - Recoloring to match your theme — unsupported; brand marks keep their
+ *   official colors.
+ *
+ * @remarks Anti-patterns
+ * - ❌ A decorative `BrandIcon` next to visible brand text AND a `title` —
+ *   double-announces ("Google Continue with Google"). Keep it `aria-hidden`
+ *   (the default) beside a label.
+ */
+export const BrandIcon = forwardRef<SVGSVGElement, BrandIconProps>(function BrandIcon(
+  { name, size = 20, title, className, ...rest },
+  ref,
+) {
+  const icon = ICONS[name];
+  const labeled = title != null && title !== '';
+  return (
+    // {...rest} last (Pattern A) so a consumer can override the a11y defaults.
+    <svg
+      ref={ref}
+      width={size}
+      height={size}
+      viewBox={icon.viewBox}
+      className={clsx(styles.icon, className)}
+      role={labeled ? 'img' : undefined}
+      aria-label={labeled ? title : undefined}
+      aria-hidden={labeled ? undefined : true}
+      {...rest}
+    >
+      {labeled && <title>{title}</title>}
+      {icon.body}
+    </svg>
+  );
+});
+```
+
+- [ ] **Step 5: Create `index.ts`**
+
+```ts
+export { BrandIcon } from './BrandIcon';
+export type { BrandIconProps, BrandName } from './BrandIcon';
+```
+
+- [ ] **Step 6: Run the test — verify it PASSES**
+
+Run: `cd packages/design-system && npx vitest run src/components/BrandIcon/BrandIcon.test.tsx`
+Expected: PASS — all 7 tests green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/BrandIcon
+git commit -m "feat(BrandIcon): multi-color brand marks (google, yandex)"
+```
+
+---
+
+## Task 2: Library wiring (export + manifest + AGENTS + TODO)
+
+- [ ] **Step 1: Re-export from `src/index.ts`** — add directly after the Badge export block (`export type { BadgeProps, … } from './components/Badge';`):
+
+```ts
+export { BrandIcon } from './components/BrandIcon';
+export type { BrandIconProps, BrandName } from './components/BrandIcon';
+```
+
+- [ ] **Step 2: Classify in BOTH manifest sources** — add `BrandIcon: 'Display',` to the `CLUSTERS` map in `packages/design-system/src/_meta/manifest.ts` AND in `packages/design-system/scripts/generate-manifest.mjs` (next to `Badge: 'Display',`).
+
+- [ ] **Step 3: Regenerate the manifest**
+
+Run: `cd packages/design-system && npm run build:manifest`
+Expected: `components.manifest.json` gains `BrandIcon` with `tier: 'primitive'`, `cluster: 'Display'`, `composes: []`. Stage it.
+
+- [ ] **Step 4: Update `TODO.md`**
+
+In `packages/design-system/src/components/TODO.md`:
+
+(a) Tick the `<BrandIcon>` entry — change its heading to `### [x]` and add a shipped note after the **Filed:** line:
+
+```markdown
+**Shipped:** 2026-05-30 — `packages/design-system/src/components/BrandIcon/`. The Login mockup's inline Google `<svg>` now uses `<BrandIcon name="google" size={16} />`. Ships `google` + `yandex`; extend the `BrandName` union + `ICONS` registry for more.
+```
+
+(b) Annotate the `<AuthScreen>` entry as deferred (leave it `[ ]` open — the Login mockup keeps its layout escape hatch). Add after its **Filed:** line:
+
+```markdown
+**Deferred:** 2026-05-30 — the login screen is a single playground mockup; a reusable auth-layout primitive is YAGNI for one screen. The Login wrapper escape hatches stay as a contained one-off. Revisit only if a second auth screen appears.
+```
+
+- [ ] **Step 5: Add the AGENTS.md TL;DR** (Display section):
+
+````markdown
+### `<BrandIcon>` — third-party brand marks
+
+```tsx
+<Button variant="secondary">
+  <BrandIcon name="google" size={16} /> Continue with Google
+</Button>
+```
+
+Full-color official brand marks for SSO buttons. Ships `google` + `yandex`.
+
+- `name`: `'google' | 'yandex'`. `size`: px (default 20). Colors are brand-mandated (not themeable).
+- Decorative by default (`aria-hidden`); pass `title` for a labeled standalone icon (`role="img"`).
+
+**When NOT to use:** generic UI glyphs → `lucide-react`. Don't recolor brand marks.
+````
+
+- [ ] **Step 6: Verify library gates**
+
+Run: `make build-lib && make test`
+Expected: typecheck clean; all tests pass (incl. `structure.test.ts` — BrandIcon has the 4 files + export — and the manifest meta-test).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/index.ts packages/design-system/src/_meta/manifest.ts packages/design-system/scripts/generate-manifest.mjs packages/design-system/src/components.manifest.json packages/design-system/src/components/TODO.md packages/design-system/AGENTS.md
+git commit -m "feat(BrandIcon): export + manifest + AGENTS; tick TODO, defer AuthScreen"
+```
+
+---
+
+## Task 3: Login refactor + playground demo
+
+- [ ] **Step 1: Refactor the Login mockup** — `packages/playground/src/pages/mockups/Login/Login.tsx`
+
+Add `BrandIcon` to the `@eocrm/design-system` import (alphabetically, after `Alert,`):
+
+```tsx
+  Alert,
+  BrandIcon,
+  Button,
+```
+
+Replace the SSO button's inline-svg escape hatch. Change:
+
+```tsx
+              <Button variant="secondary">
+                {/* TODO: replace when a brand/social icon set ships — see components/TODO.md.
+                    Multi-color Google "G"; not in lucide. Brand hex is intentional. */}
+                <svg width="16" height="16" viewBox="0 0 48 48" aria-hidden="true">
+                  <path
+                    fill="#EA4335"
+                    d="M24 9.5c3.5 0 6.6 1.2 9 3.6l6.7-6.7C35.6 2.4 30.1 0 24 0 14.6 0 6.4 5.4 2.6 13.2l7.8 6.1C12.2 13.3 17.6 9.5 24 9.5z"
+                  />
+                  <path
+                    fill="#4285F4"
+                    d="M46.1 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.4c-.5 2.9-2.1 5.3-4.6 7l7.1 5.5c4.2-3.9 6.6-9.6 6.6-16.5z"
+                  />
+                  <path
+                    fill="#FBBC05"
+                    d="M10.4 28.3c-.5-1.4-.8-3-.8-4.3s.3-2.9.8-4.3l-7.8-6.1C1 16.8 0 20.3 0 24s1 7.2 2.6 10.4l7.8-6.1z"
+                  />
+                  <path
+                    fill="#34A853"
+                    d="M24 48c6.5 0 11.9-2.1 15.9-5.8l-7.1-5.5c-2 1.3-4.5 2.1-8.8 2.1-6.4 0-11.8-3.8-13.6-9.1l-7.8 6.1C6.4 42.6 14.6 48 24 48z"
+                  />
+                </svg>
+                Continue with Google
+              </Button>
+```
+
+to:
+
+```tsx
+              <Button variant="secondary">
+                <BrandIcon name="google" size={16} />
+                Continue with Google
+              </Button>
+```
+
+(This deletes a Hard-rule-6 escape hatch + its TODO comment — a net improvement to the mockup.)
+
+- [ ] **Step 2: Create the demo** — `packages/playground/src/pages/components/BrandIconDemo.tsx`
+
+```tsx
+import { BrandIcon, Button, Cluster, Stack, Text } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import { getComponentFiles } from '../../lib/componentFiles';
+
+export function BrandIconDemo() {
+  return (
+    <DemoLayout
+      name="BrandIcon"
+      componentName="BrandIcon"
+      description="Full-color official brand marks for SSO buttons and brand chrome. Ships google + yandex; colors are brand-mandated (not themeable). For generic UI glyphs use lucide-react."
+      files={getComponentFiles('BrandIcon')}
+    >
+      <Example
+        title="The marks"
+        description="Each brand at a few sizes. size is pixels (default 20)."
+        code={`<BrandIcon name="google" />
+<BrandIcon name="yandex" size={32} />`}
+      >
+        <Cluster gap="lg" align="center">
+          {(['google', 'yandex'] as const).map((name) => (
+            <Stack key={name} gap="xs" align="center">
+              <Cluster gap="sm" align="center">
+                <BrandIcon name={name} size={16} />
+                <BrandIcon name={name} size={20} />
+                <BrandIcon name={name} size={32} />
+              </Cluster>
+              <Text size="xs" tone="muted">
+                {name}
+              </Text>
+            </Stack>
+          ))}
+        </Cluster>
+      </Example>
+
+      <Example
+        title="In SSO buttons"
+        description="The canonical use — decorative icon (aria-hidden) beside the provider name."
+        code={`<Button variant="secondary"><BrandIcon name="google" size={16} /> Continue with Google</Button>`}
+      >
+        <Stack gap="sm">
+          <Button variant="secondary">
+            <BrandIcon name="google" size={16} /> Continue with Google
+          </Button>
+          <Button variant="secondary">
+            <BrandIcon name="yandex" size={16} /> Continue with Yandex
+          </Button>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Labeled (standalone)"
+        description="Pass title for a standalone icon — renders role=img + aria-label."
+        code={`<BrandIcon name="yandex" title="Yandex" size={28} />`}
+      >
+        <BrandIcon name="yandex" title="Yandex" size={28} />
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+- [ ] **Step 3: Add the route in `App.tsx`** — import + route near the other Display demos (e.g. after the `/components/badge` route):
+
+```tsx
+import { BrandIconDemo } from './pages/components/BrandIconDemo';
+```
+```tsx
+            <Route path="/components/brand-icon" element={<BrandIconDemo />} />
+```
+
+- [ ] **Step 4: Add the nav entry in `AppShell.tsx`** — add `Fingerprint` to the `lucide-react` import (confirm it isn't already imported; if unavailable, use `BadgeCheck`), then add to the `Display` group after the Badge item:
+
+```tsx
+      { to: '/components/brand-icon', label: 'BrandIcon', icon: Fingerprint, end: false },
+```
+
+- [ ] **Step 5: Add the overview card in `ComponentsIndex.tsx`** — add `import { BrandIcon } from '@eocrm/design-system';` and an `items` entry:
+
+```tsx
+  {
+    to: '/components/brand-icon',
+    name: 'BrandIcon',
+    description: 'Full-color brand marks (Google, Yandex) for SSO buttons.',
+    preview: (
+      <Cluster gap="md" justify="center">
+        <BrandIcon name="google" size={28} />
+        <BrandIcon name="yandex" size={28} />
+      </Cluster>
+    ),
+  },
+```
+
+(`Cluster` is already imported in `ComponentsIndex.tsx`.)
+
+- [ ] **Step 6: Build the playground**
+
+Run: `make build`
+Expected: typecheck + bundle pass. If `Fingerprint` doesn't resolve, swap to `BadgeCheck` and rebuild.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/playground/src/pages/mockups/Login/Login.tsx packages/playground/src/pages/components/BrandIconDemo.tsx packages/playground/src/App.tsx packages/playground/src/layout/AppShell/AppShell.tsx packages/playground/src/pages/components/ComponentsIndex.tsx
+git commit -m "feat(playground): BrandIcon demo + nav + index; Login uses BrandIcon"
+```
+
+---
+
+## Task 4: Gates + review loops
+
+This touches `packages/design-system/**` (Rule-8 library loop) AND a mockup `packages/playground/src/pages/mockups/Login/**` (Rule-7 mockup loop). One reviewer pass covers both.
+
+- [ ] **Step 1: Run all gates**
+
+```bash
+make test
+make build-lib
+make lint
+make build
+npm pack --dry-run -w @eocrm/design-system   # ships BrandIcon source, excludes the test
+```
+All must pass.
+
+- [ ] **Step 2: Spawn a fresh-context reviewer** (`general-purpose`) on `git diff main..HEAD`. Brief it on:
+  - **Rule-8 (library):** bugs, a11y (decorative default vs `title` → role=img + `<title>`; spread-last lets consumer override), API/types (`Record<BrandName>` completeness; `Omit<SVGAttributes,'children'>`), Rules 1/4/5/6/7 (tests; `.icon` class is Rule-4-clean — only `display`/`vertical-align`; export; forwardRef + spread; JSDoc), token discipline (brand hex is the documented inline exception; `.module.scss` token-free is fine), manifest in both files, `npm pack` excludes the test.
+  - **Rule-7 (Login mockup):** the inline-svg escape hatch is fully removed (no leftover raw `<svg>`/`style`), the `{/* TODO: replace when a brand/social icon set ships */}` comment is gone, the `<BrandIcon>` TODO entry is ticked, and no new Hard-rule-6 violations were introduced. The two remaining `<AuthScreen>` escape hatches in Login are intentionally kept (deferred).
+  - Confirm the Yandex `<text>`-based "Я" is acceptable as a documented v1 representation (vs official path art).
+  Ask for Critical/Important/Nice-to-have/Regression-watch + verdict.
+
+- [ ] **Step 3: Fix every Critical + Important.** Re-run gates. Re-review. Repeat until `clean enough to stop` (0 Critical / 0 Important).
+
+- [ ] **Step 4: Commit any fixes.**
+
+---
+
+## Task 5: Visual verification + PR
+
+- [ ] **Step 1: Visual check** — `make dev` (or reuse the running playground on :8080); drive a browser (Playwright MCP) to `http://localhost:8080/components/brand-icon` (marks at sizes, SSO buttons, labeled) AND `http://localhost:8080/mockups/login` (the Google mark still renders in the SSO button via `<BrandIcon>`). Screenshot both; confirm no new console errors.
+
+- [ ] **Step 2: Push** — `git push -u origin feat/brand-icon` (fix any prettier issues with `prettier --write`; never `--no-verify`).
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --base main --title "Add BrandIcon component (Google, Yandex)" --body "$(cat <<'EOF'
+## Summary
+A `<BrandIcon name="google" | "yandex">` primitive — full-color official brand marks for SSO buttons. Extensible via the `BrandName` union + `ICONS` registry (compile-time-complete). `size` px (default 20); decorative by default (`aria-hidden`), `title` opts into a labeled `role="img"`. Brand hex is inline (documented exception to token-only color). Refactors the Login mockup's inline Google `<svg>` escape hatch → `<BrandIcon>`, ticks the `<BrandIcon>` TODO, and defers `<AuthScreen>`.
+
+Note: the Yandex mark uses an SVG `<text>` "Я" as a v1 representation; swap for official logomark path art in a follow-up.
+
+## Test Plan
+- [x] make test / build-lib / lint / build green; npm pack excludes the test
+- [x] Rule-8 (library) + Rule-7 (Login mockup) review → clean
+- [x] Visual: /components/brand-icon + /mockups/login (Google mark via BrandIcon)
+- [ ] CI Quality / check
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Wait for `Quality / check`.**
+
+---
+
+## Self-review checklist
+
+1. **Spec coverage:** single `<BrandIcon name>` + registry (Task 1) ✓; google + yandex marks ✓; `size` default 20 ✓; decorative/`title` a11y ✓; `.module.scss` for structure-test ✓; full-color inline hex ✓; export/manifest(both)/AGENTS ✓ (Task 2); tick BrandIcon + defer AuthScreen (Task 2) ✓; Login refactor ✓ + demo/route/nav/index (Task 3) ✓; Rule-8 + Rule-7 review (Task 4) ✓; Display/primitive/no-i18n ✓.
+2. **Placeholders:** none — full source for scss/test/tsx/index, exact registry SVGs, exact Login before/after, exact wiring + TODO edits + commands.
+3. **Type/name consistency:** `BrandName`/`BrandIconProps`, `ICONS`/`BrandSvg`, `name`/`size`/`title`/`labeled`, `styles.icon` used consistently across component, test, and demo.

--- a/docs/superpowers/plans/2026-05-30-brand-icon-component.md
+++ b/docs/superpowers/plans/2026-05-30-brand-icon-component.md
@@ -14,23 +14,23 @@
 
 ## File Structure
 
-| File | Responsibility |
-| --- | --- |
-| `packages/design-system/src/components/BrandIcon/BrandIcon.tsx` | NEW — component + `ICONS` registry |
-| `packages/design-system/src/components/BrandIcon/BrandIcon.module.scss` | NEW — `.icon` class |
-| `packages/design-system/src/components/BrandIcon/BrandIcon.test.tsx` | NEW — unit tests |
-| `packages/design-system/src/components/BrandIcon/index.ts` | NEW — exports |
-| `packages/design-system/src/index.ts` | MODIFY — re-export (after the Badge block) |
-| `packages/design-system/src/_meta/manifest.ts` | MODIFY — `BrandIcon: 'Display'` |
-| `packages/design-system/scripts/generate-manifest.mjs` | MODIFY — `BrandIcon: 'Display'` (kept in sync) |
-| `packages/design-system/src/components.manifest.json` | REGEN — `npm run build:manifest` |
-| `packages/design-system/src/components/TODO.md` | MODIFY — tick `<BrandIcon>`; annotate `<AuthScreen>` deferred |
-| `packages/design-system/AGENTS.md` | MODIFY — `<BrandIcon>` TL;DR (Display) |
-| `packages/playground/src/pages/mockups/Login/Login.tsx` | MODIFY — inline Google `<svg>` → `<BrandIcon>` |
-| `packages/playground/src/pages/components/BrandIconDemo.tsx` | NEW — demo |
-| `packages/playground/src/App.tsx` | MODIFY — `/components/brand-icon` route |
-| `packages/playground/src/layout/AppShell/AppShell.tsx` | MODIFY — Display nav entry + `Fingerprint` import |
-| `packages/playground/src/pages/components/ComponentsIndex.tsx` | MODIFY — overview card |
+| File                                                                    | Responsibility                                                |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `packages/design-system/src/components/BrandIcon/BrandIcon.tsx`         | NEW — component + `ICONS` registry                            |
+| `packages/design-system/src/components/BrandIcon/BrandIcon.module.scss` | NEW — `.icon` class                                           |
+| `packages/design-system/src/components/BrandIcon/BrandIcon.test.tsx`    | NEW — unit tests                                              |
+| `packages/design-system/src/components/BrandIcon/index.ts`              | NEW — exports                                                 |
+| `packages/design-system/src/index.ts`                                   | MODIFY — re-export (after the Badge block)                    |
+| `packages/design-system/src/_meta/manifest.ts`                          | MODIFY — `BrandIcon: 'Display'`                               |
+| `packages/design-system/scripts/generate-manifest.mjs`                  | MODIFY — `BrandIcon: 'Display'` (kept in sync)                |
+| `packages/design-system/src/components.manifest.json`                   | REGEN — `npm run build:manifest`                              |
+| `packages/design-system/src/components/TODO.md`                         | MODIFY — tick `<BrandIcon>`; annotate `<AuthScreen>` deferred |
+| `packages/design-system/AGENTS.md`                                      | MODIFY — `<BrandIcon>` TL;DR (Display)                        |
+| `packages/playground/src/pages/mockups/Login/Login.tsx`                 | MODIFY — inline Google `<svg>` → `<BrandIcon>`                |
+| `packages/playground/src/pages/components/BrandIconDemo.tsx`            | NEW — demo                                                    |
+| `packages/playground/src/App.tsx`                                       | MODIFY — `/components/brand-icon` route                       |
+| `packages/playground/src/layout/AppShell/AppShell.tsx`                  | MODIFY — Display nav entry + `Fingerprint` import             |
+| `packages/playground/src/pages/components/ComponentsIndex.tsx`          | MODIFY — overview card                                        |
 
 ---
 
@@ -348,38 +348,38 @@ Add `BrandIcon` to the `@eocrm/design-system` import (alphabetically, after `Ale
 Replace the SSO button's inline-svg escape hatch. Change:
 
 ```tsx
-              <Button variant="secondary">
-                {/* TODO: replace when a brand/social icon set ships — see components/TODO.md.
+<Button variant="secondary">
+  {/* TODO: replace when a brand/social icon set ships — see components/TODO.md.
                     Multi-color Google "G"; not in lucide. Brand hex is intentional. */}
-                <svg width="16" height="16" viewBox="0 0 48 48" aria-hidden="true">
-                  <path
-                    fill="#EA4335"
-                    d="M24 9.5c3.5 0 6.6 1.2 9 3.6l6.7-6.7C35.6 2.4 30.1 0 24 0 14.6 0 6.4 5.4 2.6 13.2l7.8 6.1C12.2 13.3 17.6 9.5 24 9.5z"
-                  />
-                  <path
-                    fill="#4285F4"
-                    d="M46.1 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.4c-.5 2.9-2.1 5.3-4.6 7l7.1 5.5c4.2-3.9 6.6-9.6 6.6-16.5z"
-                  />
-                  <path
-                    fill="#FBBC05"
-                    d="M10.4 28.3c-.5-1.4-.8-3-.8-4.3s.3-2.9.8-4.3l-7.8-6.1C1 16.8 0 20.3 0 24s1 7.2 2.6 10.4l7.8-6.1z"
-                  />
-                  <path
-                    fill="#34A853"
-                    d="M24 48c6.5 0 11.9-2.1 15.9-5.8l-7.1-5.5c-2 1.3-4.5 2.1-8.8 2.1-6.4 0-11.8-3.8-13.6-9.1l-7.8 6.1C6.4 42.6 14.6 48 24 48z"
-                  />
-                </svg>
-                Continue with Google
-              </Button>
+  <svg width="16" height="16" viewBox="0 0 48 48" aria-hidden="true">
+    <path
+      fill="#EA4335"
+      d="M24 9.5c3.5 0 6.6 1.2 9 3.6l6.7-6.7C35.6 2.4 30.1 0 24 0 14.6 0 6.4 5.4 2.6 13.2l7.8 6.1C12.2 13.3 17.6 9.5 24 9.5z"
+    />
+    <path
+      fill="#4285F4"
+      d="M46.1 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.4c-.5 2.9-2.1 5.3-4.6 7l7.1 5.5c4.2-3.9 6.6-9.6 6.6-16.5z"
+    />
+    <path
+      fill="#FBBC05"
+      d="M10.4 28.3c-.5-1.4-.8-3-.8-4.3s.3-2.9.8-4.3l-7.8-6.1C1 16.8 0 20.3 0 24s1 7.2 2.6 10.4l7.8-6.1z"
+    />
+    <path
+      fill="#34A853"
+      d="M24 48c6.5 0 11.9-2.1 15.9-5.8l-7.1-5.5c-2 1.3-4.5 2.1-8.8 2.1-6.4 0-11.8-3.8-13.6-9.1l-7.8 6.1C6.4 42.6 14.6 48 24 48z"
+    />
+  </svg>
+  Continue with Google
+</Button>
 ```
 
 to:
 
 ```tsx
-              <Button variant="secondary">
-                <BrandIcon name="google" size={16} />
-                Continue with Google
-              </Button>
+<Button variant="secondary">
+  <BrandIcon name="google" size={16} />
+  Continue with Google
+</Button>
 ```
 
 (This deletes a Hard-rule-6 escape hatch + its TODO comment — a net improvement to the mockup.)
@@ -454,8 +454,9 @@ export function BrandIconDemo() {
 ```tsx
 import { BrandIconDemo } from './pages/components/BrandIconDemo';
 ```
+
 ```tsx
-            <Route path="/components/brand-icon" element={<BrandIconDemo />} />
+<Route path="/components/brand-icon" element={<BrandIconDemo />} />
 ```
 
 - [ ] **Step 4: Add the nav entry in `AppShell.tsx`** — add `Fingerprint` to the `lucide-react` import (confirm it isn't already imported; if unavailable, use `BadgeCheck`), then add to the `Display` group after the Badge item:
@@ -509,13 +510,14 @@ make lint
 make build
 npm pack --dry-run -w @eocrm/design-system   # ships BrandIcon source, excludes the test
 ```
+
 All must pass.
 
 - [ ] **Step 2: Spawn a fresh-context reviewer** (`general-purpose`) on `git diff main..HEAD`. Brief it on:
   - **Rule-8 (library):** bugs, a11y (decorative default vs `title` → role=img + `<title>`; spread-last lets consumer override), API/types (`Record<BrandName>` completeness; `Omit<SVGAttributes,'children'>`), Rules 1/4/5/6/7 (tests; `.icon` class is Rule-4-clean — only `display`/`vertical-align`; export; forwardRef + spread; JSDoc), token discipline (brand hex is the documented inline exception; `.module.scss` token-free is fine), manifest in both files, `npm pack` excludes the test.
   - **Rule-7 (Login mockup):** the inline-svg escape hatch is fully removed (no leftover raw `<svg>`/`style`), the `{/* TODO: replace when a brand/social icon set ships */}` comment is gone, the `<BrandIcon>` TODO entry is ticked, and no new Hard-rule-6 violations were introduced. The two remaining `<AuthScreen>` escape hatches in Login are intentionally kept (deferred).
   - Confirm the Yandex `<text>`-based "Я" is acceptable as a documented v1 representation (vs official path art).
-  Ask for Critical/Important/Nice-to-have/Regression-watch + verdict.
+    Ask for Critical/Important/Nice-to-have/Regression-watch + verdict.
 
 - [ ] **Step 3: Fix every Critical + Important.** Re-run gates. Re-review. Repeat until `clean enough to stop` (0 Critical / 0 Important).
 

--- a/docs/superpowers/specs/2026-05-30-brand-icon-design.md
+++ b/docs/superpowers/specs/2026-05-30-brand-icon-design.md
@@ -1,0 +1,133 @@
+# `<BrandIcon>` — multi-color brand / social-provider marks
+
+## Goal
+
+A small library primitive that renders a brand's official multi-color mark for SSO buttons and
+brand chrome — `<BrandIcon name="google" />`. Ships **Google** and **Yandex** in v1; extensible
+to more brands later. Closes the `<BrandIcon>` `TODO.md` gap (the Login mockup hand-rolls an
+inline Google `<svg>` escape hatch today).
+
+## Locked-in decisions (brainstorm)
+
+1. **Single component, `name` union:** `<BrandIcon name="google" | "yandex" />` (not individual
+   `<GoogleIcon>` components). Fits the library's one-dir-per-component convention; one demo /
+   test / manifest entry; the union documents the available brands.
+2. **v1 brands:** `google` (4-color "G") + `yandex` (red rounded-square "Я" logomark, `#FC3F1D`).
+3. **Full-color, brand-mandated.** No `color`/`tone` prop — brand guidelines fix the colors; this
+   is the documented exception to the token-only-color rule. Uses official brand SVG path data.
+4. **`size`:** numeric px, default **20** (matches how the codebase sizes lucide icons).
+5. **Decorative by default** (`aria-hidden="true"`); a `title` prop opts into a labeled `role="img"`.
+6. **Cluster:** Display · **tier:** primitive · **no i18n** (brand names are proper nouns,
+   consumer-supplied).
+7. **Refactor + bookkeeping:** replace the Login mockup's inline Google `<svg>` with
+   `<BrandIcon name="google" size={16} />`; tick the `<BrandIcon>` `TODO.md` entry; mark the
+   `<AuthScreen>` entry **deferred** (we won't build a reusable auth-layout primitive for a single
+   mockup screen).
+
+## Architecture
+
+An internal SVG registry keyed by brand, rendered into a single `<svg>`:
+
+```tsx
+type BrandSvg = { viewBox: string; body: ReactNode };
+// Record<BrandName, …> makes completeness a COMPILE-TIME guarantee: TypeScript
+// fails the build if a BrandName is added to the union without a registry entry.
+const ICONS: Record<BrandName, BrandSvg> = {
+  google: { viewBox: '0 0 48 48', body: <>…4 brand-colored <path>s…</> },
+  yandex: { viewBox: '0 0 24 24', body: <>…red rounded-square + white "Я"…</> },
+};
+```
+
+Render: `<svg ref={ref} width={size} height={size} viewBox={icon.viewBox} className={clsx(styles.icon, className)} {...a11y} {...rest}>{titleEl}{icon.body}</svg>` (consumer `className` destructured + merged; `{...rest}` last so a consumer can still override the a11y defaults).
+
+- **a11y:** when `title` is omitted → `aria-hidden="true"` (decorative; the adjacent text label
+  carries the name). When `title` is set → `role="img"` + `aria-label={title}` + a `<title>` child.
+  `{...rest}` spreads LAST so a consumer can override either (Pattern A).
+- **Brand hex** lives in the SVG path `fill`s (not tokens) — the documented exception. The exact
+  path data comes from official brand assets (Google's 4-color G; Yandex's red logomark); where an
+  official asset isn't to hand, a faithful hand-authored mark is used (same as the approved preview).
+
+## Props
+
+```ts
+import { type SVGAttributes } from 'react';
+
+/** Brands shipped today. Extend the union + the ICONS registry to add more. */
+export type BrandName = 'google' | 'yandex';
+
+export interface BrandIconProps extends Omit<SVGAttributes<SVGSVGElement>, 'children'> {
+  /** Which brand mark to render. */
+  name: BrandName;
+  /** Square pixel size (width = height). Defaults to `20`. */
+  size?: number;
+  /**
+   * Accessible name. Omit (default) for a decorative icon next to a text label —
+   * the icon is then `aria-hidden`. Set it for a standalone icon (e.g. an
+   * icon-only button) → renders `role="img"` + `aria-label`.
+   */
+  title?: string;
+}
+```
+
+`forwardRef` → the `<svg>`. `className`/`style` and any other SVG attrs spread onto the `<svg>`.
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `packages/design-system/src/components/BrandIcon/BrandIcon.tsx` | NEW — component + `ICONS` registry |
+| `packages/design-system/src/components/BrandIcon/BrandIcon.module.scss` | NEW — minimal `.icon` class |
+| `packages/design-system/src/components/BrandIcon/BrandIcon.test.tsx` | NEW — unit tests |
+| `packages/design-system/src/components/BrandIcon/index.ts` | NEW — `export { BrandIcon }` + `export type { BrandIconProps, BrandName }` |
+| `packages/design-system/src/index.ts` | MODIFY — re-export |
+| `packages/design-system/src/_meta/manifest.ts` | MODIFY — `BrandIcon: 'Display'` in `CLUSTERS` |
+| `packages/design-system/scripts/generate-manifest.mjs` | MODIFY — same `BrandIcon: 'Display'` (kept in sync) |
+| `packages/design-system/src/components.manifest.json` | REGEN — `npm run build:manifest` |
+| `packages/design-system/src/components/TODO.md` | MODIFY — tick `<BrandIcon>`; mark `<AuthScreen>` deferred |
+| `packages/design-system/AGENTS.md` | MODIFY — `<BrandIcon>` TL;DR (Display) |
+| `packages/playground/src/pages/mockups/Login/Login.tsx` | MODIFY — inline Google `<svg>` → `<BrandIcon name="google" size={16} />`; drop the escape-hatch TODO comment |
+| `packages/playground/src/pages/components/BrandIconDemo.tsx` | NEW — demo |
+| `packages/playground/src/App.tsx` | MODIFY — `/components/brand-icon` route |
+| `packages/playground/src/layout/AppShell/AppShell.tsx` | MODIFY — Display nav entry (a lucide icon, e.g. `Fingerprint` or `BadgeCheck`; plan picks one not already imported) |
+| `packages/playground/src/pages/components/ComponentsIndex.tsx` | MODIFY — overview card |
+
+**`BrandIcon.module.scss`:** `structure.test.ts` requires a `<Name>.module.scss` for every
+component, so `BrandIcon` ships one with a single `.icon` class applied to the `<svg>` —
+`display: inline-block; vertical-align: middle; flex: none;` (sane inline placement next to text +
+no shrink inside a flex SSO button). No `.tokens.scss`: brand colors are inline hex (the documented
+exception) and there's no token-styled surface, and `.tokens.scss` isn't one of the four
+structure-test-required files.
+
+## Tests (`BrandIcon.test.tsx` minimum)
+
+- `name="google"` renders an `<svg>` (and its 4 colored `<path>`s); `name="yandex"` renders the
+  Yandex mark — assert they differ (e.g. distinct path counts / a brand-hex fill present).
+- `size` sets the `<svg>` `width` + `height` (default `20`; `size={32}` → 32).
+- Decorative by default: no `title` → `aria-hidden="true"`, no `role`.
+- `title="Google"` → `role="img"`, `aria-label="Google"`, a `<title>` child, and NOT `aria-hidden`.
+- `ref` forwards to the `<svg>`.
+- `className` merges; other SVG attrs (e.g. `data-*`) spread onto the `<svg>`.
+- Every `BrandName` renders without throwing (guards the registry; `Record<BrandName,…>` already
+  enforces completeness at compile time).
+
+## Demo page outline (`BrandIconDemo.tsx`)
+
+1. The marks — `google` + `yandex` at `size` 16 / 20 / 32.
+2. In SSO buttons — `<Button variant="secondary"><BrandIcon name="google" size={16} /> Continue with Google</Button>` and the Yandex equivalent (the canonical use).
+3. Labeled standalone — `<BrandIcon name="yandex" title="Yandex" />` (shows the `role="img"` path).
+
+## When NOT to use (JSDoc `@remarks` + AGENTS.md)
+
+- Generic UI glyphs (chevrons, search, close) → use `lucide-react`. `BrandIcon` is only for
+  third-party **brand** marks.
+- Recoloring to match your theme → not supported; brand marks must keep their official colors.
+  If you need a monochrome treatment for a dark bar, that's a future variant, not a recolor prop.
+- Anti-pattern: ❌ a decorative `BrandIcon` next to visible brand text AND a `title` — that
+  double-announces ("Google Continue with Google"). Keep it `aria-hidden` (default) beside a label.
+
+## Out of scope (v1)
+
+- Monochrome / single-color variant.
+- Brands beyond Google + Yandex (added later by extending the union + registry).
+- `<AuthScreen>` (deferred — see TODO.md).
+- A `size` token scale (numeric px only, matching lucide usage).

--- a/docs/superpowers/specs/2026-05-30-brand-icon-design.md
+++ b/docs/superpowers/specs/2026-05-30-brand-icon-design.md
@@ -73,23 +73,23 @@ export interface BrandIconProps extends Omit<SVGAttributes<SVGSVGElement>, 'chil
 
 ## Files
 
-| File | Change |
-| --- | --- |
-| `packages/design-system/src/components/BrandIcon/BrandIcon.tsx` | NEW — component + `ICONS` registry |
-| `packages/design-system/src/components/BrandIcon/BrandIcon.module.scss` | NEW — minimal `.icon` class |
-| `packages/design-system/src/components/BrandIcon/BrandIcon.test.tsx` | NEW — unit tests |
-| `packages/design-system/src/components/BrandIcon/index.ts` | NEW — `export { BrandIcon }` + `export type { BrandIconProps, BrandName }` |
-| `packages/design-system/src/index.ts` | MODIFY — re-export |
-| `packages/design-system/src/_meta/manifest.ts` | MODIFY — `BrandIcon: 'Display'` in `CLUSTERS` |
-| `packages/design-system/scripts/generate-manifest.mjs` | MODIFY — same `BrandIcon: 'Display'` (kept in sync) |
-| `packages/design-system/src/components.manifest.json` | REGEN — `npm run build:manifest` |
-| `packages/design-system/src/components/TODO.md` | MODIFY — tick `<BrandIcon>`; mark `<AuthScreen>` deferred |
-| `packages/design-system/AGENTS.md` | MODIFY — `<BrandIcon>` TL;DR (Display) |
-| `packages/playground/src/pages/mockups/Login/Login.tsx` | MODIFY — inline Google `<svg>` → `<BrandIcon name="google" size={16} />`; drop the escape-hatch TODO comment |
-| `packages/playground/src/pages/components/BrandIconDemo.tsx` | NEW — demo |
-| `packages/playground/src/App.tsx` | MODIFY — `/components/brand-icon` route |
-| `packages/playground/src/layout/AppShell/AppShell.tsx` | MODIFY — Display nav entry (a lucide icon, e.g. `Fingerprint` or `BadgeCheck`; plan picks one not already imported) |
-| `packages/playground/src/pages/components/ComponentsIndex.tsx` | MODIFY — overview card |
+| File                                                                    | Change                                                                                                              |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `packages/design-system/src/components/BrandIcon/BrandIcon.tsx`         | NEW — component + `ICONS` registry                                                                                  |
+| `packages/design-system/src/components/BrandIcon/BrandIcon.module.scss` | NEW — minimal `.icon` class                                                                                         |
+| `packages/design-system/src/components/BrandIcon/BrandIcon.test.tsx`    | NEW — unit tests                                                                                                    |
+| `packages/design-system/src/components/BrandIcon/index.ts`              | NEW — `export { BrandIcon }` + `export type { BrandIconProps, BrandName }`                                          |
+| `packages/design-system/src/index.ts`                                   | MODIFY — re-export                                                                                                  |
+| `packages/design-system/src/_meta/manifest.ts`                          | MODIFY — `BrandIcon: 'Display'` in `CLUSTERS`                                                                       |
+| `packages/design-system/scripts/generate-manifest.mjs`                  | MODIFY — same `BrandIcon: 'Display'` (kept in sync)                                                                 |
+| `packages/design-system/src/components.manifest.json`                   | REGEN — `npm run build:manifest`                                                                                    |
+| `packages/design-system/src/components/TODO.md`                         | MODIFY — tick `<BrandIcon>`; mark `<AuthScreen>` deferred                                                           |
+| `packages/design-system/AGENTS.md`                                      | MODIFY — `<BrandIcon>` TL;DR (Display)                                                                              |
+| `packages/playground/src/pages/mockups/Login/Login.tsx`                 | MODIFY — inline Google `<svg>` → `<BrandIcon name="google" size={16} />`; drop the escape-hatch TODO comment        |
+| `packages/playground/src/pages/components/BrandIconDemo.tsx`            | NEW — demo                                                                                                          |
+| `packages/playground/src/App.tsx`                                       | MODIFY — `/components/brand-icon` route                                                                             |
+| `packages/playground/src/layout/AppShell/AppShell.tsx`                  | MODIFY — Display nav entry (a lucide icon, e.g. `Fingerprint` or `BadgeCheck`; plan picks one not already imported) |
+| `packages/playground/src/pages/components/ComponentsIndex.tsx`          | MODIFY — overview card                                                                                              |
 
 **`BrandIcon.module.scss`:** `structure.test.ts` requires a `<Name>.module.scss` for every
 component, so `BrandIcon` ships one with a single `.icon` class applied to the `<svg>` —

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1160,6 +1160,21 @@ import { Divider } from '@eocrm/design-system';
 - **Non-interactive.** If it's clickable, use `<Button>` instead.
 - Doesn't auto-add `role="status"`. Wrap in `aria-live` if a state change should be announced.
 
+### `<BrandIcon>` — third-party brand marks
+
+```tsx
+<Button variant="secondary">
+  <BrandIcon name="google" size={16} /> Continue with Google
+</Button>
+```
+
+Full-color official brand marks for SSO buttons. Ships `google` + `yandex`.
+
+- `name`: `'google' | 'yandex'`. `size`: px (default 20). Colors are brand-mandated (not themeable).
+- Decorative by default (`aria-hidden`); pass `title` for a labeled standalone icon (`role="img"`).
+
+**When NOT to use:** generic UI glyphs → `lucide-react`. Don't recolor brand marks.
+
 ### Palette — categorical color set
 
 ```tsx

--- a/packages/design-system/scripts/generate-manifest.mjs
+++ b/packages/design-system/scripts/generate-manifest.mjs
@@ -56,6 +56,7 @@ const CLUSTERS = {
   Avatar: 'Display',
   Image: 'Display',
   Badge: 'Display',
+  BrandIcon: 'Display',
   Calendar: 'Display',
   DefinitionList: 'Display',
   CircularProgress: 'Display',

--- a/packages/design-system/src/_meta/manifest.ts
+++ b/packages/design-system/src/_meta/manifest.ts
@@ -78,6 +78,7 @@ const CLUSTERS: Record<string, string> = {
   Avatar: 'Display',
   Image: 'Display',
   Badge: 'Display',
+  BrandIcon: 'Display',
   DefinitionList: 'Display',
   Calendar: 'Display',
   CircularProgress: 'Display',

--- a/packages/design-system/src/components.manifest.json
+++ b/packages/design-system/src/components.manifest.json
@@ -32,6 +32,12 @@
       "OptionsPicker"
     ]
   },
+  "BrandIcon": {
+    "tier": "primitive",
+    "cluster": "Display",
+    "composes": [],
+    "composedBy": []
+  },
   "Breadcrumb": {
     "tier": "composition",
     "cluster": "Navigation",

--- a/packages/design-system/src/components/BrandIcon/BrandIcon.module.scss
+++ b/packages/design-system/src/components/BrandIcon/BrandIcon.module.scss
@@ -1,0 +1,4 @@
+.icon {
+  display: inline-block;
+  vertical-align: middle;
+}

--- a/packages/design-system/src/components/BrandIcon/BrandIcon.module.scss
+++ b/packages/design-system/src/components/BrandIcon/BrandIcon.module.scss
@@ -1,4 +1,5 @@
 .icon {
   display: inline-block;
   vertical-align: middle;
+  flex: none;
 }

--- a/packages/design-system/src/components/BrandIcon/BrandIcon.test.tsx
+++ b/packages/design-system/src/components/BrandIcon/BrandIcon.test.tsx
@@ -1,0 +1,64 @@
+import { createRef } from 'react';
+import { render } from '@testing-library/react';
+import { BrandIcon } from './BrandIcon';
+
+function svgOf(c: HTMLElement): SVGSVGElement {
+  return c.querySelector('svg') as SVGSVGElement;
+}
+
+describe('BrandIcon', () => {
+  it('renders the google mark (4 colored paths, 0 0 48 48)', () => {
+    const { container } = render(<BrandIcon name="google" />);
+    const svg = svgOf(container);
+    expect(svg).not.toBeNull();
+    expect(svg.querySelectorAll('path')).toHaveLength(4);
+    expect(svg.getAttribute('viewBox')).toBe('0 0 48 48');
+  });
+
+  it('renders the yandex mark (distinct viewBox + brand red)', () => {
+    const { container } = render(<BrandIcon name="yandex" />);
+    expect(svgOf(container).getAttribute('viewBox')).toBe('0 0 24 24');
+    expect(container.innerHTML).toMatch(/#FC3F1D/i);
+  });
+
+  it('renders every known brand without throwing', () => {
+    (['google', 'yandex'] as const).forEach((name) => {
+      expect(() => render(<BrandIcon name={name} />)).not.toThrow();
+    });
+  });
+
+  it('sizes the svg (default 20, overridable)', () => {
+    const { container, rerender } = render(<BrandIcon name="google" />);
+    expect(svgOf(container).getAttribute('width')).toBe('20');
+    expect(svgOf(container).getAttribute('height')).toBe('20');
+    rerender(<BrandIcon name="google" size={32} />);
+    expect(svgOf(container).getAttribute('width')).toBe('32');
+    expect(svgOf(container).getAttribute('height')).toBe('32');
+  });
+
+  it('is decorative by default (aria-hidden, no role)', () => {
+    const { container } = render(<BrandIcon name="google" />);
+    const svg = svgOf(container);
+    expect(svg.getAttribute('aria-hidden')).toBe('true');
+    expect(svg.getAttribute('role')).toBeNull();
+  });
+
+  it('title makes it a labeled image', () => {
+    const { container, getByTitle } = render(<BrandIcon name="yandex" title="Yandex" />);
+    const svg = svgOf(container);
+    expect(svg.getAttribute('role')).toBe('img');
+    expect(svg.getAttribute('aria-label')).toBe('Yandex');
+    expect(svg.getAttribute('aria-hidden')).toBeNull();
+    expect(getByTitle('Yandex')).toBeInTheDocument();
+  });
+
+  it('forwards ref to the svg, merges className, spreads attrs', () => {
+    const ref = createRef<SVGSVGElement>();
+    const { container } = render(
+      <BrandIcon name="google" ref={ref} className="custom" data-testid="bi" />,
+    );
+    expect(ref.current).toBe(svgOf(container));
+    expect(svgOf(container).getAttribute('class')).toMatch(/custom/);
+    expect(svgOf(container).getAttribute('data-testid')).toBe('bi');
+  });
+});

--- a/packages/design-system/src/components/BrandIcon/BrandIcon.tsx
+++ b/packages/design-system/src/components/BrandIcon/BrandIcon.tsx
@@ -1,0 +1,121 @@
+import { forwardRef, type ReactNode, type SVGAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './BrandIcon.module.scss';
+
+/** Brands shipped today. Extend the union + the `ICONS` registry to add more. */
+export type BrandName = 'google' | 'yandex';
+
+export interface BrandIconProps extends Omit<SVGAttributes<SVGSVGElement>, 'children'> {
+  /** Which brand mark to render. */
+  name: BrandName;
+  /** Square pixel size (width = height). Defaults to `20`. */
+  size?: number;
+  /**
+   * Accessible name. Omit (default) for a decorative icon beside a text label —
+   * the icon renders `aria-hidden`. Set it for a standalone icon (e.g. an
+   * icon-only button) → `role="img"` + `aria-label`.
+   */
+  title?: string;
+}
+
+type BrandSvg = { viewBox: string; body: ReactNode };
+
+// `Record<BrandName, …>` makes the registry complete at COMPILE time — adding a
+// brand to `BrandName` without art fails typecheck. Brand hex is inline (the
+// documented exception to token-only color; the colors are brand-mandated).
+const ICONS: Record<BrandName, BrandSvg> = {
+  google: {
+    viewBox: '0 0 48 48',
+    body: (
+      <>
+        <path
+          fill="#EA4335"
+          d="M24 9.5c3.5 0 6.6 1.2 9 3.6l6.7-6.7C35.6 2.4 30.1 0 24 0 14.6 0 6.4 5.4 2.6 13.2l7.8 6.1C12.2 13.3 17.6 9.5 24 9.5z"
+        />
+        <path
+          fill="#4285F4"
+          d="M46.1 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.4c-.5 2.9-2.1 5.3-4.6 7l7.1 5.5c4.2-3.9 6.6-9.6 6.6-16.5z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M10.4 28.3c-.5-1.4-.8-3-.8-4.3s.3-2.9.8-4.3l-7.8-6.1C1 16.8 0 20.3 0 24s1 7.2 2.6 10.4l7.8-6.1z"
+        />
+        <path
+          fill="#34A853"
+          d="M24 48c6.5 0 11.9-2.1 15.9-5.8l-7.1-5.5c-2 1.3-4.5 2.1-8.8 2.1-6.4 0-11.8-3.8-13.6-9.1l-7.8 6.1C6.4 42.6 14.6 48 24 48z"
+        />
+      </>
+    ),
+  },
+  yandex: {
+    viewBox: '0 0 24 24',
+    body: (
+      <>
+        <rect width="24" height="24" rx="5" fill="#FC3F1D" />
+        {/* v1 representation of the Yandex "Я" logomark; swap for official path art when sourced. */}
+        <text
+          x="12"
+          y="17.5"
+          textAnchor="middle"
+          fontFamily="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif"
+          fontWeight="700"
+          fontSize="16"
+          fill="#fff"
+        >
+          Я
+        </text>
+      </>
+    ),
+  },
+};
+
+/**
+ * Renders a third-party brand's official multi-color mark — for SSO buttons and
+ * brand chrome. Colors are brand-mandated (not themeable). Decorative by
+ * default; pass `title` for standalone, labeled use.
+ *
+ * @example
+ * // In an SSO button (decorative — the text carries the name):
+ * <Button variant="secondary">
+ *   <BrandIcon name="google" size={16} /> Continue with Google
+ * </Button>
+ *
+ * @example
+ * // Standalone, labeled:
+ * <BrandIcon name="yandex" title="Yandex" size={24} />
+ *
+ * @remarks When NOT to use
+ * - Generic UI glyphs (chevron, search, close) → use `lucide-react`. This is
+ *   only for third-party brand marks.
+ * - Recoloring to match your theme — unsupported; brand marks keep their
+ *   official colors.
+ *
+ * @remarks Anti-patterns
+ * - ❌ A decorative `BrandIcon` next to visible brand text AND a `title` —
+ *   double-announces ("Google Continue with Google"). Keep it `aria-hidden`
+ *   (the default) beside a label.
+ */
+export const BrandIcon = forwardRef<SVGSVGElement, BrandIconProps>(function BrandIcon(
+  { name, size = 20, title, className, ...rest },
+  ref,
+) {
+  const icon = ICONS[name];
+  const labeled = title != null && title !== '';
+  return (
+    // {...rest} last (Pattern A) so a consumer can override the a11y defaults.
+    <svg
+      ref={ref}
+      width={size}
+      height={size}
+      viewBox={icon.viewBox}
+      className={clsx(styles.icon, className)}
+      role={labeled ? 'img' : undefined}
+      aria-label={labeled ? title : undefined}
+      aria-hidden={labeled ? undefined : true}
+      {...rest}
+    >
+      {labeled && <title>{title}</title>}
+      {icon.body}
+    </svg>
+  );
+});

--- a/packages/design-system/src/components/BrandIcon/index.ts
+++ b/packages/design-system/src/components/BrandIcon/index.ts
@@ -1,0 +1,2 @@
+export { BrandIcon } from './BrandIcon';
+export type { BrandIconProps, BrandName } from './BrandIcon';

--- a/packages/design-system/src/components/TODO.md
+++ b/packages/design-system/src/components/TODO.md
@@ -30,6 +30,7 @@ Keep entries terse but specific. The "Mocked in" path is load-bearing — the im
 ### [ ] `<AuthScreen>` (or `<AuthLayout>`) — full-viewport centered surface with a tinted backdrop for auth pages
 
 **Filed:** 2026-05-29
+**Deferred:** 2026-05-30 — the login screen is a single playground mockup; a reusable auth-layout primitive is YAGNI for one screen. The Login wrapper escape hatches stay as a contained one-off. Revisit only if a second auth screen appears.
 **Mocked in:**
 
 - `packages/playground/src/pages/mockups/Login/Login.tsx:51` — outer full-bleed wrapper (gradient backdrop, flex column, full viewport height)
@@ -43,9 +44,10 @@ Two raw `<div style={{…}}>` at the exact mock site, token-only values: the out
 
 **When this ships:** refactor the Login mockup's two wrapper `<div>`s to use the primitive, then tick this checkbox.
 
-### [ ] `<BrandIcon>` / social-login icon set — multi-color brand marks (Google, Microsoft, Apple…)
+### [x] `<BrandIcon>` / social-login icon set — multi-color brand marks (Google, Microsoft, Apple…)
 
 **Filed:** 2026-05-29
+**Shipped:** 2026-05-30 — `packages/design-system/src/components/BrandIcon/`. The Login mockup's inline Google `<svg>` now uses `<BrandIcon name="google" size={16} />`. Ships `google` + `yandex`; extend the `BrandName` union + `ICONS` registry for more.
 **Mocked in:**
 
 - `packages/playground/src/pages/mockups/Login/Login.tsx:89` — the Google "G" inside the "Continue with Google" SSO button.

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -86,6 +86,9 @@ export type { AvatarProps, AvatarSize, AvatarStatus, AvatarGroupProps } from './
 export { Badge } from './components/Badge';
 export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot, BadgeVariant } from './components/Badge';
 
+export { BrandIcon } from './components/BrandIcon';
+export type { BrandIconProps, BrandName } from './components/BrandIcon';
+
 export { FilterChip } from './components/FilterChip';
 export type {
   FilterChipProps,

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -46,6 +46,7 @@ import { StackDemo } from './pages/components/StackDemo';
 import { ClusterDemo } from './pages/components/ClusterDemo';
 import { AvatarDemo } from './pages/components/AvatarDemo';
 import { BadgeDemo } from './pages/components/BadgeDemo';
+import { BrandIconDemo } from './pages/components/BrandIconDemo';
 import { TabsDemo } from './pages/components/TabsDemo';
 import { DropdownMenuDemo } from './pages/components/DropdownMenuDemo';
 import { TooltipDemo } from './pages/components/TooltipDemo';
@@ -133,6 +134,7 @@ export default function App() {
             <Route path="/components/cluster" element={<ClusterDemo />} />
             <Route path="/components/avatar" element={<AvatarDemo />} />
             <Route path="/components/badge" element={<BadgeDemo />} />
+            <Route path="/components/brand-icon" element={<BrandIconDemo />} />
             <Route path="/components/tabs" element={<TabsDemo />} />
             <Route path="/components/dropdown-menu" element={<DropdownMenuDemo />} />
             <Route path="/components/tooltip" element={<TooltipDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -68,6 +68,7 @@ import {
   Palette,
   GalleryVerticalEnd,
   Settings as SettingsIcon,
+  Fingerprint,
   type LucideIcon,
 } from 'lucide-react';
 import { useState, useEffect } from 'react';
@@ -157,6 +158,7 @@ const componentGroups = [
     items: [
       { to: '/components/avatar', label: 'Avatar', icon: CircleUser, end: false },
       { to: '/components/badge', label: 'Badge', icon: Tag, end: false },
+      { to: '/components/brand-icon', label: 'BrandIcon', icon: Fingerprint, end: false },
       { to: '/components/calendar', label: 'Calendar', icon: CalendarDays, end: false },
       {
         to: '/components/circular-progress',

--- a/packages/playground/src/pages/components/BrandIconDemo.tsx
+++ b/packages/playground/src/pages/components/BrandIconDemo.tsx
@@ -1,0 +1,60 @@
+import { BrandIcon, Button, Cluster, Stack, Text } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import { getComponentFiles } from '../../lib/componentFiles';
+
+export function BrandIconDemo() {
+  return (
+    <DemoLayout
+      name="BrandIcon"
+      componentName="BrandIcon"
+      description="Full-color official brand marks for SSO buttons and brand chrome. Ships google + yandex; colors are brand-mandated (not themeable). For generic UI glyphs use lucide-react."
+      files={getComponentFiles('BrandIcon')}
+    >
+      <Example
+        title="The marks"
+        description="Each brand at a few sizes. size is pixels (default 20)."
+        code={`<BrandIcon name="google" />
+<BrandIcon name="yandex" size={32} />`}
+      >
+        <Cluster gap="lg" align="center">
+          {(['google', 'yandex'] as const).map((name) => (
+            <Stack key={name} gap="xs" align="center">
+              <Cluster gap="sm" align="center">
+                <BrandIcon name={name} size={16} />
+                <BrandIcon name={name} size={20} />
+                <BrandIcon name={name} size={32} />
+              </Cluster>
+              <Text size="xs" tone="muted">
+                {name}
+              </Text>
+            </Stack>
+          ))}
+        </Cluster>
+      </Example>
+
+      <Example
+        title="In SSO buttons"
+        description="The canonical use — decorative icon (aria-hidden) beside the provider name."
+        code={`<Button variant="secondary"><BrandIcon name="google" size={16} /> Continue with Google</Button>`}
+      >
+        <Stack gap="sm">
+          <Button variant="secondary">
+            <BrandIcon name="google" size={16} /> Continue with Google
+          </Button>
+          <Button variant="secondary">
+            <BrandIcon name="yandex" size={16} /> Continue with Yandex
+          </Button>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Labeled (standalone)"
+        description="Pass title for a standalone icon — renders role=img + aria-label."
+        code={`<BrandIcon name="yandex" title="Yandex" size={28} />`}
+      >
+        <BrandIcon name="yandex" title="Yandex" size={28} />
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -4,6 +4,7 @@ import { Accordion } from '@eocrm/design-system';
 import { Alert } from '@eocrm/design-system';
 import { Avatar } from '@eocrm/design-system';
 import { Badge } from '@eocrm/design-system';
+import { BrandIcon } from '@eocrm/design-system';
 import { Breadcrumb } from '@eocrm/design-system';
 import { Link as DSLink } from '@eocrm/design-system';
 import { Button } from '@eocrm/design-system';
@@ -628,6 +629,17 @@ const items: { to: string; name: string; description: string; preview: React.Rea
         <Badge tone="info">New</Badge>
         <Badge tone="success">Active</Badge>
         <Badge tone="warning">Pending</Badge>
+      </Cluster>
+    ),
+  },
+  {
+    to: '/components/brand-icon',
+    name: 'BrandIcon',
+    description: 'Full-color brand marks (Google, Yandex) for SSO buttons.',
+    preview: (
+      <Cluster gap="md" justify="center">
+        <BrandIcon name="google" size={28} />
+        <BrandIcon name="yandex" size={28} />
       </Cluster>
     ),
   },

--- a/packages/playground/src/pages/mockups/Login/Login.tsx
+++ b/packages/playground/src/pages/mockups/Login/Login.tsx
@@ -2,6 +2,7 @@ import { useState, type KeyboardEvent } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import {
   Alert,
+  BrandIcon,
   Button,
   Card,
   Checkbox,
@@ -84,26 +85,7 @@ export function Login() {
               </Stack>
 
               <Button variant="secondary">
-                {/* TODO: replace when a brand/social icon set ships — see components/TODO.md.
-                    Multi-color Google "G"; not in lucide. Brand hex is intentional. */}
-                <svg width="16" height="16" viewBox="0 0 48 48" aria-hidden="true">
-                  <path
-                    fill="#EA4335"
-                    d="M24 9.5c3.5 0 6.6 1.2 9 3.6l6.7-6.7C35.6 2.4 30.1 0 24 0 14.6 0 6.4 5.4 2.6 13.2l7.8 6.1C12.2 13.3 17.6 9.5 24 9.5z"
-                  />
-                  <path
-                    fill="#4285F4"
-                    d="M46.1 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.4c-.5 2.9-2.1 5.3-4.6 7l7.1 5.5c4.2-3.9 6.6-9.6 6.6-16.5z"
-                  />
-                  <path
-                    fill="#FBBC05"
-                    d="M10.4 28.3c-.5-1.4-.8-3-.8-4.3s.3-2.9.8-4.3l-7.8-6.1C1 16.8 0 20.3 0 24s1 7.2 2.6 10.4l7.8-6.1z"
-                  />
-                  <path
-                    fill="#34A853"
-                    d="M24 48c6.5 0 11.9-2.1 15.9-5.8l-7.1-5.5c-2 1.3-4.5 2.1-8.8 2.1-6.4 0-11.8-3.8-13.6-9.1l-7.8 6.1C6.4 42.6 14.6 48 24 48z"
-                  />
-                </svg>
+                <BrandIcon name="google" size={16} />
                 Continue with Google
               </Button>
 

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -5,6 +5,7 @@ export type ComponentName =
   | 'Alert'
   | 'Avatar'
   | 'Badge'
+  | 'BrandIcon'
   | 'Breadcrumb'
   | 'Button'
   | 'ButtonGroup'
@@ -299,6 +300,7 @@ export const MOCKUPS = [
     blurb: 'Full-screen eocrm sign-in — branded card, email/password, Google SSO, error states.',
     usesComponents: [
       'Alert',
+      'BrandIcon',
       'Button',
       'Card',
       'Checkbox',


### PR DESCRIPTION
## Summary

A new `<BrandIcon name="google" | "yandex">` library primitive — full-color official brand marks for SSO buttons and brand chrome.

- **One component, extensible registry:** `ICONS: Record<BrandName, …>` makes brand-completeness a compile-time guarantee; add a brand by extending the union + dropping in the SVG. `name` documents what's available.
- **`size`** px (default 20) · brand-mandated colors (inline hex — the documented exception to token-only color, isolated to SVG `fill`s) · **decorative by default** (`aria-hidden`), `title` opts into a labeled `role="img"` + `<title>`.
- **Refactors the Login mockup:** the hand-rolled inline Google `<svg>` escape hatch → `<BrandIcon name="google" size={16} />` (one fewer Hard-rule-6 escape hatch). Ticks the `<BrandIcon>` TODO; marks `<AuthScreen>` **deferred** (a reusable auth-layout primitive is YAGNI for one mockup screen).
- Full wiring: 7 tests, demo (`/components/brand-icon`), exports, manifest (both sources), AGENTS entry, nav, index card.

Note: the Yandex mark uses an SVG `<text>` "Я" as a v1 representation; swap for official logomark path art in a follow-up.

## Test Plan
- [x] `make test` (2389) · `make build-lib` · `make lint` · `make build` green; `npm pack` excludes the test; manifest no-drift
- [x] Rule-8 (library) + Rule-7 (Login mockup) review → clean (0 Critical / 0 Important)
- [x] Visual: `/components/brand-icon` (marks, SSO buttons, labeled) + `/mockups/login` (Google mark now via `<BrandIcon>`, visually identical)
- [ ] CI `Quality / check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)