### PR TITLE
fix(Link): pointer cursor for non-anchor `as` (e.g. as="button") (#122)

### DIFF
--- a/packages/design-system/src/components/Link/Link.module.scss
+++ b/packages/design-system/src/components/Link/Link.module.scss
@@ -2,6 +2,10 @@
 @use './Link.tokens';
 
 .link {
+  // A link-styled control rendered via `as` on a non-anchor (e.g. `as="button"`)
+  // gets no pointer cursor from the UA — only `<a>` does — so set it explicitly.
+  // Makes the affordance element-agnostic (like how Button owns its own cursor).
+  cursor: pointer;
   font-family: inherit;
   font-size: inherit;
   color: inherit;

--- a/packages/design-system/src/components/Link/Link.test.tsx
+++ b/packages/design-system/src/components/Link/Link.test.tsx
@@ -104,6 +104,22 @@ describe('<Link>', () => {
     expect(ref.current?.tagName).toBe('A');
   });
 
+  it('renders a real <button> via as="button" carrying the link classes (pointer affordance)', () => {
+    render(
+      <Link as="button" type="button">
+        Change email
+      </Link>,
+    );
+    const el = screen.getByText('Change email');
+    expect(el.tagName).toBe('BUTTON');
+    // The pointer-cursor affordance lives on the `.link` class (Link.module.scss),
+    // so a non-anchor must still receive it. The cursor *value* is verified
+    // visually / via Playwright (jsdom doesn't apply CSS-module rules); this locks
+    // that as="button" gets the link styling where `cursor: pointer` lives.
+    expect(el.className).toMatch(/link/);
+    expect(el.className).toMatch(/default/);
+  });
+
   it('children renders inside the link', () => {
     render(
       <Link href="/x">

--- a/packages/playground/src/pages/components/LinkDemo.tsx
+++ b/packages/playground/src/pages/components/LinkDemo.tsx
@@ -56,6 +56,26 @@ export function LinkDemo() {
       </Example>
 
       <Example
+        title={'Link-styled action via `as="button"`'}
+        description="An action that must visually match a sibling Link but can't be a real href (a fake href is the Link anti-pattern) → render a real <button>. It inherits the link look AND the pointer cursor."
+        code={`<Cluster gap="md">
+  <Link href="/forgot-password">Forgot?</Link>
+  <Link as="button" type="button" onClick={handleChangeEmail}>
+    Change email
+  </Link>
+</Cluster>`}
+      >
+        <Cluster gap="md">
+          <Link href="#forgot" onClick={(e) => e.preventDefault()}>
+            Forgot?
+          </Link>
+          <Link as="button" type="button" onClick={() => {}}>
+            Change email
+          </Link>
+        </Cluster>
+      </Example>
+
+      <Example
         title="Composed with an icon"
         description="Compose Link with whatever children you want — it's just a styled anchor."
         code={`<Link href="https://docs.example.com" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Addresses #122.

## Problem
`<Link as="button">` lost its pointer cursor — the text got the correct accent color + hover underline, but the cursor was the default arrow, so a link-styled action read as "not clickable." Root cause: `.link` set no `cursor`, relying on the `<a>` UA stylesheet's `cursor: pointer`; a `<button>` (and `reset.scss`) provides none.

## Fix
Add `cursor: pointer` to `.link` so the affordance is element-agnostic (mirrors how `Button` owns its own cursor). Harmless for anchors (already pointer), and consistent for `as={button|RouterLink|…}`.

## Test plan
- [x] **Playwright-verified** on the running demo: the `as="button"` "Change email" element is a real `<button>` with `getComputedStyle().cursor === 'pointer'`, matching the sibling `Forgot?` anchor (also `pointer`); plain links still `pointer` (no regression)
- [x] Regression test (`as="button"` → real `<button>` carrying `.link`/`.default`); cursor value verified visually (jsdom doesn't apply CSS-module rules)
- [x] Demo example added (`Change email` button beside a `Forgot?` link)
- [x] `make test` (2537), `make lint`, `make build-lib`, `make build`, `npm run format:check` — green
- [x] Rule-8 review (2 fresh reviewers) → clean; dropped a speculative `:disabled` guard per review (Link has no disabled state — YAGNI)
- [ ] CI `Quality / check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)