### PR TITLE
feat(Dot): bare palette/tone colored dot primitive + FilterChip.Value color (#164)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1420,6 +1420,22 @@ import { Divider } from '@eocrm/design-system';
 - **Non-interactive.** If it's clickable, use `<Button>` instead.
 - Doesn't auto-add `role="status"`. Wrap in `aria-live` if a state change should be announced.
 
+### `<Dot>` — bare palette/tone colored circle
+
+```tsx
+// Palette color, paired with a label:
+<Cluster gap="xs"><Dot color="violet" /> Design</Cluster>
+
+// Semantic tone:
+<Dot tone="success" />
+```
+
+- A bare, background-less 6px circle (`--size-badge-dot`) for color-coding affordances — a leading dot on a filter / `FilterChip`, a status indicator, a legend swatch. Unlike `<Badge dot>` it paints NO badge surface; it is just the dot.
+- `color`: optional `PaletteColor` (30 categorical colors) — renders the dot in that color's saturated `--color-palette-<name>-fg` token (the same color OptionsPicker groups / palette Badges use). Takes precedence over `tone`.
+- `tone`: optional `BadgeTone` (`neutral` default / `info` / `success` / `warning` / `danger` / `purple`) — used when `color` is omitted. Neither set → `neutral`.
+- **Decorative**: `aria-hidden` by default (overridable). The dot alone conveys nothing to assistive tech — always pair it with a visible label / accessible text.
+- **When NOT to use**: a status pill WITH text → use `<Badge>` (it owns a surface + label). The sole signal of meaning → color isn't an accessible signal on its own; accompany with text.
+
 ### `<BrandIcon>` — third-party brand marks
 
 ```tsx
@@ -1509,7 +1525,7 @@ function TeamChip({ team }: { team: string }) {
 - `dismissLabel`: overrides the default `'Remove filter'` `aria-label` on the dismiss button. Pass a contextual label (`'Remove Event: auth.* filter'`) for screen-reader clarity.
 - `onActivate`: makes the chip BODY a `<button>` (for _editable_ filters — e.g. a date-range chip whose body re-opens its range-picker). Wire it to a controlled `<Popover open onOpenChange>` to open an editor popover. The dismiss ✕ stays a separate button whose click **stops propagation**, so removing the filter never fires `onActivate` (and never bubbles to a wrapping `Popover.Trigger` / ancestor click handler).
 - `expanded`: surfaced as `aria-expanded` on the body button — pass the open state of the disclosure the body opens. Only meaningful with `onActivate`; omit if the body doesn't toggle a disclosure. The body button also carries `aria-haspopup="dialog"`.
-- `<FilterChip.Value tone={...}>`: optional `tone` (same palette as `<Badge>`) prefixes a colored 6px dot before the value text. Omit `tone` for plain values (e.g., a tenant slug).
+- `<FilterChip.Value tone={...}>`: optional `tone` (same palette as `<Badge>`) prefixes a colored 6px dot (a `<Dot>`) before the value text. Or pass `color` for a full `PaletteColor` (30 categorical colors) when the 6 tones aren't enough — `color` wins over `tone`. Omit both for plain values (e.g., a tenant slug).
 - **Use for active-filter pills, not tags / status badges.** If it's a status or category, use `<Badge>`. If it's a clickable filter trigger that navigates or runs an action, use `<Button>` or `<OptionsPicker.Trigger>`.
 - Root carries `role="group"` so screen readers announce the chip as one unit. A read-only chip's only interactive target is the dismiss ✕; an _editable_ chip adds a body button via `onActivate`.
 

--- a/packages/design-system/scripts/generate-manifest.mjs
+++ b/packages/design-system/scripts/generate-manifest.mjs
@@ -64,6 +64,7 @@ const CLUSTERS = {
   Avatar: 'Display',
   Image: 'Display',
   Badge: 'Display',
+  Dot: 'Display',
   BrandIcon: 'Display',
   Logo: 'Display',
   Calendar: 'Display',

--- a/packages/design-system/src/_meta/manifest.ts
+++ b/packages/design-system/src/_meta/manifest.ts
@@ -86,6 +86,7 @@ const CLUSTERS: Record<string, string> = {
   Avatar: 'Display',
   Image: 'Display',
   Badge: 'Display',
+  Dot: 'Display',
   BrandIcon: 'Display',
   Logo: 'Display',
   DefinitionList: 'Display',

--- a/packages/design-system/src/components.manifest.json
+++ b/packages/design-system/src/components.manifest.json
@@ -34,6 +34,7 @@
     "cluster": "Display",
     "composes": [],
     "composedBy": [
+      "Dot",
       "FilterChip",
       "OptionsPicker"
     ]
@@ -213,6 +214,16 @@
     "composes": [],
     "composedBy": []
   },
+  "Dot": {
+    "tier": "composition",
+    "cluster": "Display",
+    "composes": [
+      "Badge"
+    ],
+    "composedBy": [
+      "FilterChip"
+    ]
+  },
   "Drawer": {
     "tier": "composition",
     "cluster": "Overlays",
@@ -265,6 +276,7 @@
     "cluster": "Display",
     "composes": [
       "Badge",
+      "Dot",
       "Text"
     ],
     "composedBy": []

--- a/packages/design-system/src/components/Dot/Dot.module.scss
+++ b/packages/design-system/src/components/Dot/Dot.module.scss
@@ -1,0 +1,35 @@
+@use './Dot.tokens';
+
+.dot {
+  display: inline-block;
+  width: var(--dot-size);
+  height: var(--dot-size);
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+
+  // Semantic tones (when no palette `color` — palette colors come from the
+  // inline style's `--color-palette-<name>-fg`). Mirrors FilterChip's tone dot.
+  &[data-tone='neutral'] {
+    background: var(--color-fg-subtle);
+  }
+
+  &[data-tone='info'] {
+    background: var(--color-info);
+  }
+
+  &[data-tone='success'] {
+    background: var(--color-success);
+  }
+
+  &[data-tone='warning'] {
+    background: var(--color-warning);
+  }
+
+  &[data-tone='danger'] {
+    background: var(--color-danger);
+  }
+
+  &[data-tone='purple'] {
+    background: var(--badge-fg-purple);
+  }
+}

--- a/packages/design-system/src/components/Dot/Dot.test.tsx
+++ b/packages/design-system/src/components/Dot/Dot.test.tsx
@@ -1,0 +1,75 @@
+import { createRef } from 'react';
+import { render } from '@testing-library/react';
+import { Dot } from './Dot';
+
+it('renders a span with the dot class', () => {
+  const { container } = render(<Dot />);
+  const el = container.firstElementChild as HTMLElement;
+  expect(el.tagName).toBe('SPAN');
+  expect(el.className).toMatch(/dot/);
+});
+
+it('is aria-hidden="true" by default', () => {
+  const { container } = render(<Dot />);
+  expect(container.firstElementChild).toHaveAttribute('aria-hidden', 'true');
+});
+
+it('aria-hidden is overridable via prop', () => {
+  const { container } = render(<Dot aria-hidden={false} />);
+  // React serializes aria-hidden={false} to the string "false".
+  expect(container.firstElementChild).toHaveAttribute('aria-hidden', 'false');
+});
+
+it('color renders a palette dot with the saturated fg token and no data-tone', () => {
+  const { container } = render(<Dot color="violet" />);
+  const el = container.firstElementChild as HTMLElement;
+  expect(el).toHaveAttribute('data-palette', 'violet');
+  expect(el.style.background).toContain('color-palette-violet-fg');
+  expect(el).not.toHaveAttribute('data-tone');
+});
+
+it('tone renders a semantic dot via data-tone and no data-palette', () => {
+  const { container } = render(<Dot tone="success" />);
+  const el = container.firstElementChild as HTMLElement;
+  expect(el).toHaveAttribute('data-tone', 'success');
+  expect(el).not.toHaveAttribute('data-palette');
+});
+
+it('color takes precedence over tone (data-palette present, data-tone absent)', () => {
+  const { container } = render(<Dot color="amber" tone="danger" />);
+  const el = container.firstElementChild as HTMLElement;
+  expect(el).toHaveAttribute('data-palette', 'amber');
+  expect(el).not.toHaveAttribute('data-tone');
+});
+
+it('defaults to the neutral tone when neither color nor tone is set', () => {
+  const { container } = render(<Dot />);
+  const el = container.firstElementChild as HTMLElement;
+  expect(el).toHaveAttribute('data-tone', 'neutral');
+  expect(el).not.toHaveAttribute('data-palette');
+});
+
+it('merges className with the internal dot class', () => {
+  const { container } = render(<Dot className="custom-dot" />);
+  const el = container.firstElementChild as HTMLElement;
+  expect(el).toHaveClass('custom-dot');
+  expect(el.className).toMatch(/dot/);
+});
+
+it('forwards ref to the span', () => {
+  const ref = createRef<HTMLSpanElement>();
+  render(<Dot ref={ref} />);
+  expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+});
+
+it('spreads native HTML attributes onto the span', () => {
+  const { container } = render(<Dot data-testid="my-dot" />);
+  expect(container.firstElementChild).toHaveAttribute('data-testid', 'my-dot');
+});
+
+it('merges a consumer style with the palette background', () => {
+  const { container } = render(<Dot color="teal" style={{ opacity: '0.5' }} />);
+  const el = container.firstElementChild as HTMLElement;
+  expect(el.style.background).toContain('color-palette-teal-fg');
+  expect(el.style.opacity).toBe('0.5');
+});

--- a/packages/design-system/src/components/Dot/Dot.tokens.scss
+++ b/packages/design-system/src/components/Dot/Dot.tokens.scss
@@ -1,0 +1,4 @@
+// Dot.tokens.scss — component tokens for <Dot>. Size mirrors the Badge dot.
+:root {
+  --dot-size: var(--size-badge-dot);
+}

--- a/packages/design-system/src/components/Dot/Dot.tsx
+++ b/packages/design-system/src/components/Dot/Dot.tsx
@@ -1,0 +1,69 @@
+import { forwardRef, type CSSProperties, type HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import { type PaletteColor } from '../../palette';
+import { type BadgeTone } from '../Badge';
+import styles from './Dot.module.scss';
+
+export interface DotProps extends HTMLAttributes<HTMLSpanElement> {
+  /**
+   * One of the 30 `PaletteColor`s — renders the bare circle in that color's
+   * saturated `--color-palette-<name>-fg` token. Takes precedence over `tone`.
+   */
+  color?: PaletteColor;
+  /**
+   * A semantic `BadgeTone` (`neutral` default / `info` / `success` / `warning` /
+   * `danger` / `purple`) — used when `color` is omitted.
+   */
+  tone?: BadgeTone;
+}
+
+/**
+ * A bare, background-less colored circle (`--size-badge-dot`, 6px) for
+ * color-coding affordances — a leading dot on a filter trigger / `FilterChip`,
+ * a status indicator, a legend swatch. Unlike `<Badge dot>` it paints NO badge
+ * surface; it is just the dot. Decorative: rendered `aria-hidden` by default —
+ * always pair it with a visible label / accessible text (the dot alone conveys
+ * nothing to assistive tech).
+ *
+ * Pass `color` for any of the 30 `PaletteColor`s, or `tone` for one of the 6
+ * semantic `BadgeTone`s. `color` wins if both are set; neither → `neutral`.
+ *
+ * @example
+ * // Palette color, paired with a label:
+ * <Cluster gap="xs"><Dot color="violet" /> Range</Cluster>
+ *
+ * @example
+ * // Semantic tone:
+ * <Dot tone="success" />
+ *
+ * @remarks When NOT to use
+ * - As a status pill WITH text → use `<Badge>` (it owns a surface + label).
+ * - As the sole signal of meaning → a bare dot is decorative (`aria-hidden`);
+ *   always accompany it with text or an accessible label.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Relying on the dot color alone to convey state to all users — color is
+ *   not an accessible signal on its own; pair with text.
+ */
+export const Dot = forwardRef<HTMLSpanElement, DotProps>(function Dot(
+  { color, tone = 'neutral', className, style, 'aria-hidden': ariaHidden, ...props },
+  ref,
+) {
+  return (
+    <span
+      // {...props} first so component-owned attrs (aria-hidden default, data-*,
+      // class, color style) win; consumer can still override via explicit props.
+      {...props}
+      ref={ref}
+      aria-hidden={ariaHidden ?? true}
+      data-tone={color ? undefined : tone}
+      data-palette={color}
+      className={clsx(styles.dot, className)}
+      style={
+        color
+          ? ({ background: `var(--color-palette-${color}-fg)`, ...style } as CSSProperties)
+          : style
+      }
+    />
+  );
+});

--- a/packages/design-system/src/components/Dot/index.ts
+++ b/packages/design-system/src/components/Dot/index.ts
@@ -1,0 +1,2 @@
+export { Dot } from './Dot';
+export type { DotProps } from './Dot';

--- a/packages/design-system/src/components/FilterChip/FilterChip.module.scss
+++ b/packages/design-system/src/components/FilterChip/FilterChip.module.scss
@@ -39,43 +39,6 @@
   gap: var(--filter-chip-value-gap);
 }
 
-.dot {
-  // Reuse the existing Badge dot size token (6px). Keeps the chip's tone
-  // dot visually identical to Badge's tone dot and avoids raw px literals.
-  display: inline-block;
-  width: var(--size-badge-dot);
-  height: var(--size-badge-dot);
-  border-radius: var(--radius-full);
-  flex-shrink: 0;
-
-  // Tone color map for the dot. Saturated colors so the dot stays
-  // visible at small size. Token names match tokens.scss exactly — no
-  // top-level --color-purple, so purple uses --badge-fg-purple.
-  &[data-tone='neutral'] {
-    background: var(--color-fg-subtle);
-  }
-
-  &[data-tone='info'] {
-    background: var(--color-info);
-  }
-
-  &[data-tone='success'] {
-    background: var(--color-success);
-  }
-
-  &[data-tone='warning'] {
-    background: var(--color-warning);
-  }
-
-  &[data-tone='danger'] {
-    background: var(--color-danger);
-  }
-
-  &[data-tone='purple'] {
-    background: var(--badge-fg-purple);
-  }
-}
-
 .dismiss {
   display: inline-flex;
   align-items: center;

--- a/packages/design-system/src/components/FilterChip/FilterChip.test.tsx
+++ b/packages/design-system/src/components/FilterChip/FilterChip.test.tsx
@@ -91,6 +91,19 @@ it('Value renders a tone dot when tone is set', () => {
   expect(dot).not.toBeNull();
 });
 
+it('Value renders a palette-color dot when color is set', () => {
+  const { container } = render(
+    <FilterChip>
+      <FilterChip.Label>Team</FilterChip.Label>
+      <FilterChip.Value color="violet">Design</FilterChip.Value>
+    </FilterChip>,
+  );
+  const dot = container.querySelector('[data-palette="violet"]');
+  expect(dot).not.toBeNull();
+  // color wins over tone — no data-tone on a palette-colored dot.
+  expect(dot).not.toHaveAttribute('data-tone');
+});
+
 it('root has role="group"', () => {
   render(
     <FilterChip>

--- a/packages/design-system/src/components/FilterChip/FilterChip.tsx
+++ b/packages/design-system/src/components/FilterChip/FilterChip.tsx
@@ -3,6 +3,8 @@ import clsx from 'clsx';
 import { X } from 'lucide-react';
 import { Text } from '../Text';
 import { type BadgeTone } from '../Badge';
+import { Dot } from '../Dot';
+import { type PaletteColor } from '../../palette';
 import { useTranslation } from '../../i18n/useTranslation';
 import styles from './FilterChip.module.scss';
 
@@ -71,19 +73,28 @@ export interface FilterChipLabelProps extends HTMLAttributes<HTMLSpanElement> {
 
 export interface FilterChipValueProps extends HTMLAttributes<HTMLSpanElement> {
   /**
+   * Optional full `PaletteColor` (one of the 30 named categorical colors)
+   * for the leading dot. Use when the 6 semantic tones aren't enough to
+   * distinguish filter categories (e.g., per-tenant or per-tag color
+   * coding that matches an `OptionsPicker` group). Takes precedence over
+   * `tone` when both are set. Renders a bare `<Dot>` in that color.
+   */
+  color?: PaletteColor;
+
+  /**
    * Optional dot tone. When set, prefixes a 6px colored circle before
    * the value text — use to distinguish filter categories that share
    * a screen (e.g., event filters get a tone-matched dot, tenant
    * filters get no dot). Reuses Badge's tone palette: `neutral`,
    * `info`, `success`, `warning`, `danger`, `purple`. Omit for plain
-   * text values.
+   * text values. For a richer categorical color, use `color` instead.
    */
   tone?: BadgeTone;
 
   /**
    * The value text — what the filter is actually filtering by
-   * (`auth.*`, `beta`, `Won`). Pair with an optional `tone` dot to
-   * categorize.
+   * (`auth.*`, `beta`, `Won`). Pair with an optional `tone` / `color`
+   * dot to categorize.
    */
   children: ReactNode;
 }
@@ -240,8 +251,10 @@ const FilterChipLabel = forwardRef<HTMLSpanElement, FilterChipLabelProps>(functi
 /**
  * Value slot for the chip's filter value. Set `tone` to prefix a 6px
  * colored dot before the text — use the same `BadgeTone` palette as
- * `<Badge>` for cross-component consistency. Omit `tone` for plain
- * values (e.g., a tenant slug).
+ * `<Badge>` for cross-component consistency. Or set `color` for a full
+ * `PaletteColor` (30 categorical colors) when the 6 tones aren't enough;
+ * `color` wins over `tone`. Omit both for plain values (e.g., a tenant
+ * slug).
  *
  * @example
  * // Plain value, no dot
@@ -252,18 +265,22 @@ const FilterChipLabel = forwardRef<HTMLSpanElement, FilterChipLabelProps>(functi
  * <FilterChip.Value tone="info">auth.* (3)</FilterChip.Value>
  *
  * @example
+ * // Palette-color dot (categorical) — matches an OptionsPicker group color
+ * <FilterChip.Value color="violet">Design</FilterChip.Value>
+ *
+ * @example
  * // Mixed content — Value accepts any ReactNode
  * <FilterChip.Value tone="success">
  *   <Avatar size="2xs" name="Sarah" /> Sarah
  * </FilterChip.Value>
  */
 const FilterChipValue = forwardRef<HTMLSpanElement, FilterChipValueProps>(function FilterChipValue(
-  { tone, className, children, ...rest },
+  { color, tone, className, children, ...rest },
   ref,
 ) {
   return (
     <span ref={ref} className={clsx(styles.value, className)} {...rest}>
-      {tone && <span className={styles.dot} data-tone={tone} aria-hidden="true" />}
+      {(color || tone) && <Dot color={color} tone={tone} />}
       <Text as="span" size="sm">
         {children}
       </Text>

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -97,6 +97,9 @@ export type { AvatarProps, AvatarSize, AvatarStatus, AvatarGroupProps } from './
 export { Badge } from './components/Badge';
 export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot, BadgeVariant } from './components/Badge';
 
+export { Dot } from './components/Dot';
+export type { DotProps } from './components/Dot';
+
 export { BrandIcon } from './components/BrandIcon';
 export type { BrandIconProps, BrandName } from './components/BrandIcon';
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -57,6 +57,7 @@ import { StackDemo } from './pages/components/StackDemo';
 import { ClusterDemo } from './pages/components/ClusterDemo';
 import { AvatarDemo } from './pages/components/AvatarDemo';
 import { BadgeDemo } from './pages/components/BadgeDemo';
+import { DotDemo } from './pages/components/DotDemo';
 import { BrandIconDemo } from './pages/components/BrandIconDemo';
 import { LogoDemo } from './pages/components/LogoDemo';
 import { TabsDemo } from './pages/components/TabsDemo';
@@ -164,6 +165,7 @@ export default function App() {
             <Route path="/components/cluster" element={<ClusterDemo />} />
             <Route path="/components/avatar" element={<AvatarDemo />} />
             <Route path="/components/badge" element={<BadgeDemo />} />
+            <Route path="/components/dot" element={<DotDemo />} />
             <Route path="/components/brand-icon" element={<BrandIconDemo />} />
             <Route path="/components/logo" element={<LogoDemo />} />
             <Route path="/components/tabs" element={<TabsDemo />} />

--- a/packages/playground/src/layout/AppShell/navItems.ts
+++ b/packages/playground/src/layout/AppShell/navItems.ts
@@ -20,6 +20,7 @@ import {
   Ruler,
   LayoutGrid,
   CircleUser,
+  Circle,
   Tag,
   PanelTop,
   PanelsTopLeft,
@@ -179,6 +180,7 @@ export const componentGroups: { heading: string; items: NavItem[] }[] = [
     items: [
       { to: '/components/avatar', label: 'Avatar', icon: CircleUser, end: false },
       { to: '/components/badge', label: 'Badge', icon: Tag, end: false },
+      { to: '/components/dot', label: 'Dot', icon: Circle, end: false },
       { to: '/components/brand-icon', label: 'BrandIcon', icon: Fingerprint, end: false },
       { to: '/components/logo', label: 'Logo', icon: Hexagon, end: false },
       { to: '/components/calendar', label: 'Calendar', icon: CalendarDays, end: false },

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -4,6 +4,7 @@ import { Accordion } from '@eocrm/design-system';
 import { Alert } from '@eocrm/design-system';
 import { Avatar } from '@eocrm/design-system';
 import { Badge } from '@eocrm/design-system';
+import { Dot } from '@eocrm/design-system';
 import { BrandIcon } from '@eocrm/design-system';
 import { Logo } from '@eocrm/design-system';
 import eocrmLogo from '../../assets/eocrm-logo.svg';
@@ -771,6 +772,19 @@ const items: { to: string; name: string; description: string; preview: React.Rea
         <Badge tone="info">New</Badge>
         <Badge tone="success">Active</Badge>
         <Badge tone="warning">Pending</Badge>
+      </Cluster>
+    ),
+  },
+  {
+    to: '/components/dot',
+    name: 'Dot',
+    description: 'Bare palette/tone colored circle for color-coding affordances.',
+    preview: (
+      <Cluster gap="sm" align="center">
+        <Dot color="violet" />
+        <Dot color="teal" />
+        <Dot tone="success" />
+        <Dot tone="danger" />
       </Cluster>
     ),
   },

--- a/packages/playground/src/pages/components/DotDemo.tsx
+++ b/packages/playground/src/pages/components/DotDemo.tsx
@@ -1,0 +1,97 @@
+import { Dot, Cluster, Stack, Text, PALETTE_COLORS } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import { getComponentFiles } from '../../lib/componentFiles';
+
+const TONES = ['neutral', 'info', 'success', 'warning', 'danger', 'purple'] as const;
+
+export function DotDemo() {
+  return (
+    <DemoLayout
+      name="Dot"
+      description="A bare, background-less colored circle (6px) for color-coding affordances — a leading dot on a filter, a status indicator, a legend swatch. Decorative (aria-hidden); always pair it with a visible label."
+      files={getComponentFiles('Dot')}
+      componentName="Dot"
+    >
+      <Example
+        title="Semantic tones"
+        description="Pass `tone` for one of the 6 semantic BadgeTones. Matches the Badge tone palette so a dot legend lines up with status badges. `neutral` is the default when neither `tone` nor `color` is set."
+        code={`<Dot tone="neutral" />
+<Dot tone="info" />
+<Dot tone="success" />
+<Dot tone="warning" />
+<Dot tone="danger" />
+<Dot tone="purple" />`}
+      >
+        <Cluster gap="md" align="center">
+          {TONES.map((tone) => (
+            <Cluster key={tone} gap="xs" align="center">
+              <Dot tone={tone} />
+              <Text as="span" size="sm">
+                {tone}
+              </Text>
+            </Cluster>
+          ))}
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Palette colors (categorical)"
+        description="Pass `color` for any of the 30 categorical PaletteColors. The dot paints with that color's saturated `--color-palette-<name>-fg` token — the same color OptionsPicker groups and palette Badges use, so a color-coded filter dot matches its source exactly. `color` wins over `tone` when both are set."
+        code={`<Dot color="violet" />
+<Dot color="teal" />
+<Dot color="amber" />
+<Dot color="rose" />`}
+      >
+        <Cluster gap="md" align="center" wrap>
+          {PALETTE_COLORS.map((color) => (
+            <Cluster key={color} gap="xs" align="center">
+              <Dot color={color} />
+              <Text as="span" size="sm">
+                {color}
+              </Text>
+            </Cluster>
+          ))}
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Color-coding a filter (realistic)"
+        description="The canonical use: a small leading dot beside a label to color-code a category — e.g. an audit-log event-source legend or a per-team filter row. The dot is decorative; the text is the accessible label."
+        code={`<Stack gap="xs">
+  <Cluster gap="xs" align="center"><Dot color="blue" /> Authentication</Cluster>
+  <Cluster gap="xs" align="center"><Dot color="emerald" /> Billing</Cluster>
+  <Cluster gap="xs" align="center"><Dot color="orange" /> Permissions</Cluster>
+  <Cluster gap="xs" align="center"><Dot tone="danger" /> Security alert</Cluster>
+</Stack>`}
+      >
+        <Stack gap="xs">
+          <Cluster gap="xs" align="center">
+            <Dot color="blue" />
+            <Text as="span" size="sm">
+              Authentication
+            </Text>
+          </Cluster>
+          <Cluster gap="xs" align="center">
+            <Dot color="emerald" />
+            <Text as="span" size="sm">
+              Billing
+            </Text>
+          </Cluster>
+          <Cluster gap="xs" align="center">
+            <Dot color="orange" />
+            <Text as="span" size="sm">
+              Permissions
+            </Text>
+          </Cluster>
+          <Cluster gap="xs" align="center">
+            <Dot tone="danger" />
+            <Text as="span" size="sm">
+              Security alert
+            </Text>
+          </Cluster>
+        </Stack>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -25,6 +25,7 @@ export type ComponentName =
   | 'DateRangePicker'
   | 'DefinitionList'
   | 'Divider'
+  | 'Dot'
   | 'Drawer'
   | 'DropdownMenu'
   | 'EmptyState'


### PR DESCRIPTION
Addresses #164.

## Summary
Adds a **`Dot`** primitive — a bare, background-less colored circle (`--size-badge-dot`, 6px) for color-coding affordances (a leading dot on a filter trigger / `FilterChip`, a status indicator, a legend swatch). Generalizes `OptionsPicker`'s internal `GroupDot` into a public primitive. Unlike `<Badge dot>` it paints NO surface — just the dot.

- `color?: PaletteColor` → the saturated `--color-palette-<name>-fg` (all 30 palette colors); `tone?: BadgeTone` → one of the 6 semantic tones. `color` wins; neither → `neutral`. `aria-hidden` by default (decorative — pair with a label).
- **Bonus:** `FilterChip.Value` now accepts `color?: PaletteColor` (in addition to `tone`) and renders its leading dot **via `<Dot>`** — so a chip can be color-coded to its trigger. (Dedupes: FilterChip's old `.dot` SCSS is removed.)

Full Core invariant: tests, demo + nav/index/registry wiring, root export, JSDoc `@remarks`, AGENTS.md TL;DR, manifest CLUSTERS entry (both maps + regenerated JSON).

## Test plan
- `make test` — 2630 pass (+11 Dot, +1 FilterChip palette); **manifest drift test green**.
- `make build-lib`, `make lint`, `npm run format:check` green; `npm pack --dry-run` leaks nothing.
- **Verified in-browser** (Playwright) on `DotDemo`: 40 dots render with 35 distinct resolved colors, none transparent (palette vars resolve), 6px full circles, `aria-hidden`; tones + palette colors correct. 0 console errors. FilterChip's tone dot is pixel-identical (same tokens via `Dot`).
- Hard-rule-8 adversarial review: 0 Critical / 0 Important — "clean enough to stop" (Core invariant complete; color/tone mutual-exclusion correct; FilterChip bonus preserves existing dot tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)