### PR TITLE
perf(RichText): per-block renderDoc memoization (leaf blocks)

### DIFF
--- a/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
@@ -1,6 +1,8 @@
+import type { ReactElement } from 'react';
 import { render } from '@testing-library/react';
 import { I18nProvider } from '../../../i18n';
 import { renderDoc } from './renderDoc';
+import type { RenderDocOptions } from './renderDoc';
 import { createBlock } from './model';
 import type { RichDoc } from './model';
 
@@ -600,4 +602,78 @@ it('stamps data-align on a centered attachment figure', () => {
     'data-align',
     'center',
   );
+});
+
+describe('renderDoc per-block memoization', () => {
+  // renderDoc returns the array of top-level block elements; cast for ref checks.
+  const blockEls = (doc: RichDoc, opts?: RenderDocOptions): ReactElement[] =>
+    renderDoc(doc, opts) as unknown as ReactElement[];
+
+  it('returns the SAME element reference for an unchanged block across renders (cache hit)', () => {
+    const doc: RichDoc = {
+      blocks: [
+        createBlock('paragraph', 'one', { id: 'p1' }),
+        createBlock('heading', 'two', { level: 2, id: 'h1' }),
+      ],
+    };
+    const a = blockEls(doc);
+    const b = blockEls(doc); // same doc → same block refs → same opts → cache hit
+    expect(a[0]).toBe(b[0]);
+    expect(a[1]).toBe(b[1]);
+  });
+
+  it('rebuilds only the changed block; an unchanged sibling keeps its element reference', () => {
+    const p1 = createBlock('paragraph', 'one', { id: 'p1' });
+    const p2 = createBlock('paragraph', 'two', { id: 'p2' });
+    const out1 = blockEls({ blocks: [p1, p2] });
+
+    // Edit p1 → a NEW object; p2 keeps its reference (immutable-engine invariant).
+    const p1b = createBlock('paragraph', 'one-edited', { id: 'p1' });
+    const out2 = blockEls({ blocks: [p1b, p2] });
+
+    expect(out2[0]).not.toBe(out1[0]); // changed block → new element
+    expect(out2[1]).toBe(out1[1]); // unchanged sibling → same element (cache hit)
+  });
+
+  it('caches the COMPLETE top-level element including its React key', () => {
+    const doc: RichDoc = { blocks: [createBlock('paragraph', 'x', { id: 'pk' })] };
+    const el = blockEls(doc)[0];
+    expect(el.key).toBe('pk'); // the cached element carries its key
+    expect(blockEls(doc)[0]).toBe(el); // and the same keyed instance is reused
+  });
+
+  it('a different renderLink identity invalidates the cache (options are part of the key)', () => {
+    const doc: RichDoc = { blocks: [createBlock('paragraph', 'x', { id: 'p1' })] };
+    const a = blockEls(doc, { renderLink: (_l, def) => def });
+    const b = blockEls(doc, { renderLink: (_l, def) => def }); // different fn identity
+    expect(a[0]).not.toBe(b[0]);
+  });
+
+  it('a different renderMention identity invalidates the cache', () => {
+    const doc: RichDoc = { blocks: [createBlock('paragraph', 'x', { id: 'p1' })] };
+    const a = blockEls(doc, { renderMention: (_m, def) => def });
+    const b = blockEls(doc, { renderMention: (_m, def) => def }); // different fn identity
+    expect(a[0]).not.toBe(b[0]);
+  });
+
+  it('the editable flag is part of the cache key', () => {
+    const doc: RichDoc = { blocks: [createBlock('paragraph', 'x', { id: 'p1' })] };
+    const ro = blockEls(doc);
+    const ed = blockEls(doc, { editable: true });
+    expect(ro[0]).not.toBe(ed[0]);
+  });
+
+  it('does NOT cache list items: a sibling depth change rebuilds the list with correct nesting', () => {
+    // `c` keeps its reference across both docs, but its nesting changes when `b`'s
+    // depth changes — proving the list path is rebuilt every render, never reused.
+    const a = createBlock('bullet_item', 'a', { id: 'l1', depth: 0 });
+    const c = createBlock('bullet_item', 'c', { id: 'l3', depth: 1 });
+
+    const b1 = createBlock('bullet_item', 'b', { id: 'l2', depth: 1 });
+    expect(html({ blocks: [a, b1, c] })).toBe('<ul><li>a<ul><li>b</li><li>c</li></ul></li></ul>');
+
+    // Change ONLY b's depth (new b object); a and c keep their references.
+    const b2 = createBlock('bullet_item', 'b', { id: 'l2', depth: 0 });
+    expect(html({ blocks: [a, b2, c] })).toBe('<ul><li>a</li><li>b<ul><li>c</li></ul></li></ul>');
+  });
 });

--- a/packages/design-system/src/components/RichText/engine/renderDoc.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.tsx
@@ -1,6 +1,6 @@
 // renderDoc.tsx — pure model → React. Read-only; used by <RichText>. The model
 // is flat; this reconstructs list nesting from `depth` at render time.
-import { Fragment, type ReactNode } from 'react';
+import { Fragment, type ReactElement, type ReactNode } from 'react';
 import type { RichDoc, Block, Inline, Mark, MarkType } from './model';
 import { runsText, runsLength } from './inlines';
 import { safeHref } from './safeHref';
@@ -38,6 +38,50 @@ interface ResolvedOptions {
   editable: boolean;
   renderLink?: RenderLink;
   renderMention?: RenderMention;
+}
+
+// Per-block element cache for CONTEXT-INDEPENDENT blocks only (paragraph, heading,
+// blockquote, code_block, attachment). The model is immutable: a block keeps its
+// reference across edits unless it changed, so an element built purely from
+// (block + options) can be cached by block reference — reusing the same element
+// lets React bail out of reconciling unchanged blocks (referential equality).
+//
+// Keyed in a WeakMap on the immutable Block object, so entries are GC'd with their
+// block — no leak, no manual invalidation. The render options are part of the
+// stored entry: a change to `editable`/`renderLink`/`renderMention` correctly
+// misses the cache and rebuilds.
+//
+// LIST items (bullet_item/ordered_item) are NEVER cached here: their nested
+// <ul>/<ol>/<li> shape depends on NEIGHBORS (grouping + relative depth), so a
+// sibling change can alter a list item's output while its own reference is
+// unchanged. They render fresh every time via collectList/renderListTree.
+type BlockCacheEntry = {
+  editable: boolean;
+  renderLink?: RenderLink;
+  renderMention?: RenderMention;
+  el: ReactElement;
+};
+const blockCache = new WeakMap<Block, BlockCacheEntry>();
+
+function cachedBlockEl(
+  block: Block,
+  editable: boolean,
+  renderLink: RenderLink | undefined,
+  renderMention: RenderMention | undefined,
+  build: () => ReactElement,
+): ReactElement {
+  const hit = blockCache.get(block);
+  if (
+    hit &&
+    hit.editable === editable &&
+    hit.renderLink === renderLink &&
+    hit.renderMention === renderMention
+  ) {
+    return hit.el;
+  }
+  const el = build();
+  blockCache.set(block, { editable, renderLink, renderMention, el });
+  return el;
 }
 
 function wrapMark(type: MarkType, mark: Mark, child: ReactNode): ReactNode {
@@ -191,7 +235,12 @@ function blockContent(block: Block, opts: ResolvedOptions): ReactNode {
   return renderInlines(block.inlines, opts);
 }
 
-function renderBlock(block: Block, opts: ResolvedOptions): ReactNode {
+// Build the element for a single NON-LIST block. Pure in (block, opts): no
+// position/index/depth/neighbor input (the effective depths computed in renderDoc
+// are consumed only by the list path). Every branch returns a single top-level
+// element carrying `key={block.id}` — so caching + reusing the reference preserves
+// the key and lets React skip reconciling the block.
+function buildBlock(block: Block, opts: ResolvedOptions): ReactElement {
   const anchor = opts.editable ? { 'data-block-id': block.id } : undefined;
   switch (block.type) {
     case 'heading': {
@@ -236,6 +285,14 @@ function renderBlock(block: Block, opts: ResolvedOptions): ReactNode {
         </p>
       );
   }
+}
+
+// Cache wrapper for a non-list block: returns the cached element when the block
+// reference AND the relevant options are unchanged, otherwise builds + stores it.
+function renderBlock(block: Block, opts: ResolvedOptions): ReactElement {
+  return cachedBlockEl(block, opts.editable, opts.renderLink, opts.renderMention, () =>
+    buildBlock(block, opts),
+  );
 }
 
 interface ListItemNode {


### PR DESCRIPTION
## Summary

Deep-review follow-up P-C (final item). Caches each rendered block element in a module-level `WeakMap<Block, …>` so an edit only rebuilds the changed block's element; React then skips reconciling the unchanged blocks via referential equality. For very large docs this cuts per-keystroke render work from O(blocks) to O(edited block).

**Correct by construction:** the engine is immutable — a block gets a new reference only when it changes. Caching is scoped to **context-independent block types** (paragraph/heading/blockquote/code_block/attachment), whose rendered element is a pure function of `(block, editable, renderLink, renderMention)` — all in the cache key. **List items are never cached** (their nested `<ul>/<ol>/<li>` shape depends on neighbors/grouping) — they build fresh exactly as before.

## Test plan

- `make test` (3471, +7 cache tests), `make build`, `make lint`, `npm run format:check` — green.
- Rule 8 review (clean) PROVED safety: `buildBlock` reads nothing outside the cache key (no `eff`/index/neighbors/locale/Date/module-state); transforms never mutate blocks in place (new ref per change); list items can't reach the cached path; `editable` in the key isolates the read-only viewer from the editor; attachment field changes always produce a new block ref. The cached element keeps its React `key`. Existing renderDoc/toHtml/serialize output is byte-identical.
- Live: typing renders correctly (edited block rebuilds, no stale), lists render with correct nesting, headings render.

Note (pre-existing, not introduced): cached attachment subtrees still receive React context updates (e.g. i18n/theme) normally — element-reuse bailout is orthogonal to context propagation.

This completes the deep-review decision list (`docs/superpowers/reviews/2026-06-27-rte-deep-review.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)