### PR TITLE
perf(RichTextEditor): one selectionchange listener; no double mention recompute

### DIFF
--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -379,6 +379,9 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     );
 
     const controlsOn = blockControls && !readOnly;
+    // The same gate the mention menu uses — drives both `useMention`'s `enabled`
+    // and the consolidated selectionchange listener's mention fan-out below.
+    const mentionsEnabled = !!mentions && !readOnly;
     const shellRef = useRef<HTMLDivElement | null>(null);
     // Active block = hover wins, else the caret block (keyboard / after the mouse
     // leaves). Split so clearing hover on editor-leave never wipes the caret target.
@@ -552,7 +555,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     );
 
     const mention = useMention({
-      enabled: !!mentions && !readOnly,
+      enabled: mentionsEnabled,
       rootRef,
       doc: value,
       trigger: mentions?.trigger ?? '@',
@@ -679,6 +682,15 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       if (value !== historyRef.current.present.doc) {
         historyRef.current = historyReset({ doc: value, selection: null });
         syncHistoryFlags();
+        // A programmatic value swap fires no user `selectionchange`, so the
+        // consolidated listener below never re-runs the mention menu for it.
+        // Recompute here so an external swap updates/closes the menu. Internal
+        // commits keep `present.doc === value`, so they DON'T reach this branch —
+        // no per-keystroke double-recompute is reintroduced.
+        if (mentionsEnabled) {
+          const r = rootRef.current;
+          mention.recompute(r ? readSelection(r) : null);
+        }
       }
       const root = rootRef.current;
       const pending = pendingSelectionRef.current;
@@ -686,7 +698,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         writeSelection(root, pending);
         pendingSelectionRef.current = null;
       }
-    }, [value, syncHistoryFlags]);
+    }, [value, syncHistoryFlags, mentionsEnabled, mention.recompute]);
 
     // Native beforeinput (React's onBeforeInput is NOT the modern beforeinput —
     // it's a legacy textInput polyfill that carries no `inputType`).
@@ -871,34 +883,63 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       if (autoFocus) rootRef.current?.focus();
     }, [autoFocus]);
 
-    // Track the selection so the toolbar can reflect active marks + block type.
-    // Only subscribed when the toolbar needs it (and the editor is editable).
+    // ONE selectionchange subscription shared by the toolbar, block-controls caret
+    // tracking, and the mention menu. A caret move (incl. every keystroke, which
+    // moves the caret) reads the model selection ONCE here and fans it out, instead
+    // of three independent listeners each re-walking the DOM via their own
+    // readSelection. Only subscribed when at least one consumer needs it.
     useEffect(() => {
-      if (!toolbar || readOnly) return;
-      const root = rootRef.current;
-      if (!root) return;
+      const toolbarOn = toolbar && !readOnly;
+      if (!toolbarOn && !controlsOn && !mentionsEnabled) return;
       const onSelChange = () => {
-        const sel = readSelection(root);
-        setSelection(sel);
-        if (sel != null) lastSelectionRef.current = sel;
-        // Abandon pending marks if the caret left its staged point (the user
-        // moved the caret or made a selection instead of typing there).
-        const pend = pendingMarksRef.current;
-        const stagedAt = pendingAtRef.current;
-        const sameSpot =
-          sel != null &&
-          isCollapsed(sel) &&
-          stagedAt != null &&
-          sel.anchor.blockId === stagedAt.blockId &&
-          sel.anchor.offset === stagedAt.offset;
-        if (pend && !sameSpot) {
-          setPendingMarks(null);
-          pendingAtRef.current = null;
+        const root = rootRef.current;
+        const sel = root ? readSelection(root) : null;
+        if (toolbarOn) {
+          setSelection(sel);
+          if (sel != null) lastSelectionRef.current = sel;
+          // Abandon pending marks if the caret left its staged point (the user
+          // moved the caret or made a selection instead of typing there).
+          const pend = pendingMarksRef.current;
+          const stagedAt = pendingAtRef.current;
+          const sameSpot =
+            sel != null &&
+            isCollapsed(sel) &&
+            stagedAt != null &&
+            sel.anchor.blockId === stagedAt.blockId &&
+            sel.anchor.offset === stagedAt.offset;
+          if (pend && !sameSpot) {
+            setPendingMarks(null);
+            pendingAtRef.current = null;
+          }
         }
+        if (controlsOn) {
+          // Caret → active block (keyboard users get a gutter target too). Reads the
+          // NATIVE selection's anchorNode directly (not the model `sel` above): a
+          // root-level caret beside a void block resolves to no data-block-id here,
+          // leaving the active block unchanged — the original behavior, preserved.
+          const domSel = root?.ownerDocument.getSelection();
+          if (domSel && root && domSel.anchorNode && root.contains(domSel.anchorNode)) {
+            const id = blockIdFromNode(domSel.anchorNode);
+            if (id) setCaretBlockId(id);
+          }
+        }
+        if (mentionsEnabled) mention.recompute(sel);
       };
       document.addEventListener('selectionchange', onSelChange);
       return () => document.removeEventListener('selectionchange', onSelChange);
-    }, [toolbar, readOnly]);
+    }, [toolbar, readOnly, controlsOn, mentionsEnabled, blockIdFromNode, mention.recompute]);
+
+    // Initial mention computation: on mount, when mentions toggle on, or when the
+    // trigger changes. The selectionchange listener above covers caret moves AND
+    // typing (a typed char commits → writeSelection re-sets the DOM selection →
+    // selectionchange fires), so this deliberately omits `value` from its deps —
+    // depending on it would recompute a second time per keystroke, the very
+    // redundancy this consolidation removes.
+    useEffect(() => {
+      if (!mentionsEnabled) return;
+      const root = rootRef.current;
+      mention.recompute(root ? readSelection(root) : null);
+    }, [mentionsEnabled, mentions?.trigger, mention.recompute]);
 
     // Hover tracking (mouse). Listens on the SHELL (which wraps both the editable and
     // the gutter) so reaching from a block onto its controls keeps them alive:
@@ -966,21 +1007,6 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         if (moveRaf) cancelAnimationFrame(moveRaf);
       };
     }, [controlsOn, blockIdFromNode, blockAtPointerY]);
-
-    // Caret tracking → active block (keyboard users get a gutter target too).
-    useEffect(() => {
-      if (!controlsOn) return;
-      const onSel = () => {
-        const root = rootRef.current;
-        const sel = root?.ownerDocument.getSelection();
-        if (sel && root && sel.anchorNode && root.contains(sel.anchorNode)) {
-          const id = blockIdFromNode(sel.anchorNode);
-          if (id) setCaretBlockId(id);
-        }
-      };
-      document.addEventListener('selectionchange', onSel);
-      return () => document.removeEventListener('selectionchange', onSel);
-    }, [controlsOn, blockIdFromNode]);
 
     const onKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLDivElement>) => {

--- a/packages/design-system/src/components/RichTextEditor/useMention.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/useMention.test.tsx
@@ -11,10 +11,10 @@ vi.mock('./selection', async () => {
     selectionRect: vi.fn(actual.selectionRect),
   };
 });
-import { readSelection, selectionRect } from './selection';
+import { selectionRect } from './selection';
 import { useMention } from './useMention';
+import type { Range } from '../RichText/engine/model';
 
-const mockReadSelection = vi.mocked(readSelection);
 const mockSelectionRect = vi.mocked(selectionRect);
 
 function makeRoot(): HTMLDivElement {
@@ -27,8 +27,15 @@ const docWith = (text: string): RichDoc => ({
   blocks: [{ id: 'b', type: 'paragraph', inlines: [{ text, marks: [] }] }],
 });
 
+// A collapsed model selection at `offset` in the test doc's block. The hook no
+// longer reads the DOM selection itself — the editor passes the already-read
+// selection into recompute() — so tests drive it the same way the editor does.
+const caretAt = (offset: number): Range => ({
+  anchor: { blockId: 'b', offset },
+  focus: { blockId: 'b', offset },
+});
+
 beforeEach(() => {
-  mockReadSelection.mockReset();
   mockSelectionRect.mockReset();
   // Default to a stable rect; individual tests override with mockReturnValueOnce.
   mockSelectionRect.mockReturnValue({ top: 0, left: 0, width: 0, height: 0 });
@@ -64,10 +71,6 @@ it('exposes getAnchorRect that reads the caret rect LIVE on each call (tracks sc
 
 it('opens and queries with the text after the trigger', async () => {
   const root = makeRoot();
-  mockReadSelection.mockReturnValue({
-    anchor: { blockId: 'b', offset: 4 },
-    focus: { blockId: 'b', offset: 4 },
-  });
   const onQuery = vi.fn().mockResolvedValue([{ id: 'u1', label: 'Alice' }]);
   const onInsert = vi.fn();
   const { result } = renderHook(() =>
@@ -80,6 +83,7 @@ it('opens and queries with the text after the trigger', async () => {
       onInsert,
     }),
   );
+  act(() => result.current.recompute(caretAt(4)));
   await waitFor(() => expect(onQuery).toHaveBeenCalledWith(''));
   await waitFor(() => expect(result.current.open).toBe(true));
   await waitFor(() => expect(result.current.items).toHaveLength(1));
@@ -87,10 +91,6 @@ it('opens and queries with the text after the trigger', async () => {
 
 it('commitActive inserts the active item over the trigger+query range', async () => {
   const root = makeRoot();
-  mockReadSelection.mockReturnValue({
-    anchor: { blockId: 'b', offset: 6 },
-    focus: { blockId: 'b', offset: 6 },
-  });
   const onQuery = vi.fn().mockResolvedValue([{ id: 'u1', label: 'Alice' }]);
   const onInsert = vi.fn();
   const { result } = renderHook(() =>
@@ -103,6 +103,7 @@ it('commitActive inserts the active item over the trigger+query range', async ()
       onInsert,
     }),
   );
+  act(() => result.current.recompute(caretAt(6)));
   await waitFor(() => expect(result.current.items).toHaveLength(1));
   act(() => result.current.commitActive());
   expect(onInsert).toHaveBeenCalledWith('b', { from: 3, to: 6 }, '@', { id: 'u1', label: 'Alice' });
@@ -110,10 +111,6 @@ it('commitActive inserts the active item over the trigger+query range', async ()
 
 it('drops a stale async resolution', async () => {
   const root = makeRoot();
-  mockReadSelection.mockReturnValue({
-    anchor: { blockId: 'b', offset: 5 },
-    focus: { blockId: 'b', offset: 5 },
-  });
   let resolveFirst: (v: { id: string; label: string }[]) => void = () => {};
   const first = new Promise<{ id: string; label: string }[]>((r) => (resolveFirst = r));
   const onQuery = vi
@@ -132,13 +129,11 @@ it('drops a stale async resolution', async () => {
       }),
     { initialProps: { doc: docWith('hi @a') } },
   );
+  act(() => result.current.recompute(caretAt(5)));
   await waitFor(() => expect(onQuery).toHaveBeenCalledWith('a'));
-  // caret moves: query becomes 'ab'
-  mockReadSelection.mockReturnValue({
-    anchor: { blockId: 'b', offset: 6 },
-    focus: { blockId: 'b', offset: 6 },
-  });
+  // caret moves + a char is typed: doc + selection update, query becomes 'ab'
   rerender({ doc: docWith('hi @ab') });
+  act(() => result.current.recompute(caretAt(6)));
   await waitFor(() => expect(onQuery).toHaveBeenCalledWith('ab'));
   await waitFor(() => expect(result.current.items).toEqual([{ id: 'u2', label: 'Bob' }]));
   // late resolution of the first (stale) query must be ignored
@@ -149,10 +144,6 @@ it('drops a stale async resolution', async () => {
 
 it('move() wraps around the item list', async () => {
   const root = makeRoot();
-  mockReadSelection.mockReturnValue({
-    anchor: { blockId: 'b', offset: 6 },
-    focus: { blockId: 'b', offset: 6 },
-  });
   const onQuery = vi.fn().mockResolvedValue([
     { id: 'u1', label: 'Alice' },
     { id: 'u2', label: 'Bob' },
@@ -167,6 +158,7 @@ it('move() wraps around the item list', async () => {
       onInsert: vi.fn(),
     }),
   );
+  act(() => result.current.recompute(caretAt(6)));
   await waitFor(() => expect(result.current.items).toHaveLength(2));
   act(() => result.current.move(1));
   expect(result.current.activeIndex).toBe(1);
@@ -178,10 +170,6 @@ it('move() wraps around the item list', async () => {
 
 it('close() drops an in-flight query result', async () => {
   const root = makeRoot();
-  mockReadSelection.mockReturnValue({
-    anchor: { blockId: 'b', offset: 6 },
-    focus: { blockId: 'b', offset: 6 },
-  });
   let resolveQuery: (v: { id: string; label: string }[]) => void = () => {};
   const pending = new Promise<{ id: string; label: string }[]>((r) => (resolveQuery = r));
   const onQuery = vi.fn().mockReturnValue(pending);
@@ -195,10 +183,9 @@ it('close() drops an in-flight query result', async () => {
       onInsert: vi.fn(),
     }),
   );
+  act(() => result.current.recompute(caretAt(6)));
   await waitFor(() => expect(onQuery).toHaveBeenCalled());
-  // Dismissal: the caret leaves the trigger context, so the next recompute
-  // (the hook has no separate "stay closed" latch) keeps the menu closed.
-  mockReadSelection.mockReturnValue(null);
+  // close() bumps the stale token, so the in-flight resolution is dropped.
   act(() => result.current.close());
   act(() => resolveQuery([{ id: 'u1', label: 'Alice' }]));
   await Promise.resolve();

--- a/packages/design-system/src/components/RichTextEditor/useMention.ts
+++ b/packages/design-system/src/components/RichTextEditor/useMention.ts
@@ -2,11 +2,11 @@
 // Owns context detection (driven by the editor's selection/content cycle), async
 // querying with stale-drop, and the active-index for keyboard navigation. DOM
 // glue only; the pure decision lives in mentionContext.ts.
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
-import type { RichDoc } from '../RichText/engine/model';
+import { useCallback, useId, useRef, useState } from 'react';
+import type { RichDoc, Range } from '../RichText/engine/model';
 import { runsText } from '../RichText/engine/inlines';
 import { isCollapsed } from '../RichText/engine/position';
-import { readSelection, selectionRect, type Rect } from './selection';
+import { selectionRect, type Rect } from './selection';
 import { getMentionContext } from './mentionContext';
 import type { MentionItem } from './mentions';
 
@@ -40,6 +40,13 @@ export interface UseMentionResult {
   listboxId: string;
   activeOptionId: string | undefined;
   getOptionId: (index: number) => string;
+  /**
+   * Recompute the menu from a model selection the EDITOR already read. The hook no
+   * longer owns a `selectionchange` listener — the editor drives this from its
+   * single consolidated subscription, passing the selection it read once. A
+   * `null` / non-collapsed / out-of-trigger-context selection closes the menu.
+   */
+  recompute: (sel: Range | null) => void;
   setActiveIndex: (index: number) => void;
   move: (delta: 1 | -1) => void;
   selectIndex: (index: number) => void;
@@ -116,68 +123,57 @@ export function useMention(params: UseMentionParams): UseMentionResult {
     [], // stable: reads onQueryRef.current
   );
 
-  // Stable recompute — reads all mutable values via refs, never recreated.
-  const recompute = useCallback(() => {
-    const root = rootRef.current;
-    const qFn = onQueryRef.current;
-    if (!enabledRef.current || !root || !qFn) {
-      if (openRef.current) close();
-      return;
-    }
-    const sel = readSelection(root);
-    if (!sel || !isCollapsed(sel)) {
-      if (openRef.current) close();
-      return;
-    }
-    const currentDoc = docRef.current;
-    const block = currentDoc.blocks.find((b) => b.id === sel.anchor.blockId);
-    if (!block) {
-      if (openRef.current) close();
-      return;
-    }
-    const text = runsText(block.inlines);
-    const trig = triggerRef.current;
-    const ctx = getMentionContext(text, sel.anchor.offset, trig);
-    if (!ctx) {
-      if (openRef.current) close();
-      return;
-    }
-    ctxRef.current = {
-      blockId: block.id,
-      from: ctx.triggerOffset,
-      to: ctx.triggerOffset + trig.length + ctx.query.length,
-    };
-    // Only update anchorRect state if the value changed (prevents render loops).
-    const newRect = selectionRect(root);
-    if (!rectEqual(anchorRectRef.current, newRect)) {
-      anchorRectRef.current = newRect;
-      setAnchorRect(newRect);
-    }
-    // Only flip open state if not already open (prevents render loops).
-    if (!openRef.current) {
-      openRef.current = true;
-      setOpen(true);
-    }
-    if (ctx.query !== lastQuery.current) {
-      lastQuery.current = ctx.query;
-      runQuery(ctx.query);
-    }
-  }, [rootRef, close, runQuery]); // stable: reads props via refs
-
-  // Register selectionchange listener; re-register only if enabled changes.
-  useEffect(() => {
-    if (!enabled) return;
-    const handler = () => recompute();
-    document.addEventListener('selectionchange', handler);
-    recompute();
-    return () => document.removeEventListener('selectionchange', handler);
-  }, [enabled, recompute]);
-
-  // Re-run recompute when doc or trigger changes (typing updates the query).
-  useEffect(() => {
-    if (!enabled) return;
-    recompute();
-  }, [enabled, doc, trigger, recompute]);
+  // Stable recompute — reads all mutable values via refs, never recreated. The
+  // editor passes the model selection it already read from its single
+  // `selectionchange` listener, so the menu doesn't re-walk the DOM here.
+  const recompute = useCallback(
+    (sel: Range | null) => {
+      const root = rootRef.current;
+      const qFn = onQueryRef.current;
+      if (!enabledRef.current || !root || !qFn) {
+        if (openRef.current) close();
+        return;
+      }
+      if (!sel || !isCollapsed(sel)) {
+        if (openRef.current) close();
+        return;
+      }
+      const currentDoc = docRef.current;
+      const block = currentDoc.blocks.find((b) => b.id === sel.anchor.blockId);
+      if (!block) {
+        if (openRef.current) close();
+        return;
+      }
+      const text = runsText(block.inlines);
+      const trig = triggerRef.current;
+      const ctx = getMentionContext(text, sel.anchor.offset, trig);
+      if (!ctx) {
+        if (openRef.current) close();
+        return;
+      }
+      ctxRef.current = {
+        blockId: block.id,
+        from: ctx.triggerOffset,
+        to: ctx.triggerOffset + trig.length + ctx.query.length,
+      };
+      // Only update anchorRect state if the value changed (prevents render loops).
+      const newRect = selectionRect(root);
+      if (!rectEqual(anchorRectRef.current, newRect)) {
+        anchorRectRef.current = newRect;
+        setAnchorRect(newRect);
+      }
+      // Only flip open state if not already open (prevents render loops).
+      if (!openRef.current) {
+        openRef.current = true;
+        setOpen(true);
+      }
+      if (ctx.query !== lastQuery.current) {
+        lastQuery.current = ctx.query;
+        runQuery(ctx.query);
+      }
+    },
+    [rootRef, close, runQuery], // stable: reads props via refs
+  );
 
   const move = useCallback(
     (delta: 1 | -1) => {
@@ -220,6 +216,7 @@ export function useMention(params: UseMentionParams): UseMentionResult {
     listboxId,
     activeOptionId: open && items.length > 0 ? getOptionId(activeIndex) : undefined,
     getOptionId,
+    recompute,
     setActiveIndex,
     move,
     selectIndex,


### PR DESCRIPTION
## Summary

Deep-review follow-up P-A + P-D. Collapses the three independent `document` `selectionchange` listeners (toolbar active-marks tracking, caret→active-block tracking, and `useMention`'s own listener) into ONE editor-owned subscription that calls `readSelection(root)` once per event and fans out. Removes `useMention`'s redundant `[doc]` recompute effect, so a keystroke recomputes mentions once instead of twice. ~3× fewer DOM range walks per caret move with all features on.

- `useMention.recompute` now takes the already-read selection (stable `useCallback`); the editor drives it from the consolidated listener.
- Typing is covered because every `commit` → `writeSelection` re-sets the DOM selection → fires `selectionchange`. A programmatic `value` swap (no user event) is handled in the editor's existing external-replacement branch (which internal commits never hit, so no per-keystroke double).
- Behavior preserved verbatim: the toolbar pending-marks-clear-on-move logic; the caret-block tracking still reads the **native** selection (so a root-level caret beside a void/figure block leaves `caretBlockId` unchanged, as before).

## Test plan

- `make test` (3464), `make build`, `make lint`, `npm run format:check` — green.
- Rule 8 review (clean): traced every recompute/selection path — none missing; the double is removed; gating/guards match the originals; `mentionsEnabled` is a stable boolean so the listener doesn't re-subscribe. `useMention.test.tsx` updated to drive `recompute(sel)` explicitly (faithful, not weakened); editor mention tests pass unchanged.
- Live: typing "@al" opens the mention menu filtered to "Alice Nguyen" (recompute via the consolidated listener); toolbar + gutter behavior intact.

No public API change (`useMention`/`recompute` are internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)