### PR TITLE
fix(a11y): <Field> names composite controls (Select/Slider/ColorPicker/FileUpload/TimeField)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-field-labels-composites.md
+++ b/docs/superpowers/plans/2026-06-02-field-labels-composites.md
@@ -1,0 +1,619 @@
+# Field Names Composite Controls (a11y) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `<Field label="X"><Control/></Field>` expose an accessible name on composite controls (Select, Slider, ColorPicker, FileUpload, TimeField), not just native inputs.
+
+**Architecture:** Field's auto-clone (and its render-prop `field` object) also convey `aria-labelledby={labelId}` (guarded; only when a label is rendered; child's explicit value wins). Select + Slider already forward `aria-labelledby` to their focusable element → named for free. ColorPicker, FileUpload, and TimeField each forward `aria-labelledby` (+ `aria-describedby`) onto their focusable element; TimeField's `aria-label` becomes optional. Naming for native controls is unchanged (the `*` marker is `aria-hidden`, `(optional)` is already in the label, so `aria-labelledby` resolves to the same name as `htmlFor`).
+
+**Tech Stack:** React (`cloneElement`, `forwardRef`), TypeScript, Vitest + @testing-library (assert accessible name via `getByRole(role, { name })`). Branch: `fix/field-labels-composites` (off `main`). Spec: `docs/superpowers/specs/2026-06-02-field-labels-composites-design.md`.
+
+---
+
+## File map
+
+- `Field/Field.tsx` — inject `aria-labelledby` in auto-clone + add to `FieldRenderProps`/`field` + JSDoc. `Field/Field.test.tsx` — 4 new tests.
+- `ColorPicker/ColorPicker.tsx` — accept + forward `aria-labelledby`/`aria-describedby` to the trigger button. `ColorPicker/ColorPicker.test.tsx` — tests.
+- `FileUpload/FileUpload.tsx` — re-route `aria-labelledby`/`aria-describedby` onto the `role="button"` dropzone. `FileUpload/FileUpload.test.tsx` — tests.
+- `TimeField/TimeField.tsx` — `aria-label` optional + accept/forward `aria-labelledby`. `TimeField/TimeField.test.tsx` — tests.
+- `Select/Select.test.tsx`, `Slider/Slider.test.tsx` — regression tests only (NO source change; they already forward `aria-labelledby`).
+
+Order matters: **Task 1 (Field) first** — the per-control integration tests pass only once Field injects `aria-labelledby`.
+
+---
+
+## Task 0: Pre-flight
+
+- [ ] **Step 1: Confirm branch + hooks**
+
+```bash
+cd /Users/dpws/projects/design-system
+git branch --show-current        # expect: fix/field-labels-composites
+git config --get core.hooksPath  # expect: .husky/_
+```
+
+---
+
+## Task 1: Field injects `aria-labelledby`
+
+**Files:** Modify `packages/design-system/src/components/Field/Field.tsx`; Test `packages/design-system/src/components/Field/Field.test.tsx`.
+
+- [ ] **Step 1: Edit the auto-clone `injected` block**
+
+In `Field.tsx`, replace the `const injected … cloneElement(child, injected);` block with an if/else so the conditional `aria-labelledby` can be added only when a label is rendered:
+
+```tsx
+    const child = children as ReactElement<Record<string, unknown>>;
+    const childProps = child.props;
+    let injected: Record<string, unknown>;
+    if (asGroup) {
+      injected = {
+        invalid: childProps.invalid ?? invalid,
+        required: childProps.required ?? requiredBool,
+      };
+    } else {
+      injected = {
+        id: controlId,
+        'aria-describedby': childProps['aria-describedby'] ?? describedBy,
+        invalid: childProps.invalid ?? invalid,
+        required: childProps.required ?? requiredBool,
+      };
+      if (label != null) {
+        injected['aria-labelledby'] = childProps['aria-labelledby'] ?? labelId;
+      }
+    }
+    control = cloneElement(child, injected);
+```
+
+- [ ] **Step 2: Add `aria-labelledby` to `FieldRenderProps`**
+
+```tsx
+export interface FieldRenderProps {
+  id: string;
+  'aria-describedby': string | undefined;
+  /** Id of the label element to name the control — set only when a label is rendered. */
+  'aria-labelledby': string | undefined;
+  'aria-invalid': boolean | undefined;
+  invalid: boolean;
+  required: boolean;
+  /** Id of the label/caption element — for manual `aria-labelledby` wiring. */
+  labelId: string;
+}
+```
+
+- [ ] **Step 3: Set it on the `field` object**
+
+```tsx
+  const field: FieldRenderProps = {
+    id: controlId,
+    'aria-describedby': describedBy,
+    'aria-labelledby': label != null ? labelId : undefined,
+    'aria-invalid': invalid || undefined,
+    invalid,
+    required: requiredBool,
+    labelId,
+  };
+```
+
+- [ ] **Step 4: Update Field JSDoc**
+
+In the component description, change the wiring list to include `aria-labelledby` and add a sentence:
+> "…wires the `id` / `aria-labelledby` / `aria-describedby` / `aria-invalid` association by construction. When a label is present, Field also injects `aria-labelledby` onto the cloned child, so composite controls that forward unknown ARIA props (Select, Slider, ColorPicker, FileUpload, TimeField) get an accessible name automatically. For wrapped/nested DOM that doesn't forward props, use the render-prop and spread `field` (it carries `aria-labelledby`)."
+
+- [ ] **Step 5: Write the Field tests**
+
+Add to `Field.test.tsx` (these use a local stub that forwards `aria-labelledby`, mirroring the existing `RawControl` pattern):
+
+```tsx
+  it('auto-clone injects aria-labelledby=labelId when a label is present', () => {
+    function LabelledStub(props: { id?: string; 'aria-labelledby'?: string }) {
+      return <input data-testid="control" id={props.id} aria-labelledby={props['aria-labelledby']} />;
+    }
+    const { container } = render(
+      <Field label="Work email">
+        <LabelledStub />
+      </Field>,
+    );
+    const input = screen.getByTestId('control');
+    const label = container.querySelector(`label[for="${input.id}"]`) as HTMLElement;
+    expect(label.id).toBeTruthy();
+    expect(input).toHaveAttribute('aria-labelledby', label.id);
+  });
+
+  it('auto-clone does NOT inject aria-labelledby when there is no label', () => {
+    function LabelledStub(props: { 'aria-labelledby'?: string }) {
+      return <input data-testid="control" aria-labelledby={props['aria-labelledby']} />;
+    }
+    render(
+      <Field>
+        <LabelledStub />
+      </Field>,
+    );
+    expect(screen.getByTestId('control')).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it("the child's explicit aria-labelledby wins over Field's", () => {
+    function LabelledStub(props: { 'aria-labelledby'?: string }) {
+      return <input data-testid="control" aria-labelledby={props['aria-labelledby']} />;
+    }
+    render(
+      <Field label="Email">
+        <LabelledStub aria-labelledby="custom-label" />
+      </Field>,
+    );
+    expect(screen.getByTestId('control')).toHaveAttribute('aria-labelledby', 'custom-label');
+  });
+
+  it('render-prop field object carries aria-labelledby (= labelId when labelled)', () => {
+    let received: Record<string, unknown> = {};
+    render(
+      <Field label="Email">
+        {(field) => {
+          received = field as unknown as Record<string, unknown>;
+          return <input data-testid="control" {...field} />;
+        }}
+      </Field>,
+    );
+    expect(received['aria-labelledby']).toBe(received.labelId);
+    expect(screen.getByTestId('control')).toHaveAttribute('aria-labelledby', received.labelId as string);
+  });
+
+  it('asGroup does NOT inject aria-labelledby onto the child (it lives on the role=group wrapper)', () => {
+    function LabelledStub(props: { 'aria-labelledby'?: string }) {
+      return <input data-testid="control" aria-labelledby={props['aria-labelledby']} />;
+    }
+    render(
+      <Field asGroup label="Notify me">
+        <LabelledStub />
+      </Field>,
+    );
+    expect(screen.getByTestId('control')).not.toHaveAttribute('aria-labelledby');
+  });
+```
+
+- [ ] **Step 6: Run Field tests + typecheck + lint**
+
+```bash
+cd /Users/dpws/projects/design-system/packages/design-system && npx vitest run src/components/Field
+cd /Users/dpws/projects/design-system && make build-lib && make lint
+```
+Expected: all Field tests green (existing 13 + 4 new); typecheck + lint clean. (No existing Field test asserts the *absence* of `aria-labelledby`, so none regress.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/dpws/projects/design-system
+git add packages/design-system/src/components/Field/Field.tsx packages/design-system/src/components/Field/Field.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(Field): wire aria-labelledby so composite controls get an accessible name
+
+Auto-clone (and the render-prop `field` object) now also convey
+aria-labelledby={labelId}, guarded (child's value wins; only when a label is
+rendered). Native controls are unchanged (same name via htmlFor). Composite
+controls that forward aria-labelledby (Select, Slider, …) are now named by a
+Field label.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: ColorPicker forwards `aria-labelledby`/`aria-describedby` to the trigger
+
+**Files:** Modify `packages/design-system/src/components/ColorPicker/ColorPicker.tsx`; Test `.../ColorPicker.test.tsx`. (Everything is in `ColorPicker.tsx` — `DefaultTrigger` is an internal `forwardRef` button; there is no separate trigger file. `cloneElement` is NOT yet imported there — add it to the React import.)
+
+- [ ] **Step 1: Add the two props to `ColorPickerProps`** (after the `triggerLabel` block):
+
+```tsx
+  /**
+   * Id(s) of element(s) that label the trigger button. Forwarded onto the
+   * focusable trigger (not the root wrapper) and takes precedence over the
+   * generated `aria-label`. Set automatically when wrapped in `<Field label>`.
+   */
+  'aria-labelledby'?: string;
+  /**
+   * Id(s) of element(s) that describe the trigger button (e.g. a Field error or
+   * helper text). Forwarded onto the focusable trigger, not the root wrapper.
+   */
+  'aria-describedby'?: string;
+```
+
+- [ ] **Step 2: Add `labelledBy`/`describedBy` to `DefaultTriggerProps`** (after `open: boolean;`):
+
+```tsx
+    labelledBy?: string;
+    describedBy?: string;
+```
+
+- [ ] **Step 3: Wire them on the `DefaultTrigger` button**
+
+Change the `DefaultTrigger` destructure to `{ hex, label, disabled, open, onClick, labelledBy, describedBy }` and the `<button>` head to:
+
+```tsx
+        <button
+          ref={ref}
+          type="button"
+          className={styles.trigger}
+          disabled={disabled}
+          // An external label (e.g. <Field label>) wins; otherwise fall back to
+          // the self-describing generated label. Never set both.
+          aria-label={labelledBy ? undefined : `${label}, current value ${display}`}
+          aria-labelledby={labelledBy}
+          aria-describedby={describedBy}
+          aria-haspopup="true"
+          aria-expanded={open}
+          onClick={onClick}
+        >
+```
+
+- [ ] **Step 4: Destructure the props in `ColorPickerRoot` and pass them down**
+
+In `ColorPickerRoot`'s destructure add `'aria-labelledby': ariaLabelledBy,` and `'aria-describedby': ariaDescribedBy,` (before `children`). On the `<DefaultTrigger …>` element add `labelledBy={ariaLabelledBy}` and `describedBy={ariaDescribedBy}`. For the **custom-trigger** branch, clone the consumer child to inject the same so custom triggers are named too:
+
+```tsx
+    const triggerElement = customTrigger ? (
+      cloneElement(customTrigger.props.children as ReactElement, {
+        'aria-labelledby': ariaLabelledBy,
+        'aria-describedby': ariaDescribedBy,
+      })
+    ) : (
+      <DefaultTrigger
+        hex={value}
+        label={resolvedTriggerLabel}
+        disabled={disabled}
+        open={open}
+        labelledBy={ariaLabelledBy}
+        describedBy={ariaDescribedBy}
+        onClick={() => {}}
+      />
+    );
+```
+
+Add **only** `cloneElement` to the existing `react` import (it's a value import — put it in the non-type group, e.g. after `Children,`). **`ReactElement` is already imported** (`type ReactElement,` on line ~8) — do NOT re-add it (duplicate import = TS2300). This Step replaces the whole existing `const triggerElement = customTrigger ? (...) : (...)` expression (you may keep or drop its two inline comments). (`...rest` no longer carries the two aria props — they're destructured out — so they stop leaking onto the wrapper `<div>`.)
+
+- [ ] **Step 5: Tests** — add to `ColorPicker.test.tsx` (add `import { Field } from '../Field';`; reuse the file's existing pointer-capture/ResizeObserver shims):
+
+```tsx
+describe('ColorPicker — labelledby / describedby forwarding', () => {
+  it('a Field label names the trigger button (auto-clone)', () => {
+    render(
+      <Field label="Brand color">
+        <ColorPicker value="#4F46E5" onChange={() => {}} />
+      </Field>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Brand color' });
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(trigger).toHaveAttribute('aria-labelledby');
+    expect(trigger).not.toHaveAttribute('aria-label');
+  });
+
+  it('forwards aria-labelledby / aria-describedby to the trigger, not the root', () => {
+    const { container } = render(
+      <>
+        <span id="lbl">Pick brand color</span>
+        <span id="desc">Used across the app</span>
+        <ColorPicker value="#FF0000" onChange={() => {}} aria-labelledby="lbl" aria-describedby="desc" />
+      </>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Pick brand color' });
+    expect(trigger).toHaveAttribute('aria-labelledby', 'lbl');
+    expect(trigger).toHaveAttribute('aria-describedby', 'desc');
+    expect(container.querySelector('div')).not.toHaveAttribute('aria-labelledby');
+  });
+});
+```
+
+> Also add a **custom-trigger** test covering the new `cloneElement` branch: render a ColorPicker with a custom trigger inside a Field and assert the Field label names it. Confirm the exact custom-trigger API from `ColorPicker.tsx` first (it reads `customTrigger.props.children`, where `customTrigger` is the `ColorPickerTrigger` marker child) — e.g. `<Field label="Brand color"><ColorPicker value="#000" onChange={()=>{}}><ColorPickerTrigger><Button>Pick</Button></ColorPickerTrigger></ColorPicker></Field>` then `getByRole('button', { name: 'Brand color' })`. Adjust to the real marker API.
+
+- [ ] **Step 6: Verify + commit**
+
+```bash
+cd /Users/dpws/projects/design-system/packages/design-system && npx vitest run src/components/ColorPicker
+cd /Users/dpws/projects/design-system && make build-lib && make lint
+git add packages/design-system/src/components/ColorPicker/ColorPicker.tsx packages/design-system/src/components/ColorPicker/ColorPicker.test.tsx
+git commit -m "$(cat <<'EOF'
+fix(ColorPicker): forward aria-labelledby/aria-describedby to the trigger button
+
+So a <Field label> names the focusable trigger (not the wrapper div); an
+external aria-labelledby wins over the generated aria-label.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: FileUpload forwards `aria-labelledby`/`aria-describedby` to the dropzone
+
+**Files:** Modify `packages/design-system/src/components/FileUpload/FileUpload.tsx`; Test `.../FileUpload.test.tsx`. (No prop-interface change — `FileUploadProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>`, which already includes `aria-labelledby`/`aria-describedby`; we only re-route them.)
+
+- [ ] **Step 1: Destructure the two props out of `...rest`** (add before `className` in the props destructure):
+
+```tsx
+    'aria-labelledby': ariaLabelledBy,
+    'aria-describedby': ariaDescribedBy,
+```
+
+- [ ] **Step 2: Put them on the `role="button"` dropzone** (the focusable element). Add `aria-labelledby`/`aria-describedby` to the dropzone, keeping the existing `aria-label` as a fallback (accessible-name precedence picks `aria-labelledby` when present):
+
+```tsx
+          role="button"
+          tabIndex={disabled ? -1 : 0}
+          aria-labelledby={ariaLabelledBy}
+          aria-label={typeof dropzoneLabel === 'string' ? dropzoneLabel : t('fileUpload.upload')}
+          aria-describedby={ariaDescribedBy}
+          aria-disabled={disabled || undefined}
+```
+
+(The root `<div {...rest}>` is unchanged in shape but no longer receives the two aria props.)
+
+- [ ] **Step 3: Tests** — add to `FileUpload.test.tsx` (`import { Field } from '../Field';`):
+
+```tsx
+  it('a Field label names the dropzone (auto-clone)', () => {
+    render(
+      <Field label="Attachments">
+        <FileUpload files={[]} onFilesAdded={() => {}} onFileRemove={() => {}} />
+      </Field>,
+    );
+    expect(screen.getByRole('button', { name: 'Attachments' })).toBeInTheDocument();
+  });
+
+  it('forwards aria-labelledby onto the dropzone, not the root', () => {
+    render(
+      <>
+        <span id="ext-label">Attachments</span>
+        <FileUpload aria-labelledby="ext-label" files={[]} onFilesAdded={() => {}} onFileRemove={() => {}} />
+      </>,
+    );
+    expect(screen.getByRole('button', { name: 'Attachments' })).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 4: Verify + commit**
+
+```bash
+cd /Users/dpws/projects/design-system/packages/design-system && npx vitest run src/components/FileUpload
+cd /Users/dpws/projects/design-system && make build-lib && make lint
+git add packages/design-system/src/components/FileUpload/FileUpload.tsx packages/design-system/src/components/FileUpload/FileUpload.test.tsx
+git commit -m "$(cat <<'EOF'
+fix(FileUpload): forward aria-labelledby/aria-describedby to the dropzone
+
+Re-route the aria attrs from the root wrapper onto the focusable role="button"
+dropzone, so a <Field label> names it. aria-label remains the fallback.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: TimeField — `aria-label` optional + accept/forward `aria-labelledby`
+
+**Files:** Modify `packages/design-system/src/components/TimeField/TimeField.tsx`; Test `.../TimeField.test.tsx`. Backward-compatible: every caller (DatePicker/DateRangePicker + inline variants + demos) already passes `aria-label`, so widening it to optional breaks nothing.
+
+- [ ] **Step 1: Make `aria-label` optional + add `aria-labelledby` to the props**
+
+```tsx
+    /**
+     * Accessible label. Optional, but the control MUST be named: pass `aria-label`
+     * for a standalone TimeField, OR `aria-labelledby` when an external element
+     * (e.g. a `<Field>` label) names it. If both are given, `aria-labelledby` wins.
+     */
+    'aria-label'?: string;
+    /**
+     * Id(s) of element(s) that label this control — forwarded onto the inner
+     * `<input>` so a `<Field label>` names it. Takes precedence over `aria-label`.
+     */
+    'aria-labelledby'?: string;
+```
+
+- [ ] **Step 2: Destructure `aria-labelledby`** (next to `'aria-label': ariaLabel,`):
+
+```tsx
+    'aria-labelledby': ariaLabelledBy,
+```
+
+- [ ] **Step 3: Forward it on the `role="group"` wrapper** (alongside the existing `aria-label`):
+
+```tsx
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      {...rest}
+```
+
+- [ ] **Step 4: Forward it on the time `<input>`** (insert right after the existing `aria-label={ariaLabel}` line, before `aria-haspopup="listbox"`):
+
+```tsx
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+```
+
+- [ ] **Step 5: Keep the chevron toggle named when only `aria-labelledby` is given.** The toggle composes `"<label>, <open-list hint>"`; when `ariaLabel` is undefined, that string would read "undefined, …". Make the toggle's `aria-label` conditional and also accept `aria-labelledby` (no new i18n key):
+
+```tsx
+        aria-label={ariaLabel ? `${ariaLabel}, ${t('datePicker.timeOpenList')}` : undefined}
+        aria-labelledby={ariaLabelledBy}
+```
+
+(When `aria-label` is present, the toggle keeps its current rich name; when only `aria-labelledby` is supplied, the toggle is named by the external label.)
+
+- [ ] **Step 6: Tests** — add to `TimeField.test.tsx` (`import { Field } from '../Field';`; reuse the file's existing `wrap()` provider helper):
+
+```tsx
+describe('TimeField — labelling', () => {
+  it('a Field label names the inner input (auto-clone)', () => {
+    function Driver() {
+      const [v, setV] = useState<TimeValue | null>({ hours: 9, minutes: 0 });
+      return (
+        <Field label="Start time">
+          <TimeField value={v} hourCycle="24" onChange={setV} />
+        </Field>
+      );
+    }
+    render(<Driver />, { wrapper: wrap() });
+    expect(screen.getByRole('textbox', { name: 'Start time' })).toHaveValue('09:00');
+  });
+
+  it('back-compat: passing only aria-label still names the input + group', () => {
+    render(<TimeField value={{ hours: 14, minutes: 30 }} hourCycle="24" aria-label="Departure time" onChange={() => {}} />, {
+      wrapper: wrap(),
+    });
+    expect(screen.getByRole('textbox', { name: 'Departure time' })).toHaveValue('14:30');
+    expect(screen.getByRole('group', { name: 'Departure time' })).toBeInTheDocument();
+  });
+});
+```
+
+> Note: the auto-clone test relies on Task 1 (Field injects `aria-labelledby`) — run after Task 1 is committed. Only `import { Field } from '../Field';` needs adding — `useState`, `TimeValue`, and the `wrap()` provider helper are already present in `TimeField.test.tsx`.
+> Step-3 ordering: the `aria-labelledby={ariaLabelledBy}` on the `role="group"` wrapper sits **before** `{...rest}`, which is only safe because Step 2 destructures `aria-labelledby` out of props — keep Step 2 before Step 3.
+
+- [ ] **Step 7: Verify + commit**
+
+```bash
+cd /Users/dpws/projects/design-system/packages/design-system && npx vitest run src/components/TimeField src/components/DatePicker src/components/DateRangePicker
+cd /Users/dpws/projects/design-system && make build-lib && make lint
+git add packages/design-system/src/components/TimeField/TimeField.tsx packages/design-system/src/components/TimeField/TimeField.test.tsx
+git commit -m "$(cat <<'EOF'
+fix(TimeField): aria-label optional + forward aria-labelledby to the input
+
+Lets a <Field label> name the time input (aria-labelledby wins over aria-label).
+Backward-compatible — all existing callers still pass aria-label.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Select + Slider regression tests (no source change)
+
+**Files:** Test-only — `packages/design-system/src/components/Select/Select.test.tsx`, `packages/design-system/src/components/Slider/Slider.test.tsx`. Both controls already forward `aria-labelledby` to their focusable element; these tests lock the Field integration (they pass because of Task 1).
+
+- [ ] **Step 1: Select test** — add (`import { Field } from '../Field';`):
+
+```tsx
+  it('a Field label names the combobox (auto-clone)', async () => {
+    render(
+      <Field label="Status">
+        <Select
+          options={[
+            { value: 'a', label: 'Active' },
+            { value: 'b', label: 'Archived' },
+          ]}
+        />
+      </Field>,
+    );
+    expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
+  });
+```
+> The default single, non-searchable Select trigger is a `<button aria-haspopup="listbox">`. If the file's other tests query it as `combobox`, match that role instead — use whatever role the existing "opens the listbox on trigger click" test uses for the trigger.
+
+- [ ] **Step 2: Slider test** — add (`import { Field } from '../Field';`):
+
+```tsx
+  it('a Field label names the slider thumb (auto-clone)', () => {
+    render(
+      <Field label="Volume">
+        <Slider value={40} onChange={() => {}} />
+      </Field>,
+    );
+    expect(screen.getByRole('slider', { name: 'Volume' })).toBeInTheDocument();
+  });
+```
+> Use the minimal valid Slider props the file's existing tests use (single-value). If Slider is uncontrolled-capable, `defaultValue` is fine.
+
+> **Multi-select Select note:** the multi-select trigger variants emit a fallback `aria-label` (e.g. "Open select" / "Selected: …"). When wrapped in a Field, the trigger carries BOTH that fallback `aria-label` and the injected `aria-labelledby` → per AccName `aria-labelledby` wins, so the name is still the Field label (harmless, intentional). Optionally add a multi-select regression test (`<Field label="Status"><Select multiple .../></Field>` → `getByRole('button', { name: 'Status' })`) — confirm the multi trigger role/props from `Select/Trigger.tsx` first. Select source stays **unchanged** (per spec); suppressing the stale fallback `aria-label` when `aria-labelledby` is present is an optional follow-up.
+
+- [ ] **Step 3: Run + commit**
+
+```bash
+cd /Users/dpws/projects/design-system/packages/design-system && npx vitest run src/components/Select src/components/Slider
+cd /Users/dpws/projects/design-system && make build-lib && make lint
+git add packages/design-system/src/components/Select/Select.test.tsx packages/design-system/src/components/Slider/Slider.test.tsx
+git commit -m "$(cat <<'EOF'
+test(Select,Slider): lock Field-label accessible-name integration
+
+No source change — both already forward aria-labelledby; these regression tests
+prove a <Field label> names the combobox / slider thumb (via Field's new
+aria-labelledby injection).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Full verify + Rule 8 review + PR
+
+- [ ] **Step 1: Full gates**
+
+```bash
+cd /Users/dpws/projects/design-system
+make test          # full vitest suite — all green (incl. all new tests)
+make build         # typecheck + bundle
+make lint          # stylelint
+npm run format:check
+npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -ciE '\.test\.|\.spec\.'   # expect 0
+```
+If `format:check` flags new/changed files, `npx prettier --write` them and amend.
+
+- [ ] **Step 2: Library Rule 8 review-fix loop**
+
+Changes touch `packages/design-system/**`, so run the pre-push review cycle (`packages/design-system/CLAUDE.md` Rule 8): a fresh-context reviewer over the diff, briefed on the 10 categories (bugs, a11y, API consistency, type safety, Rules 1–7, test coverage, token discipline, SCSS, cross-package leakage, packaging). Fix Critical/Important; re-run gates; re-review until "clean enough to stop". Pay special attention to: no control emits BOTH a conflicting `aria-label` and `aria-labelledby` that name differently; native controls' accessible names unchanged; TimeField callers still compile. **Known/pre-existing (do not re-flag):** Field already injects the DS `invalid`/`required` props onto auto-cloned children; for composite controls that don't consume them, they fall through `{...rest}` onto a root `<div>` and React logs a dev warning. This predates this change (the new `aria-labelledby` is a valid global attribute and adds no warning) and is out of scope for the a11y fix.
+
+- [ ] **Step 3: Manual smoke (optional)**
+
+`make dev` → open `/components/select`, `/components/color-picker`, `/components/file-upload`, `/components/timefield`; verify each, when wrapped by a Field (or via the custom-fields / member-profile mockups), exposes the Field label as its accessible name (inspect the focusable element's computed name in the a11y panel).
+
+- [ ] **Step 4: Push + PR**
+
+```bash
+cd /Users/dpws/projects/design-system
+git push -u origin fix/field-labels-composites
+gh pr create --base main --head fix/field-labels-composites \
+  --title "fix(a11y): <Field> names composite controls (Select/Slider/ColorPicker/FileUpload/TimeField)" \
+  --body "$(cat <<'EOF'
+## Summary
+`<Field label="X"><Select/></Field>` (and Slider/ColorPicker/FileUpload/TimeField) exposed **no accessible name** — Field named via `<label htmlFor>` + an injected `id`, which lands on a wrapper `<div>` for composite controls while the focusable trigger keeps its own id.
+
+- **Field**: auto-clone + the render-prop `field` object now also convey `aria-labelledby={labelId}` (guarded; child's value wins; only when a label is rendered). Native controls unchanged (same name). **Select + Slider** get named for free (they already forward `aria-labelledby`).
+- **ColorPicker / FileUpload / TimeField**: forward `aria-labelledby` (+ `aria-describedby`) onto their focusable element; **TimeField**'s `aria-label` is now optional (backward-compatible).
+
+## Test plan
+- [x] Field unit tests (inject when labelled / not when unlabelled / child wins / render-prop carries it)
+- [x] Per-control: `<Field label="X"><Control/></Field>` → `getByRole(role, { name: 'X' })` for Select, Slider, ColorPicker, FileUpload, TimeField
+- [x] Back-compat: TimeField with only `aria-label` still named; native controls unchanged
+- [x] `make test` / `make build` / `make lint` / `prettier --check` green; `npm pack --dry-run` test-free
+- [x] Library Rule 8 review loop clean
+- [ ] CI `Quality / check`
+
+## Downstream
+After merge, the merged member-profile mockup's Selects get named automatically; the custom-fields Type Select can simplify from its render-prop workaround back to auto-clone (separate follow-up).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review (against the spec)
+
+**Spec coverage:** ✅ Field core injects/exposes `aria-labelledby` (Task 1). ✅ ColorPicker (Task 2), FileUpload (Task 3), TimeField incl. optional aria-label (Task 4) forward it. ✅ Select + Slider regression tests, no source change (Task 5). ✅ Acceptance test per control (`getByRole(role,{name})`). ✅ Native controls unchanged; back-compat for TimeField callers. ✅ Rule 1/7/8. ✅ No FieldContext; OptionsPicker excluded.
+
+**Placeholder scan:** none — exact before/after edits + full test code + commands. (The Select trigger-role and Slider minimal-props notes point to the existing test conventions rather than guessing.)
+
+**Type consistency:** `FieldRenderProps` gains `'aria-labelledby': string | undefined`, set on `field` and used by the auto-clone injection. ColorPicker adds `'aria-labelledby'`/`'aria-describedby'` to `ColorPickerProps` + `labelledBy`/`describedBy` to `DefaultTriggerProps`. FileUpload/TimeField rely on existing HTMLAttributes aria keys (TimeField also adds explicit `aria-labelledby` to its props). Test imports use the relative `../Field` path (same-package convention).
+
+## Follow-ups (out of scope)
+- Simplify the custom-fields mockup's Type Select from render-prop to plain auto-clone.
+- The stray consumer-`id`-on-wrapper hygiene in Select/Slider (inert) — optional.

--- a/docs/superpowers/plans/2026-06-02-field-labels-composites.md
+++ b/docs/superpowers/plans/2026-06-02-field-labels-composites.md
@@ -43,26 +43,26 @@ git config --get core.hooksPath  # expect: .husky/_
 In `Field.tsx`, replace the `const injected … cloneElement(child, injected);` block with an if/else so the conditional `aria-labelledby` can be added only when a label is rendered:
 
 ```tsx
-    const child = children as ReactElement<Record<string, unknown>>;
-    const childProps = child.props;
-    let injected: Record<string, unknown>;
-    if (asGroup) {
-      injected = {
-        invalid: childProps.invalid ?? invalid,
-        required: childProps.required ?? requiredBool,
-      };
-    } else {
-      injected = {
-        id: controlId,
-        'aria-describedby': childProps['aria-describedby'] ?? describedBy,
-        invalid: childProps.invalid ?? invalid,
-        required: childProps.required ?? requiredBool,
-      };
-      if (label != null) {
-        injected['aria-labelledby'] = childProps['aria-labelledby'] ?? labelId;
-      }
-    }
-    control = cloneElement(child, injected);
+const child = children as ReactElement<Record<string, unknown>>;
+const childProps = child.props;
+let injected: Record<string, unknown>;
+if (asGroup) {
+  injected = {
+    invalid: childProps.invalid ?? invalid,
+    required: childProps.required ?? requiredBool,
+  };
+} else {
+  injected = {
+    id: controlId,
+    'aria-describedby': childProps['aria-describedby'] ?? describedBy,
+    invalid: childProps.invalid ?? invalid,
+    required: childProps.required ?? requiredBool,
+  };
+  if (label != null) {
+    injected['aria-labelledby'] = childProps['aria-labelledby'] ?? labelId;
+  }
+}
+control = cloneElement(child, injected);
 ```
 
 - [ ] **Step 2: Add `aria-labelledby` to `FieldRenderProps`**
@@ -84,20 +84,21 @@ export interface FieldRenderProps {
 - [ ] **Step 3: Set it on the `field` object**
 
 ```tsx
-  const field: FieldRenderProps = {
-    id: controlId,
-    'aria-describedby': describedBy,
-    'aria-labelledby': label != null ? labelId : undefined,
-    'aria-invalid': invalid || undefined,
-    invalid,
-    required: requiredBool,
-    labelId,
-  };
+const field: FieldRenderProps = {
+  id: controlId,
+  'aria-describedby': describedBy,
+  'aria-labelledby': label != null ? labelId : undefined,
+  'aria-invalid': invalid || undefined,
+  invalid,
+  required: requiredBool,
+  labelId,
+};
 ```
 
 - [ ] **Step 4: Update Field JSDoc**
 
 In the component description, change the wiring list to include `aria-labelledby` and add a sentence:
+
 > "…wires the `id` / `aria-labelledby` / `aria-describedby` / `aria-invalid` association by construction. When a label is present, Field also injects `aria-labelledby` onto the cloned child, so composite controls that forward unknown ARIA props (Select, Slider, ColorPicker, FileUpload, TimeField) get an accessible name automatically. For wrapped/nested DOM that doesn't forward props, use the render-prop and spread `field` (it carries `aria-labelledby`)."
 
 - [ ] **Step 5: Write the Field tests**
@@ -105,70 +106,73 @@ In the component description, change the wiring list to include `aria-labelledby
 Add to `Field.test.tsx` (these use a local stub that forwards `aria-labelledby`, mirroring the existing `RawControl` pattern):
 
 ```tsx
-  it('auto-clone injects aria-labelledby=labelId when a label is present', () => {
-    function LabelledStub(props: { id?: string; 'aria-labelledby'?: string }) {
-      return <input data-testid="control" id={props.id} aria-labelledby={props['aria-labelledby']} />;
-    }
-    const { container } = render(
-      <Field label="Work email">
-        <LabelledStub />
-      </Field>,
-    );
-    const input = screen.getByTestId('control');
-    const label = container.querySelector(`label[for="${input.id}"]`) as HTMLElement;
-    expect(label.id).toBeTruthy();
-    expect(input).toHaveAttribute('aria-labelledby', label.id);
-  });
+it('auto-clone injects aria-labelledby=labelId when a label is present', () => {
+  function LabelledStub(props: { id?: string; 'aria-labelledby'?: string }) {
+    return <input data-testid="control" id={props.id} aria-labelledby={props['aria-labelledby']} />;
+  }
+  const { container } = render(
+    <Field label="Work email">
+      <LabelledStub />
+    </Field>,
+  );
+  const input = screen.getByTestId('control');
+  const label = container.querySelector(`label[for="${input.id}"]`) as HTMLElement;
+  expect(label.id).toBeTruthy();
+  expect(input).toHaveAttribute('aria-labelledby', label.id);
+});
 
-  it('auto-clone does NOT inject aria-labelledby when there is no label', () => {
-    function LabelledStub(props: { 'aria-labelledby'?: string }) {
-      return <input data-testid="control" aria-labelledby={props['aria-labelledby']} />;
-    }
-    render(
-      <Field>
-        <LabelledStub />
-      </Field>,
-    );
-    expect(screen.getByTestId('control')).not.toHaveAttribute('aria-labelledby');
-  });
+it('auto-clone does NOT inject aria-labelledby when there is no label', () => {
+  function LabelledStub(props: { 'aria-labelledby'?: string }) {
+    return <input data-testid="control" aria-labelledby={props['aria-labelledby']} />;
+  }
+  render(
+    <Field>
+      <LabelledStub />
+    </Field>,
+  );
+  expect(screen.getByTestId('control')).not.toHaveAttribute('aria-labelledby');
+});
 
-  it("the child's explicit aria-labelledby wins over Field's", () => {
-    function LabelledStub(props: { 'aria-labelledby'?: string }) {
-      return <input data-testid="control" aria-labelledby={props['aria-labelledby']} />;
-    }
-    render(
-      <Field label="Email">
-        <LabelledStub aria-labelledby="custom-label" />
-      </Field>,
-    );
-    expect(screen.getByTestId('control')).toHaveAttribute('aria-labelledby', 'custom-label');
-  });
+it("the child's explicit aria-labelledby wins over Field's", () => {
+  function LabelledStub(props: { 'aria-labelledby'?: string }) {
+    return <input data-testid="control" aria-labelledby={props['aria-labelledby']} />;
+  }
+  render(
+    <Field label="Email">
+      <LabelledStub aria-labelledby="custom-label" />
+    </Field>,
+  );
+  expect(screen.getByTestId('control')).toHaveAttribute('aria-labelledby', 'custom-label');
+});
 
-  it('render-prop field object carries aria-labelledby (= labelId when labelled)', () => {
-    let received: Record<string, unknown> = {};
-    render(
-      <Field label="Email">
-        {(field) => {
-          received = field as unknown as Record<string, unknown>;
-          return <input data-testid="control" {...field} />;
-        }}
-      </Field>,
-    );
-    expect(received['aria-labelledby']).toBe(received.labelId);
-    expect(screen.getByTestId('control')).toHaveAttribute('aria-labelledby', received.labelId as string);
-  });
+it('render-prop field object carries aria-labelledby (= labelId when labelled)', () => {
+  let received: Record<string, unknown> = {};
+  render(
+    <Field label="Email">
+      {(field) => {
+        received = field as unknown as Record<string, unknown>;
+        return <input data-testid="control" {...field} />;
+      }}
+    </Field>,
+  );
+  expect(received['aria-labelledby']).toBe(received.labelId);
+  expect(screen.getByTestId('control')).toHaveAttribute(
+    'aria-labelledby',
+    received.labelId as string,
+  );
+});
 
-  it('asGroup does NOT inject aria-labelledby onto the child (it lives on the role=group wrapper)', () => {
-    function LabelledStub(props: { 'aria-labelledby'?: string }) {
-      return <input data-testid="control" aria-labelledby={props['aria-labelledby']} />;
-    }
-    render(
-      <Field asGroup label="Notify me">
-        <LabelledStub />
-      </Field>,
-    );
-    expect(screen.getByTestId('control')).not.toHaveAttribute('aria-labelledby');
-  });
+it('asGroup does NOT inject aria-labelledby onto the child (it lives on the role=group wrapper)', () => {
+  function LabelledStub(props: { 'aria-labelledby'?: string }) {
+    return <input data-testid="control" aria-labelledby={props['aria-labelledby']} />;
+  }
+  render(
+    <Field asGroup label="Notify me">
+      <LabelledStub />
+    </Field>,
+  );
+  expect(screen.getByTestId('control')).not.toHaveAttribute('aria-labelledby');
+});
 ```
 
 - [ ] **Step 6: Run Field tests + typecheck + lint**
@@ -177,7 +181,8 @@ Add to `Field.test.tsx` (these use a local stub that forwards `aria-labelledby`,
 cd /Users/dpws/projects/design-system/packages/design-system && npx vitest run src/components/Field
 cd /Users/dpws/projects/design-system && make build-lib && make lint
 ```
-Expected: all Field tests green (existing 13 + 4 new); typecheck + lint clean. (No existing Field test asserts the *absence* of `aria-labelledby`, so none regress.)
+
+Expected: all Field tests green (existing 13 + 4 new); typecheck + lint clean. (No existing Field test asserts the _absence_ of `aria-labelledby`, so none regress.)
 
 - [ ] **Step 7: Commit**
 
@@ -253,22 +258,22 @@ Change the `DefaultTrigger` destructure to `{ hex, label, disabled, open, onClic
 In `ColorPickerRoot`'s destructure add `'aria-labelledby': ariaLabelledBy,` and `'aria-describedby': ariaDescribedBy,` (before `children`). On the `<DefaultTrigger …>` element add `labelledBy={ariaLabelledBy}` and `describedBy={ariaDescribedBy}`. For the **custom-trigger** branch, clone the consumer child to inject the same so custom triggers are named too:
 
 ```tsx
-    const triggerElement = customTrigger ? (
-      cloneElement(customTrigger.props.children as ReactElement, {
-        'aria-labelledby': ariaLabelledBy,
-        'aria-describedby': ariaDescribedBy,
-      })
-    ) : (
-      <DefaultTrigger
-        hex={value}
-        label={resolvedTriggerLabel}
-        disabled={disabled}
-        open={open}
-        labelledBy={ariaLabelledBy}
-        describedBy={ariaDescribedBy}
-        onClick={() => {}}
-      />
-    );
+const triggerElement = customTrigger ? (
+  cloneElement(customTrigger.props.children as ReactElement, {
+    'aria-labelledby': ariaLabelledBy,
+    'aria-describedby': ariaDescribedBy,
+  })
+) : (
+  <DefaultTrigger
+    hex={value}
+    label={resolvedTriggerLabel}
+    disabled={disabled}
+    open={open}
+    labelledBy={ariaLabelledBy}
+    describedBy={ariaDescribedBy}
+    onClick={() => {}}
+  />
+);
 ```
 
 Add **only** `cloneElement` to the existing `react` import (it's a value import — put it in the non-type group, e.g. after `Children,`). **`ReactElement` is already imported** (`type ReactElement,` on line ~8) — do NOT re-add it (duplicate import = TS2300). This Step replaces the whole existing `const triggerElement = customTrigger ? (...) : (...)` expression (you may keep or drop its two inline comments). (`...rest` no longer carries the two aria props — they're destructured out — so they stop leaking onto the wrapper `<div>`.)
@@ -294,7 +299,12 @@ describe('ColorPicker — labelledby / describedby forwarding', () => {
       <>
         <span id="lbl">Pick brand color</span>
         <span id="desc">Used across the app</span>
-        <ColorPicker value="#FF0000" onChange={() => {}} aria-labelledby="lbl" aria-describedby="desc" />
+        <ColorPicker
+          value="#FF0000"
+          onChange={() => {}}
+          aria-labelledby="lbl"
+          aria-describedby="desc"
+        />
       </>,
     );
     const trigger = screen.getByRole('button', { name: 'Pick brand color' });
@@ -353,24 +363,29 @@ EOF
 - [ ] **Step 3: Tests** — add to `FileUpload.test.tsx` (`import { Field } from '../Field';`):
 
 ```tsx
-  it('a Field label names the dropzone (auto-clone)', () => {
-    render(
-      <Field label="Attachments">
-        <FileUpload files={[]} onFilesAdded={() => {}} onFileRemove={() => {}} />
-      </Field>,
-    );
-    expect(screen.getByRole('button', { name: 'Attachments' })).toBeInTheDocument();
-  });
+it('a Field label names the dropzone (auto-clone)', () => {
+  render(
+    <Field label="Attachments">
+      <FileUpload files={[]} onFilesAdded={() => {}} onFileRemove={() => {}} />
+    </Field>,
+  );
+  expect(screen.getByRole('button', { name: 'Attachments' })).toBeInTheDocument();
+});
 
-  it('forwards aria-labelledby onto the dropzone, not the root', () => {
-    render(
-      <>
-        <span id="ext-label">Attachments</span>
-        <FileUpload aria-labelledby="ext-label" files={[]} onFilesAdded={() => {}} onFileRemove={() => {}} />
-      </>,
-    );
-    expect(screen.getByRole('button', { name: 'Attachments' })).toBeInTheDocument();
-  });
+it('forwards aria-labelledby onto the dropzone, not the root', () => {
+  render(
+    <>
+      <span id="ext-label">Attachments</span>
+      <FileUpload
+        aria-labelledby="ext-label"
+        files={[]}
+        onFilesAdded={() => {}}
+        onFileRemove={() => {}}
+      />
+    </>,
+  );
+  expect(screen.getByRole('button', { name: 'Attachments' })).toBeInTheDocument();
+});
 ```
 
 - [ ] **Step 4: Verify + commit**
@@ -462,9 +477,17 @@ describe('TimeField — labelling', () => {
   });
 
   it('back-compat: passing only aria-label still names the input + group', () => {
-    render(<TimeField value={{ hours: 14, minutes: 30 }} hourCycle="24" aria-label="Departure time" onChange={() => {}} />, {
-      wrapper: wrap(),
-    });
+    render(
+      <TimeField
+        value={{ hours: 14, minutes: 30 }}
+        hourCycle="24"
+        aria-label="Departure time"
+        onChange={() => {}}
+      />,
+      {
+        wrapper: wrap(),
+      },
+    );
     expect(screen.getByRole('textbox', { name: 'Departure time' })).toHaveValue('14:30');
     expect(screen.getByRole('group', { name: 'Departure time' })).toBeInTheDocument();
   });
@@ -500,34 +523,36 @@ EOF
 - [ ] **Step 1: Select test** — add (`import { Field } from '../Field';`):
 
 ```tsx
-  it('a Field label names the combobox (auto-clone)', async () => {
-    render(
-      <Field label="Status">
-        <Select
-          options={[
-            { value: 'a', label: 'Active' },
-            { value: 'b', label: 'Archived' },
-          ]}
-        />
-      </Field>,
-    );
-    expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
-  });
+it('a Field label names the combobox (auto-clone)', async () => {
+  render(
+    <Field label="Status">
+      <Select
+        options={[
+          { value: 'a', label: 'Active' },
+          { value: 'b', label: 'Archived' },
+        ]}
+      />
+    </Field>,
+  );
+  expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
+});
 ```
+
 > The default single, non-searchable Select trigger is a `<button aria-haspopup="listbox">`. If the file's other tests query it as `combobox`, match that role instead — use whatever role the existing "opens the listbox on trigger click" test uses for the trigger.
 
 - [ ] **Step 2: Slider test** — add (`import { Field } from '../Field';`):
 
 ```tsx
-  it('a Field label names the slider thumb (auto-clone)', () => {
-    render(
-      <Field label="Volume">
-        <Slider value={40} onChange={() => {}} />
-      </Field>,
-    );
-    expect(screen.getByRole('slider', { name: 'Volume' })).toBeInTheDocument();
-  });
+it('a Field label names the slider thumb (auto-clone)', () => {
+  render(
+    <Field label="Volume">
+      <Slider value={40} onChange={() => {}} />
+    </Field>,
+  );
+  expect(screen.getByRole('slider', { name: 'Volume' })).toBeInTheDocument();
+});
 ```
+
 > Use the minimal valid Slider props the file's existing tests use (single-value). If Slider is uncontrolled-capable, `defaultValue` is fine.
 
 > **Multi-select Select note:** the multi-select trigger variants emit a fallback `aria-label` (e.g. "Open select" / "Selected: …"). When wrapped in a Field, the trigger carries BOTH that fallback `aria-label` and the injected `aria-labelledby` → per AccName `aria-labelledby` wins, so the name is still the Field label (harmless, intentional). Optionally add a multi-select regression test (`<Field label="Status"><Select multiple .../></Field>` → `getByRole('button', { name: 'Status' })`) — confirm the multi trigger role/props from `Select/Trigger.tsx` first. Select source stays **unchanged** (per spec); suppressing the stale fallback `aria-label` when `aria-labelledby` is present is an optional follow-up.
@@ -564,6 +589,7 @@ make lint          # stylelint
 npm run format:check
 npm pack --dry-run -w @eocrm/design-system 2>&1 | grep -ciE '\.test\.|\.spec\.'   # expect 0
 ```
+
 If `format:check` flags new/changed files, `npx prettier --write` them and amend.
 
 - [ ] **Step 2: Library Rule 8 review-fix loop**
@@ -615,5 +641,6 @@ EOF
 **Type consistency:** `FieldRenderProps` gains `'aria-labelledby': string | undefined`, set on `field` and used by the auto-clone injection. ColorPicker adds `'aria-labelledby'`/`'aria-describedby'` to `ColorPickerProps` + `labelledBy`/`describedBy` to `DefaultTriggerProps`. FileUpload/TimeField rely on existing HTMLAttributes aria keys (TimeField also adds explicit `aria-labelledby` to its props). Test imports use the relative `../Field` path (same-package convention).
 
 ## Follow-ups (out of scope)
+
 - Simplify the custom-fields mockup's Type Select from render-prop to plain auto-clone.
 - The stray consumer-`id`-on-wrapper hygiene in Select/Slider (inert) — optional.

--- a/docs/superpowers/specs/2026-06-02-field-labels-composites-design.md
+++ b/docs/superpowers/specs/2026-06-02-field-labels-composites-design.md
@@ -26,7 +26,7 @@ Discovered during the custom-fields mockup review (worked around there with Fiel
 - `FieldRenderProps` gains `'aria-labelledby': string | undefined` (= `label != null ? labelId : undefined`), so `{...field}` conveys it too.
 - `id` injection stays (native controls still name via `htmlFor`); `asGroup` is unchanged (group naming already lives on the `role="group"` wrapper).
 
-**Why it's safe:** the `*` marker is `aria-hidden` and `(optional)` is already inside the label text, so `aria-labelledby={labelId}` resolves to the *same* accessible name `htmlFor` already produces — no double-announce, no name change for native controls (belt-and-suspenders). `Select` and `Slider` already forward `aria-labelledby` to their focusable element, so they get named **with no control changes**.
+**Why it's safe:** the `*` marker is `aria-hidden` and `(optional)` is already inside the label text, so `aria-labelledby={labelId}` resolves to the _same_ accessible name `htmlFor` already produces — no double-announce, no name change for native controls (belt-and-suspenders). `Select` and `Slider` already forward `aria-labelledby` to their focusable element, so they get named **with no control changes**.
 
 ### Per-control forwarding (the remaining composites)
 

--- a/docs/superpowers/specs/2026-06-02-field-labels-composites-design.md
+++ b/docs/superpowers/specs/2026-06-02-field-labels-composites-design.md
@@ -1,0 +1,79 @@
+# `<Field>` names composite controls (accessible-name fix)
+
+**Date:** 2026-06-02
+**Status:** Approved (brainstorm) → ready for implementation plan
+**Package:** `@eocrm/design-system`
+
+## Problem
+
+`<Field label="X"><Select/></Field>` gives the Select's combobox **no accessible name**. Field associates its label purely via a native `<label htmlFor={controlId}>` and auto-clones `id={controlId}` onto the child's root element. That works only when the child's root **is** the focusable, labelable element (native `<input>`). For composite controls the injected `id` lands on a wrapper `<div>` while the real focusable trigger keeps its own internal id, so `<label htmlFor>` points at a non-labelable wrapper and the control is announced unnamed.
+
+Discovered during the custom-fields mockup review (worked around there with Field's render-prop). The **already-merged member-profile** mockup has the same latent gap (Field + Select for timezone/language/role).
+
+**Scope audit (focusable element vs. the id-receiving element):**
+
+- **Fine** (id reaches the real `<input>`, `htmlFor` works): `Input`, `Textarea`, `Checkbox`, `Radio`, `Switch`, `PasswordInput`, `DatePicker`, `DateRangePicker`. No change.
+- **Affected** (focusable trigger ≠ id-receiving root): `Select`, `Slider`, `ColorPicker`, `FileUpload`, `TimeField`.
+- **Excluded:** `OptionsPicker` (documented "not a form field — use Select"), `RadioGroup` (uses Field `asGroup`).
+
+## Approach (chosen)
+
+### Core: Field also conveys `aria-labelledby`
+
+`<Field>` already computes a stable `labelId = ${controlId}-label` and renders `<label id={labelId} htmlFor={controlId}>`. The fix: Field's **auto-clone** (non-`asGroup`) and its **render-prop `field` object** also carry `aria-labelledby={labelId}` — guarded so the child's own value wins and it's only set when a label is rendered:
+
+- Auto-clone `injected` (non-group) gains: `...(label != null ? { 'aria-labelledby': childProps['aria-labelledby'] ?? labelId } : {})`.
+- `FieldRenderProps` gains `'aria-labelledby': string | undefined` (= `label != null ? labelId : undefined`), so `{...field}` conveys it too.
+- `id` injection stays (native controls still name via `htmlFor`); `asGroup` is unchanged (group naming already lives on the `role="group"` wrapper).
+
+**Why it's safe:** the `*` marker is `aria-hidden` and `(optional)` is already inside the label text, so `aria-labelledby={labelId}` resolves to the *same* accessible name `htmlFor` already produces — no double-announce, no name change for native controls (belt-and-suspenders). `Select` and `Slider` already forward `aria-labelledby` to their focusable element, so they get named **with no control changes**.
+
+### Per-control forwarding (the remaining composites)
+
+Each must forward `aria-labelledby` (read from props) onto its **focusable** element:
+
+- **`ColorPicker`** — forward `aria-labelledby` (and `aria-describedby`) onto the trigger `<button>` (DefaultTrigger), not the root wrapper.
+- **`FileUpload`** — forward `aria-labelledby` (and `aria-describedby`) onto the `role="button"` dropzone element, not the root wrapper.
+- **`TimeField`** — relax its **required** `aria-label` to **optional**, accept `aria-labelledby`, and forward it onto the time `<input>`. Backward-compatible: existing callers (e.g. DatePicker embedding TimeField) keep passing `aria-label`; when `aria-labelledby` is present it provides the name (ARIA precedence) so a `<Field>` label wins.
+
+`Select` and `Slider` need **no change** (already forward `aria-labelledby`).
+
+## Components changed
+
+- **`Field`** (core: inject/expose `aria-labelledby`) — `Field.tsx`, `FieldRenderProps`, JSDoc, tests.
+- **`ColorPicker`** — forward `aria-labelledby`/`aria-describedby` to the trigger; tests.
+- **`FileUpload`** — forward `aria-labelledby`/`aria-describedby` to the dropzone; tests.
+- **`TimeField`** — `aria-label` optional + accept/forward `aria-labelledby`; tests.
+- **`Select`, `Slider`** — unchanged; add a regression test each proving `<Field label>` names them.
+
+## Testing (the acceptance criteria)
+
+For each affected control, a test that `<Field label="Type"><Control/></Field>` exposes the accessible name on the focusable element (`getByRole('combobox' | 'slider' | 'button', { name: 'Type' })` or assert `aria-labelledby` on the focusable node resolves to the label):
+
+- **Field unit:** auto-clone injects `aria-labelledby={labelId}` when a label exists; not when label is absent; child's explicit `aria-labelledby` wins; `field` render-prop object includes `aria-labelledby`; existing id/aria-describedby/invalid/required behavior unchanged.
+- **Select / Slider:** `<Field label>` → named focusable (regression lock; no control change).
+- **ColorPicker / FileUpload:** `<Field label>` → named trigger/dropzone.
+- **TimeField:** `aria-label` now omittable; `<Field label>` → named input; passing `aria-label` alone still names it (back-compat).
+- No regression: existing Select/Slider/ColorPicker/FileUpload/TimeField/Field tests stay green; native controls (Input etc.) still named and unchanged.
+
+## Constraints
+
+- **Rule 1** (tests next to each changed component), **Rule 7** (JSDoc: document that Field now wires `aria-labelledby`, and that composite controls forward it; update the `aria-label`/`aria-labelledby` notes on ColorPicker/FileUpload/TimeField), **Rule 8** (pre-push library review-fix loop), **Rule 6** spread-order preserved.
+- No public API removal. `TimeField`'s `aria-label` goes from required → optional (additive/back-compat). No new exported types beyond the added `aria-labelledby` key on `FieldRenderProps`.
+- No SCSS/token changes. i18n unaffected (these are consumer-supplied ARIA props).
+
+## Non-goals
+
+- No `FieldContext` (rejected — overkill for a prop-injection fix).
+- No change to the native-control `id`/`htmlFor` naming path.
+- `OptionsPicker` (not a form field) — left as-is.
+- The stray consumer-`id`-on-wrapper hygiene in Select et al. (inert; not this fix) — optional follow-up.
+
+## Downstream (after merge)
+
+- **member-profile** mockup Selects (timezone/language/role) become named automatically — no change needed.
+- **custom-fields** mockup's Type Select can simplify from the render-prop workaround back to plain auto-clone — optional follow-up (the render-prop still works, just becomes unnecessary).
+
+## Branch
+
+`fix/field-labels-composites`, off `main`. Its own PR.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -556,7 +556,11 @@ import { Switch } from '@eocrm/design-system';
 ```
 
 - Wraps ONE control with its label + help/error + required marker, and auto-wires
-  `id` / `aria-describedby` / `invalid` (controls map `invalid → aria-invalid`).
+  `id` / `aria-labelledby` / `aria-describedby` / `invalid` (controls map `invalid → aria-invalid`).
+- When a `label` is present, Field injects `aria-labelledby` onto the cloned child, so
+  composite controls that forward ARIA props (`Select`, `Slider`, `ColorPicker`,
+  `FileUpload`, `TimeField`) get an accessible name for free. The render-prop `field`
+  object also carries `aria-labelledby` for wrapped/nested DOM.
 - `error` replaces `description` and flips the control invalid. `required` shows `*`;
   `optional` shows `(optional)`. `orientation="horizontal"` = label beside control.
 - Field owns the control `id` — to set one, use `<Field id>`, not the control.

--- a/packages/design-system/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/design-system/src/components/ColorPicker/ColorPicker.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, useState } from 'react';
 import { ColorPicker, hexToHsv, hsvToHex } from './index';
+import { Field } from '../Field';
 
 // jsdom doesn't implement setPointerCapture / releasePointerCapture; stub.
 function ensurePointerCaptureShim() {
@@ -431,6 +432,52 @@ describe('ColorPicker — misc', () => {
       fireEvent.blur(input);
     });
     expect(input.value).toBe('#AABBCC');
+  });
+});
+
+describe('ColorPicker — labelledby / describedby forwarding', () => {
+  it('a Field label names the trigger button (auto-clone)', () => {
+    render(
+      <Field label="Brand color">
+        <ColorPicker value="#4F46E5" onChange={() => {}} />
+      </Field>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Brand color' });
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(trigger).toHaveAttribute('aria-labelledby');
+    expect(trigger).not.toHaveAttribute('aria-label');
+  });
+
+  it('forwards aria-labelledby / aria-describedby to the trigger, not the root', () => {
+    const { container } = render(
+      <>
+        <span id="lbl">Pick brand color</span>
+        <span id="desc">Used across the app</span>
+        <ColorPicker
+          value="#FF0000"
+          onChange={() => {}}
+          aria-labelledby="lbl"
+          aria-describedby="desc"
+        />
+      </>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Pick brand color' });
+    expect(trigger).toHaveAttribute('aria-labelledby', 'lbl');
+    expect(trigger).toHaveAttribute('aria-describedby', 'desc');
+    expect(container.querySelector('div')).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('a Field label names a custom trigger (cloneElement branch)', () => {
+    render(
+      <Field label="Brand color">
+        <ColorPicker value="#000000" onChange={() => {}}>
+          <ColorPicker.Trigger asChild>
+            <button type="button">Pick</button>
+          </ColorPicker.Trigger>
+        </ColorPicker>
+      </Field>,
+    );
+    expect(screen.getByRole('button', { name: 'Brand color' })).toBeInTheDocument();
   });
 });
 

--- a/packages/design-system/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/design-system/src/components/ColorPicker/ColorPicker.test.tsx
@@ -479,6 +479,22 @@ describe('ColorPicker — labelledby / describedby forwarding', () => {
     );
     expect(screen.getByRole('button', { name: 'Brand color' })).toBeInTheDocument();
   });
+
+  it('does NOT clobber a consumer aria-labelledby on a custom trigger when not in a Field', () => {
+    render(
+      <>
+        <span id="ext-cp">My color</span>
+        <ColorPicker value="#000000" onChange={() => {}}>
+          <ColorPicker.Trigger asChild>
+            <button type="button" aria-labelledby="ext-cp" />
+          </ColorPicker.Trigger>
+        </ColorPicker>
+      </>,
+    );
+    // The consumer's own labelling must survive — passing `undefined` through
+    // cloneElement previously stripped it, leaving the trigger nameless.
+    expect(screen.getByRole('button', { name: 'My color' })).toBeInTheDocument();
+  });
 });
 
 describe('round-trip', () => {

--- a/packages/design-system/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/design-system/src/components/ColorPicker/ColorPicker.tsx
@@ -228,10 +228,12 @@ const ColorPickerRoot = forwardRef<HTMLDivElement, ColorPickerProps>(function Co
   const triggerElement = customTrigger ? (
     // The consumer's child is cloned to inject the label/description ids so a
     // custom trigger is named too; <Popover.Trigger> then clones it again to
-    // inject onClick + aria-* + ref.
+    // inject onClick + aria-* + ref. Only inject keys we actually have — passing
+    // `undefined` through cloneElement would CLOBBER any aria-labelledby /
+    // aria-describedby the consumer already set on their own trigger.
     cloneElement(customTrigger.props.children as ReactElement<Record<string, unknown>>, {
-      'aria-labelledby': ariaLabelledBy,
-      'aria-describedby': ariaDescribedBy,
+      ...(ariaLabelledBy !== undefined && { 'aria-labelledby': ariaLabelledBy }),
+      ...(ariaDescribedBy !== undefined && { 'aria-describedby': ariaDescribedBy }),
     })
   ) : (
     <DefaultTrigger

--- a/packages/design-system/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/design-system/src/components/ColorPicker/ColorPicker.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useState,
   Children,
+  cloneElement,
   type HTMLAttributes,
   type ReactElement,
   type ReactNode,
@@ -92,6 +93,17 @@ export interface ColorPickerProps extends Omit<HTMLAttributes<HTMLDivElement>, '
    * a custom trigger is provided via `<ColorPicker.Trigger>`.
    */
   triggerLabel?: string;
+  /**
+   * Id(s) of element(s) that label the trigger button. Forwarded onto the
+   * focusable trigger (not the root wrapper) and takes precedence over the
+   * generated `aria-label`. Set automatically when wrapped in `<Field label>`.
+   */
+  'aria-labelledby'?: string;
+  /**
+   * Id(s) of element(s) that describe the trigger button (e.g. a Field error or
+   * helper text). Forwarded onto the focusable trigger, not the root wrapper.
+   */
+  'aria-describedby'?: string;
   /** Popover placement (split internally into side + align). Default `'bottom-start'`. */
   popoverPlacement?: PopoverPlacement;
   /** Optional `<ColorPicker.Trigger asChild>` override for custom triggers. */
@@ -103,11 +115,13 @@ interface DefaultTriggerProps {
   label: string;
   disabled: boolean;
   open: boolean;
+  labelledBy?: string;
+  describedBy?: string;
   onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 const DefaultTrigger = forwardRef<HTMLButtonElement, DefaultTriggerProps>(function DefaultTrigger(
-  { hex, label, disabled, open, onClick },
+  { hex, label, disabled, open, onClick, labelledBy, describedBy },
   ref,
 ) {
   const display = normalizeHex(hex) ?? FALLBACK_HEX;
@@ -117,7 +131,11 @@ const DefaultTrigger = forwardRef<HTMLButtonElement, DefaultTriggerProps>(functi
       type="button"
       className={styles.trigger}
       disabled={disabled}
-      aria-label={`${label}, current value ${display}`}
+      // An external label (e.g. <Field label>) wins; otherwise fall back to
+      // the self-describing generated label. Never set both.
+      aria-label={labelledBy ? undefined : `${label}, current value ${display}`}
+      aria-labelledby={labelledBy}
+      aria-describedby={describedBy}
       aria-haspopup="true"
       aria-expanded={open}
       onClick={onClick}
@@ -186,6 +204,8 @@ const ColorPickerRoot = forwardRef<HTMLDivElement, ColorPickerProps>(function Co
     disabled = false,
     triggerLabel,
     popoverPlacement = 'bottom-start',
+    'aria-labelledby': ariaLabelledBy,
+    'aria-describedby': ariaDescribedBy,
     children,
     className,
     ...rest
@@ -206,15 +226,21 @@ const ColorPickerRoot = forwardRef<HTMLDivElement, ColorPickerProps>(function Co
   );
 
   const triggerElement = customTrigger ? (
-    // The consumer's child is rendered as-is; <Popover.Trigger> clones it
-    // to inject onClick + aria-* + ref.
-    (customTrigger.props.children as ReactElement)
+    // The consumer's child is cloned to inject the label/description ids so a
+    // custom trigger is named too; <Popover.Trigger> then clones it again to
+    // inject onClick + aria-* + ref.
+    cloneElement(customTrigger.props.children as ReactElement<Record<string, unknown>>, {
+      'aria-labelledby': ariaLabelledBy,
+      'aria-describedby': ariaDescribedBy,
+    })
   ) : (
     <DefaultTrigger
       hex={value}
       label={resolvedTriggerLabel}
       disabled={disabled}
       open={open}
+      labelledBy={ariaLabelledBy}
+      describedBy={ariaDescribedBy}
       // onClick is overridden by Popover.Trigger's cloneElement; we set a
       // no-op here so DefaultTrigger's prop type is satisfied.
       onClick={() => {}}

--- a/packages/design-system/src/components/Field/Field.test.tsx
+++ b/packages/design-system/src/components/Field/Field.test.tsx
@@ -174,4 +174,74 @@ describe('Field', () => {
     expect(raw).toHaveAttribute('data-invalid', 'true');
     expect(raw).not.toHaveAttribute('aria-invalid');
   });
+
+  it('auto-clone injects aria-labelledby=labelId when a label is present', () => {
+    function LabelledStub(props: { id?: string; 'aria-labelledby'?: string }) {
+      return (
+        <input data-testid="control" id={props.id} aria-labelledby={props['aria-labelledby']} />
+      );
+    }
+    const { container } = render(
+      <Field label="Work email">
+        <LabelledStub />
+      </Field>,
+    );
+    const input = screen.getByTestId('control');
+    const label = container.querySelector(`label[for="${input.id}"]`) as HTMLElement;
+    expect(label.id).toBeTruthy();
+    expect(input).toHaveAttribute('aria-labelledby', label.id);
+  });
+
+  it('auto-clone does NOT inject aria-labelledby when there is no label', () => {
+    function LabelledStub(props: { 'aria-labelledby'?: string }) {
+      return <input data-testid="control" aria-labelledby={props['aria-labelledby']} />;
+    }
+    render(
+      <Field>
+        <LabelledStub />
+      </Field>,
+    );
+    expect(screen.getByTestId('control')).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it("the child's explicit aria-labelledby wins over Field's", () => {
+    function LabelledStub(props: { 'aria-labelledby'?: string }) {
+      return <input data-testid="control" aria-labelledby={props['aria-labelledby']} />;
+    }
+    render(
+      <Field label="Email">
+        <LabelledStub aria-labelledby="custom-label" />
+      </Field>,
+    );
+    expect(screen.getByTestId('control')).toHaveAttribute('aria-labelledby', 'custom-label');
+  });
+
+  it('render-prop field object carries aria-labelledby (= labelId when labelled)', () => {
+    let received: Record<string, unknown> = {};
+    render(
+      <Field label="Email">
+        {(field) => {
+          received = field as unknown as Record<string, unknown>;
+          return <input data-testid="control" {...field} />;
+        }}
+      </Field>,
+    );
+    expect(received['aria-labelledby']).toBe(received.labelId);
+    expect(screen.getByTestId('control')).toHaveAttribute(
+      'aria-labelledby',
+      received.labelId as string,
+    );
+  });
+
+  it('asGroup does NOT inject aria-labelledby onto the child (it lives on the role=group wrapper)', () => {
+    function LabelledStub(props: { 'aria-labelledby'?: string }) {
+      return <input data-testid="control" aria-labelledby={props['aria-labelledby']} />;
+    }
+    render(
+      <Field asGroup label="Notify me">
+        <LabelledStub />
+      </Field>,
+    );
+    expect(screen.getByTestId('control')).not.toHaveAttribute('aria-labelledby');
+  });
 });

--- a/packages/design-system/src/components/Field/Field.tsx
+++ b/packages/design-system/src/components/Field/Field.tsx
@@ -22,6 +22,8 @@ export type FieldSize = 'sm' | 'md' | 'lg';
 export interface FieldRenderProps {
   id: string;
   'aria-describedby': string | undefined;
+  /** Id of the label element to name the control — set only when a label is rendered. */
+  'aria-labelledby': string | undefined;
   'aria-invalid': boolean | undefined;
   invalid: boolean;
   required: boolean;
@@ -59,7 +61,12 @@ const MSG_SIZE: Record<FieldSize, TextSize> = { sm: 'xs', md: 'sm', lg: 'sm' };
 /**
  * Labeled-control unit — the editable sibling of `<DefinitionList>`. Wraps a
  * single control with its label, helper/error message, required marker, and the
- * `id` / `aria-describedby` / `aria-invalid` wiring done by construction.
+ * `id` / `aria-labelledby` / `aria-describedby` / `aria-invalid` association by
+ * construction. When a label is present, Field also injects `aria-labelledby`
+ * onto the cloned child, so composite controls that forward unknown ARIA props
+ * (Select, Slider, ColorPicker, FileUpload, TimeField) get an accessible name
+ * automatically. For wrapped/nested DOM that doesn't forward props, use the
+ * render-prop and spread `field` (it carries `aria-labelledby`).
  *
  * The common case auto-wires a single child via `cloneElement`. For wrapped,
  * nested, or native controls, pass a render-prop and spread the `field` object.
@@ -132,6 +139,7 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(function Field(
   const field: FieldRenderProps = {
     id: controlId,
     'aria-describedby': describedBy,
+    'aria-labelledby': label != null ? labelId : undefined,
     'aria-invalid': invalid || undefined,
     invalid,
     required: requiredBool,
@@ -144,14 +152,23 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(function Field(
   } else if (isValidElement(children)) {
     const child = children as ReactElement<Record<string, unknown>>;
     const childProps = child.props;
-    const injected: Record<string, unknown> = asGroup
-      ? { invalid: childProps.invalid ?? invalid, required: childProps.required ?? requiredBool }
-      : {
-          id: controlId,
-          'aria-describedby': childProps['aria-describedby'] ?? describedBy,
-          invalid: childProps.invalid ?? invalid,
-          required: childProps.required ?? requiredBool,
-        };
+    let injected: Record<string, unknown>;
+    if (asGroup) {
+      injected = {
+        invalid: childProps.invalid ?? invalid,
+        required: childProps.required ?? requiredBool,
+      };
+    } else {
+      injected = {
+        id: controlId,
+        'aria-describedby': childProps['aria-describedby'] ?? describedBy,
+        invalid: childProps.invalid ?? invalid,
+        required: childProps.required ?? requiredBool,
+      };
+      if (label != null) {
+        injected['aria-labelledby'] = childProps['aria-labelledby'] ?? labelId;
+      }
+    }
     control = cloneElement(child, injected);
   } else {
     control = children;

--- a/packages/design-system/src/components/FileUpload/FileUpload.test.tsx
+++ b/packages/design-system/src/components/FileUpload/FileUpload.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import { FileUpload, type FileEntry } from './FileUpload';
+import { Field } from '../Field';
 
 // Helper — build a File with controllable name + size + MIME for tests.
 function makeFile(name: string, sizeBytes: number, type: string): File {
@@ -418,5 +419,29 @@ describe('FileUpload', () => {
     expect(dropzone.className).toMatch(/dragOver/);
     fireEvent.dragLeave(dropzone);
     expect(dropzone.className).not.toMatch(/dragOver/);
+  });
+
+  it('a Field label names the dropzone (auto-clone)', () => {
+    render(
+      <Field label="Attachments">
+        <FileUpload files={[]} onFilesAdded={() => {}} onFileRemove={() => {}} />
+      </Field>,
+    );
+    expect(screen.getByRole('button', { name: 'Attachments' })).toBeInTheDocument();
+  });
+
+  it('forwards aria-labelledby onto the dropzone, not the root', () => {
+    render(
+      <>
+        <span id="ext-label">Attachments</span>
+        <FileUpload
+          aria-labelledby="ext-label"
+          files={[]}
+          onFilesAdded={() => {}}
+          onFileRemove={() => {}}
+        />
+      </>,
+    );
+    expect(screen.getByRole('button', { name: 'Attachments' })).toBeInTheDocument();
   });
 });

--- a/packages/design-system/src/components/FileUpload/FileUpload.tsx
+++ b/packages/design-system/src/components/FileUpload/FileUpload.tsx
@@ -290,6 +290,8 @@ export const FileUpload = forwardRef<HTMLDivElement, FileUploadProps>(function F
     dropzoneLabel,
     dropzoneIcon,
     dropzoneHint,
+    'aria-labelledby': ariaLabelledBy,
+    'aria-describedby': ariaDescribedBy,
     className,
     ...rest
   },
@@ -428,7 +430,9 @@ export const FileUpload = forwardRef<HTMLDivElement, FileUploadProps>(function F
         <div
           role="button"
           tabIndex={disabled ? -1 : 0}
+          aria-labelledby={ariaLabelledBy}
           aria-label={typeof dropzoneLabel === 'string' ? dropzoneLabel : t('fileUpload.upload')}
+          aria-describedby={ariaDescribedBy}
           aria-disabled={disabled || undefined}
           className={clsx(styles.dropzone, isDragOver && styles.dragOver)}
           onDragEnter={handleDragEnter}

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -2,6 +2,7 @@ import { act, configure, fireEvent, render, screen, waitFor } from '@testing-lib
 import userEvent from '@testing-library/user-event';
 import React, { createRef } from 'react';
 import { Select, type SelectOption } from './Select';
+import { Field } from '../Field';
 import styles from './Select.module.scss';
 
 const STATUSES: SelectOption[] = [
@@ -1230,5 +1231,21 @@ describe('Select — overlay elevation', () => {
     render(<Select options={STATUSES} aria-label="Status" />);
     await user.click(screen.getByRole('button'));
     expect(screen.getByRole('listbox')).not.toHaveAttribute('data-in-overlay');
+  });
+});
+
+describe('Select — Field label integration', () => {
+  it('a Field label names the combobox (auto-clone)', () => {
+    render(
+      <Field label="Status">
+        <Select
+          options={[
+            { value: 'a', label: 'Active' },
+            { value: 'b', label: 'Archived' },
+          ]}
+        />
+      </Field>,
+    );
+    expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
   });
 });

--- a/packages/design-system/src/components/Slider/Slider.test.tsx
+++ b/packages/design-system/src/components/Slider/Slider.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { createRef } from 'react';
 import { Slider, type SliderOrientation, type SliderSize, type SliderTone } from './Slider';
+import { Field } from '../Field';
 
 // jsdom doesn't implement setPointerCapture; stub it on HTMLElement so the
 // component's try/catch fast-path is exercised (and we still get pointer
@@ -487,5 +488,16 @@ describe('Slider', () => {
       const inputs = container.querySelectorAll('input[type="hidden"]');
       expect(inputs).toHaveLength(0);
     });
+  });
+});
+
+describe('Slider — Field label integration', () => {
+  it('a Field label names the slider thumb (auto-clone)', () => {
+    render(
+      <Field label="Volume">
+        <Slider value={40} onChange={() => {}} />
+      </Field>,
+    );
+    expect(screen.getByRole('slider', { name: 'Volume' })).toBeInTheDocument();
   });
 });

--- a/packages/design-system/src/components/Slider/Slider.test.tsx
+++ b/packages/design-system/src/components/Slider/Slider.test.tsx
@@ -213,6 +213,17 @@ describe('Slider', () => {
       expect(thumb).toHaveAttribute('aria-labelledby', 'vol-label');
     });
 
+    it('forwards root aria-describedby to the thumb', () => {
+      const { container } = render(
+        <>
+          <span id="vol-desc">0 is muted</span>
+          <Slider value={50} aria-label="Volume" aria-describedby="vol-desc" onChange={() => {}} />
+        </>,
+      );
+      const thumb = container.querySelector('[role="slider"]');
+      expect(thumb).toHaveAttribute('aria-describedby', 'vol-desc');
+    });
+
     it('range mode: both thumbs get the forwarded aria-label', () => {
       const { container } = render(
         <Slider value={[20, 80]} aria-label="Price range" onChange={() => {}} />,
@@ -499,5 +510,18 @@ describe('Slider — Field label integration', () => {
       </Field>,
     );
     expect(screen.getByRole('slider', { name: 'Volume' })).toBeInTheDocument();
+  });
+
+  it('a Field error description reaches the focusable thumb (not just the root)', () => {
+    render(
+      <Field label="Volume" error="Out of range">
+        <Slider value={40} onChange={() => {}} />
+      </Field>,
+    );
+    // The accessible description must land on the focusable role="slider" thumb,
+    // so a screen reader announces the error when the thumb has focus — not on
+    // the non-focusable root div where {...rest} also drops it.
+    const thumb = screen.getByRole('slider', { name: 'Volume' });
+    expect(thumb).toHaveAccessibleDescription('Out of range');
   });
 });

--- a/packages/design-system/src/components/Slider/Slider.tsx
+++ b/packages/design-system/src/components/Slider/Slider.tsx
@@ -586,6 +586,13 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
             (rest as { 'aria-label'?: string })['aria-label']
           }
           aria-labelledby={(rest as { 'aria-labelledby'?: string })['aria-labelledby']}
+          aria-describedby={
+            // Forward the root's aria-describedby to each focusable thumb so a
+            // <Field error/description> wrapping a Slider is announced when a
+            // thumb has focus. It also remains on the root via {...rest}, which
+            // is harmless — the root is non-focusable and carries no role.
+            (rest as { 'aria-describedby'?: string })['aria-describedby']
+          }
           className={clsx(styles.thumb, isDragging[index] && styles.thumbDragging)}
           style={thumbStyle(thumbValue)}
           onPointerDown={(e) => handleThumbPointerDown(e, index)}

--- a/packages/design-system/src/components/TimeField/TimeField.test.tsx
+++ b/packages/design-system/src/components/TimeField/TimeField.test.tsx
@@ -913,4 +913,21 @@ describe('TimeField — labelling', () => {
       'tf-desc',
     );
   });
+
+  it('the toggle keeps a distinct name (not the field label) when wrapped in a Field', () => {
+    function LabelDriver() {
+      const [v, setV] = useState<TimeValue | null>({ hours: 9, minutes: 0 });
+      return (
+        <Field label="Start time">
+          <TimeField value={v} hourCycle="24" onChange={setV} />
+        </Field>
+      );
+    }
+    render(<LabelDriver />, { wrapper: wrap() });
+    // The input carries the field label…
+    expect(screen.getByRole('textbox', { name: 'Start time' })).toBeInTheDocument();
+    // …but the toggle must NOT duplicate it — it owns the open-list action name.
+    expect(screen.queryByRole('button', { name: 'Start time' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Open time list' })).toBeInTheDocument();
+  });
 });

--- a/packages/design-system/src/components/TimeField/TimeField.test.tsx
+++ b/packages/design-system/src/components/TimeField/TimeField.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { createRef, type ReactNode, useState } from 'react';
 import { LocaleProvider } from '../../i18n/LocaleProvider';
 import { TimeField, type TimeValue } from './TimeField';
+import { Field } from '../Field';
 
 function wrap(locale = 'en-US') {
   return ({ children }: { children: ReactNode }) => (
@@ -840,5 +841,36 @@ describe('TimeField', () => {
     await waitFor(() =>
       expect(within(minutes).getByRole('option', { name: '45' })).toHaveAttribute('tabindex', '0'),
     );
+  });
+});
+
+describe('TimeField — labelling', () => {
+  it('a Field label names the inner input (auto-clone)', () => {
+    function LabelDriver() {
+      const [v, setV] = useState<TimeValue | null>({ hours: 9, minutes: 0 });
+      return (
+        <Field label="Start time">
+          <TimeField value={v} hourCycle="24" onChange={setV} />
+        </Field>
+      );
+    }
+    render(<LabelDriver />, { wrapper: wrap() });
+    expect(screen.getByRole('textbox', { name: 'Start time' })).toHaveValue('09:00');
+  });
+
+  it('back-compat: passing only aria-label still names the input + group', () => {
+    render(
+      <TimeField
+        value={{ hours: 14, minutes: 30 }}
+        hourCycle="24"
+        aria-label="Departure time"
+        onChange={() => {}}
+      />,
+      {
+        wrapper: wrap(),
+      },
+    );
+    expect(screen.getByRole('textbox', { name: 'Departure time' })).toHaveValue('14:30');
+    expect(screen.getByRole('group', { name: 'Departure time' })).toBeInTheDocument();
   });
 });

--- a/packages/design-system/src/components/TimeField/TimeField.test.tsx
+++ b/packages/design-system/src/components/TimeField/TimeField.test.tsx
@@ -873,4 +873,44 @@ describe('TimeField — labelling', () => {
     expect(screen.getByRole('textbox', { name: 'Departure time' })).toHaveValue('14:30');
     expect(screen.getByRole('group', { name: 'Departure time' })).toBeInTheDocument();
   });
+
+  it('a Field error description reaches the inner input (not the group wrapper)', () => {
+    function ErrorDriver() {
+      const [v, setV] = useState<TimeValue | null>({ hours: 9, minutes: 0 });
+      return (
+        <Field label="Start time" error="Required field">
+          <TimeField value={v} hourCycle="24" onChange={setV} />
+        </Field>
+      );
+    }
+    render(<ErrorDriver />, { wrapper: wrap() });
+    // The accessible description must land on the focusable input, so a screen
+    // reader announces the error when the input has focus.
+    const input = screen.getByRole('textbox', { name: 'Start time' });
+    expect(input).toHaveAccessibleDescription('Required field');
+    // …and not on the role="group" wrapper (where {...rest} used to dump it).
+    expect(screen.getByRole('group', { name: 'Start time' })).not.toHaveAttribute(
+      'aria-describedby',
+    );
+  });
+
+  it('forwards aria-describedby onto the input directly', () => {
+    render(
+      <>
+        <span id="tf-desc">Use 24-hour format</span>
+        <TimeField
+          value={{ hours: 14, minutes: 30 }}
+          hourCycle="24"
+          aria-label="Departure time"
+          aria-describedby="tf-desc"
+          onChange={() => {}}
+        />
+      </>,
+      { wrapper: wrap() },
+    );
+    expect(screen.getByRole('textbox', { name: 'Departure time' })).toHaveAttribute(
+      'aria-describedby',
+      'tf-desc',
+    );
+  });
 });

--- a/packages/design-system/src/components/TimeField/TimeField.tsx
+++ b/packages/design-system/src/components/TimeField/TimeField.tsx
@@ -614,8 +614,15 @@ export const TimeField = forwardRef<HTMLDivElement, TimeFieldProps>(function Tim
       <button
         type="button"
         className={styles.timeToggle}
-        aria-label={ariaLabel ? `${ariaLabel}, ${t('datePicker.timeOpenList')}` : undefined}
-        aria-labelledby={ariaLabelledBy}
+        // The toggle needs its OWN distinct name (the open-list action), never
+        // the field label — otherwise the input and toggle would share an
+        // identical accessible name. With a self-label, suffix the action; when
+        // only a Field labels the control (no aria-label), use the action text
+        // alone and DON'T forward aria-labelledby (which would duplicate the
+        // input's name on the toggle).
+        aria-label={
+          ariaLabel ? `${ariaLabel}, ${t('datePicker.timeOpenList')}` : t('datePicker.timeOpenList')
+        }
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? popoverId : undefined}

--- a/packages/design-system/src/components/TimeField/TimeField.tsx
+++ b/packages/design-system/src/components/TimeField/TimeField.tsx
@@ -77,8 +77,17 @@ export interface TimeFieldProps extends Omit<
    * (button shown).
    */
   hideNowButton?: boolean;
-  /** Accessible label. Required — TimeField is a primitive with no implicit default. */
-  'aria-label': string;
+  /**
+   * Accessible label. Optional, but the control MUST be named: pass `aria-label`
+   * for a standalone TimeField, OR `aria-labelledby` when an external element
+   * (e.g. a `<Field>` label) names it. If both are given, `aria-labelledby` wins.
+   */
+  'aria-label'?: string;
+  /**
+   * Id(s) of element(s) that label this control — forwarded onto the inner
+   * `<input>` so a `<Field label>` names it. Takes precedence over `aria-label`.
+   */
+  'aria-labelledby'?: string;
   /** Disables the input + popover trigger. */
   disabled?: boolean;
   /** Stable id for the input (so an external `<label htmlFor>` can target it). */
@@ -153,6 +162,7 @@ export const TimeField = forwardRef<HTMLDivElement, TimeFieldProps>(function Tim
     locale: localeProp,
     hideNowButton = false,
     'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
     disabled = false,
     id: idProp,
     className,
@@ -568,6 +578,7 @@ export const TimeField = forwardRef<HTMLDivElement, TimeFieldProps>(function Tim
     <div
       role="group"
       aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
       {...rest}
       ref={setWrapperRef}
       className={clsx(styles.timeField, isDisabled && styles.disabled, className)}
@@ -583,6 +594,7 @@ export const TimeField = forwardRef<HTMLDivElement, TimeFieldProps>(function Tim
         value={draft}
         autoComplete="off"
         aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? popoverId : undefined}
@@ -594,7 +606,8 @@ export const TimeField = forwardRef<HTMLDivElement, TimeFieldProps>(function Tim
       <button
         type="button"
         className={styles.timeToggle}
-        aria-label={`${ariaLabel}, ${t('datePicker.timeOpenList')}`}
+        aria-label={ariaLabel ? `${ariaLabel}, ${t('datePicker.timeOpenList')}` : undefined}
+        aria-labelledby={ariaLabelledBy}
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? popoverId : undefined}

--- a/packages/design-system/src/components/TimeField/TimeField.tsx
+++ b/packages/design-system/src/components/TimeField/TimeField.tsx
@@ -88,6 +88,12 @@ export interface TimeFieldProps extends Omit<
    * `<input>` so a `<Field label>` names it. Takes precedence over `aria-label`.
    */
   'aria-labelledby'?: string;
+  /**
+   * Id(s) of element(s) that describe this control (e.g. a `<Field>` error or
+   * helper message) — forwarded onto the inner `<input>`, not the wrapper, so
+   * the description is announced when the input is focused.
+   */
+  'aria-describedby'?: string;
   /** Disables the input + popover trigger. */
   disabled?: boolean;
   /** Stable id for the input (so an external `<label htmlFor>` can target it). */
@@ -163,6 +169,7 @@ export const TimeField = forwardRef<HTMLDivElement, TimeFieldProps>(function Tim
     hideNowButton = false,
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
+    'aria-describedby': ariaDescribedBy,
     disabled = false,
     id: idProp,
     className,
@@ -595,6 +602,7 @@ export const TimeField = forwardRef<HTMLDivElement, TimeFieldProps>(function Tim
         autoComplete="off"
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? popoverId : undefined}


### PR DESCRIPTION
## Summary
`<Field label="X"><Select/></Field>` (and Slider/ColorPicker/FileUpload/TimeField) exposed **no accessible name** — Field named purely via `<label htmlFor>` + an injected `id`, which lands on a wrapper `<div>` for composite controls while the focusable trigger keeps its own internal id.

- **Field** — auto-clone + the render-prop `field` object now also convey `aria-labelledby={labelId}` (guarded; child's value wins; only when a label is rendered). Native controls are unchanged (same name; `*` is `aria-hidden`, `(optional)` already in the label). **Select + Slider** get named for free (they already forward `aria-labelledby`).
- **ColorPicker / FileUpload / TimeField** — forward `aria-labelledby` (+ `aria-describedby`) onto their focusable element. ColorPicker suppresses its generated `aria-label` when labelled externally and never clobbers a consumer's own aria on a custom trigger. TimeField's `aria-label` is now **optional** (backward-compatible) and its open-list toggle keeps a distinct name (never duplicating the input's).

## Test plan
- [x] Field unit tests (inject when labelled / not when unlabelled / child wins / render-prop carries it / asGroup does NOT inject)
- [x] Per-control: `<Field label="X"><Control/></Field>` → `getByRole(role, { name: 'X' })` for Select, Slider, ColorPicker (default + custom trigger), FileUpload, TimeField
- [x] Regression: TimeField back-compat (`aria-label` only) + distinct toggle name; ColorPicker custom trigger keeps its own aria outside a Field; native controls unchanged
- [x] Full suite **2528** green; `make build` / `make lint` / `prettier --check` clean; `npm pack --dry-run` test-free
- [x] Library Rule 8 review loop clean (4 lenses × 2 fix rounds)
- [ ] CI `Quality / check`

## Downstream / follow-ups
- The merged **member-profile** Selects get named automatically after this lands.
- The **custom-fields** Type Select can simplify from its render-prop workaround back to plain auto-clone (separate follow-up).
- Pre-existing & out of scope: Field injects DS `invalid`/`required` which fall onto composite root `<div>`s (dev warning) — unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)