### PR TITLE
fix(Sortable): render dragged item in DragOverlay so async/optimistic reorders don't glitch (#165)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -806,6 +806,8 @@ Props on the root: `onReorder?: ({ from, to, id }) => void` — fires only when 
 
 **Keyboard reorder**: Tab to focus the Handle (or the Item if no Handle), press **Space** to pick up, **ArrowUp** / **ArrowDown** to move, **Space** to drop, **Escape** to cancel. dnd-kit's KeyboardSensor ships built-in `aria-live` announcements describing each move.
 
+**Drop visual / async-safe**: the dragged item renders in a dnd-kit `<DragOverlay>` (a portaled, fixed-position clone); the active list `<li>` is an invisible placeholder during drag. Because the overlay owns the drop animation, the in-list row never carries a stale drag transform — so `onReorder` may commit the new order **asynchronously / optimistically** (e.g. an optimistic TanStack mutation's `onMutate` that lands a tick late) without the dropped row glitching ("fly up then settle"). You no longer need to reorder synchronously. The drop animation respects `prefers-reduced-motion` (it's disabled under reduced motion).
+
 **Anti-patterns**
 
 - ❌ Mutating items in place inside `onReorder`. Always return a new array (`arrayMove(items, from, to)` from `@dnd-kit/sortable`) — React needs a fresh reference.

--- a/packages/design-system/src/components/Sortable/Sortable.module.scss
+++ b/packages/design-system/src/components/Sortable/Sortable.module.scss
@@ -22,9 +22,14 @@
 }
 
 .item[data-dragging='true'] {
+  // The in-list dragged item is an invisible placeholder (opacity 0, set inline)
+  // — the lifted visual lives on .overlayItem in the DragOverlay (#165).
   cursor: grabbing;
+}
+
+.overlayItem {
   box-shadow: var(--sortable-item-shadow-dragging);
-  z-index: 1;
+  cursor: grabbing;
 }
 
 .handle {

--- a/packages/design-system/src/components/Sortable/Sortable.test.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.test.tsx
@@ -139,6 +139,27 @@ describe('Sortable', () => {
     consoleError.mockRestore();
   });
 
+  it('at rest renders one <li> per item and no DragOverlay clone', () => {
+    // DragOverlay only renders content during an active drag. With no drag in
+    // progress it renders null, so each item's content appears exactly once
+    // (in its <li>) — there is no second, overlay copy in the DOM.
+    const { container } = render(
+      <Sortable>
+        <Sortable.Item id="a">
+          <span data-testid="content">Alpha</span>
+        </Sortable.Item>
+        <Sortable.Item id="b">
+          <span data-testid="content">Beta</span>
+        </Sortable.Item>
+      </Sortable>,
+    );
+    expect(container.querySelectorAll('li')).toHaveLength(2);
+    // No overlay clone at rest — exactly one node per item content.
+    expect(container.querySelectorAll('[data-testid="content"]')).toHaveLength(2);
+    // The lifted-overlay marker is never present without an active drag.
+    expect(container.querySelectorAll('[data-dragging="true"]')).toHaveLength(0);
+  });
+
   it('renders empty list (no items) without crashing', () => {
     const { container } = render(<Sortable>{null}</Sortable>);
     expect(container.querySelector('ol')).not.toBeNull();

--- a/packages/design-system/src/components/Sortable/Sortable.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.tsx
@@ -5,17 +5,20 @@ import {
   isValidElement,
   useContext,
   useMemo,
+  useState,
   type ButtonHTMLAttributes,
   type HTMLAttributes,
   type ReactNode,
 } from 'react';
 import {
   DndContext,
+  DragOverlay,
   KeyboardSensor,
   PointerSensor,
   useSensor,
   useSensors,
   type DragEndEvent,
+  type DragStartEvent,
 } from '@dnd-kit/core';
 import {
   SortableContext,
@@ -74,6 +77,14 @@ export interface SortableItemContextValue {
 }
 
 export const SortableItemContext = createContext<SortableItemContextValue | null>(null);
+
+// Inert context for the DragOverlay clone — the overlay is a static visual; its
+// Handle (if any) must render without wiring real drag listeners.
+const OVERLAY_ITEM_CONTEXT: SortableItemContextValue = {
+  listeners: undefined,
+  attributes: {} as SortableItemContextValue['attributes'],
+  setActivatorNodeRef: () => {},
+};
 
 /**
  * Recursively check whether the children subtree contains a `Sortable.Handle`.
@@ -177,6 +188,8 @@ const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function Sortab
   { onReorder, className, children, ...rest },
   ref,
 ) {
+  const [activeId, setActiveId] = useState<string | number | null>(null);
+
   const itemIds = useMemo(() => {
     const ids: (string | number)[] = [];
     Children.forEach(children, (child) => {
@@ -187,12 +200,35 @@ const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function Sortab
     return ids;
   }, [children]);
 
+  // The active item's content, rendered into the DragOverlay clone. Looking it
+  // up by id (rather than capturing a snapshot on drag-start) keeps the overlay
+  // in sync if the consumer's item content re-renders mid-drag.
+  const activeChildren = useMemo<ReactNode>(() => {
+    if (activeId == null) return null;
+    let content: ReactNode = null;
+    Children.forEach(children, (child) => {
+      if (
+        isValidElement(child) &&
+        child.type === SortableItem &&
+        (child.props as SortableItemProps).id === activeId
+      ) {
+        content = (child.props as SortableItemProps).children;
+      }
+    });
+    return content;
+  }, [activeId, children]);
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(event.active.id as string | number);
+  };
+
   const handleDragEnd = (event: DragEndEvent) => {
+    setActiveId(null);
     const { active, over } = event;
     if (!over || active.id === over.id) return;
     const from = itemIds.indexOf(active.id as string | number);
@@ -201,13 +237,41 @@ const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function Sortab
     onReorder?.({ from, to, id: active.id as string | number });
   };
 
+  const handleDragCancel = () => {
+    setActiveId(null);
+  };
+
+  // SSR-safe reduced-motion probe; disables the overlay's drop animation.
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
   return (
-    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
       <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
         <ol ref={ref} className={clsx(styles.list, className)} {...rest}>
           {children}
         </ol>
       </SortableContext>
+      {/* The dragged item lives in a portaled, fixed-position overlay that owns
+          the drag + drop animation. The list <li> becomes an invisible
+          placeholder during drag, so a late/async order update from onReorder
+          can never leave a stale dnd-kit transform on a list <li> (#165). */}
+      <DragOverlay dropAnimation={prefersReducedMotion ? null : undefined}>
+        {activeChildren != null ? (
+          <SortableItemContext.Provider value={OVERLAY_ITEM_CONTEXT}>
+            <div className={clsx(styles.item, styles.overlayItem)} data-dragging="true">
+              {activeChildren}
+            </div>
+          </SortableItemContext.Provider>
+        ) : null}
+      </DragOverlay>
     </DndContext>
   );
 });
@@ -258,6 +322,10 @@ export const SortableItem = forwardRef<HTMLLIElement, SortableItemProps>(functio
         style={{
           transform: CSS.Transform.toString(transform),
           transition,
+          // The DragOverlay renders the dragged item's visual; the in-list copy
+          // is an invisible placeholder so it never carries a stale drag/drop
+          // transform when onReorder commits the new order asynchronously (#165).
+          opacity: isDragging ? 0 : undefined,
         }}
         data-dragging={isDragging ? 'true' : undefined}
         className={clsx(styles.item, className)}

--- a/packages/playground/src/pages/components/SortableDemo.tsx
+++ b/packages/playground/src/pages/components/SortableDemo.tsx
@@ -42,6 +42,14 @@ export function SortableDemo() {
     Array.from({ length: 20 }, (_, i) => ({ id: i + 1, label: `Ticket #${1000 + i}` })),
   );
 
+  const [stages, setStages] = useState([
+    { id: 'stage-1', label: 'Lead captured' },
+    { id: 'stage-2', label: 'Qualified' },
+    { id: 'stage-3', label: 'Proposal sent' },
+    { id: 'stage-4', label: 'Negotiation' },
+    { id: 'stage-5', label: 'Closed won' },
+  ]);
+
   return (
     <DemoLayout
       name="Sortable"
@@ -224,6 +232,35 @@ export function SortableDemo() {
             ))}
           </Sortable>
         </div>
+      </Example>
+
+      <Example
+        title="Async / optimistic reorder"
+        description="onReorder applies the new order a tick late — as it would with an optimistic TanStack mutation's onMutate. Before this fix the dropped row kept dnd-kit's stale drag transform and animated in from ~100px off (a 'fly up then settle' glitch). The dragged item now renders in a DragOverlay that owns the drop animation, so the late state update lands smoothly. Drag a stage to feel it."
+        code={`// Order arrives a tick late, like an optimistic mutation's onMutate.
+<Sortable
+  onReorder={({ from, to }) =>
+    setTimeout(() => setStages((curr) => arrayMove(curr, from, to)), 0)
+  }
+>
+  {stages.map((s) => (
+    <Sortable.Item key={s.id} id={s.id}>
+      <Card padding="sm">{s.label}</Card>
+    </Sortable.Item>
+  ))}
+</Sortable>`}
+      >
+        <Sortable
+          onReorder={({ from, to }) =>
+            setTimeout(() => setStages((curr) => arrayMove(curr, from, to)), 0)
+          }
+        >
+          {stages.map((s) => (
+            <Sortable.Item key={s.id} id={s.id}>
+              <Card padding="sm">{s.label}</Card>
+            </Sortable.Item>
+          ))}
+        </Sortable>
       </Example>
 
       <Stack gap="xs">


### PR DESCRIPTION
Addresses #165.

## Summary
`Sortable.Item` applied dnd-kit's `useSortable` `{transform, transition}` to each `<li>`. When the consumer committed the reorder ASYNCHRONOUSLY (a tick late — an optimistic TanStack mutation's `onMutate`), the dropped `<li>` kept its stale drag transform and `transition` animated it from ~100px off into the slot — a visible "fly up then settle" glitch.

**Fix (dnd-kit canonical recipe):** render the dragged item in a **`<DragOverlay>`** and make the in-list active row an invisible placeholder (`opacity: 0`) during drag. The overlay owns the drag + drop visual independently of when the list re-renders, so the list `<li>` never carries the stale transform — async/optimistic `onReorder` is now glitch-free (consumers no longer must reorder synchronously).
- `onDragStart`/`onDragCancel` track the active id; the overlay clones the active item's content under an inert context (so a nested `Sortable.Handle` renders as a static visual). The lifted shadow moved to `.overlayItem`.
- Respects `prefers-reduced-motion` (overlay drop animation disabled). Keyboard reorder, the Handle/no-Handle activator logic, and the `onReorder` contract are unchanged.

## Test plan
- `make test` — 2631 pass (+1: at-rest renders one `<li>` per item, no overlay clone). Existing structural tests unaffected (jsdom never starts a real drag → overlay renders null at rest).
- `make build-lib`, `make lint`, `npm run format:check` green; `npm pack --dry-run` leaks nothing.
- **Verified in-browser** (Playwright) on a new `SortableDemo` "Async / optimistic reorder" example (commits the order via `setTimeout(0)`): keyboard reorder commits correctly and **all rows settle at `transform: none` / `opacity: 1` — no stale transform**; mid-drag the overlay clone renders the lifted visual (with shadow) while the active row is `opacity: 0`; Escape cancels cleanly. 0 console errors.
- Hard-rule-8 adversarial review (incl. a dnd-kit 6.3.1 source trace): 0 Critical / 0 Important — "clean enough to stop" (no double-image, no stranded-invisible row, layout preserved, a11y + reduced-motion correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)