### PR TITLE
refactor(RichTextEditor): deep-review cleanups (dead code, fallback unify, rAF hover)

### DIFF
--- a/packages/design-system/src/components/RichText/engine/position.test.ts
+++ b/packages/design-system/src/components/RichText/engine/position.test.ts
@@ -1,7 +1,6 @@
 import {
   blockLength,
   findBlockIndex,
-  clampPoint,
   comparePoints,
   isCollapsed,
   orderedRange,
@@ -25,11 +24,6 @@ describe('position', () => {
   it('findBlockIndex returns index or -1', () => {
     expect(findBlockIndex(doc, 'b')).toBe(1);
     expect(findBlockIndex(doc, 'zzz')).toBe(-1);
-  });
-
-  it('clampPoint clamps offset into [0, blockLength]', () => {
-    expect(clampPoint(doc, { blockId: 'a', offset: 99 })).toEqual({ blockId: 'a', offset: 5 });
-    expect(clampPoint(doc, { blockId: 'a', offset: -3 })).toEqual({ blockId: 'a', offset: 0 });
   });
 
   it('comparePoints orders within and across blocks', () => {

--- a/packages/design-system/src/components/RichText/engine/position.ts
+++ b/packages/design-system/src/components/RichText/engine/position.ts
@@ -31,17 +31,6 @@ export function findBlockIndex(doc: RichDoc, blockId: string): number {
   return doc.blocks.findIndex((b) => b.id === blockId);
 }
 
-/**
- * Clamp `point.offset` to the valid range `[0, blockLength]` for the block.
- * Returns `point` unchanged if the block is not found in `doc`.
- */
-export function clampPoint(doc: RichDoc, point: Point): Point {
-  const idx = findBlockIndex(doc, point.blockId);
-  if (idx === -1) return point;
-  const len = blockLength(doc.blocks[idx]);
-  return { blockId: point.blockId, offset: Math.max(0, Math.min(point.offset, len)) };
-}
-
 /** Document order: -1 if a before b, 1 if after, 0 if equal. */
 export function comparePoints(doc: RichDoc, a: Point, b: Point): -1 | 0 | 1 {
   if (a.blockId === b.blockId) {

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -1296,7 +1296,7 @@ describe('blockControls', () => {
       expect(screen.getByRole('button', { name: 'Block actions' })).toBeInTheDocument();
     });
 
-    it('reveals the row controls when hovering the gutter column (resolved by pointer height)', () => {
+    it('reveals the row controls when hovering the gutter column (resolved by pointer height)', async () => {
       render(
         <I18nProvider locale="en">
           <Controlled blockControls />
@@ -1323,10 +1323,14 @@ describe('blockControls', () => {
       // block element under it) at the SECOND block's height. The controls should
       // appear for THAT block, resolved by the pointer's vertical position.
       fireEvent.mouseMove(textbox, { clientY: 110 });
-      const gutter = screen
-        .getByRole('button', { name: 'Insert block below' })
-        .closest('[contenteditable="false"]') as HTMLElement;
-      expect(gutter.style.top).toBe('100px');
+      // The gutter-column hover resolution is rAF-throttled, so the update lands a
+      // frame later — await it rather than asserting synchronously.
+      await waitFor(() => {
+        const gutter = screen
+          .getByRole('button', { name: 'Insert block below' })
+          .closest('[contenteditable="false"]') as HTMLElement;
+        expect(gutter.style.top).toBe('100px');
+      });
     });
 
     it('hides the gutter when the pointer leaves the editor (no caret)', async () => {

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -929,11 +929,11 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       // gutter-column hover at most once per animation frame: capture the latest move
       // on every event, but coalesce the actual resolution into a single rAF.
       let moveRaf = 0;
-      let lastMove: { clientX: number; clientY: number; target: EventTarget | null } | null = null;
+      let lastMove: { clientY: number; target: EventTarget | null } | null = null;
       const onMove = (e: MouseEvent) => {
         if (blockMenuOpenRef.current || draggingRef.current) return;
         // capture the latest move; resolve at most once per frame
-        lastMove = { clientX: e.clientX, clientY: e.clientY, target: e.target };
+        lastMove = { clientY: e.clientY, target: e.target };
         if (moveRaf) return;
         moveRaf = requestAnimationFrame(() => {
           moveRaf = 0;

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -1164,26 +1164,27 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         if (type === 'link' || type === 'mention' || type === 'textColor' || type === 'bgColor')
           return;
         const root = rootRef.current;
-        const range = (root ? readSelection(root) : null) ?? selection;
+        // lastSelectionRef = last non-null selection; survives a toolbar popover taking focus
+        const range = (root ? readSelection(root) : null) ?? lastSelectionRef.current;
         if (range) stageOrToggleMark(range, { type });
       },
-      [selection, stageOrToggleMark],
+      [stageOrToggleMark],
     );
     const onToolbarSetBlock = useCallback(
       (choice: BlockChoice) => {
         const root = rootRef.current;
-        const range = (root ? readSelection(root) : null) ?? selection;
+        const range = (root ? readSelection(root) : null) ?? lastSelectionRef.current;
         if (range) commit(runSetBlock(value, range, choice));
       },
-      [value, selection, commit],
+      [value, commit],
     );
     const onToolbarToggleList = useCallback(
       (listType: 'bullet_item' | 'ordered_item') => {
         const root = rootRef.current;
-        const range = (root ? readSelection(root) : null) ?? selection;
+        const range = (root ? readSelection(root) : null) ?? lastSelectionRef.current;
         if (range) commit(runToggleList(value, range, listType));
       },
-      [value, selection, commit],
+      [value, commit],
     );
 
     const onBlockInsertBelow = useCallback(

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -925,19 +925,31 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       // Scoped to the no-block case so block-targeted hovers stay on the cheap
       // `mouseover` path; `mousemove` (not `mouseover`) is needed because sliding
       // within the column fires no new `mouseover`.
+      // blockAtPointerY is an O(blocks) getBoundingClientRect scan, so resolve the
+      // gutter-column hover at most once per animation frame: capture the latest move
+      // on every event, but coalesce the actual resolution into a single rAF.
+      let moveRaf = 0;
+      let lastMove: { clientX: number; clientY: number; target: EventTarget | null } | null = null;
       const onMove = (e: MouseEvent) => {
         if (blockMenuOpenRef.current || draggingRef.current) return;
-        const root = rootRef.current;
-        if (!root) return;
-        // Only the editable's OWN area (its reserved left column / padding). The gutter
-        // overlay is a sibling of the editable, not a descendant, so this skips it —
-        // its buttons stay alive via onOver's leave-unchanged path, and we never fight
-        // the controls the pointer is aiming for.
-        const target = e.target as Node;
-        if (!root.contains(target)) return;
-        if (blockIdFromNode(target)) return; // a real block hover — onOver has it
-        const id = blockAtPointerY(root, e.clientY);
-        if (id) setHoverBlockId(id);
+        // capture the latest move; resolve at most once per frame
+        lastMove = { clientX: e.clientX, clientY: e.clientY, target: e.target };
+        if (moveRaf) return;
+        moveRaf = requestAnimationFrame(() => {
+          moveRaf = 0;
+          const m = lastMove;
+          if (!m) return;
+          const root = rootRef.current;
+          if (!root) return;
+          // Only the editable's OWN area (its reserved left column / padding). The gutter
+          // overlay is a sibling of the editable, not a descendant, so this skips it —
+          // its buttons stay alive via onOver's leave-unchanged path, and we never fight
+          // the controls the pointer is aiming for.
+          if (!root.contains(m.target as Node)) return;
+          if (blockIdFromNode(m.target as Node)) return; // a real block hover — onOver has it
+          const id = blockAtPointerY(root, m.clientY);
+          if (id) setHoverBlockId(id);
+        });
       };
       const onLeave = () => {
         // Keep the active block while the menu is open or a drag is mid-flight.
@@ -951,6 +963,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         shell.removeEventListener('mouseover', onOver);
         shell.removeEventListener('mousemove', onMove);
         shell.removeEventListener('mouseleave', onLeave);
+        if (moveRaf) cancelAnimationFrame(moveRaf);
       };
     }, [controlsOn, blockIdFromNode, blockAtPointerY]);
 


### PR DESCRIPTION
## Summary

First of the deep-review follow-up PRs (`docs/superpowers/reviews/2026-06-27-rte-deep-review.md`). Three low-risk items:

- **S-C** — delete the unused `clampPoint` engine helper (referenced only by its own test; no production caller, not exported).
- **S-B** — unify the toolbar "operative range" fallback: `onToolbarMark`/`onToolbarSetBlock`/`onToolbarToggleList` now fall back on `lastSelectionRef.current` (the last non-null selection) like `onSetColor`/`onInsertEmoji` already do, instead of the `selection` state. Behavior-equivalent (both are written from the same `sel`; `selection` is always null-or-equal to the ref) and strictly more robust when the live selection is momentarily null.
- **P-B** — rAF-throttle the gutter-column hover resolution (`blockAtPointerY`, an O(blocks) `getBoundingClientRect` scan) to at most once per animation frame; cancel the pending frame on cleanup. Guards (menu-open/dragging bail, `root.contains`, block-under-pointer early-return) preserved exactly.

## Test plan

- `make test` (3464), `make build`, `make lint`, `npm run format:check` — green.
- Rule 8 review (clean): verified `clampPoint` is truly unreferenced; the fallback unify can't pick a different live range (state and ref derive from the same `sel`, so they never hold two distinct non-null values) and `selection` stays used by the toolbar memos; the rAF throttle preserves every guard, doesn't drop the final move, and cancels on unmount. The gutter-column hover test was made `async`/`await waitFor` for the deferred update (assertion unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)