### PR TITLE
feat(ConfirmationPopover): initialFocusRef to focus description content on open (#163)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -2020,6 +2020,7 @@ const [show, setShow] = useState(true);
 - Built on top of `<Popover>`. Declarative: `title` / `description` / `confirmLabel` / `cancelLabel` / `variant` / `onConfirm` / `onCancel`.
 - `variant`: `'default'` (Confirm is primary) | `'danger'` (Confirm is danger).
 - **Initial focus on Cancel** for both variants — keyboard Enter never accidentally confirms. Tab once to Confirm.
+- **`initialFocusRef`** (`RefObject<HTMLElement | null>`) overrides the Cancel default: directs initial focus into the `description` content instead — e.g. an `<Input>` rendered there for a rename flow. The component focuses `initialFocusRef.current` after the panel mounts (mirrors `<Modal>`'s `initialFocusRef`). Tip: add `onFocus={(e) => e.currentTarget.select()}` to a text input so its contents are selected on open and the user can type a replacement immediately.
 - **Async-aware** `onConfirm`. May return a Promise. While pending, both buttons disable, Confirm shows a spinner, and Escape / click-outside are blocked.
 - **Failure mode**: on reject, popover stays open and buttons re-enable. Consumer surfaces the error externally — ConfirmationPopover does NOT render inline errors.
 - Anchors above the trigger by default (`side="top"`).

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.test.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState, type RefObject } from 'react';
 import { act, configure, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ConfirmationPopover } from './ConfirmationPopover';
@@ -143,6 +144,35 @@ describe('ConfirmationPopover — initial focus', () => {
     // Re-rendering with a new variant keeps the popover open; focus has
     // already moved to Cancel on the original open. Verify it's still there.
     expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+  });
+
+  it('initialFocusRef receives focus on open (overrides Cancel)', async () => {
+    const user = userEvent.setup();
+    function FocusHarness() {
+      const [open, setOpen] = useState(false);
+      const inputRef = useRef<HTMLInputElement | null>(null);
+      return (
+        <ConfirmationPopover
+          open={open}
+          onOpenChange={setOpen}
+          title="Rename view?"
+          description={<input aria-label="New name" ref={inputRef} />}
+          initialFocusRef={inputRef as RefObject<HTMLElement | null>}
+          confirmLabel="Rename"
+          onConfirm={() => {}}
+        >
+          <button type="button">Open</button>
+        </ConfirmationPopover>
+      );
+    }
+    render(<FocusHarness />);
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    // Drain the microtask queue so both Popover.Content's panel-focus and
+    // ConfirmationPopover's initialFocusRef-focus have run.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(document.activeElement).toBe(screen.getByLabelText('New name'));
+    // The hosted input — NOT the Cancel button — owns focus.
+    expect(screen.getByRole('button', { name: 'Cancel' })).not.toHaveFocus();
   });
 });
 

--- a/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
+++ b/packages/design-system/src/components/ConfirmationPopover/ConfirmationPopover.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type ReactElement,
   type ReactNode,
+  type RefObject,
 } from 'react';
 import { Button } from '../Button';
 import { Cluster } from '../Cluster';
@@ -65,6 +66,16 @@ export interface ConfirmationPopoverProps {
   /** Optional. Fires on Cancel click, Escape, or click-outside dismissal. NOT fired if `onConfirm` rejects. */
   onCancel?: () => void;
 
+  /**
+   * Direct initial focus into the panel's content instead of the default
+   * Cancel button — e.g. an `<Input>` rendered in `description` for a rename
+   * flow. When provided and its `.current` is non-null on open, the component
+   * focuses this element after the panel mounts (skipping the Cancel-focus).
+   * Tip: add `onFocus={(e) => e.currentTarget.select()}` to a text input to
+   * select its contents so the user can type/replace immediately.
+   */
+  initialFocusRef?: RefObject<HTMLElement | null>;
+
   /** Preferred side. Default `'top'` — confirmations anchor above the trigger by convention. */
   side?: 'top' | 'right' | 'bottom' | 'left';
 
@@ -92,7 +103,9 @@ export interface ConfirmationPopoverProps {
  *
  * - **Initial focus** lands on Cancel for both variants. Safer default —
  *   keyboard "Enter" never accidentally confirms; the user must Tab once
- *   to Confirm.
+ *   to Confirm. Pass `initialFocusRef` to override this and focus a given
+ *   element instead (e.g. an `<Input>` rendered in `description` for a
+ *   rename flow).
  * - **Async-aware** `onConfirm`. While the returned Promise is in flight,
  *   both buttons disable, the Confirm shows a spinner, and Escape /
  *   click-outside dismissal is blocked.
@@ -147,6 +160,7 @@ export function ConfirmationPopover({
   variant = 'default',
   onConfirm,
   onCancel,
+  initialFocusRef,
   side = 'top',
   align = 'center',
   sideOffset = 10,
@@ -192,11 +206,15 @@ export function ConfirmationPopover({
   // Focus the Cancel button after Popover.Content focuses the panel.
   // queueMicrotask runs after Popover.Content's own focus effect (which also
   // uses queueMicrotask), so by the time this runs, the panel has focus and
-  // we override it with Cancel.
+  // we override it with Cancel. A consumer-supplied initialFocusRef takes
+  // precedence (mirrors Modal) — e.g. an <Input> in the description slot.
   useEffect(() => {
     if (!open) return;
-    queueMicrotask(() => cancelRef.current?.focus({ preventScroll: true }));
-  }, [open]);
+    queueMicrotask(() => {
+      const target = initialFocusRef?.current ?? cancelRef.current;
+      target?.focus({ preventScroll: true });
+    });
+  }, [open, initialFocusRef]);
 
   const handleConfirm = useCallback(() => {
     if (pending) return;

--- a/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
+++ b/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Button, Cluster, ConfirmationPopover, DropdownMenu } from '@eocrm/design-system';
+import { useRef, useState } from 'react';
+import { Button, Cluster, ConfirmationPopover, DropdownMenu, Input } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
@@ -9,6 +9,8 @@ const fakeDelay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 export function ConfirmationPopoverDemo() {
   const [archiveCount, setArchiveCount] = useState(0);
   const [deleteCount, setDeleteCount] = useState(0);
+  const [viewName, setViewName] = useState('Untitled view');
+  const renameRef = useRef<HTMLInputElement | null>(null);
 
   return (
     <DemoLayout
@@ -166,6 +168,51 @@ export function ConfirmationPopoverDemo() {
               </ConfirmationPopover>
             </DropdownMenu.Content>
           </DropdownMenu>
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Rename — focus a hosted input"
+        description="Pass initialFocusRef to override the default Cancel focus and land focus on an <Input> rendered inside the description slot. The onFocus select-all means the user can type a replacement immediately — exactly the saved-views Rename flow."
+        code={`const renameRef = useRef<HTMLInputElement | null>(null);
+
+<ConfirmationPopover
+  title="Rename view"
+  description={
+    <Input
+      ref={renameRef}
+      aria-label="View name"
+      value={viewName}
+      onChange={(e) => setViewName(e.target.value)}
+      onFocus={(e) => e.currentTarget.select()}
+    />
+  }
+  initialFocusRef={renameRef}
+  confirmLabel="Rename"
+  onConfirm={() => saveViewName(viewName)}
+>
+  <Button variant="secondary">Rename…</Button>
+</ConfirmationPopover>`}
+      >
+        <Cluster gap="md" justify="center">
+          <ConfirmationPopover
+            title="Rename view"
+            description={
+              <Input
+                ref={renameRef}
+                aria-label="View name"
+                value={viewName}
+                onChange={(e) => setViewName(e.target.value)}
+                onFocus={(e) => e.currentTarget.select()}
+              />
+            }
+            initialFocusRef={renameRef}
+            confirmLabel="Rename"
+            onConfirm={() => {}}
+          >
+            <Button variant="secondary">Rename…</Button>
+          </ConfirmationPopover>
+          <span>Current name: {viewName}</span>
         </Cluster>
       </Example>
     </DemoLayout>


### PR DESCRIPTION
Addresses #163.

## Summary
`ConfirmationPopover` hard-focuses Cancel on open (a queued microtask that overrides the panel focus, so Enter never accidentally confirms). That made it impossible to direct initial focus into editable `description` content (e.g. a rename `<Input>`).

Adds **`initialFocusRef?: RefObject<HTMLElement | null>`** (mirrors `Modal`'s prop exactly). When provided, the open-focus effect focuses `initialFocusRef.current ?? cancelRef.current` — so the consumer-supplied element wins, skipping the Cancel-focus; default behavior (focus Cancel) is unchanged when the prop is omitted. Tip documented: add `onFocus={(e) => e.currentTarget.select()}` to a text input to select-all on open.

## Test plan
- `make test` — 2616 pass (+1: `initialFocusRef receives focus on open (overrides Cancel)` — drains the microtask queue, asserts the description input owns focus and Cancel does NOT; existing Cancel-default test untouched).
- `make build-lib`, `make lint`, `npm run format:check` green; `npm pack --dry-run` leaks nothing. `ConfirmationPopoverProps` re-exported from the package root.
- **Verified in-browser** (Playwright) on the new `ConfirmationPopoverDemo` "Rename — focus a hosted input" example: opening the popover focuses the `<Input>` (not Cancel) and selects its text; 0 console errors.
- Hard-rule-8 adversarial review: 0 Critical / 0 Important — "clean enough to stop".

🤖 Generated with [Claude Code](https://claude.com/claude-code)