### PR TITLE
fix(OptionsPicker): popover arrow no longer overlaps the search input

### DIFF
--- a/packages/design-system/src/components/OptionsPicker/OptionsPicker.module.scss
+++ b/packages/design-system/src/components/OptionsPicker/OptionsPicker.module.scss
@@ -3,13 +3,18 @@
 
 // Override Popover.Content's default padding — the picker manages its own
 // section padding internally (searchBar, list rows, footer each have their
-// own space-2 padding) so the panel wrapper itself sits flush.
+// own space-2 padding) so the sections stay flush to the left/right edges.
+// Vertical inset only: the Popover arrow (a 12px square rotated 45deg, centered
+// on the panel edge) pokes its inner tip ~8px into the panel, so without
+// top/bottom clearance it overlaps the (focused) search input or the footer
+// buttons. space-1 here + each section's own space-2 = space-3, which matches
+// the Popover's default --popover-padding (the arrow's intended clearance).
 .panel {
   display: flex;
   flex-direction: column;
   min-width: var(--options-picker-panel-min-width);
   max-width: var(--options-picker-panel-max-width);
-  padding: 0;
+  padding: var(--space-1) 0;
 }
 
 .list {


### PR DESCRIPTION
## Summary

The OptionsPicker popover's arrow overlapped the search input (and its focus ring), as reported. Root cause: `OptionsPicker`'s `.panel` zeroed `Popover.Content`'s default padding (`--popover-padding: var(--space-3)`) to manage its own per-section spacing — but the Popover arrow is centered on the panel edge and dips ~6px *into* the panel, so with the search bar flush at the top it collided with the focused input's ring.

**Fix:** add `var(--space-1)` vertical inset to `.panel` (`padding: var(--space-1) 0`). Combined with each section's own `--space-2`, content now sits `space-3` from the panel edge — exactly the clearance a default Popover gives the arrow. Sections stay flush left/right; the list/footer are unaffected. CSS-only, one property.

## Test plan

- **Browser (Playwright, live):** opened the "Stage (1)" picker; measured the arrow's bottom (399px) vs the focused input's ring top (401px) → **2px clearance, no overlap** (matches a default Popover, which also clears the arrow by ~2px). Screenshot confirms the notch sits cleanly above the search input with no cut-in.
- Reasoned through the flipped (arrow-on-bottom → footer), single-mode (no footer), and `searchable={false}` (list-first) cases — all clear or improve.
- No behavioral change (layout-only); all 3016 tests pass, lint + format green. No new unit test — the regression is purely visual (jsdom has no layout engine to assert pixel clearance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)