### PR TITLE
feat(RichTextEditor): resize any image on hover + hide handle while reordering (0.2.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ permissions:
   id-token: write # forwarded to the chained deploy-playground job
 
 env:
-  BUMP: patch
+  BUMP: minor
 
 jobs:
   quality:

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -1707,7 +1707,10 @@ describe('attachment config', () => {
     await waitFor(() => expect(screen.queryByTitle('Drag to resize')).toBeNull());
   });
 
-  it('shows no resize handle when blockControls is on but upload is off (no slider fallback)', async () => {
+  it('shows the resize handle on hover even when upload is off (decoupled from the slider)', async () => {
+    // Behavior change: the handle used to require upload (so the keyboard Width slider
+    // was its accessible fallback). It now shows for ANY previewable image on hover —
+    // the slider remains the a11y path only where blockControls+upload are configured.
     const user = userEvent.setup();
     function Harness() {
       const [doc, setDoc] = useState<RichDoc>({
@@ -1727,10 +1730,37 @@ describe('attachment config', () => {
     }
     renderEditor(<Harness />);
     await user.hover(document.querySelector('figure[data-block-id="img"]') as HTMLElement);
-    // The gutter still shows (blockControls), but without upload there's no accessible
-    // Width slider — so the pointer-only handle must not appear either.
-    await screen.findByRole('button', { name: 'Block actions' });
-    expect(screen.queryByTitle('Drag to resize')).toBeNull();
+    expect(await screen.findByTitle('Drag to resize')).toBeInTheDocument();
+  });
+
+  it('shows the resize handle on hover in a toolbar-only editor (no blockControls/upload)', async () => {
+    // A pasted image in a toolbar-only composer gets a handle too: it only needs an
+    // editable editor with a shell to anchor in (toolbar provides the shell).
+    const user = userEvent.setup();
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>({
+        blocks: [
+          {
+            id: 'img',
+            type: 'attachment',
+            status: 'ready',
+            src: 'http://u/p.png',
+            mime: 'image/png',
+            name: 'p.png',
+            inlines: [],
+          },
+          { id: 'p', type: 'paragraph', inlines: [{ text: 'hi', marks: [] }] },
+        ],
+      });
+      return <RichTextEditor toolbar value={doc} onChange={setDoc} />;
+    }
+    renderEditor(<Harness />);
+    const fig = document.querySelector('figure[data-block-id="img"]') as HTMLElement;
+    await user.hover(fig);
+    expect(await screen.findByTitle('Drag to resize')).toBeInTheDocument();
+    // Leaving the shell clears the hover → the handle goes away (when not dragging).
+    fireEvent.mouseLeave(screen.getByRole('textbox').parentElement as HTMLElement);
+    await waitFor(() => expect(screen.queryByTitle('Drag to resize')).toBeNull());
   });
 
   it('readOnly shows no Configure (the whole gutter is suppressed)', async () => {

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -371,6 +371,11 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     );
 
     const controlsOn = blockControls && !readOnly;
+    // Whether the stable `.shell` wrapper is rendered (a toolbar mode is active or
+    // block controls need the anchor). The image resize handle anchors into the
+    // shell, so its hover tracking + element are gated on this. Declared up here
+    // (vs. near the shell render) so the image-hover effect below can depend on it.
+    const usesShell = toolbar === true || autoToolbar || controlsOn;
     // The same gate the mention menu uses — drives both `useMention`'s `enabled`
     // and the consolidated selectionchange listener's mention fan-out below.
     const mentionsEnabled = !!mentions && !readOnly;
@@ -391,10 +396,26 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // progress the active block must not change (it IS the block being dragged), so
     // the hover handlers below read this ref and bail — mirroring blockMenuOpenRef.
     const draggingRef = useRef(false);
-    // Stable setter for draggingRef — passed to both overlays so their memoized
-    // shells don't re-render every keystroke on a fresh inline lambda.
+    // Stable setter for draggingRef — passed to the image resizer so its memoized
+    // shell doesn't re-render every keystroke on a fresh inline lambda. Used by the
+    // resizer's OWN drag: it sets draggingRef only (NOT blockDragging), so a resize
+    // never hides the handle mid-drag.
     const setDragging = useCallback((d: boolean) => {
       draggingRef.current = d;
+    }, []);
+    // The previewable image currently under the pointer → the resize-handle target.
+    // Tracked independently of blockControls/upload/active-block so the handle shows
+    // for ANY previewable image on hover (see the image-hover effect below).
+    const [hoveredImageId, setHoveredImageId] = useState<string | null>(null);
+    // True while a blockControls reorder drag is in flight. Hides the image resize
+    // handle (it can't follow the block's in-place reflow); it reappears at the drop.
+    const [blockDragging, setBlockDragging] = useState(false);
+    // Block-drag report (passed to RichTextBlockControls): set draggingRef so the
+    // hover/caret tracking bails AND set blockDragging so the image handle hides.
+    // Separate from setDragging (which the resizer's own drag uses) on purpose.
+    const onBlockDraggingChange = useCallback((d: boolean) => {
+      draggingRef.current = d;
+      setBlockDragging(d);
     }, []);
 
     // Resolve the [data-block-id] of the block element containing a DOM node.
@@ -406,6 +427,27 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         el = el.parentElement;
       }
       return null; // reached the root (or ran out of ancestors) — no block
+    }, []);
+
+    // Resolve the [data-block-id] of the previewable-image FIGURE containing a DOM
+    // node, or null. A previewable image renders `<figure data-block-id><img></figure>`;
+    // a non-preview file chip renders `<figure data-block-id><a></figure>` — so a
+    // figure that contains an <img> = a previewable image. DOM-based (no `value`
+    // dep), so it stays stable; the editor re-validates the id against the model.
+    const imageFigureIdAt = useCallback((node: Node | null): string | null => {
+      let el: HTMLElement | null =
+        node instanceof HTMLElement ? node : (node?.parentElement ?? null);
+      while (el && el !== rootRef.current) {
+        if (
+          el.tagName === 'FIGURE' &&
+          el.hasAttribute('data-block-id') &&
+          el.querySelector('img')
+        ) {
+          return el.getAttribute('data-block-id');
+        }
+        el = el.parentElement;
+      }
+      return null;
     }, []);
 
     // The block whose vertical band contains viewport-y `clientY`, or null. Used to
@@ -975,6 +1017,40 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       };
     }, [controlsOn, blockIdFromNode, blockAtPointerY]);
 
+    // Image-hover tracking (mouse) → drives the resize handle. Independent of the
+    // blockControls hover/caret tracking above so the handle shows for ANY
+    // previewable image, even in a toolbar-only composer (no blockControls/upload).
+    // Gated on `usesShell` because the handle anchors into the shell — without a
+    // shell there's nowhere to position it. Listens on the SHELL so reaching from
+    // the image onto the handle (a shell child, outside the editable) keeps it alive.
+    useEffect(() => {
+      if (readOnly || !usesShell) return;
+      const shell = shellRef.current;
+      if (!shell) return;
+      const onOver = (e: MouseEvent) => {
+        if (draggingRef.current) return; // don't retarget mid-drag (block OR resize)
+        const t = e.target as HTMLElement;
+        const id = imageFigureIdAt(t);
+        if (id) {
+          setHoveredImageId(id);
+          return;
+        }
+        // Over the handle itself → keep it alive (it sits at the image's corner,
+        // just outside the figure, so it wouldn't match imageFigureIdAt).
+        if (t.closest?.('[data-rte-resize-handle]')) return;
+        setHoveredImageId(null); // over text/other content → clear
+      };
+      const onLeave = () => {
+        if (!draggingRef.current) setHoveredImageId(null);
+      };
+      shell.addEventListener('mouseover', onOver);
+      shell.addEventListener('mouseleave', onLeave);
+      return () => {
+        shell.removeEventListener('mouseover', onOver);
+        shell.removeEventListener('mouseleave', onLeave);
+      };
+    }, [readOnly, usesShell, imageFigureIdAt]);
+
     const onKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLDivElement>) => {
         if (readOnly) return;
@@ -1276,13 +1352,13 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       uploaderRef,
     });
     // Stable resize handler for the image resizer — keeps the memoized resizer from
-    // re-rendering every keystroke on a fresh inline lambda. Guards activeBlockId so
-    // a late move after the active block clears is a no-op.
+    // re-rendering every keystroke on a fresh inline lambda. Targets the hovered
+    // image; guards hoveredImageId so a late move after the hover clears is a no-op.
     const onImageResize = useCallback(
       (w: number) => {
-        if (activeBlockId) onConfigWidth(activeBlockId, w);
+        if (hoveredImageId) onConfigWidth(hoveredImageId, w);
       },
-      [onConfigWidth, activeBlockId],
+      [onConfigWidth, hoveredImageId],
     );
 
     // Delegate clicks on the error-state attachment Retry/Remove buttons (they
@@ -1417,31 +1493,39 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         onReorder={onBlockReorder}
         onConfigure={canConfigure ? onConfigOpen : undefined}
         onColor={onBlockColor}
-        onDraggingChange={setDragging}
+        onDraggingChange={onBlockDraggingChange}
       />
     ) : null;
 
-    // A bottom-right resize handle on the active image — only when it renders as a
-    // preview (a safe, fetchable src) AND the keyboard-accessible Width slider is
-    // also available (`uploadOn`, same as `canConfigure`), so the pointer-only handle
-    // never appears without its accessible fallback. The layoutKey carries the
-    // image's width so the handle re-measures and tracks the corner as it resizes.
-    const activeIsResizableImage =
-      controlsOn &&
-      uploadOn &&
-      activeBlock?.type === 'attachment' &&
-      activeBlock.status === 'ready' &&
-      attachmentIsImage(activeBlock) &&
-      !!safeHref(activeBlock.src ?? '');
+    // A bottom-right resize handle on the HOVERED previewable image — shown for any
+    // previewable image (a safe, fetchable src that renders as <img>) on hover, as
+    // long as the editor is editable and has a shell to anchor the handle in
+    // (`usesShell`). Independent of blockControls/upload/active-block: a pasted image
+    // in a toolbar-only composer gets a handle too. The keyboard-accessible Width
+    // slider remains the a11y path where blockControls+upload are configured (the
+    // Configure popover). The layoutKey carries the image's width so the handle
+    // re-measures as it resizes; `hidden` hides it during a block reorder (it can't
+    // track the in-place reflow), reappearing at the drop.
+    const resizableImage = hoveredImageId
+      ? value.blocks.find(
+          (b) =>
+            b.id === hoveredImageId &&
+            b.type === 'attachment' &&
+            b.status === 'ready' &&
+            attachmentIsImage(b) &&
+            !!safeHref(b.src ?? ''),
+        )
+      : undefined;
     const imageResizerEl =
-      activeIsResizableImage && activeBlockId ? (
+      !readOnly && usesShell && resizableImage ? (
         <RichTextImageResizer
           rootRef={shellRef}
-          blockId={activeBlockId}
-          layoutKey={`${blockOrderKey}:${activeBlock?.width ?? ''}`}
+          blockId={hoveredImageId!}
+          layoutKey={`${blockOrderKey}:${resizableImage.width ?? ''}`}
           maxWidth={rootRef.current?.getBoundingClientRect().width ?? 600}
           onResize={onImageResize}
           onDraggingChange={setDragging}
+          hidden={blockDragging}
         />
       ) : null;
 
@@ -1487,9 +1571,8 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     const overlayOpen = linkEditor != null || mention.open;
     const showToolbar =
       toolbar === true || (autoToolbar && (focused || !isEmptyDoc(value) || overlayOpen));
-    // Render the stable `.shell` whenever a toolbar mode is active (so the bar can
-    // toggle WITHOUT remounting the editable) or block controls need the anchor.
-    const usesShell = toolbar === true || autoToolbar || controlsOn;
+    // `usesShell` (the stable `.shell` gate) is declared near the top so the
+    // image-hover effect can depend on it; it's reused here for the shell render.
 
     const toolbarBar = showToolbar ? (
       <RichTextToolbar

--- a/packages/design-system/src/components/RichTextEditor/RichTextImageResizer.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextImageResizer.test.tsx
@@ -4,7 +4,7 @@ import { useRef } from 'react';
 import { I18nProvider } from '../../i18n';
 import { RichTextImageResizer } from './RichTextImageResizer';
 
-function Harness({ withImg = true }: { withImg?: boolean }) {
+function Harness({ withImg = true, hidden = false }: { withImg?: boolean; hidden?: boolean }) {
   const rootRef = useRef<HTMLDivElement>(null);
   return (
     <I18nProvider locale="en">
@@ -12,7 +12,13 @@ function Harness({ withImg = true }: { withImg?: boolean }) {
         <figure data-block-id="v" contentEditable={false}>
           {withImg ? <img alt="x" src="http://u/p.png" /> : null}
         </figure>
-        <RichTextImageResizer rootRef={rootRef} blockId="v" maxWidth={600} onResize={() => {}} />
+        <RichTextImageResizer
+          rootRef={rootRef}
+          blockId="v"
+          maxWidth={600}
+          onResize={() => {}}
+          hidden={hidden}
+        />
       </div>
     </I18nProvider>
   );
@@ -25,6 +31,13 @@ it('renders a resize handle when the target image is present', () => {
 
 it('renders nothing when the target image is absent (e.g. a file chip)', () => {
   render(<Harness withImg={false} />);
+  expect(screen.queryByTitle('Drag to resize')).toBeNull();
+});
+
+it('hidden → renders nothing but stays mounted (no throw)', () => {
+  // Hidden during a block reorder: the element must still MOUNT (so its drag-end
+  // cleanup doesn't fire and clobber the editor's block-drag flag) but render nothing.
+  expect(() => render(<Harness hidden />)).not.toThrow();
   expect(screen.queryByTitle('Drag to resize')).toBeNull();
 });
 

--- a/packages/design-system/src/components/RichTextEditor/RichTextImageResizer.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextImageResizer.tsx
@@ -16,7 +16,7 @@ const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v
 export interface RichTextImageResizerProps {
   /** The editor shell element ref — to locate the image and anchor the handle. */
   rootRef: RefObject<HTMLElement | null>;
-  /** Id of the active (ready, previewable) image attachment block. */
+  /** Id of the hovered (ready, previewable) image attachment block. */
   blockId: string;
   /**
    * A signature that changes whenever block order or the image's width shifts, so
@@ -32,12 +32,21 @@ export interface RichTextImageResizerProps {
    * changes while resizing (mirrors RichTextBlockControls' onDraggingChange).
    */
   onDraggingChange?: (dragging: boolean) => void;
+  /**
+   * Hide the handle WITHOUT unmounting it — used while a block-controls reorder
+   * drag is in flight (the handle can't track the block's in-place reflow, so it
+   * hides, then reappears at the dropped position). The component stays mounted so
+   * its drag-end unmount cleanup doesn't fire `onDraggingChange(false)` and clobber
+   * the editor's block-drag dragging flag.
+   */
+  hidden?: boolean;
 }
 
 /**
  * Internal: the bottom-right resize handle for a ready image attachment. Rendered
- * by `<RichTextEditor>` when the active block is a previewable image; not exported
- * from the package.
+ * by `<RichTextEditor>` when a previewable image is hovered (independent of
+ * blockControls/upload — see the editor's image-hover tracking); not exported from
+ * the package.
  */
 export const RichTextImageResizer = memo(function RichTextImageResizer({
   rootRef,
@@ -46,6 +55,7 @@ export const RichTextImageResizer = memo(function RichTextImageResizer({
   maxWidth,
   onResize,
   onDraggingChange,
+  hidden,
 }: RichTextImageResizerProps) {
   const t = useTranslation();
   // Drag origin, captured on pointerdown. null when not dragging.
@@ -99,13 +109,18 @@ export const RichTextImageResizer = memo(function RichTextImageResizer({
     reportDragging(false);
   };
 
-  if (!box) return null;
+  // Early return is AFTER every hook above so hook order stays stable when
+  // `hidden` toggles. The component stays MOUNTED while hidden (the editor keeps
+  // rendering the element) — only its render bails — so the unmount cleanup in
+  // useDraggingReporter never fires mid-reorder.
+  if (hidden || !box) return null;
 
   return (
     <div
       className={styles.resizeHandle}
       style={{ top: box.top, left: box.left }}
       contentEditable={false}
+      data-rte-resize-handle=""
       title={t('richTextEditor.attachmentResize')}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -60,8 +60,12 @@ export function RichTextEditorDemo() {
   const [autoDoc, setAutoDoc] = useState<RichDoc>(() => docFromText(''));
   const [linkDoc, setLinkDoc] = useState<RichDoc>(docFromText('Read the docs and visit our site.'));
   const [importDoc, setImportDoc] = useState<RichDoc>(() =>
-    fromMarkdown(
-      '# Imported\n\nThis editor was **seeded** from Markdown — paste rich HTML to import more.',
+    // Seeded via fromHtml so it carries an embedded image — this editor has a toolbar
+    // but NO blockControls, demonstrating that a pasted/imported image is still
+    // resizable: hover it and drag the corner handle.
+    fromHtml(
+      '<h1>Imported</h1><p>This editor was <strong>seeded</strong> from HTML — paste rich HTML to import more. Hover the image and drag its corner to resize (no block controls needed).</p>' +
+        `<img src="${sampleEmbedSrc}" width="280" alt="Imported sample image" />`,
     ),
   );
   const [blockDoc, setBlockDoc] = useState<RichDoc>(() =>
@@ -207,7 +211,7 @@ export function RichTextEditorDemo() {
 
       <Example
         title="Import (HTML / Markdown) + rich paste"
-        description="Seed the editor from stored HTML or Markdown with fromHtml / fromMarkdown, and paste rich HTML (from the web, Word, Google Docs) straight into the editor — it becomes formatted content, not plain text."
+        description="Seed the editor from stored HTML or Markdown with fromHtml / fromMarkdown, and paste rich HTML (from the web, Word, Google Docs) straight into the editor — it becomes formatted content, not plain text. This editor has a toolbar but no blockControls, yet the imported image is still resizable: hover it and drag the bottom-right corner handle."
         code={`import { fromMarkdown } from '@eocrm/design-system'; // (fromHtml too — same API)
 const [doc, setDoc] = useState(() => fromMarkdown('# Imported\\n\\n- one\\n- two'));
 <RichTextEditor value={doc} onChange={setDoc} toolbar />`}


### PR DESCRIPTION
## Summary

Two image-resize improvements, plus a minor version bump to **0.2.0**.

1. **Resize handle for any previewable image, independent of `blockControls`/`upload`.** Previously the corner resize handle only appeared with `blockControls` + `upload`. Now it shows whenever you **hover a previewable image** in an editable editor that has a shell (toolbar/auto-toolbar/blockControls) — so a pasted/imported image in a plain `toolbar` composer is resizable. New `hoveredImageId` + a shell `mouseover`/`mouseleave` tracker (`imageFigureIdAt` resolves a `<figure><img>` and excludes `<figure><a>` chips), kept alive while the pointer is over the handle (`data-rte-resize-handle`). The width-resize path (`onConfigWidth`/`commitResizeLive`) never needed `upload` — it just updates the block width.
2. **The handle no longer lingers during a block reorder.** Moving to the ⠿ gutter to grab it already clears the image hover; plus a `hidden={blockDragging}` guard (`blockDragging` set by the block-controls drag) hides the handle during any reorder and it reappears at the dropped position. The resizer stays **mounted** while hidden (returns null after its hooks) so its unmount cleanup can't clobber the drag's `draggingRef`.

A11y note (deliberate, documented): without `blockControls`+`upload` there's no Width-slider keyboard path, so the handle is pointer-only there (matches the gutter-drag precedent); where they're configured, the slider remains.

Demo: the toolbar-only "Import" editor is now seeded (via `fromHtml`) with an embedded image to demonstrate resizing without blockControls.

## Test plan

- `make test` (3473), `make build` (lib + playground), `make lint`, `npm run format:check` — green.
- Rule 8 review (clean): proved the unmount-clobber race is impossible (reorder is commit-on-drop; `hoveredImageId` is frozen during the drag, so the resizer never unmounts mid-reorder); confirmed no regression to the blockControls+upload path; `usesShell` reorder is value-identical; memo stability preserved.
- Live: in the toolbar-only Import editor (no gutter) hovering the image shows the handle and dragging it resized 280→205px; in the blockControls editor the handle clears when moving to the gutter, stays gone during the reorder drag, and reappears after drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)