### PR TITLE
feat(RichTextEditor): inline links — toolbar button + ⌘K bubble (create/edit/remove)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -922,6 +922,7 @@ const [doc, setDoc] = useState(emptyDoc());
 - **Mark buttons** — Bold, Italic, Underline, Strikethrough. Reflect `aria-pressed` based on the current selection (or pending marks at a collapsed caret). Clicking with a selection toggles the mark over it; clicking at a collapsed caret sets a "pending" mark applied to the next typed characters (then clears).
 - **Block-type dropdown** — Paragraph, Heading 1–3, Quote, Code block. Shows the current block type; mixed multi-block selections show "Mixed".
 - **List toggles** — Bullet list, Numbered list. Toggle between the list type and paragraph.
+- **Link button** — add/edit a link on the selection. Reflects `aria-pressed` when the caret is inside a link.
 
 **List keys:**
 
@@ -930,7 +931,9 @@ const [doc, setDoc] = useState(emptyDoc());
 
 **Pending marks:** toggling a mark at a collapsed caret (via toolbar or ⌘B/I/U/⌘⇧X shortcut) queues it; the next inserted text gets that mark applied, then the queue clears. Moving the caret discards pending marks.
 
-When NOT to use: read-only display → `<RichText>`. No links or undo yet (later slices). It's controlled — render `onChange`'s doc back into `value`, never mutate in place.
+**Links:** select text and press ⌘/Ctrl+K (or the toolbar link button) to add or edit a link; with the caret inside a link the URL is pre-filled and a Remove button appears; with no selection the URL is inserted as linked text. Esc / click-outside cancels. Stored hrefs are sanitized at render time (`safeHref` blocks `javascript:`/`data:`/protocol-relative).
+
+When NOT to use: read-only display → `<RichText>`. No undo/redo yet (later slice). It's controlled — render `onChange`'s doc back into `value`, never mutate in place.
 
 ### `<ImageCrop>` — controlled image cropper
 

--- a/packages/design-system/src/components.manifest.json
+++ b/packages/design-system/src/components.manifest.json
@@ -128,7 +128,8 @@
     "composedBy": [
       "Calendar",
       "ConfirmationPopover",
-      "OptionsPicker"
+      "OptionsPicker",
+      "RichTextEditor"
     ]
   },
   "Code": {
@@ -340,7 +341,8 @@
     "composes": [],
     "composedBy": [
       "ColorPicker",
-      "OptionsPicker"
+      "OptionsPicker",
+      "RichTextEditor"
     ]
   },
   "Kanban": {
@@ -517,8 +519,11 @@
     "cluster": "Forms",
     "composes": [
       "Button",
+      "Cluster",
       "DropdownMenu",
-      "RichText"
+      "Input",
+      "RichText",
+      "Stack"
     ],
     "composedBy": []
   },
@@ -582,7 +587,8 @@
     "composes": [],
     "composedBy": [
       "ConfirmationPopover",
-      "Page"
+      "Page",
+      "RichTextEditor"
     ]
   },
   "Switch": {

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
@@ -66,3 +66,18 @@
   border-start-start-radius: 0;
   border-start-end-radius: 0;
 }
+
+// The floating link-edit bubble (RichTextLinkEditor). A portaled overlay
+// positioned by Floating UI's inline `floatingStyles` (so `position`/offsets are
+// NOT set here). `min-width` is the established sizing convention for floating
+// overlays (cf. LiquidEditor's `.menu`), not page layout — Rule 4 targets
+// in-flow component layout, not a portaled popover's intrinsic size.
+.linkBubble {
+  z-index: var(--z-overlay-floating);
+  min-width: var(--size-dropdown-min-width);
+  padding: var(--space-2);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  box-shadow: var(--shadow-lg);
+}

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -130,4 +130,39 @@ describe('RichTextEditor toolbar', () => {
     await user.click(screen.getByRole('button', { name: 'Bullet list' }));
     expect(screen.getByRole('listitem')).toHaveTextContent('hi');
   });
+
+  it('renders the toolbar Link button when the toolbar is on', () => {
+    function Harness() {
+      const [doc, setDoc] = useState(docFromText('hello'));
+      return <RichTextEditor value={doc} onChange={setDoc} toolbar />;
+    }
+    render(
+      <I18nProvider locale="en">
+        <Harness />
+      </I18nProvider>,
+    );
+    expect(screen.getByRole('button', { name: 'Link' })).toBeInTheDocument();
+  });
+
+  it('opening the link editor from the toolbar shows the link bubble', async () => {
+    const user = userEvent.setup();
+    // Stub readSelection so openLinkEditor gets a valid range (jsdom has no real caret).
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 5 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hello', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} toolbar autoFocus />;
+    }
+    render(
+      <I18nProvider locale="en">
+        <Harness />
+      </I18nProvider>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+    expect(await screen.findByRole('group', { name: 'Edit link' })).toBeInTheDocument();
+  });
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -165,4 +165,39 @@ describe('RichTextEditor toolbar', () => {
     await user.click(screen.getByRole('button', { name: 'Link' }));
     expect(await screen.findByRole('group', { name: 'Edit link' })).toBeInTheDocument();
   });
+
+  it('⌘K opens the link editor without leaking the shortcut to a host key handler', async () => {
+    const user = userEvent.setup();
+    // Stub readSelection so the ⌘K handler resolves a range (jsdom has no caret).
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 5 },
+    });
+    const hostKeyDown = vi.fn();
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hello', marks: [] }] }],
+      });
+      // A host wrapper standing in for a CRM's global ⌘K (command palette / search).
+      return (
+        <div onKeyDown={hostKeyDown}>
+          <RichTextEditor value={doc} onChange={setDoc} toolbar autoFocus />
+        </div>
+      );
+    }
+    render(
+      <I18nProvider locale="en">
+        <Harness />
+      </I18nProvider>,
+    );
+    screen.getByRole('textbox', { name: 'Rich text editor' }).focus();
+    await user.keyboard('{Meta>}k{/Meta}');
+    // The editor opened its own link bubble…
+    expect(await screen.findByRole('group', { name: 'Edit link' })).toBeInTheDocument();
+    // …and stopped the ⌘K from bubbling to the host handler.
+    const kReachedHost = hostKeyDown.mock.calls.some(
+      ([ev]) => (ev as React.KeyboardEvent).key.toLowerCase() === 'k',
+    );
+    expect(kReachedHost).toBe(false);
+  });
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -369,9 +369,12 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         if (!root) return;
         const range = readSelection(root);
         if (!range) return;
-        // ⌘/Ctrl+K opens the link editor (create or edit a link).
+        // ⌘/Ctrl+K opens the link editor (create or edit a link). Stop
+        // propagation so the shortcut doesn't ALSO trigger a host app's global
+        // ⌘K (command palette / search) while the editor is focused.
         if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'k') {
           e.preventDefault();
+          e.stopPropagation();
           openLinkEditor();
           return;
         }

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -112,9 +112,11 @@ function selectionRect(root: HTMLElement): Rect {
  * engine. Type to edit; ⌘/Ctrl+B/I/U and ⌘/Ctrl+⇧X toggle marks over a
  * selection (with a collapsed caret they stage a *pending* mark applied to the
  * next typed text); Enter splits, Backspace/Delete merge. Pass `toolbar` for the
- * built-in formatting toolbar. Inside a list, Tab/⇧Tab indent/outdent and Enter
- * on an empty item exits to a paragraph. The model is the source of truth: every
- * input is replayed as an engine transform and the DOM re-rendered.
+ * built-in formatting toolbar. ⌘/Ctrl+K (or the toolbar link button) opens a
+ * floating editor to add, edit, or remove a link on the selection. Inside a
+ * list, Tab/⇧Tab indent/outdent and Enter on an empty item exits to a paragraph.
+ * The model is the source of truth: every input is replayed as an engine
+ * transform and the DOM re-rendered.
  *
  * @example
  * const [doc, setDoc] = useState(emptyDoc());
@@ -135,8 +137,10 @@ function selectionRect(root: HTMLElement): Rect {
  * - ❌ Treating it as uncontrolled — you MUST feed `onChange`'s doc back into
  *   `value`, or edits won't stick.
  * - ❌ Mutating `value` in place — pass the new doc the transforms return.
- * - ❌ Expecting links / undo — not in this slice; use the keyboard shortcuts or
- *   `toolbar` for marks/blocks/lists and Enter/Backspace for structure.
+ * - ❌ Expecting undo/redo — not in this slice.
+ * - ❌ Hand-rolling a link UI by reaching into the DOM — press ⌘/Ctrl+K or the
+ *   toolbar link button; both open the built-in editor and route through the
+ *   controlled `value`/`onChange` round-trip.
  * - ❌ Building your own toolbar by reaching into the DOM — pass `toolbar`, or
  *   drive marks/blocks through the controlled `value`/`onChange` round-trip.
  */
@@ -228,7 +232,13 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       linkKeyRef.current += 1;
       setLinkEditor(
         existing
-          ? { range: existing.range, href: existing.href, editing: true, anchorRect, key: linkKeyRef.current }
+          ? {
+              range: existing.range,
+              href: existing.href,
+              editing: true,
+              anchorRect,
+              key: linkKeyRef.current,
+            }
           : { range, href: '', editing: false, anchorRect, key: linkKeyRef.current },
       );
     }, []);

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -12,6 +12,8 @@ import clsx from 'clsx';
 import type { RichDoc, Range, Mark, MarkType, Point } from '../RichText/engine/model';
 import { renderDoc } from '../RichText/engine/renderDoc';
 import { blockLength, isCollapsed } from '../RichText/engine/position';
+import { linkAt, setLink, removeLink } from './links';
+import { RichTextLinkEditor } from './RichTextLinkEditor';
 import { insertText } from '../RichText/engine/transforms';
 import { hasMark, withMark, withoutMark } from '../RichText/engine/marks';
 import { useTranslation } from '../../i18n';
@@ -77,6 +79,25 @@ function marksAtCaretMarks(doc: RichDoc, caret: Point): Mark[] {
   return [];
 }
 
+type Rect = { top: number; left: number; height: number; width: number };
+
+/** The viewport rect of the current DOM selection, falling back to the editor root. */
+function selectionRect(root: HTMLElement): Rect {
+  const sel = typeof window !== 'undefined' ? window.getSelection() : null;
+  if (sel && sel.rangeCount > 0) {
+    try {
+      const r = sel.getRangeAt(0).getBoundingClientRect();
+      if (r.width || r.height || r.top || r.left) {
+        return { top: r.top, left: r.left, width: r.width, height: r.height };
+      }
+    } catch {
+      // jsdom does not implement Range.getBoundingClientRect — fall through
+    }
+  }
+  const rr = root.getBoundingClientRect();
+  return { top: rr.top, left: rr.left, width: 0, height: rr.height };
+}
+
 /**
  * Controlled rich-text editor — a contentEditable surface over the in-house
  * engine. Type to edit; ⌘/Ctrl+B/I/U and ⌘/Ctrl+⇧X toggle marks over a
@@ -133,6 +154,17 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     const latest = useRef({ value, onChange, readOnly });
     latest.current = { value, onChange, readOnly };
 
+    // Link editor state.
+    interface LinkEditorOpen {
+      range: Range;
+      href: string;
+      editing: boolean;
+      anchorRect: Rect;
+      key: number;
+    }
+    const [linkEditor, setLinkEditor] = useState<LinkEditorOpen | null>(null);
+    const linkKeyRef = useRef(0);
+
     // Toolbar state: the live selection (tracked via `selectionchange`) and any
     // marks staged at a collapsed caret to apply to the next typed character.
     const [selection, setSelection] = useState<Range | null>(null);
@@ -179,6 +211,58 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       },
       [commit],
     );
+
+    // Open the link editor for the live selection: edit the link under the caret
+    // if there is one (href pre-filled, Remove available), else create over the
+    // selection (or insert at a collapsed caret on Apply).
+    const openLinkEditor = useCallback(() => {
+      if (latest.current.readOnly) return;
+      const root = rootRef.current;
+      if (!root) return;
+      const range = readSelection(root);
+      if (!range) return;
+      const existing = linkAt(latest.current.value, range.focus);
+      const anchorRect = selectionRect(root);
+      linkKeyRef.current += 1;
+      setLinkEditor(
+        existing
+          ? { range: existing.range, href: existing.href, editing: true, anchorRect, key: linkKeyRef.current }
+          : { range, href: '', editing: false, anchorRect, key: linkKeyRef.current },
+      );
+    }, []);
+
+    const onLinkApply = useCallback(
+      (href: string) => {
+        const le = linkEditor;
+        if (!le) return;
+        const trimmed = href.trim();
+        if (trimmed !== '') {
+          commit(setLink(latest.current.value, le.range, trimmed));
+        } else if (le.editing) {
+          commit(removeLink(latest.current.value, le.range));
+        }
+        // empty href while creating → just close (cancel).
+        setLinkEditor(null);
+        rootRef.current?.focus();
+      },
+      [linkEditor, commit],
+    );
+
+    const onLinkRemove = useCallback(() => {
+      const le = linkEditor;
+      if (!le) return;
+      commit(removeLink(latest.current.value, le.range));
+      setLinkEditor(null);
+      rootRef.current?.focus();
+    }, [linkEditor, commit]);
+
+    const onLinkCancel = useCallback(() => {
+      const le = linkEditor;
+      setLinkEditor(null);
+      const root = rootRef.current;
+      if (root && le) writeSelection(root, le.range);
+      root?.focus();
+    }, [linkEditor]);
 
     // Restore the caret/selection after a model-driven re-render.
     useLayoutEffect(() => {
@@ -273,6 +357,13 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         if (!root) return;
         const range = readSelection(root);
         if (!range) return;
+        // ⌘/Ctrl+K opens the link editor (create or edit a link).
+        if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'k') {
+          e.preventDefault();
+          openLinkEditor();
+          return;
+        }
+
         const blockType = deriveCurrentBlock(value, range)?.type;
         const inList = blockType === 'bullet_item' || blockType === 'ordered_item';
 
@@ -303,7 +394,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           return;
         }
       },
-      [value, readOnly, commit, stageOrToggleMark],
+      [value, readOnly, commit, stageOrToggleMark, openLinkEditor],
     );
 
     const onCompositionStart = useCallback(() => {
@@ -338,6 +429,10 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     );
     const toolbarBlock = useMemo<BlockChoice | null>(
       () => (selection ? deriveCurrentBlock(value, selection) : null),
+      [value, selection],
+    );
+    const toolbarLinkActive = useMemo<boolean>(
+      () => (selection ? linkAt(value, selection.focus) != null : false),
       [value, selection],
     );
 
@@ -399,7 +494,27 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       </div>
     );
 
-    if (!toolbar) return editable;
+    const linkBubble =
+      linkEditor && !readOnly ? (
+        <RichTextLinkEditor
+          key={linkEditor.key}
+          href={linkEditor.href}
+          editing={linkEditor.editing}
+          anchorRect={linkEditor.anchorRect}
+          onApply={onLinkApply}
+          onRemove={onLinkRemove}
+          onCancel={onLinkCancel}
+        />
+      ) : null;
+
+    if (!toolbar) {
+      return (
+        <>
+          {editable}
+          {linkBubble}
+        </>
+      );
+    }
     return (
       <div className={styles.shell}>
         <RichTextToolbar
@@ -409,9 +524,11 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           onToggleMark={onToolbarMark}
           onSetBlock={onToolbarSetBlock}
           onToggleList={onToolbarToggleList}
-          onOpenLink={() => {}} // wired in Task 7
+          linkActive={toolbarLinkActive}
+          onOpenLink={openLinkEditor}
         />
         {editable}
+        {linkBubble}
       </div>
     );
   },

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -409,6 +409,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           onToggleMark={onToolbarMark}
           onSetBlock={onToolbarSetBlock}
           onToggleList={onToolbarToggleList}
+          onOpenLink={() => {}} // wired in Task 7
         />
         {editable}
       </div>

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -81,17 +81,26 @@ function marksAtCaretMarks(doc: RichDoc, caret: Point): Mark[] {
 
 type Rect = { top: number; left: number; height: number; width: number };
 
+interface LinkEditorOpen {
+  range: Range;
+  href: string;
+  editing: boolean;
+  anchorRect: Rect;
+  key: number;
+}
+
 /** The viewport rect of the current DOM selection, falling back to the editor root. */
 function selectionRect(root: HTMLElement): Rect {
   const sel = typeof window !== 'undefined' ? window.getSelection() : null;
   if (sel && sel.rangeCount > 0) {
+    let r: DOMRect | null = null;
     try {
-      const r = sel.getRangeAt(0).getBoundingClientRect();
-      if (r.width || r.height || r.top || r.left) {
-        return { top: r.top, left: r.left, width: r.width, height: r.height };
-      }
+      r = sel.getRangeAt(0).getBoundingClientRect();
     } catch {
-      // jsdom does not implement Range.getBoundingClientRect — fall through
+      // jsdom does not implement Range.getBoundingClientRect — fall through.
+    }
+    if (r && (r.width || r.height || r.top || r.left)) {
+      return { top: r.top, left: r.left, width: r.width, height: r.height };
     }
   }
   const rr = root.getBoundingClientRect();
@@ -155,13 +164,6 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     latest.current = { value, onChange, readOnly };
 
     // Link editor state.
-    interface LinkEditorOpen {
-      range: Range;
-      href: string;
-      editing: boolean;
-      anchorRect: Rect;
-      key: number;
-    }
     const [linkEditor, setLinkEditor] = useState<LinkEditorOpen | null>(null);
     const linkKeyRef = useRef(0);
 

--- a/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RichTextLinkEditor } from './RichTextLinkEditor';
+import { I18nProvider } from '../../i18n';
+
+function renderBubble(props: Partial<React.ComponentProps<typeof RichTextLinkEditor>> = {}) {
+  const onApply = vi.fn();
+  const onRemove = vi.fn();
+  const onCancel = vi.fn();
+  render(
+    <I18nProvider locale="en">
+      <RichTextLinkEditor
+        href=""
+        editing={false}
+        anchorRect={{ top: 0, left: 0, width: 0, height: 0 }}
+        onApply={onApply}
+        onRemove={onRemove}
+        onCancel={onCancel}
+        {...props}
+      />
+    </I18nProvider>,
+  );
+  return { onApply, onRemove, onCancel };
+}
+
+describe('RichTextLinkEditor', () => {
+  it('renders a URL field and Apply, no Remove when creating', () => {
+    renderBubble();
+    expect(screen.getByRole('textbox', { name: 'Link URL' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Remove link' })).not.toBeInTheDocument();
+  });
+
+  it('shows Remove and pre-fills the href when editing', () => {
+    renderBubble({ editing: true, href: 'https://x.test' });
+    expect(screen.getByRole('textbox', { name: 'Link URL' })).toHaveValue('https://x.test');
+    expect(screen.getByRole('button', { name: 'Remove link' })).toBeInTheDocument();
+  });
+
+  it('Enter applies the trimmed URL', async () => {
+    const user = userEvent.setup();
+    const { onApply } = renderBubble();
+    await user.type(screen.getByRole('textbox', { name: 'Link URL' }), '  /docs  {Enter}');
+    expect(onApply).toHaveBeenCalledWith('/docs');
+  });
+
+  it('Escape cancels', async () => {
+    const user = userEvent.setup();
+    const { onCancel } = renderBubble();
+    await user.type(screen.getByRole('textbox', { name: 'Link URL' }), '{Escape}');
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('Remove fires onRemove', async () => {
+    const user = userEvent.setup();
+    const { onRemove } = renderBubble({ editing: true, href: '/p' });
+    await user.click(screen.getByRole('button', { name: 'Remove link' }));
+    expect(onRemove).toHaveBeenCalled();
+  });
+
+  it('the bubble is a labelled group', () => {
+    renderBubble();
+    expect(screen.getByRole('group', { name: 'Edit link' })).toBeInTheDocument();
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { RichTextLinkEditor } from './RichTextLinkEditor';
 import { I18nProvider } from '../../i18n';
@@ -61,5 +61,19 @@ describe('RichTextLinkEditor', () => {
   it('the bubble is a labelled group', () => {
     renderBubble();
     expect(screen.getByRole('group', { name: 'Edit link' })).toBeInTheDocument();
+  });
+
+  it('Apply button click applies the URL', async () => {
+    const user = userEvent.setup();
+    const { onApply } = renderBubble();
+    await user.type(screen.getByRole('textbox', { name: 'Link URL' }), 'https://example.com');
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(onApply).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('a pointerdown outside the bubble calls onCancel', () => {
+    const { onCancel } = renderBubble();
+    fireEvent.pointerDown(document.body);
+    expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
@@ -1,0 +1,142 @@
+// RichTextLinkEditor.tsx — the floating link-edit bubble for <RichTextEditor>.
+// Presentational: the editor owns all state and passes the current href + the
+// selection rect; this renders the URL form and positions it at the rect via a
+// Floating UI virtual element (the same portal+virtual-anchor pattern as
+// LiquidEditor's AutocompleteMenu, so it escapes the editor's overflow and any
+// Drawer/Modal ancestor). Enter applies, Esc / click-outside cancels.
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useFloating, autoUpdate, flip, shift, offset } from '@floating-ui/react-dom';
+import { Button } from '../Button';
+import { Input } from '../Input';
+import { Stack } from '../Stack';
+import { Cluster } from '../Cluster';
+import { useTranslation } from '../../i18n';
+import styles from './RichTextEditor.module.scss';
+
+export interface RichTextLinkEditorProps {
+  /** Initial URL value (empty when creating). */
+  href: string;
+  /** Whether an existing link is being edited (shows the Remove button). */
+  editing: boolean;
+  /** Selection rect (viewport coords) the bubble anchors to. */
+  anchorRect: { top: number; left: number; height: number; width: number };
+  /** Apply the (trimmed) URL. */
+  onApply: (href: string) => void;
+  /** Remove the link (only reachable when `editing`). */
+  onRemove: () => void;
+  /** Dismiss without changes (Esc / click-outside). */
+  onCancel: () => void;
+}
+
+/**
+ * Internal floating bubble for editing a link's URL. Rendered by
+ * `<RichTextEditor>` when the link editor is open; not exported from the
+ * package. Remount it (via `key`) per open so the URL field re-seeds from `href`.
+ */
+export function RichTextLinkEditor({
+  href,
+  editing,
+  anchorRect,
+  onApply,
+  onRemove,
+  onCancel,
+}: RichTextLinkEditorProps) {
+  const t = useTranslation();
+  const [value, setValue] = useState(href);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const bubbleRef = useRef<HTMLDivElement | null>(null);
+
+  // Floating UI virtual element — only `getBoundingClientRect` is required.
+  const virtualRef = useMemo(
+    () => ({
+      getBoundingClientRect: () => ({
+        x: anchorRect.left,
+        y: anchorRect.top,
+        top: anchorRect.top,
+        left: anchorRect.left,
+        right: anchorRect.left + anchorRect.width,
+        bottom: anchorRect.top + anchorRect.height,
+        width: anchorRect.width,
+        height: anchorRect.height,
+      }),
+    }),
+    [anchorRect],
+  );
+
+  const { refs, floatingStyles } = useFloating({
+    placement: 'bottom-start',
+    strategy: 'fixed',
+    whileElementsMounted: autoUpdate,
+    middleware: [offset(6), flip(), shift({ padding: 4 })],
+    elements: { reference: virtualRef },
+  });
+
+  // Focus the URL field on open; select its contents when editing so a re-type
+  // replaces the existing href.
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+    input.focus();
+    if (editing) input.select();
+  }, [editing]);
+
+  // Dismiss on a pointerdown outside the bubble.
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      if (bubbleRef.current && !bubbleRef.current.contains(e.target as Node)) onCancel();
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [onCancel]);
+
+  const setRefs = (node: HTMLDivElement | null) => {
+    bubbleRef.current = node;
+    refs.setFloating(node);
+  };
+
+  return createPortal(
+    <div
+      ref={setRefs}
+      className={styles.linkBubble}
+      style={floatingStyles}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          onCancel();
+        }
+      }}
+    >
+      <form
+        role="group"
+        aria-label={t('richTextEditor.linkEditorLabel')}
+        onSubmit={(e) => {
+          e.preventDefault();
+          onApply(value.trim());
+        }}
+      >
+        <Stack gap="xs">
+          <Cluster gap="xs">
+            <Input
+              ref={inputRef}
+              size="sm"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              aria-label={t('richTextEditor.linkUrl')}
+              placeholder={t('richTextEditor.linkUrlPlaceholder')}
+            />
+            <Button type="submit" size="sm" variant="primary">
+              {t('richTextEditor.linkApply')}
+            </Button>
+          </Cluster>
+          {editing ? (
+            <Button type="button" size="sm" variant="danger" onClick={onRemove}>
+              {t('richTextEditor.linkRemove')}
+            </Button>
+          ) : null}
+        </Stack>
+      </form>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
@@ -4,7 +4,7 @@
 // Floating UI virtual element (the same portal+virtual-anchor pattern as
 // LiquidEditor's AutocompleteMenu, so it escapes the editor's overflow and any
 // Drawer/Modal ancestor). Enter applies, Esc / click-outside cancels.
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useFloating, autoUpdate, flip, shift, offset } from '@floating-ui/react-dom';
 import { Button } from '../Button';
@@ -90,10 +90,13 @@ export function RichTextLinkEditor({
     return () => document.removeEventListener('pointerdown', onPointerDown, true);
   }, [onCancel]);
 
-  const setRefs = (node: HTMLDivElement | null) => {
-    bubbleRef.current = node;
-    refs.setFloating(node);
-  };
+  const setRefs = useCallback(
+    (node: HTMLDivElement | null) => {
+      bubbleRef.current = node;
+      refs.setFloating(node);
+    },
+    [refs],
+  );
 
   return createPortal(
     <div
@@ -103,6 +106,7 @@ export function RichTextLinkEditor({
       onKeyDown={(e) => {
         if (e.key === 'Escape') {
           e.preventDefault();
+          e.stopPropagation();
           onCancel();
         }
       }}

--- a/packages/design-system/src/components/RichTextEditor/RichTextToolbar.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextToolbar.test.tsx
@@ -7,6 +7,7 @@ function renderTb(props: Partial<React.ComponentProps<typeof RichTextToolbar>> =
   const onToggleMark = vi.fn();
   const onSetBlock = vi.fn();
   const onToggleList = vi.fn();
+  const onOpenLink = vi.fn();
   render(
     <I18nProvider locale="en">
       <RichTextToolbar
@@ -15,11 +16,12 @@ function renderTb(props: Partial<React.ComponentProps<typeof RichTextToolbar>> =
         onToggleMark={onToggleMark}
         onSetBlock={onSetBlock}
         onToggleList={onToggleList}
+        onOpenLink={onOpenLink}
         {...props}
       />
     </I18nProvider>,
   );
-  return { onToggleMark, onSetBlock, onToggleList };
+  return { onToggleMark, onSetBlock, onToggleList, onOpenLink };
 }
 
 describe('RichTextToolbar', () => {
@@ -78,5 +80,27 @@ describe('RichTextToolbar', () => {
     expect(screen.getByRole('button', { name: 'Bold' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Numbered list' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Text style' })).toBeDisabled();
+  });
+
+  it('renders a Link button', () => {
+    renderTb();
+    expect(screen.getByRole('button', { name: 'Link' })).toBeInTheDocument();
+  });
+
+  it('reflects linkActive via aria-pressed', () => {
+    renderTb({ linkActive: true });
+    expect(screen.getByRole('button', { name: 'Link' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('fires onOpenLink when the Link button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onOpenLink } = renderTb();
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+    expect(onOpenLink).toHaveBeenCalled();
+  });
+
+  it('disables the Link button when disabled', () => {
+    renderTb({ disabled: true });
+    expect(screen.getByRole('button', { name: 'Link' })).toBeDisabled();
   });
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextToolbar.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextToolbar.tsx
@@ -10,6 +10,7 @@ import {
   StrikeIcon,
   BulletListIcon,
   OrderedListIcon,
+  LinkIcon,
 } from './icons';
 import styles from './RichTextEditor.module.scss';
 
@@ -29,6 +30,10 @@ export interface RichTextToolbarProps {
   onSetBlock: (choice: BlockChoice) => void;
   /** Toggle the selected blocks into/out of a bullet or numbered list. */
   onToggleList: (listType: 'bullet_item' | 'ordered_item') => void;
+  /** Whether the current selection sits inside a link (drives the Link button's pressed state). */
+  linkActive?: boolean;
+  /** Open the link editor for the current selection. */
+  onOpenLink: () => void;
 }
 
 const MARKS: {
@@ -65,6 +70,8 @@ export function RichTextToolbar({
   onToggleMark,
   onSetBlock,
   onToggleList,
+  linkActive = false,
+  onOpenLink,
 }: RichTextToolbarProps) {
   const t = useTranslation();
 
@@ -145,6 +152,21 @@ export function RichTextToolbar({
           </Button>
         );
       })}
+
+      <Button
+        size="sm"
+        variant={linkActive ? 'secondary' : 'ghost'}
+        iconOnly
+        aria-label={t('richTextEditor.link')}
+        aria-pressed={linkActive}
+        disabled={disabled}
+        // Preserve the editor's DOM selection (a mousedown that moves focus out
+        // of the contentEditable would collapse it before the bubble opens).
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={onOpenLink}
+      >
+        <LinkIcon />
+      </Button>
 
       <span className={styles.toolbarSep} aria-hidden="true" />
 

--- a/packages/design-system/src/components/RichTextEditor/icons.tsx
+++ b/packages/design-system/src/components/RichTextEditor/icons.tsx
@@ -70,3 +70,11 @@ export function OrderedListIcon() {
     </svg>
   );
 }
+export function LinkIcon() {
+  return (
+    <svg {...base}>
+      <path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07l-1.41 1.41" />
+      <path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 0 0 7.07 7.07l1.41-1.41" />
+    </svg>
+  );
+}

--- a/packages/design-system/src/components/RichTextEditor/links.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/links.test.ts
@@ -1,0 +1,133 @@
+import { linkAt, setLink, removeLink } from './links';
+import { createBlock } from '../RichText/engine/model';
+import type { RichDoc, Range, Inline } from '../RichText/engine/model';
+
+const at = (blockId: string, offset: number) => ({ blockId, offset });
+const span = (
+  a: { blockId: string; offset: number },
+  f: { blockId: string; offset: number },
+): Range => ({ anchor: a, focus: f });
+const bold = { type: 'bold' as const };
+const link = (href: string) => ({ type: 'link' as const, href });
+
+function para(id: string, inlines: Inline[]): RichDoc['blocks'][number] {
+  return { id, type: 'paragraph', inlines };
+}
+
+describe('linkAt', () => {
+  it('caret inside a link → its href + full contiguous extent', () => {
+    const doc: RichDoc = {
+      blocks: [
+        para('a', [
+          { text: 'go ', marks: [] },
+          { text: 'home', marks: [link('/home')] },
+          { text: ' now', marks: [] },
+        ]),
+      ],
+    };
+    expect(linkAt(doc, at('a', 5))).toEqual({ href: '/home', range: span(at('a', 3), at('a', 7)) });
+  });
+
+  it('caret outside any link → null', () => {
+    const doc: RichDoc = { blocks: [para('a', [{ text: 'plain', marks: [] }])] };
+    expect(linkAt(doc, at('a', 2))).toBeNull();
+  });
+
+  it('caret at the link trailing boundary (block end) resolves to the link', () => {
+    const doc: RichDoc = {
+      blocks: [
+        para('a', [
+          { text: 'x', marks: [] },
+          { text: 'link', marks: [link('/p')] },
+        ]),
+      ],
+    };
+    expect(linkAt(doc, at('a', 5))).toEqual({ href: '/p', range: span(at('a', 1), at('a', 5)) });
+  });
+
+  it('two adjacent links with different hrefs stay separate', () => {
+    const doc: RichDoc = {
+      blocks: [
+        para('a', [
+          { text: 'aa', marks: [link('/1')] },
+          { text: 'bb', marks: [link('/2')] },
+        ]),
+      ],
+    };
+    expect(linkAt(doc, at('a', 1))).toEqual({ href: '/1', range: span(at('a', 0), at('a', 2)) });
+    expect(linkAt(doc, at('a', 3))).toEqual({ href: '/2', range: span(at('a', 2), at('a', 4)) });
+  });
+
+  it('caret at offset 0 of a leading non-link run → null', () => {
+    const doc: RichDoc = { blocks: [para('a', [{ text: 'hi', marks: [] }])] };
+    expect(linkAt(doc, at('a', 0))).toBeNull();
+  });
+
+  it('unknown block id → null', () => {
+    const doc: RichDoc = { blocks: [createBlock('paragraph', 'x', { id: 'a' })] };
+    expect(linkAt(doc, at('zzz', 0))).toBeNull();
+  });
+});
+
+describe('removeLink', () => {
+  it('strips the link over the range, keeping other marks', () => {
+    const doc: RichDoc = { blocks: [para('a', [{ text: 'hi', marks: [link('/p'), bold] }])] };
+    const r = removeLink(doc, span(at('a', 0), at('a', 2)));
+    expect(r.doc.blocks[0].inlines).toEqual([{ text: 'hi', marks: [bold] }]);
+    expect(r.selection).toEqual(span(at('a', 0), at('a', 2)));
+  });
+});
+
+describe('setLink', () => {
+  it('case 1 — non-collapsed selection gets the link mark', () => {
+    const doc: RichDoc = { blocks: [createBlock('paragraph', 'abcd', { id: 'a' })] };
+    const r = setLink(doc, span(at('a', 0), at('a', 4)), '/p');
+    expect(r.doc.blocks[0].inlines).toEqual([{ text: 'abcd', marks: [link('/p')] }]);
+    expect(r.selection).toEqual(span(at('a', 0), at('a', 4)));
+  });
+
+  it('case 1 — re-applying replaces the href (no stacking)', () => {
+    const doc: RichDoc = { blocks: [para('a', [{ text: 'abcd', marks: [link('/old')] }])] };
+    const r = setLink(doc, span(at('a', 0), at('a', 4)), '/new');
+    expect(r.doc.blocks[0].inlines).toEqual([{ text: 'abcd', marks: [link('/new')] }]);
+  });
+
+  it('case 2 — collapsed caret in a link re-links its full extent', () => {
+    const doc: RichDoc = {
+      blocks: [
+        para('a', [
+          { text: 'go ', marks: [] },
+          { text: 'home', marks: [link('/old')] },
+        ]),
+      ],
+    };
+    const r = setLink(doc, span(at('a', 5), at('a', 5)), '/new');
+    expect(r.doc.blocks[0].inlines).toEqual([
+      { text: 'go ', marks: [] },
+      { text: 'home', marks: [link('/new')] },
+    ]);
+    expect(r.selection).toEqual(span(at('a', 3), at('a', 7)));
+  });
+
+  it('case 3 — collapsed caret elsewhere inserts the href as linked text', () => {
+    const doc: RichDoc = { blocks: [createBlock('paragraph', 'go ', { id: 'a' })] };
+    const r = setLink(doc, span(at('a', 3), at('a', 3)), '/p');
+    expect(r.doc.blocks[0].inlines).toEqual([
+      { text: 'go ', marks: [] },
+      { text: '/p', marks: [link('/p')] },
+    ]);
+    expect(r.selection).toEqual(span(at('a', 3), at('a', 5)));
+  });
+
+  it('empty href — removes an existing link at a collapsed caret', () => {
+    const doc: RichDoc = { blocks: [para('a', [{ text: 'home', marks: [link('/p')] }])] };
+    const r = setLink(doc, span(at('a', 2), at('a', 2)), '  ');
+    expect(r.doc.blocks[0].inlines).toEqual([{ text: 'home', marks: [] }]);
+  });
+
+  it('empty href — no-op when there is nothing to link', () => {
+    const doc: RichDoc = { blocks: [createBlock('paragraph', 'plain', { id: 'a' })] };
+    const r = setLink(doc, span(at('a', 2), at('a', 2)), '');
+    expect(r.doc).toBe(doc);
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/links.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/links.test.ts
@@ -130,4 +130,10 @@ describe('setLink', () => {
     const r = setLink(doc, span(at('a', 2), at('a', 2)), '');
     expect(r.doc).toBe(doc);
   });
+
+  it('empty href — non-collapsed selection removes the link', () => {
+    const doc: RichDoc = { blocks: [para('a', [{ text: 'hi', marks: [link('/p')] }])] };
+    const r = setLink(doc, span(at('a', 0), at('a', 2)), '');
+    expect(r.doc.blocks[0].inlines).toEqual([{ text: 'hi', marks: [] }]);
+  });
 });

--- a/packages/design-system/src/components/RichTextEditor/links.ts
+++ b/packages/design-system/src/components/RichTextEditor/links.ts
@@ -40,7 +40,10 @@ export function linkAt(doc: RichDoc, point: Point): LinkAtResult | null {
   while (end < len && hrefs[end] === href) end += 1;
   return {
     href,
-    range: { anchor: { blockId: block.id, offset: start }, focus: { blockId: block.id, offset: end } },
+    range: {
+      anchor: { blockId: block.id, offset: start },
+      focus: { blockId: block.id, offset: end },
+    },
   };
 }
 

--- a/packages/design-system/src/components/RichTextEditor/links.ts
+++ b/packages/design-system/src/components/RichTextEditor/links.ts
@@ -1,0 +1,92 @@
+// links.ts — pure link commands for <RichTextEditor>. No DOM, no React. Each
+// command composes the engine's existing mark/text transforms; `setLink` covers
+// the three link cases (selection / caret-in-link / caret-elsewhere). Safety of
+// the stored href is enforced at render time by the engine's `safeHref`.
+import type { RichDoc, Range, Point, Mark } from '../RichText/engine/model';
+import { applyMark, removeMark, insertText } from '../RichText/engine/transforms';
+import { findBlockIndex, blockLength, isCollapsed } from '../RichText/engine/position';
+
+/** The link covering a point: its href and the full contiguous same-href range. */
+export interface LinkAtResult {
+  href: string;
+  range: Range;
+}
+
+/**
+ * The link at a (collapsed) point: its href and the full contiguous run of
+ * characters sharing that exact href, or `null` when the point is not in a link.
+ * The owning character is the one at `offset`, or the one before it when the
+ * caret sits at the block's end (so a caret just after a link still resolves).
+ */
+export function linkAt(doc: RichDoc, point: Point): LinkAtResult | null {
+  const idx = findBlockIndex(doc, point.blockId);
+  if (idx === -1) return null;
+  const block = doc.blocks[idx];
+  const len = blockLength(block);
+  // Per-character link href across the block (null where no link).
+  const hrefs: (string | null)[] = [];
+  for (const run of block.inlines) {
+    const mark = run.marks.find((m) => m.type === 'link');
+    const href = mark && mark.type === 'link' ? mark.href : null;
+    for (let i = 0; i < run.text.length; i += 1) hrefs.push(href);
+  }
+  const probe = point.offset < len ? point.offset : point.offset - 1;
+  if (probe < 0 || probe >= len) return null;
+  const href = hrefs[probe];
+  if (href === null) return null;
+  let start = probe;
+  while (start > 0 && hrefs[start - 1] === href) start -= 1;
+  let end = probe + 1;
+  while (end < len && hrefs[end] === href) end += 1;
+  return {
+    href,
+    range: { anchor: { blockId: block.id, offset: start }, focus: { blockId: block.id, offset: end } },
+  };
+}
+
+/** Remove the link mark over `range`. */
+export function removeLink(doc: RichDoc, range: Range): { doc: RichDoc; selection: Range } {
+  return removeMark(doc, range, 'link');
+}
+
+/**
+ * Apply, update, or insert a link over `range`. Three cases, decided by
+ * `isCollapsed` + `linkAt`:
+ * 1. Non-collapsed selection → link it (replacing any existing href).
+ * 2. Collapsed caret inside a link → re-link the link's full extent.
+ * 3. Collapsed caret elsewhere → insert the href as linked text.
+ * An empty/whitespace href removes an existing link (cases 1–2) or is a no-op
+ * (case 3). `href` is trimmed but otherwise stored verbatim — `safeHref`
+ * sanitizes at render time. Returns the `{ doc, selection }` commit payload.
+ */
+export function setLink(
+  doc: RichDoc,
+  range: Range,
+  href: string,
+): { doc: RichDoc; selection: Range } {
+  const trimmed = href.trim();
+  const collapsed = isCollapsed(range);
+
+  if (trimmed === '') {
+    if (!collapsed) return removeLink(doc, range);
+    const existing = linkAt(doc, range.anchor);
+    return existing ? removeLink(doc, existing.range) : { doc, selection: range };
+  }
+
+  const mark: Mark = { type: 'link', href: trimmed };
+
+  // Case 1 — selection.
+  if (!collapsed) return applyMark(doc, range, mark);
+
+  // Case 2 — caret inside an existing link.
+  const existing = linkAt(doc, range.anchor);
+  if (existing) return applyMark(doc, existing.range, mark);
+
+  // Case 3 — caret elsewhere: insert the href, then link the inserted span.
+  const inserted = insertText(doc, range.anchor, trimmed);
+  const linkedSpan: Range = {
+    anchor: range.anchor,
+    focus: { blockId: range.anchor.blockId, offset: range.anchor.offset + trimmed.length },
+  };
+  return applyMark(inserted.doc, linkedSpan, mark);
+}

--- a/packages/design-system/src/components/RichTextEditor/links.ts
+++ b/packages/design-system/src/components/RichTextEditor/links.ts
@@ -13,7 +13,7 @@ export interface LinkAtResult {
 }
 
 /**
- * The link at a (collapsed) point: its href and the full contiguous run of
+ * The link at a point: its href and the full contiguous run of
  * characters sharing that exact href, or `null` when the point is not in a link.
  * The owning character is the one at `offset`, or the one before it when the
  * caret sits at the block's end (so a caret just after a link still resolves).
@@ -88,5 +88,7 @@ export function setLink(
     anchor: range.anchor,
     focus: { blockId: range.anchor.blockId, offset: range.anchor.offset + trimmed.length },
   };
+  // Select the inserted link text (not a collapsed caret after it) so the user
+  // sees the link that was just created.
   return applyMark(inserted.doc, linkedSpan, mark);
 }

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -189,5 +189,11 @@ export const en: Messages = {
     strike: 'Strikethrough',
     bulletList: 'Bullet list',
     orderedList: 'Numbered list',
+    link: 'Link',
+    linkUrl: 'Link URL',
+    linkUrlPlaceholder: 'https://… or /path',
+    linkApply: 'Apply',
+    linkRemove: 'Remove link',
+    linkEditorLabel: 'Edit link',
   },
 };

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -309,6 +309,18 @@ export interface Messages {
     bulletList: string;
     /** aria-label on the numbered-list toggle button. */
     orderedList: string;
+    /** aria-label on the toolbar Link button. */
+    link: string;
+    /** Label (aria) for the URL field in the link bubble. */
+    linkUrl: string;
+    /** Placeholder for the URL field in the link bubble. */
+    linkUrlPlaceholder: string;
+    /** Apply button in the link bubble. */
+    linkApply: string;
+    /** Remove-link button in the link bubble (shown when editing a link). */
+    linkRemove: string;
+    /** Accessible name for the link bubble's form group. */
+    linkEditorLabel: string;
   };
 }
 

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -191,5 +191,11 @@ export const ru: Messages = {
     strike: 'Зачёркнутый',
     bulletList: 'Маркированный список',
     orderedList: 'Нумерованный список',
+    link: 'Ссылка',
+    linkUrl: 'URL ссылки',
+    linkUrlPlaceholder: 'https://… или /path',
+    linkApply: 'Применить',
+    linkRemove: 'Удалить ссылку',
+    linkEditorLabel: 'Редактирование ссылки',
   },
 };

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -6,6 +6,7 @@ import { getComponentFiles } from '../../lib/componentFiles';
 
 export function RichTextEditorDemo() {
   const [doc, setDoc] = useState<RichDoc>(docFromText('Type here. Select a word and press ⌘B.'));
+  const [linkDoc, setLinkDoc] = useState<RichDoc>(docFromText('Read the docs and visit our site.'));
 
   return (
     <DemoLayout
@@ -26,6 +27,20 @@ export function RichTextEditorDemo() {
             Toolbar + shortcuts: ⌘/Ctrl+B bold · I italic · U underline · ⇧X strike
           </Text>
         </Stack>
+      </Example>
+
+      <Example
+        title="Links"
+        description="Select text and press ⌘/Ctrl+K (or the toolbar link button) to open the link editor; type a URL and Apply. With the caret inside a link the URL is pre-filled and Remove appears. With no selection, the URL is inserted as linked text. Esc or a click outside cancels."
+        code={`const [doc, setDoc] = useState(docFromText('…'));
+<RichTextEditor value={doc} onChange={setDoc} toolbar />`}
+      >
+        <RichTextEditor
+          value={linkDoc}
+          onChange={setLinkDoc}
+          toolbar
+          placeholder="Select text, then ⌘K…"
+        />
       </Example>
 
       <Example


### PR DESCRIPTION
Adds inline hyperlink editing to `<RichTextEditor>` (Slice 4 of the WYSIWYG roadmap). A toolbar **Link** button and **⌘/Ctrl+K** open a selection-anchored floating bubble to create, edit, or remove a link.

Spec: `docs/superpowers/specs/2026-06-18-richtext-editor-links-design.md` · Plan: `docs/superpowers/plans/2026-06-18-richtext-editor-links.md`

## Summary

- **`links.ts`** — pure commands `linkAt` / `setLink` / `removeLink`, composing the existing engine transforms (no new engine ops). `setLink` covers three cases: selection → link it; caret-in-link → re-link the full extent (updates href); collapsed-elsewhere → insert the URL as linked text. Empty href removes (when editing) or no-ops.
- **`RichTextLinkEditor.tsx`** — internal floating bubble (URL `Input` + Apply / Remove `Button`s), portaled + positioned at the selection rect via a Floating UI virtual element (the `AutocompleteMenu` pattern). Enter applies, Esc / click-outside cancels, autofocus on open.
- **Editor + toolbar wiring** — `linkEditor` open-state, ⌘K, toolbar Link button (`aria-pressed` when the caret is in a link), apply/remove/cancel routed through the existing `commit({ doc, selection })` path with DOM selection capture/restore. ⌘K stops propagation so it doesn't also trigger a host app's global ⌘K (command palette / search).
- **Safety** — stored hrefs are sanitized at render time by the engine's existing `safeHref` (blocks `javascript:`/`data:`/protocol-relative); no second sanitizer.
- Six new i18n keys (en + ru), a `LinkIcon`, a links example in the demo, JSDoc `@remarks` + `AGENTS.md` notes, and a regenerated component manifest (the bubble composes `Input`/`Stack`/`Cluster`).

Internal-only: `links.ts` and `RichTextLinkEditor.tsx` are not added to `src/index.ts` — no new public export, no new demo page.

## Test plan

- **Unit (jsdom):** `links.test.ts` (14 — linkAt boundaries, setLink's 3 cases + empty-href, removeLink), `RichTextLinkEditor.test.tsx` (8 — render/edit/Enter/Esc/Remove/click-outside/group label), `RichTextToolbar.test.tsx` (Link button + aria-pressed + onOpenLink + disabled), `RichTextEditor.test.tsx` (toolbar Link button, open-from-toolbar, ⌘K does not leak to a host key handler). Full suite green.
- **Gates:** `make test` · `make build-lib` · `make lint` · `npm run format:check` all pass; `npm pack --dry-run` shows 0 test/internal leaks; manifest in sync.
- **Browser (Playwright, manual — the caret flows jsdom can't cover):** select-text → ⌘K → type URL → Enter renders an `<a>`; caret-in-link → ⌘K pre-fills URL + shows Remove → edit → Apply updates href over the whole link; Remove strips the link, keeps text; collapsed caret → ⌘K → URL inserted as linked text; Esc closes + restores focus with no model change; `javascript:` href applies the mark but renders with **no** `href` (safeHref drops it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)