### PR TITLE
fix(Lightbox): render PDFs in Chrome by dropping the iframe sandbox (#213)

### DIFF
--- a/packages/design-system/src/components/Lightbox/Lightbox.test.tsx
+++ b/packages/design-system/src/components/Lightbox/Lightbox.test.tsx
@@ -179,11 +179,14 @@ describe('Lightbox', () => {
     }
   });
 
-  it('sandboxes the PDF iframe (opaque origin: no allow-same-origin)', () => {
+  it('does not sandbox the PDF iframe (Chrome blocks its PDF viewer in any sandboxed frame), keeps no-referrer', () => {
     render(<Lightbox open onOpenChange={() => {}} items={[pdfItem]} />);
-    const sandbox = document.querySelector('iframe')!.getAttribute('sandbox') ?? '';
-    expect(sandbox).toContain('allow-scripts');
-    expect(sandbox).not.toContain('allow-same-origin');
+    const frame = document.querySelector('iframe')!;
+    // No `sandbox`: Chrome refuses to render PDFs inside ANY sandboxed iframe
+    // (regardless of allow-* tokens), which blocks the viewer entirely. The real
+    // guards stay: no-referrer + the http(s)/relative-only src check (safeDocSrc).
+    expect(frame.hasAttribute('sandbox')).toBe(false);
+    expect(frame.getAttribute('referrerpolicy')).toBe('no-referrer');
   });
 
   it('the download link opens in a new tab (cross-origin download safety)', () => {

--- a/packages/design-system/src/components/Lightbox/Lightbox.tsx
+++ b/packages/design-system/src/components/Lightbox/Lightbox.tsx
@@ -28,7 +28,10 @@ export interface LightboxItem {
   alt: string;
   /** Item kind. Defaults to `'image'`, or `'pdf'` when `src` ends in `.pdf`. A
    *  `pdf` item renders in an `<iframe>` (the browser's PDF viewer) with a download
-   *  action instead of an `<img>`. */
+   *  action instead of an `<img>`. Security: the PDF iframe is NOT sandboxed (Chrome
+   *  blocks its PDF viewer in any sandboxed frame), so a `pdf` `src` MUST be a trusted
+   *  URL — the scheme is restricted to http(s)/relative, but a URL that returns HTML
+   *  instead of a PDF would run with its own origin's privileges. */
   kind?: 'image' | 'pdf';
   /** Optional caption shown below the stage. */
   caption?: ReactNode;
@@ -314,12 +317,16 @@ export function Lightbox({
                 title={currentItem.alt}
                 className={styles.doc}
                 referrerPolicy="no-referrer"
-                // Harden against a consumer-supplied URL that resolves to HTML:
-                // omit `allow-same-origin` so framed content runs in an opaque
-                // origin (can't reach the app's DOM/cookies/storage). `allow-scripts`
-                // is needed by Firefox's pdf.js viewer; `allow-downloads` keeps the
-                // in-viewer save button working.
-                sandbox="allow-scripts allow-downloads"
+                // No `sandbox`: a PDF is rendered by the browser's own PDF engine
+                // (PDFium / pdf.js), which already isolates the PDF's JS from the
+                // page — so a sandbox adds nothing for PDF content while BLOCKING
+                // Chrome's PDF viewer entirely ("This page has been blocked by
+                // Chrome"; Chrome refuses to render PDFs in ANY sandboxed iframe,
+                // regardless of allow-* tokens). `referrerPolicy="no-referrer"` and the
+                // http(s)/relative-only `safeDocSrc` check (blocks javascript:/data:/
+                // blob:) defend against SCHEME attacks; a URL that returns HTML instead
+                // of a PDF would run unsandboxed, so this path relies on the documented
+                // contract that the consumer frames its own trusted file URLs.
               />
             ) : (
               <div


### PR DESCRIPTION
Addresses #213 (reopened).

## Summary
The `0.1.76` PDF Lightbox renders in Firefox but is **blocked in Chrome/Chromium** — Chrome refuses to render its built-in PDF viewer (PDFium) inside **any** sandboxed `<iframe>`, regardless of `allow-*` tokens, so the shipped `sandbox="allow-scripts allow-downloads"` showed Chrome's "This page has been blocked by Chrome" placeholder instead of the PDF.

Fix: **drop the `sandbox` attribute** on the PDF iframe. A PDF is rendered by the browser's own PDF engine, which already isolates the PDF's JS from the embedding page — so the sandbox added no protection for PDF content while breaking Chrome entirely. The guards that defend against a malicious **URL** are retained:
- `referrerPolicy="no-referrer"`
- `safeDocSrc` — http(s)/relative-only scheme check (blocks `javascript:`/`data:`/`blob:`)

The `kind:'pdf'` `src` must be a trusted URL (documented on the `LightboxItem.kind` prop): the iframe is unsandboxed, so a URL that returns HTML instead of a PDF would run with its own origin's privileges. This matches the component's contract (the consumer frames its own file URLs) and was accepted in a fresh-context security review.

## Test plan
- Reworked the iframe security test: asserts **no** `sandbox` attribute (Chrome PDF-viewer compat) **and** retained `referrerPolicy="no-referrer"`.
- Kept the scheme-blocking tests (`javascript:`/`data:`/`blob:` → no iframe, "Preview unavailable") and the download-new-tab test.
- Gates green: `make test` (3331 passed), `make build-lib`, `make lint`, `npm run format:check`; `npm pack --dry-run` ships no test/internal files.
- Rule 8 security review (fresh context): verdict "clean enough to stop" — dropping the sandbox is the right call and effectively the only way to make Chrome render PDFs; SOP still prevents a cross-origin framed doc from touching the app; residual non-PDF-HTML/top-nav risk is bounded to the consumer-trust contract and now documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)