### PR TITLE
feat(Sticky): optional scroll-viewport mode for tall pinned sidebars (#210)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1410,6 +1410,7 @@ Pins its box to the top of the scroll container while the page scrolls past — 
 ```
 
 - `top`: `none` (default, `top:0`) / `xs` / `sm` / `md` / `lg` / `xl` — offset from the top (spacing scale); use a non-zero step to clear a sticky header.
+- `scroll`: cap the pinned box at the viewport height with internal `overflow-y:auto` + `overscroll-behavior:contain` — for a sidebar taller than the screen (pair with a non-`none` `top`).
 - Inside a `<Split>` aside, pair with `align="stretch"` (else the content-height aside track gives nowhere to pin).
 
 When NOT to use: arranging children → `<Stack>`/`<Cluster>`; a fixed overlay above content → `position: fixed` chrome (`Popover`/`Modal`/app bar); the split itself → `<Split>`. Note: `position: sticky` breaks if a clipping ancestor (`overflow: hidden/auto`) isn't the intended scroll container.

--- a/packages/design-system/src/components/Sticky/Sticky.module.scss
+++ b/packages/design-system/src/components/Sticky/Sticky.module.scss
@@ -17,24 +17,41 @@
 
 .top-none {
   top: 0;
+  --sticky-offset: 0px;
 }
 
 .top-xs {
   top: var(--sticky-top-xs);
+  --sticky-offset: var(--sticky-top-xs);
 }
 
 .top-sm {
   top: var(--sticky-top-sm);
+  --sticky-offset: var(--sticky-top-sm);
 }
 
 .top-md {
   top: var(--sticky-top-md);
+  --sticky-offset: var(--sticky-top-md);
 }
 
 .top-lg {
   top: var(--sticky-top-lg);
+  --sticky-offset: var(--sticky-top-lg);
 }
 
 .top-xl {
   top: var(--sticky-top-xl);
+  --sticky-offset: var(--sticky-top-xl);
+}
+
+// Scroll-viewport mode (Rule 4: <Sticky> is a layout primitive — capping its own
+// pinned box + internal overflow is its job, like position:sticky itself). Caps
+// at the dynamic viewport height minus the top offset and an equal bottom gap, so
+// a column taller than the screen scrolls within itself. `overscroll-behavior:
+// contain` stops the page from scroll-chaining when the box hits its end.
+.scroll {
+  max-height: calc(100dvh - (2 * var(--sticky-offset, 0px)));
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }

--- a/packages/design-system/src/components/Sticky/Sticky.module.scss
+++ b/packages/design-system/src/components/Sticky/Sticky.module.scss
@@ -51,6 +51,9 @@
 // a column taller than the screen scrolls within itself. `overscroll-behavior:
 // contain` stops the page from scroll-chaining when the box hits its end.
 .scroll {
+  // 100vh first as a fallback for browsers without dvh (Safari < 15.4), then the
+  // dynamic-viewport unit — mirrors the Modal/Drawer convention.
+  max-height: calc(100vh - (2 * var(--sticky-offset, 0px)));
   max-height: calc(100dvh - (2 * var(--sticky-offset, 0px)));
   overflow-y: auto;
   overscroll-behavior: contain;

--- a/packages/design-system/src/components/Sticky/Sticky.test.tsx
+++ b/packages/design-system/src/components/Sticky/Sticky.test.tsx
@@ -35,6 +35,18 @@ describe('Sticky', () => {
     },
   );
 
+  it('applies the scroll class only when scroll is set', () => {
+    const { container, rerender } = render(<Sticky top="lg">x</Sticky>);
+    // default: no scroll-viewport class
+    expect((container.firstChild as HTMLElement).className).not.toMatch(/scroll/);
+    rerender(
+      <Sticky top="lg" scroll>
+        x
+      </Sticky>,
+    );
+    expect((container.firstChild as HTMLElement).className).toMatch(/scroll/);
+  });
+
   it('merges className and spreads other attrs', () => {
     const { container } = render(
       <Sticky className="my-cls" data-foo="bar">

--- a/packages/design-system/src/components/Sticky/Sticky.tsx
+++ b/packages/design-system/src/components/Sticky/Sticky.tsx
@@ -21,7 +21,9 @@ export interface StickyProps extends HTMLAttributes<HTMLDivElement> {
    * within the box instead of below the fold). Sets `max-height` to
    * `calc(100dvh - top offset - an equal bottom gap)`, `overflow-y: auto`, and
    * `overscroll-behavior: contain` (page scroll doesn't chain from the box).
-   * Default `false`. Pair with a non-`none` `top` to leave breathing room.
+   * Default `false`. Pair with a non-`none` `top` to leave breathing room. The cap
+   * is viewport-relative (`dvh`), so this assumes the page (or a viewport-tall
+   * ancestor) is the scroll context — not a short fixed-height scroll container.
    */
   scroll?: boolean;
   /** The content to pin. Required — a `Sticky` with nothing inside pins nothing. */

--- a/packages/design-system/src/components/Sticky/Sticky.tsx
+++ b/packages/design-system/src/components/Sticky/Sticky.tsx
@@ -15,6 +15,15 @@ export interface StickyProps extends HTMLAttributes<HTMLDivElement> {
    * sticky header or add breathing room.
    */
   top?: StickyTop;
+  /**
+   * Cap the pinned box at the viewport height and scroll its content internally,
+   * so a column TALLER than the screen stays fully reachable (the overflow scrolls
+   * within the box instead of below the fold). Sets `max-height` to
+   * `calc(100dvh - top offset - an equal bottom gap)`, `overflow-y: auto`, and
+   * `overscroll-behavior: contain` (page scroll doesn't chain from the box).
+   * Default `false`. Pair with a non-`none` `top` to leave breathing room.
+   */
+  scroll?: boolean;
   /** The content to pin. Required — a `Sticky` with nothing inside pins nothing. */
   children: ReactNode;
 }
@@ -49,6 +58,12 @@ export interface StickyProps extends HTMLAttributes<HTMLDivElement> {
  *   <FilterPanel />
  * </Sticky>
  *
+ * @example
+ * // A tall pinned sidebar that scrolls within itself when it exceeds the screen.
+ * <Sticky top="lg" scroll>
+ *   <Stack gap="md">{manyCards}</Stack>
+ * </Sticky>
+ *
  * @remarks When NOT to use
  * - Arranging children → `<Stack>` / `<Cluster>` / `<Grid>`. Sticky positions its
  *   own box; it doesn't arrange what's inside.
@@ -64,12 +79,16 @@ export interface StickyProps extends HTMLAttributes<HTMLDivElement> {
  *   only; spacing comes from the parent layout primitive.
  */
 export const Sticky = forwardRef<HTMLDivElement, StickyProps>(function Sticky(
-  { top = 'none', className, children, ...rest },
+  { top = 'none', scroll = false, className, children, ...rest },
   ref,
 ) {
   // {...rest} last so consumer overrides win (Pattern A) — Sticky locks no attrs.
   return (
-    <div ref={ref} className={clsx(styles.sticky, styles[`top-${top}`], className)} {...rest}>
+    <div
+      ref={ref}
+      className={clsx(styles.sticky, styles[`top-${top}`], scroll && styles.scroll, className)}
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/packages/playground/src/pages/components/StickyDemo.tsx
+++ b/packages/playground/src/pages/components/StickyDemo.tsx
@@ -5,6 +5,10 @@ import { getComponentFiles } from '../../lib/componentFiles';
 
 const MAIN_ROWS = Array.from({ length: 14 }, (_, i) => i + 1);
 
+// Deliberately more items than fit on a screen, so scroll-viewport mode has
+// something to scroll internally (the box caps at the viewport height).
+const SIDEBAR_ITEMS = Array.from({ length: 20 }, (_, i) => i + 1);
+
 // A bordered, internally-scrolling box so the sticky behaviour is visible inside
 // the demo (the box is the scroll container the aside pins within).
 const scrollBox: React.CSSProperties = {
@@ -93,6 +97,52 @@ export function StickyDemo() {
             </Stack>
           </Split>
         </div>
+      </Example>
+
+      <Example
+        title="Scroll-viewport mode: a sidebar taller than the screen"
+        description="With scroll, the pinned box is capped at the viewport height (minus the top offset and an equal bottom gap) and scrolls its own content — so a sidebar with more items than fit on screen stays fully reachable instead of running off below the fold. Scroll the page: the sidebar pins, and once it hits the bottom its own scrollbar takes over (overscroll-behavior:contain keeps the page from scroll-chaining). Pair with a non-none top for breathing room."
+        code={`<Split side="end" asideWidth="240px" align="stretch"
+  aside={
+    <Sticky top="lg" scroll>
+      <Stack gap="md">{manyCards}</Stack>
+    </Sticky>
+  }>
+  <Stack gap="md">…long main column…</Stack>
+</Split>`}
+      >
+        <Split
+          side="end"
+          asideWidth="240px"
+          gap="lg"
+          align="stretch"
+          aside={
+            <Sticky top="lg" scroll>
+              <Stack gap="md">
+                {SIDEBAR_ITEMS.map((n) => (
+                  <Card key={n}>
+                    <Stack gap="xs">
+                      <Title order={4} size="sm">
+                        Linked record {n}
+                      </Title>
+                      <Text size="sm" tone="muted">
+                        Account · updated {n} day{n === 1 ? '' : 's'} ago
+                      </Text>
+                    </Stack>
+                  </Card>
+                ))}
+              </Stack>
+            </Sticky>
+          }
+        >
+          <Stack gap="md">
+            {MAIN_ROWS.map((n) => (
+              <Card key={n}>
+                <Text>Main column row {n}</Text>
+              </Card>
+            ))}
+          </Stack>
+        </Split>
       </Example>
     </DemoLayout>
   );


### PR DESCRIPTION
Addresses #210.

## Summary
Adds an opt-in `scroll?: boolean` to `<Sticky>`. When set, the pinned box is capped at the viewport height (minus the `top` offset and an equal bottom gap) with `overflow-y: auto` + `overscroll-behavior: contain`, so a sidebar **taller than the viewport** scrolls **within itself** while the page scrolls normally — instead of leaving the overflow unreachable below the fold.

- Each `.top-*` class now also exposes its offset as `--sticky-offset`, so `.scroll` computes `max-height: calc(100dvh - 2 × offset)` (with a `100vh` fallback line first, mirroring the Modal/Drawer convention for Safari < 15.4).
- `overscroll-behavior: contain` stops page scroll-chaining when the box hits its end.
- Default `false`; composes with `top`. The cap is viewport-relative (documented), so it assumes the page (or a viewport-tall ancestor) is the scroll context.

This lets the eoCRM detail-page sidebars retire their `StickyScroll` shim.

## Test plan
- `make test` (full suite **3314 passing**), `make build-lib`, `make lint`, `npm run format:check` — all green; `npm pack --dry-run` ships no test files; no manifest change (no new component).
- New unit test: the `scroll` class is applied only when `scroll` is set; existing `top` tests unchanged.
- Ran the CLAUDE.md Rule 8 review loop to a clean verdict (added the `100vh` fallback + viewport-context JSDoc note per review).
- Docs: `AGENTS.md` prop bullet; JSDoc + `@example`; playground `StickyDemo` gains a scroll-viewport example (a `top="lg" scroll` sidebar with more cards than fit on screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)