### PR TITLE
feat(Image): size prop for fixed-square thumbnails (#189)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -2432,6 +2432,7 @@ placeholder with a retry button on failure.
 - `src` / `alt` — required (`alt=""` for decorative).
 - `objectFit`: `cover` (default) | `contain` | `fill` | `none` | `scale-down`.
 - `aspectRatio`: number (`1.5`) or string (`'16 / 9'`) — reserves the box, no layout shift.
+- `size`: `xs` (20) | `sm` (24) | `md` (32) | `lg` (40 px) — fixed **square** box from the `--size-*` scale instead of `width:100%` (dense table-cell thumbnails; won't squish in a flex row). Omit for responsive. Overrides `aspectRatio`.
 - `radius`: `none` | `sm` | `md` (default) | `lg` | `full`.
 - `fallback` — custom node shown on error instead of the default placeholder.
 - `loading` defaults to `'lazy'`; `ref` → the `<img>`; `className`/`style` → the wrapper box.

--- a/packages/design-system/src/components/Image/Image.module.scss
+++ b/packages/design-system/src/components/Image/Image.module.scss
@@ -8,6 +8,34 @@
   background: var(--image-bg);
 }
 
+// Fixed-square `size` variant — opt-in, overrides the default width:100% (the
+// compound `.wrapper.sizeX` selector beats `.wrapper` so order is irrelevant).
+// A component-owned fixed size, mirroring Avatar's size scale; `flex-shrink: 0`
+// keeps the box from squishing in a flex row / table cell.
+.wrapper.sizeXs {
+  width: var(--image-size-xs);
+  height: var(--image-size-xs);
+  flex-shrink: 0;
+}
+
+.wrapper.sizeSm {
+  width: var(--image-size-sm);
+  height: var(--image-size-sm);
+  flex-shrink: 0;
+}
+
+.wrapper.sizeMd {
+  width: var(--image-size-md);
+  height: var(--image-size-md);
+  flex-shrink: 0;
+}
+
+.wrapper.sizeLg {
+  width: var(--image-size-lg);
+  height: var(--image-size-lg);
+  flex-shrink: 0;
+}
+
 .radiusNone {
   border-radius: var(--image-radius-none);
 }

--- a/packages/design-system/src/components/Image/Image.test.tsx
+++ b/packages/design-system/src/components/Image/Image.test.tsx
@@ -114,6 +114,33 @@ describe('Image', () => {
     expect(img.getAttribute('sizes')).toBe('50vw');
   });
 
+  it('applies a fixed-square size class only when size is set (default has none)', () => {
+    const { container, rerender } = render(<Image src={SRC} alt="" />);
+    const wrapper = container.querySelector('span') as HTMLElement;
+    expect(wrapper.className).not.toMatch(/size(Xs|Sm|Md|Lg)/);
+    rerender(<Image src={SRC} alt="" size="lg" />);
+    expect(wrapper.className).toMatch(/sizeLg/);
+  });
+
+  it('maps each size value to its class', () => {
+    const { container, rerender } = render(<Image src={SRC} alt="" size="xs" />);
+    const wrapper = container.querySelector('span') as HTMLElement;
+    expect(wrapper.className).toMatch(/sizeXs/);
+    rerender(<Image src={SRC} alt="" size="sm" />);
+    expect(wrapper.className).toMatch(/sizeSm/);
+    rerender(<Image src={SRC} alt="" size="md" />);
+    expect(wrapper.className).toMatch(/sizeMd/);
+    rerender(<Image src={SRC} alt="" size="lg" />);
+    expect(wrapper.className).toMatch(/sizeLg/);
+  });
+
+  it('ignores aspectRatio when size is set (the fixed square wins)', () => {
+    const { container } = render(<Image src={SRC} alt="" size="lg" aspectRatio="16 / 9" />);
+    const wrapper = container.querySelector('span') as HTMLElement;
+    expect(wrapper.style.aspectRatio).toBe('');
+    expect(wrapper.className).toMatch(/sizeLg/);
+  });
+
   it('renders a decorative image with an empty alt without error', () => {
     const { container } = render(<Image src={SRC} alt="" />);
     const img = getImg(container);

--- a/packages/design-system/src/components/Image/Image.tokens.scss
+++ b/packages/design-system/src/components/Image/Image.tokens.scss
@@ -5,6 +5,13 @@
   --image-radius-lg: var(--radius-lg);
   --image-radius-full: var(--radius-full);
 
+  // Fixed-square sizes (the `size` prop). Aligned to the shared --size-* scale
+  // so a sized Image lines up with an Avatar / Button of the same size key.
+  --image-size-xs: var(--size-xs);
+  --image-size-sm: var(--size-sm);
+  --image-size-md: var(--size-md);
+  --image-size-lg: var(--size-lg);
+
   --image-bg: var(--color-bg-muted);
   --image-transition: var(--transition-base);
 

--- a/packages/design-system/src/components/Image/Image.tsx
+++ b/packages/design-system/src/components/Image/Image.tsx
@@ -19,6 +19,9 @@ export type ImageObjectFit = 'cover' | 'contain' | 'fill' | 'none' | 'scale-down
 /** Corner rounding. Maps to the radius token scale. */
 export type ImageRadius = 'none' | 'sm' | 'md' | 'lg' | 'full';
 
+/** Fixed square size, aligned to the shared `--size-*` scale (xs 20 / sm 24 / md 32 / lg 40 px). */
+export type ImageSize = 'xs' | 'sm' | 'md' | 'lg';
+
 export interface ImageProps extends Omit<
   ImgHTMLAttributes<HTMLImageElement>,
   'alt' | 'children' | 'src' | 'loading'
@@ -43,6 +46,15 @@ export interface ImageProps extends Omit<
    * Number (`1.5`) or CSS string (`'16 / 9'`).
    */
   aspectRatio?: string | number;
+  /**
+   * Render a fixed **square** box of this size (from the shared `--size-*`
+   * scale: `'xs'` 20 / `'sm'` 24 / `'md'` 32 / `'lg'` 40 px) instead of filling
+   * the container's width. Use for dense thumbnails (e.g. a 40px image cell in a
+   * table row) so you don't need a consumer-owned fixed-width wrapper. Omit for
+   * the default responsive behavior. When set, `aspectRatio` is ignored (the box
+   * is already square); pair with `objectFit="cover"` to crop.
+   */
+  size?: ImageSize;
   /**
    * Corner rounding. Defaults to `'md'`. Pass `'none'` for square corners; for
    * circular profile images use `<Avatar>`.
@@ -70,6 +82,13 @@ const RADIUS_CLASS: Record<ImageRadius, string> = {
   full: styles.radiusFull,
 };
 
+const SIZE_CLASS: Record<ImageSize, string> = {
+  xs: styles.sizeXs,
+  sm: styles.sizeSm,
+  md: styles.sizeMd,
+  lg: styles.sizeLg,
+};
+
 /**
  * Displays a remote image with built-in loading and error states. Reserves its
  * box (no layout shift), shows a `Skeleton` while loading, fades in on load, and
@@ -77,15 +96,20 @@ const RADIUS_CLASS: Record<ImageRadius, string> = {
  * failure.
  *
  * The wrapper fills its container's width — give it an `aspectRatio` (or a
- * height) so the box is reserved before the image arrives. `className` / `style`
- * apply to the wrapper box; `ref` forwards to the underlying `<img>`. The wrapper
- * owns sizing: rendered height comes from `aspectRatio` (or the container), and
- * native `width`/`height` attrs on the `<img>` are intrinsic-ratio hints only,
- * not the rendered size.
+ * height) so the box is reserved before the image arrives — UNLESS you pass
+ * `size`, which renders a fixed square box (e.g. a table-cell thumbnail).
+ * `className` / `style` apply to the wrapper box; `ref` forwards to the
+ * underlying `<img>`. The wrapper owns sizing: rendered height comes from `size`
+ * or `aspectRatio` (or the container), and native `width`/`height` attrs on the
+ * `<img>` are intrinsic-ratio hints only, not the rendered size.
  *
  * @example
  * // Responsive 16:9 thumbnail
  * <Image src={url} alt="Quarterly revenue chart" aspectRatio="16 / 9" />
+ *
+ * @example
+ * // Fixed 40px square thumbnail (e.g. a dense table cell) — no width:100% stretch
+ * <Image src={url} alt="report.pdf preview" size="lg" objectFit="cover" />
  *
  * @example
  * // Contain a logo on its muted box, square corners
@@ -117,6 +141,7 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
     alt,
     objectFit = 'cover',
     aspectRatio,
+    size,
     radius = 'md',
     fallback,
     loading = 'lazy',
@@ -141,8 +166,9 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
   };
 
   const wrapperStyle = {
+    // A fixed `size` sets an explicit square box, so aspectRatio is moot.
     aspectRatio:
-      aspectRatio === undefined
+      size !== undefined || aspectRatio === undefined
         ? undefined
         : typeof aspectRatio === 'number'
           ? String(aspectRatio)
@@ -153,7 +179,7 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
 
   return (
     <span
-      className={clsx(styles.wrapper, RADIUS_CLASS[radius], className)}
+      className={clsx(styles.wrapper, RADIUS_CLASS[radius], size && SIZE_CLASS[size], className)}
       style={wrapperStyle}
       data-state={state}
     >

--- a/packages/design-system/src/components/Image/index.ts
+++ b/packages/design-system/src/components/Image/index.ts
@@ -1,2 +1,2 @@
 export { Image } from './Image';
-export type { ImageProps, ImageObjectFit, ImageRadius } from './Image';
+export type { ImageProps, ImageObjectFit, ImageRadius, ImageSize } from './Image';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -365,7 +365,7 @@ export type {
 } from './components/FileUpload';
 
 export { Image } from './components/Image';
-export type { ImageProps, ImageObjectFit, ImageRadius } from './components/Image';
+export type { ImageProps, ImageObjectFit, ImageRadius, ImageSize } from './components/Image';
 
 export { ImageCrop, extractCropBlob, useCropPreview } from './components/ImageCrop';
 export type {

--- a/packages/playground/src/pages/components/ImageDemo.tsx
+++ b/packages/playground/src/pages/components/ImageDemo.tsx
@@ -175,6 +175,23 @@ export function ImageDemo() {
       </Example>
 
       <Example
+        title="Fixed-size thumbnail (size)"
+        description="size renders a fixed square box from the --size-* scale (xs 20 / sm 24 / md 32 / lg 40 px) instead of filling the container width — for dense thumbnails like a table-row image cell. No consumer-owned fixed-width wrapper needed; it won't squish in a flex row."
+        code={`<Image src={url} alt="report.pdf preview" size="lg" objectFit="cover" />`}
+      >
+        <Cluster gap="md" align="center">
+          {(['xs', 'sm', 'md', 'lg'] as const).map((s) => (
+            <Stack key={s} gap="xs" align="center">
+              <Image src={PHOTO} alt="" size={s} objectFit="cover" />
+              <Text size="xs" tone="muted">
+                {s}
+              </Text>
+            </Stack>
+          ))}
+        </Cluster>
+      </Example>
+
+      <Example
         title="Error + retry"
         description="A failed load shows the ImageOff placeholder with a Retry button (re-fetches the source)."
         code={`<Image src={brokenUrl} alt="…" aspectRatio="16 / 9" />`}


### PR DESCRIPTION
Addresses #189.

## Summary

Adds a `size?: ImageSize` prop (`'xs'` 20 / `'sm'` 24 / `'md'` 32 / `'lg'` 40 px, from the shared `--size-*` scale) to `<Image>`. When set, the wrapper renders a **fixed square box** instead of the default `width:100%` — so a dense table-cell thumbnail no longer needs a consumer-owned fixed-width wrapper (the exact gap #189 describes). Omitted = unchanged responsive behavior.

```tsx
<Image src={url} alt="report.pdf preview" size="lg" objectFit="cover" /> // 40×40 square
```

- Component tokens `--image-size-*` → `--size-*`; compound SCSS selectors `.wrapper.sizeX` (override `width:100%` by specificity, order-independent) with `flex-shrink: 0` so it won't squish in a flex row. Mirrors Avatar's component-owned fixed-size precedent.
- `aspectRatio` is ignored when `size` is set (the box is already square).
- `ImageSize` exported from the barrel; JSDoc + `@example` + AGENTS.md + demo example added.

eoCRM can retire its local `Thumbnail` shim once this ships.

## Test plan

- **Unit (3021 suite green; Image 17):** size→class, default→no size class, each size value (xs/sm/md/lg), aspectRatio-ignored-when-sized; existing loading/error/objectFit/radius/aspectRatio/ref tests unchanged.
- **Browser (Playwright, live demo):** the four sized thumbnails render exact squares — 20/24/32/**40**px — each `flex-shrink: 0`; default `aspectRatio` examples untouched.
- **Review:** adversarial reviewer → 0 Critical / 0 Important (confirmed specificity override, true square, Rule-4 Avatar precedent, Rule-3 tokens, exports/JSDoc).
- Gates: `make test` / `build-lib` / `build` / `lint` / `format:check` green; tarball ships no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)