### PR TITLE
feat(Logo): themeable wordmark font/weight (playground tries Outfit @600)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1345,6 +1345,7 @@ import logo from '../assets/eocrm-logo.svg'; // a consumer-owned asset
 - `size`: `sm` (24) / `md` (32, default) / `lg` (40) — the mark box; rendered as `<img object-fit:contain>` (no CSS recolor — the asset carries its own color).
 - `text` → wordmark + decorative mark (`alt=""`); `label` → the image `alt`/accessible name for a mark-only logo (never pass both). For third-party SSO marks use `<BrandIcon>`, not `<Logo>`.
 - `subtext` → a small muted line under the wordmark (e.g. `subtext="Free trial"`); only shown when `text` is set.
+- **Wordmark font:** override `--logo-text-font` / `--logo-text-font-weight` to set the wordmark's font + weight (defaults: inherited sans, bold). Affects only `text`, not the mark or `subtext`; load the font yourself (the DS ships none).
 
 ### Palette — categorical color set
 

--- a/packages/design-system/src/components/Logo/Logo.module.scss
+++ b/packages/design-system/src/components/Logo/Logo.module.scss
@@ -17,7 +17,12 @@
 
 .text {
   color: var(--color-fg);
-  font-weight: var(--font-weight-bold);
+
+  // Wordmark font/weight — overridable via --logo-text-font / --logo-text-font-weight.
+  // Read with fallbacks (NOT declared as a :root default) so a consumer's :root
+  // override always wins, regardless of when this component CSS is injected.
+  font-family: var(--logo-text-font, inherit);
+  font-weight: var(--logo-text-font-weight, var(--font-weight-bold));
   line-height: 1.1;
 }
 

--- a/packages/design-system/src/components/Logo/Logo.tokens.scss
+++ b/packages/design-system/src/components/Logo/Logo.tokens.scss
@@ -2,3 +2,9 @@
   // Gap between the mark and the wordmark.
   --logo-gap: var(--space-2);
 }
+
+// Wordmark typography is overridable via --logo-text-font / --logo-text-font-weight
+// to set a brand font/weight for the wordmark `text` (the mark is an image; the
+// `subtext` is NOT affected). These are intentionally read with fallbacks in
+// Logo.module.scss rather than declared at :root here — so a consumer's :root
+// override wins regardless of CSS injection order. Defaults: inherited font, bold.

--- a/packages/design-system/src/components/Logo/Logo.tsx
+++ b/packages/design-system/src/components/Logo/Logo.tsx
@@ -51,6 +51,9 @@ const sizeClass: Record<LogoSize, string> = {
  * design system arranges and sizes the lockup; the mark itself is a
  * consumer-owned asset — import an SVG/PNG and pass its URL.
  *
+ * The wordmark's font + weight are themeable via the `--logo-text-font` /
+ * `--logo-text-font-weight` CSS variables (the `subtext` is unaffected).
+ *
  * @example
  * // Mark + wordmark — the common app-header / auth lockup:
  * import logo from '../assets/eocrm-logo.svg';

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Design System</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <script>
       // SPA routing decoder — pairs with public/404.html.
       // If we landed at /<repo>/?/<encoded-path>, rewrite history back to

--- a/packages/playground/src/main.tsx
+++ b/packages/playground/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import '@eocrm/design-system/styles/global.scss';
+import './playground.css';
 import App from './App';
 
 createRoot(document.getElementById('root')!).render(

--- a/packages/playground/src/playground.css
+++ b/packages/playground/src/playground.css
@@ -1,0 +1,8 @@
+/* Playground-only brand styling — never shipped. Sets the Logo wordmark to
+   Outfit (a free, Gilroy-like geometric sans, loaded via index.html) at weight
+   600. Loaded after the design system's global.scss so it overrides the Logo's
+   --logo-text-* defaults. Only affects the wordmark `text`, not the subtext. */
+:root {
+  --logo-text-font: 'Outfit', system-ui, sans-serif;
+  --logo-text-font-weight: var(--font-weight-semibold);
+}


### PR DESCRIPTION
## Summary
Lets consumers set the `<Logo>` **wordmark** font + weight, and tries **Outfit** (a free Gilroy-like geometric sans) at weight **600** in the playground.

- `<Logo>` wordmark (`.text`) now reads `--logo-text-font` / `--logo-text-font-weight`, with `var(..., fallback)` defaults (inherited sans / bold). They're **not** declared as a `:root` default — so a consumer's `:root` override always wins regardless of when the lazily-injected component CSS loads (the bug the first attempt hit). Affects **only** the wordmark — the mark `<img>` and the `subtext` are untouched.
- Playground loads Outfit via a Google Fonts `<link>` (index.html) and sets `--logo-text-font: 'Outfit', …` + `--logo-text-font-weight: 600` in `playground.css` (never shipped).

> Gilroy is a paid font with no file in the repo; Outfit is the free stand-in. To use real Gilroy later, drop the licensed file in and point `--logo-text-font` at it — same token, no code change.

## Test plan
- [x] `make test` (2551), `make build-lib`, `make build`, `make lint`, `npm run format:check` — green
- [x] **Playwright-verified:** wordmark computes to `Outfit` / `600` (webfont loaded: `document.fonts.check('600 16px Outfit') = true`); subtext unaffected (system sans / 400); login wordmark = Outfit/600
- [x] Library default unchanged for non-overriding consumers (inherited sans, bold)
- [x] Rule-8 / Rule-7 review — clean (the cascade fix re-verified)
- [ ] CI `Quality / check`

> Touches `packages/design-system/**` → merging publishes a new library version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)