### PR TITLE
feat(Popover): maxWidth prop on Popover.Content (uncap 360px) (#154)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1889,7 +1889,7 @@ import { Bell, Plus } from 'lucide-react';
 - Compound API: `<Popover>` is the provider; `<Popover.Trigger>` clones its single child to inject ARIA + click; `<Popover.Content>` portals to `document.body` and positions via Floating UI; `<Popover.Heading>` (optional) wires `aria-labelledby`; `<Popover.Close>` clones its child to inject a close-onClick.
 - Trigger child must accept a ref (`forwardRef`). `<Button>` does.
 - **Non-modal**: focus moves to the panel on open; Tab traverses INTO content, then OUT to the page behind. Click-outside or Escape dismisses. Page is NOT inert.
-- `<Popover.Content>` props: `side` (`'top'` | `'right'` | `'bottom'` | `'left'`, default `'bottom'`), `align` (default `'center'`), `sideOffset` (default `10`), `minWidth`.
+- `<Popover.Content>` props: `side` (`'top'` | `'right'` | `'bottom'` | `'left'`, default `'bottom'`), `align` (default `'center'`), `sideOffset` (default `10`), `minWidth`, `maxWidth` (overrides the default 360px cap — pass a px number, a CSS length, `'fit-content'`, or `'none'` for wide content like calendars/tables).
 - `<Popover.Heading>` props: `as` (`'h2'` – `'h6'`, default `'h3'`).
 - Opens with a short scale-fade from the trigger side (140ms). Closes instantly. Respects `prefers-reduced-motion: reduce`.
 - **From a DropdownMenu item.** Wrap a `<DropdownMenu.Item closeOnSelect={false}>` as the `<Popover.Trigger>` child — the Item itself becomes the trigger, so the full highlighted row opens the popover. `closeOnSelect={false}` keeps the menu open while the popover is shown.

--- a/packages/design-system/src/components/Popover/Content.tsx
+++ b/packages/design-system/src/components/Popover/Content.tsx
@@ -32,6 +32,13 @@ export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {
    * `--size-popover-min-width` (220px) applied via SCSS.
    */
   minWidth?: number | string;
+  /**
+   * Maximum width in px or any CSS length, overriding the default cap
+   * (`--popover-max-width`, 360px). Use for wide content — calendars, tables —
+   * that would otherwise overflow the panel. Accepts a number (px),
+   * `'fit-content'`, `'none'` to remove the cap, or any CSS length.
+   */
+  maxWidth?: number | string;
 }
 
 /**
@@ -42,7 +49,16 @@ export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {
  * the trigger.
  */
 export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function Content(
-  { side = 'bottom', align = 'center', sideOffset = 10, minWidth, className, children, ...rest },
+  {
+    side = 'bottom',
+    align = 'center',
+    sideOffset = 10,
+    minWidth,
+    maxWidth,
+    className,
+    children,
+    ...rest
+  },
   forwardedRef,
 ) {
   const ctx = usePopoverContext('Content');
@@ -115,6 +131,12 @@ export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function 
         ? `${minWidth}px`
         : minWidth
       : undefined;
+  const maxWidthStyle =
+    maxWidth !== undefined
+      ? typeof maxWidth === 'number'
+        ? `${maxWidth}px`
+        : maxWidth
+      : undefined;
 
   return createPortal(
     <div
@@ -128,7 +150,7 @@ export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function 
       data-side={resolvedSide}
       data-popover-content=""
       data-in-overlay={inOverlay ? '' : undefined}
-      style={{ ...floatingStyles, minWidth: minWidthStyle }}
+      style={{ ...floatingStyles, minWidth: minWidthStyle, maxWidth: maxWidthStyle }}
       className={clsx(styles.content, className)}
     >
       {children}

--- a/packages/design-system/src/components/Popover/Popover.module.scss
+++ b/packages/design-system/src/components/Popover/Popover.module.scss
@@ -7,7 +7,7 @@
 .content {
   position: relative;
   min-width: var(--popover-min-width);
-  max-width: 360px;
+  max-width: var(--popover-max-width);
   padding: var(--popover-padding);
   background: var(--popover-bg);
   color: var(--popover-fg);

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -510,6 +510,56 @@ describe('Popover — cleanup + Tab traversal', () => {
   });
 });
 
+describe('Popover.Content — width props', () => {
+  it('applies no inline max-width by default (uses the token cap)', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content>panel</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog').style.maxWidth).toBe('');
+  });
+
+  it('applies maxWidth as an inline style (number → px)', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content maxWidth={560}>panel</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog').style.maxWidth).toBe('560px');
+  });
+
+  it('passes a string maxWidth through verbatim', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content maxWidth="fit-content">panel</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog').style.maxWidth).toBe('fit-content');
+  });
+
+  it('applies minWidth as an inline style (number → px)', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content minWidth={300}>panel</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog').style.minWidth).toBe('300px');
+  });
+});
+
 describe('Popover — overlay elevation', () => {
   it('elevates the content (data-in-overlay) when opened inside an overlay', async () => {
     const user = userEvent.setup();

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -547,6 +547,18 @@ describe('Popover.Content — width props', () => {
     expect(screen.getByRole('dialog').style.maxWidth).toBe('fit-content');
   });
 
+  it('passes maxWidth="none" through verbatim (removes the cap — the marquee use case)', () => {
+    render(
+      <Popover defaultOpen>
+        <Popover.Trigger>
+          <button type="button">Open</button>
+        </Popover.Trigger>
+        <Popover.Content maxWidth="none">panel</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.getByRole('dialog').style.maxWidth).toBe('none');
+  });
+
   it('applies minWidth as an inline style (number → px)', () => {
     render(
       <Popover defaultOpen>

--- a/packages/design-system/src/components/Popover/Popover.tokens.scss
+++ b/packages/design-system/src/components/Popover/Popover.tokens.scss
@@ -8,6 +8,7 @@
   --popover-shadow: var(--shadow-lg);
   --popover-padding: var(--space-3);
   --popover-min-width: var(--size-popover-min-width);
+  --popover-max-width: var(--size-popover-max-width);
   --popover-z: var(--z-popover);
 
   // Entrance transition

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -220,6 +220,7 @@
   // trigger-tight clusters.
   --size-dropdown-min-width: 160px;
   --size-popover-min-width: 220px; // slightly wider than dropdown — popovers carry richer content
+  --size-popover-max-width: 360px; // default cap for popover-shaped surfaces; override per-instance via the maxWidth prop
 
   // Width/height of the leading indicator slot in DropdownMenu checkbox/radio items.
   --size-dropdown-indicator: 16px;

--- a/packages/playground/src/pages/components/PopoverDemo.tsx
+++ b/packages/playground/src/pages/components/PopoverDemo.tsx
@@ -210,7 +210,84 @@ export function PopoverDemo() {
           <ControlledExample />
         </Cluster>
       </Example>
+
+      <Example
+        title="Wide content (maxWidth)"
+        description="The panel caps at 360px by default, which clips wide content like a two-column filter or a date-range calendar. Pass maxWidth to let the panel grow — here a 480px two-column layout that would otherwise overflow."
+        code={`<Popover>
+  <Popover.Trigger>
+    <Button variant="secondary">Date range filter</Button>
+  </Popover.Trigger>
+  <Popover.Content maxWidth={520}>
+    <Stack gap="sm">
+      <Popover.Heading>Pick a date range</Popover.Heading>
+      <Cluster gap="md" align="start">
+        {/* two side-by-side month grids ≈ 480px wide */}
+        <div style={{ width: 220 }}>(start month)</div>
+        <div style={{ width: 220 }}>(end month)</div>
+      </Cluster>
+      <Cluster justify="end" gap="sm">
+        <Popover.Close>
+          <Button variant="secondary" size="sm">Cancel</Button>
+        </Popover.Close>
+        <Popover.Close>
+          <Button size="sm">Apply</Button>
+        </Popover.Close>
+      </Cluster>
+    </Stack>
+  </Popover.Content>
+</Popover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <Popover>
+            <Popover.Trigger>
+              <Button variant="secondary">Default cap (clips at 360px)</Button>
+            </Popover.Trigger>
+            <Popover.Content>
+              <WideRangeBody />
+            </Popover.Content>
+          </Popover>
+          <Popover>
+            <Popover.Trigger>
+              <Button variant="secondary">maxWidth=520 (fits)</Button>
+            </Popover.Trigger>
+            <Popover.Content maxWidth={520}>
+              <WideRangeBody />
+            </Popover.Content>
+          </Popover>
+        </Cluster>
+      </Example>
     </DemoLayout>
+  );
+}
+
+// Wide two-column body (~480px) that overflows the 360px default cap.
+// Both popovers share it so the only difference between them is maxWidth.
+function WideRangeBody() {
+  return (
+    <Stack gap="sm">
+      <Popover.Heading>Pick a date range</Popover.Heading>
+      <Cluster gap="md" align="start">
+        <Stack gap="xs" style={{ width: 220 }}>
+          <strong>Start month</strong>
+          <div>A 31-cell month grid would render here (~220px wide).</div>
+        </Stack>
+        <Stack gap="xs" style={{ width: 220 }}>
+          <strong>End month</strong>
+          <div>The second month grid sits beside it (~220px wide).</div>
+        </Stack>
+      </Cluster>
+      <Cluster justify="end" gap="sm">
+        <Popover.Close>
+          <Button variant="secondary" size="sm">
+            Cancel
+          </Button>
+        </Popover.Close>
+        <Popover.Close>
+          <Button size="sm">Apply</Button>
+        </Popover.Close>
+      </Cluster>
+    </Stack>
   );
 }
 


### PR DESCRIPTION
Addresses #154.

## Summary
`Popover.Content` hard-capped `max-width: 360px`, so wide content (e.g. a two-month `InlineDateRangePicker` ≈ 520px) spilled outside the panel. Adds a **`maxWidth`** prop mirroring the existing `minWidth`:

- `maxWidth?: number | string` — number → px; strings (`'fit-content'`, `'none'`, any CSS length) pass through; applied as an inline `max-width` that overrides the default cap. Omitted → unchanged 360px default (backward compatible).
- The default cap is now **tokenized**: `--size-popover-max-width: 360px` (global) → `--popover-max-width` (component) → `max-width: var(--popover-max-width)` in SCSS, mirroring the existing `--popover-min-width` chain (the raw `360px` left `.module.scss`).

## Test plan
- `make test` — 2595 pass (5 new Popover tests: default cap / number→px / `'fit-content'` / `'none'` / `minWidth` backfill).
- `make build-lib`, `make lint`, `npm run format:check` green; `npm pack --dry-run` leaks nothing.
- Playground `PopoverDemo` gains a "Wide content (maxWidth)" example (default-capped vs `maxWidth={520}`).
- Hard-rule-8 adversarial review: 0 Critical / 0 Important — "clean enough to stop" (verified `floatingStyles` can't clobber the inline width with `transform: false`; token chain end-to-end; backward compat via ConfirmationPopover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)