### PR TITLE
feat: Rail.Header default brand padding + divider (#136)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1637,6 +1637,7 @@ import { Home, Users, Settings } from 'lucide-react';
 ```
 
 - **Compound API** — `Rail.Header` / `Rail.Section` / `Rail.Item` / `Rail.Group` / `Rail.Spacer` / `Rail.Footer` / `Rail.CollapseToggle`.
+- **`Rail.Header` brand area (default)** — a padded brand block with a header→nav divider out of the box: `--rail-header-padding` (default `var(--space-4)`) + `--rail-header-divider-width` (default `var(--border-width)`, color `--rail-border-color`). Matches the canonical rail brand with **no prop and no raw CSS**. For a bare header, override either token to `0`. _Migration:_ if you previously shimmed your own brand padding/divider on the header, remove it or it doubles.
 - **Layout-owning primitive (Hard rule 4 exception)** — like `<Modal>`, `<Drawer>`, `<Page>`, the rail owns its own width and height because that IS its job. Place the rail inside whatever container shape your page needs (sticky aside, fixed sidebar, in-flow column).
 - **Collapse state**: controlled (`collapsed` + `onCollapsedChange`) or uncontrolled (`defaultCollapsed`). The `<Rail.CollapseToggle>` button reads context and flips the state without prop drilling.
 - **`Rail.Item` is polymorphic** — `as={NavLink}` (or any router primitive) sets `aria-current="page"` on the rendered anchor; Rail's CSS applies the active accent via `[aria-current="page"]` and `:has([aria-current="page"])` selectors. No router dependency in the library.

--- a/packages/design-system/src/components/Rail/Rail.module.scss
+++ b/packages/design-system/src/components/Rail/Rail.module.scss
@@ -45,6 +45,12 @@
 // ─── Header / Footer / Spacer ───────────────────────────────────────────
 .header {
   flex-shrink: 0;
+
+  // Padded brand area + a header→nav divider by default (token-driven, override
+  // to 0 for a bare slot) so a DS-only consumer matches the mockup rail brand
+  // without raw CSS. Mirrors .flyoutHeader's border-bottom token pattern.
+  padding: var(--rail-header-padding);
+  border-bottom: var(--rail-header-divider-width) solid var(--rail-border-color);
   // stylelint-disable-next-line declaration-property-value-disallowed-list -- collapse-mode clip per spec
   overflow: hidden;
 }

--- a/packages/design-system/src/components/Rail/Rail.tokens.scss
+++ b/packages/design-system/src/components/Rail/Rail.tokens.scss
@@ -14,6 +14,13 @@
   --rail-border-color: var(--color-border);
   --rail-border-width: var(--border-width);
 
+  // Header (brand area) — padded with a header→nav divider by default, so a
+  // DS-only consumer matches the mockup rail brand (a generous brand block over
+  // a divider) with no raw CSS. Divider color reuses --rail-border-color.
+  // Override either to `0` for a bare header slot.
+  --rail-header-padding: var(--space-4);
+  --rail-header-divider-width: var(--border-width);
+
   // Section grouping
   --rail-section-gap: var(--space-3);
   --rail-section-title-fg: var(--color-fg-muted);

--- a/packages/design-system/src/components/Rail/RailHeader.tsx
+++ b/packages/design-system/src/components/Rail/RailHeader.tsx
@@ -5,11 +5,18 @@ import styles from './Rail.module.scss';
 export type RailHeaderProps = HTMLAttributes<HTMLDivElement>;
 
 /**
- * Top slot of the rail — typically a logo or brand mark. When the rail is
- * collapsed, the header has `overflow: hidden` so anything wider than the
- * collapsed rail (~56px) is clipped. The consumer is expected to render a
- * smaller version of their brand at collapsed widths (e.g., just the mark,
- * no wordmark) — the library doesn't enforce this; we just clip overflow
+ * Top slot of the rail — typically a logo or brand mark. By default it's a
+ * padded brand area with a header→nav divider, matching the canonical rail
+ * brand: `--rail-header-padding` (default `var(--space-4)`) +
+ * `--rail-header-divider-width` (default `var(--border-width)`, color
+ * `--rail-border-color`). A DS-only consumer gets the mockup rail brand with
+ * **no prop and no raw CSS**. For a bare slot (no padding / no divider),
+ * override either token to `0` in your scope — there is no prop.
+ *
+ * When the rail is collapsed, the header has `overflow: hidden` so anything
+ * wider than the collapsed rail (~56px) is clipped. The consumer is expected to
+ * render a smaller version of their brand at collapsed widths (e.g., just the
+ * mark, no wordmark) — the library doesn't enforce this; we just clip overflow
  * so a stretched logo never visually breaks the rail.
  *
  * @example

--- a/packages/playground/src/layout/AppShell/AppShell.module.scss
+++ b/packages/playground/src/layout/AppShell/AppShell.module.scss
@@ -46,12 +46,13 @@
   height: 100%;
 }
 
+// Brand internal layout only. The padding + header→nav divider now come from
+// the DS <Rail.Header> default (--rail-header-padding / --rail-header-divider-width
+// = the canonical rail brand) — was a raw shim here before the DS shipped it.
 .brand {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-4);
-  border-bottom: var(--border-width) solid var(--color-border);
 }
 
 .nav {


### PR DESCRIPTION
Addresses #136.

## Summary
`Rail.Header` was a bare slot; the mockup rail brand uses `padding: var(--space-4)` + a bottom divider, and there was no DS-only way to get it. This makes the canonical rail brand the **default**, with **no prop**:
- New tokens `--rail-header-padding` (default `var(--space-4)`) + `--rail-header-divider-width` (default `var(--border-width)`; divider color reuses `--rail-border-color`). `.header` consumes them. A DS-only consumer matches the mockup rail brand with no prop, no raw CSS.
- **Bare-header escape hatch (no prop):** override either token to `0` in your scope.
- Dogfood: removed the playground AppShell `.brand` raw padding/divider shim (now provided by the DS default).
- JSDoc + AGENTS.md updated.

## ⚠️ Migration (for existing Rail consumers)
Every `Rail.Header` now gets a 24px… (16px) gutter + a header→nav divider where it previously had none. If you shimmed your own brand padding/divider on the header (e.g. `apps/web`'s `RailBrand`), **remove it** or it doubles.

## Test plan
- ✅ `make test` (2567), `make build-lib`, `make lint`, `npm run format:check`, `npm pack --dry-run` (Rail.tokens.scss ships, 0 test-file leaks)
- ✅ Playwright on the real AppShell rail: `.header` computes **16px padding + 1px solid divider** (DS default); the playground `.brand` shim is now **0/0** → single divider, no doubling; override both tokens to `0` → bare header. Mockups use AppShell (not Rail directly) — unaffected.
- ✅ Library Rule-8 review: clean enough to stop (0 Critical / 0 Important)