### PR TITLE
fix(AppLayout): match CRM shell topology — full-height sidebar + top bar over content

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1089,8 +1089,8 @@ Use this instead of `Card.List` + `Card.ListRow` whenever the data is genuinely 
 </AppLayout>
 ```
 
-- Top-level shell layout, mounted **once** at the app root. Full-height flex column: `topBar` across the top, then a row of `sidebar` (left, intrinsic width) + main `children` (fills the rest). Root is `min-height: 100vh`.
-- `topBar`: optional top region (omit for none). `sidebar`: optional left region (omit for none). `children`: the main content (required).
+- Top-level shell layout, mounted **once** at the app root. Matches the CRM shell topology: a **full-height `sidebar`** down the left, an optional `topBar` **over the content column** (not full window width), and the main `children` below it. Root is `min-height: 100vh`.
+- `topBar`: optional region over the content column (omit for none). `sidebar`: optional full-height left region, intrinsic width (omit for none). `children`: the main content (required).
 - Layout-owning primitive (the `<Page>` / `<Screen>` / `<Rail>` exception to "no layout properties"). Carries no visual styling — slots bring their own surfaces. Don't nest inside another `AppLayout` / `<Page>` / `<Screen>`; for a chromeless page use `<Screen>`, for in-page layout use `<Stack>` / `<Cluster>`.
 - **Page-scroll shell:** `min-height: 100vh` means tall content scrolls the whole window (chrome scrolls away). For fixed chrome + independently-scrolling content, override the root to a fixed `height: 100vh` / `100dvh` via `className`.
 

--- a/packages/design-system/src/components/AppLayout/AppLayout.module.scss
+++ b/packages/design-system/src/components/AppLayout/AppLayout.module.scss
@@ -1,35 +1,42 @@
 // AppLayout is a layout-owning primitive — the documented exception to the
 // "no layout properties on components" rule (like Page / Screen / Rail). Owning
-// the viewport-filling shell (min-height + flex column + sidebar row) is its
-// whole job. No visual styling — the topBar / sidebar slots bring their own
-// surfaces. (stylelint's property-disallowed-list blocks flex-grow / flex-basis
-// but not the `flex` shorthand, min-height, or min-width, so no disable needed.)
+// the viewport-filling shell is its whole job. No visual styling — the topBar /
+// sidebar slots bring their own surfaces. Matches the CRM shell topology (see the
+// playground AppShell): a full-height sidebar down the left, the top bar over the
+// content column, and the main content below it. (stylelint's property-disallowed-list
+// blocks flex-grow / flex-basis but not the `flex` shorthand, min-height, or
+// min-width, so no disable is needed here.)
 .root {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+
+  // Explicit (it's the default) — the full-height sidebar depends on the row
+  // stretching its items to the row's height; don't change this to center/start.
+  align-items: stretch;
   min-height: 100vh;
 }
 
-// Full-width top bar; natural height.
-.topBar {
-  flex: none;
-}
-
-// The sidebar + content row fills the remaining viewport height.
-.body {
-  display: flex;
-  flex: 1;
-  flex-direction: row;
-  min-height: 0;
-}
-
-// Sidebar sets its own width.
+// Full-height sidebar down the left (stretches to the row height). Sets its own
+// width.
 .sidebar {
   flex: none;
 }
 
-// Content fills the rest; min-width:0 lets wide content (tables) shrink instead
-// of overflowing the row.
+// The top bar + content column to the right of the sidebar. min-width:0 lets the
+// column (and wide content like tables) shrink instead of pushing the sidebar.
+.body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}
+
+// Top bar over the content column; natural height.
+.topBar {
+  flex: none;
+}
+
+// Main content fills the rest of the column.
 .main {
   flex: 1;
   min-width: 0;

--- a/packages/design-system/src/components/AppLayout/AppLayout.test.tsx
+++ b/packages/design-system/src/components/AppLayout/AppLayout.test.tsx
@@ -61,7 +61,8 @@ describe('AppLayout', () => {
 
   it('applies the structural layout classes (root / topBar / body / sidebar / main)', () => {
     // Anchors the load-bearing classes — the root carries the min-height:100vh
-    // flex column — so a future SCSS edit can't silently gut the viewport fill.
+    // flex row (full-height sidebar + content column) — so a future SCSS edit
+    // can't silently gut the shell structure.
     const { container } = render(
       <AppLayout topBar={<span>t</span>} sidebar={<span>s</span>}>
         <span>c</span>

--- a/packages/design-system/src/components/AppLayout/AppLayout.tsx
+++ b/packages/design-system/src/components/AppLayout/AppLayout.tsx
@@ -4,23 +4,23 @@ import styles from './AppLayout.module.scss';
 
 export interface AppLayoutProps extends HTMLAttributes<HTMLDivElement> {
   /**
-   * Top bar slot — spans the full width above the sidebar + content row.
-   * Omit for a shell with no top bar.
+   * Top bar slot — sits above the main content, spanning the content column to
+   * the right of the sidebar (not the full window width). Omit for no top bar.
    */
   topBar?: ReactNode;
   /**
-   * Sidebar slot — sits to the left of the content, filling the height of the
-   * row below the top bar. Sets its own width (intrinsic). Omit for no sidebar.
+   * Sidebar slot — runs the full height down the left, alongside both the top
+   * bar and the content. Sets its own width (intrinsic). Omit for no sidebar.
    */
   sidebar?: ReactNode;
-  /** Main content slot — fills the remaining space. */
+  /** Main content slot — fills the remaining space below the top bar. */
   children: ReactNode;
 }
 
 /**
- * Viewport-filling application shell layout. A full-height flex column: an
- * optional `topBar` across the top, then a row of an optional `sidebar` (left)
- * and the main `children` (right) that together fill the viewport height
+ * Viewport-filling application shell layout, matching the CRM shell topology: a
+ * full-height `sidebar` down the left, an optional `topBar` over the content
+ * column, and the main `children` below it. Fills the viewport
  * (`min-height: 100vh`).
  *
  * Replaces the ad-hoc `Stack` + `Cluster` shell composition consumers hand-rolled,
@@ -41,8 +41,9 @@ export interface AppLayoutProps extends HTMLAttributes<HTMLDivElement> {
  * @remarks Layout-owning primitive
  * Like `<Page>` / `<Screen>` / `<Rail>`, AppLayout is the documented exception to
  * the "components don't own layout" rule — owning the full-height shell layout
- * (viewport fill + flex column + sidebar row) is its entire job. It carries no
- * visual styling; the `topBar` / `sidebar` slots bring their own surfaces.
+ * (viewport fill + full-height sidebar + top-bar-over-content) is its entire job.
+ * It carries no visual styling; the `topBar` / `sidebar` slots bring their own
+ * surfaces.
  *
  * @remarks When NOT to use
  * - ❌ For in-page content layout — use `<Stack>` / `<Cluster>` / `<Grid>`.
@@ -52,10 +53,10 @@ export interface AppLayoutProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @remarks Scrolling
  * This is a **page-scroll** shell: `min-height: 100vh` lets it grow with tall
- * content, so the whole window scrolls and the top bar / sidebar scroll away
- * with it. For the common "fixed chrome + independently-scrolling content"
- * layout, override the root to a fixed `height: 100vh` (or `100dvh`) via
- * `className` — then `<Rail>` / the main region manage their own overflow.
+ * content, so the whole window scrolls and the chrome scrolls away with it. For
+ * the common "fixed chrome + independently-scrolling content" layout, override
+ * the root to a fixed `height: 100vh` (or `100dvh`) via `className` — then
+ * `<Rail>` / the main region manage their own overflow.
  */
 export const AppLayout = forwardRef<HTMLDivElement, AppLayoutProps>(function AppLayout(
   { topBar, sidebar, children, className, ...props },
@@ -63,11 +64,14 @@ export const AppLayout = forwardRef<HTMLDivElement, AppLayoutProps>(function App
 ) {
   // Pattern A — props last: AppLayout is a consumer-overridable layout
   // primitive (like Stack/Card), so {...props} wins over our defaults.
+  // Topology: a row of [full-height sidebar | a column of (topBar, main)] — so
+  // the sidebar spans the whole height and the top bar sits only over the
+  // content column, matching the CRM shell (see playground AppShell).
   return (
     <div ref={ref} className={clsx(styles.root, className)} {...props}>
-      {topBar != null && <div className={styles.topBar}>{topBar}</div>}
+      {sidebar != null && <div className={styles.sidebar}>{sidebar}</div>}
       <div className={styles.body}>
-        {sidebar != null && <div className={styles.sidebar}>{sidebar}</div>}
+        {topBar != null && <div className={styles.topBar}>{topBar}</div>}
         <div className={styles.main}>{children}</div>
       </div>
     </div>

--- a/packages/playground/src/pages/components/AppLayoutDemo.tsx
+++ b/packages/playground/src/pages/components/AppLayoutDemo.tsx
@@ -60,12 +60,12 @@ export function AppLayoutDemo() {
   return (
     <DemoLayout
       name="AppLayout"
-      description="Viewport-filling application shell: an optional topBar across the top, then a row of an optional sidebar (left) and the main content. The top-level layout primitive, mounted once at the app root."
+      description="Viewport-filling application shell, matching the CRM shell topology: a full-height sidebar down the left, an optional top bar over the content column, and the main content below it. The top-level layout primitive, mounted once at the app root."
       files={getComponentFiles('AppLayout')}
     >
       <Example
-        title="Full shell (topBar + sidebar + content)"
-        description="The canonical app shell. AppLayout fills the viewport; shown clipped to a bounded frame."
+        title="Full shell (sidebar + topBar + content)"
+        description="The canonical CRM shell — full-height sidebar on the left, top bar over the content column. AppLayout fills the viewport; shown clipped to a bounded frame."
         code={`<AppLayout topBar={<TopBar />} sidebar={<Rail>{nav}</Rail>}>
   <Page>{content}</Page>
 </AppLayout>`}


### PR DESCRIPTION
Follow-up to #117 — the shipped `0.1.11` topology didn't match our mockup pages.

## Problem
`<AppLayout>` (0.1.11) was a flex **column**: the top bar spanned the full window width across the very top, with the sidebar **below** it. But every mockup renders inside `AppShell`, whose shell is the opposite: a **full-height sidebar on the left** with the top bar **only over the content column**.

## Fix
Restructured to that topology — a flex **row** `[sidebar | column(topBar, main)]`:
- full-height `sidebar` down the left (stretches via the row's `align-items: stretch`, now explicit),
- `topBar` over the content column only,
- `main` below it. DOM/tab order `sidebar → topBar → main` matches `AppShell`.

Updated JSDoc, AGENTS.md, and the demo to describe the new topology.

## Verification
- **Playwright-measured** the AppLayout demo against `/mockups/dashboard`: regions now line up — `topBar.left == sidebar.right` (not `0`), sidebar full-height-left, content below the bar — i.e. identical relationship to `AppShell`.
- `make test` (2536), `make lint`, `make build-lib`, `make build` (playground), `npm run format:check` — all green.
- Hard-rule-8 review (2 fresh reviewers: empirical topology + code/regression) → clean after fixing one stale comment.
- [ ] CI `Quality / check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)