### PR TITLE
feat(RichText): import — fromHtml / fromMarkdown + rich-HTML paste

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -933,6 +933,8 @@ const [doc, setDoc] = useState(emptyDoc());
 
 **Links:** select text and press ⌘/Ctrl+K (or the toolbar link button) to add or edit a link; with the caret inside a link the URL is pre-filled and a Remove button appears; with no selection the URL is inserted as linked text. Esc / click-outside cancels. Stored hrefs are sanitized at render time (`safeHref` blocks `javascript:`/`data:`/protocol-relative).
 
+**Import:** `fromHtml(html)` and `fromMarkdown(md)` parse a string into a `RichDoc` (e.g. to seed `value` from stored/legacy content). Pasting rich HTML into the editor imports it as formatted content (parsed + sanitized). Markdown import is via `fromMarkdown` only — pasted plain text (incl. Markdown source) inserts literally. Both `from*` functions require a DOM environment (`DOMParser`); Markdown has no underline syntax and images/tables aren't modeled.
+
 When NOT to use: read-only display → `<RichText>`. No undo/redo yet (later slice). It's controlled — render `onChange`'s doc back into `value`, never mutate in place.
 
 ### `<ImageCrop>` — controlled image cropper

--- a/packages/design-system/src/components/RichText/engine/fromHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/fromHtml.test.ts
@@ -117,6 +117,11 @@ describe('fromHtml — inline marks', () => {
     expect(bad.blocks[0].inlines).toEqual([{ text: 't', marks: [] }]);
   });
 
+  it('drops a tab-obfuscated javascript: href but keeps the text', () => {
+    const d = fromHtml('<p><a href="java\tscript:alert(1)">x</a></p>');
+    expect(d.blocks[0].inlines).toEqual([{ text: 'x', marks: [] }]);
+  });
+
   it('recovers bold/italic/underline/strike from inline CSS (Word/Docs)', () => {
     const d = fromHtml(
       '<p><span style="font-weight:700">b</span><span style="font-style:italic">i</span><span style="text-decoration:underline">u</span><span style="text-decoration:line-through">s</span></p>',

--- a/packages/design-system/src/components/RichText/engine/fromHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/fromHtml.test.ts
@@ -71,6 +71,21 @@ describe('fromHtml — blocks', () => {
     expect(fromHtml('   \n  ').blocks.length).toBe(1);
     expect(runsText(fromHtml('   ').blocks[0].inlines)).toBe('');
   });
+
+  it('drops SVG and MathML foreign content (including embedded script text)', () => {
+    expect(
+      fromHtml('<p>a</p><svg><text>x</text><script>bad()</script></svg><p>b</p>').blocks.map(text),
+    ).toEqual(['a', 'b']);
+    expect(
+      fromHtml('<p>a</p><math><mn>42</mn></math><p>b</p>').blocks.map(text),
+    ).toEqual(['a', 'b']);
+  });
+
+  it('drops <noscript> content', () => {
+    expect(
+      fromHtml('<p>a</p><noscript><p>hidden</p></noscript><p>b</p>').blocks.map(text),
+    ).toEqual(['a', 'b']);
+  });
 });
 
 describe('fromHtml — inline marks', () => {

--- a/packages/design-system/src/components/RichText/engine/fromHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/fromHtml.test.ts
@@ -52,7 +52,9 @@ describe('fromHtml — blocks', () => {
   });
 
   it('drops script/style/table/img/hr', () => {
-    const d = fromHtml('<p>a</p><script>bad()</script><style>x{}</style><table><tr><td>t</td></tr></table><img src="x"><hr><p>b</p>');
+    const d = fromHtml(
+      '<p>a</p><script>bad()</script><style>x{}</style><table><tr><td>t</td></tr></table><img src="x"><hr><p>b</p>',
+    );
     expect(d.blocks.map(text)).toEqual(['a', 'b']);
   });
 
@@ -76,15 +78,16 @@ describe('fromHtml — blocks', () => {
     expect(
       fromHtml('<p>a</p><svg><text>x</text><script>bad()</script></svg><p>b</p>').blocks.map(text),
     ).toEqual(['a', 'b']);
-    expect(
-      fromHtml('<p>a</p><math><mn>42</mn></math><p>b</p>').blocks.map(text),
-    ).toEqual(['a', 'b']);
+    expect(fromHtml('<p>a</p><math><mn>42</mn></math><p>b</p>').blocks.map(text)).toEqual([
+      'a',
+      'b',
+    ]);
   });
 
   it('drops <noscript> content', () => {
-    expect(
-      fromHtml('<p>a</p><noscript><p>hidden</p></noscript><p>b</p>').blocks.map(text),
-    ).toEqual(['a', 'b']);
+    expect(fromHtml('<p>a</p><noscript><p>hidden</p></noscript><p>b</p>').blocks.map(text)).toEqual(
+      ['a', 'b'],
+    );
   });
 });
 
@@ -115,7 +118,9 @@ describe('fromHtml — inline marks', () => {
   });
 
   it('recovers bold/italic/underline/strike from inline CSS (Word/Docs)', () => {
-    const d = fromHtml('<p><span style="font-weight:700">b</span><span style="font-style:italic">i</span><span style="text-decoration:underline">u</span><span style="text-decoration:line-through">s</span></p>');
+    const d = fromHtml(
+      '<p><span style="font-weight:700">b</span><span style="font-style:italic">i</span><span style="text-decoration:underline">u</span><span style="text-decoration:line-through">s</span></p>',
+    );
     expect(d.blocks[0].inlines).toEqual([
       { text: 'b', marks: [{ type: 'bold' }] },
       { text: 'i', marks: [{ type: 'italic' }] },

--- a/packages/design-system/src/components/RichText/engine/fromHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/fromHtml.test.ts
@@ -1,0 +1,116 @@
+import { fromHtml } from './fromHtml';
+import { runsText } from './inlines';
+import type { Block } from './model';
+
+const text = (b: Block) => runsText(b.inlines);
+
+describe('fromHtml — blocks', () => {
+  it('maps headings (h4–h6 clamp to level 3) and paragraphs', () => {
+    const d = fromHtml('<h1>A</h1><h2>B</h2><h5>C</h5><p>D</p>');
+    expect(d.blocks.map((b) => [b.type, b.level, text(b)])).toEqual([
+      ['heading', 1, 'A'],
+      ['heading', 2, 'B'],
+      ['heading', 3, 'C'],
+      ['paragraph', undefined, 'D'],
+    ]);
+  });
+
+  it('maps a blockquote (inner paragraphs → blockquote blocks)', () => {
+    const d = fromHtml('<blockquote><p>one</p><p>two</p></blockquote>');
+    expect(d.blocks.map((b) => [b.type, text(b)])).toEqual([
+      ['blockquote', 'one'],
+      ['blockquote', 'two'],
+    ]);
+  });
+
+  it('maps pre/code to a code_block preserving whitespace', () => {
+    const d = fromHtml('<pre><code>a\n  b</code></pre>');
+    expect(d.blocks[0].type).toBe('code_block');
+    expect(text(d.blocks[0])).toBe('a\n  b');
+  });
+
+  it('maps nested lists to flat items with depth', () => {
+    const d = fromHtml('<ul><li>a<ul><li>b</li></ul></li><li>c</li></ul>');
+    expect(d.blocks.map((b) => [b.type, b.depth, text(b)])).toEqual([
+      ['bullet_item', 0, 'a'],
+      ['bullet_item', 1, 'b'],
+      ['bullet_item', 0, 'c'],
+    ]);
+  });
+
+  it('uses ordered_item for <ol>', () => {
+    const d = fromHtml('<ol><li>a</li></ol>');
+    expect(d.blocks[0].type).toBe('ordered_item');
+  });
+
+  it('unwraps unknown containers and wraps loose text in a paragraph', () => {
+    const d = fromHtml('<div><p>x</p></div>loose');
+    expect(d.blocks.map((b) => [b.type, text(b)])).toEqual([
+      ['paragraph', 'x'],
+      ['paragraph', 'loose'],
+    ]);
+  });
+
+  it('drops script/style/table/img/hr', () => {
+    const d = fromHtml('<p>a</p><script>bad()</script><style>x{}</style><table><tr><td>t</td></tr></table><img src="x"><hr><p>b</p>');
+    expect(d.blocks.map(text)).toEqual(['a', 'b']);
+  });
+
+  it('splits a <br> into separate blocks', () => {
+    const d = fromHtml('<p>a<br>b</p>');
+    expect(d.blocks.map((b) => [b.type, text(b)])).toEqual([
+      ['paragraph', 'a'],
+      ['paragraph', 'b'],
+    ]);
+  });
+
+  it('returns emptyDoc for empty/whitespace input', () => {
+    expect(fromHtml('').blocks).toEqual([
+      { id: expect.any(String), type: 'paragraph', inlines: [{ text: '', marks: [] }] },
+    ]);
+    expect(fromHtml('   \n  ').blocks.length).toBe(1);
+    expect(runsText(fromHtml('   ').blocks[0].inlines)).toBe('');
+  });
+});
+
+describe('fromHtml — inline marks', () => {
+  it('maps semantic inline tags to marks', () => {
+    const d = fromHtml('<p><strong>b</strong><em>i</em><u>u</u><s>s</s><code>c</code></p>');
+    expect(d.blocks[0].inlines).toEqual([
+      { text: 'b', marks: [{ type: 'bold' }] },
+      { text: 'i', marks: [{ type: 'italic' }] },
+      { text: 'u', marks: [{ type: 'underline' }] },
+      { text: 's', marks: [{ type: 'strike' }] },
+      { text: 'c', marks: [{ type: 'code' }] },
+    ]);
+  });
+
+  it('combines nested marks', () => {
+    const d = fromHtml('<p><strong><em>x</em></strong></p>');
+    expect(d.blocks[0].inlines).toEqual([
+      { text: 'x', marks: [{ type: 'bold' }, { type: 'italic' }] },
+    ]);
+  });
+
+  it('maps a[href] to a link via safeHref, dropping unsafe hrefs but keeping text', () => {
+    const ok = fromHtml('<p><a href="/x">t</a></p>');
+    expect(ok.blocks[0].inlines).toEqual([{ text: 't', marks: [{ type: 'link', href: '/x' }] }]);
+    const bad = fromHtml('<p><a href="javascript:alert(1)">t</a></p>');
+    expect(bad.blocks[0].inlines).toEqual([{ text: 't', marks: [] }]);
+  });
+
+  it('recovers bold/italic/underline/strike from inline CSS (Word/Docs)', () => {
+    const d = fromHtml('<p><span style="font-weight:700">b</span><span style="font-style:italic">i</span><span style="text-decoration:underline">u</span><span style="text-decoration:line-through">s</span></p>');
+    expect(d.blocks[0].inlines).toEqual([
+      { text: 'b', marks: [{ type: 'bold' }] },
+      { text: 'i', marks: [{ type: 'italic' }] },
+      { text: 'u', marks: [{ type: 'underline' }] },
+      { text: 's', marks: [{ type: 'strike' }] },
+    ]);
+  });
+
+  it('collapses whitespace and trims block edges', () => {
+    const d = fromHtml('<p>  a   b  </p>');
+    expect(text(d.blocks[0])).toBe('a b');
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/fromHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/fromHtml.ts
@@ -7,6 +7,7 @@ import type { RichDoc, Block, Inline, Mark, BlockType } from './model';
 import { nextId, emptyDoc } from './model';
 import { normalizeInlines } from './inlines';
 import { safeHref } from './safeHref';
+import { withMark } from './marks';
 
 const HEADING_LEVEL: Record<string, 1 | 2 | 3> = { H1: 1, H2: 2, H3: 3, H4: 3, H5: 3, H6: 3 };
 
@@ -25,15 +26,14 @@ const DROP_TAGS = new Set([
   'HR', 'FORM', 'INPUT', 'SELECT', 'TEXTAREA', 'BUTTON', 'LABEL', 'FIGURE',
 ]);
 
-const isElement = (n: Node): n is HTMLElement => n.nodeType === 1;
+const HTML_NS = 'http://www.w3.org/1999/xhtml';
+// Only HTML-namespace elements are walked; SVG/MathML foreign content (which has
+// lowercase tagNames the uppercase allowlists would miss) is dropped entirely.
+const isElement = (n: Node): n is HTMLElement =>
+  n.nodeType === 1 && (n as Element).namespaceURI === HTML_NS;
 const isText = (n: Node): n is Text => n.nodeType === 3;
 
 const collapseWs = (s: string): string => s.replace(/\s+/g, ' ');
-
-/** Replace a same-type mark (e.g. nested links), else append. */
-function addMark(marks: Mark[], mark: Mark): Mark[] {
-  return [...marks.filter((m) => m.type !== mark.type), mark];
-}
 
 /** Marks active for the descendants of `el`: parent ∪ tag mark ∪ link ∪ inline CSS. */
 function marksFor(el: HTMLElement, parent: Mark[]): Mark[] {
@@ -41,26 +41,26 @@ function marksFor(el: HTMLElement, parent: Mark[]): Mark[] {
   switch (el.tagName) {
     case 'STRONG':
     case 'B':
-      marks = addMark(marks, { type: 'bold' });
+      marks = withMark(marks, { type: 'bold' });
       break;
     case 'EM':
     case 'I':
-      marks = addMark(marks, { type: 'italic' });
+      marks = withMark(marks, { type: 'italic' });
       break;
     case 'U':
-      marks = addMark(marks, { type: 'underline' });
+      marks = withMark(marks, { type: 'underline' });
       break;
     case 'S':
     case 'DEL':
     case 'STRIKE':
-      marks = addMark(marks, { type: 'strike' });
+      marks = withMark(marks, { type: 'strike' });
       break;
     case 'CODE':
-      marks = addMark(marks, { type: 'code' });
+      marks = withMark(marks, { type: 'code' });
       break;
     case 'A': {
       const href = safeHref(el.getAttribute('href') ?? '');
-      if (href !== undefined) marks = addMark(marks, { type: 'link', href });
+      if (href !== undefined) marks = withMark(marks, { type: 'link', href });
       break;
     }
   }
@@ -74,13 +74,13 @@ function applyCssMarks(el: HTMLElement, marks: Mark[]): Mark[] {
   const s = style.toLowerCase();
   const weight = /font-weight\s*:\s*(\d+|bold|bolder)/.exec(s);
   if (weight && (weight[1] === 'bold' || weight[1] === 'bolder' || Number(weight[1]) >= 600)) {
-    marks = addMark(marks, { type: 'bold' });
+    marks = withMark(marks, { type: 'bold' });
   }
-  if (/font-style\s*:\s*(italic|oblique)/.test(s)) marks = addMark(marks, { type: 'italic' });
+  if (/font-style\s*:\s*(italic|oblique)/.test(s)) marks = withMark(marks, { type: 'italic' });
   const deco = /text-decoration(?:-line)?\s*:\s*([^;]+)/.exec(s);
   if (deco) {
-    if (deco[1].includes('underline')) marks = addMark(marks, { type: 'underline' });
-    if (deco[1].includes('line-through')) marks = addMark(marks, { type: 'strike' });
+    if (deco[1].includes('underline')) marks = withMark(marks, { type: 'underline' });
+    if (deco[1].includes('line-through')) marks = withMark(marks, { type: 'strike' });
   }
   return marks;
 }
@@ -225,6 +225,9 @@ function collectBlocks(parent: Node, out: Block[], listDepth: number): void {
  */
 export function fromHtml(html: string): RichDoc {
   const parsed = new DOMParser().parseFromString(html, 'text/html');
+  // DOMParser disables scripting, so <noscript> children are promoted into the
+  // tree as real elements — remove them so their content isn't extracted.
+  parsed.body.querySelectorAll('noscript').forEach((el) => el.remove());
   const blocks: Block[] = [];
   collectBlocks(parsed.body, blocks, 0);
   return blocks.length ? { blocks } : emptyDoc();

--- a/packages/design-system/src/components/RichText/engine/fromHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/fromHtml.ts
@@ -13,17 +13,67 @@ const HEADING_LEVEL: Record<string, 1 | 2 | 3> = { H1: 1, H2: 2, H3: 3, H4: 3, H
 
 // Block-level tags that flush the loose-inline buffer and emit their own block(s).
 const BLOCK_TAGS = new Set([
-  'P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'PRE', 'BLOCKQUOTE', 'UL', 'OL', 'LI',
-  'DIV', 'SECTION', 'ARTICLE', 'MAIN', 'HEADER', 'FOOTER', 'ASIDE', 'NAV', 'ADDRESS',
-  'DL', 'DT', 'DD', 'FIGCAPTION',
+  'P',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'PRE',
+  'BLOCKQUOTE',
+  'UL',
+  'OL',
+  'LI',
+  'DIV',
+  'SECTION',
+  'ARTICLE',
+  'MAIN',
+  'HEADER',
+  'FOOTER',
+  'ASIDE',
+  'NAV',
+  'ADDRESS',
+  'DL',
+  'DT',
+  'DD',
+  'FIGCAPTION',
 ]);
 
 // Tags whose entire subtree is dropped (no text extracted).
 const DROP_TAGS = new Set([
-  'SCRIPT', 'STYLE', 'HEAD', 'TITLE', 'NOSCRIPT', 'TEMPLATE',
-  'IMG', 'PICTURE', 'SVG', 'VIDEO', 'AUDIO', 'IFRAME', 'OBJECT', 'EMBED', 'CANVAS',
-  'TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TR', 'TD', 'TH', 'COLGROUP', 'COL',
-  'HR', 'FORM', 'INPUT', 'SELECT', 'TEXTAREA', 'BUTTON', 'LABEL', 'FIGURE',
+  'SCRIPT',
+  'STYLE',
+  'HEAD',
+  'TITLE',
+  'NOSCRIPT',
+  'TEMPLATE',
+  'IMG',
+  'PICTURE',
+  'SVG',
+  'VIDEO',
+  'AUDIO',
+  'IFRAME',
+  'OBJECT',
+  'EMBED',
+  'CANVAS',
+  'TABLE',
+  'THEAD',
+  'TBODY',
+  'TFOOT',
+  'TR',
+  'TD',
+  'TH',
+  'COLGROUP',
+  'COL',
+  'HR',
+  'FORM',
+  'INPUT',
+  'SELECT',
+  'TEXTAREA',
+  'BUTTON',
+  'LABEL',
+  'FIGURE',
 ]);
 
 const HTML_NS = 'http://www.w3.org/1999/xhtml';
@@ -112,7 +162,11 @@ function trimSegment(seg: Inline[]): Inline[] {
   return out;
 }
 
-function blockFrom(type: BlockType, inlines: Inline[], attrs: { level?: 1 | 2 | 3; depth?: number } = {}): Block {
+function blockFrom(
+  type: BlockType,
+  inlines: Inline[],
+  attrs: { level?: 1 | 2 | 3; depth?: number } = {},
+): Block {
   const norm = normalizeInlines(inlines);
   const block: Block = { id: nextId(), type, inlines: norm };
   if (attrs.level !== undefined) block.level = attrs.level;
@@ -123,7 +177,12 @@ function blockFrom(type: BlockType, inlines: Inline[], attrs: { level?: 1 | 2 | 
 const isEmptySeg = (inlines: Inline[]): boolean => inlines.length === 1 && inlines[0].text === '';
 
 /** Emit an inline-only block (paragraph/heading), splitting at <br> into siblings. */
-function pushInlineBlocks(el: HTMLElement, type: BlockType, out: Block[], attrs: { level?: 1 | 2 | 3 }): void {
+function pushInlineBlocks(
+  el: HTMLElement,
+  type: BlockType,
+  out: Block[],
+  attrs: { level?: 1 | 2 | 3 },
+): void {
   const segments: Inline[][] = [[]];
   for (const child of Array.from(el.childNodes)) walkInline(child, [], segments);
   let pushed = false;

--- a/packages/design-system/src/components/RichText/engine/fromHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/fromHtml.ts
@@ -1,0 +1,231 @@
+// fromHtml.ts — parse an HTML string into the RichText model. Uses the browser's
+// built-in DOMParser (inert: scripts never run) and walks the DOM with a strict
+// allowlist — the walk IS the sanitizer, since it only extracts text + known
+// marks + safeHref-checked links and emits a plain model. Requires a DOM
+// environment (browser; jsdom in tests).
+import type { RichDoc, Block, Inline, Mark, BlockType } from './model';
+import { nextId, emptyDoc } from './model';
+import { normalizeInlines } from './inlines';
+import { safeHref } from './safeHref';
+
+const HEADING_LEVEL: Record<string, 1 | 2 | 3> = { H1: 1, H2: 2, H3: 3, H4: 3, H5: 3, H6: 3 };
+
+// Block-level tags that flush the loose-inline buffer and emit their own block(s).
+const BLOCK_TAGS = new Set([
+  'P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'PRE', 'BLOCKQUOTE', 'UL', 'OL', 'LI',
+  'DIV', 'SECTION', 'ARTICLE', 'MAIN', 'HEADER', 'FOOTER', 'ASIDE', 'NAV', 'ADDRESS',
+  'DL', 'DT', 'DD', 'FIGCAPTION',
+]);
+
+// Tags whose entire subtree is dropped (no text extracted).
+const DROP_TAGS = new Set([
+  'SCRIPT', 'STYLE', 'HEAD', 'TITLE', 'NOSCRIPT', 'TEMPLATE',
+  'IMG', 'PICTURE', 'SVG', 'VIDEO', 'AUDIO', 'IFRAME', 'OBJECT', 'EMBED', 'CANVAS',
+  'TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TR', 'TD', 'TH', 'COLGROUP', 'COL',
+  'HR', 'FORM', 'INPUT', 'SELECT', 'TEXTAREA', 'BUTTON', 'LABEL', 'FIGURE',
+]);
+
+const isElement = (n: Node): n is HTMLElement => n.nodeType === 1;
+const isText = (n: Node): n is Text => n.nodeType === 3;
+
+const collapseWs = (s: string): string => s.replace(/\s+/g, ' ');
+
+/** Replace a same-type mark (e.g. nested links), else append. */
+function addMark(marks: Mark[], mark: Mark): Mark[] {
+  return [...marks.filter((m) => m.type !== mark.type), mark];
+}
+
+/** Marks active for the descendants of `el`: parent ∪ tag mark ∪ link ∪ inline CSS. */
+function marksFor(el: HTMLElement, parent: Mark[]): Mark[] {
+  let marks = parent;
+  switch (el.tagName) {
+    case 'STRONG':
+    case 'B':
+      marks = addMark(marks, { type: 'bold' });
+      break;
+    case 'EM':
+    case 'I':
+      marks = addMark(marks, { type: 'italic' });
+      break;
+    case 'U':
+      marks = addMark(marks, { type: 'underline' });
+      break;
+    case 'S':
+    case 'DEL':
+    case 'STRIKE':
+      marks = addMark(marks, { type: 'strike' });
+      break;
+    case 'CODE':
+      marks = addMark(marks, { type: 'code' });
+      break;
+    case 'A': {
+      const href = safeHref(el.getAttribute('href') ?? '');
+      if (href !== undefined) marks = addMark(marks, { type: 'link', href });
+      break;
+    }
+  }
+  return applyCssMarks(el, marks);
+}
+
+/** Recover bold/italic/underline/strike from a small set of inline CSS props. */
+function applyCssMarks(el: HTMLElement, marks: Mark[]): Mark[] {
+  const style = el.getAttribute('style');
+  if (!style) return marks;
+  const s = style.toLowerCase();
+  const weight = /font-weight\s*:\s*(\d+|bold|bolder)/.exec(s);
+  if (weight && (weight[1] === 'bold' || weight[1] === 'bolder' || Number(weight[1]) >= 600)) {
+    marks = addMark(marks, { type: 'bold' });
+  }
+  if (/font-style\s*:\s*(italic|oblique)/.test(s)) marks = addMark(marks, { type: 'italic' });
+  const deco = /text-decoration(?:-line)?\s*:\s*([^;]+)/.exec(s);
+  if (deco) {
+    if (deco[1].includes('underline')) marks = addMark(marks, { type: 'underline' });
+    if (deco[1].includes('line-through')) marks = addMark(marks, { type: 'strike' });
+  }
+  return marks;
+}
+
+/** Walk inline content, appending runs to `segments` (last entry = current soft-line). */
+function walkInline(node: Node, marks: Mark[], segments: Inline[][]): void {
+  if (isText(node)) {
+    const t = collapseWs(node.nodeValue ?? '');
+    if (t) segments[segments.length - 1].push({ text: t, marks });
+    return;
+  }
+  if (!isElement(node)) return;
+  if (DROP_TAGS.has(node.tagName)) return;
+  if (node.tagName === 'BR') {
+    segments.push([]);
+    return;
+  }
+  const next = marksFor(node, marks);
+  for (const child of Array.from(node.childNodes)) walkInline(child, next, segments);
+}
+
+/** Trim leading whitespace of the first run and trailing whitespace of the last. */
+function trimSegment(seg: Inline[]): Inline[] {
+  if (seg.length === 0) return seg;
+  const out = seg.map((r) => ({ ...r }));
+  out[0] = { ...out[0], text: out[0].text.replace(/^\s+/, '') };
+  const last = out.length - 1;
+  out[last] = { ...out[last], text: out[last].text.replace(/\s+$/, '') };
+  return out;
+}
+
+function blockFrom(type: BlockType, inlines: Inline[], attrs: { level?: 1 | 2 | 3; depth?: number } = {}): Block {
+  const norm = normalizeInlines(inlines);
+  const block: Block = { id: nextId(), type, inlines: norm };
+  if (attrs.level !== undefined) block.level = attrs.level;
+  if (attrs.depth !== undefined) block.depth = attrs.depth;
+  return block;
+}
+
+const isEmptySeg = (inlines: Inline[]): boolean => inlines.length === 1 && inlines[0].text === '';
+
+/** Emit an inline-only block (paragraph/heading), splitting at <br> into siblings. */
+function pushInlineBlocks(el: HTMLElement, type: BlockType, out: Block[], attrs: { level?: 1 | 2 | 3 }): void {
+  const segments: Inline[][] = [[]];
+  for (const child of Array.from(el.childNodes)) walkInline(child, [], segments);
+  let pushed = false;
+  for (const seg of segments) {
+    const inlines = normalizeInlines(trimSegment(seg));
+    if (segments.length > 1 && isEmptySeg(inlines)) continue;
+    out.push(blockFrom(type, inlines, attrs));
+    pushed = true;
+  }
+  if (!pushed) out.push(blockFrom(type, [{ text: '', marks: [] }], attrs));
+}
+
+function emitListItem(li: HTMLElement, itemType: BlockType, out: Block[], depth: number): void {
+  const segments: Inline[][] = [[]];
+  const nested: HTMLElement[] = [];
+  for (const child of Array.from(li.childNodes)) {
+    if (isElement(child) && (child.tagName === 'UL' || child.tagName === 'OL')) nested.push(child);
+    else walkInline(child, [], segments);
+  }
+  for (const seg of segments) {
+    const inlines = normalizeInlines(trimSegment(seg));
+    if (segments.length > 1 && isEmptySeg(inlines)) continue;
+    out.push({ id: nextId(), type: itemType, depth, inlines });
+  }
+  for (const sub of nested) emitBlock(sub, out, depth + 1);
+}
+
+function emitBlock(el: HTMLElement, out: Block[], listDepth: number): void {
+  const tag = el.tagName;
+  if (tag in HEADING_LEVEL) {
+    pushInlineBlocks(el, 'heading', out, { level: HEADING_LEVEL[tag] });
+    return;
+  }
+  if (tag === 'P') {
+    pushInlineBlocks(el, 'paragraph', out, {});
+    return;
+  }
+  if (tag === 'PRE') {
+    out.push(blockFrom('code_block', [{ text: el.textContent ?? '', marks: [] }]));
+    return;
+  }
+  if (tag === 'BLOCKQUOTE') {
+    const inner: Block[] = [];
+    collectBlocks(el, inner, listDepth);
+    for (const b of inner) out.push({ id: nextId(), type: 'blockquote', inlines: b.inlines });
+    return;
+  }
+  if (tag === 'UL' || tag === 'OL') {
+    const itemType: BlockType = tag === 'OL' ? 'ordered_item' : 'bullet_item';
+    for (const child of Array.from(el.children)) {
+      if (child.tagName === 'LI') emitListItem(child as HTMLElement, itemType, out, listDepth);
+    }
+    return;
+  }
+  if (tag === 'LI') {
+    emitListItem(el, 'bullet_item', out, listDepth);
+    return;
+  }
+  // Unknown block container → unwrap.
+  collectBlocks(el, out, listDepth);
+}
+
+function collectBlocks(parent: Node, out: Block[], listDepth: number): void {
+  let buffer: Inline[][] = [[]];
+  const flush = () => {
+    for (const seg of buffer) {
+      const inlines = normalizeInlines(trimSegment(seg));
+      if (isEmptySeg(inlines)) continue;
+      out.push(blockFrom('paragraph', inlines));
+    }
+    buffer = [[]];
+  };
+  for (const child of Array.from(parent.childNodes)) {
+    if (isText(child)) {
+      const t = collapseWs(child.nodeValue ?? '');
+      if (t) buffer[buffer.length - 1].push({ text: t, marks: [] });
+      continue;
+    }
+    if (!isElement(child)) continue;
+    if (DROP_TAGS.has(child.tagName)) continue;
+    if (BLOCK_TAGS.has(child.tagName)) {
+      flush();
+      emitBlock(child, out, listDepth);
+    } else {
+      walkInline(child, [], buffer); // unknown inline element → into the buffer
+    }
+  }
+  flush();
+}
+
+/**
+ * Parse an HTML string into a `RichDoc`. Recognized tags map to blocks/marks; an
+ * inline-CSS subset (font-weight/style/text-decoration) recovers Word/Docs
+ * formatting; unknown containers unwrap (text kept); script/style/table/img/etc.
+ * are dropped. Hrefs are sanitized via `safeHref`. Requires a DOM environment.
+ *
+ * @example
+ * const doc = fromHtml('<h1>Title</h1><p>Hello <strong>world</strong></p>');
+ */
+export function fromHtml(html: string): RichDoc {
+  const parsed = new DOMParser().parseFromString(html, 'text/html');
+  const blocks: Block[] = [];
+  collectBlocks(parsed.body, blocks, 0);
+  return blocks.length ? { blocks } : emptyDoc();
+}

--- a/packages/design-system/src/components/RichText/engine/fromMarkdown.test.ts
+++ b/packages/design-system/src/components/RichText/engine/fromMarkdown.test.ts
@@ -29,4 +29,17 @@ describe('fromMarkdown', () => {
     const marks = d.blocks[0].inlines.flatMap((r) => r.marks.map((m) => m.type));
     expect(marks).not.toContain('underline');
   });
+
+  it('neutralizes dangerous link hrefs end-to-end (safeHref drops them)', () => {
+    // javascript: scheme → link mark dropped, text kept.
+    expect(fromMarkdown('[x](javascript:evil)').blocks[0].inlines).toEqual([
+      { text: 'x', marks: [] },
+    ]);
+    // An attribute-breakout attempt never injects a handler: the whole thing is
+    // one (https) href, so only a link mark — and no stray marks/runs — results.
+    const d = fromMarkdown('[x](https://a" onmouseover="y)');
+    expect(d.blocks[0].inlines.length).toBe(1);
+    expect(d.blocks[0].inlines[0].text).toBe('x');
+    expect(d.blocks[0].inlines[0].marks.map((m) => m.type)).toEqual(['link']);
+  });
 });

--- a/packages/design-system/src/components/RichText/engine/fromMarkdown.test.ts
+++ b/packages/design-system/src/components/RichText/engine/fromMarkdown.test.ts
@@ -1,0 +1,32 @@
+import { fromMarkdown } from './fromMarkdown';
+import { runsText } from './inlines';
+
+describe('fromMarkdown', () => {
+  it('parses a representative document end-to-end', () => {
+    const md = '# Title\n\nRead the [docs](/x) and **note** this.\n\n- a\n  - b\n\n> quote\n\n```\ncode\n```';
+    const d = fromMarkdown(md);
+    expect(d.blocks.map((b) => [b.type, b.depth, runsText(b.inlines)])).toEqual([
+      ['heading', undefined, 'Title'],
+      ['paragraph', undefined, 'Read the docs and note this.'],
+      ['bullet_item', 0, 'a'],
+      ['bullet_item', 1, 'b'],
+      ['blockquote', undefined, 'quote'],
+      ['code_block', undefined, 'code'],
+    ]);
+  });
+
+  it('carries link + bold marks through the HTML hop', () => {
+    const d = fromMarkdown('[t](/u) and **b**');
+    expect(d.blocks[0].inlines).toEqual([
+      { text: 't', marks: [{ type: 'link', href: '/u' }] },
+      { text: ' and ', marks: [] },
+      { text: 'b', marks: [{ type: 'bold' }] },
+    ]);
+  });
+
+  it('never produces underline (no Markdown syntax for it)', () => {
+    const d = fromMarkdown('**b** *i* ~~s~~');
+    const marks = d.blocks[0].inlines.flatMap((r) => r.marks.map((m) => m.type));
+    expect(marks).not.toContain('underline');
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/fromMarkdown.test.ts
+++ b/packages/design-system/src/components/RichText/engine/fromMarkdown.test.ts
@@ -3,7 +3,8 @@ import { runsText } from './inlines';
 
 describe('fromMarkdown', () => {
   it('parses a representative document end-to-end', () => {
-    const md = '# Title\n\nRead the [docs](/x) and **note** this.\n\n- a\n  - b\n\n> quote\n\n```\ncode\n```';
+    const md =
+      '# Title\n\nRead the [docs](/x) and **note** this.\n\n- a\n  - b\n\n> quote\n\n```\ncode\n```';
     const d = fromMarkdown(md);
     expect(d.blocks.map((b) => [b.type, b.depth, runsText(b.inlines)])).toEqual([
       ['heading', undefined, 'Title'],

--- a/packages/design-system/src/components/RichText/engine/fromMarkdown.ts
+++ b/packages/design-system/src/components/RichText/engine/fromMarkdown.ts
@@ -1,0 +1,20 @@
+// fromMarkdown.ts — parse a Markdown string into the RichText model by routing
+// through HTML (mdToHtml) so the tag→model mapping + sanitization live in one
+// place (fromHtml). CommonMark + GFM strikethrough subset. Requires a DOM
+// environment (DOMParser, via fromHtml).
+import type { RichDoc } from './model';
+import { fromHtml } from './fromHtml';
+import { mdToHtml } from './mdToHtml';
+
+/**
+ * Parse a Markdown string into a `RichDoc`. Supports headings, bold/italic,
+ * strikethrough (`~~`), inline code, links, blockquotes, ordered/unordered
+ * (nested) lists, and fenced code blocks. Lossy by nature: Markdown has no
+ * underline syntax (never produced) and images/tables are not modeled.
+ *
+ * @example
+ * const doc = fromMarkdown('# Title\n\n- one\n- two');
+ */
+export function fromMarkdown(md: string): RichDoc {
+  return fromHtml(mdToHtml(md));
+}

--- a/packages/design-system/src/components/RichText/engine/mdToHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/mdToHtml.test.ts
@@ -26,6 +26,13 @@ describe('mdToHtml — inline', () => {
   it('converts bold/italic/strike/code', () => {
     expect(mdToHtml('**b** *i* ~~s~~ `c`')).toBe('<p><strong>b</strong> <em>i</em> <del>s</del> <code>c</code></p>');
   });
+  it('converts triple markers to bold+italic', () => {
+    expect(mdToHtml('***x***')).toBe('<p><strong><em>x</em></strong></p>');
+    expect(mdToHtml('___y___')).toBe('<p><strong><em>y</em></strong></p>');
+  });
+  it('does not wrap whitespace in emphasis (flanking)', () => {
+    expect(mdToHtml('a _ b _ c')).toBe('<p>a _ b _ c</p>');
+  });
   it('converts links but not images', () => {
     expect(mdToHtml('[t](/u)')).toBe('<p><a href="/u">t</a></p>');
     expect(mdToHtml('![alt](/img.png)')).toBe('<p>alt</p>');

--- a/packages/design-system/src/components/RichText/engine/mdToHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/mdToHtml.test.ts
@@ -1,0 +1,37 @@
+import { mdToHtml } from './mdToHtml';
+
+describe('mdToHtml — blocks', () => {
+  it('converts ATX headings', () => {
+    expect(mdToHtml('# A\n## B')).toBe('<h1>A</h1><h2>B</h2>');
+  });
+  it('converts paragraphs (wrapped lines joined)', () => {
+    expect(mdToHtml('one\ntwo\n\nthree')).toBe('<p>one two</p><p>three</p>');
+  });
+  it('converts fenced code verbatim and escaped', () => {
+    expect(mdToHtml('```\na <b>\n```')).toBe('<pre><code>a &lt;b&gt;</code></pre>');
+  });
+  it('converts blockquotes', () => {
+    expect(mdToHtml('> quoted')).toBe('<blockquote><p>quoted</p></blockquote>');
+  });
+  it('converts unordered and ordered lists', () => {
+    expect(mdToHtml('- a\n- b')).toBe('<ul><li>a</li><li>b</li></ul>');
+    expect(mdToHtml('1. a\n2. b')).toBe('<ol><li>a</li><li>b</li></ol>');
+  });
+  it('nests lists by indentation', () => {
+    expect(mdToHtml('- a\n  - b')).toBe('<ul><li>a<ul><li>b</li></ul></li></ul>');
+  });
+});
+
+describe('mdToHtml — inline', () => {
+  it('converts bold/italic/strike/code', () => {
+    expect(mdToHtml('**b** *i* ~~s~~ `c`')).toBe('<p><strong>b</strong> <em>i</em> <del>s</del> <code>c</code></p>');
+  });
+  it('converts links but not images', () => {
+    expect(mdToHtml('[t](/u)')).toBe('<p><a href="/u">t</a></p>');
+    expect(mdToHtml('![alt](/img.png)')).toBe('<p>alt</p>');
+  });
+  it('honors backslash escapes and escapes HTML in text', () => {
+    expect(mdToHtml('a \\* b')).toBe('<p>a * b</p>');
+    expect(mdToHtml('a < b & c')).toBe('<p>a &lt; b &amp; c</p>');
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/mdToHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/mdToHtml.test.ts
@@ -24,7 +24,9 @@ describe('mdToHtml — blocks', () => {
 
 describe('mdToHtml — inline', () => {
   it('converts bold/italic/strike/code', () => {
-    expect(mdToHtml('**b** *i* ~~s~~ `c`')).toBe('<p><strong>b</strong> <em>i</em> <del>s</del> <code>c</code></p>');
+    expect(mdToHtml('**b** *i* ~~s~~ `c`')).toBe(
+      '<p><strong>b</strong> <em>i</em> <del>s</del> <code>c</code></p>',
+    );
   });
   it('converts triple markers to bold+italic', () => {
     expect(mdToHtml('***x***')).toBe('<p><strong><em>x</em></strong></p>');

--- a/packages/design-system/src/components/RichText/engine/mdToHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/mdToHtml.test.ts
@@ -34,4 +34,9 @@ describe('mdToHtml — inline', () => {
     expect(mdToHtml('a \\* b')).toBe('<p>a * b</p>');
     expect(mdToHtml('a < b & c')).toBe('<p>a &lt; b &amp; c</p>');
   });
+  it('escapes quotes in a link href so it cannot break out of the attribute', () => {
+    expect(mdToHtml('[x](https://a" onmouseover="y)')).toBe(
+      '<p><a href="https://a&quot; onmouseover=&quot;y">x</a></p>',
+    );
+  });
 });

--- a/packages/design-system/src/components/RichText/engine/mdToHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/mdToHtml.ts
@@ -49,6 +49,17 @@ function inline(src: string): string {
         continue;
       }
     }
+    // Triple marker → bold+italic. Checked before the double marker so `***x***`
+    // isn't mis-split into `**` + a stray `*`.
+    if ((c === '*' || c === '_') && src[i + 1] === c && src[i + 2] === c) {
+      const marker = c + c + c;
+      const end = src.indexOf(marker, i + 3);
+      if (end > i + 3) {
+        out += '<strong><em>' + inline(src.slice(i + 3, end)) + '</em></strong>';
+        i = end + 3;
+        continue;
+      }
+    }
     if ((c === '*' || c === '_') && src[i + 1] === c) {
       const marker = c + c;
       const end = src.indexOf(marker, i + 2);
@@ -66,9 +77,12 @@ function inline(src: string): string {
         continue;
       }
     }
-    if (c === '*' || c === '_') {
+    // Emphasis: require non-space immediately inside the markers (a minimal
+    // CommonMark flanking check) so `a _ b _ c` stays literal instead of
+    // wrapping whitespace in <em>.
+    if ((c === '*' || c === '_') && src[i + 1] !== ' ') {
       const end = src.indexOf(c, i + 1);
-      if (end > i + 1) {
+      if (end > i + 1 && src[end - 1] !== ' ') {
         out += '<em>' + inline(src.slice(i + 1, end)) + '</em>';
         i = end + 1;
         continue;

--- a/packages/design-system/src/components/RichText/engine/mdToHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/mdToHtml.ts
@@ -1,0 +1,163 @@
+// mdToHtml.ts — minimal Markdown → HTML-subset converter (INTERNAL). Emits only
+// the tags fromHtml understands (h1-6, p, pre>code, blockquote, ul/ol/li, and
+// inline strong/em/del/code/a), so fromMarkdown = fromHtml(mdToHtml(md)) reuses
+// one mapping. CommonMark + GFM strikethrough subset. Never throws.
+
+const ESC: Record<string, string> = { '&': '&amp;', '<': '&lt;', '>': '&gt;' };
+const escapeHtml = (s: string): string => s.replace(/[&<>]/g, (c) => ESC[c]);
+
+const LIST_RE = /^(\s*)([-*+]|\d+[.)])\s+(.*)$/;
+
+/** Convert inline Markdown to HTML. Unbalanced markers degrade to literal text. */
+function inline(src: string): string {
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === '\\' && i + 1 < src.length) {
+      out += escapeHtml(src[i + 1]);
+      i += 2;
+      continue;
+    }
+    if (c === '`') {
+      const end = src.indexOf('`', i + 1);
+      if (end !== -1) {
+        out += '<code>' + escapeHtml(src.slice(i + 1, end)) + '</code>';
+        i = end + 1;
+        continue;
+      }
+    }
+    if (c === '!' && src[i + 1] === '[') {
+      const m = /^!\[([^\]]*)\]\(([^)]*)\)/.exec(src.slice(i));
+      if (m) {
+        out += inline(m[1]); // image → its alt text (not a link, not an <img>)
+        i += m[0].length;
+        continue;
+      }
+    }
+    if (c === '[') {
+      const m = /^\[([^\]]*)\]\(([^)]*)\)/.exec(src.slice(i));
+      if (m) {
+        out += '<a href="' + escapeHtml(m[2].trim()) + '">' + inline(m[1]) + '</a>';
+        i += m[0].length;
+        continue;
+      }
+    }
+    if ((c === '*' || c === '_') && src[i + 1] === c) {
+      const marker = c + c;
+      const end = src.indexOf(marker, i + 2);
+      if (end !== -1) {
+        out += '<strong>' + inline(src.slice(i + 2, end)) + '</strong>';
+        i = end + 2;
+        continue;
+      }
+    }
+    if (c === '~' && src[i + 1] === '~') {
+      const end = src.indexOf('~~', i + 2);
+      if (end !== -1) {
+        out += '<del>' + inline(src.slice(i + 2, end)) + '</del>';
+        i = end + 2;
+        continue;
+      }
+    }
+    if (c === '*' || c === '_') {
+      const end = src.indexOf(c, i + 1);
+      if (end > i + 1) {
+        out += '<em>' + inline(src.slice(i + 1, end)) + '</em>';
+        i = end + 1;
+        continue;
+      }
+    }
+    out += escapeHtml(c);
+    i += 1;
+  }
+  return out;
+}
+
+/** Parse one list starting at `lines[start]` whose marker indent is `indent`. */
+function parseList(lines: string[], start: number, indent: number): [string, number] {
+  const ordered = /\d/.test(LIST_RE.exec(lines[start])![2]);
+  const tag = ordered ? 'ol' : 'ul';
+  let i = start;
+  let html = `<${tag}>`;
+  while (i < lines.length) {
+    const m = LIST_RE.exec(lines[i]);
+    if (!m || m[1].length < indent) break;
+    if (m[1].length > indent) break; // deeper line handled as nested below
+    let item = '<li>' + inline(m[3].trim());
+    i += 1;
+    while (i < lines.length) {
+      const deeper = LIST_RE.exec(lines[i]);
+      if (deeper && deeper[1].length > indent) {
+        const [nested, consumed] = parseList(lines, i, deeper[1].length);
+        item += nested;
+        i = consumed;
+      } else break;
+    }
+    item += '</li>';
+    html += item;
+  }
+  return [html + `</${tag}>`, i];
+}
+
+/** Convert a Markdown string to the HTML subset fromHtml understands. */
+export function mdToHtml(md: string): string {
+  const lines = md.replace(/\r\n?/g, '\n').split('\n');
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.trim() === '') {
+      i += 1;
+      continue;
+    }
+    const fence = /^(```|~~~)/.exec(line);
+    if (fence) {
+      i += 1;
+      const code: string[] = [];
+      while (i < lines.length && !lines[i].startsWith(fence[1])) {
+        code.push(lines[i]);
+        i += 1;
+      }
+      if (i < lines.length) i += 1; // skip closing fence
+      out.push('<pre><code>' + escapeHtml(code.join('\n')) + '</code></pre>');
+      continue;
+    }
+    const h = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (h) {
+      const level = h[1].length;
+      out.push(`<h${level}>` + inline(h[2].trim()) + `</h${level}>`);
+      i += 1;
+      continue;
+    }
+    if (/^>\s?/.test(line)) {
+      const quote: string[] = [];
+      while (i < lines.length && /^>\s?/.test(lines[i])) {
+        quote.push(lines[i].replace(/^>\s?/, ''));
+        i += 1;
+      }
+      out.push('<blockquote>' + mdToHtml(quote.join('\n')) + '</blockquote>');
+      continue;
+    }
+    if (LIST_RE.test(line)) {
+      const [html, consumed] = parseList(lines, i, LIST_RE.exec(line)![1].length);
+      out.push(html);
+      i = consumed;
+      continue;
+    }
+    const buf: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== '' &&
+      !/^(```|~~~)/.test(lines[i]) &&
+      !/^#{1,6}\s/.test(lines[i]) &&
+      !/^>\s?/.test(lines[i]) &&
+      !LIST_RE.test(lines[i])
+    ) {
+      buf.push(lines[i].trim());
+      i += 1;
+    }
+    out.push('<p>' + inline(buf.join(' ')) + '</p>');
+  }
+  return out.join('');
+}

--- a/packages/design-system/src/components/RichText/engine/mdToHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/mdToHtml.ts
@@ -6,6 +6,12 @@
 const ESC: Record<string, string> = { '&': '&amp;', '<': '&lt;', '>': '&gt;' };
 const escapeHtml = (s: string): string => s.replace(/[&<>]/g, (c) => ESC[c]);
 
+// Attribute context also needs the quotes escaped, or a `"` in a link URL would
+// break out of the href and inject attributes. Scheme safety is NOT enforced
+// here — fromHtml runs every href through safeHref (the single sanitizer).
+const ATTR_ESC: Record<string, string> = { ...ESC, '"': '&quot;', "'": '&#39;' };
+const escapeAttr = (s: string): string => s.replace(/["'&<>]/g, (c) => ATTR_ESC[c]);
+
 const LIST_RE = /^(\s*)([-*+]|\d+[.)])\s+(.*)$/;
 
 /** Convert inline Markdown to HTML. Unbalanced markers degrade to literal text. */
@@ -38,7 +44,7 @@ function inline(src: string): string {
     if (c === '[') {
       const m = /^\[([^\]]*)\]\(([^)]*)\)/.exec(src.slice(i));
       if (m) {
-        out += '<a href="' + escapeHtml(m[2].trim()) + '">' + inline(m[1]) + '</a>';
+        out += '<a href="' + escapeAttr(m[2].trim()) + '">' + inline(m[1]) + '</a>';
         i += m[0].length;
         continue;
       }

--- a/packages/design-system/src/components/RichText/engine/renderDoc.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.tsx
@@ -3,24 +3,11 @@
 import { Fragment, type ReactNode } from 'react';
 import type { RichDoc, Block, Inline, Mark, MarkType } from './model';
 import { runsText, runsLength } from './inlines';
+import { safeHref } from './safeHref';
 
 export interface RenderDocOptions {
   /** Editable surface: add `data-block-id` anchors + render empty blocks with a `<br>`. */
   editable?: boolean;
-}
-
-// Allow relative URLs and a small scheme allowlist; block javascript:/data:/etc.
-function safeHref(href: string): string | undefined {
-  const trimmed = href.trim();
-  if (trimmed === '') return undefined;
-  // Block protocol-relative URLs (`//host`) — they navigate cross-origin and
-  // would otherwise slip through the "relative" branch below.
-  if (trimmed.startsWith('//')) return undefined;
-  // Has an explicit scheme? Only http(s)/mailto/tel are allowed.
-  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
-    return /^(https?:|mailto:|tel:)/i.test(trimmed) ? trimmed : undefined;
-  }
-  return trimmed; // relative (/, ./, #, ?, plain path) — safe
 }
 
 // Outer → inner nesting order so output is stable + diff-friendly.

--- a/packages/design-system/src/components/RichText/engine/safeHref.test.ts
+++ b/packages/design-system/src/components/RichText/engine/safeHref.test.ts
@@ -18,4 +18,14 @@ describe('safeHref', () => {
     expect(safeHref('   ')).toBeUndefined();
     expect(safeHref('')).toBeUndefined();
   });
+
+  it('strips tab/newline/CR and leading control chars before the scheme check', () => {
+    expect(safeHref('java\tscript:alert(1)')).toBeUndefined();
+    expect(safeHref('java\nscript:alert(1)')).toBeUndefined();
+    expect(safeHref('java\rscript:alert(1)')).toBeUndefined();
+    expect(safeHref('\x01javascript:alert(1)')).toBeUndefined();
+    expect(safeHref('  \t javascript:alert(1)')).toBeUndefined();
+    // a legitimate relative path with internal spaces is still preserved
+    expect(safeHref('/a b')).toBe('/a b');
+  });
 });

--- a/packages/design-system/src/components/RichText/engine/safeHref.test.ts
+++ b/packages/design-system/src/components/RichText/engine/safeHref.test.ts
@@ -1,0 +1,21 @@
+import { safeHref } from './safeHref';
+
+describe('safeHref', () => {
+  it('keeps relative paths and the http(s)/mailto/tel schemes', () => {
+    expect(safeHref('/path')).toBe('/path');
+    expect(safeHref('./x')).toBe('./x');
+    expect(safeHref('#frag')).toBe('#frag');
+    expect(safeHref('https://x.test')).toBe('https://x.test');
+    expect(safeHref('http://x.test')).toBe('http://x.test');
+    expect(safeHref('mailto:a@b.test')).toBe('mailto:a@b.test');
+    expect(safeHref('tel:+123')).toBe('tel:+123');
+  });
+
+  it('drops dangerous and protocol-relative URLs', () => {
+    expect(safeHref('javascript:alert(1)')).toBeUndefined();
+    expect(safeHref('data:text/html;base64,xx')).toBeUndefined();
+    expect(safeHref('//evil.test')).toBeUndefined();
+    expect(safeHref('   ')).toBeUndefined();
+    expect(safeHref('')).toBeUndefined();
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/safeHref.ts
+++ b/packages/design-system/src/components/RichText/engine/safeHref.ts
@@ -1,0 +1,15 @@
+// safeHref.ts — URL allowlist shared by the renderer (renderDoc) and the HTML
+// importer (fromHtml). Allows relative URLs + a small scheme allowlist; blocks
+// javascript:/data:/protocol-relative so a hostile href never reaches output.
+export function safeHref(href: string): string | undefined {
+  const trimmed = href.trim();
+  if (trimmed === '') return undefined;
+  // Block protocol-relative URLs (`//host`) — they navigate cross-origin and
+  // would otherwise slip through the "relative" branch below.
+  if (trimmed.startsWith('//')) return undefined;
+  // Has an explicit scheme? Only http(s)/mailto/tel are allowed.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
+    return /^(https?:|mailto:|tel:)/i.test(trimmed) ? trimmed : undefined;
+  }
+  return trimmed; // relative (/, ./, #, ?, plain path) — safe
+}

--- a/packages/design-system/src/components/RichText/engine/safeHref.ts
+++ b/packages/design-system/src/components/RichText/engine/safeHref.ts
@@ -1,8 +1,15 @@
-// safeHref.ts — URL allowlist shared by the renderer (renderDoc) and the HTML
-// importer (fromHtml). Allows relative URLs + a small scheme allowlist; blocks
-// javascript:/data:/protocol-relative so a hostile href never reaches output.
+// safeHref.ts — the canonical, render-independent URL allowlist shared by the
+// renderer (renderDoc) and the HTML importer (fromHtml). It is the SOLE scheme
+// gate for hrefs that enter the model from untrusted input, so it must normalize
+// URLs the way browsers do before resolving a scheme. Allows relative URLs + a
+// small scheme allowlist; blocks javascript:/data:/protocol-relative.
 export function safeHref(href: string): string | undefined {
-  const trimmed = href.trim();
+  // Browsers strip ASCII tab/LF/CR from anywhere in a URL, and drop leading C0
+  // controls + spaces, before resolving the scheme — so `java\tscript:` and
+  // `\x01javascript:` would both navigate as javascript:. Normalize the same way
+  // so the scheme allowlist below can't be smuggled past with embedded or leading
+  // control characters.
+  const trimmed = href.replace(/[\t\n\r]/g, '').replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '');
   if (trimmed === '') return undefined;
   // Block protocol-relative URLs (`//host`) — they navigate cross-origin and
   // would otherwise slip through the "relative" branch below.

--- a/packages/design-system/src/components/RichText/engine/transforms.test.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.test.ts
@@ -7,6 +7,7 @@ import {
   removeMark,
   toggleMark,
   setBlockType,
+  insertFragment,
 } from './transforms';
 import { createBlock } from './model';
 import { runsText } from './inlines';
@@ -111,5 +112,58 @@ describe('transforms', () => {
     expect(r.doc.blocks[0].level).toBe(2);
     const back = setBlockType(r.doc, 'a', { type: 'paragraph' });
     expect(back.doc.blocks[0].level).toBeUndefined();
+  });
+});
+
+describe('insertFragment', () => {
+  const fpara = (id: string, text: string) => createBlock('paragraph', text, { id });
+  const fat = (blockId: string, offset: number) => ({ blockId, offset });
+  const fcollapsed = (blockId: string, offset: number) => ({
+    anchor: fat(blockId, offset),
+    focus: fat(blockId, offset),
+  });
+
+  it('single-block fragment → inline splice with caret after it', () => {
+    const doc: RichDoc = { blocks: [fpara('a', 'abcd')] };
+    const frag: RichDoc = { blocks: [createBlock('paragraph', 'XY', { id: 'f' })] };
+    const r = insertFragment(doc, fcollapsed('a', 2), frag);
+    expect(r.doc.blocks.length).toBe(1);
+    expect(r.doc.blocks[0].inlines).toEqual([{ text: 'abXYcd', marks: [] }]);
+    expect(r.selection).toEqual(fcollapsed('a', 4));
+  });
+
+  it('multi-block fragment → split current block and merge ends', () => {
+    const doc: RichDoc = { blocks: [fpara('a', 'abcd')] };
+    const frag: RichDoc = {
+      blocks: [
+        createBlock('paragraph', 'X', { id: 'f0' }),
+        createBlock('heading', 'Y', { id: 'f1', level: 2 }),
+        createBlock('paragraph', 'Z', { id: 'f2' }),
+      ],
+    };
+    const r = insertFragment(doc, fcollapsed('a', 2), frag);
+    expect(r.doc.blocks.map((b) => [b.type, b.inlines.map((i) => i.text).join('')])).toEqual([
+      ['paragraph', 'abX'],
+      ['heading', 'Y'],
+      ['paragraph', 'Zcd'],
+    ]);
+    expect(r.selection.anchor.offset).toBe(1);
+    expect(r.selection.anchor.blockId).toBe(r.doc.blocks[2].id);
+  });
+
+  it('non-collapsed range is deleted first, then the fragment inserted', () => {
+    const doc: RichDoc = { blocks: [fpara('a', 'abcd')] };
+    const frag: RichDoc = { blocks: [createBlock('paragraph', 'X', { id: 'f' })] };
+    const r = insertFragment(doc, { anchor: fat('a', 1), focus: fat('a', 3) }, frag);
+    expect(r.doc.blocks[0].inlines).toEqual([{ text: 'aXd', marks: [] }]);
+  });
+
+  it('an empty fragment is a no-op (collapsed caret returned)', () => {
+    const doc: RichDoc = { blocks: [fpara('a', 'abcd')] };
+    const r = insertFragment(doc, fcollapsed('a', 2), {
+      blocks: [createBlock('paragraph', '', { id: 'e' })],
+    });
+    expect(r.doc).toBe(doc);
+    expect(r.selection).toEqual(fcollapsed('a', 2));
   });
 });

--- a/packages/design-system/src/components/RichText/engine/transforms.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.ts
@@ -1,10 +1,10 @@
 // transforms.ts — Layer D. Document transforms. Pure + immutable; each returns
 // { doc, selection } (the new doc + where the caret/selection should land).
 import type { RichDoc, Block, Point, Range, Mark, MarkType } from './model';
-import { createBlock } from './model';
-import { normalizeInlines, sliceInlines, mapMarksOverRange } from './inlines';
+import { createBlock, nextId } from './model';
+import { normalizeInlines, sliceInlines, mapMarksOverRange, runsLength } from './inlines';
 import { withMark, withoutMark, hasMark } from './marks';
-import { blockLength, findBlockIndex, orderedRange } from './position';
+import { blockLength, findBlockIndex, orderedRange, isCollapsed } from './position';
 
 function collapsed(point: Point): Range {
   return { anchor: point, focus: point };
@@ -229,4 +229,51 @@ export function setBlockType(
   if (next.type !== 'heading') delete next.level;
   if (next.type !== 'bullet_item' && next.type !== 'ordered_item') delete next.depth;
   return { doc: replaceBlock(doc, idx, next), selection: collapsed({ blockId, offset: 0 }) };
+}
+
+/**
+ * Pure/immutable. Insert a multi-block `fragment` at `range`, replacing any
+ * selection, with the conventional paste merge: the fragment's first block
+ * continues the current line and its last block rejoins the trailing text.
+ * Returns `{ doc, selection }` with the caret at the join. An empty fragment is
+ * a no-op (returns the input doc + a collapsed caret).
+ */
+export function insertFragment(
+  doc: RichDoc,
+  range: Range,
+  fragment: RichDoc,
+): { doc: RichDoc; selection: Range } {
+  const frag = fragment.blocks;
+  const fragEmpty = frag.length === 0 || (frag.length === 1 && blockLength(frag[0]) === 0);
+
+  const base = isCollapsed(range) ? { doc, selection: range } : deleteRange(doc, range);
+  const caret = base.selection.anchor;
+  if (fragEmpty) return { doc: base.doc, selection: collapsed(caret) };
+
+  const idx = findBlockIndex(base.doc, caret.blockId);
+  if (idx === -1) return { doc: base.doc, selection: collapsed(caret) };
+  const B = base.doc.blocks[idx];
+  const left = sliceInlines(B.inlines, 0, caret.offset);
+  const right = sliceInlines(B.inlines, caret.offset, blockLength(B));
+
+  if (frag.length === 1) {
+    const merged = normalizeInlines([...left, ...frag[0].inlines, ...right]);
+    const offset = caret.offset + runsLength(frag[0].inlines);
+    return {
+      doc: replaceBlock(base.doc, idx, { ...B, inlines: merged }),
+      selection: collapsed({ blockId: B.id, offset }),
+    };
+  }
+
+  const first = frag[0];
+  const last = frag[frag.length - 1];
+  const middle = frag.slice(1, -1).map((b) => ({ ...b, id: nextId() }));
+  const bleft: Block = { ...B, inlines: normalizeInlines([...left, ...first.inlines]) };
+  const bright: Block = { ...last, id: nextId(), inlines: normalizeInlines([...last.inlines, ...right]) };
+  const blocks = base.doc.blocks.slice();
+  blocks.splice(idx, 1, bleft, ...middle, bright);
+  return {
+    doc: { blocks },
+    selection: collapsed({ blockId: bright.id, offset: runsLength(last.inlines) }),
+  };
 }

--- a/packages/design-system/src/components/RichText/engine/transforms.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.ts
@@ -269,7 +269,11 @@ export function insertFragment(
   const last = frag[frag.length - 1];
   const middle = frag.slice(1, -1).map((b) => ({ ...b, id: nextId() }));
   const bleft: Block = { ...B, inlines: normalizeInlines([...left, ...first.inlines]) };
-  const bright: Block = { ...last, id: nextId(), inlines: normalizeInlines([...last.inlines, ...right]) };
+  const bright: Block = {
+    ...last,
+    id: nextId(),
+    inlines: normalizeInlines([...last.inlines, ...right]),
+  };
   const blocks = base.doc.blocks.slice();
   blocks.splice(idx, 1, bleft, ...middle, bright);
   return {

--- a/packages/design-system/src/components/RichText/index.ts
+++ b/packages/design-system/src/components/RichText/index.ts
@@ -25,3 +25,5 @@ export {
   toggleMark,
   setBlockType,
 } from './engine/transforms';
+export { fromHtml } from './engine/fromHtml';
+export { fromMarkdown } from './engine/fromMarkdown';

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { vi } from 'vitest';
@@ -231,9 +231,35 @@ describe('RichTextEditor paste', () => {
     (evt as { clipboardData: unknown }).clipboardData = {
       getData: (t: string) => (t === 'text/html' ? '<p>a <strong>bold</strong></p>' : ''),
     };
-    editor.dispatchEvent(evt);
+    act(() => {
+      editor.dispatchEvent(evt);
+    });
     expect(await screen.findByText('bold')).toBeInTheDocument();
     expect(screen.getByText('bold').closest('strong')).not.toBeNull();
+  });
+
+  it('readOnly editor ignores HTML paste (onChange does not fire)', () => {
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 0 },
+    });
+    const onChange = vi.fn();
+    render(
+      <I18nProvider locale="en">
+        <RichTextEditor value={docFromText('x')} onChange={onChange} readOnly />
+      </I18nProvider>,
+    );
+    const editor = screen.getByRole('textbox', { name: 'Rich text editor' });
+    const evt: Event & { clipboardData?: unknown } = new Event('paste', {
+      bubbles: true,
+      cancelable: true,
+    });
+    (evt as { clipboardData: unknown }).clipboardData = {
+      getData: (t: string) => (t === 'text/html' ? '<p>injected</p>' : ''),
+    };
+    editor.dispatchEvent(evt);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(evt.defaultPrevented).toBe(false);
   });
 
   it('plain-text-only paste does not preventDefault (falls through to beforeinput)', () => {

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -201,3 +201,67 @@ describe('RichTextEditor toolbar', () => {
     expect(kReachedHost).toBe(false);
   });
 });
+
+describe('RichTextEditor paste', () => {
+  beforeEach(() => {
+    mockReadSelection.mockReset();
+  });
+
+  it('rich-HTML paste inserts formatted content', async () => {
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 0 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: '', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} />;
+    }
+    render(
+      <I18nProvider locale="en">
+        <Harness />
+      </I18nProvider>,
+    );
+    const editor = screen.getByRole('textbox', { name: 'Rich text editor' });
+    const evt: Event & { clipboardData?: unknown } = new Event('paste', {
+      bubbles: true,
+      cancelable: true,
+    });
+    (evt as { clipboardData: unknown }).clipboardData = {
+      getData: (t: string) => (t === 'text/html' ? '<p>a <strong>bold</strong></p>' : ''),
+    };
+    editor.dispatchEvent(evt);
+    expect(await screen.findByText('bold')).toBeInTheDocument();
+    expect(screen.getByText('bold').closest('strong')).not.toBeNull();
+  });
+
+  it('plain-text-only paste does not preventDefault (falls through to beforeinput)', () => {
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 0 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: '', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} />;
+    }
+    render(
+      <I18nProvider locale="en">
+        <Harness />
+      </I18nProvider>,
+    );
+    const editor = screen.getByRole('textbox', { name: 'Rich text editor' });
+    const evt: Event & { clipboardData?: unknown } = new Event('paste', {
+      bubbles: true,
+      cancelable: true,
+    });
+    (evt as { clipboardData: unknown }).clipboardData = {
+      getData: (t: string) => (t === 'text/plain' ? 'hello' : ''),
+    };
+    editor.dispatchEvent(evt);
+    // No HTML → handler returns without preventing default.
+    expect(evt.defaultPrevented).toBe(false);
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -116,6 +116,7 @@ function selectionRect(root: HTMLElement): Rect {
  * built-in formatting toolbar. ⌘/Ctrl+K (or the toolbar link button) opens a
  * floating editor to add, edit, or remove a link on the selection. Inside a
  * list, Tab/⇧Tab indent/outdent and Enter on an empty item exits to a paragraph.
+ * Pasting rich HTML (web, Word, Google Docs) imports it as formatted content.
  * The model is the source of truth: every input is replayed as an engine
  * transform and the DOM re-rendered.
  *
@@ -144,6 +145,9 @@ function selectionRect(root: HTMLElement): Rect {
  *   controlled `value`/`onChange` round-trip.
  * - ❌ Building your own toolbar by reaching into the DOM — pass `toolbar`, or
  *   drive marks/blocks through the controlled `value`/`onChange` round-trip.
+ * - ❌ Pre-stripping pasted HTML to plain text — paste rich HTML directly; the
+ *   editor parses it (sanitized) into the model. Seed stored content with
+ *   `fromHtml` / `fromMarkdown`.
  */
 export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
   function RichTextEditor(

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -14,7 +14,8 @@ import { renderDoc } from '../RichText/engine/renderDoc';
 import { blockLength, isCollapsed } from '../RichText/engine/position';
 import { linkAt, setLink, removeLink } from './links';
 import { RichTextLinkEditor } from './RichTextLinkEditor';
-import { insertText } from '../RichText/engine/transforms';
+import { insertText, insertFragment } from '../RichText/engine/transforms';
+import { fromHtml } from '../RichText/engine/fromHtml';
 import { hasMark, withMark, withoutMark } from '../RichText/engine/marks';
 import { useTranslation } from '../../i18n';
 import { readSelection, writeSelection } from './selection';
@@ -328,6 +329,27 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       };
       root.addEventListener('beforeinput', onBeforeInput);
       return () => root.removeEventListener('beforeinput', onBeforeInput);
+    }, [commit]);
+
+    // Rich paste: when the clipboard carries HTML, parse it into the model and
+    // splice it at the selection. No HTML → don't preventDefault, so the native
+    // beforeinput path inserts text/plain (unchanged behavior).
+    useEffect(() => {
+      const root = rootRef.current;
+      if (!root) return;
+      const onPaste = (e: ClipboardEvent) => {
+        if (latest.current.readOnly) return;
+        const html = e.clipboardData?.getData('text/html');
+        if (!html || !html.trim()) return;
+        const range = readSelection(root);
+        if (!range) return;
+        const fragment = fromHtml(html);
+        if (isEmptyDoc(fragment)) return;
+        e.preventDefault();
+        commit(insertFragment(latest.current.value, range, fragment));
+      };
+      root.addEventListener('paste', onPaste);
+      return () => root.removeEventListener('paste', onPaste);
     }, [commit]);
 
     useEffect(() => {

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -468,6 +468,8 @@ export {
   removeMark,
   toggleMark,
   setBlockType,
+  fromHtml,
+  fromMarkdown,
 } from './components/RichText';
 
 export { Text } from './components/Text';

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -58,7 +58,7 @@ export function RichTextEditorDemo() {
       <Example
         title="Import (HTML / Markdown) + rich paste"
         description="Seed the editor from stored HTML or Markdown with fromHtml / fromMarkdown, and paste rich HTML (from the web, Word, Google Docs) straight into the editor — it becomes formatted content, not plain text."
-        code={`import { fromHtml, fromMarkdown } from '@eocrm/design-system';
+        code={`import { fromMarkdown } from '@eocrm/design-system'; // (fromHtml too — same API)
 const [doc, setDoc] = useState(() => fromMarkdown('# Imported\\n\\n- one\\n- two'));
 <RichTextEditor value={doc} onChange={setDoc} toolbar />`}
       >

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react';
-import { RichTextEditor, docFromText, Text, Stack, type RichDoc } from '@eocrm/design-system';
+import {
+  RichTextEditor,
+  docFromText,
+  fromMarkdown,
+  Text,
+  Stack,
+  type RichDoc,
+} from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
@@ -7,6 +14,11 @@ import { getComponentFiles } from '../../lib/componentFiles';
 export function RichTextEditorDemo() {
   const [doc, setDoc] = useState<RichDoc>(docFromText('Type here. Select a word and press ⌘B.'));
   const [linkDoc, setLinkDoc] = useState<RichDoc>(docFromText('Read the docs and visit our site.'));
+  const [importDoc, setImportDoc] = useState<RichDoc>(() =>
+    fromMarkdown(
+      '# Imported\n\nThis editor was **seeded** from Markdown — paste rich HTML to import more.',
+    ),
+  );
 
   return (
     <DemoLayout
@@ -40,6 +52,21 @@ export function RichTextEditorDemo() {
           onChange={setLinkDoc}
           toolbar
           placeholder="Select text, then ⌘K…"
+        />
+      </Example>
+
+      <Example
+        title="Import (HTML / Markdown) + rich paste"
+        description="Seed the editor from stored HTML or Markdown with fromHtml / fromMarkdown, and paste rich HTML (from the web, Word, Google Docs) straight into the editor — it becomes formatted content, not plain text."
+        code={`import { fromHtml, fromMarkdown } from '@eocrm/design-system';
+const [doc, setDoc] = useState(() => fromMarkdown('# Imported\\n\\n- one\\n- two'));
+<RichTextEditor value={doc} onChange={setDoc} toolbar />`}
+      >
+        <RichTextEditor
+          value={importDoc}
+          onChange={setImportDoc}
+          toolbar
+          placeholder="Paste rich HTML here…"
         />
       </Example>
 


### PR DESCRIPTION
Adds content **import** to `<RichTextEditor>` (Slice 5): parse existing HTML/Markdown into the model, and paste rich HTML straight into the editor as formatted content.

Spec: `docs/superpowers/specs/2026-06-19-richtext-serialization-import-design.md` · Plan: `docs/superpowers/plans/2026-06-19-richtext-serialization-import.md`

## Summary

- **`fromHtml(html): RichDoc`** — parses HTML via the browser's `DOMParser` (inert) and an **allowlist DOM walk** that *is* the sanitizer: only text + the 6 known marks + `safeHref`-checked links reach the model. Recovers Word/Google-Docs formatting from inline CSS (`font-weight`/`font-style`/`text-decoration`); unknown containers unwrap, `script`/`style`/`table`/`img`/foreign SVG·MathML/`noscript` are dropped.
- **`fromMarkdown(md): RichDoc`** = `fromHtml(mdToHtml(md))` — CommonMark + GFM-strikethrough subset routed through HTML so there's one tag→model + sanitization path. (Underline/images aren't representable — documented.)
- **`insertFragment`** — one new pure engine transform: splice a multi-block fragment at the caret with the conventional paste merge (first block continues the line, tail rejoins).
- **Rich paste** — a `paste` listener parses clipboard `text/html` → `fromHtml` → `insertFragment`; plain text is unchanged (Markdown import is the standalone function only).
- **`safeHref` extracted** to a shared `engine/safeHref.ts` (one sanitizer for render + import), and hardened: strips ASCII tab/LF/CR + leading control chars before the scheme check, matching browser URL normalization (blocks `java\tscript:`-style bypasses now reachable via untrusted import).
- New public exports `fromHtml` / `fromMarkdown` (pure utilities — no new component, demo page, or manifest entry). Demo example + JSDoc `@remarks` + `AGENTS.md` updated.

## Test plan

- **Unit (jsdom):** `safeHref` (12, incl. tab/newline/control bypasses), `fromHtml` (14, incl. SVG/MathML/noscript drop + inline-CSS + nested-list depth), `mdToHtml` (12, incl. triple-marker + flanking + attr-escaping), `fromMarkdown` (4), `insertFragment` (4), `RichTextEditor` paste (rich-paste-formats / plain-text-passthrough / readOnly-ignores). Full suite green (2873 tests).
- **Gates:** `make test` · `build-lib` · `lint` · `format:check` green; `npm pack --dry-run` 0 test/internal leaks; no manifest drift.
- **Adversarial security review (opus, Hard-rule-8):** found + fixed one Critical (`safeHref` tab/newline scheme bypass); re-review verdict "clean enough to stop".
- **Browser (Playwright, manual):** `fromMarkdown` seeding renders `<h1>`/`<strong>`; rich-HTML paste imports bold/link/italic + a `<ul>` and merges at the caret; **security** — paste of `<script>` / `javascript:` href / `onclick` / `<img onerror>` / `<svg><script>` executes nothing and injects nothing (link + handlers stripped, text kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)