### PR TITLE
feat(EmojiPicker): recent prop — top 'Recently used' section

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -2500,6 +2500,10 @@ with a `Popover` (or use `EmojiPickerPopover`).
 `EmojiPickerPopover` takes `trigger` + `onSelect`, plus the standard
 controlled-open contract (`open` / `onOpenChange` / `defaultOpen`).
 
+`recent?: string[]` (on both) pins a "Recently used" section at the top (shown only
+while not searching). The consumer owns persistence — keep the list (e.g.
+localStorage), update it in `onSelect` (move-to-front + de-dupe + cap), pass it back.
+
 **When NOT to use:** a small fixed reaction set (👍 ❤️ 🎉) → render a `Cluster`
 of `Button`s; a searchable grid is overkill for 3-6 choices. Also not for inline
 `:smile`-style autocomplete (the editor's suggestion engine owns that) or for

--- a/packages/design-system/src/components/EmojiPicker/EmojiPicker.test.tsx
+++ b/packages/design-system/src/components/EmojiPicker/EmojiPicker.test.tsx
@@ -236,3 +236,18 @@ it('EmojiPickerPopover forwards recent to the picker', () => {
   );
   expect(screen.getByRole('group', { name: 'Recently used' })).toBeInTheDocument();
 });
+
+it('roving keyboard nav crosses from the recent group into the categories', async () => {
+  const user = userEvent.setup();
+  // recent has a single item → flat index 0 is the recent 👍; index 1 is the first
+  // category emoji (grinning face). ArrowRight must cross the section boundary.
+  render(<EmojiPicker onSelect={() => {}} recent={['👍']} />);
+  await user.click(screen.getByRole('textbox'));
+  await user.keyboard('{ArrowDown}'); // into the grid → first cell (recent 👍)
+  const recentGroup = screen.getByRole('group', { name: 'Recently used' });
+  expect(document.activeElement).toBe(
+    within(recentGroup).getByRole('option', { name: 'thumbs up' }),
+  );
+  await user.keyboard('{ArrowRight}'); // cross into the first category
+  expect(document.activeElement).toBe(screen.getByRole('option', { name: 'grinning face' }));
+});

--- a/packages/design-system/src/components/EmojiPicker/EmojiPicker.test.tsx
+++ b/packages/design-system/src/components/EmojiPicker/EmojiPicker.test.tsx
@@ -1,5 +1,5 @@
 import { createRef } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { EmojiPicker, EmojiPickerPopover } from './EmojiPicker';
 
@@ -181,4 +181,58 @@ it('EmojiPickerPopover (controlled, open) fires onSelect and requests close on p
   expect(onSelect).toHaveBeenCalledWith('👍');
   // Selecting always requests close, even in controlled mode.
   expect(onOpenChange).toHaveBeenCalledWith(false);
+});
+
+// ---------------------------------------------------------------------------
+// EmojiPicker — recent
+// ---------------------------------------------------------------------------
+
+it('renders a "Recently used" group at the top from the recent prop', () => {
+  render(<EmojiPicker onSelect={() => {}} recent={['🎉', '❤️']} />);
+  // The recent section is a group labelled "Recently used".
+  const recentGroup = screen.getByRole('group', { name: 'Recently used' });
+  expect(recentGroup).toBeInTheDocument();
+  // Its emojis resolve their dataset names for the accessible label.
+  expect(within(recentGroup).getByRole('option', { name: 'party popper' })).toBeInTheDocument();
+  // It is the FIRST group in the listbox (pinned to the top).
+  const groups = screen.getAllByRole('group');
+  expect(groups[0]).toBe(recentGroup);
+});
+
+it('clicking a recent emoji fires onSelect with its char', async () => {
+  const user = userEvent.setup();
+  const onSelect = vi.fn();
+  render(<EmojiPicker onSelect={onSelect} recent={['🎉']} />);
+  const recentGroup = screen.getByRole('group', { name: 'Recently used' });
+  await user.click(within(recentGroup).getByRole('option', { name: 'party popper' }));
+  expect(onSelect).toHaveBeenCalledWith('🎉');
+});
+
+it('de-dupes recent and keeps most-recent-first order', () => {
+  render(<EmojiPicker onSelect={() => {}} recent={['🎉', '🎉', '❤️']} />);
+  const recentGroup = screen.getByRole('group', { name: 'Recently used' });
+  // 🎉 appears once in the recent group despite being passed twice.
+  expect(within(recentGroup).getAllByRole('option', { name: 'party popper' })).toHaveLength(1);
+});
+
+it('hides the recent group while searching', async () => {
+  const user = userEvent.setup();
+  render(<EmojiPicker onSelect={() => {}} recent={['🎉']} />);
+  expect(screen.getByRole('group', { name: 'Recently used' })).toBeInTheDocument();
+  await user.type(screen.getByRole('textbox'), 'pizza');
+  expect(screen.queryByRole('group', { name: 'Recently used' })).toBeNull();
+});
+
+it('no recent group when recent is omitted or empty', () => {
+  const { rerender } = render(<EmojiPicker onSelect={() => {}} />);
+  expect(screen.queryByRole('group', { name: 'Recently used' })).toBeNull();
+  rerender(<EmojiPicker onSelect={() => {}} recent={[]} />);
+  expect(screen.queryByRole('group', { name: 'Recently used' })).toBeNull();
+});
+
+it('EmojiPickerPopover forwards recent to the picker', () => {
+  render(
+    <EmojiPickerPopover trigger={<button>open</button>} onSelect={() => {}} recent={['🎉']} open />,
+  );
+  expect(screen.getByRole('group', { name: 'Recently used' })).toBeInTheDocument();
 });

--- a/packages/design-system/src/components/EmojiPicker/EmojiPicker.tsx
+++ b/packages/design-system/src/components/EmojiPicker/EmojiPicker.tsx
@@ -23,6 +23,12 @@ import styles from './EmojiPicker.module.scss';
 // sync with what the user sees.
 const COLUMNS = 8;
 
+// char → dataset entry, for resolving a `recent` char's name (accessible label).
+// A char not in the curated set falls back to the char itself as its name.
+const ENTRY_BY_CHAR = new Map<string, EmojiEntry>(
+  EMOJI_CATEGORIES.flatMap((cat) => cat.emojis.map((e) => [e.char, e] as const)),
+);
+
 // ----------------------------------------------------------------------------
 // EmojiPicker
 // ----------------------------------------------------------------------------
@@ -34,6 +40,15 @@ export interface EmojiPickerProps extends Omit<HTMLAttributes<HTMLDivElement>, '
    * output — wire it to insert into an editor, set a reaction, etc.
    */
   onSelect: (emoji: string) => void;
+  /**
+   * Recently-used emoji characters (e.g. `['👍', '🎉', '❤️']`), most-recent first.
+   * When provided, a "Recently used" section renders at the top of the grid (only
+   * while not searching). The consumer owns persistence — keep the list yourself
+   * (e.g. in localStorage), update it in `onSelect`, and pass it back. Duplicates
+   * are de-duped; a char outside the curated set still renders (labelled by the
+   * char). Omit or pass `[]` for no recent section.
+   */
+  recent?: string[];
 }
 
 /** One visible emoji plus its flat-array index (for roving keyboard nav). */
@@ -42,9 +57,10 @@ interface IndexedEmoji {
   index: number;
 }
 
-/** A category section after filtering, carrying flat indices for its emojis. */
+/** A section after filtering, carrying flat indices for its emojis. `'recent'` is
+ *  the synthetic recently-used section rendered above the curated categories. */
 interface VisibleCategory {
-  id: EmojiCategoryId;
+  id: EmojiCategoryId | 'recent';
   items: IndexedEmoji[];
 }
 
@@ -100,7 +116,7 @@ interface VisibleCategory {
  *   no notion of which emoji are already selected or how many times.
  */
 export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(function EmojiPicker(
-  { onSelect, className, ...rest },
+  { onSelect, recent, className, ...rest },
   ref,
 ) {
   const t = useTranslation();
@@ -126,18 +142,35 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(function
 
     const flatList: EmojiEntry[] = [];
     const cats: VisibleCategory[] = [];
-    for (const cat of EMOJI_CATEGORIES) {
-      const filtered = cat.emojis.filter(matches);
-      if (filtered.length === 0) continue;
-      const items = filtered.map<IndexedEmoji>((emoji) => {
+    const pushSection = (id: VisibleCategory['id'], emojis: EmojiEntry[]) => {
+      const items = emojis.map<IndexedEmoji>((emoji) => {
         const index = flatList.length;
         flatList.push(emoji);
         return { emoji, index };
       });
-      cats.push({ id: cat.id, items });
+      cats.push({ id, items });
+    };
+
+    // "Recently used" pins to the top, but only when not searching (search spans
+    // the whole set). De-dupe by char, preserving most-recent-first order; a char
+    // outside the curated set still renders, labelled by the char.
+    if (q === '' && recent && recent.length > 0) {
+      const seen = new Set<string>();
+      const recentEntries: EmojiEntry[] = [];
+      for (const char of recent) {
+        if (seen.has(char)) continue;
+        seen.add(char);
+        recentEntries.push(ENTRY_BY_CHAR.get(char) ?? { char, name: char, keywords: [] });
+      }
+      if (recentEntries.length > 0) pushSection('recent', recentEntries);
+    }
+
+    for (const cat of EMOJI_CATEGORIES) {
+      const filtered = cat.emojis.filter(matches);
+      if (filtered.length > 0) pushSection(cat.id, filtered);
     }
     return { categories: cats, flat: flatList };
-  }, [query]);
+  }, [query, recent]);
 
   // Clamp the active index to the current result set so the tabbable cell is
   // always valid after the filter shrinks the grid.
@@ -242,15 +275,12 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(function
         ) : (
           categories.map((cat) => {
             const labelId = `${baseId}-${cat.id}`;
+            const label =
+              cat.id === 'recent' ? t('emojiPicker.recent') : t(`emojiPicker.category.${cat.id}`);
             return (
-              <div
-                key={cat.id}
-                className={styles.section}
-                role="group"
-                aria-label={t(`emojiPicker.category.${cat.id}`)}
-              >
+              <div key={cat.id} className={styles.section} role="group" aria-label={label}>
                 <Text as="div" size="xs" tone="muted" id={labelId} className={styles.sectionLabel}>
-                  {t(`emojiPicker.category.${cat.id}`)}
+                  {label}
                 </Text>
                 <div className={styles.grid}>
                   {cat.items.map(({ emoji, index }) => (
@@ -296,6 +326,8 @@ export interface EmojiPickerPopoverProps {
    * (both controlled and uncontrolled).
    */
   onSelect: (emoji: string) => void;
+  /** Recently-used emoji chars shown in a top "Recently used" section — see `EmojiPicker`. */
+  recent?: string[];
   /**
    * Controlled open state. Provide alongside `onOpenChange` to drive open
    * externally. Omit both to let the wrapper own its state (the common case).
@@ -331,6 +363,7 @@ export interface EmojiPickerPopoverProps {
 export function EmojiPickerPopover({
   trigger,
   onSelect,
+  recent,
   open,
   onOpenChange,
   defaultOpen = false,
@@ -357,7 +390,7 @@ export function EmojiPickerPopover({
           isValidElement and throws on anything else, so the cast is safe. */}
       <Popover.Trigger>{trigger as ReactElement}</Popover.Trigger>
       <Popover.Content>
-        <EmojiPicker onSelect={handleSelect} />
+        <EmojiPicker onSelect={handleSelect} recent={recent} />
       </Popover.Content>
     </Popover>
   );

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -108,6 +108,7 @@ export const en: Messages = {
   emojiPicker: {
     search: 'Search emoji',
     label: 'Emoji',
+    recent: 'Recently used',
     noResults: 'No emoji found',
     category: {
       smileys: 'Smileys',

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -177,6 +177,8 @@ export interface Messages {
     search: string;
     /** Accessible label for the emoji listbox surface. */
     label: string;
+    /** Section header for the recently-used emoji (the `recent` prop). */
+    recent: string;
     /** Copy shown when the search query matches no emoji. */
     noResults: string;
     /** Localized section headers, keyed by `EmojiCategoryId`. */

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -110,6 +110,7 @@ export const ru: Messages = {
   emojiPicker: {
     search: 'Поиск эмодзи',
     label: 'Эмодзи',
+    recent: 'Недавние',
     noResults: 'Эмодзи не найдены',
     category: {
       smileys: 'Смайлики',

--- a/packages/playground/src/pages/components/EmojiPickerDemo.tsx
+++ b/packages/playground/src/pages/components/EmojiPickerDemo.tsx
@@ -23,6 +23,10 @@ export function EmojiPickerDemo() {
   const [reactions, setReactions] = useState<Record<string, number>>({ '👍': 2, '🎉': 1 });
   const [draft, setDraft] = useState('Great work shipping the Q3 renewal flow ');
   const [lastInserted, setLastInserted] = useState<string | null>(null);
+  const [recent, setRecent] = useState<string[]>(['👍', '🎉', '❤️', '🔥', '✅']);
+  // Canonical recent pattern: move the pick to the front, de-dupe, cap the list.
+  const addRecent = (emoji: string) =>
+    setRecent((r) => [emoji, ...r.filter((c) => c !== emoji)].slice(0, 16));
 
   return (
     <DemoLayout
@@ -114,6 +118,23 @@ export function EmojiPickerDemo() {
           <EmojiPicker onSelect={setLastInserted} />
           <Text size="sm" tone="muted">
             Last picked: {lastInserted ?? '—'}
+          </Text>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Recently used (recent prop)"
+        description="Pass recent={[...]} to pin a 'Recently used' section at the top (shown only while not searching). The consumer owns persistence — keep the list yourself (e.g. localStorage), update it in onSelect, and pass it back. Here, picking an emoji moves it to the front of the recent row."
+        code={`const [recent, setRecent] = useState<string[]>(['👍', '🎉', '❤️', '🔥', '✅']);
+const addRecent = (emoji: string) =>
+  setRecent((r) => [emoji, ...r.filter((c) => c !== emoji)].slice(0, 16));
+
+<EmojiPicker recent={recent} onSelect={addRecent} />`}
+      >
+        <Stack gap="sm">
+          <EmojiPicker recent={recent} onSelect={addRecent} />
+          <Text size="sm" tone="muted">
+            recent: {recent.join(' ')}
           </Text>
         </Stack>
       </Example>


### PR DESCRIPTION
Follow-up to #221 (the EmojiPicker shipped in v0.1.83).

## Summary
Adds a **`recent?: string[]`** prop (on both `EmojiPicker` and `EmojiPickerPopover`) that pins a **"Recently used"** section to the top of the grid:

```tsx
const [recent, setRecent] = useState<string[]>(['👍', '🎉', '❤️']);
const addRecent = (e: string) => setRecent((r) => [e, ...r.filter((c) => c !== e)].slice(0, 16));

<EmojiPicker recent={recent} onSelect={addRecent} />
```

- Most-recent-first, **de-duped**; shown **only while not searching** (search spans the whole set).
- Each recent char resolves its dataset **name** for the cell's `aria-label`; a char outside the curated set still renders (labelled by the char).
- Reuses the existing flat-index/roving-tabindex grid — keyboard nav flows from the recent group into the categories.
- **Consumer owns persistence** — keep the list (e.g. localStorage), update it in `onSelect`, pass it back. New i18n key `emojiPicker.recent` (en + ru).

## Test plan
- New tests: recent group renders at the top with dataset names; clicking a recent emoji fires `onSelect`; de-dupe + order; hidden while searching; absent when omitted/empty; `EmojiPickerPopover` forwards `recent`; roving nav crosses the recent→category boundary. EmojiPicker suite 23 pass; full suite **3378 passed**; build-lib / playground typecheck / lint / format clean; tarball ships no test/internal files; i18n parity compiler-enforced.
- Demo: a "Recently used" example with the canonical move-to-front/de-dupe/cap update pattern.
- Rule 8 review: "clean enough to stop" (0 Critical/Important).

🤖 Generated with [Claude Code](https://claude.com/claude-code)