### PR TITLE
feat(RichTextEditor): Notion-style block controls (Slice 1)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-richtexteditor-block-controls-slice1.md
+++ b/docs/superpowers/plans/2026-06-25-richtexteditor-block-controls-slice1.md
@@ -1,0 +1,1644 @@
+# RichTextEditor Block Controls (Slice 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in, keyboard-accessible Notion-style per-block control layer to `RichTextEditor` (gutter `＋`/`⠿`, block menu: turn into / duplicate / move / delete, subtree-aware reorder incl. drag).
+
+**Architecture:** New **pure engine transforms** (`blockUnit.ts`) do all model mutation (unit = a block plus, for a list item, its deeper descendant run). A new **overlay gutter** (rendered outside the `contentEditable`, anchored to the active block's box) exposes `＋` and a `⠿` that is the trigger of one controlled `DropdownMenu`. The editor gains a `blockControls` prop, active-block tracking (hover + caret), keyboard shortcuts, and dnd-kit-core drag. Everything routes through the editor's existing `commit()` so each op is one undo step.
+
+**Tech Stack:** React + TypeScript, the in-house RichText engine, `DropdownMenu`, `@dnd-kit/core` (allowed dep), SCSS modules + design tokens, Vitest + Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-06-25-richtexteditor-block-controls-design.md`
+
+---
+
+## Conventions for every task
+
+- Run tests from the repo root: `npm test -- <path>` (Vitest, `globals: true` — do **not** import `describe/it/expect/vi`).
+- Engine files live in `packages/design-system/src/components/RichText/engine/`.
+- Editor files live in `packages/design-system/src/components/RichTextEditor/`.
+- Commit after each task with the message shown in its final step.
+- Branch first (Task 0). All library code goes through a PR (root `CLAUDE.md` git workflow).
+
+---
+
+## File structure
+
+**Create:**
+- `…/RichText/engine/blockUnit.ts` — unit range + sibling helper + 5 transforms (pure).
+- `…/RichText/engine/blockUnit.test.ts` — engine tests.
+- `…/RichTextEditor/RichTextBlockMenu.tsx` — `DropdownMenu` wrapper (presentational).
+- `…/RichTextEditor/RichTextBlockMenu.test.tsx`
+- `…/RichTextEditor/RichTextBlockControls.tsx` — overlay gutter (`＋`, `⠿`+menu) + drag.
+- `…/RichTextEditor/RichTextBlockControls.test.tsx`
+
+**Modify:**
+- `…/RichTextEditor/icons.tsx` — add `PlusIcon`, `GripIcon`, `DuplicateIcon`, `ArrowUpIcon`, `ArrowDownIcon`, `TrashIcon`.
+- `…/RichTextEditor/RichTextEditor.tsx` — `blockControls` prop, active-block state, keyboard, render `<RichTextBlockControls>`.
+- `…/RichTextEditor/RichTextEditor.module.scss` — gutter styles + left padding + relative anchor.
+- `src/i18n/messages.ts`, `src/i18n/en.ts`, `src/i18n/ru.ts` — new keys.
+- `packages/design-system/AGENTS.md` — TL;DR for `blockControls`.
+- `packages/playground/src/pages/components/RichTextEditorDemo.tsx` — a `blockControls` example.
+
+No `src/index.ts` change (no new public component), no manifest change (no new component/cluster).
+
+---
+
+## Task 0: Branch
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+cd /Users/dpws/projects/design-system
+git checkout main && git pull --ff-only
+git checkout -b feat/rte-block-controls-slice1
+```
+
+- [ ] **Step 2: Verify hooks installed**
+
+Run: `git config --get core.hooksPath`
+Expected: `.husky/_`
+
+---
+
+## Task 1: Engine — `blockUnitRange` + `prevSiblingAnchor`
+
+**Files:**
+- Create: `packages/design-system/src/components/RichText/engine/blockUnit.ts`
+- Test: `packages/design-system/src/components/RichText/engine/blockUnit.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// blockUnit.test.ts
+import { createBlock } from './model';
+import { blockUnitRange, prevSiblingAnchor } from './blockUnit';
+import type { Block } from './model';
+
+const p = (id: string) => createBlock('paragraph', id, { id });
+const li = (id: string, depth: number) => createBlock('bullet_item', id, { id, depth });
+
+describe('blockUnitRange', () => {
+  it('a non-list block is its own unit', () => {
+    const blocks: Block[] = [p('a'), p('b')];
+    expect(blockUnitRange(blocks, 0)).toEqual({ start: 0, end: 1 });
+  });
+
+  it('a list item carries its deeper descendant run', () => {
+    // a(d0) > b(d1) > c(d2), then d(d0)
+    const blocks = [li('a', 0), li('b', 1), li('c', 2), li('d', 0)];
+    expect(blockUnitRange(blocks, 0)).toEqual({ start: 0, end: 3 }); // a + b + c
+    expect(blockUnitRange(blocks, 1)).toEqual({ start: 1, end: 3 }); // b + c
+    expect(blockUnitRange(blocks, 3)).toEqual({ start: 3, end: 4 }); // d alone
+  });
+
+  it('stops at a sibling of equal depth', () => {
+    const blocks = [li('a', 0), li('b', 1), li('c', 0)];
+    expect(blockUnitRange(blocks, 0)).toEqual({ start: 0, end: 2 });
+  });
+
+  it('stops at a non-list block', () => {
+    const blocks = [li('a', 0), p('b')];
+    expect(blockUnitRange(blocks, 0)).toEqual({ start: 0, end: 1 });
+  });
+});
+
+describe('prevSiblingAnchor', () => {
+  it('returns the previous top-level block for a paragraph', () => {
+    const blocks = [p('a'), p('b')];
+    expect(prevSiblingAnchor(blocks, 1)).toBe(0);
+  });
+  it('skips a previous sibling subtree to find the sibling anchor', () => {
+    // a(d0) b(d1) c(d0): c's prev sibling is a (b is a's child)
+    const blocks = [li('a', 0), li('b', 1), li('c', 0)];
+    expect(prevSiblingAnchor(blocks, 2)).toBe(0);
+  });
+  it('returns -1 for a first child (no prev sibling at its depth)', () => {
+    const blocks = [li('a', 0), li('b', 1)];
+    expect(prevSiblingAnchor(blocks, 1)).toBe(-1);
+  });
+});
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `npm test -- src/components/RichText/engine/blockUnit.test.ts`
+Expected: FAIL — `blockUnit` module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// blockUnit.ts — Layer D. Block-"unit" helpers + structural transforms. A unit is
+// a single block, except a list item, which carries its deeper descendant run
+// (the contiguous following items at greater effective depth). Pure + immutable.
+import type { RichDoc, Block, Range } from './model';
+import { createBlock, nextId } from './model';
+import { isListItem, effectiveDepths } from './listDepths';
+import { findBlockIndex } from './position';
+
+function collapsed(blockId: string, offset = 0): Range {
+  return { anchor: { blockId, offset }, focus: { blockId, offset } };
+}
+
+/** Half-open index range `[start, end)` of the unit anchored at `index`. */
+export function blockUnitRange(blocks: Block[], index: number): { start: number; end: number } {
+  if (index < 0 || index >= blocks.length) return { start: index, end: index };
+  if (!isListItem(blocks[index])) return { start: index, end: index + 1 };
+  const eff = effectiveDepths(blocks);
+  const d = eff[index];
+  let end = index + 1;
+  while (end < blocks.length && isListItem(blocks[end]) && eff[end] > d) end += 1;
+  return { start: index, end };
+}
+
+/**
+ * Index of the previous sibling's anchor (same effective depth, same list run),
+ * or -1 when `index` is the first child / first block. Descendant blocks of an
+ * earlier sibling (greater depth) are skipped.
+ */
+export function prevSiblingAnchor(blocks: Block[], index: number): number {
+  const eff = effectiveDepths(blocks);
+  const d = eff[index];
+  for (let i = index - 1; i >= 0; i -= 1) {
+    if (eff[i] < d) return -1; // hit an ancestor (or a depth-0 boundary for d>0)
+    if (eff[i] === d && (d === 0 || isListItem(blocks[i]))) return i;
+    // eff[i] > d → descendant of an earlier sibling: keep skipping
+  }
+  return -1;
+}
+```
+
+(`collapsed`, `nextId`, `createBlock` are imported now so later tasks reuse them.)
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `npm test -- src/components/RichText/engine/blockUnit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/RichText/engine/blockUnit.ts packages/design-system/src/components/RichText/engine/blockUnit.test.ts
+git commit -m "feat(RichText): blockUnitRange + prevSiblingAnchor unit helpers"
+```
+
+---
+
+## Task 2: Engine — `moveBlockUnit` (sibling swap)
+
+**Files:**
+- Modify: `…/engine/blockUnit.ts`
+- Test: `…/engine/blockUnit.test.ts`
+
+- [ ] **Step 1: Add the failing test** (append to `blockUnit.test.ts`)
+
+```ts
+import { moveBlockUnit } from './blockUnit';
+import type { RichDoc } from './model';
+
+const doc = (blocks: Block[]): RichDoc => ({ blocks });
+const ids = (d: RichDoc) => d.blocks.map((b) => b.id);
+
+describe('moveBlockUnit', () => {
+  it('moves a paragraph down past the next unit', () => {
+    const d = doc([p('a'), p('b'), p('c')]);
+    expect(ids(moveBlockUnit(d, 'a', 1).doc)).toEqual(['b', 'a', 'c']);
+  });
+  it('moves a paragraph up past the previous unit', () => {
+    const d = doc([p('a'), p('b'), p('c')]);
+    expect(ids(moveBlockUnit(d, 'c', -1).doc)).toEqual(['a', 'c', 'b']);
+  });
+  it('is a no-op at the top edge', () => {
+    const d = doc([p('a'), p('b')]);
+    expect(moveBlockUnit(d, 'a', -1).doc).toBe(d); // same reference → no commit
+  });
+  it('is a no-op at the bottom edge', () => {
+    const d = doc([p('a'), p('b')]);
+    expect(moveBlockUnit(d, 'b', 1).doc).toBe(d);
+  });
+  it('carries a list item subtree when swapping with a sibling subtree', () => {
+    // a(d0) a1(d1) | b(d0) b1(d1) → move a down → b b1 a a1
+    const d = doc([li('a', 0), li('a1', 1), li('b', 0), li('b1', 1)]);
+    expect(ids(moveBlockUnit(d, 'a', 1).doc)).toEqual(['b', 'b1', 'a', 'a1']);
+  });
+  it('moves a nested item among its siblings only', () => {
+    const d = doc([li('a', 0), li('x', 1), li('y', 1)]);
+    expect(ids(moveBlockUnit(d, 'x', 1).doc)).toEqual(['a', 'y', 'x']);
+  });
+  it('caret lands on the moved anchor', () => {
+    const d = doc([p('a'), p('b')]);
+    expect(moveBlockUnit(d, 'a', 1).selection.anchor.blockId).toBe('a');
+  });
+});
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `npm test -- src/components/RichText/engine/blockUnit.test.ts -t moveBlockUnit`
+Expected: FAIL — `moveBlockUnit` not exported.
+
+- [ ] **Step 3: Implement** (append to `blockUnit.ts`)
+
+```ts
+/**
+ * Swap the unit anchored at `blockId` with its adjacent SIBLING unit (`dir`: -1
+ * up / +1 down). Same-depth swap, so depths are preserved. No-op (returns the
+ * SAME doc reference) at an edge / when there is no sibling in that direction.
+ */
+export function moveBlockUnit(doc: RichDoc, blockId: string, dir: -1 | 1): { doc: RichDoc; selection: Range } {
+  const blocks = doc.blocks;
+  const idx = findBlockIndex(doc, blockId);
+  if (idx === -1) return { doc, selection: collapsed(blockId) };
+  const u = blockUnitRange(blocks, idx);
+
+  if (dir < 0) {
+    const p = prevSiblingAnchor(blocks, idx);
+    if (p === -1) return { doc, selection: collapsed(blockId) };
+    const moving = blocks.slice(u.start, u.end);
+    const before = blocks.slice(p, u.start);
+    const next = [...blocks.slice(0, p), ...moving, ...before, ...blocks.slice(u.end)];
+    return { doc: { blocks: next }, selection: collapsed(blockId) };
+  }
+
+  const eff = effectiveDepths(blocks);
+  const d = eff[idx];
+  // A next sibling exists only when the block at u.end sits at the SAME depth.
+  if (u.end >= blocks.length || eff[u.end] !== d) return { doc, selection: collapsed(blockId) };
+  const nextUnit = blockUnitRange(blocks, u.end);
+  const moving = blocks.slice(u.start, u.end);
+  const after = blocks.slice(u.end, nextUnit.end);
+  const next = [...blocks.slice(0, u.start), ...after, ...moving, ...blocks.slice(nextUnit.end)];
+  return { doc: { blocks: next }, selection: collapsed(blockId) };
+}
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `npm test -- src/components/RichText/engine/blockUnit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/RichText/engine/blockUnit.ts packages/design-system/src/components/RichText/engine/blockUnit.test.ts
+git commit -m "feat(RichText): moveBlockUnit subtree-aware sibling swap"
+```
+
+---
+
+## Task 3: Engine — `duplicateBlockUnit`
+
+**Files:** Modify `blockUnit.ts`; Test `blockUnit.test.ts`.
+
+- [ ] **Step 1: Add the failing test**
+
+```ts
+import { duplicateBlockUnit } from './blockUnit';
+
+describe('duplicateBlockUnit', () => {
+  it('clones a paragraph right after itself with a fresh id', () => {
+    const d = doc([p('a'), p('b')]);
+    const r = duplicateBlockUnit(d, 'a');
+    expect(r.doc.blocks.length).toBe(3);
+    expect(r.doc.blocks[1].id).not.toBe('a');
+    expect(r.doc.blocks.map((b) => b.id)[2]).toBe('b');
+  });
+  it('clones a list subtree with fresh ids and same depths', () => {
+    const d = doc([li('a', 0), li('a1', 1), p('z')]);
+    const r = duplicateBlockUnit(d, 'a');
+    expect(r.doc.blocks.length).toBe(4); // a a1 a' a1' ... wait: a a1 [copy a, copy a1] z
+    expect(r.doc.blocks.map((b) => b.type)).toEqual([
+      'bullet_item', 'bullet_item', 'bullet_item', 'bullet_item', 'paragraph',
+    ].slice(0, r.doc.blocks.length));
+    expect(r.doc.blocks[2].depth).toBe(0);
+    expect(r.doc.blocks[3].depth).toBe(1);
+  });
+  it('caret lands on the clone anchor', () => {
+    const d = doc([p('a')]);
+    const r = duplicateBlockUnit(d, 'a');
+    expect(r.selection.anchor.blockId).toBe(r.doc.blocks[1].id);
+  });
+});
+```
+
+> Note: the second test's `.slice(...)` guard tolerates exact length; the key
+> assertions are the fresh ids + preserved depths. Replace with the exact
+> expected array `['bullet_item','bullet_item','bullet_item','bullet_item','paragraph']`
+> once you confirm 5 blocks (a, a1, a-copy, a1-copy, z).
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `npm test -- src/components/RichText/engine/blockUnit.test.ts -t duplicateBlockUnit`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** (append to `blockUnit.ts`)
+
+```ts
+/** Deep-ish clone of a block with a fresh id (inlines are immutable, shared safely). */
+function cloneBlock(b: Block): Block {
+  return { ...b, id: nextId(), inlines: b.inlines.map((r) => ({ ...r, marks: r.marks.slice() })) };
+}
+
+/**
+ * Duplicate the unit anchored at `blockId`, inserting the clones immediately
+ * after the unit. Fresh ids; depths preserved. Caret lands on the clone's anchor.
+ */
+export function duplicateBlockUnit(doc: RichDoc, blockId: string): { doc: RichDoc; selection: Range } {
+  const idx = findBlockIndex(doc, blockId);
+  if (idx === -1) return { doc, selection: collapsed(blockId) };
+  const u = blockUnitRange(doc.blocks, idx);
+  const copies = doc.blocks.slice(u.start, u.end).map(cloneBlock);
+  const blocks = [...doc.blocks.slice(0, u.end), ...copies, ...doc.blocks.slice(u.end)];
+  return { doc: { blocks }, selection: collapsed(copies[0].id) };
+}
+```
+
+- [ ] **Step 4: Run — verify pass** (fix the slice-guard test to the exact array now that you see 5 blocks)
+
+Run: `npm test -- src/components/RichText/engine/blockUnit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A packages/design-system/src/components/RichText/engine/
+git commit -m "feat(RichText): duplicateBlockUnit"
+```
+
+---
+
+## Task 4: Engine — `removeBlockUnit`
+
+**Files:** Modify `blockUnit.ts`; Test `blockUnit.test.ts`.
+
+- [ ] **Step 1: Add the failing test**
+
+```ts
+import { removeBlockUnit } from './blockUnit';
+import { emptyDoc } from './model';
+
+describe('removeBlockUnit', () => {
+  it('removes a paragraph; caret to the next block', () => {
+    const d = doc([p('a'), p('b')]);
+    const r = removeBlockUnit(d, 'a');
+    expect(r.doc.blocks.map((x) => x.id)).toEqual(['b']);
+    expect(r.selection.anchor.blockId).toBe('b');
+  });
+  it('removes a list subtree as a unit', () => {
+    const d = doc([li('a', 0), li('a1', 1), p('z')]);
+    const r = removeBlockUnit(d, 'a');
+    expect(r.doc.blocks.map((x) => x.id)).toEqual(['z']);
+  });
+  it('removing the last block leaves one empty paragraph', () => {
+    const d = doc([p('a')]);
+    const r = removeBlockUnit(d, 'a');
+    expect(r.doc.blocks.length).toBe(1);
+    expect(r.doc.blocks[0].type).toBe('paragraph');
+    expect(r.doc.blocks[0].id).not.toBe('a');
+  });
+  it('caret falls back to the previous block when removing the last unit', () => {
+    const d = doc([p('a'), p('b')]);
+    const r = removeBlockUnit(d, 'b');
+    expect(r.selection.anchor.blockId).toBe('a');
+  });
+});
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `npm test -- src/components/RichText/engine/blockUnit.test.ts -t removeBlockUnit`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** (append to `blockUnit.ts`; add `emptyDoc` to the model import at top)
+
+```ts
+// at top: import { createBlock, nextId, emptyDoc } from './model';
+
+/**
+ * Remove the unit anchored at `blockId`. Empties to a single empty paragraph if
+ * it was the whole document. Caret lands on the next surviving block, else the
+ * previous, else the new empty paragraph.
+ */
+export function removeBlockUnit(doc: RichDoc, blockId: string): { doc: RichDoc; selection: Range } {
+  const idx = findBlockIndex(doc, blockId);
+  if (idx === -1) return { doc, selection: collapsed(blockId) };
+  const u = blockUnitRange(doc.blocks, idx);
+  const blocks = [...doc.blocks.slice(0, u.start), ...doc.blocks.slice(u.end)];
+  if (blocks.length === 0) {
+    const fresh = emptyDoc();
+    return { doc: fresh, selection: collapsed(fresh.blocks[0].id) };
+  }
+  const caretIdx = Math.min(u.start, blocks.length - 1);
+  return { doc: { blocks }, selection: collapsed(blocks[caretIdx].id) };
+}
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `npm test -- src/components/RichText/engine/blockUnit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A packages/design-system/src/components/RichText/engine/
+git commit -m "feat(RichText): removeBlockUnit (empties to one paragraph)"
+```
+
+---
+
+## Task 5: Engine — `insertEmptyBlockBelow`
+
+**Files:** Modify `blockUnit.ts`; Test `blockUnit.test.ts`.
+
+- [ ] **Step 1: Add the failing test**
+
+```ts
+import { insertEmptyBlockBelow } from './blockUnit';
+
+describe('insertEmptyBlockBelow', () => {
+  it('inserts an empty paragraph after the block unit; caret in it', () => {
+    const d = doc([p('a'), p('b')]);
+    const r = insertEmptyBlockBelow(d, 'a');
+    expect(r.doc.blocks.map((x) => x.id)[0]).toBe('a');
+    expect(r.doc.blocks[1].type).toBe('paragraph');
+    expect(r.doc.blocks[1].id).toBe(r.selection.anchor.blockId);
+    expect(r.doc.blocks.map((x) => x.id)[2]).toBe('b');
+  });
+  it('inserts after a list subtree, not inside it', () => {
+    const d = doc([li('a', 0), li('a1', 1)]);
+    const r = insertEmptyBlockBelow(d, 'a');
+    expect(r.doc.blocks.length).toBe(3);
+    expect(r.doc.blocks[2].type).toBe('paragraph');
+  });
+});
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `npm test -- src/components/RichText/engine/blockUnit.test.ts -t insertEmptyBlockBelow`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** (append)
+
+```ts
+/** Insert an empty paragraph directly after the block unit anchored at `blockId`. */
+export function insertEmptyBlockBelow(doc: RichDoc, blockId: string): { doc: RichDoc; selection: Range } {
+  const idx = findBlockIndex(doc, blockId);
+  if (idx === -1) return { doc, selection: collapsed(blockId) };
+  const u = blockUnitRange(doc.blocks, idx);
+  const fresh = createBlock('paragraph');
+  const blocks = [...doc.blocks.slice(0, u.end), fresh, ...doc.blocks.slice(u.end)];
+  return { doc: { blocks }, selection: collapsed(fresh.id) };
+}
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `npm test -- src/components/RichText/engine/blockUnit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A packages/design-system/src/components/RichText/engine/
+git commit -m "feat(RichText): insertEmptyBlockBelow"
+```
+
+---
+
+## Task 6: Engine — `moveBlockUnitToIndex` (for drag)
+
+**Files:** Modify `blockUnit.ts`; Test `blockUnit.test.ts`.
+
+- [ ] **Step 1: Add the failing test**
+
+```ts
+import { moveBlockUnitToIndex } from './blockUnit';
+
+describe('moveBlockUnitToIndex', () => {
+  it('moves a paragraph to a later gap', () => {
+    const d = doc([p('a'), p('b'), p('c')]);
+    // move 'a' to the gap after index 2 (end)
+    expect(ids(moveBlockUnitToIndex(d, 'a', 3).doc)).toEqual(['b', 'c', 'a']);
+  });
+  it('moves a paragraph to an earlier gap', () => {
+    const d = doc([p('a'), p('b'), p('c')]);
+    expect(ids(moveBlockUnitToIndex(d, 'c', 0).doc)).toEqual(['c', 'a', 'b']);
+  });
+  it('no-op when target is inside the moving unit', () => {
+    const d = doc([li('a', 0), li('a1', 1), p('z')]);
+    expect(moveBlockUnitToIndex(d, 'a', 1).doc).toBe(d);
+  });
+  it('clamps the dropped list item depth when it lands among non-list blocks', () => {
+    const d = doc([li('a', 1), p('z')]); // a is raw depth 1
+    const r = moveBlockUnitToIndex(d, 'a', 2); // drop after z (top level)
+    const moved = r.doc.blocks.find((b) => b.id === 'a')!;
+    expect(moved.depth).toBe(0); // clamped: no list item precedes
+  });
+});
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `npm test -- src/components/RichText/engine/blockUnit.test.ts -t moveBlockUnitToIndex`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** (append)
+
+```ts
+/**
+ * Move the unit anchored at `blockId` so its first block lands at array index
+ * `target` (coordinates of the CURRENT array). The moved unit's top depth is
+ * clamped to a value valid for its new predecessor (`prevListDepth + 1`, else 0);
+ * descendants shift by the same delta. No-op when `target` falls inside the unit.
+ */
+export function moveBlockUnitToIndex(doc: RichDoc, blockId: string, target: number): { doc: RichDoc; selection: Range } {
+  const blocks = doc.blocks;
+  const idx = findBlockIndex(doc, blockId);
+  if (idx === -1) return { doc, selection: collapsed(blockId) };
+  const u = blockUnitRange(blocks, idx);
+  if (target > u.start && target < u.end) return { doc, selection: collapsed(blockId) };
+  const moving = blocks.slice(u.start, u.end);
+  const rest = [...blocks.slice(0, u.start), ...blocks.slice(u.end)];
+  let insertAt = target > u.start ? target - moving.length : target;
+  insertAt = Math.max(0, Math.min(insertAt, rest.length));
+
+  let adjusted = moving;
+  if (isListItem(moving[0])) {
+    const prev = insertAt - 1;
+    const prevDepth = prev >= 0 && isListItem(rest[prev]) ? (rest[prev].depth ?? 0) : -1;
+    const maxDepth = prevDepth + 1;
+    const topRaw = moving[0].depth ?? 0;
+    const newTop = Math.max(0, Math.min(topRaw, maxDepth));
+    const delta = newTop - topRaw;
+    if (delta !== 0) {
+      adjusted = moving.map((b) =>
+        isListItem(b) ? { ...b, depth: Math.max(0, (b.depth ?? 0) + delta) } : b,
+      );
+    }
+  }
+  const next = [...rest.slice(0, insertAt), ...adjusted, ...rest.slice(insertAt)];
+  return { doc: { blocks: next }, selection: collapsed(blockId) };
+}
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `npm test -- src/components/RichText/engine/blockUnit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A packages/design-system/src/components/RichText/engine/
+git commit -m "feat(RichText): moveBlockUnitToIndex with depth clamp (drag target)"
+```
+
+---
+
+## Task 7: i18n keys
+
+**Files:** Modify `src/i18n/messages.ts`, `src/i18n/en.ts`, `src/i18n/ru.ts`.
+
+The "Turn into" submenu reuses the EXISTING labels (`paragraph`, `heading1/2/3`, `blockquote`, `codeBlock`, `bulletList`, `orderedList`). Add only the new control/action labels.
+
+- [ ] **Step 1: Add to `messages.ts`** — inside `richTextEditor: { … }` (after `mentionsEmpty`), before its closing `}`:
+
+```ts
+    /** aria-label on the block "insert below" (＋) gutter button. */
+    blockInsert: string;
+    /** aria-label on the block actions (⠿) gutter handle. */
+    blockActions: string;
+    /** "Turn into" submenu label in the block menu. */
+    blockTurnInto: string;
+    /** "Duplicate" item in the block menu. */
+    blockDuplicate: string;
+    /** "Move up" item in the block menu. */
+    blockMoveUp: string;
+    /** "Move down" item in the block menu. */
+    blockMoveDown: string;
+    /** "Delete" item in the block menu. */
+    blockDelete: string;
+```
+
+- [ ] **Step 2: Add to `en.ts`** — inside `richTextEditor`, after `mentionsEmpty: 'No matches',`:
+
+```ts
+    blockInsert: 'Insert block below',
+    blockActions: 'Block actions',
+    blockTurnInto: 'Turn into',
+    blockDuplicate: 'Duplicate',
+    blockMoveUp: 'Move up',
+    blockMoveDown: 'Move down',
+    blockDelete: 'Delete',
+```
+
+- [ ] **Step 3: Add to `ru.ts`** — inside `richTextEditor`, after `mentionsEmpty: 'Нет совпадений',`:
+
+```ts
+    blockInsert: 'Вставить блок ниже',
+    blockActions: 'Действия с блоком',
+    blockTurnInto: 'Преобразовать в',
+    blockDuplicate: 'Дублировать',
+    blockMoveUp: 'Переместить вверх',
+    blockMoveDown: 'Переместить вниз',
+    blockDelete: 'Удалить',
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd packages/design-system && npx tsc --noEmit` (or `npm run typecheck` from root)
+Expected: PASS (the `Messages` interface and both locale objects agree).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/i18n/
+git commit -m "feat(i18n): RichTextEditor block-control strings (en+ru)"
+```
+
+---
+
+## Task 8: Icons
+
+**Files:** Modify `…/RichTextEditor/icons.tsx`.
+
+- [ ] **Step 1: Append six icons** (match the existing `base` props pattern)
+
+```tsx
+export function PlusIcon() {
+  return (
+    <svg {...base}>
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+export function GripIcon() {
+  return (
+    <svg {...base}>
+      <circle cx="9" cy="6" r="1" fill="currentColor" stroke="none" />
+      <circle cx="9" cy="12" r="1" fill="currentColor" stroke="none" />
+      <circle cx="9" cy="18" r="1" fill="currentColor" stroke="none" />
+      <circle cx="15" cy="6" r="1" fill="currentColor" stroke="none" />
+      <circle cx="15" cy="12" r="1" fill="currentColor" stroke="none" />
+      <circle cx="15" cy="18" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+export function DuplicateIcon() {
+  return (
+    <svg {...base}>
+      <rect x="9" y="9" width="11" height="11" rx="2" />
+      <path d="M5 15V5a2 2 0 0 1 2-2h10" />
+    </svg>
+  );
+}
+export function ArrowUpIcon() {
+  return (
+    <svg {...base}>
+      <line x1="12" y1="19" x2="12" y2="5" />
+      <path d="M5 12l7-7 7 7" />
+    </svg>
+  );
+}
+export function ArrowDownIcon() {
+  return (
+    <svg {...base}>
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <path d="M5 12l7 7 7-7" />
+    </svg>
+  );
+}
+export function TrashIcon() {
+  return (
+    <svg {...base}>
+      <path d="M3 6h18" />
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+    </svg>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/RichTextEditor/icons.tsx
+git commit -m "feat(RichTextEditor): block-control icons"
+```
+
+---
+
+## Task 9: `RichTextBlockMenu` component
+
+A presentational wrapper over `DropdownMenu` (controlled open) whose trigger is
+the `⠿` handle. The "Turn into" submenu reuses existing block-type labels.
+
+**Files:**
+- Create: `…/RichTextEditor/RichTextBlockMenu.tsx`
+- Test: `…/RichTextEditor/RichTextBlockMenu.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// RichTextBlockMenu.test.tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nProvider } from '../../i18n';
+import { RichTextBlockMenu } from './RichTextBlockMenu';
+
+function setup(props: Partial<React.ComponentProps<typeof RichTextBlockMenu>> = {}) {
+  const onAction = vi.fn();
+  const onTurnInto = vi.fn();
+  render(
+    <I18nProvider>
+      <RichTextBlockMenu
+        open
+        onOpenChange={() => {}}
+        onAction={onAction}
+        onTurnInto={onTurnInto}
+        {...props}
+      />
+    </I18nProvider>,
+  );
+  return { onAction, onTurnInto };
+}
+
+it('renders the handle with the block-actions aria-label', () => {
+  setup({ open: false });
+  expect(screen.getByRole('button', { name: 'Block actions' })).toBeInTheDocument();
+});
+
+it('fires onAction("duplicate") when Duplicate is chosen', async () => {
+  const { onAction } = setup();
+  await userEvent.click(screen.getByRole('menuitem', { name: /duplicate/i }));
+  expect(onAction).toHaveBeenCalledWith('duplicate');
+});
+
+it('fires onAction("delete") for the Delete item', async () => {
+  const { onAction } = setup();
+  await userEvent.click(screen.getByRole('menuitem', { name: /delete/i }));
+  expect(onAction).toHaveBeenCalledWith('delete');
+});
+
+it('the handle is not a tab stop', () => {
+  setup({ open: false });
+  expect(screen.getByRole('button', { name: 'Block actions' })).toHaveAttribute('tabindex', '-1');
+});
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `npm test -- src/components/RichTextEditor/RichTextBlockMenu.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```tsx
+// RichTextBlockMenu.tsx — internal block actions menu (DropdownMenu wrapper). The
+// `⠿` handle is the trigger; open is controlled by the editor so a keyboard
+// Shift+F10 can open the SAME menu anchored to the active block's handle.
+import { forwardRef } from 'react';
+import { Button } from '../Button';
+import { DropdownMenu } from '../DropdownMenu';
+import { useTranslation } from '../../i18n';
+import type { BlockChoice } from './RichTextToolbar';
+import { GripIcon } from './icons';
+import styles from './RichTextEditor.module.scss';
+
+export type BlockAction = 'duplicate' | 'moveUp' | 'moveDown' | 'delete';
+
+export interface RichTextBlockMenuProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Fired for the flat actions (duplicate/move/delete). */
+  onAction: (action: BlockAction) => void;
+  /** Fired for a "Turn into" choice. */
+  onTurnInto: (choice: BlockChoice) => void;
+}
+
+/** Internal: the `⠿` handle + its action menu. Trigger is `tabindex=-1`. */
+export const RichTextBlockMenu = forwardRef<HTMLButtonElement, RichTextBlockMenuProps>(
+  function RichTextBlockMenu({ open, onOpenChange, onAction, onTurnInto }, ref) {
+    const t = useTranslation();
+    return (
+      <DropdownMenu open={open} onOpenChange={onOpenChange}>
+        <DropdownMenu.Trigger>
+          <Button
+            ref={ref}
+            size="sm"
+            variant="ghost"
+            iconOnly
+            tabIndex={-1}
+            aria-label={t('richTextEditor.blockActions')}
+            className={styles.gutterButton}
+            // Keep the editor's DOM selection alive while opening.
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            <GripIcon />
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content side="bottom" align="start">
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger>{t('richTextEditor.blockTurnInto')}</DropdownMenu.SubTrigger>
+            <DropdownMenu.SubContent>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'paragraph' })}>
+                {t('richTextEditor.paragraph')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'heading', level: 1 })}>
+                {t('richTextEditor.heading1')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'heading', level: 2 })}>
+                {t('richTextEditor.heading2')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'heading', level: 3 })}>
+                {t('richTextEditor.heading3')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'bullet_item', depth: 0 })}>
+                {t('richTextEditor.bulletList')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'ordered_item', depth: 0 })}>
+                {t('richTextEditor.orderedList')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'blockquote' })}>
+                {t('richTextEditor.blockquote')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'code_block' })}>
+                {t('richTextEditor.codeBlock')}
+              </DropdownMenu.Item>
+            </DropdownMenu.SubContent>
+          </DropdownMenu.Sub>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item shortcut="⌘D" onSelect={() => onAction('duplicate')}>
+            {t('richTextEditor.blockDuplicate')}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item shortcut="⌘⇧↑" onSelect={() => onAction('moveUp')}>
+            {t('richTextEditor.blockMoveUp')}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item shortcut="⌘⇧↓" onSelect={() => onAction('moveDown')}>
+            {t('richTextEditor.blockMoveDown')}
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item tone="danger" onSelect={() => onAction('delete')}>
+            {t('richTextEditor.blockDelete')}
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    );
+  },
+);
+```
+
+> If `DropdownMenu.Item` has no `shortcut` prop, drop those props (the labels still
+> render). Verify against `DropdownMenu/Item.tsx` during implementation.
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `npm test -- src/components/RichTextEditor/RichTextBlockMenu.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.tsx packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.test.tsx
+git commit -m "feat(RichTextEditor): RichTextBlockMenu (block actions DropdownMenu)"
+```
+
+---
+
+## Task 10: `RichTextBlockControls` overlay (gutter + positioning + ＋ + menu)
+
+Renders the gutter for the active block, positioned over the active block's box
+inside the editor shell (which is `position: relative`). Owns the menu open state.
+
+**Files:**
+- Create: `…/RichTextEditor/RichTextBlockControls.tsx`
+- Test: `…/RichTextEditor/RichTextBlockControls.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// RichTextBlockControls.test.tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRef } from 'react';
+import { I18nProvider } from '../../i18n';
+import { RichTextBlockControls } from './RichTextBlockControls';
+
+function Harness(props: Partial<React.ComponentProps<typeof RichTextBlockControls>>) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  return (
+    <I18nProvider>
+      <div ref={rootRef} style={{ position: 'relative' }}>
+        <p data-block-id="b1">hello</p>
+        <RichTextBlockControls
+          rootRef={rootRef}
+          activeBlockId="b1"
+          menuOpen={false}
+          onMenuOpenChange={() => {}}
+          onInsertBelow={props.onInsertBelow ?? (() => {})}
+          onAction={props.onAction ?? (() => {})}
+          onTurnInto={props.onTurnInto ?? (() => {})}
+          {...props}
+        />
+      </div>
+    </I18nProvider>
+  );
+}
+
+it('renders insert + actions buttons for the active block', () => {
+  render(<Harness />);
+  expect(screen.getByRole('button', { name: 'Insert block below' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Block actions' })).toBeInTheDocument();
+});
+
+it('fires onInsertBelow with the active block id', async () => {
+  const onInsertBelow = vi.fn();
+  render(<Harness onInsertBelow={onInsertBelow} />);
+  await userEvent.click(screen.getByRole('button', { name: 'Insert block below' }));
+  expect(onInsertBelow).toHaveBeenCalledWith('b1');
+});
+
+it('renders nothing when activeBlockId is null', () => {
+  const rootRef = { current: document.createElement('div') };
+  render(
+    <I18nProvider>
+      <RichTextBlockControls
+        rootRef={rootRef as React.RefObject<HTMLDivElement>}
+        activeBlockId={null}
+        menuOpen={false}
+        onMenuOpenChange={() => {}}
+        onInsertBelow={() => {}}
+        onAction={() => {}}
+        onTurnInto={() => {}}
+      />
+    </I18nProvider>,
+  );
+  expect(screen.queryByRole('button', { name: 'Insert block below' })).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `npm test -- src/components/RichTextEditor/RichTextBlockControls.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```tsx
+// RichTextBlockControls.tsx — the per-block gutter overlay. Absolutely positioned
+// inside the editor shell (position: relative), aligned to the active block's box.
+// Lives OUTSIDE the contentEditable so it is never editable content.
+import { useLayoutEffect, useRef, useState, type RefObject } from 'react';
+import { Button } from '../Button';
+import { useTranslation } from '../../i18n';
+import { RichTextBlockMenu, type BlockAction } from './RichTextBlockMenu';
+import type { BlockChoice } from './RichTextToolbar';
+import { PlusIcon } from './icons';
+import styles from './RichTextEditor.module.scss';
+
+export interface RichTextBlockControlsProps {
+  rootRef: RefObject<HTMLElement | null>;
+  /** Block currently hovered or holding the caret; null hides the gutter. */
+  activeBlockId: string | null;
+  menuOpen: boolean;
+  onMenuOpenChange: (open: boolean) => void;
+  onInsertBelow: (blockId: string) => void;
+  onAction: (blockId: string, action: BlockAction) => void;
+  onTurnInto: (blockId: string, choice: BlockChoice) => void;
+}
+
+export function RichTextBlockControls({
+  rootRef,
+  activeBlockId,
+  menuOpen,
+  onMenuOpenChange,
+  onInsertBelow,
+  onAction,
+  onTurnInto,
+}: RichTextBlockControlsProps) {
+  const t = useTranslation();
+  const [top, setTop] = useState<number | null>(null);
+
+  // Measure the active block's vertical offset within the shell after each render.
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root || !activeBlockId) {
+      setTop(null);
+      return;
+    }
+    const el = root.querySelector<HTMLElement>(`[data-block-id="${CSS.escape(activeBlockId)}"]`);
+    if (!el) {
+      setTop(null);
+      return;
+    }
+    const rootBox = root.getBoundingClientRect();
+    const box = el.getBoundingClientRect();
+    setTop(box.top - rootBox.top + (box.height - 24) / 2); // 24 = gutter row height
+  }, [rootRef, activeBlockId, menuOpen]);
+
+  if (!activeBlockId || top == null) return null;
+
+  return (
+    <div className={styles.gutter} style={{ top }} contentEditable={false} aria-hidden={false}>
+      <Button
+        size="sm"
+        variant="ghost"
+        iconOnly
+        tabIndex={-1}
+        aria-label={t('richTextEditor.blockInsert')}
+        className={styles.gutterButton}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => onInsertBelow(activeBlockId)}
+      >
+        <PlusIcon />
+      </Button>
+      <RichTextBlockMenu
+        open={menuOpen}
+        onOpenChange={onMenuOpenChange}
+        onAction={(a) => onAction(activeBlockId, a)}
+        onTurnInto={(c) => onTurnInto(activeBlockId, c)}
+      />
+    </div>
+  );
+}
+```
+
+> The exact `top` math (and a horizontal offset) may need a small runtime nudge;
+> the test only asserts presence/wiring (jsdom has no layout). Iterate visually in
+> the playground (Task 14).
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `npm test -- src/components/RichTextEditor/RichTextBlockControls.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+git commit -m "feat(RichTextEditor): RichTextBlockControls gutter overlay"
+```
+
+---
+
+## Task 11: Wire `blockControls` into `RichTextEditor`
+
+Add the prop, active-block tracking (hover + caret), the keyboard shortcuts, and
+render the gutter. All mutations go through `commit()`.
+
+**Files:**
+- Modify: `…/RichTextEditor/RichTextEditor.tsx`
+- Test: `…/RichTextEditor/RichTextEditor.test.tsx`
+
+- [ ] **Step 1: Write failing tests** (append to `RichTextEditor.test.tsx`)
+
+```tsx
+import { RichTextEditor } from './RichTextEditor';
+import { docFromText } from '../RichText/engine/model';
+// (render/screen/userEvent/I18nProvider already imported at top of the file — reuse them.)
+
+function renderRTE(extra = {}) {
+  function C() {
+    const [doc, setDoc] = useState(docFromText('one\ntwo\nthree'));
+    return <RichTextEditor value={doc} onChange={setDoc} blockControls {...extra} />;
+  }
+  return render(<I18nProvider><C /></I18nProvider>);
+}
+
+it('blockControls: gutter is absent by default', () => {
+  function C() {
+    const [doc, setDoc] = useState(docFromText('x'));
+    return <RichTextEditor value={doc} onChange={setDoc} />;
+  }
+  render(<I18nProvider><C /></I18nProvider>);
+  expect(screen.queryByRole('button', { name: 'Block actions' })).toBeNull();
+});
+
+it('blockControls: hovering a block reveals its gutter', async () => {
+  renderRTE();
+  const block = document.querySelector('[data-block-id]') as HTMLElement;
+  await userEvent.hover(block);
+  expect(screen.getByRole('button', { name: 'Block actions' })).toBeInTheDocument();
+});
+
+it('blockControls: ＋ inserts an empty paragraph below', async () => {
+  renderRTE();
+  const block = document.querySelector('[data-block-id]') as HTMLElement;
+  await userEvent.hover(block);
+  const before = document.querySelectorAll('[data-block-id]').length;
+  await userEvent.click(screen.getByRole('button', { name: 'Insert block below' }));
+  expect(document.querySelectorAll('[data-block-id]').length).toBe(before + 1);
+});
+
+it('blockControls: readOnly suppresses the gutter', async () => {
+  function C() {
+    const [doc, setDoc] = useState(docFromText('x'));
+    return <RichTextEditor value={doc} onChange={setDoc} blockControls readOnly />;
+  }
+  render(<I18nProvider><C /></I18nProvider>);
+  const block = document.querySelector('[data-block-id]') as HTMLElement;
+  await userEvent.hover(block);
+  expect(screen.queryByRole('button', { name: 'Block actions' })).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `npm test -- src/components/RichTextEditor/RichTextEditor.test.tsx -t blockControls`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** — edits to `RichTextEditor.tsx`:
+
+3a. Add the prop to `RichTextEditorProps` (with JSDoc — see Task 13 for the final doc text; a short doc is fine now):
+
+```ts
+  /** Show Notion-style per-block controls (gutter ＋/⠿, block menu, reorder). Default false. Ignored when readOnly. */
+  blockControls?: boolean;
+```
+
+3b. Destructure it in the component signature: add `blockControls = false,` next to `toolbar = false,`.
+
+3c. Add imports at the top:
+
+```ts
+import {
+  moveBlockUnit,
+  duplicateBlockUnit,
+  removeBlockUnit,
+  insertEmptyBlockBelow,
+} from '../RichText/engine/blockUnit';
+import { runSetBlock, runToggleList } from './commands'; // runSetBlock/runToggleList already imported — ensure present
+import { RichTextBlockControls } from './RichTextBlockControls';
+import type { BlockAction } from './RichTextBlockMenu';
+import type { BlockChoice } from './RichTextToolbar';
+```
+
+3d. Add state + handlers (inside the component, near the other state):
+
+```ts
+    const controlsOn = blockControls && !readOnly;
+    const [activeBlockId, setActiveBlockId] = useState<string | null>(null);
+    const [blockMenuOpen, setBlockMenuOpen] = useState(false);
+
+    // Resolve the block element under a node to its data-block-id.
+    const blockIdFromNode = useCallback((node: Node | null): string | null => {
+      let el = node instanceof HTMLElement ? node : node?.parentElement ?? null;
+      while (el && el !== rootRef.current) {
+        if (el.hasAttribute?.('data-block-id')) return el.getAttribute('data-block-id');
+        el = el.parentElement;
+      }
+      return null;
+    }, []);
+
+    // Hover tracking (mouse).
+    useEffect(() => {
+      if (!controlsOn) return;
+      const root = rootRef.current;
+      if (!root) return;
+      const onOver = (e: MouseEvent) => setActiveBlockId(blockIdFromNode(e.target as Node));
+      root.addEventListener('mouseover', onOver);
+      return () => root.removeEventListener('mouseover', onOver);
+    }, [controlsOn, blockIdFromNode]);
+
+    // Caret tracking → active block (so keyboard users get a gutter target).
+    useEffect(() => {
+      if (!controlsOn) return;
+      const onSel = () => {
+        const root = rootRef.current;
+        const sel = root?.ownerDocument.getSelection();
+        if (sel && root && sel.anchorNode && root.contains(sel.anchorNode)) {
+          setActiveBlockId(blockIdFromNode(sel.anchorNode));
+        }
+      };
+      document.addEventListener('selectionchange', onSel);
+      return () => document.removeEventListener('selectionchange', onSel);
+    }, [controlsOn, blockIdFromNode]);
+
+    const onBlockInsertBelow = useCallback((id: string) => {
+      commit(insertEmptyBlockBelow(latest.current.value, id), 'other');
+    }, [commit]);
+
+    const onBlockAction = useCallback((id: string, action: BlockAction) => {
+      const v = latest.current.value;
+      if (action === 'duplicate') commit(duplicateBlockUnit(v, id), 'other');
+      else if (action === 'moveUp') commit(moveBlockUnit(v, id, -1), 'other');
+      else if (action === 'moveDown') commit(moveBlockUnit(v, id, 1), 'other');
+      else if (action === 'delete') commit(removeBlockUnit(v, id), 'other');
+      setBlockMenuOpen(false);
+    }, [commit]);
+
+    const onBlockTurnInto = useCallback((id: string, choice: BlockChoice) => {
+      const v = latest.current.value;
+      const range = { anchor: { blockId: id, offset: 0 }, focus: { blockId: id, offset: 0 } };
+      if (choice.type === 'bullet_item' || choice.type === 'ordered_item') {
+        commit(runToggleList(v, range, choice.type), 'other');
+      } else {
+        commit(runSetBlock(v, range, choice), 'other');
+      }
+      setBlockMenuOpen(false);
+    }, [commit]);
+```
+
+3e. In `onKeyDown`, add the keyboard shortcuts. Insert this block AFTER the
+undo/redo handling but BEFORE the `readSelection` guard's later use — right after
+`const range = readSelection(root); if (!range) return;` is fine, since these need
+the caret's block:
+
+```ts
+        // Block controls keyboard: move/duplicate/menu for the caret's block.
+        if (controlsOn) {
+          const caretBlock = range.anchor.blockId;
+          if (mod && e.shiftKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
+            e.preventDefault();
+            commit(moveBlockUnit(value, caretBlock, e.key === 'ArrowUp' ? -1 : 1), 'other');
+            return;
+          }
+          if (mod && !e.shiftKey && e.key.toLowerCase() === 'd') {
+            e.preventDefault();
+            commit(duplicateBlockUnit(value, caretBlock), 'other');
+            return;
+          }
+          if (e.shiftKey && e.key === 'F10') {
+            e.preventDefault();
+            setActiveBlockId(caretBlock);
+            setBlockMenuOpen(true);
+            return;
+          }
+          if (e.key === 'ContextMenu') {
+            e.preventDefault();
+            setActiveBlockId(caretBlock);
+            setBlockMenuOpen(true);
+            return;
+          }
+        }
+```
+
+> Add `controlsOn`, `onBlock*` handlers, `moveBlockUnit`, `duplicateBlockUnit` to
+> the `onKeyDown` `useCallback` dependency array.
+
+3f. Render the gutter. In BOTH return branches (`if (!toolbar) return …` and the
+toolbar `return`), add `{controlsOn && <RichTextBlockControls … />}` next to
+`{linkBubble}`. Define the element once above the returns:
+
+```tsx
+    const blockControlsEl = controlsOn ? (
+      <RichTextBlockControls
+        rootRef={rootRef}
+        activeBlockId={activeBlockId}
+        menuOpen={blockMenuOpen}
+        onMenuOpenChange={setBlockMenuOpen}
+        onInsertBelow={onBlockInsertBelow}
+        onAction={onBlockAction}
+        onTurnInto={onBlockTurnInto}
+      />
+    ) : null;
+```
+
+Then add `{blockControlsEl}` after `{mentionMenu}` in both the fragment return and
+the `styles.shell` return. **Important:** the non-toolbar branch currently returns
+a fragment with no wrapper that is `position: relative`. Wrap it so the gutter can
+anchor:
+
+```tsx
+    if (!toolbar) {
+      return (
+        <div className={styles.shell}>
+          {editable}
+          {linkBubble}
+          {mentionMenu}
+          {blockControlsEl}
+        </div>
+      );
+    }
+```
+
+(The `styles.shell` already wraps the toolbar branch; reusing it here is fine and
+gives the relative anchor. Confirm `shell` has no toolbar-specific assumptions; if
+it does, add a dedicated `styles.root`-level relative wrapper class instead.)
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `npm test -- src/components/RichTextEditor/RichTextEditor.test.tsx`
+Expected: PASS (all existing + new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+git commit -m "feat(RichTextEditor): wire blockControls (hover/caret tracking, menu, keyboard)"
+```
+
+---
+
+## Task 12: SCSS — gutter styles
+
+**Files:** Modify `…/RichTextEditor/RichTextEditor.module.scss`.
+
+- [ ] **Step 1: Inspect current `shell`/`root`** to choose insertion points
+
+Run: `sed -n '1,60p' packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss`
+Expected: see `.shell`, `.root`, `.toolbar` rules.
+
+- [ ] **Step 2: Add styles** (tokens only; `position: relative` on the shell is the allowed internal-anchor exception; left padding reserves gutter space — padding is permitted, margin is not)
+
+```scss
+.shell {
+  position: relative; // anchor for the absolutely-positioned block gutter
+}
+
+.gutter {
+  position: absolute;
+  left: 0;
+  display: flex;
+  gap: var(--space-1);
+  height: var(--space-6); // ~24px row; align with the measured offset in TS
+  align-items: center;
+  pointer-events: auto;
+}
+
+.gutterButton {
+  color: var(--color-text-muted);
+}
+
+.root {
+  // Reserve room for the gutter so controls don't overlap text.
+  padding-left: var(--space-7);
+}
+```
+
+> Verify the exact token names against `src/styles/tokens.scss` (`--space-6`,
+> `--space-7`, `--color-text-muted`). Substitute the nearest existing tokens if a
+> name differs — do NOT introduce raw values (stylelint blocks them).
+
+- [ ] **Step 3: Lint**
+
+Run: `npm run lint:css`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
+git commit -m "style(RichTextEditor): block gutter styles"
+```
+
+---
+
+## Task 13: JSDoc + `@remarks` for `blockControls`
+
+**Files:** Modify `…/RichTextEditor/RichTextEditor.tsx`.
+
+- [ ] **Step 1: Replace the short prop doc** with the full version:
+
+```ts
+  /**
+   * Show Notion-style per-block controls: a left gutter that appears on the
+   * hovered/focused block with an insert button (`＋`, adds an empty paragraph
+   * below) and a drag handle (`⠿`) that reorders blocks and opens a block menu
+   * (Turn into ▸, Duplicate, Move up/down, Delete). Reordering is subtree-aware
+   * for nested lists. Keyboard: Shift+F10 / the ContextMenu key opens the focused
+   * block's menu; ⌘/Ctrl+⇧↑ / ⌘/Ctrl+⇧↓ move the block; ⌘/Ctrl+D duplicates.
+   * Default `false`. Ignored when `readOnly`. Independent of `toolbar`.
+   */
+  blockControls?: boolean;
+```
+
+- [ ] **Step 2: Add anti-patterns to the component's `@remarks`** — append to the existing Anti-patterns block:
+
+```ts
+ * - ❌ Building a custom block drag/menu by reaching into the DOM — pass
+ *   `blockControls`; insert/move/duplicate/delete route through the controlled
+ *   `value`/`onChange` round-trip and are undoable.
+ * - ❌ Expecting Backspace to delete a whole block — it edits text; use the block
+ *   menu's Delete (or select + delete) to remove a block.
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+git commit -m "docs(RichTextEditor): JSDoc for blockControls prop"
+```
+
+---
+
+## Task 14: Drag-to-reorder (dnd-kit core)
+
+Add pointer-drag reorder using the `⠿` handle. Drop index is computed from block
+geometry; the move is committed via `moveBlockUnitToIndex`.
+
+**Files:**
+- Modify: `…/RichTextEditor/RichTextBlockControls.tsx` (handle drag via `@dnd-kit/core`)
+- Modify: `…/RichTextEditor/RichTextEditor.tsx` (pass an `onReorder(blockId, targetIndex)` callback)
+- Test: `…/RichTextEditor/RichTextEditor.test.tsx`
+
+- [ ] **Step 1: Add an `onReorder` callback in the editor** that maps to `moveBlockUnitToIndex`:
+
+```ts
+    const onBlockReorder = useCallback((id: string, targetIndex: number) => {
+      commit(moveBlockUnitToIndex(latest.current.value, id, targetIndex), 'other');
+    }, [commit]);
+```
+
+Pass `onReorder={onBlockReorder}` to `<RichTextBlockControls>`; import
+`moveBlockUnitToIndex` from `blockUnit`.
+
+- [ ] **Step 2: Implement drag in `RichTextBlockControls`** using `@dnd-kit/core`'s
+`DndContext` + `useDraggable` on the `⠿` handle, with a pointer sensor. On drag end,
+compute the target gap index from the pointer's Y against every `[data-block-id]`
+rect (the midpoint rule), then call `onReorder(activeBlockId, targetIndex)`. Render
+a horizontal drop-indicator line at the candidate gap during drag.
+
+```tsx
+// sketch — wire concretely against @dnd-kit/core during implementation:
+// const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
+// On drag move: setDropIndex(computeGapIndex(root, event.activatorEvent.clientY + delta.y));
+// On drag end: if (dropIndex != null) onReorder(activeBlockId, dropIndex);
+// computeGapIndex: iterate root.querySelectorAll('[data-block-id]'); the gap is the
+// first block whose vertical midpoint is below the pointer; default to blocks.length.
+```
+
+- [ ] **Step 3: Add a test** that exercises the geometry→index mapping by extracting
+`computeGapIndex` as a pure exported helper and unit-testing it with stubbed rects:
+
+```ts
+// in a new file blockDrop.ts: export function gapIndexFromY(rects: {top:number;height:number}[], y: number): number
+import { gapIndexFromY } from './blockDrop';
+it('returns the gap before the first block whose midpoint is below y', () => {
+  const rects = [{ top: 0, height: 20 }, { top: 20, height: 20 }, { top: 40, height: 20 }];
+  expect(gapIndexFromY(rects, 5)).toBe(0);   // above block 0 midpoint (10)
+  expect(gapIndexFromY(rects, 25)).toBe(1);  // below block 0 midpoint, above block 1 midpoint
+  expect(gapIndexFromY(rects, 100)).toBe(3); // past everything → end
+});
+```
+
+```ts
+// blockDrop.ts
+/** Index of the gap (0..n) where a drop at viewport-Y `y` should land. */
+export function gapIndexFromY(rects: { top: number; height: number }[], y: number): number {
+  for (let i = 0; i < rects.length; i += 1) {
+    if (y < rects[i].top + rects[i].height / 2) return i;
+  }
+  return rects.length;
+}
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `npm test -- src/components/RichTextEditor/blockDrop.test.ts`
+Expected: PASS. Then verify the full editor suite still passes:
+Run: `npm test -- src/components/RichTextEditor/`
+
+- [ ] **Step 5: Manual verification in the playground** (jsdom can't test real drag):
+Run `make dev`, open the RichTextEditor demo, drag a block by its `⠿` handle, confirm
+reorder + nested-list subtree move + undo (⌘Z) restores.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/RichTextEditor/
+git commit -m "feat(RichTextEditor): drag-to-reorder blocks (dnd-kit core)"
+```
+
+---
+
+## Task 15: Playground demo
+
+**Files:** Modify `packages/playground/src/pages/components/RichTextEditorDemo.tsx`.
+
+- [ ] **Step 1: Add state** near the other `useState` calls:
+
+```tsx
+  const [blockDoc, setBlockDoc] = useState<RichDoc>(() =>
+    fromMarkdown('# Block controls\n\nHover a line for the ＋/⠿ gutter.\n\n- first\n- second\n\n> Drag, duplicate, or turn into another type.'),
+  );
+```
+
+- [ ] **Step 2: Add an `<Example>`** (place it after the toolbar example):
+
+```tsx
+      <Example
+        title="Block controls"
+        description="Set blockControls to show a per-block gutter on hover/focus: ＋ inserts a block, ⠿ drags to reorder and opens a menu (turn into / duplicate / move / delete). Keyboard: Shift+F10 opens the menu, ⌘/Ctrl+⇧↑/↓ move, ⌘/Ctrl+D duplicates. Works with or without the toolbar."
+        code={`const [doc, setDoc] = useState(fromMarkdown('…'));
+<RichTextEditor value={doc} onChange={setDoc} blockControls />`}
+      >
+        <RichTextEditor value={blockDoc} onChange={setBlockDoc} blockControls placeholder="Write…" />
+      </Example>
+```
+
+- [ ] **Step 3: Build the playground**
+
+Run: `make build` (or `cd packages/playground && npm run build`)
+Expected: typecheck + bundle PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/playground/src/pages/components/RichTextEditorDemo.tsx
+git commit -m "demo(RichTextEditor): blockControls example"
+```
+
+---
+
+## Task 16: AGENTS.md TL;DR
+
+**Files:** Modify `packages/design-system/AGENTS.md`.
+
+- [ ] **Step 1: Find the RichTextEditor section**
+
+Run: `grep -n "RichTextEditor" packages/design-system/AGENTS.md | head`
+
+- [ ] **Step 2: Add a line/sub-bullet** to that section documenting `blockControls`:
+
+```md
+- `blockControls` (opt-in, default off): Notion-style per-block gutter — `＋`
+  insert, `⠿` drag-to-reorder + a block menu (turn into / duplicate / move up·down
+  / delete). Subtree-aware for nested lists. Keyboard: Shift+F10 opens the menu,
+  ⌘/Ctrl+⇧↑·↓ move, ⌘/Ctrl+D duplicate. Independent of `toolbar`; ignored when
+  `readOnly`. All ops route through `value`/`onChange` and are undoable.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/AGENTS.md
+git commit -m "docs(AGENTS): RichTextEditor blockControls TL;DR"
+```
+
+---
+
+## Task 17: Gates + pre-push review-fix loop (Rule 8)
+
+- [ ] **Step 1: Run all gates from the repo root**
+
+```bash
+npm test
+npm run typecheck
+npm run lint:css
+npm run build
+npm pack --dry-run -w @eocrm/design-system
+```
+
+Expected: all PASS; `npm pack` shows **no** test files / internal-only paths in the tarball.
+
+- [ ] **Step 2: Spawn a fresh-context review agent** targeted at
+`packages/design-system/` per CLAUDE.md Rule 8 (10 categories; Critical/Important/
+Nice-to-have/Regression-watch + verdict). Fix every Critical + Important; note any
+deliberate skips.
+
+- [ ] **Step 3: Re-run gates; re-review until verdict is "clean enough to stop."**
+
+- [ ] **Step 4: Push + open PR**
+
+```bash
+git push -u origin feat/rte-block-controls-slice1
+gh pr create --fill --title "feat(RichTextEditor): Notion-style block controls (Slice 1)"
+```
+
+- [ ] **Step 5: Wait for `Quality / check` to pass, then merge.**
+
+---
+
+## Self-review (plan vs spec)
+
+**Spec coverage:**
+- `blockControls` opt-in prop → Task 11, 13. ✓
+- Gutter `＋`/`⠿` → Tasks 8, 10. ✓
+- Block menu (turn into / duplicate / move / delete) → Task 9. ✓
+- Subtree-aware reorder (move + drag) → Tasks 1,2,6,14. ✓
+- Engine transforms `blockUnitRange`/`moveBlockUnit`/`duplicateBlockUnit`/`removeBlockUnit` (+ `insertEmptyBlockBelow`, `moveBlockUnitToIndex`) → Tasks 1–6. ✓
+- Keyboard model (Shift+F10 / ContextMenu, ⌘⇧↑/↓, ⌘D) → Task 11. ✓
+- `tabindex=-1` handles → Tasks 9, 10 (+ test). ✓
+- readOnly suppression → Task 11 (test). ✓
+- i18n en+ru (reusing existing block-type labels) → Task 7. ✓
+- JSDoc + @remarks → Task 13. ✓
+- Tokens-only SCSS, no layout props (relative anchor + padding only) → Task 12. ✓
+- Playground demo → Task 15. ✓
+- AGENTS.md → Task 16. ✓
+- Tests (engine + component) → every task. ✓
+- DoD / review loop / pack check → Task 17. ✓
+
+**Open verification points flagged for the implementer (not placeholders — known runtime-only unknowns):**
+1. `DropdownMenu.Item` `shortcut` prop existence — Task 9 notes the fallback.
+2. Exact token names in Task 12 — verify against `tokens.scss`.
+3. Gutter `top`/`left` pixel math — Task 10/14 iterate in the playground (jsdom has no layout).
+4. `styles.shell` reuse for the non-toolbar branch — Task 11 notes the fallback (dedicated relative wrapper) if `shell` carries toolbar assumptions.
+
+**Type consistency:** `BlockAction` (RichTextBlockMenu) and `BlockChoice`
+(RichTextToolbar) are reused verbatim across Tasks 9–11. Transform names match
+across tasks and the editor wiring. ✓
+```

--- a/docs/superpowers/plans/2026-06-25-richtexteditor-block-controls-slice1.md
+++ b/docs/superpowers/plans/2026-06-25-richtexteditor-block-controls-slice1.md
@@ -25,6 +25,7 @@
 ## File structure
 
 **Create:**
+
 - `…/RichText/engine/blockUnit.ts` — unit range + sibling helper + 5 transforms (pure).
 - `…/RichText/engine/blockUnit.test.ts` — engine tests.
 - `…/RichTextEditor/RichTextBlockMenu.tsx` — `DropdownMenu` wrapper (presentational).
@@ -33,6 +34,7 @@
 - `…/RichTextEditor/RichTextBlockControls.test.tsx`
 
 **Modify:**
+
 - `…/RichTextEditor/icons.tsx` — add `PlusIcon`, `GripIcon`, `DuplicateIcon`, `ArrowUpIcon`, `ArrowDownIcon`, `TrashIcon`.
 - `…/RichTextEditor/RichTextEditor.tsx` — `blockControls` prop, active-block state, keyboard, render `<RichTextBlockControls>`.
 - `…/RichTextEditor/RichTextEditor.module.scss` — gutter styles + left padding + relative anchor.
@@ -64,6 +66,7 @@ Expected: `.husky/_`
 ## Task 1: Engine — `blockUnitRange` + `prevSiblingAnchor`
 
 **Files:**
+
 - Create: `packages/design-system/src/components/RichText/engine/blockUnit.ts`
 - Test: `packages/design-system/src/components/RichText/engine/blockUnit.test.ts`
 
@@ -187,6 +190,7 @@ git commit -m "feat(RichText): blockUnitRange + prevSiblingAnchor unit helpers"
 ## Task 2: Engine — `moveBlockUnit` (sibling swap)
 
 **Files:**
+
 - Modify: `…/engine/blockUnit.ts`
 - Test: `…/engine/blockUnit.test.ts`
 
@@ -245,7 +249,11 @@ Expected: FAIL — `moveBlockUnit` not exported.
  * up / +1 down). Same-depth swap, so depths are preserved. No-op (returns the
  * SAME doc reference) at an edge / when there is no sibling in that direction.
  */
-export function moveBlockUnit(doc: RichDoc, blockId: string, dir: -1 | 1): { doc: RichDoc; selection: Range } {
+export function moveBlockUnit(
+  doc: RichDoc,
+  blockId: string,
+  dir: -1 | 1,
+): { doc: RichDoc; selection: Range } {
   const blocks = doc.blocks;
   const idx = findBlockIndex(doc, blockId);
   if (idx === -1) return { doc, selection: collapsed(blockId) };
@@ -307,9 +315,12 @@ describe('duplicateBlockUnit', () => {
     const d = doc([li('a', 0), li('a1', 1), p('z')]);
     const r = duplicateBlockUnit(d, 'a');
     expect(r.doc.blocks.length).toBe(4); // a a1 a' a1' ... wait: a a1 [copy a, copy a1] z
-    expect(r.doc.blocks.map((b) => b.type)).toEqual([
-      'bullet_item', 'bullet_item', 'bullet_item', 'bullet_item', 'paragraph',
-    ].slice(0, r.doc.blocks.length));
+    expect(r.doc.blocks.map((b) => b.type)).toEqual(
+      ['bullet_item', 'bullet_item', 'bullet_item', 'bullet_item', 'paragraph'].slice(
+        0,
+        r.doc.blocks.length,
+      ),
+    );
     expect(r.doc.blocks[2].depth).toBe(0);
     expect(r.doc.blocks[3].depth).toBe(1);
   });
@@ -343,7 +354,10 @@ function cloneBlock(b: Block): Block {
  * Duplicate the unit anchored at `blockId`, inserting the clones immediately
  * after the unit. Fresh ids; depths preserved. Caret lands on the clone's anchor.
  */
-export function duplicateBlockUnit(doc: RichDoc, blockId: string): { doc: RichDoc; selection: Range } {
+export function duplicateBlockUnit(
+  doc: RichDoc,
+  blockId: string,
+): { doc: RichDoc; selection: Range } {
   const idx = findBlockIndex(doc, blockId);
   if (idx === -1) return { doc, selection: collapsed(blockId) };
   const u = blockUnitRange(doc.blocks, idx);
@@ -483,7 +497,10 @@ Expected: FAIL.
 
 ```ts
 /** Insert an empty paragraph directly after the block unit anchored at `blockId`. */
-export function insertEmptyBlockBelow(doc: RichDoc, blockId: string): { doc: RichDoc; selection: Range } {
+export function insertEmptyBlockBelow(
+  doc: RichDoc,
+  blockId: string,
+): { doc: RichDoc; selection: Range } {
   const idx = findBlockIndex(doc, blockId);
   if (idx === -1) return { doc, selection: collapsed(blockId) };
   const u = blockUnitRange(doc.blocks, idx);
@@ -553,7 +570,11 @@ Expected: FAIL.
  * clamped to a value valid for its new predecessor (`prevListDepth + 1`, else 0);
  * descendants shift by the same delta. No-op when `target` falls inside the unit.
  */
-export function moveBlockUnitToIndex(doc: RichDoc, blockId: string, target: number): { doc: RichDoc; selection: Range } {
+export function moveBlockUnitToIndex(
+  doc: RichDoc,
+  blockId: string,
+  target: number,
+): { doc: RichDoc; selection: Range } {
   const blocks = doc.blocks;
   const idx = findBlockIndex(doc, blockId);
   if (idx === -1) return { doc, selection: collapsed(blockId) };
@@ -606,20 +627,20 @@ The "Turn into" submenu reuses the EXISTING labels (`paragraph`, `heading1/2/3`,
 - [ ] **Step 1: Add to `messages.ts`** — inside `richTextEditor: { … }` (after `mentionsEmpty`), before its closing `}`:
 
 ```ts
-    /** aria-label on the block "insert below" (＋) gutter button. */
-    blockInsert: string;
-    /** aria-label on the block actions (⠿) gutter handle. */
-    blockActions: string;
-    /** "Turn into" submenu label in the block menu. */
-    blockTurnInto: string;
-    /** "Duplicate" item in the block menu. */
-    blockDuplicate: string;
-    /** "Move up" item in the block menu. */
-    blockMoveUp: string;
-    /** "Move down" item in the block menu. */
-    blockMoveDown: string;
-    /** "Delete" item in the block menu. */
-    blockDelete: string;
+/** aria-label on the block "insert below" (＋) gutter button. */
+blockInsert: string;
+/** aria-label on the block actions (⠿) gutter handle. */
+blockActions: string;
+/** "Turn into" submenu label in the block menu. */
+blockTurnInto: string;
+/** "Duplicate" item in the block menu. */
+blockDuplicate: string;
+/** "Move up" item in the block menu. */
+blockMoveUp: string;
+/** "Move down" item in the block menu. */
+blockMoveDown: string;
+/** "Delete" item in the block menu. */
+blockDelete: string;
 ```
 
 - [ ] **Step 2: Add to `en.ts`** — inside `richTextEditor`, after `mentionsEmpty: 'No matches',`:
@@ -742,6 +763,7 @@ A presentational wrapper over `DropdownMenu` (controlled open) whose trigger is
 the `⠿` handle. The "Turn into" submenu reuses existing block-type labels.
 
 **Files:**
+
 - Create: `…/RichTextEditor/RichTextBlockMenu.tsx`
 - Test: `…/RichTextEditor/RichTextBlockMenu.test.tsx`
 
@@ -919,6 +941,7 @@ Renders the gutter for the active block, positioned over the active block's box
 inside the editor shell (which is `position: relative`). Owns the menu open state.
 
 **Files:**
+
 - Create: `…/RichTextEditor/RichTextBlockControls.tsx`
 - Test: `…/RichTextEditor/RichTextBlockControls.test.tsx`
 
@@ -1095,6 +1118,7 @@ Add the prop, active-block tracking (hover + caret), the keyboard shortcuts, and
 render the gutter. All mutations go through `commit()`.
 
 **Files:**
+
 - Modify: `…/RichTextEditor/RichTextEditor.tsx`
 - Test: `…/RichTextEditor/RichTextEditor.test.tsx`
 
@@ -1110,7 +1134,11 @@ function renderRTE(extra = {}) {
     const [doc, setDoc] = useState(docFromText('one\ntwo\nthree'));
     return <RichTextEditor value={doc} onChange={setDoc} blockControls {...extra} />;
   }
-  return render(<I18nProvider><C /></I18nProvider>);
+  return render(
+    <I18nProvider>
+      <C />
+    </I18nProvider>,
+  );
 }
 
 it('blockControls: gutter is absent by default', () => {
@@ -1118,7 +1146,11 @@ it('blockControls: gutter is absent by default', () => {
     const [doc, setDoc] = useState(docFromText('x'));
     return <RichTextEditor value={doc} onChange={setDoc} />;
   }
-  render(<I18nProvider><C /></I18nProvider>);
+  render(
+    <I18nProvider>
+      <C />
+    </I18nProvider>,
+  );
   expect(screen.queryByRole('button', { name: 'Block actions' })).toBeNull();
 });
 
@@ -1143,7 +1175,11 @@ it('blockControls: readOnly suppresses the gutter', async () => {
     const [doc, setDoc] = useState(docFromText('x'));
     return <RichTextEditor value={doc} onChange={setDoc} blockControls readOnly />;
   }
-  render(<I18nProvider><C /></I18nProvider>);
+  render(
+    <I18nProvider>
+      <C />
+    </I18nProvider>,
+  );
   const block = document.querySelector('[data-block-id]') as HTMLElement;
   await userEvent.hover(block);
   expect(screen.queryByRole('button', { name: 'Block actions' })).toBeNull();
@@ -1184,67 +1220,76 @@ import type { BlockChoice } from './RichTextToolbar';
 3d. Add state + handlers (inside the component, near the other state):
 
 ```ts
-    const controlsOn = blockControls && !readOnly;
-    const [activeBlockId, setActiveBlockId] = useState<string | null>(null);
-    const [blockMenuOpen, setBlockMenuOpen] = useState(false);
+const controlsOn = blockControls && !readOnly;
+const [activeBlockId, setActiveBlockId] = useState<string | null>(null);
+const [blockMenuOpen, setBlockMenuOpen] = useState(false);
 
-    // Resolve the block element under a node to its data-block-id.
-    const blockIdFromNode = useCallback((node: Node | null): string | null => {
-      let el = node instanceof HTMLElement ? node : node?.parentElement ?? null;
-      while (el && el !== rootRef.current) {
-        if (el.hasAttribute?.('data-block-id')) return el.getAttribute('data-block-id');
-        el = el.parentElement;
-      }
-      return null;
-    }, []);
+// Resolve the block element under a node to its data-block-id.
+const blockIdFromNode = useCallback((node: Node | null): string | null => {
+  let el = node instanceof HTMLElement ? node : (node?.parentElement ?? null);
+  while (el && el !== rootRef.current) {
+    if (el.hasAttribute?.('data-block-id')) return el.getAttribute('data-block-id');
+    el = el.parentElement;
+  }
+  return null;
+}, []);
 
-    // Hover tracking (mouse).
-    useEffect(() => {
-      if (!controlsOn) return;
-      const root = rootRef.current;
-      if (!root) return;
-      const onOver = (e: MouseEvent) => setActiveBlockId(blockIdFromNode(e.target as Node));
-      root.addEventListener('mouseover', onOver);
-      return () => root.removeEventListener('mouseover', onOver);
-    }, [controlsOn, blockIdFromNode]);
+// Hover tracking (mouse).
+useEffect(() => {
+  if (!controlsOn) return;
+  const root = rootRef.current;
+  if (!root) return;
+  const onOver = (e: MouseEvent) => setActiveBlockId(blockIdFromNode(e.target as Node));
+  root.addEventListener('mouseover', onOver);
+  return () => root.removeEventListener('mouseover', onOver);
+}, [controlsOn, blockIdFromNode]);
 
-    // Caret tracking → active block (so keyboard users get a gutter target).
-    useEffect(() => {
-      if (!controlsOn) return;
-      const onSel = () => {
-        const root = rootRef.current;
-        const sel = root?.ownerDocument.getSelection();
-        if (sel && root && sel.anchorNode && root.contains(sel.anchorNode)) {
-          setActiveBlockId(blockIdFromNode(sel.anchorNode));
-        }
-      };
-      document.addEventListener('selectionchange', onSel);
-      return () => document.removeEventListener('selectionchange', onSel);
-    }, [controlsOn, blockIdFromNode]);
+// Caret tracking → active block (so keyboard users get a gutter target).
+useEffect(() => {
+  if (!controlsOn) return;
+  const onSel = () => {
+    const root = rootRef.current;
+    const sel = root?.ownerDocument.getSelection();
+    if (sel && root && sel.anchorNode && root.contains(sel.anchorNode)) {
+      setActiveBlockId(blockIdFromNode(sel.anchorNode));
+    }
+  };
+  document.addEventListener('selectionchange', onSel);
+  return () => document.removeEventListener('selectionchange', onSel);
+}, [controlsOn, blockIdFromNode]);
 
-    const onBlockInsertBelow = useCallback((id: string) => {
-      commit(insertEmptyBlockBelow(latest.current.value, id), 'other');
-    }, [commit]);
+const onBlockInsertBelow = useCallback(
+  (id: string) => {
+    commit(insertEmptyBlockBelow(latest.current.value, id), 'other');
+  },
+  [commit],
+);
 
-    const onBlockAction = useCallback((id: string, action: BlockAction) => {
-      const v = latest.current.value;
-      if (action === 'duplicate') commit(duplicateBlockUnit(v, id), 'other');
-      else if (action === 'moveUp') commit(moveBlockUnit(v, id, -1), 'other');
-      else if (action === 'moveDown') commit(moveBlockUnit(v, id, 1), 'other');
-      else if (action === 'delete') commit(removeBlockUnit(v, id), 'other');
-      setBlockMenuOpen(false);
-    }, [commit]);
+const onBlockAction = useCallback(
+  (id: string, action: BlockAction) => {
+    const v = latest.current.value;
+    if (action === 'duplicate') commit(duplicateBlockUnit(v, id), 'other');
+    else if (action === 'moveUp') commit(moveBlockUnit(v, id, -1), 'other');
+    else if (action === 'moveDown') commit(moveBlockUnit(v, id, 1), 'other');
+    else if (action === 'delete') commit(removeBlockUnit(v, id), 'other');
+    setBlockMenuOpen(false);
+  },
+  [commit],
+);
 
-    const onBlockTurnInto = useCallback((id: string, choice: BlockChoice) => {
-      const v = latest.current.value;
-      const range = { anchor: { blockId: id, offset: 0 }, focus: { blockId: id, offset: 0 } };
-      if (choice.type === 'bullet_item' || choice.type === 'ordered_item') {
-        commit(runToggleList(v, range, choice.type), 'other');
-      } else {
-        commit(runSetBlock(v, range, choice), 'other');
-      }
-      setBlockMenuOpen(false);
-    }, [commit]);
+const onBlockTurnInto = useCallback(
+  (id: string, choice: BlockChoice) => {
+    const v = latest.current.value;
+    const range = { anchor: { blockId: id, offset: 0 }, focus: { blockId: id, offset: 0 } };
+    if (choice.type === 'bullet_item' || choice.type === 'ordered_item') {
+      commit(runToggleList(v, range, choice.type), 'other');
+    } else {
+      commit(runSetBlock(v, range, choice), 'other');
+    }
+    setBlockMenuOpen(false);
+  },
+  [commit],
+);
 ```
 
 3e. In `onKeyDown`, add the keyboard shortcuts. Insert this block AFTER the
@@ -1253,32 +1298,32 @@ undo/redo handling but BEFORE the `readSelection` guard's later use — right af
 the caret's block:
 
 ```ts
-        // Block controls keyboard: move/duplicate/menu for the caret's block.
-        if (controlsOn) {
-          const caretBlock = range.anchor.blockId;
-          if (mod && e.shiftKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
-            e.preventDefault();
-            commit(moveBlockUnit(value, caretBlock, e.key === 'ArrowUp' ? -1 : 1), 'other');
-            return;
-          }
-          if (mod && !e.shiftKey && e.key.toLowerCase() === 'd') {
-            e.preventDefault();
-            commit(duplicateBlockUnit(value, caretBlock), 'other');
-            return;
-          }
-          if (e.shiftKey && e.key === 'F10') {
-            e.preventDefault();
-            setActiveBlockId(caretBlock);
-            setBlockMenuOpen(true);
-            return;
-          }
-          if (e.key === 'ContextMenu') {
-            e.preventDefault();
-            setActiveBlockId(caretBlock);
-            setBlockMenuOpen(true);
-            return;
-          }
-        }
+// Block controls keyboard: move/duplicate/menu for the caret's block.
+if (controlsOn) {
+  const caretBlock = range.anchor.blockId;
+  if (mod && e.shiftKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
+    e.preventDefault();
+    commit(moveBlockUnit(value, caretBlock, e.key === 'ArrowUp' ? -1 : 1), 'other');
+    return;
+  }
+  if (mod && !e.shiftKey && e.key.toLowerCase() === 'd') {
+    e.preventDefault();
+    commit(duplicateBlockUnit(value, caretBlock), 'other');
+    return;
+  }
+  if (e.shiftKey && e.key === 'F10') {
+    e.preventDefault();
+    setActiveBlockId(caretBlock);
+    setBlockMenuOpen(true);
+    return;
+  }
+  if (e.key === 'ContextMenu') {
+    e.preventDefault();
+    setActiveBlockId(caretBlock);
+    setBlockMenuOpen(true);
+    return;
+  }
+}
 ```
 
 > Add `controlsOn`, `onBlock*` handlers, `moveBlockUnit`, `duplicateBlockUnit` to
@@ -1289,17 +1334,17 @@ toolbar `return`), add `{controlsOn && <RichTextBlockControls … />}` next to
 `{linkBubble}`. Define the element once above the returns:
 
 ```tsx
-    const blockControlsEl = controlsOn ? (
-      <RichTextBlockControls
-        rootRef={rootRef}
-        activeBlockId={activeBlockId}
-        menuOpen={blockMenuOpen}
-        onMenuOpenChange={setBlockMenuOpen}
-        onInsertBelow={onBlockInsertBelow}
-        onAction={onBlockAction}
-        onTurnInto={onBlockTurnInto}
-      />
-    ) : null;
+const blockControlsEl = controlsOn ? (
+  <RichTextBlockControls
+    rootRef={rootRef}
+    activeBlockId={activeBlockId}
+    menuOpen={blockMenuOpen}
+    onMenuOpenChange={setBlockMenuOpen}
+    onInsertBelow={onBlockInsertBelow}
+    onAction={onBlockAction}
+    onTurnInto={onBlockTurnInto}
+  />
+) : null;
 ```
 
 Then add `{blockControlsEl}` after `{mentionMenu}` in both the fragment return and
@@ -1308,16 +1353,16 @@ a fragment with no wrapper that is `position: relative`. Wrap it so the gutter c
 anchor:
 
 ```tsx
-    if (!toolbar) {
-      return (
-        <div className={styles.shell}>
-          {editable}
-          {linkBubble}
-          {mentionMenu}
-          {blockControlsEl}
-        </div>
-      );
-    }
+if (!toolbar) {
+  return (
+    <div className={styles.shell}>
+      {editable}
+      {linkBubble}
+      {mentionMenu}
+      {blockControlsEl}
+    </div>
+  );
+}
 ```
 
 (The `styles.shell` already wraps the toolbar branch; reusing it here is fine and
@@ -1441,6 +1486,7 @@ Add pointer-drag reorder using the `⠿` handle. Drop index is computed from blo
 geometry; the move is committed via `moveBlockUnitToIndex`.
 
 **Files:**
+
 - Modify: `…/RichTextEditor/RichTextBlockControls.tsx` (handle drag via `@dnd-kit/core`)
 - Modify: `…/RichTextEditor/RichTextEditor.tsx` (pass an `onReorder(blockId, targetIndex)` callback)
 - Test: `…/RichTextEditor/RichTextEditor.test.tsx`
@@ -1448,19 +1494,22 @@ geometry; the move is committed via `moveBlockUnitToIndex`.
 - [ ] **Step 1: Add an `onReorder` callback in the editor** that maps to `moveBlockUnitToIndex`:
 
 ```ts
-    const onBlockReorder = useCallback((id: string, targetIndex: number) => {
-      commit(moveBlockUnitToIndex(latest.current.value, id, targetIndex), 'other');
-    }, [commit]);
+const onBlockReorder = useCallback(
+  (id: string, targetIndex: number) => {
+    commit(moveBlockUnitToIndex(latest.current.value, id, targetIndex), 'other');
+  },
+  [commit],
+);
 ```
 
 Pass `onReorder={onBlockReorder}` to `<RichTextBlockControls>`; import
 `moveBlockUnitToIndex` from `blockUnit`.
 
 - [ ] **Step 2: Implement drag in `RichTextBlockControls`** using `@dnd-kit/core`'s
-`DndContext` + `useDraggable` on the `⠿` handle, with a pointer sensor. On drag end,
-compute the target gap index from the pointer's Y against every `[data-block-id]`
-rect (the midpoint rule), then call `onReorder(activeBlockId, targetIndex)`. Render
-a horizontal drop-indicator line at the candidate gap during drag.
+      `DndContext` + `useDraggable` on the `⠿` handle, with a pointer sensor. On drag end,
+      compute the target gap index from the pointer's Y against every `[data-block-id]`
+      rect (the midpoint rule), then call `onReorder(activeBlockId, targetIndex)`. Render
+      a horizontal drop-indicator line at the candidate gap during drag.
 
 ```tsx
 // sketch — wire concretely against @dnd-kit/core during implementation:
@@ -1472,15 +1521,19 @@ a horizontal drop-indicator line at the candidate gap during drag.
 ```
 
 - [ ] **Step 3: Add a test** that exercises the geometry→index mapping by extracting
-`computeGapIndex` as a pure exported helper and unit-testing it with stubbed rects:
+      `computeGapIndex` as a pure exported helper and unit-testing it with stubbed rects:
 
 ```ts
 // in a new file blockDrop.ts: export function gapIndexFromY(rects: {top:number;height:number}[], y: number): number
 import { gapIndexFromY } from './blockDrop';
 it('returns the gap before the first block whose midpoint is below y', () => {
-  const rects = [{ top: 0, height: 20 }, { top: 20, height: 20 }, { top: 40, height: 20 }];
-  expect(gapIndexFromY(rects, 5)).toBe(0);   // above block 0 midpoint (10)
-  expect(gapIndexFromY(rects, 25)).toBe(1);  // below block 0 midpoint, above block 1 midpoint
+  const rects = [
+    { top: 0, height: 20 },
+    { top: 20, height: 20 },
+    { top: 40, height: 20 },
+  ];
+  expect(gapIndexFromY(rects, 5)).toBe(0); // above block 0 midpoint (10)
+  expect(gapIndexFromY(rects, 25)).toBe(1); // below block 0 midpoint, above block 1 midpoint
   expect(gapIndexFromY(rects, 100)).toBe(3); // past everything → end
 });
 ```
@@ -1503,8 +1556,8 @@ Expected: PASS. Then verify the full editor suite still passes:
 Run: `npm test -- src/components/RichTextEditor/`
 
 - [ ] **Step 5: Manual verification in the playground** (jsdom can't test real drag):
-Run `make dev`, open the RichTextEditor demo, drag a block by its `⠿` handle, confirm
-reorder + nested-list subtree move + undo (⌘Z) restores.
+      Run `make dev`, open the RichTextEditor demo, drag a block by its `⠿` handle, confirm
+      reorder + nested-list subtree move + undo (⌘Z) restores.
 
 - [ ] **Step 6: Commit**
 
@@ -1522,22 +1575,24 @@ git commit -m "feat(RichTextEditor): drag-to-reorder blocks (dnd-kit core)"
 - [ ] **Step 1: Add state** near the other `useState` calls:
 
 ```tsx
-  const [blockDoc, setBlockDoc] = useState<RichDoc>(() =>
-    fromMarkdown('# Block controls\n\nHover a line for the ＋/⠿ gutter.\n\n- first\n- second\n\n> Drag, duplicate, or turn into another type.'),
-  );
+const [blockDoc, setBlockDoc] = useState<RichDoc>(() =>
+  fromMarkdown(
+    '# Block controls\n\nHover a line for the ＋/⠿ gutter.\n\n- first\n- second\n\n> Drag, duplicate, or turn into another type.',
+  ),
+);
 ```
 
 - [ ] **Step 2: Add an `<Example>`** (place it after the toolbar example):
 
 ```tsx
-      <Example
-        title="Block controls"
-        description="Set blockControls to show a per-block gutter on hover/focus: ＋ inserts a block, ⠿ drags to reorder and opens a menu (turn into / duplicate / move / delete). Keyboard: Shift+F10 opens the menu, ⌘/Ctrl+⇧↑/↓ move, ⌘/Ctrl+D duplicates. Works with or without the toolbar."
-        code={`const [doc, setDoc] = useState(fromMarkdown('…'));
+<Example
+  title="Block controls"
+  description="Set blockControls to show a per-block gutter on hover/focus: ＋ inserts a block, ⠿ drags to reorder and opens a menu (turn into / duplicate / move / delete). Keyboard: Shift+F10 opens the menu, ⌘/Ctrl+⇧↑/↓ move, ⌘/Ctrl+D duplicates. Works with or without the toolbar."
+  code={`const [doc, setDoc] = useState(fromMarkdown('…'));
 <RichTextEditor value={doc} onChange={setDoc} blockControls />`}
-      >
-        <RichTextEditor value={blockDoc} onChange={setBlockDoc} blockControls placeholder="Write…" />
-      </Example>
+>
+  <RichTextEditor value={blockDoc} onChange={setBlockDoc} blockControls placeholder="Write…" />
+</Example>
 ```
 
 - [ ] **Step 3: Build the playground**
@@ -1596,9 +1651,9 @@ npm pack --dry-run -w @eocrm/design-system
 Expected: all PASS; `npm pack` shows **no** test files / internal-only paths in the tarball.
 
 - [ ] **Step 2: Spawn a fresh-context review agent** targeted at
-`packages/design-system/` per CLAUDE.md Rule 8 (10 categories; Critical/Important/
-Nice-to-have/Regression-watch + verdict). Fix every Critical + Important; note any
-deliberate skips.
+      `packages/design-system/` per CLAUDE.md Rule 8 (10 categories; Critical/Important/
+      Nice-to-have/Regression-watch + verdict). Fix every Critical + Important; note any
+      deliberate skips.
 
 - [ ] **Step 3: Re-run gates; re-review until verdict is "clean enough to stop."**
 
@@ -1616,6 +1671,7 @@ gh pr create --fill --title "feat(RichTextEditor): Notion-style block controls (
 ## Self-review (plan vs spec)
 
 **Spec coverage:**
+
 - `blockControls` opt-in prop → Task 11, 13. ✓
 - Gutter `＋`/`⠿` → Tasks 8, 10. ✓
 - Block menu (turn into / duplicate / move / delete) → Task 9. ✓
@@ -1633,6 +1689,7 @@ gh pr create --fill --title "feat(RichTextEditor): Notion-style block controls (
 - DoD / review loop / pack check → Task 17. ✓
 
 **Open verification points flagged for the implementer (not placeholders — known runtime-only unknowns):**
+
 1. `DropdownMenu.Item` `shortcut` prop existence — Task 9 notes the fallback.
 2. Exact token names in Task 12 — verify against `tokens.scss`.
 3. Gutter `top`/`left` pixel math — Task 10/14 iterate in the playground (jsdom has no layout).
@@ -1641,4 +1698,7 @@ gh pr create --fill --title "feat(RichTextEditor): Notion-style block controls (
 **Type consistency:** `BlockAction` (RichTextBlockMenu) and `BlockChoice`
 (RichTextToolbar) are reused verbatim across Tasks 9–11. Transform names match
 across tasks and the editor wiring. ✓
+
+```
+
 ```

--- a/docs/superpowers/specs/2026-06-25-richtexteditor-block-controls-design.md
+++ b/docs/superpowers/specs/2026-06-25-richtexteditor-block-controls-design.md
@@ -1,0 +1,296 @@
+# RichTextEditor block controls (Notion-style) — design
+
+**Date:** 2026-06-25
+**Status:** Approved (brainstorm) → ready for implementation plan
+**Component:** `@eocrm/design-system` › `RichTextEditor`
+**Slice:** 1 of 3
+
+---
+
+## Context — the larger effort
+
+This spec covers **Slice 1** of a three-slice effort that grew out of a request to
+add file upload to `RichTextEditor`. During brainstorming the scope expanded to a
+Notion-style block experience, which is genuinely three features. They will ship as
+three independent spec → plan → PR cycles, in this order:
+
+1. **Block control layer (this spec).** Per-block gutter controls (`＋` insert, `⠿`
+   drag/menu), a block actions menu (turn into / duplicate / move / delete), and
+   subtree-aware drag-to-reorder — built on the **existing** block types.
+2. **File upload + attachment blocks.** Void image/file **block** types + their
+   selection/caret/delete + serialization; toolbar button + clipboard-file paste →
+   consumer-provided upload handler → **inline loader** (a transient node, no full
+   placeholder) → block. Attachment blocks inherit Slice 1's controls automatically.
+3. **Attachment config.** Alt text, alignment, replace, open/download — surfaced
+   through Slice 1's block menu.
+
+**Cross-slice decisions already locked** (recorded here so later slices keep
+continuity):
+
+- Uploaded files are represented as **block-level nodes**, not inline marks — so
+  they are first-class blocks that the Slice 1 controls can drag/configure/delete,
+  consistent with the Notion model.
+- Upload feedback is a **minimal inline loader** at the insertion point (not a
+  toolbar indicator — `toolbar` defaults off and the CRM composer does not use it;
+  not a full image-sized placeholder). The editor will signal "upload in flight" so
+  the consumer can disable submit while a file is uploading.
+
+Slices 2 and 3 are **out of scope** for this spec.
+
+---
+
+## Goal
+
+Give `RichTextEditor` an opt-in, keyboard-accessible per-block control layer so a
+user can insert, reorder (including nested lists), convert, duplicate, and delete
+blocks directly — the structural-editing foundation every later slice builds on.
+
+## Scope (Slice 1)
+
+In scope:
+
+- A new opt-in prop `blockControls?: boolean` (default `false`).
+- A left **gutter overlay** that reveals two controls on the hovered/focused block:
+  - `＋` — insert an empty paragraph below the block.
+  - `⠿` — drag handle (reorder) **and** click target that opens the block menu.
+- A **block menu** (built on the existing `DropdownMenu`) with:
+  - **Turn into ▸** submenu: Text (paragraph), Heading 1/2/3, Bulleted list,
+    Numbered list, Quote, Code.
+  - **Duplicate** (⌘/Ctrl+D)
+  - **Move up** (⌘/Ctrl+⇧↑) · **Move down** (⌘/Ctrl+⇧↓)
+  - **Delete**
+- **Subtree-aware** reorder/duplicate/delete: a list item carries its descendant
+  run (following items at greater effective depth) as one unit.
+- **Drag-to-reorder** by pointer (dnd-kit core — an allowed dependency).
+- A standards-based **keyboard model** (see below).
+- New pure engine transforms: `blockUnit` (range helper), `moveBlockUnit`,
+  `duplicateBlockUnit`, `removeBlockUnit`; reuse existing `setBlockType` /
+  list toggles for "turn into".
+
+Out of scope (Slice 1):
+
+- Attachment/image blocks and upload (Slice 2). Block controls are written so a
+  void block "just works" as a unit, but no void-block rendering ships here.
+- Per-block color/background (YAGNI).
+- Multi-block selection / multi-drag. One block unit at a time.
+- A standalone exported "block menu" component. The menu is internal to
+  `RichTextEditor`.
+
+## Non-goals / guardrails
+
+- No change to default behavior: with `blockControls` unset, `RichTextEditor`
+  renders and behaves exactly as today.
+- Honors `readOnly`: when `readOnly`, no gutter, no menu, no drag.
+- Obeys CLAUDE.md Rule 4: the editor root may use `position: relative` (allowed
+  internal-anchor exception) + left padding for the gutter; **no** `margin` or
+  external layout properties.
+
+---
+
+## Public API
+
+```ts
+export interface RichTextEditorProps {
+  // …existing…
+  /**
+   * Show Notion-style per-block controls: a hover/focus gutter with an insert
+   * (`＋`) button and a drag handle (`⠿`) that reorders blocks and opens a block
+   * menu (turn into / duplicate / move / delete). Reordering is subtree-aware for
+   * nested lists. Keyboard: Shift+F10 / ContextMenu opens the focused block's
+   * menu; ⌘/Ctrl+⇧↑/↓ move it; ⌘/Ctrl+D duplicates. Default `false`. Ignored when
+   * `readOnly`.
+   */
+  blockControls?: boolean;
+}
+```
+
+No new public callbacks. All mutations route through the existing controlled
+`value` / `onChange` round-trip and the editor's internal `commit()` (so block
+operations are undoable like every other edit).
+
+---
+
+## Interaction design
+
+### Mouse
+
+- Hovering a block reveals its gutter (`＋`, `⠿`). The gutter aligns vertically to
+  the block's box; it sits in the editor's left padding, **outside** the
+  `contentEditable` (so it is never editable/selectable content).
+- `＋` → insert an empty paragraph directly below the hovered block; place the
+  caret in it.
+- `⠿` click → open the block menu, anchored to the handle.
+- `⠿` drag → reorder (see Drag-and-drop).
+
+### Keyboard (caret inside a block)
+
+- **Shift+F10 / ContextMenu key** → open the current block's menu, anchored to the
+  caret. The menu is `DropdownMenu`, already arrow/Home/End/Esc/Enter accessible.
+- **⌘/Ctrl+⇧↑ / ⌘/Ctrl+⇧↓** → move the block unit up/down by one sibling unit.
+- **⌘/Ctrl+D** → duplicate the block unit (caret lands in the copy).
+- **Enter** already inserts a block (normal split); there is no extra insert
+  shortcut. Block **Delete** is menu-only — Backspace/Delete keep editing text.
+- The gutter buttons are real `<button>`s with i18n `aria-label`s but
+  `tabindex={-1}`, so a long document does not add one tab stop per block. The
+  keyboard path is Shift+F10 + the shortcuts above.
+
+### Menu → engine mapping
+
+| Menu item        | Engine call                                              |
+| ---------------- | ------------------------------------------------------- |
+| Turn into: Text  | `setBlockType(doc, id, { type: 'paragraph' })`          |
+| Turn into: H1–3  | `setBlockType(doc, id, { type: 'heading', level })`     |
+| Turn into: lists | existing list toggle (`runToggleList`) semantics        |
+| Turn into: Quote | `setBlockType(doc, id, { type: 'blockquote' })`          |
+| Turn into: Code  | `setBlockType(doc, id, { type: 'code_block' })`          |
+| Duplicate        | `duplicateBlockUnit(doc, id)`                            |
+| Move up / down   | `moveBlockUnit(doc, id, -1 | +1)`                        |
+| Delete           | `removeBlockUnit(doc, id)`                               |
+
+"Turn into" acts on the single anchor block (matching the existing toolbar
+block-type behavior); it does not rewrite a whole subtree.
+
+---
+
+## Engine changes (pure, immutable, tested in isolation)
+
+New file `RichText/engine/blockUnit.ts` (or fold into `transforms.ts`):
+
+- **`blockUnitRange(blocks, index): { start: number; end: number }`** — the
+  half-open index range of the "unit" anchored at `index`. For a non-list block,
+  `{ index, index+1 }`. For a list item at effective depth `d`, extend through the
+  maximal contiguous run of following list items whose effective depth `> d`
+  (computed via `effectiveDepths` + `isListItem`). This is the descendant run.
+
+Transforms returning `{ doc, selection }` (consistent with the existing transform
+contract):
+
+- **`moveBlockUnit(doc, blockId, dir: -1 | 1)`** — find the unit; find the adjacent
+  **sibling unit** in `dir` (skipping over a sibling's whole subtree); splice the
+  moving unit to the other side. No-op at the document edges. Depth handling: the
+  unit keeps its internal relative depths; the unit's top block clamps to a depth
+  valid for its new neighbor (`[0, prevSiblingEffectiveDepth + 1]`), descendants
+  shift by the same delta. `effectiveDepths` normalizes any residual gap at render.
+- **`duplicateBlockUnit(doc, blockId)`** — clone the unit's blocks with fresh ids
+  (`nextId()`), insert immediately after the unit; caret to the start of the clone.
+- **`removeBlockUnit(doc, blockId)`** — delete the unit's blocks. If that empties
+  the document, leave a single empty paragraph (mirror `emptyDoc()`); caret to the
+  nearest surviving block (next, else previous).
+
+`setBlockType` and the list-toggle command already exist and are reused as-is.
+
+All four are pure and get a dedicated `*.test.ts` covering: plain blocks, a list
+item with/without children, units at the first/last position, single-block doc,
+and depth clamping on drop.
+
+---
+
+## Component structure
+
+- **`RichTextBlockGutter.tsx`** (new, internal) — the overlay layer. Given the
+  editor root ref and the doc, it renders, for the active (hovered/focused) block,
+  the `＋` and `⠿` buttons positioned at that block's box (measured from the block
+  element's `getBoundingClientRect()` relative to the root). Hidden when none
+  active or `readOnly`.
+- **`RichTextBlockMenu.tsx`** (new, internal) — wraps `DropdownMenu` with the
+  fixed action set + the "Turn into" submenu; takes the target `blockId` and
+  callbacks that dispatch the engine transforms through the editor's `commit()`.
+- **`RichTextEditor.tsx`** (modified) — when `blockControls && !readOnly`:
+  - track the **active block** (block under the pointer; and the block containing
+    the caret via the existing `selectionchange` subscription);
+  - render the gutter + menu next to the existing editable / link bubble / mention
+    menu fragments;
+  - add the keyboard handlers (Shift+F10, ⌘⇧↑/↓, ⌘D) in `onKeyDown`, routing to the
+    new transforms via `commit()`;
+  - wrap (only when enabled) the editable in the dnd context for reorder.
+- **`RichTextEditor.module.scss`** (modified) — gutter/overlay styles (tokens
+  only), editor left-padding to reserve gutter space, `position: relative` anchor.
+
+The engine's `renderDoc` already stamps `data-block-id` on every block element in
+editable mode, which the gutter uses to locate block boxes — **no renderDoc change
+needed** for Slice 1.
+
+## Drag-and-drop
+
+Blocks render inside a single `contentEditable`, so each block is not an
+independent React component we can hang `useSortable` on. Approach:
+
+- Use **dnd-kit core** (`@dnd-kit/core`, allowed) with the `⠿` handle as the
+  draggable. Compute the **drop index** from the pointer's Y against block boxes
+  (`data-block-id` rects). Render a drop indicator line between blocks.
+- On drop, translate (fromUnit, toIndex) into a `moveBlockUnit`-style splice and
+  `commit()` once (one undo step).
+- Evaluate the existing `<Sortable>` wrapper first; if the single-contentEditable
+  root prevents per-item sortable nodes, fall back to dnd-kit core with the
+  geometry-based drop calc above. Keyboard reorder is served by ⌘⇧↑/↓ (the
+  dnd-kit keyboard sensor is optional parity, not required for a11y here).
+- Disable native `draggable` text behavior conflicts: dragging starts only from
+  the handle, never from selected text.
+
+## Focus & selection management
+
+- After insert/duplicate/move/turn-into/delete, set `pendingSelectionRef` so the
+  existing `useLayoutEffect` restores the caret to the right block after re-render
+  (same mechanism every current transform uses).
+- Opening the menu does not move the model caret; closing returns focus to the
+  editable.
+
+## Edge cases
+
+- Move up/down at the document edge → no-op (no commit, no history entry).
+- Turn into / delete inside a list correctly handle the subtree via the unit
+  helpers; `effectiveDepths` keeps rendering gap-free.
+- Empty document after delete → one empty paragraph remains.
+- `readOnly` → controls fully suppressed.
+- Code blocks and quotes are plain non-list units (range is the single block).
+
+---
+
+## i18n (new keys; values in both `en.ts` and `ru.ts`)
+
+- `richTextEditor.blockInsert` — `＋` aria-label ("Insert block below")
+- `richTextEditor.blockActions` — `⠿` aria-label ("Block actions")
+- `richTextEditor.blockMenu.turnInto` (+ option labels: text, heading1/2/3,
+  bulletList, numberedList, quote, code)
+- `richTextEditor.blockMenu.duplicate`
+- `richTextEditor.blockMenu.moveUp`
+- `richTextEditor.blockMenu.moveDown`
+- `richTextEditor.blockMenu.delete`
+
+---
+
+## Testing
+
+Engine (pure): dedicated tests for `blockUnitRange`, `moveBlockUnit`,
+`duplicateBlockUnit`, `removeBlockUnit` (cases listed above).
+
+Component (`RichTextEditor.test.tsx` additions):
+
+- `blockControls` off → no gutter/menu in the DOM (default-behavior guard).
+- Gutter appears for the focused block; buttons carry the i18n aria-labels and are
+  `tabindex=-1`.
+- `＋` inserts an empty paragraph below and moves the caret into it.
+- Menu opens via click and via Shift+F10; arrow/Esc work (DropdownMenu).
+- Turn into → block type changes; Duplicate → clone after the unit; Move up/down →
+  reorder (incl. a nested list unit moving with its children); Delete → unit gone.
+- ⌘⇧↑/↓, ⌘D shortcuts fire the same transforms; each is a single undo step.
+- `readOnly` → no controls.
+
+## Definition of done (design-system checklist)
+
+- [ ] Engine transforms + tests (Rule 1)
+- [ ] `RichTextEditor` wiring + component tests (Rule 1)
+- [ ] All new strings via i18n in `en.ts` + `ru.ts` (Rule 9)
+- [ ] JSDoc on the new `blockControls` prop + `@remarks` anti-patterns (Rule 7)
+- [ ] Tokens only in SCSS; no forbidden layout props (Rules 3, 4)
+- [ ] Playground demo updated to show `blockControls` (Rule 2) — extend
+      `RichTextEditorDemo.tsx`; no new route needed (same component)
+- [ ] `AGENTS.md` TL;DR updated for the new prop
+- [ ] Manifest unchanged (no new component/cluster) — confirm during plan
+- [ ] Pre-push review-fix loop (Rule 8); gates green; `npm pack --dry-run` clean
+
+## Future (later slices, not built here)
+
+- Slice 2: void attachment blocks + upload + inline loader + busy signal.
+- Slice 3: attachment config via the block menu (alt text, align, replace,
+  open/download).

--- a/docs/superpowers/specs/2026-06-25-richtexteditor-block-controls-design.md
+++ b/docs/superpowers/specs/2026-06-25-richtexteditor-block-controls-design.md
@@ -136,16 +136,16 @@ operations are undoable like every other edit).
 
 ### Menu → engine mapping
 
-| Menu item        | Engine call                                              |
-| ---------------- | ------------------------------------------------------- |
-| Turn into: Text  | `setBlockType(doc, id, { type: 'paragraph' })`          |
-| Turn into: H1–3  | `setBlockType(doc, id, { type: 'heading', level })`     |
-| Turn into: lists | existing list toggle (`runToggleList`) semantics        |
-| Turn into: Quote | `setBlockType(doc, id, { type: 'blockquote' })`          |
-| Turn into: Code  | `setBlockType(doc, id, { type: 'code_block' })`          |
-| Duplicate        | `duplicateBlockUnit(doc, id)`                            |
-| Move up / down   | `moveBlockUnit(doc, id, -1 | +1)`                        |
-| Delete           | `removeBlockUnit(doc, id)`                               |
+| Menu item        | Engine call                                         |
+| ---------------- | --------------------------------------------------- | ---- |
+| Turn into: Text  | `setBlockType(doc, id, { type: 'paragraph' })`      |
+| Turn into: H1–3  | `setBlockType(doc, id, { type: 'heading', level })` |
+| Turn into: lists | existing list toggle (`runToggleList`) semantics    |
+| Turn into: Quote | `setBlockType(doc, id, { type: 'blockquote' })`     |
+| Turn into: Code  | `setBlockType(doc, id, { type: 'code_block' })`     |
+| Duplicate        | `duplicateBlockUnit(doc, id)`                       |
+| Move up / down   | `moveBlockUnit(doc, id, -1                          | +1)` |
+| Delete           | `removeBlockUnit(doc, id)`                          |
 
 "Turn into" acts on the single anchor block (matching the existing toolbar
 block-type behavior); it does not rewrite a whole subtree.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -977,7 +977,7 @@ const [doc, setDoc] = useState(emptyDoc());
 
 **Pending marks:** toggling a mark at a collapsed caret (via toolbar or ⌘B/I/U/⌘⇧X shortcut) queues it; the next inserted text gets that mark applied, then the queue clears. Moving the caret discards pending marks.
 
-**`blockControls` prop** (opt-in, default off): Notion-style per-block gutter — `＋` insert below, `⠿` drag-to-reorder + a block menu (turn into / duplicate / move up·down / delete). Subtree-aware for nested lists. Keyboard: Shift+F10 opens the menu, ⌘/Ctrl+⇧↑·↓ move, ⌘/Ctrl+D duplicate. Independent of `toolbar`; ignored when `readOnly`. All ops route through `value`/`onChange` and are undoable.
+**`blockControls` prop** (opt-in, default off): Notion-style per-block gutter — `＋` insert below, `⠿` drag-to-reorder + a block menu (turn into / duplicate / move up·down / delete). Reorder/duplicate/delete are subtree-aware for nested lists (a list item carries its nested children); **turn-into acts on the single anchor block only** (idempotent — choosing the current type is a no-op). Keyboard: Shift+F10 opens the menu, ⌘/Ctrl+⇧↑·↓ move, ⌘/Ctrl+D duplicate. Independent of `toolbar`; ignored when `readOnly`. All ops route through `value`/`onChange` and are undoable.
 
 **Links:** select text and press ⌘/Ctrl+K (or the toolbar link button) to add or edit a link; with the caret inside a link the URL is pre-filled and a Remove button appears; with no selection the URL is inserted as linked text. Esc / click-outside cancels. Stored hrefs are sanitized at render time (`safeHref` blocks `javascript:`/`data:`/protocol-relative).
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -977,6 +977,8 @@ const [doc, setDoc] = useState(emptyDoc());
 
 **Pending marks:** toggling a mark at a collapsed caret (via toolbar or ⌘B/I/U/⌘⇧X shortcut) queues it; the next inserted text gets that mark applied, then the queue clears. Moving the caret discards pending marks.
 
+**`blockControls` prop** (opt-in, default off): Notion-style per-block gutter — `＋` insert below, `⠿` drag-to-reorder + a block menu (turn into / duplicate / move up·down / delete). Subtree-aware for nested lists. Keyboard: Shift+F10 opens the menu, ⌘/Ctrl+⇧↑·↓ move, ⌘/Ctrl+D duplicate. Independent of `toolbar`; ignored when `readOnly`. All ops route through `value`/`onChange` and are undoable.
+
 **Links:** select text and press ⌘/Ctrl+K (or the toolbar link button) to add or edit a link; with the caret inside a link the URL is pre-filled and a Remove button appears; with no selection the URL is inserted as linked text. Esc / click-outside cancels. Stored hrefs are sanitized at render time (`safeHref` blocks `javascript:`/`data:`/protocol-relative).
 
 **Autolink** (`autolink` prop, default `true`): typing a URL followed by a space, or pasting text containing a URL, turns it into a `link` mark automatically (`http(s)://…` or a bare `www.…` host; unsafe schemes are left as plain text). Set `autolink={false}` to disable both the type rule and paste autolinking.

--- a/packages/design-system/src/components/RichText/engine/blockUnit.test.ts
+++ b/packages/design-system/src/components/RichText/engine/blockUnit.test.ts
@@ -160,4 +160,19 @@ describe('moveBlockUnitToIndex', () => {
     const r = moveBlockUnitToIndex(doc([li('a', 1), p('z')]), 'a', 2);
     expect(r.doc.blocks.find((b) => b.id === 'a')!.depth).toBe(0);
   });
+  it('no-op (same ref) when dropped back onto its own slot', () => {
+    const d = doc([p('a'), p('b')]);
+    expect(moveBlockUnitToIndex(d, 'a', 0).doc).toBe(d);
+  });
+});
+
+describe('unknown blockId', () => {
+  it('every transform is a no-op returning the same doc ref', () => {
+    const d = doc([p('a')]);
+    expect(moveBlockUnit(d, 'nope', 1).doc).toBe(d);
+    expect(duplicateBlockUnit(d, 'nope').doc).toBe(d);
+    expect(removeBlockUnit(d, 'nope').doc).toBe(d);
+    expect(insertEmptyBlockBelow(d, 'nope').doc).toBe(d);
+    expect(moveBlockUnitToIndex(d, 'nope', 0).doc).toBe(d);
+  });
 });

--- a/packages/design-system/src/components/RichText/engine/blockUnit.test.ts
+++ b/packages/design-system/src/components/RichText/engine/blockUnit.test.ts
@@ -1,0 +1,163 @@
+import { createBlock } from './model';
+import type { Block, RichDoc } from './model';
+import {
+  blockUnitRange,
+  prevSiblingAnchor,
+  moveBlockUnit,
+  duplicateBlockUnit,
+  removeBlockUnit,
+  insertEmptyBlockBelow,
+  moveBlockUnitToIndex,
+} from './blockUnit';
+
+const p = (id: string) => createBlock('paragraph', id, { id });
+const li = (id: string, depth: number) => createBlock('bullet_item', id, { id, depth });
+const doc = (blocks: Block[]): RichDoc => ({ blocks });
+const ids = (d: RichDoc) => d.blocks.map((b) => b.id);
+
+describe('blockUnitRange', () => {
+  it('a non-list block is its own unit', () => {
+    expect(blockUnitRange([p('a'), p('b')], 0)).toEqual({ start: 0, end: 1 });
+  });
+  it('a list item carries its deeper descendant run', () => {
+    const blocks = [li('a', 0), li('b', 1), li('c', 2), li('d', 0)];
+    expect(blockUnitRange(blocks, 0)).toEqual({ start: 0, end: 3 });
+    expect(blockUnitRange(blocks, 1)).toEqual({ start: 1, end: 3 });
+    expect(blockUnitRange(blocks, 3)).toEqual({ start: 3, end: 4 });
+  });
+  it('stops at a sibling of equal depth', () => {
+    expect(blockUnitRange([li('a', 0), li('b', 1), li('c', 0)], 0)).toEqual({ start: 0, end: 2 });
+  });
+  it('stops at a non-list block', () => {
+    expect(blockUnitRange([li('a', 0), p('b')], 0)).toEqual({ start: 0, end: 1 });
+  });
+});
+
+describe('prevSiblingAnchor', () => {
+  it('returns the previous top-level block for a paragraph', () => {
+    expect(prevSiblingAnchor([p('a'), p('b')], 1)).toBe(0);
+  });
+  it('skips a previous sibling subtree to find the sibling anchor', () => {
+    expect(prevSiblingAnchor([li('a', 0), li('b', 1), li('c', 0)], 2)).toBe(0);
+  });
+  it('returns -1 for a first child (no prev sibling at its depth)', () => {
+    expect(prevSiblingAnchor([li('a', 0), li('b', 1)], 1)).toBe(-1);
+  });
+});
+
+describe('moveBlockUnit', () => {
+  it('moves a paragraph down past the next unit', () => {
+    expect(ids(moveBlockUnit(doc([p('a'), p('b'), p('c')]), 'a', 1).doc)).toEqual(['b', 'a', 'c']);
+  });
+  it('moves a paragraph up past the previous unit', () => {
+    expect(ids(moveBlockUnit(doc([p('a'), p('b'), p('c')]), 'c', -1).doc)).toEqual(['a', 'c', 'b']);
+  });
+  it('is a no-op at the top edge (same ref)', () => {
+    const d = doc([p('a'), p('b')]);
+    expect(moveBlockUnit(d, 'a', -1).doc).toBe(d);
+  });
+  it('is a no-op at the bottom edge (same ref)', () => {
+    const d = doc([p('a'), p('b')]);
+    expect(moveBlockUnit(d, 'b', 1).doc).toBe(d);
+  });
+  it('carries a list subtree when swapping with a sibling subtree', () => {
+    const d = doc([li('a', 0), li('a1', 1), li('b', 0), li('b1', 1)]);
+    expect(ids(moveBlockUnit(d, 'a', 1).doc)).toEqual(['b', 'b1', 'a', 'a1']);
+  });
+  it('moves a nested item among its siblings only', () => {
+    expect(ids(moveBlockUnit(doc([li('a', 0), li('x', 1), li('y', 1)]), 'x', 1).doc)).toEqual([
+      'a',
+      'y',
+      'x',
+    ]);
+  });
+  it('caret lands on the moved anchor', () => {
+    expect(moveBlockUnit(doc([p('a'), p('b')]), 'a', 1).selection.anchor.blockId).toBe('a');
+  });
+});
+
+describe('duplicateBlockUnit', () => {
+  it('clones a paragraph right after itself with a fresh id', () => {
+    const r = duplicateBlockUnit(doc([p('a'), p('b')]), 'a');
+    expect(r.doc.blocks.length).toBe(3);
+    expect(r.doc.blocks[1].id).not.toBe('a');
+    expect(ids(r.doc)[2]).toBe('b');
+  });
+  it('clones a list subtree with fresh ids and same depths', () => {
+    const r = duplicateBlockUnit(doc([li('a', 0), li('a1', 1), p('z')]), 'a');
+    expect(r.doc.blocks.map((b) => b.type)).toEqual([
+      'bullet_item',
+      'bullet_item',
+      'bullet_item',
+      'bullet_item',
+      'paragraph',
+    ]);
+    expect(r.doc.blocks[2].depth).toBe(0);
+    expect(r.doc.blocks[3].depth).toBe(1);
+    expect(r.doc.blocks[2].id).not.toBe('a');
+  });
+  it('caret lands on the clone anchor', () => {
+    const r = duplicateBlockUnit(doc([p('a')]), 'a');
+    expect(r.selection.anchor.blockId).toBe(r.doc.blocks[1].id);
+  });
+});
+
+describe('removeBlockUnit', () => {
+  it('removes a paragraph; caret to the next block', () => {
+    const r = removeBlockUnit(doc([p('a'), p('b')]), 'a');
+    expect(ids(r.doc)).toEqual(['b']);
+    expect(r.selection.anchor.blockId).toBe('b');
+  });
+  it('removes a list subtree as a unit', () => {
+    expect(ids(removeBlockUnit(doc([li('a', 0), li('a1', 1), p('z')]), 'a').doc)).toEqual(['z']);
+  });
+  it('removing the last block leaves one empty paragraph', () => {
+    const r = removeBlockUnit(doc([p('a')]), 'a');
+    expect(r.doc.blocks.length).toBe(1);
+    expect(r.doc.blocks[0].type).toBe('paragraph');
+    expect(r.doc.blocks[0].id).not.toBe('a');
+  });
+  it('caret falls back to the previous block when removing the last unit', () => {
+    expect(removeBlockUnit(doc([p('a'), p('b')]), 'b').selection.anchor.blockId).toBe('a');
+  });
+});
+
+describe('insertEmptyBlockBelow', () => {
+  it('inserts an empty paragraph after the block unit; caret in it', () => {
+    const r = insertEmptyBlockBelow(doc([p('a'), p('b')]), 'a');
+    expect(ids(r.doc)[0]).toBe('a');
+    expect(r.doc.blocks[1].type).toBe('paragraph');
+    expect(r.doc.blocks[1].id).toBe(r.selection.anchor.blockId);
+    expect(ids(r.doc)[2]).toBe('b');
+  });
+  it('inserts after a list subtree, not inside it', () => {
+    const r = insertEmptyBlockBelow(doc([li('a', 0), li('a1', 1)]), 'a');
+    expect(r.doc.blocks.length).toBe(3);
+    expect(r.doc.blocks[2].type).toBe('paragraph');
+  });
+});
+
+describe('moveBlockUnitToIndex', () => {
+  it('moves a paragraph to a later gap', () => {
+    expect(ids(moveBlockUnitToIndex(doc([p('a'), p('b'), p('c')]), 'a', 3).doc)).toEqual([
+      'b',
+      'c',
+      'a',
+    ]);
+  });
+  it('moves a paragraph to an earlier gap', () => {
+    expect(ids(moveBlockUnitToIndex(doc([p('a'), p('b'), p('c')]), 'c', 0).doc)).toEqual([
+      'c',
+      'a',
+      'b',
+    ]);
+  });
+  it('no-op when target is inside the moving unit (same ref)', () => {
+    const d = doc([li('a', 0), li('a1', 1), p('z')]);
+    expect(moveBlockUnitToIndex(d, 'a', 1).doc).toBe(d);
+  });
+  it('clamps a dropped list item depth when it lands among non-list blocks', () => {
+    const r = moveBlockUnitToIndex(doc([li('a', 1), p('z')]), 'a', 2);
+    expect(r.doc.blocks.find((b) => b.id === 'a')!.depth).toBe(0);
+  });
+});

--- a/packages/design-system/src/components/RichText/engine/blockUnit.ts
+++ b/packages/design-system/src/components/RichText/engine/blockUnit.ts
@@ -143,11 +143,16 @@ export function moveBlockUnitToIndex(
   const rest = [...blocks.slice(0, u.start), ...blocks.slice(u.end)];
   let insertAt = target > u.start ? target - moving.length : target;
   insertAt = Math.max(0, Math.min(insertAt, rest.length));
+  // No movement (dropped back onto its own slot) → same doc ref, like moveBlockUnit's no-ops.
+  if (insertAt === u.start) return { doc, selection: collapsed(blockId) };
 
   let adjusted = moving;
   if (isListItem(moving[0])) {
     const prev = insertAt - 1;
-    const prevDepth = prev >= 0 && isListItem(rest[prev]) ? (rest[prev].depth ?? 0) : -1;
+    // Clamp against the predecessor's EFFECTIVE depth (what the renderer shows),
+    // consistent with the rest of the engine's depth reasoning.
+    const effRest = effectiveDepths(rest);
+    const prevDepth = prev >= 0 && isListItem(rest[prev]) ? effRest[prev] : -1;
     const maxDepth = prevDepth + 1;
     const topRaw = moving[0].depth ?? 0;
     const newTop = Math.max(0, Math.min(topRaw, maxDepth));

--- a/packages/design-system/src/components/RichText/engine/blockUnit.ts
+++ b/packages/design-system/src/components/RichText/engine/blockUnit.ts
@@ -1,0 +1,163 @@
+// blockUnit.ts — Layer D. Block-"unit" helpers + structural transforms. A unit is
+// a single block, except a list item, which carries its deeper descendant run
+// (the contiguous following items at greater effective depth). Pure + immutable.
+import type { RichDoc, Block, Range } from './model';
+import { createBlock, nextId, emptyDoc } from './model';
+import { isListItem, effectiveDepths } from './listDepths';
+import { findBlockIndex } from './position';
+
+function collapsed(blockId: string, offset = 0): Range {
+  return { anchor: { blockId, offset }, focus: { blockId, offset } };
+}
+
+/** Half-open index range `[start, end)` of the unit anchored at `index`. */
+export function blockUnitRange(blocks: Block[], index: number): { start: number; end: number } {
+  if (index < 0 || index >= blocks.length) return { start: index, end: index };
+  if (!isListItem(blocks[index])) return { start: index, end: index + 1 };
+  const eff = effectiveDepths(blocks);
+  const d = eff[index];
+  let end = index + 1;
+  while (end < blocks.length && isListItem(blocks[end]) && eff[end] > d) end += 1;
+  return { start: index, end };
+}
+
+/**
+ * Index of the previous sibling's anchor (same effective depth, same list run),
+ * or -1 when `index` is the first child / first block. Descendant blocks of an
+ * earlier sibling (greater depth) are skipped.
+ */
+export function prevSiblingAnchor(blocks: Block[], index: number): number {
+  const eff = effectiveDepths(blocks);
+  const d = eff[index];
+  for (let i = index - 1; i >= 0; i -= 1) {
+    if (eff[i] < d) return -1; // hit an ancestor (or a depth-0 boundary for d>0)
+    if (eff[i] === d && (d === 0 || isListItem(blocks[i]))) return i;
+    // eff[i] > d → descendant of an earlier sibling: keep skipping
+  }
+  return -1;
+}
+
+/**
+ * Swap the unit anchored at `blockId` with its adjacent SIBLING unit (`dir`: -1
+ * up / +1 down). Same-depth swap, so depths are preserved. No-op (returns the
+ * SAME doc reference) at an edge / when there is no sibling in that direction.
+ */
+export function moveBlockUnit(
+  doc: RichDoc,
+  blockId: string,
+  dir: -1 | 1,
+): { doc: RichDoc; selection: Range } {
+  const blocks = doc.blocks;
+  const idx = findBlockIndex(doc, blockId);
+  if (idx === -1) return { doc, selection: collapsed(blockId) };
+  const u = blockUnitRange(blocks, idx);
+
+  if (dir < 0) {
+    const p = prevSiblingAnchor(blocks, idx);
+    if (p === -1) return { doc, selection: collapsed(blockId) };
+    const moving = blocks.slice(u.start, u.end);
+    const before = blocks.slice(p, u.start);
+    const next = [...blocks.slice(0, p), ...moving, ...before, ...blocks.slice(u.end)];
+    return { doc: { blocks: next }, selection: collapsed(blockId) };
+  }
+
+  const eff = effectiveDepths(blocks);
+  const d = eff[idx];
+  if (u.end >= blocks.length || eff[u.end] !== d) return { doc, selection: collapsed(blockId) };
+  const nextUnit = blockUnitRange(blocks, u.end);
+  const moving = blocks.slice(u.start, u.end);
+  const after = blocks.slice(u.end, nextUnit.end);
+  const next = [...blocks.slice(0, u.start), ...after, ...moving, ...blocks.slice(nextUnit.end)];
+  return { doc: { blocks: next }, selection: collapsed(blockId) };
+}
+
+/** Clone a block with a fresh id (inline runs copied so marks aren't shared). */
+function cloneBlock(b: Block): Block {
+  return { ...b, id: nextId(), inlines: b.inlines.map((r) => ({ ...r, marks: r.marks.slice() })) };
+}
+
+/**
+ * Duplicate the unit anchored at `blockId`, inserting the clones immediately
+ * after the unit. Fresh ids; depths preserved. Caret lands on the clone's anchor.
+ */
+export function duplicateBlockUnit(
+  doc: RichDoc,
+  blockId: string,
+): { doc: RichDoc; selection: Range } {
+  const idx = findBlockIndex(doc, blockId);
+  if (idx === -1) return { doc, selection: collapsed(blockId) };
+  const u = blockUnitRange(doc.blocks, idx);
+  const copies = doc.blocks.slice(u.start, u.end).map(cloneBlock);
+  const blocks = [...doc.blocks.slice(0, u.end), ...copies, ...doc.blocks.slice(u.end)];
+  return { doc: { blocks }, selection: collapsed(copies[0].id) };
+}
+
+/**
+ * Remove the unit anchored at `blockId`. Empties to a single empty paragraph if
+ * it was the whole document. Caret lands on the next surviving block, else the
+ * previous, else the new empty paragraph.
+ */
+export function removeBlockUnit(doc: RichDoc, blockId: string): { doc: RichDoc; selection: Range } {
+  const idx = findBlockIndex(doc, blockId);
+  if (idx === -1) return { doc, selection: collapsed(blockId) };
+  const u = blockUnitRange(doc.blocks, idx);
+  const blocks = [...doc.blocks.slice(0, u.start), ...doc.blocks.slice(u.end)];
+  if (blocks.length === 0) {
+    const fresh = emptyDoc();
+    return { doc: fresh, selection: collapsed(fresh.blocks[0].id) };
+  }
+  const caretIdx = Math.min(u.start, blocks.length - 1);
+  return { doc: { blocks }, selection: collapsed(blocks[caretIdx].id) };
+}
+
+/** Insert an empty paragraph directly after the block unit anchored at `blockId`. */
+export function insertEmptyBlockBelow(
+  doc: RichDoc,
+  blockId: string,
+): { doc: RichDoc; selection: Range } {
+  const idx = findBlockIndex(doc, blockId);
+  if (idx === -1) return { doc, selection: collapsed(blockId) };
+  const u = blockUnitRange(doc.blocks, idx);
+  const fresh = createBlock('paragraph');
+  const blocks = [...doc.blocks.slice(0, u.end), fresh, ...doc.blocks.slice(u.end)];
+  return { doc: { blocks }, selection: collapsed(fresh.id) };
+}
+
+/**
+ * Move the unit anchored at `blockId` so its first block lands at array index
+ * `target` (coordinates of the CURRENT array). The moved unit's top depth is
+ * clamped to a value valid for its new predecessor (`prevListDepth + 1`, else 0);
+ * descendants shift by the same delta. No-op when `target` falls inside the unit.
+ */
+export function moveBlockUnitToIndex(
+  doc: RichDoc,
+  blockId: string,
+  target: number,
+): { doc: RichDoc; selection: Range } {
+  const blocks = doc.blocks;
+  const idx = findBlockIndex(doc, blockId);
+  if (idx === -1) return { doc, selection: collapsed(blockId) };
+  const u = blockUnitRange(blocks, idx);
+  if (target > u.start && target < u.end) return { doc, selection: collapsed(blockId) };
+  const moving = blocks.slice(u.start, u.end);
+  const rest = [...blocks.slice(0, u.start), ...blocks.slice(u.end)];
+  let insertAt = target > u.start ? target - moving.length : target;
+  insertAt = Math.max(0, Math.min(insertAt, rest.length));
+
+  let adjusted = moving;
+  if (isListItem(moving[0])) {
+    const prev = insertAt - 1;
+    const prevDepth = prev >= 0 && isListItem(rest[prev]) ? (rest[prev].depth ?? 0) : -1;
+    const maxDepth = prevDepth + 1;
+    const topRaw = moving[0].depth ?? 0;
+    const newTop = Math.max(0, Math.min(topRaw, maxDepth));
+    const delta = newTop - topRaw;
+    if (delta !== 0) {
+      adjusted = moving.map((b) =>
+        isListItem(b) ? { ...b, depth: Math.max(0, (b.depth ?? 0) + delta) } : b,
+      );
+    }
+  }
+  const next = [...rest.slice(0, insertAt), ...adjusted, ...rest.slice(insertAt)];
+  return { doc: { blocks: next }, selection: collapsed(blockId) };
+}

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
@@ -39,6 +39,21 @@ it('fires onInsertBelow with the active block id', async () => {
   expect(onInsertBelow).toHaveBeenCalledWith('b1');
 });
 
+it('binds the active block id into the menu onAction callback', async () => {
+  const onAction = vi.fn();
+  render(<Harness menuOpen onAction={onAction} />);
+  await userEvent.click(screen.getByRole('menuitem', { name: /duplicate/i }));
+  expect(onAction).toHaveBeenCalledWith('b1', 'duplicate');
+});
+
+it('binds the active block id into the menu onTurnInto callback', async () => {
+  const onTurnInto = vi.fn();
+  render(<Harness menuOpen onTurnInto={onTurnInto} />);
+  await userEvent.click(screen.getByRole('menuitem', { name: /turn into/i }));
+  await userEvent.click(await screen.findByRole('menuitem', { name: 'Heading 1' }));
+  expect(onTurnInto).toHaveBeenCalledWith('b1', { type: 'heading', level: 1 });
+});
+
 it('renders nothing when activeBlockId is null', () => {
   function NullHarness() {
     const rootRef = useRef<HTMLDivElement>(null);

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
@@ -19,6 +19,7 @@ function Harness(props: Partial<React.ComponentProps<typeof RichTextBlockControl
           onInsertBelow={() => {}}
           onAction={() => {}}
           onTurnInto={() => {}}
+          onReorder={() => {}}
           {...props}
         />
       </div>
@@ -68,6 +69,7 @@ it('renders nothing when activeBlockId is null', () => {
             onInsertBelow={() => {}}
             onAction={() => {}}
             onTurnInto={() => {}}
+            onReorder={() => {}}
           />
         </div>
       </I18nProvider>

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
@@ -1,0 +1,63 @@
+// RichTextBlockControls.test.tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRef } from 'react';
+import { I18nProvider } from '../../i18n';
+import { RichTextBlockControls } from './RichTextBlockControls';
+
+function Harness(props: Partial<React.ComponentProps<typeof RichTextBlockControls>>) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  return (
+    <I18nProvider locale="en">
+      <div ref={rootRef} style={{ position: 'relative' }}>
+        <p data-block-id="b1">hello</p>
+        <RichTextBlockControls
+          rootRef={rootRef}
+          activeBlockId="b1"
+          menuOpen={false}
+          onMenuOpenChange={() => {}}
+          onInsertBelow={() => {}}
+          onAction={() => {}}
+          onTurnInto={() => {}}
+          {...props}
+        />
+      </div>
+    </I18nProvider>
+  );
+}
+
+it('renders insert + actions buttons for the active block', () => {
+  render(<Harness />);
+  expect(screen.getByRole('button', { name: 'Insert block below' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Block actions' })).toBeInTheDocument();
+});
+
+it('fires onInsertBelow with the active block id', async () => {
+  const onInsertBelow = vi.fn();
+  render(<Harness onInsertBelow={onInsertBelow} />);
+  await userEvent.click(screen.getByRole('button', { name: 'Insert block below' }));
+  expect(onInsertBelow).toHaveBeenCalledWith('b1');
+});
+
+it('renders nothing when activeBlockId is null', () => {
+  function NullHarness() {
+    const rootRef = useRef<HTMLDivElement>(null);
+    return (
+      <I18nProvider locale="en">
+        <div ref={rootRef}>
+          <RichTextBlockControls
+            rootRef={rootRef}
+            activeBlockId={null}
+            menuOpen={false}
+            onMenuOpenChange={() => {}}
+            onInsertBelow={() => {}}
+            onAction={() => {}}
+            onTurnInto={() => {}}
+          />
+        </div>
+      </I18nProvider>
+    );
+  }
+  render(<NullHarness />);
+  expect(screen.queryByRole('button', { name: 'Insert block below' })).toBeNull();
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -48,6 +48,7 @@ export function RichTextBlockControls({
   useLayoutEffect(() => {
     if (!activeBlockId) {
       setTop(null);
+      setRetry(0); // fresh retry budget for the next activation
       return;
     }
     const root = rootRef.current;

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -2,15 +2,25 @@
 // inside the editor shell (position: relative), aligned to the active block's box.
 // Lives OUTSIDE the contentEditable so it is never editable content.
 import { useLayoutEffect, useState, type RefObject } from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  useDraggable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragMoveEvent,
+} from '@dnd-kit/core';
 import { Button } from '../Button';
 import { useTranslation } from '../../i18n';
 import { RichTextBlockMenu, type BlockAction } from './RichTextBlockMenu';
 import type { BlockChoice } from './RichTextToolbar';
 import { PlusIcon } from './icons';
+import { gapIndexFromY } from './blockDrop';
 import styles from './RichTextEditor.module.scss';
 
 export interface RichTextBlockControlsProps {
-  /** The editor root (contentEditable) element ref — used to locate block boxes. */
+  /** The editor shell element ref — used to locate block boxes + anchor overlays. */
   rootRef: RefObject<HTMLElement | null>;
   /** Block currently hovered or holding the caret; null hides the gutter. */
   activeBlockId: string | null;
@@ -20,14 +30,54 @@ export interface RichTextBlockControlsProps {
   onInsertBelow: (blockId: string) => void;
   onAction: (blockId: string, action: BlockAction) => void;
   onTurnInto: (blockId: string, choice: BlockChoice) => void;
+  /**
+   * Reorder the active block to land at `targetIndex` — a "gap" (0..N) in the
+   * CURRENT block array. Fired when a grip drag is dropped. Wired by the editor
+   * to the subtree-aware `moveBlockUnitToIndex` engine transform.
+   */
+  onReorder: (blockId: string, targetIndex: number) => void;
 }
 
 const GUTTER_ROW_HEIGHT = 24;
+// Stable draggable id — there is only ever one active grip in the gutter at a
+// time, so a constant id is sufficient.
+const GRIP_DRAGGABLE_ID = 'rte-block-grip';
+
+/** Read each block box's vertical geometry, relative to the shell's top edge. */
+function blockRects(root: HTMLElement): { top: number; height: number }[] {
+  const shellTop = root.getBoundingClientRect().top;
+  return Array.from(root.querySelectorAll<HTMLElement>('[data-block-id]')).map((el) => {
+    const box = el.getBoundingClientRect();
+    return { top: box.top - shellTop, height: box.height };
+  });
+}
+
+/**
+ * Wraps the grip (the `⠿` menu trigger) in a dnd-kit draggable. Pointer-move
+ * past the activation distance starts a drag; a plain click falls through to the
+ * menu trigger underneath (the 4px constraint guarantees a click never becomes a
+ * drag). Renders its children — the real `<RichTextBlockMenu>` `<button>` — so
+ * the menu's role/aria/click handling is untouched.
+ */
+function DraggableGrip({ children }: { children: React.ReactNode }) {
+  const { setNodeRef, listeners, attributes } = useDraggable({ id: GRIP_DRAGGABLE_ID });
+  return (
+    // A thin wrapper whose pointer listeners feed the PointerSensor. The grip
+    // button stays the live menu trigger; spreading drag {...listeners} on this
+    // span (not the button) means a sub-4px click reaches the button normally
+    // while a drag is intercepted by the sensor before it becomes a click.
+    <span ref={setNodeRef} className={styles.gripDrag} {...listeners} {...attributes}>
+      {children}
+    </span>
+  );
+}
 
 /**
  * Internal: the gutter overlay for the active block. Measures the block element's
  * vertical offset within the shell and renders the `＋` insert button + the block
- * menu there. Renders nothing when there is no active block.
+ * menu there. Renders nothing when there is no active block. The grip doubles as
+ * a drag handle: dragging it reorders the active block to the drop gap, while a
+ * plain click still opens the block menu.
  */
 export function RichTextBlockControls({
   rootRef,
@@ -37,6 +87,7 @@ export function RichTextBlockControls({
   onInsertBelow,
   onAction,
   onTurnInto,
+  onReorder,
 }: RichTextBlockControlsProps) {
   const t = useTranslation();
   const [top, setTop] = useState<number | null>(null);
@@ -44,6 +95,12 @@ export function RichTextBlockControls({
   // attached on the first layout-effect pass (the parent's element ref can attach
   // after this child's effect runs on mount).
   const [retry, setRetry] = useState(0);
+  // The candidate drop gap (0..N) tracked during an active grip drag; null when
+  // not dragging. Drives the absolutely-positioned drop indicator line.
+  const [dropGap, setDropGap] = useState<number | null>(null);
+  const [dropY, setDropY] = useState<number | null>(null);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
 
   useLayoutEffect(() => {
     if (!activeBlockId) {
@@ -64,28 +121,84 @@ export function RichTextBlockControls({
     setTop(box.top - rootBox.top + (box.height - GUTTER_ROW_HEIGHT) / 2);
   }, [rootRef, activeBlockId, menuOpen, retry]);
 
+  // Compute the candidate gap from the pointer's current Y (initial pointer Y +
+  // drag delta), measured relative to the shell. Returns null if not measurable.
+  const computeDrop = (event: DragMoveEvent | DragEndEvent): { gap: number; y: number } | null => {
+    const root = rootRef.current;
+    if (!root) return null;
+    const activator = event.activatorEvent as PointerEvent;
+    const initialY = typeof activator?.clientY === 'number' ? activator.clientY : null;
+    if (initialY == null) return null;
+    const shellTop = root.getBoundingClientRect().top;
+    const y = initialY + event.delta.y - shellTop;
+    const rects = blockRects(root);
+    return { gap: gapIndexFromY(rects, y), y };
+  };
+
+  const handleDragMove = (event: DragMoveEvent) => {
+    const drop = computeDrop(event);
+    if (!drop) return;
+    setDropGap(drop.gap);
+    // Indicator sits at the top edge of the block AFTER the gap (or the bottom of
+    // the last block when dropping at the end).
+    const root = rootRef.current;
+    if (!root) return;
+    const rects = blockRects(root);
+    const line =
+      drop.gap < rects.length
+        ? rects[drop.gap].top
+        : rects.length > 0
+          ? rects[rects.length - 1].top + rects[rects.length - 1].height
+          : 0;
+    setDropY(line);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const drop = computeDrop(event);
+    if (drop && activeBlockId) onReorder(activeBlockId, drop.gap);
+    setDropGap(null);
+    setDropY(null);
+  };
+
+  const handleDragCancel = () => {
+    setDropGap(null);
+    setDropY(null);
+  };
+
   if (!activeBlockId || top == null) return null;
 
   return (
-    <div className={styles.gutter} style={{ top }} contentEditable={false}>
-      <Button
-        size="sm"
-        variant="ghost"
-        iconOnly
-        tabIndex={-1}
-        aria-label={t('richTextEditor.blockInsert')}
-        className={styles.gutterButton}
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => onInsertBelow(activeBlockId)}
-      >
-        <PlusIcon />
-      </Button>
-      <RichTextBlockMenu
-        open={menuOpen}
-        onOpenChange={onMenuOpenChange}
-        onAction={(a) => onAction(activeBlockId, a)}
-        onTurnInto={(c) => onTurnInto(activeBlockId, c)}
-      />
-    </div>
+    <DndContext
+      sensors={sensors}
+      onDragMove={handleDragMove}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <div className={styles.gutter} style={{ top }} contentEditable={false}>
+        <Button
+          size="sm"
+          variant="ghost"
+          iconOnly
+          tabIndex={-1}
+          aria-label={t('richTextEditor.blockInsert')}
+          className={styles.gutterButton}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => onInsertBelow(activeBlockId)}
+        >
+          <PlusIcon />
+        </Button>
+        <DraggableGrip>
+          <RichTextBlockMenu
+            open={menuOpen}
+            onOpenChange={onMenuOpenChange}
+            onAction={(a) => onAction(activeBlockId, a)}
+            onTurnInto={(c) => onTurnInto(activeBlockId, c)}
+          />
+        </DraggableGrip>
+      </div>
+      {dropGap != null && dropY != null ? (
+        <div className={styles.dropIndicator} style={{ top: dropY }} contentEditable={false} />
+      ) : null}
+    </DndContext>
   );
 }

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -60,13 +60,18 @@ function blockRects(root: HTMLElement): { top: number; height: number }[] {
  * the menu's role/aria/click handling is untouched.
  */
 function DraggableGrip({ children }: { children: React.ReactNode }) {
-  const { setNodeRef, listeners, attributes } = useDraggable({ id: GRIP_DRAGGABLE_ID });
+  // Only the pointer `listeners` — deliberately NOT dnd-kit's `attributes`, which
+  // add role="button" + tabIndex=0 and would (a) make this span a tab stop,
+  // breaking the "gutter is not in the tab order" contract, and (b) nest a button
+  // role around the real grip <button>. Keyboard reorder is the editor's
+  // ⌘/Ctrl+⇧↑/↓ shortcuts, so the drag handle stays pointer-only.
+  const { setNodeRef, listeners } = useDraggable({ id: GRIP_DRAGGABLE_ID });
   return (
     // A thin wrapper whose pointer listeners feed the PointerSensor. The grip
     // button stays the live menu trigger; spreading drag {...listeners} on this
     // span (not the button) means a sub-4px click reaches the button normally
     // while a drag is intercepted by the sensor before it becomes a click.
-    <span ref={setNodeRef} className={styles.gripDrag} {...listeners} {...attributes}>
+    <span ref={setNodeRef} className={styles.gripDrag} {...listeners}>
       {children}
     </span>
   );

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -1,0 +1,90 @@
+// RichTextBlockControls.tsx — the per-block gutter overlay. Absolutely positioned
+// inside the editor shell (position: relative), aligned to the active block's box.
+// Lives OUTSIDE the contentEditable so it is never editable content.
+import { useLayoutEffect, useState, type RefObject } from 'react';
+import { Button } from '../Button';
+import { useTranslation } from '../../i18n';
+import { RichTextBlockMenu, type BlockAction } from './RichTextBlockMenu';
+import type { BlockChoice } from './RichTextToolbar';
+import { PlusIcon } from './icons';
+import styles from './RichTextEditor.module.scss';
+
+export interface RichTextBlockControlsProps {
+  /** The editor root (contentEditable) element ref — used to locate block boxes. */
+  rootRef: RefObject<HTMLElement | null>;
+  /** Block currently hovered or holding the caret; null hides the gutter. */
+  activeBlockId: string | null;
+  /** Controlled open state of the block menu. */
+  menuOpen: boolean;
+  onMenuOpenChange: (open: boolean) => void;
+  onInsertBelow: (blockId: string) => void;
+  onAction: (blockId: string, action: BlockAction) => void;
+  onTurnInto: (blockId: string, choice: BlockChoice) => void;
+}
+
+const GUTTER_ROW_HEIGHT = 24;
+
+/**
+ * Internal: the gutter overlay for the active block. Measures the block element's
+ * vertical offset within the shell and renders the `＋` insert button + the block
+ * menu there. Renders nothing when there is no active block.
+ */
+export function RichTextBlockControls({
+  rootRef,
+  activeBlockId,
+  menuOpen,
+  onMenuOpenChange,
+  onInsertBelow,
+  onAction,
+  onTurnInto,
+}: RichTextBlockControlsProps) {
+  const t = useTranslation();
+  const [top, setTop] = useState<number | null>(null);
+  // Bumped to re-run measurement when the root ref / block element is not yet
+  // attached on the first layout-effect pass (the parent's element ref can attach
+  // after this child's effect runs on mount).
+  const [retry, setRetry] = useState(0);
+
+  useLayoutEffect(() => {
+    if (!activeBlockId) {
+      setTop(null);
+      return;
+    }
+    const root = rootRef.current;
+    const el = root?.querySelector<HTMLElement>(`[data-block-id="${CSS.escape(activeBlockId)}"]`);
+    if (!root || !el) {
+      setTop(null);
+      // The root or block element isn't measurable yet; retry once it mounts.
+      if (retry < 2) setRetry((n) => n + 1);
+      return;
+    }
+    const rootBox = root.getBoundingClientRect();
+    const box = el.getBoundingClientRect();
+    setTop(box.top - rootBox.top + (box.height - GUTTER_ROW_HEIGHT) / 2);
+  }, [rootRef, activeBlockId, menuOpen, retry]);
+
+  if (!activeBlockId || top == null) return null;
+
+  return (
+    <div className={styles.gutter} style={{ top }} contentEditable={false}>
+      <Button
+        size="sm"
+        variant="ghost"
+        iconOnly
+        tabIndex={-1}
+        aria-label={t('richTextEditor.blockInsert')}
+        className={styles.gutterButton}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => onInsertBelow(activeBlockId)}
+      >
+        <PlusIcon />
+      </Button>
+      <RichTextBlockMenu
+        open={menuOpen}
+        onOpenChange={onMenuOpenChange}
+        onAction={(a) => onAction(activeBlockId, a)}
+        onTurnInto={(c) => onTurnInto(activeBlockId, c)}
+      />
+    </div>
+  );
+}

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.test.tsx
@@ -1,0 +1,44 @@
+// RichTextBlockMenu.test.tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nProvider } from '../../i18n';
+import { RichTextBlockMenu } from './RichTextBlockMenu';
+
+function setup(props: Partial<React.ComponentProps<typeof RichTextBlockMenu>> = {}) {
+  const onAction = vi.fn();
+  const onTurnInto = vi.fn();
+  render(
+    <I18nProvider locale="en">
+      <RichTextBlockMenu
+        open
+        onOpenChange={() => {}}
+        onAction={onAction}
+        onTurnInto={onTurnInto}
+        {...props}
+      />
+    </I18nProvider>,
+  );
+  return { onAction, onTurnInto };
+}
+
+it('renders the handle with the block-actions aria-label', () => {
+  setup({ open: false });
+  expect(screen.getByRole('button', { name: 'Block actions' })).toBeInTheDocument();
+});
+
+it('the handle is not a tab stop', () => {
+  setup({ open: false });
+  expect(screen.getByRole('button', { name: 'Block actions' })).toHaveAttribute('tabindex', '-1');
+});
+
+it('fires onAction("duplicate") when Duplicate is chosen', async () => {
+  const { onAction } = setup();
+  await userEvent.click(screen.getByRole('menuitem', { name: /duplicate/i }));
+  expect(onAction).toHaveBeenCalledWith('duplicate');
+});
+
+it('fires onAction("delete") for the Delete item', async () => {
+  const { onAction } = setup();
+  await userEvent.click(screen.getByRole('menuitem', { name: /delete/i }));
+  expect(onAction).toHaveBeenCalledWith('delete');
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.test.tsx
@@ -42,3 +42,18 @@ it('fires onAction("delete") for the Delete item', async () => {
   await userEvent.click(screen.getByRole('menuitem', { name: /delete/i }));
   expect(onAction).toHaveBeenCalledWith('delete');
 });
+
+it('fires onTurnInto with a BlockChoice from the Turn into submenu', async () => {
+  const { onTurnInto } = setup();
+  // Open the "Turn into" submenu, then pick Heading 1.
+  await userEvent.click(screen.getByRole('menuitem', { name: /turn into/i }));
+  await userEvent.click(await screen.findByRole('menuitem', { name: 'Heading 1' }));
+  expect(onTurnInto).toHaveBeenCalledWith({ type: 'heading', level: 1 });
+});
+
+it('conveys a list turn-into as a list BlockChoice (no depth)', async () => {
+  const { onTurnInto } = setup();
+  await userEvent.click(screen.getByRole('menuitem', { name: /turn into/i }));
+  await userEvent.click(await screen.findByRole('menuitem', { name: 'Bullet list' }));
+  expect(onTurnInto).toHaveBeenCalledWith({ type: 'bullet_item' });
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.tsx
@@ -1,0 +1,97 @@
+// RichTextBlockMenu.tsx — internal block actions menu (DropdownMenu wrapper). The
+// `⠿` handle is the trigger; open is controlled by the editor so a keyboard
+// Shift+F10 can open the SAME menu anchored to the active block's handle.
+import { forwardRef } from 'react';
+import { Button } from '../Button';
+import { DropdownMenu } from '../DropdownMenu';
+import { useTranslation } from '../../i18n';
+import type { BlockChoice } from './RichTextToolbar';
+import { GripIcon } from './icons';
+import styles from './RichTextEditor.module.scss';
+
+export type BlockAction = 'duplicate' | 'moveUp' | 'moveDown' | 'delete';
+
+export interface RichTextBlockMenuProps {
+  /** Controlled open state of the menu. */
+  open: boolean;
+  /** Fired when the menu wants to open/close. */
+  onOpenChange: (open: boolean) => void;
+  /** Fired for the flat actions (duplicate / move / delete). */
+  onAction: (action: BlockAction) => void;
+  /** Fired for a "Turn into" choice. */
+  onTurnInto: (choice: BlockChoice) => void;
+}
+
+/**
+ * Internal: the `⠿` block-actions handle and its menu. The handle is the
+ * DropdownMenu trigger and is `tabIndex={-1}` (not a tab stop — keyboard users
+ * open it via Shift+F10 in the editor). "Turn into" reuses the block-type labels.
+ */
+export const RichTextBlockMenu = forwardRef<HTMLButtonElement, RichTextBlockMenuProps>(
+  function RichTextBlockMenu({ open, onOpenChange, onAction, onTurnInto }, ref) {
+    const t = useTranslation();
+    return (
+      <DropdownMenu open={open} onOpenChange={onOpenChange}>
+        <DropdownMenu.Trigger>
+          <Button
+            ref={ref}
+            size="sm"
+            variant="ghost"
+            iconOnly
+            tabIndex={-1}
+            aria-label={t('richTextEditor.blockActions')}
+            className={styles.gutterButton}
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            <GripIcon />
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content side="bottom" align="start">
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger>{t('richTextEditor.blockTurnInto')}</DropdownMenu.SubTrigger>
+            <DropdownMenu.SubContent>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'paragraph' })}>
+                {t('richTextEditor.paragraph')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'heading', level: 1 })}>
+                {t('richTextEditor.heading1')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'heading', level: 2 })}>
+                {t('richTextEditor.heading2')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'heading', level: 3 })}>
+                {t('richTextEditor.heading3')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'bullet_item' })}>
+                {t('richTextEditor.bulletList')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'ordered_item' })}>
+                {t('richTextEditor.orderedList')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'blockquote' })}>
+                {t('richTextEditor.blockquote')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => onTurnInto({ type: 'code_block' })}>
+                {t('richTextEditor.codeBlock')}
+              </DropdownMenu.Item>
+            </DropdownMenu.SubContent>
+          </DropdownMenu.Sub>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item shortcut="⌘D" onSelect={() => onAction('duplicate')}>
+            {t('richTextEditor.blockDuplicate')}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item shortcut="⌘⇧↑" onSelect={() => onAction('moveUp')}>
+            {t('richTextEditor.blockMoveUp')}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item shortcut="⌘⇧↓" onSelect={() => onAction('moveDown')}>
+            {t('richTextEditor.blockMoveDown')}
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item tone="danger" onSelect={() => onAction('delete')}>
+            {t('richTextEditor.blockDelete')}
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    );
+  },
+);

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
@@ -42,10 +42,12 @@
 }
 
 // When block controls are on, reserve a left column on the editable so the gutter
-// (＋ / ⠿) sits beside the text instead of overlapping it. Only applied via the
-// `withGutter` modifier, so editors without block controls are unaffected.
+// (＋ / ⠿) sits beside the text instead of overlapping it. The gutter holds two
+// ~24px (--size-sm) icon buttons plus gaps (~52px total), so the reservation must
+// clear that. Only applied via the `withGutter` modifier, so editors without block
+// controls are unaffected.
 .root.withGutter {
-  padding-inline-start: var(--space-6);
+  padding-inline-start: var(--space-16);
 }
 
 // The per-block gutter overlay (RichTextBlockControls). Absolutely positioned

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
@@ -64,6 +64,31 @@
   color: var(--color-fg-muted);
 }
 
+// Thin wrapper around the grip that feeds dnd-kit's PointerSensor. `inline-flex`
+// keeps it shrink-wrapped to the grip button (so it doesn't enlarge the gutter's
+// hit area) and `grab`/`grabbing` cursors signal the drag affordance. No layout
+// props — it's a pass-through around the button.
+.gripDrag {
+  display: inline-flex;
+  cursor: grab;
+}
+
+.gripDrag:active {
+  cursor: grabbing;
+}
+
+// The drop-indicator line shown during a block drag. Absolutely positioned inside
+// `.shell`; its vertical `top` is set inline by JS from the candidate drop gap
+// (cf. the Rule 4 note on `.gutter`/`.linkBubble` — overlay anchoring, not in-flow
+// component layout). A thin accent-colored rule spanning the editable width.
+.dropIndicator {
+  position: absolute;
+  inset-inline: 0;
+  height: var(--border-width);
+  background: var(--color-accent);
+  pointer-events: none;
+}
+
 .toolbar {
   display: flex;
   align-items: center;

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
@@ -31,12 +31,37 @@
   background: var(--color-bg-muted);
 }
 
-// The component's own internal wrapper when `toolbar` is set: stacks the toolbar
-// above the editable surface as one bordered control.
+// The component's own internal wrapper when `toolbar` and/or `blockControls` is
+// set: stacks the toolbar above the editable surface as one bordered control and
+// anchors the absolutely-positioned block gutter (`.gutter`).
 .shell {
+  position: relative; // anchor for the block-controls gutter overlay
   display: flex;
   flex-direction: column;
   width: 100%;
+}
+
+// When block controls are on, reserve a left column on the editable so the gutter
+// (＋ / ⠿) sits beside the text instead of overlapping it. Only applied via the
+// `withGutter` modifier, so editors without block controls are unaffected.
+.root.withGutter {
+  padding-inline-start: var(--space-6);
+}
+
+// The per-block gutter overlay (RichTextBlockControls). Absolutely positioned
+// inside `.shell`; its vertical `top` is set inline by JS from the active block's
+// measured box. `left`/`position` here are the overlay's own anchoring, not
+// in-flow component layout (cf. the Rule 4 notes on `.linkBubble`/`.mentionMenu`).
+.gutter {
+  position: absolute;
+  inset-inline-start: var(--space-05);
+  display: flex;
+  gap: var(--space-05);
+  align-items: center;
+}
+
+.gutterButton {
+  color: var(--color-fg-muted);
 }
 
 .toolbar {

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -830,3 +830,54 @@ describe('RichTextEditor renderLink', () => {
     expect(box.textContent).toBe('go ');
   });
 });
+
+describe('blockControls', () => {
+  function Controlled(props: { blockControls?: boolean; readOnly?: boolean }) {
+    const [doc, setDoc] = useState(docFromText('one\ntwo\nthree'));
+    return <RichTextEditor value={doc} onChange={setDoc} {...props} />;
+  }
+
+  it('is absent by default', () => {
+    render(
+      <I18nProvider locale="en">
+        <Controlled />
+      </I18nProvider>,
+    );
+    expect(screen.queryByRole('button', { name: 'Block actions' })).toBeNull();
+  });
+
+  it('hovering a block reveals its gutter', async () => {
+    render(
+      <I18nProvider locale="en">
+        <Controlled blockControls />
+      </I18nProvider>,
+    );
+    const block = document.querySelector('[data-block-id]') as HTMLElement;
+    await userEvent.hover(block);
+    expect(screen.getByRole('button', { name: 'Block actions' })).toBeInTheDocument();
+  });
+
+  it('＋ inserts an empty paragraph below', async () => {
+    render(
+      <I18nProvider locale="en">
+        <Controlled blockControls />
+      </I18nProvider>,
+    );
+    const block = document.querySelector('[data-block-id]') as HTMLElement;
+    await userEvent.hover(block);
+    const before = document.querySelectorAll('[data-block-id]').length;
+    await userEvent.click(screen.getByRole('button', { name: 'Insert block below' }));
+    expect(document.querySelectorAll('[data-block-id]').length).toBe(before + 1);
+  });
+
+  it('readOnly suppresses the gutter', async () => {
+    render(
+      <I18nProvider locale="en">
+        <Controlled blockControls readOnly />
+      </I18nProvider>,
+    );
+    const block = document.querySelector('[data-block-id]') as HTMLElement;
+    await userEvent.hover(block);
+    expect(screen.queryByRole('button', { name: 'Block actions' })).toBeNull();
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -880,4 +880,43 @@ describe('blockControls', () => {
     await userEvent.hover(block);
     expect(screen.queryByRole('button', { name: 'Block actions' })).toBeNull();
   });
+
+  it('⌘⇧↓ moves the caret block down (subtree-aware, via commit)', async () => {
+    const user = userEvent.setup();
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'a', offset: 0 },
+      focus: { blockId: 'a', offset: 0 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [
+          { id: 'a', type: 'paragraph', inlines: [{ text: 'AAA', marks: [] }] },
+          { id: 'b', type: 'paragraph', inlines: [{ text: 'BBB', marks: [] }] },
+        ],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} blockControls />;
+    }
+    renderEditor(<Harness />);
+    screen.getByRole('textbox').focus();
+    await user.keyboard('{Meta>}{Shift>}{ArrowDown}{/Shift}{/Meta}');
+    const order = Array.from(document.querySelectorAll('[data-block-id]')).map((el) =>
+      el.getAttribute('data-block-id'),
+    );
+    expect(order).toEqual(['b', 'a']);
+  });
+
+  it('block menu Duplicate routes through commit (block count grows)', async () => {
+    const user = userEvent.setup();
+    render(
+      <I18nProvider locale="en">
+        <Controlled blockControls />
+      </I18nProvider>,
+    );
+    const block = document.querySelector('[data-block-id]') as HTMLElement;
+    await user.hover(block);
+    const before = document.querySelectorAll('[data-block-id]').length;
+    await user.click(screen.getByRole('button', { name: 'Block actions' }));
+    await user.click(await screen.findByRole('menuitem', { name: /duplicate/i }));
+    expect(document.querySelectorAll('[data-block-id]').length).toBe(before + 1);
+  });
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -905,6 +905,27 @@ describe('blockControls', () => {
     expect(order).toEqual(['b', 'a']);
   });
 
+  it('block menu Turn into a list is idempotent (SET, not toggle)', async () => {
+    const user = userEvent.setup();
+    render(
+      <I18nProvider locale="en">
+        <Controlled blockControls />
+      </I18nProvider>,
+    );
+    const turnIntoBullet = async (el: HTMLElement) => {
+      await user.hover(el);
+      await user.click(screen.getByRole('button', { name: 'Block actions' }));
+      await user.click(screen.getByRole('menuitem', { name: /turn into/i }));
+      await user.click(await screen.findByRole('menuitem', { name: 'Bullet list' }));
+    };
+    await turnIntoBullet(document.querySelector('[data-block-id]') as HTMLElement);
+    expect(document.querySelector('li[data-block-id]')).toBeTruthy();
+    // Choosing the SAME type again must keep it a list — the old toggle bug
+    // reverted it to a paragraph.
+    await turnIntoBullet(document.querySelector('li[data-block-id]') as HTMLElement);
+    expect(document.querySelector('li[data-block-id]')).toBeTruthy();
+  });
+
   it('block menu Duplicate routes through commit (block count grows)', async () => {
     const user = userEvent.setup();
     render(

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -926,6 +926,51 @@ describe('blockControls', () => {
     expect(document.querySelector('li[data-block-id]')).toBeTruthy();
   });
 
+  it('⌘D duplicates the caret block (via commit)', async () => {
+    const user = userEvent.setup();
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'a', offset: 0 },
+      focus: { blockId: 'a', offset: 0 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'a', type: 'paragraph', inlines: [{ text: 'AAA', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} blockControls />;
+    }
+    renderEditor(<Harness />);
+    screen.getByRole('textbox').focus();
+    await user.keyboard('{Meta>}d{/Meta}');
+    expect(document.querySelectorAll('[data-block-id]').length).toBe(2);
+  });
+
+  it('open menu acts on its block even after hovering another (no hover steal)', async () => {
+    const user = userEvent.setup();
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [
+          { id: 'a', type: 'paragraph', inlines: [{ text: 'AAA', marks: [] }] },
+          { id: 'b', type: 'paragraph', inlines: [{ text: 'BBB', marks: [] }] },
+        ],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} blockControls />;
+    }
+    renderEditor(<Harness />);
+    const [blockA, blockB] = Array.from(
+      document.querySelectorAll('[data-block-id]'),
+    ) as HTMLElement[];
+    // Open the menu on block A…
+    await user.hover(blockA);
+    await user.click(screen.getByRole('button', { name: 'Block actions' }));
+    // …then hover block B before choosing Delete.
+    await user.hover(blockB);
+    await user.click(await screen.findByRole('menuitem', { name: /delete/i }));
+    // Block A must be the one removed, leaving B.
+    const remaining = Array.from(document.querySelectorAll('[data-block-id]'));
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].textContent).toBe('BBB');
+  });
+
   it('block menu Duplicate routes through commit (block count grows)', async () => {
     const user = userEvent.setup();
     render(

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -46,6 +46,14 @@ import {
 } from './commands';
 import { RichTextToolbar, type BlockChoice } from './RichTextToolbar';
 import {
+  moveBlockUnit,
+  duplicateBlockUnit,
+  removeBlockUnit,
+  insertEmptyBlockBelow,
+} from '../RichText/engine/blockUnit';
+import { RichTextBlockControls } from './RichTextBlockControls';
+import type { BlockAction } from './RichTextBlockMenu';
+import {
   reset as historyReset,
   record as historyRecord,
   undo as historyUndo,
@@ -118,6 +126,16 @@ export interface RichTextEditorProps extends Omit<
    * return `defaultNode` for stay plain, editable anchors.
    */
   renderLink?: RenderLink;
+  /**
+   * Show Notion-style per-block controls: a left gutter that appears on the
+   * hovered/focused block with an insert button (`＋`, adds an empty paragraph
+   * below) and a drag handle (`⠿`) that opens a block menu (Turn into ▸,
+   * Duplicate, Move up/down, Delete). Reordering is subtree-aware for nested
+   * lists. Keyboard: Shift+F10 / the ContextMenu key opens the focused block's
+   * menu; ⌘/Ctrl+⇧↑ / ⌘/Ctrl+⇧↓ move the block; ⌘/Ctrl+D duplicates. Default
+   * `false`. Ignored when `readOnly`. Independent of `toolbar`.
+   */
+  blockControls?: boolean;
 }
 
 function isEmptyDoc(doc: RichDoc): boolean {
@@ -219,6 +237,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       placeholder,
       autoFocus,
       toolbar = false,
+      blockControls = false,
       mentions,
       autolink = true,
       renderLink,
@@ -260,6 +279,22 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       },
       [ref],
     );
+
+    const controlsOn = blockControls && !readOnly;
+    const shellRef = useRef<HTMLDivElement | null>(null);
+    const [activeBlockId, setActiveBlockId] = useState<string | null>(null);
+    const [blockMenuOpen, setBlockMenuOpen] = useState(false);
+
+    // Resolve the [data-block-id] of the block element containing a DOM node.
+    const blockIdFromNode = useCallback((node: Node | null): string | null => {
+      let el: HTMLElement | null =
+        node instanceof HTMLElement ? node : (node?.parentElement ?? null);
+      while (el && el !== rootRef.current) {
+        if (el.hasAttribute('data-block-id')) return el.getAttribute('data-block-id');
+        el = el.parentElement;
+      }
+      return el?.getAttribute?.('data-block-id') ?? null;
+    }, []);
 
     const historyRef = useRef<History>(historyReset({ doc: value, selection: null }));
     // Timestamp of the last ⌘Z/⌘⇧Z/⌘Y keydown — lets the beforeinput net skip the
@@ -635,6 +670,34 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       return () => document.removeEventListener('selectionchange', onSelChange);
     }, [toolbar, readOnly]);
 
+    // Hover tracking (mouse).
+    useEffect(() => {
+      if (!controlsOn) return;
+      const root = rootRef.current;
+      if (!root) return;
+      const onOver = (e: MouseEvent) => {
+        const id = blockIdFromNode(e.target as Node);
+        if (id) setActiveBlockId(id);
+      };
+      root.addEventListener('mouseover', onOver);
+      return () => root.removeEventListener('mouseover', onOver);
+    }, [controlsOn, blockIdFromNode]);
+
+    // Caret tracking → active block (keyboard users get a gutter target too).
+    useEffect(() => {
+      if (!controlsOn) return;
+      const onSel = () => {
+        const root = rootRef.current;
+        const sel = root?.ownerDocument.getSelection();
+        if (sel && root && sel.anchorNode && root.contains(sel.anchorNode)) {
+          const id = blockIdFromNode(sel.anchorNode);
+          if (id) setActiveBlockId(id);
+        }
+      };
+      document.addEventListener('selectionchange', onSel);
+      return () => document.removeEventListener('selectionchange', onSel);
+    }, [controlsOn, blockIdFromNode]);
+
     const onKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLDivElement>) => {
         if (readOnly) return;
@@ -663,6 +726,25 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         }
         const range = readSelection(root);
         if (!range) return;
+        if (controlsOn) {
+          const caretBlock = range.anchor.blockId;
+          if (mod && e.shiftKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
+            e.preventDefault();
+            commit(moveBlockUnit(value, caretBlock, e.key === 'ArrowUp' ? -1 : 1), 'other');
+            return;
+          }
+          if (mod && !e.shiftKey && e.key.toLowerCase() === 'd') {
+            e.preventDefault();
+            commit(duplicateBlockUnit(value, caretBlock), 'other');
+            return;
+          }
+          if ((e.shiftKey && e.key === 'F10') || e.key === 'ContextMenu') {
+            e.preventDefault();
+            setActiveBlockId(caretBlock);
+            setBlockMenuOpen(true);
+            return;
+          }
+        }
         // Mention menu navigation takes priority over editor keys when open.
         if (mention.open && mention.items.length > 0) {
           if (e.key === 'ArrowDown') {
@@ -727,7 +809,17 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           return;
         }
       },
-      [value, readOnly, commit, stageOrToggleMark, openLinkEditor, onUndo, onRedo, mention],
+      [
+        value,
+        readOnly,
+        commit,
+        stageOrToggleMark,
+        openLinkEditor,
+        onUndo,
+        onRedo,
+        mention,
+        controlsOn,
+      ],
     );
 
     const onCompositionStart = useCallback(() => {
@@ -798,6 +890,35 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       [value, selection, commit],
     );
 
+    const onBlockInsertBelow = useCallback(
+      (id: string) => commit(insertEmptyBlockBelow(latest.current.value, id), 'other'),
+      [commit],
+    );
+    const onBlockAction = useCallback(
+      (id: string, action: BlockAction) => {
+        const v = latest.current.value;
+        if (action === 'duplicate') commit(duplicateBlockUnit(v, id), 'other');
+        else if (action === 'moveUp') commit(moveBlockUnit(v, id, -1), 'other');
+        else if (action === 'moveDown') commit(moveBlockUnit(v, id, 1), 'other');
+        else if (action === 'delete') commit(removeBlockUnit(v, id), 'other');
+        setBlockMenuOpen(false);
+      },
+      [commit],
+    );
+    const onBlockTurnInto = useCallback(
+      (id: string, choice: BlockChoice) => {
+        const v = latest.current.value;
+        const range = { anchor: { blockId: id, offset: 0 }, focus: { blockId: id, offset: 0 } };
+        if (choice.type === 'bullet_item' || choice.type === 'ordered_item') {
+          commit(runToggleList(v, range, choice.type), 'other');
+        } else {
+          commit(runSetBlock(v, range, choice), 'other');
+        }
+        setBlockMenuOpen(false);
+      },
+      [commit],
+    );
+
     const editable = (
       <div
         // {...rest} FIRST so the component's own role/aria/contentEditable/handlers
@@ -865,7 +986,29 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         />
       ) : null;
 
+    const blockControlsEl = controlsOn ? (
+      <RichTextBlockControls
+        rootRef={shellRef}
+        activeBlockId={activeBlockId}
+        menuOpen={blockMenuOpen}
+        onMenuOpenChange={setBlockMenuOpen}
+        onInsertBelow={onBlockInsertBelow}
+        onAction={onBlockAction}
+        onTurnInto={onBlockTurnInto}
+      />
+    ) : null;
+
     if (!toolbar) {
+      if (controlsOn) {
+        return (
+          <div className={styles.shell} ref={shellRef}>
+            {editable}
+            {linkBubble}
+            {mentionMenu}
+            {blockControlsEl}
+          </div>
+        );
+      }
       return (
         <>
           {editable}
@@ -875,7 +1018,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       );
     }
     return (
-      <div className={styles.shell}>
+      <div className={styles.shell} ref={shellRef}>
         <RichTextToolbar
           activeMarks={toolbarMarks}
           block={toolbarBlock}
@@ -893,6 +1036,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         {editable}
         {linkBubble}
         {mentionMenu}
+        {blockControlsEl}
       </div>
     );
   },

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -290,6 +290,12 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     const shellRef = useRef<HTMLDivElement | null>(null);
     const [activeBlockId, setActiveBlockId] = useState<string | null>(null);
     const [blockMenuOpen, setBlockMenuOpen] = useState(false);
+    // Mirror the open state into a ref so the hover listener can read it without
+    // re-subscribing: while the menu is open, hovering another block must NOT move
+    // the active block (the menu's actions are bound to it — moving it would make
+    // a click act on the wrong block).
+    const blockMenuOpenRef = useRef(false);
+    blockMenuOpenRef.current = blockMenuOpen;
 
     // Resolve the [data-block-id] of the block element containing a DOM node.
     const blockIdFromNode = useCallback((node: Node | null): string | null => {
@@ -299,7 +305,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         if (el.hasAttribute('data-block-id')) return el.getAttribute('data-block-id');
         el = el.parentElement;
       }
-      return el?.getAttribute?.('data-block-id') ?? null;
+      return null; // reached the root (or ran out of ancestors) — no block
     }, []);
 
     const historyRef = useRef<History>(historyReset({ doc: value, selection: null }));
@@ -682,6 +688,9 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       const root = rootRef.current;
       if (!root) return;
       const onOver = (e: MouseEvent) => {
+        // Don't let hover steal the active block while the menu is open — its
+        // actions are bound to the active block.
+        if (blockMenuOpenRef.current) return;
         const id = blockIdFromNode(e.target as Node);
         if (id) setActiveBlockId(id);
       };
@@ -736,11 +745,13 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           const caretBlock = range.anchor.blockId;
           if (mod && e.shiftKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
             e.preventDefault();
+            e.stopPropagation();
             commit(moveBlockUnit(value, caretBlock, e.key === 'ArrowUp' ? -1 : 1), 'other');
             return;
           }
           if (mod && !e.shiftKey && e.key.toLowerCase() === 'd') {
             e.preventDefault();
+            e.stopPropagation();
             commit(duplicateBlockUnit(value, caretBlock), 'other');
             return;
           }

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -927,7 +927,12 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         // decide whether to fall back to the i18n default.
         {...rest}
         ref={setRefs}
-        className={clsx(styles.root, readOnly && styles.readOnly, className)}
+        className={clsx(
+          styles.root,
+          readOnly && styles.readOnly,
+          controlsOn && styles.withGutter,
+          className,
+        )}
         contentEditable={!readOnly}
         suppressContentEditableWarning
         role="textbox"

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -228,6 +228,11 @@ interface LinkEditorOpen {
  *   (or by the `query`); the menu renders what you return.
  * - ❌ Relying on Markdown to preserve mentions — `toMarkdown` is lossy (plain
  *   `@label`); use `toHtml`/`fromHtml` to round-trip a mention's id.
+ * - ❌ Building a custom block drag/menu by reaching into the DOM — pass
+ *   `blockControls`; insert/move/duplicate/delete route through the controlled
+ *   `value`/`onChange` round-trip and are undoable.
+ * - ❌ Expecting Backspace to delete a whole block — it edits text; use the block
+ *   menu's Delete (or select the block's text and delete) to remove a block.
  */
 export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
   function RichTextEditor(

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -47,6 +47,7 @@ import {
 import { RichTextToolbar, type BlockChoice } from './RichTextToolbar';
 import {
   moveBlockUnit,
+  moveBlockUnitToIndex,
   duplicateBlockUnit,
   removeBlockUnit,
   insertEmptyBlockBelow,
@@ -918,6 +919,11 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       },
       [commit],
     );
+    const onBlockReorder = useCallback(
+      (id: string, targetIndex: number) =>
+        commit(moveBlockUnitToIndex(latest.current.value, id, targetIndex), 'other'),
+      [commit],
+    );
 
     const editable = (
       <div
@@ -1000,6 +1006,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         onInsertBelow={onBlockInsertBelow}
         onAction={onBlockAction}
         onTurnInto={onBlockTurnInto}
+        onReorder={onBlockReorder}
       />
     ) : null;
 

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -903,10 +903,25 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     const onBlockAction = useCallback(
       (id: string, action: BlockAction) => {
         const v = latest.current.value;
-        if (action === 'duplicate') commit(duplicateBlockUnit(v, id), 'other');
-        else if (action === 'moveUp') commit(moveBlockUnit(v, id, -1), 'other');
-        else if (action === 'moveDown') commit(moveBlockUnit(v, id, 1), 'other');
-        else if (action === 'delete') commit(removeBlockUnit(v, id), 'other');
+        switch (action) {
+          case 'duplicate':
+            commit(duplicateBlockUnit(v, id), 'other');
+            break;
+          case 'moveUp':
+            commit(moveBlockUnit(v, id, -1), 'other');
+            break;
+          case 'moveDown':
+            commit(moveBlockUnit(v, id, 1), 'other');
+            break;
+          case 'delete':
+            commit(removeBlockUnit(v, id), 'other');
+            break;
+          default: {
+            // Exhaustiveness: a new BlockAction must be handled above.
+            const _never: never = action;
+            return _never;
+          }
+        }
         setBlockMenuOpen(false);
       },
       [commit],
@@ -915,11 +930,14 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       (id: string, choice: BlockChoice) => {
         const v = latest.current.value;
         const range = { anchor: { blockId: id, offset: 0 }, focus: { blockId: id, offset: 0 } };
-        if (choice.type === 'bullet_item' || choice.type === 'ordered_item') {
-          commit(runToggleList(v, range, choice.type), 'other');
-        } else {
-          commit(runSetBlock(v, range, choice), 'other');
-        }
+        // "Turn into X" is an idempotent SET (not a toggle) on the single anchor
+        // block — choosing the block's current type is a no-op, never a revert.
+        // List types carry depth 0; runSetBlock routes both through setBlockType.
+        const patch =
+          choice.type === 'bullet_item' || choice.type === 'ordered_item'
+            ? { type: choice.type, depth: 0 }
+            : choice;
+        commit(runSetBlock(v, range, patch), 'other');
         setBlockMenuOpen(false);
       },
       [commit],

--- a/packages/design-system/src/components/RichTextEditor/blockDrop.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/blockDrop.test.ts
@@ -1,0 +1,24 @@
+import { gapIndexFromY } from './blockDrop';
+
+describe('gapIndexFromY', () => {
+  const rects = [
+    { top: 0, height: 20 },
+    { top: 20, height: 20 },
+    { top: 40, height: 20 },
+  ];
+  it('returns 0 above the first block midpoint', () => {
+    expect(gapIndexFromY(rects, 5)).toBe(0);
+  });
+  it('returns 1 between the first and second midpoints', () => {
+    expect(gapIndexFromY(rects, 25)).toBe(1);
+  });
+  it('returns 2 between the second and third midpoints', () => {
+    expect(gapIndexFromY(rects, 45)).toBe(2);
+  });
+  it('returns rects.length past the last block', () => {
+    expect(gapIndexFromY(rects, 100)).toBe(3);
+  });
+  it('handles an empty list', () => {
+    expect(gapIndexFromY([], 10)).toBe(0);
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/blockDrop.ts
+++ b/packages/design-system/src/components/RichTextEditor/blockDrop.ts
@@ -1,0 +1,9 @@
+// blockDrop.ts — pure geometry for block drag-to-reorder. Maps a pointer Y to the
+// "gap" index (0..n) where a dropped block should land, by comparing against each
+// block box's vertical midpoint.
+export function gapIndexFromY(rects: { top: number; height: number }[], y: number): number {
+  for (let i = 0; i < rects.length; i += 1) {
+    if (y < rects[i].top + rects[i].height / 2) return i;
+  }
+  return rects.length;
+}

--- a/packages/design-system/src/components/RichTextEditor/icons.tsx
+++ b/packages/design-system/src/components/RichTextEditor/icons.tsx
@@ -94,3 +94,56 @@ export function RedoIcon() {
     </svg>
   );
 }
+export function PlusIcon() {
+  return (
+    <svg {...base}>
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+export function GripIcon() {
+  return (
+    <svg {...base}>
+      <circle cx="9" cy="6" r="1" fill="currentColor" stroke="none" />
+      <circle cx="9" cy="12" r="1" fill="currentColor" stroke="none" />
+      <circle cx="9" cy="18" r="1" fill="currentColor" stroke="none" />
+      <circle cx="15" cy="6" r="1" fill="currentColor" stroke="none" />
+      <circle cx="15" cy="12" r="1" fill="currentColor" stroke="none" />
+      <circle cx="15" cy="18" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+export function DuplicateIcon() {
+  return (
+    <svg {...base}>
+      <rect x="9" y="9" width="11" height="11" rx="2" />
+      <path d="M5 15V5a2 2 0 0 1 2-2h10" />
+    </svg>
+  );
+}
+export function ArrowUpIcon() {
+  return (
+    <svg {...base}>
+      <line x1="12" y1="19" x2="12" y2="5" />
+      <path d="M5 12l7-7 7 7" />
+    </svg>
+  );
+}
+export function ArrowDownIcon() {
+  return (
+    <svg {...base}>
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <path d="M5 12l7 7 7-7" />
+    </svg>
+  );
+}
+export function TrashIcon() {
+  return (
+    <svg {...base}>
+      <path d="M3 6h18" />
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+    </svg>
+  );
+}

--- a/packages/design-system/src/components/RichTextEditor/icons.tsx
+++ b/packages/design-system/src/components/RichTextEditor/icons.tsx
@@ -114,36 +114,3 @@ export function GripIcon() {
     </svg>
   );
 }
-export function DuplicateIcon() {
-  return (
-    <svg {...base}>
-      <rect x="9" y="9" width="11" height="11" rx="2" />
-      <path d="M5 15V5a2 2 0 0 1 2-2h10" />
-    </svg>
-  );
-}
-export function ArrowUpIcon() {
-  return (
-    <svg {...base}>
-      <line x1="12" y1="19" x2="12" y2="5" />
-      <path d="M5 12l7-7 7 7" />
-    </svg>
-  );
-}
-export function ArrowDownIcon() {
-  return (
-    <svg {...base}>
-      <line x1="12" y1="5" x2="12" y2="19" />
-      <path d="M5 12l7 7 7-7" />
-    </svg>
-  );
-}
-export function TrashIcon() {
-  return (
-    <svg {...base}>
-      <path d="M3 6h18" />
-      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
-      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-    </svg>
-  );
-}

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -211,5 +211,12 @@ export const en: Messages = {
     redo: 'Redo',
     mentionsLabel: 'Mentions',
     mentionsEmpty: 'No matches',
+    blockInsert: 'Insert block below',
+    blockActions: 'Block actions',
+    blockTurnInto: 'Turn into',
+    blockDuplicate: 'Duplicate',
+    blockMoveUp: 'Move up',
+    blockMoveDown: 'Move down',
+    blockDelete: 'Delete',
   },
 };

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -349,6 +349,20 @@ export interface Messages {
     mentionsLabel: string;
     /** Empty-state row when no mention candidates match. */
     mentionsEmpty: string;
+    /** aria-label on the block "insert below" (＋) gutter button. */
+    blockInsert: string;
+    /** aria-label on the block actions (⠿) gutter handle. */
+    blockActions: string;
+    /** "Turn into" submenu label in the block menu. */
+    blockTurnInto: string;
+    /** "Duplicate" item in the block menu. */
+    blockDuplicate: string;
+    /** "Move up" item in the block menu. */
+    blockMoveUp: string;
+    /** "Move down" item in the block menu. */
+    blockMoveDown: string;
+    /** "Delete" item in the block menu. */
+    blockDelete: string;
   };
 }
 

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -213,5 +213,12 @@ export const ru: Messages = {
     redo: 'Повторить',
     mentionsLabel: 'Упоминания',
     mentionsEmpty: 'Нет совпадений',
+    blockInsert: 'Вставить блок ниже',
+    blockActions: 'Действия с блоком',
+    blockTurnInto: 'Преобразовать в',
+    blockDuplicate: 'Дублировать',
+    blockMoveUp: 'Переместить вверх',
+    blockMoveDown: 'Переместить вниз',
+    blockDelete: 'Удалить',
   },
 };

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -33,6 +33,11 @@ export function RichTextEditorDemo() {
       '# Imported\n\nThis editor was **seeded** from Markdown — paste rich HTML to import more.',
     ),
   );
+  const [blockDoc, setBlockDoc] = useState<RichDoc>(() =>
+    fromMarkdown(
+      '# Block controls\n\nHover a line for the ＋ / ⠿ gutter.\n\n- first item\n- second item\n\n> Drag the handle to reorder, or open the menu to turn into / duplicate / delete.',
+    ),
+  );
   const [mentionDoc, setMentionDoc] = useState<RichDoc>(() => docFromText('Assign this to '));
   const [autolinkDoc, setAutolinkDoc] = useState<RichDoc>(() =>
     docFromText('Type a task URL below to watch it autolink. '),
@@ -71,6 +76,20 @@ export function RichTextEditorDemo() {
             Markdown → <Code>{toMarkdown(doc).replace(/\n/g, '⏎')}</Code>
           </Text>
         </Stack>
+      </Example>
+
+      <Example
+        title="Block controls"
+        description="Set blockControls for a per-block gutter on hover/focus: ＋ inserts a block below, ⠿ drags to reorder (subtree-aware for nested lists) and opens a menu (turn into / duplicate / move / delete). Keyboard: Shift+F10 opens the menu, ⌘/Ctrl+⇧↑/↓ move the block, ⌘/Ctrl+D duplicates. Works with or without the toolbar."
+        code={`const [doc, setDoc] = useState(fromMarkdown('…'));
+<RichTextEditor value={doc} onChange={setDoc} blockControls placeholder="Write…" />`}
+      >
+        <RichTextEditor
+          value={blockDoc}
+          onChange={setBlockDoc}
+          blockControls
+          placeholder="Write…"
+        />
       </Example>
 
       <Example


### PR DESCRIPTION
## What

Adds an opt-in **`blockControls`** prop to `RichTextEditor` — a Notion-style per-block control layer. This is **Slice 1 of 3** of a larger effort that started as "add file upload to the editor" and was decomposed during brainstorming (Slice 2 = file upload + attachment blocks; Slice 3 = attachment config). Foundation-first: this slice builds the block-controls layer on the *existing* block types so the later attachment blocks inherit it for free.

### Feature
- **Gutter on hover/focus**: `＋` inserts an empty paragraph below; `⠿` is a drag handle and opens a block menu.
- **Block menu** (built on `DropdownMenu`): **Turn into ▸** (Text / H1-3 / Bulleted / Numbered / Quote / Code), **Duplicate**, **Move up/down**, **Delete**.
- **Subtree-aware** reorder / duplicate / delete: a list item carries its nested children as one unit. (Turn-into acts on the single anchor block, idempotently.)
- **Drag-to-reorder** via `@dnd-kit/core` (existing allowed dep); a 4px activation distance keeps a plain click on `⠿` opening the menu.
- **Keyboard**: Shift+F10 / ContextMenu open the focused block's menu; ⌘/Ctrl+⇧↑/↓ move; ⌘/Ctrl+D duplicates. Gutter buttons are `tabindex=-1` (no per-block tab stops).
- Opt-in (`default false`), **independent of `toolbar`**, fully **suppressed when `readOnly`**. All ops route through the controlled `value`/`onChange` + internal `commit()`, so each is one undo step. Default behavior with the prop off is byte-for-byte unchanged.

## How it's built
- New pure engine transforms in `RichText/engine/blockUnit.ts` (unit range + sibling helper, `moveBlockUnit`, `duplicateBlockUnit`, `removeBlockUnit`, `insertEmptyBlockBelow`, `moveBlockUnitToIndex`) — immutable, same-ref no-ops, depth-clamped.
- New internal components `RichTextBlockMenu` (DropdownMenu wrapper) + `RichTextBlockControls` (overlay gutter, measured against the relative shell). Pure drop-geometry in `blockDrop.ts`.
- i18n keys (en + ru), 2 new icons, gutter SCSS (tokens only; overlay-anchoring Rule-4 exception documented).

## Testing
- Engine + geometry unit tests, menu/overlay component tests, and editor-level integration tests (hover gutter, ＋ insert, ⌘⇧↓ move, ⌘D duplicate, menu Duplicate/Turn-into routing, the open-menu-vs-hover targeting guard, readOnly suppression).
- Full suite: **3210 passing**; typecheck, stylelint, build green; `npm pack --dry-run` ships no test files.
- Ran the CLAUDE.md Rule 8 review-fix loop (3 rounds) to a clean verdict — fixes included an idempotent turn-into, a wider gutter reservation, a drag-handle a11y fix (kept out of tab order), and a hover-vs-open-menu targeting guard.

## Follow-ups (separate PRs)
- Slice 2: void image/file blocks + upload (toolbar button + clipboard paste, consumer handler) + inline loader.
- Slice 3: attachment config (alt text / align / replace / download) via the block menu.

Spec: `docs/superpowers/specs/2026-06-25-richtexteditor-block-controls-design.md` · Plan: `docs/superpowers/plans/2026-06-25-richtexteditor-block-controls-slice1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)