### PR TITLE
fix(Tabs): vertical tablist fills its container (composes with Split asideWidth) (#150)

### DIFF
--- a/packages/design-system/src/components/Tabs/Tabs.module.scss
+++ b/packages/design-system/src/components/Tabs/Tabs.module.scss
@@ -141,7 +141,15 @@
   flex-direction: column;
   gap: var(--tabs-vertical-gap);
   border-bottom: none; // no horizontal track in vertical mode
-  min-width: 0;
+
+  // Fill the container's inline size (overrides the base inline-flex
+  // shrink-to-content) so rows — and their `trailing` adornments — span the
+  // full rail. This is what makes a vertical rail compose correctly with a
+  // sized column such as `<Split asideWidth="240px">`: without it the tablist
+  // floats at content width inside a wider/pinned column. An explicit 100%
+  // (not min-width: 100%) also constrains long labels so the `.label` ellipsis
+  // engages instead of overflowing the column.
+  width: 100%;
 
   .tab {
     width: 100%;


### PR DESCRIPTION
Addresses #150.

## Summary
A vertical `Tabs` tablist is `display: inline-flex` (base `.tabs`) and the `.vertical` modifier set `min-width: 0`, so the rail shrank to its content's intrinsic width. Inside a sized column — notably `<Split asideWidth="240px" aside={<Tabs orientation="vertical" …/>}>` — the rail floated at content width within the wider/pinned column, so rows (and their `trailing` adornments) didn't span the column.

**Fix:** one line in `Tabs.module.scss` — the `.vertical` modifier now sets `width: 100%` (instead of `min-width: 0`), so the tablist fills its container's inline size. Chose `width: 100%` over the issue's suggested `min-width: 100%` because an explicit width also caps the rail, so the existing `.label` text-overflow ellipsis engages when a pinned column is narrower than a label (rather than overflowing). Scoped entirely to `.vertical`; horizontal mode untouched.

## Test plan
- **Verified in-browser** (Playwright) on the `Split` demo: `side="end"` with `asideWidth="200px"` — tablist now **200px** (was 181px), tab buttons 200px, the `trailing` "Unsaved" badge pins to the column edge; the `auto`-width example is unchanged at 181px; 0 console errors.
- `make test` (2590 pass), `make build-lib`, `make lint`, `npm run format:check` green; `npm pack --dry-run` leaks nothing.
- Fresh-context adversarial review (Hard rule 8): 0 Critical / 0 Important — "clean enough to stop" (checked pinned/auto track sizing, the indicator, RTL, overflow under `box-sizing: border-box`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)