### PR TITLE
feat: <AppProvider> root provider

### DIFF
--- a/docs/superpowers/plans/2026-06-01-app-provider.md
+++ b/docs/superpowers/plans/2026-06-01-app-provider.md
@@ -1,0 +1,454 @@
+# `<AppProvider>` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<AppProvider>` — a single root component that composes the design-system's app-level contexts (`LocaleProvider` + `I18nProvider` + an auto-mounted `<ToastViewport>`), parameterized by `locale` / `intlLocale` / `translations` / `toast` props — and dogfood it via the playground root.
+
+**Architecture:** A pure provider composition in `src/app/` (provider infra, like `src/i18n/` — not a gallery component, so no `.module.scss`, no manifest cluster, no `structure.test` 4-file set). `LocaleProvider` (outermost, gets `intlLocale ?? locale`) → `I18nProvider` (`locale` + `translations` overrides) → `children` + `<ToastViewport>` (inside the providers, after children; skipped when `toast === false`).
+
+**Tech Stack:** React 18 + TypeScript, Vitest + React Testing Library (globals on; jsdom), npm workspaces.
+
+**Branch:** `feat/app-provider` (already created off `main`; the spec doc is committed there).
+
+---
+
+## Conventions every task follows
+
+- **Library gates** (Task 1, from `packages/design-system/`): `npm test && npm run typecheck && npm run lint:css && npm run build`. TDD single-file run: `npx vitest run src/app/AppProvider.test.tsx`.
+- **Playground gates** (Task 2, from repo root): `make build && make lint`.
+- No `forwardRef` / no `{...rest}` — `AppProvider` is a provider composition, not a DOM element (consistent with `I18nProvider`/`LocaleProvider`). Full JSDoc on the component + every prop (Rule 7).
+- No i18n strings of its own (props-driven; all copy is consumer-supplied).
+- Commit messages end with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## File structure
+
+- `packages/design-system/src/app/AppProvider.tsx` — the component + props + JSDoc.
+- `packages/design-system/src/app/index.ts` — barrel: `export { AppProvider }` + `export type { AppProviderProps }`.
+- `packages/design-system/src/app/AppProvider.test.tsx` — unit tests (context probes + toast).
+- `packages/design-system/src/index.ts` — MODIFY: re-export.
+- `packages/design-system/AGENTS.md` — MODIFY: "Setup" section.
+- `packages/playground/src/App.tsx` — MODIFY (dogfood).
+
+---
+
+## Task 1: `<AppProvider>` (component + tests + exports + AGENTS Setup)
+
+**Files:**
+
+- Create: `packages/design-system/src/app/AppProvider.tsx`
+- Create: `packages/design-system/src/app/index.ts`
+- Create: `packages/design-system/src/app/AppProvider.test.tsx`
+- Modify: `packages/design-system/src/index.ts` (after the i18n export block, ~line 431)
+- Modify: `packages/design-system/AGENTS.md` ("## Setup (once per consuming app)", ~lines 19–28)
+
+- [ ] **Step 1: Write the failing test** — `packages/design-system/src/app/AppProvider.test.tsx`
+
+```tsx
+import { render, screen, act } from '@testing-library/react';
+import { AppProvider } from './AppProvider';
+import { useLocale } from '../i18n/useLocale';
+import { useTranslation } from '../i18n/useTranslation';
+import { toast, _setViewportConfig } from '../components/Toast/api';
+import { store } from '../components/Toast/store';
+
+function LocaleProbe() {
+  return <span data-testid="locale">{useLocale()}</span>;
+}
+function AlertDismiss() {
+  const t = useTranslation();
+  return <span data-testid="alert-dismiss">{t('alert.dismiss')}</span>;
+}
+function ToastDismiss() {
+  const t = useTranslation();
+  return <span data-testid="toast-dismiss">{t('toast.dismiss')}</span>;
+}
+function ToastNotifications() {
+  const t = useTranslation();
+  return <span data-testid="toast-notifications">{t('toast.notifications')}</span>;
+}
+
+describe('AppProvider', () => {
+  // Mirror Toast.test.tsx hygiene: clear the global toast store + reset the
+  // viewport config baseline, and use fake timers so the 4s auto-dismiss
+  // timer a toast schedules doesn't leak across tests.
+  beforeEach(() => {
+    store._reset();
+    _setViewportConfig({ position: 'bottom-right', duration: 4000 });
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    store._reset();
+  });
+
+  it('renders children', () => {
+    render(
+      <AppProvider locale="en">
+        <span data-testid="child">hi</span>
+      </AppProvider>,
+    );
+    expect(screen.getByTestId('child')).toHaveTextContent('hi');
+  });
+
+  it('useLocale() returns intlLocale when provided', () => {
+    render(
+      <AppProvider locale="en" intlLocale="en-US">
+        <LocaleProbe />
+      </AppProvider>,
+    );
+    expect(screen.getByTestId('locale')).toHaveTextContent('en-US');
+  });
+
+  it('useLocale() falls back to locale when intlLocale is omitted', () => {
+    render(
+      <AppProvider locale="ru">
+        <LocaleProbe />
+      </AppProvider>,
+    );
+    expect(screen.getByTestId('locale')).toHaveTextContent('ru');
+  });
+
+  it('useTranslation() reflects locale (en vs ru)', () => {
+    const { rerender } = render(
+      <AppProvider locale="en">
+        <AlertDismiss />
+      </AppProvider>,
+    );
+    expect(screen.getByTestId('alert-dismiss')).toHaveTextContent('Dismiss');
+    rerender(
+      <AppProvider locale="ru">
+        <AlertDismiss />
+      </AppProvider>,
+    );
+    expect(screen.getByTestId('alert-dismiss')).toHaveTextContent('Закрыть');
+  });
+
+  it('translations overrides deep-merge over built-in messages', () => {
+    render(
+      <AppProvider locale="en" translations={{ toast: { dismiss: 'Hide' } }}>
+        <ToastDismiss />
+        <ToastNotifications />
+      </AppProvider>,
+    );
+    // overridden key wins…
+    expect(screen.getByTestId('toast-dismiss')).toHaveTextContent('Hide');
+    // …and the sibling key in the SAME section keeps its built-in default
+    // (proves deep-merge, not whole-bundle replace).
+    expect(screen.getByTestId('toast-notifications')).toHaveTextContent('Notifications');
+  });
+
+  it('auto-mounts the toast viewport (toasts render)', () => {
+    render(
+      <AppProvider locale="en">
+        <span />
+      </AppProvider>,
+    );
+    act(() => {
+      toast('Saved successfully');
+    });
+    expect(screen.getByText('Saved successfully')).toBeInTheDocument();
+  });
+
+  it('toast={false} mounts no viewport', () => {
+    render(
+      <AppProvider locale="en" toast={false}>
+        <span />
+      </AppProvider>,
+    );
+    act(() => {
+      toast('Should not appear');
+    });
+    expect(screen.queryByText('Should not appear')).toBeNull();
+  });
+
+  it('toast config (position) is forwarded to the viewport', () => {
+    render(
+      <AppProvider locale="en" toast={{ position: 'top-right' }}>
+        <span />
+      </AppProvider>,
+    );
+    act(() => {
+      toast('Positioned toast');
+    });
+    const ol = screen.getByText('Positioned toast').closest('ol');
+    expect(ol).toHaveAttribute('data-position', 'top-right');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/design-system && npx vitest run src/app/AppProvider.test.tsx`
+Expected: FAIL — `Failed to resolve import './AppProvider'`.
+
+- [ ] **Step 3: Create the component** — `packages/design-system/src/app/AppProvider.tsx`
+
+```tsx
+import { type ReactNode } from 'react';
+import {
+  LocaleProvider,
+  I18nProvider,
+  type DeepPartial,
+  type Locale,
+  type Messages,
+} from '../i18n';
+import { ToastViewport, type ToastViewportProps } from '../components/Toast';
+
+export interface AppProviderProps {
+  /**
+   * UI-string locale — selects the built-in message bundle. v1 ships `'en'`
+   * and `'ru'`. Drives every design-system component's copy via `useTranslation`.
+   */
+  locale: Locale;
+  /**
+   * BCP-47 locale for Intl-facing formatting (Calendar, dates, numbers), read
+   * by components via `useLocale`. Optional — defaults to `locale` verbatim
+   * (`'en'` / `'ru'` are valid language tags). Set it for a region, e.g.
+   * `'en-US'` / `'ru-RU'` / `'en-GB'`.
+   */
+  intlLocale?: string;
+  /**
+   * Deep-partial overrides deep-merged over the built-in messages for `locale`.
+   * Supply only the keys you rebrand/retext; the rest fall back to the shipped
+   * defaults. Memoize this object — passing a fresh literal every render
+   * rebuilds the merged messages each time.
+   */
+  translations?: DeepPartial<Messages>;
+  /**
+   * Toast viewport configuration (`position`, `duration`, …), or `false` to
+   * NOT mount a viewport (place `<ToastViewport>` yourself). Omitted ⇒ a
+   * viewport is mounted with the library defaults.
+   */
+  toast?: ToastViewportProps | false;
+  children: ReactNode;
+}
+
+/**
+ * Root provider for a consuming app. Wrap your tree once to get the
+ * design-system's app-level contexts wired in one place — instead of nesting
+ * `LocaleProvider` + `I18nProvider` and remembering to mount `<ToastViewport>`.
+ *
+ * Composes (outermost → in): `LocaleProvider` (Intl locale = `intlLocale ?? locale`)
+ * → `I18nProvider` (`locale` + `translations` overrides) → `children`, plus a
+ * `<ToastViewport>` rendered inside the providers (so toast chrome is translated)
+ * unless `toast={false}`.
+ *
+ * Routing is the app's own concern (`AppProvider` ships no router), and the
+ * stylesheet import (`@eocrm/design-system/styles/global.scss`) is still
+ * required at your entry point.
+ *
+ * @example
+ * import '@eocrm/design-system/styles/global.scss';
+ * import { AppProvider } from '@eocrm/design-system';
+ *
+ * <AppProvider locale="en" intlLocale="en-US">
+ *   <YourRouter />
+ * </AppProvider>;
+ *
+ * @example
+ * // Russian UI + a couple of rebranded strings + top-right toasts:
+ * const translations = useMemo(() => ({ alert: { dismiss: 'Скрыть' } }), []);
+ * <AppProvider locale="ru" translations={translations} toast={{ position: 'top-right' }}>
+ *   <App />
+ * </AppProvider>;
+ *
+ * @remarks When NOT to use
+ * - **Per-subtree locale / i18n override** → nest `LocaleProvider` /
+ *   `I18nProvider` directly. `AppProvider` is the single app root; don't nest a
+ *   second `AppProvider`.
+ * - **A tiny embed / isolated test that only needs strings** → use
+ *   `I18nProvider` alone (or pass `toast={false}` here) so you don't get an
+ *   unwanted toast viewport.
+ */
+export function AppProvider({
+  locale,
+  intlLocale,
+  translations,
+  toast,
+  children,
+}: AppProviderProps) {
+  return (
+    <LocaleProvider locale={intlLocale ?? locale}>
+      <I18nProvider locale={locale} overrides={translations}>
+        {children}
+        {toast !== false && <ToastViewport {...(toast ?? {})} />}
+      </I18nProvider>
+    </LocaleProvider>
+  );
+}
+```
+
+- [ ] **Step 4: Create the barrel** — `packages/design-system/src/app/index.ts`
+
+```ts
+export { AppProvider } from './AppProvider';
+export type { AppProviderProps } from './AppProvider';
+```
+
+- [ ] **Step 5: Re-export from `src/index.ts`.** Find the i18n export block (around line 425–431, the `// i18n — translated UI strings.` group ending with `export type { I18nProviderProps, Locale, Messages, MessageKey, DeepPartial } from './i18n';`). Immediately after it, add:
+
+```ts
+// App root — bundles the locale + i18n + toast contexts for a consuming app.
+export { AppProvider } from './app';
+export type { AppProviderProps } from './app';
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd packages/design-system && npx vitest run src/app/AppProvider.test.tsx`
+Expected: PASS (all 8 cases).
+
+- [ ] **Step 7: Update the AGENTS.md Setup section.** Replace the current "## Setup (once per consuming app)" block (the stylesheet-only version, ~lines 19–28, ending with "Everything else flows from it." and the `---`) with:
+
+````markdown
+## Setup (once per consuming app)
+
+Two steps at your app root:
+
+```tsx
+// 1. Import the stylesheet once (tokens, modern reset, base typography).
+import '@eocrm/design-system/styles/global.scss';
+
+// 2. Wrap your tree in <AppProvider>.
+import { AppProvider } from '@eocrm/design-system';
+
+<AppProvider locale="en" intlLocale="en-US">
+  <App />
+</AppProvider>;
+```
+
+`<AppProvider>` bundles the app-level contexts so you don't wire them by hand:
+
+- `locale` (`'en' | 'ru'`) — selects the built-in UI-string bundle.
+- `intlLocale?` (BCP-47, e.g. `'en-US'`) — locale for Intl formatting (Calendar, dates, numbers). Defaults to `locale`.
+- `translations?` — deep-partial overrides merged over the built-in strings (rebrand a few keys; memoize the object).
+- `toast?` — `<ToastViewport>` config, or `false` to mount it yourself. Omitted ⇒ mounted with defaults.
+
+It composes `LocaleProvider` + `I18nProvider` and mounts the toast viewport. **Routing is yours** (`<AppProvider>` ships no router), and the stylesheet import above is still required. The individual providers (`LocaleProvider`, `I18nProvider`, `ToastViewport`) remain exported for advanced cases like pinning a subtree to a different locale.
+
+---
+````
+
+- [ ] **Step 8: Run the full library gates**
+
+Run: `cd packages/design-system && npm test && npm run typecheck && npm run lint:css && npm run build`
+Expected: all green. (`structure.test` does not scan `src/app/`, so no `.module.scss` is required; the manifest does not include `src/app/`.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/design-system/src/app packages/design-system/src/index.ts packages/design-system/AGENTS.md
+git commit -m "feat: add <AppProvider> root provider
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Dogfood — refactor the playground root onto `<AppProvider>`
+
+**Files:**
+
+- Modify: `packages/playground/src/App.tsx` (import line 84; provider open line 88; toast + closes lines 181–183)
+
+- [ ] **Step 1: Swap the import.** In `packages/playground/src/App.tsx`, change line 84 from:
+
+```tsx
+import { I18nProvider, ToastViewport } from '@eocrm/design-system';
+```
+
+to:
+
+```tsx
+import { AppProvider } from '@eocrm/design-system';
+```
+
+- [ ] **Step 2: Replace the provider wrapper.** The current structure is:
+
+```tsx
+<I18nProvider locale="en">
+  <BrowserRouter basename={import.meta.env.BASE_URL}>
+    <AppShell>{/* …routes… */}</AppShell>
+    <ToastViewport position="bottom-right" />
+  </BrowserRouter>
+</I18nProvider>
+```
+
+Change the opening `<I18nProvider locale="en">` (line 88) to:
+
+```tsx
+    <AppProvider locale="en" intlLocale="en-US" toast={{ position: 'bottom-right' }}>
+```
+
+Delete the standalone `<ToastViewport position="bottom-right" />` line (line 181) — the viewport is now auto-mounted by `AppProvider`.
+
+Change the closing `</I18nProvider>` (line 183) to:
+
+```tsx
+    </AppProvider>
+```
+
+The resulting structure:
+
+```tsx
+<AppProvider locale="en" intlLocale="en-US" toast={{ position: 'bottom-right' }}>
+  <BrowserRouter basename={import.meta.env.BASE_URL}>
+    <AppShell>{/* …routes… (unchanged) */}</AppShell>
+  </BrowserRouter>
+</AppProvider>
+```
+
+(Net effect: the manual `<ToastViewport>` is gone — `AppProvider` mounts it — and `LocaleProvider` is now in the tree for the first time via `intlLocale="en-US"`, so Calendar/date formatting gets a real locale. Routing stays inside, owned by the app.)
+
+- [ ] **Step 3: Run the playground gates**
+
+Run (from repo root): `make build && make lint`
+Expected: green. (Typecheck confirms `AppProvider` resolves from the library and `I18nProvider`/`ToastViewport` are no longer referenced. No unused imports.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/playground/src/App.tsx
+git commit -m "refactor(playground): wire root via <AppProvider>
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Final gates + library review-fix loop + finish
+
+- [ ] **Step 1: Repo-wide gates.** From repo root:
+
+```bash
+make test && make build && make lint
+( cd packages/design-system && npm run typecheck && npm run lint:css && npm pack --dry-run -w @eocrm/design-system )
+```
+
+Expected: all green; `npm pack --dry-run` ships `src/app/AppProvider.tsx` + `src/app/index.ts` and does NOT include `src/app/AppProvider.test.tsx`.
+
+- [ ] **Step 2: Library review-fix loop (Hard rule 8).** Spawn a fresh-context `general-purpose` reviewer scoped to the library changes (`src/app/`, `src/index.ts`, `AGENTS.md`). Brief it on the 10 categories (bugs, a11y, API inconsistencies, type safety, Rules 1–7, test coverage, token discipline, SCSS, cross-package leakage, package/distribution); tell it to read `CLAUDE.md` + `AGENTS.md` first; note that `AppProvider` is provider infra (no `forwardRef`/`.module.scss`/manifest entry by design, like `I18nProvider`). Fix every Critical + Important; document any deliberate skip; re-run gates; re-review until `clean enough to stop`.
+
+  (The mockup review loop, Hard rule 7, does NOT apply — this branch changes no files under `packages/playground/src/pages/mockups/`. `App.tsx` is playground tooling, not a mockup.)
+
+- [ ] **Step 3: Finish the branch.** Use `superpowers:finishing-a-development-branch` → verify tests, push `feat/app-provider`, open a PR. PR summary: new `<AppProvider>` root provider (bundles LocaleProvider + I18nProvider + ToastViewport; `locale`/`intlLocale`/`translations`/`toast` props), AGENTS Setup update, playground dogfood. Wait for `Quality / check` before merging.
+
+---
+
+## Self-review (against the spec)
+
+**Spec coverage:**
+
+- `AppProvider` in `src/app/`, composition of LocaleProvider + I18nProvider + ToastViewport → Task 1 (Step 3). ✓
+- Props `locale` / `intlLocale?` (defaults to `locale`) / `translations?` (overrides) / `toast?` (`ToastViewportProps | false`) → Task 1 props + tests. ✓
+- Nesting order + ToastViewport inside providers + `toast !== false` guard → Task 1 Step 3. ✓
+- No forwardRef / no spread / full JSDoc / no i18n strings → Task 1 Step 3 (documented in component + plan conventions). ✓
+- Re-export from `src/index.ts` → Task 1 Step 5. ✓
+- Tests: renders children; useLocale intlLocale + fallback; useTranslation en/ru; deep-merge overrides; toast auto-mount; `toast={false}`; position forwarding → Task 1 Step 1. ✓
+- AGENTS "Setup" update → Task 1 Step 7. ✓
+- Dogfood playground root (removes standalone ToastViewport; adds LocaleProvider via intlLocale) → Task 2. ✓
+- Out-of-scope items (routing, stylesheet, theme provider, full-bundle replace, gallery page) → none implemented. ✓
+
+**Placeholder scan:** No TBD/"handle X"/"similar to". Concrete code in every step. Real message values verified (`alert.dismiss` = `Dismiss`/`Закрыть`; `toast.dismiss`/`toast.notifications` = `Dismiss`/`Notifications`). Real test-cleanup API verified (`store._reset` at store.ts:107, `_setViewportConfig` from Toast/api). Real `<ol data-position>` attribute verified in `ToastViewport.tsx`.
+
+**Type consistency:** `AppProviderProps` fields match the destructure in `AppProvider`, the test prop usage, and the AGENTS prose. `Locale` ('en'|'ru'), `DeepPartial<Messages>`, `ToastViewportProps` are the real exported types (from `../i18n` and `../components/Toast`). The `translations` → `I18nProvider overrides` mapping and `intlLocale ?? locale` → `LocaleProvider locale` mapping match the spec's architecture snippet.

--- a/docs/superpowers/specs/2026-06-01-app-provider-design.md
+++ b/docs/superpowers/specs/2026-06-01-app-provider-design.md
@@ -1,0 +1,205 @@
+# `<AppProvider>` — root provider that wires the design-system contexts
+
+## Goal
+
+A single root component a consuming app (the CRM) wraps around its tree to get all the design-system's
+**app-level contexts** in one place, parameterized by props — instead of hand-wiring `LocaleProvider` +
+`I18nProvider` + `ToastViewport` and risking forgetting one (the playground currently skips
+`LocaleProvider` entirely).
+
+```tsx
+import '@eocrm/design-system/styles/global.scss';
+import { AppProvider } from '@eocrm/design-system';
+
+<AppProvider locale="en" intlLocale="en-US" translations={brandOverrides}>
+  <YourRouter />
+</AppProvider>;
+```
+
+## Locked-in decisions (brainstorm)
+
+1. **Name:** `AppProvider`.
+2. **Translations = partial overrides (merge).** The `translations` prop is a `DeepPartial<Messages>`
+   deep-merged over the built-in en/ru bundle (exactly `I18nProvider`'s `overrides` model). The library
+   ships the defaults; the consumer supplies only the keys they rebrand/retext.
+3. **Two explicit locale props.** `locale: 'en' | 'ru'` selects the UI-string bundle; `intlLocale?:
+string` (BCP-47) drives Intl formatting. No magic `en→en-US` mapping.
+4. **`intlLocale` optional, defaults to `locale` verbatim.** Omitting it passes the language tag through
+   to `LocaleProvider` (`'en'`/`'ru'` are valid BCP-47 language tags); set it for a region (`'en-US'`).
+5. **Auto-mounts the toast viewport.** A `toast?: ToastViewportProps | false` prop: omitted ⇒ mount with
+   library defaults; object ⇒ forward as config; `false` ⇒ don't mount (consumer places it themselves).
+6. **Lives in `src/app/`, not `src/components/`.** It's provider infrastructure (like `src/i18n/`), so
+   it's exempt from the component-gallery rules — no `.module.scss`, no `structure.test` 4-file set, no
+   manifest cluster, no gallery demo card. Re-exported from `src/index.ts` and documented in AGENTS.md.
+7. **Out of scope:** routing (`react-router` is playground-only), the `global.scss` import (an
+   entry-point CSS side-effect a component can't do for the consumer), a theme/color-scheme provider
+   (theming is CSS-token based — no React context), and any new playground gallery page.
+
+## Architecture
+
+`AppProvider` is a pure composition of three existing exports — no DOM node of its own, no styles, no
+i18n strings.
+
+```tsx
+import { type ReactNode } from 'react';
+import { LocaleProvider } from '../i18n/LocaleProvider';
+import { I18nProvider } from '../i18n/I18nProvider';
+import { ToastViewport, type ToastViewportProps } from '../components/Toast';
+import type { DeepPartial, Locale, Messages } from '../i18n/messages';
+
+export interface AppProviderProps {
+  /**
+   * UI-string locale — selects the built-in message bundle. v1 ships `'en'` and `'ru'`.
+   */
+  locale: Locale;
+  /**
+   * BCP-47 locale for Intl-facing formatting (Calendar, number/date). Optional —
+   * defaults to `locale` verbatim (`'en'` / `'ru'` are valid language tags). Set it
+   * for a region, e.g. `'en-US'` / `'ru-RU'`.
+   */
+  intlLocale?: string;
+  /**
+   * Deep-partial overrides deep-merged over the built-in messages for `locale`.
+   * Memoize this object — a fresh literal each render rebuilds the merged messages.
+   */
+  translations?: DeepPartial<Messages>;
+  /**
+   * Toast viewport configuration, or `false` to NOT mount it (place `<ToastViewport>`
+   * yourself). Omitted ⇒ mounts with library defaults.
+   */
+  toast?: ToastViewportProps | false;
+  children: ReactNode;
+}
+
+export function AppProvider({
+  locale,
+  intlLocale,
+  translations,
+  toast,
+  children,
+}: AppProviderProps) {
+  return (
+    <LocaleProvider locale={intlLocale ?? locale}>
+      <I18nProvider locale={locale} overrides={translations}>
+        {children}
+        {toast !== false && <ToastViewport {...(toast ?? {})} />}
+      </I18nProvider>
+    </LocaleProvider>
+  );
+}
+```
+
+### Why this nesting
+
+- `LocaleProvider` is outermost (Intl locale is the broadest context). `I18nProvider` inside it.
+- `<ToastViewport>` renders **inside** `I18nProvider` (and `LocaleProvider`) so toast chrome (e.g. a
+  dismiss button's `aria-label`) resolves translated strings, and any locale-aware toast content
+  formats correctly. It's a sibling of `children`, after it, so toasts paint above app content.
+- `toast` accepted as `ToastViewportProps | false`: `false` short-circuits the mount; otherwise spread
+  `(toast ?? {})` so omitted ⇒ all `ToastViewport` defaults, object ⇒ the consumer's config.
+
+### Props notes
+
+- **No `forwardRef`.** `AppProvider` renders only providers — there is no single DOM node to forward a
+  ref to. (Rule 6's forwardRef requirement is about DOM components; a provider composition is exempt,
+  like `I18nProvider`/`LocaleProvider`, which also don't forward refs.)
+- **No `{...rest}` spread.** Its surface is exactly the five props above; it is not an HTML element.
+
+## Files
+
+| File                                                  | Change                                                                                                                                |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/design-system/src/app/AppProvider.tsx`      | NEW — component + props + JSDoc                                                                                                       |
+| `packages/design-system/src/app/index.ts`             | NEW — `export { AppProvider }; export type { AppProviderProps }`                                                                      |
+| `packages/design-system/src/app/AppProvider.test.tsx` | NEW — unit tests                                                                                                                      |
+| `packages/design-system/src/index.ts`                 | MODIFY — `export { AppProvider } from './app'; export type { AppProviderProps } from './app';`                                        |
+| `packages/design-system/AGENTS.md`                    | MODIFY — update the "Setup (once per consuming app)" section to recommend `<AppProvider>`                                             |
+| `packages/playground/src/App.tsx`                     | MODIFY (dogfood) — replace manual `<I18nProvider>` + standalone `<ToastViewport>` with `<AppProvider locale="en" intlLocale="en-US">` |
+
+`structure.test` only scans `src/components/`, so `src/app/` needs no `.module.scss`. The manifest only
+scans `src/components/`, so no cluster entry. No gallery demo page (consistent with the i18n providers).
+
+## Tests (`AppProvider.test.tsx`)
+
+Use small probe components that read the contexts and render their values.
+
+- **Renders children.**
+- **`useLocale()` returns `intlLocale` when provided** (e.g. `intlLocale="en-US"` → `"en-US"`).
+- **`useLocale()` falls back to `locale` when `intlLocale` omitted** (`locale="ru"` with no `intlLocale`
+  → `"ru"`).
+- **`useTranslation()` reflects `locale`** — a known built-in key differs between `locale="en"` and
+  `locale="ru"` (e.g. a shipped Alert/Toast dismiss label).
+- **`translations` overrides merge** — passing `translations={{ <section>: { <key>: 'X' } }}` makes that
+  key resolve to `'X'` while a sibling key keeps its built-in default (verifies deep-merge, not replace).
+- **Toast auto-mounts by default** — after `toast(...)` the toast text appears in the document.
+- **`toast={false}` mounts no viewport** — no toast region in the DOM; a `toast(...)` call renders
+  nothing.
+- **`toast={{ position }}` forwards config** — the rendered viewport reflects the passed prop (assert on
+  the position class / data attribute the viewport applies).
+
+(The exact built-in keys + the viewport's position class are read from `src/i18n/en.ts` / `ru.ts` and
+`ToastViewport.tsx` when writing the tests, not guessed.)
+
+## Dogfood — playground refactor
+
+`packages/playground/src/App.tsx` today:
+
+```tsx
+<I18nProvider locale="en">
+  <BrowserRouter basename={import.meta.env.BASE_URL}>
+    <AppShell>…</AppShell>
+  </BrowserRouter>
+  <ToastViewport position="bottom-right" />
+</I18nProvider>
+```
+
+becomes:
+
+```tsx
+<AppProvider locale="en" intlLocale="en-US" toast={{ position: 'bottom-right' }}>
+  <BrowserRouter basename={import.meta.env.BASE_URL}>
+    <AppShell>…</AppShell>
+  </BrowserRouter>
+</AppProvider>
+```
+
+Net effect: the standalone `<ToastViewport>` is gone (auto-mounted inside `AppProvider`), and the
+playground now mounts `LocaleProvider` for the first time (`intlLocale="en-US"`), so Calendar/date
+formatting gets a real locale. Routing (`BrowserRouter`) stays exactly where it is — inside the
+provider, owned by the app. Imports updated (`AppProvider` in, `I18nProvider`/`ToastViewport` out).
+
+## AGENTS.md — Setup section update
+
+Update the existing "Setup (once per consuming app)" section to lead with `<AppProvider>`:
+
+```tsx
+// 1. Import the stylesheet once at your entry point.
+import '@eocrm/design-system/styles/global.scss';
+
+// 2. Wrap your app in <AppProvider>.
+import { AppProvider } from '@eocrm/design-system';
+
+<AppProvider locale="en" intlLocale="en-US">
+  <App />
+</AppProvider>;
+```
+
+Document the props (`locale`, `intlLocale`, `translations`, `toast`), that it bundles
+`LocaleProvider` + `I18nProvider` + the toast viewport, and that routing + the stylesheet import remain
+the app's responsibility. Keep a short note that the individual providers are still exported for advanced
+nesting (per-subtree locale overrides).
+
+## When NOT to use (JSDoc `@remarks` + AGENTS.md)
+
+- **Per-subtree locale/i18n override** → nest `LocaleProvider` / `I18nProvider` directly. `AppProvider`
+  is the single app root; don't nest a second `AppProvider`.
+- **A non-app context (Storybook story, isolated test, an embedded widget)** that only needs strings →
+  use `I18nProvider` alone. `AppProvider` also mounts a toast viewport, which a tiny embed may not want
+  (pass `toast={false}`, or just use the lower-level providers).
+
+## Out of scope (v1)
+
+- Routing, the stylesheet import, a theme/color-scheme React provider.
+- A `direction`/RTL provider (no RTL support in the library yet).
+- Accepting a **full** replacement message bundle (overrides-merge only, per the brainstorm).
+- A playground gallery demo card (the root dogfood + AGENTS Setup are the documentation).

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -18,12 +18,28 @@ Read this first. The authoritative per-component contracts live in **JSDoc on ea
 
 ## Setup (once per consuming app)
 
-```ts
-// In your app root (e.g. main.tsx):
+Two steps at your app root:
+
+```tsx
+// 1. Import the stylesheet once (tokens, modern reset, base typography).
 import '@eocrm/design-system/styles/global.scss';
+
+// 2. Wrap your tree in <AppProvider>.
+import { AppProvider } from '@eocrm/design-system';
+
+<AppProvider locale="en" intlLocale="en-US">
+  <App />
+</AppProvider>;
 ```
 
-That import wires up tokens, the modern reset, and base typography. Everything else flows from it.
+`<AppProvider>` bundles the app-level contexts so you don't wire them by hand:
+
+- `locale` (`'en' | 'ru'`) — selects the built-in UI-string bundle.
+- `intlLocale?` (BCP-47, e.g. `'en-US'`) — locale for Intl formatting (Calendar, dates, numbers). Defaults to `locale`.
+- `translations?` — deep-partial overrides merged over the built-in strings (rebrand a few keys; memoize the object).
+- `toast?` — `<ToastViewport>` config, or `false` to mount it yourself. Omitted ⇒ mounted with defaults.
+
+It composes `LocaleProvider` + `I18nProvider` and mounts the toast viewport. **Routing is yours** (`<AppProvider>` ships no router), and the stylesheet import above is still required. The individual providers (`LocaleProvider`, `I18nProvider`, `ToastViewport`) remain exported for advanced cases like pinning a subtree to a different locale.
 
 ---
 

--- a/packages/design-system/src/app/AppProvider.test.tsx
+++ b/packages/design-system/src/app/AppProvider.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, act } from '@testing-library/react';
+import { AppProvider } from './AppProvider';
+import { useLocale } from '../i18n/useLocale';
+import { useTranslation } from '../i18n/useTranslation';
+import { toast, _setViewportConfig } from '../components/Toast/api';
+import { store } from '../components/Toast/store';
+
+function LocaleProbe() {
+  return <span data-testid="locale">{useLocale()}</span>;
+}
+function AlertDismiss() {
+  const t = useTranslation();
+  return <span data-testid="alert-dismiss">{t('alert.dismiss')}</span>;
+}
+function ToastDismiss() {
+  const t = useTranslation();
+  return <span data-testid="toast-dismiss">{t('toast.dismiss')}</span>;
+}
+function ToastNotifications() {
+  const t = useTranslation();
+  return <span data-testid="toast-notifications">{t('toast.notifications')}</span>;
+}
+
+describe('AppProvider', () => {
+  // Mirror Toast.test.tsx hygiene: clear the global toast store + reset the
+  // viewport config baseline, and use fake timers so the 4s auto-dismiss
+  // timer a toast schedules doesn't leak across tests.
+  beforeEach(() => {
+    store._reset();
+    _setViewportConfig({ position: 'bottom-right', duration: 4000 });
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    store._reset();
+  });
+
+  it('renders children', () => {
+    render(
+      <AppProvider locale="en">
+        <span data-testid="child">hi</span>
+      </AppProvider>,
+    );
+    expect(screen.getByTestId('child')).toHaveTextContent('hi');
+  });
+
+  it('useLocale() returns intlLocale when provided', () => {
+    render(
+      <AppProvider locale="en" intlLocale="en-US">
+        <LocaleProbe />
+      </AppProvider>,
+    );
+    expect(screen.getByTestId('locale')).toHaveTextContent('en-US');
+  });
+
+  it('useLocale() falls back to locale when intlLocale is omitted', () => {
+    render(
+      <AppProvider locale="ru">
+        <LocaleProbe />
+      </AppProvider>,
+    );
+    expect(screen.getByTestId('locale')).toHaveTextContent('ru');
+  });
+
+  it('useTranslation() reflects locale (en vs ru)', () => {
+    const { rerender } = render(
+      <AppProvider locale="en">
+        <AlertDismiss />
+      </AppProvider>,
+    );
+    expect(screen.getByTestId('alert-dismiss')).toHaveTextContent('Dismiss');
+    rerender(
+      <AppProvider locale="ru">
+        <AlertDismiss />
+      </AppProvider>,
+    );
+    expect(screen.getByTestId('alert-dismiss')).toHaveTextContent('Закрыть');
+  });
+
+  it('translations overrides deep-merge over built-in messages', () => {
+    render(
+      <AppProvider locale="en" translations={{ toast: { dismiss: 'Hide' } }}>
+        <ToastDismiss />
+        <ToastNotifications />
+      </AppProvider>,
+    );
+    // overridden key wins…
+    expect(screen.getByTestId('toast-dismiss')).toHaveTextContent('Hide');
+    // …and the sibling key in the SAME section keeps its built-in default
+    // (proves deep-merge, not whole-bundle replace).
+    expect(screen.getByTestId('toast-notifications')).toHaveTextContent('Notifications');
+  });
+
+  it('auto-mounts the toast viewport (toasts render)', () => {
+    render(
+      <AppProvider locale="en">
+        <span />
+      </AppProvider>,
+    );
+    act(() => {
+      toast('Saved successfully');
+    });
+    expect(screen.getByText('Saved successfully')).toBeInTheDocument();
+  });
+
+  it('toast={false} mounts no viewport', () => {
+    render(
+      <AppProvider locale="en" toast={false}>
+        <span />
+      </AppProvider>,
+    );
+    act(() => {
+      toast('Should not appear');
+    });
+    expect(screen.queryByText('Should not appear')).toBeNull();
+  });
+
+  it('toast config (position) is forwarded to the viewport', () => {
+    render(
+      <AppProvider locale="en" toast={{ position: 'top-right' }}>
+        <span />
+      </AppProvider>,
+    );
+    act(() => {
+      toast('Positioned toast');
+    });
+    const ol = screen.getByText('Positioned toast').closest('ol');
+    expect(ol).toHaveAttribute('data-position', 'top-right');
+  });
+});

--- a/packages/design-system/src/app/AppProvider.tsx
+++ b/packages/design-system/src/app/AppProvider.tsx
@@ -1,0 +1,92 @@
+import { type ReactNode } from 'react';
+import {
+  LocaleProvider,
+  I18nProvider,
+  type DeepPartial,
+  type Locale,
+  type Messages,
+} from '../i18n';
+import { ToastViewport, type ToastViewportProps } from '../components/Toast';
+
+export interface AppProviderProps {
+  /**
+   * UI-string locale — selects the built-in message bundle. v1 ships `'en'`
+   * and `'ru'`. Drives every design-system component's copy via `useTranslation`.
+   */
+  locale: Locale;
+  /**
+   * BCP-47 locale for Intl-facing formatting (Calendar, dates, numbers), read
+   * by components via `useLocale`. Optional — defaults to `locale` verbatim
+   * (`'en'` / `'ru'` are valid language tags). Set it for a region, e.g.
+   * `'en-US'` / `'ru-RU'` / `'en-GB'`.
+   */
+  intlLocale?: string;
+  /**
+   * Deep-partial overrides deep-merged over the built-in messages for `locale`.
+   * Supply only the keys you rebrand/retext; the rest fall back to the shipped
+   * defaults. Memoize this object — passing a fresh literal every render
+   * rebuilds the merged messages each time.
+   */
+  translations?: DeepPartial<Messages>;
+  /**
+   * Toast viewport configuration (`position`, `duration`, …), or `false` to
+   * NOT mount a viewport (place `<ToastViewport>` yourself). Omitted ⇒ a
+   * viewport is mounted with the library defaults.
+   */
+  toast?: ToastViewportProps | false;
+  children: ReactNode;
+}
+
+/**
+ * Root provider for a consuming app. Wrap your tree once to get the
+ * design-system's app-level contexts wired in one place — instead of nesting
+ * `LocaleProvider` + `I18nProvider` and remembering to mount `<ToastViewport>`.
+ *
+ * Composes (outermost → in): `LocaleProvider` (Intl locale = `intlLocale ?? locale`)
+ * → `I18nProvider` (`locale` + `translations` overrides) → `children`, plus a
+ * `<ToastViewport>` rendered inside the providers (so toast chrome is translated)
+ * unless `toast={false}`.
+ *
+ * Routing is the app's own concern (`AppProvider` ships no router), and the
+ * stylesheet import (`@eocrm/design-system/styles/global.scss`) is still
+ * required at your entry point.
+ *
+ * @example
+ * import '@eocrm/design-system/styles/global.scss';
+ * import { AppProvider } from '@eocrm/design-system';
+ *
+ * <AppProvider locale="en" intlLocale="en-US">
+ *   <YourRouter />
+ * </AppProvider>;
+ *
+ * @example
+ * // Russian UI + a couple of rebranded strings + top-right toasts:
+ * const translations = useMemo(() => ({ alert: { dismiss: 'Скрыть' } }), []);
+ * <AppProvider locale="ru" translations={translations} toast={{ position: 'top-right' }}>
+ *   <App />
+ * </AppProvider>;
+ *
+ * @remarks When NOT to use
+ * - **Per-subtree locale / i18n override** → nest `LocaleProvider` /
+ *   `I18nProvider` directly. `AppProvider` is the single app root; don't nest a
+ *   second `AppProvider`.
+ * - **A tiny embed / isolated test that only needs strings** → use
+ *   `I18nProvider` alone (or pass `toast={false}` here) so you don't get an
+ *   unwanted toast viewport.
+ */
+export function AppProvider({
+  locale,
+  intlLocale,
+  translations,
+  toast,
+  children,
+}: AppProviderProps) {
+  return (
+    <LocaleProvider locale={intlLocale ?? locale}>
+      <I18nProvider locale={locale} overrides={translations}>
+        {children}
+        {toast !== false && <ToastViewport {...(toast ?? {})} />}
+      </I18nProvider>
+    </LocaleProvider>
+  );
+}

--- a/packages/design-system/src/app/index.ts
+++ b/packages/design-system/src/app/index.ts
@@ -1,0 +1,2 @@
+export { AppProvider } from './AppProvider';
+export type { AppProviderProps } from './AppProvider';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -430,6 +430,10 @@ export type { LocaleProviderProps } from './i18n';
 export { I18nProvider, useTranslation, useTranslationArray, ruPlural } from './i18n';
 export type { I18nProviderProps, Locale, Messages, MessageKey, DeepPartial } from './i18n';
 
+// App root — bundles the locale + i18n + toast contexts for a consuming app.
+export { AppProvider } from './app';
+export type { AppProviderProps } from './app';
+
 // Calendar primitives (hooks + date math + Intl formatters + locale week info).
 // The Calendar UI components below and a future DatePicker compose against
 // these — use them directly when you need date math without the UI.

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -81,11 +81,11 @@ import { LinkDemo } from './pages/components/LinkDemo';
 import { RailDemo } from './pages/components/RailDemo';
 import { ToastDemo } from './pages/components/ToastDemo';
 import { TopBarDemo } from './pages/components/TopBarDemo';
-import { I18nProvider, ToastViewport } from '@eocrm/design-system';
+import { AppProvider } from '@eocrm/design-system';
 
 export default function App() {
   return (
-    <I18nProvider locale="en">
+    <AppProvider locale="en" intlLocale="en-US" toast={{ position: 'bottom-right' }}>
       <BrowserRouter basename={import.meta.env.BASE_URL}>
         <AppShell>
           <Routes>
@@ -178,8 +178,7 @@ export default function App() {
             <Route path="/components/toast" element={<ToastDemo />} />
           </Routes>
         </AppShell>
-        <ToastViewport position="bottom-right" />
       </BrowserRouter>
-    </I18nProvider>
+    </AppProvider>
   );
 }


### PR DESCRIPTION
## Summary

A single root provider that wires the design-system's app-level contexts, so a consuming app stops hand-wiring them (and stops forgetting `LocaleProvider`).

- **`<AppProvider>`** (new, `src/app/`) composes `LocaleProvider` (Intl locale = `intlLocale ?? locale`) → `I18nProvider` (`locale` + `translations` deep-merged as overrides) → `children`, and auto-mounts `<ToastViewport>` (inside the providers so toast chrome is translated; `toast={false}` opts out, `toast={{…}}` configures it).
- **Props:** `locale: 'en'|'ru'`, `intlLocale?` (BCP-47, defaults to `locale`), `translations?` (`DeepPartial<Messages>` overrides), `toast?` (`ToastViewportProps | false`), `children`.
- Provider infrastructure (like `src/i18n/`) — not a gallery component (no `.module.scss`/manifest/forwardRef, consistent with `I18nProvider`/`LocaleProvider`). Re-exported from `src/index.ts`.
- **AGENTS.md "Setup"** rewritten to recommend `<AppProvider>` (stylesheet import + wrapper); notes routing stays the app's own concern and the individual providers remain exported for advanced nesting.
- **Dogfood:** the playground root now uses `<AppProvider locale="en" intlLocale="en-US" toast={{ position: 'bottom-right' }}>`, replacing the manual `<I18nProvider>` + standalone `<ToastViewport>` — and mounts `LocaleProvider` for the first time, so Calendar/date formatting finally has a locale.

Spec: `docs/superpowers/specs/2026-06-01-app-provider-design.md` · Plan: `docs/superpowers/plans/2026-06-01-app-provider.md`.

## Test Plan

- [x] 2420/2420 unit tests pass (8 new AppProvider tests: locale fallback/override, en↔ru strings, deep-merge-not-replace, toast auto-mount/`false`/position)
- [x] typecheck, lint:css, `make build`, `make lint` green
- [x] `npm pack --dry-run` ships `src/app/AppProvider.tsx` + `index.ts`, no test files
- [x] Library review-fix loop (Hard rule 8): 0 Critical / 0 Important
- [ ] `Quality / check` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)