### PR TITLE
refactor(mockup): custom-fields Type Select uses plain auto-clone (post-#115)

### DIFF
--- a/packages/playground/src/pages/mockups/CustomFields/FieldDrawer.tsx
+++ b/packages/playground/src/pages/mockups/CustomFields/FieldDrawer.tsx
@@ -147,16 +147,11 @@ export function FieldDrawer({
               />
             </Field>
             <Field label="Type" required>
-              {(field) => (
-                <Select
-                  options={TYPE_OPTIONS}
-                  value={draft.type}
-                  onChange={(value) => onType(value as FieldType)}
-                  aria-labelledby={field.labelId}
-                  aria-describedby={field['aria-describedby']}
-                  invalid={field.invalid}
-                />
-              )}
+              <Select
+                options={TYPE_OPTIONS}
+                value={draft.type}
+                onChange={(value) => onType(value as FieldType)}
+              />
             </Field>
           </FormSection>
 


### PR DESCRIPTION
## Summary
Now that #115 makes `<Field>` inject `aria-labelledby` (plus `id`/`aria-describedby`/`invalid`/`required`) into its auto-cloned child and `Select` forwards `aria-labelledby` to its combobox trigger, the custom-fields **Type** field no longer needs the render-prop workaround that manually wired those props. Reverted it to plain auto-clone:

```tsx
<Field label="Type" required>
  <Select options={TYPE_OPTIONS} value={draft.type} onChange={(v) => onType(v as FieldType)} />
</Field>
```

Same accessible name, less boilerplate, and a real dogfooding proof that the library a11y fix works through ordinary `<Field>` usage.

## Why it's safe
- **Name preserved:** `Field` auto-clone → `Select` forwards `aria-labelledby` → `ButtonTrigger` applies it to the focusable `<button>`. The combobox keeps the name "Type".
- **No error-path regression:** the removed `invalid`/`aria-describedby` wiring was always inert for the Type field (it has no `error` prop), and auto-clone reproduces identical values.
- Auto-clone now also forwards `required` (the render-prop didn't) — a small correctness improvement, not a regression.

## Test plan
- [x] `make build` (playground typecheck + bundle), `make lint`, `prettier --check`, `make test` (2528) — all green
- [x] Rule-7 mockup review-fix loop: two fresh reviewers (full 10-category + adversarial a11y name-trace) → **clean** in one round, 0 Critical / 0 Important
- [x] Accessible name guaranteed by #115's `Select.test.tsx` (`<Field label><Select/></Field>` → `getByRole('button', { name })`)
- [ ] CI `Quality / check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)