### PR TITLE
feat(RichTextEditor): drag the block gutter along with the lifted row

### DIFF
--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
@@ -129,6 +129,10 @@ it('applies no transform or lifted style at rest', () => {
   const block = container.querySelector('[data-block-id="b1"]') as HTMLElement;
   expect(block.style.transform).toBe('');
   expect(block.className).not.toContain('blockLifted');
+  // The gutter only translates while dragging (it follows the lifted row); at rest
+  // it carries no transform.
+  const gutter = container.querySelector('[contenteditable="false"]') as HTMLElement;
+  expect(gutter.style.transform).toBe('');
 });
 
 it('re-measures the gutter position when blockOrderKey changes (post-drop / insert / delete)', () => {

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -1,7 +1,7 @@
 // RichTextBlockControls.tsx — the per-block gutter overlay. Absolutely positioned
 // inside the editor shell (position: relative), aligned to the active block's box.
 // Lives OUTSIDE the contentEditable so it is never editable content.
-import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
 import {
   DndContext,
   PointerSensor,
@@ -92,16 +92,26 @@ function clearReflow(
 function DraggableGutter({
   top,
   height,
+  innerRef,
   children,
 }: {
   top: number;
   height: number | null;
+  /** Captures the gutter DOM node so the drag can translate it with the lifted row. */
+  innerRef: RefObject<HTMLDivElement | null>;
   children: React.ReactNode;
 }) {
   const { setNodeRef, listeners } = useDraggable({ id: GUTTER_DRAGGABLE_ID });
+  const setRefs = useCallback(
+    (node: HTMLDivElement | null) => {
+      setNodeRef(node);
+      innerRef.current = node;
+    },
+    [setNodeRef, innerRef],
+  );
   return (
     <div
-      ref={setNodeRef}
+      ref={setRefs}
       className={styles.gutter}
       style={{ top, height: height ?? undefined }}
       contentEditable={false}
@@ -150,6 +160,8 @@ export function RichTextBlockControls({
   } | null>(null);
   // Block id captured at drag start — reorder by this, not the live activeBlockId.
   const draggedIdRef = useRef<string | null>(null);
+  // The gutter DOM node, so the drag can translate it in lockstep with the lifted row.
+  const gutterElRef = useRef<HTMLDivElement | null>(null);
 
   // Latest onDraggingChange, read by the unmount cleanup without re-subscribing.
   const onDraggingChangeRef = useRef(onDraggingChange);
@@ -252,10 +264,17 @@ export function RichTextBlockControls({
       const own = reflow.shifts[i] - (pid >= 0 ? reflow.shifts[pid] : 0);
       snap.els[i].style.transform = own ? `translateY(${own}px)` : '';
     }
+    // Carry the gutter (＋ / ⚙ / ⠿) along with the lifted row by the same clamped
+    // travel, so the controls feel attached to the row being dragged. The gutter is
+    // not nested, so it shifts by the unit's net movement (liftDy) directly.
+    if (gutterElRef.current) {
+      gutterElRef.current.style.transform = reflow.liftDy ? `translateY(${reflow.liftDy}px)` : '';
+    }
   };
 
   const endDrag = () => {
     clearReflow(dragRef.current, rootRef.current);
+    if (gutterElRef.current) gutterElRef.current.style.transform = '';
     dragRef.current = null;
     draggedIdRef.current = null;
     onDraggingChange?.(false);
@@ -292,7 +311,7 @@ export function RichTextBlockControls({
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      <DraggableGutter top={top} height={height}>
+      <DraggableGutter top={top} height={height} innerRef={gutterElRef}>
         <Button
           size="sm"
           variant="ghost"


### PR DESCRIPTION
## Summary

Makes the block-controls gutter (the ＋ / ⚙ / ⠿ strip) move together with the row while it's being drag-reordered. Previously the gutter stayed pinned at its measured position while the lifted row slid out from under it.

- `DraggableGutter` captures its DOM node (merging an `innerRef` with dnd-kit's `setNodeRef` via a stable `useCallback` ref).
- On each drag move, the gutter is translated by the lifted unit's clamped travel (`reflow.liftDy`) — the exact net movement the row itself makes — so the controls feel attached to the row. The gutter is a shell-level sibling (not nested in a block), so it shifts by `liftDy` directly.
- The transform is reset on drag end/cancel, after which the gutter re-measures to the dropped row's new position (via the `blockOrderKey` mechanism shipped in #231). React only reconciles `top`/`height` in the gutter's style, so the imperatively-cleared transform isn't re-applied — no doubled offset.

## Test plan

- `make test` (3386), `make lint`, `make build-lib`, `npm run format:check` — all green. Added a gutter-at-rest assertion (carries no transform until a drag).
- The live drag lifecycle isn't drivable in jsdom (dnd-kit needs real pointer-capture); the `liftDy` geometry is covered by `blockReflow.test.ts`.
- Live Playwright on `/components/rich-text-editor` (blockControls example): a synthetic dnd-kit pointer-drag showed the gutter transform tracking the lifted row in lockstep (`translateY(50px)` → both clamp to `translateY(107.969px)` at the container edge), and the gutter transform reset to empty after drop while landing on the dropped row's new position.

One Rule 8 review pass (verdict: clean enough to stop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)