### PR TITLE
refactor(RichTextEditor): extract shared overlay/measurement hooks (dedup, no behavior change)

### DIFF
--- a/packages/design-system/src/components/RichText/engine/position.ts
+++ b/packages/design-system/src/components/RichText/engine/position.ts
@@ -1,5 +1,5 @@
 // position.ts — Layer C. Point/range helpers over a RichDoc.
-import type { RichDoc, Block, Point, Range } from './model';
+import type { RichDoc, Block, Point, Range, Mark } from './model';
 import { runsLength } from './inlines';
 
 /** Total character length of a block (sum of all inline run lengths). */
@@ -50,6 +50,24 @@ export function comparePoints(doc: RichDoc, a: Point, b: Point): -1 | 0 | 1 {
   const ia = findBlockIndex(doc, a.blockId);
   const ib = findBlockIndex(doc, b.blockId);
   return ia < ib ? -1 : ia > ib ? 1 : 0;
+}
+
+/**
+ * The marks carried by the character immediately before `point` (raw — includes
+ * `mention`). Empty (`[]`) at a block start (`offset <= 0`) or when the block is
+ * not found. Callers that must exclude `mention` (the typing-inheritance paths)
+ * filter it out themselves — this primitive stays mark-agnostic.
+ */
+export function marksBeforeCaret(doc: RichDoc, point: Point): Mark[] {
+  const idx = findBlockIndex(doc, point.blockId);
+  if (idx === -1 || point.offset <= 0) return [];
+  let pos = 0;
+  for (const run of doc.blocks[idx].inlines) {
+    const end = pos + run.text.length;
+    if (point.offset - 1 >= pos && point.offset - 1 < end) return run.marks;
+    pos = end;
+  }
+  return [];
 }
 
 /** A collapsed range at a single point. */

--- a/packages/design-system/src/components/RichText/engine/transforms.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.ts
@@ -4,7 +4,14 @@ import type { RichDoc, Block, Point, Range, Mark, MarkType } from './model';
 import { createBlock, nextId } from './model';
 import { normalizeInlines, sliceInlines, mapMarksOverRange, runsLength } from './inlines';
 import { withMark, withoutMark, hasMark } from './marks';
-import { blockLength, findBlockIndex, orderedRange, isCollapsed, collapsedRange } from './position';
+import {
+  blockLength,
+  findBlockIndex,
+  orderedRange,
+  isCollapsed,
+  collapsedRange,
+  marksBeforeCaret,
+} from './position';
 import { isVoidBlock } from './attachment';
 
 function collapsed(point: Point): Range {
@@ -15,19 +22,6 @@ function replaceBlock(doc: RichDoc, index: number, block: Block): RichDoc {
   const blocks = doc.blocks.slice();
   blocks[index] = block;
   return { blocks };
-}
-
-/** Marks of the character immediately before `offset` (inherited on insert). */
-function marksBefore(block: Block, offset: number): Mark[] {
-  if (offset <= 0) return [];
-  let pos = 0;
-  for (const run of block.inlines) {
-    const runEnd = pos + run.text.length;
-    if (offset - 1 >= pos && offset - 1 < runEnd)
-      return run.marks.filter((m) => m.type !== 'mention');
-    pos = runEnd;
-  }
-  return [];
 }
 
 /** Bounds of the mention run strictly containing `offset`, or null. */
@@ -74,9 +68,11 @@ export function insertText(
   // A void block (e.g. an attachment) holds no editable text — never splice the
   // typed text into it (that would corrupt the block). No-op.
   if (isVoidBlock(block)) return { doc, selection: collapsed(point) };
+  // Inherit the marks of the char before the caret (mention excluded — typed text
+  // never extends a mention chip).
   const inlines = normalizeInlines([
     ...sliceInlines(block.inlines, 0, point.offset),
-    { text, marks: marksBefore(block, point.offset) },
+    { text, marks: marksBeforeCaret(doc, point).filter((m) => m.type !== 'mention') },
     ...sliceInlines(block.inlines, point.offset, blockLength(block)),
   ]);
   return {

--- a/packages/design-system/src/components/RichTextEditor/RichTextAttachmentConfig.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextAttachmentConfig.tsx
@@ -5,9 +5,8 @@
 // align/replace/open/download — plus width ONLY when the image renders as a
 // preview (a safe, fetchable src — an embed); an uploaded object-URL image is a
 // chip, so it gets no width. Non-image chips get replace/open/download.
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { useFloating, autoUpdate, flip, shift, offset } from '@floating-ui/react-dom';
 import { Button } from '../Button';
 import { Input } from '../Input';
 import { Slider } from '../Slider';
@@ -18,6 +17,7 @@ import type { Block } from '../RichText/engine/model';
 import { safeHref } from '../RichText/engine/safeHref';
 import { attachmentIsImage } from '../RichText/engine/attachment';
 import type { Rect } from './selection';
+import { useAnchoredFloating } from './useAnchoredFloating';
 import styles from './RichTextEditor.module.scss';
 
 export interface RichTextAttachmentConfigProps {
@@ -95,34 +95,7 @@ export function RichTextAttachmentConfig({
     if (alt !== seededAlt) onAltChange(alt);
   }, [alt, seededAlt, onAltChange]);
 
-  // Floating UI virtual element — only `getBoundingClientRect` is required. Read
-  // the LIVE rect (via getAnchorRect) on every reposition so the popover tracks
-  // the figure on scroll; fall back to the static `anchorRect`.
-  const virtualRef = useMemo(
-    () => ({
-      getBoundingClientRect: () => {
-        const r = getAnchorRect?.() ?? anchorRect;
-        return {
-          x: r.left,
-          y: r.top,
-          top: r.top,
-          left: r.left,
-          right: r.left + r.width,
-          bottom: r.top + r.height,
-          width: r.width,
-          height: r.height,
-        };
-      },
-    }),
-    [anchorRect, getAnchorRect],
-  );
-  const { refs, floatingStyles } = useFloating({
-    placement: 'bottom-start',
-    strategy: 'fixed',
-    whileElementsMounted: autoUpdate,
-    middleware: [offset(6), flip(), shift({ padding: 4 })],
-    elements: { reference: virtualRef },
-  });
+  const { refs, floatingStyles } = useAnchoredFloating(anchorRect, getAnchorRect, { offset: 6 });
   const setRefs = useCallback(
     (node: HTMLDivElement | null) => {
       popRef.current = node;

--- a/packages/design-system/src/components/RichTextEditor/RichTextAttachmentConfig.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextAttachmentConfig.tsx
@@ -18,6 +18,7 @@ import { safeHref } from '../RichText/engine/safeHref';
 import { attachmentIsImage } from '../RichText/engine/attachment';
 import type { Rect } from './selection';
 import { useAnchoredFloating } from './useAnchoredFloating';
+import { useDismissOnOutsidePointerDown } from './useDismissOnOutsidePointerDown';
 import styles from './RichTextEditor.module.scss';
 
 export interface RichTextAttachmentConfigProps {
@@ -105,13 +106,7 @@ export function RichTextAttachmentConfig({
   );
 
   // Dismiss on a pointerdown outside the popover.
-  useEffect(() => {
-    const onPointerDown = (e: PointerEvent) => {
-      if (popRef.current && !popRef.current.contains(e.target as Node)) onClose();
-    };
-    document.addEventListener('pointerdown', onPointerDown, true);
-    return () => document.removeEventListener('pointerdown', onPointerDown, true);
-  }, [onClose]);
+  useDismissOnOutsidePointerDown(popRef, onClose);
 
   // Move focus into the popover on open so the Escape handler (on the container)
   // works without the trigger keeping focus — mirrors RichTextLinkEditor focusing

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -1,15 +1,7 @@
 // RichTextBlockControls.tsx — the per-block gutter overlay. Absolutely positioned
 // inside the editor shell (position: relative), aligned to the active block's box.
 // Lives OUTSIDE the contentEditable so it is never editable content.
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type RefObject,
-} from 'react';
+import { memo, useCallback, useEffect, useRef, type RefObject } from 'react';
 import {
   DndContext,
   PointerSensor,
@@ -29,6 +21,7 @@ import { PlusIcon } from './icons';
 import { preventSelectionLoss } from './preventSelectionLoss';
 import { computeReflow, type BlockRect, type UnitRange } from './blockReflow';
 import { gapIndexFromY } from './blockDrop';
+import { useShellRelativeRect, useDraggingReporter } from './useOverlayRect';
 import styles from './RichTextEditor.module.scss';
 
 export interface RichTextBlockControlsProps {
@@ -162,12 +155,6 @@ export const RichTextBlockControls = memo(function RichTextBlockControls({
   onDraggingChange,
 }: RichTextBlockControlsProps) {
   const t = useTranslation();
-  const [top, setTop] = useState<number | null>(null);
-  const [height, setHeight] = useState<number | null>(null);
-  // Bumped to re-run measurement when the root ref / block element is not yet
-  // attached on the first layout-effect pass (the parent's element ref can attach
-  // after this child's effect runs on mount).
-  const [retry, setRetry] = useState(0);
   // Drag snapshot, captured once at drag start (measuring transformed DOM would feed
   // back on itself). null when not dragging.
   const dragRef = useRef<{
@@ -181,47 +168,41 @@ export const RichTextBlockControls = memo(function RichTextBlockControls({
   // The gutter DOM node, so the drag can translate it in lockstep with the lifted row.
   const gutterElRef = useRef<HTMLDivElement | null>(null);
 
-  // Latest onDraggingChange, read by the unmount cleanup without re-subscribing.
-  const onDraggingChangeRef = useRef(onDraggingChange);
-  onDraggingChangeRef.current = onDraggingChange;
+  // Reports block-drag lifecycle + fires (false) on a mid-drag unmount so nothing
+  // leaks (dnd-kit fires neither end nor cancel when the controls unmount).
+  const reportDragging = useDraggingReporter(onDraggingChange);
 
   // If the controls unmount mid-drag (blockControls turned off, or the editor
-  // unmounts), dnd-kit fires neither end nor cancel — clear any applied transforms
-  // and report drag end so nothing leaks.
+  // unmounts), clear any applied reflow transforms. The dragging-state report is
+  // handled by useDraggingReporter; this effect owns the DOM-style cleanup. Order:
+  // this effect is registered AFTER the reporter, so its cleanup runs FIRST —
+  // clearReflow then onDraggingChange(false), matching the original order.
   useEffect(() => {
     return () => {
       clearReflow(dragRef.current, rootRef.current);
       dragRef.current = null;
-      onDraggingChangeRef.current?.(false);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
 
-  useLayoutEffect(() => {
-    if (!activeBlockId) {
-      setTop(null);
-      setHeight(null);
-      setRetry(0);
-      return;
-    }
-    const root = rootRef.current;
-    const el = root?.querySelector<HTMLElement>(`[data-block-id="${CSS.escape(activeBlockId)}"]`);
-    if (!root || !el) {
-      setTop(null);
-      setHeight(null);
-      if (retry < 2) setRetry((n) => n + 1);
-      return;
-    }
-    const rootBox = root.getBoundingClientRect();
-    const box = el.getBoundingClientRect();
-    setTop(box.top - rootBox.top);
-    setHeight(box.height);
-    // blockOrderKey is a dep so a reorder/insert/delete (which keeps the active
-    // block's id but moves its row) re-measures rather than leaving the gutter
-    // stranded at the old position.
-  }, [rootRef, activeBlockId, blockOrderKey, menuOpen, retry]);
+  // Measure the active block's box relative to the shell. getEl folds in
+  // activeBlockId (null → no target); blockOrderKey + menuOpen drive re-measure via
+  // `key` — a reorder/insert/delete keeps the active block's id but moves its row, so
+  // an order-derived key re-measures rather than leaving the gutter stranded.
+  const blockEl = useCallback(
+    () =>
+      activeBlockId
+        ? (rootRef.current?.querySelector<HTMLElement>(
+            `[data-block-id="${CSS.escape(activeBlockId)}"]`,
+          ) ?? null)
+        : null,
+    [rootRef, activeBlockId],
+  );
+  const rect = useShellRelativeRect(rootRef, blockEl, `${blockOrderKey ?? ''}|${menuOpen}`);
+  const top = rect?.top ?? null;
+  const height = rect?.height ?? null;
 
   const handleDragStart = (_event: DragStartEvent) => {
     const root = rootRef.current;
@@ -260,7 +241,7 @@ export const RichTextBlockControls = memo(function RichTextBlockControls({
 
     draggedIdRef.current = activeBlockId;
     onMenuOpenChange(false); // a drag should never leave the block menu open
-    onDraggingChange?.(true);
+    reportDragging(true);
     dragRef.current = { rects, els: nodes, unit, parentIdx };
     root.classList.add(styles.reflowing);
     nodes[unit.u0].classList.add(styles.blockLifted);
@@ -295,7 +276,7 @@ export const RichTextBlockControls = memo(function RichTextBlockControls({
     if (gutterElRef.current) gutterElRef.current.style.transform = '';
     dragRef.current = null;
     draggedIdRef.current = null;
-    onDraggingChange?.(false);
+    reportDragging(false);
   };
 
   const handleDragEnd = (event: DragEndEvent) => {

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -19,6 +19,7 @@ import {
   isCollapsed,
   wholeBlockRange,
   collapsedRange,
+  marksBeforeCaret,
 } from '../RichText/engine/position';
 import { linkAt, setLink, removeLink } from './links';
 import { applyTypeAutolink, atomicLinkDeleteRange } from './autolinkInput';
@@ -204,18 +205,9 @@ function toggleInList(marks: Mark[], mark: Mark): Mark[] {
   return hasMark(marks, mark.type) ? withoutMark(marks, mark.type) : withMark(marks, mark);
 }
 
-/** Marks of the character immediately before the caret (none at a block start). */
+/** Marks inherited by text typed at the caret — the char before it, mention excluded. */
 function marksAtCaretMarks(doc: RichDoc, caret: Point): Mark[] {
-  const idx = doc.blocks.findIndex((b) => b.id === caret.blockId);
-  if (idx === -1 || caret.offset <= 0) return [];
-  let pos = 0;
-  for (const run of doc.blocks[idx].inlines) {
-    const end = pos + run.text.length;
-    if (caret.offset - 1 >= pos && caret.offset - 1 < end)
-      return run.marks.filter((m) => m.type !== 'mention');
-    pos = end;
-  }
-  return [];
+  return marksBeforeCaret(doc, caret).filter((m) => m.type !== 'mention');
 }
 
 interface LinkEditorOpen {

--- a/packages/design-system/src/components/RichTextEditor/RichTextImageResizer.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextImageResizer.tsx
@@ -4,16 +4,9 @@
 // model path the Configure → Width slider drives). It is a POINTER affordance only
 // (mirrors the gutter drag handle); keyboard / assistive-tech users resize via the
 // Configure → Width slider, which is the accessible, keyboard-operable control.
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type RefObject,
-} from 'react';
+import { memo, useCallback, useRef, type RefObject } from 'react';
 import { useTranslation } from '../../i18n';
+import { useShellRelativeRect, useDraggingReporter } from './useOverlayRect';
 import styles from './RichTextEditor.module.scss';
 
 /** Smallest width the handle resizes to (matches RichTextAttachmentConfig's MIN_W). */
@@ -55,27 +48,13 @@ export const RichTextImageResizer = memo(function RichTextImageResizer({
   onDraggingChange,
 }: RichTextImageResizerProps) {
   const t = useTranslation();
-  const [box, setBox] = useState<{ top: number; left: number } | null>(null);
-  // Bumped to re-run measurement when the shell ref / image isn't attached yet on
-  // the first layout-effect pass (the parent's element ref can attach after this
-  // child's effect runs on mount) — mirrors RichTextBlockControls.
-  const [retry, setRetry] = useState(0);
   // Drag origin, captured on pointerdown. null when not dragging.
   const dragRef = useRef<{ startX: number; startW: number } | null>(null);
 
-  // Latest onDraggingChange, read by the unmount cleanup without re-subscribing.
-  const onDraggingChangeRef = useRef(onDraggingChange);
-  onDraggingChangeRef.current = onDraggingChange;
-
-  // If the handle unmounts mid-drag (image removed, blockControls/readOnly toggled,
-  // or `value` replaced), no pointerup/cancel fires — report drag end so the editor's
-  // `draggingRef` doesn't stick `true` and freeze hover. Mirrors RichTextBlockControls.
-  useEffect(() => {
-    return () => {
-      dragRef.current = null;
-      onDraggingChangeRef.current?.(false);
-    };
-  }, []);
+  // Reports drag start/end + fires (false) on a mid-drag unmount (image removed,
+  // blockControls/readOnly toggled, or `value` replaced) so the editor's draggingRef
+  // never sticks `true`. Mirrors RichTextBlockControls.
+  const reportDragging = useDraggingReporter(onDraggingChange);
 
   const imgEl = useCallback(
     () =>
@@ -86,18 +65,8 @@ export const RichTextImageResizer = memo(function RichTextImageResizer({
 
   // Position the handle on the image's bottom-right corner, measured relative to the
   // shell. Re-runs on layoutKey so it tracks the corner as the image resizes.
-  useLayoutEffect(() => {
-    const root = rootRef.current;
-    const img = imgEl();
-    if (!root || !img) {
-      setBox(null);
-      if (retry < 2) setRetry((n) => n + 1);
-      return;
-    }
-    const rb = root.getBoundingClientRect();
-    const b = img.getBoundingClientRect();
-    setBox({ top: b.bottom - rb.top, left: b.right - rb.left });
-  }, [rootRef, imgEl, layoutKey, retry]);
+  const rect = useShellRelativeRect(rootRef, imgEl, layoutKey);
+  const box = rect ? { top: rect.top + rect.height, left: rect.left + rect.width } : null;
 
   const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     const img = imgEl();
@@ -106,7 +75,7 @@ export const RichTextImageResizer = memo(function RichTextImageResizer({
     e.stopPropagation(); // don't let the gutter dnd-kit sensor see this press
     e.currentTarget.setPointerCapture(e.pointerId);
     dragRef.current = { startX: e.clientX, startW: img.getBoundingClientRect().width };
-    onDraggingChange?.(true);
+    reportDragging(true);
   };
 
   const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -127,7 +96,7 @@ export const RichTextImageResizer = memo(function RichTextImageResizer({
     } catch {
       // capture may already be gone (pointercancel) — ignore
     }
-    onDraggingChange?.(false);
+    reportDragging(false);
   };
 
   if (!box) return null;

--- a/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
@@ -4,15 +4,15 @@
 // Floating UI virtual element (the same portal+virtual-anchor pattern as
 // LiquidEditor's AutocompleteMenu, so it escapes the editor's overflow and any
 // Drawer/Modal ancestor). Enter applies, Esc / click-outside cancels.
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { useFloating, autoUpdate, flip, shift, offset } from '@floating-ui/react-dom';
 import { Button } from '../Button';
 import { Input } from '../Input';
 import { Stack } from '../Stack';
 import { Cluster } from '../Cluster';
 import { useTranslation } from '../../i18n';
 import type { Rect } from './selection';
+import { useAnchoredFloating } from './useAnchoredFloating';
 import styles from './RichTextEditor.module.scss';
 
 export interface RichTextLinkEditorProps {
@@ -56,35 +56,7 @@ export function RichTextLinkEditor({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const bubbleRef = useRef<HTMLDivElement | null>(null);
 
-  // Floating UI virtual element — only `getBoundingClientRect` is required. Read the
-  // LIVE rect (via getAnchorRect) on every reposition so the bubble tracks the
-  // selection line on scroll; fall back to the static `anchorRect`.
-  const virtualRef = useMemo(
-    () => ({
-      getBoundingClientRect: () => {
-        const r = getAnchorRect?.() ?? anchorRect;
-        return {
-          x: r.left,
-          y: r.top,
-          top: r.top,
-          left: r.left,
-          right: r.left + r.width,
-          bottom: r.top + r.height,
-          width: r.width,
-          height: r.height,
-        };
-      },
-    }),
-    [anchorRect, getAnchorRect],
-  );
-
-  const { refs, floatingStyles } = useFloating({
-    placement: 'bottom-start',
-    strategy: 'fixed',
-    whileElementsMounted: autoUpdate,
-    middleware: [offset(6), flip(), shift({ padding: 4 })],
-    elements: { reference: virtualRef },
-  });
+  const { refs, floatingStyles } = useAnchoredFloating(anchorRect, getAnchorRect, { offset: 6 });
 
   // Focus the URL field on open; select its contents when editing so a re-type
   // replaces the existing href.

--- a/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
@@ -13,6 +13,7 @@ import { Cluster } from '../Cluster';
 import { useTranslation } from '../../i18n';
 import type { Rect } from './selection';
 import { useAnchoredFloating } from './useAnchoredFloating';
+import { useDismissOnOutsidePointerDown } from './useDismissOnOutsidePointerDown';
 import styles from './RichTextEditor.module.scss';
 
 export interface RichTextLinkEditorProps {
@@ -68,13 +69,7 @@ export function RichTextLinkEditor({
   }, [editing]);
 
   // Dismiss on a pointerdown outside the bubble.
-  useEffect(() => {
-    const onPointerDown = (e: PointerEvent) => {
-      if (bubbleRef.current && !bubbleRef.current.contains(e.target as Node)) onCancel();
-    };
-    document.addEventListener('pointerdown', onPointerDown, true);
-    return () => document.removeEventListener('pointerdown', onPointerDown, true);
-  }, [onCancel]);
+  useDismissOnOutsidePointerDown(bubbleRef, onCancel);
 
   const setRefs = useCallback(
     (node: HTMLDivElement | null) => {

--- a/packages/design-system/src/components/RichTextEditor/RichTextMentionMenu.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextMentionMenu.tsx
@@ -3,13 +3,12 @@
 // items + active index + anchor rect; this renders a role="listbox" positioned at
 // the caret rect via a Floating UI virtual element (same portal+virtual-anchor
 // pattern as RichTextLinkEditor). Not exported from the package.
-import { useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { useFloating, autoUpdate, flip, shift, offset } from '@floating-ui/react-dom';
 import { Avatar } from '../Avatar';
 import { Text } from '../Text';
 import type { MentionItem } from './mentions';
 import type { Rect } from './selection';
+import { useAnchoredFloating } from './useAnchoredFloating';
 import styles from './RichTextEditor.module.scss';
 
 export interface RichTextMentionMenuProps {
@@ -45,35 +44,7 @@ export function RichTextMentionMenu({
   onSelect,
   onHover,
 }: RichTextMentionMenuProps) {
-  const virtualRef = useMemo(
-    () => ({
-      // Re-read the caret rect on every call — Floating UI's autoUpdate invokes this
-      // on scroll/resize, so the menu follows the caret (the static `anchorRect` is
-      // the fallback for the initial frame / when no live rect is available).
-      getBoundingClientRect: () => {
-        const r = getAnchorRect?.() ?? anchorRect;
-        return {
-          x: r.left,
-          y: r.top,
-          top: r.top,
-          left: r.left,
-          right: r.left + r.width,
-          bottom: r.top + r.height,
-          width: r.width,
-          height: r.height,
-        };
-      },
-    }),
-    [anchorRect, getAnchorRect],
-  );
-
-  const { refs, floatingStyles } = useFloating({
-    placement: 'bottom-start',
-    strategy: 'fixed',
-    whileElementsMounted: autoUpdate,
-    middleware: [offset(4), flip(), shift({ padding: 4 })],
-    elements: { reference: virtualRef },
-  });
+  const { refs, floatingStyles } = useAnchoredFloating(anchorRect, getAnchorRect, { offset: 4 });
 
   return createPortal(
     <div

--- a/packages/design-system/src/components/RichTextEditor/commands.ts
+++ b/packages/design-system/src/components/RichTextEditor/commands.ts
@@ -15,6 +15,7 @@ import {
   findBlockIndex,
   blockLength,
   isCollapsed,
+  marksBeforeCaret,
 } from '../RichText/engine/position';
 import { hasMark } from '../RichText/engine/marks';
 
@@ -33,22 +34,9 @@ function blocksInRange(doc: RichDoc, range: Range): { si: number; ei: number } {
   return { si: findBlockIndex(doc, start.blockId), ei: findBlockIndex(doc, end.blockId) };
 }
 
-/** Full marks of the character immediately before the caret (none at a block start). */
-function marksAtCaretFull(doc: RichDoc, caret: Point): Mark[] {
-  const idx = findBlockIndex(doc, caret.blockId);
-  if (idx === -1 || caret.offset <= 0) return [];
-  let pos = 0;
-  for (const run of doc.blocks[idx].inlines) {
-    const end = pos + run.text.length;
-    if (caret.offset - 1 >= pos && caret.offset - 1 < end) return run.marks;
-    pos = end;
-  }
-  return [];
-}
-
 /** Mark types of the character immediately before the caret (none at a block start). */
 function marksAtCaret(doc: RichDoc, caret: Point): MarkType[] {
-  return marksAtCaretFull(doc, caret).map((m) => m.type);
+  return marksBeforeCaret(doc, caret).map((m) => m.type);
 }
 
 /**
@@ -136,7 +124,7 @@ function colorOf(marks: Mark[], type: 'textColor' | 'bgColor'): string | undefin
  */
 export function activeColors(doc: RichDoc, range: Range, pending: Mark[] | null): ActiveColors {
   if (isCollapsed(range)) {
-    const marks = pending ?? marksAtCaretFull(doc, range.anchor);
+    const marks = pending ?? marksBeforeCaret(doc, range.anchor);
     const out: ActiveColors = {};
     for (const type of COLOR_TYPES) {
       const c = colorOf(marks, type);

--- a/packages/design-system/src/components/RichTextEditor/useAnchoredFloating.ts
+++ b/packages/design-system/src/components/RichTextEditor/useAnchoredFloating.ts
@@ -1,0 +1,50 @@
+// useAnchoredFloating.ts — shared portal-overlay positioning for <RichTextEditor>.
+// The link bubble, @-mention listbox, and attachment config popover all anchor a
+// Floating UI virtual element to a (live) selection/figure rect — fixed strategy,
+// flip + shift, auto-updating on scroll/resize. This collapses that duplicated
+// scaffolding into one hook. Internal; NOT exported from the package.
+import { useMemo } from 'react';
+import { useFloating, autoUpdate, flip, shift, offset } from '@floating-ui/react-dom';
+import type { Rect } from './selection';
+
+/** Expand a `Rect` (top/left/width/height) into the full DOMRect shape Floating UI reads. */
+function rectToDomRect(r: Rect): DOMRect {
+  return {
+    x: r.left,
+    y: r.top,
+    top: r.top,
+    left: r.left,
+    right: r.left + r.width,
+    bottom: r.top + r.height,
+    width: r.width,
+    height: r.height,
+  } as DOMRect;
+}
+
+/**
+ * Shared portal-overlay positioning: a Floating UI virtual element anchored to a
+ * (live) rect, fixed strategy + flip + shift, auto-updating on scroll/resize.
+ * Mirrors the link/mention/attachment overlays' anchoring in one place.
+ *
+ * `getAnchorRect`, when provided, is re-read on every reposition so the overlay
+ * tracks the selection line / figure on scroll (the static `anchorRect` is the
+ * fallback for the initial frame / when the live rect is unavailable). `opts.offset`
+ * sets the gap between anchor and overlay (defaults to 6).
+ */
+export function useAnchoredFloating(
+  anchorRect: Rect,
+  getAnchorRect: (() => Rect | null) | undefined,
+  opts: { offset?: number } = {},
+) {
+  const virtualRef = useMemo(
+    () => ({ getBoundingClientRect: () => rectToDomRect(getAnchorRect?.() ?? anchorRect) }),
+    [anchorRect, getAnchorRect],
+  );
+  return useFloating({
+    placement: 'bottom-start',
+    strategy: 'fixed',
+    whileElementsMounted: autoUpdate,
+    middleware: [offset(opts.offset ?? 6), flip(), shift({ padding: 4 })],
+    elements: { reference: virtualRef },
+  });
+}

--- a/packages/design-system/src/components/RichTextEditor/useDismissOnOutsidePointerDown.ts
+++ b/packages/design-system/src/components/RichTextEditor/useDismissOnOutsidePointerDown.ts
@@ -1,0 +1,26 @@
+// useDismissOnOutsidePointerDown.ts — shared "click outside to dismiss" for the
+// <RichTextEditor> floating overlays (link bubble, attachment config popover).
+// A capture-phase document pointerdown listener fires `onClose` when the press
+// lands outside `ref`. Capture phase + pointerdown (not click) so the dismissal
+// runs before the press can move/clear the editor selection. Internal; NOT
+// exported from the package.
+import { useEffect, type RefObject } from 'react';
+
+/**
+ * Call `onClose` when a pointerdown lands outside the element referenced by `ref`.
+ * The listener is registered on `document` in the capture phase. `ref` is a stable
+ * `useRef` object, so the effect effectively re-subscribes only when `onClose`'s
+ * identity changes — matching the overlays' original `[onClose]`-keyed effects.
+ */
+export function useDismissOnOutsidePointerDown(
+  ref: RefObject<HTMLElement | null>,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [ref, onClose]);
+}

--- a/packages/design-system/src/components/RichTextEditor/useOverlayRect.ts
+++ b/packages/design-system/src/components/RichTextEditor/useOverlayRect.ts
@@ -1,0 +1,73 @@
+// useOverlayRect.ts — shared gutter/handle overlay plumbing for <RichTextEditor>.
+// The block-controls gutter and the image resize handle both (a) measure a target
+// element's box relative to the editor shell, retrying across the mount race, and
+// (b) report drag start/end while guarding against a mid-drag unmount. Both live
+// here so the two overlays don't reimplement them. Internal; NOT exported from
+// the package.
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
+
+/** A box measured relative to the editor shell (top/left/width/height, all in px). */
+export interface ShellRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Measure `getEl()`'s box relative to the shell (`rootRef`), re-running whenever
+ * `key` or `getEl` changes. Returns `null` when the shell or target element is
+ * missing, retrying up to twice — the parent's element ref can attach after this
+ * child's layout pass on mount, so the first measurement can race and come up empty.
+ * Callers derive whatever they need from the returned rect (gutter: top/height;
+ * resize handle: the bottom-right corner = top+height / left+width).
+ */
+export function useShellRelativeRect(
+  rootRef: RefObject<HTMLElement | null>,
+  getEl: () => HTMLElement | null,
+  key: unknown,
+): ShellRect | null {
+  const [rect, setRect] = useState<ShellRect | null>(null);
+  // Bumped to re-run measurement when the shell ref / target element is not yet
+  // attached on the first layout-effect pass. Capped at 2.
+  const [retry, setRetry] = useState(0);
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    const el = getEl();
+    if (!root || !el) {
+      setRect(null);
+      if (retry < 2) setRetry((n) => n + 1);
+      return;
+    }
+    const rootBox = root.getBoundingClientRect();
+    const box = el.getBoundingClientRect();
+    setRect({
+      top: box.top - rootBox.top,
+      left: box.left - rootBox.left,
+      width: box.width,
+      height: box.height,
+    });
+  }, [rootRef, getEl, key, retry]);
+  return rect;
+}
+
+/**
+ * Returns a stable setter to report drag start/end, and fires `onDraggingChange(false)`
+ * on unmount — so an overlay that unmounts mid-drag (its content removed, the editor
+ * toggled to read-only, etc.) never leaves the editor stuck in a dragging state (no
+ * pointerup/cancel fires in that case). The setter reads the latest `onDraggingChange`
+ * via a ref, so it stays referentially stable across renders.
+ */
+export function useDraggingReporter(
+  onDraggingChange?: (dragging: boolean) => void,
+): (dragging: boolean) => void {
+  // Latest callback, read by the stable setter + the unmount cleanup without resubscribing.
+  const ref = useRef(onDraggingChange);
+  ref.current = onDraggingChange;
+  useEffect(() => {
+    return () => {
+      ref.current?.(false);
+    };
+  }, []);
+  return useCallback((dragging: boolean) => ref.current?.(dragging), []);
+}


### PR DESCRIPTION
## Summary

Pure, behavior-preserving dedup from the deep RTE review. Four shared internal helpers replace copy-pasted logic; no public API or behavior change, all tests green.

- **`marksBeforeCaret(doc, point)`** (engine/position.ts) — one primitive replacing three near-identical "marks of the char before the caret" scans (`transforms.marksBefore`, editor `marksAtCaretMarks`, `commands.marksAtCaretFull`). Raw (includes mention); the two sites that filtered `mention` keep filtering inline, commands keeps not filtering.
- **`useAnchoredFloating`** — the Floating-UI virtual-anchor + `useFloating` scaffolding shared by the link / mention / attachment-config popovers (each keeps its exact `offset`: 6/4/6). The live `getAnchorRect` is still read on every reposition, so scroll-tracking is preserved.
- **`useDismissOnOutsidePointerDown`** — the capture-phase outside-pointerdown dismiss shared by the link editor + attachment config.
- **`useShellRelativeRect` + `useDraggingReporter`** (useOverlayRect.ts) — the measure-relative-to-shell + first-mount retry, and the drag-reporter + mid-drag-unmount cleanup, shared by the block gutter + image resizer.

All helpers are internal (not exported from `index.ts`).

## Test plan

- `make test` (3465), `make build`, `make lint`, `npm run format:check` — green. Manifest unchanged.
- Rule 8 review traced every measurement/positioning/focus path against its pre-refactor original and confirmed exact equivalence (offsets, `rectToDomRect` shape, char-before-caret semantics + mention-filter sites, corner derivation `top=b.bottom-rb.top`/`left=b.right-rb.left`, retry cap, unmount cleanup order). Two benign divergences flagged + proven inert (the gutter's `retry` budget isn't replenished on deactivation — never blocks a real re-measure since activation changes the measured-element identity; ImageResizer's `dragRef` nulling on unmount dropped — GC'd anyway).
- Live: link popover opens near the line + dismisses on outside-click; gutter shows on hover; image resize handle shows.

Part 2 of acting on the deep RTE review. The remaining items have trade-offs and are written up for a decision (see the review summary I'll post).

🤖 Generated with [Claude Code](https://claude.com/claude-code)