### PR TITLE
feat(playground): auto API tables + self-contained code blocks (Phase A)

### DIFF
--- a/docs/superpowers/specs/2026-06-28-demo-docs-overhaul-design.md
+++ b/docs/superpowers/specs/2026-06-28-demo-docs-overhaul-design.md
@@ -1,0 +1,86 @@
+# Demo-docs overhaul — self-contained code blocks + auto API tables (2026-06-28)
+
+Two improvements to every component demo page in the playground, requested while
+the user was AFK ("do all components one by one"). The whole effort is
+**playground-only** — no library files change, so it triggers no `@eocrm/design-system`
+release and is not subject to the library's Rule 8 review loop.
+
+## Workstream 1 — API reference table (DONE, Phase A)
+
+Each demo gets an **API** section at the bottom listing the component's props.
+
+- **Source of truth:** the component's own `<Name>Props` TypeScript + JSDoc
+  (Rule 7 guarantees it's complete). Never hand-written, so it can't drift.
+- **Extractor:** `packages/playground/scripts/extract-props.mjs` uses the TS
+  compiler API to resolve each `<Name>Props` exported from
+  `design-system/src/components/<Name>/index.ts`, enumerate its apparent
+  properties, and keep only those _declared in the library source_ (drops the
+  hundreds of inherited `HTMLAttributes` members). For each prop it records
+  `{ name, type, required, default, description }`. `default` comes from a
+  `@default` JSDoc tag if present, else from the prose convention
+  `` `primary` (default) ``. `| undefined` is stripped from optional types.
+- **Manifest:** `packages/playground/src/lib/props.manifest.json`. Regenerated on
+  every dev/build by a Vite `buildStart` plugin (`vite.config.ts`) so the committed
+  copy can never go stale; `npm run build:props` regenerates it manually.
+- **Render:** `packages/playground/src/pages/components/ComponentApi.tsx` —
+  `<ComponentApi name>` renders a `<Table>` (Prop / Type / Default / Description)
+  with a small markdown-lite renderer for the JSDoc (paragraphs, `-` bullets,
+  inline `` `code` `` and `**bold**`). Required props get a red `required` Badge.
+  Wired once into `DemoBody`, keyed off the existing `componentName`, so all
+  demos that pass `componentName` get the table for free. Components with no
+  public props (e.g. Toast — imperative API) render nothing.
+
+86 of 90 components produce a table (584 props total). The four demos without a
+`componentName` (AppLayout, DatePickers, Field, FormRow, FormSection) are wired
+up in Workstream 2.
+
+## Workstream 2 — self-contained code blocks (Phase B, fan-out)
+
+Today each `<Example code={`…`}>` shows only the bare JSX fragment — no imports,
+no data objects. The goal: **copy the block, paste it, reproduce the demo.**
+
+### Convention (reference implementation: `ButtonDemo.tsx`)
+
+Every `code` string becomes a complete, runnable snippet:
+
+1. **Imports first**, in this order, only what the snippet uses:
+   `react` (hooks/types) → third-party (`lucide-react` icons, etc.) →
+   `@eocrm/design-system`. One blank line after the imports.
+2. **Data objects next** — any `const rows = […]` / `const options = […]` the
+   example references, with realistic data, inlined here (not hidden in a
+   module-level const the reader can't see).
+3. **The example as a component** — `export function Demo() { return (…); }`, or
+   keep the example's existing named function (e.g. `SaveWithSuccessFlash`) and
+   just prepend imports. The JSX **must match the live preview exactly** (same
+   props, same children, same wrapper) so the code never lies about what's shown.
+
+Rules:
+
+- The code is a template literal; never introduce an unescaped `${` (escape as
+  `\${` if the snippet genuinely needs it).
+- Don't import demo-harness modules (`DemoLayout`, `Example`, `getComponentFiles`)
+  — those are not part of what the consumer copies.
+- If the live preview uses playground-only mock data, inline a small realistic
+  literal in the snippet instead of importing `../../data/mock`.
+- Keep indentation valid TSX so the snippet reads as real code.
+
+### Execution
+
+Fan out one subagent per demo (batched, ~12 per PR). Each subagent rewrites only
+the `code` props of its file to the convention above, matching each Example's
+live preview, then the batch is gated (`make build`, `make lint`,
+`npm run format:check`) and shipped as a playground-only PR. ButtonDemo is the
+worked reference.
+
+## Decisions made autonomously (open to revisit)
+
+- **Auto-extracted API table over hand-written prose.** Scales to 90 components
+  with zero drift; the trade-off is the table reflects exactly the JSDoc — if a
+  prop's JSDoc is thin, its row is thin. Fix by improving the component JSDoc
+  (a library change), which the table then picks up for free.
+- **`default` via the `(default)` prose heuristic** since the codebase doesn't
+  use `@default` tags. Adding `@default` tags later would make the column
+  authoritative, but that's a library-wide edit deferred for now.
+- **Code blocks wrapped in `export function Demo()`** rather than left as bare
+  JSX, to satisfy "reproduce demo component." Verbose but unambiguous; the
+  disclosure is collapsed by default so it doesn't add visual noise.

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "build:props": "node scripts/build-props.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/playground/scripts/build-props.mjs
+++ b/packages/playground/scripts/build-props.mjs
@@ -1,0 +1,20 @@
+// build-props.mjs — write the props manifest to src/lib/props.manifest.json.
+// Run via `npm run build:props`. The Vite plugin (vite.config.ts) calls the same
+// extractor on every dev/build so the committed copy can't drift; this CLI exists
+// for an explicit one-off regen and as the npm-script entry point.
+import { writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { extractProps } from './extract-props.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT_PATH = join(__dirname, '..', 'src', 'lib', 'props.manifest.json');
+
+const manifest = extractProps();
+writeFileSync(OUTPUT_PATH, JSON.stringify(manifest, null, 2) + '\n');
+
+const count = Object.keys(manifest).length;
+const total = Object.values(manifest).reduce((sum, c) => sum + c.props.length, 0);
+console.log(
+  `props.manifest.json regenerated — ${count} components, ${total} props → ${relative(process.cwd(), OUTPUT_PATH)}`,
+);

--- a/packages/playground/scripts/extract-props.mjs
+++ b/packages/playground/scripts/extract-props.mjs
@@ -1,0 +1,143 @@
+// extract-props.mjs — read each design-system component's public `<Name>Props`
+// type (and its JSDoc) into a flat props manifest the playground renders as the
+// "API" table at the bottom of every demo page.
+//
+// Source of truth is the component's own TypeScript + JSDoc (Rule 7 guarantees
+// it's complete), so the table can never drift from the shipped API. Inherited
+// DOM/React attributes are filtered out — only props *declared in the library
+// source* show up, which is exactly the component-specific surface.
+//
+// Consumed by the Vite plugin in vite.config.ts (regenerates on every dev/build)
+// and by `npm run build:props`. Pure read; no dependency on a running app.
+import ts from 'typescript';
+import { readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DS_SRC = resolve(__dirname, '..', '..', 'design-system', 'src');
+const COMPONENTS_DIR = join(DS_SRC, 'components');
+
+/** Compiler options mirroring tsconfig.base.json (enough to resolve types). */
+const COMPILER_OPTIONS = {
+  target: ts.ScriptTarget.ES2022,
+  lib: ['lib.es2022.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts'],
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  jsx: ts.JsxEmit.ReactJSX,
+  strict: true,
+  esModuleInterop: true,
+  skipLibCheck: true,
+  resolveJsonModule: true,
+  noEmit: true,
+};
+
+/** Component directories that expose an `index.ts` barrel. */
+function componentDirs() {
+  return readdirSync(COMPONENTS_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => {
+      try {
+        return statSync(join(COMPONENTS_DIR, name, 'index.ts')).isFile();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+function isLibrarySourceFile(fileName) {
+  return fileName.includes('/design-system/src/') && !fileName.endsWith('.d.ts');
+}
+
+/** Strip the `| undefined` an optional prop's resolved type carries — the
+ * `required` flag already conveys optionality, so it's pure noise in the table. */
+function cleanTypeText(text) {
+  return text.replace(/\s*\|\s*undefined\b/g, '').trim();
+}
+
+/**
+ * The documented default for a prop. Prefers an explicit `@default` JSDoc tag;
+ * falls back to the codebase's prose convention of marking the default option
+ * inline, e.g. `` `primary` (default) `` or `` `md` (32px, default) ``.
+ */
+function documentedDefault(symbol, checker, description) {
+  const tag = symbol
+    .getJsDocTags(checker)
+    .find((t) => t.name === 'default' || t.name === 'defaultValue');
+  if (tag) {
+    return ts
+      .displayPartsToString(tag.text)
+      .trim()
+      .replace(/^[`'"]|[`'"]$/g, '');
+  }
+  // `<token>` immediately followed by a parenthetical that contains "default".
+  const match = description.match(/`([^`]+)`\s*\([^)]*\bdefault\b[^)]*\)/i);
+  return match ? match[1] : '';
+}
+
+/** Build the manifest for every component that exports `<Name>Props`. */
+export function extractProps() {
+  const names = componentDirs();
+  const rootNames = names.map((n) => join(COMPONENTS_DIR, n, 'index.ts'));
+  const program = ts.createProgram(rootNames, COMPILER_OPTIONS);
+  const checker = program.getTypeChecker();
+
+  const manifest = {};
+
+  for (const name of names) {
+    const indexPath = join(COMPONENTS_DIR, name, 'index.ts');
+    const sourceFile = program.getSourceFile(indexPath);
+    if (!sourceFile) continue;
+
+    const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+    if (!moduleSymbol) continue;
+
+    const exports = checker.getExportsOfModule(moduleSymbol);
+    const propsSymbol = exports.find((s) => s.getName() === `${name}Props`);
+    if (!propsSymbol) continue;
+
+    const type = checker.getDeclaredTypeOfSymbol(propsSymbol);
+    const members = type.getApparentProperties();
+
+    const props = [];
+    for (const member of members) {
+      const decls = member.getDeclarations() ?? [];
+      // Keep only props authored in the library source — drops the hundreds of
+      // inherited HTMLAttributes/DOMAttributes members from lib.dom.d.ts.
+      const ownDecl = decls.find((d) => isLibrarySourceFile(d.getSourceFile().fileName));
+      if (!ownDecl) continue;
+
+      const propType = checker.getTypeOfSymbolAtLocation(member, ownDecl);
+      const typeText = cleanTypeText(
+        checker.typeToString(
+          propType,
+          ownDecl,
+          ts.TypeFormatFlags.NoTruncation |
+            ts.TypeFormatFlags.UseAliasDefinedOutsideCurrentScope |
+            ts.TypeFormatFlags.InTypeAlias,
+        ),
+      );
+      const description = ts.displayPartsToString(member.getDocumentationComment(checker)).trim();
+
+      props.push({
+        name: member.getName(),
+        type: typeText,
+        required: (member.flags & ts.SymbolFlags.Optional) === 0,
+        default: documentedDefault(member, checker, description),
+        description,
+        // Source position so we can present props in authored order.
+        order: ownDecl.getStart(),
+      });
+    }
+
+    if (props.length === 0) continue;
+    props.sort((a, b) => a.order - b.order);
+    manifest[name] = {
+      props: props.map(({ order, ...rest }) => rest),
+    };
+  }
+
+  return manifest;
+}

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -1,0 +1,4434 @@
+{
+  "Accordion": {
+    "props": [
+      {
+        "name": "variant",
+        "type": "AccordionVariant",
+        "required": false,
+        "default": "",
+        "description": "Visual variant. Defaults to `'bordered'`."
+      },
+      {
+        "name": "size",
+        "type": "AccordionSize",
+        "required": false,
+        "default": "",
+        "description": "Trigger size (font + padding). Defaults to `'md'`."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "type",
+        "type": "\"single\" | \"multiple\"",
+        "required": true,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "value",
+        "type": "string | string[]",
+        "required": false,
+        "default": "",
+        "description": "Controlled open item value. `''` = nothing open (only meaningful when `collapsible`).\nControlled open items array."
+      },
+      {
+        "name": "defaultValue",
+        "type": "string | string[]",
+        "required": false,
+        "default": "",
+        "description": "Initial open item for uncontrolled use.\nInitial open items for uncontrolled use."
+      },
+      {
+        "name": "onValueChange",
+        "type": "((next: string) => void) | ((next: string[]) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires when the open item changes.\nFires when the set of open items changes."
+      },
+      {
+        "name": "collapsible",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "When true, clicking the currently-open item closes it. Default: `false`\n(matches Radix; prevents accidentally closing the only available content)."
+      }
+    ]
+  },
+  "Alert": {
+    "props": [
+      {
+        "name": "tone",
+        "type": "AlertTone",
+        "required": false,
+        "default": "",
+        "description": "Tone. Defaults to `'info'`. See `AlertTone` for full descriptions."
+      },
+      {
+        "name": "title",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Optional bold heading. Renders above the description. ReactNode so you\ncan embed inline emphasis (`<>Update <strong>1.2.3</strong> available</>`).\n\nThe native HTML `title` attribute (tooltip-on-hover) is collapsed by this\nprop. Use `aria-label` if you need that."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Description body. Rendered below the title in muted color."
+      },
+      {
+        "name": "icon",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Override the tone's default icon. Pass any ReactNode (typically a\nlucide-react icon). Pass `null` to hide the icon entirely.\n\nDefaults: `info` → `Info`, `success` → `CheckCircle2`,\n`warning` → `AlertTriangle`, `error` → `XCircle`."
+      },
+      {
+        "name": "actions",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Optional action row rendered below the description. Typically a single\nButton or a Cluster of two (\"Retry\", \"Dismiss\"). The component doesn't\nmanage the action row's layout — pass a pre-laid-out node."
+      },
+      {
+        "name": "onDismiss",
+        "type": "(() => void)",
+        "required": false,
+        "default": "",
+        "description": "Called when the user clicks the close (×) button. When set, the close\nbutton renders; when omitted, no close button. Alert is **controlled** —\nthe component does NOT manage internal hidden state. Hide via\nconditional render in the consumer:\n\n```tsx\nconst [show, setShow] = useState(true);\n{show && <Alert tone=\"success\" onDismiss={() => setShow(false)}>Saved</Alert>}\n```"
+      }
+    ]
+  },
+  "AppLayout": {
+    "props": [
+      {
+        "name": "topBar",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Top bar slot — sits above the main content, spanning the content column to\nthe right of the sidebar (not the full window width). Omit for no top bar."
+      },
+      {
+        "name": "sidebar",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Sidebar slot — runs the full height down the left, alongside both the top\nbar and the content. Sets its own width (intrinsic). Omit for no sidebar."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "Main content slot — fills the remaining space below the top bar."
+      }
+    ]
+  },
+  "Avatar": {
+    "props": [
+      {
+        "name": "name",
+        "type": "string",
+        "required": true,
+        "default": "",
+        "description": "The person's name. Required — used as the `alt`/`aria-label`, as the\nsource of the initials, and as the seed for the deterministic fallback\ncolor. The same name always renders the same color. When `tooltip` is\ntrue, also used as the tooltip body."
+      },
+      {
+        "name": "src",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Image URL. When provided, the `<img>` is rendered with `alt={name}`.\nEmpty/whitespace strings are treated as missing. If the image fails to\nload (404, network), the component automatically falls back to initials."
+      },
+      {
+        "name": "size",
+        "type": "AvatarSize",
+        "required": false,
+        "default": "md",
+        "description": "Diameter.\n- `sm` (24px) — table rows, dense lists.\n- `md` (32px, default) — most uses.\n- `lg` (40px) — detail-page headers.\n\nInside `<AvatarGroup>`, the group's `size` overrides this."
+      },
+      {
+        "name": "status",
+        "type": "AvatarStatus",
+        "required": false,
+        "default": "",
+        "description": "Presence dot in the bottom-right.\n- `'online'`  — green.\n- `'busy'`    — red.\n- `'away'`    — amber.\n- `'offline'` — gray.\nOmit to render no dot at all."
+      },
+      {
+        "name": "tooltip",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Whether to wrap the avatar in a `<Tooltip>` showing `name`. Defaults to\n`false` (back-compat — existing renders don't gain a hover affordance).\nInside `<AvatarGroup>`, the group's `tooltip` prop becomes the default\n(which itself defaults to `true` for grouped avatars); explicit\nper-child still wins."
+      }
+    ]
+  },
+  "Badge": {
+    "props": [
+      {
+        "name": "tone",
+        "type": "BadgeTone",
+        "required": false,
+        "default": "neutral",
+        "description": "Semantic tone.\n- `neutral` (default) — generic tag, no semantic meaning.\n- `info` — new / in-progress / informational states (\"Lead\", \"Pipeline 2026\").\n- `success` — positive states (\"Active\", \"Won\", \"Healthy\").\n- `warning` — at-risk / pending states (\"Renewal due\", \"Pending review\").\n- `danger` — negative states (\"Churned\", \"Lost\", \"Blocked\").\n- `purple` — special / highlighted categories (\"Enterprise\", \"VIP\")."
+      },
+      {
+        "name": "size",
+        "type": "BadgeSize",
+        "required": false,
+        "default": "md",
+        "description": "Pill height and emphasis.\n- `md` (20px, default) — the standard \"loud label\" pill. Uppercase, tracked,\n  semibold. Reads as a deliberate status marker.\n- `sm` (16px) — quieter inline tag for tight table cells, compact toolbars,\n  or anywhere a 20px uppercase pill visually crowds adjacent text. Drops\n  the uppercase transform and caps tracking so it sits next to body copy\n  without shouting; case is preserved as-typed (write `Active`, get\n  `Active`). Same 11px size and semibold weight as `md`."
+      },
+      {
+        "name": "dot",
+        "type": "BadgeDot",
+        "required": false,
+        "default": "",
+        "description": "Render a small filled circle in the badge's text color alongside the\ncontent. Useful when the dot is the primary status signal and the label\nis supporting context (\"● Active\", \"Failed ●\").\n- `start` — dot before the content.\n- `end` — dot after the content.\n\nOmit for no dot. The dot is purely decorative (`aria-hidden`) — the badge\ntext remains the accessible label."
+      },
+      {
+        "name": "variant",
+        "type": "BadgeVariant",
+        "required": false,
+        "default": "'filled'",
+        "description": "Visual variant.\n- `'filled'` (default) — solid tone-tinted pill. The standard \"loud status\" look.\n- `'stripe'` — rectangular block with a tone-colored left stripe + soft tinted body.\n  Use for category markers or sidebar labels where pill emphasis is too loud."
+      },
+      {
+        "name": "color",
+        "type": "PaletteColor",
+        "required": false,
+        "default": "",
+        "description": "Optional categorical palette color. When set, takes precedence over\n`tone`: the badge fills with the matching `--color-palette-<name>-bg/fg`\ntokens. Use for non-semantic categorical labels (e.g., audit event\nnamespaces, tag colors) where the 6 semantic tones aren't enough.\n\nBoth filled and stripe variants are supported; for stripe the\nleft-border picks up the palette `fg` token."
+      }
+    ]
+  },
+  "BrandIcon": {
+    "props": [
+      {
+        "name": "name",
+        "type": "\"google\" | \"yandex\"",
+        "required": true,
+        "default": "",
+        "description": "Which brand mark to render."
+      },
+      {
+        "name": "size",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Square pixel size (width = height). Defaults to `20`."
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible name. Omit (default) for a decorative icon beside a text label —\nthe icon renders `aria-hidden`. Set it for a standalone icon (e.g. an\nicon-only button) → `role=\"img\"` + `aria-label`."
+      }
+    ]
+  },
+  "Breadcrumb": {
+    "props": [
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "One or more `<Breadcrumb.Item>` children. The component injects the\nseparator between items and auto-marks the last child as current\n(renders as `<span aria-current=\"page\">` instead of a link)."
+      },
+      {
+        "name": "separator",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Custom separator between items. Defaults to a small `<ChevronRight>`\nlucide icon. The separator renders inside a `<span aria-hidden=\"true\">`\nwrapper automatically."
+      },
+      {
+        "name": "ariaLabel",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Visible label for the `<nav>` element. Defaults to the i18n value at\n`breadcrumb.ariaLabel` (`'Breadcrumb'` in English). Override when\nmultiple breadcrumb instances coexist on the same page."
+      },
+      {
+        "name": "className",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Pass-through className applied to the `<nav>` wrapper."
+      }
+    ]
+  },
+  "Button": {
+    "props": [
+      {
+        "name": "variant",
+        "type": "ButtonVariant",
+        "required": false,
+        "default": "primary",
+        "description": "Visual variant.\n- `primary` (default) — the section's main action. Use **one** per page section.\n- `secondary` — supporting actions like \"Cancel\", \"Export\", \"Filter\".\n- `ghost` — tertiary actions in dense UIs (toolbar buttons, row actions).\n- `danger` — destructive operations only (Delete, Revoke, Remove). Pair with a confirmation if irreversible.\n- `success` — **transient confirmation only**, not an initial state. Flip to\n  `success` for ~1.5s after an action resolves (Save → \"Saved!\"), then\n  flip back. Never render a button as `success` on mount — it has no\n  action-intent meaning, only post-action feedback. See the `@example`\n  below for the timer pattern."
+      },
+      {
+        "name": "size",
+        "type": "ButtonSize",
+        "required": false,
+        "default": "md",
+        "description": "Control height (matches the shared `--size-*` scale used by Input and Avatar).\n- `xs` (20px) — icon-only or very dense inline actions (row controls,\n  chip-adjacent buttons). Pass `aria-label` when icon-only. Below WCAG\n  2.5.5 Level AAA touch-target guidance; reserve for desktop-first surfaces.\n- `sm` (24px) — dense toolbars, tables, inline actions.\n- `md` (32px, default) — most contexts.\n- `lg` (40px) — marketing-style empty states or emphasized primary actions."
+      },
+      {
+        "name": "iconOnly",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Render the button as a square icon-only target — `aspect-ratio` is forced\nto 1 so width tracks the size's `height` token (`xs` → 20×20, `sm` → 24×24,\n`md` → 32×32, `lg` → 40×40) and `padding` is tightened to a small inset\n(4px) so the icon has breathing room without changing the outer shape.\n\n**Always pass `aria-label`** when `iconOnly` is set, otherwise the button\nhas no accessible name. Pass a single icon as `children`.\n\nUse for inline density (row controls, chip-adjacent actions, toolbar\naffordances). For an icon + short text label, leave `iconOnly` off — the\nbutton will lay out as a normal rectangle with the existing gap."
+      }
+    ]
+  },
+  "ButtonGroup": {
+    "props": [
+      {
+        "name": "size",
+        "type": "ButtonSize",
+        "required": false,
+        "default": "",
+        "description": "Size propagated to children. Per-child `size` (Button or Item) wins\nwhen explicitly set. In visual mode this happens via cloneElement on\nButton children. In segmented mode, `<ButtonGroup.Item>` reads from\ncontext."
+      },
+      {
+        "name": "disabled",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Disabled state for the whole group. In segmented mode this is\nauthoritative (all items become aria-disabled, clicks no-op). In\nvisual mode this is a no-op — pass `disabled` per `<Button>` instead."
+      },
+      {
+        "name": "className",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "style",
+        "type": "CSSProperties",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Visual mode marker. Never set; absence flips to visual.\nCurrently-selected item value. Triggers segmented mode."
+      },
+      {
+        "name": "onValueChange",
+        "type": "((next: string) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fired when a different Item is selected.\n\nConsumers wanting literal-union narrowing can cast the setter:\n`onValueChange={(v) => setView(v as 'grid' | 'list')}`."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible name for the group landmark. Optional but recommended.\nRequired in segmented mode (radiogroup needs a label)."
+      },
+      {
+        "name": "aria-labelledby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Identifies the element (or elements) that labels the current element.\nAlternative to aria-label: id of an external labelling element."
+      }
+    ]
+  },
+  "Calendar": {
+    "props": [
+      {
+        "name": "events",
+        "type": "readonly CalendarEvent[]",
+        "required": false,
+        "default": "",
+        "description": "Events to display."
+      },
+      {
+        "name": "view",
+        "type": "CalendarView",
+        "required": false,
+        "default": "",
+        "description": "Active view (controlled). Pair with `onViewChange`."
+      },
+      {
+        "name": "defaultView",
+        "type": "CalendarView",
+        "required": false,
+        "default": "",
+        "description": "Initial view (uncontrolled). Defaults to `'month'`."
+      },
+      {
+        "name": "onViewChange",
+        "type": "((view: CalendarView) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires when the user clicks the view switcher."
+      },
+      {
+        "name": "value",
+        "type": "Date",
+        "required": false,
+        "default": "",
+        "description": "Navigation cursor (controlled)."
+      },
+      {
+        "name": "defaultValue",
+        "type": "Date",
+        "required": false,
+        "default": "",
+        "description": "Initial cursor (uncontrolled). Defaults to `new Date()`."
+      },
+      {
+        "name": "onChange",
+        "type": "((date: Date) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires on prev/next/today/keyboard navigation."
+      },
+      {
+        "name": "onDayClick",
+        "type": "((date: Date) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires when the user clicks a day cell's empty space.\n- Month view: empty space in a day cell, the \"+N more\" overflow chip, or\n  keyboard activation (Enter/Space) on a focused cell.\n- Week/Day view: empty hour-grid space inside that day's column —\n  **mouse click only**. There is no keyboard equivalent in v3; consumers\n  needing keyboard activation in week/day should surface their detail UI\n  through the focusable event chips (which fire `onEventClick`)."
+      },
+      {
+        "name": "onEventClick",
+        "type": "((event: CalendarEvent) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires when the user clicks an event chip."
+      },
+      {
+        "name": "locale",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Override locale. Defaults to `useLocale()`."
+      },
+      {
+        "name": "weekStartsOn",
+        "type": "0 | 1 | 2 | 3 | 4 | 5 | 6",
+        "required": false,
+        "default": "",
+        "description": "Override locale-derived first day of week."
+      },
+      {
+        "name": "maxLanesPerWeek",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Lane cap per week before \"+N more\" appears in affected cells (month view). Default 3."
+      },
+      {
+        "name": "hourRange",
+        "type": "[number, number]",
+        "required": false,
+        "default": "",
+        "description": "Hour range shown in week/day views (inclusive start, exclusive end).\nDefaults to `[7, 19]` (7am–7pm). Hours outside this range are NOT\nrendered (no row in the grid)."
+      },
+      {
+        "name": "hourRowHeight",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Pixel height per hour row in week/day views. Default 48."
+      },
+      {
+        "name": "renderEvent",
+        "type": "RenderEvent",
+        "required": false,
+        "default": "",
+        "description": "Optional custom renderer for the inner content of every event chip\nacross views (month chips, week/day timed blocks, all-day band chips).\nThe returned ReactNode replaces the default `<time> · <title>` markup\ninside the chip's button wrapper — the wrapper still handles tone\nbackground, click, tooltip, and (for timed blocks) absolute positioning.\n\nTo override colors, return content with inline styling that fills the\nwrapper (e.g., `position: absolute; inset: 0; background: <color>`).\n\nThe `ctx` argument carries view-aware metadata: `view`, `asAllDay`,\n`continuesLeft`/`continuesRight` (multi-day), `timeLabel`, `duration`."
+      }
+    ]
+  },
+  "Card": {
+    "props": [
+      {
+        "name": "padding",
+        "type": "CardPadding",
+        "required": false,
+        "default": "",
+        "description": "Inner padding.\n- `none` — use when the card contains a table or list that should bleed\n  edge-to-edge; inner sections manage their own padding.\n- `sm` (12px) — dense info cards.\n- `md` (16px) — default for plain-content cards.\n- `lg` (24px) — emphasis cards, marketing-style panels.\n\nWhen omitted, defaults to `'md'` for plain content, or `'none'` when the\ncard contains compound subcomponents (`Card.Header` / `Card.List` /\n`Card.ListRow`) so the header and rows bleed to the card edge automatically.\nPass an explicit value to override the auto-detect.\n\n**Detection is shallow:** only direct children are inspected. Fragments\n(`<>...</>`) are transparent — the detection recurses into them, so\nconditional renders that wrap compound children in a Fragment still\ntrigger the auto-detect. But wrapping a `Card.Header` in any other\nelement (`<div>`, `<Stack>`, etc.) defeats the heuristic — pass\n`padding=\"none\"` explicitly in that case."
+      },
+      {
+        "name": "tone",
+        "type": "CardTone",
+        "required": false,
+        "default": "",
+        "description": "Optional left-edge tone stripe (3px). Useful for \"stat card\" / \"status card\"\npatterns where one card in a row needs visual emphasis. Default: no stripe\n(the card keeps its standard bordered look).\n\nUses the same tone vocabulary as `Alert`: `accent` / `info` / `success` /\n`warning` / `danger`."
+      },
+      {
+        "name": "overflow",
+        "type": "CardOverflow",
+        "required": false,
+        "default": "hidden",
+        "description": "How the card clips its children at the rounded border.\n- `hidden` (default) — children are clipped to the rounded border. This\n  prevents the visible seam that appears at the corners when a child has\n  square corners (Table's internal scroll wrapper, images, full-bleed\n  media). Overlays in this library (DropdownMenu, Tooltip, Popover, Drawer,\n  Modal) portal to `document.body` and are NOT clipped by this. Focus\n  outlines use CSS `outline`, which is not affected by ancestor overflow.\n- `visible` — opt out of clipping. Use when a direct child needs to\n  overhang the card edge — decorative badges that protrude from a corner,\n  hover-lift transforms whose shadow extends past the card border, etc."
+      }
+    ]
+  },
+  "Checkbox": {
+    "props": [
+      {
+        "name": "size",
+        "type": "CheckboxSize",
+        "required": false,
+        "default": "",
+        "description": "Box diameter + label type scale. Defaults to `'md'`.\n- `'sm'` — 14px box, font-size-sm label. Dense tables, inline filters.\n- `'md'` — 16px box, font-size-md label. Default.\n- `'lg'` — 20px box, font-size-lg label. Hero forms, mobile-friendly.\n\nNote: shadows the native HTML `<input size>` attribute (which on\ncheckboxes is meaningless anyway)."
+      },
+      {
+        "name": "checked",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Controlled checked state. Pair with `onChange`. Omit (with optional\n`defaultChecked`) for uncontrolled use."
+      },
+      {
+        "name": "defaultChecked",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Initial checked state for uncontrolled use. Defaults to `false`."
+      },
+      {
+        "name": "indeterminate",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Indeterminate (mixed) visual + a11y state. Independent of `checked` —\nthe box paints with a dash icon and `input.indeterminate = true` so AT\nannounces \"mixed\". Consumer drives this based on partial selection\n(e.g., a \"select all\" header where some-but-not-all rows are selected).\n\nWhen the user clicks an indeterminate checkbox, the native change event\nfires with the next `checked` value (`true` if it was `false`). The\nconsumer typically responds by clearing `indeterminate`."
+      },
+      {
+        "name": "label",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Optional label rendered next to the box. The whole `<label>` is the\nclick target. Omit for icon-only checkboxes (e.g., a DataTable row\nselector) — pass `aria-label` instead."
+      },
+      {
+        "name": "invalid",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Toggles the error visual + sets `aria-invalid=\"true\"`."
+      },
+      {
+        "name": "color",
+        "type": "PaletteColor",
+        "required": false,
+        "default": "",
+        "description": "Optional palette color for the checked / indeterminate fill. When\nset, the filled state uses the palette color's fg token instead\nof `--color-accent`. Use to color-tag checkbox groups (per-team,\nper-status, per-category). Default unchanged (accent blue).\n\nThe focus ring, hover border, and unchecked state remain\naccent-colored regardless of `color` — only the checked /\nindeterminate fill is affected."
+      },
+      {
+        "name": "onChange",
+        "type": "((checked: boolean, event: ChangeEvent<HTMLInputElement>) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires on every change. Receives the next checked state AND the native\nevent so consumers can do `event.preventDefault()`, read modifier keys,\netc."
+      }
+    ]
+  },
+  "CircularProgress": {
+    "props": [
+      {
+        "name": "value",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Current progress value. Omit (or pass `undefined`) to render the\nindeterminate spinning animation.\n\nTwo-channel behavior for out-of-range and degenerate values:\n- **Visual arc** is clamped to [0%, 100%]. Values outside [0, max]\n  render at the nearest valid bound.\n- **ARIA `aria-valuenow`** reports the raw number so consumer bugs\n  (a value drifting past max) surface in audits and SR announcements.\n\nDegenerate inputs fall back to the indeterminate spinner: `NaN`,\n`Infinity`, `-Infinity`, and the case where `max <= 0`. This is the\ncommon file-upload race condition (`bytes_uploaded / total_bytes`\nbefore `total_bytes` is known produces NaN)."
+      },
+      {
+        "name": "max",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Upper bound. Defaults to `100`. Consumers using fraction values\n(0.0–1.0) pass `max={1}`. Consumers tracking a count (\"3 of 10\")\npass `max={10}`."
+      },
+      {
+        "name": "size",
+        "type": "CircularProgressSize",
+        "required": false,
+        "default": "",
+        "description": "Diameter + stroke pairing.\n- `sm` — 16px diameter, 2px stroke (inline next to a button — also the\n  shape to use for \"Saving…\" loading affordances; pass no `value` for\n  the indeterminate spinner.)\n- `md` — 32px diameter, 3px stroke (default — near a heading)\n- `lg` — 56px diameter, 4px stroke (page-level loader)"
+      },
+      {
+        "name": "tone",
+        "type": "CircularProgressTone",
+        "required": false,
+        "default": "",
+        "description": "Stroke color tone. Defaults to `'default'` (accent blue). Same vocab\nas `<Progress>`. Indeterminate ignores tone — always accent."
+      },
+      {
+        "name": "label",
+        "type": "ReactNode",
+        "required": false,
+        "default": "false",
+        "description": "Optional centered label.\n- `false` (default) — no label\n- `true` — render `{Math.round(percent)}%` centered. Auto-suppressed\n  at `size='sm'` (16px circle has no room for text) AND when\n  indeterminate.\n- `ReactNode` — render the node centered in BOTH modes. Still\n  auto-suppressed at `size='sm'` regardless — the geometry doesn't\n  change."
+      }
+    ]
+  },
+  "Cluster": {
+    "props": [
+      {
+        "name": "gap",
+        "type": "ClusterGap",
+        "required": false,
+        "default": "md",
+        "description": "Gap between children, in pixels:\n`xs` (4) / `sm` (8) / `md` (12, default) / `lg` (16) / `xl` (24) / `2xl` (32)."
+      },
+      {
+        "name": "justify",
+        "type": "ClusterJustify",
+        "required": false,
+        "default": "start",
+        "description": "Horizontal distribution.\n- `start` (default) — items at the start.\n- `center` — items centered.\n- `end` — items at the end. Canonical form-footer pattern.\n- `between` — first item at start, last at end, gap between. Canonical toolbar pattern (title left, actions right)."
+      },
+      {
+        "name": "align",
+        "type": "ClusterAlign",
+        "required": false,
+        "default": "center",
+        "description": "Vertical alignment.\n- `start` / `center` (default) / `end` / `baseline`."
+      },
+      {
+        "name": "wrap",
+        "type": "boolean",
+        "required": false,
+        "default": "true",
+        "description": "Whether children wrap to additional lines when the container is narrow.\n- `true` (default) — natural for toolbars and tag lists.\n- `false` — use sparingly, when overflow is preferable to wrapping\n  (e.g. inside a narrow table cell with fixed-width action buttons)."
+      }
+    ]
+  },
+  "Code": {
+    "props": [
+      {
+        "name": "tone",
+        "type": "CodeTone",
+        "required": false,
+        "default": "",
+        "description": "Color tone for the code text. The chip background stays the same;\nonly the text color changes.\n- `default` — `--color-fg`\n- `muted` — `--color-fg-muted`\n- `accent` — `--color-accent`\n- `danger` — `--color-danger`"
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "Code content."
+      }
+    ]
+  },
+  "ColorPicker": {
+    "props": [
+      {
+        "name": "value",
+        "type": "string",
+        "required": true,
+        "default": "",
+        "description": "Current color as `#RRGGBB`. Controlled — required."
+      },
+      {
+        "name": "onChange",
+        "type": "(hex: string) => void",
+        "required": true,
+        "default": "",
+        "description": "Fires per drag tick + on input change + on preset click. High frequency during drags."
+      },
+      {
+        "name": "onChangeEnd",
+        "type": "((hex: string) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires on the trailing edge of an interaction. Use for commit-style logic."
+      },
+      {
+        "name": "presets",
+        "type": "string[]",
+        "required": false,
+        "default": "",
+        "description": "Optional preset color swatches. If provided, rendered as a grid below\nthe hue slider in the panel."
+      },
+      {
+        "name": "disabled",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Disable interaction. Trigger doesn't open; panel is non-interactive."
+      },
+      {
+        "name": "triggerLabel",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible label for the default trigger. Defaults to the i18n value at\n`colorPicker.triggerLabel` (`'Pick a color'` in English). Ignored when\na custom trigger is provided via `<ColorPicker.Trigger>`."
+      },
+      {
+        "name": "aria-labelledby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Id(s) of element(s) that label the trigger button. Forwarded onto the\nfocusable trigger (not the root wrapper) and takes precedence over the\ngenerated `aria-label`. Set automatically when wrapped in `<Field label>`."
+      },
+      {
+        "name": "aria-describedby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Id(s) of element(s) that describe the trigger button (e.g. a Field error or\nhelper text). Forwarded onto the focusable trigger, not the root wrapper."
+      },
+      {
+        "name": "popoverPlacement",
+        "type": "PopoverPlacement",
+        "required": false,
+        "default": "",
+        "description": "Popover placement (split internally into side + align). Default `'bottom-start'`."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Optional `<ColorPicker.Trigger asChild>` override for custom triggers."
+      }
+    ]
+  },
+  "ConfirmationPopover": {
+    "props": [
+      {
+        "name": "children",
+        "type": "ReactElement<unknown, string | JSXElementConstructor<any>>",
+        "required": true,
+        "default": "",
+        "description": "The trigger element. Same forwardRef-required contract as\n`<Popover.Trigger>` — `<Button>` qualifies; a custom component without\n`forwardRef` does not."
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "required": true,
+        "default": "",
+        "description": "Heading text. Renders inside `<Popover.Heading>` (an `<h3>`) and wires\n`aria-labelledby` on the dialog automatically."
+      },
+      {
+        "name": "description",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Optional body text below the title. When provided, wires\n`aria-describedby` so screen readers announce it."
+      },
+      {
+        "name": "confirmLabel",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Confirm button label. Defaults to the i18n value at\n`confirmationPopover.confirm` (`'Confirm'` in English)."
+      },
+      {
+        "name": "variant",
+        "type": "ConfirmationVariant",
+        "required": false,
+        "default": "",
+        "description": "`'danger'` makes Confirm a danger-variant button. Defaults to `'default'` (primary)."
+      },
+      {
+        "name": "onConfirm",
+        "type": "() => void | Promise<void>",
+        "required": true,
+        "default": "",
+        "description": "Async-aware confirm handler. May return a Promise; while pending,\nboth buttons disable, the Confirm button shows a small spinner, and\nEscape / click-outside dismissal is blocked.\n\n- Resolve → popover closes.\n- Reject → popover stays open, buttons re-enable. `onCancel` is NOT\n  fired (the user neither confirmed nor cancelled — it's an error\n  state owned by the consumer).\n\nThe consumer is expected to surface error feedback externally (toast,\ninline message, etc.). ConfirmationPopover does NOT render errors."
+      },
+      {
+        "name": "onCancel",
+        "type": "(() => void)",
+        "required": false,
+        "default": "",
+        "description": "Optional. Fires on Cancel click, Escape, or click-outside dismissal. NOT fired if `onConfirm` rejects."
+      },
+      {
+        "name": "initialFocusRef",
+        "type": "RefObject<HTMLElement | null>",
+        "required": false,
+        "default": "",
+        "description": "Direct initial focus into the panel's content instead of the default\nCancel button — e.g. an `<Input>` rendered in `description` for a rename\nflow. When provided and its `.current` is non-null on open, the component\nfocuses this element after the panel mounts (skipping the Cancel-focus).\nTip: add `onFocus={(e) => e.currentTarget.select()}` to a text input to\nselect its contents so the user can type/replace immediately."
+      },
+      {
+        "name": "side",
+        "type": "\"top\" | \"bottom\" | \"right\" | \"left\"",
+        "required": false,
+        "default": "",
+        "description": "Preferred side. Default `'top'` — confirmations anchor above the trigger by convention."
+      },
+      {
+        "name": "align",
+        "type": "\"start\" | \"end\" | \"center\"",
+        "required": false,
+        "default": "",
+        "description": "Edge alignment. Default `'center'`."
+      },
+      {
+        "name": "sideOffset",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Gap in px between trigger and panel. Default `10`."
+      },
+      {
+        "name": "open",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Controlled open state. Pair with `onOpenChange`."
+      },
+      {
+        "name": "onOpenChange",
+        "type": "((open: boolean) => void)",
+        "required": false,
+        "default": "",
+        "description": "Open-change callback. Required when `open` is provided."
+      },
+      {
+        "name": "defaultOpen",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Default open state for uncontrolled usage. Defaults to `false`."
+      }
+    ]
+  },
+  "Constrain": {
+    "props": [
+      {
+        "name": "width",
+        "type": "ConstrainWidth",
+        "required": false,
+        "default": "",
+        "description": "Fixed width — a named step (`xs`–`xl`) or `'full'` (100%)."
+      },
+      {
+        "name": "minWidth",
+        "type": "ConstrainWidth",
+        "required": false,
+        "default": "",
+        "description": "Minimum width floor — a named step or `'full'` (100%)."
+      },
+      {
+        "name": "maxWidth",
+        "type": "ConstrainWidth",
+        "required": false,
+        "default": "",
+        "description": "Maximum width cap — the common case (e.g. a search input at `'sm'`)."
+      },
+      {
+        "name": "flex",
+        "type": "ConstrainFlex",
+        "required": false,
+        "default": "",
+        "description": "Flex behavior as a child of a flex row/column.\n- `'grow'` — fill remaining space (`flex: 1 1 0`) and shrink below content\n  width (`min-width: 0`) so a truncating child (`<Text truncate>`) can clip.\n- `'auto'` — size to content, may grow/shrink (`flex: 1 1 auto`).\n- `'shrink'` — don't grow, may shrink (`flex: 0 1 auto`, the flex default).\n- `'none'` — fixed, never grow/shrink (`flex: 0 0 auto`)."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "The content to size. Required — a Constrain with nothing inside has nothing to constrain."
+      }
+    ]
+  },
+  "CursorPagination": {
+    "props": [
+      {
+        "name": "hasPrevious",
+        "type": "boolean",
+        "required": true,
+        "default": "",
+        "description": "Whether a previous page exists. When `false`, the previous button is\nrendered as `disabled` (layout stays stable; consumer doesn't have to\nconditionally hide it)."
+      },
+      {
+        "name": "hasNext",
+        "type": "boolean",
+        "required": true,
+        "default": "",
+        "description": "Whether a next page exists."
+      },
+      {
+        "name": "onPrevious",
+        "type": "() => void",
+        "required": true,
+        "default": "",
+        "description": "Called when the user clicks previous (not fired when disabled)."
+      },
+      {
+        "name": "onNext",
+        "type": "() => void",
+        "required": true,
+        "default": "",
+        "description": "Called when the user clicks next (not fired when disabled)."
+      },
+      {
+        "name": "previousLabel",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Label for the previous button. Defaults to the i18n value at\n`pagination.previous` (`'Previous'` in English). Override for domain\nphrasing (`'Newer'` in a reverse-chronological feed)."
+      },
+      {
+        "name": "nextLabel",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Label for the next button. Defaults to the i18n value at\n`pagination.next` (`'Next'` in English)."
+      },
+      {
+        "name": "size",
+        "type": "PaginationSize",
+        "required": false,
+        "default": "'md'",
+        "description": "Visual size — `'sm'` / `'md'` (default) / `'lg'`. Shares the\n`<Pagination>` size scale so the two components match when used\nalongside each other."
+      },
+      {
+        "name": "disabled",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "When `true`, both buttons are disabled regardless of has-prev/-next."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible name for the wrapper `<nav>`. Defaults to the i18n value at\n`pagination.ariaLabel` (`'Pagination'` in English)."
+      }
+    ]
+  },
+  "DataTable": {
+    "props": [
+      {
+        "name": "instance",
+        "type": "DataTableInstance<T>",
+        "required": true,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "density",
+        "type": "TableDensity",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "striped",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "hover",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Hover highlight on body rows. Defaults TRUE (DataTable rows are usually interactive)."
+      },
+      {
+        "name": "bordered",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "loading",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "loadingRowCount",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Number of skeleton rows when `loading`. Defaults 10."
+      },
+      {
+        "name": "emptyState",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Element shown when `data` is empty and not loading. Defaults to a stock <EmptyState>."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Required for a11y when no caption is provided."
+      },
+      {
+        "name": "caption",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "className",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": ""
+      }
+    ]
+  },
+  "DatePicker": {
+    "props": [
+      {
+        "name": "value",
+        "type": "Date | null",
+        "required": false,
+        "default": "",
+        "description": "Selected date. `null` = no value. Pair with `onChange` for controlled use."
+      },
+      {
+        "name": "defaultValue",
+        "type": "Date | null",
+        "required": false,
+        "default": "",
+        "description": "Initial selected date for uncontrolled use."
+      },
+      {
+        "name": "onChange",
+        "type": "((date: Date | null) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires when the value changes."
+      },
+      {
+        "name": "locale",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Override locale (otherwise reads `useLocale()`)."
+      },
+      {
+        "name": "min",
+        "type": "Date",
+        "required": false,
+        "default": "",
+        "description": "Earliest selectable date (inclusive)."
+      },
+      {
+        "name": "max",
+        "type": "Date",
+        "required": false,
+        "default": "",
+        "description": "Latest selectable date (inclusive)."
+      },
+      {
+        "name": "isDateDisabled",
+        "type": "((date: Date) => boolean)",
+        "required": false,
+        "default": "",
+        "description": "Per-date disable callback."
+      },
+      {
+        "name": "clearable",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Show the ✕ clear button when a value is set. Defaults to `true`."
+      },
+      {
+        "name": "invalid",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Toggle red border + focus ring + `aria-invalid=\"true\"`."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Form name. When set, renders a hidden mirror `<input>` with the ISO date."
+      },
+      {
+        "name": "size",
+        "type": "DatePickerSize",
+        "required": false,
+        "default": "",
+        "description": "Field height + type scale. Same scale as `<Input>`. Defaults to `'md'`.\nAffects only the trigger row; the popover month grid is fixed-size.\n\n- `'sm'` — 24px tall.\n- `'md'` — 32px tall (default).\n- `'lg'` — 40px tall."
+      },
+      {
+        "name": "granularity",
+        "type": "DateTimeGranularity",
+        "required": false,
+        "default": "'day'",
+        "description": "Picker precision.\n\n- `'day'` (default) — date only; behavior unchanged from prior releases.\n- `'minute'` — adds a manual-entry time input below the calendar grid.\n  The trigger text shows `HH:mm` after the date. The hidden form mirror\n  (when `name` is set) emits ISO local datetime (`2026-05-28T14:30`).\n\nTime is preserved across date re-picks. Picking from a `null` value\ndefaults the time to `00:00`."
+      },
+      {
+        "name": "timeStep",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Minutes step for the `<TimeField>` popover and for rounding typed\ntime input on commit. Defaults to `15`. Set `1` to disable rounding.\nOnly meaningful when `granularity='minute'`."
+      },
+      {
+        "name": "hourCycle",
+        "type": "HourCycle",
+        "required": false,
+        "default": "'auto'",
+        "description": "Display cycle for the embedded `<TimeField>` + the trigger's time tail.\n\n- `'24'` — `\"HH:mm\"` in the trigger; 24h hour list in the time popover.\n- `'12'` — `\"h:mm AM/PM\"` in the trigger; 12h hour list + AM/PM column.\n- `'auto'` (default) — derives from the active locale via Intl. en-US →\n  `'12'`; ru-RU / de-DE / fr-FR → `'24'`.\n\nOnly meaningful when `granularity='minute'`. Typed input is lenient\nregardless of cycle — both `\"14:30\"` and `\"2:30 PM\"` parse on blur."
+      }
+    ]
+  },
+  "DateRangePicker": {
+    "props": [
+      {
+        "name": "value",
+        "type": "DateRange | null",
+        "required": false,
+        "default": "",
+        "description": "Selected range. `null` = no range. Pair with `onChange` for controlled use."
+      },
+      {
+        "name": "defaultValue",
+        "type": "DateRange | null",
+        "required": false,
+        "default": "",
+        "description": "Initial range for uncontrolled use."
+      },
+      {
+        "name": "onChange",
+        "type": "((range: DateRange | null) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires when a complete range commits (after second click in grid, or successful typed parse on blur)."
+      },
+      {
+        "name": "locale",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Override locale (otherwise reads `useLocale()`)."
+      },
+      {
+        "name": "min",
+        "type": "Date",
+        "required": false,
+        "default": "",
+        "description": "Earliest selectable date (inclusive). Both halves and typed input are gated."
+      },
+      {
+        "name": "max",
+        "type": "Date",
+        "required": false,
+        "default": "",
+        "description": "Latest selectable date (inclusive)."
+      },
+      {
+        "name": "isDateDisabled",
+        "type": "((date: Date) => boolean)",
+        "required": false,
+        "default": "",
+        "description": "Per-date disable predicate."
+      },
+      {
+        "name": "size",
+        "type": "DateRangePickerSize",
+        "required": false,
+        "default": "",
+        "description": "Field height + type scale. Same scale as `<DatePicker>`. Defaults to `'md'`.\nAffects only the trigger row; the two-month popover grid is fixed-size.\n\n- `'sm'` — 24px tall.\n- `'md'` — 32px tall (default).\n- `'lg'` — 40px tall."
+      },
+      {
+        "name": "clearable",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Show the ✕ clear button when a range is set. Defaults to `true`."
+      },
+      {
+        "name": "invalid",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Toggle red border + focus ring + `aria-invalid=\"true\"`."
+      },
+      {
+        "name": "nameStart",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Form name for the START half (hidden `<input>`)."
+      },
+      {
+        "name": "nameEnd",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Form name for the END half."
+      },
+      {
+        "name": "granularity",
+        "type": "DateTimeGranularity",
+        "required": false,
+        "default": "'day'",
+        "description": "Picker precision.\n\n- `'day'` (default) — date only; behavior unchanged from prior releases.\n- `'minute'` — adds two manual-entry time inputs (start + end) below\n  the two-month grid. The trigger text shows `HH:mm` after each date.\n  Hidden form mirrors (when `nameStart` / `nameEnd` are set) emit ISO\n  local datetime (`2026-05-28T14:30`).\n\nAt `'minute'` the start/end time inputs are shown and editable in the\npopover even before a range is picked (defaulting to `00:00` / `23:59`).\nTimes entered in the empty state are applied when the range is committed\n(instead of the bare defaults), and existing times are preserved across\ndate re-picks. Same-day ranges with end-time < start-time are silently\nclamped so end-time ≥ start-time."
+      },
+      {
+        "name": "timeStep",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Minutes step for the start + end `<TimeField>` popovers and for\nrounding typed time input on commit. Defaults to `15`. Set `1` to\ndisable rounding. Only meaningful when `granularity='minute'`."
+      },
+      {
+        "name": "hourCycle",
+        "type": "HourCycle",
+        "required": false,
+        "default": "'auto'",
+        "description": "Display cycle for the two embedded `<TimeField>`s + the trigger's\ntime tails.\n\n- `'24'` — `\"HH:mm\"` in trigger + 24h hour lists in popovers.\n- `'12'` — `\"h:mm AM/PM\"` in trigger + 12h hour lists + AM/PM column.\n- `'auto'` (default) — derives from the active locale via Intl. en-US →\n  `'12'`; ru-RU → `'24'`.\n\nOnly meaningful when `granularity='minute'`. Typed input is lenient\nregardless of cycle — both `\"14:30\"` and `\"2:30 PM\"` parse on blur."
+      }
+    ]
+  },
+  "DefinitionList": {
+    "props": [
+      {
+        "name": "layout",
+        "type": "DefinitionListLayout",
+        "required": false,
+        "default": "",
+        "description": "Layout direction. See `DefinitionListLayout`. Default `'horizontal'`."
+      },
+      {
+        "name": "termWidth",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "CSS length applied to the term column in horizontal layout (e.g. `'180px'`,\n`'20%'`, `'max-content'`). Default `'max-content'` — column sizes to the\nlongest term across all rows. Set explicitly when you need consistent\nalignment across multiple DefinitionLists on the same screen."
+      },
+      {
+        "name": "spacing",
+        "type": "DefinitionListSpacing",
+        "required": false,
+        "default": "",
+        "description": "Vertical padding per item. See `DefinitionListSpacing`. Default `'sm'`."
+      },
+      {
+        "name": "dividers",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Render a 1px border between items. Default `false` (clean, dense look).\nSet when migrating from a `Card.List` and you want to preserve the\ntable-row separator visual."
+      }
+    ]
+  },
+  "Divider": {
+    "props": [
+      {
+        "name": "orientation",
+        "type": "DividerOrientation",
+        "required": false,
+        "default": "",
+        "description": "Layout direction. Defaults to `'horizontal'`."
+      },
+      {
+        "name": "variant",
+        "type": "DividerVariant",
+        "required": false,
+        "default": "",
+        "description": "Line style. Defaults to `'solid'`."
+      },
+      {
+        "name": "size",
+        "type": "DividerSize",
+        "required": false,
+        "default": "",
+        "description": "Line thickness tier. Defaults to `'sm'`."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Optional centered label rendered between two line segments.\nCommon pattern: `<Divider>OR</Divider>` for auth-form section breaks.\n\nWhen `children` is set, the root becomes `<div role=\"separator\">`\ninstead of `<hr>` (HTML `<hr>` cannot have children).\n\nWorks with `orientation=\"vertical\"` but renders awkwardly (text wraps\nacross two short line segments). Avoid vertical + label combos."
+      }
+    ]
+  },
+  "Dot": {
+    "props": [
+      {
+        "name": "color",
+        "type": "PaletteColor",
+        "required": false,
+        "default": "",
+        "description": "One of the 30 `PaletteColor`s — renders the bare circle in that color's\nsaturated `--color-palette-<name>-fg` token. Takes precedence over `tone`."
+      },
+      {
+        "name": "tone",
+        "type": "BadgeTone",
+        "required": false,
+        "default": "BadgeTone",
+        "description": "A semantic `BadgeTone` (`neutral` default / `info` / `success` / `warning` /\n`danger` / `purple`) — used when `color` is omitted."
+      }
+    ]
+  },
+  "Drawer": {
+    "props": [
+      {
+        "name": "open",
+        "type": "boolean",
+        "required": true,
+        "default": "",
+        "description": "Controlled open state. Required — Drawer has no uncontrolled mode."
+      },
+      {
+        "name": "onOpenChange",
+        "type": "(open: boolean) => void",
+        "required": true,
+        "default": "",
+        "description": "Fired when Drawer wants to change open state — Esc, overlay click, Close, swipe, programmatic."
+      },
+      {
+        "name": "side",
+        "type": "DrawerSide",
+        "required": false,
+        "default": "",
+        "description": "Edge the drawer slides in from. Defaults to 'right'."
+      },
+      {
+        "name": "size",
+        "type": "DrawerSize",
+        "required": false,
+        "default": "",
+        "description": "Size preset. Width for left/right, height for top/bottom. Defaults to 'md'."
+      },
+      {
+        "name": "overlay",
+        "type": "DrawerOverlayVariant",
+        "required": false,
+        "default": "",
+        "description": "Overlay variant. 'solid' (default) | 'blur'."
+      },
+      {
+        "name": "stackMode",
+        "type": "OverlayStackMode",
+        "required": false,
+        "default": "",
+        "description": "How this drawer relates to other open overlays (Modals or Drawers).\n'overlay' (default): parent stays visible. 'replace': parent hidden via display:none."
+      },
+      {
+        "name": "disableEscapeClose",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Disable Escape-to-close. Default false."
+      },
+      {
+        "name": "dismissOnOverlayClick",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "When false, overlay click does NOT close. Default true."
+      },
+      {
+        "name": "dragToClose",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Enable swipe-to-close gesture on touch devices (from Header). Default true."
+      },
+      {
+        "name": "initialFocusRef",
+        "type": "RefObject<HTMLElement | null>",
+        "required": false,
+        "default": "",
+        "description": "Initial focus target on open."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "className",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "style",
+        "type": "CSSProperties",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "aria-describedby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": ""
+      }
+    ]
+  },
+  "DropdownMenu": {
+    "props": [
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "Must contain exactly one `<DropdownMenu.Trigger>` and one `<DropdownMenu.Content>`."
+      },
+      {
+        "name": "open",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Controlled open state. Provide alongside `onOpenChange` to drive open\nexternally. Omit both to let DropdownMenu own its own state (the common\ncase)."
+      },
+      {
+        "name": "onOpenChange",
+        "type": "((open: boolean) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fired whenever DropdownMenu wants to change open state. Required when `open` is provided."
+      },
+      {
+        "name": "defaultOpen",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Default open state for uncontrolled usage. Defaults to `false`."
+      }
+    ]
+  },
+  "EmojiPicker": {
+    "props": [
+      {
+        "name": "onSelect",
+        "type": "(emoji: string) => void",
+        "required": true,
+        "default": "",
+        "description": "Fired with the chosen emoji character (e.g. `'👍'`) when the user clicks a\ncell or presses Enter/Space on a focused cell. This is the picker's single\noutput — wire it to insert into an editor, set a reaction, etc."
+      },
+      {
+        "name": "recent",
+        "type": "string[]",
+        "required": false,
+        "default": "",
+        "description": "Recently-used emoji characters (e.g. `['👍', '🎉', '❤️']`), most-recent first.\nWhen provided, a \"Recently used\" section renders at the top of the grid (only\nwhile not searching). The consumer owns persistence — keep the list yourself\n(e.g. in localStorage), update it in `onSelect`, and pass it back. Duplicates\nare de-duped; a char outside the curated set still renders (labelled by the\nchar). Omit or pass `[]` for no recent section."
+      }
+    ]
+  },
+  "EmptyState": {
+    "props": [
+      {
+        "name": "icon",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Icon rendered above the title. Pass a lucide icon, custom SVG, or any\nReactNode. Sized by the consumer — recommended: sm=24, md=32, lg=48.\nOmit for an icon-less empty state."
+      },
+      {
+        "name": "title",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "Required title. Rendered as a semantic heading (default `<h3>`).\nAccepts ReactNode so inline emphasis works\n(e.g., `<>Found <strong>0</strong> results</>`). Keep it short and\nannounceable — AT users hear it via heading navigation."
+      },
+      {
+        "name": "description",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Optional description rendered below the title."
+      },
+      {
+        "name": "actions",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Optional action(s) rendered below the description. Typically a\n`<Button>` or a `<Cluster gap=\"sm\">` of buttons."
+      },
+      {
+        "name": "size",
+        "type": "EmptyStateSize",
+        "required": false,
+        "default": "",
+        "description": "Visual size. Defaults to `'md'`.\n- `'sm'` — compact for inline / popover use (empty Select results,\n  empty filter chips). Icon target 24px, font-size-sm title.\n- `'md'` — default for cards / sections (DataTable empty row, inbox\n  empty). Icon target 32px, font-size-md title.\n- `'lg'` — hero / full-page empty states. Icon target 48px,\n  font-size-xl title."
+      },
+      {
+        "name": "align",
+        "type": "EmptyStateAlign",
+        "required": false,
+        "default": "",
+        "description": "Horizontal alignment of the stacked content. Defaults to `'center'`.\nUse `'start'` when the empty state sits in a tight column where\ncentering would look stranded."
+      },
+      {
+        "name": "headingLevel",
+        "type": "EmptyStateHeadingLevel",
+        "required": false,
+        "default": "",
+        "description": "Heading level for the `title`. Defaults to `3` (renders `<h3>`).\nSet higher (4–6) when the empty state lives deep inside the page's\nheading hierarchy. Set to `2` when the empty state IS the page's\nprimary content. Values outside `1–6` clamp to `3`."
+      }
+    ]
+  },
+  "ErrorState": {
+    "props": [
+      {
+        "name": "icon",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Icon rendered above the title. Pass a lucide icon (sized by the consumer —\nlg=48, md=32, sm=24), custom SVG, or any ReactNode. The icon's color is set\nby `tone`; pass `aria-hidden=\"true\"` on it when purely decorative."
+      },
+      {
+        "name": "title",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "Required title, rendered as a semantic heading (default `<h1>` — it's\nusually the page heading). Accepts ReactNode for inline emphasis."
+      },
+      {
+        "name": "description",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Optional description rendered below the title."
+      },
+      {
+        "name": "actions",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Optional action(s) below the description — a `<Button>` or a\n`<Cluster gap=\"sm\">` of buttons. Keep to ONE primary action."
+      },
+      {
+        "name": "extra",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Optional supplemental content rendered below the actions — e.g. an\n`Error ID: …` line or a \"view status\" link. Reads as metadata, not primary\ncopy. Distinct from `description`, which sits above the actions."
+      },
+      {
+        "name": "tone",
+        "type": "ErrorStateTone",
+        "required": false,
+        "default": "",
+        "description": "Status tone. Defaults to `'neutral'`.\n- `'neutral'` — informational (404 / not-found). Icon uses `--color-fg-muted`.\n- `'danger'` — an error (500 / crash). Icon uses `--color-danger`, and the\n  wrapper gets `role=\"alert\"` so an error-boundary fallback announces on\n  mount. Override the role by passing your own `role`."
+      },
+      {
+        "name": "size",
+        "type": "ErrorStateSize",
+        "required": false,
+        "default": "",
+        "description": "Visual size. Defaults to `'lg'` (full-page hero). Use `'sm'` / `'md'` when\nthe state is embedded in a smaller surface."
+      },
+      {
+        "name": "align",
+        "type": "ErrorStateAlign",
+        "required": false,
+        "default": "",
+        "description": "Horizontal alignment of the stacked content. Defaults to `'center'`.\nUse `'start'` in a tight column where centering looks stranded."
+      },
+      {
+        "name": "headingLevel",
+        "type": "ErrorStateHeadingLevel",
+        "required": false,
+        "default": "",
+        "description": "Heading level for `title`. Defaults to `1` (page-level). Lower it when the\nscreen is nested under an existing heading. Values outside `1–6` clamp to `1`."
+      }
+    ]
+  },
+  "Field": {
+    "props": [
+      {
+        "name": "label",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Label text. Renders a `<label htmlFor>` (or, in `asGroup`, a `role=\"group\"` caption)."
+      },
+      {
+        "name": "description",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Helper text below the control. Hidden while `error` is present."
+      },
+      {
+        "name": "error",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Error message. Replaces `description`, flips the control to `invalid`, links `aria-describedby`."
+      },
+      {
+        "name": "required",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Marks the field required: shows `*` and injects `required` onto the control."
+      },
+      {
+        "name": "optional",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Marks the field optional: shows `(optional)`. Mutually exclusive with `required`."
+      },
+      {
+        "name": "orientation",
+        "type": "FieldOrientation",
+        "required": false,
+        "default": "",
+        "description": "Label placement. Default `'vertical'`. `'horizontal'` puts the label beside the control."
+      },
+      {
+        "name": "size",
+        "type": "FieldSize",
+        "required": false,
+        "default": "",
+        "description": "Label/message type scale. Default `'md'`. Size primarily scales the label; the help/error message uses a compact fixed scale (`md` and `lg` both render the message at `sm`)."
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Explicit control id. Field owns the id by default (auto-generated) so the label always matches."
+      },
+      {
+        "name": "asGroup",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Group mode for radio/checkbox sets: label becomes a `role=\"group\"` caption (no `htmlFor`)."
+      },
+      {
+        "name": "children",
+        "type": "ReactNode | ((field: FieldRenderProps) => ReactNode)",
+        "required": true,
+        "default": "",
+        "description": "A single control element (auto-wired) or a render-prop `(field) => ReactNode`."
+      }
+    ]
+  },
+  "FileUpload": {
+    "props": [
+      {
+        "name": "files",
+        "type": "FileEntry[]",
+        "required": true,
+        "default": "",
+        "description": "Controlled file list. The component renders this; consumer owns the state."
+      },
+      {
+        "name": "onFilesAdded",
+        "type": "(files: File[]) => void",
+        "required": true,
+        "default": "",
+        "description": "Called when the user drops or picks new files AND those files pass\nvalidation. The component does NOT mutate state — consumer is responsible\nfor adding the returned `File[]` to `files` (typically wrapped in\n`FileEntry` shape with new IDs)."
+      },
+      {
+        "name": "onFileRemove",
+        "type": "(entry: FileEntry) => void",
+        "required": true,
+        "default": "",
+        "description": "Called when the user clicks the X on a file row. Consumer removes from `files`."
+      },
+      {
+        "name": "onFileReject",
+        "type": "((file: File, reason: FileRejectReason, message?: string) => void)",
+        "required": false,
+        "default": "",
+        "description": "Called when a file fails validation. `reason` is one of `FileRejectReason`;\n`message` is the custom message from `validator` (only present when\nreason='custom'). Use for toasts or inline error rendering."
+      },
+      {
+        "name": "multiple",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Allow multi-file selection. Default `false`. In single mode (default),\n`files` should have at most 1 entry; the dropzone hides once a file is\npresent and re-appears after removal."
+      },
+      {
+        "name": "accept",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accepted file types — MIME types and/or extensions, comma-separated.\nForwarded to the native `<input accept>` attribute AND used for the\nbuilt-in `invalid-type` validation. Default: no filter.\n\nExamples:\n- `accept=\"image/*\"` — any image\n- `accept=\".csv,application/vnd.ms-excel\"` — CSV or Excel\n- `accept=\"application/pdf,image/png,image/jpeg\"` — explicit MIME list"
+      },
+      {
+        "name": "maxSize",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Per-file size cap in bytes. Default: no limit.\nFiles exceeding this fire `onFileReject` with reason `'too-large'`."
+      },
+      {
+        "name": "maxFiles",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Total file count cap. Only meaningful when `multiple=true`. Counts existing\nentries in `files` PLUS new files being added. Default: no limit.\nExcess files fire `onFileReject` with reason `'too-many'`."
+      },
+      {
+        "name": "validator",
+        "type": "((file: File) => string | null)",
+        "required": false,
+        "default": "",
+        "description": "Custom validation hook. Return `null` for valid; return a string error\nmessage for invalid (fires `onFileReject` with reason='custom', message=\nthe returned string). Runs LAST in the validation chain (after type,\nsize, count, duplicate checks)."
+      },
+      {
+        "name": "disabled",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Disable the entire component. Dropzone shows muted, drag/click handlers\nare no-ops, remove buttons disabled. Default `false`."
+      },
+      {
+        "name": "dropzoneLabel",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Override the dropzone's main label. Default: the i18n value at\n`fileUpload.dragHint`. Pass a ReactNode for richer content (e.g. with a\n`<Code>` for accepted extensions).\n\n**A11y note:** when `dropzoneLabel` is a plain string, the component\nuses it as `aria-label` on the dropzone. When it's a ReactNode, the\ncomponent falls back to the i18n value at `fileUpload.upload` and the\nrich content is visible-only. To give screen readers the equivalent\ntext, pass `aria-label` via the spread (e.g. `aria-label=\"Upload CSV\nor Excel files\"`)."
+      },
+      {
+        "name": "dropzoneIcon",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Override the dropzone icon. Default: lucide `CloudUpload` at 32px.\nPass an SVG ReactNode or another icon component instance."
+      },
+      {
+        "name": "dropzoneHint",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Optional secondary line under the main label, typically describing\naccepted formats / size limits. Renders muted at `--font-size-sm`.\nDefault: undefined (no secondary text)."
+      }
+    ]
+  },
+  "FilterChip": {
+    "props": [
+      {
+        "name": "onDismiss",
+        "type": "(() => void)",
+        "required": false,
+        "default": "",
+        "description": "Dismiss callback. When provided, the chip renders a trailing `×`\nbutton wired to this handler; the chip itself does NOT animate or\nunmount — the consumer's state update must remove the chip. Omit\nthe prop to render a read-only chip with no dismiss button."
+      },
+      {
+        "name": "dismissLabel",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Override the dismiss button's `aria-label`. Defaults to the i18n value\nat `filterChip.dismiss` (`'Remove filter'` in English). Pass a\ncontextual label (e.g., `'Remove Event: auth.* filter'`) when the\nchip's filter category isn't obvious from the surrounding\nscreen-reader context."
+      },
+      {
+        "name": "onActivate",
+        "type": "(() => void)",
+        "required": false,
+        "default": "",
+        "description": "Makes the chip BODY interactive: when provided, the Label/Value content is\nwrapped in a `<button>` that fires `onActivate` on click and Enter/Space\n(native button keyboard). Use for *editable* filters — e.g. a date-range\nchip whose body re-opens its range-picker. Wire it to a controlled\n`<Popover open onOpenChange>` to open an editor popover.\n\nThe dismiss ✕ stays a separate button whose click stops propagation, so\nremoving the filter never fires `onActivate` (and never bubbles to an\nancestor click handler). Omit for a read-only chip (current behavior).\n\nControlled-only: FilterChip does NOT consume `Popover.Trigger`'s injected\nref/ARIA, so wrapping it in `<Popover.Trigger>` won't auto-wire it — drive\nthe popover's `open` yourself from this callback (see the example above)."
+      },
+      {
+        "name": "expanded",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Open state of the disclosure the body opens (e.g. the editor popover),\nsurfaced as `aria-expanded` on the body button. Only meaningful with\n`onActivate`. Omit if the body doesn't toggle a disclosure."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "One or two `FilterChip.Label` / `FilterChip.Value` subcomponents.\nUse both for `Label: Value` chips; pass just a Value for chips\nwhere the category is implicit (e.g., a tenant slug)."
+      }
+    ]
+  },
+  "FormRow": {
+    "props": [
+      {
+        "name": "columns",
+        "type": "2 | 3",
+        "required": false,
+        "default": "",
+        "description": "Fixed equal-width column count. Omit for responsive auto-fit (the default)."
+      },
+      {
+        "name": "minColumnWidth",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Min field width before the row reflows to stacked (auto-fit mode). Default `'16rem'`."
+      },
+      {
+        "name": "gap",
+        "type": "GridGap",
+        "required": false,
+        "default": "",
+        "description": "Gap between fields. Default `'lg'`."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "The fields (usually `<Field>`)."
+      }
+    ]
+  },
+  "FormSection": {
+    "props": [
+      {
+        "name": "title",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Section heading."
+      },
+      {
+        "name": "description",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Secondary text under the heading."
+      },
+      {
+        "name": "titleOrder",
+        "type": "TitleOrder",
+        "required": false,
+        "default": "",
+        "description": "Heading level for `title`. Default `2`."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "The fields (usually `<Field>` / `<FormRow>`)."
+      }
+    ]
+  },
+  "Grid": {
+    "props": [
+      {
+        "name": "gap",
+        "type": "GridGap",
+        "required": false,
+        "default": "md",
+        "description": "Gap between cells.\n`xs` (4) / `sm` (8) / `md` (12, default) / `lg` (16) / `xl` (24) / `2xl` (32).\nSame scale as Stack and Cluster."
+      },
+      {
+        "name": "alignItems",
+        "type": "GridAlignItems",
+        "required": false,
+        "default": "",
+        "description": "Cross-axis (vertical within row) alignment of each cell. Default browser\nbehavior is `stretch`; omit to use the default."
+      },
+      {
+        "name": "justifyItems",
+        "type": "GridJustifyItems",
+        "required": false,
+        "default": "",
+        "description": "Main-axis (horizontal within track) alignment of each cell. Default\nbrowser behavior is `stretch`; omit to use the default."
+      },
+      {
+        "name": "as",
+        "type": "GridAs",
+        "required": false,
+        "default": "",
+        "description": "Element to render. Default `'div'`. Limited to common layout / semantic elements."
+      },
+      {
+        "name": "columns",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Fixed number of equal-width columns. Mutually exclusive with `minColumnWidth`."
+      },
+      {
+        "name": "minColumnWidth",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Minimum column width for auto-fit responsive layout. Columns reflow\nbased on container width — no breakpoints needed. CSS length string\nlike `'240px'` or `'15rem'`. Defaults to `'240px'` when neither\n`columns` nor `minColumnWidth` is provided."
+      }
+    ]
+  },
+  "IconTile": {
+    "props": [
+      {
+        "name": "icon",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "The icon to frame — a lucide icon (sized by you, ~14–20px), custom SVG, or\nany ReactNode. Required; IconTile is purely an icon frame."
+      },
+      {
+        "name": "color",
+        "type": "PaletteColor",
+        "required": false,
+        "default": "",
+        "description": "Palette color for the tint — one of the 30 categorical colors. Defaults to\n`'slate'`. Categorical (visual identity), NOT semantic; for status use a\n`<Badge tone>` instead."
+      },
+      {
+        "name": "size",
+        "type": "IconTileSize",
+        "required": false,
+        "default": "",
+        "description": "Tile box size. `'sm'` 24 / `'md'` 32 (**default**) / `'lg'` 40 px. Sizes the\ntile box — size your icon child separately."
+      },
+      {
+        "name": "shape",
+        "type": "IconTileShape",
+        "required": false,
+        "default": "'square'",
+        "description": "`'square'` (radius-md, **default**) or `'circle'` (radius-full)."
+      },
+      {
+        "name": "label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible name. Omit (**default**) → the tile is decorative\n(`aria-hidden`), for use beside text that carries the meaning. Set it →\n`role=\"img\"` + `aria-label`, for a standalone tile whose icon is the only\nindicator."
+      }
+    ]
+  },
+  "Image": {
+    "props": [
+      {
+        "name": "src",
+        "type": "string",
+        "required": true,
+        "default": "",
+        "description": "Image URL. Changing it resets the component to the loading state."
+      },
+      {
+        "name": "alt",
+        "type": "string",
+        "required": true,
+        "default": "",
+        "description": "Alternative text (required). Describe the image's content or function.\nPass an empty string (`alt=\"\"`) for purely decorative images."
+      },
+      {
+        "name": "objectFit",
+        "type": "ImageObjectFit",
+        "required": false,
+        "default": "",
+        "description": "How the image fills its box. Defaults to `'cover'`.\n- `'cover'` — fill + crop (no distortion). Best for thumbnails / heroes.\n- `'contain'` — whole image, letterboxed on the box background.\n- `'fill'` — stretch to the box (may distort).\n- `'none'` / `'scale-down'` — native size / the smaller of none|contain."
+      },
+      {
+        "name": "aspectRatio",
+        "type": "string | number",
+        "required": false,
+        "default": "",
+        "description": "Reserve the box at a fixed ratio to prevent layout shift while loading.\nNumber (`1.5`) or CSS string (`'16 / 9'`)."
+      },
+      {
+        "name": "size",
+        "type": "ImageSize",
+        "required": false,
+        "default": "",
+        "description": "Render a fixed **square** box of this size (from the shared `--size-*`\nscale: `'xs'` 20 / `'sm'` 24 / `'md'` 32 / `'lg'` 40 px) instead of filling\nthe container's width. Use for dense thumbnails (e.g. a 40px image cell in a\ntable row) so you don't need a consumer-owned fixed-width wrapper. Omit for\nthe default responsive behavior. When set, `aspectRatio` is ignored (the box\nis already square); pair with `objectFit=\"cover\"` to crop."
+      },
+      {
+        "name": "radius",
+        "type": "ImageRadius",
+        "required": false,
+        "default": "",
+        "description": "Corner rounding. Defaults to `'md'`. Pass `'none'` for square corners; for\ncircular profile images use `<Avatar>`."
+      },
+      {
+        "name": "fallback",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Custom node rendered in place of the default broken-image placeholder when\nthe image fails to load. Overrides the icon + message + retry entirely."
+      },
+      {
+        "name": "loading",
+        "type": "\"eager\" | \"lazy\"",
+        "required": false,
+        "default": "",
+        "description": "Native lazy-loading hint. Defaults to `'lazy'`. Pass `'eager'` for\nabove-the-fold / LCP images."
+      },
+      {
+        "name": "interactive",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Make the image a flush, keyboard-accessible click target — renders the image\ninside a chromeless `<button>` (no padding/border/background; DS focus ring on\n`:focus-visible`). Implied when `onClick` is set. Use for a thumbnail that opens\na preview/lightbox. The broken-image error state is non-interactive (its retry\ncontrol takes over)."
+      },
+      {
+        "name": "onClick",
+        "type": "MouseEventHandler<HTMLButtonElement>",
+        "required": false,
+        "default": "",
+        "description": "Click handler for the interactive trigger. Setting it implies `interactive`.\nFires on click and on Enter/Space (native `<button>` keyboard behavior)."
+      },
+      {
+        "name": "ariaLabel",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible label for the interactive trigger — action-oriented, e.g.\n`\"Preview report.png\"`. Defaults to `alt`. Only used when interactive. Note:\na native `aria-label` passed via `{...rest}` lands on the `<img>`, not the\ntrigger button — use `ariaLabel` to name the trigger."
+      }
+    ]
+  },
+  "ImageCrop": {
+    "props": [
+      {
+        "name": "src",
+        "type": "string | File | Blob",
+        "required": true,
+        "default": "",
+        "description": "Image source. String URLs (HTTP/HTTPS, data:, blob:) pass through.\nFile/Blob are normalized to object URLs internally via\n`URL.createObjectURL()`, with cleanup on unmount and `src` change."
+      },
+      {
+        "name": "value",
+        "type": "CropArea | null",
+        "required": true,
+        "default": "",
+        "description": "Controlled crop area in SOURCE-IMAGE pixel coordinates. Pass `null` to\nuse the component's default centered crop (the largest centered region\nmatching `aspectRatio` at zoom=1). The component computes the visual\nposition from this + the image's natural size + the viewport size."
+      },
+      {
+        "name": "onChange",
+        "type": "(area: CropArea) => void",
+        "required": true,
+        "default": "",
+        "description": "Fires on every drag/zoom tick. High frequency."
+      },
+      {
+        "name": "onChangeEnd",
+        "type": "((area: CropArea) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires once when the user releases the drag or releases the zoom slider thumb."
+      },
+      {
+        "name": "aspectRatio",
+        "type": "number",
+        "required": false,
+        "default": "value",
+        "description": "Fixed aspect ratio for the crop box (e.g. `1` for square, `16/9` for\nlandscape, `4/3` for traditional photo). Omit for free aspect — the crop\nbox fills the entire viewport and the user controls the cropped region\nvia zoom only.\n\nTypically a stable prop from the consumer (set once per page). Toggling\n`aspectRatio` at runtime updates the crop box dimensions but does NOT\nautomatically re-fit `value` to the new ratio — pass a fresh `value`\n(or `null` for the new default) when you change ratios."
+      },
+      {
+        "name": "minZoom",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Minimum zoom level. Default `1` (image fits viewport at zoom=1)."
+      },
+      {
+        "name": "maxZoom",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Maximum zoom level. Default `3`."
+      },
+      {
+        "name": "showZoomControl",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Render the embedded `<Slider>` zoom control below the canvas. Default\n`true`. Set `false` for a pure canvas with no zoom UI — but the\ncomponent's internal zoom state isn't exposed (v2 feature)."
+      },
+      {
+        "name": "disabled",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Disable all interaction (drag, zoom). Default `false`. Image still\nrenders; the zoom slider is also disabled."
+      }
+    ]
+  },
+  "Indent": {
+    "props": [
+      {
+        "name": "level",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Nesting depth — multiplies the gutter. `0` = flush (no indent, e.g. a\nroot-level comment). Defaults to `1` (one gutter). Negative values clamp to `0`."
+      },
+      {
+        "name": "gutter",
+        "type": "IndentGutter",
+        "required": false,
+        "default": "",
+        "description": "Per-level indent size — a spacing step. Defaults to `'lg'` (16px per level).\n- `xs` 4px · `sm` 8px · `md` 12px · `lg` 16px · `xl` 24px · `2xl` 32px"
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "The nested content to indent. Required — an Indent with nothing inside indents nothing."
+      }
+    ]
+  },
+  "Input": {
+    "props": [
+      {
+        "name": "invalid",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Toggles the error visual (red border + focus ring) and sets `aria-invalid=\"true\"`.\nPair with a visible error message and `aria-describedby` pointing at the message id."
+      },
+      {
+        "name": "size",
+        "type": "InputSize",
+        "required": false,
+        "default": "",
+        "description": "Visual size. Defaults to `'md'`.\n- `'sm'` — 24px tall; toolbars, secondary forms.\n- `'md'` — 32px tall (default); most form contexts.\n- `'lg'` — 40px tall; hero search, mobile-friendly forms.\n\nNote: this shadows the native HTML `<input size>` attribute (visible\ncharacter count). If you need that legacy attribute, set width via\n`style` or a parent container."
+      },
+      {
+        "name": "disableAutofill",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Block browser autofill AND password managers from offering to fill\nthis input. Applies the standard set of opt-out hints:\n- `autoComplete=\"off\"`\n- `data-1p-ignore` (1Password)\n- `data-lpignore=\"true\"` (LastPass)\n- `data-form-type=\"other\"` (generic \"not a login field\")\n\n**Smart default**: when omitted, the input blocks autofill iff `autoComplete`\nis also omitted (or `'off'`). Explicit autocomplete hints\n(`autoComplete=\"email\"`, `\"current-password\"`, `\"username\"`, etc.) opt back\nIN to autofill — the assumption is that a consumer specifying autoComplete\nactually wants password-manager interaction. Pass `disableAutofill={true}`\nto force-block even with an autocomplete hint, or `false` to force-allow."
+      }
+    ]
+  },
+  "Kanban": {
+    "props": [
+      {
+        "name": "onMove",
+        "type": "((event: KanbanMoveEvent) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires once per drag (on drop) with the from/to positions and the cardId.\nNOT fired on drag cancel. NOT fired when from === to (no-op drop).\n\nConsumer should update their items state immutably, e.g.:\n```ts\nconst [cols, setCols] = useState({ todo: ['a', 'b'], done: ['c'] });\nconst handleMove = ({ from, to, cardId }) => {\n  setCols((prev) => {\n    const next = { ...prev };\n    next[from.columnId] = [...prev[from.columnId]];\n    next[from.columnId].splice(from.index, 1);\n    next[to.columnId] = [...prev[to.columnId]];\n    next[to.columnId].splice(to.index, 0, cardId);\n    return next;\n  });\n};\n```"
+      }
+    ]
+  },
+  "Kbd": {
+    "props": [
+      {
+        "name": "keys",
+        "type": "string[]",
+        "required": true,
+        "default": "",
+        "description": "Keys to display. Each entry renders one `<kbd>` chip. Multiple entries\nare joined with an inline `+` separator; a single-entry array renders\nno separator. Pass the literal label you want shown (`'⌘'`, `'Ctrl'`,\n`'Shift'`, `'K'`) — the component does NOT platform-translate."
+      },
+      {
+        "name": "size",
+        "type": "KbdSize",
+        "required": false,
+        "default": "sm",
+        "description": "Visual size. `'sm'` is the inline-chrome size (18px tall — matches\n`TopBar.Search`'s hotkey hint). `'md'` is the standalone shortcut size\n(24px tall — for command-palette / shortcut-sheet UI)."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible label for the whole shortcut, read as a single phrase by\nscreen readers. Defaults to `keys.join(' + ')` (e.g. `'⌘ + K'`).\nOverride when the raw keys are unintuitive — e.g. `keys={['⌘', 'K']}`\nwith `aria-label=\"Open command palette\"`."
+      }
+    ]
+  },
+  "Lightbox": {
+    "props": [
+      {
+        "name": "open",
+        "type": "boolean",
+        "required": true,
+        "default": "",
+        "description": "Controlled open state."
+      },
+      {
+        "name": "onOpenChange",
+        "type": "(open: boolean) => void",
+        "required": true,
+        "default": "",
+        "description": "Fired when the Lightbox wants to close — Esc, backdrop click, the × button."
+      },
+      {
+        "name": "items",
+        "type": "LightboxItem[]",
+        "required": true,
+        "default": "",
+        "description": "The images. An empty array renders nothing."
+      },
+      {
+        "name": "defaultIndex",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Initial image index (uncontrolled). Defaults to `0`. Clamped to range."
+      },
+      {
+        "name": "index",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Controlled current index. When set, pair with `onIndexChange`."
+      },
+      {
+        "name": "onIndexChange",
+        "type": "((index: number) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fired on navigation (chevron / arrow key / thumbnail click)."
+      },
+      {
+        "name": "loop",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Wrap past the first/last image. Defaults to `true`."
+      },
+      {
+        "name": "className",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "className for the dialog container."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible label for the dialog. Defaults to the i18n \"Image gallery\"."
+      }
+    ]
+  },
+  "Link": {
+    "props": [
+      {
+        "name": "variant",
+        "type": "LinkVariant",
+        "required": false,
+        "default": "",
+        "description": "Visual variant. See `LinkVariant` for descriptions."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "as",
+        "type": "C",
+        "required": false,
+        "default": "",
+        "description": ""
+      }
+    ]
+  },
+  "LinkCard": {
+    "props": [
+      {
+        "name": "padding",
+        "type": "CardPadding",
+        "required": false,
+        "default": "",
+        "description": "Inner padding — same scale as `Card`. Defaults to `'md'`."
+      },
+      {
+        "name": "tone",
+        "type": "CardTone",
+        "required": false,
+        "default": "",
+        "description": "Optional left-edge tone stripe — same vocabulary as `Card`."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "as",
+        "type": "C",
+        "required": false,
+        "default": "",
+        "description": ""
+      }
+    ]
+  },
+  "LiquidEditor": {
+    "props": [
+      {
+        "name": "value",
+        "type": "string",
+        "required": true,
+        "default": "",
+        "description": "Controlled template source."
+      },
+      {
+        "name": "onChange",
+        "type": "(value: string) => void",
+        "required": true,
+        "default": "",
+        "description": "Fires on every edit (typing, paste, variable insert, autocomplete accept)."
+      },
+      {
+        "name": "variables",
+        "type": "LiquidVariable[]",
+        "required": false,
+        "default": "",
+        "description": "Available variables → insert menu, autocomplete, unknown flagging."
+      },
+      {
+        "name": "flagUnknownVariables",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Underline `{{ vars }}` not present in `variables`. Default `true` (no-op when `variables` empty)."
+      },
+      {
+        "name": "invalid",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "External error visual (red border) — set from a backend Liquid syntax error. Default `false`."
+      },
+      {
+        "name": "error",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "External error message shown in the footer. Pairs with `invalid`."
+      },
+      {
+        "name": "preview",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Consumer-rendered preview output. When set (or `previewStatus` ≠ 'idle'), the pane shows."
+      },
+      {
+        "name": "previewStatus",
+        "type": "LiquidPreviewStatus",
+        "required": false,
+        "default": "",
+        "description": "Preview pane chrome. Default `'idle'`."
+      },
+      {
+        "name": "previewPlacement",
+        "type": "LiquidPreviewPlacement",
+        "required": false,
+        "default": "",
+        "description": "Preview pane position. Default `'bottom'`."
+      },
+      {
+        "name": "showLineNumbers",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Show the line-number gutter. Default `true`."
+      },
+      {
+        "name": "showToolbar",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Show the toolbar (variable-insert menu). Default `true`."
+      },
+      {
+        "name": "toolbarActions",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Custom action buttons rendered in the toolbar, right-aligned just before the\n\"Insert variable\" button (e.g. a Docs / Help link). Pass `<Button size=\"sm\">`\nelements (or a fragment of them); a `ghost` variant pairs well next to the\nbordered \"Insert variable\" button. Only renders when `showToolbar` is true."
+      },
+      {
+        "name": "filters",
+        "type": "string[]",
+        "required": false,
+        "default": "",
+        "description": "Filter names offered in autocomplete after `|`. Defaults to a common Liquid set."
+      },
+      {
+        "name": "minRows",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Minimum visible rows. Default `4`."
+      },
+      {
+        "name": "maxRows",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Maximum visible rows before the editor scrolls internally. Default unbounded."
+      },
+      {
+        "name": "readOnly",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Read-only: caret + selection allowed, no edits. Default `false`."
+      },
+      {
+        "name": "disabled",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Disabled: non-interactive + dimmed. Default `false`."
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Optional id forwarded to the textarea (for `<Field>` / label association)."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Optional name forwarded to the textarea."
+      },
+      {
+        "name": "placeholder",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Placeholder shown when empty."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible label (defaults to the i18n `liquidEditor.editorLabel`)."
+      },
+      {
+        "name": "aria-labelledby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Id of an external label element."
+      },
+      {
+        "name": "aria-describedby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Id(s) of external description element(s). Merged with the component's own\nfooter description (the `error` / unknown-variable message), so a screen\nreader announces both. You usually don't need this — the footer is wired\nautomatically; pass it only to add an extra external description."
+      },
+      {
+        "name": "className",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Extra class on the root wrapper."
+      }
+    ]
+  },
+  "Logo": {
+    "props": [
+      {
+        "name": "src",
+        "type": "string",
+        "required": true,
+        "default": "",
+        "description": "The brand mark image URL — typically an imported SVG/PNG asset. The mark is\na **consumer-owned asset**; the design system ships no logo of its own."
+      },
+      {
+        "name": "text",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Wordmark rendered beside (or below) the mark — consumers pass `\"eocrm\"`.\nOmit for a mark-only logo."
+      },
+      {
+        "name": "textPlacement",
+        "type": "LogoTextPlacement",
+        "required": false,
+        "default": "",
+        "description": "Where the wordmark sits relative to the mark. Defaults to `'end'` (beside);\n`'bottom'` stacks it under the mark, centered."
+      },
+      {
+        "name": "size",
+        "type": "LogoSize",
+        "required": false,
+        "default": "'md'",
+        "description": "Mark size — `'sm'` (24) / `'md'` (32, default) / `'lg'` (40)."
+      },
+      {
+        "name": "label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible name for the mark when there's no `text` (used as the image\n`alt`). Omit for a decorative mark (`alt=\"\"`), or when `text` is present\n(the wordmark is the name)."
+      },
+      {
+        "name": "subtext",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Small, muted secondary line rendered under `text` — e.g. a plan or tagline\n(`subtext=\"Free trial\"`). Only shown when `text` is present."
+      }
+    ]
+  },
+  "Masonry": {
+    "props": [
+      {
+        "name": "gap",
+        "type": "MasonryGap",
+        "required": false,
+        "default": "md",
+        "description": "`xs`(4) / `sm`(8) / `md`(12, default) / `lg`(16) / `xl`(24) / `2xl`(32)."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "columns",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Fixed number of columns. Mutually exclusive with `minColumnWidth`."
+      },
+      {
+        "name": "minColumnWidth",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Min column width (px) for a responsive column count. Default `'240px'`."
+      }
+    ]
+  },
+  "MediaTile": {
+    "props": [
+      {
+        "name": "media",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "Tile body — full-bleed media (an `<Image>`, or a centered file-type icon)."
+      },
+      {
+        "name": "title",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Top-bar leading content (e.g. the file name). Truncates with an ellipsis."
+      },
+      {
+        "name": "meta",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Top-bar trailing content (e.g. the file size). Sits at the end of the row."
+      },
+      {
+        "name": "actions",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Bottom-bar controls (e.g. preview / download / delete icon buttons), centered."
+      },
+      {
+        "name": "revealOn",
+        "type": "MediaTileReveal",
+        "required": false,
+        "default": "",
+        "description": "When the bars + scrims reveal. Default `'hover'`.\n- `'hover'` — on pointer hover OR keyboard focus-within (focus always included for a11y).\n- `'focus'` — only on focus-within (no mouse-over reveal).\n- `'visible'` — always shown."
+      },
+      {
+        "name": "radius",
+        "type": "MediaTileRadius",
+        "required": false,
+        "default": "",
+        "description": "Corner rounding (clips the media). Default `'md'`."
+      }
+    ]
+  },
+  "Modal": {
+    "props": [
+      {
+        "name": "open",
+        "type": "boolean",
+        "required": true,
+        "default": "",
+        "description": "Controlled open state. Required."
+      },
+      {
+        "name": "onOpenChange",
+        "type": "(open: boolean) => void",
+        "required": true,
+        "default": "",
+        "description": "Fired when Modal wants to change open state — Esc, overlay click, Close button, programmatic."
+      },
+      {
+        "name": "size",
+        "type": "ModalSize",
+        "required": false,
+        "default": "",
+        "description": "Size preset. Defaults to 'md'."
+      },
+      {
+        "name": "overlay",
+        "type": "ModalOverlayVariant",
+        "required": false,
+        "default": "",
+        "description": "Overlay variant. 'solid' (default) paints a dark dimming layer.\n'blur' uses a light tinted background plus `backdrop-filter: blur(4px)`\nfor a frosted-glass effect. 'blur' costs an extra compositor layer —\nfine for normal use; avoid stacking three blurred modals at once."
+      },
+      {
+        "name": "stackMode",
+        "type": "ModalStackMode",
+        "required": false,
+        "default": "'overlay'",
+        "description": "How this modal relates to existing modals in the stack when it opens.\n\n- `'overlay'` (default): if there's a modal below this one, it stays\n  visible underneath. This modal's own overlay paints transparent so\n  the parent's dim shows through. Only the bottom modal (depth 0)\n  paints the actual dim/blur. The user sees the parent's context behind\n  the active modal.\n- `'replace'`: any modals below this one are hidden via `display: none`\n  (React state preserved). This modal paints its own overlay normally.\n  Best for forced-step modals where the parent context is irrelevant.\n\nHas no effect when this is the only open modal."
+      },
+      {
+        "name": "disableEscapeClose",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Disable Escape-to-close. Default false. Combined with `dismissOnOverlayClick: false`\nand omitting `<Modal.Close>` produces a fully forced step."
+      },
+      {
+        "name": "dismissOnOverlayClick",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "When false, clicking the overlay backdrop does NOT close the modal. Default true."
+      },
+      {
+        "name": "initialFocusRef",
+        "type": "RefObject<HTMLElement | null>",
+        "required": false,
+        "default": "",
+        "description": "Initial focus target on open. Default: the dialog container itself.\nPass a ref to override (e.g. focus the first input in a form)."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "Compound children: Header / Body / Footer / Close + any consumer JSX."
+      },
+      {
+        "name": "className",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "className passes through to the dialog container."
+      },
+      {
+        "name": "style",
+        "type": "CSSProperties",
+        "required": false,
+        "default": "",
+        "description": "style passes through to the dialog container."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Required for a11y when no Modal.Header is rendered. When Header IS rendered,\naria-labelledby auto-binds to the heading id; this prop is then ignored."
+      },
+      {
+        "name": "aria-describedby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Optional id of an external descriptor element; sets aria-describedby on the dialog."
+      }
+    ]
+  },
+  "OptionsPicker": {
+    "props": [
+      {
+        "name": "mode",
+        "type": "\"single\" | \"multi\"",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "selected",
+        "type": "string | string[] | null",
+        "required": true,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "onApply",
+        "type": "((next: string[]) => void) | ((next: string | null) => void)",
+        "required": true,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "onCancel",
+        "type": "(() => void) | (() => void)",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "open",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "onOpenChange",
+        "type": "((open: boolean) => void) | ((open: boolean) => void)",
+        "required": false,
+        "default": "",
+        "description": ""
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": ""
+      }
+    ]
+  },
+  "Page": {
+    "props": [
+      {
+        "name": "gap",
+        "type": "StackGap",
+        "required": false,
+        "default": "lg",
+        "description": "Vertical rhythm between top-level page sections.\n- `xs` (4) / `sm` (8) / `md` (12) — tighter than canonical; rare.\n- `lg` (16, **default**) — the canonical CRM page rhythm; matches\n  every shipped mockup.\n- `xl` (24) / `2xl` (32) — looser; for spacious overview / hero pages."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": ""
+      }
+    ]
+  },
+  "PageHeader": {
+    "props": [
+      {
+        "name": "borderBottom",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Render a 1px bottom border under the header. Default `true`. Set\n`false` when placing a `<Tabs>` component as a sibling below — Tabs\nhas its own `border-bottom`, and you don't want the double line."
+      }
+    ]
+  },
+  "Pagination": {
+    "props": [
+      {
+        "name": "currentPage",
+        "type": "number",
+        "required": true,
+        "default": "",
+        "description": "Current 1-indexed page. Values outside `[1, pageCount]` clamp at\nrender time (defensive — same precedent as `clampHeading` in\n`<EmptyState>`)."
+      },
+      {
+        "name": "pageCount",
+        "type": "number",
+        "required": true,
+        "default": "",
+        "description": "Total number of pages. Values `< 1` clamp to `1`. The component still\nrenders when `pageCount === 1` (single disabled-current button + both\nprev/next disabled) so consumers don't have to conditionally hide it."
+      },
+      {
+        "name": "onPageChange",
+        "type": "(page: number) => void",
+        "required": true,
+        "default": "",
+        "description": "Called with the new 1-indexed page when the user clicks prev, next,\nor a page number. Not fired when the user clicks the current page\n(the button is `disabled`)."
+      },
+      {
+        "name": "siblingCount",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "How many page-number buttons to show on each side of `currentPage`.\nDefault `1`. Set to `0` for the tightest possible display (sidebar /\nnarrow column) or `2` for wider footers. Boundary is fixed at 1 —\nfirst and last pages are always shown."
+      },
+      {
+        "name": "size",
+        "type": "PaginationSize",
+        "required": false,
+        "default": "'md'",
+        "description": "Visual size — `'sm'` (24px), `'md'` (32px, default), `'lg'` (40px).\nTracks the Button / Input scale so Pagination sits cleanly inside\na `<Cluster>` next to those components."
+      },
+      {
+        "name": "disabled",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "When `true`, all buttons (prev / next / numbers) are disabled. Use\nduring page transitions (loading, saving) to prevent double-clicks."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible name for the `<nav>` wrapper. Defaults to `'Pagination'`.\nOverride when multiple paginations appear on the same page (e.g.,\n`'Top pagination'` / `'Bottom pagination'`)."
+      }
+    ]
+  },
+  "PasswordInput": {
+    "props": [
+      {
+        "name": "size",
+        "type": "PasswordInputSize",
+        "required": false,
+        "default": "",
+        "description": "Field height + type scale. Same scale as `<Input>`. Defaults to `'md'`."
+      },
+      {
+        "name": "invalid",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Toggles the error visual + sets `aria-invalid=\"true\"`."
+      },
+      {
+        "name": "revealed",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Controlled revealed state. Pair with `onRevealChange`."
+      },
+      {
+        "name": "defaultRevealed",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Initial revealed state for uncontrolled use. Defaults to `false`."
+      },
+      {
+        "name": "onRevealChange",
+        "type": "((revealed: boolean) => void)",
+        "required": false,
+        "default": "",
+        "description": "Called when the user clicks the eye toggle. Receives the next revealed state."
+      },
+      {
+        "name": "revealable",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Whether to render the eye toggle button. Defaults to `true`. Set\n`revealable={false}` for compliance / kiosk screens where revealing\nis forbidden — the input then behaves like a plain locked-down\n`<input type='password'>`."
+      },
+      {
+        "name": "capsLockWarning",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Opt-in caps-lock detection. When `true`, on every keypress the\ninput reads `event.getModifierState('CapsLock')`; when active, a\nwarning icon + polite `aria-live` announce it. Cleared on blur.\n\nDefaults to `false`. Opt in on screens where caps-lock matters\n(login, password creation, password confirmation)."
+      },
+      {
+        "name": "wrongLayoutWarning",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Opt-in wrong-keyboard-layout detection. When `true`, detects\nkeystrokes that produce non-ASCII single characters (e.g., Cyrillic\n`ф` from a Russian layout). Shows a warning icon + polite live\nregion. Cleared on blur.\n\nHeuristic, not deterministic — any non-ASCII keystroke triggers.\nOnly enable when the system expects Latin-only password input.\nDefaults to `false`."
+      }
+    ]
+  },
+  "PasswordStrengthMeter": {
+    "props": [
+      {
+        "name": "value",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "The password to evaluate. Required UNLESS `score` is provided. Evaluated\nvia the default scoring heuristic or a consumer-supplied `scoreFn`."
+      },
+      {
+        "name": "score",
+        "type": "PasswordStrengthScore",
+        "required": false,
+        "default": "",
+        "description": "Pre-computed score (0–4). Wins over `value` + `scoreFn` when both are\npresent. Use this when scoring is done by zxcvbn or server-side."
+      },
+      {
+        "name": "scoreFn",
+        "type": "((value: string) => PasswordStrengthScore)",
+        "required": false,
+        "default": "",
+        "description": "Custom scoring fn. Receives the password, returns 0–4. Defaults to a\nlength + character-class heuristic — fine for prototypes, NOT a\nsecurity control. Production should pass a real scorer via `score`."
+      },
+      {
+        "name": "showLabel",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Render the textual label next to the segments. Defaults to `true`."
+      }
+    ]
+  },
+  "PersonDisplay": {
+    "props": [
+      {
+        "name": "size",
+        "type": "PersonDisplaySize",
+        "required": false,
+        "default": "",
+        "description": "Visual size of the entire composition. `md` is the default — suits\nsidebars, members lists, and most card / table contexts. `sm` is\nthe compact density for tight table cells; `lg` is the detail-page\nhero size. Propagates to the Avatar size and the Name / Description\ntext sizes via context."
+      },
+      {
+        "name": "shrink",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Force the composition to shrink-wrap to its content (avatar + name) instead of\nstretching to fill a parent. Default `false`. The root is `inline-flex` and\nshrink-wraps on its own — but as a child of a *stretching* flex/grid container\n(a detail/sidebar card column with `align-items: stretch` / `justify-self:\nstretch`) CSS blockifies it and the parent stretches it to the full column\nwidth. The avatar+name then sit in the left portion and the trailing empty\nspace joins the box, so a `Popover.Trigger` / `Tooltip` cloned onto the\nPersonDisplay anchors to that wide box and centers far to the right of the\nperson. Set `shrink` on such an overlay trigger to keep it content-width\n(`width: fit-content`) regardless of the parent, so the overlay anchors to the\nvisible avatar+name."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "`<PersonDisplay.Avatar>` + `<PersonDisplay.Name>` (+ optional repeating\n`<PersonDisplay.Description>`) subcomponents in any order — Root sorts\nthe Avatar into its own slot."
+      }
+    ]
+  },
+  "PhoneInput": {
+    "props": [
+      {
+        "name": "value",
+        "type": "string | null",
+        "required": true,
+        "default": "",
+        "description": "Controlled E.164 value (e.g. `\"+442071838750\"`); `null` = empty."
+      },
+      {
+        "name": "onChange",
+        "type": "(e164: string | null) => void",
+        "required": true,
+        "default": "",
+        "description": "Fires with canonical E.164 on every edit; `null` when empty."
+      },
+      {
+        "name": "defaultCountry",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "ISO 3166-1 alpha-2 country used to seed the picker when `value` is empty. Default `\"US\"`."
+      },
+      {
+        "name": "countries",
+        "type": "string[]",
+        "required": false,
+        "default": "",
+        "description": "Restrict the picker to this ISO-code subset. Defaults to all libphonenumber-js countries. An empty array is treated as all countries."
+      },
+      {
+        "name": "countryDisplay",
+        "type": "CountryDisplay",
+        "required": false,
+        "default": "",
+        "description": "How the SELECTED country renders in the picker trigger. Default `\"code\"`.\n- `\"code\"` — calling code only (`+1`).\n- `\"iso\"` — ISO code + code (`US +1`).\n- `\"name\"` — full country name + code (`United States +1`).\n- `\"flag\"` — emoji flag + code (`🇺🇸 +1`). Note: emoji flags don't render on\n  Windows Chrome/Edge (they show the letters), so prefer `\"iso\"` there.\n\nThe dropdown rows always show the full country name + code (plus a flag in\n`\"flag\"` mode) so they stay searchable + identifiable regardless of this."
+      },
+      {
+        "name": "size",
+        "type": "PhoneInputSize",
+        "required": false,
+        "default": "",
+        "description": "Control size, forwarded to the Select + Input. Default `\"md\"`."
+      },
+      {
+        "name": "invalid",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Error chrome on both controls (host/Field-driven)."
+      },
+      {
+        "name": "disabled",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Disable both controls."
+      },
+      {
+        "name": "required",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Mark required (forwarded for Field semantics)."
+      },
+      {
+        "name": "locale",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "BCP-47 locale for country-name localization. Defaults to the i18n locale, else `\"en\"`."
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Stable id; placed on the number field so an external `<label htmlFor>` focuses it."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible name when used STANDALONE (outside `<Field>`). A standalone\nPhoneInput MUST be named via `aria-label` or `aria-labelledby`, else the\ncountry/number group is unnamed. Inside `<Field>` the label is wired\nautomatically via `aria-labelledby`."
+      },
+      {
+        "name": "aria-labelledby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Ids of elements labelling the group (injected by `<Field>`; takes precedence over `aria-label`)."
+      },
+      {
+        "name": "aria-describedby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Ids of description/error elements; forwarded to the number field so it is announced on focus (injected by `<Field>`)."
+      }
+    ]
+  },
+  "Popover": {
+    "props": [
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "Must contain exactly one `<Popover.Trigger>` (or `<Popover.Anchor>` for a\ncontrolled popover whose anchor owns its own toggle + ARIA) and one\n`<Popover.Content>`. `<Popover.Heading>` and `<Popover.Close>` are optional\nand may appear anywhere inside `<Popover.Content>`."
+      },
+      {
+        "name": "open",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Controlled open state. Provide alongside `onOpenChange` to drive open\nexternally. Omit both to let Popover own its state (the common case)."
+      },
+      {
+        "name": "onOpenChange",
+        "type": "((open: boolean) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fired whenever Popover wants to change open state. Required when `open` is provided."
+      },
+      {
+        "name": "defaultOpen",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Default open state for uncontrolled usage. Defaults to `false`."
+      },
+      {
+        "name": "modal",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Reserved future hint. v1 ignores the value and always renders non-modal.\nWill gate focus-trap + inert-background once `<Modal>` lands."
+      }
+    ]
+  },
+  "Progress": {
+    "props": [
+      {
+        "name": "value",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Current progress value. Omit (or pass `undefined`) to render the\nindeterminate animation.\n\nTwo-channel behavior for out-of-range and degenerate values:\n- **Visual fill** is clamped to [0%, 100%]. Values outside [0, max]\n  render at the nearest valid bound.\n- **ARIA `aria-valuenow`** reports the raw number — this is the right\n  screen-reader behavior so consumer bugs (a value drifting past max)\n  surface in audits and SR announcements.\n\nDegenerate inputs fall back to the indeterminate animation: `NaN`,\n`Infinity`, `-Infinity`, and the case where `max <= 0`. This is the\ncommon file-upload race condition (`bytes_uploaded / total_bytes`\nbefore `total_bytes` is known produces NaN)."
+      },
+      {
+        "name": "max",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Upper bound. Defaults to `100`. Consumers using fraction values\n(0.0–1.0) pass `max={1}`. Consumers tracking a count (\"3 of 10\")\npass `max={10}`."
+      },
+      {
+        "name": "size",
+        "type": "ProgressSize",
+        "required": false,
+        "default": "",
+        "description": "Track height.\n- `sm` — 4px (compact / inside form rows)\n- `md` — 8px (default)\n- `lg` — 12px (page-level emphasis)"
+      },
+      {
+        "name": "tone",
+        "type": "ProgressTone",
+        "required": false,
+        "default": "",
+        "description": "Fill color tone. Defaults to `'default'` (accent blue). Tone applies\nONLY to determinate mode; indeterminate always uses the accent tone\nbecause state-color semantics don't apply to an unknown total.\n- `default` — `--color-accent`\n- `success` — `--color-success`\n- `warning` — `--color-warning`\n- `danger` — `--color-danger`"
+      },
+      {
+        "name": "label",
+        "type": "ReactNode",
+        "required": false,
+        "default": "false",
+        "description": "Optional label rendered to the RIGHT of the bar.\n- `false` (default) — no label\n- `true` — render `{Math.round((value / max) * 100)}%` when determinate.\n  Auto-suppressed when indeterminate (there's no percentage to show).\n- `ReactNode` — render the node as-is, in BOTH determinate and\n  indeterminate modes. Consumers wanting \"Loading…\" text next to an\n  indeterminate bar pass `label=\"Loading…\"`."
+      }
+    ]
+  },
+  "Radio": {
+    "props": [
+      {
+        "name": "value",
+        "type": "string",
+        "required": true,
+        "default": "",
+        "description": "The value submitted when this radio is selected."
+      },
+      {
+        "name": "size",
+        "type": "RadioSize",
+        "required": false,
+        "default": "",
+        "description": "Ring diameter + label type scale. Defaults to `'md'`.\n- `'sm'` — 14px ring, font-size-sm label.\n- `'md'` — 16px ring, font-size-md label.\n- `'lg'` — 20px ring, font-size-lg label.\n\nInside `<RadioGroup>`, the group's `size` becomes the default; explicit\nper-radio `size` still wins."
+      },
+      {
+        "name": "checked",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Controlled checked state. Inside `<RadioGroup>`, leave this unset —\nthe group computes `checked` from its `value`. If you explicitly set\n`checked` on a Radio inside a group, your prop wins and the group's\ncontrolled invariant breaks (don't do this)."
+      },
+      {
+        "name": "defaultChecked",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Initial checked state for uncontrolled standalone use."
+      },
+      {
+        "name": "label",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Label rendered next to the ring. The whole `<label>` is the click\ntarget. Omit for icon-only radios + pass `aria-label`."
+      },
+      {
+        "name": "invalid",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Toggles the error visual + `aria-invalid='true'`. Inside a\n`<RadioGroup>`, the group's `invalid` becomes the default for this\nradio — explicit per-child `invalid` (including `false`) still wins."
+      },
+      {
+        "name": "onChange",
+        "type": "((value: string, event: ChangeEvent<HTMLInputElement>) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires when the radio is selected. Receives the radio's `value` AND\nthe native event. Inside a group, this runs FIRST, then the group's\n`onChange` fires."
+      }
+    ]
+  },
+  "Rail": {
+    "props": [
+      {
+        "name": "collapsed",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Controlled collapsed flag. Provide alongside `onCollapsedChange` to drive\nthe rail's narrow/wide state externally (e.g. persisted to localStorage\nor URL). Omit both `collapsed` and `defaultCollapsed` to let the rail\nstay expanded."
+      },
+      {
+        "name": "defaultCollapsed",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Initial collapsed state for the uncontrolled case. Has no effect when\n`collapsed` is provided. Defaults to `false` — the rail mounts expanded."
+      },
+      {
+        "name": "onCollapsedChange",
+        "type": "((collapsed: boolean) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires whenever the rail toggles, both controlled and uncontrolled. Useful\nfor persisting the state to localStorage or the URL."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible label for the wrapping `<nav>` landmark. Defaults to\n`t('rail.navigation')` so screen readers always announce a name for the\nregion. Override when the page has multiple navigation rails."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "Rail children — typically a sequence of `<Rail.Header>`, `<Rail.Section>`,\n`<Rail.Group>`, `<Rail.Spacer>`, `<Rail.Footer>`. Order matters: the\n`<Rail.Spacer>` is what pushes a subsequent `<Rail.Footer>` to the\nbottom of the rail."
+      }
+    ]
+  },
+  "RichText": {
+    "props": [
+      {
+        "name": "value",
+        "type": "RichDoc",
+        "required": true,
+        "default": "",
+        "description": "The document to render. Build one with `emptyDoc()` / `createBlock()` or the transforms."
+      },
+      {
+        "name": "renderLink",
+        "type": "RenderLink",
+        "required": false,
+        "default": "",
+        "description": "Substitute how a link renders. Called per link with `{ href, text }` and the\ndefault `<a>` node; return your own node (e.g. a task/member chip) or the\n`defaultNode` to keep the standard anchor. Render-time only — the document\nmodel is unchanged, so serialization still emits a plain link."
+      },
+      {
+        "name": "renderMention",
+        "type": "RenderMention",
+        "required": false,
+        "default": "",
+        "description": "Substitute how an `@`-mention renders. Called per mention with `{ id, label }`\nand the default mention span; return your own node (e.g. an interactive member\nchip / popover trigger) or the `defaultNode` to keep the standard\nnon-interactive span. Render-time only — the document model is unchanged, so\nserialization still emits the mention mark. Composes with `renderLink`."
+      }
+    ]
+  },
+  "RichTextEditor": {
+    "props": [
+      {
+        "name": "value",
+        "type": "RichDoc",
+        "required": true,
+        "default": "",
+        "description": "Controlled document. Render the doc returned by `onChange` back into `value`."
+      },
+      {
+        "name": "onChange",
+        "type": "(doc: RichDoc) => void",
+        "required": true,
+        "default": "",
+        "description": "Fires with the new document after every edit."
+      },
+      {
+        "name": "readOnly",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Non-editable: renders the content read-only (prefer `<RichText>` for pure display)."
+      },
+      {
+        "name": "placeholder",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Shown when the document is empty."
+      },
+      {
+        "name": "autoFocus",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Focus the editor on mount."
+      },
+      {
+        "name": "toolbar",
+        "type": "boolean | \"auto\"",
+        "required": false,
+        "default": "",
+        "description": "Render the built-in formatting toolbar above the editor — Undo/Redo buttons,\nmark toggle buttons (bold/italic/underline/strike), a block-type dropdown\n(paragraph/headings/quote/code), and bullet/numbered list toggles. The\ntoolbar dispatches through the same commit path the keyboard uses and\nreflects the active marks + current block of the live selection. Default\n`false` (keyboard-only). When `readOnly`, the toolbar renders disabled.\n\n`'auto'` shows the toolbar only when the editor is **focused or non-empty**,\nand keeps it shown while the editor's own overlays (the link editor / mention\nmenu) are open — so opening the link editor on a focused-but-empty composer\ndoesn't collapse the bar. The editable is NOT remounted as the bar appears or\nhides (the bar toggles in a stable shell), so there's no focus/selection loss.\nUse it for a compact, focus-gated composer (e.g. a comment box) instead of\nhand-rolling the show-on-focus logic and working around overlay focus theft."
+      },
+      {
+        "name": "mentions",
+        "type": "MentionsConfig",
+        "required": false,
+        "default": "",
+        "description": "Enable `@`-mention autocomplete. Supply `onQuery` to resolve candidates for\nthe text typed after the trigger (default `@`); the editor renders a floating\ncombobox and inserts a styled mention chip carrying the chosen item's `id`.\nOmit to disable mentions. See {@link MentionsConfig}."
+      },
+      {
+        "name": "autolink",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Turn typed and pasted URLs into links automatically. While typing, a URL is\nlinked when you type a space after it; on paste, plain-text URLs are linked\n(a single bare URL pasted over a selection links the selection). Default\n`true`. Set `false` to disable both the type rule and paste autolinking (the\n⌘/Ctrl+K link tool still works). The href is sanitized — only safe schemes\n(http/https/`www.`) become links."
+      },
+      {
+        "name": "renderLink",
+        "type": "RenderLink",
+        "required": false,
+        "default": "",
+        "description": "Substitute how a link renders. Called per link with `{ href, text }` and the\ndefault `<a>`; return your own node (e.g. a task/member chip) or the\n`defaultNode` to keep the standard anchor. A custom node renders as a\nnon-editable **atomic chip** — the caret steps over it and a single Backspace/\nDelete removes the whole link."
+      },
+      {
+        "name": "renderMention",
+        "type": "RenderMention",
+        "required": false,
+        "default": "",
+        "description": "Substitute how an `@`-mention renders. Called per mention with `{ id, label }`\nand the default mention span; return your own node (e.g. an interactive member\nchip / popover trigger) or the `defaultNode` to keep the standard\nnon-interactive span. A custom node renders as a non-editable **atomic chip** —\nthe caret steps over it as a single unit. Composes with `renderLink` (both\nusable together)."
+      },
+      {
+        "name": "blockControls",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Show Notion-style per-block controls: a left gutter that appears on the\nhovered/focused block with an insert button (`＋`, adds an empty paragraph\nbelow) and a drag handle (`⠿`) that opens a block menu (Turn into ▸,\nDuplicate, Move up/down, Delete). Reordering is subtree-aware for nested\nlists. Keyboard: Shift+F10 / the ContextMenu key opens the focused block's\nmenu; ⌘/Ctrl+⇧↑ / ⌘/Ctrl+⇧↓ move the block; ⌘/Ctrl+D duplicates. Default\n`false`. Ignored when `readOnly`. Independent of `toolbar`."
+      },
+      {
+        "name": "upload",
+        "type": "UploadConfig",
+        "required": false,
+        "default": "",
+        "description": "Enable file upload: a toolbar button (when `toolbar`) and clipboard-file paste.\n`onUpload(file)` resolves with where the file landed; images render inline as a\npreview, other files as a download chip. Reject `onUpload` to show a retry/remove\nerror. `onUploadingChange` fires while any upload is in flight — wire it to your\nsubmit button's disabled state. Validation (size/type) belongs in `onUpload`\n(`accept` is only a native-picker hint and is bypassed by paste). Omit to\ndisable. Ignored when `readOnly`.\nWhen `blockControls` is also on, a ready image attachment can be configured\n(alt text, alignment, replace, open/download) via the block menu's\n\"Configure\" item. The width slider appears only for an image that renders as\na preview (a safe, fetchable src — an embed); an uploaded image whose\nobject-URL src renders as a download chip isn't resizable here. Alignment +\nwidth round-trip through HTML but not Markdown."
+      }
+    ]
+  },
+  "Screen": {
+    "props": [
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "The centered main content."
+      },
+      {
+        "name": "header",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Pinned-top slot — a back link, wordmark, etc. Omit for none."
+      },
+      {
+        "name": "footer",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Pinned-bottom slot — legal / footer links. Omit for none."
+      },
+      {
+        "name": "fill",
+        "type": "ScreenFill",
+        "required": false,
+        "default": "",
+        "description": "Screen height. Defaults to `'viewport'`.\n- `'viewport'` — `min-height: 100vh`; a true standalone page (login,\n  standalone 404 / error).\n- `'block'` — fills its container instead of the viewport; use when the\n  Screen is embedded inside the app shell's content area (the in-app\n  404 / error variants)."
+      },
+      {
+        "name": "backdrop",
+        "type": "ScreenBackdrop",
+        "required": false,
+        "default": "",
+        "description": "Backdrop behind the content. Defaults to `'none'` (transparent — inherits\nthe surface; use with `fill=\"block\"` inside the shell).\n- `'plain'` — solid subtle surface.\n- `'accent'` — accent-tinted radial (the login backdrop).\n- `'danger'` — danger-tinted radial (standalone error screen)."
+      },
+      {
+        "name": "align",
+        "type": "ScreenAlign",
+        "required": false,
+        "default": "",
+        "description": "Vertical placement of the main content. Defaults to `'center'`."
+      }
+    ]
+  },
+  "Select": {
+    "props": [
+      {
+        "name": "options",
+        "type": "SelectOptions<T>",
+        "required": false,
+        "default": "",
+        "description": "Sync options — flat list or list of groups. Ignored when `loadOptions`\nis provided (dev warning fires if both are non-empty). For grouped\ninput, every element must carry an `options` field; mixing flat options\nwith groups at the same level is not supported."
+      },
+      {
+        "name": "loadOptions",
+        "type": "((query: string, signal: AbortSignal) => Promise<SelectOptions<T>>)",
+        "required": false,
+        "default": "",
+        "description": "Async fetcher that returns the options for a given query. When set, the\nSelect switches to async mode: the local substring filter is bypassed\n(the server filters), loading/error/empty rows replace the listbox\nbody, and `options` is ignored (with a dev warning). The `signal`\nargument is aborted whenever a newer query supersedes this one — wire\nit through to `fetch` to cancel in-flight requests."
+      },
+      {
+        "name": "loadOnOpen",
+        "type": "boolean",
+        "required": false,
+        "default": "true",
+        "description": "When `true` (default), defers the first `loadOptions` call until the\nuser opens the listbox. Set to `false` to fetch eagerly on mount."
+      },
+      {
+        "name": "searchDebounceMs",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Debounce window (ms) between the last query keystroke and the next\n`loadOptions` call. Default `250`."
+      },
+      {
+        "name": "multiple",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Enables multi-select. `value` / `defaultValue` become `string[]` and\n`onChange` emits arrays. Picking a row toggles it in/out of the\nselection instead of replacing-and-closing."
+      },
+      {
+        "name": "triggerDisplay",
+        "type": "SelectTriggerDisplay",
+        "required": false,
+        "default": "",
+        "description": "How the trigger renders the selected value(s) in multi mode. Ignored\nin single mode. See `SelectTriggerDisplay`. Defaults to `'chips'`."
+      },
+      {
+        "name": "searchable",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Renders the trigger as a combobox text input with substring filtering\nover the (sync) options. In async mode the filter is delegated to the\nserver. Required by `creatable`."
+      },
+      {
+        "name": "selectOnOpen",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "When the searchable combobox opens, select the current text so the user\ncan immediately type to replace it (type-to-search). Default `false`.\nOnly affects the single searchable trigger."
+      },
+      {
+        "name": "creatable",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Adds a \"+ Create <query>\" row when the trimmed query has no exact\nlabel match. Activating it fires `onCreate(label)` and folds the new\nvalue into the selection. Requires `searchable` (throws in dev otherwise)."
+      },
+      {
+        "name": "onCreate",
+        "type": "((label: string) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires when the user activates the \"+ Create\" row (creatable mode).\nThe trimmed query string is passed as `label`. After this fires,\nthe Select also calls `onChange` with the new value: in single mode\nthe value replaces the current selection and the listbox closes; in\nmulti mode the value is appended to the current selection and the\nquery is cleared.\n\nConsumers typically use this hook to persist the new option upstream\n(e.g. POST to a backend) and reconcile their `options` array."
+      },
+      {
+        "name": "value",
+        "type": "string | string[]",
+        "required": false,
+        "default": "",
+        "description": "Controlled selection. `string` in single mode, `string[]` in multi.\nProvide alongside `onChange` to drive the value externally."
+      },
+      {
+        "name": "defaultValue",
+        "type": "string | string[]",
+        "required": false,
+        "default": "",
+        "description": "Initial selection for uncontrolled usage. `string` in single mode,\n`string[]` in multi. Ignored when `value` is provided."
+      },
+      {
+        "name": "onChange",
+        "type": "((value: string | string[], option: SelectOption<T> | SelectOption<T>[] | null) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires when the selection changes. The first argument is the next\nvalue (`string` in single mode, `string[]` in multi). The second\nargument is the matched `SelectOption` (single), the matched array\n(multi), or `null` when the selection clears in single mode. For\ncreatable rows not present in `options`, a synthetic\n`{ value, label: value }` is supplied."
+      },
+      {
+        "name": "open",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Controlled open state. Pair with `onOpenChange`. Omit both to let\nSelect own its open state (the common case)."
+      },
+      {
+        "name": "defaultOpen",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Initial open state for uncontrolled usage. Defaults to `false`."
+      },
+      {
+        "name": "onOpenChange",
+        "type": "((open: boolean) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires whenever Select wants to change open state."
+      },
+      {
+        "name": "size",
+        "type": "SelectSize",
+        "required": false,
+        "default": "",
+        "description": "Trigger height + type scale. See `SelectSize`. Defaults to `'md'`."
+      },
+      {
+        "name": "invalid",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Marks the trigger as invalid — applies the error border + sets\n`aria-invalid=\"true\"`. Pair with an external error message linked via\n`aria-describedby`."
+      },
+      {
+        "name": "placeholder",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Placeholder shown when nothing is selected. In searchable mode, also\nthe input's `placeholder` until the user types."
+      },
+      {
+        "name": "clearable",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Shows a `✕` button in the trigger that clears the selection. Default\nis `true` in single mode (when not `required`), `false` in multi mode.\nForced `false` when `disabled` or `readOnly`."
+      },
+      {
+        "name": "disabled",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Disables the trigger entirely — non-interactive, dimmed, focusable\nonly via assistive tech. Hidden form inputs are also disabled."
+      },
+      {
+        "name": "readOnly",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Read-only — trigger is focusable but cannot open or change the\nselection. Useful for displaying a value inside a form that's not yet\neditable."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Name attribute for native form submission. In multi mode, one hidden\n`<input>` per selected value is emitted (so `FormData.getAll(name)`\nreturns the array)."
+      },
+      {
+        "name": "required",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Marks the field as required for native form validation. When `true`,\n`clearable` defaults to `false` and an empty selection blocks submit."
+      },
+      {
+        "name": "form",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "`form` attribute forwarded to the hidden `<input>` elements."
+      },
+      {
+        "name": "renderOption",
+        "type": "((opt: SelectOption<T>, state: { active: boolean; selected: boolean; }) => ReactNode)",
+        "required": false,
+        "default": "",
+        "description": "Custom renderer for a row inside the listbox. Receives the option and\nits current `{ active, selected }` state (active = keyboard-focused\nrow, selected = part of the current value). The returned node\nreplaces the default label / description layout — chrome (padding,\nbackground, `aria-*`) stays."
+      },
+      {
+        "name": "renderValue",
+        "type": "((opt: SelectOption<T>) => ReactNode)",
+        "required": false,
+        "default": "",
+        "description": "Custom renderer for the selected value inside the single-mode trigger.\nIgnored in multi mode (see `renderTag`)."
+      },
+      {
+        "name": "renderTag",
+        "type": "((opt: SelectOption<T>, remove: () => void) => ReactNode)",
+        "required": false,
+        "default": "",
+        "description": "Custom renderer for a chip inside the multi-mode `chips` trigger.\nReceives the option and a `remove` callback that deselects it. Ignored\nin single mode and in `triggerDisplay='summary'`."
+      },
+      {
+        "name": "renderEmpty",
+        "type": "((query: string) => ReactNode)",
+        "required": false,
+        "default": "",
+        "description": "Custom empty-state renderer. Fires when the filtered listbox has no\nrows. Receives the current trimmed query for use in messages like\n\"No matches for 'foo'\"."
+      },
+      {
+        "name": "renderLoading",
+        "type": "(() => ReactNode)",
+        "required": false,
+        "default": "",
+        "description": "Custom loading-state renderer for async mode."
+      },
+      {
+        "name": "renderError",
+        "type": "((err: Error, retry: () => void) => ReactNode)",
+        "required": false,
+        "default": "",
+        "description": "Custom error-state renderer for async mode. Receives the thrown\n`Error` and a `retry` callback that re-invokes `loadOptions` with the\ncurrent query."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible name for the trigger. Use this when a visible `<label>` is\nnot present. Mutually exclusive with `aria-labelledby`."
+      },
+      {
+        "name": "aria-labelledby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "ID of an element that labels the trigger. Use when the label is a\nsibling node (e.g. a `<Field>` label)."
+      },
+      {
+        "name": "aria-describedby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "ID of an element that describes the trigger — e.g. an error message\nor helper hint paired with `invalid`."
+      }
+    ]
+  },
+  "Skeleton": {
+    "props": [
+      {
+        "name": "variant",
+        "type": "SkeletonVariant",
+        "required": false,
+        "default": "",
+        "description": "Shape preset. Defaults to `'text'`.\n- `'text'` — inline-block; `height` defaults to `1em` so it sits on text\n  baselines. Use inside paragraphs / labels for word-shaped placeholders.\n- `'circular'` — `border-radius: 50%`; when only one of `width`/`height`\n  is set, the other matches (square). Avatar / icon placeholder.\n- `'rectangular'` — block, small radius. Image / card / button placeholder."
+      },
+      {
+        "name": "width",
+        "type": "string | number",
+        "required": false,
+        "default": "",
+        "description": "Explicit width. Number → px, string → as-is (e.g., `'60%'`, `'12rem'`)."
+      },
+      {
+        "name": "height",
+        "type": "string | number",
+        "required": false,
+        "default": "",
+        "description": "Explicit height. Number → px, string → as-is.\nDefaults: `text` → `1em`, `circular` → matches `width` (square),\n`rectangular` → no default (consumer must size)."
+      },
+      {
+        "name": "animation",
+        "type": "SkeletonAnimation",
+        "required": false,
+        "default": "",
+        "description": "Animation. Defaults to `'pulse'`.\n- `'pulse'` — opacity 1 → 0.6 → 1, 1.5s ease-in-out infinite.\n- `'none'` — static. Use when stacking many skeletons to avoid motion\n  overload.\n\nRegardless of this prop, animation is suppressed when the user has\n`prefers-reduced-motion: reduce`."
+      }
+    ]
+  },
+  "Slider": {
+    "props": [
+      {
+        "name": "value",
+        "type": "number | [number, number]",
+        "required": true,
+        "default": "",
+        "description": "Current value. A single `number` for one-thumb mode; a `[min, max]` tuple\nfor two-thumb (range) mode. The component type-discriminates internally.\nRequired — Slider is controlled-only."
+      },
+      {
+        "name": "onChange",
+        "type": "(value: SliderValue) => void",
+        "required": true,
+        "default": "",
+        "description": "Called on every thumb-drag tick (high frequency). For server-side or\nexpensive update logic, prefer `onChangeEnd` or debounce in the consumer.\nThe argument has the same shape as `value`: `number` for single,\n`[number, number]` for range."
+      },
+      {
+        "name": "onChangeEnd",
+        "type": "((value: SliderValue) => void)",
+        "required": false,
+        "default": "",
+        "description": "Called once when the user \"commits\" a value change — at pointerup\nafter a drag, or at blur after keyboard-nav that actually changed\nthe value. Does NOT fire on Tab-in / Tab-out without any value\nchange. Use for committing the value to a server or running an\nexpensive recalculation. Receives the final value with the same\nshape as `value`."
+      },
+      {
+        "name": "min",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Minimum allowed value (inclusive). Default `0`."
+      },
+      {
+        "name": "max",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Maximum allowed value (inclusive). Default `100`."
+      },
+      {
+        "name": "step",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Step granularity. Default `1`. Use fractional steps (e.g. `0.1`) for\nzoom / opacity-style controls. Values are snapped to `min + (n * step)`."
+      },
+      {
+        "name": "marks",
+        "type": "number[] | SliderMark[]",
+        "required": false,
+        "default": "",
+        "description": "Tick marks. Pass `number[]` for auto-labeled ticks (label = value) or\n`SliderMark[]` for custom labels (label = ReactNode). Marks render under\nthe track (horizontal) or to the right (vertical)."
+      },
+      {
+        "name": "label",
+        "type": "boolean | ((value: number) => ReactNode)",
+        "required": false,
+        "default": "false",
+        "description": "Value bubble on the thumb.\n- `false` (default) — no bubble.\n- `true` — show the current value (formatted via `toString()`) on hover /\n  focus / drag. Auto-hides otherwise.\n- `(value: number) => ReactNode` — custom formatter. For range mode, the\n  formatter is called once per thumb."
+      },
+      {
+        "name": "size",
+        "type": "SliderSize",
+        "required": false,
+        "default": "",
+        "description": "Track + thumb sizing. Defaults to `'md'`.\n- `sm` — 4px track, 14px thumb.\n- `md` — 6px track, 18px thumb (default).\n- `lg` — 8px track, 22px thumb."
+      },
+      {
+        "name": "tone",
+        "type": "SliderTone",
+        "required": false,
+        "default": "",
+        "description": "Fill color tone (the track segment between min and value). Defaults to\n`'default'` (accent). State-coded `success` / `warning` / `danger` for\nthreshold-style sliders (e.g. disk usage approaching capacity)."
+      },
+      {
+        "name": "orientation",
+        "type": "SliderOrientation",
+        "required": false,
+        "default": "",
+        "description": "Orientation. Defaults to `'horizontal'`."
+      },
+      {
+        "name": "disabled",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Disabled state. Defaults to `false`."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Native form-input name. When set, a hidden `<input>` (or two for range,\nwith `-min`/`-max` suffixes) is rendered with the current value(s) so\nthe slider works inside uncontrolled HTML forms without consumer JS\nserialization. When the slider is `disabled`, the hidden input(s) are\nNOT rendered so the form does not submit a stale disabled value."
+      }
+    ]
+  },
+  "SocialButton": {
+    "props": [
+      {
+        "name": "provider",
+        "type": "\"google\" | \"yandex\"",
+        "required": true,
+        "default": "",
+        "description": "Which provider's brand mark to show. Tied to `<BrandIcon>`'s set, so it\ngrows as BrandIcon does (today: `'google'` / `'yandex'`)."
+      },
+      {
+        "name": "label",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "The button text — e.g. `\"Continue with Google\"`. Required (consumer-supplied)."
+      },
+      {
+        "name": "variant",
+        "type": "ButtonVariant",
+        "required": false,
+        "default": "primary",
+        "description": "Visual variant.\n- `primary` (default) — the section's main action. Use **one** per page section.\n- `secondary` — supporting actions like \"Cancel\", \"Export\", \"Filter\".\n- `ghost` — tertiary actions in dense UIs (toolbar buttons, row actions).\n- `danger` — destructive operations only (Delete, Revoke, Remove). Pair with a confirmation if irreversible.\n- `success` — **transient confirmation only**, not an initial state. Flip to\n  `success` for ~1.5s after an action resolves (Save → \"Saved!\"), then\n  flip back. Never render a button as `success` on mount — it has no\n  action-intent meaning, only post-action feedback. See the `@example`\n  below for the timer pattern."
+      },
+      {
+        "name": "size",
+        "type": "ButtonSize",
+        "required": false,
+        "default": "md",
+        "description": "Control height (matches the shared `--size-*` scale used by Input and Avatar).\n- `xs` (20px) — icon-only or very dense inline actions (row controls,\n  chip-adjacent buttons). Pass `aria-label` when icon-only. Below WCAG\n  2.5.5 Level AAA touch-target guidance; reserve for desktop-first surfaces.\n- `sm` (24px) — dense toolbars, tables, inline actions.\n- `md` (32px, default) — most contexts.\n- `lg` (40px) — marketing-style empty states or emphasized primary actions."
+      }
+    ]
+  },
+  "Sortable": {
+    "props": [
+      {
+        "name": "onReorder",
+        "type": "((event: SortableReorderEvent) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires after a drag or keyboard move with the new position. Consumer\nholds the items array and re-renders with the new order.\n\nNot fired if the drop position equals the source position (no-op)."
+      },
+      {
+        "name": "restrictToContainer",
+        "type": "boolean",
+        "required": false,
+        "default": "true",
+        "description": "When `true` (default), the dragged item is clamped to the list's bounding\nbox — it can't be dragged outside the `<ol>`. Set `false` for free-drag\n(the item can be dragged anywhere on the page). For a vertical list this\nconstrains the drag vertically to the list's extent."
+      }
+    ]
+  },
+  "SortableGroup": {
+    "props": [
+      {
+        "name": "onMove",
+        "type": "((event: SortableMoveEvent) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires on every cross-container handoff (during the drag) AND on the final\ndrop. Apply it to your controlled per-container state — see `moveSortableItem`."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "The `<SortableGroup.Container>` lists."
+      }
+    ]
+  },
+  "Split": {
+    "props": [
+      {
+        "name": "aside",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "The narrow, intrinsic-width pane — a vertical `Tabs` rail, filter list, or nav column."
+      },
+      {
+        "name": "side",
+        "type": "SplitSide",
+        "required": false,
+        "default": "'start'",
+        "description": "Which side `aside` sits on.\n- `'start'` (default) — leading edge (left in LTR).\n- `'end'` — trailing edge (right in LTR)."
+      },
+      {
+        "name": "asideWidth",
+        "type": "string",
+        "required": false,
+        "default": "'auto'",
+        "description": "`aside` column width.\n- `'auto'` (default) — intrinsic; sizes to the pane's content.\n- a CSS length (e.g. `'240px'`) — pins the column so `main` doesn't reflow\n  when `aside` content changes width."
+      },
+      {
+        "name": "gap",
+        "type": "SplitGap",
+        "required": false,
+        "default": "md",
+        "description": "Gap between the two panes, in pixels:\n`xs` (4) / `sm` (8) / `md` (12, default) / `lg` (16) / `xl` (24) / `2xl` (32).\nSame scale as Stack, Cluster, and Grid."
+      },
+      {
+        "name": "align",
+        "type": "SplitAlign",
+        "required": false,
+        "default": "'start'",
+        "description": "Cross-axis (vertical) alignment of the panes.\n- `'start'` (default) — panes hug the top.\n- `'stretch'` — `aside` matches `main`'s height (full-height bordered rail).\n- `'center'` — panes vertically centered."
+      }
+    ]
+  },
+  "Stack": {
+    "props": [
+      {
+        "name": "gap",
+        "type": "StackGap",
+        "required": false,
+        "default": "md",
+        "description": "Gap between children, in pixels:\n`xs` (4) / `sm` (8) / `md` (12, default) / `lg` (16) / `xl` (24) / `2xl` (32)."
+      },
+      {
+        "name": "align",
+        "type": "StackAlign",
+        "required": false,
+        "default": "stretch",
+        "description": "Cross-axis alignment.\n- `stretch` (default) — children fill the stack's horizontal width.\n- `start` / `center` / `end` — left, center, right alignment."
+      }
+    ]
+  },
+  "Sticky": {
+    "props": [
+      {
+        "name": "top",
+        "type": "StickyTop",
+        "required": false,
+        "default": "",
+        "description": "Offset from the top of the scroll container at which the content pins.\nDefaults to `'none'` (`top: 0`, flush). Use a non-zero step to clear a\nsticky header or add breathing room."
+      },
+      {
+        "name": "scroll",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Cap the pinned box at the viewport height and scroll its content internally,\nso a column TALLER than the screen stays fully reachable (the overflow scrolls\nwithin the box instead of below the fold). Sets `max-height` to\n`calc(100dvh - top offset - an equal bottom gap)`, `overflow-y: auto`, and\n`overscroll-behavior: contain` (page scroll doesn't chain from the box).\nDefault `false`. Pair with a non-`none` `top` to leave breathing room. The cap\nis viewport-relative (`dvh`), so this assumes the page (or a viewport-tall\nancestor) is the scroll context — not a short fixed-height scroll container."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "The content to pin. Required — a `Sticky` with nothing inside pins nothing."
+      }
+    ]
+  },
+  "Switch": {
+    "props": [
+      {
+        "name": "size",
+        "type": "SwitchSize",
+        "required": false,
+        "default": "",
+        "description": "Visual scale. Defaults to `'md'`.\n- `'sm'` — 28×16 track, 12px thumb, `--font-size-sm` label.\n- `'md'` — 36×20 track, 16px thumb, `--font-size-md` label (default).\n- `'lg'` — 44×24 track, 20px thumb, `--font-size-lg` label.\n\nNote: shadows the native HTML `<input size>` attribute (meaningless on checkboxes)."
+      },
+      {
+        "name": "tone",
+        "type": "SwitchTone",
+        "required": false,
+        "default": "",
+        "description": "Track color when checked. Defaults to `'accent'`.\n- `'accent'` — blue (default).\n- `'success'` — green. Use for affirmative toggles (\"Enable notifications\").\n- `'danger'` — red. Use for destructive toggles (\"Allow root access\")."
+      },
+      {
+        "name": "checked",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Controlled checked state. Pair with `onChange`. Omit (with optional\n`defaultChecked`) for uncontrolled use."
+      },
+      {
+        "name": "defaultChecked",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Initial checked state for uncontrolled use. Defaults to `false`."
+      },
+      {
+        "name": "onChange",
+        "type": "((checked: boolean, e: ChangeEvent<HTMLInputElement>) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fires when the user toggles the switch. The first arg is the next\nboolean (convenience); the original change event is the second arg.\nMatches `<Checkbox>`'s signature."
+      },
+      {
+        "name": "invalid",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Toggles `aria-invalid=\"true\"` and adds a danger-tone border to the\ntrack. Use when the switch's state has caused a validation error."
+      },
+      {
+        "name": "loading",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Disables interaction and shows a spinner inside the thumb. Use for\ntoggles that persist to a server. Sets `aria-busy=\"true\"` and\n`disabled` on the native input so neither click nor Space-key can\nfire onChange while the async operation is in flight.\n\nThe consumer is responsible for managing the optimistic-update flow:\n\n```tsx\nconst [enabled, setEnabled] = useState(initial);\nconst [saving, setSaving] = useState(false);\n\nconst handleToggle = async (next: boolean) => {\n  setSaving(true);\n  setEnabled(next);            // optimistic\n  try { await api.save(next); }\n  catch { setEnabled(!next); } // rollback\n  finally { setSaving(false); }\n};\n\n<Switch checked={enabled} loading={saving} onChange={handleToggle} />\n```"
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Label rendered next to the track. The whole `<label>` is the click\ntarget — clicking anywhere toggles. Omit for icon-only switches +\npair with `aria-label`."
+      }
+    ]
+  },
+  "Table": {
+    "props": [
+      {
+        "name": "density",
+        "type": "TableDensity",
+        "required": false,
+        "default": "",
+        "description": "Row height + cell padding scale. Defaults to `'comfortable'`.\n- `'comfortable'` — 32px row, 12px horiz padding, font-size-md.\n- `'dense'`       — 24px row, 8px horiz padding, font-size-sm."
+      },
+      {
+        "name": "striped",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Zebra-striped body rows (even rows tinted). Defaults to `false`."
+      },
+      {
+        "name": "bordered",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Full-grid borders — outer border + vertical borders between every cell\non top of the existing horizontal row dividers. Defaults to `false`\n(Atlassian-style minimal: header underline + row dividers only)."
+      },
+      {
+        "name": "hover",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Hover highlight on body rows. Defaults to `false` — turn on when the\ntable represents a list of clickable / selectable items (a row a user\nis likely to act on). Leave off for read-only data displays where the\nhover affordance would suggest interactivity that isn't there."
+      },
+      {
+        "name": "stickyHeader",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "`position: sticky` on the header so it stays visible while body\nscrolls. Requires a scrollable ancestor — the default `scroll`\nwrapper provides one. Defaults to `false`."
+      },
+      {
+        "name": "scroll",
+        "type": "boolean",
+        "required": false,
+        "default": "true",
+        "description": "When `true` (default), the `<table>` is wrapped in a `<div>` with\n`overflow-x: auto` so wide tables scroll horizontally inside their\ncontainer. Set to `false` to render a bare `<table>` — the consumer\nmanages their own scroll context."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Compound-subcomponent children."
+      }
+    ]
+  },
+  "Tabs": {
+    "props": [
+      {
+        "name": "items",
+        "type": "TabItem[]",
+        "required": true,
+        "default": "",
+        "description": "The tabs to render. Each item must have a unique `id`."
+      },
+      {
+        "name": "activeId",
+        "type": "string",
+        "required": true,
+        "default": "",
+        "description": "The id of the currently-active tab. If it doesn't match any item, the strip still stays keyboard-reachable (first tab gets tabindex=0)."
+      },
+      {
+        "name": "onChange",
+        "type": "(id: string) => void",
+        "required": true,
+        "default": "",
+        "description": "Called with the tab id when the user activates a different tab. Won't fire when re-clicking the already-active tab."
+      },
+      {
+        "name": "panelIdPrefix",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Optional id prefix for controlled tabpanels. When set, each tab gets\n`aria-controls=\"${panelIdPrefix}-${itemId}-panel\"` — the consumer must\nrender the matching panel with that id. When omitted, an internal id\n(sanitized React `useId`) is generated."
+      },
+      {
+        "name": "activationMode",
+        "type": "TabsActivationMode",
+        "required": false,
+        "default": "'auto'",
+        "description": "`'auto'` (default): arrow keys move focus AND fire onChange — the visible\npanel changes with each keystroke. Best for cheap, eager-rendered panels.\n\n`'manual'`: arrow keys only move focus; Enter/Space (the native button\nactivation keys) then commits via onChange. Use this when panels are\nexpensive (lazy-load, network) so the user can scan tab labels without\ntriggering loads."
+      },
+      {
+        "name": "orientation",
+        "type": "TabsOrientation",
+        "required": false,
+        "default": "'horizontal'",
+        "description": "`'horizontal'` (default) — a horizontal strip with a sliding underline.\n`'vertical'` — a stacked master–detail rail: full-width rows, a left accent\nbar + tinted background on the active row, and ArrowUp/ArrowDown navigation.\nSets `aria-orientation` on the tablist accordingly. Put a vertical strip in a\n`Split`'s `aside`, with the detail panel as the `Split`'s children beside it."
+      }
+    ]
+  },
+  "Text": {
+    "props": [
+      {
+        "name": "htmlFor",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Associates a `<label>` with its form control. Only meaningful when\n`as=\"label\"` — passes through as the native `for` attribute."
+      },
+      {
+        "name": "as",
+        "type": "TextAs",
+        "required": false,
+        "default": "'p'",
+        "description": "Rendered element. Defaults to `'p'` (block, default body text). Use\n`'span'` for inline runs, `'div'` for block containers that can't be a\n`<p>` (e.g. when the body needs nested block-level elements that React\nwould warn about inside `<p>`), `'label'` for form labels (pair with\n`htmlFor`)."
+      },
+      {
+        "name": "size",
+        "type": "TextSize",
+        "required": false,
+        "default": "",
+        "description": "Visual size. Defaults to `'md'` (body text).\n- `xs` — 11px, dense metadata / captions\n- `sm` — 12px, small body / labels\n- `md` — 14px, body text (default)\n- `lg` — 16px, large body / lead text\n- `xl` — 20px, very large body (rare)"
+      },
+      {
+        "name": "tone",
+        "type": "TextTone",
+        "required": false,
+        "default": "",
+        "description": "Color tone. Defaults to `'default'`.\n- `default` — `--color-fg`\n- `muted` — `--color-fg-muted` (for secondary copy)\n- `subtle` — `--color-fg-subtle` (for tertiary metadata)\n- `accent` — `--color-accent`\n- `danger` / `success` / `warning` — state-coded text"
+      },
+      {
+        "name": "weight",
+        "type": "TextWeight",
+        "required": false,
+        "default": "",
+        "description": "Font weight. Defaults to `'regular'`."
+      },
+      {
+        "name": "align",
+        "type": "TextAlign",
+        "required": false,
+        "default": "",
+        "description": "Text alignment. Defaults to `'left'`."
+      },
+      {
+        "name": "truncate",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Truncate to a single line with ellipsis. Defaults to `false`. Use inside\nnarrow containers (table cells, card list rows). Mutually exclusive with\n`lineClamp` — if both are set, `lineClamp` wins."
+      },
+      {
+        "name": "lineClamp",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Clamp to N lines with ellipsis (uses `-webkit-line-clamp`). Defaults to\n`undefined`. Overrides `truncate` when set. Example: `lineClamp={2}` for\na 2-line description that ellipses on the third.\n\nIf you also pass `style.WebkitLineClamp`, the `lineClamp` prop takes\nprecedence — the component merges the dynamic line-clamp value into\n`style` AFTER spreading your `style`, so the prop wins."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "Text content."
+      }
+    ]
+  },
+  "Textarea": {
+    "props": [
+      {
+        "name": "invalid",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Toggles the error visual (red border + danger focus ring) and sets\n`aria-invalid=\"true\"`. Pair with a visible error message and an\n`aria-describedby` pointer at the message id."
+      },
+      {
+        "name": "size",
+        "type": "TextareaSize",
+        "required": false,
+        "default": "",
+        "description": "Visual size. Defaults to `'md'`.\n- `'sm'` — tighter padding + `--font-size-sm`. Used in dense forms.\n- `'md'` — default padding + `--font-size-md`. Most form contexts.\n- `'lg'` — same padding as md but `--font-size-lg`. Hero / focus textareas.\n\nNote: this collapses the native HTML `<textarea size>` attribute. Use\n`style={{ width }}` or a parent container for explicit width."
+      },
+      {
+        "name": "disableAutofill",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Block browser autofill AND password managers from offering to fill\nthis textarea. Same heuristic as Input — see Input's JSDoc for the\nfull set of opt-out attributes applied.\n\nSmart default: when omitted, block iff `autoComplete` is also omitted\n(or `'off'`). Explicit autocomplete hints opt back IN to autofill.\nPass `true` to force-block, `false` to force-allow."
+      },
+      {
+        "name": "minRows",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Minimum visible rows. The textarea never renders shorter than this,\nregardless of content. Default: `3`. Also seeds the native `rows`\nattribute for SSR / no-JS rendering."
+      },
+      {
+        "name": "maxRows",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Maximum visible rows. Beyond this, content scrolls inside the field\ninstead of expanding further. Only meaningful when `autoGrow` is true.\nDefault: `undefined` (unbounded growth)."
+      },
+      {
+        "name": "autoGrow",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "When true, height adapts to content between `minRows` and `maxRows`.\nDefault: `true`. When false, height locks at `minRows` and a scrollbar\nappears past it."
+      },
+      {
+        "name": "resize",
+        "type": "TextareaResize",
+        "required": false,
+        "default": "",
+        "description": "User-drag resize handle direction. Default: `'vertical'`.\n\n**Forced to `'none'`** when `autoGrow` is `true` — user-drag fights\nthe auto-grow measurement and produces erratic behavior. To enable\na resize handle, opt out of auto-grow with `autoGrow={false}`."
+      },
+      {
+        "name": "showCount",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Show the character counter (`${value.length}` or\n`${value.length} / ${maxLength}` when both are set).\n\nDefault: `true` when `maxLength` is set, `false` otherwise.\n\nThe counter renders as a `<span aria-live=\"polite\" aria-atomic=\"true\">`\ninside the wrapper, below the textarea. It updates on every input —\nworks for both controlled and uncontrolled textareas."
+      }
+    ]
+  },
+  "Thread": {
+    "props": [
+      {
+        "name": "maxDepth",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Max visual nesting depth before replies render flat (no further indent). Once the\ncap is reached, deeper replies keep the same indent level so the thread stops\nmarching right. Default `4`."
+      },
+      {
+        "name": "compact",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Tighter gaps for dense surfaces (sidebars, panels). The remapped tokens cascade to\nevery nested item via CSS custom properties. Default `false`."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "The `<Thread.Item>`s."
+      }
+    ]
+  },
+  "TimeField": {
+    "props": [
+      {
+        "name": "value",
+        "type": "TimeValue | null",
+        "required": true,
+        "default": "",
+        "description": "Selected time. `null` disables the field — the field cannot be\nactivated until the parent supplies a value (used by the picker family\nto gate time selection on a date being chosen first)."
+      },
+      {
+        "name": "onChange",
+        "type": "(value: TimeValue) => void",
+        "required": true,
+        "default": "",
+        "description": "Fired when the user commits a new time, either by typing + blur /\nEnter, by clicking a row in the popover, or by clicking the Now button.\nThe emitted value is always 24-hour internal regardless of display cycle."
+      },
+      {
+        "name": "step",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Minutes step. Default `15`. Controls the row count in the minutes\ncolumn (e.g., 15 → 4 rows: 00/15/30/45) AND rounds typed input on\ncommit. Set `1` to disable rounding."
+      },
+      {
+        "name": "hourCycle",
+        "type": "HourCycle",
+        "required": false,
+        "default": "'auto'",
+        "description": "Display + parse cycle.\n- `'24'` — hour list 00–23, text input shows `HH:mm`, no AM/PM column.\n- `'12'` — hour list `12, 1, 2, …, 11` with an AM/PM column; text\n  input shows `h:mm AM/PM`.\n- `'auto'` (default) — reads the active locale via\n  `Intl.DateTimeFormat`; en-US → 12h, ru-RU → 24h.\n\nTyped input is lenient regardless of cycle — both 24h (`14:30`) and\nAM/PM (`2:30 PM`) shapes parse in either mode."
+      },
+      {
+        "name": "locale",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Locale override for `hourCycle='auto'` detection + text formatting.\nDefaults to the active `<LocaleProvider>` / browser locale."
+      },
+      {
+        "name": "hideNowButton",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Hide the \"Now\" quick-pick button in the popover footer. Default `false`\n(button shown)."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible label. Optional, but the control MUST be named: pass `aria-label`\nfor a standalone TimeField, OR `aria-labelledby` when an external element\n(e.g. a `<Field>` label) names it. If both are given, `aria-labelledby` wins."
+      },
+      {
+        "name": "aria-labelledby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Id(s) of element(s) that label this control — forwarded onto the inner\n`<input>` so a `<Field label>` names it. Takes precedence over `aria-label`."
+      },
+      {
+        "name": "aria-describedby",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Id(s) of element(s) that describe this control (e.g. a `<Field>` error or\nhelper message) — forwarded onto the inner `<input>`, not the wrapper, so\nthe description is announced when the input is focused."
+      },
+      {
+        "name": "disabled",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Disables the input + popover trigger."
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Stable id for the input (so an external `<label htmlFor>` can target it)."
+      },
+      {
+        "name": "className",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Additional className on the wrapper."
+      }
+    ]
+  },
+  "Timeline": {
+    "props": [
+      {
+        "name": "compact",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Tighter gutter, node box, and spacing for dense sidebar widgets. Default `false`."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "`<Timeline.Item>`s."
+      }
+    ]
+  },
+  "Title": {
+    "props": [
+      {
+        "name": "order",
+        "type": "1 | 2 | 3 | 4 | 5 | 6",
+        "required": true,
+        "default": "",
+        "description": "Heading semantic level (1–6). REQUIRED — forces the consumer to think about\nheading hierarchy on the page. Drives both the rendered element (`<h1>`–`<h6>`)\nand the default visual size (1→3xl, 2→2xl, 3→xl, 4→lg, 5→md, 6→sm)."
+      },
+      {
+        "name": "size",
+        "type": "TitleSize",
+        "required": false,
+        "default": "",
+        "description": "Visual size override. Defaults to the size for the given `order`. Use this\nwhen the semantic level and the visual size need to diverge — e.g. a small\nsection title that's still an `<h2>` for screen readers."
+      },
+      {
+        "name": "tone",
+        "type": "TitleTone",
+        "required": false,
+        "default": "",
+        "description": "Color tone. Defaults to `'default'` (full foreground).\n- `default` — `--color-fg`\n- `muted` — `--color-fg-muted`\n- `subtle` — `--color-fg-subtle`\n- `accent` — `--color-accent`\n- `danger` — `--color-danger`"
+      },
+      {
+        "name": "weight",
+        "type": "TitleWeight",
+        "required": false,
+        "default": "",
+        "description": "Font weight. Defaults to `'semibold'` (matches the most common heading\nweight across the existing mockups)."
+      },
+      {
+        "name": "truncate",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Truncate the title to a single line with ellipsis. Useful inside narrow\ncards or grid cells. Defaults to `false`. The full text remains in the\naccessibility tree — screen readers read the entire string. Don't\nadditionally add `aria-label` to \"compensate\" for the visual clip."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "Title text content."
+      }
+    ]
+  },
+  "Tooltip": {
+    "props": [
+      {
+        "name": "content",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": true,
+        "default": "",
+        "description": "Tooltip body. ReactNode so you can include inline `<kbd>` or icons.\nIf `null`, `undefined`, or `\"\"`, the trigger renders as-is with no\nlisteners and no `aria-describedby` — useful for conditional UIs."
+      },
+      {
+        "name": "children",
+        "type": "ReactElement<unknown, string | JSXElementConstructor<any>>",
+        "required": true,
+        "default": "",
+        "description": "Exactly one React element that accepts a ref. Cloned to inject the\ntooltip's ref + listeners + aria. `<Button>` and raw `<button>` both\nqualify; a custom component without `forwardRef` does not."
+      },
+      {
+        "name": "side",
+        "type": "TooltipSide",
+        "required": false,
+        "default": "",
+        "description": "Preferred side. Default `'top'`. Auto-flips on collision via Floating UI."
+      },
+      {
+        "name": "align",
+        "type": "TooltipAlign",
+        "required": false,
+        "default": "",
+        "description": "Edge alignment. Default `'center'`."
+      },
+      {
+        "name": "sideOffset",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Gap in px between trigger and tooltip. Default `6` (room for the arrow)."
+      },
+      {
+        "name": "delay",
+        "type": "number",
+        "required": false,
+        "default": "",
+        "description": "Delay in ms before hover opens the tooltip. Default `400`. Keyboard\nfocus is always immediate (a11y). Close is always immediate."
+      },
+      {
+        "name": "open",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Controlled open state. Provide alongside `onOpenChange` to drive open\nexternally. Omit both to let Tooltip own its state (the common case)."
+      },
+      {
+        "name": "onOpenChange",
+        "type": "((open: boolean) => void)",
+        "required": false,
+        "default": "",
+        "description": "Fired whenever Tooltip wants to change open state. Required when `open` is provided."
+      },
+      {
+        "name": "defaultOpen",
+        "type": "boolean",
+        "required": false,
+        "default": "",
+        "description": "Default open state for uncontrolled usage. Defaults to `false`."
+      }
+    ]
+  },
+  "TopBar": {
+    "props": [
+      {
+        "name": "as",
+        "type": "TopBarElement",
+        "required": false,
+        "default": "",
+        "description": "Element to render. Defaults to `'header'`. Pick `'div'` when the bar is\nnested inside another content area where a second `<header>` landmark\nwould conflict with page semantics."
+      },
+      {
+        "name": "aria-label",
+        "type": "string",
+        "required": false,
+        "default": "",
+        "description": "Accessible label for the bar's landmark. Defaults to `t('topBar.label')`\nso screen readers always announce a name for the region. Override when a\npage has multiple bars to disambiguate them."
+      },
+      {
+        "name": "children",
+        "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+        "required": false,
+        "default": "",
+        "description": "Children of the bar — typically `<TopBar.Start>` + `<TopBar.End>`. The\nchildren area is open so consumers can render a single cluster, a\nsingle trailing element, or any other arrangement they need."
+      }
+    ]
+  }
+}

--- a/packages/playground/src/pages/components/ButtonDemo.tsx
+++ b/packages/playground/src/pages/components/ButtonDemo.tsx
@@ -48,11 +48,19 @@ export function ButtonDemo() {
       <Example
         title="Variants"
         description="Five visual variants. Use primary for the page's main action, secondary for supporting actions, ghost for tertiary actions in dense UIs, danger for destructive operations. The success variant is a transient confirmation state — see the next example."
-        code={`<Button variant="primary">Primary</Button>
-<Button variant="secondary">Secondary</Button>
-<Button variant="ghost">Ghost</Button>
-<Button variant="danger">Danger</Button>
-<Button variant="success">Success</Button>`}
+        code={`import { Button, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <Button variant="primary">Primary</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="ghost">Ghost</Button>
+      <Button variant="danger">Danger</Button>
+      <Button variant="success">Success</Button>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm">
           <Button variant="primary">Primary</Button>
@@ -66,7 +74,11 @@ export function ButtonDemo() {
       <Example
         title="Success flash (transient confirmation)"
         description="Use the success variant for ~1.5s after an action resolves, then flip back. The timer lives in the consumer, not in Button — this keeps Button stateless and lets you pick any duration. Click Save to try it."
-        code={`function SaveWithSuccessFlash() {
+        code={`import { useEffect, useRef, useState } from 'react';
+import { Check } from 'lucide-react';
+import { Button, Cluster } from '@eocrm/design-system';
+
+export function SaveWithSuccessFlash() {
   const [saved, setSaved] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -86,7 +98,13 @@ export function ButtonDemo() {
   return (
     <Cluster gap="sm">
       <Button variant={saved ? 'success' : 'primary'} onClick={handleClick}>
-        {saved ? <><Check size={14} /> Saved!</> : 'Save'}
+        {saved ? (
+          <>
+            <Check size={14} /> Saved!
+          </>
+        ) : (
+          'Save'
+        )}
       </Button>
     </Cluster>
   );
@@ -98,10 +116,18 @@ export function ButtonDemo() {
       <Example
         title="Sizes"
         description="Four sizes. xs for icon-only or very dense inline actions, sm for dense toolbars/tables, md (default) for most contexts, lg for emphasis."
-        code={`<Button size="xs">Extra small</Button>
-<Button size="sm">Small</Button>
-<Button size="md">Medium</Button>
-<Button size="lg">Large</Button>`}
+        code={`import { Button, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm" align="center">
+      <Button size="xs">Extra small</Button>
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" align="center">
           <Button size="xs">Extra small</Button>
@@ -114,15 +140,24 @@ export function ButtonDemo() {
       <Example
         title="Icon-only (square)"
         description="Pass iconOnly for a square shape that tracks the size's height — 20×20 at xs, 32×32 at md. Always pair iconOnly with aria-label."
-        code={`<Button size="xs" variant="ghost" iconOnly aria-label="Remove">
-  <X size={12} />
-</Button>
-<Button size="xs" variant="secondary" iconOnly aria-label="Edit">
-  <Pencil size={12} />
-</Button>
-<Button size="md" variant="secondary" iconOnly aria-label="Search">
-  <Search size={16} />
-</Button>`}
+        code={`import { Pencil, Search, X } from 'lucide-react';
+import { Button, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm" align="center">
+      <Button size="xs" variant="ghost" iconOnly aria-label="Remove">
+        <X size={12} />
+      </Button>
+      <Button size="xs" variant="secondary" iconOnly aria-label="Edit">
+        <Pencil size={12} />
+      </Button>
+      <Button size="md" variant="secondary" iconOnly aria-label="Search">
+        <Search size={16} />
+      </Button>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" align="center">
           <Button size="xs" variant="ghost" iconOnly aria-label="Remove">
@@ -140,9 +175,24 @@ export function ButtonDemo() {
       <Example
         title="With icons"
         description="Pass icons (from lucide-react or any source) as children. The button handles spacing via gap."
-        code={`<Button><Plus size={14} /> Add contact</Button>
-<Button variant="secondary"><Search size={14} /> Search</Button>
-<Button variant="danger"><Trash2 size={14} /> Delete</Button>`}
+        code={`import { Plus, Search, Trash2 } from 'lucide-react';
+import { Button, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <Button>
+        <Plus size={14} /> Add contact
+      </Button>
+      <Button variant="secondary">
+        <Search size={14} /> Search
+      </Button>
+      <Button variant="danger">
+        <Trash2 size={14} /> Delete
+      </Button>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm">
           <Button>
@@ -160,11 +210,25 @@ export function ButtonDemo() {
       <Example
         title="Disabled"
         description="Native disabled attribute. Visually muted, pointer-events disabled."
-        code={`<Button disabled>Primary</Button>
-<Button variant="secondary" disabled>Secondary</Button>
-<Button size="xs" variant="ghost" iconOnly disabled aria-label="Remove">
-  <X size={12} />
-</Button>`}
+        code={`import { X } from 'lucide-react';
+import { Button, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm" align="center">
+      <Button disabled>Primary</Button>
+      <Button variant="secondary" disabled>
+        Secondary
+      </Button>
+      <Button variant="danger" disabled>
+        Danger
+      </Button>
+      <Button size="xs" variant="ghost" iconOnly disabled aria-label="Remove">
+        <X size={12} />
+      </Button>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" align="center">
           <Button disabled>Primary</Button>

--- a/packages/playground/src/pages/components/ComponentApi.module.scss
+++ b/packages/playground/src/pages/components/ComponentApi.module.scss
@@ -1,0 +1,66 @@
+.api {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.title {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-fg);
+}
+
+.subtitle {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+}
+
+// Horizontal scroll on narrow viewports rather than squashing the columns.
+.tableWrap {
+  overflow-x: auto;
+}
+
+.propName {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  white-space: nowrap;
+}
+
+.dash {
+  color: var(--color-fg-subtle);
+}
+
+.description {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-width: 60ch;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  color: var(--color-fg-muted);
+
+  p {
+    margin: 0;
+  }
+}
+
+.list {
+  margin: 0;
+  padding-left: var(--space-4);
+
+  li {
+    margin: 0;
+  }
+}
+
+.inlineCode {
+  padding: 0 var(--space-1);
+  font-family: var(--font-family-mono);
+  font-size: 0.9em;
+  color: var(--color-fg);
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-sm);
+}

--- a/packages/playground/src/pages/components/ComponentApi.tsx
+++ b/packages/playground/src/pages/components/ComponentApi.tsx
@@ -1,0 +1,153 @@
+import { Fragment, type ReactNode } from 'react';
+import { Badge, Code, Table } from '@eocrm/design-system';
+import propsManifest from '../../lib/props.manifest.json';
+import styles from './ComponentApi.module.scss';
+
+interface PropEntry {
+  name: string;
+  type: string;
+  required: boolean;
+  default: string;
+  description: string;
+}
+
+const manifest = propsManifest as Record<string, { props: PropEntry[] }>;
+
+/**
+ * Auto-generated "API" reference rendered at the bottom of every component demo.
+ * Reads `props.manifest.json` — extracted from each component's `<Name>Props`
+ * TypeScript + JSDoc by `scripts/extract-props.mjs` and regenerated on every
+ * dev/build — so the table is always in sync with the shipped props. Components
+ * with no public props (e.g. imperative APIs like Toast) render nothing.
+ */
+export function ComponentApi({ name }: { name: string }) {
+  const entry = manifest[name];
+  if (!entry || entry.props.length === 0) return null;
+
+  return (
+    <section className={styles.api} aria-labelledby="component-api-heading">
+      <h2 id="component-api-heading" className={styles.title}>
+        API
+      </h2>
+      <p className={styles.subtitle}>
+        Props for <Code>{`<${name}>`}</Code>. Generated from the component&rsquo;s TypeScript types
+        and JSDoc.
+      </p>
+      <div className={styles.tableWrap}>
+        <Table density="dense">
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Prop</Table.HeaderCell>
+              <Table.HeaderCell>Type</Table.HeaderCell>
+              <Table.HeaderCell>Default</Table.HeaderCell>
+              <Table.HeaderCell>Description</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {entry.props.map((prop) => (
+              <Table.Row key={prop.name}>
+                <Table.Cell>
+                  <span className={styles.propName}>
+                    <Code>{prop.name}</Code>
+                    {prop.required && (
+                      <Badge tone="danger" size="sm">
+                        required
+                      </Badge>
+                    )}
+                  </span>
+                </Table.Cell>
+                <Table.Cell>
+                  <Code tone="accent">{prop.type}</Code>
+                </Table.Cell>
+                <Table.Cell>
+                  {prop.default ? (
+                    <Code tone="muted">{prop.default}</Code>
+                  ) : (
+                    <span className={styles.dash}>—</span>
+                  )}
+                </Table.Cell>
+                <Table.Cell>
+                  <div className={styles.description}>{renderRichText(prop.description)}</div>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Tiny markdown-lite renderer for JSDoc prop descriptions: paragraphs, `-`
+ * bullet lists, inline `` `code` `` and `**bold**`. Deliberately minimal — it
+ * only handles the conventions the library's JSDoc actually uses.
+ */
+function renderRichText(text: string): ReactNode {
+  const lines = text.split('\n');
+  const blocks: ReactNode[] = [];
+  let paragraph: string[] = [];
+  let listItems: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return;
+    blocks.push(<p key={`p-${blocks.length}`}>{renderInline(paragraph.join(' '))}</p>);
+    paragraph = [];
+  };
+  const flushList = () => {
+    if (listItems.length === 0) return;
+    blocks.push(
+      <ul key={`ul-${blocks.length}`} className={styles.list}>
+        {listItems.map((item, i) => (
+          <li key={i}>{renderInline(item)}</li>
+        ))}
+      </ul>,
+    );
+    listItems = [];
+  };
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    const bullet = line.match(/^[-*]\s+(.*)$/);
+    if (bullet) {
+      flushParagraph();
+      listItems.push(bullet[1]);
+    } else if (line === '') {
+      flushParagraph();
+      flushList();
+    } else {
+      flushList();
+      paragraph.push(line);
+    }
+  }
+  flushParagraph();
+  flushList();
+  return blocks;
+}
+
+/** Inline formatting: `` `code` `` → <code>, `**bold**` → <strong>. */
+function renderInline(text: string): ReactNode {
+  // Split on code spans first (they win over bold), keeping the delimiters.
+  const parts = text.split(/(`[^`]+`)/g);
+  return parts.map((part, i) => {
+    if (part.startsWith('`') && part.endsWith('`') && part.length > 1) {
+      return (
+        <code key={i} className={styles.inlineCode}>
+          {part.slice(1, -1)}
+        </code>
+      );
+    }
+    return <Fragment key={i}>{renderBold(part)}</Fragment>;
+  });
+}
+
+function renderBold(text: string): ReactNode {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g);
+  return parts.map((part, i) =>
+    part.startsWith('**') && part.endsWith('**') && part.length > 2 ? (
+      <strong key={i}>{part.slice(2, -2)}</strong>
+    ) : (
+      <Fragment key={i}>{part}</Fragment>
+    ),
+  );
+}

--- a/packages/playground/src/pages/components/DemoBody.tsx
+++ b/packages/playground/src/pages/components/DemoBody.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from 'react';
 import { ChevronDown, Code2 } from 'lucide-react';
 import { Card, Tabs } from '@eocrm/design-system';
 import { CodeBlock } from './CodeBlock';
+import { ComponentApi } from './ComponentApi';
 import { CrossLinks } from '../shared/CrossLinks';
 import type { ComponentName } from '../mockups/registry';
 import type { ComponentFile } from '../../lib/componentFiles';
@@ -55,6 +56,7 @@ export function DemoBody({ files, componentName, children }: DemoBodyProps) {
       <h2 className={styles.sectionTitle}>Examples</h2>
       <div className={styles.examplesGrid}>{children}</div>
 
+      {componentName && <ComponentApi name={componentName} />}
       {componentName && <CrossLinks kind="component" name={componentName} />}
     </>
   );

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,9 +1,31 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
+import { writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+// @ts-expect-error — plain ESM helper, no type declarations needed for config use.
+import { extractProps } from './scripts/extract-props.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Regenerate src/lib/props.manifest.json from the library's TypeScript + JSDoc
+// at the start of every dev server and production build, so the demo "API"
+// tables can never drift from the shipped component props. The committed copy
+// exists only so a fresh checkout type-checks before the first build.
+function propsManifestPlugin(): Plugin {
+  const outPath = path.resolve(__dirname, 'src/lib/props.manifest.json');
+  return {
+    name: 'props-manifest',
+    buildStart() {
+      try {
+        writeFileSync(outPath, JSON.stringify(extractProps(), null, 2) + '\n');
+      } catch (err) {
+        // Non-fatal: fall back to the committed manifest if extraction fails.
+        console.warn('[props-manifest] regeneration failed, using committed copy:', err);
+      }
+    },
+  };
+}
 
 // GitHub Pages serves at /<repo-name>/, not at /. The deploy workflow sets
 // VITE_BASE_PATH to "/<repo-name>/" so asset URLs resolve correctly. Local
@@ -12,7 +34,7 @@ const base = process.env.VITE_BASE_PATH ?? '/';
 
 export default defineConfig({
   base,
-  plugins: [react()],
+  plugins: [propsManifestPlugin(), react()],
   resolve: {
     alias: {
       // Sibling-workspace alias used only by demo pages for `?raw` source-display


### PR DESCRIPTION
Phase A of the demo-docs overhaul. **Playground-only** — no library files change, so no `@eocrm/design-system` release.

## What this adds

**1. An API reference table at the bottom of every demo.**
- `scripts/extract-props.mjs` reads each `<Name>Props` TypeScript + JSDoc via the TS compiler API → `src/lib/props.manifest.json` (86 components, 584 props). Only props *declared in the library source* are kept (inherited `HTMLAttributes` are dropped).
- A Vite `buildStart` plugin regenerates the manifest on every dev/build, so the committed copy can't drift. `npm run build:props` regenerates manually.
- `<ComponentApi>` renders Prop / Type / Default / Description (with a markdown-lite renderer for the JSDoc — paragraphs, bullets, inline code, bold). Required props get a `required` badge. Wired once into `DemoBody` off the existing `componentName`, so all 85 demos that pass it get the table for free. No-prop components (e.g. Toast) render nothing.

**2. Self-contained code blocks — reference implementation on `ButtonDemo`.**
Each `code` block is now copy-paste-reproducible: imports → data objects → the example as a component, matching the live preview exactly. This is the convention the rest of the demos follow in Phase B (see the design doc).

## Test plan
- `make build` (typecheck + bundle, exercises the Vite plugin), `make lint`, `npm run format:check` — all green.
- Live (dev server): API table renders on Button (variant/size/iconOnly with extracted `primary`/`md` defaults) and Avatar (`name` shows the `required` badge); Button's 6 code blocks now lead with imports + `export function Demo()`.

Design + convention doc: `docs/superpowers/specs/2026-06-28-demo-docs-overhaul-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)