### PR TITLE
demo(Timeline): 'Add activity' composer as the top node

### DIFF
--- a/packages/playground/src/pages/components/TimelineDemo.tsx
+++ b/packages/playground/src/pages/components/TimelineDemo.tsx
@@ -1,5 +1,5 @@
-import { Timeline, Avatar, Dot, Stack, Text, IconTile } from '@eocrm/design-system';
-import { GitCommit, Mail } from 'lucide-react';
+import { Timeline, Avatar, Dot, Stack, Text, IconTile, Button } from '@eocrm/design-system';
+import { GitCommit, Mail, Plus } from 'lucide-react';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
@@ -14,8 +14,11 @@ export function TimelineDemo() {
     >
       <Example
         title="Activity feed (avatar / icon nodes)"
-        description="Each item's node is a slot — an Avatar for a person, an IconTile for a system event. The connector links consecutive nodes and stops at the last."
+        description="Each item's node is a slot — an Avatar for a person, an IconTile for a system event, or an action like the “Add activity” composer pinned as the most-recent node at the top. The connector links consecutive nodes and stops at the last."
         code={`<Timeline>
+  <Timeline.Item node={<IconTile icon={<Plus size={16} />} color="blue" size="sm" />}>
+    <Button variant="secondary" size="sm" onClick={addActivity}>Add activity</Button>
+  </Timeline.Item>
   <Timeline.Item node={<Avatar name="Dana Reyes" size="sm" />}>
     <Stack gap="xs">
       <Text size="sm"><strong>Dana Reyes</strong> · note · 2h ago</Text>
@@ -29,6 +32,12 @@ export function TimelineDemo() {
 </Timeline>`}
       >
         <Timeline>
+          {/* Composer entry as the most-recent (top) node — its connector flows into the feed below. */}
+          <Timeline.Item node={<IconTile icon={<Plus size={16} />} color="blue" size="sm" />}>
+            <Button variant="secondary" size="sm" onClick={() => {}}>
+              Add activity
+            </Button>
+          </Timeline.Item>
           <Timeline.Item node={<Avatar name="Dana Reyes" size="sm" />}>
             <Stack gap="xs">
               <Text size="sm">


### PR DESCRIPTION
Playground-only change (no library/version change).

## Summary
Adds an **Add activity** composer entry as the most-recent (top) node in the Timeline demo's Activity feed — a `+` `IconTile` node + a secondary `Button`, with the connector flowing from it into the feed below. Demonstrates that a Timeline node can be an action, not just an avatar/icon. Updates the example's displayed code + description to match.

## Test plan
- `make build` (typecheck + bundle) — clean.
- `npm run format:check` — clean.
- Browser (`/components/timeline`): the `+` / "Add activity" entry renders at the top; the connector flows from it through the feed and stops at the last node; 0 console errors.

Touches only `packages/playground/**`, so the Release run's `publish` job is skipped (no `@eocrm/design-system` version bump); the playground redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)