### PR TITLE
feat(PhoneInput): countryDisplay prop, non-clearable country, single-line option rows

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -477,7 +477,7 @@ import { Textarea } from '@eocrm/design-system';
 
 ### `<PhoneInput>`
 
-International phone field: searchable country picker (DS `Select`) + national-number `Input`, controlled on a single `value: string | null` (**E.164**), `onChange(e164 | null)`. `defaultCountry` (ISO alpha-2) seeds the picker when empty; `countries` restricts the list; `size`/`invalid`/`disabled` pass through. Country names are localized via `Intl.DisplayNames`; metadata/validation via `libphonenumber-js`. Validate with the exported `isValidPhone(e164)` and drive `invalid` (or wrap in `<Field error>`). Rows show "Country name +code" (no flags). Store the emitted E.164, not the formatted display.
+International phone field: searchable country picker (DS `Select`) + national-number `Input`, controlled on a single `value: string | null` (**E.164**), `onChange(e164 | null)`. `defaultCountry` (ISO alpha-2) seeds the picker when empty; `countries` restricts the list; `size`/`invalid`/`disabled` pass through. Country names are localized via `Intl.DisplayNames`; metadata/validation via `libphonenumber-js`. Validate with the exported `isValidPhone(e164)` and drive `invalid` (or wrap in `<Field error>`). `countryDisplay` sets how the SELECTED country shows in the trigger — `"name"` (default, `United States +1`), `"iso"` (`US +1`), `"code"` (`+1`), or `"flag"` (`🇺🇸 +1`; emoji flags don't render on Windows Chrome/Edge). Dropdown rows always show the full name (searchable); the country can't be cleared. Store the emitted E.164, not the formatted display.
 
 ```tsx
 const [phone, setPhone] = useState<string | null>(null);

--- a/packages/design-system/src/components/PhoneInput/PhoneInput.module.scss
+++ b/packages/design-system/src/components/PhoneInput/PhoneInput.module.scss
@@ -13,3 +13,11 @@
 .number {
   width: 100%;
 }
+
+// Dropdown rows: keep "Country name +code" on a single line (no wrapping).
+.option {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/packages/design-system/src/components/PhoneInput/PhoneInput.test.tsx
+++ b/packages/design-system/src/components/PhoneInput/PhoneInput.test.tsx
@@ -165,6 +165,12 @@ describe('PhoneInput', () => {
     expect(combo.value).toBe('+1');
   });
 
+  it('countryDisplay="flag" shows the emoji flag + calling code in the trigger', () => {
+    renderWith(<PhoneInput value="+12025550123" onChange={() => {}} countryDisplay="flag" />);
+    const combo = screen.getByRole('combobox', { name: 'Country' }) as HTMLInputElement;
+    expect(combo.value).toBe('🇺🇸 +1');
+  });
+
   it('keeps the country searchable by name even in a compact display mode', async () => {
     const user = userEvent.setup();
     function Harness() {

--- a/packages/design-system/src/components/PhoneInput/PhoneInput.test.tsx
+++ b/packages/design-system/src/components/PhoneInput/PhoneInput.test.tsx
@@ -141,4 +141,41 @@ describe('PhoneInput', () => {
       'Enter a valid number',
     );
   });
+
+  it('does not offer to clear the country selection', () => {
+    renderWith(<PhoneInput value="+12025550123" onChange={() => {}} />);
+    expect(screen.queryByRole('button', { name: /clear/i })).toBeNull();
+  });
+
+  it('defaults to the full country name in the trigger', () => {
+    renderWith(<PhoneInput value="+12025550123" onChange={() => {}} />);
+    const combo = screen.getByRole('combobox', { name: 'Country' }) as HTMLInputElement;
+    expect(combo.value).toBe('United States +1');
+  });
+
+  it('countryDisplay="iso" shows the ISO code + calling code in the trigger', () => {
+    renderWith(<PhoneInput value="+12025550123" onChange={() => {}} countryDisplay="iso" />);
+    const combo = screen.getByRole('combobox', { name: 'Country' }) as HTMLInputElement;
+    expect(combo.value).toBe('US +1');
+  });
+
+  it('countryDisplay="code" shows only the calling code in the trigger', () => {
+    renderWith(<PhoneInput value="+12025550123" onChange={() => {}} countryDisplay="code" />);
+    const combo = screen.getByRole('combobox', { name: 'Country' }) as HTMLInputElement;
+    expect(combo.value).toBe('+1');
+  });
+
+  it('keeps the country searchable by name even in a compact display mode', async () => {
+    const user = userEvent.setup();
+    function Harness() {
+      const [v, setV] = useState<string | null>(null);
+      return <PhoneInput value={v} onChange={setV} defaultCountry="US" countryDisplay="code" />;
+    }
+    renderWith(<Harness />);
+    const combo = screen.getByRole('combobox', { name: 'Country' });
+    await user.click(combo);
+    await user.type(combo, 'United Kingdom');
+    // the row is found by its full-name content even though the trigger label is just "+44"
+    expect(await screen.findByRole('option', { name: /United Kingdom/i })).toBeInTheDocument();
+  });
 });

--- a/packages/design-system/src/components/PhoneInput/PhoneInput.tsx
+++ b/packages/design-system/src/components/PhoneInput/PhoneInput.tsx
@@ -16,8 +16,11 @@ import {
   parseE164,
   formatNational,
   toE164,
+  isoToFlag,
+  countryDisplayLabel,
   type CountryCode,
   type CountryOption,
+  type CountryDisplay,
 } from './phone';
 import styles from './PhoneInput.module.scss';
 
@@ -36,6 +39,18 @@ export interface PhoneInputProps extends Omit<
   defaultCountry?: string;
   /** Restrict the picker to this ISO-code subset. Defaults to all libphonenumber-js countries. An empty array is treated as all countries. */
   countries?: string[];
+  /**
+   * How the SELECTED country renders in the picker trigger. Default `"name"`.
+   * - `"flag"` — emoji flag + code (`🇺🇸 +1`). Note: emoji flags don't render on
+   *   Windows Chrome/Edge (they show the letters), so prefer `"iso"` there.
+   * - `"iso"` — ISO code + code (`US +1`).
+   * - `"name"` — full country name + code (`United States +1`).
+   * - `"code"` — calling code only (`+1`).
+   *
+   * The dropdown rows always show the full country name (plus a flag in `"flag"`
+   * mode) so they stay searchable + identifiable regardless of this setting.
+   */
+  countryDisplay?: CountryDisplay;
   /** Control size, forwarded to the Select + Input. Default `"md"`. */
   size?: PhoneInputSize;
   /** Error chrome on both controls (host/Field-driven). */
@@ -115,6 +130,7 @@ export const PhoneInput = forwardRef<HTMLDivElement, PhoneInputProps>(function P
     onChange,
     defaultCountry = 'US',
     countries,
+    countryDisplay = 'name',
     size = 'md',
     invalid,
     disabled,
@@ -137,8 +153,18 @@ export const PhoneInput = forwardRef<HTMLDivElement, PhoneInputProps>(function P
     [resolvedLocale, countries],
   );
   const selectOptions = useMemo<SelectOption<CountryOption>[]>(
-    () => options.map((o) => ({ value: o.iso, label: `${o.name} +${o.callingCode}`, data: o })),
-    [options],
+    () =>
+      options.map((o) => ({
+        value: o.iso,
+        // The combobox trigger shows the option's `label` (renderValue is ignored
+        // for a searchable Select), so the label IS the compact trigger format…
+        label: countryDisplayLabel(o, countryDisplay),
+        // …while `description` carries the full search terms (name + iso + code)
+        // so filtering still matches by name even in `"code"`/`"iso"` modes.
+        description: `${o.name} ${o.iso} +${o.callingCode}`,
+        data: o,
+      })),
+    [options, countryDisplay],
   );
 
   const [country, setCountry] = useState<CountryCode>(() => seedCountry(value, defaultCountry));
@@ -208,12 +234,25 @@ export const PhoneInput = forwardRef<HTMLDivElement, PhoneInputProps>(function P
         value={country}
         onChange={(v) => onCountryChange(Array.isArray(v) ? v[0] : v)}
         searchable
+        // A phone always has a country — never offer to clear the selection.
+        clearable={false}
         size={size}
         invalid={invalid}
         disabled={disabled}
         aria-label={t('phoneInput.countryLabel')}
         placeholder={t('phoneInput.countrySearch')}
-        renderValue={(opt) => (opt.data ? `${opt.data.iso} +${opt.data.callingCode}` : opt.label)}
+        // Rows always show the full name (+ flag in `flag` mode), single-line.
+        renderOption={(opt) =>
+          opt.data ? (
+            <span className={styles.option}>
+              {countryDisplay === 'flag'
+                ? `${isoToFlag(opt.data.iso)} ${opt.data.name} +${opt.data.callingCode}`
+                : `${opt.data.name} +${opt.data.callingCode}`}
+            </span>
+          ) : (
+            opt.label
+          )
+        }
       />
       <Input
         className={styles.number}

--- a/packages/design-system/src/components/PhoneInput/index.ts
+++ b/packages/design-system/src/components/PhoneInput/index.ts
@@ -1,4 +1,4 @@
 export { PhoneInput } from './PhoneInput';
 export type { PhoneInputProps, PhoneInputSize } from './PhoneInput';
 export { isValidPhone } from './phone';
-export type { CountryOption, CountryCode } from './phone';
+export type { CountryOption, CountryCode, CountryDisplay } from './phone';

--- a/packages/design-system/src/components/PhoneInput/phone.test.ts
+++ b/packages/design-system/src/components/PhoneInput/phone.test.ts
@@ -1,4 +1,13 @@
-import { getCountryOptions, parseE164, formatNational, toE164, isValidPhone } from './phone';
+import {
+  getCountryOptions,
+  parseE164,
+  formatNational,
+  toE164,
+  isValidPhone,
+  isoToFlag,
+  countryDisplayLabel,
+} from './phone';
+import type { CountryOption } from './phone';
 
 describe('phone engine', () => {
   describe('getCountryOptions', () => {
@@ -72,6 +81,23 @@ describe('phone engine', () => {
       expect(isValidPhone('+1202')).toBe(false);
       expect(isValidPhone('')).toBe(false);
       expect(isValidPhone(null)).toBe(false);
+    });
+  });
+
+  describe('isoToFlag', () => {
+    it('maps an ISO alpha-2 code to its emoji flag', () => {
+      expect(isoToFlag('US')).toBe('🇺🇸');
+      expect(isoToFlag('gb')).toBe('🇬🇧');
+    });
+  });
+
+  describe('countryDisplayLabel', () => {
+    const us: CountryOption = { iso: 'US', name: 'United States', callingCode: '1' };
+    it('formats each display mode', () => {
+      expect(countryDisplayLabel(us, 'code')).toBe('+1');
+      expect(countryDisplayLabel(us, 'iso')).toBe('US +1');
+      expect(countryDisplayLabel(us, 'name')).toBe('United States +1');
+      expect(countryDisplayLabel(us, 'flag')).toBe('🇺🇸 +1');
     });
   });
 });

--- a/packages/design-system/src/components/PhoneInput/phone.test.ts
+++ b/packages/design-system/src/components/PhoneInput/phone.test.ts
@@ -89,6 +89,12 @@ describe('phone engine', () => {
       expect(isoToFlag('US')).toBe('🇺🇸');
       expect(isoToFlag('gb')).toBe('🇬🇧');
     });
+    it('strips non-letters and never throws on junk input', () => {
+      expect(isoToFlag('')).toBe('');
+      expect(isoToFlag('1')).toBe('');
+      // junk-in/junk-out but safe: the stray digit is dropped, leaving one indicator
+      expect(isoToFlag('U1')).toBe(String.fromCodePoint(0x1f1fa));
+    });
   });
 
   describe('countryDisplayLabel', () => {

--- a/packages/design-system/src/components/PhoneInput/phone.ts
+++ b/packages/design-system/src/components/PhoneInput/phone.ts
@@ -19,6 +19,43 @@ export interface CountryOption {
   callingCode: string;
 }
 
+/**
+ * How the SELECTED country renders in the picker trigger:
+ * - `'flag'` — emoji flag + calling code (`🇺🇸 +1`)
+ * - `'iso'` — ISO code + calling code (`US +1`)
+ * - `'name'` — full country name + calling code (`United States +1`)
+ * - `'code'` — calling code only (`+1`)
+ */
+export type CountryDisplay = 'flag' | 'iso' | 'name' | 'code';
+
+/**
+ * Emoji flag for an ISO 3166-1 alpha-2 code, built from Unicode regional-
+ * indicator symbols. Note: emoji flags do NOT render on Windows Chrome/Edge —
+ * those show the letters (e.g. "US") instead.
+ */
+export function isoToFlag(iso: string): string {
+  return iso
+    .toUpperCase()
+    .replace(/[^A-Z]/g, '')
+    .replace(/./g, (c) => String.fromCodePoint(0x1f1e6 + c.charCodeAt(0) - 65));
+}
+
+/** The compact trigger label for `country` under the chosen `display` mode. */
+export function countryDisplayLabel(country: CountryOption, display: CountryDisplay): string {
+  const code = `+${country.callingCode}`;
+  switch (display) {
+    case 'flag':
+      return `${isoToFlag(country.iso)} ${code}`;
+    case 'iso':
+      return `${country.iso} ${code}`;
+    case 'code':
+      return code;
+    case 'name':
+    default:
+      return `${country.name} ${code}`;
+  }
+}
+
 function displayNames(locale: string): Intl.DisplayNames {
   try {
     return new Intl.DisplayNames([locale], { type: 'region' });

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -262,6 +262,7 @@ export type {
   PhoneInputSize,
   CountryOption,
   CountryCode,
+  CountryDisplay,
 } from './components/PhoneInput';
 
 export { Select } from './components/Select';

--- a/packages/playground/src/pages/components/PhoneInputDemo.tsx
+++ b/packages/playground/src/pages/components/PhoneInputDemo.tsx
@@ -60,6 +60,10 @@ export function PhoneInputDemo() {
               />
             </Cluster>
           ))}
+          <Text size="sm" tone="muted">
+            All four share one value — editing any updates the rest, so only the trigger format
+            differs.
+          </Text>
         </Stack>
       </Example>
 

--- a/packages/playground/src/pages/components/PhoneInputDemo.tsx
+++ b/packages/playground/src/pages/components/PhoneInputDemo.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { PhoneInput, isValidPhone, Stack, Text, Code, Field } from '@eocrm/design-system';
+import { PhoneInput, isValidPhone, Stack, Cluster, Text, Code, Field } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
@@ -7,6 +7,7 @@ import { getComponentFiles } from '../../lib/componentFiles';
 export function PhoneInputDemo() {
   const [phone, setPhone] = useState<string | null>(null);
   const [gb, setGb] = useState<string | null>('+442071838750');
+  const [dv, setDv] = useState<string | null>('+12025550123');
 
   return (
     <DemoLayout
@@ -37,6 +38,29 @@ export function PhoneInputDemo() {
 <PhoneInput value={gb} onChange={setGb} />`}
       >
         <PhoneInput value={gb} onChange={setGb} />
+      </Example>
+
+      <Example
+        title="Country display formats (countryDisplay)"
+        description="Controls how the SELECTED country shows in the trigger — full name+code (default), ISO+code, just the code, or emoji flag+code. The dropdown rows always show the full country name and stay searchable. Note: emoji flags don't render on Windows Chrome/Edge — prefer 'iso' there."
+        code={`<PhoneInput value={v} onChange={setV} countryDisplay="name" /> // United States +1 (default)
+<PhoneInput value={v} onChange={setV} countryDisplay="iso" />  // US +1
+<PhoneInput value={v} onChange={setV} countryDisplay="code" /> // +1
+<PhoneInput value={v} onChange={setV} countryDisplay="flag" /> // 🇺🇸 +1`}
+      >
+        <Stack gap="sm">
+          {(['name', 'iso', 'code', 'flag'] as const).map((mode) => (
+            <Cluster key={mode} gap="sm">
+              <Code>{mode}</Code>
+              <PhoneInput
+                value={dv}
+                onChange={setDv}
+                countryDisplay={mode}
+                aria-label={`${mode} display`}
+              />
+            </Cluster>
+          ))}
+        </Stack>
       </Example>
 
       <Example


### PR DESCRIPTION
Follow-up tweaks to `<PhoneInput>` (shipped in v0.1.56), requested after review of the live component.

## Summary

1. **Country can't be cleared** — the country `Select` is now `clearable={false}` (a phone always has a country; the "×" clear button is removed).
2. **New `countryDisplay` prop** (`'flag' | 'iso' | 'name' | 'code'`, default `'name'`) controls how the SELECTED country renders in the trigger:
   - `name` → `United States +1` (default, unchanged)
   - `iso` → `US +1`
   - `code` → `+1`
   - `flag` → `🇺🇸 +1` (emoji flags don't render on Windows Chrome/Edge — documented; prefer `iso` there)
   - The dropdown rows **always** show the full country name (with a flag prefix in `flag` mode) and stay searchable by name — even in compact modes — because search is decoupled onto the option `description` while the `label` carries the compact trigger format. (Searchable Selects show the option `label` in the combobox input; `renderValue` is ignored there.)
3. **No line breaks in options** — dropdown rows are single-line (`white-space: nowrap` + ellipsis).

`CountryDisplay` is exported; `isoToFlag` + `countryDisplayLabel` added to the pure `phone.ts`. The `'name'` default is a verified no-op vs v0.1.56.

## Test plan

- **Unit (3009+ suite green; PhoneInput 32):** `isoToFlag` (incl. junk input), `countryDisplayLabel` (all 4 modes); component — no clear button, each `countryDisplay` trigger value (name/iso/code/flag), search-by-name still works in `code` mode, all prior round-trip/seed/country-change/Field tests still green.
- **Review:** one fresh-context adversarial reviewer → 0 Critical / 0 Important (verified default path unchanged, search holds in every mode, dropdown option accessible name stays the full country name, SCSS/Rule-4 clean).
- **Browser (Playwright, live demo):** 0 clear buttons; the four modes render "United States +1" / "US +1" / "+1" / "🇺🇸 +1"; the `code`-mode dropdown still lists 245 full-name options, single-line (`nowrap`).
- Gates: `make test` / `build-lib` / `build` / `lint` / `format:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)