### PR TITLE
feat(RichTextEditor): toolbar="auto" focus-gated toolbar (#222)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -964,7 +964,7 @@ const [doc, setDoc] = useState(emptyDoc());
 <RichTextEditor value={doc} onChange={setDoc} toolbar placeholder="Write a note…" />;
 ```
 
-**`toolbar` prop** (default `false`): renders a formatting bar above the editor surface. The toolbar contains:
+**`toolbar` prop** (`boolean | 'auto'`, default `false`): renders a formatting bar above the editor surface. `toolbar="auto"` shows the bar only when the editor is **focused or non-empty**, and keeps it shown while the editor's own overlays (link editor / mention menu) are open — so opening the link editor on a focused-but-empty composer doesn't collapse the bar. The editable is not remounted as the bar appears/hides (no focus/selection loss). Use `'auto'` for a compact, focus-gated composer (e.g. a comment box) instead of hand-rolling show-on-focus + overlay-focus handling. The toolbar contains:
 
 - **Mark buttons** — Bold, Italic, Underline, Strikethrough. Reflect `aria-pressed` based on the current selection (or pending marks at a collapsed caret). Clicking with a selection toggles the mark over it; clicking at a collapsed caret sets a "pending" mark applied to the next typed characters (then clears).
 - **Block-type dropdown** — Paragraph, Heading 1–3, Quote, Code block. Shows the current block type; mixed multi-block selections show "Mixed".

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -85,6 +85,67 @@ describe('RichTextEditor', () => {
   });
 });
 
+describe('RichTextEditor toolbar="auto"', () => {
+  beforeEach(() => {
+    mockReadSelection.mockReset();
+  });
+
+  it('hides the toolbar when the editor is empty and unfocused', () => {
+    renderEditor(<RichTextEditor value={emptyDoc()} onChange={() => {}} toolbar="auto" />);
+    expect(screen.queryByRole('toolbar')).toBeNull();
+  });
+
+  it('shows the toolbar on focus, hides it again on blur (while empty)', () => {
+    renderEditor(<RichTextEditor value={emptyDoc()} onChange={() => {}} toolbar="auto" />);
+    const box = screen.getByRole('textbox');
+    fireEvent.focus(box);
+    expect(screen.getByRole('toolbar')).toBeInTheDocument();
+    fireEvent.blur(box);
+    expect(screen.queryByRole('toolbar')).toBeNull();
+  });
+
+  it('shows the toolbar when non-empty even while unfocused', () => {
+    renderEditor(<RichTextEditor value={docFromText('hi')} onChange={() => {}} toolbar="auto" />);
+    expect(screen.getByRole('toolbar')).toBeInTheDocument();
+  });
+
+  it('keeps the toolbar shown while the link editor is open, even after the editable blurs', async () => {
+    const user = userEvent.setup();
+    // openLinkEditor needs a valid range (jsdom has no real caret).
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 0 },
+      focus: { blockId: 'k', offset: 0 },
+    });
+    function Harness() {
+      // Empty composer (single empty block) so only focus / overlay keep the bar up.
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} toolbar="auto" autoFocus />;
+    }
+    renderEditor(<Harness />);
+    const box = screen.getByRole('textbox');
+    fireEvent.focus(box); // ensure focused → bar visible
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+    expect(await screen.findByRole('group', { name: 'Edit link' })).toBeInTheDocument();
+    // The link editor (portaled to body) stole focus → the editable blurs. The bar
+    // must stay up (overlay-open), not collapse mid-action.
+    fireEvent.blur(box);
+    expect(screen.getByRole('toolbar')).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Edit link' })).toBeInTheDocument();
+  });
+
+  it('toolbar={true} always shows; toolbar={false} never (no regression)', () => {
+    const { unmount } = renderEditor(
+      <RichTextEditor value={emptyDoc()} onChange={() => {}} toolbar />,
+    );
+    expect(screen.getByRole('toolbar')).toBeInTheDocument();
+    unmount();
+    renderEditor(<RichTextEditor value={emptyDoc()} onChange={() => {}} toolbar={false} />);
+    expect(screen.queryByRole('toolbar')).toBeNull();
+  });
+});
+
 describe('RichTextEditor toolbar', () => {
   beforeEach(() => {
     mockReadSelection.mockReset();

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -97,8 +97,16 @@ export interface RichTextEditorProps extends Omit<
    * toolbar dispatches through the same commit path the keyboard uses and
    * reflects the active marks + current block of the live selection. Default
    * `false` (keyboard-only). When `readOnly`, the toolbar renders disabled.
+   *
+   * `'auto'` shows the toolbar only when the editor is **focused or non-empty**,
+   * and keeps it shown while the editor's own overlays (the link editor / mention
+   * menu) are open — so opening the link editor on a focused-but-empty composer
+   * doesn't collapse the bar. The editable is NOT remounted as the bar appears or
+   * hides (the bar toggles in a stable shell), so there's no focus/selection loss.
+   * Use it for a compact, focus-gated composer (e.g. a comment box) instead of
+   * hand-rolling the show-on-focus logic and working around overlay focus theft.
    */
-  toolbar?: boolean;
+  toolbar?: boolean | 'auto';
   /**
    * Enable `@`-mention autocomplete. Supply `onQuery` to resolve candidates for
    * the text typed after the trigger (default `@`); the editor renders a floating
@@ -330,6 +338,13 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // Link editor state.
     const [linkEditor, setLinkEditor] = useState<LinkEditorOpen | null>(null);
     const linkKeyRef = useRef(0);
+
+    // Focus state — only consulted by `toolbar="auto"` to gate the bar's visibility.
+    // Focus moving to an editor overlay (the link editor / mention menu, portaled to
+    // <body>) fires a blur, so `focused` flips false there; the `showToolbar`
+    // formula keeps the bar up via the overlay-open term instead.
+    const [focused, setFocused] = useState(false);
+    const autoToolbar = toolbar === 'auto';
 
     // Toolbar state: the live selection (tracked via `selectionchange`) and any
     // marks staged at a collapsed caret to apply to the next typed character.
@@ -1222,6 +1237,10 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         onClick={onEditableClick}
         onCompositionStart={onCompositionStart}
         onCompositionEnd={onCompositionEnd}
+        // Only tracked for `toolbar="auto"` (gates the bar's visibility); omitted
+        // otherwise so other modes never re-render on focus changes.
+        onFocus={autoToolbar ? () => setFocused(true) : undefined}
+        onBlur={autoToolbar ? () => setFocused(false) : undefined}
       >
         {renderDoc(value, { editable: true, renderLink, renderMention })}
       </div>
@@ -1318,18 +1337,37 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           })()
         : null;
 
-    if (!toolbar) {
-      if (controlsOn) {
-        return (
-          <div className={styles.shell} ref={shellRef}>
-            {editable}
-            {linkBubble}
-            {mentionMenu}
-            {blockControlsEl}
-            {configEl}
-          </div>
-        );
-      }
+    // Toolbar visibility. `true` → always; `'auto'` → focused, non-empty, or while
+    // one of the editor's own overlays is open (so opening the link editor on a
+    // focused-but-empty composer keeps the bar up rather than collapsing it). The
+    // overlay term is what survives the blur caused by the overlay stealing focus.
+    const overlayOpen = linkEditor != null || mention.open;
+    const showToolbar =
+      toolbar === true || (autoToolbar && (focused || !isEmptyDoc(value) || overlayOpen));
+    // Render the stable `.shell` whenever a toolbar mode is active (so the bar can
+    // toggle WITHOUT remounting the editable) or block controls need the anchor.
+    const usesShell = toolbar === true || autoToolbar || controlsOn;
+
+    const toolbarBar = showToolbar ? (
+      <RichTextToolbar
+        activeMarks={toolbarMarks}
+        block={toolbarBlock}
+        disabled={readOnly}
+        onToggleMark={onToolbarMark}
+        onSetBlock={onToolbarSetBlock}
+        onToggleList={onToolbarToggleList}
+        linkActive={toolbarLinkActive}
+        onOpenLink={openLinkEditor}
+        canUndo={canUndo}
+        canRedo={canRedo}
+        onUndo={onUndo}
+        onRedo={onRedo}
+        onUpload={uploadOn ? (files) => uploaderRef.current.uploadFiles(files) : undefined}
+        uploadAccept={upload?.accept}
+      />
+    ) : null;
+
+    if (!usesShell) {
       return (
         <>
           {editable}
@@ -1340,22 +1378,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     }
     return (
       <div className={styles.shell} ref={shellRef}>
-        <RichTextToolbar
-          activeMarks={toolbarMarks}
-          block={toolbarBlock}
-          disabled={readOnly}
-          onToggleMark={onToolbarMark}
-          onSetBlock={onToolbarSetBlock}
-          onToggleList={onToolbarToggleList}
-          linkActive={toolbarLinkActive}
-          onOpenLink={openLinkEditor}
-          canUndo={canUndo}
-          canRedo={canRedo}
-          onUndo={onUndo}
-          onRedo={onRedo}
-          onUpload={uploadOn ? (files) => uploaderRef.current.uploadFiles(files) : undefined}
-          uploadAccept={upload?.accept}
-        />
+        {toolbarBar}
         {editable}
         {linkBubble}
         {mentionMenu}

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -51,6 +51,7 @@ const renderMention: RenderMention = ({ id, label }) => (
 
 export function RichTextEditorDemo() {
   const [doc, setDoc] = useState<RichDoc>(docFromText('Type here. Select a word and press ⌘B.'));
+  const [autoDoc, setAutoDoc] = useState<RichDoc>(() => docFromText(''));
   const [linkDoc, setLinkDoc] = useState<RichDoc>(docFromText('Read the docs and visit our site.'));
   const [importDoc, setImportDoc] = useState<RichDoc>(() =>
     fromMarkdown(
@@ -111,6 +112,20 @@ export function RichTextEditorDemo() {
             Markdown → <Code>{toMarkdown(doc).replace(/\n/g, '⏎')}</Code>
           </Text>
         </Stack>
+      </Example>
+
+      <Example
+        title='Focus-gated toolbar (toolbar="auto")'
+        description='toolbar="auto" shows the formatting bar only when the editor is focused or non-empty — ideal for a compact comment composer. Click into the empty editor below: the bar appears; click away (while still empty) and it hides. Crucially, the bar stays up while the editor’s own overlays are open — focus the empty editor, click the Link button (or ⌘/Ctrl+K): the link editor opens and the bar does NOT collapse, even though focus moved into the link popover. The editable is never remounted as the bar toggles, so there is no focus/selection loss.'
+        code={`const [doc, setDoc] = useState(docFromText(''));
+<RichTextEditor value={doc} onChange={setDoc} toolbar="auto" placeholder="Add a comment…" />`}
+      >
+        <RichTextEditor
+          value={autoDoc}
+          onChange={setAutoDoc}
+          toolbar="auto"
+          placeholder="Add a comment… (toolbar appears on focus)"
+        />
       </Example>
 
       <Example


### PR DESCRIPTION
Addresses #222.

## Summary
Adds **`toolbar="auto"`** to `<RichTextEditor>` (`toolbar?: boolean | 'auto'`). In `'auto'` mode the built-in toolbar shows only when the editor is **focused or non-empty**, and stays shown while the editor's own overlays (link editor / mention menu) are open. This fixes the consumer pain: clicking the **Link** button on a focused-but-empty composer used to collapse a hand-rolled focus-gated toolbar (the link editor portals to `<body>` and steals focus) and orphan the link bubble. The bar toggles inside a **stable shell**, so the editable is never remounted (no focus/selection loss) — removing the consumer's `autoFocus` + deferred-blur workaround too.

`showToolbar = toolbar === true || (auto && (focused || !empty || overlayOpen))`, where `overlayOpen = linkEditor open || mention menu open`. The overlay term survives the blur the overlay causes; toolbar buttons already `preventDefault` on mousedown, so clicking them never blurs the editor.

`toolbar={true}` (always) and `toolbar={false}` (never) are unchanged.

## Test plan
- New `toolbar="auto"` tests: hidden when empty+unfocused; shows on focus, hides on blur (while empty); shown when non-empty even unfocused; **stays shown after the editable blurs while the link editor is open** (the consumer's repro); `true`/`false` regression. Full suite **3343 passed**; `make build-lib` / `make lint` / `npm run format:check` clean; playground typechecks; `npm pack --dry-run` ships no test/internal files.
- JSDoc on the `toolbar` union + AGENTS.md note + a "Focus-gated toolbar" demo example.
- Rule 8 review: "clean enough to stop" — confirmed no editable remount (keyless index-1 reconciliation), no flicker window, no `true`/`false` regression.

## Notes
A mention menu can't open over an empty doc (it needs typed `@…` text → non-empty), so the `!empty` term already keeps the bar there; the link test covers the meaningful empty+overlay path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)