### PR TITLE
feat(RichText): autolink + renderLink link substitution (viewer + editor)

### DIFF
--- a/docs/superpowers/plans/2026-06-24-richtext-links.md
+++ b/docs/superpowers/plans/2026-06-24-richtext-links.md
@@ -1,0 +1,509 @@
+# RichText links (autolink + `renderLink`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add **autolink** (editor turns typed/pasted URLs into `link` marks) and **`renderLink`** (consumer render-prop that substitutes a link's rendering with a custom block, in the read-only `<RichText>` viewer AND as a non-editable atomic chip inside `<RichTextEditor>`) to `@eocrm/design-system`, per `docs/superpowers/specs/2026-06-24-richtext-links-design.md`.
+
+**Architecture:** Pure engine helpers (`autolink.ts`) + a `renderLink` option threaded through `renderDoc` + widget-aware `selection.ts` (so an editor chip whose display text differs from the model URL maps correctly) + editor hooks (type rule, paste, atomic delete). The model is unchanged (links stay `{type:'link',href}` marks); `renderLink` is render-time only.
+
+**Tech Stack:** TypeScript, React, the in-house rich-text engine, Vitest + Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-06-24-richtext-links-design.md`
+
+---
+
+## File map
+
+Library (`packages/design-system/`):
+
+- `src/components/RichText/engine/autolink.ts` (new) — pure URL detection + linkify.
+- `src/components/RichText/engine/renderLink.ts` (new) — shared `RichTextLink` / `RenderLink` types.
+- `src/components/RichText/engine/renderDoc.tsx` (modify) — `renderLink` option + atomic widget.
+- `src/components/RichTextEditor/selection.ts` (modify) — widget-aware DOM↔model mapping.
+- `src/components/RichTextEditor/autolinkInput.ts` (new) — pure type-rule + atomic-delete helpers.
+- `src/components/RichTextEditor/RichTextEditor.tsx` (modify) — props + beforeinput/paste hooks.
+- `src/components/RichText/RichText.tsx` (modify) — `renderLink` prop.
+- `src/index.ts` (modify) — export `RichTextLink` / `RenderLink`.
+- `AGENTS.md` (modify).
+- (+ the `*.test.ts(x)` beside each.)
+
+Playground (`packages/playground/`):
+
+- `src/pages/components/RichTextEditorDemo.tsx` + `RichTextDemo.tsx` (modify) — `renderLink` + autolink examples.
+
+---
+
+## Task 1: `autolink.ts` engine helper (pure, TDD)
+
+**Files:** Create `src/components/RichText/engine/autolink.ts` + `autolink.test.ts`.
+
+- [ ] **Step 1: Write `autolink.test.ts`**
+
+```ts
+import { findUrl, linkifyRuns } from './autolink';
+
+describe('findUrl', () => {
+  it('finds an http(s) URL ending at the caret', () => {
+    expect(findUrl('see https://a.com/x')).toEqual({ start: 4, end: 19, href: 'https://a.com/x' });
+  });
+  it('normalizes a bare www. host to https', () => {
+    expect(findUrl('go www.a.com')).toEqual({ start: 3, end: 12, href: 'https://www.a.com' });
+  });
+  it('excludes trailing sentence punctuation', () => {
+    expect(findUrl('see https://a.com.')).toEqual({ start: 4, end: 17, href: 'https://a.com' });
+    expect(findUrl('(https://a.com)')).toEqual({ start: 1, end: 14, href: 'https://a.com' });
+  });
+  it('returns null when the text does not end in a URL', () => {
+    expect(findUrl('just words')).toBeNull();
+    expect(findUrl('https://a.com then more')).toBeNull(); // URL not at the end
+  });
+  it('rejects unsafe schemes', () => {
+    expect(findUrl('x javascript:alert(1)')).toBeNull();
+  });
+});
+
+describe('linkifyRuns', () => {
+  it('splits a string into plain + link runs', () => {
+    expect(linkifyRuns('a https://b.com c')).toEqual([
+      { text: 'a ', marks: [] },
+      { text: 'https://b.com', marks: [{ type: 'link', href: 'https://b.com' }] },
+      { text: ' c', marks: [] },
+    ]);
+  });
+  it('returns a single plain run when there is no URL', () => {
+    expect(linkifyRuns('no urls here')).toEqual([{ text: 'no urls here', marks: [] }]);
+  });
+  it('drops unsafe URLs (leaves them as plain text)', () => {
+    expect(linkifyRuns('javascript:alert(1)')).toEqual([
+      { text: 'javascript:alert(1)', marks: [] },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL** (`cd packages/design-system && npx vitest run src/components/RichText/engine/autolink.test.ts`).
+
+- [ ] **Step 3: Implement `autolink.ts`**
+
+```ts
+// autolink.ts — pure URL detection for the editor's autolink (type + paste) and
+// the RichText importer. No DOM. hrefs pass through safeHref so only safe schemes
+// become links.
+import type { Inline } from './model';
+import { safeHref } from './safeHref';
+
+// http(s)://… or a bare www.… host. Kept deliberately conservative.
+const URL_RE = /\b(?:https?:\/\/|www\.)[^\s<>()[\]]+/gi;
+// Strip trailing sentence punctuation that is unlikely to be part of the URL.
+const TRAILING = /[.,;:!?'"]+$/;
+
+function normalize(raw: string): { url: string; href: string } | null {
+  let url = raw.replace(TRAILING, '');
+  // Drop an unmatched closing bracket/paren (e.g. "(https://a.com)").
+  if (/[)\]]$/.test(url) && !/[([]/.test(url)) url = url.slice(0, -1);
+  if (url === '') return null;
+  const candidate = url.startsWith('www.') ? `https://${url}` : url;
+  const safe = safeHref(candidate);
+  if (!safe || !/^https?:/i.test(safe)) return null;
+  return { url, href: safe };
+}
+
+/** The URL that ends exactly at the end of `text`, or null. (For the type rule:
+ *  the caller passes the text up to the caret.) */
+export function findUrl(text: string): { start: number; end: number; href: string } | null {
+  let m: RegExpExecArray | null;
+  URL_RE.lastIndex = 0;
+  let last: { start: number; end: number; href: string } | null = null;
+  while ((m = URL_RE.exec(text)) !== null) {
+    const norm = normalize(m[0]);
+    if (!norm) continue;
+    const start = m.index;
+    const end = start + norm.url.length;
+    last = { start, end, href: norm.href };
+  }
+  // Only return when the matched URL reaches the end of `text`.
+  return last && last.end === text.length ? last : null;
+}
+
+/** Split `text` into plain + link runs (for paste / import). */
+export function linkifyRuns(text: string): Inline[] {
+  const runs: Inline[] = [];
+  let i = 0;
+  let m: RegExpExecArray | null;
+  URL_RE.lastIndex = 0;
+  while ((m = URL_RE.exec(text)) !== null) {
+    const norm = normalize(m[0]);
+    if (!norm) continue;
+    const start = m.index;
+    if (start > i) runs.push({ text: text.slice(i, start), marks: [] });
+    runs.push({ text: norm.url, marks: [{ type: 'link', href: norm.href }] });
+    i = start + norm.url.length;
+  }
+  if (i < text.length) runs.push({ text: text.slice(i), marks: [] });
+  return runs.length ? runs : [{ text, marks: [] }];
+}
+```
+
+- [ ] **Step 4: Run → PASS.** Adjust the regex/normalize against the test cases until green (the test is the spec — the punctuation/bracket edge cases must pass).
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(RichText): autolink URL detection engine helper"`.
+
+---
+
+## Task 2: `renderLink` types + `renderDoc` threading (TDD)
+
+**Files:** Create `src/components/RichText/engine/renderLink.ts`; modify `renderDoc.tsx`; extend `renderDoc.test.tsx`.
+
+- [ ] **Step 1: Create `renderLink.ts`**
+
+```ts
+import type { ReactNode } from 'react';
+
+/** A link encountered while rendering, passed to `renderLink`. */
+export interface RichTextLink {
+  /** The sanitized URL. */
+  href: string;
+  /** The link's visible text in the document. */
+  text: string;
+}
+
+/**
+ * Replace how a link renders. Return your own node (e.g. a task/member chip) to
+ * substitute the link, or `defaultNode` for the standard `<a>`.
+ */
+export type RenderLink = (link: RichTextLink, defaultNode: ReactNode) => ReactNode;
+```
+
+- [ ] **Step 2: Add failing tests to `renderDoc.test.tsx`**
+
+```tsx
+import { renderDoc } from './renderDoc';
+import { createBlock } from './model';
+// (render with @testing-library/react; the file already imports render)
+
+it('renderLink substitutes a link node in the viewer', () => {
+  const doc = {
+    blocks: [createBlock('paragraph', 'x', { marks: [{ type: 'link', href: 'https://a.com' }] })],
+  };
+  const { container } = render(
+    <div>{renderDoc(doc, { renderLink: ({ href }) => <span data-chip>{href}</span> })}</div>,
+  );
+  expect(container.querySelector('[data-chip]')).not.toBeNull();
+  expect(container.querySelector('a')).toBeNull();
+});
+
+it('editable mode wraps a custom link return in an atomic widget; a fallback return is not wrapped', () => {
+  const doc = {
+    blocks: [createBlock('paragraph', 'abc', { marks: [{ type: 'link', href: 'https://a.com' }] })],
+  };
+  const custom = render(
+    <div>
+      {renderDoc(doc, { editable: true, renderLink: ({ href }) => <span data-chip>{href}</span> })}
+    </div>,
+  );
+  const w = custom.container.querySelector('[data-rich-link]');
+  expect(w).not.toBeNull();
+  expect(w!.getAttribute('data-len')).toBe('3'); // model run text length
+  expect(w!.getAttribute('contenteditable')).toBe('false');
+
+  const fb = render(
+    <div>{renderDoc(doc, { editable: true, renderLink: (_l, fallback) => fallback })}</div>,
+  );
+  expect(fb.container.querySelector('[data-rich-link]')).toBeNull(); // plain link stays editable
+  expect(fb.container.querySelector('a')).not.toBeNull();
+});
+```
+
+(Note: `createBlock('paragraph', 'x', { marks })` applies `marks` to the run — verify the `CreateBlockAttrs` shape supports per-run marks; if not, build the block inline with `inlines: [{ text, marks }]`.)
+
+- [ ] **Step 3: Thread `renderLink` through `renderDoc.tsx`**
+
+Add to `RenderDocOptions`: `renderLink?: RenderLink;`. Thread `options` down through `renderBlock`/`blockContent`/`renderInlines`/`renderRun` to `wrapMark` (pass the run's plain text + the options). Replace the `case 'link'` in `wrapMark` with:
+
+```tsx
+case 'link': {
+  const href = mark.type === 'link' ? safeHref(mark.href) : undefined;
+  const fallback = (
+    <a href={href} rel="noopener noreferrer">
+      {child}
+    </a>
+  );
+  if (!opts.renderLink || !href) return fallback;
+  const custom = opts.renderLink({ href, text: runText }, fallback);
+  if (custom === fallback) return fallback; // consumer declined → plain editable link
+  if (!opts.editable) return custom;
+  return (
+    <span data-rich-link data-len={runText.length} contentEditable={false}>
+      {custom}
+    </span>
+  );
+}
+```
+
+`runText` is the plain text of the run being wrapped (pass it from `renderRun` — it's `run.text`). `opts` carries `{ editable, renderLink }`. Keep the existing signatures otherwise; thread `opts`/`runText` as params (do NOT use module state). The default `renderDoc(value)` (no options) behaves exactly as today.
+
+- [ ] **Step 4: Run renderDoc + autolink tests → PASS** (`npx vitest run src/components/RichText/engine/`), `npx tsc --noEmit`.
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(RichText): renderLink option + atomic link widget in renderDoc"`.
+
+---
+
+## Task 3: widget-aware `selection.ts` (TDD — the risk area)
+
+**Files:** Modify `RichTextEditor/selection.ts`; extend `selection.test.ts`.
+
+Goal: `pointFromDom`/`pointToDom` must treat a `[data-rich-link]` widget as one atomic unit of `data-len` model chars (its display text differs from the model URL).
+
+- [ ] **Step 1: Add failing round-trip tests to `selection.test.ts`**
+
+Build an editable block in jsdom containing: text `"hi "` + an atomic widget (`<span data-rich-link data-len="13" contenteditable="false">#1 Task</span>`) + text `" end"`, all inside a `<p data-block-id="b1">`. The widget's model length is 13 (e.g. `https://a/t/1`), display `#1 Task` (7 chars). Assert:
+
+```ts
+// caret just before the widget → model offset 3 ("hi ")
+// caret just after the widget  → model offset 3 + 13 = 16
+// caret at end (" end")        → model offset 16 + 4 = 20
+```
+
+Write these as `pointFromDom(root, node, offset)` cases (place the DOM caret before/after the widget and at the end) AND the reverse `pointToDom(root, { blockId:'b1', offset })` for 3 / 16 / 20 (offsets at widget boundaries map to a DOM point adjacent to the widget, never inside it).
+
+- [ ] **Step 2: Run → FAIL** (current code counts the widget's display text, so offsets after it are wrong).
+
+- [ ] **Step 3: Make `offsetWithinBlock` widget-aware**
+
+Keep `range.toString().length` as `raw`, then correct for each `[data-rich-link]` widget that lies **fully before** the range end:
+
+```ts
+function offsetWithinBlock(blockEl: HTMLElement, node: Node, offset: number): number {
+  const doc = blockEl.ownerDocument;
+  const range = doc.createRange();
+  range.setStart(blockEl, 0);
+  try {
+    range.setEnd(node, offset);
+  } catch {
+    return 0;
+  }
+  let len = range.toString().length;
+  for (const w of Array.from(blockEl.querySelectorAll<HTMLElement>('[data-rich-link]'))) {
+    // Is the widget entirely within [blockStart, (node,offset)] ? Compare the
+    // range end against a point just AFTER the widget.
+    const afterW = doc.createRange();
+    afterW.setStartAfter(w);
+    afterW.collapse(true);
+    // range end >= afterW  ⇒  widget fully counted in `raw`.
+    if (range.compareBoundaryPoints(Range.END_TO_START, afterW) >= 0) {
+      const declared = Number(w.dataset.len ?? '0');
+      const shown = w.textContent?.length ?? 0;
+      len += declared - shown;
+    }
+  }
+  return len;
+}
+```
+
+(`compareBoundaryPoints(Range.END_TO_START, afterW)` compares THIS range's end to afterW's start; `>= 0` means our end is at/after the point just past the widget. Verify the comparison direction against the test; flip to `START_TO_END` / sign as needed until the round-trip tests pass — the TESTS are the spec.)
+
+- [ ] **Step 4: Make `pointToDom` widget-aware**
+
+Replace the text-only TreeWalker with a walk over text nodes AND `[data-rich-link]` widgets, accumulating model length (text → `textContent.length`; widget → `data-len`, do not descend). When `remaining` falls:
+
+- inside a text node → `{ node: textNode, offset: remaining }`;
+- at a widget boundary (`remaining === 0` at the widget, or after consuming it) → a DOM point in the widget's parent at the widget's child index (before) or +1 (after), so the caret sits adjacent, never inside.
+
+```ts
+export function pointToDom(root: HTMLElement, point: Point): { node: Node; offset: number } | null {
+  const blockEl = root.querySelector<HTMLElement>(`[data-block-id="${CSS.escape(point.blockId)}"]`);
+  if (!blockEl) return null;
+  let remaining = point.offset;
+  const walker = blockEl.ownerDocument.createTreeWalker(
+    blockEl,
+    NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
+    {
+      acceptNode(n) {
+        if (n.nodeType === Node.TEXT_NODE) return NodeFilter.FILTER_ACCEPT;
+        if (n instanceof HTMLElement && n.hasAttribute('data-rich-link'))
+          return NodeFilter.FILTER_ACCEPT;
+        return NodeFilter.FILTER_SKIP; // descend into non-widget elements
+      },
+    },
+  );
+  let last: Text | null = null;
+  let n = walker.nextNode();
+  while (n) {
+    if (n.nodeType === Node.TEXT_NODE) {
+      const t = n as Text;
+      const len = t.textContent?.length ?? 0;
+      if (remaining <= len) return { node: t, offset: remaining };
+      remaining -= len;
+      last = t;
+    } else {
+      const w = n as HTMLElement;
+      const declared = Number(w.dataset.len ?? '0');
+      if (remaining <= 0) {
+        const parent = w.parentNode!;
+        return { node: parent, offset: Array.prototype.indexOf.call(parent.childNodes, w) };
+      }
+      if (remaining <= declared) {
+        const parent = w.parentNode!;
+        return { node: parent, offset: Array.prototype.indexOf.call(parent.childNodes, w) + 1 };
+      }
+      remaining -= declared;
+      last = null;
+    }
+    n = walker.nextNode();
+  }
+  if (last) return { node: last, offset: last.textContent?.length ?? 0 };
+  return { node: blockEl, offset: 0 };
+}
+```
+
+- [ ] **Step 5: Run the selection tests → PASS** + the full editor suite (`npx vitest run src/components/RichTextEditor/selection.test.ts && npx vitest run src/components/RichTextEditor/`). The EXISTING selection tests (no widgets) must stay green — the corrections are no-ops when no `[data-rich-link]` is present.
+
+- [ ] **Step 6: Commit** — `git commit -m "feat(RichTextEditor): widget-aware DOM<->model selection mapping for atomic link chips"`.
+
+---
+
+## Task 4: editor autolink (type + paste) + atomic delete
+
+**Files:** Create `RichTextEditor/autolinkInput.ts` + test; modify `RichTextEditor.tsx`.
+
+- [ ] **Step 1: `autolinkInput.ts` (pure) + test**
+
+```ts
+// autolinkInput.ts — pure helpers the editor's beforeinput handler uses for
+// autolink-on-type and atomic deletion of a resolved-link run.
+import type { RichDoc, Range, Point } from '../RichText/engine/model';
+import { findBlockIndex } from '../RichText/engine/position';
+import { runsText } from '../RichText/engine/inlines';
+import { linkAt, setLink } from './links';
+import { findUrl } from '../RichText/engine/autolink';
+
+/** When typing `boundary` (e.g. ' ') at a collapsed caret, link the URL that ends
+ *  at the caret. Returns the linked { doc, selection } with the caret AFTER the
+ *  inserted boundary char, or null if there's no URL to link. */
+export function applyTypeAutolink(
+  doc: RichDoc,
+  caret: Point,
+  boundary: string,
+): { doc: RichDoc; selection: Range } | null {
+  const idx = findBlockIndex(doc, caret.blockId);
+  if (idx === -1) return null;
+  const text = runsText(doc.blocks[idx].inlines).slice(0, caret.offset);
+  const found = findUrl(text);
+  if (!found) return null;
+  // Already linked? (caret inside/after an existing link) → skip.
+  if (linkAt(doc, caret)) return null;
+  const range: Range = {
+    anchor: { blockId: caret.blockId, offset: found.start },
+    focus: { blockId: caret.blockId, offset: found.end },
+  };
+  const linked = setLink(doc, range, found.href);
+  // Caret returns to the original position; the boundary char is inserted by the
+  // caller's normal insertText path AFTER this (the editor sequences them).
+  return { doc: linked.doc, selection: { anchor: caret, focus: caret } };
+}
+
+/** If the collapsed caret sits immediately AFTER (backward) or BEFORE (forward) a
+ *  link run that `isResolved(href)` accepts, return the whole-run range to delete
+ *  atomically, else null. */
+export function atomicLinkDeleteRange(
+  doc: RichDoc,
+  caret: Point,
+  dir: 'backward' | 'forward',
+  isResolved: (href: string) => boolean,
+): Range | null {
+  const probe: Point =
+    dir === 'backward' ? caret : { blockId: caret.blockId, offset: caret.offset + 1 };
+  const at = linkAt(doc, probe);
+  if (!at || !isResolved(at.href)) return null;
+  // Only when the caret is exactly at the run's edge (after it for backward,
+  // before it for forward).
+  if (dir === 'backward' && caret.offset !== at.range.focus.offset) return null;
+  if (dir === 'forward' && caret.offset !== at.range.anchor.offset) return null;
+  return at.range;
+}
+```
+
+Test `applyTypeAutolink` (URL before caret → links it; no URL → null; already-linked → null) and `atomicLinkDeleteRange` (caret after a resolved link → returns run range; unresolved → null; mid-run → null). Use small hand-built docs.
+
+- [ ] **Step 2: Run → FAIL → implement → PASS.**
+
+- [ ] **Step 3: Wire into `RichTextEditor.tsx` `onBeforeInput`**
+
+In the `onBeforeInput` handler (after the block-rule branch ~line 433, before the generic `applyInput` at ~454):
+
+(a) **Autolink on type:** when `latest.current.autolink !== false`, `e.inputType === 'insertText'`, `isCollapsed(range)`, and `e.data` is a boundary char (`' '` — Enter is handled via insertParagraph, optionally also link before splitting): call `applyTypeAutolink(doc, range.anchor, e.data)`. If it returns a result, first apply the link, then insert the boundary char (`insertText`) on the linked doc, `commit` the combined result, `e.preventDefault()`, return. (Sequence: link the URL, then insert the space after it.)
+
+(b) **Atomic delete:** for `deleteContentBackward`/`deleteContentForward` with collapsed caret, when `latest.current.renderLink` is set, compute `isResolved = (href) => latest.current.renderLink!({ href, text: href }, FALLBACK_SENTINEL) !== FALLBACK_SENTINEL` and call `atomicLinkDeleteRange(doc, range.anchor, dir, isResolved)`. If it returns a range, `commit(deleteRange(doc, range))`, `preventDefault()`, return. (Use a stable sentinel node for the fallback so "consumer returned a custom node" is detectable.)
+
+- [ ] **Step 4: Extend `onPaste` for plain-text URLs**
+
+In the existing `onPaste` (after the HTML branch): if there's NO usable HTML but there IS `text/plain` that contains a URL and `autolink !== false`:
+
+- selection non-empty + the plain text is a single bare URL → `commit(setLink(value, range, url))`, `preventDefault()`.
+- otherwise → build a fragment from `linkifyRuns(plain)` (one paragraph block whose inlines are the linkified runs) and `commit(insertFragment(value, range, fragment))`, `preventDefault()`.
+
+- [ ] **Step 5: Run the editor suite + typecheck.** Commit — `git commit -m "feat(RichTextEditor): autolink on type + paste; atomic delete of resolved-link chips"`.
+
+---
+
+## Task 5: `renderLink` / `autolink` props on the components
+
+**Files:** Modify `RichText/RichText.tsx`, `RichTextEditor/RichTextEditor.tsx`; extend both component tests.
+
+- [ ] **Step 1: `RichText.tsx`** — add `renderLink?: RenderLink` to `RichTextProps` (import the type from `./engine/renderLink`); pass it: `renderDoc(value, { renderLink })`. Add JSDoc. Test: a `renderLink` returning a chip renders the chip (`getByText`/querySelector), absent → default `<a>`.
+
+- [ ] **Step 2: `RichTextEditor.tsx`** — add `renderLink?: RenderLink` and `autolink?: boolean` (default true) to `RichTextEditorProps` + the `latest` ref mirror (so the native listeners read them). Pass `renderDoc(value, { editable: true, renderLink })` at the existing call (~line 726). Add JSDoc (`@remarks`: don't do heavy sync work in `renderLink`; it's render-time, serialization stays a link; an editor chip is atomic, not editable text). Test: `renderLink` renders a chip wrapped in `[data-rich-link]`; `autolink={false}` disables the type rule.
+
+- [ ] **Step 3: Run both component suites + typecheck.** Commit — `git commit -m "feat(RichText,RichTextEditor): renderLink + autolink props"`.
+
+---
+
+## Task 6: Exports + demos + AGENTS
+
+**Files:** Modify `src/index.ts`, playground demos, `AGENTS.md`.
+
+- [ ] **Step 1: `src/index.ts`** — export the types near the existing RichText exports:
+
+```ts
+export type { RichTextLink, RenderLink } from './components/RichText/engine/renderLink';
+```
+
+(Verify the existing RichText/RichTextEditor barrel exports; add `RichTextLink`/`RenderLink` alongside. No new component, no manifest change.)
+
+- [ ] **Step 2: Demos** — in `RichTextEditorDemo.tsx` and `RichTextDemo.tsx`, add a `renderLink` example. A tiny in-file resolver:
+
+```tsx
+const TASK_RE = /^https?:\/\/app\.eocrm\/task\/(\d+)/i;
+const renderLink: RenderLink = ({ href }, fallback) => {
+  const m = TASK_RE.exec(href);
+  return m ? <Badge tone="accent">#{m[1]} · Ship the gallery</Badge> : fallback;
+};
+```
+
+Show: a doc containing `https://app.eocrm/task/123` (renders the Badge chip) + a plain external link (renders `<a>`); and (editor) a note to type/paste a URL to autolink. Build the playground (`make build`).
+
+- [ ] **Step 3: AGENTS.md** — extend the RichText/RichTextEditor entries: autolink (type+paste, `autolink` default true) + `renderLink` (viewer + editor; consumer owns in-space check + lookup; returns a chip or the fallback; editor chip is atomic).
+
+- [ ] **Step 4: Format + commit** — `npx prettier --write` the changed files; `git commit -m "feat(RichText): export renderLink types; demos + AGENTS"`.
+
+---
+
+## Task 7: Full gates + browser verification
+
+- [ ] **Step 1: Gates** — `make test && make build-lib && make lint && npm run format:check`; tarball gate `0`.
+
+- [ ] **Step 2: Browser (Playwright) on `/components/rich-text-editor`:**
+  - Type `see https://app.eocrm/task/123 ` → the URL becomes a link, then (with the demo `renderLink`) renders as the `#123` chip. Place the caret after the chip and press Backspace → the whole chip is removed in one step (atomic delete).
+  - Arrow-left/right across the chip → the caret steps over it (never inside).
+  - Paste a URL over selected text → the selection becomes linked.
+  - On `/components/rich-text` (viewer): a doc with a task URL renders the chip; an external URL renders a plain link.
+  - No console errors.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** autolink type rule (T4) + paste (T4) via `autolink.ts` (T1) · `renderLink` types (T2) threaded through `renderDoc` viewer + editor atomic widget (T2) · widget-aware `selection.ts` (T3) · atomic delete (T4) · props on both components (T5) · exports + demos + AGENTS (T6) · no model/serialization change · no i18n. All spec sections map to a task.
+- **Type consistency:** `RichTextLink { href, text }` + `RenderLink` defined in `renderLink.ts` (T2), consumed by `renderDoc` (T2), `RichText`/`RichTextEditor` (T5), re-exported from `src/index.ts` (T6). `[data-rich-link][data-len]` produced in T2 is consumed by the T3 selection mapping and T4 atomic delete.
+- **Risk:** T3 (selection mapping) is the crux — the `compareBoundaryPoints` direction and the `pointToDom` widget walk must be validated against the T3 round-trip tests (the tests are the spec; adjust the comparison sign until green) and the browser pass (T7). The corrections are no-ops without `[data-rich-link]`, so existing selection behavior is preserved.
+- **Backward-compat:** `renderDoc(value)` with no options is unchanged; `renderLink`/`autolink` are additive optional props; the model + `toHtml`/`toMarkdown` are untouched.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -245,6 +245,16 @@ const doc = {
 <RichText value={doc} />;
 ```
 
+**`renderLink`** (optional) — substitute how a link renders. The consumer checks "is this URL in my space?" and returns its own node (e.g. a task/member chip) or the supplied `fallback` (the standard `<a>`). It's render-time only — the model and `toHtml`/`toMarkdown` still emit a plain link, so serialization is unchanged. Don't do heavy synchronous work or block on the network inside it; return a component that handles its own lookup/cache. The same resolver works in `<RichText>` (viewer) and `<RichTextEditor>` (where a substituted link becomes an atomic chip).
+
+```tsx
+const renderLink: RenderLink = ({ href }, fallback) => {
+  const m = /^https?:\/\/app\.eocrm\/task\/(\d+)/i.exec(href);
+  return m ? <Badge tone="purple">#{m[1]}</Badge> : fallback;
+};
+<RichText value={doc} renderLink={renderLink} />;
+```
+
 When NOT to use: plain text → `Text`. For editing → `<RichTextEditor>`. The model is immutable; render the doc returned by a transform, never mutate in place.
 
 ### `<Button>` — action triggers
@@ -969,7 +979,20 @@ const [doc, setDoc] = useState(emptyDoc());
 
 **Links:** select text and press ⌘/Ctrl+K (or the toolbar link button) to add or edit a link; with the caret inside a link the URL is pre-filled and a Remove button appears; with no selection the URL is inserted as linked text. Esc / click-outside cancels. Stored hrefs are sanitized at render time (`safeHref` blocks `javascript:`/`data:`/protocol-relative).
 
-**Import:** `fromHtml(html)` and `fromMarkdown(md)` parse a string into a `RichDoc` (e.g. to seed `value` from stored/legacy content). Pasting rich HTML into the editor imports it as formatted content (parsed + sanitized). Markdown import is via `fromMarkdown` only — pasted plain text (incl. Markdown source) inserts literally. Both `from*` functions require a DOM environment (`DOMParser`); Markdown has no underline syntax and images/tables aren't modeled.
+**Autolink** (`autolink` prop, default `true`): typing a URL followed by a space, or pasting text containing a URL, turns it into a `link` mark automatically (`http(s)://…` or a bare `www.…` host; unsafe schemes are left as plain text). Set `autolink={false}` to disable both the type rule and paste autolinking.
+
+**`renderLink`** (optional, same `RenderLink` as `<RichText>`): preview links inline — the consumer checks "is this URL in my space?" and returns a chip or the `fallback` `<a>`. In the editor a substituted link becomes an **atomic chip**: the caret sits before/after it (arrow keys step over it, never inside) and Backspace deletes the whole chip in one step. It's render-time only — `toHtml`/`toMarkdown` and the model still emit a plain link, so serialization is unchanged. Don't do heavy synchronous work inside it.
+
+```tsx
+const renderLink: RenderLink = ({ href }, fallback) => {
+  const m = /^https?:\/\/app\.eocrm\/task\/(\d+)/i.exec(href);
+  return m ? <Badge tone="purple">#{m[1]}</Badge> : fallback;
+};
+// autolink is on by default; type/paste a URL to link it
+<RichTextEditor value={doc} onChange={setDoc} toolbar renderLink={renderLink} />;
+```
+
+**Import:** `fromHtml(html)` and `fromMarkdown(md)` parse a string into a `RichDoc` (e.g. to seed `value` from stored/legacy content). Pasting rich HTML into the editor imports it as formatted content (parsed + sanitized). Markdown import is via `fromMarkdown` only — pasted plain text (incl. Markdown source) inserts literally, except that bare URLs in pasted plain text autolink (see Autolink above). Both `from*` functions require a DOM environment (`DOMParser`); Markdown has no underline syntax and images/tables aren't modeled.
 
 **Export:** `toHtml(doc)` and `toMarkdown(doc)` serialize a `RichDoc` back to a string (the inverse of `fromHtml`/`fromMarkdown`) — e.g. for storage, email bodies, or display outside the editor. `toHtml` is lossless (`fromHtml(toHtml(doc))` round-trips); `toMarkdown` drops underline (no Markdown syntax — use `toHtml` for full fidelity). Both escape output and run hrefs through `safeHref`.
 

--- a/packages/design-system/src/components/RichText/RichText.test.tsx
+++ b/packages/design-system/src/components/RichText/RichText.test.tsx
@@ -34,4 +34,35 @@ describe('RichText', () => {
     expect(container.querySelector('.custom')).not.toBeNull();
     expect(screen.getByTestId('rt')).toBeInTheDocument();
   });
+
+  it('renders a default <a> for links when no renderLink is supplied', () => {
+    const doc: RichDoc = {
+      blocks: [
+        {
+          id: '1',
+          type: 'paragraph',
+          inlines: [{ text: 'site', marks: [{ type: 'link', href: 'https://a.com' }] }],
+        },
+      ],
+    };
+    const { container } = render(<RichText value={doc} />);
+    expect(container.querySelector('a')).not.toBeNull();
+  });
+
+  it('renderLink substitutes a custom node for a link', () => {
+    const doc: RichDoc = {
+      blocks: [
+        {
+          id: '1',
+          type: 'paragraph',
+          inlines: [{ text: 'site', marks: [{ type: 'link', href: 'https://a.com' }] }],
+        },
+      ],
+    };
+    const { container } = render(
+      <RichText value={doc} renderLink={({ href }) => <span data-chip>{href}</span>} />,
+    );
+    expect(container.querySelector('[data-chip]')).not.toBeNull();
+    expect(container.querySelector('a')).toBeNull();
+  });
 });

--- a/packages/design-system/src/components/RichText/RichText.tsx
+++ b/packages/design-system/src/components/RichText/RichText.tsx
@@ -2,11 +2,23 @@ import { forwardRef, type HTMLAttributes } from 'react';
 import clsx from 'clsx';
 import type { RichDoc } from './engine/model';
 import { renderDoc } from './engine/renderDoc';
+import type { RenderLink } from './engine/renderLink';
 import styles from './RichText.module.scss';
 
 export interface RichTextProps extends HTMLAttributes<HTMLDivElement> {
   /** The document to render. Build one with `emptyDoc()` / `createBlock()` or the transforms. */
   value: RichDoc;
+  /**
+   * Substitute how a link renders. Called per link with `{ href, text }` and the
+   * default `<a>` node; return your own node (e.g. a task/member chip) or the
+   * `defaultNode` to keep the standard anchor. Render-time only — the document
+   * model is unchanged, so serialization still emits a plain link.
+   *
+   * @remarks Keep it cheap — it runs on every render. Don't block on a network
+   * call inside `renderLink`; return a component that fetches/caches the lookup
+   * itself (or falls back to `defaultNode` while loading).
+   */
+  renderLink?: RenderLink;
 }
 
 /**
@@ -41,14 +53,14 @@ export interface RichTextProps extends HTMLAttributes<HTMLDivElement> {
  * - ❌ Hand-writing HTML to display rich content — feed a `RichDoc` to `<RichText>`.
  */
 export const RichText = forwardRef<HTMLDivElement, RichTextProps>(function RichText(
-  { value, className, ...props },
+  { value, renderLink, className, ...props },
   ref,
 ) {
   // {...props} last so the consumer can override anything except the composed
   // className (Pattern A — consumer wins).
   return (
     <div ref={ref} className={clsx(styles.root, className)} {...props}>
-      {renderDoc(value)}
+      {renderDoc(value, { renderLink })}
     </div>
   );
 });

--- a/packages/design-system/src/components/RichText/engine/autolink.test.ts
+++ b/packages/design-system/src/components/RichText/engine/autolink.test.ts
@@ -1,0 +1,39 @@
+import { findUrl, linkifyRuns } from './autolink';
+
+describe('findUrl', () => {
+  it('finds an http(s) URL ending at the caret', () => {
+    expect(findUrl('see https://a.com/x')).toEqual({ start: 4, end: 19, href: 'https://a.com/x' });
+  });
+  it('normalizes a bare www. host to https', () => {
+    expect(findUrl('go www.a.com')).toEqual({ start: 3, end: 12, href: 'https://www.a.com' });
+  });
+  it('excludes trailing sentence punctuation', () => {
+    expect(findUrl('see https://a.com.')).toEqual({ start: 4, end: 17, href: 'https://a.com' });
+    expect(findUrl('(https://a.com)')).toEqual({ start: 1, end: 14, href: 'https://a.com' });
+  });
+  it('returns null when the text does not end in a URL', () => {
+    expect(findUrl('just words')).toBeNull();
+    expect(findUrl('https://a.com then more')).toBeNull(); // URL not at the end
+  });
+  it('rejects unsafe schemes', () => {
+    expect(findUrl('x javascript:alert(1)')).toBeNull();
+  });
+});
+
+describe('linkifyRuns', () => {
+  it('splits a string into plain + link runs', () => {
+    expect(linkifyRuns('a https://b.com c')).toEqual([
+      { text: 'a ', marks: [] },
+      { text: 'https://b.com', marks: [{ type: 'link', href: 'https://b.com' }] },
+      { text: ' c', marks: [] },
+    ]);
+  });
+  it('returns a single plain run when there is no URL', () => {
+    expect(linkifyRuns('no urls here')).toEqual([{ text: 'no urls here', marks: [] }]);
+  });
+  it('drops unsafe URLs (leaves them as plain text)', () => {
+    expect(linkifyRuns('javascript:alert(1)')).toEqual([
+      { text: 'javascript:alert(1)', marks: [] },
+    ]);
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/autolink.ts
+++ b/packages/design-system/src/components/RichText/engine/autolink.ts
@@ -1,0 +1,64 @@
+// autolink.ts — pure URL detection for the editor's autolink (type + paste) and
+// the RichText importer. No DOM. hrefs pass through safeHref so only safe schemes
+// become links.
+import type { Inline } from './model';
+import { safeHref } from './safeHref';
+
+// http(s)://… or a bare www.… host. Kept deliberately conservative.
+const URL_RE = /\b(?:https?:\/\/|www\.)[^\s<>()[\]]+/gi;
+// Strip trailing sentence punctuation that is unlikely to be part of the URL.
+const TRAILING = /[.,;:!?'"]+$/;
+
+function normalize(raw: string): { url: string; href: string } | null {
+  let url = raw.replace(TRAILING, '');
+  // Drop an unmatched closing bracket/paren (e.g. "(https://a.com)").
+  if (/[)\]]$/.test(url) && !/[([]/.test(url)) url = url.slice(0, -1);
+  if (url === '') return null;
+  const candidate = url.startsWith('www.') ? `https://${url}` : url;
+  const safe = safeHref(candidate);
+  if (!safe || !/^https?:/i.test(safe)) return null;
+  return { url, href: safe };
+}
+
+/** The URL that ends exactly at the end of `text`, or null. (For the type rule:
+ *  the caller passes the text up to the caret.) */
+export function findUrl(text: string): { start: number; end: number; href: string } | null {
+  let m: RegExpExecArray | null;
+  URL_RE.lastIndex = 0;
+  let last: { start: number; end: number; href: string; rawEnd: number } | null = null;
+  while ((m = URL_RE.exec(text)) !== null) {
+    const norm = normalize(m[0]);
+    if (!norm) continue;
+    const start = m.index;
+    const end = start + norm.url.length;
+    // `rawEnd` is where the raw match ended (incl. stripped trailing punctuation /
+    // brackets), so a URL at the caret followed only by punctuation still counts.
+    const rawEnd = start + m[0].length;
+    last = { start, end, href: norm.href, rawEnd };
+  }
+  // Only return when the matched URL reaches the end of `text` — allowing for
+  // trailing punctuation/brackets that `normalize` stripped from `end` and for a
+  // closing bracket/paren the regex itself excluded (e.g. `(https://a.com)`).
+  if (!last) return null;
+  const tail = text.slice(last.rawEnd);
+  if (!/^[.,;:!?'")\]]*$/.test(tail)) return null;
+  return { start: last.start, end: last.end, href: last.href };
+}
+
+/** Split `text` into plain + link runs (for paste / import). */
+export function linkifyRuns(text: string): Inline[] {
+  const runs: Inline[] = [];
+  let i = 0;
+  let m: RegExpExecArray | null;
+  URL_RE.lastIndex = 0;
+  while ((m = URL_RE.exec(text)) !== null) {
+    const norm = normalize(m[0]);
+    if (!norm) continue;
+    const start = m.index;
+    if (start > i) runs.push({ text: text.slice(i, start), marks: [] });
+    runs.push({ text: norm.url, marks: [{ type: 'link', href: norm.href }] });
+    i = start + norm.url.length;
+  }
+  if (i < text.length) runs.push({ text: text.slice(i), marks: [] });
+  return runs.length ? runs : [{ text, marks: [] }];
+}

--- a/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
@@ -295,7 +295,10 @@ describe('renderDoc renderLink option', () => {
     };
     const custom = render(
       <div>
-        {renderDoc(doc, { editable: true, renderLink: ({ href }) => <span data-chip>{href}</span> })}
+        {renderDoc(doc, {
+          editable: true,
+          renderLink: ({ href }) => <span data-chip>{href}</span>,
+        })}
       </div>,
     );
     const w = custom.container.querySelector('[data-rich-link]');

--- a/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
@@ -274,3 +274,39 @@ describe('renderDoc editable option', () => {
     expect(html(doc)).toBe('<p>hi</p>');
   });
 });
+
+describe('renderDoc renderLink option', () => {
+  it('renderLink substitutes a link node in the viewer', () => {
+    const doc = {
+      blocks: [createBlock('paragraph', 'x', { marks: [{ type: 'link', href: 'https://a.com' }] })],
+    };
+    const { container } = render(
+      <div>{renderDoc(doc, { renderLink: ({ href }) => <span data-chip>{href}</span> })}</div>,
+    );
+    expect(container.querySelector('[data-chip]')).not.toBeNull();
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it('editable mode wraps a custom link return in an atomic widget; a fallback return is not wrapped', () => {
+    const doc = {
+      blocks: [
+        createBlock('paragraph', 'abc', { marks: [{ type: 'link', href: 'https://a.com' }] }),
+      ],
+    };
+    const custom = render(
+      <div>
+        {renderDoc(doc, { editable: true, renderLink: ({ href }) => <span data-chip>{href}</span> })}
+      </div>,
+    );
+    const w = custom.container.querySelector('[data-rich-link]');
+    expect(w).not.toBeNull();
+    expect(w!.getAttribute('data-len')).toBe('3'); // model run text length
+    expect(w!.getAttribute('contenteditable')).toBe('false');
+
+    const fb = render(
+      <div>{renderDoc(doc, { editable: true, renderLink: (_l, fallback) => fallback })}</div>,
+    );
+    expect(fb.container.querySelector('[data-rich-link]')).toBeNull(); // plain link stays editable
+    expect(fb.container.querySelector('a')).not.toBeNull();
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
@@ -312,4 +312,55 @@ describe('renderDoc renderLink option', () => {
     expect(fb.container.querySelector('[data-rich-link]')).toBeNull(); // plain link stays editable
     expect(fb.container.querySelector('a')).not.toBeNull();
   });
+
+  it('coalesces a same-href link split across runs into ONE chip', () => {
+    // Two adjacent runs share the same link href (e.g. internal bold, or HTML import).
+    const doc = {
+      blocks: [
+        {
+          id: 'b1',
+          type: 'paragraph' as const,
+          inlines: [
+            { text: 'ab', marks: [{ type: 'link' as const, href: 'https://a.com' }] },
+            {
+              text: 'cd',
+              marks: [{ type: 'link' as const, href: 'https://a.com' }, { type: 'bold' as const }],
+            },
+          ],
+        },
+      ],
+    };
+    let calls = 0;
+    const chips = render(
+      <div>
+        {renderDoc(doc, {
+          renderLink: ({ href, text }) => {
+            calls += 1;
+            return (
+              <span data-chip data-text={text}>
+                {href}
+              </span>
+            );
+          },
+        })}
+      </div>,
+    );
+    // One chip for the whole span, with the concatenated text — not one per run.
+    expect(chips.container.querySelectorAll('[data-chip]')).toHaveLength(1);
+    expect(chips.container.querySelector('[data-chip]')!.getAttribute('data-text')).toBe('abcd');
+    expect(calls).toBe(1);
+
+    // Editable: a single widget whose data-len is the full span length (4).
+    const ed = render(
+      <div>
+        {renderDoc(doc, {
+          editable: true,
+          renderLink: ({ href }) => <span data-chip>{href}</span>,
+        })}
+      </div>,
+    );
+    const widgets = ed.container.querySelectorAll('[data-rich-link]');
+    expect(widgets).toHaveLength(1);
+    expect(widgets[0].getAttribute('data-len')).toBe('4');
+  });
 });

--- a/packages/design-system/src/components/RichText/engine/renderDoc.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.tsx
@@ -5,16 +5,37 @@ import type { RichDoc, Block, Inline, Mark, MarkType } from './model';
 import { runsText, runsLength } from './inlines';
 import { safeHref } from './safeHref';
 import { isListItem, effectiveDepths } from './listDepths';
+import type { RenderLink } from './renderLink';
 
 export interface RenderDocOptions {
   /** Editable surface: add `data-block-id` anchors + render empty blocks with a `<br>`. */
   editable?: boolean;
+  /**
+   * Replace how a link renders (e.g. a task/member chip). In the read-only viewer
+   * the returned node substitutes the `<a>` directly; on an editable surface a
+   * substituted node is wrapped in an atomic, non-editable `[data-rich-link]`
+   * widget so the caret steps over it as a single unit. Return the supplied
+   * default node to keep the standard `<a>`.
+   */
+  renderLink?: RenderLink;
+}
+
+// Resolved options threaded through the render call chain (never module state).
+interface ResolvedOptions {
+  editable: boolean;
+  renderLink?: RenderLink;
 }
 
 // Outer → inner nesting order so output is stable + diff-friendly.
 const MARK_ORDER: MarkType[] = ['mention', 'link', 'bold', 'italic', 'underline', 'strike', 'code'];
 
-function wrapMark(type: MarkType, mark: Mark, child: ReactNode): ReactNode {
+function wrapMark(
+  type: MarkType,
+  mark: Mark,
+  child: ReactNode,
+  runText: string,
+  opts: ResolvedOptions,
+): ReactNode {
   switch (type) {
     case 'bold':
       return <strong>{child}</strong>;
@@ -26,12 +47,23 @@ function wrapMark(type: MarkType, mark: Mark, child: ReactNode): ReactNode {
       return <s>{child}</s>;
     case 'code':
       return <code>{child}</code>;
-    case 'link':
-      return (
-        <a href={mark.type === 'link' ? safeHref(mark.href) : undefined} rel="noopener noreferrer">
+    case 'link': {
+      const href = mark.type === 'link' ? safeHref(mark.href) : undefined;
+      const fallback = (
+        <a href={href} rel="noopener noreferrer">
           {child}
         </a>
       );
+      if (!opts.renderLink || !href) return fallback;
+      const custom = opts.renderLink({ href, text: runText }, fallback);
+      if (custom === fallback) return fallback; // consumer declined → plain editable link
+      if (!opts.editable) return custom;
+      return (
+        <span data-rich-link data-len={runText.length} contentEditable={false}>
+          {custom}
+        </span>
+      );
+    }
     case 'mention':
       return (
         <span
@@ -47,49 +79,49 @@ function wrapMark(type: MarkType, mark: Mark, child: ReactNode): ReactNode {
   }
 }
 
-function renderRun(run: Inline, key: number): ReactNode {
+function renderRun(run: Inline, key: number, opts: ResolvedOptions): ReactNode {
   const present = MARK_ORDER.filter((t) => run.marks.some((m) => m.type === t));
   let node: ReactNode = run.text;
   // Wrap innermost-first so present[0] (link) ends up outermost.
   for (let i = present.length - 1; i >= 0; i -= 1) {
     const type = present[i];
     const mark = run.marks.find((m) => m.type === type)!;
-    node = wrapMark(type, mark, node);
+    node = wrapMark(type, mark, node, run.text, opts);
   }
   return <Fragment key={key}>{node}</Fragment>;
 }
 
-function renderInlines(inlines: Inline[]): ReactNode {
-  return inlines.map((run, i) => renderRun(run, i));
+function renderInlines(inlines: Inline[], opts: ResolvedOptions): ReactNode {
+  return inlines.map((run, i) => renderRun(run, i, opts));
 }
 
-function blockContent(block: Block, editable: boolean): ReactNode {
-  if (editable && runsLength(block.inlines) === 0) return <br />;
-  return renderInlines(block.inlines);
+function blockContent(block: Block, opts: ResolvedOptions): ReactNode {
+  if (opts.editable && runsLength(block.inlines) === 0) return <br />;
+  return renderInlines(block.inlines, opts);
 }
 
-function renderBlock(block: Block, editable: boolean): ReactNode {
-  const anchor = editable ? { 'data-block-id': block.id } : undefined;
+function renderBlock(block: Block, opts: ResolvedOptions): ReactNode {
+  const anchor = opts.editable ? { 'data-block-id': block.id } : undefined;
   switch (block.type) {
     case 'heading': {
       const Tag = `h${block.level ?? 1}` as 'h1' | 'h2' | 'h3';
       return (
         <Tag key={block.id} {...anchor}>
-          {blockContent(block, editable)}
+          {blockContent(block, opts)}
         </Tag>
       );
     }
     case 'blockquote':
       return (
         <blockquote key={block.id} {...anchor}>
-          {blockContent(block, editable)}
+          {blockContent(block, opts)}
         </blockquote>
       );
     case 'code_block':
       return (
         <pre key={block.id} {...anchor}>
           <code>
-            {editable && runsLength(block.inlines) === 0 ? <br /> : runsText(block.inlines)}
+            {opts.editable && runsLength(block.inlines) === 0 ? <br /> : runsText(block.inlines)}
           </code>
         </pre>
       );
@@ -97,7 +129,7 @@ function renderBlock(block: Block, editable: boolean): ReactNode {
     default:
       return (
         <p key={block.id} {...anchor}>
-          {blockContent(block, editable)}
+          {blockContent(block, opts)}
         </p>
       );
   }
@@ -118,7 +150,7 @@ function collectList(
   blocks: Block[],
   start: number,
   eff: number[],
-  editable: boolean,
+  opts: ResolvedOptions,
 ): { tag: 'ul' | 'ol'; items: ListItemNode[]; next: number } {
   const baseDepth = eff[start];
   const tag = blocks[start].type === 'ordered_item' ? 'ol' : 'ul';
@@ -128,16 +160,16 @@ function collectList(
     const d = eff[i];
     if (d < baseDepth) break;
     if (d > baseDepth) {
-      const sub = collectList(blocks, i, eff, editable);
+      const sub = collectList(blocks, i, eff, opts);
       if (items.length > 0)
-        items[items.length - 1].child = renderListTree(sub.tag, sub.items, editable);
+        items[items.length - 1].child = renderListTree(sub.tag, sub.items, opts);
       i = sub.next;
       continue;
     }
     items.push({
       key: blocks[i].id,
       blockId: blocks[i].id,
-      content: blockContent(blocks[i], editable),
+      content: blockContent(blocks[i], opts),
       child: null,
     });
     i += 1;
@@ -145,12 +177,12 @@ function collectList(
   return { tag, items, next: i };
 }
 
-function renderListTree(tag: 'ul' | 'ol', items: ListItemNode[], editable: boolean): ReactNode {
+function renderListTree(tag: 'ul' | 'ol', items: ListItemNode[], opts: ResolvedOptions): ReactNode {
   const ListTag = tag;
   return (
     <ListTag>
       {items.map((it) => (
-        <li key={it.key} {...(editable ? { 'data-block-id': it.blockId } : {})}>
+        <li key={it.key} {...(opts.editable ? { 'data-block-id': it.blockId } : {})}>
           {it.content}
           {it.child}
         </li>
@@ -175,18 +207,21 @@ function renderListTree(tag: 'ul' | 'ol', items: ListItemNode[], editable: boole
  * Read-only output (default) is byte-identical to the pre-options behaviour.
  */
 export function renderDoc(doc: RichDoc, options: RenderDocOptions = {}): ReactNode {
-  const editable = options.editable ?? false;
+  const opts: ResolvedOptions = {
+    editable: options.editable ?? false,
+    renderLink: options.renderLink,
+  };
   const eff = effectiveDepths(doc.blocks);
   const out: ReactNode[] = [];
   let i = 0;
   while (i < doc.blocks.length) {
     if (isListItem(doc.blocks[i])) {
       const startId = doc.blocks[i].id;
-      const { tag, items, next } = collectList(doc.blocks, i, eff, editable);
-      out.push(<Fragment key={`list-${startId}`}>{renderListTree(tag, items, editable)}</Fragment>);
+      const { tag, items, next } = collectList(doc.blocks, i, eff, opts);
+      out.push(<Fragment key={`list-${startId}`}>{renderListTree(tag, items, opts)}</Fragment>);
       i = next;
     } else {
-      out.push(renderBlock(doc.blocks[i], editable));
+      out.push(renderBlock(doc.blocks[i], opts));
       i += 1;
     }
   }

--- a/packages/design-system/src/components/RichText/engine/renderDoc.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.tsx
@@ -29,13 +29,7 @@ interface ResolvedOptions {
 // Outer → inner nesting order so output is stable + diff-friendly.
 const MARK_ORDER: MarkType[] = ['mention', 'link', 'bold', 'italic', 'underline', 'strike', 'code'];
 
-function wrapMark(
-  type: MarkType,
-  mark: Mark,
-  child: ReactNode,
-  runText: string,
-  opts: ResolvedOptions,
-): ReactNode {
+function wrapMark(type: MarkType, mark: Mark, child: ReactNode): ReactNode {
   switch (type) {
     case 'bold':
       return <strong>{child}</strong>;
@@ -48,20 +42,14 @@ function wrapMark(
     case 'code':
       return <code>{child}</code>;
     case 'link': {
+      // The `renderLink` substitution is handled in `renderInlines` (which coalesces
+      // contiguous same-href runs into one logical link); here we only emit the
+      // default <a> for the unsubstituted path.
       const href = mark.type === 'link' ? safeHref(mark.href) : undefined;
-      const fallback = (
+      return (
         <a href={href} rel="noopener noreferrer">
           {child}
         </a>
-      );
-      if (!opts.renderLink || !href) return fallback;
-      const custom = opts.renderLink({ href, text: runText }, fallback);
-      if (custom === fallback) return fallback; // consumer declined → plain editable link
-      if (!opts.editable) return custom;
-      return (
-        <span data-rich-link data-len={runText.length} contentEditable={false}>
-          {custom}
-        </span>
       );
     }
     case 'mention':
@@ -79,20 +67,65 @@ function wrapMark(
   }
 }
 
-function renderRun(run: Inline, key: number, opts: ResolvedOptions): ReactNode {
+function renderRun(run: Inline, key: number): ReactNode {
   const present = MARK_ORDER.filter((t) => run.marks.some((m) => m.type === t));
   let node: ReactNode = run.text;
   // Wrap innermost-first so present[0] (link) ends up outermost.
   for (let i = present.length - 1; i >= 0; i -= 1) {
     const type = present[i];
     const mark = run.marks.find((m) => m.type === type)!;
-    node = wrapMark(type, mark, node, run.text, opts);
+    node = wrapMark(type, mark, node);
   }
   return <Fragment key={key}>{node}</Fragment>;
 }
 
 function renderInlines(inlines: Inline[], opts: ResolvedOptions): ReactNode {
-  return inlines.map((run, i) => renderRun(run, i, opts));
+  const out: ReactNode[] = [];
+  let i = 0;
+  while (i < inlines.length) {
+    const run = inlines[i];
+    const lm = run.marks.find((m) => m.type === 'link');
+    const linkHref = lm && lm.type === 'link' ? lm.href : null;
+    const safe = opts.renderLink && linkHref != null ? safeHref(linkHref) : undefined;
+    if (safe) {
+      // Coalesce contiguous runs that share this exact link href into ONE logical
+      // link, so a link split across runs (e.g. internal formatting, HTML import)
+      // resolves to a single chip — not one chip per run.
+      let j = i;
+      let text = '';
+      while (j < inlines.length) {
+        const m = inlines[j].marks.find((mm) => mm.type === 'link');
+        if (!m || m.type !== 'link' || m.href !== linkHref) break;
+        text += inlines[j].text;
+        j += 1;
+      }
+      const fallback = (
+        <a href={safe} rel="noopener noreferrer">
+          {text}
+        </a>
+      );
+      const custom = opts.renderLink!({ href: safe, text }, fallback);
+      if (custom !== fallback) {
+        // Substituted: one node for the whole span. In the editor it's an atomic,
+        // non-editable widget tagged with the span's MODEL length (`data-len`).
+        out.push(
+          opts.editable ? (
+            <span key={i} data-rich-link data-len={text.length} contentEditable={false}>
+              {custom}
+            </span>
+          ) : (
+            <Fragment key={i}>{custom}</Fragment>
+          ),
+        );
+        i = j;
+        continue;
+      }
+      // Consumer declined → fall through to normal per-run rendering (default <a>).
+    }
+    out.push(renderRun(run, i));
+    i += 1;
+  }
+  return out;
 }
 
 function blockContent(block: Block, opts: ResolvedOptions): ReactNode {

--- a/packages/design-system/src/components/RichText/engine/renderLink.ts
+++ b/packages/design-system/src/components/RichText/engine/renderLink.ts
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+/** A link encountered while rendering, passed to `renderLink`. */
+export interface RichTextLink {
+  /** The sanitized URL. */
+  href: string;
+  /** The link's visible text in the document. */
+  text: string;
+}
+
+/**
+ * Replace how a link renders. Return your own node (e.g. a task/member chip) to
+ * substitute the link, or `defaultNode` for the standard `<a>`.
+ */
+export type RenderLink = (link: RichTextLink, defaultNode: ReactNode) => ReactNode;

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -590,3 +590,243 @@ describe('RichTextEditor mentions', () => {
     expect(box.querySelector('[data-mention-id]')).toBeNull();
   });
 });
+
+describe('RichTextEditor autolink', () => {
+  beforeEach(() => mockReadSelection.mockReset());
+
+  function typeSpaceAt(editor: HTMLElement) {
+    const evt = new Event('beforeinput', { bubbles: true, cancelable: true });
+    Object.defineProperty(evt, 'inputType', { value: 'insertText' });
+    Object.defineProperty(evt, 'data', { value: ' ' });
+    act(() => {
+      editor.dispatchEvent(evt);
+    });
+    return evt;
+  }
+
+  function pasteEvent(data: Record<string, string>) {
+    const evt: Event & { clipboardData?: unknown } = new Event('paste', {
+      bubbles: true,
+      cancelable: true,
+    });
+    (evt as { clipboardData: unknown }).clipboardData = {
+      getData: (t: string) => data[t] ?? '',
+    };
+    return evt;
+  }
+
+  it('typing a space after a URL links it (and inserts the space)', () => {
+    const text = 'see https://a.com';
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: text.length },
+      focus: { blockId: 'k', offset: text.length },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text, marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox', { name: 'Rich text editor' });
+    const evt = typeSpaceAt(box);
+    expect(evt.defaultPrevented).toBe(true);
+    const a = box.querySelector('a');
+    expect(a).not.toBeNull();
+    expect(a?.getAttribute('href')).toBe('https://a.com');
+    // The space was inserted after the link.
+    expect(box.textContent).toBe('see https://a.com ');
+  });
+
+  it('autolink={false} disables the type rule (no link, space still inserted)', () => {
+    const text = 'see https://a.com';
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: text.length },
+      focus: { blockId: 'k', offset: text.length },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text, marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} autolink={false} />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox', { name: 'Rich text editor' });
+    typeSpaceAt(box);
+    expect(box.querySelector('a')).toBeNull();
+    expect(box.textContent).toBe('see https://a.com ');
+  });
+
+  it('pasting a plain-text URL over a selection links the selection', () => {
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 5 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hello', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox', { name: 'Rich text editor' });
+    const evt = pasteEvent({ 'text/plain': 'https://a.com' });
+    act(() => {
+      box.dispatchEvent(evt);
+    });
+    expect(evt.defaultPrevented).toBe(true);
+    const a = box.querySelector('a');
+    expect(a?.getAttribute('href')).toBe('https://a.com');
+    // The selected text "hello" is preserved as the link's display text.
+    expect(a?.textContent).toBe('hello');
+  });
+
+  it('pasting text containing a URL at a collapsed caret linkifies it', () => {
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 0 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: '', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox', { name: 'Rich text editor' });
+    const evt = pasteEvent({ 'text/plain': 'go https://a.com now' });
+    act(() => {
+      box.dispatchEvent(evt);
+    });
+    expect(evt.defaultPrevented).toBe(true);
+    const a = box.querySelector('a');
+    expect(a?.getAttribute('href')).toBe('https://a.com');
+    expect(box.textContent).toBe('go https://a.com now');
+  });
+
+  it('plain-text paste with NO url does not preventDefault (falls through)', () => {
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 0 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: '', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox', { name: 'Rich text editor' });
+    const evt = pasteEvent({ 'text/plain': 'just words' });
+    act(() => {
+      box.dispatchEvent(evt);
+    });
+    expect(evt.defaultPrevented).toBe(false);
+  });
+
+  it('autolink={false} disables plain-text paste linkifying (falls through)', () => {
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 0 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: '', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} autolink={false} />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox', { name: 'Rich text editor' });
+    const evt = pasteEvent({ 'text/plain': 'https://a.com' });
+    act(() => {
+      box.dispatchEvent(evt);
+    });
+    expect(evt.defaultPrevented).toBe(false);
+  });
+});
+
+describe('RichTextEditor renderLink', () => {
+  beforeEach(() => mockReadSelection.mockReset());
+
+  const chip: React.ComponentProps<typeof RichTextEditor>['renderLink'] = ({ href }, fallback) =>
+    href.startsWith('https://chip') ? <span data-chip>{href}</span> : fallback;
+
+  it('renders a resolved link as a non-editable atomic [data-rich-link] chip', () => {
+    mockReadSelection.mockReturnValue(null);
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [
+          {
+            id: 'k',
+            type: 'paragraph',
+            inlines: [{ text: 'task', marks: [{ type: 'link', href: 'https://chip/1' }] }],
+          },
+        ],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} renderLink={chip} />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox', { name: 'Rich text editor' });
+    const widget = box.querySelector('[data-rich-link]');
+    expect(widget).not.toBeNull();
+    expect(widget?.getAttribute('contenteditable')).toBe('false');
+    expect(widget?.querySelector('[data-chip]')).not.toBeNull();
+  });
+
+  it('a declined link (renderLink returns fallback) stays a plain editable anchor', () => {
+    mockReadSelection.mockReturnValue(null);
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [
+          {
+            id: 'k',
+            type: 'paragraph',
+            inlines: [{ text: 'ext', marks: [{ type: 'link', href: 'https://other.com' }] }],
+          },
+        ],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} renderLink={chip} />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox', { name: 'Rich text editor' });
+    expect(box.querySelector('[data-rich-link]')).toBeNull();
+    expect(box.querySelector('a')).not.toBeNull();
+  });
+
+  it('Backspace just after a resolved chip deletes the whole link atomically', () => {
+    // "go " (3) + linked chip "https://chip/1" (14) → caret at offset 17 (end).
+    const href = 'https://chip/1';
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 3 + href.length },
+      focus: { blockId: 'k', offset: 3 + href.length },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [
+          {
+            id: 'k',
+            type: 'paragraph',
+            inlines: [
+              { text: 'go ', marks: [] },
+              { text: href, marks: [{ type: 'link', href }] },
+            ],
+          },
+        ],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} renderLink={chip} />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox', { name: 'Rich text editor' });
+    expect(box.querySelector('[data-rich-link]')).not.toBeNull();
+    const evt = new Event('beforeinput', { bubbles: true, cancelable: true });
+    Object.defineProperty(evt, 'inputType', { value: 'deleteContentBackward' });
+    Object.defineProperty(evt, 'data', { value: null });
+    act(() => {
+      box.dispatchEvent(evt);
+    });
+    expect(evt.defaultPrevented).toBe(true);
+    // The whole chip is gone; only "go " remains.
+    expect(box.querySelector('[data-rich-link]')).toBeNull();
+    expect(box.textContent).toBe('go ');
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -474,9 +474,10 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
             }
           }
         }
-        // Autolink on type: typing a space after a URL links the URL, then inserts
-        // the space — both in one commit (one undo step). Skips when the caret is
-        // already inside a link (handled by `applyTypeAutolink`).
+        // Autolink on type: typing a space after a URL links the URL AND inserts the
+        // space — both in one commit (one undo step). `applyTypeAutolink` inserts the
+        // boundary first (so it stays OUTSIDE the link) and links only the URL. Skips
+        // when the caret is already inside a link.
         if (
           autolinkOn !== false &&
           e.inputType === 'insertText' &&
@@ -486,11 +487,9 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           const linked = applyTypeAutolink(doc, range.anchor, e.data);
           if (linked) {
             e.preventDefault();
-            // Link first, then insert the space after it on the linked doc.
-            const inserted = insertText(linked.doc, range.anchor, e.data);
             setPendingMarks(null);
             pendingAtRef.current = null;
-            commit({ doc: inserted.doc, selection: inserted.selection }, 'type');
+            commit(linked, 'type');
             return;
           }
         }

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -10,11 +10,20 @@ import {
 } from 'react';
 import clsx from 'clsx';
 import type { RichDoc, Range, Mark, MarkType, Point } from '../RichText/engine/model';
+import { nextId } from '../RichText/engine/model';
 import { renderDoc } from '../RichText/engine/renderDoc';
+import type { RenderLink } from '../RichText/engine/renderLink';
 import { blockLength, isCollapsed } from '../RichText/engine/position';
 import { linkAt, setLink, removeLink } from './links';
+import { applyTypeAutolink, atomicLinkDeleteRange } from './autolinkInput';
 import { RichTextLinkEditor } from './RichTextLinkEditor';
-import { insertText, insertFragment, insertMention } from '../RichText/engine/transforms';
+import {
+  insertText,
+  insertFragment,
+  insertMention,
+  deleteRange,
+} from '../RichText/engine/transforms';
+import { linkifyRuns, findUrl } from '../RichText/engine/autolink';
 import { useMention } from './useMention';
 import { RichTextMentionMenu } from './RichTextMentionMenu';
 import type { MentionItem, MentionsConfig } from './mentions';
@@ -47,6 +56,13 @@ import {
 import type { History, EditKind } from './history';
 import styles from './RichTextEditor.module.scss';
 
+// Stable sentinel ReactNode passed as `renderLink`'s `defaultNode` when probing
+// whether a link is "resolved" (the consumer returns a custom chip) vs. declined
+// (returns the fallback). A custom return is `!== FALLBACK_SENTINEL` by identity;
+// declining returns the exact sentinel back. A frozen one-off element keeps a
+// stable reference across calls.
+const FALLBACK_SENTINEL: React.ReactNode = Object.freeze(<span key="rt-fallback-sentinel" />);
+
 export interface RichTextEditorProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   'onChange' | 'children'
@@ -77,6 +93,31 @@ export interface RichTextEditorProps extends Omit<
    * Omit to disable mentions. See {@link MentionsConfig}.
    */
   mentions?: MentionsConfig;
+  /**
+   * Turn typed and pasted URLs into links automatically. While typing, a URL is
+   * linked when you type a space after it; on paste, plain-text URLs are linked
+   * (a single bare URL pasted over a selection links the selection). Default
+   * `true`. Set `false` to disable both the type rule and paste autolinking (the
+   * ⌘/Ctrl+K link tool still works). The href is sanitized — only safe schemes
+   * (http/https/`www.`) become links.
+   */
+  autolink?: boolean;
+  /**
+   * Substitute how a link renders. Called per link with `{ href, text }` and the
+   * default `<a>`; return your own node (e.g. a task/member chip) or the
+   * `defaultNode` to keep the standard anchor. A custom node renders as a
+   * non-editable **atomic chip** — the caret steps over it and a single Backspace/
+   * Delete removes the whole link.
+   *
+   * @remarks Render-time only — the model is unchanged, so `toHtml`/`toMarkdown`
+   * still serialize a plain link. Keep it cheap (it runs on every render): don't
+   * do heavy synchronous work or block on the network inside `renderLink`; return
+   * a component that fetches/caches the lookup itself (falling back to
+   * `defaultNode` while loading). Because the chip is atomic and not editable
+   * text, only links your `renderLink` actually replaces become chips — links you
+   * return `defaultNode` for stay plain, editable anchors.
+   */
+  renderLink?: RenderLink;
 }
 
 function isEmptyDoc(doc: RichDoc): boolean {
@@ -179,6 +220,8 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       autoFocus,
       toolbar = false,
       mentions,
+      autolink = true,
+      renderLink,
       className,
       ...rest
     },
@@ -190,8 +233,8 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // Selection to restore after the next model-driven re-render.
     const pendingSelectionRef = useRef<Range | null>(null);
     // Latest props for the native beforeinput listener (avoids stale closures).
-    const latest = useRef({ value, onChange, readOnly });
-    latest.current = { value, onChange, readOnly };
+    const latest = useRef({ value, onChange, readOnly, autolink, renderLink });
+    latest.current = { value, onChange, readOnly, autolink, renderLink };
 
     // Link editor state.
     const [linkEditor, setLinkEditor] = useState<LinkEditorOpen | null>(null);
@@ -397,7 +440,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       const root = rootRef.current;
       if (!root) return;
       const onBeforeInput = (e: InputEvent) => {
-        const { value: doc, readOnly: ro } = latest.current;
+        const { value: doc, readOnly: ro, autolink: autolinkOn, renderLink: rl } = latest.current;
         if (ro || isComposingRef.current) return;
         // Undo/redo via beforeinput. Always preventDefault so the browser's native
         // contentEditable undo never mutates the DOM under the controlled model.
@@ -429,6 +472,47 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
               commit(applyBlockRule(doc, block.id, match), 'other');
               return;
             }
+          }
+        }
+        // Autolink on type: typing a space after a URL links the URL, then inserts
+        // the space — both in one commit (one undo step). Skips when the caret is
+        // already inside a link (handled by `applyTypeAutolink`).
+        if (
+          autolinkOn !== false &&
+          e.inputType === 'insertText' &&
+          e.data === ' ' &&
+          isCollapsed(range)
+        ) {
+          const linked = applyTypeAutolink(doc, range.anchor, e.data);
+          if (linked) {
+            e.preventDefault();
+            // Link first, then insert the space after it on the linked doc.
+            const inserted = insertText(linked.doc, range.anchor, e.data);
+            setPendingMarks(null);
+            pendingAtRef.current = null;
+            commit({ doc: inserted.doc, selection: inserted.selection }, 'type');
+            return;
+          }
+        }
+        // Atomic delete: a Backspace just after (or Delete just before) a link that
+        // `renderLink` resolves to a custom chip removes the whole link in one step.
+        // `isResolved` probes `renderLink` with a stable fallback sentinel: a custom
+        // return (chip) is `!== FALLBACK_SENTINEL`; declining returns the sentinel.
+        if (
+          rl &&
+          (e.inputType === 'deleteContentBackward' || e.inputType === 'deleteContentForward') &&
+          isCollapsed(range)
+        ) {
+          const dir = e.inputType === 'deleteContentBackward' ? 'backward' : 'forward';
+          const isResolved = (href: string) =>
+            rl({ href, text: href }, FALLBACK_SENTINEL) !== FALLBACK_SENTINEL;
+          const delRange = atomicLinkDeleteRange(doc, range.anchor, dir, isResolved);
+          if (delRange) {
+            e.preventDefault();
+            setPendingMarks(null);
+            pendingAtRef.current = null;
+            commit(deleteRange(doc, delRange), 'delete');
+            return;
           }
         }
         // Pending marks: a mark toggled at a collapsed caret applies to the next
@@ -474,19 +558,45 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     }, [commit, onUndo, onRedo]);
 
     // Rich paste: when the clipboard carries HTML, parse it into the model and
-    // splice it at the selection. No HTML → don't preventDefault, so the native
-    // beforeinput path inserts text/plain (unchanged behavior).
+    // splice it at the selection. No usable HTML → if autolink is on and the
+    // plain text carries a URL, linkify it; otherwise don't preventDefault, so the
+    // native beforeinput path inserts text/plain (unchanged behavior).
     useEffect(() => {
       const root = rootRef.current;
       if (!root) return;
       const onPaste = (e: ClipboardEvent) => {
         if (latest.current.readOnly) return;
         const html = e.clipboardData?.getData('text/html');
-        if (!html || !html.trim()) return;
+        if (html && html.trim()) {
+          const range = readSelection(root);
+          if (!range) return;
+          const fragment = fromHtml(html);
+          if (isEmptyDoc(fragment)) return;
+          e.preventDefault();
+          commit(insertFragment(latest.current.value, range, fragment));
+          return;
+        }
+        // No usable HTML — autolink plain-text URLs.
+        if (latest.current.autolink === false) return;
+        const plain = e.clipboardData?.getData('text/plain');
+        if (!plain || !plain.trim()) return;
+        const runs = linkifyRuns(plain);
+        const hasLink = runs.some((r) => r.marks.some((m) => m.type === 'link'));
+        if (!hasLink) return; // no URL → let the native path insert the text
         const range = readSelection(root);
         if (!range) return;
-        const fragment = fromHtml(html);
-        if (isEmptyDoc(fragment)) return;
+        const trimmed = plain.trim();
+        const whole = findUrl(trimmed);
+        // A single bare URL pasted over a selection → link the selection in place.
+        if (!isCollapsed(range) && whole && whole.start === 0 && whole.end === trimmed.length) {
+          e.preventDefault();
+          commit(setLink(latest.current.value, range, trimmed));
+          return;
+        }
+        // Otherwise splice a one-paragraph fragment of linkified runs.
+        const fragment: RichDoc = {
+          blocks: [{ id: nextId(), type: 'paragraph', inlines: runs }],
+        };
         e.preventDefault();
         commit(insertFragment(latest.current.value, range, fragment));
       };
@@ -723,7 +833,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         onCompositionStart={onCompositionStart}
         onCompositionEnd={onCompositionEnd}
       >
-        {renderDoc(value, { editable: true })}
+        {renderDoc(value, { editable: true, renderLink })}
       </div>
     );
 

--- a/packages/design-system/src/components/RichTextEditor/autolinkInput.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/autolinkInput.test.ts
@@ -1,0 +1,97 @@
+import { applyTypeAutolink, atomicLinkDeleteRange } from './autolinkInput';
+import type { RichDoc, Inline, Point } from '../RichText/engine/model';
+
+const at = (blockId: string, offset: number): Point => ({ blockId, offset });
+const link = (href: string) => ({ type: 'link' as const, href });
+
+function para(id: string, inlines: Inline[]): RichDoc {
+  return { blocks: [{ id, type: 'paragraph', inlines }] };
+}
+
+describe('applyTypeAutolink', () => {
+  it('links the URL that ends at the caret', () => {
+    // "see https://a.com" — caret at the end (offset 17).
+    const doc = para('b', [{ text: 'see https://a.com', marks: [] }]);
+    const result = applyTypeAutolink(doc, at('b', 17), ' ');
+    expect(result).not.toBeNull();
+    // The link run carries the href.
+    const inlines = result!.doc.blocks[0].inlines;
+    const linked = inlines.find((r) => r.marks.some((m) => m.type === 'link'));
+    expect(linked?.text).toBe('https://a.com');
+    expect(linked?.marks).toEqual([link('https://a.com')]);
+    // Caret stays at the original caret (the caller inserts the boundary after).
+    expect(result!.selection).toEqual({ anchor: at('b', 17), focus: at('b', 17) });
+  });
+
+  it('returns null when there is no URL ending at the caret', () => {
+    const doc = para('b', [{ text: 'just words', marks: [] }]);
+    expect(applyTypeAutolink(doc, at('b', 10), ' ')).toBeNull();
+  });
+
+  it('returns null when the caret is already inside an existing link', () => {
+    const doc = para('b', [
+      { text: 'go ', marks: [] },
+      { text: 'https://a.com', marks: [link('https://a.com')] },
+    ]);
+    expect(applyTypeAutolink(doc, at('b', 16), ' ')).toBeNull();
+  });
+
+  it('returns null when the block does not exist', () => {
+    const doc = para('b', [{ text: 'see https://a.com', marks: [] }]);
+    expect(applyTypeAutolink(doc, at('missing', 17), ' ')).toBeNull();
+  });
+
+  it('only considers text up to the caret (URL after the caret is ignored)', () => {
+    // Caret at offset 3 ("see"), URL is after it → no URL ends at the caret.
+    const doc = para('b', [{ text: 'see https://a.com', marks: [] }]);
+    expect(applyTypeAutolink(doc, at('b', 3), ' ')).toBeNull();
+  });
+});
+
+describe('atomicLinkDeleteRange', () => {
+  const resolved = () => true;
+  const unresolved = () => false;
+
+  it('caret just after a resolved link (backward) → returns the run range', () => {
+    const doc = para('b', [
+      { text: 'go ', marks: [] },
+      { text: 'https://a.com', marks: [link('https://a.com')] },
+    ]);
+    // caret at offset 16 = end of the link run.
+    const range = atomicLinkDeleteRange(doc, at('b', 16), 'backward', resolved);
+    expect(range).toEqual({ anchor: at('b', 3), focus: at('b', 16) });
+  });
+
+  it('caret just before a resolved link (forward) → returns the run range', () => {
+    const doc = para('b', [
+      { text: 'go ', marks: [] },
+      { text: 'https://a.com', marks: [link('https://a.com')] },
+    ]);
+    // caret at offset 3 = start of the link run; forward delete probes offset+1.
+    const range = atomicLinkDeleteRange(doc, at('b', 3), 'forward', resolved);
+    expect(range).toEqual({ anchor: at('b', 3), focus: at('b', 16) });
+  });
+
+  it('returns null when the link is not resolved by renderLink', () => {
+    const doc = para('b', [
+      { text: 'go ', marks: [] },
+      { text: 'https://a.com', marks: [link('https://a.com')] },
+    ]);
+    expect(atomicLinkDeleteRange(doc, at('b', 16), 'backward', unresolved)).toBeNull();
+  });
+
+  it('returns null mid-run (caret inside the link, not at its edge)', () => {
+    const doc = para('b', [
+      { text: 'go ', marks: [] },
+      { text: 'https://a.com', marks: [link('https://a.com')] },
+    ]);
+    // caret at offset 8 = inside the link run → not at the trailing edge.
+    expect(atomicLinkDeleteRange(doc, at('b', 8), 'backward', resolved)).toBeNull();
+  });
+
+  it('returns null when there is no link at the probe point', () => {
+    const doc = para('b', [{ text: 'plain text', marks: [] }]);
+    expect(atomicLinkDeleteRange(doc, at('b', 5), 'backward', resolved)).toBeNull();
+    expect(atomicLinkDeleteRange(doc, at('b', 5), 'forward', resolved)).toBeNull();
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/autolinkInput.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/autolinkInput.test.ts
@@ -9,18 +9,32 @@ function para(id: string, inlines: Inline[]): RichDoc {
 }
 
 describe('applyTypeAutolink', () => {
-  it('links the URL that ends at the caret', () => {
+  it('links the URL and inserts the boundary space after it (caret past the space)', () => {
     // "see https://a.com" — caret at the end (offset 17).
     const doc = para('b', [{ text: 'see https://a.com', marks: [] }]);
     const result = applyTypeAutolink(doc, at('b', 17), ' ');
     expect(result).not.toBeNull();
-    // The link run carries the href.
+    // The link run carries exactly the URL href.
     const inlines = result!.doc.blocks[0].inlines;
     const linked = inlines.find((r) => r.marks.some((m) => m.type === 'link'));
     expect(linked?.text).toBe('https://a.com');
     expect(linked?.marks).toEqual([link('https://a.com')]);
-    // Caret stays at the original caret (the caller inserts the boundary after).
-    expect(result!.selection).toEqual({ anchor: at('b', 17), focus: at('b', 17) });
+    // Caret lands AFTER the inserted space (offset 18).
+    expect(result!.selection).toEqual({ anchor: at('b', 18), focus: at('b', 18) });
+  });
+
+  it('the inserted boundary space is NOT swept into the link', () => {
+    const doc = para('b', [{ text: 'see https://a.com', marks: [] }]);
+    const result = applyTypeAutolink(doc, at('b', 17), ' ');
+    const inlines = result!.doc.blocks[0].inlines;
+    // No run that is link-marked may contain the space.
+    for (const r of inlines) {
+      if (r.marks.some((m) => m.type === 'link')) expect(r.text).not.toContain(' ');
+    }
+    // The trailing space exists as an unmarked run.
+    const tail = inlines[inlines.length - 1];
+    expect(tail.text.endsWith(' ')).toBe(true);
+    expect(tail.marks.some((m) => m.type === 'link')).toBe(false);
   });
 
   it('returns null when there is no URL ending at the caret', () => {
@@ -93,5 +107,16 @@ describe('atomicLinkDeleteRange', () => {
     const doc = para('b', [{ text: 'plain text', marks: [] }]);
     expect(atomicLinkDeleteRange(doc, at('b', 5), 'backward', resolved)).toBeNull();
     expect(atomicLinkDeleteRange(doc, at('b', 5), 'forward', resolved)).toBeNull();
+  });
+
+  it('backward delete between two adjacent links targets the link ENDING at the caret', () => {
+    // "AAABBB" — link A = [0,3), link B = [3,6); caret at offset 3 (A's end / B's start).
+    const doc = para('b', [
+      { text: 'AAA', marks: [link('https://a.com')] },
+      { text: 'BBB', marks: [link('https://b.com')] },
+    ]);
+    const range = atomicLinkDeleteRange(doc, at('b', 3), 'backward', resolved);
+    // Must delete link A (ends at 3), not link B (starts at 3).
+    expect(range).toEqual({ anchor: at('b', 0), focus: at('b', 3) });
   });
 });

--- a/packages/design-system/src/components/RichTextEditor/autolinkInput.ts
+++ b/packages/design-system/src/components/RichTextEditor/autolinkInput.ts
@@ -1,0 +1,60 @@
+// autolinkInput.ts — pure helpers the editor's beforeinput handler uses for
+// autolink-on-type and atomic deletion of a resolved-link run. No DOM, no React.
+import type { RichDoc, Range, Point } from '../RichText/engine/model';
+import { findBlockIndex } from '../RichText/engine/position';
+import { runsText } from '../RichText/engine/inlines';
+import { linkAt, setLink } from './links';
+import { findUrl } from '../RichText/engine/autolink';
+
+/**
+ * When typing `boundary` (e.g. `' '`) at a collapsed caret, link the URL that
+ * ends at the caret. Returns the linked `{ doc, selection }` with the caret kept
+ * at the original position (the caller inserts the boundary char AFTER on the
+ * linked doc), or `null` when there's no URL to link or the caret already sits in
+ * a link. `_boundary` signals the triggering char (e.g. `' '`); the caller
+ * sequences its insertion, so this helper only links.
+ */
+export function applyTypeAutolink(
+  doc: RichDoc,
+  caret: Point,
+  _boundary: string,
+): { doc: RichDoc; selection: Range } | null {
+  const idx = findBlockIndex(doc, caret.blockId);
+  if (idx === -1) return null;
+  const text = runsText(doc.blocks[idx].inlines).slice(0, caret.offset);
+  const found = findUrl(text);
+  if (!found) return null;
+  // Already linked? (caret inside/after an existing link) → skip.
+  if (linkAt(doc, caret)) return null;
+  const range: Range = {
+    anchor: { blockId: caret.blockId, offset: found.start },
+    focus: { blockId: caret.blockId, offset: found.end },
+  };
+  const linked = setLink(doc, range, found.href);
+  // Caret returns to the original position; the boundary char is inserted by the
+  // caller's normal insertText path AFTER this (the editor sequences them).
+  return { doc: linked.doc, selection: { anchor: caret, focus: caret } };
+}
+
+/**
+ * If the collapsed caret sits immediately AFTER (`backward`) or BEFORE
+ * (`forward`) a link run that `isResolved(href)` accepts, return the whole-run
+ * range to delete atomically, else `null`. Only fires at the run's exact edge so
+ * a delete inside an editable plain link still removes one character.
+ */
+export function atomicLinkDeleteRange(
+  doc: RichDoc,
+  caret: Point,
+  dir: 'backward' | 'forward',
+  isResolved: (href: string) => boolean,
+): Range | null {
+  const probe: Point =
+    dir === 'backward' ? caret : { blockId: caret.blockId, offset: caret.offset + 1 };
+  const at = linkAt(doc, probe);
+  if (!at || !isResolved(at.href)) return null;
+  // Only when the caret is exactly at the run's edge (after it for backward,
+  // before it for forward).
+  if (dir === 'backward' && caret.offset !== at.range.focus.offset) return null;
+  if (dir === 'forward' && caret.offset !== at.range.anchor.offset) return null;
+  return at.range;
+}

--- a/packages/design-system/src/components/RichTextEditor/autolinkInput.ts
+++ b/packages/design-system/src/components/RichTextEditor/autolinkInput.ts
@@ -3,21 +3,22 @@
 import type { RichDoc, Range, Point } from '../RichText/engine/model';
 import { findBlockIndex } from '../RichText/engine/position';
 import { runsText } from '../RichText/engine/inlines';
+import { insertText } from '../RichText/engine/transforms';
 import { linkAt, setLink } from './links';
 import { findUrl } from '../RichText/engine/autolink';
 
 /**
  * When typing `boundary` (e.g. `' '`) at a collapsed caret, link the URL that
- * ends at the caret. Returns the linked `{ doc, selection }` with the caret kept
- * at the original position (the caller inserts the boundary char AFTER on the
- * linked doc), or `null` when there's no URL to link or the caret already sits in
- * a link. `_boundary` signals the triggering char (e.g. `' '`); the caller
- * sequences its insertion, so this helper only links.
+ * ends at the caret AND insert the boundary char — returning the combined
+ * `{ doc, selection }` (caret after the boundary), or `null` when there's no URL
+ * to link or the caret already sits in a link. The boundary char is inserted
+ * BEFORE the link is applied, so it is never swept into the `<a>` (the URL run is
+ * linked over `[start, end]`, excluding the boundary at `end`).
  */
 export function applyTypeAutolink(
   doc: RichDoc,
   caret: Point,
-  _boundary: string,
+  boundary: string,
 ): { doc: RichDoc; selection: Range } | null {
   const idx = findBlockIndex(doc, caret.blockId);
   if (idx === -1) return null;
@@ -26,14 +27,15 @@ export function applyTypeAutolink(
   if (!found) return null;
   // Already linked? (caret inside/after an existing link) → skip.
   if (linkAt(doc, caret)) return null;
+  // Insert the boundary first (so it carries no link mark), then link only the URL.
+  const inserted = insertText(doc, caret, boundary);
   const range: Range = {
     anchor: { blockId: caret.blockId, offset: found.start },
     focus: { blockId: caret.blockId, offset: found.end },
   };
-  const linked = setLink(doc, range, found.href);
-  // Caret returns to the original position; the boundary char is inserted by the
-  // caller's normal insertText path AFTER this (the editor sequences them).
-  return { doc: linked.doc, selection: { anchor: caret, focus: caret } };
+  const linked = setLink(inserted.doc, range, found.href);
+  const after: Point = { blockId: caret.blockId, offset: caret.offset + boundary.length };
+  return { doc: linked.doc, selection: { anchor: after, focus: after } };
 }
 
 /**
@@ -48,13 +50,16 @@ export function atomicLinkDeleteRange(
   dir: 'backward' | 'forward',
   isResolved: (href: string) => boolean,
 ): Range | null {
-  const probe: Point =
-    dir === 'backward' ? caret : { blockId: caret.blockId, offset: caret.offset + 1 };
-  const at = linkAt(doc, probe);
-  if (!at || !isResolved(at.href)) return null;
-  // Only when the caret is exactly at the run's edge (after it for backward,
-  // before it for forward).
-  if (dir === 'backward' && caret.offset !== at.range.focus.offset) return null;
-  if (dir === 'forward' && caret.offset !== at.range.anchor.offset) return null;
-  return at.range;
+  if (dir === 'backward') {
+    if (caret.offset <= 0) return null;
+    // Probe the char BEFORE the caret so we pick the link ENDING at the caret
+    // (not a different link starting there, when two are adjacent).
+    const at = linkAt(doc, { blockId: caret.blockId, offset: caret.offset - 1 });
+    if (at && isResolved(at.href) && at.range.focus.offset === caret.offset) return at.range;
+    return null;
+  }
+  // forward: the char AT the caret belongs to the link starting there.
+  const at = linkAt(doc, { blockId: caret.blockId, offset: caret.offset });
+  if (at && isResolved(at.href) && at.range.anchor.offset === caret.offset) return at.range;
+  return null;
 }

--- a/packages/design-system/src/components/RichTextEditor/selection.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.test.ts
@@ -62,3 +62,85 @@ describe('selection mapping', () => {
     root.remove();
   });
 });
+
+// An atomic [data-rich-link] widget renders DISPLAY text ("#1 Task", 7 chars) but
+// represents `data-len` MODEL chars (13, e.g. the URL "https://a/t/1"). The
+// caret can only sit BEFORE or AFTER it (contenteditable=false), never inside.
+//   <p data-block-id="b1">hi <span data-rich-link data-len="13" …>#1 Task</span> end</p>
+//   model: "hi " (3) + widget (13) + " end" (4) = 20 model chars total.
+function buildWidgetRoot(): HTMLElement {
+  const root = document.createElement('div');
+  root.innerHTML =
+    '<p data-block-id="b1">hi <span data-rich-link data-len="13" contenteditable="false">#1 Task</span> end</p>';
+  document.body.appendChild(root);
+  return root;
+}
+
+describe('selection mapping — atomic [data-rich-link] widget', () => {
+  it('pointFromDom: counts the widget as data-len (13), not its 7 display chars', () => {
+    const root = buildWidgetRoot();
+    const p = root.querySelector('[data-block-id="b1"]') as HTMLElement;
+    const lead = p.firstChild as Text; // "hi "
+    const trail = p.lastChild as Text; // " end"
+
+    // caret just before the widget → end of "hi " (3 model chars)
+    expect(pointFromDom(root, lead, 3)).toEqual({ blockId: 'b1', offset: 3 });
+    // element-node boundary: <p> at child index 1 (between "hi " and the widget)
+    expect(pointFromDom(root, p, 1)).toEqual({ blockId: 'b1', offset: 3 });
+
+    // caret just after the widget → 3 + 13 = 16 (NOT 3 + 7 = 10)
+    expect(pointFromDom(root, trail, 0)).toEqual({ blockId: 'b1', offset: 16 });
+    // element-node boundary: <p> at child index 2 (just after the widget)
+    expect(pointFromDom(root, p, 2)).toEqual({ blockId: 'b1', offset: 16 });
+
+    // caret at the very end of " end" → 16 + 4 = 20
+    expect(pointFromDom(root, trail, 4)).toEqual({ blockId: 'b1', offset: 20 });
+    root.remove();
+  });
+
+  it('pointToDom: widget-boundary offsets map adjacent to the widget, never inside', () => {
+    const root = buildWidgetRoot();
+    const p = root.querySelector('[data-block-id="b1"]') as HTMLElement;
+    const lead = p.firstChild as Text; // "hi "
+    const widget = p.querySelector('[data-rich-link]') as HTMLElement;
+    const trail = p.lastChild as Text; // " end"
+    const widgetIndex = Array.prototype.indexOf.call(p.childNodes, widget); // 1
+
+    // offset 3 → before the widget. Either end of "hi " text OR <p> at widget index.
+    const before = pointToDom(root, { blockId: 'b1', offset: 3 })!;
+    if (before.node === lead) {
+      expect(before.offset).toBe(3); // end of "hi "
+    } else {
+      expect(before.node).toBe(p);
+      expect(before.offset).toBe(widgetIndex); // before the widget child
+    }
+    // critically: it does NOT point inside the widget
+    expect(widget.contains(before.node)).toBe(false);
+
+    // offset 16 → after the widget: <p> at the index just past the widget,
+    // or the start of the trailing text node.
+    const after = pointToDom(root, { blockId: 'b1', offset: 16 })!;
+    expect(widget.contains(after.node)).toBe(false);
+    if (after.node === trail) {
+      expect(after.offset).toBe(0); // start of " end"
+    } else {
+      expect(after.node).toBe(p);
+      expect(after.offset).toBe(widgetIndex + 1); // just after the widget child
+    }
+
+    // offset 20 → end of the trailing " end" text node
+    const end = pointToDom(root, { blockId: 'b1', offset: 20 })!;
+    expect(end.node).toBe(trail);
+    expect(end.offset).toBe(4);
+    root.remove();
+  });
+
+  it('pointFromDom/pointToDom round-trip across the widget boundary', () => {
+    const root = buildWidgetRoot();
+    for (const offset of [0, 3, 16, 18, 20]) {
+      const dom = pointToDom(root, { blockId: 'b1', offset })!;
+      expect(pointFromDom(root, dom.node, dom.offset)).toEqual({ blockId: 'b1', offset });
+    }
+    root.remove();
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/selection.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.ts
@@ -2,6 +2,14 @@
 // functions take the editable root element; block elements carry `data-block-id`.
 import type { Point, Range } from '../RichText/engine/model';
 
+/** The MODEL length an atomic `[data-rich-link]` widget represents. Falls back to
+ *  its display-text length if `data-len` is missing/non-numeric (so a malformed
+ *  widget degrades gracefully instead of poisoning the offset math with NaN). */
+function widgetLen(w: HTMLElement): number {
+  const n = Number(w.dataset.len);
+  return Number.isFinite(n) ? n : (w.textContent?.length ?? 0);
+}
+
 function blockElementFor(root: HTMLElement, node: Node): HTMLElement | null {
   let el: Node | null = node.nodeType === Node.TEXT_NODE ? node.parentNode : node;
   while (el && el !== root) {
@@ -51,7 +59,7 @@ function offsetWithinBlock(blockEl: HTMLElement, node: Node, offset: number): nu
     afterW.setStartAfter(w);
     afterW.collapse(true);
     if (range.compareBoundaryPoints(Range.END_TO_END, afterW) >= 0) {
-      const declared = Number(w.dataset.len ?? '0');
+      const declared = widgetLen(w);
       const shown = w.textContent?.length ?? 0;
       len += declared - shown;
     }
@@ -131,7 +139,7 @@ export function pointToDom(root: HTMLElement, point: Point): { node: Node; offse
       const w = n as HTMLElement;
       const parent = w.parentNode!;
       const index = Array.prototype.indexOf.call(parent.childNodes, w);
-      const declared = Number(w.dataset.len ?? '0');
+      const declared = widgetLen(w);
       // At the widget's leading edge → caret just before it.
       if (remaining <= 0) return { node: parent, offset: index };
       // Inside the widget's model span (incl. its trailing edge) → caret after it.

--- a/packages/design-system/src/components/RichTextEditor/selection.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.ts
@@ -19,16 +19,44 @@ function blockElementFor(root: HTMLElement, node: Node): HTMLElement | null {
  * produces both. Measured as the length of the text between the block start and
  * the point via a DOM Range, which counts only character data (so `<br>`,
  * empty blocks, and nested mark spans are all handled correctly).
+ *
+ * Atomic `[data-rich-link]` widgets are corrected for: such a widget renders
+ * DISPLAY text (e.g. "#1 Task") but represents `data-len` MODEL chars (e.g. the
+ * URL it links). `range.toString()` counts the display text, so for every widget
+ * that lies fully before the range end we add `data-len - displayLength`. When a
+ * block contains no `[data-rich-link]` the correction loop runs zero times, so
+ * this is an exact no-op for ordinary content.
  */
 function offsetWithinBlock(blockEl: HTMLElement, node: Node, offset: number): number {
-  const range = blockEl.ownerDocument.createRange();
+  const doc = blockEl.ownerDocument;
+  const range = doc.createRange();
   range.setStart(blockEl, 0);
   try {
     range.setEnd(node, offset);
   } catch {
     return 0; // node not inside blockEl (shouldn't happen) → block start
   }
-  return range.toString().length;
+  let len = range.toString().length;
+  for (const w of blockEl.querySelectorAll<HTMLElement>('[data-rich-link]')) {
+    // The widget's display text is included in `len` iff our range end is at or
+    // past the point immediately AFTER the widget. Compare our range's END
+    // boundary against a collapsed range positioned just after the widget:
+    // compareBoundaryPoints(END_TO_END, afterW) returns where our END sits
+    // relative to afterW's (collapsed) boundary — >= 0 means our end is at/after
+    // the point just past the widget, so the whole widget falls within
+    // [blockStart, (node,offset)] and we replace its display length with data-len.
+    // (END_TO_END, not END_TO_START: the latter compares against afterW's START
+    // and mis-classifies the exact-boundary case in jsdom.)
+    const afterW = doc.createRange();
+    afterW.setStartAfter(w);
+    afterW.collapse(true);
+    if (range.compareBoundaryPoints(Range.END_TO_END, afterW) >= 0) {
+      const declared = Number(w.dataset.len ?? '0');
+      const shown = w.textContent?.length ?? 0;
+      len += declared - shown;
+    }
+  }
+  return len;
 }
 
 /**
@@ -61,16 +89,57 @@ export function pointFromDom(root: HTMLElement, node: Node, offset: number): Poi
 export function pointToDom(root: HTMLElement, point: Point): { node: Node; offset: number } | null {
   const blockEl = root.querySelector<HTMLElement>(`[data-block-id="${CSS.escape(point.blockId)}"]`);
   if (!blockEl) return null;
-  const walker = blockEl.ownerDocument.createTreeWalker(blockEl, NodeFilter.SHOW_TEXT);
+  // Walk TEXT nodes and atomic `[data-rich-link]` widgets, accumulating model
+  // length: text → its char length, widget → `data-len` (NOT its display text;
+  // we never descend into a widget). A widget is contenteditable=false, so the
+  // caret can only sit adjacent to it — when `remaining` lands at a widget we
+  // return a point in the widget's PARENT at the widget's child index (before)
+  // or +1 (after), never inside it. With no widgets present this behaves exactly
+  // like the previous text-only TreeWalker (FILTER_SKIP descends into mark spans).
+  const walker = blockEl.ownerDocument.createTreeWalker(
+    blockEl,
+    NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
+    {
+      acceptNode(n) {
+        if (n instanceof HTMLElement && n.hasAttribute('data-rich-link'))
+          return NodeFilter.FILTER_ACCEPT; // the widget itself, atomic
+        // Reject the widget's contents so the walk treats it as one opaque unit
+        // (a TreeWalker descends into an ACCEPTED element, so we must REJECT its
+        // descendants — REJECT skips the node AND its subtree, unlike SKIP).
+        let p: Node | null = n.parentNode;
+        while (p && p !== blockEl) {
+          if (p instanceof HTMLElement && p.hasAttribute('data-rich-link'))
+            return NodeFilter.FILTER_REJECT;
+          p = p.parentNode;
+        }
+        if (n.nodeType === Node.TEXT_NODE) return NodeFilter.FILTER_ACCEPT;
+        return NodeFilter.FILTER_SKIP; // descend into ordinary inline elements
+      },
+    },
+  );
   let remaining = point.offset;
   let last: Text | null = null;
-  let n = walker.nextNode() as Text | null;
+  let n = walker.nextNode();
   while (n) {
-    const len = n.textContent?.length ?? 0;
-    if (remaining <= len) return { node: n, offset: remaining };
-    remaining -= len;
-    last = n;
-    n = walker.nextNode() as Text | null;
+    if (n.nodeType === Node.TEXT_NODE) {
+      const t = n as Text;
+      const len = t.textContent?.length ?? 0;
+      if (remaining <= len) return { node: t, offset: remaining };
+      remaining -= len;
+      last = t;
+    } else {
+      const w = n as HTMLElement;
+      const parent = w.parentNode!;
+      const index = Array.prototype.indexOf.call(parent.childNodes, w);
+      const declared = Number(w.dataset.len ?? '0');
+      // At the widget's leading edge → caret just before it.
+      if (remaining <= 0) return { node: parent, offset: index };
+      // Inside the widget's model span (incl. its trailing edge) → caret after it.
+      if (remaining <= declared) return { node: parent, offset: index + 1 };
+      remaining -= declared;
+      last = null; // can't anchor a leftover offset to a non-text widget
+    }
+    n = walker.nextNode();
   }
   if (last) return { node: last, offset: last.textContent?.length ?? 0 };
   return { node: blockEl, offset: 0 }; // empty block (only a <br>)

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -485,6 +485,7 @@ export type {
   RichPoint,
   RichRange,
 } from './components/RichText';
+export type { RichTextLink, RenderLink } from './components/RichText/engine/renderLink';
 export {
   emptyDoc,
   createBlock,

--- a/packages/playground/src/pages/components/RichTextDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextDemo.tsx
@@ -6,11 +6,44 @@ import {
   setBlockType,
   Cluster,
   Button,
+  Badge,
   type RichDoc,
+  type RenderLink,
 } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
+
+// A consumer-supplied resolver: links pointing at an in-space task URL render as
+// a task chip; everything else falls back to a normal <a>.
+const TASK_RE = /^https?:\/\/app\.eocrm\/task\/(\d+)/i;
+const renderLink: RenderLink = ({ href }, fallback) => {
+  const m = TASK_RE.exec(href);
+  return m ? <Badge tone="purple">#{m[1]} · Ship the gallery</Badge> : fallback;
+};
+
+// A doc with one resolvable task link (→ chip) and one plain external link (→ <a>).
+const LINK_DOC: RichDoc = {
+  blocks: [
+    {
+      id: 'lr',
+      type: 'paragraph',
+      inlines: [
+        { text: 'Track ', marks: [] },
+        {
+          text: 'https://app.eocrm/task/123',
+          marks: [{ type: 'link', href: 'https://app.eocrm/task/123' }],
+        },
+        { text: ' and read more at ', marks: [] },
+        {
+          text: 'example.com',
+          marks: [{ type: 'link', href: 'https://example.com' }],
+        },
+        { text: '.', marks: [] },
+      ],
+    },
+  ],
+};
 
 const SAMPLE: RichDoc = {
   blocks: [
@@ -83,6 +116,18 @@ setDoc(r.doc);`}
           </Button>
         </Cluster>
         <RichText value={doc} />
+      </Example>
+
+      <Example
+        title="Link substitution (renderLink)"
+        description="Pass renderLink to swap how a link renders. Here a link to an in-space task URL (https://app.eocrm/task/123) becomes a task chip, while a plain external link stays a normal <a>. The model is unchanged — renderLink is render-time only; serialization still emits a link."
+        code={`const renderLink: RenderLink = ({ href }, fallback) => {
+  const m = /^https?:\\/\\/app\\.eocrm\\/task\\/(\\d+)/i.exec(href);
+  return m ? <Badge tone="purple">#{m[1]} · Ship the gallery</Badge> : fallback;
+};
+<RichText value={doc} renderLink={renderLink} />`}
+      >
+        <RichText value={LINK_DOC} renderLink={renderLink} />
       </Example>
     </DemoLayout>
   );

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -5,14 +5,25 @@ import {
   fromMarkdown,
   toHtml,
   toMarkdown,
+  Badge,
   Code,
   Text,
   Stack,
   type RichDoc,
+  type RenderLink,
 } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
+
+// A consumer-supplied resolver: a link to an in-space task URL renders as a task
+// chip; everything else falls back to a normal <a>. Same resolver works in the
+// read-only <RichText> viewer and here in the editor (as an atomic chip).
+const TASK_RE = /^https?:\/\/app\.eocrm\/task\/(\d+)/i;
+const renderLink: RenderLink = ({ href }, fallback) => {
+  const m = TASK_RE.exec(href);
+  return m ? <Badge tone="purple">#{m[1]} · Ship the gallery</Badge> : fallback;
+};
 
 export function RichTextEditorDemo() {
   const [doc, setDoc] = useState<RichDoc>(docFromText('Type here. Select a word and press ⌘B.'));
@@ -23,6 +34,9 @@ export function RichTextEditorDemo() {
     ),
   );
   const [mentionDoc, setMentionDoc] = useState<RichDoc>(() => docFromText('Assign this to '));
+  const [autolinkDoc, setAutolinkDoc] = useState<RichDoc>(() =>
+    docFromText('Type a task URL below to watch it autolink. '),
+  );
   const TEAM = [
     { id: 'u1', label: 'Alice Nguyen', description: 'alice@eocrm.dev' },
     { id: 'u2', label: 'Bob Martinez', description: 'bob@eocrm.dev' },
@@ -101,6 +115,31 @@ const [doc, setDoc] = useState(() => fromMarkdown('# Imported\\n\\n- one\\n- two
           placeholder="Type @ to mention someone…"
           mentions={{ onQuery: queryTeam }}
         />
+      </Example>
+
+      <Example
+        title="Autolink + link previews"
+        description="Autolink is on by default — type or paste a URL like https://app.eocrm/task/123 (add a trailing space) and it becomes a link. With renderLink, a resolvable task URL renders as an atomic task chip: the caret sits before/after it and Backspace deletes the whole chip in one step. It's render-time only — serialization still emits a plain link. A plain external URL stays an editable <a>."
+        code={`const renderLink: RenderLink = ({ href }, fallback) => {
+  const m = /^https?:\\/\\/app\\.eocrm\\/task\\/(\\d+)/i.exec(href);
+  return m ? <Badge tone="purple">#{m[1]} · Ship the gallery</Badge> : fallback;
+};
+// autolink is on by default; pass renderLink to preview resolvable links as chips
+<RichTextEditor value={doc} onChange={setDoc} toolbar renderLink={renderLink} />`}
+      >
+        <Stack gap="sm">
+          <RichTextEditor
+            value={autolinkDoc}
+            onChange={setAutolinkDoc}
+            toolbar
+            renderLink={renderLink}
+            placeholder="Type https://app.eocrm/task/123 then a space…"
+          />
+          <Text size="sm" tone="muted">
+            Try typing or pasting <Code>https://app.eocrm/task/123</Code> (task chip) and{' '}
+            <Code>https://example.com</Code> (plain link).
+          </Text>
+        </Stack>
       </Example>
 
       <Example


### PR DESCRIPTION
## Summary

Two capabilities on the in-house rich-text engine (no model/serialization change — links stay `{type:'link',href}` marks; `renderLink` is render-time only):

1. **Autolink** — `<RichTextEditor>` turns typed/pasted URLs into links. **Type:** a URL + space links the URL (the space stays OUTSIDE the link). **Paste:** a URL over a selection wraps it; a bare/embedded URL pastes linked. `autolink` prop (default `true`) opts out. Conservative matcher + `safeHref`.
2. **`renderLink` substitution** — `renderLink(link, defaultNode) => ReactNode` on **both** `<RichText>` (viewer) and `<RichTextEditor>` (editor). The consumer checks 'is this URL in my space?', does the lookup (sync or async via their own component), and returns a chip (task #/title, member, contact) — or the fallback `<a>`. In the editor the chip renders as a **non-editable atomic widget**: the caret sits before/after it, arrows step over it, and Backspace deletes the whole link as one unit. New exports: `RichTextLink`, `RenderLink`.

**The hard part** — the editor chip's display text differs from the model URL, so `selection.ts`'s DOM↔model mapping is now **widget-aware**: `offsetWithinBlock` corrects for `[data-rich-link][data-len]` widgets, `pointToDom` treats them as opaque atomic units. Exact no-op when no widget is present (existing selection behavior preserved).

Enhancement to existing components — no new manifest/i18n; updated JSDoc, both playground demos, AGENTS.

## Test plan

- `make test` — **3146 passed** (new: `autolink` URL detection, `renderDoc` renderLink + split-link coalescing, widget-aware `selection.ts` round-trips, `autolinkInput` type-rule + atomic-delete, both component props).
- `make build-lib` / `make lint` / `npm run format:check` — clean. Tarball gate: 0.
- **Two-round adversarial Hard-rule-8 review** — round 1 found 2 Important (autolink swept the trailing space into the link; a same-href link split across runs rendered duplicate chips) + 3 nice-to-haves; all fixed (insert-space-then-link; coalesce contiguous same-href runs into one chip; robust adjacent-link atomic delete; `data-len` NaN guard) with pinning tests; round 2 verdict `clean enough to stop` (default render path confirmed byte-identical to main).
- **Browser (Playwright):** typing `https://app.eocrm/task/123 ` → an atomic `#123` chip (`data-len=26`, **space outside the link**); Backspace after the chip deletes it as one unit (no nibbling); the viewer renders the task URL as a chip and an external URL as a plain link; 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)