### PR TITLE
feat(RichTextEditor): markdown input rules (auto-format on typing)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -940,6 +940,8 @@ const [doc, setDoc] = useState(emptyDoc());
 
 **Undo/redo:** built in — ⌘/Ctrl+Z undo, ⌘/Ctrl+Shift+Z (or ⌘/Ctrl+Y) redo, plus the toolbar Undo/Redo buttons. Typing coalesces into one step (short bursts), and replacing `value` from outside the editor clears the history.
 
+**Input rules:** typing a Markdown marker + space at the start of a paragraph auto-converts the block — `# `/`## `/`### ` → headings, `- `/`* `/`+ ` → bullet list, `1. ` → ordered list, `> ` → blockquote, a triple-backtick fence → code block. One Undo reverts the conversion.
+
 When NOT to use: read-only display → `<RichText>`. It's controlled — render `onChange`'s doc back into `value`, never mutate in place.
 
 ### `<ImageCrop>` — controlled image cropper

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -292,6 +292,69 @@ describe('RichTextEditor paste', () => {
   });
 });
 
+describe('RichTextEditor input rules', () => {
+  beforeEach(() => {
+    mockReadSelection.mockReset();
+  });
+
+  function typeSpace(editor: HTMLElement) {
+    const evt = new Event('beforeinput', { bubbles: true, cancelable: true });
+    Object.defineProperty(evt, 'inputType', { value: 'insertText' });
+    Object.defineProperty(evt, 'data', { value: ' ' });
+    act(() => {
+      editor.dispatchEvent(evt);
+    });
+    return evt;
+  }
+
+  function renderWith(text: string) {
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: text.length },
+      focus: { blockId: 'k', offset: text.length },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text, marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} />;
+    }
+    render(
+      <I18nProvider locale="en">
+        <Harness />
+      </I18nProvider>,
+    );
+    return screen.getByRole('textbox', { name: 'Rich text editor' });
+  }
+
+  it('"# " converts the paragraph to a heading (space consumed)', () => {
+    const editor = renderWith('#');
+    const evt = typeSpace(editor);
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    expect(evt.defaultPrevented).toBe(true);
+  });
+
+  it('"- " converts to a bullet list', () => {
+    const editor = renderWith('-');
+    typeSpace(editor);
+    expect(screen.getByRole('listitem')).toBeInTheDocument();
+  });
+
+  it('">" converts to a blockquote', () => {
+    const editor = renderWith('>');
+    typeSpace(editor);
+    expect(editor.querySelector('blockquote')).not.toBeNull();
+  });
+
+  it('a space after non-marker text does not convert (inserts normally)', () => {
+    const editor = renderWith('x');
+    const evt = typeSpace(editor);
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    expect(editor.querySelector('blockquote')).toBeNull();
+    expect(evt.defaultPrevented).toBe(true);
+    expect(editor).toHaveTextContent('x');
+  });
+});
+
 describe('RichTextEditor undo/redo', () => {
   beforeEach(() => {
     mockReadSelection.mockReset();

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -339,19 +339,68 @@ describe('RichTextEditor input rules', () => {
     expect(screen.getByRole('listitem')).toBeInTheDocument();
   });
 
-  it('">" converts to a blockquote', () => {
+  it('"> " converts to a blockquote', () => {
     const editor = renderWith('>');
     typeSpace(editor);
     expect(editor.querySelector('blockquote')).not.toBeNull();
   });
 
-  it('a space after non-marker text does not convert (inserts normally)', () => {
+  it('keeps trailing content when converting a marker with text after it', () => {
+    // "#foo" with the caret right after the "#" → heading "foo".
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 1 },
+      focus: { blockId: 'k', offset: 1 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: '#foo', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} />;
+    }
+    render(
+      <I18nProvider locale="en">
+        <Harness />
+      </I18nProvider>,
+    );
+    const editor = screen.getByRole('textbox', { name: 'Rich text editor' });
+    typeSpace(editor);
+    expect(screen.getByRole('heading', { level: 1, name: 'foo' })).toBeInTheDocument();
+  });
+
+  it('a space after non-marker text does not convert (inserts the space)', () => {
     const editor = renderWith('x');
     const evt = typeSpace(editor);
     expect(screen.queryByRole('heading')).not.toBeInTheDocument();
     expect(editor.querySelector('blockquote')).toBeNull();
     expect(evt.defaultPrevented).toBe(true);
-    expect(editor).toHaveTextContent('x');
+    // textContent (NOT toHaveTextContent, which trims) — the space must survive.
+    expect(editor.textContent).toBe('x ');
+  });
+
+  it('a converted block is a single undo step (⌘Z reverts the conversion)', async () => {
+    const user = userEvent.setup();
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 1 },
+      focus: { blockId: 'k', offset: 1 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: '#', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} toolbar />;
+    }
+    render(
+      <I18nProvider locale="en">
+        <Harness />
+      </I18nProvider>,
+    );
+    const editor = screen.getByRole('textbox', { name: 'Rich text editor' });
+    typeSpace(editor);
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeEnabled();
+    await user.click(screen.getByRole('button', { name: 'Undo' }));
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    expect(editor).toHaveTextContent('#');
   });
 });
 

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -129,6 +129,8 @@ function selectionRect(root: HTMLElement): Rect {
  * list, Tab/⇧Tab indent/outdent and Enter on an empty item exits to a paragraph.
  * Pasting rich HTML (web, Word, Google Docs) imports it as formatted content.
  * ⌘/Ctrl+Z / ⌘/Ctrl+Shift+Z (and the toolbar Undo/Redo buttons) undo and redo.
+ * Markdown shortcuts auto-format on typing — `# `, `- `, `1. `, `> `, or a code
+ * fence at a line start convert the block (Undo reverts the conversion).
  * The model is the source of truth: every input is replayed as an engine
  * transform and the DOM re-rendered.
  *

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -20,6 +20,8 @@ import { hasMark, withMark, withoutMark } from '../RichText/engine/marks';
 import { useTranslation } from '../../i18n';
 import { readSelection, writeSelection } from './selection';
 import { applyInput } from './input';
+import { matchBlockRule, applyBlockRule } from './inputRules';
+import { runsText } from '../RichText/engine/inlines';
 import { shortcutMark } from './shortcuts';
 import {
   activeMarks as deriveActiveMarks,
@@ -383,6 +385,23 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         }
         const range = readSelection(root);
         if (!range) return;
+        // Markdown block input rules: a marker + space at the start of a paragraph
+        // converts the block (e.g. "# " → heading, "- " → bullet). The space is
+        // consumed; one commit → one undo step (⌘Z reverts the conversion).
+        if (e.inputType === 'insertText' && e.data === ' ' && isCollapsed(range)) {
+          const block = doc.blocks.find((b) => b.id === range.anchor.blockId);
+          if (block) {
+            const before = runsText(block.inlines).slice(0, range.anchor.offset);
+            const match = matchBlockRule(block.type, before, ' ');
+            if (match) {
+              e.preventDefault();
+              setPendingMarks(null);
+              pendingAtRef.current = null;
+              commit(applyBlockRule(doc, block.id, match), 'other');
+              return;
+            }
+          }
+        }
         // Pending marks: a mark toggled at a collapsed caret applies to the next
         // typed text, then clears. Handle insertText here before generic input.
         const pend = pendingMarksRef.current;

--- a/packages/design-system/src/components/RichTextEditor/inputRules.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/inputRules.test.ts
@@ -4,25 +4,49 @@ import type { RichDoc } from '../RichText/engine/model';
 
 describe('matchBlockRule', () => {
   it('matches heading markers #/##/###', () => {
-    expect(matchBlockRule('paragraph', '#', ' ')).toEqual({ change: { type: 'heading', level: 1 }, markerLen: 1 });
-    expect(matchBlockRule('paragraph', '##', ' ')).toEqual({ change: { type: 'heading', level: 2 }, markerLen: 2 });
-    expect(matchBlockRule('paragraph', '###', ' ')).toEqual({ change: { type: 'heading', level: 3 }, markerLen: 3 });
+    expect(matchBlockRule('paragraph', '#', ' ')).toEqual({
+      change: { type: 'heading', level: 1 },
+      markerLen: 1,
+    });
+    expect(matchBlockRule('paragraph', '##', ' ')).toEqual({
+      change: { type: 'heading', level: 2 },
+      markerLen: 2,
+    });
+    expect(matchBlockRule('paragraph', '###', ' ')).toEqual({
+      change: { type: 'heading', level: 3 },
+      markerLen: 3,
+    });
   });
 
   it('matches bullet markers -/*/+', () => {
     for (const m of ['-', '*', '+']) {
-      expect(matchBlockRule('paragraph', m, ' ')).toEqual({ change: { type: 'bullet_item', depth: 0 }, markerLen: 1 });
+      expect(matchBlockRule('paragraph', m, ' ')).toEqual({
+        change: { type: 'bullet_item', depth: 0 },
+        markerLen: 1,
+      });
     }
   });
 
   it('matches ordered markers like 1. and 2)', () => {
-    expect(matchBlockRule('paragraph', '1.', ' ')).toEqual({ change: { type: 'ordered_item', depth: 0 }, markerLen: 2 });
-    expect(matchBlockRule('paragraph', '2)', ' ')).toEqual({ change: { type: 'ordered_item', depth: 0 }, markerLen: 2 });
+    expect(matchBlockRule('paragraph', '1.', ' ')).toEqual({
+      change: { type: 'ordered_item', depth: 0 },
+      markerLen: 2,
+    });
+    expect(matchBlockRule('paragraph', '2)', ' ')).toEqual({
+      change: { type: 'ordered_item', depth: 0 },
+      markerLen: 2,
+    });
   });
 
   it('matches blockquote and code fence', () => {
-    expect(matchBlockRule('paragraph', '>', ' ')).toEqual({ change: { type: 'blockquote' }, markerLen: 1 });
-    expect(matchBlockRule('paragraph', '```', ' ')).toEqual({ change: { type: 'code_block' }, markerLen: 3 });
+    expect(matchBlockRule('paragraph', '>', ' ')).toEqual({
+      change: { type: 'blockquote' },
+      markerLen: 1,
+    });
+    expect(matchBlockRule('paragraph', '```', ' ')).toEqual({
+      change: { type: 'code_block' },
+      markerLen: 3,
+    });
   });
 
   it('returns null for non-paragraph source, non-space trigger, and non-markers', () => {

--- a/packages/design-system/src/components/RichTextEditor/inputRules.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/inputRules.test.ts
@@ -1,0 +1,65 @@
+import { matchBlockRule, applyBlockRule } from './inputRules';
+import { createBlock } from '../RichText/engine/model';
+import type { RichDoc } from '../RichText/engine/model';
+
+describe('matchBlockRule', () => {
+  it('matches heading markers #/##/###', () => {
+    expect(matchBlockRule('paragraph', '#', ' ')).toEqual({ change: { type: 'heading', level: 1 }, markerLen: 1 });
+    expect(matchBlockRule('paragraph', '##', ' ')).toEqual({ change: { type: 'heading', level: 2 }, markerLen: 2 });
+    expect(matchBlockRule('paragraph', '###', ' ')).toEqual({ change: { type: 'heading', level: 3 }, markerLen: 3 });
+  });
+
+  it('matches bullet markers -/*/+', () => {
+    for (const m of ['-', '*', '+']) {
+      expect(matchBlockRule('paragraph', m, ' ')).toEqual({ change: { type: 'bullet_item', depth: 0 }, markerLen: 1 });
+    }
+  });
+
+  it('matches ordered markers like 1. and 2)', () => {
+    expect(matchBlockRule('paragraph', '1.', ' ')).toEqual({ change: { type: 'ordered_item', depth: 0 }, markerLen: 2 });
+    expect(matchBlockRule('paragraph', '2)', ' ')).toEqual({ change: { type: 'ordered_item', depth: 0 }, markerLen: 2 });
+  });
+
+  it('matches blockquote and code fence', () => {
+    expect(matchBlockRule('paragraph', '>', ' ')).toEqual({ change: { type: 'blockquote' }, markerLen: 1 });
+    expect(matchBlockRule('paragraph', '```', ' ')).toEqual({ change: { type: 'code_block' }, markerLen: 3 });
+  });
+
+  it('returns null for non-paragraph source, non-space trigger, and non-markers', () => {
+    expect(matchBlockRule('heading', '#', ' ')).toBeNull();
+    expect(matchBlockRule('paragraph', '#', 'x')).toBeNull();
+    expect(matchBlockRule('paragraph', '#x', ' ')).toBeNull();
+    expect(matchBlockRule('paragraph', 'text', ' ')).toBeNull();
+    expect(matchBlockRule('paragraph', '####', ' ')).toBeNull();
+  });
+});
+
+describe('applyBlockRule', () => {
+  const collapsed = (blockId: string, offset: number) => ({
+    anchor: { blockId, offset },
+    focus: { blockId, offset },
+  });
+
+  it('strips the marker and sets the heading type/level, caret at 0', () => {
+    const doc: RichDoc = { blocks: [createBlock('paragraph', '#foo', { id: 'a' })] };
+    const r = applyBlockRule(doc, 'a', { change: { type: 'heading', level: 1 }, markerLen: 1 });
+    expect(r.doc.blocks[0].type).toBe('heading');
+    expect(r.doc.blocks[0].level).toBe(1);
+    expect(r.doc.blocks[0].inlines.map((i) => i.text).join('')).toBe('foo');
+    expect(r.selection).toEqual(collapsed('a', 0));
+  });
+
+  it('converts a bare marker to an empty block', () => {
+    const doc: RichDoc = { blocks: [createBlock('paragraph', '>', { id: 'a' })] };
+    const r = applyBlockRule(doc, 'a', { change: { type: 'blockquote' }, markerLen: 1 });
+    expect(r.doc.blocks[0].type).toBe('blockquote');
+    expect(r.doc.blocks[0].inlines.map((i) => i.text).join('')).toBe('');
+  });
+
+  it('sets list depth 0 for a bullet rule', () => {
+    const doc: RichDoc = { blocks: [createBlock('paragraph', '-item', { id: 'a' })] };
+    const r = applyBlockRule(doc, 'a', { change: { type: 'bullet_item', depth: 0 }, markerLen: 1 });
+    expect(r.doc.blocks[0].type).toBe('bullet_item');
+    expect(r.doc.blocks[0].depth).toBe(0);
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/inputRules.ts
+++ b/packages/design-system/src/components/RichTextEditor/inputRules.ts
@@ -1,0 +1,71 @@
+// inputRules.ts — Markdown block input rules for <RichTextEditor>. Pure: match a
+// marker typed at the start of a paragraph (the trigger is always a space) and
+// apply the block conversion by composing existing engine transforms.
+import type { RichDoc, BlockType, Range } from '../RichText/engine/model';
+import { deleteRange, setBlockType } from '../RichText/engine/transforms';
+
+/** The block change a matched rule applies. */
+export interface BlockRuleChange {
+  type: BlockType;
+  level?: 1 | 2 | 3;
+  depth?: number;
+}
+export interface BlockRuleMatch {
+  change: BlockRuleChange;
+  /** Number of leading marker chars to strip from the block. */
+  markerLen: number;
+}
+
+/** Map an exact marker string to a block change, or null. */
+function changeFor(before: string): BlockRuleChange | null {
+  switch (before) {
+    case '#':
+      return { type: 'heading', level: 1 };
+    case '##':
+      return { type: 'heading', level: 2 };
+    case '###':
+      return { type: 'heading', level: 3 };
+    case '-':
+    case '*':
+    case '+':
+      return { type: 'bullet_item', depth: 0 };
+    case '>':
+      return { type: 'blockquote' };
+    case '```':
+      return { type: 'code_block' };
+    default:
+      return /^\d+[.)]$/.test(before) ? { type: 'ordered_item', depth: 0 } : null;
+  }
+}
+
+/**
+ * Match a block input rule. Fires only when `sourceType` is 'paragraph', the
+ * `trigger` is a single space, and `before` (block start → caret) is exactly a
+ * marker. Returns the block change + marker length, or null.
+ */
+export function matchBlockRule(
+  sourceType: BlockType,
+  before: string,
+  trigger: string,
+): BlockRuleMatch | null {
+  if (sourceType !== 'paragraph' || trigger !== ' ') return null;
+  const change = changeFor(before);
+  return change ? { change, markerLen: before.length } : null;
+}
+
+/**
+ * Apply a matched rule to the block: strip the marker prefix, then set the block
+ * type (composing `deleteRange` + `setBlockType`). Returns the `{ doc, selection }`
+ * commit payload with the caret at the block start.
+ */
+export function applyBlockRule(
+  doc: RichDoc,
+  blockId: string,
+  match: BlockRuleMatch,
+): { doc: RichDoc; selection: Range } {
+  const stripped = deleteRange(doc, {
+    anchor: { blockId, offset: 0 },
+    focus: { blockId, offset: match.markerLen },
+  });
+  return setBlockType(stripped.doc, blockId, match.change);
+}

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -32,7 +32,7 @@ export function RichTextEditorDemo() {
     >
       <Example
         title="Editable with toolbar"
-        description="The toolbar prop adds a formatting bar above the editor. Keyboard shortcuts and toolbar buttons both work — select text to format it, or toggle a mark at a collapsed caret and then type to apply it to new text. Enter on an empty list item exits the list; Tab / Shift+Tab indent and outdent list items. Undo/redo: ⌘/Ctrl+Z and ⌘/Ctrl+Shift+Z (or the toolbar Undo/Redo buttons)."
+        description='The toolbar prop adds a formatting bar above the editor. Keyboard shortcuts and toolbar buttons both work — select text to format it, or toggle a mark at a collapsed caret and then type to apply it to new text. Enter on an empty list item exits the list; Tab / Shift+Tab indent and outdent list items. Undo/redo: ⌘/Ctrl+Z and ⌘/Ctrl+Shift+Z (or the toolbar Undo/Redo buttons). Type "# ", "- ", "1. ", or "> " at the start of a line to auto-format.'
         code={`const [doc, setDoc] = useState(docFromText('…'));
 <RichTextEditor value={doc} onChange={setDoc} toolbar placeholder="Write a note…" />`}
       >


### PR DESCRIPTION
Adds Markdown-style block **input rules** to `<RichTextEditor>` (Slice 8) — typing a marker + space at the start of a paragraph auto-converts the block, so the editor feels like a modern Markdown-aware editor.

| Type at a line start | Becomes |
|---|---|
| `# ` / `## ` / `### ` | Heading 1/2/3 |
| `- ` / `* ` / `+ ` | Bullet list |
| `1. ` / `1) ` | Ordered list |
| `> ` | Blockquote |
| ` ``` ` + space | Code block |

Spec: `docs/superpowers/specs/2026-06-19-richtext-editor-input-rules-design.md` · Plan: `docs/superpowers/plans/2026-06-19-richtext-editor-input-rules.md`

## Summary

- **`inputRules.ts`** (pure, internal): `matchBlockRule(sourceType, before, trigger)` — fires only for a `paragraph` source, a space trigger, and an exact marker; `applyBlockRule(doc, blockId, match)` strips the marker and sets the block type, composing the existing `deleteRange` + `setBlockType` (no new engine transform).
- **Editor wiring**: hooked into the `beforeinput` insertText path (before the pending-marks branch). On a match → `preventDefault` (the space is consumed), clear any staged pending marks, and `commit(…, 'other')` so the conversion is **one undo step** (⌘Z reverts it, restoring the marker text).
- No new public API, no new dependency, no editor-prop change.

## Test plan

- **Unit (pure):** `inputRules.test.ts` — every marker maps to the right change; non-paragraph source / non-space trigger / non-marker / `####` → null; `applyBlockRule` strips the marker, sets type/level/depth, caret at 0, preserves trailing text.
- **Editor (jsdom):** synthetic `beforeinput` insertText space — `# `→heading, `- `→bullet, `> `→blockquote; **mid-block-caret** (`#foo` → heading "foo"); a non-marker space inserts normally (exact `textContent` check); **a conversion is a single undo step** (toolbar Undo reverts to the marker text). Full suite green (2936 tests); no manifest drift.
- **Adversarial review:** the wiring review confirmed correct placement (rules before pending-marks, so a marker isn't typed with a staged mark), complete guards (readOnly/composing/collapsed), and no over-fire; minor test-quality fixes applied.
- **Browser (Playwright):** typing `# ` at a paragraph start → `<h1>` with the marker consumed and text preserved; ⌘Z reverts to the paragraph with `#`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)