### PR TITLE
fix(RichTextEditor): mention menu tracks the caret on scroll

### DIFF
--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -855,6 +855,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           items={mention.items}
           activeIndex={mention.activeIndex}
           anchorRect={mention.anchorRect}
+          getAnchorRect={mention.getAnchorRect}
           listboxId={mention.listboxId}
           getOptionId={mention.getOptionId}
           label={t('richTextEditor.mentionsLabel')}

--- a/packages/design-system/src/components/RichTextEditor/RichTextMentionMenu.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextMentionMenu.tsx
@@ -16,6 +16,11 @@ export interface RichTextMentionMenuProps {
   items: MentionItem[];
   activeIndex: number;
   anchorRect: Rect;
+  /**
+   * Read the caret rect LIVE on each Floating UI `autoUpdate` (scroll/resize) so the
+   * menu tracks the caret. Falls back to the static `anchorRect` when it returns null.
+   */
+  getAnchorRect?: () => Rect | null;
   listboxId: string;
   getOptionId: (index: number) => string;
   /** Accessible name for the listbox. */
@@ -32,6 +37,7 @@ export function RichTextMentionMenu({
   items,
   activeIndex,
   anchorRect,
+  getAnchorRect,
   listboxId,
   getOptionId,
   label,
@@ -41,18 +47,24 @@ export function RichTextMentionMenu({
 }: RichTextMentionMenuProps) {
   const virtualRef = useMemo(
     () => ({
-      getBoundingClientRect: () => ({
-        x: anchorRect.left,
-        y: anchorRect.top,
-        top: anchorRect.top,
-        left: anchorRect.left,
-        right: anchorRect.left + anchorRect.width,
-        bottom: anchorRect.top + anchorRect.height,
-        width: anchorRect.width,
-        height: anchorRect.height,
-      }),
+      // Re-read the caret rect on every call — Floating UI's autoUpdate invokes this
+      // on scroll/resize, so the menu follows the caret (the static `anchorRect` is
+      // the fallback for the initial frame / when no live rect is available).
+      getBoundingClientRect: () => {
+        const r = getAnchorRect?.() ?? anchorRect;
+        return {
+          x: r.left,
+          y: r.top,
+          top: r.top,
+          left: r.left,
+          right: r.left + r.width,
+          bottom: r.top + r.height,
+          width: r.width,
+          height: r.height,
+        };
+      },
     }),
-    [anchorRect],
+    [anchorRect, getAnchorRect],
   );
 
   const { refs, floatingStyles } = useFloating({

--- a/packages/design-system/src/components/RichTextEditor/useMention.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/useMention.test.tsx
@@ -2,15 +2,20 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import type { RichDoc } from '../RichText/engine/model';
 
-// Mock readSelection (jsdom has no caret); keep the rest of ./selection real.
+// Mock readSelection + selectionRect (jsdom has no caret); keep the rest real.
 vi.mock('./selection', async () => {
   const actual = await vi.importActual<typeof import('./selection')>('./selection');
-  return { ...actual, readSelection: vi.fn(actual.readSelection) };
+  return {
+    ...actual,
+    readSelection: vi.fn(actual.readSelection),
+    selectionRect: vi.fn(actual.selectionRect),
+  };
 });
-import { readSelection } from './selection';
+import { readSelection, selectionRect } from './selection';
 import { useMention } from './useMention';
 
 const mockReadSelection = vi.mocked(readSelection);
+const mockSelectionRect = vi.mocked(selectionRect);
 
 function makeRoot(): HTMLDivElement {
   const root = document.createElement('div');
@@ -22,7 +27,40 @@ const docWith = (text: string): RichDoc => ({
   blocks: [{ id: 'b', type: 'paragraph', inlines: [{ text, marks: [] }] }],
 });
 
-beforeEach(() => mockReadSelection.mockReset());
+beforeEach(() => {
+  mockReadSelection.mockReset();
+  mockSelectionRect.mockReset();
+  // Default to a stable rect; individual tests override with mockReturnValueOnce.
+  mockSelectionRect.mockReturnValue({ top: 0, left: 0, width: 0, height: 0 });
+});
+
+it('exposes getAnchorRect that reads the caret rect LIVE on each call (tracks scroll)', () => {
+  const root = makeRoot();
+  // Two distinct rects simulate the caret moving (e.g. on scroll) between reads.
+  const r1 = { top: 100, left: 10, width: 0, height: 16 };
+  const r2 = { top: 40, left: 10, width: 0, height: 16 };
+  mockSelectionRect.mockReturnValueOnce(r1).mockReturnValueOnce(r2);
+
+  const { result } = renderHook(() =>
+    useMention({
+      enabled: true,
+      rootRef: { current: root },
+      doc: docWith(''),
+      trigger: '@',
+      onQuery: vi.fn().mockResolvedValue([]),
+      onInsert: vi.fn(),
+    }),
+  );
+
+  // Each call re-reads selectionRect (live) rather than returning a cached value.
+  expect(result.current.getAnchorRect()).toEqual(r1);
+  expect(result.current.getAnchorRect()).toEqual(r2);
+
+  // Stable identity (so the menu's virtual anchor doesn't churn every render).
+  const first = result.current.getAnchorRect;
+  act(() => result.current.close());
+  expect(result.current.getAnchorRect).toBe(first);
+});
 
 it('opens and queries with the text after the trigger', async () => {
   const root = makeRoot();

--- a/packages/design-system/src/components/RichTextEditor/useMention.ts
+++ b/packages/design-system/src/components/RichTextEditor/useMention.ts
@@ -30,6 +30,13 @@ export interface UseMentionResult {
   items: MentionItem[];
   activeIndex: number;
   anchorRect: Rect | null;
+  /**
+   * Read the caret rect LIVE (current viewport coords). The menu's Floating UI
+   * virtual anchor calls this on every `autoUpdate` (incl. scroll/resize) so the
+   * menu tracks the caret instead of sticking to the rect captured on open — the
+   * static `anchorRect` only updates on `selectionchange`, which scroll doesn't fire.
+   */
+  getAnchorRect: () => Rect | null;
   listboxId: string;
   activeOptionId: string | undefined;
   getOptionId: (index: number) => string;
@@ -196,11 +203,20 @@ export function useMention(params: UseMentionParams): UseMentionResult {
 
   const commitActive = useCallback(() => selectIndex(activeIndex), [selectIndex, activeIndex]);
 
+  // Live caret rect — read on demand (current viewport coords). Stable identity so
+  // the menu's virtual anchor doesn't churn; Floating UI's autoUpdate calls it on
+  // scroll/resize so the menu follows the caret.
+  const getAnchorRect = useCallback((): Rect | null => {
+    const root = rootRef.current;
+    return root ? selectionRect(root) : null;
+  }, [rootRef]);
+
   return {
     open,
     items,
     activeIndex,
     anchorRect,
+    getAnchorRect,
     listboxId,
     activeOptionId: open && items.length > 0 ? getOptionId(activeIndex) : undefined,
     getOptionId,


### PR DESCRIPTION
## Summary
The `@`-mention autocomplete menu stuck to the position captured when it opened — on scroll the editor (and caret) moved but the menu stayed put, detaching from the caret.

**Root cause:** the menu's Floating UI virtual element returned a **frozen** `anchorRect` (only updated on `selectionchange`, which scroll doesn't fire). `autoUpdate` fired on scroll but re-read the stale rect.

**Fix:** the virtual anchor now reads the caret rect **live** via a new stable `getAnchorRect: () => selectionRect(root)` exposed from `useMention` and threaded to `RichTextMentionMenu`. Floating UI's `autoUpdate` calls it on every scroll/resize, so the menu follows the caret. The static `anchorRect` remains a fallback. No render loop — the live read is inside the virtual element's getter, not React state.

Scope: the `@`-mention menu only. `RichTextLinkEditor` (⌘K) has the same pattern but moves focus into its own input on open, so a live editor-selection rect wouldn't track it — that's a separate follow-up needing a different anchor source.

## Test plan
- New `useMention.test.tsx` case: `getAnchorRect` re-reads `selectionRect` LIVE on each call (two distinct rects on consecutive calls) + stable identity.
- `make test` (**3156 passed**), `make build-lib`, `make lint`, `npm run format:check` — clean; tarball gate 0.
- **Adversarial review** — `clean enough to stop` (0 Critical/0 Important).
- **Browser (Playwright):** opened the mention menu, scrolled the page 120px — the menu followed the caret (menu↔caret gap stayed **4px**; pre-fix it would detach by ~120px); menu stayed open; 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)