### PR TITLE
ci(release): reset BUMP to patch (post-0.2.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ permissions:
   id-token: write # forwarded to the chained deploy-playground job
 
 env:
-  BUMP: minor
+  BUMP: patch
 
 jobs:
   quality:


### PR DESCRIPTION
Resets `BUMP` from `minor` back to `patch` after the intentional 0.2.0 release (#245), so subsequent releases patch-bump from 0.2.x. Touches only `release.yml`, so it publishes a no-op 0.2.1 (identical library code) — that's the cost of the one-shot minor bump given the workflow's publish gate.