### PR TITLE
docs(skill): implement-issue handles a BEHIND branch before merge

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -148,10 +148,21 @@ Exactly ONE issue per invocation.
    ```bash
    gh pr checks <pr> --repo eocrm/design-system --watch
    ```
-4. **Squash-merge:**
+4. **Squash-merge.** If another PR merged while yours was open, your branch is
+   `BEHIND` and branch protection blocks the merge until it's brought up to date —
+   handle that first, then merge:
    ```bash
+   # If the branch fell behind main (another PR merged), update it and re-wait for
+   # the gate on the new head before merging.
+   if [ "$(gh pr view <pr> --repo eocrm/design-system --json mergeStateStatus --jq .mergeStateStatus)" = "BEHIND" ]; then
+     gh pr update-branch <pr> --repo eocrm/design-system
+     gh pr checks <pr> --repo eocrm/design-system --watch   # re-runs Quality on the updated head
+   fi
    gh pr merge <pr> --repo eocrm/design-system --squash --delete-branch
    ```
+   If `gh pr merge` prints the `--auto` / `--admin` hint instead of merging, the
+   merge requirements still aren't met (e.g. still `BEHIND`, or a required check
+   not green) — STOP and report; never force it with `--admin`.
 5. **Find the Release run for the merge commit.** It takes a few seconds to
    register after the merge, so poll by the exact commit — never eyeball-match a
    list:


### PR DESCRIPTION
## Summary
Hardens the `implement-issue` skill's Phase 3. When another PR merges while ours is open, branch protection requires the branch be up to date before merging — the runbook's squash-merge step didn't account for that and would stall.

Phase 3 step 4 now: check `mergeStateStatus`; if `BEHIND`, run `gh pr update-branch` and re-wait for `Quality / check` on the updated head; then squash-merge. Also documents that a persistent `--auto`/`--admin` hint means requirements still aren't met → stop, never force with `--admin`.

Surfaced live by PR #120, which went `BEHIND` after #118 merged and needed a manual `update-branch` before it would merge.

## Test plan
- [x] `.claude/`-only change (the skill runbook); no code/release impact
- [x] `npm run format:check` clean
- [ ] CI `Quality / check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)