### PR TITLE
feat(FilterChip): interactive body via onActivate (#153)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1507,9 +1507,25 @@ function TeamChip({ team }: { team: string }) {
 - Compound API: `<FilterChip>` root + optional `<FilterChip.Label>` and `<FilterChip.Value>` children.
 - `onDismiss`: when provided, the chip renders a trailing `×` button wired to this callback. Omit for a read-only chip.
 - `dismissLabel`: overrides the default `'Remove filter'` `aria-label` on the dismiss button. Pass a contextual label (`'Remove Event: auth.* filter'`) for screen-reader clarity.
+- `onActivate`: makes the chip BODY a `<button>` (for _editable_ filters — e.g. a date-range chip whose body re-opens its range-picker). Wire it to a controlled `<Popover open onOpenChange>` to open an editor popover. The dismiss ✕ stays a separate button whose click **stops propagation**, so removing the filter never fires `onActivate` (and never bubbles to a wrapping `Popover.Trigger` / ancestor click handler).
+- `expanded`: surfaced as `aria-expanded` on the body button — pass the open state of the disclosure the body opens. Only meaningful with `onActivate`; omit if the body doesn't toggle a disclosure. The body button also carries `aria-haspopup="dialog"`.
 - `<FilterChip.Value tone={...}>`: optional `tone` (same palette as `<Badge>`) prefixes a colored 6px dot before the value text. Omit `tone` for plain values (e.g., a tenant slug).
-- **Use for active-filter pills, not tags / status badges.** If it's a status or category, use `<Badge>`. If it's a clickable filter trigger, use `<Button>` or `<OptionsPicker.Trigger>`.
-- Root carries `role="group"` so screen readers announce the chip as one unit. The dismiss button is the only interactive target.
+- **Use for active-filter pills, not tags / status badges.** If it's a status or category, use `<Badge>`. If it's a clickable filter trigger that navigates or runs an action, use `<Button>` or `<OptionsPicker.Trigger>`.
+- Root carries `role="group"` so screen readers announce the chip as one unit. A read-only chip's only interactive target is the dismiss ✕; an _editable_ chip adds a body button via `onActivate`.
+
+```tsx
+// Editable chip — body re-opens an editor popover; ✕ removes the filter
+const [open, setOpen] = useState(false);
+<Popover open={open} onOpenChange={setOpen}>
+  <Popover.Trigger>
+    <FilterChip onActivate={() => setOpen((o) => !o)} expanded={open} onDismiss={remove}>
+      <FilterChip.Label>Range</FilterChip.Label>
+      <FilterChip.Value>Jun 1 – Jul 31</FilterChip.Value>
+    </FilterChip>
+  </Popover.Trigger>
+  <Popover.Content maxWidth={520}>{/* range picker */}</Popover.Content>
+</Popover>;
+```
 
 ### `<Tabs>` — tab strip (horizontal or vertical)
 

--- a/packages/design-system/src/components/FilterChip/FilterChip.module.scss
+++ b/packages/design-system/src/components/FilterChip/FilterChip.module.scss
@@ -11,6 +11,23 @@
   background: var(--filter-chip-bg);
 }
 
+.body {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--filter-chip-gap);
+  padding: 0;
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  border-radius: var(--filter-chip-radius);
+
+  &:focus-visible {
+    @include focus-ring;
+  }
+}
+
 .label {
   display: inline-flex;
   align-items: center;

--- a/packages/design-system/src/components/FilterChip/FilterChip.test.tsx
+++ b/packages/design-system/src/components/FilterChip/FilterChip.test.tsx
@@ -171,3 +171,126 @@ it('value-only chip (no label) renders cleanly', () => {
   expect(screen.getByText('Platform only')).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Remove filter' })).toBeInTheDocument();
 });
+
+// ----------------------------------------------------------------------------
+// Interactive (editable) body — onActivate
+// ----------------------------------------------------------------------------
+
+it('with onActivate, the body is a button that fires onActivate on click', async () => {
+  const user = userEvent.setup();
+  const onActivate = vi.fn();
+  render(
+    <FilterChip onActivate={onActivate}>
+      <FilterChip.Label>Event</FilterChip.Label>
+      <FilterChip.Value>auth.*</FilterChip.Value>
+    </FilterChip>,
+  );
+  const body = screen.getByRole('button', { name: /Event/ });
+  await user.click(body);
+  expect(onActivate).toHaveBeenCalledTimes(1);
+});
+
+it('clicking the dismiss ✕ fires onDismiss but NOT onActivate', async () => {
+  const user = userEvent.setup();
+  const onActivate = vi.fn();
+  const onDismiss = vi.fn();
+  render(
+    <FilterChip onActivate={onActivate} onDismiss={onDismiss}>
+      <FilterChip.Label>Event</FilterChip.Label>
+      <FilterChip.Value>auth.*</FilterChip.Value>
+    </FilterChip>,
+  );
+  await user.click(screen.getByRole('button', { name: 'Remove filter' }));
+  expect(onDismiss).toHaveBeenCalledTimes(1);
+  expect(onActivate).not.toHaveBeenCalled();
+});
+
+it('dismiss ✕ click stops propagation to an ancestor click handler', async () => {
+  const user = userEvent.setup();
+  const ancestorSpy = vi.fn();
+  const onActivate = vi.fn();
+  render(
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+    <div onClick={ancestorSpy}>
+      <FilterChip onActivate={onActivate} onDismiss={() => {}}>
+        <FilterChip.Label>Event</FilterChip.Label>
+        <FilterChip.Value>auth.*</FilterChip.Value>
+      </FilterChip>
+    </div>,
+  );
+  await user.click(screen.getByRole('button', { name: 'Remove filter' }));
+  expect(ancestorSpy).not.toHaveBeenCalled();
+
+  // The body button still reaches its handler (and bubbles to the ancestor).
+  await user.click(screen.getByRole('button', { name: /Event/ }));
+  expect(onActivate).toHaveBeenCalledTimes(1);
+  expect(ancestorSpy).toHaveBeenCalledTimes(1);
+});
+
+it('body button is keyboard-actionable (Enter, Space)', async () => {
+  const user = userEvent.setup();
+  const onActivate = vi.fn();
+  render(
+    <FilterChip onActivate={onActivate}>
+      <FilterChip.Label>Event</FilterChip.Label>
+      <FilterChip.Value>auth.*</FilterChip.Value>
+    </FilterChip>,
+  );
+  const body = screen.getByRole('button', { name: /Event/ });
+  body.focus();
+  await user.keyboard('{Enter}');
+  expect(onActivate).toHaveBeenCalledTimes(1);
+  await user.keyboard(' ');
+  expect(onActivate).toHaveBeenCalledTimes(2);
+});
+
+it('body button has aria-haspopup="dialog" and reflects expanded via aria-expanded', () => {
+  const { rerender } = render(
+    <FilterChip onActivate={() => {}} expanded>
+      <FilterChip.Label>Range</FilterChip.Label>
+      <FilterChip.Value>Jun 1 – Jul 31</FilterChip.Value>
+    </FilterChip>,
+  );
+  const body = screen.getByRole('button', { name: /Range/ });
+  expect(body).toHaveAttribute('aria-haspopup', 'dialog');
+  expect(body).toHaveAttribute('aria-expanded', 'true');
+
+  rerender(
+    <FilterChip onActivate={() => {}} expanded={false}>
+      <FilterChip.Label>Range</FilterChip.Label>
+      <FilterChip.Value>Jun 1 – Jul 31</FilterChip.Value>
+    </FilterChip>,
+  );
+  expect(screen.getByRole('button', { name: /Range/ })).toHaveAttribute('aria-expanded', 'false');
+
+  // expanded omitted → React drops the attribute entirely.
+  rerender(
+    <FilterChip onActivate={() => {}}>
+      <FilterChip.Label>Range</FilterChip.Label>
+      <FilterChip.Value>Jun 1 – Jul 31</FilterChip.Value>
+    </FilterChip>,
+  );
+  expect(screen.getByRole('button', { name: /Range/ })).not.toHaveAttribute('aria-expanded');
+});
+
+it('without onActivate there is NO body button (backward compat)', () => {
+  const { rerender } = render(
+    <FilterChip>
+      <FilterChip.Label>Event</FilterChip.Label>
+      <FilterChip.Value>auth.*</FilterChip.Value>
+    </FilterChip>,
+  );
+  // Read-only, no dismiss → zero buttons.
+  expect(screen.queryAllByRole('button')).toHaveLength(0);
+
+  rerender(
+    <FilterChip onDismiss={() => {}}>
+      <FilterChip.Label>Event</FilterChip.Label>
+      <FilterChip.Value>auth.*</FilterChip.Value>
+    </FilterChip>,
+  );
+  // Dismiss only → exactly one button (the ✕), no body button.
+  const buttons = screen.getAllByRole('button');
+  expect(buttons).toHaveLength(1);
+  expect(buttons[0]).toHaveAttribute('aria-label', 'Remove filter');
+});

--- a/packages/design-system/src/components/FilterChip/FilterChip.tsx
+++ b/packages/design-system/src/components/FilterChip/FilterChip.tsx
@@ -29,6 +29,26 @@ export interface FilterChipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'r
   dismissLabel?: string;
 
   /**
+   * Makes the chip BODY interactive: when provided, the Label/Value content is
+   * wrapped in a `<button>` that fires `onActivate` on click and Enter/Space
+   * (native button keyboard). Use for *editable* filters — e.g. a date-range
+   * chip whose body re-opens its range-picker. Wire it to a controlled
+   * `<Popover open onOpenChange>` to open an editor popover.
+   *
+   * The dismiss ✕ stays a separate button whose click stops propagation, so
+   * removing the filter never fires `onActivate` (and never bubbles to an
+   * ancestor click handler). Omit for a read-only chip (current behavior).
+   */
+  onActivate?: () => void;
+
+  /**
+   * Open state of the disclosure the body opens (e.g. the editor popover),
+   * surfaced as `aria-expanded` on the body button. Only meaningful with
+   * `onActivate`. Omit if the body doesn't toggle a disclosure.
+   */
+  expanded?: boolean;
+
+  /**
    * One or two `FilterChip.Label` / `FilterChip.Value` subcomponents.
    * Use both for `Label: Value` chips; pass just a Value for chips
    * where the category is implicit (e.g., a tenant slug).
@@ -99,15 +119,30 @@ export interface FilterChipValueProps extends HTMLAttributes<HTMLSpanElement> {
  *   <FilterChip.Value>Active</FilterChip.Value>
  * </FilterChip>
  *
+ * @example
+ * // Editable chip — body re-opens an editor popover; ✕ removes the filter
+ * const [open, setOpen] = useState(false);
+ * <Popover open={open} onOpenChange={setOpen}>
+ *   <Popover.Trigger>
+ *     <FilterChip onActivate={() => setOpen((o) => !o)} expanded={open} onDismiss={remove}>
+ *       <FilterChip.Label>Range</FilterChip.Label>
+ *       <FilterChip.Value>Jun 1 – Jul 31</FilterChip.Value>
+ *     </FilterChip>
+ *   </Popover.Trigger>
+ *   <Popover.Content maxWidth={520}>{rangePicker}</Popover.Content>
+ * </Popover>
+ *
  * @remarks When NOT to use
  * - Status / category pills with no dismiss UX — use `<Badge>` instead.
  *   FilterChip's white pill + thin border + optional X is purpose-built
  *   for "currently applied filter", not "this contact is a VIP".
  * - Tags on an entity (e.g., deal labels) — `<Badge>` again. Tags don't
  *   carry a `Label: Value` shape.
- * - Clickable filter triggers — that's the role of a `<Button>` or
- *   `<OptionsPicker.Trigger>`. FilterChip's only interactive target
- *   is the dismiss button.
+ * - Clickable filter triggers that navigate or run an action — that's the
+ *   role of a `<Button>` or `<OptionsPicker.Trigger>`. A read-only chip's
+ *   only interactive target is the dismiss ✕. An *editable* chip (one that
+ *   re-opens its own editor) is the exception: pass `onActivate` to make
+ *   the body a `<button>` wired to a controlled `<Popover>`.
  *
  * @remarks Anti-patterns
  * - Putting interactive children inside `<FilterChip.Label>` or
@@ -119,7 +154,7 @@ export interface FilterChipValueProps extends HTMLAttributes<HTMLSpanElement> {
  *   Wrap the chip in your own transition if you need one.
  */
 const FilterChipRoot = forwardRef<HTMLDivElement, FilterChipProps>(function FilterChipRoot(
-  { onDismiss, dismissLabel, className, children, ...rest },
+  { onDismiss, dismissLabel, onActivate, expanded, className, children, ...rest },
   ref,
 ) {
   const t = useTranslation();
@@ -131,12 +166,29 @@ const FilterChipRoot = forwardRef<HTMLDivElement, FilterChipProps>(function Filt
       {...rest}
       role="group"
     >
-      {children}
+      {onActivate ? (
+        <button
+          type="button"
+          className={styles.body}
+          onClick={onActivate}
+          aria-haspopup="dialog"
+          aria-expanded={expanded}
+        >
+          {children}
+        </button>
+      ) : (
+        children
+      )}
       {onDismiss && (
         <button
           type="button"
           className={styles.dismiss}
-          onClick={onDismiss}
+          // stopPropagation: removing the filter must not fire the body activate
+          // OR bubble to a wrapping Popover.Trigger / ancestor click handler.
+          onClick={(e) => {
+            e.stopPropagation();
+            onDismiss();
+          }}
           aria-label={dismissLabel ?? t('filterChip.dismiss')}
         >
           <X size={12} aria-hidden="true" />

--- a/packages/design-system/src/components/FilterChip/FilterChip.tsx
+++ b/packages/design-system/src/components/FilterChip/FilterChip.tsx
@@ -38,6 +38,10 @@ export interface FilterChipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'r
    * The dismiss ✕ stays a separate button whose click stops propagation, so
    * removing the filter never fires `onActivate` (and never bubbles to an
    * ancestor click handler). Omit for a read-only chip (current behavior).
+   *
+   * Controlled-only: FilterChip does NOT consume `Popover.Trigger`'s injected
+   * ref/ARIA, so wrapping it in `<Popover.Trigger>` won't auto-wire it — drive
+   * the popover's `open` yourself from this callback (see the example above).
    */
   onActivate?: () => void;
 

--- a/packages/playground/src/pages/components/FilterChipDemo.tsx
+++ b/packages/playground/src/pages/components/FilterChipDemo.tsx
@@ -1,13 +1,31 @@
 import { useState } from 'react';
-import { Cluster, FilterChip } from '@eocrm/design-system';
+import { Cluster, FilterChip, Stack, Text } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { InputExample } from './InputExample';
 import { getComponentFiles } from '../../lib/componentFiles';
 
+type EditableFilter = { id: string; label: string; value: string };
+
+const INITIAL_EDITABLE: EditableFilter[] = [
+  { id: 'range', label: 'Range', value: 'Jun 1 – Jul 31' },
+  { id: 'owner', label: 'Owner', value: 'Sarah Chen' },
+  { id: 'event', label: 'Event', value: 'auth.* (3)' },
+];
+
 export function FilterChipDemo() {
   const [chips, setChips] = useState<string[]>(['event', 'tenant']);
   const removeChip = (id: string) => setChips((prev) => prev.filter((c) => c !== id));
+
+  // Interactive (editable) example: clicking a chip body marks it "editing"
+  // (where a real consumer would open a controlled <Popover> editor); the ✕
+  // removes the chip from the list WITHOUT activating the editor.
+  const [editable, setEditable] = useState<EditableFilter[]>(INITIAL_EDITABLE);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const removeEditable = (id: string) => {
+    setEditable((prev) => prev.filter((f) => f.id !== id));
+    setEditingId((cur) => (cur === id ? null : cur));
+  };
 
   return (
     <DemoLayout
@@ -112,6 +130,48 @@ export function FilterChipDemo() {
             <FilterChip.Label>Status</FilterChip.Label>
             <FilterChip.Value>Active</FilterChip.Value>
           </FilterChip>
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Interactive (editable) chip"
+        description="Pass onActivate to make the chip BODY a button — for editable filters whose body re-opens an editor. Click a chip body below to 'edit' it; click the ✕ to remove it. The ✕ stops propagation, so removing never fires onActivate. In a real screen, wire onActivate to a controlled <Popover open onOpenChange> whose content is the editor (e.g. a range-picker)."
+        code={`// Editable chip — body re-opens an editor popover; ✕ removes the filter
+const [open, setOpen] = useState(false);
+<Popover open={open} onOpenChange={setOpen}>
+  <Popover.Trigger>
+    <FilterChip onActivate={() => setOpen((o) => !o)} expanded={open} onDismiss={remove}>
+      <FilterChip.Label>Range</FilterChip.Label>
+      <FilterChip.Value>Jun 1 – Jul 31</FilterChip.Value>
+    </FilterChip>
+  </Popover.Trigger>
+  <Popover.Content maxWidth={520}>{/* range picker */}</Popover.Content>
+</Popover>`}
+      >
+        <InputExample width="auto">
+          <Stack gap="sm">
+            <Cluster gap="sm">
+              {editable.map((f) => (
+                <FilterChip
+                  key={f.id}
+                  onActivate={() => setEditingId((cur) => (cur === f.id ? null : f.id))}
+                  expanded={editingId === f.id}
+                  onDismiss={() => removeEditable(f.id)}
+                  dismissLabel={`Remove ${f.label}: ${f.value} filter`}
+                >
+                  <FilterChip.Label>{f.label}</FilterChip.Label>
+                  <FilterChip.Value>{f.value}</FilterChip.Value>
+                </FilterChip>
+              ))}
+            </Cluster>
+            <Text size="sm" tone="muted">
+              {editable.length === 0
+                ? 'All filters removed.'
+                : editingId
+                  ? `Editing "${editable.find((f) => f.id === editingId)?.label}" — a real consumer would now show a Popover editor here.`
+                  : 'Click a chip body to edit it; click ✕ to remove (✕ never triggers edit).'}
+            </Text>
+          </Stack>
         </InputExample>
       </Example>
     </DemoLayout>


### PR DESCRIPTION
Addresses #153.

## Summary
Adds an optional **interactive mode** to `FilterChip` for editable filters (e.g. a date-range chip that re-opens its range-picker):

- **`onActivate?: () => void`** — when set, the Label/Value content is wrapped in a real `<button>` (native Enter/Space + role) that fires `onActivate`. The chip stays visually identical to read-only chips.
- The dismiss **✕ now `stopPropagation()`s** before `onDismiss` — so removing a filter never fires the body activate, and never bubbles to an ancestor/`Popover.Trigger` (this was the reported "✕ re-opens the popover" bug).
- **`expanded?: boolean`** → `aria-expanded` on the body button (with `aria-haspopup="dialog"`) for the disclosure it opens.
- **Controlled-only** (per design decision): FilterChip does NOT route `Popover.Trigger`'s cloned props — wire `onActivate` to a controlled `<Popover open onOpenChange>`. Body + ✕ are sibling buttons inside `role="group"` (no nested interactives — a11y-correct). Read-only chips (no `onActivate`) render identically as before.

## Test plan
- `make test` — 2601 pass (6 new FilterChip tests: body-is-button + fires once; ✕ fires onDismiss not onActivate; ✕ stops propagation to an ancestor; Enter/Space; aria-haspopup/aria-expanded; backward-compat button count).
- `make build-lib`, `make lint`, `npm run format:check` green; `npm pack --dry-run` leaks nothing.
- **Verified in-browser** (Playwright) on the new `FilterChipDemo` example: clicking a chip body flips `aria-expanded` false→true (onActivate fires); clicking the ✕ removes the chip (3→2) and activates nothing (`stopPropagation` works); 0 console errors.
- Hard-rule-8 adversarial review: 0 Critical / 0 Important — "clean enough to stop".

🤖 Generated with [Claude Code](https://claude.com/claude-code)