### PR TITLE
fix(login): wider card + truncating identity row (Constrain flex=grow gets min-width:0)

### DIFF
--- a/packages/design-system/src/components/Constrain/Constrain.module.scss
+++ b/packages/design-system/src/components/Constrain/Constrain.module.scss
@@ -28,6 +28,11 @@
 
 .flex-grow {
   flex: 1 1 0;
+
+  // Allow shrinking below the content's intrinsic width so a `<Text truncate>`
+  // (or any overflow:hidden child) can actually clip inside a flex row, instead
+  // of forcing the row to overflow. Only matters under overflow — safe otherwise.
+  min-width: 0;
 }
 
 .flex-auto {

--- a/packages/design-system/src/components/Constrain/Constrain.tsx
+++ b/packages/design-system/src/components/Constrain/Constrain.tsx
@@ -17,7 +17,8 @@ export interface ConstrainProps extends HTMLAttributes<HTMLDivElement> {
   maxWidth?: ConstrainWidth;
   /**
    * Flex behavior as a child of a flex row/column.
-   * - `'grow'` — fill remaining space (`flex: 1 1 0`).
+   * - `'grow'` — fill remaining space (`flex: 1 1 0`) and shrink below content
+   *   width (`min-width: 0`) so a truncating child (`<Text truncate>`) can clip.
    * - `'auto'` — size to content, may grow/shrink (`flex: 1 1 auto`).
    * - `'shrink'` — don't grow, may shrink (`flex: 0 1 auto`, the flex default).
    * - `'none'` — fixed, never grow/shrink (`flex: 0 0 auto`).

--- a/packages/playground/src/pages/mockups/Login/Login.tsx
+++ b/packages/playground/src/pages/mockups/Login/Login.tsx
@@ -90,7 +90,7 @@ export function Login() {
       <Stack gap="lg" align="center">
         <Logo text="eocrm" size="lg" />
 
-        <Constrain width="sm">
+        <Constrain width="md">
           <Card padding="lg">
             <Stack gap="lg">
               <Stack gap="xs">
@@ -145,11 +145,13 @@ export function Login() {
               ) : (
                 <>
                   <Card padding="sm">
-                    <Cluster justify="between" align="center" wrap={false}>
-                      <Cluster gap="sm" align="center" wrap={false}>
-                        <Mail size={16} />
-                        <Text size="sm">{email}</Text>
-                      </Cluster>
+                    <Cluster align="center" wrap={false} gap="sm">
+                      <Mail size={16} />
+                      <Constrain flex="grow">
+                        <Text size="sm" truncate>
+                          {email}
+                        </Text>
+                      </Constrain>
                       <Link as="button" type="button" variant="default" onClick={changeEmail}>
                         Change
                       </Link>


### PR DESCRIPTION
## Problem
On the login step-2 identity row, a long email (`pavel.dobrovolsky@team.bumble.com`) pushed the **Change** link off the right of the card (clipped to "Cha"), and the card was too narrow.

## Root cause
`<Constrain flex="grow">` is `flex: 1 1 0` but had **`min-width: auto`**, so it couldn't shrink below its content's intrinsic (nowrap) width — the inner `<Text truncate>` (which has `min-width:0`) never got the chance to clip, and the row overflowed.

## Fix
- **Library — `Constrain`:** `.flex-grow` now sets `min-width: 0`, so a fill box can shrink below its content and let a truncating child ellipsize. Only matters under overflow (safe otherwise); benefits every `flex="grow"` consumer.
- **Login mockup:** widen the card `sm`→`md` (320→448px) and rebuild the identity row as `[Mail] [Constrain flex=grow → Text truncate] [Change]`, so the email ellipsizes and **Change stays fully visible**.

## Test plan
- [x] `make test` (2551), `make build-lib`, `make build`, `make lint`, `npm run format:check` — green
- [x] **Playwright-verified:** extreme 86-char email now truncates (scrollWidth 517 > clientWidth 290, ellipsis) with Change inside the card; normal email fits; **no regression** on the Constrain demo's Progress-in-a-row
- [x] Rule-8 (Constrain) + Rule-7 (Login) reviews
- [ ] CI `Quality / check`

> Touches `packages/design-system/**` (Constrain) → merging publishes a new library version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)