### PR TITLE
feat(RichTextEditor): flatten drag, controls follow the drop, hover the gutter column

### DIFF
--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
@@ -130,3 +130,41 @@ it('applies no transform or lifted style at rest', () => {
   expect(block.style.transform).toBe('');
   expect(block.className).not.toContain('blockLifted');
 });
+
+it('re-measures the gutter position when blockOrderKey changes (post-drop / insert / delete)', () => {
+  // The active block keeps its id across a reorder, so without an order-derived
+  // dependency the gutter's measured `top` would go stale and the controls would
+  // linger at the block's OLD row. Changing only blockOrderKey must re-measure.
+  function OrderHarness({ orderKey }: { orderKey: string }) {
+    const rootRef = useRef<HTMLDivElement>(null);
+    return (
+      <I18nProvider locale="en">
+        <div ref={rootRef} style={{ position: 'relative' }}>
+          <p data-block-id="b1">hello</p>
+          <RichTextBlockControls
+            rootRef={rootRef}
+            activeBlockId="b1"
+            blockOrderKey={orderKey}
+            menuOpen={false}
+            onMenuOpenChange={() => {}}
+            onInsertBelow={() => {}}
+            onAction={() => {}}
+            onTurnInto={() => {}}
+            onReorder={() => {}}
+          />
+        </div>
+      </I18nProvider>
+    );
+  }
+  const { container, rerender } = render(<OrderHarness orderKey="b1" />);
+  const block = container.querySelector('[data-block-id="b1"]') as HTMLElement;
+  // jsdom has no layout (rect is all-zero); stand in a moved row position.
+  block.getBoundingClientRect = () =>
+    ({ top: 40, left: 0, width: 200, height: 18, right: 200, bottom: 58, x: 0, y: 40 }) as DOMRect;
+  // Same activeBlockId/menuOpen — only the order key changes (as after a drop).
+  rerender(<OrderHarness orderKey="b1|b0" />);
+  const gutter = screen
+    .getByRole('button', { name: 'Insert block below' })
+    .closest('[contenteditable="false"]') as HTMLElement;
+  expect(gutter.style.top).toBe('40px');
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -27,6 +27,15 @@ export interface RichTextBlockControlsProps {
   rootRef: RefObject<HTMLElement | null>;
   /** Block currently hovered or holding the caret; null hides the gutter. */
   activeBlockId: string | null;
+  /**
+   * A signature of the current block order (e.g. the ids joined). The gutter's
+   * vertical position is measured from the active block's DOM box; the active
+   * block keeps its id across a reorder, so without an order-derived dependency
+   * the measurement would go stale and the controls would linger at the block's
+   * OLD row after a drop / insert / delete. Pass an order-derived string so the
+   * gutter re-measures whenever the block layout shifts.
+   */
+  blockOrderKey?: string;
   /** Type of the active block (gates the menu's "Turn into" — hidden for voids). */
   activeBlockType?: BlockType;
   /** Controlled open state of the block menu. */
@@ -113,6 +122,7 @@ function DraggableGutter({
 export function RichTextBlockControls({
   rootRef,
   activeBlockId,
+  blockOrderKey,
   activeBlockType,
   menuOpen,
   onMenuOpenChange,
@@ -178,7 +188,10 @@ export function RichTextBlockControls({
     const box = el.getBoundingClientRect();
     setTop(box.top - rootBox.top);
     setHeight(box.height);
-  }, [rootRef, activeBlockId, menuOpen, retry]);
+    // blockOrderKey is a dep so a reorder/insert/delete (which keeps the active
+    // block's id but moves its row) re-measures rather than leaving the gutter
+    // stranded at the old position.
+  }, [rootRef, activeBlockId, blockOrderKey, menuOpen, retry]);
 
   const handleDragStart = (_event: DragStartEvent) => {
     const root = rootRef.current;

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.module.scss
@@ -261,15 +261,16 @@ figure[data-attachment][data-align='right'] {
   transition: transform var(--transition-base);
 }
 
-// The grabbed row while dragging: raised above its neighbours with a card elevation
-// so it reads as "lifted". `position: relative` is the stacking context for z-index
-// (Rule 4 allows relative for an internal stacking/anchor purpose), not page layout.
+// The grabbed row while dragging: it follows the pointer in place. No card
+// elevation (border/shadow) — it should read as the same line simply moving, not a
+// detached card. `position: relative` is the stacking context for z-index (Rule 4
+// allows relative for an internal stacking/anchor purpose), not page layout; the
+// raised z-index + opaque background keep it cleanly on top of any row it briefly
+// overlaps before the others slide apart.
 .blockLifted {
   position: relative;
   z-index: 1;
   background: var(--color-bg);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-lg);
   cursor: grabbing;
   transition: none; // track the pointer with no lag
 }

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -1104,6 +1104,39 @@ describe('blockControls', () => {
       expect(screen.getByRole('button', { name: 'Block actions' })).toBeInTheDocument();
     });
 
+    it('reveals the row controls when hovering the gutter column (resolved by pointer height)', () => {
+      render(
+        <I18nProvider locale="en">
+          <Controlled blockControls />
+        </I18nProvider>,
+      );
+      const textbox = screen.getByRole('textbox');
+      const blocks = Array.from(textbox.querySelectorAll('[data-block-id]')) as HTMLElement[];
+      const stub = (el: HTMLElement, top: number) =>
+        (el.getBoundingClientRect = () =>
+          ({
+            top,
+            bottom: top + 20,
+            left: 0,
+            right: 200,
+            width: 200,
+            height: 20,
+            x: 0,
+            y: top,
+          }) as DOMRect);
+      stub(blocks[0], 0);
+      stub(blocks[1], 100);
+      stub(blocks[2], 200);
+      // Pointer over the gutter/padding column (target is the editable itself — no
+      // block element under it) at the SECOND block's height. The controls should
+      // appear for THAT block, resolved by the pointer's vertical position.
+      fireEvent.mouseMove(textbox, { clientY: 110 });
+      const gutter = screen
+        .getByRole('button', { name: 'Insert block below' })
+        .closest('[contenteditable="false"]') as HTMLElement;
+      expect(gutter.style.top).toBe('100px');
+    });
+
     it('hides the gutter when the pointer leaves the editor (no caret)', async () => {
       render(
         <I18nProvider locale="en">

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -404,7 +404,10 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // top-to-bottom, so we can stop once a block starts below the pointer; among the
     // blocks that contain the pointer the LAST in document order is the deepest (a
     // nested list item comes after — and sits inside — its parent), matching how a
-    // direct hover resolves to the innermost block.
+    // direct hover resolves to the innermost block. Reads a layout rect per block up
+    // to the pointer's row — an accepted cost: the caller only invokes this for the
+    // narrow no-block-under-pointer case (the gutter/padding column), never the hot
+    // text-hover path, so there's no need to cache rects or rAF-throttle.
     const blockAtPointerY = useCallback((root: HTMLElement, clientY: number): string | null => {
       let found: string | null = null;
       for (const el of root.querySelectorAll<HTMLElement>('[data-block-id]')) {

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -398,6 +398,23 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       return null; // reached the root (or ran out of ancestors) — no block
     }, []);
 
+    // The block whose vertical band contains viewport-y `clientY`, or null. Used to
+    // resolve a hover over the gutter/padding column (where there is no block element
+    // under the pointer) to the row beside it. Block elements are in document order =
+    // top-to-bottom, so we can stop once a block starts below the pointer; among the
+    // blocks that contain the pointer the LAST in document order is the deepest (a
+    // nested list item comes after — and sits inside — its parent), matching how a
+    // direct hover resolves to the innermost block.
+    const blockAtPointerY = useCallback((root: HTMLElement, clientY: number): string | null => {
+      let found: string | null = null;
+      for (const el of root.querySelectorAll<HTMLElement>('[data-block-id]')) {
+        const box = el.getBoundingClientRect();
+        if (box.top > clientY) break;
+        if (clientY <= box.bottom) found = el.getAttribute('data-block-id');
+      }
+      return found;
+    }, []);
+
     const historyRef = useRef<History>(historyReset({ doc: value, selection: null }));
     // Timestamp of the last ⌘Z/⌘⇧Z/⌘Y keydown — lets the beforeinput net skip the
     // historyUndo/historyRedo event that a keydown ALSO emits (already handled),
@@ -843,18 +860,42 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         const id = blockIdFromNode(e.target as Node);
         if (id) setHoverBlockId(id);
       };
+      // The gutter (＋ / ⠿) and the reserved left column are NOT inside the editable,
+      // so `mouseover` there resolves to no block id and would leave the controls
+      // stranded on whichever row was last hovered. Track the pointer's height while
+      // it's over that controls column and activate the row at that height — so
+      // hovering the controls area reveals/follows the adjacent row's controls.
+      // Scoped to the no-block case so block-targeted hovers stay on the cheap
+      // `mouseover` path; `mousemove` (not `mouseover`) is needed because sliding
+      // within the column fires no new `mouseover`.
+      const onMove = (e: MouseEvent) => {
+        if (blockMenuOpenRef.current || draggingRef.current) return;
+        const root = rootRef.current;
+        if (!root) return;
+        // Only the editable's OWN area (its reserved left column / padding). The gutter
+        // overlay is a sibling of the editable, not a descendant, so this skips it —
+        // its buttons stay alive via onOver's leave-unchanged path, and we never fight
+        // the controls the pointer is aiming for.
+        const target = e.target as Node;
+        if (!root.contains(target)) return;
+        if (blockIdFromNode(target)) return; // a real block hover — onOver has it
+        const id = blockAtPointerY(root, e.clientY);
+        if (id) setHoverBlockId(id);
+      };
       const onLeave = () => {
         // Keep the active block while the menu is open or a drag is mid-flight.
         if (blockMenuOpenRef.current || draggingRef.current) return;
         setHoverBlockId(null);
       };
       shell.addEventListener('mouseover', onOver);
+      shell.addEventListener('mousemove', onMove);
       shell.addEventListener('mouseleave', onLeave);
       return () => {
         shell.removeEventListener('mouseover', onOver);
+        shell.removeEventListener('mousemove', onMove);
         shell.removeEventListener('mouseleave', onLeave);
       };
-    }, [controlsOn, blockIdFromNode]);
+    }, [controlsOn, blockIdFromNode, blockAtPointerY]);
 
     // Caret tracking → active block (keyboard users get a gutter target too).
     useEffect(() => {
@@ -1294,6 +1335,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       <RichTextBlockControls
         rootRef={shellRef}
         activeBlockId={activeBlockId}
+        blockOrderKey={value.blocks.map((b) => b.id).join('|')}
         activeBlockType={activeBlockType}
         menuOpen={blockMenuOpen}
         onMenuOpenChange={setBlockMenuOpen}


### PR DESCRIPTION
## Summary

Three block-controls / drag polish fixes (reported in conversation):

1. **Flatten the dragged row.** `.blockLifted` dropped its `border-radius` + `box-shadow`, so the grabbed row reads as the same line moving in place rather than a detached card. It keeps only the raised `z-index` + opaque `background` needed to cleanly occlude any row it briefly overlaps before the others slide apart.

2. **Controls follow the drop.** The gutter's vertical position is measured from the active block's DOM box, but the active block keeps its id across a reorder — so the measure effect (keyed on the id) never re-ran and the controls were stranded at the block's OLD row after a drop. `RichTextBlockControls` gained a `blockOrderKey` prop (the joined block ids), added as a dependency of the measure effect; the editor passes `value.blocks.map(b => b.id).join('|')`. This also covers insert / delete, which likewise shift rows.

3. **Hover the gutter column.** The gutter (＋ / ⚙ / ⠿) and the reserved left column aren't inside the editable, so `mouseover` there resolved to no block and left the controls stranded on the last-hovered row. A `mousemove` handler — scoped to the editable's own area (`root.contains(target)`, no block under the pointer) and guarded by the same menu-open / dragging flags as the existing hover handlers — resolves the row at the pointer's vertical position (`blockAtPointerY`), so hovering the controls column reveals and follows that row's controls. The gutter overlay is a sibling of the editable, so the scope correctly excludes it (its buttons stay alive via the existing leave-unchanged path).

## Test plan

- `make test` (3386 unit tests). New coverage: `RichTextBlockControls.test.tsx` — gutter re-measures when `blockOrderKey` changes (isolates the dep); `RichTextEditor.test.tsx` — hovering the gutter column resolves the row by pointer height. All existing block-controls / attachment-config / hover-zone tests still pass.
- `make build-lib`, `make lint`, `npm run format:check` — green.
- Live Playwright on `/components/rich-text-editor` (blockControls example):
  - `.blockLifted` computed rule has no box-shadow/border-radius (keeps background + z-index).
  - Synthetic dnd-kit pointer-drag reordered a block; after drop the gutter top matched the dropped block's NEW position (not the stale original).
  - Hovering the left gutter column at another row's height moved the controls to that row.

Two Rule 8 review passes (verdict: clean enough to stop). Out-of-scope notes from review: a `ResizeObserver` could later close the gap where a hover-active block is pushed down by an async layout shift (e.g. an image above finishing load) that doesn't change the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)