### PR TITLE
feat: PageHeader breadcrumb→title / subtitle→meta spacing + mockups use PageHeader.Breadcrumb

### DIFF
--- a/packages/design-system/src/components/PageHeader/PageHeader.module.scss
+++ b/packages/design-system/src/components/PageHeader/PageHeader.module.scss
@@ -51,6 +51,9 @@
   display: flex;
   align-items: center;
   gap: var(--page-header-breadcrumb-gap);
+
+  // Separate the breadcrumb from the title row (grid row-gap is 0).
+  padding-block-end: var(--page-header-breadcrumb-gap-block);
 }
 
 .breadcrumbInner {
@@ -121,6 +124,9 @@
   flex-wrap: wrap;
   align-items: center;
   gap: var(--page-header-meta-gap);
+
+  // Separate the meta row from the subtitle/title above it (grid row-gap is 0).
+  padding-block-start: var(--page-header-meta-gap-block);
 }
 
 .actions {

--- a/packages/design-system/src/components/PageHeader/PageHeader.module.scss
+++ b/packages/design-system/src/components/PageHeader/PageHeader.module.scss
@@ -124,8 +124,12 @@
   flex-wrap: wrap;
   align-items: center;
   gap: var(--page-header-meta-gap);
+}
 
-  // Separate the meta row from the subtitle/title above it (grid row-gap is 0).
+// Separate the meta row from the subtitle above it — ONLY when a subtitle is
+// present, so a bare count badge (meta directly under the title, no subtitle)
+// stays tight (grid row-gap is 0).
+.root:has(.subtitle) .meta {
   padding-block-start: var(--page-header-meta-gap-block);
 }
 

--- a/packages/design-system/src/components/PageHeader/PageHeader.tokens.scss
+++ b/packages/design-system/src/components/PageHeader/PageHeader.tokens.scss
@@ -13,8 +13,9 @@
 
   // Vertical separation between header rows. The grid runs row-gap:0 (so the
   // title/subtitle stay tight), so these rows contribute their own block
-  // padding: space below the breadcrumb (before the title) and above the meta
-  // (after the title/subtitle).
+  // padding: space below the breadcrumb (before the title), and above the meta
+  // (after the subtitle — only when a subtitle is present, so a bare count
+  // badge stays tight under the title).
   --page-header-breadcrumb-gap-block: var(--space-2);
   --page-header-meta-gap-block: var(--space-2);
 

--- a/packages/design-system/src/components/PageHeader/PageHeader.tokens.scss
+++ b/packages/design-system/src/components/PageHeader/PageHeader.tokens.scss
@@ -11,6 +11,13 @@
   --page-header-meta-gap: var(--space-2);
   --page-header-actions-gap: var(--space-2);
 
+  // Vertical separation between header rows. The grid runs row-gap:0 (so the
+  // title/subtitle stay tight), so these rows contribute their own block
+  // padding: space below the breadcrumb (before the title) and above the meta
+  // (after the title/subtitle).
+  --page-header-breadcrumb-gap-block: var(--space-2);
+  --page-header-meta-gap-block: var(--space-2);
+
   // Back button
   --page-header-back-button-size: 32px;
   --page-header-back-button-radius: var(--radius-sm);

--- a/packages/playground/src/pages/mockups/ContactDetail/ContactDetail.tsx
+++ b/packages/playground/src/pages/mockups/ContactDetail/ContactDetail.tsx
@@ -39,14 +39,15 @@ export function ContactDetail() {
 
   return (
     <Page>
-      <Breadcrumb>
-        <Breadcrumb.Item as={RouterLink} to="/mockups/contacts">
-          Contacts
-        </Breadcrumb.Item>
-        <Breadcrumb.Item>{contact.name}</Breadcrumb.Item>
-      </Breadcrumb>
-
       <PageHeader borderBottom={false}>
+        <PageHeader.Breadcrumb>
+          <Breadcrumb>
+            <Breadcrumb.Item as={RouterLink} to="/mockups/contacts">
+              Contacts
+            </Breadcrumb.Item>
+            <Breadcrumb.Item>{contact.name}</Breadcrumb.Item>
+          </Breadcrumb>
+        </PageHeader.Breadcrumb>
         <PageHeader.Aside>
           <Avatar name={contact.name} size="lg" />
         </PageHeader.Aside>

--- a/packages/playground/src/pages/mockups/MemberProfile/MemberProfile.tsx
+++ b/packages/playground/src/pages/mockups/MemberProfile/MemberProfile.tsx
@@ -138,14 +138,15 @@ export function MemberProfile() {
 
   return (
     <Page>
-      <Breadcrumb>
-        <Breadcrumb.Item as={RouterLink} to="/mockups/members">
-          Members
-        </Breadcrumb.Item>
-        <Breadcrumb.Item>{fullName(profile)}</Breadcrumb.Item>
-      </Breadcrumb>
-
       <PageHeader borderBottom={false}>
+        <PageHeader.Breadcrumb>
+          <Breadcrumb>
+            <Breadcrumb.Item as={RouterLink} to="/mockups/members">
+              Members
+            </Breadcrumb.Item>
+            <Breadcrumb.Item>{fullName(profile)}</Breadcrumb.Item>
+          </Breadcrumb>
+        </PageHeader.Breadcrumb>
         <PageHeader.Aside>
           <Avatar name={fullName(profile)} size="lg" />
         </PageHeader.Aside>


### PR DESCRIPTION
## Summary
Two related PageHeader changes:

**Library — PageHeader vertical spacing.** The grid runs `row-gap: 0` (title/subtitle stay tight), so rows now contribute their own block padding:
- `--page-header-breadcrumb-gap-block` (default `var(--space-2)`) → space below the breadcrumb, before the title.
- `--page-header-meta-gap-block` (default `var(--space-2)`) → space above the meta row, applied **only when a subtitle is present** (`.root:has(.subtitle) .meta`) so a bare count badge under the title stays tight.
- `padding-*` (not `margin`) → no Rule-4/stylelint disable needed. Both tokens overridable.

**Playground — mockups use the canonical slot.** `ContactDetail` and `MemberProfile` rendered a standalone `<Breadcrumb>` above `<PageHeader>`; moved into `<PageHeader.Breadcrumb>` (matching `Roles` / `TenantDetail`).

## Test plan
- ✅ `make test` (2567), `make build-lib`, `make build`, `make lint`, `npm run format:check`, `npm pack --dry-run` (PageHeader.tokens.scss ships, 0 test-file leaks)
- ✅ Playwright: ContactDetail (breadcrumb+subtitle+meta) → breadcrumb 8px below, meta 8px above; **Audit (count under title, no subtitle) → meta stays tight (0px)**; breadcrumb renders inside the PageHeader on the refactored mockups
- ✅ Rule 7 (mockups) + Rule 8 (library) reviews: clean (the Rule-8 meta-under-title regression-watch was fixed by the subtitle-scoping)

## Notes
- Touches `packages/design-system` → publishes a version. Existing PageHeaders with a breadcrumb gain 8px above the title; with subtitle+meta gain 8px between them. Count-under-title layouts unchanged.