### PR TITLE
fix(Alert): center the leading icon with the first text line

### DIFF
--- a/packages/design-system/src/components/Alert/Alert.module.scss
+++ b/packages/design-system/src/components/Alert/Alert.module.scss
@@ -36,6 +36,11 @@
 .icon {
   display: grid;
   place-items: center;
+
+  // Match the first text line's box so the icon sits centered with the title
+  // line (the alert grid is align-items:start, which would otherwise top-align
+  // the 16px icon ~2px above the line's optical center).
+  min-height: var(--alert-icon-row-height);
   color: var(--alert-icon);
 }
 
@@ -63,6 +68,9 @@
   display: block;
   font-size: var(--alert-title-font-size);
   font-weight: var(--alert-title-font-weight);
+
+  // Keep this 1.4 in sync with --alert-icon-row-height (the icon centers to this
+  // line box).
   line-height: 1.4;
   color: var(--alert-title-fg);
 }

--- a/packages/design-system/src/components/Alert/Alert.tokens.scss
+++ b/packages/design-system/src/components/Alert/Alert.tokens.scss
@@ -16,6 +16,10 @@
   --alert-title-font-size: var(--font-size-md);
   --alert-title-font-weight: var(--font-weight-medium);
 
+  // Icon box height = the title's line box (font-size × 1.4 line-height), so the
+  // icon centers with the first text line instead of top-aligning above it.
+  --alert-icon-row-height: calc(var(--alert-title-font-size) * 1.4);
+
   // Description
   --alert-description-fg: var(--color-fg-muted);
   --alert-description-font-size: var(--font-size-sm);


### PR DESCRIPTION
## Problem
The `<Alert>` leading icon wasn't vertically centered — it sat ~2px high. The alert grid is `align-items: start`, so the 16px icon top-aligned to the body top, above a single-line title's optical center.

## Fix
Give the icon box the title's line-height so the glyph centers with the **first** text line:
- new token `--alert-icon-row-height: calc(var(--alert-title-font-size) * 1.4)` (the title's line box)
- `.icon { min-height: var(--alert-icon-row-height) }` (icon already `place-items: center`)

This keeps the alert `align-items: start`, so multi-line alerts keep the icon pinned to the first line (it does **not** float to the block's vertical middle). Added a breadcrumb comment so the title's `1.4` line-height stays in sync with the token.

## Test plan
- [x] `make test` (2551), `make build-lib`, `make lint`, `npm run format:check` — green
- [x] **Playwright-verified** on `/components/alert`: single-line icon center matches the title-line center (Δ 0.05px, was ~2px high); title+description keeps the icon on the first line (36px above the block center); description-only within 0.8px; dismiss button + body unshifted
- [x] Rule-8 review — clean (CSS-only; `min-height` allowed; icon stays decorative; no a11y/behavior change)
- [ ] CI `Quality / check`

> Touches `packages/design-system/**` → merging publishes a new library version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)