### PR TITLE
fix(RichTextEditor): link popover anchors to the active line and tracks it on scroll

### DIFF
--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -31,7 +31,7 @@ import type { MentionItem, MentionsConfig } from './mentions';
 import { fromHtml } from '../RichText/engine/fromHtml';
 import { hasMark, withMark, withoutMark } from '../RichText/engine/marks';
 import { useTranslation } from '../../i18n';
-import { readSelection, writeSelection, selectionRect, type Rect } from './selection';
+import { readSelection, writeSelection, selectionRect, rangeRect, type Rect } from './selection';
 import { applyInput } from './input';
 import { matchBlockRule, applyBlockRule } from './inputRules';
 import { runsText } from '../RichText/engine/inlines';
@@ -1253,6 +1253,12 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           href={linkEditor.href}
           editing={linkEditor.editing}
           anchorRect={linkEditor.anchorRect}
+          // Re-derive the anchor from the captured model range on each reposition so
+          // the bubble tracks the line on scroll (the editor's live selection is
+          // gone once the URL input takes focus, so re-measure the range, not it).
+          getAnchorRect={() =>
+            rootRef.current ? rangeRect(rootRef.current, linkEditor.range) : null
+          }
           onApply={onLinkApply}
           onRemove={onLinkRemove}
           onCancel={onLinkCancel}

--- a/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
@@ -21,6 +21,13 @@ export interface RichTextLinkEditorProps {
   editing: boolean;
   /** Selection rect (viewport coords) the bubble anchors to. */
   anchorRect: { top: number; left: number; height: number; width: number };
+  /**
+   * Live anchor rect, re-read on every Floating UI reposition so the bubble tracks
+   * the selection line on scroll (the static `anchorRect` is only the initial
+   * position; it goes stale on a pure scroll, which fires no `selectionchange`).
+   * Falls back to `anchorRect` when it returns null.
+   */
+  getAnchorRect?: () => { top: number; left: number; height: number; width: number } | null;
   /** Apply the (trimmed) URL. */
   onApply: (href: string) => void;
   /** Remove the link (only reachable when `editing`). */
@@ -38,6 +45,7 @@ export function RichTextLinkEditor({
   href,
   editing,
   anchorRect,
+  getAnchorRect,
   onApply,
   onRemove,
   onCancel,
@@ -47,21 +55,26 @@ export function RichTextLinkEditor({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const bubbleRef = useRef<HTMLDivElement | null>(null);
 
-  // Floating UI virtual element — only `getBoundingClientRect` is required.
+  // Floating UI virtual element — only `getBoundingClientRect` is required. Read the
+  // LIVE rect (via getAnchorRect) on every reposition so the bubble tracks the
+  // selection line on scroll; fall back to the static `anchorRect`.
   const virtualRef = useMemo(
     () => ({
-      getBoundingClientRect: () => ({
-        x: anchorRect.left,
-        y: anchorRect.top,
-        top: anchorRect.top,
-        left: anchorRect.left,
-        right: anchorRect.left + anchorRect.width,
-        bottom: anchorRect.top + anchorRect.height,
-        width: anchorRect.width,
-        height: anchorRect.height,
-      }),
+      getBoundingClientRect: () => {
+        const r = getAnchorRect?.() ?? anchorRect;
+        return {
+          x: r.left,
+          y: r.top,
+          top: r.top,
+          left: r.left,
+          right: r.left + r.width,
+          bottom: r.top + r.height,
+          width: r.width,
+          height: r.height,
+        };
+      },
     }),
-    [anchorRect],
+    [anchorRect, getAnchorRect],
   );
 
   const { refs, floatingStyles } = useFloating({

--- a/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
@@ -12,6 +12,7 @@ import { Input } from '../Input';
 import { Stack } from '../Stack';
 import { Cluster } from '../Cluster';
 import { useTranslation } from '../../i18n';
+import type { Rect } from './selection';
 import styles from './RichTextEditor.module.scss';
 
 export interface RichTextLinkEditorProps {
@@ -20,14 +21,14 @@ export interface RichTextLinkEditorProps {
   /** Whether an existing link is being edited (shows the Remove button). */
   editing: boolean;
   /** Selection rect (viewport coords) the bubble anchors to. */
-  anchorRect: { top: number; left: number; height: number; width: number };
+  anchorRect: Rect;
   /**
    * Live anchor rect, re-read on every Floating UI reposition so the bubble tracks
    * the selection line on scroll (the static `anchorRect` is only the initial
    * position; it goes stale on a pure scroll, which fires no `selectionchange`).
    * Falls back to `anchorRect` when it returns null.
    */
-  getAnchorRect?: () => { top: number; left: number; height: number; width: number } | null;
+  getAnchorRect?: () => Rect | null;
   /** Apply the (trimmed) URL. */
   onApply: (href: string) => void;
   /** Remove the link (only reachable when `editing`). */

--- a/packages/design-system/src/components/RichTextEditor/selection.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.test.ts
@@ -1,4 +1,4 @@
-import { pointFromDom, pointToDom } from './selection';
+import { pointFromDom, pointToDom, selectionRect } from './selection';
 
 // Build: <div root><p data-block-id="a">He<strong>ll</strong>o</p><p data-block-id="b"><br></p></div>
 function buildRoot(): HTMLElement {
@@ -283,5 +283,56 @@ describe('void-block selection', () => {
     const r = makeRoot(HTML);
     const dom = pointToDom(r, { blockId: 'v', offset: 0 })!;
     expect(pointFromDom(r, dom.node, dom.offset)).toEqual({ blockId: 'v', offset: 0 });
+  });
+});
+
+describe('selectionRect — degenerate-selection fallback', () => {
+  const rect = (top: number, left: number, width: number, height: number): DOMRect =>
+    ({
+      top,
+      left,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+
+  it('anchors to the caret BLOCK element (active line), not the whole editor', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<p data-block-id="b"><br></p>';
+    document.body.appendChild(root);
+    const block = root.querySelector<HTMLElement>('[data-block-id="b"]')!;
+    // Collapsed caret in the empty block → the selection's own rect is degenerate
+    // (jsdom's Range.getBoundingClientRect throws or returns zeros), so it should
+    // fall back to the block's rect rather than the root's full height.
+    const range = document.createRange();
+    range.setStart(block, 0);
+    range.collapse(true);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+    block.getBoundingClientRect = () => rect(120, 24, 200, 18);
+    root.getBoundingClientRect = () => rect(0, 0, 240, 500);
+
+    expect(selectionRect(root)).toEqual({ top: 120, left: 24, width: 200, height: 18 });
+    document.body.removeChild(root);
+  });
+
+  it('falls back to root only when the caret is not inside a block', () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const range = document.createRange();
+    range.setStart(root, 0);
+    range.collapse(true);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+    root.getBoundingClientRect = () => rect(0, 0, 240, 500);
+
+    expect(selectionRect(root)).toEqual({ top: 0, left: 0, width: 0, height: 500 });
+    document.body.removeChild(root);
   });
 });

--- a/packages/design-system/src/components/RichTextEditor/selection.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.test.ts
@@ -1,4 +1,4 @@
-import { pointFromDom, pointToDom, selectionRect } from './selection';
+import { pointFromDom, pointToDom, selectionRect, rangeRect } from './selection';
 
 // Build: <div root><p data-block-id="a">He<strong>ll</strong>o</p><p data-block-id="b"><br></p></div>
 function buildRoot(): HTMLElement {
@@ -333,6 +333,49 @@ describe('selectionRect — degenerate-selection fallback', () => {
     root.getBoundingClientRect = () => rect(0, 0, 240, 500);
 
     expect(selectionRect(root)).toEqual({ top: 0, left: 0, width: 0, height: 500 });
+    document.body.removeChild(root);
+  });
+});
+
+describe('rangeRect — model range → live DOM rect (scroll-tracking anchor)', () => {
+  const rect = (top: number, left: number, width: number, height: number): DOMRect =>
+    ({
+      top,
+      left,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+
+  it('re-derives a degenerate (empty-block) range to the block (active line) rect', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<p data-block-id="b"><br></p>';
+    document.body.appendChild(root);
+    const block = root.querySelector<HTMLElement>('[data-block-id="b"]')!;
+    block.getBoundingClientRect = () => rect(140, 30, 180, 18);
+    root.getBoundingClientRect = () => rect(0, 0, 240, 500);
+    // A collapsed model range in the empty block (no live window selection needed).
+    const r = rangeRect(root, {
+      anchor: { blockId: 'b', offset: 0 },
+      focus: { blockId: 'b', offset: 0 },
+    });
+    expect(r).toEqual({ top: 140, left: 30, width: 180, height: 18 });
+    document.body.removeChild(root);
+  });
+
+  it('returns null when the range cannot be mapped to the DOM', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<p data-block-id="b"><br></p>';
+    document.body.appendChild(root);
+    const r = rangeRect(root, {
+      anchor: { blockId: 'missing', offset: 0 },
+      focus: { blockId: 'missing', offset: 0 },
+    });
+    expect(r).toBeNull();
     document.body.removeChild(root);
   });
 });

--- a/packages/design-system/src/components/RichTextEditor/selection.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.test.ts
@@ -378,4 +378,38 @@ describe('rangeRect — model range → live DOM rect (scroll-tracking anchor)',
     expect(r).toBeNull();
     document.body.removeChild(root);
   });
+
+  it('measures the full span regardless of selection direction (forward === backward)', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<p data-block-id="b">abcdef</p>';
+    document.body.appendChild(root);
+    const block = root.querySelector<HTMLElement>('[data-block-id="b"]')!;
+    // Distinct block-fallback rect: if a reversed range collapsed (the bug), the
+    // zero span rect would degrade to THIS, not the span rect asserted below.
+    block.getBoundingClientRect = () => rect(200, 0, 300, 18);
+    // jsdom doesn't implement Range.getBoundingClientRect; stand in a version keyed
+    // on collapsed-ness — a properly ordered (non-collapsed) range measures the
+    // span, a wrongly-collapsed one measures zero.
+    const proto = Range.prototype as unknown as { getBoundingClientRect?: () => DOMRect };
+    const original = proto.getBoundingClientRect;
+    proto.getBoundingClientRect = function (this: Range) {
+      return this.collapsed ? rect(0, 0, 0, 0) : rect(50, 10, 90, 18);
+    };
+    try {
+      const forward = rangeRect(root, {
+        anchor: { blockId: 'b', offset: 0 },
+        focus: { blockId: 'b', offset: 3 },
+      });
+      const backward = rangeRect(root, {
+        anchor: { blockId: 'b', offset: 3 },
+        focus: { blockId: 'b', offset: 0 },
+      });
+      expect(forward).toEqual({ top: 50, left: 10, width: 90, height: 18 });
+      expect(backward).toEqual(forward);
+    } finally {
+      if (original) proto.getBoundingClientRect = original;
+      else delete proto.getBoundingClientRect;
+    }
+    document.body.removeChild(root);
+  });
 });

--- a/packages/design-system/src/components/RichTextEditor/selection.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.ts
@@ -289,18 +289,23 @@ export function rangeRect(root: HTMLElement, range: Range): Rect | null {
   const a = pointToDom(root, range.anchor);
   const f = pointToDom(root, range.focus);
   if (!a || !f) return null;
+  // Order the two boundary points by document position before building the DOM
+  // range. A backward (right-to-left) model selection has its anchor AFTER its
+  // focus; feeding setStart(anchor)/setEnd(focus) straight through would not throw —
+  // the DOM clamps end-before-start to a COLLAPSED range, which measures as a zero
+  // rect and would wrongly degrade to the block fallback below. Pick start = the
+  // earlier point so the span rect is correct regardless of selection direction.
+  const startFirst =
+    a.node === f.node
+      ? a.offset <= f.offset
+      : !!(a.node.compareDocumentPosition(f.node) & Node.DOCUMENT_POSITION_FOLLOWING);
+  const [s, e] = startFirst ? [a, f] : [f, a];
   const domRange = root.ownerDocument.createRange();
   try {
-    domRange.setStart(a.node, a.offset);
-    domRange.setEnd(f.node, f.offset);
+    domRange.setStart(s.node, s.offset);
+    domRange.setEnd(e.node, e.offset);
   } catch {
-    // Anchor after focus (backward selection) → setEnd-before-start throws; swap.
-    try {
-      domRange.setStart(f.node, f.offset);
-      domRange.setEnd(a.node, a.offset);
-    } catch {
-      return null;
-    }
+    return null;
   }
   let r: DOMRect | null = null;
   try {

--- a/packages/design-system/src/components/RichTextEditor/selection.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.ts
@@ -275,3 +275,46 @@ export function selectionRect(root: HTMLElement): Rect {
   const rr = root.getBoundingClientRect();
   return { top: rr.top, left: rr.left, width: 0, height: rr.height };
 }
+
+/**
+ * The viewport rect of a MODEL range, re-derived from the DOM live. Unlike
+ * `selectionRect` (which reads the window selection), this is independent of the
+ * current selection — so a popover that has stolen focus (the link editor) can
+ * still track its original anchor line on scroll by re-measuring on each
+ * reposition. Returns null when the range can't be mapped to the DOM. Falls back
+ * to the anchor's block element (the active line) when the range rect is
+ * degenerate (a collapsed caret in an empty block).
+ */
+export function rangeRect(root: HTMLElement, range: Range): Rect | null {
+  const a = pointToDom(root, range.anchor);
+  const f = pointToDom(root, range.focus);
+  if (!a || !f) return null;
+  const domRange = root.ownerDocument.createRange();
+  try {
+    domRange.setStart(a.node, a.offset);
+    domRange.setEnd(f.node, f.offset);
+  } catch {
+    // Anchor after focus (backward selection) → setEnd-before-start throws; swap.
+    try {
+      domRange.setStart(f.node, f.offset);
+      domRange.setEnd(a.node, a.offset);
+    } catch {
+      return null;
+    }
+  }
+  let r: DOMRect | null = null;
+  try {
+    r = domRange.getBoundingClientRect();
+  } catch {
+    // jsdom does not implement Range.getBoundingClientRect — fall through.
+  }
+  if (r && (r.width || r.height || r.top || r.left)) {
+    return { top: r.top, left: r.left, width: r.width, height: r.height };
+  }
+  const blockEl = blockElementFor(root, a.node);
+  if (blockEl) {
+    const b = blockEl.getBoundingClientRect();
+    return { top: b.top, left: b.left, width: b.width, height: b.height };
+  }
+  return null;
+}

--- a/packages/design-system/src/components/RichTextEditor/selection.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.ts
@@ -241,18 +241,35 @@ export function writeSelection(root: HTMLElement, range: Range): void {
 /** A viewport rect (subset of DOMRect) used to anchor floating UI to a selection. */
 export type Rect = { top: number; left: number; height: number; width: number };
 
-/** The viewport rect of the current DOM selection, falling back to `root`. */
+/**
+ * The viewport rect to anchor floating UI (the link editor) to the current DOM
+ * selection. Prefers the selection's own rect; when that's degenerate — a collapsed
+ * caret in an EMPTY block returns an all-zero rect — it falls back to the caret's
+ * BLOCK element (the active line), so an anchored popover opens beside that line.
+ * Only if there's no block (caret directly in root) does it fall back to `root`.
+ * (The old root fallback used the editor's full height, which dropped the link
+ * popover below the whole document — visible via `toolbar="auto"` + Link on an
+ * empty composer.)
+ */
 export function selectionRect(root: HTMLElement): Rect {
   const sel = typeof window !== 'undefined' ? window.getSelection() : null;
   if (sel && sel.rangeCount > 0) {
+    const range = sel.getRangeAt(0);
     let r: DOMRect | null = null;
     try {
-      r = sel.getRangeAt(0).getBoundingClientRect();
+      r = range.getBoundingClientRect();
     } catch {
       // jsdom does not implement Range.getBoundingClientRect — fall through.
     }
     if (r && (r.width || r.height || r.top || r.left)) {
       return { top: r.top, left: r.left, width: r.width, height: r.height };
+    }
+    // Degenerate selection rect (e.g. collapsed caret in an empty block). Anchor to
+    // the caret's block element (the active line), not the whole editor.
+    const blockEl = blockElementFor(root, range.startContainer);
+    if (blockEl) {
+      const b = blockEl.getBoundingClientRect();
+      return { top: b.top, left: b.left, width: b.width, height: b.height };
     }
   }
   const rr = root.getBoundingClientRect();


### PR DESCRIPTION
## Summary

Two fixes to the link-edit popover (`RichTextLinkEditor`), both reported during focus-gated `toolbar="auto"` use:

1. **Anchors to the active line, not below the whole document.** When the editor uses `toolbar="auto"` and the caret is a collapsed selection in an empty composer, the selection's own rect is degenerate (zero). `selectionRect` used to fall back to the editor *root* (full height), which dropped the popover below the entire document. It now falls back to the caret's **block element** (the active line), so the bubble opens beside that line.

2. **Tracks the active line on scroll.** The bubble was anchored to a static rect captured at open time. A pure scroll fires no `selectionchange`, so the rect went stale and the bubble stayed pinned to its fixed viewport position while the line scrolled away. A new `rangeRect(root, range)` re-derives a viewport rect from the **model** `Range` (independent of the live DOM selection, which a focus-stealing popover would otherwise clobber), and `RichTextLinkEditor` reads it via a `getAnchorRect` callback on every Floating UI reposition. This mirrors the live-virtual-anchor pattern already proven in `RichTextMentionMenu` (#207) and `RichTextAttachmentConfig`.

`rangeRect` orders its two boundary points by document position before building the DOM range, so a backward (right-to-left) selection measures its full span rather than collapsing to the line fallback.

## Test plan

- `make test` (3384 unit tests incl. 26 in `selection.test.ts` — new coverage for the empty-block block fallback, the model-range scroll anchor, null mapping, and a forward===backward direction-independence regression guard).
- `make build-lib`, `make lint`, `npm run format:check` — all green.
- Live Playwright verification on `/components/rich-text-editor` (`toolbar="auto"` empty composer): opened the link editor, scrolled, and measured that the popover↔line gap stays constant (block −30 / popover −30, gap stable) for small scrolls, and flips above↔below correctly near the viewport edge for large scrolls.

## Notes (out of scope, pre-existing)

The virtual reference has no `contextElement`, so scroll-tracking covers window scroll but not a scroll *inside* a nested overflow container (e.g. a scrollable `Drawer`/`Modal` ancestor). This is identical to the already-merged mention menu (#207); a future paired change could add `contextElement` to both.

Two Rule 8 review passes (verdict: clean enough to stop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)