### PR TITLE
feat: <LinkCard> clickable full-surface Card

### DIFF
--- a/docs/superpowers/plans/2026-06-01-link-card.md
+++ b/docs/superpowers/plans/2026-06-01-link-card.md
@@ -1,0 +1,693 @@
+# `<LinkCard>` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `<LinkCard>` — a polymorphic, full-surface clickable Card (hover lift + focus ring) — wire it into the gallery, and refactor the `MockupsIndex` grid onto it (closing the `<NavCard>` TODO).
+
+**Architecture:** Mirrors `Link`'s polymorphic generic-`forwardRef` + cast pattern (default `<a>`, `as={X}`), styled with `Card`'s surface via the reused `--card-*` tokens + a `--link-card-elevation` var that `:hover` and the per-tone stripe compose over. Cluster Navigation; tier composition (imports `CardPadding`/`CardTone` types).
+
+**Tech Stack:** React 18 + TS, CSS Modules + SCSS (token-only), Vitest + RTL (globals; jsdom). Branch `feat/nav-card` (created off `main`; spec committed there).
+
+**Scope note (refinement from the spec):** only `MockupsIndex` (the Rule-6 `Card`+inline-style escape hatch) is refactored onto LinkCard. `ComponentsIndex`'s grid is **not** refactored — its `.card` is legit playground CSS with hover-driven child effects (the arrow slide) that LinkCard can't drive cross-module; it only gains the normal LinkCard gallery card.
+
+---
+
+## Conventions
+
+- **Library gates** (Task 1, from `packages/design-system/`): `npm test && npm run typecheck && npm run lint:css && npm run build`. TDD single-file: `npx vitest run src/components/LinkCard/LinkCard.test.tsx`.
+- **Playground gates** (Tasks 2–3, repo root): `make build && make lint`.
+- Full JSDoc (component + props + union types) per Rule 7.
+- Reference `src/components/Link/Link.tsx` + `Link.test.tsx` (polymorphic `as` + `StubRouterLink` test) and `src/components/Card/Card.module.scss` + `Card.tokens.scss` (surface tokens).
+- Commit trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## File structure
+
+- `src/components/LinkCard/LinkCard.tsx` / `.module.scss` / `.tokens.scss` / `.test.tsx` / `index.ts`.
+- Modified: `src/index.ts`, `_meta/manifest.ts`, `scripts/generate-manifest.mjs`, `components.manifest.json`, `AGENTS.md` (Task 1); playground demo + nav + ComponentsIndex card + registry union (Task 2); `MockupsIndex.tsx`, `TODO.md` (Task 3).
+
+---
+
+## Task 1: `<LinkCard>` component (+ manifest, AGENTS)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/LinkCard/LinkCard.tsx`, `LinkCard.module.scss`, `LinkCard.tokens.scss`, `LinkCard.test.tsx`, `index.ts`
+- Modify: `packages/design-system/src/index.ts` (after the Link export, line 374)
+- Modify: `packages/design-system/src/_meta/manifest.ts` + `scripts/generate-manifest.mjs` (CLUSTERS Navigation block) + regen `components.manifest.json`
+- Modify: `packages/design-system/AGENTS.md` (Navigation TL;DR)
+
+- [ ] **Step 1: Write the failing test** — `LinkCard.test.tsx`
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef, type AnchorHTMLAttributes, type ReactNode } from 'react';
+import { LinkCard } from './LinkCard';
+
+// A stand-in for a router's <Link> — verifies polymorphic `as` + prop passthrough.
+function StubRouterLink({
+  to,
+  children,
+  ...rest
+}: { to: string; children?: ReactNode } & AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return (
+    <a href={to} data-router="true" {...rest}>
+      {children}
+    </a>
+  );
+}
+
+describe('LinkCard', () => {
+  it('renders as <a> by default and passes href + children through', () => {
+    render(<LinkCard href="/x">Go</LinkCard>);
+    const el = screen.getByText('Go');
+    expect(el.tagName).toBe('A');
+    expect(el).toHaveAttribute('href', '/x');
+  });
+
+  it('as={RouterLink} renders the component and passes `to` through', () => {
+    render(
+      <LinkCard as={StubRouterLink} to="/contacts">
+        Contacts
+      </LinkCard>,
+    );
+    const el = screen.getByText('Contacts');
+    expect(el).toHaveAttribute('href', '/contacts');
+    expect(el).toHaveAttribute('data-router', 'true');
+  });
+
+  it('as="button" renders a <button> and fires onClick', async () => {
+    const onClick = vi.fn();
+    render(
+      <LinkCard as="button" onClick={onClick}>
+        Act
+      </LinkCard>,
+    );
+    const btn = screen.getByRole('button', { name: 'Act' });
+    expect(btn.tagName).toBe('BUTTON');
+    await userEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults padding to md; padding prop swaps the class', () => {
+    const { container, rerender } = render(<LinkCard href="/x">x</LinkCard>);
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingMd/);
+    rerender(
+      <LinkCard href="/x" padding="lg">
+        x
+      </LinkCard>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingLg/);
+    rerender(
+      <LinkCard href="/x" padding="none">
+        x
+      </LinkCard>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingNone/);
+  });
+
+  it('tone sets data-tone; omitted → no data-tone', () => {
+    const { container, rerender } = render(
+      <LinkCard href="/x" tone="accent">
+        x
+      </LinkCard>,
+    );
+    expect(container.firstChild).toHaveAttribute('data-tone', 'accent');
+    rerender(<LinkCard href="/x">x</LinkCard>);
+    expect(container.firstChild).not.toHaveAttribute('data-tone');
+  });
+
+  it('forwards ref to the rendered element', () => {
+    const ref = createRef<HTMLAnchorElement>();
+    render(
+      <LinkCard ref={ref} href="/x">
+        x
+      </LinkCard>,
+    );
+    expect(ref.current?.tagName).toBe('A');
+  });
+
+  it('merges className (with the base linkCard class) and spreads other attrs', () => {
+    const { container } = render(
+      <LinkCard href="/x" className="my-cls" data-foo="bar">
+        x
+      </LinkCard>,
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toMatch(/linkCard/);
+    expect(el.className).toMatch(/my-cls/);
+    expect(el).toHaveAttribute('data-foo', 'bar');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/design-system && npx vitest run src/components/LinkCard/LinkCard.test.tsx`
+Expected: FAIL — `Failed to resolve import './LinkCard'`.
+
+- [ ] **Step 3: Create the tokens** — `LinkCard.tokens.scss`
+
+```scss
+// LinkCard.tokens.scss — interactive-state tokens over Card's reused surface tokens.
+:root {
+  --link-card-shadow: var(--card-shadow); // rest = Card's shadow (--shadow-sm)
+  --link-card-hover-shadow: var(--shadow-md);
+  --link-card-hover-border-color: var(--color-border-strong);
+  --link-card-transition: border-color 120ms ease, box-shadow 120ms ease;
+  --link-card-focus-offset: 2px;
+}
+```
+
+- [ ] **Step 4: Create the styles** — `LinkCard.module.scss`
+
+```scss
+@use './LinkCard.tokens';
+
+.linkCard {
+  --link-card-elevation: var(--link-card-shadow);
+
+  display: block;
+  background: var(--card-bg);
+  border: var(--border-width) solid var(--card-border-color);
+  border-radius: var(--card-radius);
+  box-shadow: var(--link-card-elevation);
+  overflow: hidden;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition: var(--link-card-transition);
+}
+
+.linkCard:hover {
+  --link-card-elevation: var(--link-card-hover-shadow);
+
+  border-color: var(--link-card-hover-border-color);
+}
+
+.linkCard:focus-visible {
+  outline: var(--ring-width) solid var(--ring-accent);
+  outline-offset: var(--link-card-focus-offset);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .linkCard {
+    transition: none;
+  }
+}
+
+.linkCard[data-tone='accent'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-accent),
+    var(--link-card-elevation);
+}
+
+.linkCard[data-tone='info'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-info),
+    var(--link-card-elevation);
+}
+
+.linkCard[data-tone='success'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-success),
+    var(--link-card-elevation);
+}
+
+.linkCard[data-tone='warning'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-warning),
+    var(--link-card-elevation);
+}
+
+.linkCard[data-tone='danger'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-danger),
+    var(--link-card-elevation);
+}
+
+.paddingNone {
+  padding: 0;
+}
+
+.paddingSm {
+  padding: var(--card-padding-sm);
+}
+
+.paddingMd {
+  padding: var(--card-padding-md);
+}
+
+.paddingLg {
+  padding: var(--card-padding-lg);
+}
+```
+
+- [ ] **Step 5: Create the component** — `LinkCard.tsx`
+
+```tsx
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ComponentPropsWithRef,
+  type ElementType,
+  type ForwardedRef,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import { type CardPadding, type CardTone } from '../Card';
+import styles from './LinkCard.module.scss';
+
+interface LinkCardOwnProps {
+  /** Inner padding — same scale as `Card`. Defaults to `'md'`. */
+  padding?: CardPadding;
+  /** Optional left-edge tone stripe — same vocabulary as `Card`. */
+  tone?: CardTone;
+  children?: ReactNode;
+}
+
+/** Polymorphic props helper (identical to Link's). */
+type PolymorphicProps<C extends ElementType, P> = P & { as?: C } & Omit<
+    ComponentPropsWithoutRef<C>,
+    keyof P | 'as'
+  >;
+
+/**
+ * Public LinkCard prop type. Generic `C` defaults to `'a'`. Passing
+ * `as={SomeComponent}` makes all of its props available with full inference
+ * (including `to` / `replace` for `react-router-dom`'s `<Link>`).
+ */
+export type LinkCardProps<C extends ElementType = 'a'> = PolymorphicProps<C, LinkCardOwnProps>;
+
+type LinkCardComponent = <C extends ElementType = 'a'>(
+  props: LinkCardProps<C> & { ref?: ComponentPropsWithRef<C>['ref'] },
+) => ReactElement | null;
+
+const paddingClass: Record<CardPadding, string> = {
+  none: styles.paddingNone,
+  sm: styles.paddingSm,
+  md: styles.paddingMd,
+  lg: styles.paddingLg,
+};
+
+/**
+ * A clickable Card whose entire surface is one navigation/action target.
+ * Polymorphic like `<Link>`: renders an `<a>` by default; pass `as={RouterLink}`
+ * for SPA routes or `as="button"` for an action. Carries `Card`'s surface
+ * (`padding`, `tone`) plus a hover lift and a `:focus-visible` ring.
+ *
+ * Use when the WHOLE card is clickable. For non-interactive grouping use
+ * `<Card>`; for inline text navigation use `<Link>`; for a form action use
+ * `<Button>`.
+ *
+ * @example
+ * // SPA route — pass your router's Link as `as`.
+ * import { Link as RouterLink } from 'react-router-dom';
+ * <LinkCard as={RouterLink} to="/contacts/42" padding="md">
+ *   <Stack gap="xs">
+ *     <Text weight="semibold">Acme Corp</Text>
+ *     <Text size="sm" tone="muted">12 open deals</Text>
+ *   </Stack>
+ * </LinkCard>
+ *
+ * @example
+ * // External link (native <a>) + a tone stripe.
+ * <LinkCard href="https://status.example.com" tone="success">
+ *   <Text weight="semibold">All systems operational</Text>
+ * </LinkCard>
+ *
+ * @example
+ * // Card-shaped action button.
+ * <LinkCard as="button" type="button" onClick={openImporter}>
+ *   <Text weight="semibold">Import contacts</Text>
+ * </LinkCard>
+ *
+ * @remarks When NOT to use
+ * - Non-interactive grouped content → `<Card>`.
+ * - Inline text navigation ("View all →") → `<Link>`.
+ * - A form action / trigger that isn't card-shaped → `<Button>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Nesting interactive controls (`<Button>` / `<Link>`) inside a LinkCard —
+ *   nested interactives are invalid + confusing. Keep the card content
+ *   non-interactive, or use a plain `<Card>` with explicit controls.
+ * - ❌ `<LinkCard href="#" onClick={…}>` — a fake href breaks "open in new tab".
+ *   Use `as="button"` for an action.
+ *
+ * @remarks A11y
+ * - Renders a real `<a>` / `<button>` / router link, so it has native
+ *   semantics; the children supply the accessible name — keep the primary
+ *   label first. `:focus-visible` provides the keyboard ring.
+ */
+export const LinkCard = forwardRef(function LinkCard<C extends ElementType = 'a'>(
+  { as, padding = 'md', tone, className, children, ...props }: LinkCardProps<C>,
+  ref: ForwardedRef<Element>,
+) {
+  const Component = (as || 'a') as ElementType;
+  // {...props} first, then component-owned className (merged via clsx) +
+  // data-tone — same spread order as Link, so consumer className composes.
+  return (
+    <Component
+      ref={ref}
+      {...props}
+      className={clsx(styles.linkCard, paddingClass[padding], className)}
+      data-tone={tone}
+    >
+      {children}
+    </Component>
+  );
+}) as LinkCardComponent;
+```
+
+- [ ] **Step 6: Create the barrel** — `index.ts`
+
+```ts
+export { LinkCard } from './LinkCard';
+export type { LinkCardProps } from './LinkCard';
+```
+
+- [ ] **Step 7: Re-export from `src/index.ts`** — after the Link export block (after line 374, `export type { LinkProps, LinkVariant } from './components/Link';`):
+
+```ts
+export { LinkCard } from './components/LinkCard';
+export type { LinkCardProps } from './components/LinkCard';
+```
+
+- [ ] **Step 8: Classify in BOTH manifest sources.** In `src/_meta/manifest.ts`, add to the Navigation block of `CLUSTERS` (e.g. after `Link: 'Navigation',`):
+
+```ts
+  LinkCard: 'Navigation',
+```
+
+In `scripts/generate-manifest.mjs`, add the identical line to its Navigation block.
+
+- [ ] **Step 9: Regenerate the manifest**
+
+Run: `cd packages/design-system && npm run build:manifest`
+Expected: `src/components.manifest.json` gains a `"LinkCard"` entry — `"cluster": "Navigation"`, `"tier": "composition"`, `"composes": ["Card"]`.
+
+- [ ] **Step 10: Run the test to verify it passes**
+
+Run: `cd packages/design-system && npx vitest run src/components/LinkCard/LinkCard.test.tsx`
+Expected: PASS (7 cases).
+
+- [ ] **Step 11: Add the AGENTS.md Navigation TL;DR.** Insert after the `<Link>` section:
+
+````markdown
+### `<LinkCard>` — clickable, full-surface Card
+
+```tsx
+// SPA route — pass your router's Link as `as`
+<LinkCard as={RouterLink} to="/contacts/42" padding="md">
+  <Stack gap="xs">
+    <Text weight="semibold">Acme Corp</Text>
+    <Text size="sm" tone="muted">12 open deals</Text>
+  </Stack>
+</LinkCard>
+
+<LinkCard href="https://status.example.com" tone="success">All systems operational</LinkCard>
+<LinkCard as="button" type="button" onClick={openImporter}>Import contacts</LinkCard>
+```
+
+- A Card whose **whole surface** navigates/acts. Polymorphic like `<Link>` — `as` defaults to `<a>`; pass `as={RouterLink} to=…` for routes or `as="button"` for actions (the library has no router dep).
+- Carries `Card`'s `padding` (default `md`) + `tone` stripe (reuses `--card-*` tokens), plus a hover lift (border + shadow) and a `:focus-visible` ring.
+- Use `<Card>` for non-interactive grouping, `<Link>` for inline text, `<Button>` for form actions. **Don't nest** interactive controls inside it (invalid nested interactives).
+````
+
+- [ ] **Step 12: Run the full library gates**
+
+Run: `cd packages/design-system && npm test && npm run typecheck && npm run lint:css && npm run build`
+Expected: all green (structure.test sees the 4 required files; manifest drift test passes after regen; the `composes: ["Card"]` edge is computed from the `../Card` type import).
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add packages/design-system/src/components/LinkCard packages/design-system/src/index.ts \
+  packages/design-system/src/_meta/manifest.ts packages/design-system/scripts/generate-manifest.mjs \
+  packages/design-system/src/components.manifest.json packages/design-system/AGENTS.md
+git commit -m "feat: add <LinkCard> clickable full-surface Card
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Demo page + component nav wiring
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/LinkCardDemo.tsx`
+- Modify: `packages/playground/src/App.tsx` (import + route)
+- Modify: `packages/playground/src/layout/AppShell/AppShell.tsx` (Navigation nav item + `SquareMousePointer` lucide import)
+- Modify: `packages/playground/src/pages/components/ComponentsIndex.tsx` (import + gallery card — NOT a grid refactor)
+- Modify: `packages/playground/src/pages/mockups/registry.ts` (`ComponentName` union gains `'LinkCard'`)
+
+- [ ] **Step 1: Add `'LinkCard'` to the `ComponentName` union** in `registry.ts` (e.g. after `| 'Link'`):
+
+```ts
+  | 'LinkCard'
+```
+
+- [ ] **Step 2: Create `LinkCardDemo.tsx`**
+
+```tsx
+import { Grid, LinkCard, Stack, Text } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import { getComponentFiles } from '../../lib/componentFiles';
+
+export function LinkCardDemo() {
+  return (
+    <DemoLayout
+      name="LinkCard"
+      componentName="LinkCard"
+      description="A clickable Card whose whole surface navigates or acts. Polymorphic like Link (as defaults to <a>; pass as={RouterLink} or as=\"button\"). Hover lift + focus ring."
+      files={getComponentFiles('LinkCard')}
+    >
+      <Example
+        title="As a link (default <a>)"
+        description="The whole card is one anchor. Hover for the lift; tab to it for the focus ring."
+        code={`<LinkCard href="https://status.example.com">
+  <Stack gap="xs">
+    <Text weight="semibold">Status page</Text>
+    <Text size="sm" tone="muted">All systems operational.</Text>
+  </Stack>
+</LinkCard>`}
+      >
+        <LinkCard href="https://status.example.com">
+          <Stack gap="xs">
+            <Text weight="semibold">Status page</Text>
+            <Text size="sm" tone="muted">
+              All systems operational.
+            </Text>
+          </Stack>
+        </LinkCard>
+      </Example>
+
+      <Example
+        title="As a button (action)"
+        description={`Pass as="button" for an action instead of navigation.`}
+        code={`<LinkCard as="button" type="button" onClick={openImporter}>
+  <Text weight="semibold">Import contacts</Text>
+</LinkCard>`}
+      >
+        <LinkCard as="button" type="button" onClick={() => undefined}>
+          <Text weight="semibold">Import contacts</Text>
+        </LinkCard>
+      </Example>
+
+      <Example
+        title="Index grid"
+        description="The canonical use — a grid of cards each linking somewhere. padding + tone match Card."
+        code={`<Grid minColumnWidth="220px" gap="md">
+  <LinkCard href="#" tone="accent"><Text weight="semibold">Dashboard</Text></LinkCard>
+  <LinkCard href="#" tone="success"><Text weight="semibold">Deals</Text></LinkCard>
+  <LinkCard href="#"><Text weight="semibold">Contacts</Text></LinkCard>
+</Grid>`}
+      >
+        <Grid minColumnWidth="220px" gap="md">
+          <LinkCard href="https://example.com/dashboard" tone="accent">
+            <Stack gap="xs">
+              <Text weight="semibold">Dashboard</Text>
+              <Text size="sm" tone="muted">
+                KPIs & pipeline.
+              </Text>
+            </Stack>
+          </LinkCard>
+          <LinkCard href="https://example.com/deals" tone="success">
+            <Stack gap="xs">
+              <Text weight="semibold">Deals</Text>
+              <Text size="sm" tone="muted">
+                Kanban board.
+              </Text>
+            </Stack>
+          </LinkCard>
+          <LinkCard href="https://example.com/contacts">
+            <Stack gap="xs">
+              <Text weight="semibold">Contacts</Text>
+              <Text size="sm" tone="muted">
+                Directory.
+              </Text>
+            </Stack>
+          </LinkCard>
+        </Grid>
+      </Example>
+    </DemoLayout>
+  );
+}
+```
+
+- [ ] **Step 3: Wire the route in `App.tsx`.** Add the import near the other component-demo imports:
+
+```tsx
+import { LinkCardDemo } from './pages/components/LinkCardDemo';
+```
+
+Add the route among the `/components/*` routes:
+
+```tsx
+<Route path="/components/link-card" element={<LinkCardDemo />} />
+```
+
+- [ ] **Step 4: Wire the nav in `AppShell.tsx`.** Add `SquareMousePointer` to the `lucide-react` import block. In `componentGroups`, find the **Navigation** group (`heading: 'Navigation'` — items include Accordion / Breadcrumb / Link / Rail / Tabs / TopBar) and add, after the `Link` entry:
+
+```tsx
+      { to: '/components/link-card', label: 'LinkCard', icon: SquareMousePointer, end: false },
+```
+
+- [ ] **Step 5: Add the overview card in `ComponentsIndex.tsx`.** Add the import near the others:
+
+```tsx
+import { LinkCard } from '@eocrm/design-system';
+```
+
+Add an entry to the `items` array. The preview uses `as="div"` so it's a non-interactive surface (the grid item is already wrapped in a router `<Link>` — a real `<a>`/`<button>` here would nest interactives):
+
+```tsx
+  {
+    to: '/components/link-card',
+    name: 'LinkCard',
+    description: 'A clickable Card — the whole surface navigates or acts.',
+    preview: (
+      <div style={{ width: '100%', maxWidth: '220px' }}>
+        <LinkCard as="div" padding="sm">
+          <Text size="sm" weight="semibold">
+            Dashboard
+          </Text>
+        </LinkCard>
+      </div>
+    ),
+  },
+```
+
+(`Text` is already imported in `ComponentsIndex.tsx`.)
+
+- [ ] **Step 6: Run the playground gates**
+
+Run: `make build && make lint`
+Expected: green. (Optional visual check: `/components/link-card`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/playground/src/pages/components/LinkCardDemo.tsx packages/playground/src/App.tsx \
+  packages/playground/src/layout/AppShell/AppShell.tsx \
+  packages/playground/src/pages/components/ComponentsIndex.tsx \
+  packages/playground/src/pages/mockups/registry.ts
+git commit -m "feat(playground): LinkCard demo page + nav wiring
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Refactor `MockupsIndex` onto `<LinkCard>` (close the `<NavCard>` TODO)
+
+**Files:**
+
+- Modify: `packages/playground/src/pages/mockups/MockupsIndex.tsx`
+- Modify: `packages/design-system/src/components/TODO.md` (tick `<NavCard>`)
+
+- [ ] **Step 1: Refactor the grid.** Rewrite `MockupsIndex.tsx`. Change the imports — `Link as RouterLink` from react-router, drop `Card`, add `LinkCard`:
+
+```tsx
+import { Link as RouterLink } from 'react-router-dom';
+import { Badge, Cluster, Code, Grid, LinkCard, Stack, Text, Title } from '@eocrm/design-system';
+import { MOCKUPS } from './registry';
+```
+
+Replace the grid item — the `{/* TODO: replace when <NavCard> ships … */}` comment + `<Link to={m.path} style={{…}}><Card padding="md"><Stack gap="sm">…</Stack></Card></Link>` — with:
+
+```tsx
+<LinkCard as={RouterLink} key={m.slug} to={m.path} padding="md">
+  <Stack gap="sm">
+    <Text size="lg" weight="semibold">
+      {m.title}
+    </Text>
+    <Text size="sm" tone="muted">
+      {m.blurb}
+    </Text>
+    <Cluster gap="xs">
+      {m.usesComponents.map((name) => (
+        <Badge key={name} tone="info">
+          {name}
+        </Badge>
+      ))}
+    </Cluster>
+  </Stack>
+</LinkCard>
+```
+
+(Everything else in the file — the heading Stack, the `<Grid minColumnWidth="280px" gap="md">` wrapper, the `indexMockups` filter — stays. `Card` is no longer imported; the inline `style` and TODO comment are gone.)
+
+- [ ] **Step 2: Tick the `<NavCard>` TODO.** In `packages/design-system/src/components/TODO.md`, change the `<NavCard>` heading from `### [ ]` to `### [x]`, and add a shipped note after `**Filed:**` (keep the historical body):
+
+```markdown
+**Shipped:** 2026-06-01 — shipped as `<LinkCard>` (`packages/design-system/src/components/LinkCard/`), the name `Card`'s JSDoc already referenced. Polymorphic `as` (default `<a>`, `as={RouterLink}` / `as="button"`), reuses Card's `--card-*` surface + `padding`/`tone`, adds a hover lift + `:focus-visible` ring. The MockupsIndex grid was refactored onto it (dropping the router-Link-wrapping-Card + inline-style escape hatch). ComponentsIndex keeps its own `.card` style (legit playground CSS with hover-driven child effects, not an escape hatch).
+```
+
+- [ ] **Step 3: Run the playground gates**
+
+Run (repo root): `make build && make lint`
+Expected: green. No remaining `TODO: replace when <NavCard>` comment; no inline `style` / nested `<Card>` in `MockupsIndex`; no unused `Card` import.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/playground/src/pages/mockups/MockupsIndex.tsx packages/design-system/src/components/TODO.md
+git commit -m "refactor(playground): MockupsIndex grid onto <LinkCard>; close NavCard TODO
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Final gates + review-fix loops + finish
+
+- [ ] **Step 1: Repo-wide gates.** From repo root:
+
+```bash
+make test && make build && make lint
+( cd packages/design-system && npm run typecheck && npm run lint:css && npm pack --dry-run -w @eocrm/design-system )
+```
+
+Expected: green; `npm pack` ships `src/components/LinkCard/*.tsx`/`*.scss`/`index.ts`, NOT `LinkCard.test.tsx`.
+
+- [ ] **Step 2: Library review-fix loop (Hard rule 8).** Fresh `general-purpose` reviewer scoped to `packages/design-system/` (the LinkCard dir, `src/index.ts`, manifest, AGENTS.md). Brief on the 10 categories; read CLAUDE.md + AGENTS.md first; note LinkCard mirrors `Link`'s polymorphic pattern + reuses `Card`'s tokens/types (composition tier), is a Navigation-cluster interactive primitive, and uses `box-shadow`/`outline` (not in strict-value/property-disallowed lists). Fix every Critical + Important; re-run gates; re-review to `clean enough to stop`.
+
+- [ ] **Step 3: Mockup review-fix loop (Hard rule 7).** Fresh `general-purpose` reviewer scoped to the changed mockup (`MockupsIndex.tsx`). Brief on the 10 mockup categories (esp. Rule 6 — the `Card`+inline-style escape hatch is gone, no new escape hatch, no stale `<NavCard>` TODO comment; the grid still renders + links correctly; a11y of the card-links). Fix Critical + Important; re-run `make build && make lint && make test`; re-review to `clean enough to stop`.
+
+- [ ] **Step 4: Finish.** Use `superpowers:finishing-a-development-branch` → push `feat/nav-card`, open a PR (summary: new `<LinkCard>`, demo + nav, MockupsIndex refactor closing the `<NavCard>` TODO — the last open component TODO). Wait for `Quality / check`.
+
+---
+
+## Self-review (against the spec)
+
+**Spec coverage:** Component (polymorphic `as` mirroring Link, `padding`/`tone` from Card, hover/focus, `--link-card-elevation` tone×hover compose) → Task 1 Steps 3–5. Re-export + manifest×2 (composition/Navigation) + regen → Steps 7–9. AGENTS → Step 11. Demo + nav + ComponentName union → Task 2. MockupsIndex refactor + TODO tick → Task 3. Review loops + finish → Task 4. ✓
+
+**Deviation from spec (documented):** the spec said refactor _both_ index grids; the plan refactors **MockupsIndex only**. Rationale: `ComponentsIndex`'s grid is not the same `Card`+inline-style escape hatch — it's a self-contained `.card` CSS class with hover-driven child effects (the arrow) that LinkCard can't drive cross-module; force-fitting would lose those. ComponentsIndex still gets the normal LinkCard gallery card (Task 2 Step 5). The `<NavCard>` TODO names only MockupsIndex as the mock site, so the TODO is fully closed. (Flagged to the user at handoff.)
+
+**Placeholder scan:** No TBD/"handle X". Concrete code throughout. Verified: `Link`'s polymorphic `forwardRef`+cast pattern + `StubRouterLink` test idiom; `Card` barrel re-exports `CardPadding`/`CardTone`; `--card-*` / `--color-border-strong` / `--ring-*` / `--shadow-md` / `--border-width-strong` tokens exist; `src/index.ts` Link anchor (line 374); `MockupsIndex` exact current code; `ComponentsIndex` render uses a `.card`-classed router Link (not a Card+inline-style). `SquareMousePointer` lucide exists + not yet imported in AppShell.
+
+**Type consistency:** `LinkCardProps<C>` generic + `LinkCardComponent` cast mirror Link's exactly. `paddingClass` keys (`none`/`sm`/`md`/`lg`) match the SCSS `.paddingNone/Sm/Md/Lg` and the `CardPadding` union. `data-tone` values match `CardTone` + the SCSS `[data-tone='…']` selectors. Registry `ComponentName` gains `'LinkCard'` (Task 2) before the demo's `componentName="LinkCard"`.

--- a/docs/superpowers/specs/2026-06-01-link-card-design.md
+++ b/docs/superpowers/specs/2026-06-01-link-card-design.md
@@ -1,0 +1,285 @@
+# `<LinkCard>` — clickable, full-surface Card
+
+## Goal
+
+A Card-surfaced container whose entire area is a single click target (router link / href / button), with
+a hover lift and a keyboard focus ring. Closes the last `<NavCard>` `TODO.md` gap — the index grids that
+currently fake it with a router `<Link>` wrapping a `<Card>` + inline style (and no hover). Named
+`LinkCard` to match the name `Card`'s own JSDoc already promises ("that's a different component,
+`LinkCard`, not yet shipped").
+
+```tsx
+<LinkCard as={RouterLink} to="/mockups/dashboard" padding="md">
+  <Stack gap="xs">
+    <Text weight="semibold">Dashboard</Text>
+    <Text size="sm" tone="muted">
+      KPI cards, pipeline summary, recent activity.
+    </Text>
+  </Stack>
+</LinkCard>
+```
+
+## Locked-in decisions (brainstorm)
+
+1. **Name:** `LinkCard` (matches Card's existing JSDoc reference — no Card change needed).
+2. **Polymorphic, mirroring `<Link>`.** Generic `as` (default `<a>`), full prop inference for the
+   consumer's router Link. `as` subsumes href (`<a>`) / router (`as={RouterLink} to=…`) / button
+   (`as="button" onClick=…`). The library keeps no router dependency (Rule 5).
+3. **Card-surface parity:** `padding?: CardPadding` (default `'md'`) + `tone?: CardTone` — the _same_
+   types/vocabulary as `Card` (imported, single source of truth), reusing `--card-*` tokens so it stays
+   pixel-aligned with `Card`.
+4. **Subtle hover:** border-color → `--color-border-strong`, shadow `--shadow-sm` → `--shadow-md` (no
+   transform); `:focus-visible` → `--ring-accent` / `--ring-width` ring; `transition` on border/shadow,
+   disabled under `prefers-reduced-motion`.
+5. **Single interactive element** (not a Card wrapped in an anchor) — CSS-modules can't drive a child
+   Card's hashed classes on `:hover`, so `LinkCard` IS the card-shaped link.
+6. **Cluster:** Navigation (interactive nav element, sibling to `Link`). **Tier:** composition (imports
+   Card's `CardPadding`/`CardTone` types — a real dependency on Card's contract).
+7. **Refactor both index grids:** `MockupsIndex` (the TODO's mock site) **and** `ComponentsIndex` (same
+   hack, dogfood). Ticks the `<NavCard>` TODO (shipped as `<LinkCard>`).
+
+## Architecture
+
+Mirrors `Link`'s polymorphic generic-`forwardRef` + cast pattern exactly.
+
+```tsx
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ComponentPropsWithRef,
+  type ElementType,
+  type ForwardedRef,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import { type CardPadding, type CardTone } from '../Card';
+import styles from './LinkCard.module.scss';
+
+interface LinkCardOwnProps {
+  /** Inner padding — same scale as Card. Defaults to `'md'`. */
+  padding?: CardPadding;
+  /** Optional left-edge tone stripe — same vocabulary as Card. */
+  tone?: CardTone;
+  children?: ReactNode;
+}
+
+/** Polymorphic props helper (identical to Link's). */
+type PolymorphicProps<C extends ElementType, P> = P & { as?: C } & Omit<
+    ComponentPropsWithoutRef<C>,
+    keyof P | 'as'
+  >;
+
+/** Public prop type. Generic `C` defaults to `'a'`; `as={X}` brings X's props (incl. `to`). */
+export type LinkCardProps<C extends ElementType = 'a'> = PolymorphicProps<C, LinkCardOwnProps>;
+
+type LinkCardComponent = <C extends ElementType = 'a'>(
+  props: LinkCardProps<C> & { ref?: ComponentPropsWithRef<C>['ref'] },
+) => ReactElement | null;
+
+const paddingClass: Record<CardPadding, string> = {
+  none: styles.paddingNone,
+  sm: styles.paddingSm,
+  md: styles.paddingMd,
+  lg: styles.paddingLg,
+};
+
+export const LinkCard = forwardRef(function LinkCard<C extends ElementType = 'a'>(
+  { as, padding = 'md', tone, className, children, ...props }: LinkCardProps<C>,
+  ref: ForwardedRef<Element>,
+) {
+  const Component = (as || 'a') as ElementType;
+  // {...props} first, then our className (merged via clsx) + data-tone — same
+  // order as Link, so the consumer's className merges and the surface classes
+  // are component-owned.
+  return (
+    <Component
+      ref={ref}
+      {...props}
+      className={clsx(styles.linkCard, paddingClass[padding], className)}
+      data-tone={tone}
+    >
+      {children}
+    </Component>
+  );
+}) as LinkCardComponent;
+```
+
+`import { type CardPadding, type CardTone } from '../Card'` is a real `../Card` import (the `Card` barrel
+re-exports both types — verified), so the manifest classifies `LinkCard` as **composition**
+(`composes: ['Card']`) — accurate: it's built on Card's padding/tone contract.
+
+### A11y
+
+It renders a real `<a>` (or the consumer's router Link / `<button>`), so it carries native link/button
+semantics — the children supply the accessible name (the card title text). `:focus-visible` gives the
+keyboard ring. No extra ARIA. (A whole-card link is a standard, accessible pattern; keep the primary
+label as the first text so the link's name is meaningful.)
+
+## SCSS (`LinkCard.module.scss` + `LinkCard.tokens.scss`)
+
+Reuses Card's surface tokens; an internal `--link-card-elevation` custom property holds the current
+shadow so `:hover` and the per-tone stripe compose cleanly (one elevation var, flipped on hover):
+
+```scss
+@use './LinkCard.tokens';
+
+.linkCard {
+  --link-card-elevation: var(--link-card-shadow);
+
+  display: block;
+  background: var(--card-bg);
+  border: var(--border-width) solid var(--card-border-color);
+  border-radius: var(--card-radius);
+  box-shadow: var(--link-card-elevation);
+  overflow: hidden;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition: var(--link-card-transition);
+}
+
+.linkCard:hover {
+  --link-card-elevation: var(--link-card-hover-shadow);
+  border-color: var(--link-card-hover-border-color);
+}
+
+.linkCard:focus-visible {
+  outline: var(--ring-width) solid var(--ring-accent);
+  outline-offset: var(--link-card-focus-offset);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .linkCard {
+    transition: none;
+  }
+}
+
+// Tone stripe (reuses Card's stripe tokens) layered over the live elevation var,
+// so a toned card still gets the hover elevation automatically.
+.linkCard[data-tone='accent'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-accent),
+    var(--link-card-elevation);
+}
+.linkCard[data-tone='info'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-info),
+    var(--link-card-elevation);
+}
+.linkCard[data-tone='success'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-success),
+    var(--link-card-elevation);
+}
+.linkCard[data-tone='warning'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-warning),
+    var(--link-card-elevation);
+}
+.linkCard[data-tone='danger'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-danger),
+    var(--link-card-elevation);
+}
+
+.paddingNone {
+  padding: 0;
+}
+.paddingSm {
+  padding: var(--card-padding-sm);
+}
+.paddingMd {
+  padding: var(--card-padding-md);
+}
+.paddingLg {
+  padding: var(--card-padding-lg);
+}
+```
+
+```scss
+// LinkCard.tokens.scss — interactive-state tokens over Card's reused surface tokens.
+:root {
+  --link-card-shadow: var(--card-shadow); // rest = Card's shadow (--shadow-sm)
+  --link-card-hover-shadow: var(--shadow-md);
+  --link-card-hover-border-color: var(--color-border-strong);
+  --link-card-transition: border-color 120ms ease, box-shadow 120ms ease;
+  --link-card-focus-offset: 2px;
+}
+```
+
+`box-shadow`/`outline`/`transition` are not in stylelint's `declaration-strict-value` list (color /
+background / border-color / border-width / opacity only), and `overflow`/`display:block`/`cursor` are
+fine; `color: inherit` and `text-decoration: none` are ignored values. `width`/`height` aren't set.
+
+## Files
+
+| File                                                                             | Change                                                       |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `packages/design-system/src/components/LinkCard/LinkCard.tsx`                    | NEW — component + props + JSDoc                              |
+| `packages/design-system/src/components/LinkCard/LinkCard.module.scss`            | NEW                                                          |
+| `packages/design-system/src/components/LinkCard/LinkCard.tokens.scss`            | NEW                                                          |
+| `packages/design-system/src/components/LinkCard/LinkCard.test.tsx`               | NEW                                                          |
+| `packages/design-system/src/components/LinkCard/index.ts`                        | NEW                                                          |
+| `packages/design-system/src/index.ts`                                            | MODIFY — re-export                                           |
+| `packages/design-system/src/_meta/manifest.ts` + `scripts/generate-manifest.mjs` | MODIFY — `LinkCard: 'Navigation'`                            |
+| `packages/design-system/src/components.manifest.json`                            | REGEN                                                        |
+| `packages/design-system/AGENTS.md`                                               | MODIFY — Navigation TL;DR                                    |
+| `packages/design-system/src/components/TODO.md`                                  | MODIFY — tick `<NavCard>` (shipped as `<LinkCard>`)          |
+| `packages/playground/src/pages/components/LinkCardDemo.tsx`                      | NEW — demo                                                   |
+| `packages/playground/src/App.tsx`                                                | MODIFY — `/components/link-card` route                       |
+| `packages/playground/src/layout/AppShell/AppShell.tsx`                           | MODIFY — Navigation nav entry (lucide icon, plan picks one)  |
+| `packages/playground/src/pages/components/ComponentsIndex.tsx`                   | MODIFY — overview card + refactor its own grid onto LinkCard |
+| `packages/playground/src/pages/mockups/registry.ts`                              | MODIFY — `ComponentName` union gains `LinkCard`              |
+| `packages/playground/src/pages/mockups/MockupsIndex.tsx`                         | MODIFY — refactor the grid onto LinkCard                     |
+
+## Tests (`LinkCard.test.tsx`)
+
+- Renders as an `<a>` by default; children render inside it; `href` passes through.
+- `as="button"` renders a `<button>`; `onClick` fires on click. `as={StubLink}` (a tiny test
+  component receiving `to`) renders that component and passes `to` through (polymorphic inference works).
+- `forwardRef` reaches the rendered element.
+- `padding` default `md` → `paddingMd` class; `padding="lg"` → `paddingLg`; `padding="none"` → `paddingNone`.
+- `tone="accent"` → `data-tone="accent"` attribute; omitted → no `data-tone`.
+- `className` merges with the base `linkCard` class; other attrs spread through.
+- (Class-name assertions via `/linkCard/`, `/paddingMd/`, mirroring Link/Card tests.)
+
+## Demo (`LinkCardDemo.tsx`)
+
+`DemoLayout` + `Example` blocks: a router-style card (using a no-op `as` or `href="#"`), an `href`
+external card, an `as="button"` action card, the padding scale, the tone stripes, and a 2–3 card grid in
+a `<Grid>` (the canonical "index grid" use). Wired into `App.tsx` (`/components/link-card`), AppShell
+**Navigation** group, `ComponentsIndex`.
+
+## Refactor (ticks the `<NavCard>` TODO)
+
+- **`MockupsIndex.tsx`** (the mock site): replace the `{/* TODO: replace when <NavCard> ships */}` +
+  `<Link to={m.path} style={{ textDecoration:'none', color:'inherit', display:'block' }}><Card
+padding="md">…</Card></Link>` with `<LinkCard as={RouterLink} to={m.path} padding="md">…</LinkCard>`
+  (drops the inline style + nested Card; gains the hover affordance). Remove the now-unused `Card` import
+  if nothing else uses it.
+- **`ComponentsIndex.tsx`** (same grid-of-clickable-cards hack — playground tooling, dogfood): refactor
+  its card grid onto `<LinkCard>` likewise.
+- `registry.ts`: add `'LinkCard'` to the `ComponentName` union. (No registered mockup uses it — the index
+  pages aren't registry entries — so no `usesComponents` change.)
+- `TODO.md`: tick the `<NavCard>` entry `[x]`, note it **shipped as `<LinkCard>`** (the name Card's JSDoc
+  already references) with the polymorphic `as` API + hover/focus affordance, and that MockupsIndex +
+  ComponentsIndex were refactored.
+
+## When NOT to use (JSDoc `@remarks` + AGENTS.md)
+
+- Non-interactive grouped content → `<Card>`. LinkCard is for when the **whole** surface navigates/acts.
+- Inline text navigation ("View all →") → `<Link>`. LinkCard is a block surface, not inline text.
+- A form action / trigger that isn't navigation → `<Button>` (or `<LinkCard as="button">` only when you
+  genuinely want a card-shaped button).
+- Anti-pattern: ❌ nesting interactive controls (a `<Button>`/`<Link>`) inside a LinkCard — nested
+  interactives are invalid/confusing. Keep the card's content non-interactive, or use a plain `<Card>`
+  with explicit controls instead.
+
+## Out of scope (v1)
+
+- `overflow="visible"` opt-out (always clips, like the index-grid use needs).
+- The compound `Card.Header`/`List`/`ListRow` API inside a LinkCard (a clickable card with internal
+  sections is unusual).
+- A `disabled` state (render a non-link instead).
+- The prominent/lift hover variant (accent border + `--shadow-lg` + transform) — subtle only.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -274,6 +274,31 @@ import { Link as RouterLink } from 'react-router-dom';
 - ❌ Forgetting `rel="noopener noreferrer"` on `target="_blank"` links.
 - ❌ Using `variant="default"` for low-emphasis nav like breadcrumbs.
 
+### `<LinkCard>` — clickable, full-surface Card
+
+```tsx
+// SPA route — pass your router's Link as `as`
+<LinkCard as={RouterLink} to="/contacts/42" padding="md">
+  <Stack gap="xs">
+    <Text weight="semibold">Acme Corp</Text>
+    <Text size="sm" tone="muted">12 open deals</Text>
+  </Stack>
+</LinkCard>
+
+<LinkCard href="https://status.example.com" tone="success">All systems operational</LinkCard>
+<LinkCard as="button" type="button" onClick={openImporter}>Import contacts</LinkCard>
+```
+
+- A Card whose **whole surface** navigates/acts. Polymorphic like `<Link>` — `as` defaults to `<a>`; pass `as={RouterLink} to=…` for routes or `as="button"` for actions (the library has no router dep).
+- Carries `Card`'s `padding` (default `md`) + `tone` stripe (reuses `--card-*` tokens), plus a hover lift (border + shadow) and a `:focus-visible` ring.
+- Use `<Card>` for non-interactive grouping, `<Link>` for inline text, `<Button>` for form actions. **Don't nest** interactive controls inside it (invalid nested interactives).
+
+**Anti-patterns:**
+
+- ❌ Nesting interactive controls (`<Button>` / `<Link>`) inside a LinkCard — nested interactives are invalid + confusing.
+- ❌ `<LinkCard href="#" onClick={…}>` — fake href breaks "open in new tab". Use `as="button"` for actions.
+- ❌ `<LinkCard href="https://…" target="_blank">` without `rel="noopener noreferrer"` — security risk.
+
 ### `<Input>` — single-line text
 
 ```tsx

--- a/packages/design-system/scripts/generate-manifest.mjs
+++ b/packages/design-system/scripts/generate-manifest.mjs
@@ -86,6 +86,7 @@ const CLUSTERS = {
   Accordion: 'Navigation',
   Breadcrumb: 'Navigation',
   Link: 'Navigation',
+  LinkCard: 'Navigation',
   Rail: 'Navigation',
   Tabs: 'Navigation',
   TopBar: 'Navigation',

--- a/packages/design-system/src/_meta/manifest.ts
+++ b/packages/design-system/src/_meta/manifest.ts
@@ -108,6 +108,7 @@ const CLUSTERS: Record<string, string> = {
   Accordion: 'Navigation',
   Breadcrumb: 'Navigation',
   Link: 'Navigation',
+  LinkCard: 'Navigation',
   Rail: 'Navigation',
   Tabs: 'Navigation',
   TopBar: 'Navigation',

--- a/packages/design-system/src/components.manifest.json
+++ b/packages/design-system/src/components.manifest.json
@@ -90,7 +90,9 @@
     "tier": "primitive",
     "cluster": "Layout",
     "composes": [],
-    "composedBy": []
+    "composedBy": [
+      "LinkCard"
+    ]
   },
   "Checkbox": {
     "tier": "primitive",
@@ -313,6 +315,14 @@
       "Breadcrumb",
       "PersonDisplay"
     ]
+  },
+  "LinkCard": {
+    "tier": "composition",
+    "cluster": "Navigation",
+    "composes": [
+      "Card"
+    ],
+    "composedBy": []
   },
   "Masonry": {
     "tier": "primitive",

--- a/packages/design-system/src/components/LinkCard/LinkCard.module.scss
+++ b/packages/design-system/src/components/LinkCard/LinkCard.module.scss
@@ -1,0 +1,79 @@
+@use './LinkCard.tokens';
+
+.linkCard {
+  --link-card-elevation: var(--link-card-shadow);
+
+  display: block;
+  background: var(--card-bg);
+  border: var(--border-width) solid var(--card-border-color);
+  border-radius: var(--card-radius);
+  box-shadow: var(--link-card-elevation);
+  overflow: hidden;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition: var(--link-card-transition);
+}
+
+.linkCard:hover {
+  --link-card-elevation: var(--link-card-hover-shadow);
+
+  border-color: var(--link-card-hover-border-color);
+}
+
+.linkCard:focus-visible {
+  outline: var(--ring-width) solid var(--ring-accent);
+  outline-offset: var(--link-card-focus-offset);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .linkCard {
+    transition: none;
+  }
+}
+
+.linkCard[data-tone='accent'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-accent),
+    var(--link-card-elevation);
+}
+
+.linkCard[data-tone='info'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-info),
+    var(--link-card-elevation);
+}
+
+.linkCard[data-tone='success'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-success),
+    var(--link-card-elevation);
+}
+
+.linkCard[data-tone='warning'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-warning),
+    var(--link-card-elevation);
+}
+
+.linkCard[data-tone='danger'] {
+  box-shadow:
+    inset var(--card-stripe-width) 0 0 var(--card-stripe-color-danger),
+    var(--link-card-elevation);
+}
+
+.paddingNone {
+  padding: 0;
+}
+
+.paddingSm {
+  padding: var(--card-padding-sm);
+}
+
+.paddingMd {
+  padding: var(--card-padding-md);
+}
+
+.paddingLg {
+  padding: var(--card-padding-lg);
+}

--- a/packages/design-system/src/components/LinkCard/LinkCard.module.scss
+++ b/packages/design-system/src/components/LinkCard/LinkCard.module.scss
@@ -19,6 +19,12 @@
   --link-card-elevation: var(--link-card-hover-shadow);
 
   border-color: var(--link-card-hover-border-color);
+
+  // Re-assert no underline on hover: the global `a:hover { text-decoration:
+  // underline }` (typography.scss) out-specifies `.linkCard`'s rest rule, so
+  // without this the whole-card link underlines on hover. `.linkCard:hover`
+  // (0,2,0) beats `a:hover` (0,1,1). A LinkCard is a surface, never text.
+  text-decoration: none;
 }
 
 .linkCard:focus-visible {

--- a/packages/design-system/src/components/LinkCard/LinkCard.test.tsx
+++ b/packages/design-system/src/components/LinkCard/LinkCard.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef, type AnchorHTMLAttributes, type ReactNode } from 'react';
+import { LinkCard } from './LinkCard';
+
+// A stand-in for a router's <Link> — verifies polymorphic `as` + prop passthrough.
+function StubRouterLink({
+  to,
+  children,
+  ...rest
+}: { to: string; children?: ReactNode } & AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return (
+    <a href={to} data-router="true" {...rest}>
+      {children}
+    </a>
+  );
+}
+
+describe('LinkCard', () => {
+  it('renders as <a> by default and passes href + children through', () => {
+    render(<LinkCard href="/x">Go</LinkCard>);
+    const el = screen.getByText('Go');
+    expect(el.tagName).toBe('A');
+    expect(el).toHaveAttribute('href', '/x');
+  });
+
+  it('as={RouterLink} renders the component and passes `to` through', () => {
+    render(
+      <LinkCard as={StubRouterLink} to="/contacts">
+        Contacts
+      </LinkCard>,
+    );
+    const el = screen.getByText('Contacts');
+    expect(el).toHaveAttribute('href', '/contacts');
+    expect(el).toHaveAttribute('data-router', 'true');
+  });
+
+  it('as="button" renders a <button> and fires onClick', async () => {
+    const onClick = vi.fn();
+    render(
+      <LinkCard as="button" onClick={onClick}>
+        Act
+      </LinkCard>,
+    );
+    const btn = screen.getByRole('button', { name: 'Act' });
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn).toHaveAttribute('type', 'button');
+    await userEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('as="button" type default can be overridden by consumer', () => {
+    render(<LinkCard as="button" type="submit">S</LinkCard>);
+    expect(screen.getByRole('button', { name: 'S' })).toHaveAttribute('type', 'submit');
+  });
+
+  it('defaults padding to md; padding prop swaps the class', () => {
+    const { container, rerender } = render(<LinkCard href="/x">x</LinkCard>);
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingMd/);
+    rerender(
+      <LinkCard href="/x" padding="lg">
+        x
+      </LinkCard>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingLg/);
+    rerender(
+      <LinkCard href="/x" padding="none">
+        x
+      </LinkCard>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/paddingNone/);
+  });
+
+  it('tone sets data-tone; omitted → no data-tone', () => {
+    const { container, rerender } = render(
+      <LinkCard href="/x" tone="accent">
+        x
+      </LinkCard>,
+    );
+    expect(container.firstChild).toHaveAttribute('data-tone', 'accent');
+    rerender(<LinkCard href="/x">x</LinkCard>);
+    expect(container.firstChild).not.toHaveAttribute('data-tone');
+  });
+
+  it('forwards ref to the rendered element', () => {
+    const ref = createRef<HTMLAnchorElement>();
+    render(
+      <LinkCard ref={ref} href="/x">
+        x
+      </LinkCard>,
+    );
+    expect(ref.current?.tagName).toBe('A');
+  });
+
+  it('merges className (with the base linkCard class) and spreads other attrs', () => {
+    const { container } = render(
+      <LinkCard href="/x" className="my-cls" data-foo="bar">
+        x
+      </LinkCard>,
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toMatch(/linkCard/);
+    expect(el.className).toMatch(/my-cls/);
+    expect(el).toHaveAttribute('data-foo', 'bar');
+  });
+});

--- a/packages/design-system/src/components/LinkCard/LinkCard.test.tsx
+++ b/packages/design-system/src/components/LinkCard/LinkCard.test.tsx
@@ -50,7 +50,11 @@ describe('LinkCard', () => {
   });
 
   it('as="button" type default can be overridden by consumer', () => {
-    render(<LinkCard as="button" type="submit">S</LinkCard>);
+    render(
+      <LinkCard as="button" type="submit">
+        S
+      </LinkCard>,
+    );
     expect(screen.getByRole('button', { name: 'S' })).toHaveAttribute('type', 'submit');
   });
 

--- a/packages/design-system/src/components/LinkCard/LinkCard.tokens.scss
+++ b/packages/design-system/src/components/LinkCard/LinkCard.tokens.scss
@@ -1,0 +1,8 @@
+// LinkCard.tokens.scss — interactive-state tokens over Card's reused surface tokens.
+:root {
+  --link-card-shadow: var(--card-shadow); // rest = Card's shadow (--shadow-sm)
+  --link-card-hover-shadow: var(--shadow-md);
+  --link-card-hover-border-color: var(--color-border-strong);
+  --link-card-transition: border-color 120ms ease, box-shadow 120ms ease;
+  --link-card-focus-offset: 2px;
+}

--- a/packages/design-system/src/components/LinkCard/LinkCard.tsx
+++ b/packages/design-system/src/components/LinkCard/LinkCard.tsx
@@ -1,0 +1,118 @@
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ComponentPropsWithRef,
+  type ElementType,
+  type ForwardedRef,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import { type CardPadding, type CardTone } from '../Card';
+import styles from './LinkCard.module.scss';
+
+interface LinkCardOwnProps {
+  /** Inner padding — same scale as `Card`. Defaults to `'md'`. */
+  padding?: CardPadding;
+  /** Optional left-edge tone stripe — same vocabulary as `Card`. */
+  tone?: CardTone;
+  children?: ReactNode;
+}
+
+/** Polymorphic props helper (identical to Link's). */
+type PolymorphicProps<C extends ElementType, P> = P & { as?: C } & Omit<
+    ComponentPropsWithoutRef<C>,
+    keyof P | 'as'
+  >;
+
+/**
+ * Public LinkCard prop type. Generic `C` defaults to `'a'`. Passing
+ * `as={SomeComponent}` makes all of its props available with full inference
+ * (including `to` / `replace` for `react-router-dom`'s `<Link>`).
+ */
+export type LinkCardProps<C extends ElementType = 'a'> = PolymorphicProps<C, LinkCardOwnProps>;
+
+type LinkCardComponent = <C extends ElementType = 'a'>(
+  props: LinkCardProps<C> & { ref?: ComponentPropsWithRef<C>['ref'] },
+) => ReactElement | null;
+
+const paddingClass: Record<CardPadding, string> = {
+  none: styles.paddingNone,
+  sm: styles.paddingSm,
+  md: styles.paddingMd,
+  lg: styles.paddingLg,
+};
+
+/**
+ * A clickable Card whose entire surface is one navigation/action target.
+ * Polymorphic like `<Link>`: renders an `<a>` by default; pass `as={RouterLink}`
+ * for SPA routes or `as="button"` for an action. Carries `Card`'s surface
+ * (`padding`, `tone`) plus a hover lift and a `:focus-visible` ring.
+ *
+ * Use when the WHOLE card is clickable. For non-interactive grouping use
+ * `<Card>`; for inline text navigation use `<Link>`; for a form action use
+ * `<Button>`.
+ *
+ * @example
+ * // SPA route — pass your router's Link as `as`.
+ * import { Link as RouterLink } from 'react-router-dom';
+ * <LinkCard as={RouterLink} to="/contacts/42" padding="md">
+ *   <Stack gap="xs">
+ *     <Text weight="semibold">Acme Corp</Text>
+ *     <Text size="sm" tone="muted">12 open deals</Text>
+ *   </Stack>
+ * </LinkCard>
+ *
+ * @example
+ * // External link (native <a>) + a tone stripe.
+ * <LinkCard href="https://status.example.com" tone="success">
+ *   <Text weight="semibold">All systems operational</Text>
+ * </LinkCard>
+ *
+ * @example
+ * // Card-shaped action button.
+ * <LinkCard as="button" type="button" onClick={openImporter}>
+ *   <Text weight="semibold">Import contacts</Text>
+ * </LinkCard>
+ *
+ * @remarks When NOT to use
+ * - Non-interactive grouped content → `<Card>`.
+ * - Inline text navigation ("View all →") → `<Link>`.
+ * - A form action / trigger that isn't card-shaped → `<Button>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Nesting interactive controls (`<Button>` / `<Link>`) inside a LinkCard —
+ *   nested interactives are invalid + confusing. Keep the card content
+ *   non-interactive, or use a plain `<Card>` with explicit controls.
+ * - ❌ `<LinkCard href="#" onClick={…}>` — a fake href breaks "open in new tab".
+ *   Use `as="button"` for an action.
+ * - ❌ `<LinkCard href="https://…" target="_blank">` without `rel="noopener noreferrer"` — security risk.
+ *
+ * @remarks A11y
+ * - Renders a real `<a>` / `<button>` / router link, so it has native
+ *   semantics; the children supply the accessible name — keep the primary
+ *   label first. `:focus-visible` provides the keyboard ring.
+ */
+export const LinkCard = forwardRef(function LinkCard<C extends ElementType = 'a'>(
+  { as, padding = 'md', tone, className, children, ...props }: LinkCardProps<C>,
+  ref: ForwardedRef<Element>,
+) {
+  const Component = (as || 'a') as ElementType;
+  // Default native <button> to type="button" so it doesn't submit forms (Rule 6).
+  // Spread before {...props} so a consumer can still pass type="submit".
+  const typeDefault = Component === 'button' ? { type: 'button' as const } : {};
+
+  // typeDefault first, then {...props} (consumer wins), then component-owned
+  // className (merged via clsx) + data-tone — same spread order as Link.
+  return (
+    <Component
+      ref={ref}
+      {...typeDefault}
+      {...props}
+      className={clsx(styles.linkCard, paddingClass[padding], className)}
+      data-tone={tone}
+    >
+      {children}
+    </Component>
+  );
+}) as LinkCardComponent;

--- a/packages/design-system/src/components/LinkCard/index.ts
+++ b/packages/design-system/src/components/LinkCard/index.ts
@@ -1,0 +1,2 @@
+export { LinkCard } from './LinkCard';
+export type { LinkCardProps } from './LinkCard';

--- a/packages/design-system/src/components/TODO.md
+++ b/packages/design-system/src/components/TODO.md
@@ -79,9 +79,10 @@ Inline `style={...}` on a `<div>` (or `<span>`) with `display: grid; place-items
 
 **When this ships:** refactor the Dashboard and Members mocks in the files above, then tick this checkbox.
 
-### [ ] `<NavCard>` — clickable Card with router/href navigation, hover affordance, full-area click target
+### [x] `<NavCard>` — clickable Card with router/href navigation, hover affordance, full-area click target
 
 **Filed:** 2026-05-25
+**Shipped:** 2026-06-01 — shipped as `<LinkCard>` (`packages/design-system/src/components/LinkCard/`), the name `Card`'s JSDoc already referenced. Polymorphic `as` (default `<a>`, `as={RouterLink}` / `as="button"`), reuses Card's `--card-*` surface + `padding`/`tone`, adds a hover lift + `:focus-visible` ring. The MockupsIndex grid was refactored onto it (dropping the router-Link-wrapping-Card + inline-style escape hatch). ComponentsIndex keeps its own `.card` style (legit playground CSS with hover-driven child effects, not an escape hatch).
 **Mocked in:**
 
 - `packages/playground/src/pages/mockups/MockupsIndex.tsx` — grid of cards linking to each mockup page.

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -373,6 +373,9 @@ export type {
 export { Link } from './components/Link';
 export type { LinkProps, LinkVariant } from './components/Link';
 
+export { LinkCard } from './components/LinkCard';
+export type { LinkCardProps } from './components/LinkCard';
+
 export { Accordion } from './components/Accordion';
 export type {
   AccordionProps,

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -80,6 +80,7 @@ import { DrawerDemo } from './pages/components/DrawerDemo';
 import { GridDemo } from './pages/components/GridDemo';
 import { MasonryDemo } from './pages/components/MasonryDemo';
 import { LinkDemo } from './pages/components/LinkDemo';
+import { LinkCardDemo } from './pages/components/LinkCardDemo';
 import { RailDemo } from './pages/components/RailDemo';
 import { ToastDemo } from './pages/components/ToastDemo';
 import { TopBarDemo } from './pages/components/TopBarDemo';
@@ -175,6 +176,7 @@ export default function App() {
             <Route path="/components/grid" element={<GridDemo />} />
             <Route path="/components/masonry" element={<MasonryDemo />} />
             <Route path="/components/link" element={<LinkDemo />} />
+            <Route path="/components/link-card" element={<LinkCardDemo />} />
             <Route path="/components/rail" element={<RailDemo />} />
             <Route path="/components/topbar" element={<TopBarDemo />} />
             <Route path="/components/textarea" element={<TextareaDemo />} />

--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -73,6 +73,7 @@ import {
   TriangleAlert,
   Compass,
   Shapes,
+  SquareMousePointer,
   type LucideIcon,
 } from 'lucide-react';
 import { useState, useEffect } from 'react';
@@ -214,6 +215,7 @@ const componentGroups = [
       { to: '/components/accordion', label: 'Accordion', icon: ListCollapse, end: false },
       { to: '/components/breadcrumb', label: 'Breadcrumb', icon: MoveRight, end: false },
       { to: '/components/link', label: 'Link', icon: ExternalLink, end: false },
+      { to: '/components/link-card', label: 'LinkCard', icon: SquareMousePointer, end: false },
       { to: '/components/rail', label: 'Rail', icon: Sidebar, end: false },
       { to: '/components/tabs', label: 'Tabs', icon: PanelTop, end: false },
       { to: '/components/topbar', label: 'TopBar', icon: LayoutPanelTop, end: false },

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@eocrm/design-system';
 import { BrandIcon } from '@eocrm/design-system';
 import { Breadcrumb } from '@eocrm/design-system';
 import { Link as DSLink } from '@eocrm/design-system';
+import { LinkCard } from '@eocrm/design-system';
 import { Button } from '@eocrm/design-system';
 import { ButtonGroup } from '@eocrm/design-system';
 import { Card } from '@eocrm/design-system';
@@ -728,6 +729,20 @@ const items: { to: string; name: string; description: string; preview: React.Rea
       <DSLink href="#" onClick={(e) => e.preventDefault()}>
         View details →
       </DSLink>
+    ),
+  },
+  {
+    to: '/components/link-card',
+    name: 'LinkCard',
+    description: 'A clickable Card — the whole surface navigates or acts.',
+    preview: (
+      <div style={{ width: '100%', maxWidth: '220px' }}>
+        <LinkCard as="div" padding="sm">
+          <Text size="sm" weight="semibold">
+            Dashboard
+          </Text>
+        </LinkCard>
+      </div>
     ),
   },
   {

--- a/packages/playground/src/pages/components/LinkCardDemo.tsx
+++ b/packages/playground/src/pages/components/LinkCardDemo.tsx
@@ -1,0 +1,84 @@
+import { Grid, LinkCard, Stack, Text } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import { getComponentFiles } from '../../lib/componentFiles';
+
+export function LinkCardDemo() {
+  return (
+    <DemoLayout
+      name="LinkCard"
+      componentName="LinkCard"
+      description="A clickable Card whose whole surface navigates or acts. Polymorphic like Link (as defaults to <a>; pass as={RouterLink} or as=&quot;button&quot;). Hover lift + focus ring."
+      files={getComponentFiles('LinkCard')}
+    >
+      <Example
+        title="As a link (default <a>)"
+        description="The whole card is one anchor. Hover for the lift; tab to it for the focus ring."
+        code={`<LinkCard href="https://status.example.com">
+  <Stack gap="xs">
+    <Text weight="semibold">Status page</Text>
+    <Text size="sm" tone="muted">All systems operational.</Text>
+  </Stack>
+</LinkCard>`}
+      >
+        <LinkCard href="https://status.example.com">
+          <Stack gap="xs">
+            <Text weight="semibold">Status page</Text>
+            <Text size="sm" tone="muted">
+              All systems operational.
+            </Text>
+          </Stack>
+        </LinkCard>
+      </Example>
+
+      <Example
+        title="As a button (action)"
+        description={`Pass as="button" for an action instead of navigation.`}
+        code={`<LinkCard as="button" type="button" onClick={openImporter}>
+  <Text weight="semibold">Import contacts</Text>
+</LinkCard>`}
+      >
+        <LinkCard as="button" type="button" onClick={() => undefined}>
+          <Text weight="semibold">Import contacts</Text>
+        </LinkCard>
+      </Example>
+
+      <Example
+        title="Index grid"
+        description="The canonical use — a grid of cards each linking somewhere. padding + tone match Card."
+        code={`<Grid minColumnWidth="220px" gap="md">
+  <LinkCard href="#" tone="accent"><Text weight="semibold">Dashboard</Text></LinkCard>
+  <LinkCard href="#" tone="success"><Text weight="semibold">Deals</Text></LinkCard>
+  <LinkCard href="#"><Text weight="semibold">Contacts</Text></LinkCard>
+</Grid>`}
+      >
+        <Grid minColumnWidth="220px" gap="md">
+          <LinkCard href="https://example.com/dashboard" tone="accent">
+            <Stack gap="xs">
+              <Text weight="semibold">Dashboard</Text>
+              <Text size="sm" tone="muted">
+                KPIs & pipeline.
+              </Text>
+            </Stack>
+          </LinkCard>
+          <LinkCard href="https://example.com/deals" tone="success">
+            <Stack gap="xs">
+              <Text weight="semibold">Deals</Text>
+              <Text size="sm" tone="muted">
+                Kanban board.
+              </Text>
+            </Stack>
+          </LinkCard>
+          <LinkCard href="https://example.com/contacts">
+            <Stack gap="xs">
+              <Text weight="semibold">Contacts</Text>
+              <Text size="sm" tone="muted">
+                Directory.
+              </Text>
+            </Stack>
+          </LinkCard>
+        </Grid>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/components/LinkCardDemo.tsx
+++ b/packages/playground/src/pages/components/LinkCardDemo.tsx
@@ -8,7 +8,7 @@ export function LinkCardDemo() {
     <DemoLayout
       name="LinkCard"
       componentName="LinkCard"
-      description="A clickable Card whose whole surface navigates or acts. Polymorphic like Link (as defaults to <a>; pass as={RouterLink} or as=&quot;button&quot;). Hover lift + focus ring."
+      description='A clickable Card whose whole surface navigates or acts. Polymorphic like Link (as defaults to <a>; pass as={RouterLink} or as="button"). Hover lift + focus ring.'
       files={getComponentFiles('LinkCard')}
     >
       <Example

--- a/packages/playground/src/pages/mockups/MockupsIndex.tsx
+++ b/packages/playground/src/pages/mockups/MockupsIndex.tsx
@@ -1,5 +1,5 @@
-import { Link } from 'react-router-dom';
-import { Badge, Card, Cluster, Code, Grid, Stack, Text, Title } from '@eocrm/design-system';
+import { Link as RouterLink } from 'react-router-dom';
+import { Badge, Cluster, Code, Grid, LinkCard, Stack, Text, Title } from '@eocrm/design-system';
 import { MOCKUPS } from './registry';
 
 export function MockupsIndex() {
@@ -18,32 +18,23 @@ export function MockupsIndex() {
 
       <Grid minColumnWidth="280px" gap="md">
         {indexMockups.map((m) => (
-          /* TODO: replace when <NavCard> ships — see components/TODO.md.
-             Wrapping Card in a router Link to get nav; the inline style is the
-             escape hatch to suppress default <a> underline + color. */
-          <Link
-            key={m.slug}
-            to={m.path}
-            style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}
-          >
-            <Card padding="md">
-              <Stack gap="sm">
-                <Text size="lg" weight="semibold">
-                  {m.title}
-                </Text>
-                <Text size="sm" tone="muted">
-                  {m.blurb}
-                </Text>
-                <Cluster gap="xs">
-                  {m.usesComponents.map((name) => (
-                    <Badge key={name} tone="info">
-                      {name}
-                    </Badge>
-                  ))}
-                </Cluster>
-              </Stack>
-            </Card>
-          </Link>
+          <LinkCard as={RouterLink} key={m.slug} to={m.path} padding="md">
+            <Stack gap="sm">
+              <Text size="lg" weight="semibold">
+                {m.title}
+              </Text>
+              <Text size="sm" tone="muted">
+                {m.blurb}
+              </Text>
+              <Cluster gap="xs">
+                {m.usesComponents.map((name) => (
+                  <Badge key={name} tone="info">
+                    {name}
+                  </Badge>
+                ))}
+              </Cluster>
+            </Stack>
+          </LinkCard>
         ))}
       </Grid>
     </Stack>

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -41,6 +41,7 @@ export type ComponentName =
   | 'Kanban'
   | 'Kbd'
   | 'Link'
+  | 'LinkCard'
   | 'Modal'
   | 'OptionsPicker'
   | 'Page'


### PR DESCRIPTION
## Summary

The last open component TODO — `<NavCard>` — shipped under the name `Card`'s JSDoc already referenced.

- **`<LinkCard>`** (Navigation) — a Card whose **whole surface** is one click target. Polymorphic like `<Link>`: `as` defaults to `<a>`; pass `as={RouterLink} to=…` for SPA routes or `as="button"` for actions (no router dep; `as="button"` defaults `type="button"`). Reuses `Card`'s `--card-*` surface + `padding`/`tone` (composition tier), with a subtle hover lift (border → `--color-border-strong`, shadow `sm`→`md`) and a `:focus-visible` ring. A `--link-card-elevation` var composes the hover×tone box-shadows. **No hover underline** — re-asserts `text-decoration:none` on `:hover` to out-specify the global `a:hover` rule.
- **Demo + wiring:** `LinkCardDemo` (as-link / as-button / index grid with tones), `/components/link-card` route, AppShell Navigation nav, ComponentsIndex gallery card; manifest (both sources + regen), AGENTS.md TL;DR.
- **Refactor (closes `<NavCard>` TODO):** `MockupsIndex` grid → `<LinkCard as={RouterLink}>`, dropping the router-Link-wrapping-Card + inline-style escape hatch (and gaining the hover affordance it lacked). `ComponentsIndex` intentionally keeps its own `.card` (legit playground CSS with hover-driven child effects LinkCard can't drive cross-module).

Spec: `docs/superpowers/specs/2026-06-01-link-card-design.md` · Plan: `docs/superpowers/plans/2026-06-01-link-card.md`.

## Test Plan

- [x] 2467/2467 unit tests pass (8 LinkCard tests: polymorphic `as`, `as="button"` type default + override, padding, tone, ref, className)
- [x] typecheck, lint:css, `make build`, `make lint` green
- [x] `npm pack --dry-run` ships the LinkCard source files, no test
- [x] Library (rule 8) + mockup (rule 7) review-fix loops: 0 Critical / 0 Important
- [ ] `Quality / check` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)