### PR TITLE
feat(RichText): renderMention callback for interactive @-mentions (#209)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -255,6 +255,8 @@ const renderLink: RenderLink = ({ href }, fallback) => {
 <RichText value={doc} renderLink={renderLink} />;
 ```
 
+**`renderMention`** (optional) — `(mention: { id, label }, defaultNode) => ReactNode` — same contract as `renderLink` but for `@`-mention marks (render an interactive member chip/popover trigger), or return `defaultNode` for the standard non-interactive mention span. Composes with `renderLink`. Render-time only — `toHtml`/`toMarkdown` and the model still emit the mention mark. Works in both `<RichText>` and `<RichTextEditor>` (where a substituted mention becomes an atomic chip).
+
 When NOT to use: plain text → `Text`. For editing → `<RichTextEditor>`. The model is immutable; render the doc returned by a transform, never mutate in place.
 
 ### `<Button>` — action triggers
@@ -986,6 +988,8 @@ const [doc, setDoc] = useState(emptyDoc());
 **Autolink** (`autolink` prop, default `true`): typing a URL followed by a space, or pasting text containing a URL, turns it into a `link` mark automatically (`http(s)://…` or a bare `www.…` host; unsafe schemes are left as plain text). Set `autolink={false}` to disable both the type rule and paste autolinking.
 
 **`renderLink`** (optional, same `RenderLink` as `<RichText>`): preview links inline — the consumer checks "is this URL in my space?" and returns a chip or the `fallback` `<a>`. In the editor a substituted link becomes an **atomic chip**: the caret sits before/after it (arrow keys step over it, never inside) and Backspace deletes the whole chip in one step. It's render-time only — `toHtml`/`toMarkdown` and the model still emit a plain link, so serialization is unchanged. Don't do heavy synchronous work inside it.
+
+**`renderMention`** (optional, same `RenderMention` as `<RichText>`): `(mention: { id, label }, defaultNode) => ReactNode` — same contract as `renderLink` but for `@`-mention marks (render an interactive member chip/popover trigger); composes with `renderLink`. A substituted mention becomes an **atomic chip** the caret steps over as one unit. Render-time only — `toHtml`/`toMarkdown` and the model still emit the mention mark.
 
 ```tsx
 const renderLink: RenderLink = ({ href }, fallback) => {

--- a/packages/design-system/src/components/RichText/RichText.test.tsx
+++ b/packages/design-system/src/components/RichText/RichText.test.tsx
@@ -65,4 +65,21 @@ describe('RichText', () => {
     expect(container.querySelector('[data-chip]')).not.toBeNull();
     expect(container.querySelector('a')).toBeNull();
   });
+
+  it('renderMention substitutes a custom node for a mention', () => {
+    const doc: RichDoc = {
+      blocks: [
+        {
+          id: '1',
+          type: 'paragraph',
+          inlines: [{ text: '@Alice', marks: [{ type: 'mention', id: 'u1', label: 'Alice' }] }],
+        },
+      ],
+    };
+    const { container } = render(
+      <RichText value={doc} renderMention={({ label }) => <button data-chip>{label}</button>} />,
+    );
+    expect(container.querySelector('[data-chip]')?.textContent).toBe('Alice');
+    expect(container.querySelector('[data-mention]')).toBeNull();
+  });
 });

--- a/packages/design-system/src/components/RichText/RichText.tsx
+++ b/packages/design-system/src/components/RichText/RichText.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import type { RichDoc } from './engine/model';
 import { renderDoc } from './engine/renderDoc';
 import type { RenderLink } from './engine/renderLink';
+import type { RenderMention } from './engine/renderMention';
 import styles from './RichText.module.scss';
 
 export interface RichTextProps extends HTMLAttributes<HTMLDivElement> {
@@ -19,6 +20,18 @@ export interface RichTextProps extends HTMLAttributes<HTMLDivElement> {
    * itself (or falls back to `defaultNode` while loading).
    */
   renderLink?: RenderLink;
+  /**
+   * Substitute how an `@`-mention renders. Called per mention with `{ id, label }`
+   * and the default mention span; return your own node (e.g. an interactive member
+   * chip / popover trigger) or the `defaultNode` to keep the standard
+   * non-interactive span. Render-time only — the document model is unchanged, so
+   * serialization still emits the mention mark. Composes with `renderLink`.
+   *
+   * @remarks Keep it cheap — it runs on every render. Don't block on a network
+   * call inside `renderMention`; return a component that fetches/caches the lookup
+   * itself (or falls back to `defaultNode` while loading).
+   */
+  renderMention?: RenderMention;
 }
 
 /**
@@ -53,14 +66,14 @@ export interface RichTextProps extends HTMLAttributes<HTMLDivElement> {
  * - ❌ Hand-writing HTML to display rich content — feed a `RichDoc` to `<RichText>`.
  */
 export const RichText = forwardRef<HTMLDivElement, RichTextProps>(function RichText(
-  { value, renderLink, className, ...props },
+  { value, renderLink, renderMention, className, ...props },
   ref,
 ) {
   // {...props} last so the consumer can override anything except the composed
   // className (Pattern A — consumer wins).
   return (
     <div ref={ref} className={clsx(styles.root, className)} {...props}>
-      {renderDoc(value, { renderLink })}
+      {renderDoc(value, { renderLink, renderMention })}
     </div>
   );
 });

--- a/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
@@ -366,6 +366,117 @@ describe('renderDoc renderLink option', () => {
   });
 });
 
+describe('renderDoc renderMention option', () => {
+  // A doc with one mention run ("hi " + "@Alice").
+  const mentionDoc = () => ({
+    blocks: [
+      {
+        id: 'b',
+        type: 'paragraph' as const,
+        inlines: [
+          { text: 'hi ', marks: [] },
+          { text: '@Alice', marks: [{ type: 'mention' as const, id: 'u1', label: 'Alice' }] },
+        ],
+      },
+    ],
+  });
+
+  it('renderMention substitutes a custom node (read-only)', () => {
+    const { container } = render(
+      <>{renderDoc(mentionDoc(), { renderMention: ({ label }) => <button>{label}!</button> })}</>,
+    );
+    expect(container.querySelector('button')?.textContent).toBe('Alice!');
+  });
+
+  it('renderMention declining (returns defaultNode) keeps the default mention span', () => {
+    const { container } = render(
+      <>{renderDoc(mentionDoc(), { renderMention: (_m, def) => def })}</>,
+    );
+    expect(container.querySelector('[data-mention]')).toBeTruthy();
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('on the editable surface a substituted mention is an atomic widget with data-len', () => {
+    const { container } = render(
+      <>
+        {renderDoc(mentionDoc(), {
+          editable: true,
+          renderMention: ({ label }) => <button>{label}</button>,
+        })}
+      </>,
+    );
+    const w = container.querySelector('[data-rich-mention]')!;
+    expect(w).toHaveAttribute('contenteditable', 'false');
+    expect(w).toHaveAttribute('data-len', '6'); // '@Alice'.length
+  });
+
+  it('coalesces a same-id/label mention split across runs into ONE widget', () => {
+    const doc = {
+      blocks: [
+        {
+          id: 'b',
+          type: 'paragraph' as const,
+          inlines: [
+            { text: '@Al', marks: [{ type: 'mention' as const, id: 'u1', label: 'Alice' }] },
+            {
+              text: 'ice',
+              marks: [
+                { type: 'mention' as const, id: 'u1', label: 'Alice' },
+                { type: 'bold' as const },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    let calls = 0;
+    const { container } = render(
+      <>
+        {renderDoc(doc, {
+          renderMention: ({ id }) => {
+            calls += 1;
+            return <button data-id={id}>chip</button>;
+          },
+        })}
+      </>,
+    );
+    expect(container.querySelectorAll('button')).toHaveLength(1);
+    expect(calls).toBe(1);
+
+    const ed = render(
+      <>{renderDoc(doc, { editable: true, renderMention: () => <button>chip</button> })}</>,
+    );
+    const widgets = ed.container.querySelectorAll('[data-rich-mention]');
+    expect(widgets).toHaveLength(1);
+    expect(widgets[0].getAttribute('data-len')).toBe('6'); // "@Alice"
+  });
+
+  it('renderMention composes with renderLink', () => {
+    const doc = {
+      blocks: [
+        {
+          id: 'b',
+          type: 'paragraph' as const,
+          inlines: [
+            { text: 'x', marks: [{ type: 'link' as const, href: 'https://a' }] },
+            { text: '@Bob', marks: [{ type: 'mention' as const, id: 'u2', label: 'Bob' }] },
+          ],
+        },
+      ],
+    };
+    const { container } = render(
+      <>
+        {renderDoc(doc, {
+          renderLink: (_l, def) => def,
+          renderMention: ({ label }) => <button>{label}</button>,
+        })}
+      </>,
+    );
+    expect(container.querySelector('a')).toBeTruthy();
+    expect(container.querySelector('button')?.textContent).toBe('Bob');
+  });
+});
+
 it('renders an attachment block as a contenteditable=false figure', () => {
   const doc = {
     blocks: [

--- a/packages/design-system/src/components/RichText/engine/renderDoc.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.tsx
@@ -6,6 +6,7 @@ import { runsText, runsLength } from './inlines';
 import { safeHref } from './safeHref';
 import { isListItem, effectiveDepths } from './listDepths';
 import type { RenderLink } from './renderLink';
+import type { RenderMention } from './renderMention';
 import { RichTextAttachment } from '../../RichTextEditor/RichTextAttachment';
 
 export interface RenderDocOptions {
@@ -19,12 +20,22 @@ export interface RenderDocOptions {
    * default node to keep the standard `<a>`.
    */
   renderLink?: RenderLink;
+  /**
+   * Replace how a `mention` mark renders (e.g. an interactive member chip /
+   * popover trigger). In the read-only viewer the returned node substitutes the
+   * default mention span directly; on an editable surface a substituted node is
+   * wrapped in an atomic, non-editable `[data-rich-mention]` widget so the caret
+   * steps over it as a single unit. Return the supplied default node to keep the
+   * standard non-interactive mention span. Composes with `renderLink`.
+   */
+  renderMention?: RenderMention;
 }
 
 // Resolved options threaded through the render call chain (never module state).
 interface ResolvedOptions {
   editable: boolean;
   renderLink?: RenderLink;
+  renderMention?: RenderMention;
 }
 
 // Outer → inner nesting order so output is stable + diff-friendly.
@@ -85,6 +96,43 @@ function renderInlines(inlines: Inline[], opts: ResolvedOptions): ReactNode {
   let i = 0;
   while (i < inlines.length) {
     const run = inlines[i];
+    const mm = run.marks.find((m) => m.type === 'mention');
+    const mention = mm && mm.type === 'mention' ? { id: mm.id, label: mm.label } : null;
+    if (opts.renderMention && mention) {
+      // Coalesce contiguous runs that share this exact mention (same id AND label)
+      // into ONE logical mention, so a mention split across runs (e.g. internal
+      // formatting, HTML import) resolves to a single chip — not one per run.
+      let j = i;
+      let text = '';
+      while (j < inlines.length) {
+        const m = inlines[j].marks.find((mk) => mk.type === 'mention');
+        if (!m || m.type !== 'mention' || m.id !== mention.id || m.label !== mention.label) break;
+        text += inlines[j].text;
+        j += 1;
+      }
+      const fallback = (
+        <span data-mention data-mention-id={mention.id} data-mention-label={mention.label}>
+          {text}
+        </span>
+      );
+      const custom = opts.renderMention(mention, fallback);
+      if (custom !== fallback) {
+        // Substituted: one node for the whole span. In the editor it's an atomic,
+        // non-editable widget tagged with the span's MODEL length (`data-len`).
+        out.push(
+          opts.editable ? (
+            <span key={i} data-rich-mention data-len={text.length} contentEditable={false}>
+              {custom}
+            </span>
+          ) : (
+            <Fragment key={i}>{custom}</Fragment>
+          ),
+        );
+        i = j;
+        continue;
+      }
+      // Consumer declined → fall through to the link/default handling below.
+    }
     const lm = run.marks.find((m) => m.type === 'link');
     const linkHref = lm && lm.type === 'link' ? lm.href : null;
     const safe = opts.renderLink && linkHref != null ? safeHref(linkHref) : undefined;
@@ -256,6 +304,7 @@ export function renderDoc(doc: RichDoc, options: RenderDocOptions = {}): ReactNo
   const opts: ResolvedOptions = {
     editable: options.editable ?? false,
     renderLink: options.renderLink,
+    renderMention: options.renderMention,
   };
   const eff = effectiveDepths(doc.blocks);
   const out: ReactNode[] = [];

--- a/packages/design-system/src/components/RichText/engine/renderMention.ts
+++ b/packages/design-system/src/components/RichText/engine/renderMention.ts
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+/** A mention encountered while rendering, passed to `renderMention`. */
+export interface RichTextMention {
+  /** The mention's stable id (from the `mention` mark). */
+  id: string;
+  /** The mention's display label (without the trigger). */
+  label: string;
+}
+
+/**
+ * Replace how a `mention` mark renders. Return your own node (e.g. an interactive
+ * member chip / popover trigger) to substitute the mention, or `defaultNode` for
+ * the standard non-interactive mention span. Mirrors {@link RenderLink}.
+ */
+export type RenderMention = (mention: RichTextMention, defaultNode: ReactNode) => ReactNode;

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -832,6 +832,38 @@ describe('RichTextEditor renderLink', () => {
   });
 });
 
+describe('RichTextEditor renderMention', () => {
+  beforeEach(() => mockReadSelection.mockReset());
+
+  it('renders a substituted mention as a non-editable atomic [data-rich-mention] chip', () => {
+    mockReadSelection.mockReturnValue(null);
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [
+          {
+            id: 'k',
+            type: 'paragraph',
+            inlines: [{ text: '@Alice', marks: [{ type: 'mention', id: 'u1', label: 'Alice' }] }],
+          },
+        ],
+      });
+      return (
+        <RichTextEditor
+          value={doc}
+          onChange={setDoc}
+          renderMention={({ label }) => <button data-chip>{label}</button>}
+        />
+      );
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox', { name: 'Rich text editor' });
+    const widget = box.querySelector('[data-rich-mention]');
+    expect(widget).not.toBeNull();
+    expect(widget?.getAttribute('contenteditable')).toBe('false');
+    expect(widget?.querySelector('[data-chip]')?.textContent).toBe('Alice');
+  });
+});
+
 describe('blockControls', () => {
   function Controlled(props: { blockControls?: boolean; readOnly?: boolean }) {
     const [doc, setDoc] = useState(docFromText('one\ntwo\nthree'));

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -309,7 +309,6 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       readOnly,
       autolink,
       renderLink,
-      renderMention,
       upload,
     });
     latest.current = {
@@ -318,7 +317,6 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       readOnly,
       autolink,
       renderLink,
-      renderMention,
       upload,
     };
     // The synchronous "live" doc — kept ahead of `value` between renders by the

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -13,6 +13,7 @@ import type { RichDoc, Range, Mark, MarkType, Point } from '../RichText/engine/m
 import { nextId } from '../RichText/engine/model';
 import { renderDoc } from '../RichText/engine/renderDoc';
 import type { RenderLink } from '../RichText/engine/renderLink';
+import type { RenderMention } from '../RichText/engine/renderMention';
 import { blockLength, isCollapsed } from '../RichText/engine/position';
 import { linkAt, setLink, removeLink } from './links';
 import { applyTypeAutolink, atomicLinkDeleteRange } from './autolinkInput';
@@ -131,6 +132,21 @@ export interface RichTextEditorProps extends Omit<
    */
   renderLink?: RenderLink;
   /**
+   * Substitute how an `@`-mention renders. Called per mention with `{ id, label }`
+   * and the default mention span; return your own node (e.g. an interactive member
+   * chip / popover trigger) or the `defaultNode` to keep the standard
+   * non-interactive span. A custom node renders as a non-editable **atomic chip** —
+   * the caret steps over it as a single unit. Composes with `renderLink` (both
+   * usable together).
+   *
+   * @remarks Render-time only — the model is unchanged, so `toHtml`/`toMarkdown`
+   * still serialize the mention mark. Keep it cheap (it runs on every render):
+   * don't do heavy synchronous work or block on the network inside `renderMention`;
+   * return a component that fetches/caches the lookup itself (falling back to
+   * `defaultNode` while loading).
+   */
+  renderMention?: RenderMention;
+  /**
    * Show Notion-style per-block controls: a left gutter that appears on the
    * hovered/focused block with an insert button (`＋`, adds an empty paragraph
    * below) and a drag handle (`⠿`) that opens a block menu (Turn into ▸,
@@ -241,6 +257,8 @@ interface LinkEditorOpen {
  *   (the inverse of `fromHtml` / `fromMarkdown`).
  * - ❌ Using mentions to insert plain links — that's the link tool (⌘K). A
  *   mention chip is an inert reference carrying an `id`, not a navigable anchor.
+ * - ❌ Using `renderMention` for plain links — that's `renderLink`; a mention chip
+ *   is an inert reference carrying an `id`. The two compose; use each for its mark.
  * - ❌ Returning thousands of unfiltered items from `onQuery` — filter server-side
  *   (or by the `query`); the menu renders what you return.
  * - ❌ Relying on Markdown to preserve mentions — `toMarkdown` is lossy (plain
@@ -272,6 +290,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       mentions,
       autolink = true,
       renderLink,
+      renderMention,
       upload,
       className,
       ...rest
@@ -284,8 +303,24 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // Selection to restore after the next model-driven re-render.
     const pendingSelectionRef = useRef<Range | null>(null);
     // Latest props for the native beforeinput listener (avoids stale closures).
-    const latest = useRef({ value, onChange, readOnly, autolink, renderLink, upload });
-    latest.current = { value, onChange, readOnly, autolink, renderLink, upload };
+    const latest = useRef({
+      value,
+      onChange,
+      readOnly,
+      autolink,
+      renderLink,
+      renderMention,
+      upload,
+    });
+    latest.current = {
+      value,
+      onChange,
+      readOnly,
+      autolink,
+      renderLink,
+      renderMention,
+      upload,
+    };
     // The synchronous "live" doc — kept ahead of `value` between renders by the
     // commit paths, so several async upload settles in the same tick chain off each
     // other's result instead of all reading the stale last-rendered `value` (which
@@ -1166,7 +1201,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         onCompositionStart={onCompositionStart}
         onCompositionEnd={onCompositionEnd}
       >
-        {renderDoc(value, { editable: true, renderLink })}
+        {renderDoc(value, { editable: true, renderLink, renderMention })}
       </div>
     );
 

--- a/packages/design-system/src/components/RichTextEditor/selection.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.test.ts
@@ -145,6 +145,81 @@ describe('selection mapping — atomic [data-rich-link] widget', () => {
   });
 });
 
+// An atomic [data-rich-mention] widget (a `renderMention` substitution) behaves
+// identically to a [data-rich-link] widget: it renders DISPLAY text but represents
+// `data-len` MODEL chars and the caret can only sit BEFORE or AFTER it.
+//   <p data-block-id="b1">hi <span data-rich-mention data-len="6" …>@A</span> end</p>
+//   model: "hi " (3) + widget (6, "@Alice") + " end" (4) = 13 model chars total.
+function buildMentionWidgetRoot(): HTMLElement {
+  const root = document.createElement('div');
+  root.innerHTML =
+    '<p data-block-id="b1">hi <span data-rich-mention data-len="6" contenteditable="false">@A</span> end</p>';
+  document.body.appendChild(root);
+  return root;
+}
+
+describe('selection mapping — atomic [data-rich-mention] widget', () => {
+  it('pointFromDom: counts the widget as data-len (6), not its 2 display chars', () => {
+    const root = buildMentionWidgetRoot();
+    const p = root.querySelector('[data-block-id="b1"]') as HTMLElement;
+    const lead = p.firstChild as Text; // "hi "
+    const trail = p.lastChild as Text; // " end"
+
+    // caret just before the widget → end of "hi " (3 model chars)
+    expect(pointFromDom(root, lead, 3)).toEqual({ blockId: 'b1', offset: 3 });
+    expect(pointFromDom(root, p, 1)).toEqual({ blockId: 'b1', offset: 3 });
+
+    // caret just after the widget → 3 + 6 = 9 (NOT 3 + 2 = 5)
+    expect(pointFromDom(root, trail, 0)).toEqual({ blockId: 'b1', offset: 9 });
+    expect(pointFromDom(root, p, 2)).toEqual({ blockId: 'b1', offset: 9 });
+
+    // caret at the very end of " end" → 9 + 4 = 13
+    expect(pointFromDom(root, trail, 4)).toEqual({ blockId: 'b1', offset: 13 });
+    root.remove();
+  });
+
+  it('pointToDom: widget-boundary offsets map adjacent to the widget, never inside', () => {
+    const root = buildMentionWidgetRoot();
+    const p = root.querySelector('[data-block-id="b1"]') as HTMLElement;
+    const lead = p.firstChild as Text; // "hi "
+    const widget = p.querySelector('[data-rich-mention]') as HTMLElement;
+    const trail = p.lastChild as Text; // " end"
+    const widgetIndex = Array.prototype.indexOf.call(p.childNodes, widget); // 1
+
+    const before = pointToDom(root, { blockId: 'b1', offset: 3 })!;
+    if (before.node === lead) {
+      expect(before.offset).toBe(3);
+    } else {
+      expect(before.node).toBe(p);
+      expect(before.offset).toBe(widgetIndex);
+    }
+    expect(widget.contains(before.node)).toBe(false);
+
+    const after = pointToDom(root, { blockId: 'b1', offset: 9 })!;
+    expect(widget.contains(after.node)).toBe(false);
+    if (after.node === trail) {
+      expect(after.offset).toBe(0);
+    } else {
+      expect(after.node).toBe(p);
+      expect(after.offset).toBe(widgetIndex + 1);
+    }
+
+    const end = pointToDom(root, { blockId: 'b1', offset: 13 })!;
+    expect(end.node).toBe(trail);
+    expect(end.offset).toBe(4);
+    root.remove();
+  });
+
+  it('pointFromDom/pointToDom round-trip across the widget boundary', () => {
+    const root = buildMentionWidgetRoot();
+    for (const offset of [0, 3, 9, 11, 13]) {
+      const dom = pointToDom(root, { blockId: 'b1', offset })!;
+      expect(pointFromDom(root, dom.node, dom.offset)).toEqual({ blockId: 'b1', offset });
+    }
+    root.remove();
+  });
+});
+
 function makeRoot(html: string): HTMLElement {
   const el = document.createElement('div');
   el.innerHTML = html;

--- a/packages/design-system/src/components/RichTextEditor/selection.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.ts
@@ -2,9 +2,18 @@
 // functions take the editable root element; block elements carry `data-block-id`.
 import type { Point, Range } from '../RichText/engine/model';
 
-/** The MODEL length an atomic `[data-rich-link]` widget represents. Falls back to
- *  its display-text length if `data-len` is missing/non-numeric (so a malformed
- *  widget degrades gracefully instead of poisoning the offset math with NaN). */
+/** Selector + predicate for atomic inline widgets (renderLink / renderMention
+ *  substitutions): contentEditable=false nodes whose display text may differ from
+ *  the `data-len` MODEL length they represent. */
+const ATOMIC_WIDGET_SELECTOR = '[data-rich-link],[data-rich-mention]';
+function isAtomicWidget(el: HTMLElement): boolean {
+  return el.hasAttribute('data-rich-link') || el.hasAttribute('data-rich-mention');
+}
+
+/** The MODEL length an atomic widget (`[data-rich-link]` / `[data-rich-mention]`)
+ *  represents. Falls back to its display-text length if `data-len` is
+ *  missing/non-numeric (so a malformed widget degrades gracefully instead of
+ *  poisoning the offset math with NaN). */
 function widgetLen(w: HTMLElement): number {
   const n = Number(w.dataset.len);
   return Number.isFinite(n) ? n : (w.textContent?.length ?? 0);
@@ -43,12 +52,12 @@ function figureBlock(node: Node | null | undefined): HTMLElement | null {
  * the point via a DOM Range, which counts only character data (so `<br>`,
  * empty blocks, and nested mark spans are all handled correctly).
  *
- * Atomic `[data-rich-link]` widgets are corrected for: such a widget renders
- * DISPLAY text (e.g. "#1 Task") but represents `data-len` MODEL chars (e.g. the
- * URL it links). `range.toString()` counts the display text, so for every widget
- * that lies fully before the range end we add `data-len - displayLength`. When a
- * block contains no `[data-rich-link]` the correction loop runs zero times, so
- * this is an exact no-op for ordinary content.
+ * Atomic widgets (`[data-rich-link]` / `[data-rich-mention]`) are corrected for:
+ * such a widget renders DISPLAY text (e.g. "#1 Task") but represents `data-len`
+ * MODEL chars (e.g. the URL it links). `range.toString()` counts the display
+ * text, so for every widget that lies fully before the range end we add
+ * `data-len - displayLength`. When a block contains no atomic widget the
+ * correction loop runs zero times, so this is an exact no-op for ordinary content.
  */
 function offsetWithinBlock(blockEl: HTMLElement, node: Node, offset: number): number {
   const doc = blockEl.ownerDocument;
@@ -60,7 +69,7 @@ function offsetWithinBlock(blockEl: HTMLElement, node: Node, offset: number): nu
     return 0; // node not inside blockEl (shouldn't happen) → block start
   }
   let len = range.toString().length;
-  for (const w of blockEl.querySelectorAll<HTMLElement>('[data-rich-link]')) {
+  for (const w of blockEl.querySelectorAll<HTMLElement>(ATOMIC_WIDGET_SELECTOR)) {
     // The widget's display text is included in `len` iff our range end is at or
     // past the point immediately AFTER the widget. Compare our range's END
     // boundary against a collapsed range positioned just after the widget:
@@ -134,10 +143,10 @@ export function pointToDom(root: HTMLElement, point: Point): { node: Node; offse
     const index = Array.prototype.indexOf.call(parent.childNodes, blockEl);
     return { node: parent, offset: index };
   }
-  // Walk TEXT nodes and atomic `[data-rich-link]` widgets, accumulating model
-  // length: text → its char length, widget → `data-len` (NOT its display text;
-  // we never descend into a widget). A widget is contenteditable=false, so the
-  // caret can only sit adjacent to it — when `remaining` lands at a widget we
+  // Walk TEXT nodes and atomic widgets (`[data-rich-link]` / `[data-rich-mention]`),
+  // accumulating model length: text → its char length, widget → `data-len` (NOT its
+  // display text; we never descend into a widget). A widget is contenteditable=false,
+  // so the caret can only sit adjacent to it — when `remaining` lands at a widget we
   // return a point in the widget's PARENT at the widget's child index (before)
   // or +1 (after), never inside it. With no widgets present this behaves exactly
   // like the previous text-only TreeWalker (FILTER_SKIP descends into mark spans).
@@ -146,15 +155,13 @@ export function pointToDom(root: HTMLElement, point: Point): { node: Node; offse
     NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
     {
       acceptNode(n) {
-        if (n instanceof HTMLElement && n.hasAttribute('data-rich-link'))
-          return NodeFilter.FILTER_ACCEPT; // the widget itself, atomic
+        if (n instanceof HTMLElement && isAtomicWidget(n)) return NodeFilter.FILTER_ACCEPT; // the widget itself, atomic
         // Reject the widget's contents so the walk treats it as one opaque unit
         // (a TreeWalker descends into an ACCEPTED element, so we must REJECT its
         // descendants — REJECT skips the node AND its subtree, unlike SKIP).
         let p: Node | null = n.parentNode;
         while (p && p !== blockEl) {
-          if (p instanceof HTMLElement && p.hasAttribute('data-rich-link'))
-            return NodeFilter.FILTER_REJECT;
+          if (p instanceof HTMLElement && isAtomicWidget(p)) return NodeFilter.FILTER_REJECT;
           p = p.parentNode;
         }
         if (n.nodeType === Node.TEXT_NODE) return NodeFilter.FILTER_ACCEPT;

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -490,6 +490,7 @@ export type {
   RichRange,
 } from './components/RichText';
 export type { RichTextLink, RenderLink } from './components/RichText/engine/renderLink';
+export type { RichTextMention, RenderMention } from './components/RichText/engine/renderMention';
 export {
   emptyDoc,
   createBlock,

--- a/packages/playground/src/pages/components/RichTextDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextDemo.tsx
@@ -9,6 +9,7 @@ import {
   Badge,
   type RichDoc,
   type RenderLink,
+  type RenderMention,
 } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
@@ -20,6 +21,37 @@ const TASK_RE = /^https?:\/\/app\.eocrm\/task\/(\d+)/i;
 const renderLink: RenderLink = ({ href }, fallback) => {
   const m = TASK_RE.exec(href);
   return m ? <Badge tone="purple">#{m[1]} · Ship the gallery</Badge> : fallback;
+};
+
+// A consumer-supplied mention resolver: render each @-mention as an interactive
+// member chip instead of the default non-interactive span. Composes with renderLink.
+const renderMention: RenderMention = ({ id, label }) => (
+  <Badge
+    tone="info"
+    role="button"
+    tabIndex={0}
+    title={`Open ${label}'s profile`}
+    onClick={() => alert(`Mentioned ${label} (${id})`)}
+  >
+    @{label}
+  </Badge>
+);
+
+// A doc with two @-mentions to show renderMention substitution.
+const MENTION_DOC: RichDoc = {
+  blocks: [
+    {
+      id: 'mr',
+      type: 'paragraph',
+      inlines: [
+        { text: 'Assign this to ', marks: [] },
+        { text: '@Alice', marks: [{ type: 'mention', id: 'u1', label: 'Alice Nguyen' }] },
+        { text: ' and ', marks: [] },
+        { text: '@Bob', marks: [{ type: 'mention', id: 'u2', label: 'Bob Martinez' }] },
+        { text: '.', marks: [] },
+      ],
+    },
+  ],
 };
 
 // A doc with one resolvable task link (→ chip) and one plain external link (→ <a>).
@@ -128,6 +160,19 @@ setDoc(r.doc);`}
 <RichText value={doc} renderLink={renderLink} />`}
       >
         <RichText value={LINK_DOC} renderLink={renderLink} />
+      </Example>
+
+      <Example
+        title="Mention substitution (renderMention)"
+        description="Pass renderMention to swap how an @-mention renders — same contract as renderLink but for mention marks. Here each mention becomes an interactive member chip (click one). It composes with renderLink and is render-time only; serialization still emits the mention mark."
+        code={`const renderMention: RenderMention = ({ id, label }) => (
+  <Badge tone="blue" role="button" tabIndex={0} onClick={() => openProfile(id)}>
+    @{label}
+  </Badge>
+);
+<RichText value={doc} renderMention={renderMention} />`}
+      >
+        <RichText value={MENTION_DOC} renderMention={renderMention} />
       </Example>
     </DemoLayout>
   );

--- a/packages/playground/src/pages/components/RichTextDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextDemo.tsx
@@ -25,13 +25,20 @@ const renderLink: RenderLink = ({ href }, fallback) => {
 
 // A consumer-supplied mention resolver: render each @-mention as an interactive
 // member chip instead of the default non-interactive span. Composes with renderLink.
+const openMention = (id: string, label: string) => alert(`Mentioned ${label} (${id})`);
 const renderMention: RenderMention = ({ id, label }) => (
   <Badge
     tone="info"
     role="button"
     tabIndex={0}
     title={`Open ${label}'s profile`}
-    onClick={() => alert(`Mentioned ${label} (${id})`)}
+    onClick={() => openMention(id, label)}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openMention(id, label);
+      }
+    }}
   >
     @{label}
   </Badge>
@@ -165,8 +172,17 @@ setDoc(r.doc);`}
       <Example
         title="Mention substitution (renderMention)"
         description="Pass renderMention to swap how an @-mention renders — same contract as renderLink but for mention marks. Here each mention becomes an interactive member chip (click one). It composes with renderLink and is render-time only; serialization still emits the mention mark."
-        code={`const renderMention: RenderMention = ({ id, label }) => (
-  <Badge tone="blue" role="button" tabIndex={0} onClick={() => openProfile(id)}>
+        code={`// Render an @-mention as your own interactive, keyboard-accessible chip.
+const renderMention: RenderMention = ({ id, label }) => (
+  <Badge
+    tone="info"
+    role="button"
+    tabIndex={0}
+    onClick={() => openProfile(id)}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openProfile(id); }
+    }}
+  >
     @{label}
   </Badge>
 );

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -30,13 +30,20 @@ const renderLink: RenderLink = ({ href }, fallback) => {
 // member chip (here a clickable Badge / popover trigger) instead of the default
 // non-interactive span. Composes with renderLink. Render-time only — the model
 // still carries the mention mark, so serialization is unchanged.
+const openMention = (id: string, label: string) => alert(`Mentioned ${label} (${id})`);
 const renderMention: RenderMention = ({ id, label }) => (
   <Badge
     tone="info"
     role="button"
     tabIndex={0}
     title={`Open ${label}'s profile`}
-    onClick={() => alert(`Mentioned ${label} (${id})`)}
+    onClick={() => openMention(id, label)}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openMention(id, label);
+      }
+    }}
   >
     @{label}
   </Badge>
@@ -168,8 +175,17 @@ const [doc, setDoc] = useState(() => fromMarkdown('# Imported\\n\\n- one\\n- two
       <Example
         title="Mentions (@-autocomplete)"
         description='Pass a mentions prop with onQuery to enable @-mentions. Type "@" then a name (e.g. "@al") to open the candidate menu; ↑/↓ to move, Enter/Tab to insert a chip, Esc to dismiss. The chip carries the id; Backspace removes the whole chip. Pass renderMention to swap the default span for an interactive member chip (click one below) — it composes with renderLink and is render-time only, so serialization keeps the mention mark.'
-        code={`const renderMention: RenderMention = ({ id, label }) => (
-  <Badge tone="blue" role="button" tabIndex={0} onClick={() => openProfile(id)}>
+        code={`// Render an @-mention as your own interactive, keyboard-accessible chip.
+const renderMention: RenderMention = ({ id, label }) => (
+  <Badge
+    tone="info"
+    role="button"
+    tabIndex={0}
+    onClick={() => openProfile(id)}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openProfile(id); }
+    }}
+  >
     @{label}
   </Badge>
 );

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -11,6 +11,7 @@ import {
   Stack,
   type RichDoc,
   type RenderLink,
+  type RenderMention,
 } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
@@ -24,6 +25,22 @@ const renderLink: RenderLink = ({ href }, fallback) => {
   const m = TASK_RE.exec(href);
   return m ? <Badge tone="purple">#{m[1]} · Ship the gallery</Badge> : fallback;
 };
+
+// A consumer-supplied mention resolver: render each @-mention as an interactive
+// member chip (here a clickable Badge / popover trigger) instead of the default
+// non-interactive span. Composes with renderLink. Render-time only — the model
+// still carries the mention mark, so serialization is unchanged.
+const renderMention: RenderMention = ({ id, label }) => (
+  <Badge
+    tone="info"
+    role="button"
+    tabIndex={0}
+    title={`Open ${label}'s profile`}
+    onClick={() => alert(`Mentioned ${label} (${id})`)}
+  >
+    @{label}
+  </Badge>
+);
 
 export function RichTextEditorDemo() {
   const [doc, setDoc] = useState<RichDoc>(docFromText('Type here. Select a word and press ⌘B.'));
@@ -150,9 +167,15 @@ const [doc, setDoc] = useState(() => fromMarkdown('# Imported\\n\\n- one\\n- two
 
       <Example
         title="Mentions (@-autocomplete)"
-        description='Pass a mentions prop with onQuery to enable @-mentions. Type "@" then a name (e.g. "@al") to open the candidate menu; ↑/↓ to move, Enter/Tab to insert a chip, Esc to dismiss. The chip carries the id; Backspace removes the whole chip.'
-        code={`<RichTextEditor value={doc} onChange={setDoc} toolbar
-  mentions={{ onQuery: (q) => searchUsers(q) }} />`}
+        description='Pass a mentions prop with onQuery to enable @-mentions. Type "@" then a name (e.g. "@al") to open the candidate menu; ↑/↓ to move, Enter/Tab to insert a chip, Esc to dismiss. The chip carries the id; Backspace removes the whole chip. Pass renderMention to swap the default span for an interactive member chip (click one below) — it composes with renderLink and is render-time only, so serialization keeps the mention mark.'
+        code={`const renderMention: RenderMention = ({ id, label }) => (
+  <Badge tone="blue" role="button" tabIndex={0} onClick={() => openProfile(id)}>
+    @{label}
+  </Badge>
+);
+<RichTextEditor value={doc} onChange={setDoc} toolbar
+  mentions={{ onQuery: (q) => searchUsers(q) }}
+  renderMention={renderMention} />`}
       >
         <RichTextEditor
           value={mentionDoc}
@@ -160,6 +183,7 @@ const [doc, setDoc] = useState(() => fromMarkdown('# Imported\\n\\n- one\\n- two
           toolbar
           placeholder="Type @ to mention someone…"
           mentions={{ onQuery: queryTeam }}
+          renderMention={renderMention}
         />
       </Example>
 


### PR DESCRIPTION
Addresses #209.

## Summary
Adds `renderMention?: RenderMention` to `<RichText>` and `<RichTextEditor>`, mirroring the existing `renderLink`, so consumers can render an `@`-mention mark as an interactive element (e.g. a `MemberRef` popover trigger). Composes with `renderLink` (both usable together).

- New `RenderMention = (mention: { id, label }, defaultNode) => ReactNode` + `RichTextMention` type (exported from the package root), mirroring `RenderLink`.
- `renderDoc` calls `renderMention` per `mention` mark (coalescing contiguous same-id+label runs), substituting the returned node. On the editable surface the substitution is an atomic, non-editable widget (`data-rich-mention` + `data-len`) so the caret steps over it as one unit; read-only renders a fragment. Returning `defaultNode` keeps the plain non-interactive mention span (unchanged default).
- `selection.ts`'s atomic-widget caret math was generalized so both `data-rich-link` and `data-rich-mention` widgets are handled (shared `ATOMIC_WIDGET_SELECTOR`/`isAtomicWidget`). Offset math unchanged for links.
- Mentions already snap on delete (engine `deleteRange`), so Backspace at a mention-widget edge removes the whole chip — no new delete logic.

## Test plan
- `make test` (full suite **3313 passing**), `make build-lib`, `make lint`, `npm run format:check` — all green; `npm pack --dry-run` ships no test files.
- New tests: `renderDoc` (read-only substitution, decline→default span, editable atomic widget + `data-len`, composes-with-`renderLink`, coalescing); `selection` (`data-rich-mention` widget offset round-trip); `<RichText>` + `<RichTextEditor>` prop pass-through.
- Ran the CLAUDE.md Rule 8 review loop to a clean verdict (the high-risk `selection.ts` generalization was hand-traced for a mixed link+mention block; demo mention chip made keyboard-accessible).
- Docs: `AGENTS.md` entry; JSDoc + `@remarks` on both props; playground demos (`RichTextDemo`/`RichTextEditorDemo`) show an interactive, keyboard-accessible member chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)