### PR TITLE
feat(playground): GitHub repo link in the mockups rail footer

### DIFF
--- a/packages/playground/src/layout/AppShell/AppShell.tsx
+++ b/packages/playground/src/layout/AppShell/AppShell.tsx
@@ -50,6 +50,17 @@ function renderRailItem({ to, label, icon: Icon, end }: NavItem) {
   );
 }
 
+/** GitHub mark (lucide dropped brand icons in v1) — sized to the rail's 16px
+    icon slot, inherits color via `currentColor`. Decorative: the Rail.Item
+    label "GitHub" carries the accessible name. */
+function GithubMark() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}
+
 /** Brand: the eocrm logo + wordmark when expanded, just the mark when
     collapsed. Reads collapsed state from RailContext. */
 function BrandMark() {
@@ -164,6 +175,16 @@ export function AppShell({ children }: { children: ReactNode }) {
             <Rail.Item as={NavLink} to={switchLink.to} icon={<switchLink.icon size={16} />}>
               {switchLink.label}
             </Rail.Item>
+            {!inComponents && (
+              <Rail.Item
+                href="https://github.com/eocrm/design-system"
+                target="_blank"
+                rel="noopener noreferrer"
+                icon={<GithubMark />}
+              >
+                GitHub
+              </Rail.Item>
+            )}
             <Rail.CollapseToggle />
           </Rail.Footer>
         </Rail>


### PR DESCRIPTION
## Summary
Adds a **GitHub** link to the bottom of the sidebar rail in the **Mockups** section (in `Rail.Footer`, alongside the existing Mockups↔Components switch link and the collapse toggle). Links to `https://github.com/eocrm/design-system` (`target="_blank"`, `rel="noopener noreferrer"`). Shown only under `/mockups/*` (`!inComponents`), not in the Components rail.

lucide-react v1 dropped brand icons, so the icon is a small inline GitHub-mark `<svg>` (`fill="currentColor"`, `aria-hidden`) sized to the rail's 16px slot — the `Rail.Item` label "GitHub" carries the accessible name. In the collapsed rail it falls back to the icon + tooltip like the other footer items.

Playground-only change (AppShell layout, not a mockup or library file).

## Test plan
- `make build` (tsc + vite) green; `make lint` + `npm run format:check` green.
- **Verified in-browser** (Playwright): the link renders in the mockups rail footer (href `https://github.com/eocrm/design-system`, `target=_blank`, `rel=noopener noreferrer`, SVG icon, visible) and is **absent** in the Components rail. No new console errors (the pre-existing nested-`<a>` warning in ComponentsIndex's Breadcrumb card preview is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)