### PR TITLE
feat(Sortable): restrictToContainer prop — clamp drag to list bounds (default on)

### DIFF
--- a/docs/superpowers/specs/2026-06-17-sortable-restrict-to-container-design.md
+++ b/docs/superpowers/specs/2026-06-17-sortable-restrict-to-container-design.md
@@ -1,0 +1,85 @@
+# `Sortable` — `restrictToContainer` prop — Design
+
+**Date:** 2026-06-17
+**Status:** Approved (design)
+**Package:** `@eocrm/design-system`
+
+## Problem
+
+`Sortable` lets the dragged item (and its `DragOverlay`, shipped in v0.1.43) be dragged
+anywhere on the page. Consumers want the drag confined to the list's own bounds so the
+dragged row can't float off over unrelated UI.
+
+## Solution
+
+Add **`restrictToContainer?: boolean`** to `SortableProps`, **default `true`**. When on,
+a dnd-kit **modifier** clamps the drag transform so the dragged item / overlay stays within
+the `<ol>` list element's bounding box. `restrictToContainer={false}` restores today's
+free-drag.
+
+No new dependency: `@dnd-kit/modifiers` is NOT installed and the dependency policy lists
+only `@dnd-kit/core` / `@dnd-kit/sortable` / `@dnd-kit/utilities`. A modifier is a pure
+function `(args) => Transform`; we inline a ~15-line clamp mirroring dnd-kit's
+`restrictToParentElement` / `restrictToBoundingRect`, reading the live `<ol>` rect via an
+internal ref (deterministic — restricts to the actual list element, not relying on dnd-kit's
+`containerNodeRect` detection through the overlay portal).
+
+## API
+
+```tsx
+<Sortable onReorder={…}>{…}</Sortable>                    // default: contained
+<Sortable restrictToContainer={false} onReorder={…}>{…}</Sortable>  // free drag
+```
+
+`restrictToContainer?: boolean` — JSDoc: "When `true` (default), the dragged item is
+clamped to the list's bounding box and can't be dragged outside it. Set `false` for
+free-drag (the item can be dragged anywhere). For a vertical list this constrains the drag
+vertically to the list's extent."
+
+## Implementation (`Sortable.tsx`)
+
+- Pure helper (unit-testable):
+  ```ts
+  function restrictTransformToRect(transform, nodeRect, boundingRect): Transform {
+    const value = { ...transform };
+    if (nodeRect.top + transform.y <= boundingRect.top) {
+      value.y = boundingRect.top - nodeRect.top;
+    } else if (nodeRect.bottom + transform.y >= boundingRect.top + boundingRect.height) {
+      value.y = boundingRect.top + boundingRect.height - nodeRect.bottom;
+    }
+    if (nodeRect.left + transform.x <= boundingRect.left) {
+      value.x = boundingRect.left - nodeRect.left;
+    } else if (nodeRect.right + transform.x >= boundingRect.left + boundingRect.width) {
+      value.x = boundingRect.left + boundingRect.width - nodeRect.right;
+    }
+    return value;
+  }
+  ```
+- In `SortableRoot`: internal `olRef` merged with the forwarded `ref` via `mergeRefs(olRef, ref)`.
+  A memoized `Modifier` closure clamps `draggingNodeRect` to `olRef.current.getBoundingClientRect()`.
+  `const modifiers = restrictToContainer ? [restrictModifier] : undefined;`
+- Pass `modifiers={modifiers}` to BOTH `<DndContext>` and `<DragOverlay>` (the overlay is the
+  visible drag, so it must carry the modifier; DndContext for the underlying transform too).
+
+## Deliverables (Core invariant — changes a component)
+
+- The prop + modifier in `Sortable.tsx`; JSDoc on the prop + a `@remarks` note.
+- Tests: unit-test the pure `restrictTransformToRect` clamp math (over-top / over-bottom →
+  clamped; within bounds → unchanged); structural test that `restrictToContainer={false}`
+  and the default both render without crashing. (jsdom can't measure real drag — the drag
+  constraint itself is verified in-browser.)
+- `SortableDemo`: an example contrasting `restrictToContainer` on (default) vs `false`.
+- `AGENTS.md`: a `<Sortable>` bullet documenting the prop + default.
+
+## Acceptance
+
+- Gates green; `npm pack --dry-run` clean.
+- **Verified in-browser**: with the default (on), the dragged overlay cannot leave the list's
+  vertical bounds; with `restrictToContainer={false}`, it can be dragged outside. Keyboard
+  reorder + existing behavior unchanged.
+- Ships as a library patch.
+
+## Out of scope
+
+- Axis-only locking (`restrictToVerticalAxis`) — separate concern; not requested.
+- Restricting to a scrollable ancestor rather than the list element.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -800,7 +800,7 @@ const [items, setItems] = useState([
 </Sortable>;
 ```
 
-Props on the root: `onReorder?: ({ from, to, id }) => void` — fires only when the drop position differs from the source. Consumer owns the items array and re-renders with the new order. `arrayMove` is shipped by `@dnd-kit/sortable` (the library is already a dep) — import it from there. Items must have a stable `id` prop (`string | number`).
+Props on the root: `onReorder?: ({ from, to, id }) => void` — fires only when the drop position differs from the source. Consumer owns the items array and re-renders with the new order. `arrayMove` is shipped by `@dnd-kit/sortable` (the library is already a dep) — import it from there. Items must have a stable `id` prop (`string | number`). `restrictToContainer?: boolean` (default `true`) — clamps the drag to the list's bounding box so the dragged item can't leave the `<ol>`; pass `false` for free-drag (item follows the cursor anywhere on the page).
 
 **Drag origin** (hybrid): if `<Sortable.Handle>` is present in the Item subtree, only the Handle initiates drag. If no Handle is present, the entire Item is draggable + focusable. A 5px activation distance means short clicks-without-movement on internal buttons / links pass through.
 

--- a/packages/design-system/src/components/Sortable/Sortable.test.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.test.tsx
@@ -1,6 +1,6 @@
 import { createRef } from 'react';
 import { render } from '@testing-library/react';
-import { Sortable } from './Sortable';
+import { Sortable, restrictTransformToRect } from './Sortable';
 
 describe('Sortable', () => {
   it('renders <ol> with items as <li> elements', () => {
@@ -180,5 +180,96 @@ describe('Sortable', () => {
     expect(consoleWarn).not.toHaveBeenCalled();
     consoleError.mockRestore();
     consoleWarn.mockRestore();
+  });
+
+  it('renders with restrictToContainer={false} (free drag) without crashing', () => {
+    const { container } = render(
+      <Sortable restrictToContainer={false}>
+        <Sortable.Item id="a">A</Sortable.Item>
+        <Sortable.Item id="b">B</Sortable.Item>
+      </Sortable>,
+    );
+    expect(container.querySelector('ol')).not.toBeNull();
+    expect(container.querySelectorAll('li')).toHaveLength(2);
+  });
+
+  it('forwards ref to the <ol> with restrictToContainer enabled (default)', () => {
+    // restrictToContainer merges an internal ref onto the <ol>; the consumer's
+    // ref must still resolve to the same node.
+    const ref = createRef<HTMLOListElement>();
+    render(
+      <Sortable ref={ref}>
+        <Sortable.Item id="a">A</Sortable.Item>
+      </Sortable>,
+    );
+    expect(ref.current?.tagName).toBe('OL');
+  });
+});
+
+describe('restrictTransformToRect', () => {
+  // A 50px-tall, 100px-wide node sitting at (left:10, top:20) inside a
+  // 400x300 bounding box anchored at (left:0, top:0).
+  const nodeRect = { top: 20, bottom: 70, left: 10, right: 110 };
+  const boundingRect = { top: 0, left: 0, width: 400, height: 300 };
+
+  it('returns the transform unchanged when fully within bounds', () => {
+    const transform = { x: 5, y: 5, scaleX: 1, scaleY: 1 };
+    expect(restrictTransformToRect(transform, nodeRect, boundingRect)).toEqual(transform);
+  });
+
+  it('clamps y so the top edge stays at the bound when dragged above', () => {
+    // y = -100 would push top to -80 (above boundingRect.top=0). Clamp to keep
+    // the top edge at the bound: y = boundingRect.top - nodeRect.top = -20.
+    const result = restrictTransformToRect(
+      { x: 0, y: -100, scaleX: 1, scaleY: 1 },
+      nodeRect,
+      boundingRect,
+    );
+    expect(result.y).toBe(-20);
+    expect(result.x).toBe(0);
+  });
+
+  it('clamps y so the bottom edge stays at the bound when dragged below', () => {
+    // y = 1000 would push bottom way past 300. Clamp:
+    // y = boundingRect.top + height - nodeRect.bottom = 0 + 300 - 70 = 230.
+    const result = restrictTransformToRect(
+      { x: 0, y: 1000, scaleX: 1, scaleY: 1 },
+      nodeRect,
+      boundingRect,
+    );
+    expect(result.y).toBe(230);
+  });
+
+  it('clamps x so the left edge stays at the bound when dragged left', () => {
+    // x = -100 would push left to -90 (< boundingRect.left=0). Clamp:
+    // x = boundingRect.left - nodeRect.left = 0 - 10 = -10.
+    const result = restrictTransformToRect(
+      { x: -100, y: 0, scaleX: 1, scaleY: 1 },
+      nodeRect,
+      boundingRect,
+    );
+    expect(result.x).toBe(-10);
+    expect(result.y).toBe(0);
+  });
+
+  it('clamps x so the right edge stays at the bound when dragged right', () => {
+    // x = 1000 would push right past 400. Clamp:
+    // x = boundingRect.left + width - nodeRect.right = 0 + 400 - 110 = 290.
+    const result = restrictTransformToRect(
+      { x: 1000, y: 0, scaleX: 1, scaleY: 1 },
+      nodeRect,
+      boundingRect,
+    );
+    expect(result.x).toBe(290);
+  });
+
+  it('preserves scaleX / scaleY untouched', () => {
+    const result = restrictTransformToRect(
+      { x: 1000, y: 1000, scaleX: 0.5, scaleY: 0.75 },
+      nodeRect,
+      boundingRect,
+    );
+    expect(result.scaleX).toBe(0.5);
+    expect(result.scaleY).toBe(0.75);
   });
 });

--- a/packages/design-system/src/components/Sortable/Sortable.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.tsx
@@ -5,6 +5,7 @@ import {
   isValidElement,
   useContext,
   useMemo,
+  useRef,
   useState,
   type ButtonHTMLAttributes,
   type HTMLAttributes,
@@ -19,6 +20,7 @@ import {
   useSensors,
   type DragEndEvent,
   type DragStartEvent,
+  type Modifier,
 } from '@dnd-kit/core';
 import {
   SortableContext,
@@ -26,8 +28,9 @@ import {
   useSortable,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
+import { CSS, type Transform } from '@dnd-kit/utilities';
 import clsx from 'clsx';
+import { mergeRefs } from '../_internal/refs';
 import styles from './Sortable.module.scss';
 
 /**
@@ -42,6 +45,32 @@ export interface SortableReorderEvent {
   id: string | number;
 }
 
+/**
+ * Clamp a drag `transform` so the dragged node (`nodeRect`) stays within
+ * `boundingRect`. Pure function mirroring dnd-kit's `restrictToBoundingRect`;
+ * exported so the clamp math can be unit-tested without a real DOM / drag.
+ *
+ * `scaleX` / `scaleY` pass through untouched — only the translation is clamped.
+ */
+export function restrictTransformToRect(
+  transform: Transform,
+  nodeRect: { top: number; bottom: number; left: number; right: number },
+  boundingRect: { top: number; left: number; width: number; height: number },
+): Transform {
+  const value = { ...transform };
+  if (nodeRect.top + transform.y <= boundingRect.top) {
+    value.y = boundingRect.top - nodeRect.top;
+  } else if (nodeRect.bottom + transform.y >= boundingRect.top + boundingRect.height) {
+    value.y = boundingRect.top + boundingRect.height - nodeRect.bottom;
+  }
+  if (nodeRect.left + transform.x <= boundingRect.left) {
+    value.x = boundingRect.left - nodeRect.left;
+  } else if (nodeRect.right + transform.x >= boundingRect.left + boundingRect.width) {
+    value.x = boundingRect.left + boundingRect.width - nodeRect.right;
+  }
+  return value;
+}
+
 export interface SortableProps extends HTMLAttributes<HTMLOListElement> {
   /**
    * Fires after a drag or keyboard move with the new position. Consumer
@@ -50,6 +79,13 @@ export interface SortableProps extends HTMLAttributes<HTMLOListElement> {
    * Not fired if the drop position equals the source position (no-op).
    */
   onReorder?: (event: SortableReorderEvent) => void;
+  /**
+   * When `true` (default), the dragged item is clamped to the list's bounding
+   * box — it can't be dragged outside the `<ol>`. Set `false` for free-drag
+   * (the item can be dragged anywhere on the page). For a vertical list this
+   * constrains the drag vertically to the list's extent.
+   */
+  restrictToContainer?: boolean;
 }
 
 export interface SortableItemProps extends Omit<HTMLAttributes<HTMLLIElement>, 'id'> {
@@ -159,6 +195,12 @@ function containsHandle(children: ReactNode): boolean {
  *   ))}
  * </Sortable>
  *
+ * @remarks Drag confinement
+ * - By default (`restrictToContainer`) the dragged item is clamped to the
+ *   list's bounding box and can't be dragged off over unrelated UI. Pass
+ *   `restrictToContainer={false}` for free-drag if you genuinely want the item
+ *   to follow the cursor anywhere on the page.
+ *
  * @remarks When NOT to use
  * - Tabular data — use `<Table>` / `<DataTable>` (DataTable already uses
  *   dnd-kit for column reorder).
@@ -185,10 +227,13 @@ function containsHandle(children: ReactNode): boolean {
  *   render but won't be reorderable.
  */
 const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function SortableRoot(
-  { onReorder, className, children, ...rest },
+  { onReorder, restrictToContainer = true, className, children, ...rest },
   ref,
 ) {
   const [activeId, setActiveId] = useState<string | number | null>(null);
+  // Internal handle on the <ol> so the restrict modifier can read the live
+  // list rect, independent of whether the consumer forwards a ref.
+  const olRef = useRef<HTMLOListElement | null>(null);
 
   const itemIds = useMemo(() => {
     const ids: (string | number)[] = [];
@@ -247,23 +292,42 @@ const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function Sortab
     typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
+  // Modifier that confines the drag transform to the live <ol> bounding box.
+  // A modifier is a pure `(args) => Transform`; we read the list rect from the
+  // internal ref rather than dnd-kit's `containerNodeRect` (which is unreliable
+  // through the DragOverlay portal). Memoized once — it closes over the ref,
+  // so it always sees the current node.
+  const restrictModifier = useMemo<Modifier>(
+    () =>
+      ({ transform, draggingNodeRect }) => {
+        const container = olRef.current?.getBoundingClientRect();
+        if (!draggingNodeRect || !container) return transform;
+        return restrictTransformToRect(transform, draggingNodeRect, container);
+      },
+    [],
+  );
+  const modifiers = restrictToContainer ? [restrictModifier] : undefined;
+
   return (
     <DndContext
       sensors={sensors}
+      modifiers={modifiers}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
       <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
-        <ol ref={ref} className={clsx(styles.list, className)} {...rest}>
+        <ol ref={mergeRefs(olRef, ref)} className={clsx(styles.list, className)} {...rest}>
           {children}
         </ol>
       </SortableContext>
       {/* The dragged item lives in a portaled, fixed-position overlay that owns
           the drag + drop animation. The list <li> becomes an invisible
           placeholder during drag, so a late/async order update from onReorder
-          can never leave a stale dnd-kit transform on a list <li> (#165). */}
-      <DragOverlay dropAnimation={prefersReducedMotion ? null : undefined}>
+          can never leave a stale dnd-kit transform on a list <li> (#165). The
+          overlay is the *visible* drag, so it must carry the restrict modifier
+          too — DndContext alone constrains the underlying item transform. */}
+      <DragOverlay modifiers={modifiers} dropAnimation={prefersReducedMotion ? null : undefined}>
         {activeChildren != null ? (
           <SortableItemContext.Provider value={OVERLAY_ITEM_CONTEXT}>
             <div className={clsx(styles.item, styles.overlayItem)} data-dragging="true">

--- a/packages/playground/src/pages/components/SortableDemo.tsx
+++ b/packages/playground/src/pages/components/SortableDemo.tsx
@@ -50,6 +50,18 @@ export function SortableDemo() {
     { id: 'stage-5', label: 'Closed won' },
   ]);
 
+  const [contained, setContained] = useState([
+    { id: 'c-1', label: 'Discovery call' },
+    { id: 'c-2', label: 'Demo scheduled' },
+    { id: 'c-3', label: 'Contract draft' },
+  ]);
+
+  const [freeDrag, setFreeDrag] = useState([
+    { id: 'f-1', label: 'Discovery call' },
+    { id: 'f-2', label: 'Demo scheduled' },
+    { id: 'f-3', label: 'Contract draft' },
+  ]);
+
   return (
     <DemoLayout
       name="Sortable"
@@ -261,6 +273,65 @@ export function SortableDemo() {
             </Sortable.Item>
           ))}
         </Sortable>
+      </Example>
+
+      <Example
+        title="Restrict drag to container (default)"
+        description="By default (restrictToContainer) the dragged item is clamped to the list's bounding box — it can't be dragged off over unrelated UI. Pass restrictToContainer={false} for free-drag, where the item follows the cursor anywhere on the page. Drag a row in each list and notice how the left one stays inside its bounds while the right one doesn't."
+        code={`{/* Default: dragged item clamped to the list's bounds. */}
+<Sortable
+  onReorder={({ from, to }) => setContained((curr) => arrayMove(curr, from, to))}
+>
+  {contained.map((s) => (
+    <Sortable.Item key={s.id} id={s.id}>
+      <Card padding="sm">{s.label}</Card>
+    </Sortable.Item>
+  ))}
+</Sortable>
+
+{/* Free drag: item can be dragged anywhere on the page. */}
+<Sortable
+  restrictToContainer={false}
+  onReorder={({ from, to }) => setFreeDrag((curr) => arrayMove(curr, from, to))}
+>
+  {freeDrag.map((s) => (
+    <Sortable.Item key={s.id} id={s.id}>
+      <Card padding="sm">{s.label}</Card>
+    </Sortable.Item>
+  ))}
+</Sortable>`}
+      >
+        <Cluster gap="lg" align="start">
+          <Stack gap="xs">
+            <Text size="sm" weight="medium">
+              Contained (default)
+            </Text>
+            <Sortable
+              onReorder={({ from, to }) => setContained((curr) => arrayMove(curr, from, to))}
+            >
+              {contained.map((s) => (
+                <Sortable.Item key={s.id} id={s.id}>
+                  <Card padding="sm">{s.label}</Card>
+                </Sortable.Item>
+              ))}
+            </Sortable>
+          </Stack>
+          <Stack gap="xs">
+            <Text size="sm" weight="medium">
+              Free drag (restrictToContainer=false)
+            </Text>
+            <Sortable
+              restrictToContainer={false}
+              onReorder={({ from, to }) => setFreeDrag((curr) => arrayMove(curr, from, to))}
+            >
+              {freeDrag.map((s) => (
+                <Sortable.Item key={s.id} id={s.id}>
+                  <Card padding="sm">{s.label}</Card>
+                </Sortable.Item>
+              ))}
+            </Sortable>
+          </Stack>
+        </Cluster>
       </Example>
 
       <Stack gap="xs">


### PR DESCRIPTION
## Summary
Adds **`restrictToContainer?: boolean`** to `Sortable`, **default `true`**. When on, the dragged item — and its `DragOverlay` — is clamped so it can't be dragged outside the `<ol>` list element's bounding box. `restrictToContainer={false}` restores free-drag (drag anywhere).

- **No new dependency** — `@dnd-kit/modifiers` isn't installed and the dep policy lists only core/sortable/utilities. Inlined a tiny dnd-kit `Modifier` (pure `restrictTransformToRect` clamp mirroring dnd-kit's `restrictToBoundingRect`) that reads the live `<ol>` rect via an internal ref (merged with the forwarded ref). Passed to both `<DndContext>` and `<DragOverlay>` so the visible overlay stays inside the list. For a vertical list this constrains the drag vertically to the list's extent.
- Keyboard reorder, the DragOverlay async-safe drop, the Handle/no-Handle activator logic, and `onReorder` are unchanged.

## Test plan
- `make test` — 2639 pass (+8: 6 `restrictTransformToRect` clamp-math unit tests — over-top/over-bottom/within/x-edges/scale-preserved — plus structural `restrictToContainer={false}`/default renders + ref-forward).
- `make build-lib`, `make lint`, `npm run format:check` green; `npm pack --dry-run` leaks nothing; no new dep; the helper is module-only (not added to the public root export).
- **Verified in-browser** (Playwright, real pointer drags): with the default (on), dragging 600px above the list clamps the overlay's top to the list top (`overlayTop == olTop`) — can't escape; with `restrictToContainer={false}`, the overlay follows 600px above the list (escapes), as before. 0 console errors. New `SortableDemo` example contrasts contained vs free-drag.
- Hard-rule-8 adversarial review: 0 Critical / 0 Important — "clean enough to stop" (clamp math re-verified, modifier wiring + ref-merge + no-new-dep confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)