### PR TITLE
feat: DefinitionList dense by default (spacing md → sm)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1040,7 +1040,7 @@ For displaying entity properties — contact details, settings rows, metadata si
 </DefinitionList>
 ```
 
-Props on the root: `layout='horizontal' | 'stacked'` (default `'horizontal'`), `termWidth` (CSS length, default `max-content` — column sizes to the longest term), `spacing='sm' | 'md' | 'lg'` (default `'md'`), `dividers` (default `false`). The `Description` has an `icon` prop — leading-position, automatically wrapped `aria-hidden` because the `<dt>` carries the semantic label.
+Props on the root: `layout='horizontal' | 'stacked'` (default `'horizontal'`), `termWidth` (CSS length, default `max-content` — column sizes to the longest term), `spacing='sm' | 'md' | 'lg'` (default `'sm'` — compact; bump to `md`/`lg` for roomier), `dividers` (default `false`). The `Description` has an `icon` prop — leading-position, automatically wrapped `aria-hidden` because the `<dt>` carries the semantic label.
 
 Use this instead of `Card.List` + `Card.ListRow` whenever the data is genuinely key/value (every row has a label and a value). Use `Card.List` when rows aren't keyed (activity feeds, list of cards).
 

--- a/packages/design-system/src/components/DefinitionList/DefinitionList.test.tsx
+++ b/packages/design-system/src/components/DefinitionList/DefinitionList.test.tsx
@@ -15,7 +15,7 @@ describe('DefinitionList', () => {
     const dl = container.querySelector('dl');
     expect(dl).not.toBeNull();
     expect(dl!.getAttribute('data-layout')).toBe('horizontal');
-    expect(dl!.getAttribute('data-spacing')).toBe('md');
+    expect(dl!.getAttribute('data-spacing')).toBe('sm');
     expect(dl!.getAttribute('data-dividers')).toBeNull();
   });
 

--- a/packages/design-system/src/components/DefinitionList/DefinitionList.tsx
+++ b/packages/design-system/src/components/DefinitionList/DefinitionList.tsx
@@ -23,8 +23,8 @@ export type DefinitionListLayout = 'horizontal' | 'stacked';
 
 /**
  * Vertical padding per item.
- * - `'sm'` — `var(--space-2)` (compact tables / sidebars).
- * - `'md'` — `var(--space-3)` (default; matches Card.ListRow rhythm).
+ * - `'sm'` — `var(--space-2)` (default; compact, dense rhythm).
+ * - `'md'` — `var(--space-3)` (roomier; matches Card.ListRow rhythm).
  * - `'lg'` — `var(--space-4)` (emphasis panels).
  */
 export type DefinitionListSpacing = 'sm' | 'md' | 'lg';
@@ -39,7 +39,7 @@ export interface DefinitionListProps extends HTMLAttributes<HTMLDListElement> {
    * alignment across multiple DefinitionLists on the same screen.
    */
   termWidth?: string;
-  /** Vertical padding per item. See `DefinitionListSpacing`. Default `'md'`. */
+  /** Vertical padding per item. See `DefinitionListSpacing`. Default `'sm'`. */
   spacing?: DefinitionListSpacing;
   /**
    * Render a 1px border between items. Default `false` (clean, dense look).
@@ -141,7 +141,7 @@ const DefinitionListRoot = forwardRef<HTMLDListElement, DefinitionListProps>(
     {
       layout = 'horizontal',
       termWidth,
-      spacing = 'md',
+      spacing = 'sm',
       dividers,
       className,
       style,

--- a/packages/playground/src/pages/components/DefinitionListDemo.tsx
+++ b/packages/playground/src/pages/components/DefinitionListDemo.tsx
@@ -147,6 +147,34 @@ export function DefinitionListDemo() {
       </Example>
 
       <Example
+        title="Spacing variants"
+        description="Vertical density per row. Default is sm (dense); bump to md or lg for roomier panels."
+        code={`<DefinitionList spacing="sm">…</DefinitionList>  {/* default — dense */}
+<DefinitionList spacing="md">…</DefinitionList>
+<DefinitionList spacing="lg">…</DefinitionList>`}
+      >
+        <Stack gap="lg">
+          {(['sm', 'md', 'lg'] as const).map((s) => (
+            <Stack gap="xs" key={s}>
+              <Text size="sm" tone="muted">
+                {`spacing="${s}"${s === 'sm' ? ' (default)' : ''}`}
+              </Text>
+              <DefinitionList spacing={s} dividers>
+                <DefinitionList.Item>
+                  <DefinitionList.Term>Plan</DefinitionList.Term>
+                  <DefinitionList.Description>Enterprise</DefinitionList.Description>
+                </DefinitionList.Item>
+                <DefinitionList.Item>
+                  <DefinitionList.Term>Seats</DefinitionList.Term>
+                  <DefinitionList.Description>120</DefinitionList.Description>
+                </DefinitionList.Item>
+              </DefinitionList>
+            </Stack>
+          ))}
+        </Stack>
+      </Example>
+
+      <Example
         title="Stacked layout"
         description="Stack each term above its description. Useful for settings pages, narrow viewports, or long descriptions that need to breathe."
         code={`<DefinitionList layout="stacked" dividers>


### PR DESCRIPTION
## Summary
`DefinitionList` now defaults to a **compact** rhythm: the default `spacing` changes from `md` (12px padding-block) to `sm` (8px). Roomier options stay available via `spacing="md"` / `spacing="lg"`.

- `src/components/DefinitionList/DefinitionList.tsx` — default param `spacing = 'sm'`; JSDoc (type union + prop) updated.
- Default-spacing test now asserts `data-spacing="sm"`; the parametrized `sm/md/lg` test is unchanged.
- `AGENTS.md` TL;DR updated.
- Playground: added a **"Spacing variants"** example to the DefinitionList demo (sm/md/lg side by side) so the roomier options are discoverable.

## Test plan
- ✅ `make test` (2567), `make build-lib`, `make build`, `make lint`, `npm run format:check`, `npm pack --dry-run`
- ✅ Playwright: a default DefinitionList computes 8px padding-block; the demo's variants render sm (8) / md (12) / lg (16)
- ✅ Library Rule-8 review: clean enough to stop (0 Critical / 0 Important; added the demo example it flagged as a nice-to-have)

## Notes
- Touches `packages/design-system` → publishes a version. Existing DefinitionLists that didn't set an explicit `spacing` (e.g. ContactDetail "About", MemberProfile panels) now render denser; that's the intent. Pin `spacing="md"` to keep the old rhythm.