### PR TITLE
refactor(RichTextEditor): extract useLinkEditor + useAttachmentConfig hooks

### DIFF
--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -18,7 +18,6 @@ import {
   blockLength,
   isCollapsed,
   wholeBlockRange,
-  collapsedRange,
   marksBeforeCaret,
 } from '../RichText/engine/position';
 import { linkAt, setLink } from './links';
@@ -64,12 +63,9 @@ import {
 } from '../RichText/engine/blockUnit';
 import { RichTextBlockControls } from './RichTextBlockControls';
 import { RichTextAttachmentConfig } from './RichTextAttachmentConfig';
+import { useAttachmentConfig } from './useAttachmentConfig';
 import { RichTextImageResizer } from './RichTextImageResizer';
-import {
-  updateAttachmentBlock,
-  clearAttachmentFields,
-  attachmentIsImage,
-} from '../RichText/engine/attachment';
+import { attachmentIsImage } from '../RichText/engine/attachment';
 import { safeHref } from '../RichText/engine/safeHref';
 import type { BlockAction } from './RichTextBlockMenu';
 import { useUpload, type UploadConfig } from './useUpload';
@@ -339,6 +335,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // feature hooks so their handlers read current values without re-subscribing
     // or depending on `latest`'s shape (keeps the handlers' identity stable).
     const getValue = useCallback(() => latest.current.value, []);
+    const getLiveDoc = useCallback(() => liveDocRef.current, []);
     const getReadOnly = useCallback(() => latest.current.readOnly, []);
 
     // Focus state — only consulted by `toolbar="auto"` to gate the bar's visibility.
@@ -383,7 +380,6 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     const [hoverBlockId, setHoverBlockId] = useState<string | null>(null);
     const [caretBlockId, setCaretBlockId] = useState<string | null>(null);
     const activeBlockId = hoverBlockId ?? caretBlockId;
-    const [configBlockId, setConfigBlockId] = useState<string | null>(null);
     const [blockMenuOpen, setBlockMenuOpen] = useState(false);
     // Mirror the open state into a ref so the hover listener can read it without
     // re-subscribing: while the menu is open, hovering another block must NOT move
@@ -460,6 +456,30 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         pendingSelectionRef.current = result.selection;
         liveDocRef.current = result.doc;
         latest.current.onChange(result.doc);
+      },
+      [syncHistoryFlags],
+    );
+
+    // Live-resize commit path for attachment width drags (used by
+    // useAttachmentConfig's onConfigWidth and the image resizer). Records ONE
+    // coalescing 'resize' history entry per drag (whole drag = one undo step),
+    // writes NO pending selection (the slider/handle keeps focus mid-drag — a
+    // writeSelection into the editable would yank focus), and chains off
+    // `liveDocRef` so rapid moves before a re-render stack on each other. The
+    // no-op guard skips an unchanged doc (same width). This stays in the editor
+    // so the history coupling is isolated from the hook.
+    const commitResizeLive = useCallback(
+      (doc: RichDoc) => {
+        if (doc === liveDocRef.current) return;
+        historyRef.current = historyRecord(
+          historyRef.current,
+          { doc, selection: historyRef.current.present.selection },
+          'resize',
+          Date.now(),
+        );
+        syncHistoryFlags();
+        liveDocRef.current = doc;
+        latest.current.onChange(doc);
       },
       [syncHistoryFlags],
     );
@@ -1234,84 +1254,27 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       [commit],
     );
 
-    // Attachment config popover. Config edits don't move the caret meaningfully —
-    // the popover holds focus — so each commit pins a collapsed selection on the
-    // block (via `collapsedRange`). Open/close toggle `configBlockId`; close returns
-    // focus to the editor.
-    const onConfigOpen = useCallback((id: string) => setConfigBlockId(id), []);
-    const onConfigClose = useCallback(() => {
-      setConfigBlockId(null);
-      rootRef.current?.focus();
-    }, []);
-    const onConfigAlt = useCallback(
-      (id: string, alt: string) => {
-        commit(
-          {
-            doc: updateAttachmentBlock(latest.current.value, id, { alt }),
-            selection: collapsedRange(id),
-          },
-          'other',
-        );
-      },
-      [commit],
-    );
-    const onConfigAlign = useCallback(
-      (id: string, align: 'left' | 'center' | 'right') => {
-        commit(
-          {
-            doc: updateAttachmentBlock(latest.current.value, id, { align }),
-            selection: collapsedRange(id),
-          },
-          'other',
-        );
-      },
-      [commit],
-    );
-    const onConfigWidth = useCallback(
-      (id: string, width: number) => {
-        // Live resize: fires on every slider/handle MOVE (not just the end) so the
-        // image tracks the control. Three deliberate choices vs a plain `commit`:
-        //  • Coalescing 'resize' kind → the whole drag is ONE undo step (reverting
-        //    to the pre-drag width), instead of one per pixel.
-        //  • No `pendingSelectionRef` write → the slider/handle keeps focus; a
-        //    `writeSelection` into the editable would yank focus mid-drag.
-        //  • Reads `liveDocRef` (the synchronously-latest doc) so rapid moves that
-        //    fire before React re-renders still chain off each other.
-        // Width only; clearing height lets the browser keep the aspect ratio.
-        let d = updateAttachmentBlock(liveDocRef.current, id, { width });
-        d = clearAttachmentFields(d, id, ['height']);
-        if (d === liveDocRef.current) return;
-        historyRef.current = historyRecord(
-          historyRef.current,
-          { doc: d, selection: historyRef.current.present.selection },
-          'resize',
-          Date.now(),
-        );
-        syncHistoryFlags();
-        liveDocRef.current = d;
-        latest.current.onChange(d);
-      },
-      [syncHistoryFlags],
-    );
-    const onConfigWidthReset = useCallback(
-      (id: string) => {
-        commit(
-          {
-            doc: clearAttachmentFields(latest.current.value, id, ['width', 'height']),
-            selection: collapsedRange(id),
-          },
-          'other',
-        );
-      },
-      [commit],
-    );
-    const onConfigReplace = useCallback((id: string, file: File) => {
-      uploaderRef.current.replace(id, file);
-      // The block flips to `status: 'uploading'`, which unmounts the popover (it
-      // only shows for `ready`). Clear config state too so it doesn't spontaneously
-      // reappear when the upload settles back to `ready`.
-      setConfigBlockId(null);
-    }, []);
+    // Attachment config popover: open-state + alt/align/width/reset/replace
+    // handlers (see useAttachmentConfig). The live-resize history coupling stays
+    // in this file via `commitResizeLive`; the popover JSX (which derives the
+    // configured block + anchor from render scope) is rendered below.
+    const {
+      configBlockId,
+      onConfigOpen,
+      onConfigClose,
+      onConfigAlt,
+      onConfigAlign,
+      onConfigWidth,
+      onConfigWidthReset,
+      onConfigReplace,
+    } = useAttachmentConfig({
+      rootRef,
+      commit,
+      commitResizeLive,
+      getValue,
+      getLiveDoc,
+      uploaderRef,
+    });
     // Stable resize handler for the image resizer — keeps the memoized resizer from
     // re-rendering every keystroke on a fresh inline lambda. Guards activeBlockId so
     // a late move after the active block clears is a no-op.

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -21,9 +21,10 @@ import {
   collapsedRange,
   marksBeforeCaret,
 } from '../RichText/engine/position';
-import { linkAt, setLink, removeLink } from './links';
+import { linkAt, setLink } from './links';
 import { applyTypeAutolink, atomicLinkDeleteRange } from './autolinkInput';
 import { RichTextLinkEditor } from './RichTextLinkEditor';
+import { useLinkEditor } from './useLinkEditor';
 import {
   insertText,
   insertFragment,
@@ -38,7 +39,7 @@ import type { MentionItem, MentionsConfig } from './mentions';
 import { fromHtml } from '../RichText/engine/fromHtml';
 import { hasMark, withMark, withoutMark } from '../RichText/engine/marks';
 import { useTranslation } from '../../i18n';
-import { readSelection, writeSelection, selectionRect, rangeRect, type Rect } from './selection';
+import { readSelection, writeSelection, rangeRect } from './selection';
 import { applyInput } from './input';
 import { matchBlockRule, applyBlockRule } from './inputRules';
 import { runsText } from '../RichText/engine/inlines';
@@ -210,14 +211,6 @@ function marksAtCaretMarks(doc: RichDoc, caret: Point): Mark[] {
   return marksBeforeCaret(doc, caret).filter((m) => m.type !== 'mention');
 }
 
-interface LinkEditorOpen {
-  range: Range;
-  href: string;
-  editing: boolean;
-  anchorRect: Rect;
-  key: number;
-}
-
 /**
  * Controlled rich-text editor — a contentEditable surface over the in-house
  * engine. Type to edit; ⌘/Ctrl+B/I/U and ⌘/Ctrl+⇧X toggle marks over a
@@ -342,9 +335,11 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     const liveDocRef = useRef(value);
     liveDocRef.current = value;
 
-    // Link editor state.
-    const [linkEditor, setLinkEditor] = useState<LinkEditorOpen | null>(null);
-    const linkKeyRef = useRef(0);
+    // Stable getters for the synchronously-latest doc/flags — passed to the
+    // feature hooks so their handlers read current values without re-subscribing
+    // or depending on `latest`'s shape (keeps the handlers' identity stable).
+    const getValue = useCallback(() => latest.current.value, []);
+    const getReadOnly = useCallback(() => latest.current.readOnly, []);
 
     // Focus state — only consulted by `toolbar="auto"` to gate the bar's visibility.
     // Focus moving to an editor overlay (the link editor / mention menu, portaled to
@@ -617,63 +612,15 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       [stageOrSetColor],
     );
 
-    // Open the link editor for the live selection: edit the link under the caret
-    // if there is one (href pre-filled, Remove available), else create over the
-    // selection (or insert at a collapsed caret on Apply).
-    const openLinkEditor = useCallback(() => {
-      if (latest.current.readOnly) return;
-      const root = rootRef.current;
-      if (!root) return;
-      const range = readSelection(root);
-      if (!range) return;
-      const existing = linkAt(latest.current.value, range.focus);
-      const anchorRect = selectionRect(root);
-      linkKeyRef.current += 1;
-      setLinkEditor(
-        existing
-          ? {
-              range: existing.range,
-              href: existing.href,
-              editing: true,
-              anchorRect,
-              key: linkKeyRef.current,
-            }
-          : { range, href: '', editing: false, anchorRect, key: linkKeyRef.current },
-      );
-    }, []);
-
-    const onLinkApply = useCallback(
-      (href: string) => {
-        const le = linkEditor;
-        if (!le) return;
-        const trimmed = href.trim();
-        if (trimmed !== '') {
-          commit(setLink(latest.current.value, le.range, trimmed));
-        } else if (le.editing) {
-          commit(removeLink(latest.current.value, le.range));
-        }
-        // empty href while creating → just close (cancel).
-        setLinkEditor(null);
-        rootRef.current?.focus();
-      },
-      [linkEditor, commit],
-    );
-
-    const onLinkRemove = useCallback(() => {
-      const le = linkEditor;
-      if (!le) return;
-      commit(removeLink(latest.current.value, le.range));
-      setLinkEditor(null);
-      rootRef.current?.focus();
-    }, [linkEditor, commit]);
-
-    const onLinkCancel = useCallback(() => {
-      const le = linkEditor;
-      setLinkEditor(null);
-      const root = rootRef.current;
-      if (root && le) writeSelection(root, le.range);
-      root?.focus();
-    }, [linkEditor]);
+    // Link editor: open-state + apply/remove/cancel handlers (see useLinkEditor).
+    // The toolbar's `linkActive` derivation and the `<RichTextLinkEditor>` render
+    // stay in this file — they need the live selection / render scope.
+    const { linkEditor, openLinkEditor, onLinkApply, onLinkRemove, onLinkCancel } = useLinkEditor({
+      rootRef,
+      commit,
+      getValue,
+      getReadOnly,
+    });
 
     // Restore the caret/selection after a model-driven re-render.
     useLayoutEffect(() => {

--- a/packages/design-system/src/components/RichTextEditor/useAttachmentConfig.ts
+++ b/packages/design-system/src/components/RichTextEditor/useAttachmentConfig.ts
@@ -1,0 +1,134 @@
+import { useCallback, useState } from 'react';
+import type { RichDoc, Range } from '../RichText/engine/model';
+import type { EditKind } from './history';
+import { collapsedRange } from '../RichText/engine/position';
+import { updateAttachmentBlock, clearAttachmentFields } from '../RichText/engine/attachment';
+
+interface UseAttachmentConfigArgs {
+  /** The editable root — read to refocus the editor on close. */
+  rootRef: React.RefObject<HTMLDivElement | null>;
+  /** The editor's commit path (history + onChange round-trip) for the
+   * non-live config edits (alt / align / width-reset). */
+  commit: (result: { doc: RichDoc; selection: Range }, kind?: EditKind) => void;
+  /** The editor-owned live-resize commit: records ONE coalescing `'resize'`
+   * history entry (whole drag = one undo step), writes NO pending selection (so
+   * the slider/handle keeps focus mid-drag), and chains off `liveDocRef`. The
+   * hook builds the resized doc and hands it here so the history coupling stays
+   * isolated in the editor. */
+  commitResizeLive: (doc: RichDoc) => void;
+  /** The synchronously-latest controlled doc (`() => latest.current.value`). */
+  getValue: () => RichDoc;
+  /** The synchronously-latest live doc (`() => liveDocRef.current`) — read by
+   * the live-resize handler so rapid moves chain off each other before React
+   * re-renders. */
+  getLiveDoc: () => RichDoc;
+  /** Mirror of the upload controller — `replace` swaps an attachment's file. */
+  uploaderRef: React.RefObject<{ replace: (id: string, file: File) => void }>;
+}
+
+/**
+ * The attachment-config cluster, extracted from `RichTextEditor`: owns the
+ * `configBlockId` open-state and the alt/align/width/width-reset/replace
+ * handlers for the `<RichTextAttachmentConfig>` popover. The editor keeps the
+ * popover JSX (it derives the configured block + anchor rect from render scope)
+ * and the live-resize history coupling (via the injected `commitResizeLive`);
+ * only the state + handlers live here.
+ *
+ * Config edits don't move the caret meaningfully (the popover holds focus), so
+ * each non-live commit pins a collapsed selection on the block. `onConfigWidth`
+ * is the LIVE-resize path (fires on every slider/handle move) — it builds the
+ * resized doc here and routes through `commitResizeLive`, NOT `commit`.
+ */
+export function useAttachmentConfig({
+  rootRef,
+  commit,
+  commitResizeLive,
+  getValue,
+  getLiveDoc,
+  uploaderRef,
+}: UseAttachmentConfigArgs) {
+  const [configBlockId, setConfigBlockId] = useState<string | null>(null);
+
+  // Open/close toggle `configBlockId`; close returns focus to the editor.
+  const onConfigOpen = useCallback((id: string) => setConfigBlockId(id), []);
+  const onConfigClose = useCallback(() => {
+    setConfigBlockId(null);
+    rootRef.current?.focus();
+  }, [rootRef]);
+
+  const onConfigAlt = useCallback(
+    (id: string, alt: string) => {
+      commit(
+        {
+          doc: updateAttachmentBlock(getValue(), id, { alt }),
+          selection: collapsedRange(id),
+        },
+        'other',
+      );
+    },
+    [commit, getValue],
+  );
+  const onConfigAlign = useCallback(
+    (id: string, align: 'left' | 'center' | 'right') => {
+      commit(
+        {
+          doc: updateAttachmentBlock(getValue(), id, { align }),
+          selection: collapsedRange(id),
+        },
+        'other',
+      );
+    },
+    [commit, getValue],
+  );
+  const onConfigWidth = useCallback(
+    (id: string, width: number) => {
+      // Live resize: fires on every slider/handle MOVE (not just the end) so the
+      // image tracks the control. Three deliberate choices vs a plain `commit`,
+      // all owned by the injected `commitResizeLive`:
+      //  • Coalescing 'resize' kind → the whole drag is ONE undo step (reverting
+      //    to the pre-drag width), instead of one per pixel.
+      //  • No `pendingSelectionRef` write → the slider/handle keeps focus; a
+      //    `writeSelection` into the editable would yank focus mid-drag.
+      //  • Reads `liveDocRef` (the synchronously-latest doc) so rapid moves that
+      //    fire before React re-renders still chain off each other.
+      // Width only; clearing height lets the browser keep the aspect ratio.
+      let d = updateAttachmentBlock(getLiveDoc(), id, { width });
+      d = clearAttachmentFields(d, id, ['height']);
+      commitResizeLive(d);
+    },
+    [commitResizeLive, getLiveDoc],
+  );
+  const onConfigWidthReset = useCallback(
+    (id: string) => {
+      commit(
+        {
+          doc: clearAttachmentFields(getValue(), id, ['width', 'height']),
+          selection: collapsedRange(id),
+        },
+        'other',
+      );
+    },
+    [commit, getValue],
+  );
+  const onConfigReplace = useCallback(
+    (id: string, file: File) => {
+      uploaderRef.current?.replace(id, file);
+      // The block flips to `status: 'uploading'`, which unmounts the popover (it
+      // only shows for `ready`). Clear config state too so it doesn't spontaneously
+      // reappear when the upload settles back to `ready`.
+      setConfigBlockId(null);
+    },
+    [uploaderRef],
+  );
+
+  return {
+    configBlockId,
+    onConfigOpen,
+    onConfigClose,
+    onConfigAlt,
+    onConfigAlign,
+    onConfigWidth,
+    onConfigWidthReset,
+    onConfigReplace,
+  };
+}

--- a/packages/design-system/src/components/RichTextEditor/useLinkEditor.ts
+++ b/packages/design-system/src/components/RichTextEditor/useLinkEditor.ts
@@ -1,0 +1,107 @@
+import { useCallback, useRef, useState } from 'react';
+import type { RichDoc, Range } from '../RichText/engine/model';
+import type { EditKind } from './history';
+import { linkAt, setLink, removeLink } from './links';
+import { readSelection, writeSelection, selectionRect, type Rect } from './selection';
+
+/** Open-state of the floating link editor: the captured model range, the href
+ * being edited, whether it's editing an existing link (vs. creating) — which
+ * gates the Remove action and the empty-href→remove branch — the anchor rect to
+ * position against, and a `key` that remounts the bubble on each open. */
+export interface LinkEditorOpen {
+  range: Range;
+  href: string;
+  editing: boolean;
+  anchorRect: Rect;
+  key: number;
+}
+
+interface UseLinkEditorArgs {
+  /** The editable root — read to resolve the live selection and to refocus. */
+  rootRef: React.RefObject<HTMLDivElement | null>;
+  /** The editor's commit path (history + onChange round-trip). */
+  commit: (result: { doc: RichDoc; selection: Range }, kind?: EditKind) => void;
+  /** The synchronously-latest controlled doc (`() => latest.current.value`). */
+  getValue: () => RichDoc;
+  /** The synchronously-latest readOnly flag (`() => latest.current.readOnly`). */
+  getReadOnly: () => boolean;
+}
+
+/**
+ * The link-editor cluster, extracted from `RichTextEditor`: owns the open-state
+ * and the apply/remove/cancel handlers for the floating link editor. The editor
+ * keeps the `<RichTextLinkEditor>` JSX (it needs `rangeRect`/`rootRef` from
+ * render scope) and the toolbar's `linkActive` derivation (a render-memo on the
+ * live selection, not on this open-state) — only the state + handlers live here.
+ *
+ * Returns the open-state plus stable handlers. `openLinkEditor` opens for the
+ * live selection (editing the link under the caret if there is one — href
+ * pre-filled, Remove available — else creating over the selection, inserting at
+ * a collapsed caret on Apply); `onLinkApply`/`onLinkRemove` route through
+ * `commit`; `onLinkCancel` restores the captured selection and refocuses.
+ */
+export function useLinkEditor({ rootRef, commit, getValue, getReadOnly }: UseLinkEditorArgs) {
+  // Link editor state.
+  const [linkEditor, setLinkEditor] = useState<LinkEditorOpen | null>(null);
+  const linkKeyRef = useRef(0);
+
+  // Open the link editor for the live selection: edit the link under the caret
+  // if there is one (href pre-filled, Remove available), else create over the
+  // selection (or insert at a collapsed caret on Apply).
+  const openLinkEditor = useCallback(() => {
+    if (getReadOnly()) return;
+    const root = rootRef.current;
+    if (!root) return;
+    const range = readSelection(root);
+    if (!range) return;
+    const existing = linkAt(getValue(), range.focus);
+    const anchorRect = selectionRect(root);
+    linkKeyRef.current += 1;
+    setLinkEditor(
+      existing
+        ? {
+            range: existing.range,
+            href: existing.href,
+            editing: true,
+            anchorRect,
+            key: linkKeyRef.current,
+          }
+        : { range, href: '', editing: false, anchorRect, key: linkKeyRef.current },
+    );
+  }, [rootRef, getValue, getReadOnly]);
+
+  const onLinkApply = useCallback(
+    (href: string) => {
+      const le = linkEditor;
+      if (!le) return;
+      const trimmed = href.trim();
+      if (trimmed !== '') {
+        commit(setLink(getValue(), le.range, trimmed));
+      } else if (le.editing) {
+        commit(removeLink(getValue(), le.range));
+      }
+      // empty href while creating → just close (cancel).
+      setLinkEditor(null);
+      rootRef.current?.focus();
+    },
+    [linkEditor, commit, getValue, rootRef],
+  );
+
+  const onLinkRemove = useCallback(() => {
+    const le = linkEditor;
+    if (!le) return;
+    commit(removeLink(getValue(), le.range));
+    setLinkEditor(null);
+    rootRef.current?.focus();
+  }, [linkEditor, commit, getValue, rootRef]);
+
+  const onLinkCancel = useCallback(() => {
+    const le = linkEditor;
+    setLinkEditor(null);
+    const root = rootRef.current;
+    if (root && le) writeSelection(root, le.range);
+    root?.focus();
+  }, [linkEditor, rootRef]);
+
+  return { linkEditor, openLinkEditor, onLinkApply, onLinkRemove, onLinkCancel };
+}


### PR DESCRIPTION
## Summary

Deep-review follow-up S-A. Extracts two cohesive feature clusters out of the 1572-line `RichTextEditor.tsx` into focused internal hooks, shrinking the editor file (~1628 → 1537 lines). Pure refactor — no public API or behavior change.

- **`useLinkEditor`** — owns the link-editor open-state + `openLinkEditor`/`onLinkApply`/`onLinkRemove`/`onLinkCancel`. Takes `{ rootRef, commit, getValue, getReadOnly }`. The `toolbarLinkActive` selection-memo and the `<RichTextLinkEditor>` render (incl. the live `getAnchorRect`) stay in the editor.
- **`useAttachmentConfig`** — owns `configBlockId` + the `onConfig*` handlers. The live-resize history coupling (`onConfigWidth`'s coalescing `'resize'` record, no `pendingSelectionRef` write) is isolated in an editor-level `commitResizeLive(doc)` callback the hook calls, so the hook stays clean. Takes `{ rootRef, commit, commitResizeLive, getValue, getLiveDoc, uploaderRef }`.

Empty-dep getter callbacks (`getValue`/`getLiveDoc`/`getReadOnly`) keep the handlers referentially stable — important so the `React.memo`'d image-resizer/gutter (from #239) don't start re-rendering per keystroke.

## Test plan

- `make test` (3464), `make build`, `make lint`, `npm run format:check` — green. Both hooks internal (not exported).
- Rule 8 review (clean): traced every link + config handler byte-for-byte against `main`; confirmed `commitResizeLive` is equivalent to the old `onConfigWidth` tail (coalescing 'resize', no pendingSelection write, `liveDocRef` chain + no-op guard); confirmed all handler identities stay stable so the memo overlays don't regress; pruned imports verified.
- Live: link editor opens + Apply creates the link; attachment ⠿ Configure opens with Alt + Width slider; resize handle present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)