### PR TITLE
feat(RichTextEditor): natural block drag preview + reachable gutter hover

### DIFF
--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
@@ -135,6 +135,13 @@ describe('readBlockSnapshot', () => {
   });
 });
 
+it('a plain grip click (no drag) opens the block menu', async () => {
+  const onMenuOpenChange = vi.fn();
+  render(<Harness onMenuOpenChange={onMenuOpenChange} />);
+  await userEvent.click(screen.getByRole('button', { name: 'Block actions' }));
+  expect(onMenuOpenChange).toHaveBeenCalledWith(true);
+});
+
 it('renders no drag-overlay clone and no dimmed block at rest', () => {
   const { container } = render(<Harness />);
   // No drag in progress → DragOverlay renders null; the only [data-block-id] is the

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useRef } from 'react';
 import { I18nProvider } from '../../i18n';
-import { RichTextBlockControls } from './RichTextBlockControls';
+import { RichTextBlockControls, readBlockSnapshot } from './RichTextBlockControls';
 
 function Harness(props: Partial<React.ComponentProps<typeof RichTextBlockControls>>) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -110,4 +110,34 @@ it('block menu shows a Configure item that fires onConfigure', async () => {
   render(<Harness activeBlockType="attachment" menuOpen onConfigure={onConfigure} />);
   await userEvent.click(screen.getByRole('menuitem', { name: 'Configure' }));
   expect(onConfigure).toHaveBeenCalledWith('b1');
+});
+
+describe('readBlockSnapshot', () => {
+  it('returns the block element outerHTML + measured width', () => {
+    const root = document.createElement('div');
+    const p = document.createElement('p');
+    p.setAttribute('data-block-id', 'x1');
+    p.textContent = 'hello';
+    root.appendChild(p);
+    // jsdom has no layout; stub the measured width.
+    p.getBoundingClientRect = () => ({ width: 240, height: 20, top: 0, left: 0, right: 240, bottom: 20, x: 0, y: 0, toJSON: () => ({}) });
+
+    expect(readBlockSnapshot(root, 'x1')).toEqual({
+      html: '<p data-block-id="x1">hello</p>',
+      width: 240,
+    });
+  });
+
+  it('returns null when the block id is absent or root is null', () => {
+    const root = document.createElement('div');
+    expect(readBlockSnapshot(root, 'nope')).toBeNull();
+    expect(readBlockSnapshot(null, 'x1')).toBeNull();
+  });
+});
+
+it('renders no drag-overlay clone and no dimmed block at rest', () => {
+  const { container } = render(<Harness />);
+  // No drag in progress → DragOverlay renders null; the only [data-block-id] is the
+  // single source <p> in the harness, never a second (cloned) copy.
+  expect(container.querySelectorAll('[data-block-id="b1"]')).toHaveLength(1);
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
@@ -120,7 +120,17 @@ describe('readBlockSnapshot', () => {
     p.textContent = 'hello';
     root.appendChild(p);
     // jsdom has no layout; stub the measured width.
-    p.getBoundingClientRect = () => ({ width: 240, height: 20, top: 0, left: 0, right: 240, bottom: 20, x: 0, y: 0, toJSON: () => ({}) });
+    p.getBoundingClientRect = () => ({
+      width: 240,
+      height: 20,
+      top: 0,
+      left: 0,
+      right: 240,
+      bottom: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
 
     expect(readBlockSnapshot(root, 'x1')).toEqual({
       html: '<p data-block-id="x1">hello</p>',

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
@@ -152,10 +152,10 @@ it('a plain grip click (no drag) opens the block menu', async () => {
   expect(onMenuOpenChange).toHaveBeenCalledWith(true);
 });
 
-// NOTE: the real grip-drag lifecycle (PointerSensor 4px activation → onDraggingChange,
-// floating clone, source dim, drop/reorder) is covered by Playwright in Task 4. jsdom
-// cannot drive dnd-kit's PointerSensor (no layout / pointer-capture), matching the
-// Sortable precedent of not unit-testing real drags.
+// The full grip-drag lifecycle (overlay clone, source dim, onDraggingChange, drop
+// geometry) can't be driven in jsdom (dnd-kit PointerSensor needs real layout/
+// pointer-capture) — matching the Sortable precedent, it's verified manually in the
+// playground; there is no in-repo e2e harness yet.
 it('renders no drag-overlay clone and no dimmed block at rest', () => {
   const { container } = render(<Harness />);
   // No drag in progress → DragOverlay renders null; the only [data-block-id] is the

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
@@ -142,6 +142,10 @@ it('a plain grip click (no drag) opens the block menu', async () => {
   expect(onMenuOpenChange).toHaveBeenCalledWith(true);
 });
 
+// NOTE: the real grip-drag lifecycle (PointerSensor 4px activation → onDraggingChange,
+// floating clone, source dim, drop/reorder) is covered by Playwright in Task 4. jsdom
+// cannot drive dnd-kit's PointerSensor (no layout / pointer-capture), matching the
+// Sortable precedent of not unit-testing real drags.
 it('renders no drag-overlay clone and no dimmed block at rest', () => {
   const { container } = render(<Harness />);
   // No drag in progress → DragOverlay renders null; the only [data-block-id] is the

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -163,8 +163,9 @@ export function RichTextBlockControls({
   const onDraggingChangeRef = useRef(onDraggingChange);
   onDraggingChangeRef.current = onDraggingChange;
 
-  // If the controls unmount mid-drag (e.g. the active block clears), dnd-kit fires
-  // neither end nor cancel — undo the source dim and report drag end so nothing leaks.
+  // If the controls unmount mid-drag (e.g. blockControls is turned off, or the
+  // editor unmounts), dnd-kit fires neither end nor cancel — undo the source dim
+  // and report drag end so nothing leaks.
   useEffect(() => {
     return () => {
       draggedElRef.current?.classList.remove(styles.blockDragging);

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -323,6 +323,7 @@ export function RichTextBlockControls({
             className={styles.dragOverlay}
             style={{ width: dragSnapshot.width }}
             contentEditable={false}
+            aria-hidden
             // The dragged block's OWN serialized DOM (already rendered in the live
             // doc), injected into an inert, non-editable, transient overlay that is
             // removed on drop. Not external/pasted HTML; no scripts run from an

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -1,7 +1,7 @@
 // RichTextBlockControls.tsx — the per-block gutter overlay. Absolutely positioned
 // inside the editor shell (position: relative), aligned to the active block's box.
 // Lives OUTSIDE the contentEditable so it is never editable content.
-import { useLayoutEffect, useRef, useState, type RefObject } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
 import {
   DndContext,
   DragOverlay,
@@ -64,10 +64,18 @@ const GRIP_DRAGGABLE_ID = 'rte-block-grip';
 /** Read each block box's vertical geometry, relative to the shell's top edge. */
 function blockRects(root: HTMLElement): { top: number; height: number }[] {
   const shellTop = root.getBoundingClientRect().top;
-  return Array.from(root.querySelectorAll<HTMLElement>('[data-block-id]')).map((el) => {
-    const box = el.getBoundingClientRect();
-    return { top: box.top - shellTop, height: box.height };
-  });
+  return (
+    Array.from(root.querySelectorAll<HTMLElement>('[data-block-id]'))
+      // <DragOverlay> renders INLINE (not portaled to <body>), so the floating clone —
+      // which carries data-block-id, plus nested data-block-id on each cloned <li> —
+      // lives inside this shell. Excluding anything within the overlay keeps it out of
+      // the block count so the drop gap index and indicator line stay correct.
+      .filter((el) => !el.closest(`.${styles.dragOverlay}`))
+      .map((el) => {
+        const box = el.getBoundingClientRect();
+        return { top: box.top - shellTop, height: box.height };
+      })
+  );
 }
 
 /**
@@ -147,6 +155,23 @@ export function RichTextBlockControls({
   const [dragSnapshot, setDragSnapshot] = useState<{ html: string; width: number } | null>(null);
   // The live source element we dimmed, so the dim class can be removed on drop/cancel.
   const draggedElRef = useRef<HTMLElement | null>(null);
+  // The block id captured at drag start — reorder by this, not the live activeBlockId,
+  // so a mid-drag active-block change can't reorder the wrong block.
+  const draggedIdRef = useRef<string | null>(null);
+
+  // Latest onDraggingChange, read by the unmount cleanup without re-subscribing.
+  const onDraggingChangeRef = useRef(onDraggingChange);
+  onDraggingChangeRef.current = onDraggingChange;
+
+  // If the controls unmount mid-drag (e.g. the active block clears), dnd-kit fires
+  // neither end nor cancel — undo the source dim and report drag end so nothing leaks.
+  useEffect(() => {
+    return () => {
+      draggedElRef.current?.classList.remove(styles.blockDragging);
+      draggedElRef.current = null;
+      onDraggingChangeRef.current?.(false);
+    };
+  }, []);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
 
@@ -203,6 +228,7 @@ export function RichTextBlockControls({
 
   const handleDragStart = (_event: DragStartEvent) => {
     if (!activeBlockId) return;
+    draggedIdRef.current = activeBlockId; // capture now; reorder by this id on drop
     onMenuOpenChange(false); // a drag should never leave the block menu open (Notion-style)
     onDraggingChange?.(true);
     const snap = readBlockSnapshot(rootRef.current, activeBlockId);
@@ -221,6 +247,7 @@ export function RichTextBlockControls({
   const endDrag = () => {
     draggedElRef.current?.classList.remove(styles.blockDragging);
     draggedElRef.current = null;
+    draggedIdRef.current = null;
     setDragSnapshot(null);
     setDropGap(null);
     setDropY(null);
@@ -229,7 +256,8 @@ export function RichTextBlockControls({
 
   const handleDragEnd = (event: DragEndEvent) => {
     const drop = computeDrop(event);
-    if (drop && activeBlockId) onReorder(activeBlockId, drop.gap);
+    const id = draggedIdRef.current;
+    if (drop && id) onReorder(id, drop.gap);
     endDrag();
   };
 

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -1,15 +1,17 @@
 // RichTextBlockControls.tsx — the per-block gutter overlay. Absolutely positioned
 // inside the editor shell (position: relative), aligned to the active block's box.
 // Lives OUTSIDE the contentEditable so it is never editable content.
-import { useLayoutEffect, useState, type RefObject } from 'react';
+import { useLayoutEffect, useRef, useState, type RefObject } from 'react';
 import {
   DndContext,
+  DragOverlay,
   PointerSensor,
   useDraggable,
   useSensor,
   useSensors,
   type DragEndEvent,
   type DragMoveEvent,
+  type DragStartEvent,
 } from '@dnd-kit/core';
 import { Button } from '../Button';
 import { useTranslation } from '../../i18n';
@@ -46,6 +48,12 @@ export interface RichTextBlockControlsProps {
    * to the subtree-aware `moveBlockUnitToIndex` engine transform.
    */
   onReorder: (blockId: string, targetIndex: number) => void;
+  /**
+   * Reports grip-drag lifecycle so the editor can suppress hover-driven active-block
+   * changes while a drag is in progress (mirrors how `menuOpen` is mirrored into a
+   * ref). Called `true` on drag start, `false` on drag end/cancel.
+   */
+  onDraggingChange?: (dragging: boolean) => void;
 }
 
 const GUTTER_ROW_HEIGHT = 24;
@@ -122,6 +130,7 @@ export function RichTextBlockControls({
   onTurnInto,
   onConfigure,
   onReorder,
+  onDraggingChange,
 }: RichTextBlockControlsProps) {
   const t = useTranslation();
   const [top, setTop] = useState<number | null>(null);
@@ -133,6 +142,11 @@ export function RichTextBlockControls({
   // not dragging. Drives the absolutely-positioned drop indicator line.
   const [dropGap, setDropGap] = useState<number | null>(null);
   const [dropY, setDropY] = useState<number | null>(null);
+  // DOM snapshot ({ html, width }) of the block being dragged — drives the floating
+  // <DragOverlay> clone. null when not dragging.
+  const [dragSnapshot, setDragSnapshot] = useState<{ html: string; width: number } | null>(null);
+  // The live source element we dimmed, so the dim class can be removed on drop/cancel.
+  const draggedElRef = useRef<HTMLElement | null>(null);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
 
@@ -187,16 +201,40 @@ export function RichTextBlockControls({
     setDropY(line);
   };
 
+  const handleDragStart = (_event: DragStartEvent) => {
+    if (!activeBlockId) return;
+    onMenuOpenChange(false); // a drag should never leave the block menu open (Notion-style)
+    onDraggingChange?.(true);
+    const snap = readBlockSnapshot(rootRef.current, activeBlockId);
+    setDragSnapshot(snap);
+    const el = rootRef.current?.querySelector<HTMLElement>(
+      `[data-block-id="${CSS.escape(activeBlockId)}"]`,
+    );
+    if (el) {
+      el.classList.add(styles.blockDragging);
+      draggedElRef.current = el;
+    }
+  };
+
+  // Shared teardown for both drop and cancel: undo the source dim, drop the snapshot,
+  // clear the drop indicator, and report drag end.
+  const endDrag = () => {
+    draggedElRef.current?.classList.remove(styles.blockDragging);
+    draggedElRef.current = null;
+    setDragSnapshot(null);
+    setDropGap(null);
+    setDropY(null);
+    onDraggingChange?.(false);
+  };
+
   const handleDragEnd = (event: DragEndEvent) => {
     const drop = computeDrop(event);
     if (drop && activeBlockId) onReorder(activeBlockId, drop.gap);
-    setDropGap(null);
-    setDropY(null);
+    endDrag();
   };
 
   const handleDragCancel = () => {
-    setDropGap(null);
-    setDropY(null);
+    endDrag();
   };
 
   if (!activeBlockId || top == null) return null;
@@ -204,6 +242,7 @@ export function RichTextBlockControls({
   return (
     <DndContext
       sensors={sensors}
+      onDragStart={handleDragStart}
       onDragMove={handleDragMove}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
@@ -249,6 +288,20 @@ export function RichTextBlockControls({
       {dropGap != null && dropY != null ? (
         <div className={styles.dropIndicator} style={{ top: dropY }} contentEditable={false} />
       ) : null}
+      <DragOverlay>
+        {dragSnapshot ? (
+          <div
+            className={styles.dragOverlay}
+            style={{ width: dragSnapshot.width }}
+            contentEditable={false}
+            // The dragged block's OWN serialized DOM (already rendered in the live
+            // doc), injected into an inert, non-editable, transient overlay that is
+            // removed on drop. Not external/pasted HTML; no scripts run from an
+            // innerHTML assignment. See the spec's "Snapshot safety".
+            dangerouslySetInnerHTML={{ __html: dragSnapshot.html }}
+          />
+        ) : null}
+      </DragOverlay>
     </DndContext>
   );
 }

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -63,6 +63,23 @@ function blockRects(root: HTMLElement): { top: number; height: number }[] {
 }
 
 /**
+ * Snapshot a block's rendered DOM for the drag preview: its `outerHTML` (so the
+ * floating clone shows the real content — text, marks, mention/link chips, an
+ * attachment image — with no separate render path) and its measured `width` (the
+ * `<DragOverlay>` is anchored to the tiny grip, so the overlay must be sized to the
+ * block explicitly). Returns `null` when the block element is not found. Exported so
+ * it can be unit-tested without a real drag.
+ */
+export function readBlockSnapshot(
+  root: HTMLElement | null,
+  blockId: string,
+): { html: string; width: number } | null {
+  const el = root?.querySelector<HTMLElement>(`[data-block-id="${CSS.escape(blockId)}"]`);
+  if (!el) return null;
+  return { html: el.outerHTML, width: el.getBoundingClientRect().width };
+}
+
+/**
  * Wraps the grip (the `⠿` menu trigger) in a dnd-kit draggable. Pointer-move
  * past the activation distance starts a drag; a plain click falls through to the
  * menu trigger underneath (the 4px constraint guarantees a click never becomes a

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
@@ -181,7 +181,8 @@
 // error/chip bodies. `margin: 0` resets the UA <figure> default (a reset, not
 // component layout). Tokens only.
 .root figure[data-attachment],
-.shell figure[data-attachment] {
+.shell figure[data-attachment],
+.dragOverlay figure[data-attachment] {
   // stylelint-disable-next-line property-disallowed-list -- reset UA <figure> default margin; internal
   margin: 0;
 }
@@ -271,4 +272,32 @@ figure[data-attachment][data-align='right'] {
 .configLink {
   font-size: var(--font-size-sm);
   color: var(--color-accent);
+}
+
+// The floating clone of the block being dragged, shown under the cursor by dnd-kit's
+// <DragOverlay> (portaled to <body>). A "lifted card": surface bg + elevation +
+// rounded corners + slight transparency so the block reads as picked up. Includes
+// the prose mixin because block typography is scoped to `.root`, and the clone lives
+// outside it. `pointer-events: none` keeps it from blocking the drop target under the
+// cursor; `box-sizing: border-box` so the inline width (the source block's measured
+// width, set in JS) includes padding. Width/position are the overlay's own anchoring
+// (set inline by dnd-kit / JS), not in-flow component layout (cf. `.gutter`).
+.dragOverlay {
+  @include prose.prose;
+
+  box-sizing: border-box;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  box-shadow: var(--shadow-lg);
+  opacity: var(--opacity-muted);
+  cursor: grabbing;
+  pointer-events: none;
+}
+
+// The source block while its clone is being dragged — dimmed so the user sees it has
+// been "lifted" out. Toggled as a transient class on the live block element during
+// the drag (removed on drop/cancel).
+.blockDragging {
+  opacity: var(--opacity-dragging);
 }

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
@@ -274,8 +274,9 @@ figure[data-attachment][data-align='right'] {
   color: var(--color-accent);
 }
 
-// The floating clone of the block being dragged, shown under the cursor by dnd-kit's
-// <DragOverlay> (portaled to <body>). A "lifted card": surface bg + elevation +
+// The floating clone of the block being dragged, shown under the cursor. Rendered
+// inline inside `.shell` by dnd-kit's <DragOverlay> (NOT portaled — which is why
+// `blockRects` filters the clone out of the drop geometry). A "lifted card": surface bg + elevation +
 // rounded corners + slight transparency so the block reads as picked up. Includes
 // the prose mixin because block typography is scoped to `.root`, and the clone lives
 // outside it. `pointer-events: none` keeps it from blocking the drop target under the

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
@@ -286,7 +286,7 @@ figure[data-attachment][data-align='right'] {
   @include prose.prose;
 
   box-sizing: border-box;
-  padding: var(--space-1) var(--space-2);
+  padding-block: var(--space-1);
   border-radius: var(--radius-md);
   background: var(--color-bg);
   box-shadow: var(--shadow-lg);

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { vi } from 'vitest';
@@ -1017,6 +1017,62 @@ describe('blockControls', () => {
     await user.click(screen.getByRole('button', { name: 'Block actions' }));
     await user.click(await screen.findByRole('menuitem', { name: /duplicate/i }));
     expect(document.querySelectorAll('[data-block-id]').length).toBe(before + 1);
+  });
+
+  describe('hover zone', () => {
+    // The shell is the editable's parent when blockControls is on (editable is a
+    // direct child of .shell). mouseleave doesn't bubble, so we dispatch it on the shell.
+    function shellOf(): HTMLElement {
+      return screen.getByRole('textbox').parentElement as HTMLElement;
+    }
+
+    it('keeps the gutter when the pointer moves from the block onto the gutter', async () => {
+      render(
+        <I18nProvider locale="en">
+          <Controlled blockControls />
+        </I18nProvider>,
+      );
+      const block = document.querySelector('[data-block-id]') as HTMLElement;
+      await userEvent.hover(block);
+      const actions = screen.getByRole('button', { name: 'Block actions' });
+      // Moving onto a gutter button (resolves to no block id) must NOT clear the gutter.
+      fireEvent.mouseOver(actions);
+      expect(screen.getByRole('button', { name: 'Block actions' })).toBeInTheDocument();
+    });
+
+    it('hides the gutter when the pointer leaves the editor (no caret)', async () => {
+      render(
+        <I18nProvider locale="en">
+          <Controlled blockControls />
+        </I18nProvider>,
+      );
+      const block = document.querySelector('[data-block-id]') as HTMLElement;
+      await userEvent.hover(block);
+      expect(screen.getByRole('button', { name: 'Block actions' })).toBeInTheDocument();
+      fireEvent.mouseLeave(shellOf());
+      expect(screen.queryByRole('button', { name: 'Block actions' })).toBeNull();
+    });
+
+    it('keeps a caret-driven gutter after the pointer leaves (caret fallback)', async () => {
+      render(
+        <I18nProvider locale="en">
+          <Controlled blockControls />
+        </I18nProvider>,
+      );
+      const block = document.querySelector('[data-block-id]') as HTMLElement;
+      // Put a real caret inside the block, then notify the editor.
+      const sel = document.getSelection()!;
+      const range = document.createRange();
+      range.selectNodeContents(block);
+      range.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(range);
+      fireEvent(document, new Event('selectionchange'));
+      // Hover then leave: the gutter must remain, resolved from the caret block.
+      await userEvent.hover(block);
+      fireEvent.mouseLeave(shellOf());
+      expect(screen.getByRole('button', { name: 'Block actions' })).toBeInTheDocument();
+    });
   });
 });
 

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -997,6 +997,9 @@ describe('blockControls', () => {
     await user.click(screen.getByRole('button', { name: 'Block actions' }));
     // …then hover block B before choosing Delete.
     await user.hover(blockB);
+    // While the menu is open, leaving the editor must NOT clear the active block —
+    // the menu's actions stay bound to block A (onLeave is guarded by blockMenuOpenRef).
+    fireEvent.mouseLeave(screen.getByRole('textbox').parentElement as HTMLElement);
     await user.click(await screen.findByRole('menuitem', { name: /delete/i }));
     // Block A must be the one removed, leaving B.
     const remaining = Array.from(document.querySelectorAll('[data-block-id]'));

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -354,7 +354,11 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
 
     const controlsOn = blockControls && !readOnly;
     const shellRef = useRef<HTMLDivElement | null>(null);
-    const [activeBlockId, setActiveBlockId] = useState<string | null>(null);
+    // Active block = hover wins, else the caret block (keyboard / after the mouse
+    // leaves). Split so clearing hover on editor-leave never wipes the caret target.
+    const [hoverBlockId, setHoverBlockId] = useState<string | null>(null);
+    const [caretBlockId, setCaretBlockId] = useState<string | null>(null);
+    const activeBlockId = hoverBlockId ?? caretBlockId;
     const [configBlockId, setConfigBlockId] = useState<string | null>(null);
     const [blockMenuOpen, setBlockMenuOpen] = useState(false);
     // Mirror the open state into a ref so the hover listener can read it without
@@ -363,6 +367,10 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // a click act on the wrong block).
     const blockMenuOpenRef = useRef(false);
     blockMenuOpenRef.current = blockMenuOpen;
+    // Set by RichTextBlockControls' onDraggingChange. While a grip drag is in
+    // progress the active block must not change (it IS the block being dragged), so
+    // the hover handlers below read this ref and bail — mirroring blockMenuOpenRef.
+    const draggingRef = useRef(false);
 
     // Resolve the [data-block-id] of the block element containing a DOM node.
     const blockIdFromNode = useCallback((node: Node | null): string | null => {
@@ -803,20 +811,33 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       return () => document.removeEventListener('selectionchange', onSelChange);
     }, [toolbar, readOnly]);
 
-    // Hover tracking (mouse).
+    // Hover tracking (mouse). Listens on the SHELL (which wraps both the editable and
+    // the gutter) so reaching from a block onto its controls keeps them alive:
+    // `mouseover` over the gutter resolves to no block id (it's outside the editable
+    // that blockIdFromNode stops at), so hoverBlockId is left unchanged. `mouseleave`
+    // on the shell fires only when the pointer truly leaves the editor → clear hover.
     useEffect(() => {
       if (!controlsOn) return;
-      const root = rootRef.current;
-      if (!root) return;
+      const shell = shellRef.current;
+      if (!shell) return;
       const onOver = (e: MouseEvent) => {
-        // Don't let hover steal the active block while the menu is open — its
-        // actions are bound to the active block.
-        if (blockMenuOpenRef.current) return;
+        // Don't let hover steal the active block while the menu is open (its actions
+        // are bound to the active block) or while a drag is in progress.
+        if (blockMenuOpenRef.current || draggingRef.current) return;
         const id = blockIdFromNode(e.target as Node);
-        if (id) setActiveBlockId(id);
+        if (id) setHoverBlockId(id);
       };
-      root.addEventListener('mouseover', onOver);
-      return () => root.removeEventListener('mouseover', onOver);
+      const onLeave = () => {
+        // Keep the active block while the menu is open or a drag is mid-flight.
+        if (blockMenuOpenRef.current || draggingRef.current) return;
+        setHoverBlockId(null);
+      };
+      shell.addEventListener('mouseover', onOver);
+      shell.addEventListener('mouseleave', onLeave);
+      return () => {
+        shell.removeEventListener('mouseover', onOver);
+        shell.removeEventListener('mouseleave', onLeave);
+      };
     }, [controlsOn, blockIdFromNode]);
 
     // Caret tracking → active block (keyboard users get a gutter target too).
@@ -827,7 +848,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         const sel = root?.ownerDocument.getSelection();
         if (sel && root && sel.anchorNode && root.contains(sel.anchorNode)) {
           const id = blockIdFromNode(sel.anchorNode);
-          if (id) setActiveBlockId(id);
+          if (id) setCaretBlockId(id);
         }
       };
       document.addEventListener('selectionchange', onSel);
@@ -878,7 +899,8 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           }
           if ((e.shiftKey && e.key === 'F10') || e.key === 'ContextMenu') {
             e.preventDefault();
-            setActiveBlockId(caretBlock);
+            setHoverBlockId(null);
+            setCaretBlockId(caretBlock);
             setBlockMenuOpen(true);
             return;
           }
@@ -1253,6 +1275,9 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         onTurnInto={onBlockTurnInto}
         onReorder={onBlockReorder}
         onConfigure={canConfigure ? onConfigOpen : undefined}
+        onDraggingChange={(d) => {
+          draggingRef.current = d;
+        }}
       />
     ) : null;
 

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -813,8 +813,9 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
 
     // Hover tracking (mouse). Listens on the SHELL (which wraps both the editable and
     // the gutter) so reaching from a block onto its controls keeps them alive:
-    // `mouseover` over the gutter resolves to no block id (it's outside the editable
-    // that blockIdFromNode stops at), so hoverBlockId is left unchanged. `mouseleave`
+    // `mouseover` over the gutter finds no `data-block-id` on the walk up (the gutter
+    // isn't inside the editable), so blockIdFromNode returns null and hoverBlockId is
+    // left unchanged — keeping the controls alive as you reach for them. `mouseleave`
     // on the shell fires only when the pointer truly leaves the editor → clear hover.
     useEffect(() => {
       if (!controlsOn) return;
@@ -899,6 +900,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           }
           if ((e.shiftKey && e.key === 'F10') || e.key === 'ContextMenu') {
             e.preventDefault();
+            // Clear hover so the menu binds to the caret block, not a stale hovered one.
             setHoverBlockId(null);
             setCaretBlockId(caretBlock);
             setBlockMenuOpen(true);

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -115,7 +115,7 @@ export function RichTextEditorDemo() {
 
       <Example
         title="Block controls"
-        description="Set blockControls for a per-block gutter on hover/focus: ＋ inserts a block below, ⠿ drags to reorder (subtree-aware for nested lists) and opens a menu (turn into / duplicate / move / delete). Keyboard: Shift+F10 opens the menu, ⌘/Ctrl+⇧↑/↓ move the block, ⌘/Ctrl+D duplicates. Works with or without the toolbar."
+        description="Set blockControls for a per-block gutter on hover/focus: ＋ inserts a block below, ⠿ drags to reorder (subtree-aware for nested lists) and opens a menu (turn into / duplicate / move / delete). Keyboard: Shift+F10 opens the menu, ⌘/Ctrl+⇧↑/↓ move the block, ⌘/Ctrl+D duplicates. Works with or without the toolbar. Dragging the handle shows the whole block as a floating preview, and the controls stay reachable as you move onto them."
         code={`const [doc, setDoc] = useState(fromMarkdown('…'));
 <RichTextEditor value={doc} onChange={setDoc} blockControls placeholder="Write…" />`}
       >


### PR DESCRIPTION
Refines the Notion-style block controls so reordering feels natural and the gutter is reliably reachable. Spec: `docs/superpowers/specs/2026-06-26-richtexteditor-block-drag-hover-design.md`; plan: `docs/superpowers/plans/2026-06-26-richtexteditor-block-drag-hover.md`. (Raised conversationally — no GitHub issue.)

## Summary
Three refinements to the existing block-controls layer in `RichTextEditor` — no engine/model/serialization change, no public API change.

- **A — Reachable gutter hover (bug fix).** Hover is now tracked on the editor **shell** (which wraps both the editable and the gutter) instead of the editable only. Active block resolves as `hoverBlockId ?? caretBlockId`: moving the pointer from a block onto its controls keeps them alive (gutter hover resolves to no block id → state held), the gutter hides when the pointer truly leaves the editor (`mouseleave`), and keyboard/caret users still get a gutter via the caret fallback. Guards (`blockMenuOpenRef`, new `draggingRef`) keep the active block stable while a menu is open or a drag is in progress.
- **B — Natural drag preview.** dnd-kit `<DragOverlay>` renders a floating, semi-transparent copy of the dragged block (a DOM snapshot of its `outerHTML`, so text/marks/mention+link chips/attachment images all look right) following the cursor; the source block dims; the blue drop-indicator line stays. The inline (non-portaled) overlay clone is filtered out of `blockRects` so the drop geometry isn't corrupted.
- **C — Menu vs. drag.** Starting a grip drag closes the block menu (`onDragStart` → `onMenuOpenChange(false)`); a plain click still opens it (4px activation constraint).

## Test plan
- Unit (Vitest/jsdom): `readBlockSnapshot` helper; at-rest "no overlay/dim" invariant; grip-click-opens-menu; shell hover-zone (reach onto gutter keeps it, leave hides it, caret fallback, `onLeave` menu guard). Full suite green: **3331 passed**.
- Gates: `make test` / `make build-lib` / `make lint` / `npm run format:check` all clean; `npm pack --dry-run` ships no test/internal files (grep = 0).
- Live verification (Playwright, playground "Block controls" demo) — confirmed in a real browser: gutter stays when you move onto it and hides on exit; drag shows the floating ghost + dimmed source + drop line; reorder lands correctly (clone excluded from geometry); menu closes on drag start; overlay/dim clear after drop.
- Rule 8 review-fix loop run (per-task spec + code-quality reviews and a final holistic pass): caught and fixed the inline-overlay drop-geometry bug, the mid-drag unmount leak, and reorder-by-captured-id; final verdict "clean enough to stop".

🤖 Generated with [Claude Code](https://claude.com/claude-code)