### PR TITLE
feat(Popover): add Popover.Anchor — positioning ref only, no injected ARIA (#159)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1904,6 +1904,7 @@ import { Bell, Plus } from 'lucide-react';
 ```
 
 - Compound API: `<Popover>` is the provider; `<Popover.Trigger>` clones its single child to inject ARIA + click; `<Popover.Content>` portals to `document.body` and positions via Floating UI; `<Popover.Heading>` (optional) wires `aria-labelledby`; `<Popover.Close>` clones its child to inject a close-onClick.
+- `<Popover.Anchor>` positions Content against its child by injecting ONLY the floating ref — no `onClick`, no keyboard handler, and no `aria-haspopup`/`aria-expanded`/`aria-controls`. Use it (instead of `Popover.Trigger`) for a CONTROLLED popover whose anchor already owns its own toggle + ARIA — e.g. an interactive `FilterChip` whose body `<button>` self-manages `aria-haspopup`/`aria-expanded` via `onActivate`/`expanded`; wrapping it in `Popover.Trigger` would redundantly stamp that ARIA onto the chip's `role="group"` root, whereas `Popover.Anchor` leaves the ARIA solely on the body button.
 - Trigger child must accept a ref (`forwardRef`). `<Button>` does.
 - **Non-modal**: focus moves to the panel on open; Tab traverses INTO content, then OUT to the page behind. Click-outside or Escape dismisses. Page is NOT inert.
 - `<Popover.Content>` props: `side` (`'top'` | `'right'` | `'bottom'` | `'left'`, default `'bottom'`), `align` (default `'center'`), `sideOffset` (default `10`), `minWidth`, `maxWidth` (overrides the default 360px cap — pass a px number, a CSS length, `'fit-content'`, or `'none'` for wide content like calendars/tables).

--- a/packages/design-system/src/components/Popover/Anchor.tsx
+++ b/packages/design-system/src/components/Popover/Anchor.tsx
@@ -1,0 +1,56 @@
+import { cloneElement, isValidElement, type ReactElement, type Ref } from 'react';
+import { usePopoverContext } from './context';
+import { mergeRefs } from '../_internal/refs';
+
+export interface PopoverAnchorProps {
+  /**
+   * Exactly one React element that accepts a ref. Unlike `Popover.Trigger`,
+   * Anchor injects ONLY the floating-positioning ref — no `onClick`, no keyboard
+   * handler, and no `aria-haspopup` / `aria-expanded` / `aria-controls`. Use it
+   * when the anchor element already owns its open-toggle and ARIA (e.g. an
+   * interactive `FilterChip` whose body `<button>` self-manages
+   * `aria-haspopup`/`aria-expanded`), and you drive the popover's open state
+   * yourself (controlled `open` + `onOpenChange`). The child must accept a ref
+   * (`forwardRef`); raw DOM elements and this library's components qualify.
+   */
+  children: ReactElement;
+}
+
+/**
+ * Positions `Popover.Content` against its child WITHOUT injecting any interaction
+ * or ARIA — only the floating-positioning ref. The counterpart to
+ * `Popover.Trigger` (which also wires the click-toggle + `aria-haspopup` /
+ * `aria-expanded` / `aria-controls`).
+ *
+ * Use it for a CONTROLLED popover whose anchor already owns its toggle + ARIA,
+ * so that ARIA isn't duplicated onto a wrapper. Canonical case: an interactive
+ * `FilterChip` (body `<button>` carries `aria-haspopup`/`aria-expanded` via
+ * `onActivate`/`expanded`) hosting a controlled range-picker popover — wrapping
+ * it in `Popover.Trigger` would redundantly stamp ARIA onto the chip's
+ * `role="group"` root; `Popover.Anchor` injects nothing but the ref.
+ *
+ * @example
+ * const [open, setOpen] = useState(false);
+ * <Popover open={open} onOpenChange={setOpen}>
+ *   <Popover.Anchor>
+ *     <FilterChip onActivate={() => setOpen((o) => !o)} expanded={open} onDismiss={remove}>
+ *       <FilterChip.Label>Range</FilterChip.Label>
+ *       <FilterChip.Value>Jun 1 – Jul 31</FilterChip.Value>
+ *     </FilterChip>
+ *   </Popover.Anchor>
+ *   <Popover.Content maxWidth={520}>
+ *     <RangePicker />
+ *   </Popover.Content>
+ * </Popover>
+ */
+export function Anchor({ children }: PopoverAnchorProps) {
+  const ctx = usePopoverContext('Anchor');
+  if (!isValidElement(children)) {
+    throw new Error('<Popover.Anchor> requires exactly one React element child.');
+  }
+  const childProps = children.props as { ref?: Ref<HTMLElement> };
+  // Ref only — NO aria/onClick/onKeyDown. The anchor owns its own toggle + ARIA.
+  return cloneElement(children, {
+    ref: mergeRefs(ctx.triggerRef, childProps.ref),
+  } as object);
+}

--- a/packages/design-system/src/components/Popover/Anchor.tsx
+++ b/packages/design-system/src/components/Popover/Anchor.tsx
@@ -11,7 +11,9 @@ export interface PopoverAnchorProps {
    * interactive `FilterChip` whose body `<button>` self-manages
    * `aria-haspopup`/`aria-expanded`), and you drive the popover's open state
    * yourself (controlled `open` + `onOpenChange`). The child must accept a ref
-   * (`forwardRef`); raw DOM elements and this library's components qualify.
+   * (`forwardRef`); raw DOM elements and this library's components qualify, and
+   * it should be focusable (a `<button>` or `tabIndex` host) so Escape can
+   * return focus to it on close.
    */
   children: ReactElement;
 }

--- a/packages/design-system/src/components/Popover/Popover.test.tsx
+++ b/packages/design-system/src/components/Popover/Popover.test.tsx
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { createRef } from 'react';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Popover } from './Popover';
@@ -92,6 +93,93 @@ describe('Popover.Trigger', () => {
     );
     await user.click(screen.getByRole('button', { name: 'Open' }));
     expect(consumer).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Popover.Anchor', () => {
+  it('renders its child unchanged and injects NO aria-haspopup / aria-expanded / aria-controls', () => {
+    render(
+      <Popover open>
+        <Popover.Anchor>
+          <button type="button">Chip</button>
+        </Popover.Anchor>
+        <Popover.Content>panel</Popover.Content>
+      </Popover>,
+    );
+    const anchor = screen.getByRole('button', { name: 'Chip' });
+    expect(anchor).toBeInTheDocument();
+    expect(anchor).not.toHaveAttribute('aria-haspopup');
+    expect(anchor).not.toHaveAttribute('aria-expanded');
+    expect(anchor).not.toHaveAttribute('aria-controls');
+  });
+
+  it('does NOT inject a toggle: clicking the anchor child leaves the controlled popover untouched', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Popover open onOpenChange={onOpenChange}>
+        <Popover.Anchor>
+          <button type="button">Chip</button>
+        </Popover.Anchor>
+        <Popover.Content>panel</Popover.Content>
+      </Popover>,
+    );
+    // open is controlled; Anchor wires no onClick, so clicking the child must
+    // neither toggle open state nor request a change.
+    await user.click(screen.getByRole('button', { name: 'Chip' }));
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('anchors a CONTROLLED popover: renders the portaled dialog when open, nothing when closed', () => {
+    const { rerender } = render(
+      <Popover open={false}>
+        <Popover.Anchor>
+          <button type="button">Chip</button>
+        </Popover.Anchor>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    rerender(
+      <Popover open>
+        <Popover.Anchor>
+          <button type="button">Chip</button>
+        </Popover.Anchor>
+        <Popover.Content>panel body</Popover.Content>
+      </Popover>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('panel body');
+    expect(document.body.contains(dialog)).toBe(true);
+  });
+
+  it('forwards the ref to the child so positioning has a reference', () => {
+    const ref = createRef<HTMLButtonElement>();
+    render(
+      <Popover>
+        <Popover.Anchor>
+          <button type="button" ref={ref}>
+            Chip
+          </button>
+        </Popover.Anchor>
+      </Popover>,
+    );
+    expect(ref.current).toBe(screen.getByRole('button', { name: 'Chip' }));
+  });
+
+  it('throws a clear error when children is not a valid React element', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      render(
+        <Popover>
+          {/* @ts-expect-error — intentionally invalid */}
+          <Popover.Anchor>{null}</Popover.Anchor>
+        </Popover>,
+      ),
+    ).toThrow(/exactly one React element/);
+    spy.mockRestore();
   });
 });
 

--- a/packages/design-system/src/components/Popover/Popover.tsx
+++ b/packages/design-system/src/components/Popover/Popover.tsx
@@ -1,11 +1,13 @@
 import { PopoverRoot } from './PopoverRoot';
 import { Trigger } from './Trigger';
+import { Anchor } from './Anchor';
 import { Content } from './Content';
 import { Heading } from './Heading';
 import { Close } from './Close';
 
 type PopoverNamespace = typeof PopoverRoot & {
   Trigger: typeof Trigger;
+  Anchor: typeof Anchor;
   Content: typeof Content;
   Heading: typeof Heading;
   Close: typeof Close;
@@ -13,6 +15,7 @@ type PopoverNamespace = typeof PopoverRoot & {
 
 const Popover = PopoverRoot as PopoverNamespace;
 Popover.Trigger = Trigger;
+Popover.Anchor = Anchor;
 Popover.Content = Content;
 Popover.Heading = Heading;
 Popover.Close = Close;

--- a/packages/design-system/src/components/Popover/PopoverRoot.tsx
+++ b/packages/design-system/src/components/Popover/PopoverRoot.tsx
@@ -4,9 +4,10 @@ import { sanitizeId } from '../_internal/refs';
 
 export interface PopoverProps {
   /**
-   * Must contain exactly one `<Popover.Trigger>` and one `<Popover.Content>`.
-   * `<Popover.Heading>` and `<Popover.Close>` are optional and may appear
-   * anywhere inside `<Popover.Content>`.
+   * Must contain exactly one `<Popover.Trigger>` (or `<Popover.Anchor>` for a
+   * controlled popover whose anchor owns its own toggle + ARIA) and one
+   * `<Popover.Content>`. `<Popover.Heading>` and `<Popover.Close>` are optional
+   * and may appear anywhere inside `<Popover.Content>`.
    */
   children: ReactNode;
   /**

--- a/packages/design-system/src/components/Popover/index.ts
+++ b/packages/design-system/src/components/Popover/index.ts
@@ -1,6 +1,7 @@
 export { Popover } from './Popover';
 export type { PopoverProps } from './PopoverRoot';
 export type { PopoverTriggerProps } from './Trigger';
+export type { PopoverAnchorProps } from './Anchor';
 export type { PopoverContentProps, PopoverSide, PopoverAlign } from './Content';
 export type { PopoverHeadingProps } from './Heading';
 export type { PopoverCloseProps } from './Close';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -179,6 +179,7 @@ export { Popover } from './components/Popover';
 export type {
   PopoverProps,
   PopoverTriggerProps,
+  PopoverAnchorProps,
   PopoverContentProps,
   PopoverHeadingProps,
   PopoverCloseProps,

--- a/packages/playground/src/pages/components/PopoverDemo.tsx
+++ b/packages/playground/src/pages/components/PopoverDemo.tsx
@@ -4,8 +4,10 @@ import {
   Cluster,
   ConfirmationPopover,
   DropdownMenu,
+  FilterChip,
   Popover,
   Stack,
+  Text,
 } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
@@ -297,6 +299,42 @@ export function PopoverDemo() {
       </Example>
 
       <Example
+        title="Anchor (controlled, no injected ARIA)"
+        description="Popover.Anchor positions Content against its child but injects ONLY the floating ref — no onClick, no aria-haspopup/aria-expanded/aria-controls. Use it when the anchor already owns its toggle + ARIA. Here an interactive FilterChip (its body <button> carries aria-haspopup/aria-expanded via onActivate/expanded) drives a CONTROLLED popover: clicking the chip body opens/closes the panel, and the chip's role=group root stays free of popover ARIA. (Popover.Trigger would have redundantly stamped that ARIA onto the group root.)"
+        code={`const [open, setOpen] = useState(false);
+<Popover open={open} onOpenChange={setOpen}>
+  <Popover.Anchor>
+    <FilterChip
+      onActivate={() => setOpen((o) => !o)}
+      expanded={open}
+      onDismiss={() => {/* remove the filter */}}
+    >
+      <FilterChip.Label>Date</FilterChip.Label>
+      <FilterChip.Value>Jun 1 – Jun 13</FilterChip.Value>
+    </FilterChip>
+  </Popover.Anchor>
+  <Popover.Content maxWidth={360}>
+    <Stack gap="sm">
+      <Popover.Heading>Audit log date range</Popover.Heading>
+      <Text tone="muted">(date-range picker goes here)</Text>
+      <Cluster justify="end" gap="sm">
+        <Popover.Close>
+          <Button variant="secondary" size="sm">Cancel</Button>
+        </Popover.Close>
+        <Popover.Close>
+          <Button size="sm">Apply</Button>
+        </Popover.Close>
+      </Cluster>
+    </Stack>
+  </Popover.Content>
+</Popover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <AnchorChipExample />
+        </Cluster>
+      </Example>
+
+      <Example
         title="Wide content (maxWidth)"
         description="The panel caps at 360px by default, which clips wide content like a two-column filter or a date-range calendar. Pass maxWidth to let the panel grow — here a 480px two-column layout that would otherwise overflow."
         code={`<Popover>
@@ -373,6 +411,46 @@ function WideRangeBody() {
         </Popover.Close>
       </Cluster>
     </Stack>
+  );
+}
+
+// Popover.Anchor + a controlled popover. The interactive FilterChip owns its
+// own toggle + ARIA (via onActivate/expanded on its body <button>); the Anchor
+// contributes only the positioning ref, so the chip's role="group" root carries
+// no popover ARIA. Realistic surface: an audit-log date-range filter chip.
+function AnchorChipExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Anchor>
+        <FilterChip
+          onActivate={() => setOpen((o) => !o)}
+          expanded={open}
+          onDismiss={() => {
+            /* a real screen would remove this filter from state */
+          }}
+        >
+          <FilterChip.Label>Date</FilterChip.Label>
+          <FilterChip.Value>Jun 1 – Jun 13</FilterChip.Value>
+        </FilterChip>
+      </Popover.Anchor>
+      <Popover.Content maxWidth={360}>
+        <Stack gap="sm">
+          <Popover.Heading>Audit log date range</Popover.Heading>
+          <Text tone="muted">(a date-range picker would render here)</Text>
+          <Cluster justify="end" gap="sm">
+            <Popover.Close>
+              <Button variant="secondary" size="sm">
+                Cancel
+              </Button>
+            </Popover.Close>
+            <Popover.Close>
+              <Button size="sm">Apply</Button>
+            </Popover.Close>
+          </Cluster>
+        </Stack>
+      </Popover.Content>
+    </Popover>
   );
 }
 


### PR DESCRIPTION
Addresses #159.

## Summary
Adds **`Popover.Anchor`** — a positioning anchor that clones its child injecting ONLY the floating ref (`mergeRefs(ctx.triggerRef, …)`), with NO `onClick` / keyboard handler / `aria-haspopup` / `aria-expanded` / `aria-controls`. The counterpart to `Popover.Trigger`.

For a CONTROLLED popover whose anchor already owns its toggle + ARIA, so that ARIA isn't duplicated onto a wrapper. Canonical case (companion to #153): an interactive `FilterChip` (its body `<button>` self-manages `aria-haspopup`/`aria-expanded` via `onActivate`/`expanded`) hosting a controlled range-picker popover — wrapping it in `Popover.Trigger` redundantly stamps ARIA onto the chip's `role="group"` root; `Popover.Anchor` injects nothing but the ref.

```tsx
const [open, setOpen] = useState(false);
<Popover open={open} onOpenChange={setOpen}>
  <Popover.Anchor>
    <FilterChip onActivate={() => setOpen((o) => !o)} expanded={open} onDismiss={remove}>…</FilterChip>
  </Popover.Anchor>
  <Popover.Content maxWidth={520}><RangePicker /></Popover.Content>
</Popover>
```

## Test plan
- `make test` — 2615 pass (+5: no-ARIA-injection vs Trigger; controlled open shows/hides the dialog; clicking the anchor does NOT toggle (controlled); ref forwarded via createRef; throws on invalid child).
- `make build-lib`, `make lint`, `npm run format:check` green; `npm pack --dry-run` leaks nothing. `PopoverAnchorProps` re-exported from the package root (Rule 5).
- **Verified in-browser** (Playwright) on the new `PopoverDemo` "Anchor (controlled, no injected ARIA)" example: the chip's `role="group"` root has NO `aria-haspopup`/`aria-expanded`/`aria-controls`; the body button owns them; clicking the body opens the controlled popover and flips the body's `aria-expanded`. 0 console errors.
- Hard-rule-8 adversarial review: caught a missing root-level `PopoverAnchorProps` export (fixed) → re-verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)