### PR TITLE
feat(RichTextEditor): emoji-insert toolbar button

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -970,6 +970,7 @@ const [doc, setDoc] = useState(emptyDoc());
 - **Block-type dropdown** — Paragraph, Heading 1–3, Quote, Code block. Shows the current block type; mixed multi-block selections show "Mixed".
 - **List toggles** — Bullet list, Numbered list. Toggle between the list type and paragraph.
 - **Link button** — add/edit a link on the selection. Reflects `aria-pressed` when the caret is inside a link.
+- **Emoji insert** — opens a searchable `EmojiPickerPopover`; selecting an emoji inserts it at the caret.
 - **Undo / Redo buttons** — undo/redo the last change; disabled at the ends of the history.
 
 **List keys:**

--- a/packages/design-system/src/components.manifest.json
+++ b/packages/design-system/src/components.manifest.json
@@ -256,7 +256,9 @@
       "Popover",
       "Text"
     ],
-    "composedBy": []
+    "composedBy": [
+      "RichTextEditor"
+    ]
   },
   "EmptyState": {
     "tier": "primitive",
@@ -571,6 +573,7 @@
       "CircularProgress",
       "Cluster",
       "DropdownMenu",
+      "EmojiPicker",
       "Input",
       "RichText",
       "Slider",

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -290,6 +290,32 @@ describe('RichTextEditor toolbar', () => {
       );
     });
   });
+
+  it('Emoji toolbar button replaces a non-collapsed selection', async () => {
+    const user = userEvent.setup();
+    // Stub the live selection to a non-collapsed range covering 'world' (offsets 6-11).
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 6 },
+      focus: { blockId: 'k', offset: 11 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hello world', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} toolbar />;
+    }
+    renderEditor(<Harness />);
+    await user.click(screen.getByRole('button', { name: 'Emoji' }));
+    const listbox = await screen.findByRole('listbox');
+    const firstEmoji = within(listbox).getAllByRole('option')[0];
+    const glyph = firstEmoji.textContent!.trim();
+    await user.click(firstEmoji);
+    await waitFor(() => {
+      const text = screen.getByRole('textbox', { name: 'Rich text editor' }).textContent;
+      expect(text).toContain(glyph);
+      expect(text).not.toContain('world'); // selected text was replaced, not appended
+    });
+  });
 });
 
 describe('RichTextEditor paste', () => {

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { vi } from 'vitest';
@@ -261,6 +261,34 @@ describe('RichTextEditor toolbar', () => {
       ([ev]) => (ev as React.KeyboardEvent).key.toLowerCase() === 'k',
     );
     expect(kReachedHost).toBe(false);
+  });
+
+  it('Emoji toolbar button inserts the chosen emoji at the caret', async () => {
+    const user = userEvent.setup();
+    // Stub the live selection to a collapsed caret at offset 3 (end of 'hi ').
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 3 },
+      focus: { blockId: 'k', offset: 3 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hi ', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} toolbar />;
+    }
+    renderEditor(<Harness />);
+    // Click the Emoji toolbar button to open the picker.
+    await user.click(screen.getByRole('button', { name: 'Emoji' }));
+    // The first emoji in the curated set is 'grinning face' (😀).
+    const listbox = await screen.findByRole('listbox');
+    const firstEmoji = within(listbox).getAllByRole('option')[0];
+    const glyph = firstEmoji.textContent!.trim();
+    await user.click(firstEmoji);
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Rich text editor' }).textContent).toContain(
+        glyph,
+      );
+    });
   });
 });
 

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -316,6 +316,67 @@ describe('RichTextEditor toolbar', () => {
       expect(text).not.toContain('world'); // selected text was replaced, not appended
     });
   });
+
+  it('Emoji insert uses lastSelectionRef when live selection is null (search-box focus path)', async () => {
+    const user = userEvent.setup();
+    // Start with a valid selection so the selectionchange handler captures it
+    // into lastSelectionRef, then simulate the caret being stolen by the search box.
+    const validRange: Range = {
+      anchor: { blockId: 'k', offset: 3 },
+      focus: { blockId: 'k', offset: 3 },
+    };
+    mockReadSelection.mockReturnValue(validRange);
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hi ', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} toolbar />;
+    }
+    renderEditor(<Harness />);
+    // Fire a selectionchange so the component's handler runs and captures the
+    // non-null selection into lastSelectionRef.
+    act(() => {
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+    // Now simulate focus moving to the emoji search box: live selection becomes null.
+    mockReadSelection.mockReturnValue(null);
+    await user.click(screen.getByRole('button', { name: 'Emoji' }));
+    const listbox = await screen.findByRole('listbox');
+    const firstEmoji = within(listbox).getAllByRole('option')[0];
+    const glyph = firstEmoji.textContent!.trim();
+    await user.click(firstEmoji);
+    // The emoji must still land in the editor even though live readSelection returns null.
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Rich text editor' }).textContent).toContain(
+        glyph,
+      );
+    });
+  });
+
+  it('Emoji insert refocuses the editor after the pick', async () => {
+    const user = userEvent.setup();
+    mockReadSelection.mockReturnValue({
+      anchor: { blockId: 'k', offset: 3 },
+      focus: { blockId: 'k', offset: 3 },
+    });
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [{ id: 'k', type: 'paragraph', inlines: [{ text: 'hi ', marks: [] }] }],
+      });
+      return <RichTextEditor value={doc} onChange={setDoc} toolbar />;
+    }
+    renderEditor(<Harness />);
+    await user.click(screen.getByRole('button', { name: 'Emoji' }));
+    const listbox = await screen.findByRole('listbox');
+    const firstEmoji = within(listbox).getAllByRole('option')[0];
+    await user.click(firstEmoji);
+    // After picking, the editor textbox should have focus so the user can keep typing.
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByRole('textbox', { name: 'Rich text editor' }),
+      );
+    });
+  });
 });
 
 describe('RichTextEditor paste', () => {

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -365,6 +365,10 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // The collapsed caret where pending marks were staged. Used to clear them
     // when the caret moves to a different spot (vs. typing at the same point).
     const pendingAtRef = useRef<Point | null>(null);
+    // The most recent NON-null editor selection. Survives focus moving into a toolbar
+    // popover (e.g. the emoji/search box), where the live selection reads null. Used by
+    // popover-driven inserts so they target where the caret actually was.
+    const lastSelectionRef = useRef<Range | null>(null);
 
     const setRefs = useCallback(
       (node: HTMLDivElement | null) => {
@@ -835,6 +839,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       const onSelChange = () => {
         const sel = readSelection(root);
         setSelection(sel);
+        if (sel != null) lastSelectionRef.current = sel;
         // Abandon pending marks if the caret left its staged point (the user
         // moved the caret or made a selection instead of typing there).
         const pend = pendingMarksRef.current;
@@ -1096,12 +1101,15 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     const onInsertEmoji = useCallback(
       (emoji: string) => {
         const root = rootRef.current;
-        const range = (root ? readSelection(root) : null) ?? selection;
+        const range = (root ? readSelection(root) : null) ?? lastSelectionRef.current;
         if (!range) return;
         const result = applyInput(latest.current.value, range, 'insertText', emoji);
-        if (result) commit(result);
+        if (result) {
+          commit(result);
+          root?.focus(); // keep the editor focused so typing continues after the pick
+        }
       },
-      [selection, commit],
+      [commit],
     );
 
     const onToolbarMark = useCallback(

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -1097,7 +1097,9 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       (emoji: string) => {
         const root = rootRef.current;
         const range = (root ? readSelection(root) : null) ?? selection;
-        if (range) commit(insertText(latest.current.value, range.anchor, emoji));
+        if (!range) return;
+        const result = applyInput(latest.current.value, range, 'insertText', emoji);
+        if (result) commit(result);
       },
       [selection, commit],
     );

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -1093,6 +1093,15 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // Toolbar dispatch — read the live selection (falling back to tracked state)
     // and route through the same commit path the keyboard uses. A mark at a
     // collapsed caret stages a pending mark, mirroring the keyboard shortcut.
+    const onInsertEmoji = useCallback(
+      (emoji: string) => {
+        const root = rootRef.current;
+        const range = (root ? readSelection(root) : null) ?? selection;
+        if (range) commit(insertText(latest.current.value, range.anchor, emoji));
+      },
+      [selection, commit],
+    );
+
     const onToolbarMark = useCallback(
       (type: MarkType) => {
         if (type === 'link' || type === 'mention') return; // link needs an href; mention needs id+label — toolbar fires neither
@@ -1466,6 +1475,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         onRedo={onRedo}
         onUpload={uploadOn ? (files) => uploaderRef.current.uploadFiles(files) : undefined}
         uploadAccept={upload?.accept}
+        onInsertEmoji={onInsertEmoji}
       />
     ) : null;
 

--- a/packages/design-system/src/components/RichTextEditor/RichTextToolbar.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextToolbar.test.tsx
@@ -10,6 +10,7 @@ function renderTb(props: Partial<React.ComponentProps<typeof RichTextToolbar>> =
   const onOpenLink = vi.fn();
   const onUndo = vi.fn();
   const onRedo = vi.fn();
+  const onInsertEmoji = vi.fn();
   render(
     <I18nProvider locale="en">
       <RichTextToolbar
@@ -21,11 +22,12 @@ function renderTb(props: Partial<React.ComponentProps<typeof RichTextToolbar>> =
         onOpenLink={onOpenLink}
         onUndo={onUndo}
         onRedo={onRedo}
+        onInsertEmoji={onInsertEmoji}
         {...props}
       />
     </I18nProvider>,
   );
-  return { onToggleMark, onSetBlock, onToggleList, onOpenLink, onUndo, onRedo };
+  return { onToggleMark, onSetBlock, onToggleList, onOpenLink, onUndo, onRedo, onInsertEmoji };
 }
 
 describe('RichTextToolbar', () => {
@@ -133,5 +135,15 @@ describe('RichTextToolbar', () => {
     renderTb({ canUndo: true, canRedo: true, disabled: true });
     expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled();
+  });
+
+  it('renders an Emoji button', () => {
+    renderTb();
+    expect(screen.getByRole('button', { name: 'Emoji' })).toBeInTheDocument();
+  });
+
+  it('disables the Emoji button when disabled', () => {
+    renderTb({ disabled: true });
+    expect(screen.getByRole('button', { name: 'Emoji' })).toBeDisabled();
   });
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextToolbar.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextToolbar.tsx
@@ -2,6 +2,7 @@ import { useRef, type ReactElement } from 'react';
 import type { BlockType, MarkType } from '../RichText/engine/model';
 import { Button } from '../Button';
 import { DropdownMenu } from '../DropdownMenu';
+import { EmojiPickerPopover } from '../EmojiPicker';
 import { useTranslation } from '../../i18n';
 import {
   BoldIcon,
@@ -14,6 +15,7 @@ import {
   UndoIcon,
   RedoIcon,
   AttachFileIcon,
+  SmileIcon,
 } from './icons';
 import styles from './RichTextEditor.module.scss';
 
@@ -49,6 +51,8 @@ export interface RichTextToolbarProps {
   onUpload?: (files: File[]) => void;
   /** Native file-picker `accept` filter. */
   uploadAccept?: string;
+  /** Insert an emoji at the caret. */
+  onInsertEmoji: (emoji: string) => void;
 }
 
 const MARKS: {
@@ -93,6 +97,7 @@ export function RichTextToolbar({
   onRedo,
   onUpload,
   uploadAccept,
+  onInsertEmoji,
 }: RichTextToolbarProps) {
   const t = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -212,6 +217,24 @@ export function RichTextToolbar({
       >
         <LinkIcon />
       </Button>
+
+      <EmojiPickerPopover
+        trigger={
+          <Button
+            size="sm"
+            variant="ghost"
+            iconOnly
+            aria-label={t('richTextEditor.emoji')}
+            disabled={disabled}
+            // Preserve the editor's DOM selection so the caret is still live
+            // when the emoji is chosen and onInsertEmoji reads it.
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            <SmileIcon />
+          </Button>
+        }
+        onSelect={onInsertEmoji}
+      />
 
       <span className={styles.toolbarSep} aria-hidden="true" />
 

--- a/packages/design-system/src/components/RichTextEditor/icons.tsx
+++ b/packages/design-system/src/components/RichTextEditor/icons.tsx
@@ -121,3 +121,13 @@ export function AttachFileIcon() {
     </svg>
   );
 }
+export function SmileIcon() {
+  return (
+    <svg {...base}>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M8 14s1.5 2 4 2 4-2 4-2" />
+      <line x1="9" y1="9" x2="9.01" y2="9" />
+      <line x1="15" y1="9" x2="15.01" y2="9" />
+    </svg>
+  );
+}

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -222,6 +222,7 @@ export const en: Messages = {
     bulletList: 'Bullet list',
     orderedList: 'Numbered list',
     link: 'Link',
+    emoji: 'Emoji',
     linkUrl: 'Link URL',
     linkUrlPlaceholder: 'https://… or /path',
     linkApply: 'Apply',

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -368,6 +368,8 @@ export interface Messages {
     orderedList: string;
     /** aria-label on the toolbar Link button. */
     link: string;
+    /** Emoji-insert toolbar button. */
+    emoji: string;
     /** Label (aria) for the URL field in the link bubble. */
     linkUrl: string;
     /** Placeholder for the URL field in the link bubble. */

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -224,6 +224,7 @@ export const ru: Messages = {
     bulletList: 'Маркированный список',
     orderedList: 'Нумерованный список',
     link: 'Ссылка',
+    emoji: 'Эмодзи',
     linkUrl: 'URL ссылки',
     linkUrlPlaceholder: 'https://… или /path',
     linkApply: 'Применить',

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -108,7 +108,7 @@ export function RichTextEditorDemo() {
     >
       <Example
         title="Editable with toolbar"
-        description='The toolbar prop adds a formatting bar above the editor. Keyboard shortcuts and toolbar buttons both work — select text to format it, or toggle a mark at a collapsed caret and then type to apply it to new text. Enter on an empty list item exits the list; Tab / Shift+Tab indent and outdent list items. Undo/redo: ⌘/Ctrl+Z and ⌘/Ctrl+Shift+Z (or the toolbar Undo/Redo buttons). Type "# ", "- ", "1. ", or "> " at the start of a line to auto-format.'
+        description='The toolbar prop adds a formatting bar above the editor. Keyboard shortcuts and toolbar buttons both work — select text to format it, or toggle a mark at a collapsed caret and then type to apply it to new text. Enter on an empty list item exits the list; Tab / Shift+Tab indent and outdent list items. Undo/redo: ⌘/Ctrl+Z and ⌘/Ctrl+Shift+Z (or the toolbar Undo/Redo buttons). Type "# ", "- ", "1. ", or "> " at the start of a line to auto-format. The toolbar also includes an emoji button that opens a searchable emoji picker and inserts the chosen emoji at the caret.'
         code={`const [doc, setDoc] = useState(docFromText('…'));
 <RichTextEditor value={doc} onChange={setDoc} toolbar placeholder="Write a note…" />`}
       >


### PR DESCRIPTION
## Summary

Adds an emoji button to the `<RichTextEditor toolbar>`: a smiley button opens the existing `EmojiPickerPopover`; choosing an emoji inserts it at the caret (replacing a non-collapsed selection) through the editor's `commit` path, so it's one undo step. No engine change, no new public API, no new opt-in prop — emoji is always present when `toolbar` is on (like bold/link).

Part 1 of the emoji + color plan (`docs/superpowers/plans/2026-06-27-rte-emoji-color.md`); color ships next.

## Notable details

- Insert routes through `applyInput(value, range, 'insertText', emoji)`, which deletes a non-collapsed selection then inserts (ordered-range safe).
- Opening the picker (and typing in its search box) moves focus out of the editable, which nulls the live selection. A `lastSelectionRef` (the most recent non-null editor selection) is used as the fallback so the emoji lands where the caret was — and the editor is refocused after the pick so typing continues.

## Test plan

- `make test` (3401), `make build`, `make lint`, `npm run format:check` — green. Manifest regenerated (RichTextEditor now composes EmojiPicker).
- Unit tests: emoji inserts at the caret; replaces a non-collapsed selection; inserts via the `lastSelectionRef` fallback when the live selection is null (search-box focus path); refocuses the editor after the pick; toolbar button renders + disables.
- Live Playwright: confirmed that focusing the emoji search box steals focus, yet the picked emoji still inserts at the caret and the editor refocuses.

One spec-compliance + one code-quality (Rule 8) review pass; both Important findings (replace-on-selection; search-path no-op + lost focus) fixed and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)