### PR TITLE
docs(Switch): hard rule — side-effecting toggles use async optimistic update

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -569,6 +569,10 @@ import { Switch } from '@eocrm/design-system';
 - **`loading={true}`** shows a spinner inside the thumb + disables the input (sets `aria-busy`). Consumer manages the optimistic-update flow.
 - **`onChange(checked, event)`** signature matches Checkbox — first arg is the next boolean, second is the raw event.
 
+#### Hard rule
+
+A switch whose toggle triggers an **immediate action** — persisting to a server or firing any side effect — MUST use the async optimistic-update flow: flip the state optimistically, set `loading` while the request is in flight, and roll back on failure (see the async toggle example above). Never fire-and-forget a side-effecting toggle — the user needs the in-flight (`loading`) and rollback feedback. A switch over pure local UI state (no side effect) may toggle synchronously.
+
 #### When NOT to use
 
 - ❌ Selecting one option from a list of mutually-exclusive choices → `<Radio>` / `<RadioGroup>`.

--- a/packages/design-system/src/components/Switch/Switch.tsx
+++ b/packages/design-system/src/components/Switch/Switch.tsx
@@ -154,6 +154,15 @@ const SPIN_SIZE: Record<SwitchSize, number> = {
  * // Icon-only.
  * <Switch aria-label="Mute notifications" />
  *
+ * @remarks Hard rule (consumers)
+ * A switch whose toggle triggers an **immediate action** — persisting to a
+ * server or firing any side effect — MUST use the async optimistic-update flow:
+ * flip the state optimistically, set `loading` while the request is in flight,
+ * and roll back on failure (see the async `@example` above). Never fire-and-
+ * forget a side-effecting toggle: the user needs the in-flight (`loading`) and
+ * rollback feedback. A switch over pure local UI state (no side effect) may
+ * toggle synchronously.
+ *
  * @remarks When NOT to use
  * - Mutually-exclusive choice → `<Radio>` / `<RadioGroup>`.
  * - Multi-select list → `<Checkbox>`.


### PR DESCRIPTION
## Summary
Adds a consumer-facing **Hard rule** for `<Switch>`: when a toggle triggers an immediate action (persists to a server / fires a side effect), consumers MUST use the async optimistic-update flow — flip optimistically, set `loading` while in flight, roll back on failure — never fire-and-forget. A switch over pure local UI state may toggle synchronously.

- `src/components/Switch/Switch.tsx` — new `@remarks Hard rule (consumers)` in the component JSDoc (the contract AI consumers read in-editor).
- `AGENTS.md` — new `#### Hard rule` in the Switch section.

Docs/JSDoc only — no code, API, CSS, or test change.

## Test plan
- ✅ `make build-lib`, `make test` (2567), `make lint`, `npm run format:check`, `npm pack --dry-run` (no leaks)
- Rule-8: docs-only (trivial-change escape hatch) — no behavior/regression surface.