### PR TITLE
feat(EmojiPicker): searchable emoji grid + popover wrapper (#221)

### DIFF
--- a/docs/superpowers/specs/2026-06-27-emojipicker-design.md
+++ b/docs/superpowers/specs/2026-06-27-emojipicker-design.md
@@ -1,0 +1,175 @@
+# `<EmojiPicker>` — searchable emoji grid (popover-ready) — design
+
+**Date:** 2026-06-27
+**Status:** Design (autonomous, issue #221) → plan → build
+**Component:** `@eocrm/design-system` › new `EmojiPicker`
+
+---
+
+## Context
+
+Issue #221: no DS emoji picker. Comment **reactions** need a searchable emoji grid
+that renders inside a `Popover`. `onSelect(emoji: string)` fires with the unicode
+char. Keyboard-navigable, token-themed, dark-mode-safe, localized labels where
+practical. The consumer owns the trigger (`<Popover.Content><EmojiPicker/></...>`),
+plus a convenience `<EmojiPickerPopover trigger onSelect>` wrapper.
+
+## Dependency decision: bundle a curated dataset, hand-roll the UI
+
+The package hard rule forbids **UI/component libraries** (only `@floating-ui` and
+`@dnd-kit` are excepted), and bundle size matters. So: **no emoji-picker library**
+(frimousse/emoji-mart are UI libs → out). Instead bundle a **curated local emoji
+dataset** (`emojiData.ts` — plain data, like the `libphonenumber-js` data-dep
+precedent, not a UI lib) and hand-roll the grid + search + keyboard per WAI-ARIA APG,
+exactly as the DS hand-rolls every other interactive primitive. The dataset is a
+focused common set (~10 categories, the high-frequency reaction + input emojis), kept
+light and expandable; it is NOT the full ~1900-emoji Unicode set (YAGNI for v1
+reactions).
+
+## API
+
+```tsx
+// Consumer owns the trigger:
+<Popover>
+  <Popover.Trigger><Button iconOnly aria-label="Add reaction">＋</Button></Popover.Trigger>
+  <Popover.Content><EmojiPicker onSelect={(e) => toggleReaction(e)} /></Popover.Content>
+</Popover>
+
+// Or the convenience wrapper (owns the Popover):
+<EmojiPickerPopover
+  trigger={<Button iconOnly aria-label="Add reaction">＋</Button>}
+  onSelect={(e) => toggleReaction(e)}
+/>
+```
+
+- **`EmojiPicker`** (`extends Omit<HTMLAttributes<HTMLDivElement>, 'onSelect'>`):
+  - `onSelect: (emoji: string) => void` — fires with the chosen unicode char.
+  - `className` merges; other div attrs spread (Pattern A).
+  - Renders: a search `<Input>` (filters by name + keywords), then a scrollable
+    panel of **category sections** (each a heading + a grid of emoji buttons). A
+    "no results" empty line when the filter matches nothing.
+- **`EmojiPickerPopover`**:
+  - `trigger: ReactNode` (the consumer's button — `Popover.Trigger` injects the
+    ref + ARIA), `onSelect`, and optional `open` / `onOpenChange` / `defaultOpen`
+    passthrough to `Popover`. Selecting an emoji fires `onSelect` **and closes** the
+    popover (default-uncontrolled: it manages its own open state and closes on
+    select; controlled: it calls `onOpenChange(false)`).
+
+## Keyboard + a11y (hand-rolled, APG grid pattern)
+
+- Search input is the primary focus target (type to filter). It's a normal text
+  `<Input>`; `aria-controls` the grid.
+- The emoji area is a **grid** (`role="grid"`, rows = `role="row"`, cells =
+  `role="gridcell"` wrapping a `<button>` per emoji). Roving tabindex: exactly one
+  emoji button is tabbable at a time.
+- From the search input: `ArrowDown` moves focus into the grid (first visible emoji).
+- In the grid: `ArrowLeft/Right` move by one; `ArrowUp/Down` move by one **row**
+  (column count); `Home`/`End` jump to row start/end; `Enter`/`Space` select (fires
+  `onSelect`). `ArrowUp` from the first row returns focus to the search input.
+  Typing a printable char while in the grid refocuses the search and appends (nice to
+  have — at minimum, the search box is reachable via Shift+Tab / ArrowUp).
+- Each emoji button has an `aria-label` = the emoji's name (so SR announces "thumbs
+  up"); the char itself is `aria-hidden` decorative text inside.
+- Filtering recomputes the visible grid; the roving index resets to 0.
+- Escape / outside-click dismissal is the Popover's job (when wrapped).
+
+## Dataset (`emojiData.ts`)
+
+```ts
+export interface EmojiEntry {
+  char: string;
+  name: string;
+  keywords: string[];
+}
+export interface EmojiCategory {
+  id: EmojiCategoryId;
+  emojis: EmojiEntry[];
+}
+export type EmojiCategoryId =
+  | 'smileys'
+  | 'gestures'
+  | 'people'
+  | 'animals'
+  | 'food'
+  | 'activities'
+  | 'travel'
+  | 'objects'
+  | 'symbols'
+  | 'flags';
+export const EMOJI_CATEGORIES: EmojiCategory[];
+```
+
+- Category **id** only (no label) — the component maps id → i18n key
+  (`emojiPicker.category.<id>`) via `useTranslation`, so labels localize. `name` +
+  `keywords` stay English (search corpus; "localize where practical" — names are the
+  practical floor).
+- ~12–24 emojis per category, common/reaction-first (👍👎❤️🎉😄😢😮😡🙏👏🔥💯✅❌
+  …). Authored as a static TS file (data, tree-shakeable). Each `char` is a single
+  user-perceived emoji (incl. needed ZWJ/variation sequences).
+
+## Tokens (`EmojiPicker.tokens.scss`)
+
+```
+--emoji-picker-width            // panel width (e.g. a fixed comfortable grid width)
+--emoji-picker-max-height       // scroll cap on the sections area
+--emoji-picker-cell-size        // square emoji button
+--emoji-picker-emoji-size       // font-size of the glyph
+--emoji-picker-grid-gap
+--emoji-picker-section-gap
+--emoji-picker-radius           // cell hover/focus radius (var(--radius-sm))
+--emoji-picker-cell-hover-bg    // var(--color-bg-muted)
+```
+
+All map to existing primitives (Rule 3, tokens only). Cell focus uses
+`:focus-visible` (Rule 3a). No layout props on the component beyond its own grid.
+
+## Component tokens / theming
+
+Dark mode: colors via tokens (bg, hover, fg) so it inherits the theme. The emoji
+glyphs themselves are system-rendered (no theming needed).
+
+## i18n (Rule 9)
+
+New `Messages` keys (en + ru): `emojiPicker.search` (placeholder),
+`emojiPicker.noResults`, and `emojiPicker.category.<id>` for all 10 category ids.
+Consumed via `useTranslation`. (`EmojiPickerPopover` adds no fixed strings — the
+trigger + its aria-label are the consumer's.)
+
+## Testing (`EmojiPicker.test.tsx`)
+
+- Renders the search box + category sections + emoji buttons.
+- Clicking an emoji button fires `onSelect` with its char.
+- Typing in search filters the grid (matching emojis shown, non-matching hidden);
+  no-match shows the empty message.
+- Each emoji button exposes its name as the accessible name (`aria-label`).
+- Keyboard: ArrowDown from search enters the grid; Arrow keys move the roving focus;
+  Enter selects (fires `onSelect`). (Roving tabindex: one tabbable cell.)
+- `EmojiPickerPopover`: clicking the trigger opens the panel; selecting an emoji
+  fires `onSelect` and closes the popover.
+- forwardRef on `EmojiPicker` → its root div; `className` merges; arbitrary attrs
+  spread.
+
+Live Playwright pass: open the picker in the demo, search, keyboard-navigate, select.
+
+## Core-invariant checklist (new component)
+
+- `src/components/EmojiPicker/`: `emojiData.ts`, `EmojiPicker.tsx`
+  (forwardRef + spread + full JSDoc + `@remarks`), `EmojiPicker.module.scss`,
+  `EmojiPicker.tokens.scss`, `EmojiPicker.test.tsx`, `index.ts`.
+- `src/index.ts` re-export: `EmojiPicker`, `EmojiPickerPopover`, `EmojiPickerProps`,
+  `EmojiPickerPopoverProps`, `EmojiEntry`/`EmojiCategory`/`EmojiCategoryId` types.
+- i18n keys in `messages.ts` + `en.ts` + `ru.ts`.
+- Demo `pages/components/EmojiPickerDemo.tsx` + wiring: App route, AppShell nav
+  (Forms or Display group), ComponentsIndex card, mockups registry `ComponentName`
+  union (the demo `componentName` prop is typed against it).
+- `AGENTS.md` TL;DR + canonical snippet.
+- Manifest CLUSTERS entry in BOTH `_meta/manifest.ts` + `generate-manifest.mjs`
+  (EmojiPicker composes `Popover`/`Input`/`Button`), then `npm run build:manifest`.
+
+## When NOT to use (`@remarks`)
+
+- A fixed small set of reaction choices (no search) → a `Cluster` of `Button`s.
+- A full free-text editor with inline emoji autocomplete → out of scope (that's an
+  editor `@`-style menu, cf. RichTextEditor mentions).
+- Rendering existing reactions as chips with counts → that's a `Badge`/chip cluster
+  the consumer builds; `EmojiPicker` is only the chooser.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -2467,6 +2467,44 @@ Multi mode buffers a draft until Apply; single mode commits per click.
 Don't use for form selects (use `<Select>`), action menus (use `<DropdownMenu>`),
 or single boolean toggles (use `<Checkbox>` or `<Switch>`).
 
+### `<EmojiPicker>` — searchable emoji grid (reactions + input)
+
+**Use to let the user pick an emoji** — a reaction chip, an inline insert into a
+message/comment. Searchable, category-sectioned, keyboard-navigable 8-column grid
+over a **curated common set** (not the full ~1900-emoji Unicode catalog;
+skin-tone / ZWJ variants are out). It's the chooser only — calls
+`onSelect(emoji: string)` on click or Enter/Space; it has no notion of which
+emoji are already chosen or their counts. The bare picker is a surface — pair it
+with a `Popover` (or use `EmojiPickerPopover`).
+
+```tsx
+// Inside a Popover you control (e.g. an "add reaction" button on a comment):
+<Popover>
+  <Popover.Trigger>
+    <Button iconOnly variant="ghost" aria-label="Add reaction">
+      <Smile size={16} />
+    </Button>
+  </Popover.Trigger>
+  <Popover.Content>
+    <EmojiPicker onSelect={(emoji) => addReaction(emoji)} />
+  </Popover.Content>
+</Popover>
+
+// Batteries-included wrapper — owns the Popover, closes on select:
+<EmojiPickerPopover
+  trigger={<Button variant="secondary" size="sm">Add reaction</Button>}
+  onSelect={(emoji) => appendToDraft(emoji)}
+/>
+```
+
+`EmojiPickerPopover` takes `trigger` + `onSelect`, plus the standard
+controlled-open contract (`open` / `onOpenChange` / `defaultOpen`).
+
+**When NOT to use:** a small fixed reaction set (👍 ❤️ 🎉) → render a `Cluster`
+of `Button`s; a searchable grid is overkill for 3-6 choices. Also not for inline
+`:smile`-style autocomplete (the editor's suggestion engine owns that) or for
+rendering existing reaction counts (the consumer builds that display).
+
 ### `<EmptyState>` — "nothing here" container
 
 ```tsx

--- a/packages/design-system/scripts/generate-manifest.mjs
+++ b/packages/design-system/scripts/generate-manifest.mjs
@@ -57,6 +57,7 @@ const CLUSTERS = {
   PhoneInput: 'Forms',
   Radio: 'Forms',
   OptionsPicker: 'Forms',
+  EmojiPicker: 'Forms',
   Select: 'Forms',
   Slider: 'Forms',
   Sortable: 'Forms',

--- a/packages/design-system/src/_meta/manifest.ts
+++ b/packages/design-system/src/_meta/manifest.ts
@@ -79,6 +79,7 @@ const CLUSTERS: Record<string, string> = {
   PhoneInput: 'Forms',
   Radio: 'Forms',
   OptionsPicker: 'Forms',
+  EmojiPicker: 'Forms',
   Select: 'Forms',
   Slider: 'Forms',
   Sortable: 'Forms',

--- a/packages/design-system/src/components.manifest.json
+++ b/packages/design-system/src/components.manifest.json
@@ -248,6 +248,16 @@
       "RichTextEditor"
     ]
   },
+  "EmojiPicker": {
+    "tier": "composition",
+    "cluster": "Forms",
+    "composes": [
+      "Input",
+      "Popover",
+      "Text"
+    ],
+    "composedBy": []
+  },
   "EmptyState": {
     "tier": "primitive",
     "cluster": "Display",
@@ -352,6 +362,7 @@
     "composes": [],
     "composedBy": [
       "ColorPicker",
+      "EmojiPicker",
       "OptionsPicker",
       "PhoneInput",
       "RichTextEditor"
@@ -514,6 +525,7 @@
     "composedBy": [
       "ColorPicker",
       "ConfirmationPopover",
+      "EmojiPicker",
       "OptionsPicker"
     ]
   },
@@ -677,6 +689,7 @@
     "cluster": "Display",
     "composes": [],
     "composedBy": [
+      "EmojiPicker",
       "Field",
       "FilterChip",
       "FormSection",

--- a/packages/design-system/src/components/EmojiPicker/EmojiPicker.module.scss
+++ b/packages/design-system/src/components/EmojiPicker/EmojiPicker.module.scss
@@ -1,0 +1,84 @@
+@use '../../styles/mixins' as *;
+@use './EmojiPicker.tokens';
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--emoji-picker-section-gap);
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.searchIcon {
+  flex-shrink: 0;
+  color: var(--emoji-picker-search-icon-fg);
+}
+
+// Rule 4 note: internal flex layout — the public component is the picker
+// panel, not the search input. The picker owns the search row's arrangement
+// (mirrors OptionsPicker's `.searchInput`).
+.searchInput {
+  flex: 1;
+  border: none;
+  background: transparent;
+}
+
+// The scrollable grid surface. Width is the picker's own intrinsic size
+// (see EmojiPicker.tokens.scss) — not consumer layout.
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--emoji-picker-section-gap);
+  width: var(--emoji-picker-width);
+  max-height: var(--emoji-picker-max-height);
+  overflow-y: auto;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--emoji-picker-grid-gap);
+}
+
+.sectionLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: var(--emoji-picker-grid-gap);
+}
+
+// Button reset + square-ish cell. Width comes from the grid track (1fr
+// stretch), so no explicit width is set (Rule 4).
+.cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--emoji-picker-cell-size);
+  padding: 0;
+  border: none;
+  border-radius: var(--emoji-picker-radius);
+  background: none;
+  font-size: var(--emoji-picker-emoji-size);
+  line-height: 1;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--emoji-picker-cell-hover-bg);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+  }
+}
+
+.noResults {
+  text-align: center;
+}

--- a/packages/design-system/src/components/EmojiPicker/EmojiPicker.test.tsx
+++ b/packages/design-system/src/components/EmojiPicker/EmojiPicker.test.tsx
@@ -105,9 +105,7 @@ it('roving tabIndex: only the active cell is tabbable', () => {
 
 it('forwards ref to the root div, merges className, and spreads data-* attrs', () => {
   const ref = createRef<HTMLDivElement>();
-  render(
-    <EmojiPicker ref={ref} onSelect={() => {}} className="custom" data-foo="bar" />,
-  );
+  render(<EmojiPicker ref={ref} onSelect={() => {}} className="custom" data-foo="bar" />);
   expect(ref.current).not.toBeNull();
   expect(ref.current?.tagName).toBe('DIV');
   expect(ref.current).toHaveClass('custom');
@@ -120,9 +118,7 @@ it('forwards ref to the root div, merges className, and spreads data-* attrs', (
 
 it('EmojiPickerPopover opens on trigger click and shows the picker', async () => {
   const user = userEvent.setup();
-  render(
-    <EmojiPickerPopover trigger={<button>open</button>} onSelect={() => {}} />,
-  );
+  render(<EmojiPickerPopover trigger={<button>open</button>} onSelect={() => {}} />);
   // Closed initially — no search box.
   expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   await user.click(screen.getByRole('button', { name: 'open' }));
@@ -132,9 +128,7 @@ it('EmojiPickerPopover opens on trigger click and shows the picker', async () =>
 it('EmojiPickerPopover fires onSelect and closes when an emoji is chosen', async () => {
   const user = userEvent.setup();
   const onSelect = vi.fn();
-  render(
-    <EmojiPickerPopover trigger={<button>open</button>} onSelect={onSelect} />,
-  );
+  render(<EmojiPickerPopover trigger={<button>open</button>} onSelect={onSelect} />);
   await user.click(screen.getByRole('button', { name: 'open' }));
   await user.click(screen.getByRole('gridcell', { name: 'thumbs up' }));
   expect(onSelect).toHaveBeenCalledWith('👍');

--- a/packages/design-system/src/components/EmojiPicker/EmojiPicker.test.tsx
+++ b/packages/design-system/src/components/EmojiPicker/EmojiPicker.test.tsx
@@ -10,33 +10,33 @@ import { EmojiPicker, EmojiPickerPopover } from './EmojiPicker';
 it('renders the search box and emoji cells', () => {
   render(<EmojiPicker onSelect={() => {}} />);
   expect(screen.getByRole('textbox')).toBeInTheDocument();
-  // Cells expose role="gridcell"; the accessible name is the emoji's name.
-  expect(screen.getByRole('gridcell', { name: 'thumbs up' })).toBeInTheDocument();
+  // Cells expose role="option"; the accessible name is the emoji's name.
+  expect(screen.getByRole('option', { name: 'thumbs up' })).toBeInTheDocument();
 });
 
 it('fires onSelect with the emoji char when a cell is clicked', async () => {
   const user = userEvent.setup();
   const onSelect = vi.fn();
   render(<EmojiPicker onSelect={onSelect} />);
-  await user.click(screen.getByRole('gridcell', { name: 'thumbs up' }));
+  await user.click(screen.getByRole('option', { name: 'thumbs up' }));
   expect(onSelect).toHaveBeenCalledTimes(1);
   expect(onSelect).toHaveBeenCalledWith('👍');
 });
 
 it('each emoji cell uses its name as the accessible label', () => {
   render(<EmojiPicker onSelect={() => {}} />);
-  expect(screen.getByRole('gridcell', { name: 'pizza' })).toBeInTheDocument();
-  expect(screen.getByRole('gridcell', { name: 'red apple' })).toBeInTheDocument();
+  expect(screen.getByRole('option', { name: 'pizza' })).toBeInTheDocument();
+  expect(screen.getByRole('option', { name: 'red apple' })).toBeInTheDocument();
 });
 
 it('filters by search query (name / keyword substring)', async () => {
   const user = userEvent.setup();
   render(<EmojiPicker onSelect={() => {}} />);
   // Both 'pizza' and 'thumbs up' are present before filtering.
-  expect(screen.getByRole('gridcell', { name: 'pizza' })).toBeInTheDocument();
+  expect(screen.getByRole('option', { name: 'pizza' })).toBeInTheDocument();
   await user.type(screen.getByRole('textbox'), 'thumbs');
-  expect(screen.getByRole('gridcell', { name: 'thumbs up' })).toBeInTheDocument();
-  expect(screen.queryByRole('gridcell', { name: 'pizza' })).not.toBeInTheDocument();
+  expect(screen.getByRole('option', { name: 'thumbs up' })).toBeInTheDocument();
+  expect(screen.queryByRole('option', { name: 'pizza' })).not.toBeInTheDocument();
 });
 
 it('matches keywords as well as names', async () => {
@@ -44,7 +44,7 @@ it('matches keywords as well as names', async () => {
   render(<EmojiPicker onSelect={() => {}} />);
   // 'lol' is a keyword of 'face with tears of joy', not part of its name.
   await user.type(screen.getByRole('textbox'), 'lol');
-  expect(screen.getByRole('gridcell', { name: 'face with tears of joy' })).toBeInTheDocument();
+  expect(screen.getByRole('option', { name: 'face with tears of joy' })).toBeInTheDocument();
 });
 
 it('shows the no-results message when nothing matches', async () => {
@@ -52,7 +52,7 @@ it('shows the no-results message when nothing matches', async () => {
   render(<EmojiPicker onSelect={() => {}} />);
   await user.type(screen.getByRole('textbox'), 'zzzqqqxyz');
   expect(screen.getByText('No emoji found')).toBeInTheDocument();
-  expect(screen.queryByRole('gridcell', { name: 'thumbs up' })).not.toBeInTheDocument();
+  expect(screen.queryByRole('option', { name: 'thumbs up' })).not.toBeInTheDocument();
 });
 
 // ---------------------------------------------------------------------------
@@ -65,9 +65,9 @@ it('ArrowDown from the search input moves focus into the grid', async () => {
   await user.click(screen.getByRole('textbox'));
   await user.keyboard('{ArrowDown}');
   const active = document.activeElement as HTMLElement;
-  expect(active).toHaveAttribute('role', 'gridcell');
+  expect(active).toHaveAttribute('role', 'option');
   // The first cell is the first emoji in render order (grinning face).
-  expect(active).toBe(screen.getByRole('gridcell', { name: 'grinning face' }));
+  expect(active).toBe(screen.getByRole('option', { name: 'grinning face' }));
 });
 
 it('Enter on a focused grid cell fires onSelect with that emoji', async () => {
@@ -87,16 +87,29 @@ it('ArrowRight moves the roving focus to the next cell', async () => {
   await user.keyboard('{ArrowDown}{ArrowRight}');
   // Second emoji in render order is 'grinning face with smiling eyes'.
   expect(document.activeElement).toBe(
-    screen.getByRole('gridcell', { name: 'grinning face with smiling eyes' }),
+    screen.getByRole('option', { name: 'grinning face with smiling eyes' }),
   );
 });
 
 it('roving tabIndex: only the active cell is tabbable', () => {
   render(<EmojiPicker onSelect={() => {}} />);
-  const first = screen.getByRole('gridcell', { name: 'grinning face' });
-  const second = screen.getByRole('gridcell', { name: 'grinning face with smiling eyes' });
+  const first = screen.getByRole('option', { name: 'grinning face' });
+  const second = screen.getByRole('option', { name: 'grinning face with smiling eyes' });
   expect(first).toHaveAttribute('tabindex', '0');
   expect(second).toHaveAttribute('tabindex', '-1');
+});
+
+it('ArrowUp from the first row returns focus to the search input', async () => {
+  const user = userEvent.setup();
+  render(<EmojiPicker onSelect={() => {}} />);
+  const search = screen.getByRole('textbox');
+  await user.click(search);
+  // ArrowDown drops into the first option…
+  await user.keyboard('{ArrowDown}');
+  expect(document.activeElement).toBe(screen.getByRole('option', { name: 'grinning face' }));
+  // …and ArrowUp from that first row escapes back up to the search input.
+  await user.keyboard('{ArrowUp}');
+  expect(document.activeElement).toBe(search);
 });
 
 // ---------------------------------------------------------------------------
@@ -130,7 +143,7 @@ it('EmojiPickerPopover fires onSelect and closes when an emoji is chosen', async
   const onSelect = vi.fn();
   render(<EmojiPickerPopover trigger={<button>open</button>} onSelect={onSelect} />);
   await user.click(screen.getByRole('button', { name: 'open' }));
-  await user.click(screen.getByRole('gridcell', { name: 'thumbs up' }));
+  await user.click(screen.getByRole('option', { name: 'thumbs up' }));
   expect(onSelect).toHaveBeenCalledWith('👍');
   // Picker closed → search box gone.
   expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
@@ -149,4 +162,23 @@ it('EmojiPickerPopover supports controlled open via onOpenChange', async () => {
   );
   await user.click(screen.getByRole('button', { name: 'open' }));
   expect(onOpenChange).toHaveBeenCalledWith(true);
+});
+
+it('EmojiPickerPopover (controlled, open) fires onSelect and requests close on pick', async () => {
+  const user = userEvent.setup();
+  const onSelect = vi.fn();
+  const onOpenChange = vi.fn();
+  render(
+    <EmojiPickerPopover
+      trigger={<button>open</button>}
+      onSelect={onSelect}
+      open
+      onOpenChange={onOpenChange}
+    />,
+  );
+  // Already open (controlled open=true) — pick an emoji directly.
+  await user.click(screen.getByRole('option', { name: 'thumbs up' }));
+  expect(onSelect).toHaveBeenCalledWith('👍');
+  // Selecting always requests close, even in controlled mode.
+  expect(onOpenChange).toHaveBeenCalledWith(false);
 });

--- a/packages/design-system/src/components/EmojiPicker/EmojiPicker.test.tsx
+++ b/packages/design-system/src/components/EmojiPicker/EmojiPicker.test.tsx
@@ -1,0 +1,158 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EmojiPicker, EmojiPickerPopover } from './EmojiPicker';
+
+// ---------------------------------------------------------------------------
+// EmojiPicker — rendering, selection, filtering
+// ---------------------------------------------------------------------------
+
+it('renders the search box and emoji cells', () => {
+  render(<EmojiPicker onSelect={() => {}} />);
+  expect(screen.getByRole('textbox')).toBeInTheDocument();
+  // Cells expose role="gridcell"; the accessible name is the emoji's name.
+  expect(screen.getByRole('gridcell', { name: 'thumbs up' })).toBeInTheDocument();
+});
+
+it('fires onSelect with the emoji char when a cell is clicked', async () => {
+  const user = userEvent.setup();
+  const onSelect = vi.fn();
+  render(<EmojiPicker onSelect={onSelect} />);
+  await user.click(screen.getByRole('gridcell', { name: 'thumbs up' }));
+  expect(onSelect).toHaveBeenCalledTimes(1);
+  expect(onSelect).toHaveBeenCalledWith('👍');
+});
+
+it('each emoji cell uses its name as the accessible label', () => {
+  render(<EmojiPicker onSelect={() => {}} />);
+  expect(screen.getByRole('gridcell', { name: 'pizza' })).toBeInTheDocument();
+  expect(screen.getByRole('gridcell', { name: 'red apple' })).toBeInTheDocument();
+});
+
+it('filters by search query (name / keyword substring)', async () => {
+  const user = userEvent.setup();
+  render(<EmojiPicker onSelect={() => {}} />);
+  // Both 'pizza' and 'thumbs up' are present before filtering.
+  expect(screen.getByRole('gridcell', { name: 'pizza' })).toBeInTheDocument();
+  await user.type(screen.getByRole('textbox'), 'thumbs');
+  expect(screen.getByRole('gridcell', { name: 'thumbs up' })).toBeInTheDocument();
+  expect(screen.queryByRole('gridcell', { name: 'pizza' })).not.toBeInTheDocument();
+});
+
+it('matches keywords as well as names', async () => {
+  const user = userEvent.setup();
+  render(<EmojiPicker onSelect={() => {}} />);
+  // 'lol' is a keyword of 'face with tears of joy', not part of its name.
+  await user.type(screen.getByRole('textbox'), 'lol');
+  expect(screen.getByRole('gridcell', { name: 'face with tears of joy' })).toBeInTheDocument();
+});
+
+it('shows the no-results message when nothing matches', async () => {
+  const user = userEvent.setup();
+  render(<EmojiPicker onSelect={() => {}} />);
+  await user.type(screen.getByRole('textbox'), 'zzzqqqxyz');
+  expect(screen.getByText('No emoji found')).toBeInTheDocument();
+  expect(screen.queryByRole('gridcell', { name: 'thumbs up' })).not.toBeInTheDocument();
+});
+
+// ---------------------------------------------------------------------------
+// EmojiPicker — keyboard roving grid
+// ---------------------------------------------------------------------------
+
+it('ArrowDown from the search input moves focus into the grid', async () => {
+  const user = userEvent.setup();
+  render(<EmojiPicker onSelect={() => {}} />);
+  await user.click(screen.getByRole('textbox'));
+  await user.keyboard('{ArrowDown}');
+  const active = document.activeElement as HTMLElement;
+  expect(active).toHaveAttribute('role', 'gridcell');
+  // The first cell is the first emoji in render order (grinning face).
+  expect(active).toBe(screen.getByRole('gridcell', { name: 'grinning face' }));
+});
+
+it('Enter on a focused grid cell fires onSelect with that emoji', async () => {
+  const user = userEvent.setup();
+  const onSelect = vi.fn();
+  render(<EmojiPicker onSelect={onSelect} />);
+  await user.click(screen.getByRole('textbox'));
+  await user.keyboard('{ArrowDown}');
+  await user.keyboard('{Enter}');
+  expect(onSelect).toHaveBeenCalledWith('😀');
+});
+
+it('ArrowRight moves the roving focus to the next cell', async () => {
+  const user = userEvent.setup();
+  render(<EmojiPicker onSelect={() => {}} />);
+  await user.click(screen.getByRole('textbox'));
+  await user.keyboard('{ArrowDown}{ArrowRight}');
+  // Second emoji in render order is 'grinning face with smiling eyes'.
+  expect(document.activeElement).toBe(
+    screen.getByRole('gridcell', { name: 'grinning face with smiling eyes' }),
+  );
+});
+
+it('roving tabIndex: only the active cell is tabbable', () => {
+  render(<EmojiPicker onSelect={() => {}} />);
+  const first = screen.getByRole('gridcell', { name: 'grinning face' });
+  const second = screen.getByRole('gridcell', { name: 'grinning face with smiling eyes' });
+  expect(first).toHaveAttribute('tabindex', '0');
+  expect(second).toHaveAttribute('tabindex', '-1');
+});
+
+// ---------------------------------------------------------------------------
+// EmojiPicker — ref / className / spread
+// ---------------------------------------------------------------------------
+
+it('forwards ref to the root div, merges className, and spreads data-* attrs', () => {
+  const ref = createRef<HTMLDivElement>();
+  render(
+    <EmojiPicker ref={ref} onSelect={() => {}} className="custom" data-foo="bar" />,
+  );
+  expect(ref.current).not.toBeNull();
+  expect(ref.current?.tagName).toBe('DIV');
+  expect(ref.current).toHaveClass('custom');
+  expect(ref.current).toHaveAttribute('data-foo', 'bar');
+});
+
+// ---------------------------------------------------------------------------
+// EmojiPickerPopover
+// ---------------------------------------------------------------------------
+
+it('EmojiPickerPopover opens on trigger click and shows the picker', async () => {
+  const user = userEvent.setup();
+  render(
+    <EmojiPickerPopover trigger={<button>open</button>} onSelect={() => {}} />,
+  );
+  // Closed initially — no search box.
+  expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: 'open' }));
+  expect(screen.getByRole('textbox')).toBeInTheDocument();
+});
+
+it('EmojiPickerPopover fires onSelect and closes when an emoji is chosen', async () => {
+  const user = userEvent.setup();
+  const onSelect = vi.fn();
+  render(
+    <EmojiPickerPopover trigger={<button>open</button>} onSelect={onSelect} />,
+  );
+  await user.click(screen.getByRole('button', { name: 'open' }));
+  await user.click(screen.getByRole('gridcell', { name: 'thumbs up' }));
+  expect(onSelect).toHaveBeenCalledWith('👍');
+  // Picker closed → search box gone.
+  expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+});
+
+it('EmojiPickerPopover supports controlled open via onOpenChange', async () => {
+  const user = userEvent.setup();
+  const onOpenChange = vi.fn();
+  render(
+    <EmojiPickerPopover
+      trigger={<button>open</button>}
+      onSelect={() => {}}
+      open={false}
+      onOpenChange={onOpenChange}
+    />,
+  );
+  await user.click(screen.getByRole('button', { name: 'open' }));
+  expect(onOpenChange).toHaveBeenCalledWith(true);
+});

--- a/packages/design-system/src/components/EmojiPicker/EmojiPicker.tokens.scss
+++ b/packages/design-system/src/components/EmojiPicker/EmojiPicker.tokens.scss
@@ -1,0 +1,24 @@
+// EmojiPicker.tokens.scss — component-scoped tokens for <EmojiPicker>.
+:root {
+  // Panel sizing — the picker owns its own intrinsic panel size (mirrors how
+  // OptionsPicker sizes its own panel with literal px). width/max-height are
+  // NOT covered by stylelint's strict-value set, but no existing size token
+  // fits these values, so literals are used deliberately here.
+  --emoji-picker-width: 320px;
+  --emoji-picker-max-height: 280px;
+
+  // Cell (one emoji button) + the emoji glyph inside it
+  --emoji-picker-cell-size: var(--size-md);
+  --emoji-picker-emoji-size: var(--font-size-lg);
+
+  // Spacing
+  --emoji-picker-grid-gap: var(--space-1);
+  --emoji-picker-section-gap: var(--space-3);
+
+  // Cell affordances
+  --emoji-picker-radius: var(--radius-sm);
+  --emoji-picker-cell-hover-bg: var(--color-bg-muted);
+
+  // Search row
+  --emoji-picker-search-icon-fg: var(--color-fg-subtle);
+}

--- a/packages/design-system/src/components/EmojiPicker/EmojiPicker.tsx
+++ b/packages/design-system/src/components/EmojiPicker/EmojiPicker.tsx
@@ -143,9 +143,7 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(function
   const activeSafe = flat.length === 0 ? -1 : Math.min(activeIndex, flat.length - 1);
 
   const focusCell = (index: number) => {
-    panelRef.current
-      ?.querySelector<HTMLButtonElement>(`[data-emoji-index="${index}"]`)
-      ?.focus();
+    panelRef.current?.querySelector<HTMLButtonElement>(`[data-emoji-index="${index}"]`)?.focus();
   };
 
   const onSearchKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
@@ -238,13 +236,7 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(function
             const labelId = `${baseId}-${cat.id}`;
             return (
               <div key={cat.id} className={styles.section}>
-                <Text
-                  as="div"
-                  size="xs"
-                  tone="muted"
-                  id={labelId}
-                  className={styles.sectionLabel}
-                >
+                <Text as="div" size="xs" tone="muted" id={labelId} className={styles.sectionLabel}>
                   {t(`emojiPicker.category.${cat.id}`)}
                 </Text>
                 <div className={styles.grid} role="row" aria-labelledby={labelId}>

--- a/packages/design-system/src/components/EmojiPicker/EmojiPicker.tsx
+++ b/packages/design-system/src/components/EmojiPicker/EmojiPicker.tsx
@@ -105,6 +105,7 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(function
 ) {
   const t = useTranslation();
   const baseId = useId();
+  const listboxId = useId();
   const [query, setQuery] = useState('');
   // Roving-tabindex anchor: which flat index is currently the tabbable cell.
   const [activeIndex, setActiveIndex] = useState(0);
@@ -113,7 +114,7 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(function
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Filter + flatten in one pass so each visible emoji carries a stable flat
-  // index (render order) for keyboard navigation. `🚀` appears in two
+  // index (render order) for keyboard navigation. A char can recur across
   // categories, so a char→index map would be ambiguous; a running counter is
   // the correct source of truth.
   const { categories, flat } = useMemo(() => {
@@ -221,12 +222,19 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(function
           }}
           placeholder={t('emojiPicker.search')}
           aria-label={t('emojiPicker.search')}
+          aria-controls={listboxId}
           onKeyDown={onSearchKeyDown}
           className={styles.searchInput}
         />
       </div>
 
-      <div ref={panelRef} className={styles.panel} role="grid" aria-label={t('emojiPicker.search')}>
+      <div
+        ref={panelRef}
+        id={listboxId}
+        className={styles.panel}
+        role="listbox"
+        aria-label={t('emojiPicker.label')}
+      >
         {flat.length === 0 ? (
           <Text size="sm" tone="muted" className={styles.noResults}>
             {t('emojiPicker.noResults')}
@@ -235,16 +243,22 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(function
           categories.map((cat) => {
             const labelId = `${baseId}-${cat.id}`;
             return (
-              <div key={cat.id} className={styles.section}>
+              <div
+                key={cat.id}
+                className={styles.section}
+                role="group"
+                aria-label={t(`emojiPicker.category.${cat.id}`)}
+              >
                 <Text as="div" size="xs" tone="muted" id={labelId} className={styles.sectionLabel}>
                   {t(`emojiPicker.category.${cat.id}`)}
                 </Text>
-                <div className={styles.grid} role="row" aria-labelledby={labelId}>
+                <div className={styles.grid}>
                   {cat.items.map(({ emoji, index }) => (
                     <button
                       key={emoji.char}
                       type="button"
-                      role="gridcell"
+                      role="option"
+                      aria-selected={false}
                       data-emoji-index={index}
                       className={styles.cell}
                       tabIndex={index === activeSafe ? 0 : -1}

--- a/packages/design-system/src/components/EmojiPicker/EmojiPicker.tsx
+++ b/packages/design-system/src/components/EmojiPicker/EmojiPicker.tsx
@@ -1,0 +1,358 @@
+import {
+  forwardRef,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import { Search } from 'lucide-react';
+import { Input } from '../Input';
+import { Text } from '../Text';
+import { Popover } from '../Popover';
+import { useTranslation } from '../../i18n/useTranslation';
+import { EMOJI_CATEGORIES, type EmojiCategoryId, type EmojiEntry } from './emojiData';
+import styles from './EmojiPicker.module.scss';
+
+// Fixed grid width. The CSS grid uses `repeat(8, 1fr)`, so JS roving nav
+// (ArrowDown/Up jumps a whole row) must use the same column count to stay in
+// sync with what the user sees.
+const COLUMNS = 8;
+
+// ----------------------------------------------------------------------------
+// EmojiPicker
+// ----------------------------------------------------------------------------
+
+export interface EmojiPickerProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+  /**
+   * Fired with the chosen emoji character (e.g. `'👍'`) when the user clicks a
+   * cell or presses Enter/Space on a focused cell. This is the picker's single
+   * output — wire it to insert into an editor, set a reaction, etc.
+   */
+  onSelect: (emoji: string) => void;
+}
+
+/** One visible emoji plus its flat-array index (for roving keyboard nav). */
+interface IndexedEmoji {
+  emoji: EmojiEntry;
+  index: number;
+}
+
+/** A category section after filtering, carrying flat indices for its emojis. */
+interface VisibleCategory {
+  id: EmojiCategoryId;
+  items: IndexedEmoji[];
+}
+
+/**
+ * Searchable emoji grid over a curated, common-first dataset (reactions +
+ * everyday input — NOT the full Unicode set). Renders a search box and a
+ * category-sectioned 8-column grid; calls `onSelect(char)` on click or
+ * Enter/Space. Built on `Input`, `Text`, and a lucide `Search` icon, with
+ * roving-tabindex keyboard navigation across the grid.
+ *
+ * This is the bare picker surface — pair it with a `Popover` (or use the
+ * `EmojiPickerPopover` wrapper) to open it from a trigger.
+ *
+ * @example
+ * // Inside a Popover you control:
+ * <Popover>
+ *   <Popover.Trigger>
+ *     <Button variant="secondary" iconOnly aria-label="Add reaction">
+ *       <Smile size={16} />
+ *     </Button>
+ *   </Popover.Trigger>
+ *   <Popover.Content>
+ *     <EmojiPicker onSelect={(char) => insertAtCaret(char)} />
+ *   </Popover.Content>
+ * </Popover>
+ *
+ * @example
+ * // The batteries-included wrapper (opens + closes for you):
+ * <EmojiPickerPopover
+ *   trigger={<Button variant="ghost" iconOnly aria-label="Emoji"><Smile size={16} /></Button>}
+ *   onSelect={(char) => appendToMessage(char)}
+ * />
+ *
+ * @example
+ * // A reaction toggle on a comment:
+ * <EmojiPickerPopover
+ *   trigger={<Button size="sm" variant="secondary">React</Button>}
+ *   onSelect={(char) => toggleReaction(commentId, char)}
+ * />
+ *
+ * @remarks When NOT to use
+ * - A small fixed set of reactions (👍 ❤️ 🎉) — render a `Cluster` of
+ *   `Button`s instead; a searchable grid is overkill for 3-6 choices.
+ * - Inline emoji autocomplete inside an editor (`:smile` → 😄) — out of scope;
+ *   that belongs to the editor's suggestion engine, not this chooser.
+ * - Rendering the reactions a message already has (as chips/counts) — the
+ *   consumer builds that display; this component only *chooses* an emoji.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Expecting the full ~1900-emoji Unicode set. This is a deliberately
+ *   curated common set (see `emojiData.ts`); skin-tone/ZWJ variants are out.
+ * - ❌ Using it as the reaction-count display. It is the chooser only — it has
+ *   no notion of which emoji are already selected or how many times.
+ */
+export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(function EmojiPicker(
+  { onSelect, className, ...rest },
+  ref,
+) {
+  const t = useTranslation();
+  const baseId = useId();
+  const [query, setQuery] = useState('');
+  // Roving-tabindex anchor: which flat index is currently the tabbable cell.
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Filter + flatten in one pass so each visible emoji carries a stable flat
+  // index (render order) for keyboard navigation. `🚀` appears in two
+  // categories, so a char→index map would be ambiguous; a running counter is
+  // the correct source of truth.
+  const { categories, flat } = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const matches = (e: EmojiEntry): boolean =>
+      q === '' ||
+      e.name.toLowerCase().includes(q) ||
+      e.keywords.some((k) => k.toLowerCase().includes(q));
+
+    const flatList: EmojiEntry[] = [];
+    const cats: VisibleCategory[] = [];
+    for (const cat of EMOJI_CATEGORIES) {
+      const filtered = cat.emojis.filter(matches);
+      if (filtered.length === 0) continue;
+      const items = filtered.map<IndexedEmoji>((emoji) => {
+        const index = flatList.length;
+        flatList.push(emoji);
+        return { emoji, index };
+      });
+      cats.push({ id: cat.id, items });
+    }
+    return { categories: cats, flat: flatList };
+  }, [query]);
+
+  // Clamp the active index to the current result set so the tabbable cell is
+  // always valid after the filter shrinks the grid.
+  const activeSafe = flat.length === 0 ? -1 : Math.min(activeIndex, flat.length - 1);
+
+  const focusCell = (index: number) => {
+    panelRef.current
+      ?.querySelector<HTMLButtonElement>(`[data-emoji-index="${index}"]`)
+      ?.focus();
+  };
+
+  const onSearchKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (flat.length === 0) return;
+      const target = activeSafe < 0 ? 0 : activeSafe;
+      setActiveIndex(target);
+      focusCell(target);
+    }
+  };
+
+  const onGridKeyDown = (e: ReactKeyboardEvent<HTMLButtonElement>) => {
+    const total = flat.length;
+    if (total === 0) return;
+    // The focused cell is the source of truth for "where am I" — read its own
+    // flat index rather than relying on a possibly-stale closure.
+    const current = Number(e.currentTarget.dataset.emojiIndex);
+
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onSelect(flat[current]!.char);
+      return;
+    }
+
+    let next: number;
+    switch (e.key) {
+      case 'ArrowRight':
+        next = current + 1;
+        break;
+      case 'ArrowLeft':
+        next = current - 1;
+        break;
+      case 'ArrowDown':
+        next = current + COLUMNS;
+        break;
+      case 'ArrowUp':
+        if (current < COLUMNS) {
+          // First row → escape back up to the search input.
+          e.preventDefault();
+          searchInputRef.current?.focus();
+          return;
+        }
+        next = current - COLUMNS;
+        break;
+      case 'Home':
+        next = current - (current % COLUMNS);
+        break;
+      case 'End':
+        next = Math.min(current - (current % COLUMNS) + COLUMNS - 1, total - 1);
+        break;
+      default:
+        return;
+    }
+
+    e.preventDefault();
+    next = Math.max(0, Math.min(next, total - 1));
+    setActiveIndex(next);
+    focusCell(next);
+  };
+
+  return (
+    // Pattern A (props last) — EmojiPicker is a plain surface; let consumers
+    // override anything on the root.
+    <div ref={ref} className={clsx(styles.root, className)} {...rest}>
+      <div className={styles.search}>
+        <Search size={14} aria-hidden className={styles.searchIcon} />
+        <Input
+          ref={searchInputRef}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setActiveIndex(0);
+          }}
+          placeholder={t('emojiPicker.search')}
+          aria-label={t('emojiPicker.search')}
+          onKeyDown={onSearchKeyDown}
+          className={styles.searchInput}
+        />
+      </div>
+
+      <div ref={panelRef} className={styles.panel} role="grid" aria-label={t('emojiPicker.search')}>
+        {flat.length === 0 ? (
+          <Text size="sm" tone="muted" className={styles.noResults}>
+            {t('emojiPicker.noResults')}
+          </Text>
+        ) : (
+          categories.map((cat) => {
+            const labelId = `${baseId}-${cat.id}`;
+            return (
+              <div key={cat.id} className={styles.section}>
+                <Text
+                  as="div"
+                  size="xs"
+                  tone="muted"
+                  id={labelId}
+                  className={styles.sectionLabel}
+                >
+                  {t(`emojiPicker.category.${cat.id}`)}
+                </Text>
+                <div className={styles.grid} role="row" aria-labelledby={labelId}>
+                  {cat.items.map(({ emoji, index }) => (
+                    <button
+                      key={emoji.char}
+                      type="button"
+                      role="gridcell"
+                      data-emoji-index={index}
+                      className={styles.cell}
+                      tabIndex={index === activeSafe ? 0 : -1}
+                      aria-label={emoji.name}
+                      onClick={() => onSelect(emoji.char)}
+                      onKeyDown={onGridKeyDown}
+                      onFocus={() => setActiveIndex(index)}
+                    >
+                      <span aria-hidden="true">{emoji.char}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+});
+
+// ----------------------------------------------------------------------------
+// EmojiPickerPopover
+// ----------------------------------------------------------------------------
+
+export interface EmojiPickerPopoverProps {
+  /**
+   * The element that opens the picker. Must be a single element that accepts a
+   * ref (this library's `<Button>` or a raw `<button>`); the open/close +
+   * ARIA wiring is injected by `Popover.Trigger`.
+   */
+  trigger: ReactNode;
+  /**
+   * Fired with the chosen emoji character. Selecting always closes the popover
+   * (both controlled and uncontrolled).
+   */
+  onSelect: (emoji: string) => void;
+  /**
+   * Controlled open state. Provide alongside `onOpenChange` to drive open
+   * externally. Omit both to let the wrapper own its state (the common case).
+   */
+  open?: boolean;
+  /** Fired whenever the popover wants to change open state. Required when `open` is provided. */
+  onOpenChange?: (open: boolean) => void;
+  /** Initial open state for uncontrolled usage. Defaults to `false`. */
+  defaultOpen?: boolean;
+}
+
+/**
+ * Batteries-included `<EmojiPicker>` in a `Popover`: pass a `trigger` and an
+ * `onSelect`, and the wrapper handles opening, closing-on-select, and the
+ * controlled/uncontrolled open contract.
+ *
+ * @example
+ * <EmojiPickerPopover
+ *   trigger={<Button variant="ghost" iconOnly aria-label="Emoji"><Smile size={16} /></Button>}
+ *   onSelect={(char) => appendToMessage(char)}
+ * />
+ *
+ * @example
+ * // Controlled:
+ * const [open, setOpen] = useState(false);
+ * <EmojiPickerPopover
+ *   open={open}
+ *   onOpenChange={setOpen}
+ *   trigger={<Button>Emoji</Button>}
+ *   onSelect={setEmoji}
+ * />
+ */
+export function EmojiPickerPopover({
+  trigger,
+  onSelect,
+  open,
+  onOpenChange,
+  defaultOpen = false,
+}: EmojiPickerPopoverProps) {
+  // Controlled-or-uncontrolled open: keep internal state when `open` is not
+  // provided so selecting can still close the popover.
+  const isControlled = open !== undefined;
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const actualOpen = isControlled ? open : internalOpen;
+
+  const setOpen = (next: boolean) => {
+    if (!isControlled) setInternalOpen(next);
+    onOpenChange?.(next);
+  };
+
+  const handleSelect = (emoji: string) => {
+    onSelect(emoji);
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={actualOpen} onOpenChange={setOpen}>
+      {/* Popover.Trigger wants a single ReactElement; it runtime-validates via
+          isValidElement and throws on anything else, so the cast is safe. */}
+      <Popover.Trigger>{trigger as ReactElement}</Popover.Trigger>
+      <Popover.Content>
+        <EmojiPicker onSelect={handleSelect} />
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/packages/design-system/src/components/EmojiPicker/emojiData.ts
+++ b/packages/design-system/src/components/EmojiPicker/emojiData.ts
@@ -88,7 +88,6 @@ export const EMOJI_CATEGORIES: EmojiCategory[] = [
   {
     id: 'people',
     emojis: [
-      { char: '😺', name: 'grinning cat', keywords: ['cat', 'smile'] },
       { char: '🧑', name: 'person', keywords: ['adult', 'someone'] },
       { char: '👩', name: 'woman', keywords: ['female'] },
       { char: '👨', name: 'man', keywords: ['male'] },
@@ -181,7 +180,7 @@ export const EMOJI_CATEGORIES: EmojiCategory[] = [
       { char: '🏢', name: 'office building', keywords: ['work', 'company'] },
       { char: '🗺️', name: 'world map', keywords: ['map', 'travel'] },
       { char: '🏖️', name: 'beach with umbrella', keywords: ['vacation', 'holiday'] },
-      { char: '🗻', name: 'mountain', keywords: ['fuji'] },
+      { char: '🗻', name: 'mount fuji', keywords: ['fuji', 'mountain'] },
       { char: '🌍', name: 'globe showing europe-africa', keywords: ['earth', 'world'] },
       { char: '⛰️', name: 'mountain', keywords: ['hill', 'peak'] },
     ],
@@ -230,7 +229,6 @@ export const EMOJI_CATEGORIES: EmojiCategory[] = [
       { char: '❓', name: 'question mark', keywords: ['help', 'why'] },
       { char: '❗', name: 'exclamation mark', keywords: ['important', 'alert'] },
       { char: '➕', name: 'plus', keywords: ['add', 'new'] },
-      { char: '🚀', name: 'rocket', keywords: ['ship', 'launch', 'fast'] },
       { char: '👀', name: 'eyes', keywords: ['look', 'watching', 'see'] },
     ],
   },

--- a/packages/design-system/src/components/EmojiPicker/emojiData.ts
+++ b/packages/design-system/src/components/EmojiPicker/emojiData.ts
@@ -1,0 +1,247 @@
+// emojiData.ts — a curated, common-first emoji dataset for <EmojiPicker>. Plain data
+// (not a UI library): a focused set covering reactions + everyday input, NOT the full
+// ~1900-emoji Unicode set (YAGNI for v1; expandable). Each `char` is one
+// user-perceived emoji; `name` + `keywords` are the English search corpus. Category
+// labels are localized by the component (via the `id` → `emojiPicker.category.<id>`
+// i18n key), so this file carries ids, not labels.
+
+/** One emoji and its search metadata. */
+export interface EmojiEntry {
+  /** The unicode character to insert / pass to `onSelect` (e.g. `"👍"`). */
+  char: string;
+  /** Human name — the emoji button's accessible label + part of the search corpus. */
+  name: string;
+  /** Extra search terms (synonyms) matched alongside `name`. */
+  keywords: string[];
+}
+
+/** Stable category identifier — maps to the `emojiPicker.category.<id>` i18n label. */
+export type EmojiCategoryId =
+  | 'smileys'
+  | 'gestures'
+  | 'people'
+  | 'animals'
+  | 'food'
+  | 'activities'
+  | 'travel'
+  | 'objects'
+  | 'symbols'
+  | 'flags';
+
+/** A category section: its id + the emojis it contains, in display order. */
+export interface EmojiCategory {
+  id: EmojiCategoryId;
+  emojis: EmojiEntry[];
+}
+
+/** The curated category sections, in display order (reaction-friendly first). */
+export const EMOJI_CATEGORIES: EmojiCategory[] = [
+  {
+    id: 'smileys',
+    emojis: [
+      { char: '😀', name: 'grinning face', keywords: ['smile', 'happy'] },
+      { char: '😄', name: 'grinning face with smiling eyes', keywords: ['happy', 'joy'] },
+      { char: '😁', name: 'beaming face', keywords: ['grin', 'happy'] },
+      { char: '😂', name: 'face with tears of joy', keywords: ['lol', 'laugh', 'funny'] },
+      { char: '🤣', name: 'rolling on the floor laughing', keywords: ['rofl', 'lol', 'laugh'] },
+      { char: '🙂', name: 'slightly smiling face', keywords: ['smile'] },
+      { char: '😉', name: 'winking face', keywords: ['wink'] },
+      { char: '😊', name: 'smiling face with smiling eyes', keywords: ['blush', 'happy'] },
+      { char: '😍', name: 'smiling face with heart-eyes', keywords: ['love', 'crush'] },
+      { char: '😘', name: 'face blowing a kiss', keywords: ['kiss', 'love'] },
+      { char: '😎', name: 'smiling face with sunglasses', keywords: ['cool'] },
+      { char: '🤔', name: 'thinking face', keywords: ['hmm', 'consider'] },
+      { char: '😐', name: 'neutral face', keywords: ['meh'] },
+      { char: '🙄', name: 'face with rolling eyes', keywords: ['eyeroll', 'annoyed'] },
+      { char: '😴', name: 'sleeping face', keywords: ['sleep', 'zzz', 'tired'] },
+      { char: '😢', name: 'crying face', keywords: ['sad', 'tear'] },
+      { char: '😭', name: 'loudly crying face', keywords: ['sob', 'sad', 'cry'] },
+      { char: '😡', name: 'enraged face', keywords: ['angry', 'mad'] },
+      { char: '😱', name: 'face screaming in fear', keywords: ['scared', 'shock', 'omg'] },
+      { char: '🤯', name: 'exploding head', keywords: ['mind blown', 'shock'] },
+      { char: '🥳', name: 'partying face', keywords: ['celebrate', 'party'] },
+      { char: '😬', name: 'grimacing face', keywords: ['awkward', 'yikes'] },
+      { char: '🤗', name: 'hugging face', keywords: ['hug'] },
+      { char: '😅', name: 'grinning face with sweat', keywords: ['phew', 'relief', 'nervous'] },
+    ],
+  },
+  {
+    id: 'gestures',
+    emojis: [
+      { char: '👍', name: 'thumbs up', keywords: ['yes', 'approve', 'like', '+1'] },
+      { char: '👎', name: 'thumbs down', keywords: ['no', 'disapprove', 'dislike', '-1'] },
+      { char: '👏', name: 'clapping hands', keywords: ['applause', 'bravo'] },
+      { char: '🙌', name: 'raising hands', keywords: ['celebrate', 'praise'] },
+      { char: '🙏', name: 'folded hands', keywords: ['please', 'thanks', 'pray'] },
+      { char: '👌', name: 'OK hand', keywords: ['ok', 'perfect'] },
+      { char: '🤝', name: 'handshake', keywords: ['deal', 'agree'] },
+      { char: '✌️', name: 'victory hand', keywords: ['peace'] },
+      { char: '🤞', name: 'crossed fingers', keywords: ['luck', 'hopeful'] },
+      { char: '👋', name: 'waving hand', keywords: ['hello', 'hi', 'bye'] },
+      { char: '💪', name: 'flexed biceps', keywords: ['strong', 'muscle'] },
+      { char: '🤙', name: 'call me hand', keywords: ['shaka'] },
+      { char: '👇', name: 'backhand index pointing down', keywords: ['point', 'below'] },
+      { char: '👉', name: 'backhand index pointing right', keywords: ['point'] },
+      { char: '✋', name: 'raised hand', keywords: ['stop', 'high five'] },
+    ],
+  },
+  {
+    id: 'people',
+    emojis: [
+      { char: '😺', name: 'grinning cat', keywords: ['cat', 'smile'] },
+      { char: '🧑', name: 'person', keywords: ['adult', 'someone'] },
+      { char: '👩', name: 'woman', keywords: ['female'] },
+      { char: '👨', name: 'man', keywords: ['male'] },
+      { char: '🧒', name: 'child', keywords: ['kid'] },
+      { char: '👶', name: 'baby', keywords: ['infant'] },
+      { char: '🧓', name: 'older person', keywords: ['elder', 'senior'] },
+      { char: '👮', name: 'police officer', keywords: ['cop'] },
+      { char: '🕵️', name: 'detective', keywords: ['spy', 'investigate'] },
+      { char: '👩‍💻', name: 'woman technologist', keywords: ['developer', 'coder', 'engineer'] },
+      { char: '👨‍💻', name: 'man technologist', keywords: ['developer', 'coder', 'engineer'] },
+      { char: '🦸', name: 'superhero', keywords: ['hero'] },
+      { char: '🧑‍🚀', name: 'astronaut', keywords: ['space'] },
+      { char: '👤', name: 'silhouette', keywords: ['user', 'profile', 'anonymous'] },
+    ],
+  },
+  {
+    id: 'animals',
+    emojis: [
+      { char: '🐶', name: 'dog face', keywords: ['puppy'] },
+      { char: '🐱', name: 'cat face', keywords: ['kitten'] },
+      { char: '🐭', name: 'mouse face', keywords: ['rodent'] },
+      { char: '🐹', name: 'hamster', keywords: ['pet'] },
+      { char: '🐰', name: 'rabbit face', keywords: ['bunny'] },
+      { char: '🦊', name: 'fox', keywords: [] },
+      { char: '🐻', name: 'bear', keywords: [] },
+      { char: '🐼', name: 'panda', keywords: [] },
+      { char: '🦁', name: 'lion', keywords: [] },
+      { char: '🐮', name: 'cow face', keywords: [] },
+      { char: '🐷', name: 'pig face', keywords: [] },
+      { char: '🐵', name: 'monkey face', keywords: [] },
+      { char: '🐔', name: 'chicken', keywords: ['hen'] },
+      { char: '🐧', name: 'penguin', keywords: [] },
+      { char: '🐦', name: 'bird', keywords: [] },
+      { char: '🦄', name: 'unicorn', keywords: ['magic'] },
+      { char: '🐝', name: 'honeybee', keywords: ['bee'] },
+      { char: '🦋', name: 'butterfly', keywords: [] },
+    ],
+  },
+  {
+    id: 'food',
+    emojis: [
+      { char: '🍎', name: 'red apple', keywords: ['fruit'] },
+      { char: '🍌', name: 'banana', keywords: ['fruit'] },
+      { char: '🍓', name: 'strawberry', keywords: ['fruit', 'berry'] },
+      { char: '🍕', name: 'pizza', keywords: ['food', 'slice'] },
+      { char: '🍔', name: 'hamburger', keywords: ['burger', 'food'] },
+      { char: '🍟', name: 'french fries', keywords: ['fries', 'chips'] },
+      { char: '🌮', name: 'taco', keywords: ['food', 'mexican'] },
+      { char: '🍣', name: 'sushi', keywords: ['food', 'japanese'] },
+      { char: '🍩', name: 'doughnut', keywords: ['donut', 'sweet'] },
+      { char: '🍪', name: 'cookie', keywords: ['sweet', 'biscuit'] },
+      { char: '🎂', name: 'birthday cake', keywords: ['cake', 'celebrate'] },
+      { char: '☕', name: 'hot beverage', keywords: ['coffee', 'tea'] },
+      { char: '🍺', name: 'beer mug', keywords: ['drink', 'cheers'] },
+      { char: '🍷', name: 'wine glass', keywords: ['drink'] },
+      { char: '🥂', name: 'clinking glasses', keywords: ['cheers', 'celebrate', 'toast'] },
+    ],
+  },
+  {
+    id: 'activities',
+    emojis: [
+      { char: '⚽', name: 'soccer ball', keywords: ['football', 'sport'] },
+      { char: '🏀', name: 'basketball', keywords: ['sport'] },
+      { char: '🏈', name: 'american football', keywords: ['sport'] },
+      { char: '⚾', name: 'baseball', keywords: ['sport'] },
+      { char: '🎾', name: 'tennis', keywords: ['sport'] },
+      { char: '🏆', name: 'trophy', keywords: ['win', 'award', 'champion'] },
+      { char: '🥇', name: 'first place medal', keywords: ['gold', 'win', 'medal'] },
+      { char: '🎯', name: 'direct hit', keywords: ['target', 'bullseye', 'goal'] },
+      { char: '🎮', name: 'video game', keywords: ['game', 'controller', 'gaming'] },
+      { char: '🎲', name: 'game die', keywords: ['dice', 'random'] },
+      { char: '🎉', name: 'party popper', keywords: ['celebrate', 'tada', 'congrats'] },
+      { char: '🎊', name: 'confetti ball', keywords: ['celebrate', 'party'] },
+      { char: '🎁', name: 'wrapped gift', keywords: ['present', 'gift'] },
+      { char: '🎈', name: 'balloon', keywords: ['party'] },
+      { char: '🎵', name: 'musical note', keywords: ['music', 'song'] },
+    ],
+  },
+  {
+    id: 'travel',
+    emojis: [
+      { char: '🚗', name: 'car', keywords: ['auto', 'vehicle'] },
+      { char: '✈️', name: 'airplane', keywords: ['flight', 'travel'] },
+      { char: '🚀', name: 'rocket', keywords: ['launch', 'ship', 'space', 'fast'] },
+      { char: '🚲', name: 'bicycle', keywords: ['bike'] },
+      { char: '🚆', name: 'train', keywords: ['rail'] },
+      { char: '🚕', name: 'taxi', keywords: ['cab'] },
+      { char: '⛵', name: 'sailboat', keywords: ['boat'] },
+      { char: '🏠', name: 'house', keywords: ['home'] },
+      { char: '🏢', name: 'office building', keywords: ['work', 'company'] },
+      { char: '🗺️', name: 'world map', keywords: ['map', 'travel'] },
+      { char: '🏖️', name: 'beach with umbrella', keywords: ['vacation', 'holiday'] },
+      { char: '🗻', name: 'mountain', keywords: ['fuji'] },
+      { char: '🌍', name: 'globe showing europe-africa', keywords: ['earth', 'world'] },
+      { char: '⛰️', name: 'mountain', keywords: ['hill', 'peak'] },
+    ],
+  },
+  {
+    id: 'objects',
+    emojis: [
+      { char: '💻', name: 'laptop', keywords: ['computer', 'work'] },
+      { char: '🖥️', name: 'desktop computer', keywords: ['monitor', 'pc'] },
+      { char: '📱', name: 'mobile phone', keywords: ['cell', 'smartphone'] },
+      { char: '⌨️', name: 'keyboard', keywords: ['type'] },
+      { char: '🖱️', name: 'computer mouse', keywords: ['click'] },
+      { char: '💾', name: 'floppy disk', keywords: ['save', 'disk'] },
+      { char: '📎', name: 'paperclip', keywords: ['attach', 'attachment'] },
+      { char: '📌', name: 'pushpin', keywords: ['pin'] },
+      { char: '📅', name: 'calendar', keywords: ['date', 'schedule'] },
+      { char: '📊', name: 'bar chart', keywords: ['graph', 'stats', 'analytics'] },
+      { char: '📈', name: 'chart increasing', keywords: ['growth', 'up', 'trend'] },
+      { char: '📉', name: 'chart decreasing', keywords: ['decline', 'down', 'trend'] },
+      { char: '💡', name: 'light bulb', keywords: ['idea', 'tip'] },
+      { char: '🔒', name: 'locked', keywords: ['secure', 'lock', 'private'] },
+      { char: '🔑', name: 'key', keywords: ['unlock', 'password'] },
+      { char: '📞', name: 'telephone receiver', keywords: ['call', 'phone'] },
+      { char: '✉️', name: 'envelope', keywords: ['email', 'mail', 'message'] },
+      { char: '📝', name: 'memo', keywords: ['note', 'write', 'edit'] },
+    ],
+  },
+  {
+    id: 'symbols',
+    emojis: [
+      { char: '❤️', name: 'red heart', keywords: ['love', 'like'] },
+      { char: '🧡', name: 'orange heart', keywords: ['love'] },
+      { char: '💛', name: 'yellow heart', keywords: ['love'] },
+      { char: '💚', name: 'green heart', keywords: ['love'] },
+      { char: '💙', name: 'blue heart', keywords: ['love'] },
+      { char: '💜', name: 'purple heart', keywords: ['love'] },
+      { char: '🖤', name: 'black heart', keywords: ['love'] },
+      { char: '💔', name: 'broken heart', keywords: ['sad', 'heartbreak'] },
+      { char: '🔥', name: 'fire', keywords: ['lit', 'hot', 'flame'] },
+      { char: '⭐', name: 'star', keywords: ['favorite', 'rating'] },
+      { char: '✨', name: 'sparkles', keywords: ['shiny', 'clean', 'magic'] },
+      { char: '💯', name: 'hundred points', keywords: ['100', 'perfect', 'score'] },
+      { char: '✅', name: 'check mark button', keywords: ['done', 'yes', 'approve', 'check'] },
+      { char: '❌', name: 'cross mark', keywords: ['no', 'wrong', 'cancel', 'x'] },
+      { char: '⚠️', name: 'warning', keywords: ['caution', 'alert'] },
+      { char: '❓', name: 'question mark', keywords: ['help', 'why'] },
+      { char: '❗', name: 'exclamation mark', keywords: ['important', 'alert'] },
+      { char: '➕', name: 'plus', keywords: ['add', 'new'] },
+      { char: '🚀', name: 'rocket', keywords: ['ship', 'launch', 'fast'] },
+      { char: '👀', name: 'eyes', keywords: ['look', 'watching', 'see'] },
+    ],
+  },
+  {
+    id: 'flags',
+    emojis: [
+      { char: '🏁', name: 'chequered flag', keywords: ['race', 'finish'] },
+      { char: '🚩', name: 'triangular flag', keywords: ['flag', 'mark'] },
+      { char: '🏳️', name: 'white flag', keywords: ['surrender'] },
+      { char: '🏴', name: 'black flag', keywords: [] },
+      { char: '🏳️‍🌈', name: 'rainbow flag', keywords: ['pride', 'lgbt'] },
+    ],
+  },
+];

--- a/packages/design-system/src/components/EmojiPicker/index.ts
+++ b/packages/design-system/src/components/EmojiPicker/index.ts
@@ -1,0 +1,3 @@
+export { EmojiPicker, EmojiPickerPopover } from './EmojiPicker';
+export type { EmojiPickerProps, EmojiPickerPopoverProps } from './EmojiPicker';
+export type { EmojiEntry, EmojiCategory, EmojiCategoryId } from './emojiData';

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -107,6 +107,7 @@ export const en: Messages = {
   },
   emojiPicker: {
     search: 'Search emoji',
+    label: 'Emoji',
     noResults: 'No emoji found',
     category: {
       smileys: 'Smileys',

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -105,6 +105,22 @@ export const en: Messages = {
     cancel: 'Cancel',
     noMatches: 'No matches',
   },
+  emojiPicker: {
+    search: 'Search emoji',
+    noResults: 'No emoji found',
+    category: {
+      smileys: 'Smileys',
+      gestures: 'Gestures',
+      people: 'People',
+      animals: 'Animals & nature',
+      food: 'Food & drink',
+      activities: 'Activities',
+      travel: 'Travel & places',
+      objects: 'Objects',
+      symbols: 'Symbols',
+      flags: 'Flags',
+    },
+  },
   pagination: {
     previous: 'Previous',
     next: 'Next',

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -173,8 +173,10 @@ export interface Messages {
     noMatches: string;
   };
   emojiPicker: {
-    /** Placeholder + aria-label for the emoji search input (and the grid's aria-label). */
+    /** Placeholder + aria-label for the emoji search input. */
     search: string;
+    /** Accessible label for the emoji listbox surface. */
+    label: string;
     /** Copy shown when the search query matches no emoji. */
     noResults: string;
     /** Localized section headers, keyed by `EmojiCategoryId`. */

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -172,6 +172,35 @@ export interface Messages {
     /** Copy shown when the filter query has no matches. */
     noMatches: string;
   };
+  emojiPicker: {
+    /** Placeholder + aria-label for the emoji search input (and the grid's aria-label). */
+    search: string;
+    /** Copy shown when the search query matches no emoji. */
+    noResults: string;
+    /** Localized section headers, keyed by `EmojiCategoryId`. */
+    category: {
+      /** Smileys & emotion section. */
+      smileys: string;
+      /** Hand-gesture section. */
+      gestures: string;
+      /** People & body section. */
+      people: string;
+      /** Animals & nature section. */
+      animals: string;
+      /** Food & drink section. */
+      food: string;
+      /** Activities & events section. */
+      activities: string;
+      /** Travel & places section. */
+      travel: string;
+      /** Objects section. */
+      objects: string;
+      /** Symbols section. */
+      symbols: string;
+      /** Flags section. */
+      flags: string;
+    };
+  };
   pagination: {
     /** Visible label on the previous-page button. */
     previous: string;

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -107,6 +107,22 @@ export const ru: Messages = {
     cancel: 'Отмена',
     noMatches: 'Совпадений не найдено',
   },
+  emojiPicker: {
+    search: 'Поиск эмодзи',
+    noResults: 'Эмодзи не найдены',
+    category: {
+      smileys: 'Смайлики',
+      gestures: 'Жесты',
+      people: 'Люди',
+      animals: 'Животные и природа',
+      food: 'Еда и напитки',
+      activities: 'Активности',
+      travel: 'Путешествия и места',
+      objects: 'Объекты',
+      symbols: 'Символы',
+      flags: 'Флаги',
+    },
+  },
   pagination: {
     previous: 'Назад',
     next: 'Далее',

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -109,6 +109,7 @@ export const ru: Messages = {
   },
   emojiPicker: {
     search: 'Поиск эмодзи',
+    label: 'Эмодзи',
     noResults: 'Эмодзи не найдены',
     category: {
       smileys: 'Смайлики',

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -300,6 +300,15 @@ export type {
   OptionsPickerGroup,
 } from './components/OptionsPicker';
 
+export { EmojiPicker, EmojiPickerPopover } from './components/EmojiPicker';
+export type {
+  EmojiPickerProps,
+  EmojiPickerPopoverProps,
+  EmojiEntry,
+  EmojiCategory,
+  EmojiCategoryId,
+} from './components/EmojiPicker';
+
 export { Progress } from './components/Progress';
 export type {
   ProgressProps,

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -73,6 +73,7 @@ import { TooltipDemo } from './pages/components/TooltipDemo';
 import { ModalDemo } from './pages/components/ModalDemo';
 import { LightboxDemo } from './pages/components/LightboxDemo';
 import { OptionsPickerDemo } from './pages/components/OptionsPickerDemo';
+import { EmojiPickerDemo } from './pages/components/EmojiPickerDemo';
 import { PageDemo } from './pages/components/PageDemo';
 import { PaletteDemo } from './pages/components/PaletteDemo';
 import { PageHeaderDemo } from './pages/components/PageHeaderDemo';
@@ -192,6 +193,7 @@ export default function App() {
             <Route path="/components/modal" element={<ModalDemo />} />
             <Route path="/components/lightbox" element={<LightboxDemo />} />
             <Route path="/components/options-picker" element={<OptionsPickerDemo />} />
+            <Route path="/components/emoji-picker" element={<EmojiPickerDemo />} />
             <Route path="/components/page" element={<PageDemo />} />
             <Route path="/components/palette" element={<PaletteDemo />} />
             <Route path="/components/page-header" element={<PageHeaderDemo />} />

--- a/packages/playground/src/layout/AppShell/navItems.ts
+++ b/packages/playground/src/layout/AppShell/navItems.ts
@@ -87,6 +87,7 @@ import {
   Columns2,
   Component,
   Braces,
+  Smile,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -185,6 +186,7 @@ export const componentGroups: { heading: string; items: NavItem[] }[] = [
       },
       { to: '/components/phone-input', label: 'PhoneInput', icon: Phone, end: false },
       { to: '/components/options-picker', label: 'OptionsPicker', icon: ListFilter, end: false },
+      { to: '/components/emoji-picker', label: 'EmojiPicker', icon: Smile, end: false },
       { to: '/components/radio', label: 'Radio', icon: CircleDot, end: false },
       { to: '/components/select', label: 'Select', icon: ChevronsUpDown, end: false },
       { to: '/components/slider', label: 'Slider', icon: SlidersHorizontal, end: false },

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -75,6 +75,7 @@ import { Image } from '@eocrm/design-system';
 import { MediaTile } from '@eocrm/design-system';
 import { ImageCrop } from '@eocrm/design-system';
 import { OptionsPicker } from '@eocrm/design-system';
+import { EmojiPickerPopover } from '@eocrm/design-system';
 import { PALETTE_COLORS, paletteTokens } from '@eocrm/design-system';
 import { Pagination } from '@eocrm/design-system';
 import { PersonDisplay } from '@eocrm/design-system';
@@ -1320,6 +1321,24 @@ const items: { to: string; name: string; description: string; preview: React.Rea
             ]}
           />
         </OptionsPicker>
+      </div>
+    ),
+  },
+  {
+    to: '/components/emoji-picker',
+    name: 'EmojiPicker',
+    description:
+      'Searchable, categorized emoji grid for reactions and everyday input — lives in a Popover, calls onSelect(emoji).',
+    preview: (
+      <div style={{ pointerEvents: 'none' }}>
+        <EmojiPickerPopover
+          trigger={
+            <Button size="sm" variant="secondary">
+              😀 React
+            </Button>
+          }
+          onSelect={() => {}}
+        />
       </div>
     ),
   },

--- a/packages/playground/src/pages/components/EmojiPickerDemo.tsx
+++ b/packages/playground/src/pages/components/EmojiPickerDemo.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { Smile } from 'lucide-react';
+import {
+  EmojiPicker,
+  EmojiPickerPopover,
+  Popover,
+  Button,
+  Badge,
+  Stack,
+  Cluster,
+  Text,
+} from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import { getComponentFiles } from '../../lib/componentFiles';
+
+/** Tally selections into emoji → count so picking the same emoji twice bumps it. */
+function tally(reactions: Record<string, number>, emoji: string): Record<string, number> {
+  return { ...reactions, [emoji]: (reactions[emoji] ?? 0) + 1 };
+}
+
+export function EmojiPickerDemo() {
+  const [reactions, setReactions] = useState<Record<string, number>>({ '👍': 2, '🎉': 1 });
+  const [draft, setDraft] = useState('Great work shipping the Q3 renewal flow ');
+  const [lastInserted, setLastInserted] = useState<string | null>(null);
+
+  return (
+    <DemoLayout
+      name="EmojiPicker"
+      componentName="EmojiPicker"
+      description="Searchable, categorized, keyboard-navigable emoji grid over a curated common set (reactions + everyday input — not the full Unicode catalog). Lives inside a Popover; calls onSelect(emoji) on click or Enter/Space. Use EmojiPickerPopover for the batteries-included trigger + close-on-select wrapper."
+      files={getComponentFiles('EmojiPicker')}
+    >
+      <Example
+        title="Reaction picker in a Popover"
+        description="The canonical use: an icon-only trigger opens the grid inside a Popover you control. onSelect tallies the chosen emoji into a reaction count shown as a Cluster of Badges."
+        code={`const [reactions, setReactions] = useState<Record<string, number>>({ '👍': 2, '🎉': 1 });
+
+<Cluster gap="xs" align="center">
+  {Object.entries(reactions).map(([emoji, count]) => (
+    <Badge key={emoji} tone="neutral">{emoji} {count}</Badge>
+  ))}
+  <Popover>
+    <Popover.Trigger>
+      <Button iconOnly variant="ghost" size="sm" aria-label="Add reaction">
+        <Smile size={16} />
+      </Button>
+    </Popover.Trigger>
+    <Popover.Content>
+      <EmojiPicker onSelect={(emoji) => setReactions((r) => tally(r, emoji))} />
+    </Popover.Content>
+  </Popover>
+</Cluster>`}
+      >
+        <Stack gap="sm">
+          <Text size="sm">
+            <strong>Maya Chen</strong> closed the Acme renewal — nice quarter.
+          </Text>
+          <Cluster gap="xs" align="center">
+            {Object.entries(reactions).map(([emoji, count]) => (
+              <Badge key={emoji} tone="neutral">
+                {emoji} {count}
+              </Badge>
+            ))}
+            <Popover>
+              <Popover.Trigger>
+                <Button iconOnly variant="ghost" size="sm" aria-label="Add reaction">
+                  <Smile size={16} />
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content>
+                <EmojiPicker onSelect={(emoji) => setReactions((r) => tally(r, emoji))} />
+              </Popover.Content>
+            </Popover>
+          </Cluster>
+        </Stack>
+      </Example>
+
+      <Example
+        title="EmojiPickerPopover wrapper (opens + closes for you)"
+        description="The batteries-included wrapper owns the Popover and closes on select. Pass a trigger and an onSelect — here it appends the chosen emoji to a comment draft."
+        code={`<Cluster gap="sm" align="center">
+  <Text size="sm">{draft || 'Write a comment…'}</Text>
+  <EmojiPickerPopover
+    trigger={<Button variant="secondary" size="sm">Add reaction</Button>}
+    onSelect={(emoji) => setDraft((d) => d + emoji)}
+  />
+</Cluster>`}
+      >
+        <Cluster gap="sm" align="center">
+          <Text size="sm">{draft || 'Write a comment…'}</Text>
+          <EmojiPickerPopover
+            trigger={
+              <Button variant="secondary" size="sm">
+                Add reaction
+              </Button>
+            }
+            onSelect={(emoji) => setDraft((d) => d + emoji)}
+          />
+        </Cluster>
+      </Example>
+
+      <Example
+        title="Bare grid (no Popover)"
+        description="The picker surface on its own — search box + category-sectioned 8-column grid, navigable by arrow keys. Drop it into any container; here onSelect echoes the most recent pick."
+        code={`<Stack gap="sm">
+  <EmojiPicker onSelect={setLastInserted} />
+  <Text size="sm" tone="muted">
+    Last picked: {lastInserted ?? '—'}
+  </Text>
+</Stack>`}
+      >
+        <Stack gap="sm">
+          <EmojiPicker onSelect={setLastInserted} />
+          <Text size="sm" tone="muted">
+            Last picked: {lastInserted ?? '—'}
+          </Text>
+        </Stack>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -28,6 +28,7 @@ export type ComponentName =
   | 'Dot'
   | 'Drawer'
   | 'DropdownMenu'
+  | 'EmojiPicker'
   | 'EmptyState'
   | 'ErrorState'
   | 'Field'


### PR DESCRIPTION
Addresses #221.

## Summary
New **`<EmojiPicker onSelect={(emoji: string) => void} />`** — a searchable, categorized, keyboard-navigable emoji grid for comment reactions (and any emoji input), plus **`<EmojiPickerPopover trigger onSelect>`** (owns the Popover, closes on select).

```tsx
<Popover>
  <Popover.Trigger><Button iconOnly aria-label="Add reaction">😀</Button></Popover.Trigger>
  <Popover.Content><EmojiPicker onSelect={(e) => toggleReaction(e)} /></Popover.Content>
</Popover>
// or
<EmojiPickerPopover trigger={<Button>Add reaction</Button>} onSelect={toggleReaction} />
```

- **No new dependency.** Per the hard rule (no UI/component libraries) + bundle-size concern, it bundles a **curated local emoji dataset** (`emojiData.ts`, 10 categories, common/reaction-first — not the full Unicode set) and hand-rolls the grid + search + keyboard, the same way the DS hand-rolls every interactive primitive. (A data file is fine — the `libphonenumber-js` precedent.)
- **a11y:** grouped `role="listbox"` (labeled "Emoji") with per-category `role="group"` and `role="option"` buttons; each option's accessible name is the emoji's name (glyph `aria-hidden`); roving tabindex; `aria-controls` wires the search to the listbox.
- **Keyboard:** type to filter; ArrowDown from search → list; Arrow keys rove (±1, ±columns), Home/End; Enter/Space select; ArrowUp from the first row returns to search.
- Token-built, `:focus-visible` cells, dark-mode-safe; i18n (search/no-results/10 category labels) in en + ru.

## Test plan
- `EmojiPicker.test.tsx` (16): render, click→`onSelect(char)`, search filter + no-results, accessible name = emoji name, ArrowDown-into-list + Enter select, roving tabindex, ArrowUp→search, popover open→select→**close** (uncontrolled + controlled `onOpenChange(false)`), forwardRef, className, attr spread. i18n parity (en/ru) green.
- Full suite **3372 passed**; `make build-lib` / `make build` (playground) / `make lint` / `npm run format:check` clean; `npm pack --dry-run` ships no test/internal files; manifest regenerated (no drift); `package.json` unchanged (no new dep).
- **Live Playwright verification** (playground demo): search filters (`pizza` → 1 option), gibberish → "No emoji", click fires onSelect, ArrowDown moves focus into the listbox with exactly one roving-tabbable option, `aria-controls` ↔ listbox id.
- Core invariant complete (tests, demo + route + nav + ComponentsIndex + registry union, exports, JSDoc `@remarks`, AGENTS, manifest both maps). Rule 8 review: switched the surface from a mis-structured `role="grid"` to the grouped-listbox pattern per the reviewer; final "clean".

🤖 Generated with [Claude Code](https://claude.com/claude-code)