### PR TITLE
feat(RichTextEditor): @-mention autocomplete (mentions prop)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -938,6 +938,12 @@ const [doc, setDoc] = useState(emptyDoc());
 
 **Export:** `toHtml(doc)` and `toMarkdown(doc)` serialize a `RichDoc` back to a string (the inverse of `fromHtml`/`fromMarkdown`) — e.g. for storage, email bodies, or display outside the editor. `toHtml` is lossless (`fromHtml(toHtml(doc))` round-trips); `toMarkdown` drops underline (no Markdown syntax — use `toHtml` for full fidelity). Both escape output and run hrefs through `safeHref`.
 
+**Mentions:** pass `mentions={{ onQuery }}` (optional `trigger`, default `@`) to
+enable `@`-autocomplete. `onQuery(query)` returns `MentionItem[]` (`{ id, label,
+description?, avatarUrl? }`), sync or async. Picking a candidate inserts a chip
+carrying the `id`; chips survive `toHtml`/`fromHtml` round-trips but degrade to
+plain `@label` text in `toMarkdown`. Chips are inert references, not links.
+
 **Undo/redo:** built in — ⌘/Ctrl+Z undo, ⌘/Ctrl+Shift+Z (or ⌘/Ctrl+Y) redo, plus the toolbar Undo/Redo buttons. Typing coalesces into one step (short bursts), and replacing `value` from outside the editor clears the history.
 
 **Input rules:** typing a Markdown marker + space at the start of a paragraph auto-converts the block — `# `/`## `/`### ` → headings, `- `/`* `/`+ ` → bullet list, `1. ` → ordered list, `> ` → blockquote, a triple-backtick fence → code block. One Undo reverts the conversion.

--- a/packages/design-system/src/components.manifest.json
+++ b/packages/design-system/src/components.manifest.json
@@ -26,7 +26,8 @@
       "Tooltip"
     ],
     "composedBy": [
-      "PersonDisplay"
+      "PersonDisplay",
+      "RichTextEditor"
     ]
   },
   "Badge": {
@@ -518,12 +519,14 @@
     "tier": "composition",
     "cluster": "Forms",
     "composes": [
+      "Avatar",
       "Button",
       "Cluster",
       "DropdownMenu",
       "Input",
       "RichText",
-      "Stack"
+      "Stack",
+      "Text"
     ],
     "composedBy": []
   },
@@ -622,7 +625,8 @@
       "FilterChip",
       "FormSection",
       "OptionsPicker",
-      "PersonDisplay"
+      "PersonDisplay",
+      "RichTextEditor"
     ]
   },
   "Textarea": {

--- a/packages/design-system/src/components/RichText/_prose.scss
+++ b/packages/design-system/src/components/RichText/_prose.scss
@@ -62,4 +62,13 @@
     color: var(--color-accent);
     text-decoration: underline;
   }
+
+  :where([data-mention]) {
+    padding: 0 var(--space-1);
+    border-radius: var(--radius-sm);
+    background: var(--color-accent-bg-subtle);
+    color: var(--color-accent);
+    font-weight: var(--font-weight-medium);
+    white-space: nowrap;
+  }
 }

--- a/packages/design-system/src/components/RichText/engine/fromHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/fromHtml.test.ts
@@ -167,6 +167,22 @@ it('round-trips a mention through toHtml → fromHtml', () => {
   expect(run?.marks).toEqual([{ type: 'mention', id: 'u1', label: 'Alice' }]);
 });
 
+it('round-trips a mention with special chars in id/label through toHtml → fromHtml', () => {
+  const doc: RichDoc = {
+    blocks: [
+      {
+        id: 'b',
+        type: 'paragraph',
+        inlines: [{ text: '@A&<>"B', marks: [{ type: 'mention', id: 'a&b"<', label: 'A&<>"B' }] }],
+      },
+    ],
+  };
+  const back = fromHtml(toHtml(doc));
+  const run = back.blocks[0].inlines.find((r) => r.marks.some((m) => m.type === 'mention'));
+  expect(run?.marks).toEqual([{ type: 'mention', id: 'a&b"<', label: 'A&<>"B' }]);
+  expect(run?.text).toBe('@A&<>"B');
+});
+
 it('a plain span without data-mention-id is not a mention', () => {
   const doc = fromHtml('<p><span>plain</span></p>');
   expect(doc.blocks[0].inlines.every((r) => r.marks.every((m) => m.type !== 'mention'))).toBe(true);

--- a/packages/design-system/src/components/RichText/engine/fromHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/fromHtml.test.ts
@@ -1,6 +1,7 @@
 import { fromHtml } from './fromHtml';
+import { toHtml } from './toHtml';
 import { runsText } from './inlines';
-import type { Block } from './model';
+import type { Block, RichDoc } from './model';
 
 const text = (b: Block) => runsText(b.inlines);
 
@@ -138,4 +139,40 @@ describe('fromHtml — inline marks', () => {
     const d = fromHtml('<p>  a   b  </p>');
     expect(text(d.blocks[0])).toBe('a b');
   });
+});
+
+it('parses a data-mention-id span into a mention mark', () => {
+  const doc = fromHtml(
+    '<p>cc <span data-mention-id="u1" data-mention-label="Alice">@Alice</span></p>',
+  );
+  const run = doc.blocks[0].inlines.find((r) => r.text === '@Alice');
+  expect(run?.marks).toEqual([{ type: 'mention', id: 'u1', label: 'Alice' }]);
+});
+
+it('round-trips a mention through toHtml → fromHtml', () => {
+  const doc: RichDoc = {
+    blocks: [
+      {
+        id: 'b',
+        type: 'paragraph',
+        inlines: [
+          { text: 'cc ', marks: [] },
+          { text: '@Alice', marks: [{ type: 'mention', id: 'u1', label: 'Alice' }] },
+        ],
+      },
+    ],
+  };
+  const back = fromHtml(toHtml(doc));
+  const run = back.blocks[0].inlines.find((r) => r.text === '@Alice');
+  expect(run?.marks).toEqual([{ type: 'mention', id: 'u1', label: 'Alice' }]);
+});
+
+it('a plain span without data-mention-id is not a mention', () => {
+  const doc = fromHtml('<p><span>plain</span></p>');
+  expect(doc.blocks[0].inlines.every((r) => r.marks.every((m) => m.type !== 'mention'))).toBe(true);
+});
+
+it('a span with an empty data-mention-id is treated as plain text', () => {
+  const doc = fromHtml('<p><span data-mention-id="">@x</span></p>');
+  expect(doc.blocks[0].inlines.every((r) => r.marks.every((m) => m.type !== 'mention'))).toBe(true);
 });

--- a/packages/design-system/src/components/RichText/engine/fromHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/fromHtml.ts
@@ -113,6 +113,14 @@ function marksFor(el: HTMLElement, parent: Mark[]): Mark[] {
       if (href !== undefined) marks = withMark(marks, { type: 'link', href });
       break;
     }
+    case 'SPAN': {
+      const id = el.getAttribute('data-mention-id');
+      if (id) {
+        const label = el.getAttribute('data-mention-label') ?? el.textContent ?? '';
+        marks = withMark(marks, { type: 'mention', id, label });
+      }
+      break;
+    }
   }
   return applyCssMarks(el, marks);
 }

--- a/packages/design-system/src/components/RichText/engine/marks.test.ts
+++ b/packages/design-system/src/components/RichText/engine/marks.test.ts
@@ -47,3 +47,23 @@ describe('marks', () => {
     expect(input).toEqual([bold]);
   });
 });
+
+describe('markKey / marksEqual — mentions', () => {
+  it('two mentions with different ids are NOT equal', () => {
+    const a = [{ type: 'mention', id: '1', label: 'Alice' } as const];
+    const b = [{ type: 'mention', id: '2', label: 'Alice' } as const];
+    expect(marksEqual(a, b)).toBe(false);
+  });
+
+  it('two mentions with the same id+label ARE equal', () => {
+    const a = [{ type: 'mention', id: '1', label: 'Alice' } as const];
+    const b = [{ type: 'mention', id: '1', label: 'Alice' } as const];
+    expect(marksEqual(a, b)).toBe(true);
+  });
+
+  it('a mention is not equal to a bare-type mark set of different length', () => {
+    const a = [{ type: 'mention', id: '1', label: 'Alice' } as const];
+    const b = [{ type: 'bold' } as const];
+    expect(marksEqual(a, b)).toBe(false);
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/marks.ts
+++ b/packages/design-system/src/components/RichText/engine/marks.ts
@@ -1,9 +1,11 @@
 // marks.ts — Layer A. Pure helpers over a Mark[]. Never mutate inputs.
 import type { Mark, MarkType } from './model';
 
-/** Canonical key for set comparison (link distinguished by href). */
+/** Canonical key for set comparison (link by href, mention by id+label). */
 function markKey(m: Mark): string {
-  return m.type === 'link' ? `link:${m.href}` : m.type;
+  if (m.type === 'link') return `link:${m.href}`;
+  if (m.type === 'mention') return `mention:${m.id}:${m.label}`;
+  return m.type;
 }
 
 /** Order-insensitive set equality (link href included). */

--- a/packages/design-system/src/components/RichText/engine/model.ts
+++ b/packages/design-system/src/components/RichText/engine/model.ts
@@ -12,17 +12,18 @@ export type BlockType =
   | 'blockquote'
   | 'code_block';
 
-/** All supported inline mark types. `link` carries an additional `href` field on the `Mark` union. */
-export type MarkType = 'bold' | 'italic' | 'underline' | 'strike' | 'code' | 'link';
+/** All supported inline mark types. `link` carries `href`; `mention` carries `id` + `label`. */
+export type MarkType = 'bold' | 'italic' | 'underline' | 'strike' | 'code' | 'link' | 'mention';
 
-/** A formatting mark. Flags carry no data; `link` carries an href. */
+/** A formatting mark. Flags carry no data; `link` carries an href; `mention` an id + label. */
 export type Mark =
   | { type: 'bold' }
   | { type: 'italic' }
   | { type: 'underline' }
   | { type: 'strike' }
   | { type: 'code' }
-  | { type: 'link'; href: string };
+  | { type: 'link'; href: string }
+  | { type: 'mention'; id: string; label: string };
 
 /** A run of text sharing exactly one mark set. */
 export interface Inline {

--- a/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
@@ -223,6 +223,28 @@ describe('renderDoc', () => {
   });
 });
 
+it('renders a mention mark as a data-mention span containing the chip text', () => {
+  const doc: RichDoc = {
+    blocks: [
+      {
+        id: 'b',
+        type: 'paragraph',
+        inlines: [
+          { text: 'hi ', marks: [] },
+          { text: '@Alice', marks: [{ type: 'mention', id: 'u1', label: 'Alice' }] },
+        ],
+      },
+    ],
+  };
+  const { container } = render(<>{renderDoc(doc)}</>);
+  const chip = container.querySelector('[data-mention]') as HTMLElement;
+  expect(chip).not.toBeNull();
+  expect(chip.tagName).toBe('SPAN');
+  expect(chip).toHaveAttribute('data-mention-id', 'u1');
+  expect(chip).toHaveAttribute('data-mention-label', 'Alice');
+  expect(chip.textContent).toBe('@Alice');
+});
+
 describe('renderDoc editable option', () => {
   it('adds data-block-id to block elements when editable', () => {
     const doc: RichDoc = { blocks: [createBlock('paragraph', 'hi', { id: 'b1' })] };

--- a/packages/design-system/src/components/RichText/engine/renderDoc.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.tsx
@@ -12,7 +12,7 @@ export interface RenderDocOptions {
 }
 
 // Outer → inner nesting order so output is stable + diff-friendly.
-const MARK_ORDER: MarkType[] = ['link', 'bold', 'italic', 'underline', 'strike', 'code'];
+const MARK_ORDER: MarkType[] = ['mention', 'link', 'bold', 'italic', 'underline', 'strike', 'code'];
 
 function wrapMark(type: MarkType, mark: Mark, child: ReactNode): ReactNode {
   switch (type) {
@@ -31,6 +31,16 @@ function wrapMark(type: MarkType, mark: Mark, child: ReactNode): ReactNode {
         <a href={mark.type === 'link' ? safeHref(mark.href) : undefined} rel="noopener noreferrer">
           {child}
         </a>
+      );
+    case 'mention':
+      return (
+        <span
+          data-mention
+          data-mention-id={mark.type === 'mention' ? mark.id : undefined}
+          data-mention-label={mark.type === 'mention' ? mark.label : undefined}
+        >
+          {child}
+        </span>
       );
     default:
       return child;

--- a/packages/design-system/src/components/RichText/engine/toHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/toHtml.test.ts
@@ -112,7 +112,7 @@ describe('toHtml — inline marks', () => {
         },
       ],
     };
-    expect(toHtml(doc)).toContain('data-mention-id="a&#39;b"'.replace('&#39;', '&quot;'));
+    expect(toHtml(doc)).toContain('data-mention-id="a&quot;b"');
     expect(toHtml(doc)).toContain('data-mention-label="A&quot;B"');
   });
 

--- a/packages/design-system/src/components/RichText/engine/toHtml.test.ts
+++ b/packages/design-system/src/components/RichText/engine/toHtml.test.ts
@@ -84,6 +84,38 @@ describe('toHtml — inline marks', () => {
     expect(toHtml(doc)).toBe('<p><strong>b</strong><em>i</em><u>u</u><s>s</s></p>');
   });
 
+  it('serializes a mention mark to a data-mention span', () => {
+    const doc: RichDoc = {
+      blocks: [
+        {
+          id: 'b',
+          type: 'paragraph',
+          inlines: [
+            { text: 'cc ', marks: [] },
+            { text: '@Alice', marks: [{ type: 'mention', id: 'u1', label: 'Alice' }] },
+          ],
+        },
+      ],
+    };
+    expect(toHtml(doc)).toBe(
+      '<p>cc <span data-mention-id="u1" data-mention-label="Alice">@Alice</span></p>',
+    );
+  });
+
+  it('escapes mention id/label attributes', () => {
+    const doc: RichDoc = {
+      blocks: [
+        {
+          id: 'b',
+          type: 'paragraph',
+          inlines: [{ text: '@A"B', marks: [{ type: 'mention', id: 'a"b', label: 'A"B' }] }],
+        },
+      ],
+    };
+    expect(toHtml(doc)).toContain('data-mention-id="a&#39;b"'.replace('&#39;', '&quot;'));
+    expect(toHtml(doc)).toContain('data-mention-label="A&quot;B"');
+  });
+
   it('escapes text and the href, and drops an unsafe-href anchor (keeping text)', () => {
     expect(toHtml({ blocks: [para('a', [{ text: 'a<b>&"', marks: [] }])] })).toBe(
       '<p>a&lt;b&gt;&amp;"</p>',

--- a/packages/design-system/src/components/RichText/engine/toHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/toHtml.ts
@@ -10,7 +10,7 @@ import { safeHref } from './safeHref';
 import { isListItem, effectiveDepths } from './listDepths';
 
 // Outer → inner; link outermost, code innermost (matches renderDoc).
-const MARK_ORDER: MarkType[] = ['link', 'bold', 'italic', 'underline', 'strike', 'code'];
+const MARK_ORDER: MarkType[] = ['mention', 'link', 'bold', 'italic', 'underline', 'strike', 'code'];
 
 /** Wrap an already-escaped HTML string in one mark's tag. */
 function wrapMark(type: MarkType, mark: Mark, inner: string): string {
@@ -29,6 +29,10 @@ function wrapMark(type: MarkType, mark: Mark, inner: string): string {
       const safe = mark.type === 'link' ? safeHref(mark.href) : undefined;
       if (safe === undefined) return inner; // unsafe href → drop the anchor, keep text
       return `<a href="${escapeAttr(safe)}" rel="noopener noreferrer">${inner}</a>`;
+    }
+    case 'mention': {
+      if (mark.type !== 'mention') return inner;
+      return `<span data-mention-id="${escapeAttr(mark.id)}" data-mention-label="${escapeAttr(mark.label)}">${inner}</span>`;
     }
     default:
       return inner;

--- a/packages/design-system/src/components/RichText/engine/toMarkdown.test.ts
+++ b/packages/design-system/src/components/RichText/engine/toMarkdown.test.ts
@@ -58,6 +58,22 @@ describe('toMarkdown — inline', () => {
     );
   });
 
+  it('serializes a mention as plain text (lossy — id dropped)', () => {
+    const doc: RichDoc = {
+      blocks: [
+        {
+          id: 'b',
+          type: 'paragraph',
+          inlines: [
+            { text: 'cc ', marks: [] },
+            { text: '@Alice', marks: [{ type: 'mention', id: 'u1', label: 'Alice' }] },
+          ],
+        },
+      ],
+    };
+    expect(toMarkdown(doc)).toBe('cc @Alice');
+  });
+
   it('escapes inline markdown specials and a leading block marker', () => {
     expect(toMarkdown({ blocks: [para('a', [{ text: 'a*b_c', marks: [] }])] })).toBe('a\\*b\\_c');
     expect(toMarkdown({ blocks: [para('a', [{ text: '# not a heading', marks: [] }])] })).toBe(

--- a/packages/design-system/src/components/RichText/engine/toMarkdown.ts
+++ b/packages/design-system/src/components/RichText/engine/toMarkdown.ts
@@ -56,8 +56,10 @@ function blockMd(block: Block, depth: number): string {
 
 /**
  * Serialize a `RichDoc` to Markdown (CommonMark + GFM strikethrough), the inverse
- * of `fromMarkdown`. Lossy: **underline is dropped** (no Markdown syntax — use
- * `toHtml` for full fidelity); images/tables aren't modeled; MD-special escaping
+ * of `fromMarkdown`. Lossy: **underline is dropped** (no Markdown syntax — use `toHtml` for full
+ * fidelity) and **mentions degrade to plain `@label` text** (the id is not
+ * representable in Markdown — `toHtml`/`fromHtml` preserve mentions);
+ * images/tables aren't modeled; MD-special escaping
  * is best-effort.
  *
  * @example

--- a/packages/design-system/src/components/RichText/engine/transforms.test.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.test.ts
@@ -272,4 +272,24 @@ describe('deleteRange — mention snapping', () => {
     });
     expect(runsText(doc.blocks[0].inlines)).toBe(' @Alice ok');
   });
+
+  it('snaps the END endpoint when a cross-block selection ends inside a chip', () => {
+    const doc: RichDoc = {
+      blocks: [
+        { id: 'a', type: 'paragraph', inlines: [{ text: 'hello', marks: [] }] },
+        {
+          id: 'b',
+          type: 'paragraph',
+          inlines: [{ text: '@Alice', marks: [{ type: 'mention', id: 'u1', label: 'Alice' }] }],
+        },
+      ],
+    };
+    // select from a:2 to b:3 (inside the chip [0,6)) → end snaps to 6 → whole chip gone
+    const { doc: out } = deleteRange(doc, {
+      anchor: { blockId: 'a', offset: 2 },
+      focus: { blockId: 'b', offset: 3 },
+    });
+    expect(out.blocks).toHaveLength(1);
+    expect(runsText(out.blocks[0].inlines)).toBe('he');
+  });
 });

--- a/packages/design-system/src/components/RichText/engine/transforms.test.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.test.ts
@@ -8,6 +8,7 @@ import {
   toggleMark,
   setBlockType,
   insertFragment,
+  insertMention,
 } from './transforms';
 import { createBlock } from './model';
 import { runsText } from './inlines';
@@ -165,5 +166,110 @@ describe('insertFragment', () => {
     });
     expect(r.doc).toBe(doc);
     expect(r.selection).toEqual(fcollapsed('a', 2));
+  });
+});
+
+describe('insertMention', () => {
+  const docWith = (text: string): RichDoc => ({
+    blocks: [{ id: 'b', type: 'paragraph', inlines: [{ text, marks: [] }] }],
+  });
+
+  it('replaces the trigger+query with a chip run + trailing space, caret after', () => {
+    // "hi @al" — trigger at offset 3, caret at offset 6
+    const { doc, selection } = insertMention(docWith('hi @al'), 'b', { from: 3, to: 6 }, '@', {
+      id: 'u1',
+      label: 'Alice',
+    });
+    const runs = doc.blocks[0].inlines;
+    expect(runs[0]).toEqual({ text: 'hi ', marks: [] });
+    expect(runs[1]).toEqual({
+      text: '@Alice',
+      marks: [{ type: 'mention', id: 'u1', label: 'Alice' }],
+    });
+    expect(runs[2].text).toBe(' ');
+    // caret after "hi " (3) + "@Alice" (6) + " " (1) = 10
+    expect(selection.anchor).toEqual({ blockId: 'b', offset: 10 });
+    expect(selection.focus).toEqual({ blockId: 'b', offset: 10 });
+  });
+
+  it('handles a bare trigger with no query (from===to-1)', () => {
+    const { doc } = insertMention(docWith('@'), 'b', { from: 0, to: 1 }, '@', {
+      id: 'u1',
+      label: 'Bob',
+    });
+    expect(doc.blocks[0].inlines[0]).toEqual({
+      text: '@Bob',
+      marks: [{ type: 'mention', id: 'u1', label: 'Bob' }],
+    });
+  });
+
+  it('typed text right after a chip does not inherit the mention mark', () => {
+    const doc: RichDoc = {
+      blocks: [
+        {
+          id: 'b',
+          type: 'paragraph',
+          inlines: [{ text: '@Alice', marks: [{ type: 'mention', id: 'u1', label: 'Alice' }] }],
+        },
+      ],
+    };
+    const { doc: out } = insertText(doc, { blockId: 'b', offset: 6 }, 'x');
+    const runs = out.blocks[0].inlines;
+    const last = runs[runs.length - 1];
+    expect(last.text).toBe('x');
+    expect(last.marks).toEqual([]);
+  });
+});
+
+describe('deleteRange — mention snapping', () => {
+  const docWithChip = (): RichDoc => ({
+    blocks: [
+      {
+        id: 'b',
+        type: 'paragraph',
+        inlines: [
+          { text: 'hi ', marks: [] },
+          { text: '@Alice', marks: [{ type: 'mention', id: 'u1', label: 'Alice' }] },
+          { text: ' ok', marks: [] },
+        ],
+      },
+    ],
+  });
+
+  it('a one-char delete at the chip right edge removes the WHOLE chip (backspace)', () => {
+    // chip spans [3,9); caret at 9, backspace deletes [8,9] → snaps to [3,9]
+    const { doc, selection } = deleteRange(docWithChip(), {
+      anchor: { blockId: 'b', offset: 8 },
+      focus: { blockId: 'b', offset: 9 },
+    });
+    expect(runsText(doc.blocks[0].inlines)).toBe('hi  ok');
+    expect(selection.anchor).toEqual({ blockId: 'b', offset: 3 });
+  });
+
+  it('a one-char delete at the chip left edge removes the WHOLE chip (forward delete)', () => {
+    // caret at 3, forward delete [3,4] → snaps to [3,9]
+    const { doc } = deleteRange(docWithChip(), {
+      anchor: { blockId: 'b', offset: 3 },
+      focus: { blockId: 'b', offset: 4 },
+    });
+    expect(runsText(doc.blocks[0].inlines)).toBe('hi  ok');
+  });
+
+  it('a selection that partially overlaps the chip removes the whole chip', () => {
+    // select [5,7] (inside the chip) → snaps to [3,9]
+    const { doc } = deleteRange(docWithChip(), {
+      anchor: { blockId: 'b', offset: 5 },
+      focus: { blockId: 'b', offset: 7 },
+    });
+    expect(runsText(doc.blocks[0].inlines)).toBe('hi  ok');
+  });
+
+  it('a delete entirely outside the chip is unaffected', () => {
+    // delete "hi" [0,2]
+    const { doc } = deleteRange(docWithChip(), {
+      anchor: { blockId: 'b', offset: 0 },
+      focus: { blockId: 'b', offset: 2 },
+    });
+    expect(runsText(doc.blocks[0].inlines)).toBe(' @Alice ok');
   });
 });

--- a/packages/design-system/src/components/RichText/engine/transforms.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.ts
@@ -22,7 +22,8 @@ function marksBefore(block: Block, offset: number): Mark[] {
   let pos = 0;
   for (const run of block.inlines) {
     const runEnd = pos + run.text.length;
-    if (offset - 1 >= pos && offset - 1 < runEnd) return run.marks.filter((m) => m.type !== 'mention');
+    if (offset - 1 >= pos && offset - 1 < runEnd)
+      return run.marks.filter((m) => m.type !== 'mention');
     pos = runEnd;
   }
   return [];

--- a/packages/design-system/src/components/RichText/engine/transforms.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.ts
@@ -22,10 +22,36 @@ function marksBefore(block: Block, offset: number): Mark[] {
   let pos = 0;
   for (const run of block.inlines) {
     const runEnd = pos + run.text.length;
-    if (offset - 1 >= pos && offset - 1 < runEnd) return [...run.marks];
+    if (offset - 1 >= pos && offset - 1 < runEnd) return run.marks.filter((m) => m.type !== 'mention');
     pos = runEnd;
   }
   return [];
+}
+
+/** Bounds of the mention run strictly containing `offset`, or null. */
+function mentionRunBoundsAt(block: Block, offset: number): { start: number; end: number } | null {
+  let pos = 0;
+  for (const run of block.inlines) {
+    const s = pos;
+    const e = pos + run.text.length;
+    pos = e;
+    if (offset > s && offset < e && run.marks.some((m) => m.type === 'mention')) {
+      return { start: s, end: e };
+    }
+  }
+  return null;
+}
+
+/** Snap a range START leftward out of any mention it bisects. */
+function snapStartOffset(block: Block, offset: number): number {
+  const b = mentionRunBoundsAt(block, offset);
+  return b ? b.start : offset;
+}
+
+/** Snap a range END rightward out of any mention it bisects. */
+function snapEndOffset(block: Block, offset: number): number {
+  const b = mentionRunBoundsAt(block, offset);
+  return b ? b.end : offset;
 }
 
 /**
@@ -61,13 +87,20 @@ export function insertText(
  * selection }` with the caret at the deletion point.
  */
 export function deleteRange(doc: RichDoc, range: Range): { doc: RichDoc; selection: Range } {
-  const { start, end } = orderedRange(doc, range);
+  const ord = orderedRange(doc, range);
+  let start = ord.start;
+  let end = ord.end;
+  // Collapsed input → no-op (never snap a collapsed caret into a deletion).
   if (start.blockId === end.blockId && start.offset === end.offset) {
     return { doc, selection: collapsed(start) };
   }
   const si = findBlockIndex(doc, start.blockId);
   const ei = findBlockIndex(doc, end.blockId);
   if (si === -1 || ei === -1) return { doc, selection: collapsed(start) };
+  // Snap endpoints out of any mention run they bisect, so a partial selection (or
+  // a one-char backspace/forward-delete at a chip edge) removes the whole chip.
+  start = { ...start, offset: snapStartOffset(doc.blocks[si], start.offset) };
+  end = { ...end, offset: snapEndOffset(doc.blocks[ei], end.offset) };
   const startBlock = doc.blocks[si];
   const endBlock = doc.blocks[ei];
   const inlines = normalizeInlines([
@@ -279,5 +312,36 @@ export function insertFragment(
   return {
     doc: { blocks },
     selection: collapsed({ blockId: bright.id, offset: runsLength(last.inlines) }),
+  };
+}
+
+/**
+ * Pure/immutable. Replace the block-relative span `[range.from, range.to)` with a
+ * mention chip run (`text: trigger + mention.label`, mark `{type:'mention', id,
+ * label}`) followed by a single trailing space. Returns `{ doc, selection }` with
+ * the caret after the trailing space. No-op (collapsed caret at `range.from`) when
+ * `blockId` is not found.
+ */
+export function insertMention(
+  doc: RichDoc,
+  blockId: string,
+  range: { from: number; to: number },
+  trigger: string,
+  mention: { id: string; label: string },
+): { doc: RichDoc; selection: Range } {
+  const idx = findBlockIndex(doc, blockId);
+  if (idx === -1) return { doc, selection: collapsed({ blockId, offset: range.from }) };
+  const block = doc.blocks[idx];
+  const chipText = `${trigger}${mention.label}`;
+  const inlines = normalizeInlines([
+    ...sliceInlines(block.inlines, 0, range.from),
+    { text: chipText, marks: [{ type: 'mention', id: mention.id, label: mention.label }] },
+    { text: ' ', marks: [] },
+    ...sliceInlines(block.inlines, range.to, blockLength(block)),
+  ]);
+  const offset = range.from + chipText.length + 1;
+  return {
+    doc: replaceBlock(doc, idx, { ...block, inlines }),
+    selection: collapsed({ blockId, offset }),
   };
 }

--- a/packages/design-system/src/components/RichText/engine/transforms.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.ts
@@ -332,15 +332,18 @@ export function insertMention(
 ): { doc: RichDoc; selection: Range } {
   const idx = findBlockIndex(doc, blockId);
   if (idx === -1) return { doc, selection: collapsed({ blockId, offset: range.from }) };
+  // Defensive clamp: tolerate an inverted range (from > to). No-op for valid input.
+  const from = Math.min(range.from, range.to);
+  const to = Math.max(range.from, range.to);
   const block = doc.blocks[idx];
   const chipText = `${trigger}${mention.label}`;
   const inlines = normalizeInlines([
-    ...sliceInlines(block.inlines, 0, range.from),
+    ...sliceInlines(block.inlines, 0, from),
     { text: chipText, marks: [{ type: 'mention', id: mention.id, label: mention.label }] },
     { text: ' ', marks: [] },
-    ...sliceInlines(block.inlines, range.to, blockLength(block)),
+    ...sliceInlines(block.inlines, to, blockLength(block)),
   ]);
-  const offset = range.from + chipText.length + 1;
+  const offset = from + chipText.length + 1;
   return {
     doc: replaceBlock(doc, idx, { ...block, inlines }),
     selection: collapsed({ blockId, offset }),

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
@@ -81,3 +81,46 @@
   background: var(--color-bg);
   box-shadow: var(--shadow-lg);
 }
+
+// The floating @-mention listbox (RichTextMentionMenu). Portaled to <body> and
+// positioned by Floating UI's inline `floatingStyles`. Same Rule 4 note as
+// .linkBubble applies: min/max sizing here describes the overlay's intrinsic
+// size, not in-flow layout.
+.mentionMenu {
+  display: flex;
+  flex-direction: column;
+  min-width: var(--size-dropdown-min-width);
+  max-width: var(--size-popover-max-width);
+  max-height: var(--size-listbox-max-height);
+  overflow-y: auto;
+  padding: var(--space-1);
+  background: var(--color-bg);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  z-index: var(--z-overlay-floating);
+}
+
+.mentionOption,
+.mentionOptionActive {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.mentionOptionActive {
+  background: var(--color-bg-muted);
+}
+
+.mentionText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.mentionEmpty {
+  padding: var(--space-2);
+}

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { vi } from 'vitest';
@@ -496,5 +496,56 @@ describe('RichTextEditor undo/redo', () => {
     screen.getByRole('textbox', { name: 'Rich text editor' }).focus();
     await user.keyboard('{Meta>}z{/Meta}');
     expect(screen.queryByRole('strong')).not.toBeInTheDocument();
+  });
+});
+
+describe('RichTextEditor mentions', () => {
+  beforeEach(() => mockReadSelection.mockReset());
+
+  const usersQuery = (q: string) =>
+    Promise.resolve(
+      [
+        { id: 'u1', label: 'Alice' },
+        { id: 'u2', label: 'Aaron' },
+      ].filter((u) => u.label.toLowerCase().includes(q.toLowerCase())),
+    );
+
+  it('does not open a menu when the mentions prop is absent', () => {
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 3 },
+      focus: { blockId: 'k', offset: 3 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hi @', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} />;
+    }
+    renderEditor(<Harness />);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('opens the menu for a trigger context and inserts a chip on Enter', async () => {
+    const user = userEvent.setup();
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 5 },
+      focus: { blockId: 'k', offset: 5 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hi @a', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} mentions={{ onQuery: usersQuery }} />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox');
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
+    expect(await screen.findByText('Alice')).toBeInTheDocument();
+    box.focus();
+    await user.keyboard('{Enter}');
+    // chip inserted: a data-mention span with the active item
+    await waitFor(() =>
+      expect(box.querySelector('[data-mention-id="u1"]')?.textContent).toBe('@Alice'),
+    );
   });
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -548,4 +548,45 @@ describe('RichTextEditor mentions', () => {
       expect(box.querySelector('[data-mention-id="u1"]')?.textContent).toBe('@Alice'),
     );
   });
+
+  it('exposes combobox ARIA on the textbox when the menu is open', async () => {
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 5 },
+      focus: { blockId: 'k', offset: 5 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hi @a', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} mentions={{ onQuery: usersQuery }} />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox');
+    const listbox = await screen.findByRole('listbox');
+    expect(box).toHaveAttribute('aria-expanded', 'true');
+    expect(box).toHaveAttribute('aria-controls', listbox.getAttribute('id')!);
+    expect(box).toHaveAttribute('aria-autocomplete', 'list');
+    await waitFor(() => expect(box.getAttribute('aria-activedescendant')).toBeTruthy());
+  });
+
+  it('Escape closes the menu without inserting', async () => {
+    const user = userEvent.setup();
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 5 },
+      focus: { blockId: 'k', offset: 5 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hi @a', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} mentions={{ onQuery: usersQuery }} />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox');
+    await screen.findByRole('listbox');
+    box.focus();
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('listbox')).toBeNull());
+    expect(box.querySelector('[data-mention-id]')).toBeNull();
+  });
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -122,6 +122,8 @@ interface LinkEditorOpen {
  * ⌘/Ctrl+Z / ⌘/Ctrl+Shift+Z (and the toolbar Undo/Redo buttons) undo and redo.
  * Markdown shortcuts auto-format on typing — `# `, `- `, `1. `, `> `, or a code
  * fence at a line start convert the block (Undo reverts the conversion).
+ * Pass `mentions={{ onQuery }}` to enable `@`-mention autocomplete: typing the
+ * trigger opens a combobox of candidates and inserts a chip carrying the id.
  * The model is the source of truth: every input is replayed as an engine
  * transform and the DOM re-rendered.
  *
@@ -132,6 +134,11 @@ interface LinkEditorOpen {
  * @example
  * // With the built-in toolbar (mark buttons, block-type menu, list toggles).
  * <RichTextEditor value={doc} onChange={setDoc} toolbar />
+ *
+ * @example
+ * // @-mentions: resolve candidates from your data (sync or async).
+ * <RichTextEditor value={doc} onChange={setDoc}
+ *   mentions={{ onQuery: (q) => searchUsers(q) }} />
  *
  * @example
  * // Read-only display of an existing document.
@@ -155,6 +162,12 @@ interface LinkEditorOpen {
  *   `fromHtml` / `fromMarkdown`.
  * - ❌ Hand-rolling HTML/Markdown from the model — use `toHtml` / `toMarkdown`
  *   (the inverse of `fromHtml` / `fromMarkdown`).
+ * - ❌ Using mentions to insert plain links — that's the link tool (⌘K). A
+ *   mention chip is an inert reference carrying an `id`, not a navigable anchor.
+ * - ❌ Returning thousands of unfiltered items from `onQuery` — filter server-side
+ *   (or by the `query`); the menu renders what you return.
+ * - ❌ Relying on Markdown to preserve mentions — `toMarkdown` is lossy (plain
+ *   `@label`); use `toHtml`/`fromHtml` to round-trip a mention's id.
  */
 export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
   function RichTextEditor(

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -18,7 +18,7 @@ import { insertText, insertFragment } from '../RichText/engine/transforms';
 import { fromHtml } from '../RichText/engine/fromHtml';
 import { hasMark, withMark, withoutMark } from '../RichText/engine/marks';
 import { useTranslation } from '../../i18n';
-import { readSelection, writeSelection } from './selection';
+import { readSelection, writeSelection, selectionRect, type Rect } from './selection';
 import { applyInput } from './input';
 import { matchBlockRule, applyBlockRule } from './inputRules';
 import { runsText } from '../RichText/engine/inlines';
@@ -91,8 +91,6 @@ function marksAtCaretMarks(doc: RichDoc, caret: Point): Mark[] {
   return [];
 }
 
-type Rect = { top: number; left: number; height: number; width: number };
-
 interface LinkEditorOpen {
   range: Range;
   href: string;
@@ -101,23 +99,6 @@ interface LinkEditorOpen {
   key: number;
 }
 
-/** The viewport rect of the current DOM selection, falling back to the editor root. */
-function selectionRect(root: HTMLElement): Rect {
-  const sel = typeof window !== 'undefined' ? window.getSelection() : null;
-  if (sel && sel.rangeCount > 0) {
-    let r: DOMRect | null = null;
-    try {
-      r = sel.getRangeAt(0).getBoundingClientRect();
-    } catch {
-      // jsdom does not implement Range.getBoundingClientRect — fall through.
-    }
-    if (r && (r.width || r.height || r.top || r.left)) {
-      return { top: r.top, left: r.left, width: r.width, height: r.height };
-    }
-  }
-  const rr = root.getBoundingClientRect();
-  return { top: rr.top, left: rr.left, width: 0, height: rr.height };
-}
 
 /**
  * Controlled rich-text editor — a contentEditable surface over the in-house

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -14,7 +14,10 @@ import { renderDoc } from '../RichText/engine/renderDoc';
 import { blockLength, isCollapsed } from '../RichText/engine/position';
 import { linkAt, setLink, removeLink } from './links';
 import { RichTextLinkEditor } from './RichTextLinkEditor';
-import { insertText, insertFragment } from '../RichText/engine/transforms';
+import { insertText, insertFragment, insertMention } from '../RichText/engine/transforms';
+import { useMention } from './useMention';
+import { RichTextMentionMenu } from './RichTextMentionMenu';
+import type { MentionItem, MentionsConfig } from './mentions';
 import { fromHtml } from '../RichText/engine/fromHtml';
 import { hasMark, withMark, withoutMark } from '../RichText/engine/marks';
 import { useTranslation } from '../../i18n';
@@ -67,6 +70,13 @@ export interface RichTextEditorProps extends Omit<
    * `false` (keyboard-only). When `readOnly`, the toolbar renders disabled.
    */
   toolbar?: boolean;
+  /**
+   * Enable `@`-mention autocomplete. Supply `onQuery` to resolve candidates for
+   * the text typed after the trigger (default `@`); the editor renders a floating
+   * combobox and inserts a styled mention chip carrying the chosen item's `id`.
+   * Omit to disable mentions. See {@link MentionsConfig}.
+   */
+  mentions?: MentionsConfig;
 }
 
 function isEmptyDoc(doc: RichDoc): boolean {
@@ -85,7 +95,8 @@ function marksAtCaretMarks(doc: RichDoc, caret: Point): Mark[] {
   let pos = 0;
   for (const run of doc.blocks[idx].inlines) {
     const end = pos + run.text.length;
-    if (caret.offset - 1 >= pos && caret.offset - 1 < end) return run.marks;
+    if (caret.offset - 1 >= pos && caret.offset - 1 < end)
+      return run.marks.filter((m) => m.type !== 'mention');
     pos = end;
   }
   return [];
@@ -98,7 +109,6 @@ interface LinkEditorOpen {
   anchorRect: Rect;
   key: number;
 }
-
 
 /**
  * Controlled rich-text editor — a contentEditable surface over the in-house
@@ -155,6 +165,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       placeholder,
       autoFocus,
       toolbar = false,
+      mentions,
       className,
       ...rest
     },
@@ -253,6 +264,28 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       pendingSelectionRef.current = next.present.selection;
       latest.current.onChange(next.present.doc);
     }, [syncHistoryFlags, clearPendingMarks]);
+
+    const insertMentionItem = useCallback(
+      (
+        blockId: string,
+        range: { from: number; to: number },
+        trigger: string,
+        item: MentionItem,
+      ) => {
+        commit(insertMention(latest.current.value, blockId, range, trigger, item), 'other');
+        clearPendingMarks();
+      },
+      [commit, clearPendingMarks],
+    );
+
+    const mention = useMention({
+      enabled: !!mentions && !readOnly,
+      rootRef,
+      doc: value,
+      trigger: mentions?.trigger ?? '@',
+      onQuery: mentions?.onQuery,
+      onInsert: insertMentionItem,
+    });
 
     // Shared by the keyboard shortcut and the toolbar: with a collapsed caret,
     // stage a pending mark for the next typed text (remembering where); with a
@@ -508,6 +541,30 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         }
         const range = readSelection(root);
         if (!range) return;
+        // Mention menu navigation takes priority over editor keys when open.
+        if (mention.open && mention.items.length > 0) {
+          if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            mention.move(1);
+            return;
+          }
+          if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            mention.move(-1);
+            return;
+          }
+          if (e.key === 'Enter' || e.key === 'Tab') {
+            e.preventDefault();
+            mention.commitActive();
+            return;
+          }
+        }
+        if (mention.open && e.key === 'Escape') {
+          e.preventDefault();
+          e.stopPropagation();
+          mention.close();
+          return;
+        }
         // ⌘/Ctrl+K opens the link editor (create or edit a link). Stop
         // propagation so the shortcut doesn't ALSO trigger a host app's global
         // ⌘K (command palette / search) while the editor is focused.
@@ -548,7 +605,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           return;
         }
       },
-      [value, readOnly, commit, stageOrToggleMark, openLinkEditor, onUndo, onRedo],
+      [value, readOnly, commit, stageOrToggleMark, openLinkEditor, onUndo, onRedo, mention],
     );
 
     const onCompositionStart = useCallback(() => {
@@ -595,7 +652,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // collapsed caret stages a pending mark, mirroring the keyboard shortcut.
     const onToolbarMark = useCallback(
       (type: MarkType) => {
-        if (type === 'link') return; // link needs an href; toolbar never fires it
+        if (type === 'link' || type === 'mention') return; // link needs an href; mention needs id+label — toolbar fires neither
         const root = rootRef.current;
         const range = (root ? readSelection(root) : null) ?? selection;
         if (range) stageOrToggleMark(range, { type });
@@ -633,6 +690,10 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         role="textbox"
         aria-multiline="true"
         aria-readonly={readOnly || undefined}
+        aria-haspopup={mentions ? 'listbox' : undefined}
+        aria-expanded={mentions ? mention.open : undefined}
+        aria-controls={mention.open ? mention.listboxId : undefined}
+        aria-activedescendant={mention.open ? mention.activeOptionId : undefined}
         aria-label={
           rest['aria-label'] ??
           (rest['aria-labelledby'] ? undefined : t('richTextEditor.editorLabel'))
@@ -661,11 +722,27 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         />
       ) : null;
 
+    const mentionMenu =
+      mention.open && !readOnly && mention.anchorRect ? (
+        <RichTextMentionMenu
+          items={mention.items}
+          activeIndex={mention.activeIndex}
+          anchorRect={mention.anchorRect}
+          listboxId={mention.listboxId}
+          getOptionId={mention.getOptionId}
+          label={t('richTextEditor.mentionsLabel')}
+          emptyLabel={t('richTextEditor.mentionsEmpty')}
+          onSelect={mention.selectIndex}
+          onHover={mention.setActiveIndex}
+        />
+      ) : null;
+
     if (!toolbar) {
       return (
         <>
           {editable}
           {linkBubble}
+          {mentionMenu}
         </>
       );
     }
@@ -687,6 +764,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         />
         {editable}
         {linkBubble}
+        {mentionMenu}
       </div>
     );
   },

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -703,8 +703,13 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         role="textbox"
         aria-multiline="true"
         aria-readonly={readOnly || undefined}
-        aria-haspopup={mentions ? 'listbox' : undefined}
-        aria-expanded={mentions ? mention.open : undefined}
+        // Mentions makes the textbox an editable combobox. role stays "textbox"
+        // (ARIA combobox is single-line only; this editor is multiline), with
+        // aria-autocomplete + aria-controls + aria-activedescendant describing the
+        // popup. Gated so a readOnly or mention-less editor advertises no popup.
+        aria-haspopup={mentions && !readOnly ? 'listbox' : undefined}
+        aria-autocomplete={mentions && !readOnly ? 'list' : undefined}
+        aria-expanded={mentions && !readOnly ? mention.open : undefined}
         aria-controls={mention.open ? mention.listboxId : undefined}
         aria-activedescendant={mention.open ? mention.activeOptionId : undefined}
         aria-label={

--- a/packages/design-system/src/components/RichTextEditor/RichTextMentionMenu.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextMentionMenu.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { RichTextMentionMenu } from './RichTextMentionMenu';
+import type { MentionItem } from './mentions';
+
+const items: MentionItem[] = [
+  { id: 'u1', label: 'Alice', description: 'alice@acme.com' },
+  { id: 'u2', label: 'Bob' },
+];
+const rect = { top: 10, left: 10, width: 0, height: 16 };
+
+function renderMenu(props: Partial<React.ComponentProps<typeof RichTextMentionMenu>> = {}) {
+  return render(
+    <RichTextMentionMenu
+      items={items}
+      activeIndex={0}
+      anchorRect={rect}
+      listboxId="lb"
+      getOptionId={(i) => `opt-${i}`}
+      label="Mentions"
+      emptyLabel="No matches"
+      onSelect={vi.fn()}
+      onHover={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+it('renders a labelled listbox of options', () => {
+  renderMenu();
+  const lb = screen.getByRole('listbox', { name: 'Mentions' });
+  expect(lb).toHaveAttribute('id', 'lb');
+  expect(screen.getAllByRole('option')).toHaveLength(2);
+  expect(screen.getByText('Alice')).toBeInTheDocument();
+  expect(screen.getByText('alice@acme.com')).toBeInTheDocument();
+});
+
+it('marks the active option with aria-selected + id', () => {
+  renderMenu({ activeIndex: 1 });
+  const opts = screen.getAllByRole('option');
+  expect(opts[1]).toHaveAttribute('aria-selected', 'true');
+  expect(opts[1]).toHaveAttribute('id', 'opt-1');
+  expect(opts[0]).toHaveAttribute('aria-selected', 'false');
+});
+
+it('clicking an option calls onSelect with its index', async () => {
+  const onSelect = vi.fn();
+  renderMenu({ onSelect });
+  await userEvent.click(screen.getByText('Bob'));
+  expect(onSelect).toHaveBeenCalledWith(1);
+});
+
+it('shows the empty label when there are no items', () => {
+  renderMenu({ items: [] });
+  expect(screen.getByText('No matches')).toBeInTheDocument();
+  expect(screen.queryAllByRole('option')).toHaveLength(0);
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextMentionMenu.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextMentionMenu.tsx
@@ -1,0 +1,111 @@
+// RichTextMentionMenu.tsx — the floating @-mention listbox for <RichTextEditor>.
+// Presentational: the editor (via useMention) owns all state and passes the
+// items + active index + anchor rect; this renders a role="listbox" positioned at
+// the caret rect via a Floating UI virtual element (same portal+virtual-anchor
+// pattern as RichTextLinkEditor). Not exported from the package.
+import { useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { useFloating, autoUpdate, flip, shift, offset } from '@floating-ui/react-dom';
+import { Avatar } from '../Avatar';
+import { Text } from '../Text';
+import type { MentionItem } from './mentions';
+import type { Rect } from './selection';
+import styles from './RichTextEditor.module.scss';
+
+export interface RichTextMentionMenuProps {
+  items: MentionItem[];
+  activeIndex: number;
+  anchorRect: Rect;
+  listboxId: string;
+  getOptionId: (index: number) => string;
+  /** Accessible name for the listbox. */
+  label: string;
+  /** Shown when there are no candidates. */
+  emptyLabel: string;
+  /** Pick the item at `index`. */
+  onSelect: (index: number) => void;
+  /** Set the active item (pointer hover). */
+  onHover: (index: number) => void;
+}
+
+export function RichTextMentionMenu({
+  items,
+  activeIndex,
+  anchorRect,
+  listboxId,
+  getOptionId,
+  label,
+  emptyLabel,
+  onSelect,
+  onHover,
+}: RichTextMentionMenuProps) {
+  const virtualRef = useMemo(
+    () => ({
+      getBoundingClientRect: () => ({
+        x: anchorRect.left,
+        y: anchorRect.top,
+        top: anchorRect.top,
+        left: anchorRect.left,
+        right: anchorRect.left + anchorRect.width,
+        bottom: anchorRect.top + anchorRect.height,
+        width: anchorRect.width,
+        height: anchorRect.height,
+      }),
+    }),
+    [anchorRect],
+  );
+
+  const { refs, floatingStyles } = useFloating({
+    placement: 'bottom-start',
+    strategy: 'fixed',
+    whileElementsMounted: autoUpdate,
+    middleware: [offset(4), flip(), shift({ padding: 4 })],
+    elements: { reference: virtualRef },
+  });
+
+  return createPortal(
+    <div
+      ref={refs.setFloating}
+      className={styles.mentionMenu}
+      style={floatingStyles}
+      role="listbox"
+      id={listboxId}
+      aria-label={label}
+    >
+      {items.length === 0 ? (
+        <div className={styles.mentionEmpty} aria-disabled="true">
+          <Text size="sm" tone="muted">
+            {emptyLabel}
+          </Text>
+        </div>
+      ) : (
+        items.map((item, i) => (
+          <div
+            key={item.id}
+            id={getOptionId(i)}
+            role="option"
+            aria-selected={i === activeIndex}
+            className={i === activeIndex ? styles.mentionOptionActive : styles.mentionOption}
+            // pointerdown (not click) so the editor doesn't lose its selection first
+            onPointerDown={(e) => {
+              e.preventDefault();
+              onSelect(i);
+            }}
+            onMouseMove={() => onHover(i)}
+          >
+            <Avatar name={item.label} src={item.avatarUrl} size="sm" />
+            <span className={styles.mentionText}>
+              <Text size="sm">{item.label}</Text>
+              {item.description ? (
+                <Text size="xs" tone="muted">
+                  {item.description}
+                </Text>
+              ) : null}
+            </span>
+          </div>
+        ))
+      )}
+    </div>,
+    document.body,
+  );
+}

--- a/packages/design-system/src/components/RichTextEditor/index.ts
+++ b/packages/design-system/src/components/RichTextEditor/index.ts
@@ -1,2 +1,3 @@
 export { RichTextEditor } from './RichTextEditor';
 export type { RichTextEditorProps } from './RichTextEditor';
+export type { MentionItem, MentionsConfig } from './mentions';

--- a/packages/design-system/src/components/RichTextEditor/mentionContext.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/mentionContext.test.ts
@@ -1,0 +1,35 @@
+import { getMentionContext } from './mentionContext';
+
+describe('getMentionContext', () => {
+  it('opens at the start of a block', () => {
+    expect(getMentionContext('@al', 3, '@')).toEqual({ query: 'al', triggerOffset: 0 });
+  });
+
+  it('opens after whitespace', () => {
+    expect(getMentionContext('hi @al', 6, '@')).toEqual({ query: 'al', triggerOffset: 3 });
+  });
+
+  it('returns an empty query right after the trigger', () => {
+    expect(getMentionContext('hi @', 4, '@')).toEqual({ query: '', triggerOffset: 3 });
+  });
+
+  it('does NOT open mid-word (trigger preceded by a non-space)', () => {
+    expect(getMentionContext('email@x', 7, '@')).toBeNull();
+  });
+
+  it('does NOT open when a space sits between the trigger and the caret', () => {
+    expect(getMentionContext('@al bob', 7, '@')).toBeNull();
+  });
+
+  it('chooses the nearest valid trigger', () => {
+    expect(getMentionContext('@a @bo', 6, '@')).toEqual({ query: 'bo', triggerOffset: 3 });
+  });
+
+  it('honors a custom trigger', () => {
+    expect(getMentionContext('see #re', 7, '#')).toEqual({ query: 're', triggerOffset: 4 });
+  });
+
+  it('returns null when there is no trigger before the caret', () => {
+    expect(getMentionContext('hello', 5, '@')).toBeNull();
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/mentionContext.ts
+++ b/packages/design-system/src/components/RichTextEditor/mentionContext.ts
@@ -1,0 +1,37 @@
+// mentionContext.ts — pure detection of an open mention context at a caret.
+
+/** A detected, open mention context. */
+export interface MentionContext {
+  /** Text typed after the trigger, up to the caret (may be ''). */
+  query: string;
+  /** Offset of the trigger char within the block text. */
+  triggerOffset: number;
+}
+
+/**
+ * Detect an open mention context at a collapsed caret within `blockText`.
+ * Returns a context only when the nearest `trigger` before `caretOffset` is at
+ * block start or preceded by whitespace, and no whitespace sits between it and
+ * the caret. Otherwise returns null.
+ *
+ * @example
+ * getMentionContext('hi @al', 6, '@'); // { query: 'al', triggerOffset: 3 }
+ */
+export function getMentionContext(
+  blockText: string,
+  caretOffset: number,
+  trigger: string,
+): MentionContext | null {
+  if (!trigger) return null;
+  // Scan backward from the caret to the nearest trigger; bail on whitespace.
+  for (let i = caretOffset - 1; i >= 0; i -= 1) {
+    const ch = blockText[i];
+    if (/\s/.test(ch)) return null; // whitespace between trigger and caret → closed
+    if (ch === trigger) {
+      const before = i === 0 ? '' : blockText[i - 1];
+      if (i !== 0 && !/\s/.test(before)) return null; // mid-word trigger
+      return { query: blockText.slice(i + trigger.length, caretOffset), triggerOffset: i };
+    }
+  }
+  return null;
+}

--- a/packages/design-system/src/components/RichTextEditor/mentions.ts
+++ b/packages/design-system/src/components/RichTextEditor/mentions.ts
@@ -1,0 +1,28 @@
+// mentions.ts — public types for the RichTextEditor `mentions` prop.
+
+/** One mentionable candidate returned by `MentionsConfig.onQuery`. */
+export interface MentionItem {
+  /** Stable id stored on the mention mark and emitted in serialization (`data-mention-id`). */
+  id: string;
+  /** Display text — becomes the chip's visible text (without the trigger). */
+  label: string;
+  /** Optional secondary line in the menu row (e.g. an email). Menu-only; not stored. */
+  description?: string;
+  /** Optional avatar shown in the menu row. Menu-only; not stored. */
+  avatarUrl?: string;
+}
+
+/**
+ * Enables `@`-mention autocomplete on `<RichTextEditor>`. Omit the `mentions`
+ * prop to disable mentions entirely.
+ */
+export interface MentionsConfig {
+  /**
+   * Resolve candidates for the text typed after the trigger. Called as the user
+   * types; may be sync or async. The editor drops stale async resolutions, so a
+   * slow promise that resolves after the query moved on is ignored.
+   */
+  onQuery: (query: string) => MentionItem[] | Promise<MentionItem[]>;
+  /** Trigger character that opens the menu. Default `'@'`. */
+  trigger?: string;
+}

--- a/packages/design-system/src/components/RichTextEditor/mentions.ts
+++ b/packages/design-system/src/components/RichTextEditor/mentions.ts
@@ -23,6 +23,6 @@ export interface MentionsConfig {
    * slow promise that resolves after the query moved on is ignored.
    */
   onQuery: (query: string) => MentionItem[] | Promise<MentionItem[]>;
-  /** Trigger character that opens the menu. Default `'@'`. */
+  /** Single trigger character that opens the menu. Default `'@'`. Multi-character triggers are not supported. */
   trigger?: string;
 }

--- a/packages/design-system/src/components/RichTextEditor/selection.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.ts
@@ -116,3 +116,24 @@ export function writeSelection(root: HTMLElement, range: Range): void {
     // some environments (jsdom) have a partial Selection — collapsed caret is fine
   }
 }
+
+/** A viewport rect (subset of DOMRect) used to anchor floating UI to a selection. */
+export type Rect = { top: number; left: number; height: number; width: number };
+
+/** The viewport rect of the current DOM selection, falling back to `root`. */
+export function selectionRect(root: HTMLElement): Rect {
+  const sel = typeof window !== 'undefined' ? window.getSelection() : null;
+  if (sel && sel.rangeCount > 0) {
+    let r: DOMRect | null = null;
+    try {
+      r = sel.getRangeAt(0).getBoundingClientRect();
+    } catch {
+      // jsdom does not implement Range.getBoundingClientRect — fall through.
+    }
+    if (r && (r.width || r.height || r.top || r.left)) {
+      return { top: r.top, left: r.left, width: r.width, height: r.height };
+    }
+  }
+  const rr = root.getBoundingClientRect();
+  return { top: rr.top, left: rr.left, width: 0, height: rr.height };
+}

--- a/packages/design-system/src/components/RichTextEditor/useMention.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/useMention.test.tsx
@@ -1,0 +1,110 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import type { RichDoc } from '../RichText/engine/model';
+
+// Mock readSelection (jsdom has no caret); keep the rest of ./selection real.
+vi.mock('./selection', async () => {
+  const actual = await vi.importActual<typeof import('./selection')>('./selection');
+  return { ...actual, readSelection: vi.fn(actual.readSelection) };
+});
+import { readSelection } from './selection';
+import { useMention } from './useMention';
+
+const mockReadSelection = vi.mocked(readSelection);
+
+function makeRoot(): HTMLDivElement {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  return root;
+}
+
+const docWith = (text: string): RichDoc => ({
+  blocks: [{ id: 'b', type: 'paragraph', inlines: [{ text, marks: [] }] }],
+});
+
+beforeEach(() => mockReadSelection.mockReset());
+
+it('opens and queries with the text after the trigger', async () => {
+  const root = makeRoot();
+  mockReadSelection.mockReturnValue({
+    anchor: { blockId: 'b', offset: 4 },
+    focus: { blockId: 'b', offset: 4 },
+  });
+  const onQuery = vi.fn().mockResolvedValue([{ id: 'u1', label: 'Alice' }]);
+  const onInsert = vi.fn();
+  const { result } = renderHook(() =>
+    useMention({
+      enabled: true,
+      rootRef: { current: root },
+      doc: docWith('hi @'),
+      trigger: '@',
+      onQuery,
+      onInsert,
+    }),
+  );
+  await waitFor(() => expect(onQuery).toHaveBeenCalledWith(''));
+  await waitFor(() => expect(result.current.open).toBe(true));
+  await waitFor(() => expect(result.current.items).toHaveLength(1));
+});
+
+it('commitActive inserts the active item over the trigger+query range', async () => {
+  const root = makeRoot();
+  mockReadSelection.mockReturnValue({
+    anchor: { blockId: 'b', offset: 6 },
+    focus: { blockId: 'b', offset: 6 },
+  });
+  const onQuery = vi.fn().mockResolvedValue([{ id: 'u1', label: 'Alice' }]);
+  const onInsert = vi.fn();
+  const { result } = renderHook(() =>
+    useMention({
+      enabled: true,
+      rootRef: { current: root },
+      doc: docWith('hi @al'),
+      trigger: '@',
+      onQuery,
+      onInsert,
+    }),
+  );
+  await waitFor(() => expect(result.current.items).toHaveLength(1));
+  act(() => result.current.commitActive());
+  expect(onInsert).toHaveBeenCalledWith('b', { from: 3, to: 6 }, '@', { id: 'u1', label: 'Alice' });
+});
+
+it('drops a stale async resolution', async () => {
+  const root = makeRoot();
+  mockReadSelection.mockReturnValue({
+    anchor: { blockId: 'b', offset: 5 },
+    focus: { blockId: 'b', offset: 5 },
+  });
+  let resolveFirst: (v: { id: string; label: string }[]) => void = () => {};
+  const first = new Promise<{ id: string; label: string }[]>((r) => (resolveFirst = r));
+  const onQuery = vi
+    .fn()
+    .mockReturnValueOnce(first)
+    .mockResolvedValueOnce([{ id: 'u2', label: 'Bob' }]);
+  const { result, rerender } = renderHook(
+    ({ doc }) =>
+      useMention({
+        enabled: true,
+        rootRef: { current: root },
+        doc,
+        trigger: '@',
+        onQuery,
+        onInsert: vi.fn(),
+      }),
+    { initialProps: { doc: docWith('hi @a') } },
+  );
+  await waitFor(() => expect(onQuery).toHaveBeenCalledWith('a'));
+  // caret moves: query becomes 'ab'
+  mockReadSelection.mockReturnValue({
+    anchor: { blockId: 'b', offset: 6 },
+    focus: { blockId: 'b', offset: 6 },
+  });
+  rerender({ doc: docWith('hi @ab') });
+  await waitFor(() => expect(onQuery).toHaveBeenCalledWith('ab'));
+  await waitFor(() => expect(result.current.items).toEqual([{ id: 'u2', label: 'Bob' }]));
+  // late resolution of the first (stale) query must be ignored
+  act(() => resolveFirst([{ id: 'u1', label: 'Alice' }]));
+  await Promise.resolve();
+  expect(result.current.items).toEqual([{ id: 'u2', label: 'Bob' }]);
+});

--- a/packages/design-system/src/components/RichTextEditor/useMention.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/useMention.test.tsx
@@ -108,3 +108,63 @@ it('drops a stale async resolution', async () => {
   await Promise.resolve();
   expect(result.current.items).toEqual([{ id: 'u2', label: 'Bob' }]);
 });
+
+it('move() wraps around the item list', async () => {
+  const root = makeRoot();
+  mockReadSelection.mockReturnValue({
+    anchor: { blockId: 'b', offset: 6 },
+    focus: { blockId: 'b', offset: 6 },
+  });
+  const onQuery = vi.fn().mockResolvedValue([
+    { id: 'u1', label: 'Alice' },
+    { id: 'u2', label: 'Bob' },
+  ]);
+  const { result } = renderHook(() =>
+    useMention({
+      enabled: true,
+      rootRef: { current: root },
+      doc: docWith('hi @al'),
+      trigger: '@',
+      onQuery,
+      onInsert: vi.fn(),
+    }),
+  );
+  await waitFor(() => expect(result.current.items).toHaveLength(2));
+  act(() => result.current.move(1));
+  expect(result.current.activeIndex).toBe(1);
+  act(() => result.current.move(1)); // wraps 1 -> 0
+  expect(result.current.activeIndex).toBe(0);
+  act(() => result.current.move(-1)); // wraps 0 -> 1
+  expect(result.current.activeIndex).toBe(1);
+});
+
+it('close() drops an in-flight query result', async () => {
+  const root = makeRoot();
+  mockReadSelection.mockReturnValue({
+    anchor: { blockId: 'b', offset: 6 },
+    focus: { blockId: 'b', offset: 6 },
+  });
+  let resolveQuery: (v: { id: string; label: string }[]) => void = () => {};
+  const pending = new Promise<{ id: string; label: string }[]>((r) => (resolveQuery = r));
+  const onQuery = vi.fn().mockReturnValue(pending);
+  const { result } = renderHook(() =>
+    useMention({
+      enabled: true,
+      rootRef: { current: root },
+      doc: docWith('hi @al'),
+      trigger: '@',
+      onQuery,
+      onInsert: vi.fn(),
+    }),
+  );
+  await waitFor(() => expect(onQuery).toHaveBeenCalled());
+  // Dismissal: the caret leaves the trigger context, so the next recompute
+  // (the hook has no separate "stay closed" latch) keeps the menu closed.
+  mockReadSelection.mockReturnValue(null);
+  act(() => result.current.close());
+  act(() => resolveQuery([{ id: 'u1', label: 'Alice' }]));
+  await Promise.resolve();
+  expect(result.current.open).toBe(false);
+  // The in-flight query result is dropped (close() bumped the stale token).
+  expect(result.current.items).toEqual([]);
+});

--- a/packages/design-system/src/components/RichTextEditor/useMention.ts
+++ b/packages/design-system/src/components/RichTextEditor/useMention.ts
@@ -1,0 +1,213 @@
+// useMention.ts — menu-state hook for RichTextEditor @-mention autocomplete.
+// Owns context detection (driven by the editor's selection/content cycle), async
+// querying with stale-drop, and the active-index for keyboard navigation. DOM
+// glue only; the pure decision lives in mentionContext.ts.
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { RichDoc } from '../RichText/engine/model';
+import { runsText } from '../RichText/engine/inlines';
+import { isCollapsed } from '../RichText/engine/position';
+import { readSelection, selectionRect, type Rect } from './selection';
+import { getMentionContext } from './mentionContext';
+import type { MentionItem } from './mentions';
+
+export interface UseMentionParams {
+  enabled: boolean;
+  rootRef: React.RefObject<HTMLElement | null>;
+  doc: RichDoc;
+  trigger: string;
+  onQuery?: (query: string) => MentionItem[] | Promise<MentionItem[]>;
+  /** Perform the insertion (editor wires this to commit(insertMention(...))). */
+  onInsert: (
+    blockId: string,
+    range: { from: number; to: number },
+    trigger: string,
+    item: MentionItem,
+  ) => void;
+}
+
+export interface UseMentionResult {
+  open: boolean;
+  items: MentionItem[];
+  activeIndex: number;
+  anchorRect: Rect | null;
+  listboxId: string;
+  activeOptionId: string | undefined;
+  getOptionId: (index: number) => string;
+  setActiveIndex: (index: number) => void;
+  move: (delta: 1 | -1) => void;
+  selectIndex: (index: number) => void;
+  commitActive: () => void;
+  close: () => void;
+}
+
+/** True when two Rect values are equal (avoids spurious re-renders). */
+function rectEqual(a: Rect | null, b: Rect | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height;
+}
+
+export function useMention(params: UseMentionParams): UseMentionResult {
+  const { enabled, rootRef, doc, trigger, onQuery, onInsert } = params;
+  const baseId = useId();
+  const listboxId = `${baseId}-mention-listbox`;
+  const getOptionId = useCallback((index: number) => `${baseId}-mention-opt-${index}`, [baseId]);
+
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<MentionItem[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [anchorRect, setAnchorRect] = useState<Rect | null>(null);
+
+  // Detected context (block + range), kept in a ref for commitActive.
+  const ctxRef = useRef<{ blockId: string; from: number; to: number } | null>(null);
+  // Monotonic token to drop stale async resolutions.
+  const queryToken = useRef(0);
+  // Last query string we issued (dedupe redundant onQuery calls).
+  const lastQuery = useRef<string | null>(null);
+  // Track open + anchorRect in refs for stable-function pattern.
+  const openRef = useRef(false);
+  const anchorRectRef = useRef<Rect | null>(null);
+
+  // Keep latest props in refs so recompute() is stable and doesn't cause effect re-fires.
+  const enabledRef = useRef(enabled);
+  const docRef = useRef(doc);
+  const triggerRef = useRef(trigger);
+  const onQueryRef = useRef(onQuery);
+  enabledRef.current = enabled;
+  docRef.current = doc;
+  triggerRef.current = trigger;
+  onQueryRef.current = onQuery;
+
+  const close = useCallback(() => {
+    openRef.current = false;
+    setOpen(false);
+    anchorRectRef.current = null;
+    setAnchorRect(null);
+    ctxRef.current = null;
+    lastQuery.current = null;
+    queryToken.current += 1; // invalidate any in-flight query
+  }, []);
+
+  const runQuery = useCallback(
+    (query: string) => {
+      const qFn = onQueryRef.current;
+      if (!qFn) return;
+      const token = (queryToken.current += 1);
+      Promise.resolve(qFn(query)).then(
+        (resolved) => {
+          if (token !== queryToken.current) return; // stale
+          setItems(resolved);
+          setActiveIndex(0);
+        },
+        () => {
+          if (token !== queryToken.current) return;
+          setItems([]);
+          setActiveIndex(0);
+        },
+      );
+    },
+    [], // stable: reads onQueryRef.current
+  );
+
+  // Stable recompute — reads all mutable values via refs, never recreated.
+  const recompute = useCallback(() => {
+    const root = rootRef.current;
+    const qFn = onQueryRef.current;
+    if (!enabledRef.current || !root || !qFn) {
+      if (openRef.current) close();
+      return;
+    }
+    const sel = readSelection(root);
+    if (!sel || !isCollapsed(sel)) {
+      if (openRef.current) close();
+      return;
+    }
+    const currentDoc = docRef.current;
+    const block = currentDoc.blocks.find((b) => b.id === sel.anchor.blockId);
+    if (!block) {
+      if (openRef.current) close();
+      return;
+    }
+    const text = runsText(block.inlines);
+    const trig = triggerRef.current;
+    const ctx = getMentionContext(text, sel.anchor.offset, trig);
+    if (!ctx) {
+      if (openRef.current) close();
+      return;
+    }
+    ctxRef.current = {
+      blockId: block.id,
+      from: ctx.triggerOffset,
+      to: ctx.triggerOffset + trig.length + ctx.query.length,
+    };
+    // Only update anchorRect state if the value changed (prevents render loops).
+    const newRect = selectionRect(root);
+    if (!rectEqual(anchorRectRef.current, newRect)) {
+      anchorRectRef.current = newRect;
+      setAnchorRect(newRect);
+    }
+    // Only flip open state if not already open (prevents render loops).
+    if (!openRef.current) {
+      openRef.current = true;
+      setOpen(true);
+    }
+    if (ctx.query !== lastQuery.current) {
+      lastQuery.current = ctx.query;
+      runQuery(ctx.query);
+    }
+  }, [rootRef, close, runQuery]); // stable: reads props via refs
+
+  // Register selectionchange listener; re-register only if enabled changes.
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = () => recompute();
+    document.addEventListener('selectionchange', handler);
+    recompute();
+    return () => document.removeEventListener('selectionchange', handler);
+  }, [enabled, recompute]);
+
+  // Re-run recompute when doc or trigger changes (typing updates the query).
+  useEffect(() => {
+    if (!enabled) return;
+    recompute();
+  }, [enabled, doc, trigger, recompute]);
+
+  const move = useCallback(
+    (delta: 1 | -1) => {
+      setActiveIndex((i) => {
+        const n = items.length;
+        if (n === 0) return 0;
+        return (i + delta + n) % n;
+      });
+    },
+    [items.length],
+  );
+
+  const selectIndex = useCallback(
+    (index: number) => {
+      const ctx = ctxRef.current;
+      const item = items[index];
+      if (!ctx || !item) return;
+      onInsert(ctx.blockId, { from: ctx.from, to: ctx.to }, triggerRef.current, item);
+      close();
+    },
+    [items, onInsert, close],
+  );
+
+  const commitActive = useCallback(() => selectIndex(activeIndex), [selectIndex, activeIndex]);
+
+  return {
+    open,
+    items,
+    activeIndex,
+    anchorRect,
+    listboxId,
+    activeOptionId: open && items.length > 0 ? getOptionId(activeIndex) : undefined,
+    getOptionId,
+    setActiveIndex,
+    move,
+    selectIndex,
+    commitActive,
+    close,
+  };
+}

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -197,5 +197,7 @@ export const en: Messages = {
     linkEditorLabel: 'Edit link',
     undo: 'Undo',
     redo: 'Redo',
+    mentionsLabel: 'Mentions',
+    mentionsEmpty: 'No matches',
   },
 };

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -325,6 +325,10 @@ export interface Messages {
     undo: string;
     /** aria-label on the toolbar Redo button. */
     redo: string;
+    /** Accessible name for the mentions autocomplete listbox. */
+    mentionsLabel: string;
+    /** Empty-state row when no mention candidates match. */
+    mentionsEmpty: string;
   };
 }
 

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -199,5 +199,7 @@ export const ru: Messages = {
     linkEditorLabel: 'Редактирование ссылки',
     undo: 'Отменить',
     redo: 'Повторить',
+    mentionsLabel: 'Упоминания',
+    mentionsEmpty: 'Нет совпадений',
   },
 };

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -345,6 +345,7 @@ export type {
 
 export { RichTextEditor } from './components/RichTextEditor';
 export type { RichTextEditorProps } from './components/RichTextEditor';
+export type { MentionItem, MentionsConfig } from './components/RichTextEditor';
 
 export { FileUpload } from './components/FileUpload';
 export type {

--- a/packages/design-system/src/styles/tokens.scss
+++ b/packages/design-system/src/styles/tokens.scss
@@ -222,6 +222,10 @@
   --size-popover-min-width: 220px; // slightly wider than dropdown — popovers carry richer content
   --size-popover-max-width: 360px; // default cap for popover-shaped surfaces; override per-instance via the maxWidth prop
 
+  // Maximum visible height for scrollable listboxes (mention menu, autocomplete
+  // dropdowns). Shows ~6 rows at 36px each before scrolling.
+  --size-listbox-max-height: 240px;
+
   // Width/height of the leading indicator slot in DropdownMenu checkbox/radio items.
   --size-dropdown-indicator: 16px;
 

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -22,6 +22,15 @@ export function RichTextEditorDemo() {
       '# Imported\n\nThis editor was **seeded** from Markdown — paste rich HTML to import more.',
     ),
   );
+  const [mentionDoc, setMentionDoc] = useState<RichDoc>(() => docFromText('Assign this to '));
+  const TEAM = [
+    { id: 'u1', label: 'Alice Nguyen', description: 'alice@eocrm.dev' },
+    { id: 'u2', label: 'Bob Martinez', description: 'bob@eocrm.dev' },
+    { id: 'u3', label: 'Carlos Whitfield', description: 'carlos@eocrm.dev' },
+    { id: 'u4', label: 'Dana Lee', description: 'dana@eocrm.dev' },
+  ];
+  const queryTeam = (q: string) =>
+    Promise.resolve(TEAM.filter((m) => m.label.toLowerCase().includes(q.toLowerCase())));
 
   return (
     <DemoLayout
@@ -76,6 +85,21 @@ const [doc, setDoc] = useState(() => fromMarkdown('# Imported\\n\\n- one\\n- two
           onChange={setImportDoc}
           toolbar
           placeholder="Paste rich HTML here…"
+        />
+      </Example>
+
+      <Example
+        title="Mentions (@-autocomplete)"
+        description='Pass a mentions prop with onQuery to enable @-mentions. Type "@" then a name (e.g. "@al") to open the candidate menu; ↑/↓ to move, Enter/Tab to insert a chip, Esc to dismiss. The chip carries the id; Backspace removes the whole chip.'
+        code={`<RichTextEditor value={doc} onChange={setDoc} toolbar
+  mentions={{ onQuery: (q) => searchUsers(q) }} />`}
+      >
+        <RichTextEditor
+          value={mentionDoc}
+          onChange={setMentionDoc}
+          toolbar
+          placeholder="Type @ to mention someone…"
+          mentions={{ onQuery: queryTeam }}
         />
       </Example>
 


### PR DESCRIPTION
Opt-in `@`-mention autocomplete for `<RichTextEditor>` (Slice 9). With no `mentions` prop, behavior is unchanged.

## What it does

Pass `mentions={{ onQuery }}` (optional `trigger`, default `@`). Typing the trigger after whitespace/start opens a floating combobox of consumer-supplied candidates; ↑/↓ move, Enter/Tab insert a chip, Esc/blur dismiss. The chip carries a stable `id`.

```tsx
<RichTextEditor value={doc} onChange={setDoc}
  mentions={{ onQuery: (q) => searchUsers(q) }} />
```

`onQuery(query) => MentionItem[] | Promise<MentionItem[]>` — `MentionItem = { id, label, description?, avatarUrl? }`. The menu renders an avatar + bold label + muted description row. Stale async resolutions are dropped via a request token.

## How it's built

- **Model:** a `mention` mark `{type:'mention', id, label}` (parallel to `link`) on a run whose text is `@Label`. `markKey` distinguishes chips by id+label so they never merge.
- **Atomicity:** `deleteRange` snaps an endpoint that lands *inside* a mention run out to its boundary — so a one-char Backspace at a chip edge or a partial selection removes the **whole** chip; collapsed-caret deletes still no-op. `marksBefore`/`marksAtCaretMarks` filter `mention` so typing after a chip is unmarked.
- **Detection:** pure `getMentionContext(blockText, caret, trigger)`. **Menu state:** `useMention` hook (selectionchange-driven, async stale-drop). **UI:** `RichTextMentionMenu` floating `role="listbox"` (portal + Floating UI, modeled on the link bubble). The editable div is an editable combobox (`role="textbox"` kept since combobox is single-line only; `aria-haspopup`/`aria-autocomplete`/`aria-expanded`/`aria-controls`/`aria-activedescendant`).
- **Serialization:** survives HTML round-trip (`<span data-mention-id data-mention-label>`, parsed back by `fromHtml`, escape-safe); lossy in Markdown (plain `@label`, documented like underline).

Spec: `docs/superpowers/specs/2026-06-19-richtext-editor-mentions-design.md` · Plan: `docs/superpowers/plans/2026-06-19-richtext-editor-mentions.md`.

## Test plan

- **Unit/integration (2977 tests green):** context detection; `insertMention` + `deleteRange` snap (incl. cross-block) + no-mark-inheritance; render/`toHtml`/`fromHtml` round-trip with special chars; lossy `toMarkdown`; `useMention` (open/query/stale-drop/`move` wrap/`close`); menu component; editor combobox ARIA + Escape dismissal + chip-on-Enter + no-menu-without-prop.
- **Browser (Playwright, real contentEditable):** `@al` → filtered menu (avatar+name+email) → Enter inserts `@Alice Nguyen` chip + trailing space (HTML `<span data-mention-id="u1" …>`) → Backspace removes whole chip in one step → ⌘Z reverts insertion in one step → combobox ARIA verified live.
- **Review:** three adversarial fresh-context reviewers (correctness/hooks, a11y/API/packaging, tests/tokens/leakage) + a confirmation pass → 0 Critical / 0 Important; a11y + coverage fixes folded in.
- Gates: `make test`, `make build-lib`, `make lint`, `npm run format:check`, tarball grep `0`, manifest regenerated (RichTextEditor now composes Avatar+Text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)