### PR TITLE
feat(RichTextEditor): built-in undo/redo (⌘Z/⌘⇧Z/⌘Y + toolbar)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -923,6 +923,7 @@ const [doc, setDoc] = useState(emptyDoc());
 - **Block-type dropdown** — Paragraph, Heading 1–3, Quote, Code block. Shows the current block type; mixed multi-block selections show "Mixed".
 - **List toggles** — Bullet list, Numbered list. Toggle between the list type and paragraph.
 - **Link button** — add/edit a link on the selection. Reflects `aria-pressed` when the caret is inside a link.
+- **Undo / Redo buttons** — undo/redo the last change; disabled at the ends of the history.
 
 **List keys:**
 
@@ -935,7 +936,9 @@ const [doc, setDoc] = useState(emptyDoc());
 
 **Import:** `fromHtml(html)` and `fromMarkdown(md)` parse a string into a `RichDoc` (e.g. to seed `value` from stored/legacy content). Pasting rich HTML into the editor imports it as formatted content (parsed + sanitized). Markdown import is via `fromMarkdown` only — pasted plain text (incl. Markdown source) inserts literally. Both `from*` functions require a DOM environment (`DOMParser`); Markdown has no underline syntax and images/tables aren't modeled.
 
-When NOT to use: read-only display → `<RichText>`. No undo/redo yet (later slice). It's controlled — render `onChange`'s doc back into `value`, never mutate in place.
+**Undo/redo:** built in — ⌘/Ctrl+Z undo, ⌘/Ctrl+Shift+Z (or ⌘/Ctrl+Y) redo, plus the toolbar Undo/Redo buttons. Typing coalesces into one step (short bursts), and replacing `value` from outside the editor clears the history.
+
+When NOT to use: read-only display → `<RichText>`. It's controlled — render `onChange`'s doc back into `value`, never mutate in place.
 
 ### `<ImageCrop>` — controlled image cropper
 

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -291,3 +291,69 @@ describe('RichTextEditor paste', () => {
     expect(evt.defaultPrevented).toBe(false);
   });
 });
+
+describe('RichTextEditor undo/redo', () => {
+  beforeEach(() => {
+    mockReadSelection.mockReset();
+  });
+
+  it('records an edit and undoes it via the toolbar', async () => {
+    const user = userEvent.setup();
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 2 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hi', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} toolbar />;
+    }
+    render(
+      <I18nProvider locale="en">
+        <Harness />
+      </I18nProvider>,
+    );
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Bold' }));
+    expect(screen.getByRole('strong')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeEnabled();
+    await user.click(screen.getByRole('button', { name: 'Undo' }));
+    expect(screen.queryByRole('strong')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Redo' })).toBeEnabled();
+  });
+
+  it('clears history when value is replaced externally', async () => {
+    const user = userEvent.setup();
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 2 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hi', marks: [] }] }],
+      });
+      return (
+        <div>
+          <button
+            onClick={() =>
+              setDoc({ blocks: [{ id: 'z', type: 'paragraph', inlines: [{ text: 'new', marks: [] }] }] })
+            }
+          >
+            replace
+          </button>
+          <RichTextEditor value={doc} onChange={setDoc} toolbar />
+        </div>
+      );
+    }
+    render(
+      <I18nProvider locale="en">
+        <Harness />
+      </I18nProvider>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Bold' }));
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeEnabled();
+    await user.click(screen.getByRole('button', { name: 'replace' }));
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -356,4 +356,31 @@ describe('RichTextEditor undo/redo', () => {
     await user.click(screen.getByRole('button', { name: 'replace' }));
     expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
   });
+
+  it('⌘Z undoes even with no live selection (caret lost)', async () => {
+    const user = userEvent.setup();
+    // Build one undo step (the edit needs a range).
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 2 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hi', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} toolbar />;
+    }
+    render(
+      <I18nProvider locale="en">
+        <Harness />
+      </I18nProvider>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Bold' }));
+    expect(screen.getByRole('strong')).toBeInTheDocument();
+    // Now the caret is gone — undo must still work (it needs no selection).
+    mockReadSelection.mockReturnValue(null);
+    screen.getByRole('textbox', { name: 'Rich text editor' }).focus();
+    await user.keyboard('{Meta>}z{/Meta}');
+    expect(screen.queryByRole('strong')).not.toBeInTheDocument();
+  });
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -337,7 +337,9 @@ describe('RichTextEditor undo/redo', () => {
         <div>
           <button
             onClick={() =>
-              setDoc({ blocks: [{ id: 'z', type: 'paragraph', inlines: [{ text: 'new', marks: [] }] }] })
+              setDoc({
+                blocks: [{ id: 'z', type: 'paragraph', inlines: [{ text: 'new', marks: [] }] }],
+              })
             }
           >
             replace

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -126,6 +126,7 @@ function selectionRect(root: HTMLElement): Rect {
  * floating editor to add, edit, or remove a link on the selection. Inside a
  * list, Tab/⇧Tab indent/outdent and Enter on an empty item exits to a paragraph.
  * Pasting rich HTML (web, Word, Google Docs) imports it as formatted content.
+ * ⌘/Ctrl+Z / ⌘/Ctrl+Shift+Z (and the toolbar Undo/Redo buttons) undo and redo.
  * The model is the source of truth: every input is replayed as an engine
  * transform and the DOM re-rendered.
  *

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -567,6 +567,8 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           onToggleList={onToolbarToggleList}
           linkActive={toolbarLinkActive}
           onOpenLink={openLinkEditor}
+          onUndo={() => {}} // wired in Task 4
+          onRedo={() => {}} // wired in Task 4
         />
         {editable}
         {linkBubble}

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -352,14 +352,12 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       const onBeforeInput = (e: InputEvent) => {
         const { value: doc, readOnly: ro } = latest.current;
         if (ro || isComposingRef.current) return;
-        if (e.inputType === 'historyUndo') {
+        // Suppress the browser's native contentEditable undo/redo so it never
+        // mutates the DOM out from under the controlled model. The actual undo/redo
+        // is driven solely by the ⌘Z/⌘⇧Z/⌘Y keydown handler — calling onUndo here
+        // too would double-apply (keydown fires this beforeinput as well).
+        if (e.inputType === 'historyUndo' || e.inputType === 'historyRedo') {
           e.preventDefault();
-          onUndo();
-          return;
-        }
-        if (e.inputType === 'historyRedo') {
-          e.preventDefault();
-          onRedo();
           return;
         }
         const range = readSelection(root);
@@ -404,7 +402,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       };
       root.addEventListener('beforeinput', onBeforeInput);
       return () => root.removeEventListener('beforeinput', onBeforeInput);
-    }, [commit, onUndo, onRedo]);
+    }, [commit]);
 
     // Rich paste: when the clipboard carries HTML, parse it into the model and
     // splice it at the selection. No HTML → don't preventDefault, so the native
@@ -464,8 +462,12 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         if (readOnly) return;
         const root = rootRef.current;
         if (!root) return;
-        const range = readSelection(root);
-        if (!range) return;
+        // Undo/redo don't need a live selection — check them BEFORE the
+        // readSelection guard so ⌘Z still works if the caret was lost. stopPropagation
+        // keeps the shortcut from also triggering a host app's undo. preventDefault
+        // suppresses the browser's native contentEditable undo (and the resulting
+        // historyUndo beforeinput), so the beforeinput net only fires for an
+        // Edit-menu/trackpad undo that emits no keydown.
         const mod = e.metaKey || e.ctrlKey;
         if (mod && e.key.toLowerCase() === 'z' && !e.shiftKey) {
           e.preventDefault();
@@ -479,6 +481,8 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           onRedo();
           return;
         }
+        const range = readSelection(root);
+        if (!range) return;
         // ⌘/Ctrl+K opens the link editor (create or edit a link). Stop
         // propagation so the shortcut doesn't ALSO trigger a host app's global
         // ⌘K (command palette / search) while the editor is focused.

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -31,6 +31,15 @@ import {
   applyExactMarks,
 } from './commands';
 import { RichTextToolbar, type BlockChoice } from './RichTextToolbar';
+import {
+  reset as historyReset,
+  record as historyRecord,
+  undo as historyUndo,
+  redo as historyRedo,
+  canUndo as historyCanUndo,
+  canRedo as historyCanRedo,
+} from './history';
+import type { History, EditKind } from './history';
 import styles from './RichTextEditor.module.scss';
 
 export interface RichTextEditorProps extends Omit<
@@ -139,7 +148,7 @@ function selectionRect(root: HTMLElement): Rect {
  * - ❌ Treating it as uncontrolled — you MUST feed `onChange`'s doc back into
  *   `value`, or edits won't stick.
  * - ❌ Mutating `value` in place — pass the new doc the transforms return.
- * - ❌ Expecting undo/redo — not in this slice.
+ * - ❌ Implementing your own undo/redo stack — the editor tracks history internally; use ⌘/Ctrl+Z (undo), ⌘/Ctrl+⇧Z or ⌘/Ctrl+Y (redo), or the toolbar Undo/Redo buttons.
  * - ❌ Hand-rolling a link UI by reaching into the DOM — press ⌘/Ctrl+K or the
  *   toolbar link button; both open the built-in editor and route through the
  *   controlled `value`/`onChange` round-trip.
@@ -197,14 +206,52 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       [ref],
     );
 
-    const commit = useCallback((result: { doc: RichDoc; selection: Range }) => {
-      // No-op transforms (e.g. Backspace at the very start of the document)
-      // return the SAME doc reference — skip so we don't fire onChange or leave a
-      // stale pending selection that React would never consume (no re-render).
-      if (result.doc === latest.current.value) return;
-      pendingSelectionRef.current = result.selection;
-      latest.current.onChange(result.doc);
+    const historyRef = useRef<History>(historyReset({ doc: value, selection: null }));
+    const [canUndo, setCanUndo] = useState(false);
+    const [canRedo, setCanRedo] = useState(false);
+    const syncHistoryFlags = useCallback(() => {
+      setCanUndo(historyCanUndo(historyRef.current));
+      setCanRedo(historyCanRedo(historyRef.current));
     }, []);
+
+    const commit = useCallback(
+      (result: { doc: RichDoc; selection: Range }, kind: EditKind = 'other') => {
+        // No-op transforms (e.g. Backspace at the very start of the document)
+        // return the SAME doc reference — skip so we don't fire onChange or leave a
+        // stale pending selection that React would never consume (no re-render).
+        if (result.doc === latest.current.value) return;
+        historyRef.current = historyRecord(
+          historyRef.current,
+          { doc: result.doc, selection: result.selection },
+          kind,
+          Date.now(),
+        );
+        syncHistoryFlags();
+        pendingSelectionRef.current = result.selection;
+        latest.current.onChange(result.doc);
+      },
+      [syncHistoryFlags],
+    );
+
+    const onUndo = useCallback(() => {
+      const h = historyRef.current;
+      if (!historyCanUndo(h)) return;
+      const next = historyUndo(h);
+      historyRef.current = next;
+      syncHistoryFlags();
+      pendingSelectionRef.current = next.present.selection;
+      latest.current.onChange(next.present.doc);
+    }, [syncHistoryFlags]);
+
+    const onRedo = useCallback(() => {
+      const h = historyRef.current;
+      if (!historyCanRedo(h)) return;
+      const next = historyRedo(h);
+      historyRef.current = next;
+      syncHistoryFlags();
+      pendingSelectionRef.current = next.present.selection;
+      latest.current.onChange(next.present.doc);
+    }, [syncHistoryFlags]);
 
     // Shared by the keyboard shortcut and the toolbar: with a collapsed caret,
     // stage a pending mark for the next typed text (remembering where); with a
@@ -283,13 +330,19 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
 
     // Restore the caret/selection after a model-driven re-render.
     useLayoutEffect(() => {
+      // External value replacement (parent sets a wholly different doc) — reset
+      // history so Undo can't travel back into the old document's timeline.
+      if (value !== historyRef.current.present.doc) {
+        historyRef.current = historyReset({ doc: value, selection: null });
+        syncHistoryFlags();
+      }
       const root = rootRef.current;
       const pending = pendingSelectionRef.current;
       if (root && pending) {
         writeSelection(root, pending);
         pendingSelectionRef.current = null;
       }
-    }, [value]);
+    }, [value, syncHistoryFlags]);
 
     // Native beforeinput (React's onBeforeInput is NOT the modern beforeinput —
     // it's a legacy textInput polyfill that carries no `inputType`).
@@ -299,6 +352,16 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       const onBeforeInput = (e: InputEvent) => {
         const { value: doc, readOnly: ro } = latest.current;
         if (ro || isComposingRef.current) return;
+        if (e.inputType === 'historyUndo') {
+          e.preventDefault();
+          onUndo();
+          return;
+        }
+        if (e.inputType === 'historyRedo') {
+          e.preventDefault();
+          onRedo();
+          return;
+        }
         const range = readSelection(root);
         if (!range) return;
         // Pending marks: a mark toggled at a collapsed caret applies to the next
@@ -316,7 +379,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
             const marked = applyExactMarks(inserted.doc, span, pend);
             setPendingMarks(null);
             pendingAtRef.current = null;
-            commit({ doc: marked, selection: inserted.selection });
+            commit({ doc: marked, selection: inserted.selection }, 'type');
             return;
           }
         }
@@ -329,11 +392,19 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           return;
         }
         e.preventDefault();
-        commit(result);
+        const kind: EditKind =
+          e.inputType === 'insertText' ||
+          e.inputType === 'insertCompositionText' ||
+          e.inputType === 'insertReplacementText'
+            ? 'type'
+            : e.inputType.startsWith('delete')
+              ? 'delete'
+              : 'other';
+        commit(result, kind);
       };
       root.addEventListener('beforeinput', onBeforeInput);
       return () => root.removeEventListener('beforeinput', onBeforeInput);
-    }, [commit]);
+    }, [commit, onUndo, onRedo]);
 
     // Rich paste: when the clipboard carries HTML, parse it into the model and
     // splice it at the selection. No HTML → don't preventDefault, so the native
@@ -395,6 +466,19 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         if (!root) return;
         const range = readSelection(root);
         if (!range) return;
+        const mod = e.metaKey || e.ctrlKey;
+        if (mod && e.key.toLowerCase() === 'z' && !e.shiftKey) {
+          e.preventDefault();
+          e.stopPropagation();
+          onUndo();
+          return;
+        }
+        if (mod && (e.key.toLowerCase() === 'y' || (e.key.toLowerCase() === 'z' && e.shiftKey))) {
+          e.preventDefault();
+          e.stopPropagation();
+          onRedo();
+          return;
+        }
         // ⌘/Ctrl+K opens the link editor (create or edit a link). Stop
         // propagation so the shortcut doesn't ALSO trigger a host app's global
         // ⌘K (command palette / search) while the editor is focused.
@@ -435,7 +519,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           return;
         }
       },
-      [value, readOnly, commit, stageOrToggleMark, openLinkEditor],
+      [value, readOnly, commit, stageOrToggleMark, openLinkEditor, onUndo, onRedo],
     );
 
     const onCompositionStart = useCallback(() => {
@@ -458,7 +542,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         const caret = range.focus;
         const start = { blockId: caret.blockId, offset: Math.max(0, caret.offset - text.length) };
         const result = applyInput(value, { anchor: start, focus: caret }, 'insertText', text);
-        if (result) commit(result);
+        if (result) commit(result, 'type');
       },
       [value, readOnly, commit],
     );
@@ -567,8 +651,10 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           onToggleList={onToolbarToggleList}
           linkActive={toolbarLinkActive}
           onOpenLink={openLinkEditor}
-          onUndo={() => {}} // wired in Task 4
-          onRedo={() => {}} // wired in Task 4
+          canUndo={canUndo}
+          canRedo={canRedo}
+          onUndo={onUndo}
+          onRedo={onRedo}
         />
         {editable}
         {linkBubble}

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -57,8 +57,8 @@ export interface RichTextEditorProps extends Omit<
   /** Focus the editor on mount. */
   autoFocus?: boolean;
   /**
-   * Render the built-in formatting toolbar above the editor — mark toggle
-   * buttons (bold/italic/underline/strike), a block-type dropdown
+   * Render the built-in formatting toolbar above the editor — Undo/Redo buttons,
+   * mark toggle buttons (bold/italic/underline/strike), a block-type dropdown
    * (paragraph/headings/quote/code), and bullet/numbered list toggles. The
    * toolbar dispatches through the same commit path the keyboard uses and
    * reflects the active marks + current block of the live selection. Default
@@ -208,6 +208,10 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     );
 
     const historyRef = useRef<History>(historyReset({ doc: value, selection: null }));
+    // Timestamp of the last ⌘Z/⌘⇧Z/⌘Y keydown — lets the beforeinput net skip the
+    // historyUndo/historyRedo event that a keydown ALSO emits (already handled),
+    // while still honoring a menu/trackpad undo that emits no keydown.
+    const historyKeyAtRef = useRef(0);
     const [canUndo, setCanUndo] = useState(false);
     const [canRedo, setCanRedo] = useState(false);
     const syncHistoryFlags = useCallback(() => {
@@ -234,15 +238,23 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       [syncHistoryFlags],
     );
 
+    // Drop any caret-staged pending mark — the doc + caret are about to change,
+    // so a mark staged at the old caret must not bleed into the next typed text.
+    const clearPendingMarks = useCallback(() => {
+      setPendingMarks(null);
+      pendingAtRef.current = null;
+    }, []);
+
     const onUndo = useCallback(() => {
       const h = historyRef.current;
       if (!historyCanUndo(h)) return;
       const next = historyUndo(h);
       historyRef.current = next;
       syncHistoryFlags();
+      clearPendingMarks();
       pendingSelectionRef.current = next.present.selection;
       latest.current.onChange(next.present.doc);
-    }, [syncHistoryFlags]);
+    }, [syncHistoryFlags, clearPendingMarks]);
 
     const onRedo = useCallback(() => {
       const h = historyRef.current;
@@ -250,9 +262,10 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       const next = historyRedo(h);
       historyRef.current = next;
       syncHistoryFlags();
+      clearPendingMarks();
       pendingSelectionRef.current = next.present.selection;
       latest.current.onChange(next.present.doc);
-    }, [syncHistoryFlags]);
+    }, [syncHistoryFlags, clearPendingMarks]);
 
     // Shared by the keyboard shortcut and the toolbar: with a collapsed caret,
     // stage a pending mark for the next typed text (remembering where); with a
@@ -353,12 +366,17 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       const onBeforeInput = (e: InputEvent) => {
         const { value: doc, readOnly: ro } = latest.current;
         if (ro || isComposingRef.current) return;
-        // Suppress the browser's native contentEditable undo/redo so it never
-        // mutates the DOM out from under the controlled model. The actual undo/redo
-        // is driven solely by the ⌘Z/⌘⇧Z/⌘Y keydown handler — calling onUndo here
-        // too would double-apply (keydown fires this beforeinput as well).
+        // Undo/redo via beforeinput. Always preventDefault so the browser's native
+        // contentEditable undo never mutates the DOM under the controlled model.
+        // A ⌘Z/⌘⇧Z/⌘Y keydown ALSO emits a paired historyUndo/historyRedo here —
+        // the keydown handler already ran onUndo/onRedo, so skip that one (within a
+        // short window of the keydown). A menu/trackpad undo emits no keydown, so it
+        // falls through and is honored here.
         if (e.inputType === 'historyUndo' || e.inputType === 'historyRedo') {
           e.preventDefault();
+          if (Date.now() - historyKeyAtRef.current < 100) return;
+          if (e.inputType === 'historyUndo') onUndo();
+          else onRedo();
           return;
         }
         const range = readSelection(root);
@@ -403,7 +421,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       };
       root.addEventListener('beforeinput', onBeforeInput);
       return () => root.removeEventListener('beforeinput', onBeforeInput);
-    }, [commit]);
+    }, [commit, onUndo, onRedo]);
 
     // Rich paste: when the clipboard carries HTML, parse it into the model and
     // splice it at the selection. No HTML → don't preventDefault, so the native
@@ -465,20 +483,22 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         if (!root) return;
         // Undo/redo don't need a live selection — check them BEFORE the
         // readSelection guard so ⌘Z still works if the caret was lost. stopPropagation
-        // keeps the shortcut from also triggering a host app's undo. preventDefault
-        // suppresses the browser's native contentEditable undo (and the resulting
-        // historyUndo beforeinput), so the beforeinput net only fires for an
-        // Edit-menu/trackpad undo that emits no keydown.
+        // keeps the shortcut from triggering a host app's undo. preventDefault
+        // suppresses the browser's native contentEditable undo. We stamp the time so
+        // the paired historyUndo/historyRedo beforeinput (emitted by this same
+        // keydown) is skipped there rather than double-applied.
         const mod = e.metaKey || e.ctrlKey;
         if (mod && e.key.toLowerCase() === 'z' && !e.shiftKey) {
           e.preventDefault();
           e.stopPropagation();
+          historyKeyAtRef.current = Date.now();
           onUndo();
           return;
         }
         if (mod && (e.key.toLowerCase() === 'y' || (e.key.toLowerCase() === 'z' && e.shiftKey))) {
           e.preventDefault();
           e.stopPropagation();
+          historyKeyAtRef.current = Date.now();
           onRedo();
           return;
         }

--- a/packages/design-system/src/components/RichTextEditor/RichTextToolbar.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextToolbar.test.tsx
@@ -8,6 +8,8 @@ function renderTb(props: Partial<React.ComponentProps<typeof RichTextToolbar>> =
   const onSetBlock = vi.fn();
   const onToggleList = vi.fn();
   const onOpenLink = vi.fn();
+  const onUndo = vi.fn();
+  const onRedo = vi.fn();
   render(
     <I18nProvider locale="en">
       <RichTextToolbar
@@ -17,11 +19,13 @@ function renderTb(props: Partial<React.ComponentProps<typeof RichTextToolbar>> =
         onSetBlock={onSetBlock}
         onToggleList={onToggleList}
         onOpenLink={onOpenLink}
+        onUndo={onUndo}
+        onRedo={onRedo}
         {...props}
       />
     </I18nProvider>,
   );
-  return { onToggleMark, onSetBlock, onToggleList, onOpenLink };
+  return { onToggleMark, onSetBlock, onToggleList, onOpenLink, onUndo, onRedo };
 }
 
 describe('RichTextToolbar', () => {
@@ -102,5 +106,32 @@ describe('RichTextToolbar', () => {
   it('disables the Link button when disabled', () => {
     renderTb({ disabled: true });
     expect(screen.getByRole('button', { name: 'Link' })).toBeDisabled();
+  });
+
+  it('renders Undo and Redo buttons', () => {
+    renderTb();
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Redo' })).toBeInTheDocument();
+  });
+
+  it('disables Undo/Redo when there is nothing to undo/redo', () => {
+    renderTb({ canUndo: false, canRedo: false });
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled();
+  });
+
+  it('enables and fires Undo/Redo when available', async () => {
+    const user = userEvent.setup();
+    const { onUndo, onRedo } = renderTb({ canUndo: true, canRedo: true });
+    await user.click(screen.getByRole('button', { name: 'Undo' }));
+    await user.click(screen.getByRole('button', { name: 'Redo' }));
+    expect(onUndo).toHaveBeenCalled();
+    expect(onRedo).toHaveBeenCalled();
+  });
+
+  it('disables Undo/Redo when the whole toolbar is disabled', () => {
+    renderTb({ canUndo: true, canRedo: true, disabled: true });
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled();
   });
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextToolbar.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextToolbar.tsx
@@ -11,6 +11,8 @@ import {
   BulletListIcon,
   OrderedListIcon,
   LinkIcon,
+  UndoIcon,
+  RedoIcon,
 } from './icons';
 import styles from './RichTextEditor.module.scss';
 
@@ -34,6 +36,14 @@ export interface RichTextToolbarProps {
   linkActive?: boolean;
   /** Open the link editor for the current selection. */
   onOpenLink: () => void;
+  /** Whether an undo step is available (drives the Undo button's enabled state). */
+  canUndo?: boolean;
+  /** Whether a redo step is available. */
+  canRedo?: boolean;
+  /** Undo the last change. */
+  onUndo: () => void;
+  /** Redo the last undone change. */
+  onRedo: () => void;
 }
 
 const MARKS: {
@@ -72,6 +82,10 @@ export function RichTextToolbar({
   onToggleList,
   linkActive = false,
   onOpenLink,
+  canUndo = false,
+  canRedo = false,
+  onUndo,
+  onRedo,
 }: RichTextToolbarProps) {
   const t = useTranslation();
 
@@ -96,6 +110,29 @@ export function RichTextToolbar({
 
   return (
     <div className={styles.toolbar} role="toolbar" aria-label={t('richTextEditor.toolbar')}>
+      <Button
+        size="sm"
+        variant="ghost"
+        iconOnly
+        aria-label={t('richTextEditor.undo')}
+        disabled={disabled || !canUndo}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={onUndo}
+      >
+        <UndoIcon />
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        iconOnly
+        aria-label={t('richTextEditor.redo')}
+        disabled={disabled || !canRedo}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={onRedo}
+      >
+        <RedoIcon />
+      </Button>
+      <span className={styles.toolbarSep} aria-hidden="true" />
       <DropdownMenu>
         <DropdownMenu.Trigger>
           <Button

--- a/packages/design-system/src/components/RichTextEditor/history.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/history.test.ts
@@ -70,12 +70,30 @@ describe('history record', () => {
     expect(record(h, sa, 'type', 1000)).toBe(h);
   });
 
-  it('caps the past length at 200', () => {
+  it('caps the past length at 200, dropping the oldest', () => {
     let h = reset(sa);
     for (let i = 0; i < 250; i += 1) {
       h = record(h, { doc: mkDoc('x' + i), selection: null }, 'other', i * 1000);
     }
     expect(h.past.length).toBe(200);
+    // Pushed-to-past sequence is [sa, x0, x1, …, x248]; slice(-200) drops the
+    // first 50, so the oldest survivor is x49 (guards against slice(0, CAP)).
+    expect(h.past[0].doc).toEqual(mkDoc('x49'));
+  });
+
+  it('coalescing a third same-kind edit still coalesces (lastKind persists)', () => {
+    let h = reset(sa);
+    h = record(h, sb, 'type', 1000);
+    h = record(h, sc, 'type', 1200);
+    h = record(h, { doc: mkDoc('d'), selection: null }, 'type', 1400);
+    expect(h.past).toEqual([sa]);
+  });
+
+  it('does not mutate the input history', () => {
+    const h = reset(sa);
+    record(h, sb, 'other', 1000);
+    expect(h.past).toEqual([]);
+    expect(h.present).toBe(sa);
   });
 });
 

--- a/packages/design-system/src/components/RichTextEditor/history.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/history.test.ts
@@ -129,4 +129,12 @@ describe('history undo/redo', () => {
     expect(h.past).toEqual([sa]);
     expect(h.future).toEqual([]);
   });
+
+  it('an edit after redo starts a fresh step (lastKind reset)', () => {
+    let h = reset(sa);
+    h = record(h, sb, 'other', 1000);
+    h = redo(undo(h)); // back to present=sb, past=[sa], lastKind=null
+    h = record(h, sc, 'type', 1100); // lastKind null → new step, not coalesced
+    expect(h.past).toEqual([sa, sb]);
+  });
 });

--- a/packages/design-system/src/components/RichTextEditor/history.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/history.test.ts
@@ -1,0 +1,114 @@
+import { reset, record, undo, redo, canUndo, canRedo } from './history';
+import type { Snapshot } from './history';
+import type { RichDoc } from '../RichText/engine/model';
+
+const mkDoc = (id: string): RichDoc => ({
+  blocks: [{ id, type: 'paragraph', inlines: [{ text: id, marks: [] }] }],
+});
+const sa: Snapshot = { doc: mkDoc('a'), selection: null };
+const sb: Snapshot = { doc: mkDoc('b'), selection: null };
+const sc: Snapshot = { doc: mkDoc('c'), selection: null };
+
+describe('history reset', () => {
+  it('starts empty around the present', () => {
+    const h = reset(sa);
+    expect(h.present).toBe(sa);
+    expect(canUndo(h)).toBe(false);
+    expect(canRedo(h)).toBe(false);
+  });
+});
+
+describe('history record', () => {
+  it('pushes a new step (present → past) and can undo', () => {
+    let h = reset(sa);
+    h = record(h, sb, 'other', 1000);
+    expect(h.present).toBe(sb);
+    expect(h.past).toEqual([sa]);
+    expect(canUndo(h)).toBe(true);
+  });
+
+  it('coalesces same-kind edits within the window', () => {
+    let h = reset(sa);
+    h = record(h, sb, 'type', 1000);
+    h = record(h, sc, 'type', 1200);
+    expect(h.present).toBe(sc);
+    expect(h.past).toEqual([sa]);
+  });
+
+  it('breaks coalescing when the window elapses', () => {
+    let h = reset(sa);
+    h = record(h, sb, 'type', 1000);
+    h = record(h, sc, 'type', 2000);
+    expect(h.past).toEqual([sa, sb]);
+  });
+
+  it('breaks coalescing on a kind change', () => {
+    let h = reset(sa);
+    h = record(h, sb, 'type', 1000);
+    h = record(h, sc, 'delete', 1100);
+    expect(h.past).toEqual([sa, sb]);
+  });
+
+  it('never coalesces "other"', () => {
+    let h = reset(sa);
+    h = record(h, sb, 'other', 1000);
+    h = record(h, sc, 'other', 1050);
+    expect(h.past).toEqual([sa, sb]);
+  });
+
+  it('clears the redo future on a new record', () => {
+    let h = reset(sa);
+    h = record(h, sb, 'other', 1000);
+    h = undo(h);
+    h = record(h, sc, 'other', 1100);
+    expect(h.future).toEqual([]);
+    expect(h.present).toBe(sc);
+  });
+
+  it('is a no-op when the doc is unchanged', () => {
+    const h = reset(sa);
+    expect(record(h, sa, 'type', 1000)).toBe(h);
+  });
+
+  it('caps the past length at 200', () => {
+    let h = reset(sa);
+    for (let i = 0; i < 250; i += 1) {
+      h = record(h, { doc: mkDoc('x' + i), selection: null }, 'other', i * 1000);
+    }
+    expect(h.past.length).toBe(200);
+  });
+});
+
+describe('history undo/redo', () => {
+  it('undo moves present back and into future', () => {
+    let h = reset(sa);
+    h = record(h, sb, 'other', 1000);
+    h = undo(h);
+    expect(h.present).toBe(sa);
+    expect(h.future).toEqual([sb]);
+    expect(canRedo(h)).toBe(true);
+  });
+
+  it('redo re-applies', () => {
+    let h = reset(sa);
+    h = record(h, sb, 'other', 1000);
+    h = redo(undo(h));
+    expect(h.present).toBe(sb);
+    expect(h.future).toEqual([]);
+  });
+
+  it('undo/redo are no-ops at the boundaries', () => {
+    const h = reset(sa);
+    expect(undo(h)).toBe(h);
+    expect(redo(h)).toBe(h);
+  });
+
+  it('an edit after undo starts a fresh step (no merge across the undo)', () => {
+    let h = reset(sa);
+    h = record(h, sb, 'type', 1000);
+    h = undo(h);
+    h = record(h, sc, 'type', 1100);
+    expect(h.past).toEqual([sa]);
+    expect(h.future).toEqual([]);
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/history.ts
+++ b/packages/design-system/src/components/RichTextEditor/history.ts
@@ -1,0 +1,85 @@
+// history.ts — pure undo/redo history for <RichTextEditor>. Snapshots of
+// { doc, selection }; consecutive same-kind edits (typing, deleting) coalesce
+// into one step within a short window. `now` is injected so this module stays
+// pure and deterministically testable.
+import type { RichDoc, Range } from '../RichText/engine/model';
+
+export interface Snapshot {
+  doc: RichDoc;
+  selection: Range | null;
+}
+
+/** The kind of edit that produced a snapshot — drives typing/deleting coalescing. */
+export type EditKind = 'type' | 'delete' | 'other';
+
+export interface History {
+  past: Snapshot[];
+  present: Snapshot;
+  future: Snapshot[];
+  /** Kind of the last recorded step (for coalescing); null after reset/undo/redo. */
+  lastKind: EditKind | null;
+  /** Timestamp of the last record (for the pause-based coalescing break). */
+  lastAt: number;
+}
+
+/** Consecutive same-kind edits within this many ms merge into one undo step. */
+const COALESCE_MS = 600;
+/** Max retained past entries (immutable snapshots structurally share blocks). */
+const CAP = 200;
+
+/** A fresh history whose only state is `present` (mount + external value replace). */
+export function reset(present: Snapshot): History {
+  return { past: [], present, future: [], lastKind: null, lastAt: 0 };
+}
+
+/**
+ * Record a newly committed state. Coalesces with the previous step when it's the
+ * same non-`other` kind within `COALESCE_MS`; otherwise pushes the prior present
+ * onto `past` (capped) and clears `future`. A no-op (same doc) returns `h`.
+ */
+export function record(h: History, next: Snapshot, kind: EditKind, now: number): History {
+  if (next.doc === h.present.doc) return h;
+  const coalesce = kind !== 'other' && kind === h.lastKind && now - h.lastAt < COALESCE_MS;
+  if (coalesce) {
+    return { ...h, present: next, lastAt: now };
+  }
+  return {
+    past: [...h.past, h.present].slice(-CAP),
+    present: next,
+    future: [],
+    lastKind: kind,
+    lastAt: now,
+  };
+}
+
+/** Move one step back. No-op when there's nothing to undo. */
+export function undo(h: History): History {
+  if (h.past.length === 0) return h;
+  return {
+    past: h.past.slice(0, -1),
+    present: h.past[h.past.length - 1],
+    future: [h.present, ...h.future],
+    lastKind: null,
+    lastAt: 0,
+  };
+}
+
+/** Move one step forward. No-op when there's nothing to redo. */
+export function redo(h: History): History {
+  if (h.future.length === 0) return h;
+  return {
+    past: [...h.past, h.present],
+    present: h.future[0],
+    future: h.future.slice(1),
+    lastKind: null,
+    lastAt: 0,
+  };
+}
+
+export function canUndo(h: History): boolean {
+  return h.past.length > 0;
+}
+
+export function canRedo(h: History): boolean {
+  return h.future.length > 0;
+}

--- a/packages/design-system/src/components/RichTextEditor/history.ts
+++ b/packages/design-system/src/components/RichTextEditor/history.ts
@@ -41,6 +41,9 @@ export function record(h: History, next: Snapshot, kind: EditKind, now: number):
   if (next.doc === h.present.doc) return h;
   const coalesce = kind !== 'other' && kind === h.lastKind && now - h.lastAt < COALESCE_MS;
   if (coalesce) {
+    // Extend the current step: keep `past`/`future` (the burst's single boundary
+    // already sits on top of `past`). The new value shares those arrays with `h`
+    // — safe because arrays are never mutated and no caller compares them by ref.
     return { ...h, present: next, lastAt: now };
   }
   return {

--- a/packages/design-system/src/components/RichTextEditor/icons.tsx
+++ b/packages/design-system/src/components/RichTextEditor/icons.tsx
@@ -78,3 +78,19 @@ export function LinkIcon() {
     </svg>
   );
 }
+export function UndoIcon() {
+  return (
+    <svg {...base}>
+      <path d="M9 14 4 9l5-5" />
+      <path d="M4 9h11a5 5 0 0 1 0 10h-2" />
+    </svg>
+  );
+}
+export function RedoIcon() {
+  return (
+    <svg {...base}>
+      <path d="m15 14 5-5-5-5" />
+      <path d="M20 9H9a5 5 0 0 0 0 10h2" />
+    </svg>
+  );
+}

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -195,5 +195,7 @@ export const en: Messages = {
     linkApply: 'Apply',
     linkRemove: 'Remove link',
     linkEditorLabel: 'Edit link',
+    undo: 'Undo',
+    redo: 'Redo',
   },
 };

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -321,6 +321,10 @@ export interface Messages {
     linkRemove: string;
     /** Accessible name for the link bubble's form group. */
     linkEditorLabel: string;
+    /** aria-label on the toolbar Undo button. */
+    undo: string;
+    /** aria-label on the toolbar Redo button. */
+    redo: string;
   };
 }
 

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -197,5 +197,7 @@ export const ru: Messages = {
     linkApply: 'Применить',
     linkRemove: 'Удалить ссылку',
     linkEditorLabel: 'Редактирование ссылки',
+    undo: 'Отменить',
+    redo: 'Повторить',
   },
 };

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -29,7 +29,7 @@ export function RichTextEditorDemo() {
     >
       <Example
         title="Editable with toolbar"
-        description="The toolbar prop adds a formatting bar above the editor. Keyboard shortcuts and toolbar buttons both work — select text to format it, or toggle a mark at a collapsed caret and then type to apply it to new text. Enter on an empty list item exits the list; Tab / Shift+Tab indent and outdent list items."
+        description="The toolbar prop adds a formatting bar above the editor. Keyboard shortcuts and toolbar buttons both work — select text to format it, or toggle a mark at a collapsed caret and then type to apply it to new text. Enter on an empty list item exits the list; Tab / Shift+Tab indent and outdent list items. Undo/redo: ⌘/Ctrl+Z and ⌘/Ctrl+Shift+Z (or the toolbar Undo/Redo buttons)."
         code={`const [doc, setDoc] = useState(docFromText('…'));
 <RichTextEditor value={doc} onChange={setDoc} toolbar placeholder="Write a note…" />`}
       >


### PR DESCRIPTION
Adds built-in undo/redo to `<RichTextEditor>` (Slice 6) — keyboard (⌘/Ctrl+Z, ⌘/Ctrl+Shift+Z, ⌘/Ctrl+Y) and toolbar Undo/Redo buttons, with typing coalesced into sensible steps. The editor is controlled, so history lives inside it and routes through the existing `onChange` round-trip — consumers do nothing.

Spec: `docs/superpowers/specs/2026-06-19-richtext-editor-undo-redo-design.md` · Plan: `docs/superpowers/plans/2026-06-19-richtext-editor-undo-redo.md`

## Summary

- **`history.ts`** — a pure history model (`reset`/`record`/`undo`/`redo`/`canUndo`/`canRedo`) over `{ doc, selection }` snapshots. Same-kind edits (typing, deleting) coalesce within 600 ms; capped at 200 steps; immutable. `now` is injected so it's deterministically testable.
- **Editor wiring** — recorded in the existing `commit` funnel (with an edit `kind`); `onUndo`/`onRedo` route through `onChange` + the existing selection-restore. Replacing `value` from **outside** the editor clears history (detected via the `value === present.doc` invariant — no extra bookkeeping).
- **Native-undo suppression** — ⌘Z/⌘⇧Z/⌘Y in keydown drive undo/redo; the `beforeinput historyUndo/historyRedo` net honors **menu/trackpad** undo (no keydown) but is timestamp-deduped against the keydown's paired event, and always `preventDefault`s so the browser's native contentEditable undo never mutates the controlled model.
- **Toolbar** — Undo/Redo action buttons at the start of the toolbar, disabled at the ends of the history. New `UndoIcon`/`RedoIcon` + `undo`/`redo` i18n (en + ru).
- No new public API (built-in, like the toolbar/links/paste); `history.ts` internal.

## Test plan

- **Unit (jsdom):** `history.test.ts` (16 — coalescing, cap direction, boundaries, no-mutation, fresh-step after undo *and* redo); toolbar (Undo/Redo present/disabled/fire); editor (record→undo via toolbar, external-reset clears history, **⌘Z works with no live selection**). Full suite green (2899 tests); no manifest drift.
- **Gates:** `make test` · `build-lib` · `lint` · `format` green; `npm pack --dry-run` 0 leaks.
- **Adversarial review (opus, Rule-8):** caught one Important (menu/trackpad undo was dead after the double-trigger fix) → fixed with the timestamp dedupe; nice-to-haves applied.
- **Browser (Playwright, manual):** toolbar Undo = clean single undo; **⌘Z single-undo** (caught + fixed a real double-trigger bug where the keydown + `beforeinput historyUndo` both ran `onUndo`, over-reverting and wiping history); ⌘⇧Z redo; **typing-burst coalescing** (one ⌘Z undoes " XYZ" as one step). All verified post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)