### PR TITLE
fix(PersonDisplay): shrink prop to shrink-wrap in a stretching parent (#219)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1583,6 +1583,7 @@ import { Divider } from '@eocrm/design-system';
 - `<PersonDisplay.Name href="...">` renders the name as a `<Link variant="subtle">` (real `<a>`). Omit `href` for read-only displays (audit actor, activity timeline).
 - `<PersonDisplay.Description>` is muted text; repeat for additional lines. Children can be `ReactNode` — e.g. `admin@acme.com <Badge tone="warning" size="sm">impersonating</Badge>` to inline a marker.
 - All Avatar props (`name`, `src`, `status`, `tooltip`) flow through `<PersonDisplay.Avatar>` except `size`.
+- `shrink` (boolean, default `false`): force content-width (`width: fit-content`). PersonDisplay shrink-wraps on its own, but a **stretching** flex/grid parent (`align-items: stretch` / `justify-self: stretch`) stretches it full-width, so a `Popover.Trigger`/`Tooltip` cloned onto it anchors to the wide box and centers right of the person. Add `shrink` on such an overlay trigger to re-anchor it to the avatar+name.
 - **Use for the standard "person row" — Avatar + name + 0–2 muted lines.** Not for Avatar-only badges (use `<Avatar>`), avatar stacks (use `<AvatarGroup>`), or click-anywhere row interactions (wrap PersonDisplay in your own Link).
 
 ### `<Badge>` — status / category pill

--- a/packages/design-system/src/components/PersonDisplay/PersonDisplay.module.scss
+++ b/packages/design-system/src/components/PersonDisplay/PersonDisplay.module.scss
@@ -12,6 +12,21 @@
   }
 }
 
+// Opt-in shrink-wrap (the `shrink` prop). The root is `inline-flex`, but as a child
+// of a STRETCHING flex/grid container CSS blockifies it and the parent's
+// `align-items: stretch` / `justify-self: stretch` stretches it to the full column
+// width — so a Popover/Tooltip cloned onto it anchors to that wide box and centers on
+// the empty column instead of the avatar+name (issue #219). `width: fit-content`
+// forces the box back to its content width in BOTH flex and grid (an explicit,
+// non-`auto` width opts out of the stretch), re-anchoring the overlay. This sizes the
+// element's OWN box (it doesn't place itself in the parent's layout, so it's not the
+// Rule-4 `align-self`/`justify-self` smell), and is opt-in only. `max-width: 100%`
+// keeps a long name from overflowing a narrow column.
+.shrink {
+  width: fit-content;
+  max-width: 100%;
+}
+
 // The inner column that holds Name + Descriptions stacked vertically.
 .column {
   display: inline-flex;

--- a/packages/design-system/src/components/PersonDisplay/PersonDisplay.test.tsx
+++ b/packages/design-system/src/components/PersonDisplay/PersonDisplay.test.tsx
@@ -193,3 +193,38 @@ it('renders without crashing when only Avatar + Name are passed (no Description)
   );
   expect(screen.getByText('Avery Liu')).toBeInTheDocument();
 });
+
+it('does not apply the shrink class by default', () => {
+  const { container } = render(
+    <PersonDisplay>
+      <PersonDisplay.Avatar name="Sarah" />
+      <PersonDisplay.Name>Sarah</PersonDisplay.Name>
+    </PersonDisplay>,
+  );
+  // CSS-module hashed class contains the substring "shrink" when applied.
+  expect(container.firstElementChild?.className).not.toMatch(/shrink/);
+});
+
+it('shrink applies the shrink-wrap class on the root', () => {
+  const { container } = render(
+    <PersonDisplay shrink>
+      <PersonDisplay.Avatar name="Sarah" />
+      <PersonDisplay.Name>Sarah</PersonDisplay.Name>
+    </PersonDisplay>,
+  );
+  expect(container.firstElementChild?.className).toMatch(/shrink/);
+  // shrink composes with (does not replace) the root class + data-size.
+  expect(container.firstElementChild?.className).toMatch(/root/);
+  expect(container.firstElementChild).toHaveAttribute('data-size', 'md');
+});
+
+it('shrink composes with a consumer className', () => {
+  const { container } = render(
+    <PersonDisplay shrink className="custom-root">
+      <PersonDisplay.Avatar name="Sarah" />
+      <PersonDisplay.Name>Sarah</PersonDisplay.Name>
+    </PersonDisplay>,
+  );
+  expect(container.firstElementChild).toHaveClass('custom-root');
+  expect(container.firstElementChild?.className).toMatch(/shrink/);
+});

--- a/packages/design-system/src/components/PersonDisplay/PersonDisplay.tsx
+++ b/packages/design-system/src/components/PersonDisplay/PersonDisplay.tsx
@@ -34,6 +34,20 @@ export interface PersonDisplayProps extends HTMLAttributes<HTMLDivElement> {
    */
   size?: PersonDisplaySize;
   /**
+   * Force the composition to shrink-wrap to its content (avatar + name) instead of
+   * stretching to fill a parent. Default `false`. The root is `inline-flex` and
+   * shrink-wraps on its own — but as a child of a *stretching* flex/grid container
+   * (a detail/sidebar card column with `align-items: stretch` / `justify-self:
+   * stretch`) CSS blockifies it and the parent stretches it to the full column
+   * width. The avatar+name then sit in the left portion and the trailing empty
+   * space joins the box, so a `Popover.Trigger` / `Tooltip` cloned onto the
+   * PersonDisplay anchors to that wide box and centers far to the right of the
+   * person. Set `shrink` on such an overlay trigger to keep it content-width
+   * (`width: fit-content`) regardless of the parent, so the overlay anchors to the
+   * visible avatar+name.
+   */
+  shrink?: boolean;
+  /**
    * `<PersonDisplay.Avatar>` + `<PersonDisplay.Name>` (+ optional repeating
    * `<PersonDisplay.Description>`) subcomponents in any order — Root sorts
    * the Avatar into its own slot.
@@ -267,7 +281,7 @@ const PersonDisplayDescription = forwardRef<HTMLSpanElement, PersonDisplayDescri
  *   for conditional rendering (`null`/`false` are safely ignored).
  */
 const PersonDisplayRoot = forwardRef<HTMLDivElement, PersonDisplayProps>(function PersonDisplayRoot(
-  { size = 'md', className, children, ...rest },
+  { size = 'md', shrink = false, className, children, ...rest },
   ref,
 ) {
   // Sort children into the Avatar (rendered first as a flex sibling)
@@ -287,7 +301,12 @@ const PersonDisplayRoot = forwardRef<HTMLDivElement, PersonDisplayProps>(functio
     <PersonDisplayContext.Provider value={{ size }}>
       {/* {...rest} first so internally-computed data-size (load-bearing for SCSS gap)
             can't be stomped by a consumer (Pattern B — data-size is the only locked attr). */}
-      <div ref={ref} className={clsx(styles.root, className)} {...rest} data-size={size}>
+      <div
+        ref={ref}
+        className={clsx(styles.root, shrink && styles.shrink, className)}
+        {...rest}
+        data-size={size}
+      >
         {avatarChildren}
         {columnChildren.length > 0 && <div className={styles.column}>{columnChildren}</div>}
       </div>

--- a/packages/playground/src/pages/components/PersonDisplayDemo.tsx
+++ b/packages/playground/src/pages/components/PersonDisplayDemo.tsx
@@ -136,6 +136,36 @@ export function PersonDisplayDemo() {
           </PersonDisplay>
         </InputExample>
       </Example>
+
+      <Example
+        title="Shrink-wrap for overlay triggers"
+        description="Inside a STRETCHING flex/grid column (here a Stack, which stretches its children), a default PersonDisplay blockifies and stretches to the full column width — the dashed outline shows the box reaching the right edge, so a Popover/Tooltip cloned onto it anchors to that wide box and centers far right of the person. With shrink (second row) the box hugs the avatar+name, so overlays anchor to the visible person. The dashed outlines are demo-only, to make each box's width visible."
+        code={`// In a stretching column, keep the overlay trigger content-width so it anchors right
+<PersonDisplay shrink>
+  <PersonDisplay.Avatar name="Sarah Chen" />
+  <PersonDisplay.Name>Sarah Chen</PersonDisplay.Name>
+  <PersonDisplay.Description>sarah@acme.com</PersonDisplay.Description>
+</PersonDisplay>`}
+      >
+        <InputExample>
+          <Stack gap="md">
+            <PersonDisplay style={{ outline: '1px dashed var(--color-border)' }}>
+              <PersonDisplay.Avatar name="Sarah Chen" />
+              <PersonDisplay.Name>Sarah Chen</PersonDisplay.Name>
+              <PersonDisplay.Description>
+                sarah@acme.com (default — stretches)
+              </PersonDisplay.Description>
+            </PersonDisplay>
+            <PersonDisplay shrink style={{ outline: '1px dashed var(--color-border)' }}>
+              <PersonDisplay.Avatar name="Sarah Chen" />
+              <PersonDisplay.Name>Sarah Chen</PersonDisplay.Name>
+              <PersonDisplay.Description>
+                sarah@acme.com (shrink — content-width)
+              </PersonDisplay.Description>
+            </PersonDisplay>
+          </Stack>
+        </InputExample>
+      </Example>
     </DemoLayout>
   );
 }


### PR DESCRIPTION
Addresses #219.

## Summary
`PersonDisplay`'s root is `inline-flex` (shrink-wraps), but as a child of a **stretching** flex/grid container CSS blockifies it and the parent's `align-items: stretch` / `justify-self: stretch` stretches it to the full column width. The avatar+name occupy the left portion, so a `Popover.Trigger` / `Tooltip` cloned onto the PersonDisplay anchors to that wide box and centers far right of the person.

Adds an opt-in **`shrink?: boolean`** prop (default `false`) that applies `width: fit-content; max-width: 100%` — an explicit, non-`auto` width opts out of the stretch in **both** flex and grid, re-anchoring the overlay to the visible avatar+name. This sizes the element's own box (not the Rule-4 `align-self`/`justify-self` "place yourself in the parent" smell), and `width` is not in the stylelint `property-disallowed-list`, so no override is needed.

## Test plan
- New tests: `shrink` applies the class (composing with the root class + `data-size`, and with a consumer `className`); absent by default. (jsdom can't compute layout, so class-application is the proxy.)
- Demo: a "Shrink-wrap for overlay triggers" example showing a default row (stretches to the column edge) vs a `shrink` row (content-width), with dashed outlines making each box's width visible.
- JSDoc on the prop + AGENTS.md note.
- Gates green: `make test` (3336), `make build-lib`, `make lint`, `npm run format:check`; `npm pack --dry-run` ships no test/internal files. Rule 8 review: library "clean enough to stop" (the reviewer ratified `width: fit-content` as the correct, lint-passing choice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)