### PR TITLE
fix(LiquidEditor): autocomplete menu z-index + keyboard-nav scroll (#171)

### DIFF
--- a/packages/design-system/src/components/LiquidEditor/AutocompleteMenu.tsx
+++ b/packages/design-system/src/components/LiquidEditor/AutocompleteMenu.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useFloating, autoUpdate, flip, shift, offset } from '@floating-ui/react-dom';
 import clsx from 'clsx';
@@ -61,6 +61,14 @@ export function AutocompleteMenu({
     elements: { reference: virtualRef },
   });
 
+  // Keep the keyboard-active option scrolled into view inside the menu's
+  // (max-height, overflow-y:auto) box — arrow-key nav must not move the
+  // highlight off-screen. Focus stays on the textarea, so we scroll manually.
+  const activeRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    activeRef.current?.scrollIntoView?.({ block: 'nearest' });
+  }, [activeIndex]);
+
   // Precompute group-header flags before render (no mutation during the map —
   // keeps the render pure under StrictMode double-invocation). A header shows
   // when an item's group differs from the previous item's.
@@ -88,6 +96,7 @@ export function AutocompleteMenu({
             ) : null}
             <div
               id={`${listboxId}-opt-${idx}`}
+              ref={idx === activeIndex ? activeRef : undefined}
               role="option"
               aria-selected={idx === activeIndex}
               className={clsx(styles.menuItem, idx === activeIndex && styles.menuItemActive)}

--- a/packages/design-system/src/components/LiquidEditor/LiquidEditor.test.tsx
+++ b/packages/design-system/src/components/LiquidEditor/LiquidEditor.test.tsx
@@ -211,6 +211,30 @@ describe('LiquidEditor', () => {
     expect(ta).toHaveValue('{{ last_name');
   });
 
+  it('scrolls the active suggestion into view as keyboard nav moves it', async () => {
+    const user = userEvent.setup();
+    // jsdom doesn't implement scrollIntoView at all, so define a spy (the
+    // component calls it optionally). Proves the active option is kept in view
+    // when ArrowDown changes the active row.
+    const scrollSpy = vi.fn();
+    const proto = HTMLElement.prototype as unknown as { scrollIntoView?: () => void };
+    const had = 'scrollIntoView' in proto;
+    proto.scrollIntoView = scrollSpy;
+    try {
+      renderEditor(<Harness />);
+      const ta = screen.getByRole('combobox');
+      await user.click(ta);
+      await user.type(ta, '{{{{ ');
+      expect(await screen.findByRole('listbox')).toBeInTheDocument();
+      scrollSpy.mockClear();
+      await user.keyboard('{ArrowDown}');
+      // The newly-active option scrolled itself into view.
+      expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' });
+    } finally {
+      if (!had) delete proto.scrollIntoView;
+    }
+  });
+
   it('closes autocomplete on Escape without bubbling', async () => {
     const user = userEvent.setup();
     const onParentEscape = vi.fn();

--- a/packages/design-system/src/components/LiquidEditor/LiquidEditor.tokens.scss
+++ b/packages/design-system/src/components/LiquidEditor/LiquidEditor.tokens.scss
@@ -46,5 +46,10 @@
   --liquid-editor-menu-min-width: var(--size-dropdown-min-width);
   --liquid-editor-menu-max-height: 200px;
   --liquid-editor-menu-shadow: var(--shadow-lg);
-  --liquid-editor-menu-z: var(--z-popover);
+
+  // The menu is portaled to <body>; it must clear a Drawer/Modal it's hosted
+  // inside (z-modal 1100), so it sits on the overlay-floating layer (1190) like
+  // the editor's own InsertVariableMenu (a DropdownMenu) — not the lower popover
+  // layer. Overridable via :root. (issue #171)
+  --liquid-editor-menu-z: var(--z-overlay-floating);
 }


### PR DESCRIPTION
Addresses #171.

## Summary
Two fixes to the LiquidEditor caret autocomplete menu:

1. **z-index (#171):** raise the menu to `--z-overlay-floating` (1190) so it clears a `Drawer`/`Modal` it's hosted inside (z 1100). Previously `--z-popover` (1050) left it occluded — the editor's own `InsertVariableMenu` (a `DropdownMenu`) already used the higher layer. One-token change; overridable via `:root`.
2. **Keyboard-nav scroll:** the active suggestion now `scrollIntoView({ block: 'nearest' })`s as Arrow keys move it, so the highlight no longer drifts off-screen in the menu's `max-height`/`overflow-y:auto` box.

## Test plan
- New unit test: ArrowDown scrolls the active option into view (`{ block: 'nearest' }`).
- Browser-verified: the menu's computed `z-index` is now `1190` (was `1050`).
- Gates green: `make test` (2744), `make build-lib`, `make lint`, `format:check`, `npm pack` (no test leak). Passed the Rule-8 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)