### PR TITLE
fix(Thread): elbow connectors, tighter indent, header centered on avatar

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1650,7 +1650,7 @@ import { Divider } from '@eocrm/design-system';
 
 ### `<Thread>` — nested-reply threading primitive
 
-`<Thread>` + `<Thread.Item node>` — a per-level left vertical rail connecting a parent comment to its nested replies, with the leading `node` slot (`<Avatar>` / icon / `<Dot>`) as the connection point. Replies are written as nested `<Thread.Item>`s; the recursive compound detects them (by identity) and indents under the rail. Depth-capped (`maxDepth`, default `4`) so deep threads stop marching right — past the cap, replies render flat at the same indent. `<Thread compact>` tightens the node box + gaps for dense sidebars. Semantic `<ul>`/`<li>`.
+`<Thread>` + `<Thread.Item node>` — a per-level left vertical rail connecting a parent comment to its nested replies, with the leading `node` slot (`<Avatar>` / icon / `<Dot>`) as the connection point. Replies are written as nested `<Thread.Item>`s; the recursive compound detects them (by identity) and indents under the rail. Depth-capped (`maxDepth`, default `4`) so deep threads stop marching right — past the cap, replies render flat at the same indent. `<Thread compact>` tightens the gaps for dense sidebars. Semantic `<ul>`/`<li>`.
 
 ```tsx
 <Thread maxDepth={4}>
@@ -1669,7 +1669,7 @@ import { Divider } from '@eocrm/design-system';
 </Thread>
 ```
 
-- `node` is a SLOT (pass `<Avatar size="sm">` / a small icon / `<Dot>`) — there's no built-in avatar.
+- `node` is a SLOT (pass `<Avatar size="sm">` / a small icon / `<Dot>`) — there's no built-in avatar. Match the node to `--thread-node-size` (default `sm` / 24px) so the rail/elbow connectors meet it cleanly; override `--thread-node-size` for a larger node. The rail branches to each reply with an elbow (`├─`/`└─`).
 - Plain children are the comment body; any direct `<Thread.Item>` child is a reply. Don't wrap a reply in a Fragment / wrapper — the sort matches `Thread.Item` by identity and it won't be detected.
 - `maxDepth` (default `4`): once nesting hits the cap, deeper replies render flat (same indent) instead of marching further right. `compact` flows to every nested level via CSS vars.
 - **When NOT to use**: a flat activity feed with no parent/child nesting → `<Timeline>`; plain indentation with no connecting line → `<Indent>`.

--- a/packages/design-system/src/components/Thread/Thread.module.scss
+++ b/packages/design-system/src/components/Thread/Thread.module.scss
@@ -73,6 +73,44 @@
 
 // Flat replies past the cap — a direct grid child spanning both columns so they are
 // NOT indented further (the gutter stops compounding). No parent rail in this mode.
+// Each indented reply branches off the parent rail with a horizontal elbow that meets
+// the reply's node — so the thread reads as a ├─ / └─ tree, not just a bare vertical
+// line. The parent rail sits at the parent gutter's centre, one indent level (gutter
+// half + content-gap) to the LEFT of this reply, so the elbow starts there and runs
+// to the reply's node centre (its far end tucks behind the avatar). Logical props →
+// RTL-safe. Only indented replies (not the root items or flat past-cap replies) carry
+// an elbow, since only they sit under a rail.
+.replies > .item {
+  position: relative;
+}
+
+.replies > .item::before {
+  content: '';
+  position: absolute;
+  inset-block-start: calc(var(--thread-node-size) / 2);
+  inset-inline-start: calc(-1 * (var(--thread-node-size) / 2 + var(--thread-content-gap)));
+  width: calc(var(--thread-node-size) + var(--thread-content-gap));
+  height: var(--thread-rail-width);
+  background: var(--thread-rail-color);
+  transform: translateY(-50%);
+}
+
+// The parent rail spans to the bottom of the whole reply group; mask its overshoot
+// below the LAST reply's elbow so the trunk ends at the final branch (└─) instead of
+// dangling past it. Painted in the surface colour — Thread renders on the page
+// (`--color-bg`) surface.
+.replies > .item:last-child::after {
+  content: '';
+  position: absolute;
+  inset-block-start: calc(var(--thread-node-size) / 2);
+  inset-block-end: 0;
+  inset-inline-start: calc(
+    -1 * (var(--thread-node-size) / 2 + var(--thread-content-gap)) - var(--thread-rail-width)
+  );
+  width: calc(var(--thread-rail-width) * 3);
+  background: var(--color-bg);
+}
+
 .repliesFlat {
   // stylelint-disable-next-line property-disallowed-list -- internal grid placement: flat replies span both columns to stop indent compounding
   grid-column: 1 / -1;

--- a/packages/design-system/src/components/Thread/Thread.module.scss
+++ b/packages/design-system/src/components/Thread/Thread.module.scss
@@ -41,7 +41,9 @@
   position: absolute;
   inset-inline-start: 50%;
   transform: translateX(-50%);
-  inset-block-start: var(--thread-node-size);
+
+  // Start a hairline below the node so the rail doesn't touch the avatar.
+  inset-block-start: calc(var(--thread-node-size) + var(--thread-node-gap));
   inset-block-end: 0;
   width: var(--thread-rail-width);
   background: var(--thread-rail-color);
@@ -71,13 +73,11 @@
   gap: var(--thread-row-gap);
 }
 
-// Flat replies past the cap — a direct grid child spanning both columns so they are
-// NOT indented further (the gutter stops compounding). No parent rail in this mode.
 // Each indented reply branches off the parent rail with a horizontal elbow that meets
 // the reply's node — so the thread reads as a ├─ / └─ tree, not just a bare vertical
 // line. The parent rail sits at the parent gutter's centre, one indent level (gutter
 // half + content-gap) to the LEFT of this reply, so the elbow starts there and runs
-// to the reply's node centre (its far end tucks behind the avatar). Logical props →
+// toward the reply's node (stopping a hairline short of the avatar). Logical props →
 // RTL-safe. Only indented replies (not the root items or flat past-cap replies) carry
 // an elbow, since only they sit under a rail.
 .replies > .item {
@@ -89,7 +89,10 @@
   position: absolute;
   inset-block-start: calc(var(--thread-node-size) / 2);
   inset-inline-start: calc(-1 * (var(--thread-node-size) / 2 + var(--thread-content-gap)));
-  width: calc(var(--thread-node-size) + var(--thread-content-gap));
+
+  // Run from the parent rail to a hairline short of the node, so it doesn't touch the
+  // avatar (full reach would be node/2 + content-gap; stop `node-gap` before it).
+  width: calc(var(--thread-node-size) / 2 + var(--thread-content-gap) - var(--thread-node-gap));
   height: var(--thread-rail-width);
   background: var(--thread-rail-color);
   transform: translateY(-50%);
@@ -97,8 +100,8 @@
 
 // The parent rail spans to the bottom of the whole reply group; mask its overshoot
 // below the LAST reply's elbow so the trunk ends at the final branch (└─) instead of
-// dangling past it. Painted in the surface colour — Thread renders on the page
-// (`--color-bg`) surface.
+// dangling past it. Painted in `--thread-surface` (the surface the thread sits on,
+// default `--color-bg`); override the token if Thread renders on a tinted surface.
 .replies > .item:last-child::after {
   content: '';
   position: absolute;
@@ -108,9 +111,11 @@
     -1 * (var(--thread-node-size) / 2 + var(--thread-content-gap)) - var(--thread-rail-width)
   );
   width: calc(var(--thread-rail-width) * 3);
-  background: var(--color-bg);
+  background: var(--thread-surface);
 }
 
+// Flat replies past the cap — a direct grid child spanning both columns so they are
+// NOT indented further (the gutter stops compounding). No parent rail / elbow here.
 .repliesFlat {
   // stylelint-disable-next-line property-disallowed-list -- internal grid placement: flat replies span both columns to stop indent compounding
   grid-column: 1 / -1;

--- a/packages/design-system/src/components/Thread/Thread.tokens.scss
+++ b/packages/design-system/src/components/Thread/Thread.tokens.scss
@@ -1,11 +1,21 @@
 :root {
-  --thread-node-size: var(--size-md); // 32px node column / box
-  --thread-content-gap: var(--space-3); // 12px node → content
+  // Node column / box — match it to the avatar size you pass as `node`. Default `sm`
+  // (24px): comment-thread avatars are small, and it keeps the per-level reply indent
+  // (node + content-gap) tight. Override `--thread-node-size` for larger nodes.
+  --thread-node-size: var(--size-sm); // 24px node column / box
+  --thread-content-gap: var(
+    --space-2
+  ); // 8px node → content (also the per-level reply indent: node + gap)
   --thread-row-gap: var(--space-4); // 16px between items
   --thread-rail-width: var(--border-width); // hairline rail
   --thread-rail-color: var(--color-border);
+  --thread-node-gap: 1px; // hairline gap between the connector lines and the node/avatar
+  // Surface the thread sits on; the last-reply trunk mask paints this to hide the
+  // rail's overshoot below the final branch. Override if Thread renders on a
+  // non-default (tinted) surface, else a faint stripe shows below the last reply.
+  --thread-surface: var(--color-bg);
 
   --thread-node-size-compact: var(--size-sm); // 24px
-  --thread-content-gap-compact: var(--space-2); // 8px
+  --thread-content-gap-compact: var(--space-1); // 4px
   --thread-row-gap-compact: var(--space-2); // 8px
 }

--- a/packages/design-system/src/components/Thread/Thread.tsx
+++ b/packages/design-system/src/components/Thread/Thread.tsx
@@ -36,8 +36,8 @@ export interface ThreadProps extends HTMLAttributes<HTMLUListElement> {
    */
   maxDepth?: number;
   /**
-   * Tighter node box and gaps for dense surfaces (sidebars, panels). The remapped tokens
-   * cascade to every nested item via CSS custom properties. Default `false`.
+   * Tighter gaps for dense surfaces (sidebars, panels). The remapped tokens cascade to
+   * every nested item via CSS custom properties. Default `false`.
    */
   compact?: boolean;
   /** The `<Thread.Item>`s. */
@@ -48,7 +48,9 @@ export interface ThreadItemProps extends HTMLAttributes<HTMLLIElement> {
   /**
    * The leading marker the rail connects to — an `<Avatar>`, icon, or `<Dot>`. Centered
    * in a fixed node box so the rail aligns regardless of node content. It's a slot:
-   * there is no built-in avatar.
+   * there is no built-in avatar. Size the node to `--thread-node-size` (default `sm` /
+   * 24px) — e.g. `<Avatar size="sm">` — so the rail/elbow connectors meet it cleanly;
+   * for a larger node, override `--thread-node-size` to match.
    */
   node: ReactNode;
   /**
@@ -131,13 +133,13 @@ ThreadItem.displayName = 'Thread.Item';
  * indent. Use `<Thread compact>` for dense sidebars.
  *
  * @example
- * // Basic nested thread:
+ * // Basic nested thread. Size the Avatar to match `--thread-node-size` (default sm).
  * <Thread>
- *   <Thread.Item node={<Avatar name="Ada" src={ada.url} />}>
- *     <PersonDisplay>…name · time…</PersonDisplay>
- *     <Text>Looks good to me.</Text>
- *     <Thread.Item node={<Avatar name="Linus" src={linus.url} />}>
- *       <Text>Agreed — shipping it.</Text>
+ *   <Thread.Item node={<Avatar name="Ada" src={ada.url} size="sm" />}>
+ *     <Text size="sm"><strong>Ada</strong> · 2h ago</Text>
+ *     <Text size="sm">Looks good to me.</Text>
+ *     <Thread.Item node={<Avatar name="Linus" src={linus.url} size="sm" />}>
+ *       <Text size="sm">Agreed — shipping it.</Text>
  *     </Thread.Item>
  *   </Thread.Item>
  * </Thread>
@@ -147,7 +149,7 @@ ThreadItem.displayName = 'Thread.Item';
  * <Thread maxDepth={2}>{comments.map(renderComment)}</Thread>
  *
  * @example
- * // Compact, for a sidebar activity panel:
+ * // Compact (tighter gaps), for a sidebar activity panel:
  * <Thread compact>
  *   <Thread.Item node={<Avatar name="Grace" size="sm" />}>
  *     <Text size="sm">Renewed the contract.</Text>

--- a/packages/playground/src/pages/components/ThreadDemo.tsx
+++ b/packages/playground/src/pages/components/ThreadDemo.tsx
@@ -101,7 +101,8 @@ const headerLine = { lineHeight: 'var(--size-sm)' };
       <Example
         title="Depth cap (maxDepth)"
         description="A deep back-and-forth. With maxDepth={3}, replies stop indenting once the cap is reached — the chain past level 3 renders flat at the same indent so the thread stops marching right off the page."
-        code={`<Thread maxDepth={3}>
+        code={`// headerLine = { lineHeight: 'var(--size-sm)' } — see the first example
+<Thread maxDepth={3}>
   <Thread.Item node={<Avatar name="Dana Reyes" size="sm" />}>
     <Text size="sm" style={headerLine}><strong>Dana Reyes</strong> · who's covering the EU launch demo?</Text>
     <Thread.Item node={<Avatar name="Sam Cole" size="sm" />}>
@@ -152,8 +153,9 @@ const headerLine = { lineHeight: 'var(--size-sm)' };
 
       <Example
         title="Compact (dense sidebar thread)"
-        description="compact tightens the node box and gaps for a narrow panel — a contact-record activity sidebar. The remapped tokens cascade to every nested reply."
-        code={`<Thread compact>
+        description="compact tightens the gaps for a narrow panel — a contact-record activity sidebar. The remapped tokens cascade to every nested reply."
+        code={`// headerLine = { lineHeight: 'var(--size-sm)' } — see the first example
+<Thread compact>
   <Thread.Item node={<Avatar name="Grace Liu" size="sm" />}>
     <Text size="sm" style={headerLine}><strong>Grace Liu</strong> · renewed the contract</Text>
     <Thread.Item node={<Avatar name="Marcus Bell" size="sm" />}>

--- a/packages/playground/src/pages/components/ThreadDemo.tsx
+++ b/packages/playground/src/pages/components/ThreadDemo.tsx
@@ -3,6 +3,12 @@ import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
 
+// Give the author/header line the avatar's line-height so its text centers on the
+// avatar's vertical centre (the avatar is taller than a default text line). This is a
+// consumer-side composition choice — Thread slots the node + content and top-aligns
+// the row; centering the header against the avatar is the page's call.
+const headerLine = { lineHeight: 'var(--size-sm)' } as const;
+
 export function ThreadDemo() {
   return (
     <DemoLayout
@@ -13,11 +19,14 @@ export function ThreadDemo() {
     >
       <Example
         title="Comment thread (nested replies)"
-        description="Each item's node is a slot — an Avatar for the author. Nested <Thread.Item>s render as replies under the rail; a reply can itself have replies. The rail spans alongside a parent's replies and stops at the last node."
-        code={`<Thread>
+        description="Each item's node is a slot — an Avatar for the author. Nested <Thread.Item>s render as replies under the rail; a reply can itself have replies. Each reply branches off the rail with an elbow connector to its avatar. (The author line gets the avatar's line-height so it centers on the avatar.)"
+        code={`// center the author line on the avatar — the avatar is taller than a text line
+const headerLine = { lineHeight: 'var(--size-sm)' };
+
+<Thread>
   <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
     <Stack gap="xs">
-      <Text size="sm"><strong>Maya Chen</strong> · 2h ago</Text>
+      <Text size="sm" style={headerLine}><strong>Maya Chen</strong> · 2h ago</Text>
       <Text size="sm">
         Flagged the Acme renewal — usage dropped ~30% last quarter. Worth a
         check-in before we send the contract.
@@ -25,19 +34,19 @@ export function ThreadDemo() {
     </Stack>
     <Thread.Item node={<Avatar name="Tom Okafor" size="sm" />}>
       <Stack gap="xs">
-        <Text size="sm"><strong>Tom Okafor</strong> · 1h ago</Text>
+        <Text size="sm" style={headerLine}><strong>Tom Okafor</strong> · 1h ago</Text>
         <Text size="sm">Good catch. I'll set up a call with their ops lead for Thursday.</Text>
       </Stack>
       <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
         <Stack gap="xs">
-          <Text size="sm"><strong>Maya Chen</strong> · 48m ago</Text>
+          <Text size="sm" style={headerLine}><strong>Maya Chen</strong> · 48m ago</Text>
           <Text size="sm">Perfect — loop in Priya, she owns the technical relationship.</Text>
         </Stack>
       </Thread.Item>
     </Thread.Item>
     <Thread.Item node={<Avatar name="Priya Nair" size="sm" />}>
       <Stack gap="xs">
-        <Text size="sm"><strong>Priya Nair</strong> · 20m ago</Text>
+        <Text size="sm" style={headerLine}><strong>Priya Nair</strong> · 20m ago</Text>
         <Text size="sm">On it — pulling the latest usage report so we walk in prepared.</Text>
       </Stack>
     </Thread.Item>
@@ -47,7 +56,7 @@ export function ThreadDemo() {
         <Thread>
           <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
             <Stack gap="xs">
-              <Text size="sm">
+              <Text size="sm" style={headerLine}>
                 <strong>Maya Chen</strong> · 2h ago
               </Text>
               <Text size="sm">
@@ -57,7 +66,7 @@ export function ThreadDemo() {
             </Stack>
             <Thread.Item node={<Avatar name="Tom Okafor" size="sm" />}>
               <Stack gap="xs">
-                <Text size="sm">
+                <Text size="sm" style={headerLine}>
                   <strong>Tom Okafor</strong> · 1h ago
                 </Text>
                 <Text size="sm">
@@ -66,7 +75,7 @@ export function ThreadDemo() {
               </Stack>
               <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
                 <Stack gap="xs">
-                  <Text size="sm">
+                  <Text size="sm" style={headerLine}>
                     <strong>Maya Chen</strong> · 48m ago
                   </Text>
                   <Text size="sm">
@@ -77,7 +86,7 @@ export function ThreadDemo() {
             </Thread.Item>
             <Thread.Item node={<Avatar name="Priya Nair" size="sm" />}>
               <Stack gap="xs">
-                <Text size="sm">
+                <Text size="sm" style={headerLine}>
                   <strong>Priya Nair</strong> · 20m ago
                 </Text>
                 <Text size="sm">
@@ -94,16 +103,16 @@ export function ThreadDemo() {
         description="A deep back-and-forth. With maxDepth={3}, replies stop indenting once the cap is reached — the chain past level 3 renders flat at the same indent so the thread stops marching right off the page."
         code={`<Thread maxDepth={3}>
   <Thread.Item node={<Avatar name="Dana Reyes" size="sm" />}>
-    <Text size="sm"><strong>Dana Reyes</strong> · who's covering the EU launch demo?</Text>
+    <Text size="sm" style={headerLine}><strong>Dana Reyes</strong> · who's covering the EU launch demo?</Text>
     <Thread.Item node={<Avatar name="Sam Cole" size="sm" />}>
-      <Text size="sm"><strong>Sam Cole</strong> · I can — what time zone is the client in?</Text>
+      <Text size="sm" style={headerLine}><strong>Sam Cole</strong> · I can — what time zone is the client in?</Text>
       <Thread.Item node={<Avatar name="Lena Fischer" size="sm" />}>
-        <Text size="sm"><strong>Lena Fischer</strong> · CET. They asked for 10:00 their time.</Text>
+        <Text size="sm" style={headerLine}><strong>Lena Fischer</strong> · CET. They asked for 10:00 their time.</Text>
         <Thread.Item node={<Avatar name="Raj Patel" size="sm" />}>
           {/* depth 3 hits the cap → this reply and deeper render flat */}
-          <Text size="sm"><strong>Raj Patel</strong> · Booked the room and sent the invite.</Text>
+          <Text size="sm" style={headerLine}><strong>Raj Patel</strong> · Booked the room and sent the invite.</Text>
           <Thread.Item node={<Avatar name="Olivia Wong" size="sm" />}>
-            <Text size="sm"><strong>Olivia Wong</strong> · Added the deck link to the calendar event.</Text>
+            <Text size="sm" style={headerLine}><strong>Olivia Wong</strong> · Added the deck link to the calendar event.</Text>
           </Thread.Item>
         </Thread.Item>
       </Thread.Item>
@@ -113,24 +122,24 @@ export function ThreadDemo() {
       >
         <Thread maxDepth={3}>
           <Thread.Item node={<Avatar name="Dana Reyes" size="sm" />}>
-            <Text size="sm">
+            <Text size="sm" style={headerLine}>
               <strong>Dana Reyes</strong> · who's covering the EU launch demo?
             </Text>
             <Thread.Item node={<Avatar name="Sam Cole" size="sm" />}>
-              <Text size="sm">
+              <Text size="sm" style={headerLine}>
                 <strong>Sam Cole</strong> · I can — what time zone is the client in?
               </Text>
               <Thread.Item node={<Avatar name="Lena Fischer" size="sm" />}>
-                <Text size="sm">
+                <Text size="sm" style={headerLine}>
                   <strong>Lena Fischer</strong> · CET. They asked for 10:00 their time.
                 </Text>
                 <Thread.Item node={<Avatar name="Raj Patel" size="sm" />}>
                   {/* depth 3 hits the cap → this reply and deeper render flat */}
-                  <Text size="sm">
+                  <Text size="sm" style={headerLine}>
                     <strong>Raj Patel</strong> · Booked the room and sent the invite.
                   </Text>
                   <Thread.Item node={<Avatar name="Olivia Wong" size="sm" />}>
-                    <Text size="sm">
+                    <Text size="sm" style={headerLine}>
                       <strong>Olivia Wong</strong> · Added the deck link to the calendar event.
                     </Text>
                   </Thread.Item>
@@ -146,9 +155,9 @@ export function ThreadDemo() {
         description="compact tightens the node box and gaps for a narrow panel — a contact-record activity sidebar. The remapped tokens cascade to every nested reply."
         code={`<Thread compact>
   <Thread.Item node={<Avatar name="Grace Liu" size="sm" />}>
-    <Text size="sm"><strong>Grace Liu</strong> · renewed the contract</Text>
+    <Text size="sm" style={headerLine}><strong>Grace Liu</strong> · renewed the contract</Text>
     <Thread.Item node={<Avatar name="Marcus Bell" size="sm" />}>
-      <Text size="sm"><strong>Marcus Bell</strong> · nice — invoice sent</Text>
+      <Text size="sm" style={headerLine}><strong>Marcus Bell</strong> · nice — invoice sent</Text>
     </Thread.Item>
   </Thread.Item>
 </Thread>`}
@@ -156,17 +165,17 @@ export function ThreadDemo() {
         <Constrain maxWidth="xs">
           <Thread compact>
             <Thread.Item node={<Avatar name="Grace Liu" size="sm" />}>
-              <Text size="sm">
+              <Text size="sm" style={headerLine}>
                 <strong>Grace Liu</strong> · renewed the contract
               </Text>
               <Thread.Item node={<Avatar name="Marcus Bell" size="sm" />}>
-                <Text size="sm">
+                <Text size="sm" style={headerLine}>
                   <strong>Marcus Bell</strong> · nice — invoice sent
                 </Text>
               </Thread.Item>
             </Thread.Item>
             <Thread.Item node={<Avatar name="Priya Nair" size="sm" />}>
-              <Text size="sm">
+              <Text size="sm" style={headerLine}>
                 <strong>Priya Nair</strong> · logged a support call
               </Text>
             </Thread.Item>


### PR DESCRIPTION
Visual refinements to `<Thread>` (shipped in v0.1.82), from review feedback.

## Summary
- **Elbow connectors.** Each indented reply now branches off the parent rail with a horizontal elbow to its avatar (`├─` / `└─`) instead of connecting to a bare vertical line. The rail's overshoot below the last reply is masked so the trunk ends at the final branch.
- **Tighter reply indent.** `--thread-node-size` default `md`→`sm` (24px, matching typical comment avatars) and `--thread-content-gap` →`--space-2` (8px) → per-level indent **44px → 32px**.
- **1px gap from the avatar.** New `--thread-node-gap` (1px): the rail starts a hairline below the node and the elbow stops a hairline short of it, so the lines don't touch the avatar.
- **`--thread-surface` token** for the last-reply trunk mask (default `--color-bg`; override on a tinted surface).
- **Demo: header centered on the avatar** — the author line gets the avatar's line-height (`var(--size-sm)`) so it vertically centers on the avatar (a consumer-side composition choice; Thread slots node + content and top-aligns the row).

## Notes
- `node-size` defaulting to `sm` means the node should be a small avatar; pass `<Avatar size="sm">` or override `--thread-node-size` for larger nodes (documented on the `node` prop JSDoc, the token, and AGENTS).

## Test plan
- 9 Thread unit tests green; full suite **3372 passed**; `make build-lib` / `make build` / `make lint` / `npm run format:check` clean; tarball ships no test/internal files.
- **Live Playwright verification:** elbows branch to each avatar; rail starts 1px below the avatar; per-level indent measured 32px; header center == avatar center (0px offset); trunk ends at the last branch (no tail).
- Rule 8 review across both commits: geometry verified correct, no Rule-3/4 violations; caught + fixed a JSDoc `@example` that used a default-md avatar against the new sm box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)