### PR TITLE
perf(RichTextEditor): safe render + engine optimizations (no behavior change)

### DIFF
--- a/packages/design-system/src/components/RichText/engine/attachment.ts
+++ b/packages/design-system/src/components/RichText/engine/attachment.ts
@@ -1,7 +1,7 @@
 // attachment.ts — attachment (void) block helpers + transforms. Pure + immutable.
 import type { RichDoc, Block, Point, Range } from './model';
 import { createBlock, nextId } from './model';
-import { findBlockIndex, blockLength } from './position';
+import { findBlockIndex, blockLength, collapsedRange } from './position';
 import { sliceInlines, normalizeInlines } from './inlines';
 
 /**
@@ -42,10 +42,6 @@ export function attachmentIsImage(block: Pick<Block, 'mime' | 'src'>): boolean {
   return /\.(png|jpe?g|gif|webp|avif|svg)(\?|$)/i.test(block.src ?? '');
 }
 
-function collapsed(blockId: string, offset = 0): Range {
-  return { anchor: { blockId, offset }, focus: { blockId, offset } };
-}
-
 function attachmentBlock(attrs: AttachmentAttrs): Block {
   return {
     id: nextId(),
@@ -77,7 +73,7 @@ export function insertAttachmentBlock(
 ): { doc: RichDoc; selection: Range; attachmentId: string | null } {
   const idx = findBlockIndex(doc, point.blockId);
   if (idx === -1) {
-    return { doc, selection: collapsed(point.blockId, point.offset), attachmentId: null };
+    return { doc, selection: collapsedRange(point.blockId, point.offset), attachmentId: null };
   }
   const block = doc.blocks[idx];
   const att = attachmentBlock(attrs);
@@ -85,7 +81,7 @@ export function insertAttachmentBlock(
   if (isVoidBlock(block)) {
     const after = createBlock('paragraph');
     const blocks = [...doc.blocks.slice(0, idx + 1), att, after, ...doc.blocks.slice(idx + 1)];
-    return { doc: { blocks }, selection: collapsed(after.id), attachmentId: att.id };
+    return { doc: { blocks }, selection: collapsedRange(after.id), attachmentId: att.id };
   }
 
   const left: Block = {
@@ -100,7 +96,7 @@ export function insertAttachmentBlock(
     inlines: rightInlines,
   };
   const blocks = [...doc.blocks.slice(0, idx), left, att, right, ...doc.blocks.slice(idx + 1)];
-  return { doc: { blocks }, selection: collapsed(right.id), attachmentId: att.id };
+  return { doc: { blocks }, selection: collapsedRange(right.id), attachmentId: att.id };
 }
 
 /** Patch an attachment block's fields by id. Same-ref no-op if absent/not attachment. */

--- a/packages/design-system/src/components/RichText/engine/marks.ts
+++ b/packages/design-system/src/components/RichText/engine/marks.ts
@@ -1,6 +1,23 @@
 // marks.ts — Layer A. Pure helpers over a Mark[]. Never mutate inputs.
 import type { Mark, MarkType } from './model';
 
+/**
+ * Inline-mark nesting order, outermost first. Shared by renderDoc + toHtml so
+ * render and serialize nest identically. Color spans sit just inside link/mention
+ * (so a colored link reads `<a><span style>…`) but outside the text-formatting tags.
+ */
+export const MARK_ORDER: MarkType[] = [
+  'mention',
+  'link',
+  'textColor',
+  'bgColor',
+  'bold',
+  'italic',
+  'underline',
+  'strike',
+  'code',
+];
+
 /** Canonical key for set comparison (link by href, mention by id+label, color by key). */
 function markKey(m: Mark): string {
   if (m.type === 'link') return `link:${m.href}`;
@@ -11,7 +28,10 @@ function markKey(m: Mark): string {
 
 /** Order-insensitive set equality (link href included). */
 export function marksEqual(a: Mark[], b: Mark[]): boolean {
+  if (a === b) return true;
   if (a.length !== b.length) return false;
+  if (a.length === 0) return true;
+  if (a.length === 1) return markKey(a[0]) === markKey(b[0]);
   const ka = a.map(markKey).sort();
   const kb = b.map(markKey).sort();
   return ka.every((k, i) => k === kb[i]);

--- a/packages/design-system/src/components/RichText/engine/position.ts
+++ b/packages/design-system/src/components/RichText/engine/position.ts
@@ -52,6 +52,11 @@ export function comparePoints(doc: RichDoc, a: Point, b: Point): -1 | 0 | 1 {
   return ia < ib ? -1 : ia > ib ? 1 : 0;
 }
 
+/** A collapsed range at a single point. */
+export function collapsedRange(blockId: string, offset = 0): Range {
+  return { anchor: { blockId, offset }, focus: { blockId, offset } };
+}
+
 /** Returns `true` iff `range` is collapsed — anchor and focus point to the same position. */
 export function isCollapsed(range: Range): boolean {
   return range.anchor.blockId === range.focus.blockId && range.anchor.offset === range.focus.offset;

--- a/packages/design-system/src/components/RichText/engine/renderDoc.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.tsx
@@ -6,6 +6,7 @@ import { runsText, runsLength } from './inlines';
 import { safeHref } from './safeHref';
 import { textColorVar, bgColorVar } from './colorMarks';
 import { isListItem, effectiveDepths } from './listDepths';
+import { MARK_ORDER } from './marks';
 import type { RenderLink } from './renderLink';
 import type { RenderMention } from './renderMention';
 import { RichTextAttachment } from '../../RichTextEditor/RichTextAttachment';
@@ -38,21 +39,6 @@ interface ResolvedOptions {
   renderLink?: RenderLink;
   renderMention?: RenderMention;
 }
-
-// Outer → inner nesting order so output is stable + diff-friendly. Color spans sit
-// just inside link/mention (so a colored link reads `<a><span style>…`) but outside
-// the text-formatting tags.
-const MARK_ORDER: MarkType[] = [
-  'mention',
-  'link',
-  'textColor',
-  'bgColor',
-  'bold',
-  'italic',
-  'underline',
-  'strike',
-  'code',
-];
 
 function wrapMark(type: MarkType, mark: Mark, child: ReactNode): ReactNode {
   switch (type) {

--- a/packages/design-system/src/components/RichText/engine/toHtml.ts
+++ b/packages/design-system/src/components/RichText/engine/toHtml.ts
@@ -10,20 +10,7 @@ import { safeHref } from './safeHref';
 import { textColorVar, bgColorVar } from './colorMarks';
 import { isListItem, effectiveDepths } from './listDepths';
 import { attachmentIsImage } from './attachment';
-
-// Outer → inner; link outermost, code innermost (matches renderDoc). Color spans
-// sit just inside link/mention but outside the text-formatting tags.
-const MARK_ORDER: MarkType[] = [
-  'mention',
-  'link',
-  'textColor',
-  'bgColor',
-  'bold',
-  'italic',
-  'underline',
-  'strike',
-  'code',
-];
+import { MARK_ORDER } from './marks';
 
 /** Wrap an already-escaped HTML string in one mark's tag. */
 function wrapMark(type: MarkType, mark: Mark, inner: string): string {

--- a/packages/design-system/src/components/RichText/engine/transforms.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.ts
@@ -4,11 +4,11 @@ import type { RichDoc, Block, Point, Range, Mark, MarkType } from './model';
 import { createBlock, nextId } from './model';
 import { normalizeInlines, sliceInlines, mapMarksOverRange, runsLength } from './inlines';
 import { withMark, withoutMark, hasMark } from './marks';
-import { blockLength, findBlockIndex, orderedRange, isCollapsed } from './position';
+import { blockLength, findBlockIndex, orderedRange, isCollapsed, collapsedRange } from './position';
 import { isVoidBlock } from './attachment';
 
 function collapsed(point: Point): Range {
-  return { anchor: point, focus: point };
+  return collapsedRange(point.blockId, point.offset);
 }
 
 function replaceBlock(doc: RichDoc, index: number, block: Block): RichDoc {

--- a/packages/design-system/src/components/RichTextEditor/RichTextAttachmentConfig.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextAttachmentConfig.tsx
@@ -17,19 +17,20 @@ import { useTranslation } from '../../i18n';
 import type { Block } from '../RichText/engine/model';
 import { safeHref } from '../RichText/engine/safeHref';
 import { attachmentIsImage } from '../RichText/engine/attachment';
+import type { Rect } from './selection';
 import styles from './RichTextEditor.module.scss';
 
 export interface RichTextAttachmentConfigProps {
   /** The attachment block being configured (current values). */
   block: Block;
   /** Figure rect (viewport coords) to anchor the popover to. */
-  anchorRect: { top: number; left: number; height: number; width: number };
+  anchorRect: Rect;
   /**
    * Live anchor rect — re-queried by Floating UI on scroll/resize so the popover
    * tracks the figure (the static `anchorRect` is only the initial position; it
    * goes stale on a pure scroll). Falls back to `anchorRect` when it returns null.
    */
-  getAnchorRect?: () => { top: number; left: number; height: number; width: number } | null;
+  getAnchorRect?: () => Rect | null;
   /** Editor content width (px) — the upper bound for the width slider. */
   maxWidth: number;
   /** Native picker filter for Replace. */

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -1,7 +1,15 @@
 // RichTextBlockControls.tsx — the per-block gutter overlay. Absolutely positioned
 // inside the editor shell (position: relative), aligned to the active block's box.
 // Lives OUTSIDE the contentEditable so it is never editable content.
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
 import {
   DndContext,
   PointerSensor,
@@ -137,7 +145,7 @@ function DraggableGutter({
  * (e.g. attachment settings) lives in the ⠿ menu's "Configure" item, not a
  * separate gutter button.
  */
-export function RichTextBlockControls({
+export const RichTextBlockControls = memo(function RichTextBlockControls({
   rootRef,
   activeBlockId,
   blockOrderKey,
@@ -345,4 +353,4 @@ export function RichTextBlockControls({
       </DraggableGutter>
     </DndContext>
   );
-}
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -26,6 +26,7 @@ import { RichTextBlockMenu, type BlockAction } from './RichTextBlockMenu';
 import type { BlockChoice } from './RichTextToolbar';
 import type { BlockType } from '../RichText/engine/model';
 import { PlusIcon } from './icons';
+import { preventSelectionLoss } from './preventSelectionLoss';
 import { computeReflow, type BlockRect, type UnitRange } from './blockReflow';
 import { gapIndexFromY } from './blockDrop';
 import styles from './RichTextEditor.module.scss';
@@ -336,7 +337,7 @@ export const RichTextBlockControls = memo(function RichTextBlockControls({
           tabIndex={-1}
           aria-label={t('richTextEditor.blockInsert')}
           className={styles.gutterButton}
-          onMouseDown={(e) => e.preventDefault()}
+          onMouseDown={preventSelectionLoss}
           onClick={() => onInsertBelow(activeBlockId)}
         >
           <PlusIcon />

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from '../../i18n';
 import type { BlockChoice } from './RichTextToolbar';
 import type { BlockType } from '../RichText/engine/model';
 import { RichTextColorMenu } from './RichTextColorMenu';
+import { preventSelectionLoss } from './preventSelectionLoss';
 import { GripIcon } from './icons';
 import styles from './RichTextEditor.module.scss';
 
@@ -55,7 +56,7 @@ export const RichTextBlockMenu = forwardRef<HTMLButtonElement, RichTextBlockMenu
             tabIndex={-1}
             aria-label={t('richTextEditor.blockActions')}
             className={styles.gutterButton}
-            onMouseDown={(e) => e.preventDefault()}
+            onMouseDown={preventSelectionLoss}
           >
             <GripIcon />
           </Button>

--- a/packages/design-system/src/components/RichTextEditor/RichTextColorMenu.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextColorMenu.tsx
@@ -3,6 +3,7 @@ import { Stack } from '../Stack';
 import { Cluster } from '../Cluster';
 import { useTranslation, type MessageKey } from '../../i18n';
 import { COLOR_KEYS, textColorVar, bgColorVar, type ColorKey } from '../RichText/engine/colorMarks';
+import { preventSelectionLoss } from './preventSelectionLoss';
 import styles from './RichTextEditor.module.scss';
 
 export interface RichTextColorMenuProps {
@@ -83,9 +84,7 @@ export function RichTextColorMenu({ type, active, onPick }: RichTextColorMenuPro
           title={clearLabel}
           // "Default" is the pressed state when no color of this type is active.
           aria-pressed={!active}
-          // Preserve the editor's DOM selection: a mousedown that moves focus
-          // out of the contentEditable would collapse it before the pick runs.
-          onMouseDown={(e) => e.preventDefault()}
+          onMouseDown={preventSelectionLoss}
           onClick={() => onPick(null)}
         >
           {clearLabel}
@@ -103,7 +102,7 @@ export function RichTextColorMenu({ type, active, onPick }: RichTextColorMenuPro
               aria-label={name}
               title={name}
               aria-pressed={active === key}
-              onMouseDown={(e) => e.preventDefault()}
+              onMouseDown={preventSelectionLoss}
               onClick={() => onPick(key)}
             >
               {name}

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -14,7 +14,12 @@ import { nextId } from '../RichText/engine/model';
 import { renderDoc } from '../RichText/engine/renderDoc';
 import type { RenderLink } from '../RichText/engine/renderLink';
 import type { RenderMention } from '../RichText/engine/renderMention';
-import { blockLength, isCollapsed, wholeBlockRange } from '../RichText/engine/position';
+import {
+  blockLength,
+  isCollapsed,
+  wholeBlockRange,
+  collapsedRange,
+} from '../RichText/engine/position';
 import { linkAt, setLink, removeLink } from './links';
 import { applyTypeAutolink, atomicLinkDeleteRange } from './autolinkInput';
 import { RichTextLinkEditor } from './RichTextLinkEditor';
@@ -400,6 +405,11 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // progress the active block must not change (it IS the block being dragged), so
     // the hover handlers below read this ref and bail — mirroring blockMenuOpenRef.
     const draggingRef = useRef(false);
+    // Stable setter for draggingRef — passed to both overlays so their memoized
+    // shells don't re-render every keystroke on a fresh inline lambda.
+    const setDragging = useCallback((d: boolean) => {
+      draggingRef.current = d;
+    }, []);
 
     // Resolve the [data-block-id] of the block element containing a DOM node.
     const blockIdFromNode = useCallback((node: Node | null): string | null => {
@@ -1247,11 +1257,8 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
 
     // Attachment config popover. Config edits don't move the caret meaningfully —
     // the popover holds focus — so each commit pins a collapsed selection on the
-    // block. Open/close toggle `configBlockId`; close returns focus to the editor.
-    const blockCaret = (id: string): Range => ({
-      anchor: { blockId: id, offset: 0 },
-      focus: { blockId: id, offset: 0 },
-    });
+    // block (via `collapsedRange`). Open/close toggle `configBlockId`; close returns
+    // focus to the editor.
     const onConfigOpen = useCallback((id: string) => setConfigBlockId(id), []);
     const onConfigClose = useCallback(() => {
       setConfigBlockId(null);
@@ -1262,7 +1269,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         commit(
           {
             doc: updateAttachmentBlock(latest.current.value, id, { alt }),
-            selection: blockCaret(id),
+            selection: collapsedRange(id),
           },
           'other',
         );
@@ -1274,7 +1281,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         commit(
           {
             doc: updateAttachmentBlock(latest.current.value, id, { align }),
-            selection: blockCaret(id),
+            selection: collapsedRange(id),
           },
           'other',
         );
@@ -1312,7 +1319,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         commit(
           {
             doc: clearAttachmentFields(latest.current.value, id, ['width', 'height']),
-            selection: blockCaret(id),
+            selection: collapsedRange(id),
           },
           'other',
         );
@@ -1326,6 +1333,15 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       // reappear when the upload settles back to `ready`.
       setConfigBlockId(null);
     }, []);
+    // Stable resize handler for the image resizer — keeps the memoized resizer from
+    // re-rendering every keystroke on a fresh inline lambda. Guards activeBlockId so
+    // a late move after the active block clears is a no-op.
+    const onImageResize = useCallback(
+      (w: number) => {
+        if (activeBlockId) onConfigWidth(activeBlockId, w);
+      },
+      [onConfigWidth, activeBlockId],
+    );
 
     // Delegate clicks on the error-state attachment Retry/Remove buttons (they
     // carry data-attachment-action + data-block-id). On the editable so it works
@@ -1340,6 +1356,18 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       if (action === 'retry') uploaderRef.current.retry(id);
       else if (action === 'remove') uploaderRef.current.remove(id);
     }, []);
+
+    // The rendered doc tree is a pure fn of (value, renderLink, renderMention) — it
+    // does NOT depend on selection/hover/focus. Memoize so the whole element tree is
+    // not rebuilt on selection/hover/focus re-renders that leave the doc unchanged.
+    const content = useMemo(
+      () => renderDoc(value, { editable: true, renderLink, renderMention }),
+      [value, renderLink, renderMention],
+    );
+    // Stable signature of block order — recomputed only when blocks change, not on
+    // every keystroke. Shared by the gutter (blockOrderKey) and the image resizer's
+    // layoutKey so their memoized shells stay stable while typing within a block.
+    const blockOrderKey = useMemo(() => value.blocks.map((b) => b.id).join('|'), [value.blocks]);
 
     const editable = (
       <div
@@ -1385,7 +1413,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         onFocus={autoToolbar ? () => setFocused(true) : undefined}
         onBlur={autoToolbar ? () => setFocused(false) : undefined}
       >
-        {renderDoc(value, { editable: true, renderLink, renderMention })}
+        {content}
       </div>
     );
 
@@ -1437,7 +1465,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       <RichTextBlockControls
         rootRef={shellRef}
         activeBlockId={activeBlockId}
-        blockOrderKey={value.blocks.map((b) => b.id).join('|')}
+        blockOrderKey={blockOrderKey}
         activeBlockType={activeBlockType}
         menuOpen={blockMenuOpen}
         onMenuOpenChange={setBlockMenuOpen}
@@ -1447,9 +1475,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         onReorder={onBlockReorder}
         onConfigure={canConfigure ? onConfigOpen : undefined}
         onColor={onBlockColor}
-        onDraggingChange={(d) => {
-          draggingRef.current = d;
-        }}
+        onDraggingChange={setDragging}
       />
     ) : null;
 
@@ -1470,12 +1496,10 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         <RichTextImageResizer
           rootRef={shellRef}
           blockId={activeBlockId}
-          layoutKey={`${value.blocks.map((b) => b.id).join('|')}:${activeBlock?.width ?? ''}`}
+          layoutKey={`${blockOrderKey}:${activeBlock?.width ?? ''}`}
           maxWidth={rootRef.current?.getBoundingClientRect().width ?? 600}
-          onResize={(w) => onConfigWidth(activeBlockId, w)}
-          onDraggingChange={(d) => {
-            draggingRef.current = d;
-          }}
+          onResize={onImageResize}
+          onDraggingChange={setDragging}
         />
       ) : null;
 

--- a/packages/design-system/src/components/RichTextEditor/RichTextImageResizer.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextImageResizer.tsx
@@ -4,7 +4,15 @@
 // model path the Configure → Width slider drives). It is a POINTER affordance only
 // (mirrors the gutter drag handle); keyboard / assistive-tech users resize via the
 // Configure → Width slider, which is the accessible, keyboard-operable control.
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
 import { useTranslation } from '../../i18n';
 import styles from './RichTextEditor.module.scss';
 
@@ -38,7 +46,7 @@ export interface RichTextImageResizerProps {
  * by `<RichTextEditor>` when the active block is a previewable image; not exported
  * from the package.
  */
-export function RichTextImageResizer({
+export const RichTextImageResizer = memo(function RichTextImageResizer({
   rootRef,
   blockId,
   layoutKey,
@@ -136,4 +144,4 @@ export function RichTextImageResizer({
       onPointerCancel={endDrag}
     />
   );
-}
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextToolbar.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextToolbar.tsx
@@ -6,6 +6,7 @@ import { EmojiPickerPopover } from '../EmojiPicker';
 import { Popover } from '../Popover';
 import { useTranslation } from '../../i18n';
 import { RichTextColorMenu } from './RichTextColorMenu';
+import { preventSelectionLoss } from './preventSelectionLoss';
 import type { ActiveColors } from './commands';
 import {
   BoldIcon,
@@ -140,7 +141,9 @@ export function RichTextToolbar({
         iconOnly
         aria-label={t('richTextEditor.undo')}
         disabled={disabled || !canUndo}
-        onMouseDown={(e) => e.preventDefault()}
+        // preventSelectionLoss (see its JSDoc) keeps the editor's DOM selection
+        // live across the click for every toolbar control below.
+        onMouseDown={preventSelectionLoss}
         onClick={onUndo}
       >
         <UndoIcon />
@@ -151,7 +154,7 @@ export function RichTextToolbar({
         iconOnly
         aria-label={t('richTextEditor.redo')}
         disabled={disabled || !canRedo}
-        onMouseDown={(e) => e.preventDefault()}
+        onMouseDown={preventSelectionLoss}
         onClick={onRedo}
       >
         <RedoIcon />
@@ -203,10 +206,7 @@ export function RichTextToolbar({
             aria-label={t(`richTextEditor.${key}`)}
             aria-pressed={active}
             disabled={disabled}
-            // Keep the editor focused + its DOM selection live: a mousedown that
-            // moves focus out of the contentEditable would collapse the selection
-            // before the command runs.
-            onMouseDown={(e) => e.preventDefault()}
+            onMouseDown={preventSelectionLoss}
             onClick={() => onToggleMark(type)}
           >
             <Icon />
@@ -221,9 +221,7 @@ export function RichTextToolbar({
         aria-label={t('richTextEditor.link')}
         aria-pressed={linkActive}
         disabled={disabled}
-        // Preserve the editor's DOM selection (a mousedown that moves focus out
-        // of the contentEditable would collapse it before the bubble opens).
-        onMouseDown={(e) => e.preventDefault()}
+        onMouseDown={preventSelectionLoss}
         onClick={onOpenLink}
       >
         <LinkIcon />
@@ -237,9 +235,7 @@ export function RichTextToolbar({
             iconOnly
             aria-label={t('richTextEditor.emoji')}
             disabled={disabled}
-            // Preserve the editor's DOM selection so the caret is still live
-            // when the emoji is chosen and onInsertEmoji reads it.
-            onMouseDown={(e) => e.preventDefault()}
+            onMouseDown={preventSelectionLoss}
           >
             <SmileIcon />
           </Button>
@@ -255,9 +251,7 @@ export function RichTextToolbar({
             iconOnly
             aria-label={t('richTextEditor.textColor')}
             disabled={disabled}
-            // Preserve the editor's DOM selection so it's still live when a badge
-            // is picked and onSetColor reads it (mirrors the emoji/link buttons).
-            onMouseDown={(e) => e.preventDefault()}
+            onMouseDown={preventSelectionLoss}
           >
             <TextColorIcon />
           </Button>
@@ -279,8 +273,7 @@ export function RichTextToolbar({
             iconOnly
             aria-label={t('richTextEditor.highlight')}
             disabled={disabled}
-            // Same selection-preservation as the Text-color button above.
-            onMouseDown={(e) => e.preventDefault()}
+            onMouseDown={preventSelectionLoss}
           >
             <HighlightIcon />
           </Button>
@@ -303,7 +296,7 @@ export function RichTextToolbar({
         aria-label={t('richTextEditor.bulletList')}
         aria-pressed={isList('bullet_item')}
         disabled={disabled}
-        onMouseDown={(e) => e.preventDefault()}
+        onMouseDown={preventSelectionLoss}
         onClick={() => onToggleList('bullet_item')}
       >
         <BulletListIcon />
@@ -315,7 +308,7 @@ export function RichTextToolbar({
         aria-label={t('richTextEditor.orderedList')}
         aria-pressed={isList('ordered_item')}
         disabled={disabled}
-        onMouseDown={(e) => e.preventDefault()}
+        onMouseDown={preventSelectionLoss}
         onClick={() => onToggleList('ordered_item')}
       >
         <OrderedListIcon />
@@ -342,7 +335,7 @@ export function RichTextToolbar({
             iconOnly
             aria-label={t('richTextEditor.upload')}
             disabled={disabled}
-            onMouseDown={(e) => e.preventDefault()}
+            onMouseDown={preventSelectionLoss}
             onClick={() => fileInputRef.current?.click()}
           >
             <AttachFileIcon />

--- a/packages/design-system/src/components/RichTextEditor/preventSelectionLoss.ts
+++ b/packages/design-system/src/components/RichTextEditor/preventSelectionLoss.ts
@@ -1,0 +1,13 @@
+import type { MouseEvent } from 'react';
+
+/**
+ * mousedown handler that preserves the editor's DOM selection: focus leaving the
+ * contentEditable would collapse the selection before a toolbar/menu action runs.
+ *
+ * Wire it as `onMouseDown={preventSelectionLoss}` on any toolbar/menu control that
+ * acts on the current editor selection (mark toggles, color swatches, block
+ * actions) so the caret/range is still live when the control's onClick fires.
+ */
+export function preventSelectionLoss(e: MouseEvent): void {
+  e.preventDefault();
+}

--- a/packages/design-system/src/components/RichTextEditor/preventSelectionLoss.ts
+++ b/packages/design-system/src/components/RichTextEditor/preventSelectionLoss.ts
@@ -1,3 +1,5 @@
+// preventSelectionLoss.ts — shared mousedown guard for toolbar/menu controls that
+// act on the editor's current selection (kept in one place to avoid drift).
 import type { MouseEvent } from 'react';
 
 /**


### PR DESCRIPTION
## Summary

Safe, behavior-preserving performance + dedup wins from a deep review of RichTextEditor. No public API or behavior changes; all existing tests stay green.

1. **Memoize the rendered doc** — `renderDoc(value, …)` was called inline, rebuilding the whole document element tree on *every* re-render (selection/hover/focus changes, not just edits). Now `useMemo([value, renderLink, renderMention])`, so non-edit re-renders reuse the tree and React skips reconciling the contentEditable. Biggest win; scales with doc size.
2. **Stop the block gutter + image resizer re-rendering on every keystroke** — stable `setDragging`/`onImageResize` callbacks + `React.memo` on both overlays + a memoized `blockOrderKey`.
3. **`marksEqual` fast paths** — `a===b` / length-mismatch / 0-mark / 1-mark short-circuits before the allocate+sort path (hot during text normalization).
4. **Shared `MARK_ORDER`** — the mark-nesting order array was duplicated in `renderDoc` + `toHtml`; hoisted to `engine/marks.ts` so render and serialize can't drift.
5. **`collapsedRange()` helper** in `engine/position.ts` — replaces hand-built collapsed-range literals + two private `collapsed()` helpers, and removes an in-render `blockCaret` (fixing a latent missing-dep).
6. **Named `Rect` type** in `RichTextAttachmentConfig` (was an inline literal).
7. **Shared `preventSelectionLoss`** mousedown handler (replaced ~14 inline lambdas).

All helpers are internal (not exported from `index.ts`).

## Test plan

- `make test` (3465), `make build`, `make lint`, `npm run format:check` — green. Manifest unchanged.
- Rule 8 review: verified the `renderDoc` memo deps are complete (it reads only value/renderLink/renderMention; focus/empty-dependent attrs stay outside the memo), caret restoration is unaffected, `React.memo` can't go stale (all overlay props are primitives/stable refs/useCallbacks incl. `activeBlockType`), `marksEqual` fast paths match the sort-path semantics, and `MARK_ORDER`/`collapsedRange` swaps are byte-identical.
- Live smoke: typing still inserts, the gutter still appears on hover, no console errors.

Part 1 of acting on the deep RTE review; a second PR extracts shared overlay/measurement hooks. The remaining items (with trade-offs) are written up separately for a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)