### PR TITLE
feat(RichText): serialize-out — toHtml / toMarkdown

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -936,6 +936,8 @@ const [doc, setDoc] = useState(emptyDoc());
 
 **Import:** `fromHtml(html)` and `fromMarkdown(md)` parse a string into a `RichDoc` (e.g. to seed `value` from stored/legacy content). Pasting rich HTML into the editor imports it as formatted content (parsed + sanitized). Markdown import is via `fromMarkdown` only — pasted plain text (incl. Markdown source) inserts literally. Both `from*` functions require a DOM environment (`DOMParser`); Markdown has no underline syntax and images/tables aren't modeled.
 
+**Export:** `toHtml(doc)` and `toMarkdown(doc)` serialize a `RichDoc` back to a string (the inverse of `fromHtml`/`fromMarkdown`) — e.g. for storage, email bodies, or display outside the editor. `toHtml` is lossless (`fromHtml(toHtml(doc))` round-trips); `toMarkdown` drops underline (no Markdown syntax — use `toHtml` for full fidelity). Both escape output and run hrefs through `safeHref`.
+
 **Undo/redo:** built in — ⌘/Ctrl+Z undo, ⌘/Ctrl+Shift+Z (or ⌘/Ctrl+Y) redo, plus the toolbar Undo/Redo buttons. Typing coalesces into one step (short bursts), and replacing `value` from outside the editor clears the history.
 
 When NOT to use: read-only display → `<RichText>`. It's controlled — render `onChange`'s doc back into `value`, never mutate in place.

--- a/packages/design-system/src/components/RichText/engine/escape.test.ts
+++ b/packages/design-system/src/components/RichText/engine/escape.test.ts
@@ -1,0 +1,10 @@
+import { escapeHtml, escapeAttr } from './escape';
+
+describe('escape', () => {
+  it('escapeHtml escapes & < >', () => {
+    expect(escapeHtml('a & b < c > d')).toBe('a &amp; b &lt; c &gt; d');
+  });
+  it('escapeAttr escapes & < > and quotes', () => {
+    expect(escapeAttr(`a"b'c&d<e>f`)).toBe('a&quot;b&#39;c&amp;d&lt;e&gt;f');
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/escape.ts
+++ b/packages/design-system/src/components/RichText/engine/escape.ts
@@ -1,0 +1,11 @@
+// escape.ts — HTML text/attribute escapers shared by the Markdown converter
+// (mdToHtml) and the HTML serializer (toHtml).
+const ESC: Record<string, string> = { '&': '&amp;', '<': '&lt;', '>': '&gt;' };
+/** Escape text content: `&`, `<`, `>`. */
+export const escapeHtml = (s: string): string => s.replace(/[&<>]/g, (c) => ESC[c]);
+
+// Attribute context also needs the quotes escaped (a `"` in a URL would break out
+// of the href). Scheme safety is handled separately by safeHref.
+const ATTR_ESC: Record<string, string> = { ...ESC, '"': '&quot;', "'": '&#39;' };
+/** Escape an attribute value: text escapes plus quotes. */
+export const escapeAttr = (s: string): string => s.replace(/["'&<>]/g, (c) => ATTR_ESC[c]);

--- a/packages/design-system/src/components/RichText/engine/listDepths.test.ts
+++ b/packages/design-system/src/components/RichText/engine/listDepths.test.ts
@@ -1,0 +1,26 @@
+import { isListItem, effectiveDepths } from './listDepths';
+import { createBlock } from './model';
+import type { Block } from './model';
+
+const li = (depth: number): Block => createBlock('bullet_item', 'x', { depth });
+const p = (): Block => createBlock('paragraph', 'x');
+
+describe('isListItem', () => {
+  it('is true for list items only', () => {
+    expect(isListItem(createBlock('bullet_item', 'a'))).toBe(true);
+    expect(isListItem(createBlock('ordered_item', 'a'))).toBe(true);
+    expect(isListItem(createBlock('paragraph', 'a'))).toBe(false);
+  });
+});
+
+describe('effectiveDepths', () => {
+  it('clamps gaps to at most +1 within a run', () => {
+    expect(effectiveDepths([li(0), li(2), li(1)])).toEqual([0, 1, 1]);
+  });
+  it('clamps a leading deep item to 0', () => {
+    expect(effectiveDepths([li(3)])).toEqual([0]);
+  });
+  it('resets the run on a non-list block', () => {
+    expect(effectiveDepths([li(0), li(1), p(), li(2)])).toEqual([0, 1, 0, 0]);
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/listDepths.ts
+++ b/packages/design-system/src/components/RichText/engine/listDepths.ts
@@ -1,0 +1,32 @@
+// listDepths.ts — list-item detection + gap-free depth normalization, shared by
+// the renderer (renderDoc) and the HTML serializer (toHtml) so both reconstruct
+// list nesting identically.
+import type { Block } from './model';
+
+/** True for the flat list-item block types. */
+export function isListItem(block: Block): boolean {
+  return block.type === 'bullet_item' || block.type === 'ordered_item';
+}
+
+/**
+ * Effective render depth per block. `depth` is a free integer on the model, but
+ * nesting needs gap-free levels — within each run of consecutive list items,
+ * clamp each item to at most one level deeper than the previous (never below 0).
+ * Non-list blocks get 0 and reset the run. Lossless: no item is dropped during
+ * grouping.
+ */
+export function effectiveDepths(blocks: Block[]): number[] {
+  const eff = new Array<number>(blocks.length).fill(0);
+  let prev = -1; // effective depth of the previous list item in the current run
+  for (let i = 0; i < blocks.length; i += 1) {
+    if (!isListItem(blocks[i])) {
+      prev = -1;
+      continue;
+    }
+    const raw = blocks[i].depth ?? 0;
+    const e = Math.max(0, Math.min(raw, prev + 1));
+    eff[i] = e;
+    prev = e;
+  }
+  return eff;
+}

--- a/packages/design-system/src/components/RichText/engine/mdToHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/mdToHtml.ts
@@ -3,14 +3,7 @@
 // inline strong/em/del/code/a), so fromMarkdown = fromHtml(mdToHtml(md)) reuses
 // one mapping. CommonMark + GFM strikethrough subset. Never throws.
 
-const ESC: Record<string, string> = { '&': '&amp;', '<': '&lt;', '>': '&gt;' };
-const escapeHtml = (s: string): string => s.replace(/[&<>]/g, (c) => ESC[c]);
-
-// Attribute context also needs the quotes escaped, or a `"` in a link URL would
-// break out of the href and inject attributes. Scheme safety is NOT enforced
-// here — fromHtml runs every href through safeHref (the single sanitizer).
-const ATTR_ESC: Record<string, string> = { ...ESC, '"': '&quot;', "'": '&#39;' };
-const escapeAttr = (s: string): string => s.replace(/["'&<>]/g, (c) => ATTR_ESC[c]);
+import { escapeHtml, escapeAttr } from './escape';
 
 const LIST_RE = /^(\s*)([-*+]|\d+[.)])\s+(.*)$/;
 

--- a/packages/design-system/src/components/RichText/engine/mdToHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/mdToHtml.ts
@@ -35,7 +35,9 @@ function inline(src: string): string {
       }
     }
     if (c === '[') {
-      const m = /^\[([^\]]*)\]\(([^)]*)\)/.exec(src.slice(i));
+      // Allow backslash-escaped `]` inside the link text (toMarkdown escapes a
+      // literal `]` to `\]`); a plain `[^\]]*` would stop at it and lose the link.
+      const m = /^\[((?:[^\]\\]|\\.)*)\]\(([^)]*)\)/.exec(src.slice(i));
       if (m) {
         out += '<a href="' + escapeAttr(m[2].trim()) + '">' + inline(m[1]) + '</a>';
         i += m[0].length;

--- a/packages/design-system/src/components/RichText/engine/renderDoc.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.tsx
@@ -4,6 +4,7 @@ import { Fragment, type ReactNode } from 'react';
 import type { RichDoc, Block, Inline, Mark, MarkType } from './model';
 import { runsText, runsLength } from './inlines';
 import { safeHref } from './safeHref';
+import { isListItem, effectiveDepths } from './listDepths';
 
 export interface RenderDocOptions {
   /** Editable surface: add `data-block-id` anchors + render empty blocks with a `<br>`. */
@@ -97,34 +98,6 @@ interface ListItemNode {
   blockId: string;
   content: ReactNode;
   child: ReactNode | null;
-}
-
-function isListItem(block: Block): boolean {
-  return block.type === 'bullet_item' || block.type === 'ordered_item';
-}
-
-/**
- * Effective render depth per block. `depth` on the model is a free integer, but
- * the renderer needs gap-free levels — a jump of +2 (or an outdent below the
- * list's own base) would otherwise drop items during nesting. Within each run of
- * consecutive list items we clamp each item to at most one level deeper than the
- * previous (and never below 0), so the grouping below is lossless for any input.
- * Non-list blocks get 0 and reset the run.
- */
-function effectiveDepths(blocks: Block[]): number[] {
-  const eff = new Array<number>(blocks.length).fill(0);
-  let prev = -1; // effective depth of the previous list item in the current run
-  for (let i = 0; i < blocks.length; i += 1) {
-    if (!isListItem(blocks[i])) {
-      prev = -1;
-      continue;
-    }
-    const raw = blocks[i].depth ?? 0;
-    const e = Math.max(0, Math.min(raw, prev + 1));
-    eff[i] = e;
-    prev = e;
-  }
-  return eff;
 }
 
 // Collect a list starting at `start`, at its base (effective) depth; items one

--- a/packages/design-system/src/components/RichText/engine/serializeRoundtrip.test.ts
+++ b/packages/design-system/src/components/RichText/engine/serializeRoundtrip.test.ts
@@ -6,7 +6,8 @@ import { createBlock } from './model';
 import type { RichDoc, Block, Mark } from './model';
 
 // Strip ids (parsers mint fresh ones) and sort marks (order-insensitive equality).
-const sortMarks = (marks: Mark[]): Mark[] => [...marks].sort((a, b) => a.type.localeCompare(b.type));
+const sortMarks = (marks: Mark[]): Mark[] =>
+  [...marks].sort((a, b) => a.type.localeCompare(b.type));
 const shape = (d: RichDoc) =>
   d.blocks.map((b: Block) => ({
     type: b.type,
@@ -38,7 +39,9 @@ const doc: RichDoc = {
 describe('serialize round-trip', () => {
   it('fromHtml(toHtml(doc)) reproduces the document (underline included)', () => {
     const withU: RichDoc = {
-      blocks: [{ id: 'u', type: 'paragraph', inlines: [{ text: 'u', marks: [{ type: 'underline' }] }] }],
+      blocks: [
+        { id: 'u', type: 'paragraph', inlines: [{ text: 'u', marks: [{ type: 'underline' }] }] },
+      ],
     };
     expect(shape(fromHtml(toHtml(withU)))).toEqual(shape(withU));
     expect(shape(fromHtml(toHtml(doc)))).toEqual(shape(doc));
@@ -47,10 +50,35 @@ describe('serialize round-trip', () => {
   it('fromMarkdown(toMarkdown(doc)) reproduces the document except underline', () => {
     expect(shape(fromMarkdown(toMarkdown(doc)))).toEqual(shape(doc));
     const withU: RichDoc = {
-      blocks: [{ id: 'u', type: 'paragraph', inlines: [{ text: 'u', marks: [{ type: 'underline' }] }] }],
+      blocks: [
+        { id: 'u', type: 'paragraph', inlines: [{ text: 'u', marks: [{ type: 'underline' }] }] },
+      ],
     };
     expect(shape(fromMarkdown(toMarkdown(withU)))).toEqual([
       { type: 'paragraph', inlines: [{ text: 'u', marks: [] }] },
     ]);
+  });
+
+  it('Markdown round-trips link text containing a closing bracket', () => {
+    const d: RichDoc = {
+      blocks: [
+        {
+          id: 'a',
+          type: 'paragraph',
+          inlines: [{ text: 'a]b', marks: [{ type: 'link', href: '/u' }] }],
+        },
+      ],
+    };
+    expect(shape(fromMarkdown(toMarkdown(d)))).toEqual(shape(d));
+  });
+
+  it('Markdown round-trips a bullet list immediately followed by an ordered list', () => {
+    const d: RichDoc = {
+      blocks: [
+        createBlock('bullet_item', 'a', { id: 'a', depth: 0 }),
+        createBlock('ordered_item', 'b', { id: 'b', depth: 0 }),
+      ],
+    };
+    expect(shape(fromMarkdown(toMarkdown(d)))).toEqual(shape(d));
   });
 });

--- a/packages/design-system/src/components/RichText/engine/serializeRoundtrip.test.ts
+++ b/packages/design-system/src/components/RichText/engine/serializeRoundtrip.test.ts
@@ -1,0 +1,56 @@
+import { toHtml } from './toHtml';
+import { toMarkdown } from './toMarkdown';
+import { fromHtml } from './fromHtml';
+import { fromMarkdown } from './fromMarkdown';
+import { createBlock } from './model';
+import type { RichDoc, Block, Mark } from './model';
+
+// Strip ids (parsers mint fresh ones) and sort marks (order-insensitive equality).
+const sortMarks = (marks: Mark[]): Mark[] => [...marks].sort((a, b) => a.type.localeCompare(b.type));
+const shape = (d: RichDoc) =>
+  d.blocks.map((b: Block) => ({
+    type: b.type,
+    ...(b.level !== undefined ? { level: b.level } : {}),
+    ...(b.depth !== undefined ? { depth: b.depth } : {}),
+    inlines: b.inlines.map((r) => ({ text: r.text, marks: sortMarks(r.marks) })),
+  }));
+
+const doc: RichDoc = {
+  blocks: [
+    createBlock('heading', 'Title', { level: 2, id: 'a' }),
+    {
+      id: 'b',
+      type: 'paragraph',
+      inlines: [
+        { text: 'see ', marks: [] },
+        { text: 'docs', marks: [{ type: 'link', href: '/x' }, { type: 'bold' }] },
+        { text: ' and ', marks: [] },
+        { text: 'code', marks: [{ type: 'code' }] },
+      ],
+    },
+    createBlock('blockquote', 'quote', { id: 'c' }),
+    createBlock('bullet_item', 'a', { id: 'd', depth: 0 }),
+    createBlock('bullet_item', 'b', { id: 'e', depth: 1 }),
+    createBlock('code_block', 'x = 1', { id: 'f' }),
+  ],
+};
+
+describe('serialize round-trip', () => {
+  it('fromHtml(toHtml(doc)) reproduces the document (underline included)', () => {
+    const withU: RichDoc = {
+      blocks: [{ id: 'u', type: 'paragraph', inlines: [{ text: 'u', marks: [{ type: 'underline' }] }] }],
+    };
+    expect(shape(fromHtml(toHtml(withU)))).toEqual(shape(withU));
+    expect(shape(fromHtml(toHtml(doc)))).toEqual(shape(doc));
+  });
+
+  it('fromMarkdown(toMarkdown(doc)) reproduces the document except underline', () => {
+    expect(shape(fromMarkdown(toMarkdown(doc)))).toEqual(shape(doc));
+    const withU: RichDoc = {
+      blocks: [{ id: 'u', type: 'paragraph', inlines: [{ text: 'u', marks: [{ type: 'underline' }] }] }],
+    };
+    expect(shape(fromMarkdown(toMarkdown(withU)))).toEqual([
+      { type: 'paragraph', inlines: [{ text: 'u', marks: [] }] },
+    ]);
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/toHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/toHtml.test.ts
@@ -33,6 +33,17 @@ describe('toHtml — blocks', () => {
     expect(toHtml({ blocks: [createBlock('ordered_item', 'a', { id: '1' })] })).toBe('<ol><li>a</li></ol>');
   });
 
+  it('handles 3-level deep nesting then outdent (depths 0,1,2,1,0)', () => {
+    const doc: RichDoc = {
+      blocks: [0, 1, 2, 1, 0].map((depth, n) =>
+        createBlock('bullet_item', String.fromCharCode(97 + n), { id: String(n), depth }),
+      ),
+    };
+    expect(toHtml(doc)).toBe(
+      '<ul><li>a<ul><li>b<ul><li>c</li></ul></li><li>d</li></ul></li><li>e</li></ul>',
+    );
+  });
+
   it('serializes an empty paragraph as <p></p>', () => {
     expect(toHtml({ blocks: [createBlock('paragraph', '', { id: 'a' })] })).toBe('<p></p>');
   });

--- a/packages/design-system/src/components/RichText/engine/toHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/toHtml.test.ts
@@ -37,6 +37,13 @@ describe('toHtml — blocks', () => {
     );
   });
 
+  it('clamps an out-of-range heading level to a valid tag (never <undefined>)', () => {
+    const doc: RichDoc = {
+      blocks: [{ id: 'a', type: 'heading', level: 6 as 1, inlines: [{ text: 'H', marks: [] }] }],
+    };
+    expect(toHtml(doc)).toBe('<h3>H</h3>');
+  });
+
   it('handles 3-level deep nesting then outdent (depths 0,1,2,1,0)', () => {
     const doc: RichDoc = {
       blocks: [0, 1, 2, 1, 0].map((depth, n) =>

--- a/packages/design-system/src/components/RichText/engine/toHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/toHtml.test.ts
@@ -1,0 +1,66 @@
+import { toHtml } from './toHtml';
+import { createBlock } from './model';
+import type { RichDoc, Block, Inline } from './model';
+
+const para = (id: string, inlines: Inline[]): Block => ({ id, type: 'paragraph', inlines });
+const link = (href: string) => ({ type: 'link' as const, href });
+
+describe('toHtml — blocks', () => {
+  it('serializes headings, paragraph, blockquote, code_block', () => {
+    const doc: RichDoc = {
+      blocks: [
+        createBlock('heading', 'H', { level: 2, id: 'a' }),
+        createBlock('paragraph', 'p', { id: 'b' }),
+        createBlock('blockquote', 'q', { id: 'c' }),
+        createBlock('code_block', 'a < b', { id: 'd' }),
+      ],
+    };
+    expect(toHtml(doc)).toBe('<h2>H</h2><p>p</p><blockquote>q</blockquote><pre><code>a &lt; b</code></pre>');
+  });
+
+  it('groups nested list items into ul/ol with nested li', () => {
+    const doc: RichDoc = {
+      blocks: [
+        createBlock('bullet_item', 'a', { id: '1', depth: 0 }),
+        createBlock('bullet_item', 'b', { id: '2', depth: 1 }),
+        createBlock('bullet_item', 'c', { id: '3', depth: 0 }),
+      ],
+    };
+    expect(toHtml(doc)).toBe('<ul><li>a<ul><li>b</li></ul></li><li>c</li></ul>');
+  });
+
+  it('uses <ol> for ordered items', () => {
+    expect(toHtml({ blocks: [createBlock('ordered_item', 'a', { id: '1' })] })).toBe('<ol><li>a</li></ol>');
+  });
+
+  it('serializes an empty paragraph as <p></p>', () => {
+    expect(toHtml({ blocks: [createBlock('paragraph', '', { id: 'a' })] })).toBe('<p></p>');
+  });
+});
+
+describe('toHtml — inline marks', () => {
+  it('nests marks link-outermost, code-innermost', () => {
+    const doc: RichDoc = {
+      blocks: [para('a', [{ text: 'x', marks: [link('/u'), { type: 'bold' }, { type: 'code' }] }])],
+    };
+    expect(toHtml(doc)).toBe('<p><a href="/u" rel="noopener noreferrer"><strong><code>x</code></strong></a></p>');
+  });
+
+  it('maps every mark tag including underline', () => {
+    const doc: RichDoc = {
+      blocks: [para('a', [
+        { text: 'b', marks: [{ type: 'bold' }] },
+        { text: 'i', marks: [{ type: 'italic' }] },
+        { text: 'u', marks: [{ type: 'underline' }] },
+        { text: 's', marks: [{ type: 'strike' }] },
+      ])],
+    };
+    expect(toHtml(doc)).toBe('<p><strong>b</strong><em>i</em><u>u</u><s>s</s></p>');
+  });
+
+  it('escapes text and the href, and drops an unsafe-href anchor (keeping text)', () => {
+    expect(toHtml({ blocks: [para('a', [{ text: 'a<b>&"', marks: [] }])] })).toBe('<p>a&lt;b&gt;&amp;"</p>');
+    expect(toHtml({ blocks: [para('a', [{ text: 't', marks: [link('javascript:alert(1)')] }])] })).toBe('<p>t</p>');
+    expect(toHtml({ blocks: [para('a', [{ text: 't', marks: [link('/a b')] }])] })).toBe('<p><a href="/a b" rel="noopener noreferrer">t</a></p>');
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/toHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/toHtml.test.ts
@@ -15,7 +15,9 @@ describe('toHtml — blocks', () => {
         createBlock('code_block', 'a < b', { id: 'd' }),
       ],
     };
-    expect(toHtml(doc)).toBe('<h2>H</h2><p>p</p><blockquote>q</blockquote><pre><code>a &lt; b</code></pre>');
+    expect(toHtml(doc)).toBe(
+      '<h2>H</h2><p>p</p><blockquote>q</blockquote><pre><code>a &lt; b</code></pre>',
+    );
   });
 
   it('groups nested list items into ul/ol with nested li', () => {
@@ -30,7 +32,9 @@ describe('toHtml — blocks', () => {
   });
 
   it('uses <ol> for ordered items', () => {
-    expect(toHtml({ blocks: [createBlock('ordered_item', 'a', { id: '1' })] })).toBe('<ol><li>a</li></ol>');
+    expect(toHtml({ blocks: [createBlock('ordered_item', 'a', { id: '1' })] })).toBe(
+      '<ol><li>a</li></ol>',
+    );
   });
 
   it('handles 3-level deep nesting then outdent (depths 0,1,2,1,0)', () => {
@@ -54,24 +58,34 @@ describe('toHtml — inline marks', () => {
     const doc: RichDoc = {
       blocks: [para('a', [{ text: 'x', marks: [link('/u'), { type: 'bold' }, { type: 'code' }] }])],
     };
-    expect(toHtml(doc)).toBe('<p><a href="/u" rel="noopener noreferrer"><strong><code>x</code></strong></a></p>');
+    expect(toHtml(doc)).toBe(
+      '<p><a href="/u" rel="noopener noreferrer"><strong><code>x</code></strong></a></p>',
+    );
   });
 
   it('maps every mark tag including underline', () => {
     const doc: RichDoc = {
-      blocks: [para('a', [
-        { text: 'b', marks: [{ type: 'bold' }] },
-        { text: 'i', marks: [{ type: 'italic' }] },
-        { text: 'u', marks: [{ type: 'underline' }] },
-        { text: 's', marks: [{ type: 'strike' }] },
-      ])],
+      blocks: [
+        para('a', [
+          { text: 'b', marks: [{ type: 'bold' }] },
+          { text: 'i', marks: [{ type: 'italic' }] },
+          { text: 'u', marks: [{ type: 'underline' }] },
+          { text: 's', marks: [{ type: 'strike' }] },
+        ]),
+      ],
     };
     expect(toHtml(doc)).toBe('<p><strong>b</strong><em>i</em><u>u</u><s>s</s></p>');
   });
 
   it('escapes text and the href, and drops an unsafe-href anchor (keeping text)', () => {
-    expect(toHtml({ blocks: [para('a', [{ text: 'a<b>&"', marks: [] }])] })).toBe('<p>a&lt;b&gt;&amp;"</p>');
-    expect(toHtml({ blocks: [para('a', [{ text: 't', marks: [link('javascript:alert(1)')] }])] })).toBe('<p>t</p>');
-    expect(toHtml({ blocks: [para('a', [{ text: 't', marks: [link('/a b')] }])] })).toBe('<p><a href="/a b" rel="noopener noreferrer">t</a></p>');
+    expect(toHtml({ blocks: [para('a', [{ text: 'a<b>&"', marks: [] }])] })).toBe(
+      '<p>a&lt;b&gt;&amp;"</p>',
+    );
+    expect(
+      toHtml({ blocks: [para('a', [{ text: 't', marks: [link('javascript:alert(1)')] }])] }),
+    ).toBe('<p>t</p>');
+    expect(toHtml({ blocks: [para('a', [{ text: 't', marks: [link('/a b')] }])] })).toBe(
+      '<p><a href="/a b" rel="noopener noreferrer">t</a></p>',
+    );
   });
 });

--- a/packages/design-system/src/components/RichText/engine/toHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/toHtml.ts
@@ -93,6 +93,10 @@ function blockHtml(block: Block): string {
  * is injection-safe. Lossless for the model — `fromHtml(toHtml(doc))` reproduces
  * the document structurally.
  *
+ * @remarks An unsafe href (rejected by `safeHref`) drops the `<a>` wrapper and
+ * emits the bare text — unlike `renderDoc`, which keeps a hrefless `<a>`. Both are
+ * safe and `fromHtml(toHtml(doc))` stays consistent (neither yields a link mark).
+ *
  * @example
  * const html = toHtml(doc); // '<h2>Title</h2><p>Hello <strong>world</strong></p>'
  */

--- a/packages/design-system/src/components/RichText/engine/toHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/toHtml.ts
@@ -11,7 +11,6 @@ import { isListItem, effectiveDepths } from './listDepths';
 
 // Outer → inner; link outermost, code innermost (matches renderDoc).
 const MARK_ORDER: MarkType[] = ['link', 'bold', 'italic', 'underline', 'strike', 'code'];
-const HEADING_TAG: Record<1 | 2 | 3, string> = { 1: 'h1', 2: 'h2', 3: 'h3' };
 
 /** Wrap an already-escaped HTML string in one mark's tag. */
 function wrapMark(type: MarkType, mark: Mark, inner: string): string {
@@ -75,8 +74,12 @@ function listHtml(blocks: Block[], start: number, eff: number[]): [string, numbe
 
 function blockHtml(block: Block): string {
   switch (block.type) {
-    case 'heading':
-      return `<${HEADING_TAG[block.level ?? 1]}>${inlines(block)}</${HEADING_TAG[block.level ?? 1]}>`;
+    case 'heading': {
+      // Clamp to the model's h1–h3 range so a hand-built doc with an out-of-range
+      // level never emits a malformed <undefined>/<h0> tag.
+      const tag = `h${Math.min(3, Math.max(1, block.level ?? 1))}`;
+      return `<${tag}>${inlines(block)}</${tag}>`;
+    }
     case 'blockquote':
       return `<blockquote>${inlines(block)}</blockquote>`;
     case 'code_block':

--- a/packages/design-system/src/components/RichText/engine/toHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/toHtml.ts
@@ -1,0 +1,114 @@
+// toHtml.ts — serialize a RichDoc to a compact HTML string. The inverse of
+// fromHtml; mirrors renderDoc's structure (block elements, mark nesting order,
+// list-depth grouping) but emits a string. Text/attributes are escaped and hrefs
+// run through safeHref, so output is injection-safe. Lossless for the model
+// (underline → <u>), so fromHtml(toHtml(doc)) reproduces the document.
+import type { RichDoc, Block, Inline, Mark, MarkType } from './model';
+import { runsText } from './inlines';
+import { escapeHtml, escapeAttr } from './escape';
+import { safeHref } from './safeHref';
+import { isListItem, effectiveDepths } from './listDepths';
+
+// Outer → inner; link outermost, code innermost (matches renderDoc).
+const MARK_ORDER: MarkType[] = ['link', 'bold', 'italic', 'underline', 'strike', 'code'];
+const HEADING_TAG: Record<1 | 2 | 3, string> = { 1: 'h1', 2: 'h2', 3: 'h3' };
+
+/** Wrap an already-escaped HTML string in one mark's tag. */
+function wrapMark(type: MarkType, mark: Mark, inner: string): string {
+  switch (type) {
+    case 'bold':
+      return `<strong>${inner}</strong>`;
+    case 'italic':
+      return `<em>${inner}</em>`;
+    case 'underline':
+      return `<u>${inner}</u>`;
+    case 'strike':
+      return `<s>${inner}</s>`;
+    case 'code':
+      return `<code>${inner}</code>`;
+    case 'link': {
+      const safe = mark.type === 'link' ? safeHref(mark.href) : undefined;
+      if (safe === undefined) return inner; // unsafe href → drop the anchor, keep text
+      return `<a href="${escapeAttr(safe)}" rel="noopener noreferrer">${inner}</a>`;
+    }
+    default:
+      return inner;
+  }
+}
+
+/** Serialize one inline run: escaped text wrapped innermost-first. */
+function inlineRun(run: Inline): string {
+  const present = MARK_ORDER.filter((t) => run.marks.some((m) => m.type === t));
+  let html = escapeHtml(run.text);
+  for (let i = present.length - 1; i >= 0; i -= 1) {
+    const type = present[i];
+    const mark = run.marks.find((m) => m.type === type)!;
+    html = wrapMark(type, mark, html);
+  }
+  return html;
+}
+
+const inlines = (block: Block): string => block.inlines.map(inlineRun).join('');
+
+/** Serialize a contiguous run of list items starting at `start` (its base depth). */
+function listHtml(blocks: Block[], start: number, eff: number[]): [string, number] {
+  const base = eff[start];
+  const tag = blocks[start].type === 'ordered_item' ? 'ol' : 'ul';
+  const items: string[] = [];
+  let i = start;
+  while (i < blocks.length && isListItem(blocks[i])) {
+    const d = eff[i];
+    if (d < base) break;
+    if (d > base) {
+      const [child, next] = listHtml(blocks, i, eff);
+      if (items.length > 0) {
+        items[items.length - 1] = items[items.length - 1].replace(/<\/li>$/, `${child}</li>`);
+      }
+      i = next;
+      continue;
+    }
+    items.push(`<li>${inlines(blocks[i])}</li>`);
+    i += 1;
+  }
+  return [`<${tag}>${items.join('')}</${tag}>`, i];
+}
+
+function blockHtml(block: Block): string {
+  switch (block.type) {
+    case 'heading':
+      return `<${HEADING_TAG[block.level ?? 1]}>${inlines(block)}</${HEADING_TAG[block.level ?? 1]}>`;
+    case 'blockquote':
+      return `<blockquote>${inlines(block)}</blockquote>`;
+    case 'code_block':
+      return `<pre><code>${escapeHtml(runsText(block.inlines))}</code></pre>`;
+    case 'paragraph':
+    default:
+      return `<p>${inlines(block)}</p>`;
+  }
+}
+
+/**
+ * Serialize a `RichDoc` to a compact HTML string (the inverse of `fromHtml`).
+ * Text and attributes are escaped and hrefs run through `safeHref`, so the output
+ * is injection-safe. Lossless for the model — `fromHtml(toHtml(doc))` reproduces
+ * the document structurally.
+ *
+ * @example
+ * const html = toHtml(doc); // '<h2>Title</h2><p>Hello <strong>world</strong></p>'
+ */
+export function toHtml(doc: RichDoc): string {
+  const eff = effectiveDepths(doc.blocks);
+  let out = '';
+  let i = 0;
+  while (i < doc.blocks.length) {
+    if (isListItem(doc.blocks[i])) {
+      const [html, next] = listHtml(doc.blocks, i, eff);
+      out += html;
+      i = next;
+    } else {
+      out += blockHtml(doc.blocks[i]);
+      i += 1;
+    }
+  }
+  return out;
+}

--- a/packages/design-system/src/components/RichText/engine/toMarkdown.test.ts
+++ b/packages/design-system/src/components/RichText/engine/toMarkdown.test.ts
@@ -1,0 +1,59 @@
+import { toMarkdown } from './toMarkdown';
+import { createBlock } from './model';
+import type { RichDoc, Block, Inline } from './model';
+
+const para = (id: string, inlines: Inline[]): Block => ({ id, type: 'paragraph', inlines });
+const link = (href: string) => ({ type: 'link' as const, href });
+
+describe('toMarkdown — blocks', () => {
+  it('serializes headings, paragraph, blockquote, code fence', () => {
+    const doc: RichDoc = {
+      blocks: [
+        createBlock('heading', 'H', { level: 2, id: 'a' }),
+        createBlock('paragraph', 'p', { id: 'b' }),
+        createBlock('blockquote', 'q', { id: 'c' }),
+        createBlock('code_block', 'code', { id: 'd' }),
+      ],
+    };
+    expect(toMarkdown(doc)).toBe('## H\n\np\n\n> q\n\n```\ncode\n```');
+  });
+
+  it('serializes nested lists with 2-space indentation, consecutive items joined', () => {
+    const doc: RichDoc = {
+      blocks: [
+        createBlock('bullet_item', 'a', { id: '1', depth: 0 }),
+        createBlock('bullet_item', 'b', { id: '2', depth: 1 }),
+        createBlock('ordered_item', 'c', { id: '3', depth: 0 }),
+      ],
+    };
+    expect(toMarkdown(doc)).toBe('- a\n  - b\n1. c');
+  });
+});
+
+describe('toMarkdown — inline', () => {
+  it('wraps marks and drops underline', () => {
+    const doc: RichDoc = {
+      blocks: [para('a', [
+        { text: 'b', marks: [{ type: 'bold' }] },
+        { text: ' ', marks: [] },
+        { text: 'i', marks: [{ type: 'italic' }] },
+        { text: ' ', marks: [] },
+        { text: 's', marks: [{ type: 'strike' }] },
+        { text: ' ', marks: [] },
+        { text: 'c', marks: [{ type: 'code' }] },
+        { text: ' ', marks: [] },
+        { text: 'u', marks: [{ type: 'underline' }] },
+      ])],
+    };
+    expect(toMarkdown(doc)).toBe('**b** *i* ~~s~~ `c` u');
+  });
+
+  it('serializes a link with its (safe) href', () => {
+    expect(toMarkdown({ blocks: [para('a', [{ text: 'docs', marks: [link('/u')] }])] })).toBe('[docs](/u)');
+  });
+
+  it('escapes inline markdown specials and a leading block marker', () => {
+    expect(toMarkdown({ blocks: [para('a', [{ text: 'a*b_c', marks: [] }])] })).toBe('a\\*b\\_c');
+    expect(toMarkdown({ blocks: [para('a', [{ text: '# not a heading', marks: [] }])] })).toBe('\\# not a heading');
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/toMarkdown.test.ts
+++ b/packages/design-system/src/components/RichText/engine/toMarkdown.test.ts
@@ -26,34 +26,42 @@ describe('toMarkdown — blocks', () => {
         createBlock('ordered_item', 'c', { id: '3', depth: 0 }),
       ],
     };
-    expect(toMarkdown(doc)).toBe('- a\n  - b\n1. c');
+    // bullet(0) → bullet(1) same type → single newline; bullet → ordered differs
+    // → blank line so the parser doesn't coerce the ordered item to a bullet.
+    expect(toMarkdown(doc)).toBe('- a\n  - b\n\n1. c');
   });
 });
 
 describe('toMarkdown — inline', () => {
   it('wraps marks and drops underline', () => {
     const doc: RichDoc = {
-      blocks: [para('a', [
-        { text: 'b', marks: [{ type: 'bold' }] },
-        { text: ' ', marks: [] },
-        { text: 'i', marks: [{ type: 'italic' }] },
-        { text: ' ', marks: [] },
-        { text: 's', marks: [{ type: 'strike' }] },
-        { text: ' ', marks: [] },
-        { text: 'c', marks: [{ type: 'code' }] },
-        { text: ' ', marks: [] },
-        { text: 'u', marks: [{ type: 'underline' }] },
-      ])],
+      blocks: [
+        para('a', [
+          { text: 'b', marks: [{ type: 'bold' }] },
+          { text: ' ', marks: [] },
+          { text: 'i', marks: [{ type: 'italic' }] },
+          { text: ' ', marks: [] },
+          { text: 's', marks: [{ type: 'strike' }] },
+          { text: ' ', marks: [] },
+          { text: 'c', marks: [{ type: 'code' }] },
+          { text: ' ', marks: [] },
+          { text: 'u', marks: [{ type: 'underline' }] },
+        ]),
+      ],
     };
     expect(toMarkdown(doc)).toBe('**b** *i* ~~s~~ `c` u');
   });
 
   it('serializes a link with its (safe) href', () => {
-    expect(toMarkdown({ blocks: [para('a', [{ text: 'docs', marks: [link('/u')] }])] })).toBe('[docs](/u)');
+    expect(toMarkdown({ blocks: [para('a', [{ text: 'docs', marks: [link('/u')] }])] })).toBe(
+      '[docs](/u)',
+    );
   });
 
   it('escapes inline markdown specials and a leading block marker', () => {
     expect(toMarkdown({ blocks: [para('a', [{ text: 'a*b_c', marks: [] }])] })).toBe('a\\*b\\_c');
-    expect(toMarkdown({ blocks: [para('a', [{ text: '# not a heading', marks: [] }])] })).toBe('\\# not a heading');
+    expect(toMarkdown({ blocks: [para('a', [{ text: '# not a heading', marks: [] }])] })).toBe(
+      '\\# not a heading',
+    );
   });
 });

--- a/packages/design-system/src/components/RichText/engine/toMarkdown.ts
+++ b/packages/design-system/src/components/RichText/engine/toMarkdown.ts
@@ -1,0 +1,78 @@
+// toMarkdown.ts — serialize a RichDoc to Markdown (CommonMark + GFM strikethrough,
+// restricted to the model). The inverse of fromMarkdown. Lossy: underline has no
+// Markdown syntax and is dropped — use toHtml for full fidelity.
+import type { RichDoc, Block, Inline, MarkType } from './model';
+import { runsText } from './inlines';
+import { safeHref } from './safeHref';
+import { isListItem, effectiveDepths } from './listDepths';
+
+/** Backslash-escape inline specials so literal chars don't become formatting. */
+function escapeMd(s: string): string {
+  return s.replace(/[\\*_`[\]]/g, (c) => `\\${c}`);
+}
+
+/** Escape a leading block marker at the very start of the content. */
+function escapeLineStart(s: string): string {
+  return s.replace(/^(\s*)([#>+-]|\d+\.)/, '$1\\$2');
+}
+
+// Inline marks innermost → outermost (link applied last, outermost).
+const MARKERS: { type: MarkType; open: string; close: string }[] = [
+  { type: 'code', open: '`', close: '`' },
+  { type: 'strike', open: '~~', close: '~~' },
+  { type: 'italic', open: '*', close: '*' },
+  { type: 'bold', open: '**', close: '**' },
+];
+
+function inlineRun(run: Inline): string {
+  const isCode = run.marks.some((m) => m.type === 'code');
+  // Code content is verbatim; other text is MD-escaped.
+  let text = isCode ? run.text : escapeMd(run.text);
+  for (const m of MARKERS) {
+    if (run.marks.some((mk) => mk.type === m.type)) text = `${m.open}${text}${m.close}`;
+  }
+  const linkMark = run.marks.find((m) => m.type === 'link');
+  if (linkMark && linkMark.type === 'link') text = `[${text}](${safeHref(linkMark.href) ?? ''})`;
+  return text;
+}
+
+function blockMd(block: Block, depth: number): string {
+  if (block.type === 'code_block') return '```\n' + runsText(block.inlines) + '\n```';
+  const inline = escapeLineStart(block.inlines.map(inlineRun).join(''));
+  switch (block.type) {
+    case 'heading':
+      return `${'#'.repeat(block.level ?? 1)} ${inline}`;
+    case 'blockquote':
+      return `> ${inline}`;
+    case 'bullet_item':
+      return `${'  '.repeat(depth)}- ${inline}`;
+    case 'ordered_item':
+      return `${'  '.repeat(depth)}1. ${inline}`;
+    case 'paragraph':
+    default:
+      return inline;
+  }
+}
+
+/**
+ * Serialize a `RichDoc` to Markdown (CommonMark + GFM strikethrough), the inverse
+ * of `fromMarkdown`. Lossy: **underline is dropped** (no Markdown syntax — use
+ * `toHtml` for full fidelity); images/tables aren't modeled; MD-special escaping
+ * is best-effort.
+ *
+ * @example
+ * const md = toMarkdown(doc); // '# Title\n\n- one\n- two'
+ */
+export function toMarkdown(doc: RichDoc): string {
+  const eff = effectiveDepths(doc.blocks);
+  let out = '';
+  for (let i = 0; i < doc.blocks.length; i += 1) {
+    const b = doc.blocks[i];
+    if (i > 0) {
+      // Consecutive list items stay in one list (single newline); else a blank line.
+      out += isListItem(doc.blocks[i - 1]) && isListItem(b) ? '\n' : '\n\n';
+    }
+    out += blockMd(b, isListItem(b) ? eff[i] : 0);
+  }
+  return out;
+}

--- a/packages/design-system/src/components/RichText/engine/toMarkdown.ts
+++ b/packages/design-system/src/components/RichText/engine/toMarkdown.ts
@@ -69,8 +69,11 @@ export function toMarkdown(doc: RichDoc): string {
   for (let i = 0; i < doc.blocks.length; i += 1) {
     const b = doc.blocks[i];
     if (i > 0) {
-      // Consecutive list items stay in one list (single newline); else a blank line.
-      out += isListItem(doc.blocks[i - 1]) && isListItem(b) ? '\n' : '\n\n';
+      // Consecutive SAME-TYPE list items stay in one list (single newline). A
+      // bullet→ordered transition needs a blank line, or the Markdown parser would
+      // read both as one list and coerce the second to the first's type.
+      const prev = doc.blocks[i - 1];
+      out += isListItem(prev) && isListItem(b) && prev.type === b.type ? '\n' : '\n\n';
     }
     out += blockMd(b, isListItem(b) ? eff[i] : 0);
   }

--- a/packages/design-system/src/components/RichText/index.ts
+++ b/packages/design-system/src/components/RichText/index.ts
@@ -27,3 +27,5 @@ export {
 } from './engine/transforms';
 export { fromHtml } from './engine/fromHtml';
 export { fromMarkdown } from './engine/fromMarkdown';
+export { toHtml } from './engine/toHtml';
+export { toMarkdown } from './engine/toMarkdown';

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -158,6 +158,8 @@ function selectionRect(root: HTMLElement): Rect {
  * - ❌ Pre-stripping pasted HTML to plain text — paste rich HTML directly; the
  *   editor parses it (sanitized) into the model. Seed stored content with
  *   `fromHtml` / `fromMarkdown`.
+ * - ❌ Hand-rolling HTML/Markdown from the model — use `toHtml` / `toMarkdown`
+ *   (the inverse of `fromHtml` / `fromMarkdown`).
  */
 export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
   function RichTextEditor(

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -470,6 +470,8 @@ export {
   setBlockType,
   fromHtml,
   fromMarkdown,
+  toHtml,
+  toMarkdown,
 } from './components/RichText';
 
 export { Text } from './components/Text';

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -3,6 +3,9 @@ import {
   RichTextEditor,
   docFromText,
   fromMarkdown,
+  toHtml,
+  toMarkdown,
+  Code,
   Text,
   Stack,
   type RichDoc,
@@ -37,6 +40,12 @@ export function RichTextEditorDemo() {
           <RichTextEditor value={doc} onChange={setDoc} toolbar placeholder="Write a note…" />
           <Text size="sm" tone="muted">
             Toolbar + shortcuts: ⌘/Ctrl+B bold · I italic · U underline · ⇧X strike
+          </Text>
+          <Text size="sm" tone="muted">
+            HTML → <Code>{toHtml(doc)}</Code>
+          </Text>
+          <Text size="sm" tone="muted">
+            Markdown → <Code>{toMarkdown(doc).replace(/\n/g, '⏎')}</Code>
           </Text>
         </Stack>
       </Example>


### PR DESCRIPTION
Completes the serialization round-trip (Slice 7) — the inverse of the import functions:

- `toHtml(doc: RichDoc): string` — serialize the model to a compact HTML string.
- `toMarkdown(doc: RichDoc): string` — serialize to Markdown (CommonMark + GFM strike).

Driving use case: HTML/email output, storage, and display outside the editor. `fromHtml(toHtml(doc))` reproduces the document structurally.

Spec: `docs/superpowers/specs/2026-06-19-richtext-serialization-export-design.md` · Plan: `docs/superpowers/plans/2026-06-19-richtext-serialization-export.md`

## Summary

- **`toHtml`** — pure string builder mirroring `renderDoc` (block elements, mark nesting order, list-depth grouping). Text is `escapeHtml`'d, hrefs `escapeAttr`'d **and** `safeHref`-checked (unsafe → drop the `<a>`, keep text) — injection-safe. **Lossless** (underline → `<u>`).
- **`toMarkdown`** — headings/blockquote/lists/code-fence + inline bold/italic/strike/code/link, best-effort MD escaping. **Underline dropped** (no MD syntax — `toHtml` is the full-fidelity path); documented.
- **Two behavior-preserving extractions** (DRY): `escape.ts` (the HTML escapers, shared with `mdToHtml`) and `listDepths.ts` (`effectiveDepths`/`isListItem`, shared with `renderDoc`) — so the renderer, parser, and serializer reconstruct list nesting + escaping from one source.
- New public exports `toHtml`/`toMarkdown` (pure utilities, like `fromHtml`/`fromMarkdown`); no new component, no editor change, no new dependency.

## Test plan

- **Unit (pure):** `escape` / `listDepths` (extraction contracts); `toHtml` (every block, deep-nested lists, mark order, `<u>`, escaping, unsafe-href dropped, **out-of-range heading level clamped**); `toMarkdown` (blocks, nested lists, inline markers, underline dropped, MD escaping).
- **Round-trip (strongest guarantee):** `fromHtml(toHtml(doc))` reproduces the doc incl. underline; `fromMarkdown(toMarkdown(doc))` reproduces it minus underline. Full suite green (2921 tests); no manifest drift; tarball clean.
- **Adversarial reviews:** toHtml review (security — all injection probes inert; defense-in-depth via `escapeAttr` confirmed). toMarkdown review caught **two Critical round-trip bugs** — a `]` in link text silently dropping the link, and a bullet→ordered list coercing ordered items to bullets — both **fixed with regression tests**. Final opus review caught one Important (out-of-range heading `level` → `<undefined>` tag) — **fixed + tested**.
- **Browser (Playwright):** the demo serializes the live editor's doc to HTML + Markdown reactively — bolding a word updated `<p><strong>Type</strong>…` and `**Type**…` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)