### PR TITLE
feat(Lightbox): preview PDF/document items, not just images (#213)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -2294,9 +2294,9 @@ const [open, setOpen] = useState(false);
 
 **See also:** `<Drawer>` for edge-anchored variant.
 
-### `<Lightbox>` — full-screen image gallery overlay
+### `<Lightbox>` — full-screen image & document gallery overlay
 
-`<Lightbox open onOpenChange items>` shows one large image at a time with prev/next chevrons, ← → keys, a thumbnail strip, a position counter, and an optional caption. Controlled `open` like `<Modal>`; the current index is uncontrolled (`defaultIndex`) unless you pass `index` + `onIndexChange`. `loop` (default true) wraps at the ends. The consumer owns the trigger — typically a row of interactive `<Image>` thumbnails. For a single inline image use `<Image>`.
+`<Lightbox open onOpenChange items>` shows one large item at a time (an image, or a PDF in an `<iframe>`) with prev/next chevrons, ← → keys, a thumbnail strip, a position counter, and an optional caption. Controlled `open` like `<Modal>`; the current index is uncontrolled (`defaultIndex`) unless you pass `index` + `onIndexChange`. `loop` (default true) wraps at the ends. The consumer owns the trigger — typically a row of interactive `<Image>` thumbnails. For a single inline image use `<Image>`.
 
 ```tsx
 const [open, setOpen] = useState(false);
@@ -2309,7 +2309,8 @@ const [start, setStart] = useState(0);
 />;
 ```
 
-- Each `LightboxItem` is `{ src, alt, caption?, thumbnail? }` — `alt` is required.
+- Each `LightboxItem` is `{ src, alt, kind?, caption?, thumbnail? }` — `alt` is required.
+- `items` accept `kind: 'pdf'` (or a `.pdf` src) → rendered in an `<iframe>` with a download action; mixed image+PDF galleries supported. A PDF without a `thumbnail` shows a document-icon placeholder in the strip; unsafe (non-http(s)) doc srcs show a "Preview unavailable" message.
 - Single item → chevrons, counter, and strip auto-hide. Empty `items` → renders nothing.
 - Reuses the DS overlay machinery (focus-trap, scroll-lock, Esc, stacking above modals).
 

--- a/packages/design-system/src/components/Lightbox/Lightbox.module.scss
+++ b/packages/design-system/src/components/Lightbox/Lightbox.module.scss
@@ -35,6 +35,29 @@
   cursor: pointer;
 }
 
+// Download action for the current document — an <a> styled as an icon control,
+// sitting just left of the close button (overlay chrome, like .close/.chev).
+.download {
+  position: absolute;
+  top: var(--lightbox-padding);
+  right: calc(var(--lightbox-padding) + var(--lightbox-control-size) + var(--space-2));
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--lightbox-control-size);
+  height: var(--lightbox-control-size);
+  border-radius: var(--radius-full);
+  background: var(--lightbox-control-bg);
+  color: var(--lightbox-control-fg);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.download:hover {
+  background: var(--lightbox-control-bg-hover);
+}
+
 .stage {
   flex: 1;
   position: relative;
@@ -73,7 +96,9 @@
 // Keyboard focus ring on the dark scrim (Rule 3a) — the chevrons/close are bare
 // <button>s, so the UA default outline is low-contrast here; use the DS ring.
 .close:focus-visible,
-.chev:focus-visible {
+.download:focus-visible,
+.chev:focus-visible,
+.thumbDoc:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--ring-accent);
 }
@@ -106,6 +131,21 @@
 // thing shown/announced (no doubled broken-image glyph + a11y dupe).
 .image[data-state='error'] {
   display: none;
+}
+
+// A document (PDF) has no intrinsic size to be `object-fit: contain`-ed like an
+// <img>, so the wrap is stretched to the stage and the iframe fills it.
+.imageWrap:has(.doc) {
+  width: 100%;
+  height: 100%;
+}
+
+.doc {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: var(--lightbox-radius);
+  background: var(--lightbox-doc-bg);
 }
 
 .stageOverlay {
@@ -167,4 +207,20 @@
 .thumbActive {
   opacity: var(--opacity-visible);
   box-shadow: 0 0 0 2px var(--lightbox-thumb-active-ring);
+}
+
+// Placeholder thumbnail for a document without its own image — centered icon on
+// a muted square, matching the thumbnail box (size/aspect/rounding come from .thumb).
+.thumbDoc {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  aspect-ratio: 1;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--lightbox-thumb-doc-bg);
+  color: var(--lightbox-thumb-doc-fg);
+  cursor: pointer;
 }

--- a/packages/design-system/src/components/Lightbox/Lightbox.test.tsx
+++ b/packages/design-system/src/components/Lightbox/Lightbox.test.tsx
@@ -132,6 +132,64 @@ describe('Lightbox', () => {
     expect(screen.getByText('Image failed to load')).toBeInTheDocument();
   });
 
+  const pdfItem = { src: 'https://f/contract.pdf', alt: 'Contract.pdf', kind: 'pdf' as const };
+
+  it('renders a PDF item in an iframe (not an img) with the alt as title', () => {
+    render(<Lightbox open onOpenChange={() => {}} items={[pdfItem]} />);
+    const frame = document.querySelector('iframe');
+    expect(frame).toBeTruthy();
+    expect(frame).toHaveAttribute('src', 'https://f/contract.pdf');
+    expect(frame).toHaveAttribute('title', 'Contract.pdf');
+  });
+
+  it('auto-detects a .pdf src as a document even without kind', () => {
+    render(
+      <Lightbox open onOpenChange={() => {}} items={[{ src: 'https://f/a.pdf', alt: 'A' }]} />,
+    );
+    expect(document.querySelector('iframe')).toBeTruthy();
+  });
+
+  it('shows a download action for a PDF item', () => {
+    render(<Lightbox open onOpenChange={() => {}} items={[pdfItem]} />);
+    const dl = screen.getByRole('link', { name: 'Download' });
+    expect(dl).toHaveAttribute('href', 'https://f/contract.pdf');
+    expect(dl).toHaveAttribute('download');
+  });
+
+  it('blocks an unsafe PDF src (no iframe, shows preview-unavailable)', () => {
+    render(
+      <Lightbox
+        open
+        onOpenChange={() => {}}
+        items={[{ src: 'javascript:alert(1)', alt: 'x', kind: 'pdf' }]}
+      />,
+    );
+    expect(document.querySelector('iframe')).toBeNull();
+    expect(screen.getByText('Preview unavailable')).toBeInTheDocument();
+  });
+
+  it('an image item still renders an img (no regression)', () => {
+    render(
+      <Lightbox open onOpenChange={() => {}} items={[{ src: 'https://f/p.png', alt: 'P' }]} />,
+    );
+    expect(document.querySelector('img')).toBeTruthy();
+    expect(document.querySelector('iframe')).toBeNull();
+  });
+
+  it('a mixed gallery navigates from image to pdf', async () => {
+    const user = userEvent.setup();
+    render(
+      <Lightbox
+        open
+        onOpenChange={() => {}}
+        items={[{ src: 'https://f/p.png', alt: 'P' }, pdfItem]}
+      />,
+    );
+    expect(document.querySelector('img')).toBeTruthy();
+    await user.click(screen.getByRole('button', { name: 'Next image' }));
+    expect(document.querySelector('iframe')).toBeTruthy();
+  });
+
   it('restores focus to the trigger on close', async () => {
     function Harness() {
       const [open, setOpen] = useState(false);

--- a/packages/design-system/src/components/Lightbox/Lightbox.test.tsx
+++ b/packages/design-system/src/components/Lightbox/Lightbox.test.tsx
@@ -156,7 +156,7 @@ describe('Lightbox', () => {
     expect(dl).toHaveAttribute('download');
   });
 
-  it('blocks an unsafe PDF src (no iframe, shows preview-unavailable)', () => {
+  it('blocks an unsafe PDF src (no iframe, no download, shows preview-unavailable)', () => {
     render(
       <Lightbox
         open
@@ -165,7 +165,44 @@ describe('Lightbox', () => {
       />,
     );
     expect(document.querySelector('iframe')).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Download' })).toBeNull(); // no unsafe href
     expect(screen.getByText('Preview unavailable')).toBeInTheDocument();
+  });
+
+  it('blocks data: and blob: PDF srcs too', () => {
+    for (const src of ['data:text/html,<script>1</script>', 'blob:https://x/abc']) {
+      const { unmount } = render(
+        <Lightbox open onOpenChange={() => {}} items={[{ src, alt: 'x', kind: 'pdf' as const }]} />,
+      );
+      expect(document.querySelector('iframe')).toBeNull();
+      unmount();
+    }
+  });
+
+  it('sandboxes the PDF iframe (opaque origin: no allow-same-origin)', () => {
+    render(<Lightbox open onOpenChange={() => {}} items={[pdfItem]} />);
+    const sandbox = document.querySelector('iframe')!.getAttribute('sandbox') ?? '';
+    expect(sandbox).toContain('allow-scripts');
+    expect(sandbox).not.toContain('allow-same-origin');
+  });
+
+  it('the download link opens in a new tab (cross-origin download safety)', () => {
+    render(<Lightbox open onOpenChange={() => {}} items={[pdfItem]} />);
+    const dl = screen.getByRole('link', { name: 'Download' });
+    expect(dl).toHaveAttribute('target', '_blank');
+    expect(dl).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('shows a doc-icon placeholder thumbnail for a PDF without a thumbnail', () => {
+    render(
+      <Lightbox
+        open
+        onOpenChange={() => {}}
+        items={[{ src: 'https://f/p.png', alt: 'P' }, pdfItem]}
+      />,
+    );
+    // the pdf thumb is a button (placeholder), labelled by its alt — not an <img>
+    expect(screen.getByRole('button', { name: 'Contract.pdf' })).toBeInTheDocument();
   });
 
   it('an image item still renders an img (no regression)', () => {

--- a/packages/design-system/src/components/Lightbox/Lightbox.tokens.scss
+++ b/packages/design-system/src/components/Lightbox/Lightbox.tokens.scss
@@ -13,6 +13,11 @@
   --lightbox-thumb-strip-bg: rgb(0 0 0 / 30%);
   --lightbox-thumb-active-ring: var(--ring-accent);
 
+  // Document (PDF) preview surfaces.
+  --lightbox-doc-bg: var(--color-bg);
+  --lightbox-thumb-doc-bg: var(--color-bg-muted);
+  --lightbox-thumb-doc-fg: var(--color-fg-muted);
+
   --lightbox-padding: var(--space-4);
   --lightbox-gap: var(--space-3);
   --lightbox-control-size: var(--size-lg);

--- a/packages/design-system/src/components/Lightbox/Lightbox.tsx
+++ b/packages/design-system/src/components/Lightbox/Lightbox.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import clsx from 'clsx';
-import { ChevronLeft, ChevronRight, X } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Download, FileText, X } from 'lucide-react';
 import { Image } from '../Image';
 import { Skeleton } from '../Skeleton';
 import { useFocusTrap } from '../_internal/overlay/useFocusTrap';
@@ -20,16 +20,36 @@ import { useOverlayStack } from '../_internal/overlay';
 import { useTranslation } from '../../i18n/useTranslation';
 import styles from './Lightbox.module.scss';
 
-/** One image in a `<Lightbox>`. */
+/** One item (image or document) in a `<Lightbox>`. */
 export interface LightboxItem {
-  /** Full-size image URL. */
+  /** Full-size source URL (an image, or a PDF/document when `kind: 'pdf'`). */
   src: string;
-  /** Alt text (required — describes the image, same contract as `<Image>`). */
+  /** Alt text / document name (required — the accessible stage + thumbnail name). */
   alt: string;
-  /** Optional caption shown below the stage when set. */
+  /** Item kind. Defaults to `'image'`, or `'pdf'` when `src` ends in `.pdf`. A
+   *  `pdf` item renders in an `<iframe>` (the browser's PDF viewer) with a download
+   *  action instead of an `<img>`. */
+  kind?: 'image' | 'pdf';
+  /** Optional caption shown below the stage. */
   caption?: ReactNode;
-  /** Optional thumbnail URL for the strip. Defaults to `src`. */
+  /** Optional thumbnail URL for the strip. Images default to `src`; a `pdf` item
+   *  without a thumbnail shows a document-icon placeholder. */
   thumbnail?: string;
+}
+
+const isPdfSrc = (src: string) => /\.pdf($|[?#])/i.test(src);
+const itemKind = (it: LightboxItem): 'image' | 'pdf' =>
+  it.kind ?? (isPdfSrc(it.src) ? 'pdf' : 'image');
+
+/** Allow only http(s) + relative URLs as an iframe/document src (block
+ *  javascript:/data: etc). Returns the original src when safe, else undefined. */
+function safeDocSrc(src: string): string | undefined {
+  try {
+    const u = new URL(src, 'https://_'); // dummy base resolves relative URLs
+    return u.protocol === 'http:' || u.protocol === 'https:' ? src : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export interface LightboxProps {
@@ -62,10 +82,11 @@ const PORTAL_EXEMPT =
   '[data-lightbox-portal-root], [data-modal-portal-root], [data-drawer-portal-root]';
 
 /**
- * Full-screen image gallery overlay — shows one large image at a time, cycles
- * through a set (prev/next chevrons, ← → keys, a thumbnail strip), and shows an
- * optional caption. Controlled `open` like `<Modal>`; the current index is
- * uncontrolled (`defaultIndex`) unless you pass `index` + `onIndexChange`.
+ * Full-screen image & document gallery overlay — shows one large item at a time
+ * (an image, or a PDF previewed in an `<iframe>`), cycles through a set (prev/next
+ * chevrons, ← → keys, a thumbnail strip), and shows an optional caption. Controlled
+ * `open` like `<Modal>`; the current index is uncontrolled (`defaultIndex`) unless
+ * you pass `index` + `onIndexChange`.
  *
  * The consumer owns the trigger and `open` — e.g. a row of interactive
  * `<Image>` thumbnails that set the start index and open the Lightbox.
@@ -80,9 +101,16 @@ const PORTAL_EXEMPT =
  *   items={files.map((f) => ({ src: f.url, alt: f.name, caption: f.name }))}
  * />
  *
+ * @example
+ * // Mixed gallery — images + a PDF (rendered in an iframe with a download action).
+ * <Lightbox open={open} onOpenChange={setOpen} items={[
+ *   { src: shot.url, alt: 'Screenshot' },
+ *   { src: doc.url, alt: 'Contract.pdf', kind: 'pdf' },
+ * ]} />
+ *
  * @remarks When NOT to use
  * - A single, always-visible image → `<Image>` (optionally `interactive`).
- * - A non-image modal dialog → `<Modal>`.
+ * - An arbitrary modal dialog (not an image/PDF preview) → `<Modal>`.
  *
  * @remarks Anti-patterns
  * - ❌ Building your own `Modal` + `Image` + arrows — that's what this is.
@@ -212,6 +240,7 @@ export function Lightbox({
 
   if (!open || n === 0 || !currentItem) return null;
 
+  const currentKind = itemKind(currentItem);
   const multi = n > 1;
   const atStart = current === 0;
   const atEnd = current === n - 1;
@@ -234,6 +263,18 @@ export function Lightbox({
       style={style}
       onClick={closeIfBackdrop}
     >
+      {currentKind === 'pdf' && safeDocSrc(currentItem.src) && (
+        <a
+          className={styles.download}
+          href={safeDocSrc(currentItem.src)}
+          download
+          rel="noopener noreferrer"
+          aria-label={t('lightbox.download')}
+        >
+          <Download size={20} aria-hidden="true" />
+        </a>
+      )}
+
       <button
         type="button"
         className={styles.close}
@@ -257,26 +298,46 @@ export function Lightbox({
         )}
 
         <div className={styles.imageWrap}>
-          <img
-            key={currentItem.src}
-            src={currentItem.src}
-            alt={currentItem.alt}
-            className={styles.image}
-            data-state={stageState}
-            onLoad={() => setStageState('loaded')}
-            onError={() => setStageState('error')}
-          />
-          {stageState === 'loading' && (
-            <Skeleton variant="rectangular" className={styles.stageOverlay} />
-          )}
-          {stageState === 'error' && (
-            <div
-              className={styles.stageError}
-              role="img"
-              aria-label={currentItem.alt || t('image.loadError')}
-            >
-              {t('image.loadError')}
-            </div>
+          {currentKind === 'pdf' ? (
+            (() => {
+              const docSrc = safeDocSrc(currentItem.src);
+              return docSrc ? (
+                <iframe
+                  key={currentItem.src}
+                  src={docSrc}
+                  title={currentItem.alt}
+                  className={styles.doc}
+                />
+              ) : (
+                <div className={styles.stageError} role="img" aria-label={currentItem.alt}>
+                  {t('lightbox.previewUnavailable')}
+                </div>
+              );
+            })()
+          ) : (
+            <>
+              <img
+                key={currentItem.src}
+                src={currentItem.src}
+                alt={currentItem.alt}
+                className={styles.image}
+                data-state={stageState}
+                onLoad={() => setStageState('loaded')}
+                onError={() => setStageState('error')}
+              />
+              {stageState === 'loading' && (
+                <Skeleton variant="rectangular" className={styles.stageOverlay} />
+              )}
+              {stageState === 'error' && (
+                <div
+                  className={styles.stageError}
+                  role="img"
+                  aria-label={currentItem.alt || t('image.loadError')}
+                >
+                  {t('image.loadError')}
+                </div>
+              )}
+            </>
           )}
         </div>
 
@@ -316,15 +377,26 @@ export function Lightbox({
               }}
               className={clsx(styles.thumb, i === current && styles.thumbActive)}
             >
-              <Image
-                src={it.thumbnail ?? it.src}
-                alt=""
-                aspectRatio={1}
-                objectFit="cover"
-                interactive
-                onClick={() => goTo(i)}
-                ariaLabel={it.alt}
-              />
+              {itemKind(it) === 'pdf' && !it.thumbnail ? (
+                <button
+                  type="button"
+                  className={styles.thumbDoc}
+                  aria-label={it.alt}
+                  onClick={() => goTo(i)}
+                >
+                  <FileText size={20} aria-hidden="true" />
+                </button>
+              ) : (
+                <Image
+                  src={it.thumbnail ?? it.src}
+                  alt=""
+                  aspectRatio={1}
+                  objectFit="cover"
+                  interactive
+                  onClick={() => goTo(i)}
+                  ariaLabel={it.alt}
+                />
+              )}
             </div>
           ))}
         </div>

--- a/packages/design-system/src/components/Lightbox/Lightbox.tsx
+++ b/packages/design-system/src/components/Lightbox/Lightbox.tsx
@@ -241,6 +241,10 @@ export function Lightbox({
   if (!open || n === 0 || !currentItem) return null;
 
   const currentKind = itemKind(currentItem);
+  // Sanitized document URL (http(s)/relative only) for the current PDF item, or
+  // undefined when the item isn't a PDF or its src is unsafe. Computed once and
+  // reused by the download link, the stage iframe, and the unavailable fallback.
+  const docSrc = currentKind === 'pdf' ? safeDocSrc(currentItem.src) : undefined;
   const multi = n > 1;
   const atStart = current === 0;
   const atEnd = current === n - 1;
@@ -263,11 +267,15 @@ export function Lightbox({
       style={style}
       onClick={closeIfBackdrop}
     >
-      {currentKind === 'pdf' && safeDocSrc(currentItem.src) && (
+      {docSrc && (
         <a
           className={styles.download}
-          href={safeDocSrc(currentItem.src)}
+          href={docSrc}
           download
+          // Open/save in a new tab: a cross-origin `download` is ignored by the
+          // browser, so without target the click would navigate the whole app
+          // away from the gallery. noopener/noreferrer guard the opened context.
+          target="_blank"
           rel="noopener noreferrer"
           aria-label={t('lightbox.download')}
         >
@@ -299,21 +307,28 @@ export function Lightbox({
 
         <div className={styles.imageWrap}>
           {currentKind === 'pdf' ? (
-            (() => {
-              const docSrc = safeDocSrc(currentItem.src);
-              return docSrc ? (
-                <iframe
-                  key={currentItem.src}
-                  src={docSrc}
-                  title={currentItem.alt}
-                  className={styles.doc}
-                />
-              ) : (
-                <div className={styles.stageError} role="img" aria-label={currentItem.alt}>
-                  {t('lightbox.previewUnavailable')}
-                </div>
-              );
-            })()
+            docSrc ? (
+              <iframe
+                key={docSrc}
+                src={docSrc}
+                title={currentItem.alt}
+                className={styles.doc}
+                // Harden against a consumer-supplied URL that resolves to HTML:
+                // omit `allow-same-origin` so framed content runs in an opaque
+                // origin (can't reach the app's DOM/cookies/storage). `allow-scripts`
+                // is needed by Firefox's pdf.js viewer; `allow-downloads` keeps the
+                // in-viewer save button working.
+                sandbox="allow-scripts allow-downloads"
+              />
+            ) : (
+              <div
+                className={styles.stageError}
+                role="img"
+                aria-label={`${currentItem.alt}: ${t('lightbox.previewUnavailable')}`}
+              >
+                {t('lightbox.previewUnavailable')}
+              </div>
+            )
           ) : (
             <>
               <img

--- a/packages/design-system/src/components/Lightbox/Lightbox.tsx
+++ b/packages/design-system/src/components/Lightbox/Lightbox.tsx
@@ -313,6 +313,7 @@ export function Lightbox({
                 src={docSrc}
                 title={currentItem.alt}
                 className={styles.doc}
+                referrerPolicy="no-referrer"
                 // Harden against a consumer-supplied URL that resolves to HTML:
                 // omit `allow-same-origin` so framed content runs in an opaque
                 // origin (can't reach the app's DOM/cookies/storage). `allow-scripts`

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -22,6 +22,8 @@ export const en: Messages = {
     previous: 'Previous image',
     next: 'Next image',
     close: 'Close gallery',
+    download: 'Download',
+    previewUnavailable: 'Preview unavailable',
   },
   passwordInput: {
     show: 'Show password',

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -31,6 +31,10 @@ export interface Messages {
     next: string;
     /** aria-label on the close (×) button. */
     close: string;
+    /** aria-label on the download action for a PDF/document item. */
+    download: string;
+    /** Stage message when a document's source can't be safely previewed. */
+    previewUnavailable: string;
   };
   passwordInput: {
     /** aria-label on the show-password toggle when the password is hidden. */

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -23,6 +23,8 @@ export const ru: Messages = {
     previous: 'Предыдущее изображение',
     next: 'Следующее изображение',
     close: 'Закрыть галерею',
+    download: 'Скачать',
+    previewUnavailable: 'Предпросмотр недоступен',
   },
   passwordInput: {
     show: 'Показать пароль',

--- a/packages/playground/src/pages/components/LightboxDemo.tsx
+++ b/packages/playground/src/pages/components/LightboxDemo.tsx
@@ -34,6 +34,20 @@ const PHOTOS: LightboxItem[] = [
   },
 ];
 
+// A real-ish CRM attachment set: site photos plus a contract PDF. The PDF renders
+// in an <iframe> with a download action; it has no thumbnail, so the strip shows a
+// document-icon placeholder.
+const ATTACHMENTS: LightboxItem[] = [
+  PHOTOS[0],
+  {
+    src: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
+    alt: 'Site-survey report.pdf',
+    kind: 'pdf',
+    caption: 'Site-survey report (PDF)',
+  },
+  PHOTOS[2],
+];
+
 function Gallery() {
   const [open, setOpen] = useState(false);
   const [start, setStart] = useState(0);
@@ -60,6 +74,22 @@ function Gallery() {
         Click a thumbnail — arrows / ← → cycle, the strip jumps, Esc closes.
       </Text>
       <Lightbox open={open} onOpenChange={setOpen} items={PHOTOS} defaultIndex={start} />
+    </Stack>
+  );
+}
+
+function MixedGallery() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Stack gap="sm">
+      <Button variant="secondary" size="sm" onClick={() => setOpen(true)}>
+        Open attachments (images + PDF)
+      </Button>
+      <Text size="sm" tone="muted">
+        Navigate to the PDF — it previews in an iframe with a download action; the strip shows a
+        document-icon placeholder for it.
+      </Text>
+      <Lightbox open={open} onOpenChange={setOpen} items={ATTACHMENTS} />
     </Stack>
   );
 }
@@ -98,6 +128,19 @@ const [start, setStart] = useState(0);
 <Lightbox open={open} onOpenChange={setOpen} items={photos} defaultIndex={start} />`}
       >
         <Gallery />
+      </Example>
+
+      <Example
+        title="Mixed gallery — images + PDF"
+        description="Items can be documents too: pass kind: 'pdf' (or a .pdf src) and the stage renders an iframe with a download action instead of an img. A PDF without a thumbnail gets a document-icon placeholder in the strip. Image and PDF items mix freely in one gallery."
+        code={`const items = [
+  { src: photo.url, alt: 'Site photo' },
+  { src: report.url, alt: 'Site-survey report.pdf', kind: 'pdf', caption: 'Site-survey report (PDF)' },
+  { src: photo2.url, alt: 'Ridge access road' },
+];
+<Lightbox open={open} onOpenChange={setOpen} items={items} />`}
+      >
+        <MixedGallery />
       </Example>
 
       <Example


### PR DESCRIPTION
Addresses #213.

## Summary
Extends `<Lightbox>` to preview PDF/document items alongside images (chose the issue's option a — one overlay, **mixed image+PDF galleries**, reusing the existing focus-trap / scroll-lock / overlay-stack / navigation / thumbnail infra).

- `LightboxItem` gains `kind?: 'image' | 'pdf'` (auto-detected from a `.pdf` `src`). A `pdf` item renders in an `<iframe>` (the browser's PDF viewer) instead of `<img>`, with a **download** action; the thumbnail strip shows a document-icon placeholder for PDFs without a thumbnail. Backward compatible — existing image items are unaffected.
- **Security/privacy hardening** (consumer-supplied URLs): `safeDocSrc` allows only `http(s)`/relative URLs (blocks `javascript:`/`data:`/`blob:`/…) for both the iframe `src` and the download `href`; the iframe is `sandbox="allow-scripts allow-downloads"` (no `allow-same-origin` → framed content can't reach the app origin; no top-nav hijack) + `referrerPolicy="no-referrer"`; the download opens in a new tab (`target="_blank"` + `rel="noopener noreferrer"`) since a cross-origin `download` would otherwise navigate the app away.
- Retires the eoCRM `ds-shims/PdfPreviewModal`.

## Test plan
- `make test` (full suite **3324 passing**), `make build-lib`, `make lint`, `npm run format:check` — all green; `npm pack --dry-run` ships no test files; no manifest change (existing component).
- New tests: pdf→iframe (title), `.pdf` auto-detect, download href/target, **`javascript:`/`data:`/`blob:` blocked** (no iframe, no download, "preview unavailable"), **sandbox asserts no `allow-same-origin`**, doc-icon placeholder thumbnail, image no-regression, mixed-gallery navigation.
- Ran the CLAUDE.md Rule 8 review loop to a clean verdict (2 rounds; round 1 caught the missing iframe sandbox + cross-origin download target — both fixed and tested).
- Docs: `AGENTS.md` updated; JSDoc `@example` (mixed gallery) + reworded "non-image modal → Modal" anti-pattern; playground `LightboxDemo` shows a mixed image+PDF gallery (live pdf.js sample URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)