### PR TITLE
feat(LiquidEditor): toolbarActions slot + bordered, right-aligned Insert variable

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -911,6 +911,8 @@ const VARS = [
 <LiquidEditor value={formula} onChange={setFormula} variables={VARS} />;
 ```
 
+**Toolbar:** the right-aligned "Insert variable" dropdown is a bordered `secondary` `sm` button. Pass `toolbarActions` (a `ReactNode`, e.g. `<Button variant="ghost" size="sm">…</Button>` for a Docs/Help link) to add extra buttons right-aligned just before it. Hidden when `showToolbar={false}`.
+
 When NOT to use: plain prose → `Textarea`; static read-only code → playground `CodeBlock`. Don't expect it to validate syntax (feed `error` from the backend) or to produce its own preview (preview is consumer-rendered).
 
 ### `<RichTextEditor>` — controlled rich-text editor (contentEditable)

--- a/packages/design-system/src/components/LiquidEditor/InsertVariableMenu.tsx
+++ b/packages/design-system/src/components/LiquidEditor/InsertVariableMenu.tsx
@@ -35,7 +35,7 @@ export function InsertVariableMenu({ variables, disabled, onInsert }: InsertVari
     <DropdownMenu>
       {/* Trigger clones its single child to inject ref + ARIA — no `asChild`. */}
       <DropdownMenu.Trigger>
-        <Button variant="ghost" size="sm" disabled={disabled || variables.length === 0}>
+        <Button variant="secondary" size="sm" disabled={disabled || variables.length === 0}>
           {t('liquidEditor.insertVariable')}
         </Button>
       </DropdownMenu.Trigger>

--- a/packages/design-system/src/components/LiquidEditor/LiquidEditor.test.tsx
+++ b/packages/design-system/src/components/LiquidEditor/LiquidEditor.test.tsx
@@ -259,4 +259,38 @@ describe('LiquidEditor', () => {
     await user.type(ta, 'x');
     expect(ta).toHaveValue('locked');
   });
+
+  it('renders toolbarActions in the toolbar, before the Insert variable button', () => {
+    renderEditor(
+      <LiquidEditor
+        value=""
+        onChange={() => {}}
+        variables={VARS}
+        toolbarActions={<button type="button">Docs</button>}
+      />,
+    );
+    const docs = screen.getByRole('button', { name: 'Docs' });
+    const insert = screen.getByRole('button', { name: 'Insert variable' });
+    expect(docs).toBeInTheDocument();
+    // Docs comes before Insert variable in DOM order (both right-aligned).
+    expect(docs.compareDocumentPosition(insert) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // The spacer is the first toolbar child → actions + Insert are pushed right.
+    const toolbar = docs.parentElement!;
+    expect(toolbar.firstElementChild?.tagName).toBe('SPAN');
+    expect(toolbar.firstElementChild).toBeEmptyDOMElement();
+    // Insert variable is the bordered "secondary" button.
+    expect(insert.className).toMatch(/secondary/);
+  });
+
+  it('does not render toolbarActions when the toolbar is hidden', () => {
+    renderEditor(
+      <LiquidEditor
+        value=""
+        onChange={() => {}}
+        showToolbar={false}
+        toolbarActions={<button type="button">Docs</button>}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Docs' })).not.toBeInTheDocument();
+  });
 });

--- a/packages/design-system/src/components/LiquidEditor/LiquidEditor.tsx
+++ b/packages/design-system/src/components/LiquidEditor/LiquidEditor.tsx
@@ -60,6 +60,12 @@ const MENU_NAV_KEYS = new Set(['ArrowUp', 'ArrowDown', 'Enter', 'Tab', 'Escape']
  *   <LiquidEditor value={formula} onChange={setFormula} variables={VARS} />
  * </Field>
  *
+ * @example
+ * // Extra toolbar buttons (right-aligned, before "Insert variable").
+ * <LiquidEditor value={formula} onChange={setFormula} variables={VARS}
+ *   toolbarActions={<Button variant="ghost" size="sm"><BookOpen size={14} /> Docs</Button>}
+ * />
+ *
  * @remarks When NOT to use
  * - Plain multi-line prose → use `<Textarea>`.
  * - Static, read-only code display → use the playground `CodeBlock` (the library
@@ -87,6 +93,7 @@ export const LiquidEditor = forwardRef<HTMLTextAreaElement, LiquidEditorProps>(
       previewPlacement = 'bottom',
       showLineNumbers = true,
       showToolbar = true,
+      toolbarActions,
       filters = DEFAULT_LIQUID_FILTERS as string[],
       minRows = 4,
       maxRows,
@@ -303,12 +310,14 @@ export const LiquidEditor = forwardRef<HTMLTextAreaElement, LiquidEditorProps>(
       <>
         {showToolbar ? (
           <div className={styles.toolbar}>
+            {/* Spacer first → custom actions + Insert variable are pushed right. */}
+            <span className={styles.toolbarSpacer} />
+            {toolbarActions}
             <InsertVariableMenu
               variables={variables}
               disabled={!interactive}
               onInsert={insertVariable}
             />
-            <span className={styles.toolbarSpacer} />
           </div>
         ) : null}
         <div className={styles.body}>

--- a/packages/design-system/src/components/LiquidEditor/types.ts
+++ b/packages/design-system/src/components/LiquidEditor/types.ts
@@ -41,6 +41,13 @@ export interface LiquidEditorProps {
   showLineNumbers?: boolean;
   /** Show the toolbar (variable-insert menu). Default `true`. */
   showToolbar?: boolean;
+  /**
+   * Custom action buttons rendered in the toolbar, right-aligned just before the
+   * "Insert variable" button (e.g. a Docs / Help link). Pass `<Button size="sm">`
+   * elements (or a fragment of them); a `ghost` variant pairs well next to the
+   * bordered "Insert variable" button. Only renders when `showToolbar` is true.
+   */
+  toolbarActions?: ReactNode;
   /** Filter names offered in autocomplete after `|`. Defaults to a common Liquid set. */
   filters?: string[];
   /** Minimum visible rows. Default `4`. */

--- a/packages/playground/src/pages/components/LiquidEditorDemo.tsx
+++ b/packages/playground/src/pages/components/LiquidEditorDemo.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Stack, LiquidEditor, type LiquidVariable } from '@eocrm/design-system';
+import { BookOpen } from 'lucide-react';
+import { Stack, LiquidEditor, Button, type LiquidVariable } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
@@ -53,6 +54,34 @@ export function LiquidEditorDemo() {
           onChange={setFormula}
           variables={VARS}
           preview={fakeRender(formula)}
+        />
+      </Example>
+
+      <Example
+        title="Custom toolbar actions"
+        description='Pass toolbarActions to add buttons (e.g. a Docs link) right-aligned in the toolbar, just before the bordered "Insert variable" button.'
+        code={`<LiquidEditor
+  value={formula}
+  onChange={setFormula}
+  variables={VARS}
+  toolbarActions={
+    <Button variant="ghost" size="sm">
+      <BookOpen size={14} />
+      Docs
+    </Button>
+  }
+/>`}
+      >
+        <LiquidEditor
+          value={formula}
+          onChange={setFormula}
+          variables={VARS}
+          toolbarActions={
+            <Button variant="ghost" size="sm">
+              <BookOpen size={14} />
+              Docs
+            </Button>
+          }
         />
       </Example>
 


### PR DESCRIPTION
## Summary

Per request, updates the LiquidEditor toolbar:

1. **"Insert variable" is now a bordered `secondary` `sm` button**, pulled to the **right** of the toolbar (was a left-aligned ghost button).
2. **New `toolbarActions?: ReactNode` prop** — adds custom buttons (e.g. a Docs / Help link) right-aligned in the toolbar, grouped just before "Insert variable". Only renders when `showToolbar` is true.

Layout is now `[spacer … toolbarActions Insert variable]`.

## Test plan

- **Unit (3018 suite green; LiquidEditor 25):** `toolbarActions` renders in the toolbar and is ordered before "Insert variable"; not rendered when `showToolbar={false}`; existing toolbar/insert/autocomplete/preview tests unchanged.
- **Browser (Playwright, live demo):** every "Insert variable" button carries the `secondary` + `sm` classes and sits 8px from the toolbar's right edge (right-aligned); the new "Custom toolbar actions" example shows `[📖 Docs] [Insert variable]` grouped right. Screenshot confirmed.
- Demo extended with a "Custom toolbar actions" example; JSDoc `@example` + AGENTS.md note added.
- Gates: `make test` / `build-lib` / `build` / `lint` / `format:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)