### PR TITLE
docs(playground): self-contained code blocks on every demo (Phase B)

### DIFF
--- a/packages/playground/src/pages/components/AccordionDemo.tsx
+++ b/packages/playground/src/pages/components/AccordionDemo.tsx
@@ -18,20 +18,26 @@ export function AccordionDemo() {
       <Example
         title="Single, collapsible (FAQ-style)"
         description="Only one item open at a time. Clicking the open item closes it (collapsible)."
-        code={`<Accordion type="single" collapsible defaultValue="faq-1">
-  <Accordion.Item value="faq-1">
-    <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>
-    <Accordion.Content>Visit Settings → Security → Reset password.</Accordion.Content>
-  </Accordion.Item>
-  <Accordion.Item value="faq-2">
-    <Accordion.Trigger>How do I export my data?</Accordion.Trigger>
-    <Accordion.Content>Use the gear icon → Export → CSV.</Accordion.Content>
-  </Accordion.Item>
-  <Accordion.Item value="faq-3">
-    <Accordion.Trigger>How do I invite teammates?</Accordion.Trigger>
-    <Accordion.Content>Settings → Team → Invite via email.</Accordion.Content>
-  </Accordion.Item>
-</Accordion>`}
+        code={`import { Accordion } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Accordion type="single" collapsible defaultValue="faq-1">
+      <Accordion.Item value="faq-1">
+        <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>
+        <Accordion.Content>Visit Settings → Security → Reset password.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="faq-2">
+        <Accordion.Trigger>How do I export my data?</Accordion.Trigger>
+        <Accordion.Content>Use the gear icon → Export → CSV.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="faq-3">
+        <Accordion.Trigger>How do I invite teammates?</Accordion.Trigger>
+        <Accordion.Content>Settings → Team → Invite via email.</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}`}
       >
         <Accordion type="single" collapsible defaultValue="faq-1">
           <Accordion.Item value="faq-1">
@@ -52,24 +58,30 @@ export function AccordionDemo() {
       <Example
         title="Multiple — independent sections"
         description="Any combination of items can be open. Useful for settings panels where each section is independent."
-        code={`<Accordion type="multiple" defaultValue={['account']}>
-  <Accordion.Item value="account">
-    <Accordion.Trigger>Account</Accordion.Trigger>
-    <Accordion.Content>Email, name, profile picture.</Accordion.Content>
-  </Accordion.Item>
-  <Accordion.Item value="notifications">
-    <Accordion.Trigger>Notifications</Accordion.Trigger>
-    <Accordion.Content>Email digest, in-app alerts.</Accordion.Content>
-  </Accordion.Item>
-  <Accordion.Item value="security">
-    <Accordion.Trigger>Security</Accordion.Trigger>
-    <Accordion.Content>2FA, active sessions, API keys.</Accordion.Content>
-  </Accordion.Item>
-  <Accordion.Item value="billing">
-    <Accordion.Trigger>Billing</Accordion.Trigger>
-    <Accordion.Content>Plan, invoices, payment method.</Accordion.Content>
-  </Accordion.Item>
-</Accordion>`}
+        code={`import { Accordion } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Accordion type="multiple" defaultValue={['account']}>
+      <Accordion.Item value="account">
+        <Accordion.Trigger>Account</Accordion.Trigger>
+        <Accordion.Content>Email, name, profile picture.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="notifications">
+        <Accordion.Trigger>Notifications</Accordion.Trigger>
+        <Accordion.Content>Email digest, in-app alerts.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="security">
+        <Accordion.Trigger>Security</Accordion.Trigger>
+        <Accordion.Content>2FA, active sessions, API keys.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="billing">
+        <Accordion.Trigger>Billing</Accordion.Trigger>
+        <Accordion.Content>Plan, invoices, payment method.</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}`}
       >
         <Accordion type="multiple" defaultValue={['account']}>
           <Accordion.Item value="account">
@@ -94,20 +106,30 @@ export function AccordionDemo() {
       <Example
         title="Controlled"
         description="The consumer owns the open state via value + onValueChange. Useful for syncing with URL state or external state stores."
-        code={`const [open, setOpen] = useState('');
+        code={`import { useState } from 'react';
+import { Accordion, Stack } from '@eocrm/design-system';
 
-<Accordion type="single" collapsible value={open} onValueChange={setOpen}>
-  <Accordion.Item value="a">
-    <Accordion.Trigger>Section A</Accordion.Trigger>
-    <Accordion.Content>Content A</Accordion.Content>
-  </Accordion.Item>
-  <Accordion.Item value="b">
-    <Accordion.Trigger>Section B</Accordion.Trigger>
-    <Accordion.Content>Content B</Accordion.Content>
-  </Accordion.Item>
-</Accordion>
+export function Demo() {
+  const [open, setOpen] = useState('');
 
-<p>Currently open: {open || '(none)'}</p>`}
+  return (
+    <Stack gap="sm">
+      <Accordion type="single" collapsible value={open} onValueChange={setOpen}>
+        <Accordion.Item value="a">
+          <Accordion.Trigger>Section A</Accordion.Trigger>
+          <Accordion.Content>Content A</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="b">
+          <Accordion.Trigger>Section B</Accordion.Trigger>
+          <Accordion.Content>Content B</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>
+      <p style={{ margin: 0, fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+        Currently open: {open || '(none)'}
+      </p>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Accordion type="single" collapsible value={controlled} onValueChange={setControlled}>
@@ -129,20 +151,26 @@ export function AccordionDemo() {
       <Example
         title="Disabled item"
         description="A disabled item is non-interactive (button disabled, keyboard nav skips). Useful for sections that aren't applicable to the current user/plan."
-        code={`<Accordion type="single" collapsible>
-  <Accordion.Item value="basic">
-    <Accordion.Trigger>Basic settings</Accordion.Trigger>
-    <Accordion.Content>Always available.</Accordion.Content>
-  </Accordion.Item>
-  <Accordion.Item value="premium" disabled>
-    <Accordion.Trigger>Premium settings (upgrade required)</Accordion.Trigger>
-    <Accordion.Content>You won't see this.</Accordion.Content>
-  </Accordion.Item>
-  <Accordion.Item value="advanced">
-    <Accordion.Trigger>Advanced settings</Accordion.Trigger>
-    <Accordion.Content>For power users.</Accordion.Content>
-  </Accordion.Item>
-</Accordion>`}
+        code={`import { Accordion } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Accordion type="single" collapsible>
+      <Accordion.Item value="basic">
+        <Accordion.Trigger>Basic settings</Accordion.Trigger>
+        <Accordion.Content>Always available.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="premium" disabled>
+        <Accordion.Trigger>Premium settings (upgrade required)</Accordion.Trigger>
+        <Accordion.Content>You won't see this.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="advanced">
+        <Accordion.Trigger>Advanced settings</Accordion.Trigger>
+        <Accordion.Content>For power users.</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}`}
       >
         <Accordion type="single" collapsible>
           <Accordion.Item value="basic">
@@ -163,12 +191,19 @@ export function AccordionDemo() {
       <Example
         title="Custom icon (Plus)"
         description="Override the default ChevronDown indicator via the Trigger's icon prop. The icon rotates 180° when the item is open."
-        code={`<Accordion type="single" collapsible>
-  <Accordion.Item value="a">
-    <Accordion.Trigger icon={<Plus size={16} />}>Toggle me</Accordion.Trigger>
-    <Accordion.Content>The Plus icon rotates 180° to become a Minus when open.</Accordion.Content>
-  </Accordion.Item>
-</Accordion>`}
+        code={`import { Plus } from 'lucide-react';
+import { Accordion } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Accordion type="single" collapsible>
+      <Accordion.Item value="a">
+        <Accordion.Trigger icon={<Plus size={16} aria-hidden="true" />}>Toggle me</Accordion.Trigger>
+        <Accordion.Content>The Plus icon rotates 180° to become a Minus when open.</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}`}
       >
         <Accordion type="single" collapsible>
           <Accordion.Item value="a">
@@ -185,12 +220,18 @@ export function AccordionDemo() {
       <Example
         title="Heading level override"
         description="Trigger is wrapped in <h3> by default. Override via Item.headerLevel to fit the surrounding page heading hierarchy."
-        code={`<Accordion type="single" collapsible>
-  <Accordion.Item value="a" headerLevel="h2">
-    <Accordion.Trigger>This trigger sits inside an &lt;h2&gt;</Accordion.Trigger>
-    <Accordion.Content>Inspect the DOM to verify.</Accordion.Content>
-  </Accordion.Item>
-</Accordion>`}
+        code={`import { Accordion } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Accordion type="single" collapsible>
+      <Accordion.Item value="a" headerLevel="h2">
+        <Accordion.Trigger>This trigger sits inside an &lt;h2&gt;</Accordion.Trigger>
+        <Accordion.Content>Inspect the DOM to verify.</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}`}
       >
         <Accordion type="single" collapsible>
           <Accordion.Item value="a" headerLevel="h2">
@@ -203,9 +244,44 @@ export function AccordionDemo() {
       <Example
         title="Three sizes"
         description="size controls trigger font + padding (and content padding). Default is md."
-        code={`<Accordion type="single" collapsible size="sm">...</Accordion>
-<Accordion type="single" collapsible size="md">...</Accordion>
-<Accordion type="single" collapsible size="lg">...</Accordion>`}
+        code={`import { Accordion, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Accordion type="single" collapsible size="sm" defaultValue="a">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>Small (sm)</Accordion.Trigger>
+          <Accordion.Content>Tighter padding and smaller font.</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="b">
+          <Accordion.Trigger>Second item</Accordion.Trigger>
+          <Accordion.Content>...</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>
+      <Accordion type="single" collapsible size="md" defaultValue="a">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>Medium (md, default)</Accordion.Trigger>
+          <Accordion.Content>Default padding and font.</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="b">
+          <Accordion.Trigger>Second item</Accordion.Trigger>
+          <Accordion.Content>...</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>
+      <Accordion type="single" collapsible size="lg" defaultValue="a">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>Large (lg)</Accordion.Trigger>
+          <Accordion.Content>Larger padding and font.</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="b">
+          <Accordion.Trigger>Second item</Accordion.Trigger>
+          <Accordion.Content>...</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Accordion type="single" collapsible size="sm" defaultValue="a">
@@ -244,11 +320,26 @@ export function AccordionDemo() {
       <Example
         title="Borderless variant"
         description="variant='borderless' strips the outer border + item dividing lines. Use when the accordion lives inside another bordered container, or as a quiet section divider."
-        code={`<Accordion type="multiple" variant="borderless" defaultValue={['account']}>
-  <Accordion.Item value="account">...</Accordion.Item>
-  <Accordion.Item value="notifications">...</Accordion.Item>
-  <Accordion.Item value="security">...</Accordion.Item>
-</Accordion>`}
+        code={`import { Accordion } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Accordion type="multiple" variant="borderless" defaultValue={['account']}>
+      <Accordion.Item value="account">
+        <Accordion.Trigger>Account</Accordion.Trigger>
+        <Accordion.Content>Email, name, profile picture.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="notifications">
+        <Accordion.Trigger>Notifications</Accordion.Trigger>
+        <Accordion.Content>Email digest, in-app alerts.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="security">
+        <Accordion.Trigger>Security</Accordion.Trigger>
+        <Accordion.Content>2FA, active sessions, API keys.</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}`}
       >
         <Accordion type="multiple" variant="borderless" defaultValue={['account']}>
           <Accordion.Item value="account">

--- a/packages/playground/src/pages/components/AlertDemo.tsx
+++ b/packages/playground/src/pages/components/AlertDemo.tsx
@@ -18,10 +18,18 @@ export function AlertDemo() {
       <Example
         title="Four tones"
         description="info / success / warning / error. Default icon + accent stripe per tone. Error gets role='alert' (assertive); others use role='status' (polite)."
-        code={`<Alert tone="info" title="Synced 5 minutes ago" />
-<Alert tone="success" title="Changes saved" />
-<Alert tone="warning" title="Storage at 85%" />
-<Alert tone="error" title="Request failed" />`}
+        code={`import { Alert, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Alert tone="info" title="Synced 5 minutes ago" />
+      <Alert tone="success" title="Changes saved" />
+      <Alert tone="warning" title="Storage at 85%" />
+      <Alert tone="error" title="Request failed" />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Alert tone="info" title="Synced 5 minutes ago" />
@@ -34,7 +42,11 @@ export function AlertDemo() {
       <Example
         title="Title only"
         description="The simplest form. Useful for short status messages."
-        code={`<Alert tone="info" title="Synced 5 minutes ago" />`}
+        code={`import { Alert } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Alert tone="info" title="Synced 5 minutes ago" />;
+}`}
       >
         <Alert tone="info" title="Synced 5 minutes ago" />
       </Example>
@@ -42,7 +54,11 @@ export function AlertDemo() {
       <Example
         title="Description only (no title)"
         description="Short text body without a heading. Reads as a sentence."
-        code={`<Alert tone="warning">Your storage is at 85% capacity.</Alert>`}
+        code={`import { Alert } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Alert tone="warning">Your storage is at 85% capacity.</Alert>;
+}`}
       >
         <Alert tone="warning">Your storage is at 85% capacity.</Alert>
       </Example>
@@ -50,18 +66,24 @@ export function AlertDemo() {
       <Example
         title="With actions"
         description="Pass a pre-laid-out node as `actions`. Renders below the description."
-        code={`<Alert
-  tone="warning"
-  title="Update available"
-  actions={
-    <Cluster gap="sm">
-      <Button size="sm">Reload</Button>
-      <Button size="sm" variant="ghost">Later</Button>
-    </Cluster>
-  }
->
-  A new version is ready. Reload to apply the latest improvements.
-</Alert>`}
+        code={`import { Alert, Button, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Alert
+      tone="warning"
+      title="Update available"
+      actions={
+        <Cluster gap="sm">
+          <Button size="sm">Reload</Button>
+          <Button size="sm" variant="ghost">Later</Button>
+        </Cluster>
+      }
+    >
+      A new version is ready. Reload to apply the latest improvements.
+    </Alert>
+  );
+}`}
       >
         <Alert
           tone="warning"
@@ -82,13 +104,26 @@ export function AlertDemo() {
       <Example
         title="Dismissible"
         description="onDismiss callback fires when the × is clicked. The component does NOT manage hidden state — the consumer conditionally renders."
-        code={`const [show, setShow] = useState(true);
+        code={`import { useState } from 'react';
+import { Alert, Button, Stack } from '@eocrm/design-system';
 
-{show && (
-  <Alert tone="success" onDismiss={() => setShow(false)}>
-    Changes saved.
-  </Alert>
-)}`}
+export function Demo() {
+  const [show, setShow] = useState(true);
+
+  return (
+    <Stack gap="sm">
+      {show ? (
+        <Alert tone="success" onDismiss={() => setShow(false)}>
+          Changes saved.
+        </Alert>
+      ) : (
+        <Button size="sm" variant="ghost" onClick={() => setShow(true)}>
+          Show again
+        </Button>
+      )}
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           {showSaved ? (
@@ -106,8 +141,17 @@ export function AlertDemo() {
       <Example
         title="Custom icon + suppressed icon"
         description="Pass any ReactNode to icon for an override. icon={null} hides the icon entirely."
-        code={`<Alert tone="info" icon={<Bell size={16} />} title="New mention" />
-<Alert tone="info" icon={null}>Quietly informative.</Alert>`}
+        code={`import { Bell } from 'lucide-react';
+import { Alert, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Alert tone="info" icon={<Bell size={16} aria-hidden />} title="New mention" />
+      <Alert tone="info" icon={null}>Quietly informative.</Alert>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Alert tone="info" icon={<Bell size={16} aria-hidden />} title="New mention" />

--- a/packages/playground/src/pages/components/AppLayoutDemo.tsx
+++ b/packages/playground/src/pages/components/AppLayoutDemo.tsx
@@ -62,13 +62,77 @@ export function AppLayoutDemo() {
       name="AppLayout"
       description="Viewport-filling application shell, matching the CRM shell topology: a full-height sidebar down the left, an optional top bar over the content column, and the main content below it. The top-level layout primitive, mounted once at the app root."
       files={getComponentFiles('AppLayout')}
+      apiName="AppLayout"
     >
       <Example
         title="Full shell (sidebar + topBar + content)"
         description="The canonical CRM shell — full-height sidebar on the left, top bar over the content column. AppLayout fills the viewport; shown clipped to a bounded frame."
-        code={`<AppLayout topBar={<TopBar />} sidebar={<Rail>{nav}</Rail>}>
-  <Page>{content}</Page>
-</AppLayout>`}
+        code={`import type { ReactNode } from 'react';
+import { AppLayout, Page, Stack, Text, Title } from '@eocrm/design-system';
+
+function Frame({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: 320,
+        overflow: 'hidden',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Bar({ label }: { label: string }) {
+  return (
+    <div
+      style={{
+        padding: 'var(--space-3) var(--space-4)',
+        background: 'var(--color-bg-subtle)',
+        borderBottom: 'var(--border-width) solid var(--color-border)',
+      }}
+    >
+      <Text weight="semibold">{label}</Text>
+    </div>
+  );
+}
+
+function Side() {
+  return (
+    <div
+      style={{
+        width: 180,
+        height: '100%',
+        padding: 'var(--space-4)',
+        background: 'var(--color-bg-subtle)',
+        borderRight: 'var(--border-width) solid var(--color-border)',
+      }}
+    >
+      <Stack gap="sm">
+        <Text tone="muted">Dashboard</Text>
+        <Text tone="muted">Contacts</Text>
+        <Text tone="muted">Deals</Text>
+      </Stack>
+    </div>
+  );
+}
+
+export function Demo() {
+  return (
+    <Frame>
+      <AppLayout topBar={<Bar label="eocrm" />} sidebar={<Side />}>
+        <Page>
+          <Stack gap="sm">
+            <Title order={3}>Dashboard</Title>
+            <Text tone="muted">Main content fills the remaining space.</Text>
+          </Stack>
+        </Page>
+      </AppLayout>
+    </Frame>
+  );
+}`}
       >
         <Frame>
           <AppLayout topBar={<Bar label="eocrm" />} sidebar={<Side />}>
@@ -85,9 +149,49 @@ export function AppLayoutDemo() {
       <Example
         title="No sidebar"
         description="Omit the sidebar slot for a top bar + content shell."
-        code={`<AppLayout topBar={<TopBar />}>
-  <Page>{content}</Page>
-</AppLayout>`}
+        code={`import type { ReactNode } from 'react';
+import { AppLayout, Page, Text } from '@eocrm/design-system';
+
+function Frame({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: 320,
+        overflow: 'hidden',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Bar({ label }: { label: string }) {
+  return (
+    <div
+      style={{
+        padding: 'var(--space-3) var(--space-4)',
+        background: 'var(--color-bg-subtle)',
+        borderBottom: 'var(--border-width) solid var(--color-border)',
+      }}
+    >
+      <Text weight="semibold">{label}</Text>
+    </div>
+  );
+}
+
+export function Demo() {
+  return (
+    <Frame>
+      <AppLayout topBar={<Bar label="eocrm" />}>
+        <Page>
+          <Text tone="muted">No sidebar — content spans the full width.</Text>
+        </Page>
+      </AppLayout>
+    </Frame>
+  );
+}`}
       >
         <Frame>
           <AppLayout topBar={<Bar label="eocrm" />}>
@@ -101,9 +205,55 @@ export function AppLayoutDemo() {
       <Example
         title="No top bar"
         description="Omit the topBar slot for a sidebar + content shell."
-        code={`<AppLayout sidebar={<Rail>{nav}</Rail>}>
-  <Page>{content}</Page>
-</AppLayout>`}
+        code={`import type { ReactNode } from 'react';
+import { AppLayout, Page, Stack, Text } from '@eocrm/design-system';
+
+function Frame({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: 320,
+        overflow: 'hidden',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Side() {
+  return (
+    <div
+      style={{
+        width: 180,
+        height: '100%',
+        padding: 'var(--space-4)',
+        background: 'var(--color-bg-subtle)',
+        borderRight: 'var(--border-width) solid var(--color-border)',
+      }}
+    >
+      <Stack gap="sm">
+        <Text tone="muted">Dashboard</Text>
+        <Text tone="muted">Contacts</Text>
+        <Text tone="muted">Deals</Text>
+      </Stack>
+    </div>
+  );
+}
+
+export function Demo() {
+  return (
+    <Frame>
+      <AppLayout sidebar={<Side />}>
+        <Page>
+          <Text tone="muted">No top bar — sidebar runs full height.</Text>
+        </Page>
+      </AppLayout>
+    </Frame>
+  );
+}`}
       >
         <Frame>
           <AppLayout sidebar={<Side />}>

--- a/packages/playground/src/pages/components/AvatarDemo.tsx
+++ b/packages/playground/src/pages/components/AvatarDemo.tsx
@@ -43,9 +43,17 @@ export function AvatarDemo() {
       <Example
         title="Sizes"
         description="Three sizes. sm (24px) for table rows and dense UI, md (32px) for general use, lg (40px) for detail page headers."
-        code={`<Avatar name="Alex Rivera" size="sm" />
-<Avatar name="Alex Rivera" size="md" />
-<Avatar name="Alex Rivera" size="lg" />`}
+        code={`import { Avatar, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      <Avatar name="Alex Rivera" size="sm" />
+      <Avatar name="Alex Rivera" size="md" />
+      <Avatar name="Alex Rivera" size="lg" />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           <Avatar name="Alex Rivera" size="sm" />
@@ -57,10 +65,31 @@ export function AvatarDemo() {
       <Example
         title="Deterministic color"
         description="The color is computed from the name's hash, so a given user keeps the same avatar color across every page. Six colors in the palette."
-        code={`<Avatar name="Alex Rivera" />
-<Avatar name="Maya Owens" />
-<Avatar name="Sam Chen" />
-// …same name → same color, always`}
+        code={`import { Avatar, Cluster, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      {[
+        'Alex Rivera',
+        'Aki Tanaka',
+        'Jordan Park',
+        'Sam Chen',
+        'Maya Owens',
+        'Priya Shah',
+        'Lena Ivanova',
+        'Diana Okafor',
+      ].map((name) => (
+        <Stack key={name} gap="xs" align="center">
+          <Avatar name={name} />
+          <span style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-subtle)' }}>
+            {name.split(' ')[0]}
+          </span>
+        </Stack>
+      ))}
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm">
           {[
@@ -86,7 +115,17 @@ export function AvatarDemo() {
       <Example
         title="With image"
         description="Pass src for a real photo. The name prop stays required and becomes the accessible label."
-        code={`<Avatar name="Alex Rivera" src="https://i.pravatar.cc/120?u=alex" />`}
+        code={`import { Avatar, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      <Avatar name="Alex Rivera" src="https://i.pravatar.cc/64?u=alex" size="sm" />
+      <Avatar name="Maya Owens" src="https://i.pravatar.cc/96?u=maya" size="md" />
+      <Avatar name="Sam Chen" src="https://i.pravatar.cc/120?u=sam" size="lg" />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           <Avatar name="Alex Rivera" src="https://i.pravatar.cc/64?u=alex" size="sm" />
@@ -98,10 +137,18 @@ export function AvatarDemo() {
       <Example
         title="Status indicator"
         description="Presence dot in the bottom-right. Four states: online / busy / away / offline."
-        code={`<Avatar name="Online Olivia" status="online" />
-<Avatar name="Busy Beatrice" status="busy" />
-<Avatar name="Away Adrien" status="away" />
-<Avatar name="Offline Otto" status="offline" />`}
+        code={`import { Avatar, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      <Avatar name="Online Olivia" status="online" />
+      <Avatar name="Busy Beatrice" status="busy" />
+      <Avatar name="Away Adrien" status="away" />
+      <Avatar name="Offline Otto" status="offline" />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           <Avatar name="Online Olivia" status="online" />
@@ -114,7 +161,11 @@ export function AvatarDemo() {
       <Example
         title="Name tooltip"
         description="Opt in with `tooltip` to surface the name on hover / keyboard focus. Defaults to off standalone; inside an `<AvatarGroup>` it defaults to on."
-        code={`<Avatar name="Alex Rivera" tooltip />`}
+        code={`import { Avatar } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Avatar name="Alex Rivera" tooltip />;
+}`}
       >
         <Avatar name="Alex Rivera" tooltip />
       </Example>
@@ -122,9 +173,34 @@ export function AvatarDemo() {
       <Example
         title="Avatar group with overflow handler"
         description="Up to `max` avatars render in flow; the rest collapse into a +N button. The library does not render a popover — the app's `onOverflowClick` decides what happens."
-        code={`<AvatarGroup max={4} onOverflowClick={(_e, count) => openMembersPopover(count)}>
-  {team.map((m) => <Avatar key={m.id} name={m.name} />)}
-</AvatarGroup>`}
+        code={`import { useState } from 'react';
+import { Avatar, AvatarGroup, Stack } from '@eocrm/design-system';
+
+const TEAM = [
+  'Alex Rivera',
+  'Priya Patel',
+  'Tom Kim',
+  'Sara Chen',
+  'Jaden Lee',
+];
+
+export function GroupDemo() {
+  const [clicked, setClicked] = useState<number | null>(null);
+  return (
+    <Stack gap="xs">
+      <AvatarGroup max={4} size="md" onOverflowClick={(_e, count) => setClicked(count)}>
+        {TEAM.map((n) => (
+          <Avatar key={n} name={n} />
+        ))}
+      </AvatarGroup>
+      {clicked !== null && (
+        <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+          onOverflowClick fired with hiddenCount = {clicked}
+        </code>
+      )}
+    </Stack>
+  );
+}`}
       >
         <GroupDemo />
       </Example>
@@ -132,9 +208,38 @@ export function AvatarDemo() {
       <Example
         title="Group sizes"
         description="Three sizes — sm / md (default) / lg. The group's size is the default for child avatars; per-child override still wins."
-        code={`<AvatarGroup size="sm">{...}</AvatarGroup>
-<AvatarGroup size="md">{...}</AvatarGroup>
-<AvatarGroup size="lg">{...}</AvatarGroup>`}
+        code={`import { Avatar, AvatarGroup, Stack } from '@eocrm/design-system';
+
+const TEAM = [
+  'Alex Rivera',
+  'Priya Patel',
+  'Tom Kim',
+  'Sara Chen',
+  'Jaden Lee',
+  'Mei Tanaka',
+];
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <AvatarGroup size="sm" max={5}>
+        {TEAM.slice(0, 6).map((n) => (
+          <Avatar key={n} name={n} />
+        ))}
+      </AvatarGroup>
+      <AvatarGroup size="md" max={5}>
+        {TEAM.slice(0, 6).map((n) => (
+          <Avatar key={n} name={n} />
+        ))}
+      </AvatarGroup>
+      <AvatarGroup size="lg" max={5}>
+        {TEAM.slice(0, 6).map((n) => (
+          <Avatar key={n} name={n} />
+        ))}
+      </AvatarGroup>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <AvatarGroup size="sm" max={5}>

--- a/packages/playground/src/pages/components/BadgeDemo.tsx
+++ b/packages/playground/src/pages/components/BadgeDemo.tsx
@@ -16,12 +16,20 @@ export function BadgeDemo() {
       <Example
         title="Tones"
         description="Six tones. neutral for generic tags, info for new/in-progress states, success for active/won, warning for at-risk/pending, danger for churned/blocked, purple for special categories like Enterprise."
-        code={`<Badge tone="neutral">Neutral</Badge>
-<Badge tone="info">Info</Badge>
-<Badge tone="success">Success</Badge>
-<Badge tone="warning">Warning</Badge>
-<Badge tone="danger">Danger</Badge>
-<Badge tone="purple">Purple</Badge>`}
+        code={`import { Badge, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <Badge tone="neutral">Neutral</Badge>
+      <Badge tone="info">Info</Badge>
+      <Badge tone="success">Success</Badge>
+      <Badge tone="warning">Warning</Badge>
+      <Badge tone="danger">Danger</Badge>
+      <Badge tone="purple">Purple</Badge>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm">
           <Badge tone="neutral">Neutral</Badge>
@@ -36,21 +44,30 @@ export function BadgeDemo() {
       <Example
         title="Sizes"
         description="Two emphases. md (20px, default) is the loud label pill — uppercase and tracked. sm (16px) is the quiet inline tag — case as-typed, no tracking. Use sm in dense table cells, compact toolbars, or anywhere the uppercase treatment shouts next to body copy."
-        code={`// md (default), all tones
-<Badge tone="neutral">Neutral</Badge>
-<Badge tone="info">Info</Badge>
-<Badge tone="success">Success</Badge>
-<Badge tone="warning">Warning</Badge>
-<Badge tone="danger">Danger</Badge>
-<Badge tone="purple">Purple</Badge>
+        code={`import { Badge, Cluster, Stack } from '@eocrm/design-system';
 
-// sm, all tones
-<Badge size="sm" tone="neutral">Neutral</Badge>
-<Badge size="sm" tone="info">Info</Badge>
-<Badge size="sm" tone="success">Success</Badge>
-<Badge size="sm" tone="warning">Warning</Badge>
-<Badge size="sm" tone="danger">Danger</Badge>
-<Badge size="sm" tone="purple">Purple</Badge>`}
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Cluster gap="sm" align="center">
+        <Badge tone="neutral">Neutral</Badge>
+        <Badge tone="info">Info</Badge>
+        <Badge tone="success">Success</Badge>
+        <Badge tone="warning">Warning</Badge>
+        <Badge tone="danger">Danger</Badge>
+        <Badge tone="purple">Purple</Badge>
+      </Cluster>
+      <Cluster gap="sm" align="center">
+        <Badge size="sm" tone="neutral">Neutral</Badge>
+        <Badge size="sm" tone="info">Info</Badge>
+        <Badge size="sm" tone="success">Success</Badge>
+        <Badge size="sm" tone="warning">Warning</Badge>
+        <Badge size="sm" tone="danger">Danger</Badge>
+        <Badge size="sm" tone="purple">Purple</Badge>
+      </Cluster>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Cluster gap="sm" align="center">
@@ -87,17 +104,36 @@ export function BadgeDemo() {
       <Example
         title="Status dot"
         description={`Add dot="start" or dot="end" to render a small filled circle in the badge's text color. Useful when the dot is the primary status signal (Slack/GitHub-style online/offline indicators) and the label is supporting context. Works with every tone and both sizes.`}
-        code={`// Dot at the start
-<Badge tone="success" dot="start">Active</Badge>
-<Badge tone="warning" dot="start">Pending</Badge>
-<Badge tone="danger" dot="start">Failed</Badge>
+        code={`import { Badge, Cluster, Stack } from '@eocrm/design-system';
 
-// Dot at the end
-<Badge tone="info" dot="end">Lead</Badge>
-
-// Works at sm size too
-<Badge size="sm" tone="success" dot="start">Online</Badge>
-<Badge size="sm" tone="neutral" dot="start">Away</Badge>`}
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Cluster gap="sm" align="center">
+        <Badge tone="neutral" dot="start">Neutral</Badge>
+        <Badge tone="info" dot="start">Info</Badge>
+        <Badge tone="success" dot="start">Success</Badge>
+        <Badge tone="warning" dot="start">Warning</Badge>
+        <Badge tone="danger" dot="start">Danger</Badge>
+        <Badge tone="purple" dot="start">Purple</Badge>
+      </Cluster>
+      <Cluster gap="sm" align="center">
+        <Badge tone="neutral" dot="end">Neutral</Badge>
+        <Badge tone="info" dot="end">Info</Badge>
+        <Badge tone="success" dot="end">Success</Badge>
+        <Badge tone="warning" dot="end">Warning</Badge>
+        <Badge tone="danger" dot="end">Danger</Badge>
+        <Badge tone="purple" dot="end">Purple</Badge>
+      </Cluster>
+      <Cluster gap="sm" align="center">
+        <Badge size="sm" tone="success" dot="start">Online</Badge>
+        <Badge size="sm" tone="warning" dot="start">Away</Badge>
+        <Badge size="sm" tone="danger" dot="start">Offline</Badge>
+        <Badge size="sm" tone="neutral" dot="start">Unknown</Badge>
+      </Cluster>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Cluster gap="sm" align="center">
@@ -160,12 +196,20 @@ export function BadgeDemo() {
       <Example
         title="Stripe variant (rectangular with left stripe)"
         description={`variant="stripe" renders a rectangular block with a tone-colored 3px left stripe and a softly tinted body. No uppercase, no letter-spacing — reads as a category label rather than a loud status pill. Composes with all six existing tones.`}
-        code={`<Badge variant="stripe" tone="info">Lead</Badge>
-<Badge variant="stripe" tone="success">Active</Badge>
-<Badge variant="stripe" tone="warning">Renewal due</Badge>
-<Badge variant="stripe" tone="danger">Churned</Badge>
-<Badge variant="stripe" tone="neutral">Archived</Badge>
-<Badge variant="stripe" tone="purple">Enterprise</Badge>`}
+        code={`import { Badge, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm" wrap>
+      <Badge variant="stripe" tone="info">Lead</Badge>
+      <Badge variant="stripe" tone="success">Active</Badge>
+      <Badge variant="stripe" tone="warning">Renewal due</Badge>
+      <Badge variant="stripe" tone="danger">Churned</Badge>
+      <Badge variant="stripe" tone="neutral">Archived</Badge>
+      <Badge variant="stripe" tone="purple">Enterprise</Badge>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" wrap>
           <Badge variant="stripe" tone="info">
@@ -192,15 +236,64 @@ export function BadgeDemo() {
       <Example
         title="Status patterns"
         description="The most common CRM usage: status pill on a contact, deal, or invitation."
-        code={`// Contact statuses
-<Badge tone="success">Active</Badge>
-<Badge tone="info">Lead</Badge>
-<Badge tone="danger">Churned</Badge>
+        code={`import { Badge, Cluster, Stack } from '@eocrm/design-system';
 
-// Member roles
-<Badge tone="purple">Admin</Badge>
-<Badge tone="info">Member</Badge>
-<Badge tone="neutral">Guest</Badge>`}
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <div>
+        <div
+          style={{
+            fontSize: 'var(--font-size-sm)',
+            color: 'var(--color-fg-subtle)',
+            marginBottom: 6,
+          }}
+        >
+          Contact status
+        </div>
+        <Cluster gap="sm">
+          <Badge tone="success">Active</Badge>
+          <Badge tone="info">Lead</Badge>
+          <Badge tone="danger">Churned</Badge>
+        </Cluster>
+      </div>
+      <div>
+        <div
+          style={{
+            fontSize: 'var(--font-size-sm)',
+            color: 'var(--color-fg-subtle)',
+            marginBottom: 6,
+          }}
+        >
+          Member role
+        </div>
+        <Cluster gap="sm">
+          <Badge tone="purple">Admin</Badge>
+          <Badge tone="info">Member</Badge>
+          <Badge tone="neutral">Guest</Badge>
+        </Cluster>
+      </div>
+      <div>
+        <div
+          style={{
+            fontSize: 'var(--font-size-sm)',
+            color: 'var(--color-fg-subtle)',
+            marginBottom: 6,
+          }}
+        >
+          Deal stage
+        </div>
+        <Cluster gap="sm">
+          <Badge tone="neutral">Lead</Badge>
+          <Badge tone="info">Qualified</Badge>
+          <Badge tone="warning">Proposal</Badge>
+          <Badge tone="success">Won</Badge>
+          <Badge tone="danger">Lost</Badge>
+        </Cluster>
+      </div>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <div>
@@ -259,10 +352,28 @@ export function BadgeDemo() {
       <Example
         title="Palette colors (categorical)"
         description="Optional `color` prop tints the badge with a categorical palette color — 30 named colors that carry no semantic meaning (use `tone` for status; `color` for tag-like categorical labels)."
-        code={`<Badge color="amber">Marketing</Badge>
-<Badge color="teal">Engineering</Badge>
-<Badge color="violet">Design</Badge>
-<Badge color="fuchsia" variant="stripe">Sales</Badge>`}
+        code={`import { Badge, Cluster, PALETTE_COLORS, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Cluster gap="xs" wrap>
+        {PALETTE_COLORS.map((color) => (
+          <Badge key={color} color={color}>
+            {color}
+          </Badge>
+        ))}
+      </Cluster>
+      <Cluster gap="xs" wrap>
+        {PALETTE_COLORS.slice(0, 10).map((color) => (
+          <Badge key={color} color={color} variant="stripe">
+            {color}
+          </Badge>
+        ))}
+      </Cluster>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Cluster gap="xs" wrap>

--- a/packages/playground/src/pages/components/BrandIconDemo.tsx
+++ b/packages/playground/src/pages/components/BrandIconDemo.tsx
@@ -14,8 +14,26 @@ export function BrandIconDemo() {
       <Example
         title="The marks"
         description="Each brand at a few sizes. size is pixels (default 20)."
-        code={`<BrandIcon name="google" />
-<BrandIcon name="yandex" size={32} />`}
+        code={`import { BrandIcon, Cluster, Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="lg" align="center">
+      {(['google', 'yandex'] as const).map((name) => (
+        <Stack key={name} gap="xs" align="center">
+          <Cluster gap="sm" align="center">
+            <BrandIcon name={name} size={16} />
+            <BrandIcon name={name} size={20} />
+            <BrandIcon name={name} size={32} />
+          </Cluster>
+          <Text size="xs" tone="muted">
+            {name}
+          </Text>
+        </Stack>
+      ))}
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="lg" align="center">
           {(['google', 'yandex'] as const).map((name) => (
@@ -36,7 +54,20 @@ export function BrandIconDemo() {
       <Example
         title="In SSO buttons"
         description="The canonical use — decorative icon (aria-hidden) beside the provider name."
-        code={`<Button variant="secondary"><BrandIcon name="google" size={16} /> Continue with Google</Button>`}
+        code={`import { BrandIcon, Button, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Button variant="secondary">
+        <BrandIcon name="google" size={16} /> Continue with Google
+      </Button>
+      <Button variant="secondary">
+        <BrandIcon name="yandex" size={16} /> Continue with Yandex
+      </Button>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Button variant="secondary">
@@ -51,7 +82,11 @@ export function BrandIconDemo() {
       <Example
         title="Labeled (standalone)"
         description="Pass title for a standalone icon — renders role=img + aria-label."
-        code={`<BrandIcon name="yandex" title="Yandex" size={28} />`}
+        code={`import { BrandIcon } from '@eocrm/design-system';
+
+export function Demo() {
+  return <BrandIcon name="yandex" title="Yandex" size={28} />;
+}`}
       >
         <BrandIcon name="yandex" title="Yandex" size={28} />
       </Example>

--- a/packages/playground/src/pages/components/BreadcrumbDemo.tsx
+++ b/packages/playground/src/pages/components/BreadcrumbDemo.tsx
@@ -16,11 +16,22 @@ export function BreadcrumbDemo() {
       <Example
         title="Basic — auto-current on last child"
         description="No explicit `current` prop needed; the last child becomes `<span aria-current='page'>` automatically."
-        code={`<Breadcrumb>
-  <Breadcrumb.Item as={RouterLink} to="/mockups">Mockups</Breadcrumb.Item>
-  <Breadcrumb.Item as={RouterLink} to="/mockups/contacts">Contacts</Breadcrumb.Item>
-  <Breadcrumb.Item>Acme Corp</Breadcrumb.Item>
-</Breadcrumb>`}
+        code={`import { Link as RouterLink } from 'react-router-dom';
+import { Breadcrumb } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Breadcrumb>
+      <Breadcrumb.Item as={RouterLink} to="/mockups">
+        Mockups
+      </Breadcrumb.Item>
+      <Breadcrumb.Item as={RouterLink} to="/mockups/contacts">
+        Contacts
+      </Breadcrumb.Item>
+      <Breadcrumb.Item>Acme Corp</Breadcrumb.Item>
+    </Breadcrumb>
+  );
+}`}
       >
         <Breadcrumb>
           <Breadcrumb.Item as={RouterLink} to="/mockups">
@@ -36,11 +47,23 @@ export function BreadcrumbDemo() {
       <Example
         title="Custom separator"
         description="Pass any ReactNode as the separator. The wrapper applies aria-hidden automatically."
-        code={`<Breadcrumb separator={<Slash size={12} />}>
-  <Breadcrumb.Item as={RouterLink} to="/a">A</Breadcrumb.Item>
-  <Breadcrumb.Item as={RouterLink} to="/b">B</Breadcrumb.Item>
-  <Breadcrumb.Item>C</Breadcrumb.Item>
-</Breadcrumb>`}
+        code={`import { Link as RouterLink } from 'react-router-dom';
+import { Slash } from 'lucide-react';
+import { Breadcrumb } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Breadcrumb separator={<Slash size={12} />}>
+      <Breadcrumb.Item as={RouterLink} to="/a">
+        A
+      </Breadcrumb.Item>
+      <Breadcrumb.Item as={RouterLink} to="/b">
+        B
+      </Breadcrumb.Item>
+      <Breadcrumb.Item>C</Breadcrumb.Item>
+    </Breadcrumb>
+  );
+}`}
       >
         <Breadcrumb separator={<Slash size={12} />}>
           <Breadcrumb.Item as={RouterLink} to="/a">
@@ -56,9 +79,15 @@ export function BreadcrumbDemo() {
       <Example
         title="Single crumb"
         description="A single child auto-becomes current (renders as <span>). Useful when programmatically rendering breadcrumbs from a route hierarchy that bottoms out at the root."
-        code={`<Breadcrumb>
-  <Breadcrumb.Item>Only crumb</Breadcrumb.Item>
-</Breadcrumb>`}
+        code={`import { Breadcrumb } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Breadcrumb>
+      <Breadcrumb.Item>Only crumb</Breadcrumb.Item>
+    </Breadcrumb>
+  );
+}`}
       >
         <Breadcrumb>
           <Breadcrumb.Item>Only crumb</Breadcrumb.Item>
@@ -68,14 +97,31 @@ export function BreadcrumbDemo() {
       <Example
         title="Long trail (5+ items)"
         description="v1 has no truncation. Long trails wrap naturally; pick the separator/font-size that fits your layout."
-        code={`<Breadcrumb>
-  <Breadcrumb.Item as={RouterLink} to="/a">Workspace</Breadcrumb.Item>
-  <Breadcrumb.Item as={RouterLink} to="/b">Mockups</Breadcrumb.Item>
-  <Breadcrumb.Item as={RouterLink} to="/c">Contacts</Breadcrumb.Item>
-  <Breadcrumb.Item as={RouterLink} to="/d">Acme Corp</Breadcrumb.Item>
-  <Breadcrumb.Item as={RouterLink} to="/e">Deals</Breadcrumb.Item>
-  <Breadcrumb.Item>Q4 Renewal</Breadcrumb.Item>
-</Breadcrumb>`}
+        code={`import { Link as RouterLink } from 'react-router-dom';
+import { Breadcrumb } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Breadcrumb>
+      <Breadcrumb.Item as={RouterLink} to="/a">
+        Workspace
+      </Breadcrumb.Item>
+      <Breadcrumb.Item as={RouterLink} to="/b">
+        Mockups
+      </Breadcrumb.Item>
+      <Breadcrumb.Item as={RouterLink} to="/c">
+        Contacts
+      </Breadcrumb.Item>
+      <Breadcrumb.Item as={RouterLink} to="/d">
+        Acme Corp
+      </Breadcrumb.Item>
+      <Breadcrumb.Item as={RouterLink} to="/e">
+        Deals
+      </Breadcrumb.Item>
+      <Breadcrumb.Item>Q4 Renewal</Breadcrumb.Item>
+    </Breadcrumb>
+  );
+}`}
       >
         <Breadcrumb>
           <Breadcrumb.Item as={RouterLink} to="/a">
@@ -100,11 +146,26 @@ export function BreadcrumbDemo() {
       <Example
         title="External crumb (default <a>)"
         description="No `as` prop = native <a> for external URLs."
-        code={`<Breadcrumb>
-  <Breadcrumb.Item href="https://docs.example.com" target="_blank" rel="noopener noreferrer">Docs</Breadcrumb.Item>
-  <Breadcrumb.Item as={RouterLink} to="/getting-started">Getting Started</Breadcrumb.Item>
-  <Breadcrumb.Item>This page</Breadcrumb.Item>
-</Breadcrumb>`}
+        code={`import { Link as RouterLink } from 'react-router-dom';
+import { Breadcrumb } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Breadcrumb>
+      <Breadcrumb.Item
+        href="https://example.com"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Docs
+      </Breadcrumb.Item>
+      <Breadcrumb.Item as={RouterLink} to="/mockups">
+        Getting Started
+      </Breadcrumb.Item>
+      <Breadcrumb.Item>This page</Breadcrumb.Item>
+    </Breadcrumb>
+  );
+}`}
       >
         <Breadcrumb>
           <Breadcrumb.Item href="https://example.com" target="_blank" rel="noopener noreferrer">

--- a/packages/playground/src/pages/components/ButtonGroupDemo.tsx
+++ b/packages/playground/src/pages/components/ButtonGroupDemo.tsx
@@ -27,11 +27,17 @@ function VisualSimpleExample() {
     <Example
       title="Visual: simple action group"
       description="Three Buttons joined into one visual unit. Each owns its own onClick — no shared state."
-      code={`<ButtonGroup aria-label="Edit actions">
-  <Button>Cut</Button>
-  <Button>Copy</Button>
-  <Button>Paste</Button>
-</ButtonGroup>`}
+      code={`import { Button, ButtonGroup } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <ButtonGroup aria-label="Edit actions">
+      <Button variant="secondary">Cut</Button>
+      <Button variant="secondary">Copy</Button>
+      <Button variant="secondary">Paste</Button>
+    </ButtonGroup>
+  );
+}`}
     >
       <ButtonGroup aria-label="Edit actions">
         <Button variant="secondary">Cut</Button>
@@ -47,10 +53,16 @@ function VisualMixedVariantsExample() {
     <Example
       title="Visual: mixed variants"
       description='Mixed variants are intentionally allowed. A "Save" primary + "Discard" secondary in one group lets the primary visually dominate.'
-      code={`<ButtonGroup aria-label="Save or discard">
-  <Button>Save</Button>
-  <Button variant="secondary">Discard</Button>
-</ButtonGroup>`}
+      code={`import { Button, ButtonGroup } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <ButtonGroup aria-label="Save or discard">
+      <Button>Save</Button>
+      <Button variant="secondary">Discard</Button>
+    </ButtonGroup>
+  );
+}`}
     >
       <ButtonGroup aria-label="Save or discard">
         <Button>Save</Button>
@@ -66,12 +78,28 @@ function SegmentedViewToggleExample() {
     <Example
       title="Segmented: view toggle"
       description="Single-select radiogroup with Arrow-key keyboard navigation. Try Tab to focus the group, then ←/→ to move selection."
-      code={`const [view, setView] = useState<'grid' | 'list' | 'calendar'>('grid');
-<ButtonGroup value={view} onValueChange={setView} aria-label="View mode">
-  <ButtonGroup.Item value="grid">Grid</ButtonGroup.Item>
-  <ButtonGroup.Item value="list">List</ButtonGroup.Item>
-  <ButtonGroup.Item value="calendar">Calendar</ButtonGroup.Item>
-</ButtonGroup>`}
+      code={`import { useState } from 'react';
+import { ButtonGroup, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  const [view, setView] = useState<'grid' | 'list' | 'calendar'>('grid');
+  return (
+    <Stack gap="sm">
+      <ButtonGroup
+        value={view}
+        onValueChange={(v) => setView(v as 'grid' | 'list' | 'calendar')}
+        aria-label="View mode"
+      >
+        <ButtonGroup.Item value="grid">Grid</ButtonGroup.Item>
+        <ButtonGroup.Item value="list">List</ButtonGroup.Item>
+        <ButtonGroup.Item value="calendar">Calendar</ButtonGroup.Item>
+      </ButtonGroup>
+      <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+        Selected: <strong>{view}</strong>
+      </div>
+    </Stack>
+  );
+}`}
     >
       <Stack gap="sm">
         <ButtonGroup
@@ -97,11 +125,28 @@ function SegmentedTimeframeExample() {
     <Example
       title="Segmented: timeframe filter"
       description="Same pattern, different content. Controlled via parent state."
-      code={`<ButtonGroup value={tf} onValueChange={setTf} aria-label="Timeframe">
-  <ButtonGroup.Item value="day">Day</ButtonGroup.Item>
-  <ButtonGroup.Item value="week">Week</ButtonGroup.Item>
-  <ButtonGroup.Item value="month">Month</ButtonGroup.Item>
-</ButtonGroup>`}
+      code={`import { useState } from 'react';
+import { ButtonGroup, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  const [tf, setTf] = useState<'day' | 'week' | 'month'>('week');
+  return (
+    <Stack gap="sm">
+      <ButtonGroup
+        value={tf}
+        onValueChange={(v) => setTf(v as 'day' | 'week' | 'month')}
+        aria-label="Timeframe"
+      >
+        <ButtonGroup.Item value="day">Day</ButtonGroup.Item>
+        <ButtonGroup.Item value="week">Week</ButtonGroup.Item>
+        <ButtonGroup.Item value="month">Month</ButtonGroup.Item>
+      </ButtonGroup>
+      <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+        Selected: <strong>{tf}</strong>
+      </div>
+    </Stack>
+  );
+}`}
     >
       <Stack gap="sm">
         <ButtonGroup
@@ -126,11 +171,19 @@ function SizePropagationExample() {
     <Example
       title="Size propagation"
       description="`size` on the group propagates to children. A per-child `size` override wins (third Button below)."
-      code={`<ButtonGroup size="sm" aria-label="x">
-  <Button>Cut</Button>     {/* sm */}
-  <Button>Copy</Button>    {/* sm */}
-  <Button size="md">Paste</Button>  {/* override */}
-</ButtonGroup>`}
+      code={`import { Button, ButtonGroup } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <ButtonGroup size="sm" aria-label="Demo">
+      <Button variant="secondary">Cut</Button>
+      <Button variant="secondary">Copy</Button>
+      <Button size="md" variant="secondary">
+        Paste (md override)
+      </Button>
+    </ButtonGroup>
+  );
+}`}
     >
       <ButtonGroup size="sm" aria-label="Demo">
         <Button variant="secondary">Cut</Button>
@@ -149,9 +202,19 @@ function SegmentedDisabledExample() {
     <Example
       title="Disabled segmented"
       description="Group-level `disabled` freezes selection — clicks no-op, arrow keys still focus-move but onValueChange doesn't fire."
-      code={`<ButtonGroup value={v} onValueChange={setV} aria-label="x" disabled>
-  ...
-</ButtonGroup>`}
+      code={`import { useState } from 'react';
+import { ButtonGroup } from '@eocrm/design-system';
+
+export function Demo() {
+  const [v, setV] = useState('a');
+  return (
+    <ButtonGroup value={v} onValueChange={setV} aria-label="Locked" disabled>
+      <ButtonGroup.Item value="a">A</ButtonGroup.Item>
+      <ButtonGroup.Item value="b">B</ButtonGroup.Item>
+      <ButtonGroup.Item value="c">C</ButtonGroup.Item>
+    </ButtonGroup>
+  );
+}`}
     >
       <ButtonGroup value={v} onValueChange={setV} aria-label="Locked" disabled>
         <ButtonGroup.Item value="a">A</ButtonGroup.Item>

--- a/packages/playground/src/pages/components/CalendarDemo.tsx
+++ b/packages/playground/src/pages/components/CalendarDemo.tsx
@@ -179,7 +179,11 @@ export function CalendarDemo() {
       <Example
         title="Default (empty)"
         description="Bare shell with prev/next/today navigation. No events yet."
-        code={`<Calendar defaultValue={new Date(2026, 4, 15)} />`}
+        code={`import { Calendar } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Calendar defaultValue={new Date(2026, 4, 15)} />;
+}`}
       >
         <Calendar defaultValue={TODAY} />
       </Example>
@@ -187,15 +191,19 @@ export function CalendarDemo() {
       <Example
         title="With events"
         description="Sample CRM-style events showing all 5 tones, an all-day vacation band, and timed meetings."
-        code={`const SAMPLE_EVENTS = [
-  { id: '1', title: 'Team standup', startsAt: new Date(2026, 4, 11, 9), tone: 'accent' },
-  { id: '2', title: 'Quarterly review', startsAt: new Date(2026, 4, 13, 14), endsAt: new Date(2026, 4, 13, 17), tone: 'success' },
-  { id: '3', title: 'Customer call: Acme', startsAt: new Date(2026, 4, 15, 11), tone: 'accent' },
-  { id: '4', title: 'Vacation', startsAt: new Date(2026, 4, 18), endsAt: new Date(2026, 4, 22), tone: 'warning', allDay: true },
-  { id: '5', title: 'Renewal: Beta Co.', startsAt: new Date(2026, 4, 27), tone: 'danger' },
+        code={`import { Calendar } from '@eocrm/design-system';
+
+const SAMPLE_EVENTS = [
+  { id: '1', title: 'Team standup', startsAt: new Date(2026, 4, 12, 9, 30), tone: 'accent' },
+  { id: '2', title: 'Quarterly review', startsAt: new Date(2026, 4, 13, 14, 0), endsAt: new Date(2026, 4, 13, 17, 0), tone: 'success' },
+  { id: '3', title: 'Customer call: Acme', startsAt: new Date(2026, 4, 15, 11, 0), tone: 'accent' },
+  { id: '4', title: 'Vacation', startsAt: new Date(2026, 4, 18), endsAt: new Date(2026, 4, 25), tone: 'warning', allDay: true },
+  { id: '5', title: 'Renewal: Beta Co.', startsAt: new Date(2026, 4, 27, 9, 0), tone: 'danger' },
 ];
 
-<Calendar defaultValue={new Date(2026, 4, 15)} events={SAMPLE_EVENTS} />`}
+export function Demo() {
+  return <Calendar defaultValue={new Date(2026, 4, 15)} events={SAMPLE_EVENTS} />;
+}`}
       >
         <Calendar defaultValue={TODAY} events={SAMPLE_EVENTS} />
       </Example>
@@ -203,11 +211,25 @@ export function CalendarDemo() {
       <Example
         title="Overflow (+N more)"
         description="Days with more events than maxLanesPerWeek (default 3) collapse to a +N more chip. Click fires onDayClick."
-        code={`<Calendar
-  defaultValue={new Date(2026, 4, 15)}
-  events={OVERFLOW_EVENTS}
-  onDayClick={(d) => alert('Day clicked: ' + d.toDateString())}
-/>`}
+        code={`import { Calendar } from '@eocrm/design-system';
+
+const OVERFLOW_EVENTS = [
+  { id: 'a', title: 'Standup', startsAt: new Date(2026, 4, 15, 9, 0), tone: 'accent' },
+  { id: 'b', title: '1:1 with Sam', startsAt: new Date(2026, 4, 15, 10, 0), tone: 'neutral' },
+  { id: 'c', title: 'Demo prep', startsAt: new Date(2026, 4, 15, 11, 0), tone: 'success' },
+  { id: 'd', title: 'Lunch', startsAt: new Date(2026, 4, 15, 12, 0), tone: 'neutral' },
+  { id: 'e', title: 'Customer call', startsAt: new Date(2026, 4, 15, 14, 0), tone: 'warning' },
+];
+
+export function Demo() {
+  return (
+    <Calendar
+      defaultValue={new Date(2026, 4, 15)}
+      events={OVERFLOW_EVENTS}
+      onDayClick={(d) => alert('Day clicked: ' + d.toDateString())}
+    />
+  );
+}`}
       >
         <Calendar
           defaultValue={TODAY}
@@ -219,11 +241,15 @@ export function CalendarDemo() {
       <Example
         title="Multi-week event"
         description="A 17-day event spanning three week rows (Wed May 6 → Fri May 22). Bars in middle weeks have both continuation edges flattened."
-        code={`const MULTI_WEEK_EVENTS = [
+        code={`import { Calendar } from '@eocrm/design-system';
+
+const MULTI_WEEK_EVENTS = [
   { id: 'm1', title: 'Conference', startsAt: new Date(2026, 4, 6), endsAt: new Date(2026, 4, 22), tone: 'success', allDay: true },
 ];
 
-<Calendar defaultValue={new Date(2026, 4, 15)} events={MULTI_WEEK_EVENTS} />`}
+export function Demo() {
+  return <Calendar defaultValue={new Date(2026, 4, 15)} events={MULTI_WEEK_EVENTS} />;
+}`}
       >
         <Calendar defaultValue={TODAY} events={MULTI_WEEK_EVENTS} />
       </Example>
@@ -231,13 +257,27 @@ export function CalendarDemo() {
       <Example
         title="ru-RU locale"
         description="Russian locale — Monday-start grid, Cyrillic month/weekday labels. UI strings (Today button, prev/next aria-labels, view-switcher) come from the i18n provider — wrap the Calendar in <I18nProvider locale='ru'> to use the built-in Russian translations."
-        code={`<I18nProvider locale="ru">
-  <Calendar
-    defaultValue={new Date(2026, 4, 15)}
-    events={SAMPLE_EVENTS}
-    locale="ru-RU"
-  />
-</I18nProvider>`}
+        code={`import { Calendar, I18nProvider } from '@eocrm/design-system';
+
+const SAMPLE_EVENTS = [
+  { id: '1', title: 'Team standup', startsAt: new Date(2026, 4, 12, 9, 30), tone: 'accent' },
+  { id: '2', title: 'Quarterly review', startsAt: new Date(2026, 4, 13, 14, 0), endsAt: new Date(2026, 4, 13, 17, 0), tone: 'success' },
+  { id: '3', title: 'Customer call: Acme', startsAt: new Date(2026, 4, 15, 11, 0), tone: 'accent' },
+  { id: '4', title: 'Vacation', startsAt: new Date(2026, 4, 18), endsAt: new Date(2026, 4, 25), tone: 'warning', allDay: true },
+  { id: '5', title: 'Renewal: Beta Co.', startsAt: new Date(2026, 4, 27, 9, 0), tone: 'danger' },
+];
+
+export function Demo() {
+  return (
+    <I18nProvider locale="ru">
+      <Calendar
+        defaultValue={new Date(2026, 4, 15)}
+        events={SAMPLE_EVENTS}
+        locale="ru-RU"
+      />
+    </I18nProvider>
+  );
+}`}
       >
         <I18nProvider locale="ru">
           <Calendar defaultValue={TODAY} events={SAMPLE_EVENTS} locale="ru-RU" />
@@ -247,11 +287,25 @@ export function CalendarDemo() {
       <Example
         title="Week view"
         description="7 columns × hour rows. Timed events position by hour; overlapping events cascade — each lane offset right by a small step, later lanes overlay earlier ones, and hover lifts a block to full width on top. All-day and multi-day events render in the band above the hour grid. A horizontal line marks the current time in today's column."
-        code={`<Calendar
-  defaultValue={new Date()}
-  defaultView="week"
-  events={SAMPLE_EVENTS}
-/>`}
+        code={`import { Calendar } from '@eocrm/design-system';
+
+const SAMPLE_EVENTS = [
+  { id: '1', title: 'Team standup', startsAt: new Date(2026, 4, 12, 9, 30), tone: 'accent' },
+  { id: '2', title: 'Quarterly review', startsAt: new Date(2026, 4, 13, 14, 0), endsAt: new Date(2026, 4, 13, 17, 0), tone: 'success' },
+  { id: '3', title: 'Customer call: Acme', startsAt: new Date(2026, 4, 15, 11, 0), tone: 'accent' },
+  { id: '4', title: 'Vacation', startsAt: new Date(2026, 4, 18), endsAt: new Date(2026, 4, 25), tone: 'warning', allDay: true },
+  { id: '5', title: 'Renewal: Beta Co.', startsAt: new Date(2026, 4, 27, 9, 0), tone: 'danger' },
+];
+
+export function Demo() {
+  return (
+    <Calendar
+      defaultValue={new Date(2026, 4, 15)}
+      defaultView="week"
+      events={SAMPLE_EVENTS}
+    />
+  );
+}`}
       >
         <Calendar defaultValue={TODAY} defaultView="week" events={SAMPLE_EVENTS} />
       </Example>
@@ -259,12 +313,26 @@ export function CalendarDemo() {
       <Example
         title="Day view"
         description="Single-day hour grid for focused planning. Custom hourRange tightens the visible range to business hours."
-        code={`<Calendar
-  defaultValue={new Date()}
-  defaultView="day"
-  events={SAMPLE_EVENTS}
-  hourRange={[8, 18]}
-/>`}
+        code={`import { Calendar } from '@eocrm/design-system';
+
+const SAMPLE_EVENTS = [
+  { id: '1', title: 'Team standup', startsAt: new Date(2026, 4, 12, 9, 30), tone: 'accent' },
+  { id: '2', title: 'Quarterly review', startsAt: new Date(2026, 4, 13, 14, 0), endsAt: new Date(2026, 4, 13, 17, 0), tone: 'success' },
+  { id: '3', title: 'Customer call: Acme', startsAt: new Date(2026, 4, 15, 11, 0), tone: 'accent' },
+  { id: '4', title: 'Vacation', startsAt: new Date(2026, 4, 18), endsAt: new Date(2026, 4, 25), tone: 'warning', allDay: true },
+  { id: '5', title: 'Renewal: Beta Co.', startsAt: new Date(2026, 4, 27, 9, 0), tone: 'danger' },
+];
+
+export function Demo() {
+  return (
+    <Calendar
+      defaultValue={new Date(2026, 4, 15)}
+      defaultView="day"
+      events={SAMPLE_EVENTS}
+      hourRange={[8, 18]}
+    />
+  );
+}`}
       >
         <Calendar
           defaultValue={TODAY}
@@ -277,11 +345,25 @@ export function CalendarDemo() {
       <Example
         title="Agenda view"
         description="Chronological list of the cursor's current week, grouped by day. Days without events are hidden so the list stays scannable. Multi-day events appear under every day they span. Prev/next steps a week at a time."
-        code={`<Calendar
-  defaultValue={new Date()}
-  defaultView="agenda"
-  events={SAMPLE_EVENTS}
-/>`}
+        code={`import { Calendar } from '@eocrm/design-system';
+
+const SAMPLE_EVENTS = [
+  { id: '1', title: 'Team standup', startsAt: new Date(2026, 4, 12, 9, 30), tone: 'accent' },
+  { id: '2', title: 'Quarterly review', startsAt: new Date(2026, 4, 13, 14, 0), endsAt: new Date(2026, 4, 13, 17, 0), tone: 'success' },
+  { id: '3', title: 'Customer call: Acme', startsAt: new Date(2026, 4, 15, 11, 0), tone: 'accent' },
+  { id: '4', title: 'Vacation', startsAt: new Date(2026, 4, 18), endsAt: new Date(2026, 4, 25), tone: 'warning', allDay: true },
+  { id: '5', title: 'Renewal: Beta Co.', startsAt: new Date(2026, 4, 27, 9, 0), tone: 'danger' },
+];
+
+export function Demo() {
+  return (
+    <Calendar
+      defaultValue={new Date(2026, 4, 15)}
+      defaultView="agenda"
+      events={SAMPLE_EVENTS}
+    />
+  );
+}`}
       >
         <Calendar defaultValue={TODAY} defaultView="agenda" events={SAMPLE_EVENTS} />
       </Example>
@@ -289,11 +371,22 @@ export function CalendarDemo() {
       <Example
         title="View switching (controlled)"
         description="Consumer owns the active view via `view` / `onViewChange`. Useful for URL-syncing the current view."
-        code={`function ViewSwitcherDemo() {
+        code={`import { useState } from 'react';
+import { Calendar, type CalendarView } from '@eocrm/design-system';
+
+const SAMPLE_EVENTS = [
+  { id: '1', title: 'Team standup', startsAt: new Date(2026, 4, 12, 9, 30), tone: 'accent' },
+  { id: '2', title: 'Quarterly review', startsAt: new Date(2026, 4, 13, 14, 0), endsAt: new Date(2026, 4, 13, 17, 0), tone: 'success' },
+  { id: '3', title: 'Customer call: Acme', startsAt: new Date(2026, 4, 15, 11, 0), tone: 'accent' },
+  { id: '4', title: 'Vacation', startsAt: new Date(2026, 4, 18), endsAt: new Date(2026, 4, 25), tone: 'warning', allDay: true },
+  { id: '5', title: 'Renewal: Beta Co.', startsAt: new Date(2026, 4, 27, 9, 0), tone: 'danger' },
+];
+
+export function ViewSwitcherDemo() {
   const [view, setView] = useState<CalendarView>('week');
   return (
     <Calendar
-      defaultValue={new Date()}
+      defaultValue={new Date(2026, 4, 15)}
       view={view}
       onViewChange={setView}
       events={SAMPLE_EVENTS}
@@ -307,7 +400,18 @@ export function CalendarDemo() {
       <Example
         title="Controlled navigation"
         description="Consumer owns the cursor state. Useful for URL-state sync or persisted last-viewed-month."
-        code={`function ControlledCalendarDemo() {
+        code={`import { useState } from 'react';
+import { Calendar } from '@eocrm/design-system';
+
+const SAMPLE_EVENTS = [
+  { id: '1', title: 'Team standup', startsAt: new Date(2026, 4, 12, 9, 30), tone: 'accent' },
+  { id: '2', title: 'Quarterly review', startsAt: new Date(2026, 4, 13, 14, 0), endsAt: new Date(2026, 4, 13, 17, 0), tone: 'success' },
+  { id: '3', title: 'Customer call: Acme', startsAt: new Date(2026, 4, 15, 11, 0), tone: 'accent' },
+  { id: '4', title: 'Vacation', startsAt: new Date(2026, 4, 18), endsAt: new Date(2026, 4, 25), tone: 'warning', allDay: true },
+  { id: '5', title: 'Renewal: Beta Co.', startsAt: new Date(2026, 4, 27, 9, 0), tone: 'danger' },
+];
+
+export function ControlledCalendarDemo() {
   const [cursor, setCursor] = useState(new Date(2026, 4, 15));
   return <Calendar value={cursor} onChange={setCursor} events={SAMPLE_EVENTS} />;
 }`}

--- a/packages/playground/src/pages/components/CardDemo.tsx
+++ b/packages/playground/src/pages/components/CardDemo.tsx
@@ -20,10 +20,26 @@ export function CardDemo() {
       <Example
         title="Padding sizes"
         description="Four padding options. Use none when the card contains a table or list that should bleed to the card edges."
-        code={`<Card padding="none">none</Card>
-<Card padding="sm">sm</Card>
-<Card padding="md">md (default)</Card>
-<Card padding="lg">lg</Card>`}
+        code={`import { Card, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm" align="start">
+      <Card padding="none" style={{ minWidth: 100, textAlign: 'center' }}>
+        <div style={{ padding: 4 }}>none</div>
+      </Card>
+      <Card padding="sm" style={{ minWidth: 100 }}>
+        sm
+      </Card>
+      <Card padding="md" style={{ minWidth: 100 }}>
+        md
+      </Card>
+      <Card padding="lg" style={{ minWidth: 100 }}>
+        lg
+      </Card>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" align="start">
           <Card padding="none" style={{ minWidth: 100, textAlign: 'center' }}>
@@ -44,19 +60,27 @@ export function CardDemo() {
       <Example
         title="With content"
         description="The most common shape: a heading, some details, an action row at the bottom."
-        code={`<Card padding="md">
-  <Stack gap="md">
-    <Cluster justify="between" align="start">
-      <h3>Acme team plan upgrade</h3>
-      <Badge tone="success">Won</Badge>
-    </Cluster>
-    <p>Closed $12,000 deal with Acme Inc.</p>
-    <Cluster justify="end" gap="sm">
-      <Button variant="secondary">Archive</Button>
-      <Button>View deal</Button>
-    </Cluster>
-  </Stack>
-</Card>`}
+        code={`import { Badge, Button, Card, Cluster, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Card padding="md" style={{ maxWidth: 480 }}>
+      <Stack gap="md">
+        <Cluster justify="between" align="start">
+          <h3 style={{ margin: 0 }}>Acme team plan upgrade</h3>
+          <Badge tone="success">Won</Badge>
+        </Cluster>
+        <p style={{ margin: 0, color: 'var(--color-fg-muted)' }}>
+          Closed $12,000 deal with Acme Inc. Renewal scheduled for next year.
+        </p>
+        <Cluster justify="end" gap="sm">
+          <Button variant="secondary">Archive</Button>
+          <Button>View deal</Button>
+        </Cluster>
+      </Stack>
+    </Card>
+  );
+}`}
       >
         <Card padding="md" style={{ maxWidth: 480 }}>
           <Stack gap="md">
@@ -78,11 +102,29 @@ export function CardDemo() {
       <Example
         title="Tone-coded cards (left stripe)"
         description="Five tones: accent / info / success / warning / danger. Each draws a 3px left-edge stripe in the tone color. The border-left is always reserved (transparent) so toggling tone never shifts layout."
-        code={`<Card padding="md" tone="accent">Accent</Card>
-<Card padding="md" tone="info">Info</Card>
-<Card padding="md" tone="success">Success</Card>
-<Card padding="md" tone="warning">Warning</Card>
-<Card padding="md" tone="danger">Danger</Card>`}
+        code={`import { Card, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm" align="start" wrap>
+      <Card padding="md" style={{ minWidth: 120 }} tone="accent">
+        Accent
+      </Card>
+      <Card padding="md" style={{ minWidth: 120 }} tone="info">
+        Info
+      </Card>
+      <Card padding="md" style={{ minWidth: 120 }} tone="success">
+        Success
+      </Card>
+      <Card padding="md" style={{ minWidth: 120 }} tone="warning">
+        Warning
+      </Card>
+      <Card padding="md" style={{ minWidth: 120 }} tone="danger">
+        Danger
+      </Card>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" align="start" wrap>
           <Card padding="md" style={{ minWidth: 120 }} tone="accent">
@@ -106,10 +148,45 @@ export function CardDemo() {
       <Example
         title="Padding=none with header + list"
         description="When the card contains a list or table, use padding='none' and let the inner sections control their own padding."
-        code={`<Card padding="none">
-  <div className={styles.cardHeader}>...</div>
-  <ul className={styles.list}>...</ul>
-</Card>`}
+        code={`import { Avatar, Card } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Card padding="none" style={{ maxWidth: 480 }}>
+      <div
+        style={{
+          padding: '12px 16px',
+          borderBottom: '1px solid var(--color-border)',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <strong>Owners</strong>
+        <a href="#" onClick={(e) => e.preventDefault()} style={{ fontSize: 13 }}>
+          Manage
+        </a>
+      </div>
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+        {['Alex Rivera', 'Jordan Park', 'Sam Chen'].map((name) => (
+          <li
+            key={name}
+            style={{
+              display: 'flex',
+              gap: 12,
+              padding: '12px 16px',
+              borderBottom: '1px solid var(--color-border)',
+              alignItems: 'center',
+            }}
+          >
+            <Avatar name={name} size="sm" />
+            <span>{name}</span>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}`}
       >
         <Card padding="none" style={{ maxWidth: 480 }}>
           <div
@@ -149,46 +226,62 @@ export function CardDemo() {
       <Example
         title="Section card: header + list body"
         description="The canonical Dashboard pattern. No padding prop needed — when Card.Header / Card.List / Card.ListRow appear as direct children, padding auto-defaults to 'none' so the header and rows bleed to the card edge."
-        code={`<Card>
-  <Card.Header action={<Link as={RouterLink} to="/deals">View all</Link>}>
-    Deals needing attention
-  </Card.Header>
-  <Card.List>
-    <Card.ListRow>
-      <Stack gap="xs">
-        <Cluster gap="sm">
-          <span>Acme team plan upgrade</span>
-          <Badge tone="warning">At risk</Badge>
-        </Cluster>
-        <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
-          Acme Inc · $12,000
-        </span>
-      </Stack>
-      <Avatar name="Alex Rivera" size="sm" />
-    </Card.ListRow>
-    <Card.ListRow>
-      <Stack gap="xs">
-        <Cluster gap="sm">
-          <span>Multi-region rollout</span>
-          <Badge tone="info">In progress</Badge>
-        </Cluster>
-        <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
-          Globex · $28,500
-        </span>
-      </Stack>
-      <Avatar name="Jordan Park" size="sm" />
-    </Card.ListRow>
-    <Card.ListRow>
-      <Stack gap="xs">
-        <span>Pilot conversion</span>
-        <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
-          Initech · $6,200
-        </span>
-      </Stack>
-      <Avatar name="Sam Chen" size="sm" />
-    </Card.ListRow>
-  </Card.List>
-</Card>`}
+        code={`import { Avatar, Badge, Card, Cluster, Link, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Card style={{ maxWidth: 480 }}>
+      <Card.Header
+        action={
+          <Link href="#" onClick={(e) => e.preventDefault()}>
+            View all
+          </Link>
+        }
+      >
+        Deals needing attention
+      </Card.Header>
+      <Card.List>
+        <Card.ListRow>
+          <Stack gap="xs">
+            <Cluster gap="sm">
+              <span style={{ fontWeight: 'var(--font-weight-medium)' }}>
+                Acme team plan upgrade
+              </span>
+              <Badge tone="warning">At risk</Badge>
+            </Cluster>
+            <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+              Acme Inc · $12,000
+            </span>
+          </Stack>
+          <Avatar name="Alex Rivera" size="sm" />
+        </Card.ListRow>
+        <Card.ListRow>
+          <Stack gap="xs">
+            <Cluster gap="sm">
+              <span style={{ fontWeight: 'var(--font-weight-medium)' }}>
+                Multi-region rollout
+              </span>
+              <Badge tone="info">In progress</Badge>
+            </Cluster>
+            <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+              Globex · $28,500
+            </span>
+          </Stack>
+          <Avatar name="Jordan Park" size="sm" />
+        </Card.ListRow>
+        <Card.ListRow>
+          <Stack gap="xs">
+            <span style={{ fontWeight: 'var(--font-weight-medium)' }}>Pilot conversion</span>
+            <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+              Initech · $6,200
+            </span>
+          </Stack>
+          <Avatar name="Sam Chen" size="sm" />
+        </Card.ListRow>
+      </Card.List>
+    </Card>
+  );
+}`}
       >
         <Card style={{ maxWidth: 480 }}>
           <Card.Header
@@ -245,44 +338,56 @@ export function CardDemo() {
       <Example
         title="Header without action"
         description="When there's no navigation link, omit the action prop. The title still gets the bottom-border separator and proper heading semantics."
-        code={`<Card>
-  <Card.Header>Recent activity</Card.Header>
-  <Card.List>
-    <Card.ListRow>
-      <Cluster gap="sm" wrap={false} align="start">
-        <Avatar name="Priya Shah" size="sm" />
-        <Stack gap="xs">
-          <span><strong>Priya Shah</strong> replied to your email</span>
-          <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
-            12m ago
-          </span>
-        </Stack>
-      </Cluster>
-    </Card.ListRow>
-    <Card.ListRow>
-      <Cluster gap="sm" wrap={false} align="start">
-        <Avatar name="Jordan Park" size="sm" />
-        <Stack gap="xs">
-          <span><strong>Jordan Park</strong> moved a deal to Proposal</span>
-          <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
-            1h ago
-          </span>
-        </Stack>
-      </Cluster>
-    </Card.ListRow>
-    <Card.ListRow>
-      <Cluster gap="sm" wrap={false} align="start">
-        <Avatar name="Diana Okafor" size="sm" />
-        <Stack gap="xs">
-          <span><strong>Diana Okafor</strong> booked a demo</span>
-          <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
-            3h ago
-          </span>
-        </Stack>
-      </Cluster>
-    </Card.ListRow>
-  </Card.List>
-</Card>`}
+        code={`import { Avatar, Card, Cluster, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Card style={{ maxWidth: 480 }}>
+      <Card.Header>Recent activity</Card.Header>
+      <Card.List>
+        <Card.ListRow>
+          <Cluster gap="sm" wrap={false} align="start">
+            <Avatar name="Priya Shah" size="sm" />
+            <Stack gap="xs">
+              <span style={{ fontSize: 'var(--font-size-sm)' }}>
+                <strong>Priya Shah</strong> replied to your email
+              </span>
+              <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+                12m ago
+              </span>
+            </Stack>
+          </Cluster>
+        </Card.ListRow>
+        <Card.ListRow>
+          <Cluster gap="sm" wrap={false} align="start">
+            <Avatar name="Jordan Park" size="sm" />
+            <Stack gap="xs">
+              <span style={{ fontSize: 'var(--font-size-sm)' }}>
+                <strong>Jordan Park</strong> moved a deal to Proposal
+              </span>
+              <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+                1h ago
+              </span>
+            </Stack>
+          </Cluster>
+        </Card.ListRow>
+        <Card.ListRow>
+          <Cluster gap="sm" wrap={false} align="start">
+            <Avatar name="Diana Okafor" size="sm" />
+            <Stack gap="xs">
+              <span style={{ fontSize: 'var(--font-size-sm)' }}>
+                <strong>Diana Okafor</strong> booked a demo
+              </span>
+              <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-subtle)' }}>
+                3h ago
+              </span>
+            </Stack>
+          </Cluster>
+        </Card.ListRow>
+      </Card.List>
+    </Card>
+  );
+}`}
       >
         <Card style={{ maxWidth: 480 }}>
           <Card.Header>Recent activity</Card.Header>

--- a/packages/playground/src/pages/components/CheckboxDemo.tsx
+++ b/packages/playground/src/pages/components/CheckboxDemo.tsx
@@ -140,7 +140,11 @@ export function CheckboxDemo() {
       <Example
         title="Default"
         description="Uncontrolled, with a label. The whole label is the click target."
-        code={`<Checkbox label="I agree to the terms" />`}
+        code={`import { Checkbox } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Checkbox label="I agree to the terms" />;
+}`}
       >
         <InputExample>
           <Checkbox label="I agree to the terms" />
@@ -150,9 +154,17 @@ export function CheckboxDemo() {
       <Example
         title="Sizes"
         description="Three sizes — sm (14px box / font-size-sm) / md (16px / font-size-md, default) / lg (20px / font-size-lg). Same scale as <Input>."
-        code={`<Checkbox size="sm" label="Small" />
-<Checkbox size="md" label="Medium" />
-<Checkbox size="lg" label="Large" />`}
+        code={`import { Checkbox, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Checkbox size="sm" label="Small" defaultChecked />
+      <Checkbox size="md" label="Medium" defaultChecked />
+      <Checkbox size="lg" label="Large" defaultChecked />
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="sm">
@@ -166,8 +178,20 @@ export function CheckboxDemo() {
       <Example
         title="Controlled"
         description="Provide `checked` + `onChange`. The handler receives `(nextChecked, event)`."
-        code={`const [agreed, setAgreed] = useState(false);
-<Checkbox checked={agreed} onChange={setAgreed} label="I agree" />`}
+        code={`import { useState } from 'react';
+import { Checkbox, Stack } from '@eocrm/design-system';
+
+export function ControlledDemo() {
+  const [agreed, setAgreed] = useState(false);
+  return (
+    <Stack gap="xs">
+      <Checkbox checked={agreed} onChange={setAgreed} label="I agree to the terms" />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        agreed = {String(agreed)}
+      </code>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <ControlledDemo />
@@ -177,12 +201,55 @@ export function CheckboxDemo() {
       <Example
         title="Indeterminate (select-all pattern)"
         description="When some-but-not-all child checkboxes are selected, the parent renders an indeterminate dash. Clicking the parent in indeterminate state toggles to checked → consumer responds by selecting all."
-        code={`<Checkbox
-  checked={allChecked}
-  indeterminate={someChecked}
-  onChange={(next) => toggleAll(next)}
-  label="Select all"
-/>`}
+        code={`import { useMemo, useState } from 'react';
+import { Checkbox, Stack } from '@eocrm/design-system';
+
+const TEAM = ['Alex', 'Priya', 'Tom', 'Sara', 'Jaden'];
+
+export function IndeterminateDemo() {
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+  const selectedCount = useMemo(
+    () => Object.values(selected).filter(Boolean).length,
+    [selected],
+  );
+  const allChecked = selectedCount === TEAM.length;
+  const someChecked = selectedCount > 0 && !allChecked;
+
+  function toggleAll(next: boolean) {
+    const map: Record<string, boolean> = {};
+    if (next) for (const name of TEAM) map[name] = true;
+    setSelected(map);
+  }
+
+  function toggleOne(name: string, next: boolean) {
+    setSelected((prev) => ({ ...prev, [name]: next }));
+  }
+
+  return (
+    <Stack gap="sm">
+      <Checkbox
+        checked={allChecked}
+        indeterminate={someChecked}
+        onChange={toggleAll}
+        label={
+          <strong>
+            Select all ({selectedCount} of {TEAM.length})
+          </strong>
+        }
+      />
+      <Stack gap="xs" style={{ paddingLeft: 'var(--space-5)' }}>
+        {TEAM.map((name) => (
+          <Checkbox
+            key={name}
+            checked={!!selected[name]}
+            onChange={(next) => toggleOne(name, next)}
+            label={name}
+          />
+        ))}
+      </Stack>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <IndeterminateDemo />
@@ -192,8 +259,16 @@ export function CheckboxDemo() {
       <Example
         title="Disabled"
         description="The native `disabled` attribute is forwarded — click is blocked and the box mutes."
-        code={`<Checkbox disabled defaultChecked label="Locked (checked)" />
-<Checkbox disabled label="Locked (unchecked)" />`}
+        code={`import { Checkbox, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs">
+      <Checkbox disabled defaultChecked label="Locked (checked)" />
+      <Checkbox disabled label="Locked (unchecked)" />
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="xs">
@@ -206,8 +281,21 @@ export function CheckboxDemo() {
       <Example
         title="Invalid"
         description="`invalid` adds the danger border + sets `aria-invalid='true'`. Pair with a visible error message and `aria-describedby`."
-        code={`<Checkbox invalid required aria-describedby="terms-error" label="Accept terms" />
-<p id="terms-error">You must accept to continue.</p>`}
+        code={`import { Checkbox, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs">
+      <Checkbox invalid required aria-describedby="terms-error" label="Accept terms" />
+      <p
+        id="terms-error"
+        style={{ color: 'var(--color-danger)', fontSize: 'var(--font-size-xs)' }}
+      >
+        You must accept to continue.
+      </p>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="xs">
@@ -225,7 +313,11 @@ export function CheckboxDemo() {
       <Example
         title="No label (icon-only)"
         description="Omit `label` for icon-only checkboxes (e.g., a DataTable row selector). Always pair with `aria-label`."
-        code={`<Checkbox aria-label="Select row" />`}
+        code={`import { Checkbox } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Checkbox aria-label="Select row" />;
+}`}
       >
         <InputExample>
           <Checkbox aria-label="Select row" />
@@ -235,9 +327,48 @@ export function CheckboxDemo() {
       <Example
         title='Color tagging (color="palette-name")'
         description="Optional `color` prop tints the checked / indeterminate fill with a palette color. Use to visually group checkboxes by team / category / status. Focus ring and hover stay accent-colored."
-        code={`<Checkbox color="violet" label="Marketing" />
-<Checkbox color="teal" label="Engineering" />
-<Checkbox color="amber" label="Sales" />`}
+        code={`import { useState } from 'react';
+import { Checkbox, Stack, Text, type PaletteColor } from '@eocrm/design-system';
+
+const TEAM_COLORS: { team: string; color: PaletteColor }[] = [
+  { team: 'Marketing', color: 'violet' },
+  { team: 'Engineering', color: 'teal' },
+  { team: 'Sales', color: 'amber' },
+  { team: 'Support', color: 'rose' },
+  { team: 'Design', color: 'fuchsia' },
+  { team: 'Operations', color: 'slate' },
+];
+
+export function ColorDemo() {
+  const [teams, setTeams] = useState<Record<string, boolean>>({
+    Marketing: true,
+    Engineering: true,
+    Sales: false,
+    Support: false,
+    Design: true,
+    Operations: false,
+  });
+  return (
+    <Stack gap="sm" align="start">
+      {TEAM_COLORS.map(({ team, color }) => (
+        <Checkbox
+          key={team}
+          color={color}
+          label={team}
+          checked={teams[team] ?? false}
+          onChange={(next) => setTeams((prev) => ({ ...prev, [team]: next }))}
+        />
+      ))}
+      <Text size="sm" tone="muted">
+        Selected:{' '}
+        {Object.entries(teams)
+          .filter(([, v]) => v)
+          .map(([k]) => k)
+          .join(', ') || 'none'}
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <InputExample width={280}>
           <ColorDemo />
@@ -247,14 +378,36 @@ export function CheckboxDemo() {
       <Example
         title="Form integration"
         description="`name` + `value` round-trip through native FormData. Same-`name` checkboxes group via `FormData.getAll(name)`."
-        code={`<form>
-  <Checkbox name="notify" value="email" defaultChecked label="Email" />
-  <Checkbox name="notify" value="sms" label="SMS" />
-  <Checkbox name="notify" value="push" label="Push" />
-  <button type="submit">Submit</button>
-</form>
+        code={`import { useState } from 'react';
+import { Button, Checkbox, Stack } from '@eocrm/design-system';
 
-// On submit: const values = new FormData(form).getAll('notify');`}
+export function FormDemo() {
+  const [submitted, setSubmitted] = useState<string | null>(null);
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const fd = new FormData(e.currentTarget);
+        const values = fd.getAll('notify');
+        setSubmitted(values.length ? values.join(', ') : '(none)');
+      }}
+    >
+      <Stack gap="xs">
+        <Checkbox name="notify" value="email" defaultChecked label="Email" />
+        <Checkbox name="notify" value="sms" label="SMS" />
+        <Checkbox name="notify" value="push" label="Push" />
+        <Button type="submit" size="sm">
+          Submit
+        </Button>
+        {submitted !== null && (
+          <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+            notify = {submitted}
+          </code>
+        )}
+      </Stack>
+    </form>
+  );
+}`}
       >
         <InputExample>
           <FormDemo />

--- a/packages/playground/src/pages/components/CircularProgressDemo.tsx
+++ b/packages/playground/src/pages/components/CircularProgressDemo.tsx
@@ -18,9 +18,17 @@ export function CircularProgressDemo() {
       <Example
         title="Sizes"
         description="Three diameters with proportional stroke. `sm` is 16px (inline next to a button), `md` is 32px (default), `lg` is 56px (page-level)."
-        code={`<CircularProgress size="sm" value={45} />
-<CircularProgress size="md" value={45} />
-<CircularProgress size="lg" value={45} />`}
+        code={`import { CircularProgress, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      <CircularProgress size="sm" value={45} />
+      <CircularProgress size="md" value={45} />
+      <CircularProgress size="lg" value={45} />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           <CircularProgress size="sm" value={45} />
@@ -32,10 +40,18 @@ export function CircularProgressDemo() {
       <Example
         title="Tones"
         description="Same vocabulary as <Progress> — default / success / warning / danger. Stroke color only; the track stays muted."
-        code={`<CircularProgress value={80} />
-<CircularProgress value={80} tone="success" />
-<CircularProgress value={80} tone="warning" />
-<CircularProgress value={80} tone="danger" />`}
+        code={`import { CircularProgress, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      <CircularProgress value={80} />
+      <CircularProgress value={80} tone="success" />
+      <CircularProgress value={80} tone="warning" />
+      <CircularProgress value={80} tone="danger" />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           <CircularProgress value={80} />
@@ -48,9 +64,17 @@ export function CircularProgressDemo() {
       <Example
         title="Indeterminate — the spinner use case"
         description="Omit `value` to spin. This is the canonical inline loading affordance — use `size='sm'` next to a button, `size='md'` near a heading, `size='lg'` as a centered page-loader."
-        code={`<CircularProgress size="sm" />
-<CircularProgress size="md" />
-<CircularProgress size="lg" />`}
+        code={`import { CircularProgress, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      <CircularProgress size="sm" />
+      <CircularProgress size="md" />
+      <CircularProgress size="lg" />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           <CircularProgress size="sm" />
@@ -62,9 +86,26 @@ export function CircularProgressDemo() {
       <Example
         title="Labels"
         description="`label={true}` shows {n}% centered. Auto-suppressed at `size='sm'` (no room for text) AND when `label=true` on indeterminate. ReactNode labels render in both modes (still suppressed at sm)."
-        code={`<CircularProgress size="md" value={75} label />
-<CircularProgress size="lg" value={75} label />
-<CircularProgress size="sm" value={75} label />  {/* label auto-suppressed */}`}
+        code={`import { CircularProgress, Cluster, Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      <Stack gap="xs" align="center">
+        <CircularProgress size="md" value={75} label />
+        <Text size="xs" tone="muted">md + label</Text>
+      </Stack>
+      <Stack gap="xs" align="center">
+        <CircularProgress size="lg" value={75} label />
+        <Text size="xs" tone="muted">lg + label</Text>
+      </Stack>
+      <Stack gap="xs" align="center">
+        <CircularProgress size="sm" value={75} label />
+        <Text size="xs" tone="muted">sm (label suppressed)</Text>
+      </Stack>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           <Stack gap="xs" align="center">
@@ -91,10 +132,16 @@ export function CircularProgressDemo() {
       <Example
         title="Inline with a button — the canonical 'Saving…' pattern"
         description="A tight loading indicator next to an action trigger. Use `aria-label` to tell SR users what the spinner means."
-        code={`<Cluster gap="sm" align="center">
-  <Button disabled>Save</Button>
-  <CircularProgress size="sm" aria-label="Saving" />
-</Cluster>`}
+        code={`import { Button, CircularProgress, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm" align="center">
+      <Button disabled>Save</Button>
+      <CircularProgress size="sm" aria-label="Saving" />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" align="center">
           <Button disabled>Save</Button>

--- a/packages/playground/src/pages/components/ClusterDemo.tsx
+++ b/packages/playground/src/pages/components/ClusterDemo.tsx
@@ -33,10 +33,51 @@ export function ClusterDemo() {
       <Example
         title="Justify (main-axis)"
         description="Controls horizontal distribution. between is the toolbar pattern: title on left, actions on right."
-        code={`<Cluster justify="start">…</Cluster>
-<Cluster justify="center">…</Cluster>
-<Cluster justify="end">…</Cluster>
-<Cluster justify="between">…</Cluster>`}
+        code={`import type { ReactNode } from 'react';
+import { Cluster, Stack } from '@eocrm/design-system';
+
+const Block = ({ children }: { children: ReactNode }) => (
+  <div
+    style={{
+      padding: '6px 12px',
+      background: 'var(--color-accent-subtle-bg)',
+      color: 'var(--color-accent)',
+      borderRadius: 'var(--radius-sm)',
+      fontWeight: 500,
+      fontSize: 'var(--font-size-sm)',
+    }}
+  >
+    {children}
+  </div>
+);
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      {(['start', 'center', 'end', 'between'] as const).map((j) => (
+        <div key={j}>
+          <div
+            style={{
+              fontSize: 'var(--font-size-xs)',
+              color: 'var(--color-fg-subtle)',
+              marginBottom: 6,
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+              fontWeight: 600,
+            }}
+          >
+            justify={j}
+          </div>
+          <Cluster gap="sm" justify={j}>
+            <Block>One</Block>
+            <Block>Two</Block>
+            <Block>Three</Block>
+          </Cluster>
+        </div>
+      ))}
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           {(['start', 'center', 'end', 'between'] as const).map((j) => (
@@ -66,10 +107,16 @@ export function ClusterDemo() {
       <Example
         title="Form footer (most common pattern)"
         description="Cluster with justify='end' is the canonical form footer / modal footer."
-        code={`<Cluster justify="end" gap="sm">
-  <Button variant="secondary">Cancel</Button>
-  <Button>Save</Button>
-</Cluster>`}
+        code={`import { Button, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster justify="end" gap="sm">
+      <Button variant="secondary">Cancel</Button>
+      <Button>Save changes</Button>
+    </Cluster>
+  );
+}`}
       >
         <Cluster justify="end" gap="sm" className={outlineStyles.outlined}>
           <Button variant="secondary">Cancel</Button>
@@ -80,13 +127,19 @@ export function ClusterDemo() {
       <Example
         title="Toolbar (justify='between')"
         description="Title on the left, actions on the right. Each side can be its own cluster."
-        code={`<Cluster justify="between" gap="md">
-  <h2>Users</h2>
-  <Cluster gap="sm">
-    <Button variant="secondary">Filter</Button>
-    <Button>Add user</Button>
-  </Cluster>
-</Cluster>`}
+        code={`import { Button, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster justify="between" gap="md">
+      <h2 style={{ margin: 0 }}>Users</h2>
+      <Cluster gap="sm">
+        <Button variant="secondary">Filter</Button>
+        <Button>Add user</Button>
+      </Cluster>
+    </Cluster>
+  );
+}`}
       >
         <Cluster justify="between" gap="md" className={outlineStyles.outlined}>
           <h2 style={{ margin: 0 }}>Users</h2>
@@ -100,9 +153,23 @@ export function ClusterDemo() {
       <Example
         title="Tag list (wrap=true, default)"
         description="When the container is narrow, items wrap to the next line. This is the default behavior."
-        code={`<Cluster gap="xs">
-  {tags.map(t => <Badge tone={t.tone}>{t.label}</Badge>)}
-</Cluster>`}
+        code={`import { Badge, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <Cluster gap="xs">
+        <Badge tone="purple">Enterprise</Badge>
+        <Badge tone="info">Pipeline 2026</Badge>
+        <Badge tone="success">Champion</Badge>
+        <Badge tone="warning">Renewal</Badge>
+        <Badge tone="danger">At risk</Badge>
+        <Badge tone="neutral">SMB</Badge>
+        <Badge tone="neutral">North America</Badge>
+      </Cluster>
+    </div>
+  );
+}`}
       >
         <div style={{ maxWidth: 360 }}>
           <Cluster gap="xs" className={outlineStyles.outlined}>
@@ -120,10 +187,16 @@ export function ClusterDemo() {
       <Example
         title="wrap={false}"
         description="When you need items to stay on one line (e.g. inside a narrow table cell). Use sparingly — set wrap=false when overflow is more acceptable than wrapping."
-        code={`<Cluster gap="xs" wrap={false}>
-  <Button variant="ghost" size="sm">Resend</Button>
-  <Button variant="ghost" size="sm">Revoke</Button>
-</Cluster>`}
+        code={`import { Button, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="xs" wrap={false}>
+      <Button variant="ghost" size="sm">Resend</Button>
+      <Button variant="ghost" size="sm">Revoke</Button>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="xs" wrap={false} className={outlineStyles.outlined}>
           <Button variant="ghost" size="sm">

--- a/packages/playground/src/pages/components/CodeDemo.tsx
+++ b/packages/playground/src/pages/components/CodeDemo.tsx
@@ -17,8 +17,20 @@ export function CodeDemo() {
       <Example
         title="Inline inside text"
         description="The default chip — used as part of a sentence."
-        code={`<Text>The variable <Code>userId</Code> is required.</Text>
-<Text>Use <Code>npm install</Code> to add a dependency.</Text>`}
+        code={`import { Code, Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs">
+      <Text>
+        The variable <Code>userId</Code> is required.
+      </Text>
+      <Text>
+        Use <Code>npm install</Code> to add a dependency.
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="xs">
           <Text>
@@ -33,10 +45,18 @@ export function CodeDemo() {
       <Example
         title="Tones"
         description="Four tones change only the text color — the chip background stays the same."
-        code={`<Code tone="default">default()</Code>
-<Code tone="muted">muted()</Code>
-<Code tone="accent">accent()</Code>
-<Code tone="danger">danger()</Code>`}
+        code={`import { Cluster, Code } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <Code tone="default">default()</Code>
+      <Code tone="muted">muted()</Code>
+      <Code tone="accent">accent()</Code>
+      <Code tone="danger">danger()</Code>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm">
           <Code tone="default">default()</Code>
@@ -49,7 +69,11 @@ export function CodeDemo() {
       <Example
         title="Standalone"
         description="A <Code> outside a surrounding <Text>. The chip uses var(--font-size-code), which is 0.92em — so a standalone Code inherits the document's base font-size and scales accordingly."
-        code={`<Code>fetch('/api/users')</Code>`}
+        code={`import { Code } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Code>fetch('/api/users')</Code>;
+}`}
       >
         <Code>fetch('/api/users')</Code>
       </Example>

--- a/packages/playground/src/pages/components/ColorPickerDemo.tsx
+++ b/packages/playground/src/pages/components/ColorPickerDemo.tsx
@@ -93,9 +93,19 @@ export function ColorPickerDemo() {
       <Example
         title="Inline panel, no presets"
         description="The bare picker — <ColorPicker.Panel> renders directly without a popover wrapping. Use this for theme builders and settings rows where the picker is always visible."
-        code={`function InlineNoPresets() {
+        code={`import { useState } from 'react';
+import { Code, ColorPicker, Stack, Text } from '@eocrm/design-system';
+
+export function InlineNoPresets() {
   const [hex, setHex] = useState('#4F46E5');
-  return <ColorPicker.Panel value={hex} onChange={setHex} />;
+  return (
+    <Stack gap="sm">
+      <ColorPicker.Panel value={hex} onChange={setHex} />
+      <Text size="sm" tone="muted">
+        Value: <Code>{hex}</Code>
+      </Text>
+    </Stack>
+  );
 }`}
       >
         <InlineNoPresets />
@@ -104,7 +114,20 @@ export function ColorPickerDemo() {
       <Example
         title="Popover with default trigger"
         description="The canonical CRM form-field shape. Default trigger is an input-styled button with a 16×16 color swatch and the uppercase HEX. triggerLabel customizes the accessible label."
-        code={`<ColorPicker value={hex} onChange={setHex} triggerLabel="Brand color" />`}
+        code={`import { useState } from 'react';
+import { Code, ColorPicker, Stack, Text } from '@eocrm/design-system';
+
+export function PopoverDefaultTrigger() {
+  const [hex, setHex] = useState('#10B981');
+  return (
+    <Stack gap="sm" align="start">
+      <ColorPicker value={hex} onChange={setHex} triggerLabel="Brand color" />
+      <Text size="sm" tone="muted">
+        Value: <Code>{hex}</Code>
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <PopoverDefaultTrigger />
       </Example>
@@ -112,11 +135,24 @@ export function ColorPickerDemo() {
       <Example
         title="Popover with custom trigger"
         description="Override the default trigger via <ColorPicker.Trigger asChild>. The child must forwardRef — <Popover.Trigger> clones it to inject the click handler + aria-*."
-        code={`<ColorPicker value={hex} onChange={setHex}>
-  <ColorPicker.Trigger asChild>
-    <Button variant="secondary">Pick a color ({hex})</Button>
-  </ColorPicker.Trigger>
-</ColorPicker>`}
+        code={`import { useState } from 'react';
+import { Button, Code, ColorPicker, Stack, Text } from '@eocrm/design-system';
+
+export function PopoverCustomTrigger() {
+  const [hex, setHex] = useState('#F59E0B');
+  return (
+    <Stack gap="sm" align="start">
+      <ColorPicker value={hex} onChange={setHex}>
+        <ColorPicker.Trigger asChild>
+          <Button variant="secondary">Pick a color ({hex})</Button>
+        </ColorPicker.Trigger>
+      </ColorPicker>
+      <Text size="sm" tone="muted">
+        Value: <Code>{hex}</Code>
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <PopoverCustomTrigger />
       </Example>
@@ -124,11 +160,31 @@ export function ColorPickerDemo() {
       <Example
         title="Inline with consumer-supplied presets"
         description="Pass `presets={[...]}` to render a swatch grid below the hue slider. Clicking a swatch commits the color (fires both onChange and onChangeEnd). Selected swatch gets an inset ring + check overlay."
-        code={`<ColorPicker.Panel
-  value={hex}
-  onChange={setHex}
-  presets={['#4F46E5', '#10B981', '#F59E0B', '#EF4444', '#3B82F6', '#8B5CF6', '#EC4899', '#14B8A6']}
-/>`}
+        code={`import { useState } from 'react';
+import { Code, ColorPicker, Stack, Text } from '@eocrm/design-system';
+
+const BRAND_PRESETS = [
+  '#4F46E5',
+  '#10B981',
+  '#F59E0B',
+  '#EF4444',
+  '#3B82F6',
+  '#8B5CF6',
+  '#EC4899',
+  '#14B8A6',
+];
+
+export function InlineWithPresets() {
+  const [hex, setHex] = useState('#4F46E5');
+  return (
+    <Stack gap="sm">
+      <ColorPicker.Panel value={hex} onChange={setHex} presets={BRAND_PRESETS} />
+      <Text size="sm" tone="muted">
+        Value: <Code>{hex}</Code>
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <InlineWithPresets />
       </Example>
@@ -136,8 +192,18 @@ export function ColorPickerDemo() {
       <Example
         title="Disabled — both variants"
         description="Inline panel: dimmed, SV pad has aria-disabled and tabIndex=-1, slider + input + presets are all non-interactive. Popover: trigger is disabled, click doesn't open the panel."
-        code={`<ColorPicker.Panel value={hex} onChange={setHex} disabled />
-<ColorPicker value={hex} onChange={setHex} disabled triggerLabel="Locked" />`}
+        code={`import { useState } from 'react';
+import { Cluster, ColorPicker } from '@eocrm/design-system';
+
+export function DisabledDemo() {
+  const [hex, setHex] = useState('#4F46E5');
+  return (
+    <Cluster gap="md" align="start">
+      <ColorPicker.Panel value={hex} onChange={setHex} disabled />
+      <ColorPicker value={hex} onChange={setHex} disabled triggerLabel="Locked" />
+    </Cluster>
+  );
+}`}
       >
         <DisabledDemo />
       </Example>

--- a/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
+++ b/packages/playground/src/pages/components/ConfirmationPopoverDemo.tsx
@@ -22,13 +22,24 @@ export function ConfirmationPopoverDemo() {
       <Example
         title="Default variant — Archive"
         description="Sync onConfirm. Lighter-weight confirmation for non-destructive actions like archive or publish."
-        code={`<ConfirmationPopover
-  title="Archive this contact?"
-  description="You can unarchive later from the archive view."
-  onConfirm={() => archive(id)}
->
-  <Button variant="secondary">Archive</Button>
-</ConfirmationPopover>`}
+        code={`import { useState } from 'react';
+import { Button, Cluster, ConfirmationPopover } from '@eocrm/design-system';
+
+export function Demo() {
+  const [archiveCount, setArchiveCount] = useState(0);
+  return (
+    <Cluster gap="md" justify="center">
+      <ConfirmationPopover
+        title="Archive this contact?"
+        description="You can unarchive later from the archive view."
+        onConfirm={() => setArchiveCount((n) => n + 1)}
+      >
+        <Button variant="secondary">Archive</Button>
+      </ConfirmationPopover>
+      <span>Archived {archiveCount} time(s)</span>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <ConfirmationPopover
@@ -45,15 +56,26 @@ export function ConfirmationPopoverDemo() {
       <Example
         title="Danger variant — Delete"
         description="variant='danger' makes Confirm a danger button. Initial focus is on Cancel, so keyboard Enter never accidentally deletes."
-        code={`<ConfirmationPopover
-  title="Delete record?"
-  description="This action cannot be undone."
-  confirmLabel="Delete"
-  variant="danger"
-  onConfirm={() => deleteRecord(id)}
->
-  <Button variant="danger">Delete</Button>
-</ConfirmationPopover>`}
+        code={`import { useState } from 'react';
+import { Button, Cluster, ConfirmationPopover } from '@eocrm/design-system';
+
+export function Demo() {
+  const [deleteCount, setDeleteCount] = useState(0);
+  return (
+    <Cluster gap="md" justify="center">
+      <ConfirmationPopover
+        title="Delete record?"
+        description="This action cannot be undone."
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => setDeleteCount((n) => n + 1)}
+      >
+        <Button variant="danger">Delete</Button>
+      </ConfirmationPopover>
+      <span>Deleted {deleteCount} time(s)</span>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <ConfirmationPopover
@@ -72,14 +94,25 @@ export function ConfirmationPopoverDemo() {
       <Example
         title="Async success — pending spinner"
         description="onConfirm returns a Promise that resolves after 1.5s. While pending, both buttons disable, Confirm shows a spinner, and dismissal is blocked. On resolve the popover closes."
-        code={`<ConfirmationPopover
-  title="Submit?"
-  onConfirm={async () => {
-    await submitToServer();   // 1.5s
-  }}
->
-  <Button>Submit</Button>
-</ConfirmationPopover>`}
+        code={`import { Button, Cluster, ConfirmationPopover } from '@eocrm/design-system';
+
+const fakeDelay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <ConfirmationPopover
+        title="Submit?"
+        description="Simulated 1.5s server round-trip."
+        onConfirm={async () => {
+          await fakeDelay(1500);
+        }}
+      >
+        <Button>Submit</Button>
+      </ConfirmationPopover>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <ConfirmationPopover
@@ -97,15 +130,26 @@ export function ConfirmationPopoverDemo() {
       <Example
         title="Async failure — popover stays open"
         description="onConfirm returns a Promise that rejects after 1s. The popover stays open and buttons re-enable. The consumer is expected to surface the error externally (we just console.log here)."
-        code={`<ConfirmationPopover
-  title="Submit?"
-  onConfirm={async () => {
-    await fakeDelay(1000);
-    throw new Error('network down');
-  }}
->
-  <Button>Submit (will fail)</Button>
-</ConfirmationPopover>`}
+        code={`import { Button, Cluster, ConfirmationPopover } from '@eocrm/design-system';
+
+const fakeDelay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <ConfirmationPopover
+        title="Submit?"
+        description="Simulated server failure after 1s. Buttons re-enable; popover stays open."
+        onConfirm={async () => {
+          await fakeDelay(1000);
+          throw new Error('demo failure');
+        }}
+      >
+        <Button>Submit (will fail)</Button>
+      </ConfirmationPopover>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <ConfirmationPopover
@@ -124,26 +168,36 @@ export function ConfirmationPopoverDemo() {
       <Example
         title="Inside a DropdownMenu — kebab Delete"
         description="Wrap a <DropdownMenu.Item closeOnSelect={false}> as ConfirmationPopover's trigger. The Item IS the trigger, so the full highlighted row opens the confirmation. The menu stays open until the user dismisses it (Escape, click outside, or pick another item)."
-        code={`<DropdownMenu>
-  <DropdownMenu.Trigger>
-    <Button variant="ghost" aria-label="Row actions">⋯</Button>
-  </DropdownMenu.Trigger>
-  <DropdownMenu.Content align="end">
-    <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-    <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
-    <ConfirmationPopover
-      title="Delete record?"
-      description="This action cannot be undone."
-      variant="danger"
-      confirmLabel="Delete"
-      onConfirm={remove}
-    >
-      <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}} tone="danger">
-        Delete
-      </DropdownMenu.Item>
-    </ConfirmationPopover>
-  </DropdownMenu.Content>
-</DropdownMenu>`}
+        code={`import { Button, Cluster, ConfirmationPopover, DropdownMenu } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="ghost" aria-label="Row actions">
+            ⋯
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="end">
+          <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+          <ConfirmationPopover
+            title="Delete record?"
+            description="This action cannot be undone."
+            variant="danger"
+            confirmLabel="Delete"
+            onConfirm={() => {}}
+          >
+            <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}} tone="danger">
+              Delete
+            </DropdownMenu.Item>
+          </ConfirmationPopover>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <DropdownMenu>
@@ -174,25 +228,35 @@ export function ConfirmationPopoverDemo() {
       <Example
         title="Rename — focus a hosted input"
         description="Pass initialFocusRef to override the default Cancel focus and land focus on an <Input> rendered inside the description slot. The onFocus select-all means the user can type a replacement immediately — exactly the saved-views Rename flow."
-        code={`const renameRef = useRef<HTMLInputElement | null>(null);
+        code={`import { useRef, useState } from 'react';
+import { Button, Cluster, ConfirmationPopover, Input } from '@eocrm/design-system';
 
-<ConfirmationPopover
-  title="Rename view"
-  description={
-    <Input
-      ref={renameRef}
-      aria-label="View name"
-      value={viewName}
-      onChange={(e) => setViewName(e.target.value)}
-      onFocus={(e) => e.currentTarget.select()}
-    />
-  }
-  initialFocusRef={renameRef}
-  confirmLabel="Rename"
-  onConfirm={() => saveViewName(viewName)}
->
-  <Button variant="secondary">Rename…</Button>
-</ConfirmationPopover>`}
+export function Demo() {
+  const [viewName, setViewName] = useState('Untitled view');
+  const renameRef = useRef<HTMLInputElement | null>(null);
+  return (
+    <Cluster gap="md" justify="center">
+      <ConfirmationPopover
+        title="Rename view"
+        description={
+          <Input
+            ref={renameRef}
+            aria-label="View name"
+            value={viewName}
+            onChange={(e) => setViewName(e.target.value)}
+            onFocus={(e) => e.currentTarget.select()}
+          />
+        }
+        initialFocusRef={renameRef}
+        confirmLabel="Rename"
+        onConfirm={() => {}}
+      >
+        <Button variant="secondary">Rename…</Button>
+      </ConfirmationPopover>
+      <span>Current name: {viewName}</span>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <ConfirmationPopover

--- a/packages/playground/src/pages/components/ConstrainDemo.tsx
+++ b/packages/playground/src/pages/components/ConstrainDemo.tsx
@@ -14,9 +14,23 @@ export function ConstrainDemo() {
       <Example
         title="maxWidth scale"
         description="A named scale (xs 200 / sm 320 / md 448 / lg 640 / xl 800 / full) mapped to --measure-* tokens. Here, capping a full-width Input."
-        code={`<Constrain maxWidth="xs"><Input placeholder="xs" /></Constrain>
-<Constrain maxWidth="sm"><Input placeholder="sm" /></Constrain>
-<Constrain maxWidth="md"><Input placeholder="md" /></Constrain>`}
+        code={`import { Constrain, Input, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Constrain maxWidth="xs">
+        <Input placeholder="maxWidth xs (200)" />
+      </Constrain>
+      <Constrain maxWidth="sm">
+        <Input placeholder="maxWidth sm (320)" />
+      </Constrain>
+      <Constrain maxWidth="md">
+        <Input placeholder="maxWidth md (448)" />
+      </Constrain>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Constrain maxWidth="xs">
@@ -34,10 +48,20 @@ export function ConstrainDemo() {
       <Example
         title="flex='grow' — fill a row"
         description="Inside a Cluster, flex='grow' makes the box take the remaining space next to a fixed-size sibling."
-        code={`<Cluster wrap={false} gap="sm">
-  <Constrain flex="grow"><Progress value={62} /></Constrain>
-  <Button variant="secondary" size="sm">Upgrade plan</Button>
-</Cluster>`}
+        code={`import { Button, Cluster, Constrain, Progress } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster wrap={false} gap="sm">
+      <Constrain flex="grow">
+        <Progress value={62} />
+      </Constrain>
+      <Button variant="secondary" size="sm">
+        Upgrade plan
+      </Button>
+    </Cluster>
+  );
+}`}
       >
         <Cluster wrap={false} gap="sm">
           <Constrain flex="grow">
@@ -52,9 +76,15 @@ export function ConstrainDemo() {
       <Example
         title="minWidth floor"
         description="minWidth keeps a box from collapsing below a step."
-        code={`<Constrain minWidth="sm">
-  <Text>I'm at least 320px wide.</Text>
-</Constrain>`}
+        code={`import { Constrain, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Constrain minWidth="sm">
+      <Text>I'm at least 320px wide.</Text>
+    </Constrain>
+  );
+}`}
       >
         <Constrain minWidth="sm">
           <Text>I'm at least 320px wide.</Text>

--- a/packages/playground/src/pages/components/DataTableDemo.tsx
+++ b/packages/playground/src/pages/components/DataTableDemo.tsx
@@ -100,16 +100,6 @@ export function DataTableDemo() {
   );
 }
 
-// Shared columns snippet repeated in every example's `code` prop so the
-// "Show code" panel for each variant displays the full table instance setup,
-// not just the prop being demonstrated.
-const COLUMNS_SNIPPET = `const dealColumns: ColumnDef<Deal>[] = [
-  { id: 'name',   header: 'Deal',   cell: (r) => r.name, sortable: true, size: 200 },
-  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>, size: 140 },
-  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120 },
-  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner, size: 120 },
-];`;
-
 function BasicExample() {
   const [sort, setSort] = useState<SortState | null>(null);
   const sortedDeals = useClientSort(deals, sort);
@@ -124,19 +114,64 @@ function BasicExample() {
     <Example
       title="Basic"
       description="Default DataTable with sticky header, hover rows, resizable + reorderable columns, and click-to-sort on `Deal` / `Amount`. Hover a header to reveal the drag grip."
-      code={`${COLUMNS_SNIPPET}
+      code={`import { useMemo, useState } from 'react';
+import { Badge, DataTable, useDataTable, type ColumnDef, type SortState } from '@eocrm/design-system';
 
-const [sort, setSort] = useState<SortState | null>(null);
-const sortedDeals = useClientSort(deals, sort);
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
 
-const instance = useDataTable<Deal>({
-  data: sortedDeals,
-  columns: dealColumns,
-  getRowId: (r) => r.id,
-  sort, onSortChange: setSort,
-});
+const deals: Deal[] = [
+  { id: 'd1', name: 'Acme renewal',       stage: 'Negotiation', amount: 12000, owner: 'Sara'   },
+  { id: 'd2', name: 'Globex expansion',   stage: 'Lead',        amount:  4500, owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won',         amount:  8800, owner: 'Sara'   },
+  { id: 'd4', name: 'Hooli pilot',        stage: 'Lost',        amount:     0, owner: 'Jin'    },
+];
 
-return <DataTable instance={instance} aria-label="Deals" />;`}
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger'  as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info'    as const;
+  }
+}
+
+const dealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                              sortable: true, size: 200 },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,                  size: 140 },
+  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120 },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                             size: 120 },
+];
+
+function useClientSort<T>(data: T[], sort: SortState | null): T[] {
+  return useMemo(() => {
+    if (!sort) return data;
+    return [...data].sort((a, b) => {
+      const va = (a as Record<string, unknown>)[sort.columnId] as string | number;
+      const vb = (b as Record<string, unknown>)[sort.columnId] as string | number;
+      const cmp = va < vb ? -1 : va > vb ? 1 : 0;
+      return sort.direction === 'asc' ? cmp : -cmp;
+    });
+  }, [data, sort]);
+}
+
+export function Demo() {
+  const [sort, setSort] = useState<SortState | null>(null);
+  const sortedDeals = useClientSort(deals, sort);
+  const instance = useDataTable<Deal>({
+    data: sortedDeals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    sort,
+    onSortChange: setSort,
+  });
+  return <DataTable instance={instance} aria-label="Deals" />;
+}`}
     >
       <DataTable instance={instance} aria-label="Deals (basic)" />
     </Example>
@@ -157,19 +192,64 @@ function BorderedExample() {
     <Example
       title="Bordered"
       description="Pass `bordered` for a full grid of cell borders. Useful for data-dense numeric tables or surfaces without zebra striping."
-      code={`${COLUMNS_SNIPPET}
+      code={`import { useMemo, useState } from 'react';
+import { Badge, DataTable, useDataTable, type ColumnDef, type SortState } from '@eocrm/design-system';
 
-const [sort, setSort] = useState<SortState | null>(null);
-const sortedDeals = useClientSort(deals, sort);
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
 
-const instance = useDataTable<Deal>({
-  data: sortedDeals,
-  columns: dealColumns,
-  getRowId: (r) => r.id,
-  sort, onSortChange: setSort,
-});
+const deals: Deal[] = [
+  { id: 'd1', name: 'Acme renewal',       stage: 'Negotiation', amount: 12000, owner: 'Sara'   },
+  { id: 'd2', name: 'Globex expansion',   stage: 'Lead',        amount:  4500, owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won',         amount:  8800, owner: 'Sara'   },
+  { id: 'd4', name: 'Hooli pilot',        stage: 'Lost',        amount:     0, owner: 'Jin'    },
+];
 
-return <DataTable instance={instance} bordered aria-label="Deals" />;`}
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger'  as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info'    as const;
+  }
+}
+
+const dealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                              sortable: true, size: 200 },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,                  size: 140 },
+  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120 },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                             size: 120 },
+];
+
+function useClientSort<T>(data: T[], sort: SortState | null): T[] {
+  return useMemo(() => {
+    if (!sort) return data;
+    return [...data].sort((a, b) => {
+      const va = (a as Record<string, unknown>)[sort.columnId] as string | number;
+      const vb = (b as Record<string, unknown>)[sort.columnId] as string | number;
+      const cmp = va < vb ? -1 : va > vb ? 1 : 0;
+      return sort.direction === 'asc' ? cmp : -cmp;
+    });
+  }, [data, sort]);
+}
+
+export function Demo() {
+  const [sort, setSort] = useState<SortState | null>(null);
+  const sortedDeals = useClientSort(deals, sort);
+  const instance = useDataTable<Deal>({
+    data: sortedDeals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    sort,
+    onSortChange: setSort,
+  });
+  return <DataTable instance={instance} bordered aria-label="Deals" />;
+}`}
     >
       <DataTable instance={instance} bordered aria-label="Deals (bordered)" />
     </Example>
@@ -190,19 +270,64 @@ function DenseExample() {
     <Example
       title="Dense"
       description="`density='dense'` reduces row height and cell padding — useful for data-heavy screens where vertical space is at a premium."
-      code={`${COLUMNS_SNIPPET}
+      code={`import { useMemo, useState } from 'react';
+import { Badge, DataTable, useDataTable, type ColumnDef, type SortState } from '@eocrm/design-system';
 
-const [sort, setSort] = useState<SortState | null>(null);
-const sortedDeals = useClientSort(deals, sort);
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
 
-const instance = useDataTable<Deal>({
-  data: sortedDeals,
-  columns: dealColumns,
-  getRowId: (r) => r.id,
-  sort, onSortChange: setSort,
-});
+const deals: Deal[] = [
+  { id: 'd1', name: 'Acme renewal',       stage: 'Negotiation', amount: 12000, owner: 'Sara'   },
+  { id: 'd2', name: 'Globex expansion',   stage: 'Lead',        amount:  4500, owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won',         amount:  8800, owner: 'Sara'   },
+  { id: 'd4', name: 'Hooli pilot',        stage: 'Lost',        amount:     0, owner: 'Jin'    },
+];
 
-return <DataTable instance={instance} density="dense" aria-label="Deals" />;`}
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger'  as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info'    as const;
+  }
+}
+
+const dealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                              sortable: true, size: 200 },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,                  size: 140 },
+  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120 },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                             size: 120 },
+];
+
+function useClientSort<T>(data: T[], sort: SortState | null): T[] {
+  return useMemo(() => {
+    if (!sort) return data;
+    return [...data].sort((a, b) => {
+      const va = (a as Record<string, unknown>)[sort.columnId] as string | number;
+      const vb = (b as Record<string, unknown>)[sort.columnId] as string | number;
+      const cmp = va < vb ? -1 : va > vb ? 1 : 0;
+      return sort.direction === 'asc' ? cmp : -cmp;
+    });
+  }, [data, sort]);
+}
+
+export function Demo() {
+  const [sort, setSort] = useState<SortState | null>(null);
+  const sortedDeals = useClientSort(deals, sort);
+  const instance = useDataTable<Deal>({
+    data: sortedDeals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    sort,
+    onSortChange: setSort,
+  });
+  return <DataTable instance={instance} density="dense" aria-label="Deals" />;
+}`}
     >
       <DataTable instance={instance} density="dense" aria-label="Deals (dense)" />
     </Example>
@@ -225,22 +350,68 @@ function SortableExample() {
     <Example
       title="Server-driven sort (simulated)"
       description="The demo sorts on the client for illustration, but in real code your `onSortChange` callback would refetch from the server with the new sort. DataTable does not transform data — it only manages and emits sort state."
-      code={`${COLUMNS_SNIPPET}
+      code={`import { useMemo, useState } from 'react';
+import { Badge, DataTable, useDataTable, type ColumnDef, type SortState } from '@eocrm/design-system';
 
-const [sort, setSort] = useState<SortState | null>(null);
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
 
-// In real code: refetch from the server with { sort } on change.
-// Demo: sort on the client so the effect is visible without a backend.
-const sortedDeals = useClientSort(deals, sort);
+const deals: Deal[] = [
+  { id: 'd1', name: 'Acme renewal',       stage: 'Negotiation', amount: 12000, owner: 'Sara'   },
+  { id: 'd2', name: 'Globex expansion',   stage: 'Lead',        amount:  4500, owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won',         amount:  8800, owner: 'Sara'   },
+  { id: 'd4', name: 'Hooli pilot',        stage: 'Lost',        amount:     0, owner: 'Jin'    },
+];
 
-const instance = useDataTable<Deal>({
-  data: sortedDeals,
-  columns: dealColumns,
-  getRowId: (r) => r.id,
-  sort, onSortChange: setSort,
-});
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger'  as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info'    as const;
+  }
+}
 
-return <DataTable instance={instance} aria-label="Deals" />;`}
+const dealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                              sortable: true, size: 200 },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,                  size: 140 },
+  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120 },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                             size: 120 },
+];
+
+// In real code: replace this with a server fetch keyed on \`sort\`.
+// The hook below re-sorts on the client just so the demo is visible.
+function useClientSort<T>(data: T[], sort: SortState | null): T[] {
+  return useMemo(() => {
+    if (!sort) return data;
+    return [...data].sort((a, b) => {
+      const va = (a as Record<string, unknown>)[sort.columnId] as string | number;
+      const vb = (b as Record<string, unknown>)[sort.columnId] as string | number;
+      const cmp = va < vb ? -1 : va > vb ? 1 : 0;
+      return sort.direction === 'asc' ? cmp : -cmp;
+    });
+  }, [data, sort]);
+}
+
+export function Demo() {
+  const [sort, setSort] = useState<SortState | null>(null);
+  // In real code: refetch from the server with { sort } on change.
+  // Demo: sort on the client so the effect is visible without a backend.
+  const sortedDeals = useClientSort(deals, sort);
+  const instance = useDataTable<Deal>({
+    data: sortedDeals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    sort,
+    onSortChange: setSort,
+  });
+  return <DataTable instance={instance} aria-label="Deals" />;
+}`}
     >
       <DataTable instance={instance} aria-label="Deals (sortable)" />
     </Example>
@@ -269,24 +440,77 @@ function SelectableExample() {
     <Example
       title="Selection + row click"
       description="`enableRowSelection` adds a checkbox column. The header checkbox toggles all rows on the current page (indeterminate when partially selected). Clicking elsewhere on a row fires `onRowClick` — but clicking the checkbox does not."
-      code={`${COLUMNS_SNIPPET}
+      code={`import { useMemo, useState } from 'react';
+import { Badge, Cluster, DataTable, Stack, useDataTable, type ColumnDef, type SortState } from '@eocrm/design-system';
 
-const [selection, setSelection] = useState({});
-const [sort, setSort] = useState<SortState | null>(null);
-const sortedDeals = useClientSort(deals, sort);
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
 
-const instance = useDataTable<Deal>({
-  data: sortedDeals,
-  columns: dealColumns,
-  getRowId: (r) => r.id,
-  enableRowSelection: true,
-  rowSelection: selection,
-  onRowSelectionChange: setSelection,
-  sort, onSortChange: setSort,
-  onRowClick: (row) => navigate(\`/deals/\${row.id}\`),
-});
+const deals: Deal[] = [
+  { id: 'd1', name: 'Acme renewal',       stage: 'Negotiation', amount: 12000, owner: 'Sara'   },
+  { id: 'd2', name: 'Globex expansion',   stage: 'Lead',        amount:  4500, owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won',         amount:  8800, owner: 'Sara'   },
+  { id: 'd4', name: 'Hooli pilot',        stage: 'Lost',        amount:     0, owner: 'Jin'    },
+];
 
-return <DataTable instance={instance} aria-label="Deals" />;`}
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger'  as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info'    as const;
+  }
+}
+
+const dealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                              sortable: true, size: 200 },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,                  size: 140 },
+  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120 },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                             size: 120 },
+];
+
+function useClientSort<T>(data: T[], sort: SortState | null): T[] {
+  return useMemo(() => {
+    if (!sort) return data;
+    return [...data].sort((a, b) => {
+      const va = (a as Record<string, unknown>)[sort.columnId] as string | number;
+      const vb = (b as Record<string, unknown>)[sort.columnId] as string | number;
+      const cmp = va < vb ? -1 : va > vb ? 1 : 0;
+      return sort.direction === 'asc' ? cmp : -cmp;
+    });
+  }, [data, sort]);
+}
+
+export function Demo() {
+  const [selection, setSelection] = useState<Record<string, boolean>>({});
+  const selectedCount = Object.keys(selection).length;
+  const [sort, setSort] = useState<SortState | null>(null);
+  const sortedDeals = useClientSort(deals, sort);
+  const instance = useDataTable<Deal>({
+    data: sortedDeals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    enableRowSelection: true,
+    rowSelection: selection,
+    onRowSelectionChange: setSelection,
+    sort,
+    onSortChange: setSort,
+    onRowClick: (row) => alert(\`Row clicked: \${row.name}\`),
+  });
+  return (
+    <Stack gap="sm">
+      <Cluster gap="sm">
+        <span>{selectedCount} selected</span>
+      </Cluster>
+      <DataTable instance={instance} aria-label="Deals" />
+    </Stack>
+  );
+}`}
     >
       <Stack gap="sm">
         <Cluster gap="sm">
@@ -314,27 +538,81 @@ function VisibilityExample() {
     <Example
       title="Column visibility"
       description="`ColumnVisibilityTrigger` renders a Button → DropdownMenu of CheckboxItems for every column where `enableHide` is not false. The last visible hidable column is disabled — DataTable always shows at least one data column."
-      code={`${COLUMNS_SNIPPET}
+      code={`import { useMemo, useState } from 'react';
+import {
+  Badge,
+  Cluster,
+  ColumnVisibilityTrigger,
+  DataTable,
+  Stack,
+  useDataTable,
+  type ColumnDef,
+  type SortState,
+} from '@eocrm/design-system';
 
-const [sort, setSort] = useState<SortState | null>(null);
-const sortedDeals = useClientSort(deals, sort);
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
 
-const instance = useDataTable<Deal>({
-  data: sortedDeals,
-  columns: dealColumns,
-  getRowId: (r) => r.id,
-  defaultColumnVisibility: { owner: false },
-  sort, onSortChange: setSort,
-});
+const deals: Deal[] = [
+  { id: 'd1', name: 'Acme renewal',       stage: 'Negotiation', amount: 12000, owner: 'Sara'   },
+  { id: 'd2', name: 'Globex expansion',   stage: 'Lead',        amount:  4500, owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won',         amount:  8800, owner: 'Sara'   },
+  { id: 'd4', name: 'Hooli pilot',        stage: 'Lost',        amount:     0, owner: 'Jin'    },
+];
 
-return (
-  <Stack gap="sm">
-    <Cluster gap="sm">
-      <ColumnVisibilityTrigger instance={instance} />
-    </Cluster>
-    <DataTable instance={instance} aria-label="Deals" />
-  </Stack>
-);`}
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger'  as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info'    as const;
+  }
+}
+
+const dealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                              sortable: true, size: 200 },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,                  size: 140 },
+  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120 },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                             size: 120 },
+];
+
+function useClientSort<T>(data: T[], sort: SortState | null): T[] {
+  return useMemo(() => {
+    if (!sort) return data;
+    return [...data].sort((a, b) => {
+      const va = (a as Record<string, unknown>)[sort.columnId] as string | number;
+      const vb = (b as Record<string, unknown>)[sort.columnId] as string | number;
+      const cmp = va < vb ? -1 : va > vb ? 1 : 0;
+      return sort.direction === 'asc' ? cmp : -cmp;
+    });
+  }, [data, sort]);
+}
+
+export function Demo() {
+  const [sort, setSort] = useState<SortState | null>(null);
+  const sortedDeals = useClientSort(deals, sort);
+  const instance = useDataTable<Deal>({
+    data: sortedDeals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    defaultColumnVisibility: { owner: false },
+    sort,
+    onSortChange: setSort,
+  });
+  return (
+    <Stack gap="sm">
+      <Cluster gap="sm">
+        <ColumnVisibilityTrigger instance={instance} />
+      </Cluster>
+      <DataTable instance={instance} aria-label="Deals" />
+    </Stack>
+  );
+}`}
     >
       <Stack gap="sm">
         <Cluster gap="sm">
@@ -356,15 +634,40 @@ function LoadingExample() {
     <Example
       title="Loading"
       description="Pass `loading` to render skeleton rows. `loadingRowCount` controls how many (default 10)."
-      code={`${COLUMNS_SNIPPET}
+      code={`import { Badge, DataTable, useDataTable, type ColumnDef } from '@eocrm/design-system';
 
-const instance = useDataTable<Deal>({
-  data: [], // server hasn't responded yet
-  columns: dealColumns,
-  getRowId: (r) => r.id,
-});
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
 
-return <DataTable instance={instance} loading loadingRowCount={4} aria-label="Deals" />;`}
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger'  as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info'    as const;
+  }
+}
+
+const dealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                              sortable: true, size: 200 },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,                  size: 140 },
+  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120 },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                             size: 120 },
+];
+
+export function Demo() {
+  const instance = useDataTable<Deal>({
+    data: [], // server hasn't responded yet
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+  });
+  return <DataTable instance={instance} loading loadingRowCount={4} aria-label="Deals" />;
+}`}
     >
       <DataTable instance={instance} loading loadingRowCount={4} aria-label="Loading" />
     </Example>
@@ -381,15 +684,40 @@ function EmptyExample() {
     <Example
       title="Empty"
       description="When `data` is empty and `loading` is false, DataTable shows a default `<EmptyState>`. Pass `emptyState` for a custom one."
-      code={`${COLUMNS_SNIPPET}
+      code={`import { Badge, DataTable, useDataTable, type ColumnDef } from '@eocrm/design-system';
 
-const instance = useDataTable<Deal>({
-  data: [],
-  columns: dealColumns,
-  getRowId: (r) => r.id,
-});
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
 
-return <DataTable instance={instance} aria-label="Deals" />;`}
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger'  as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info'    as const;
+  }
+}
+
+const dealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                              sortable: true, size: 200 },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,                  size: 140 },
+  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120 },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                             size: 120 },
+];
+
+export function Demo() {
+  const instance = useDataTable<Deal>({
+    data: [],
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+  });
+  return <DataTable instance={instance} aria-label="Deals" />;
+}`}
     >
       <DataTable instance={instance} aria-label="Deals (empty)" />
     </Example>
@@ -423,25 +751,76 @@ function ExpansionExample() {
     <Example
       title="Expandable rows"
       description="Pass `renderExpandedRow` to enable a per-row chevron auto-column at the left edge. Clicking the chevron toggles a detail row beneath the main row, spanning all columns. The detail content is whatever JSX the consumer returns — DataTable just provides the container and the toggle state."
-      code={`${COLUMNS_SNIPPET}
+      code={`import { useMemo, useState } from 'react';
+import { Badge, DataTable, Stack, useDataTable, type ColumnDef, type SortState } from '@eocrm/design-system';
 
-const [sort, setSort] = useState<SortState | null>(null);
-const sortedDeals = useClientSort(deals, sort);
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
 
-const instance = useDataTable<Deal>({
-  data: sortedDeals,
-  columns: dealColumns,
-  getRowId: (r) => r.id,
-  sort, onSortChange: setSort,
-  renderExpandedRow: (row) => (
-    <Stack gap="sm">
-      <p><strong>{row.name}</strong> — {row.stage}, {row.owner}.</p>
-      <p>Drop in whatever detail JSX you need.</p>
-    </Stack>
-  ),
-});
+const deals: Deal[] = [
+  { id: 'd1', name: 'Acme renewal',       stage: 'Negotiation', amount: 12000, owner: 'Sara'   },
+  { id: 'd2', name: 'Globex expansion',   stage: 'Lead',        amount:  4500, owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won',         amount:  8800, owner: 'Sara'   },
+  { id: 'd4', name: 'Hooli pilot',        stage: 'Lost',        amount:     0, owner: 'Jin'    },
+];
 
-return <DataTable instance={instance} aria-label="Deals" />;`}
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger'  as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info'    as const;
+  }
+}
+
+const dealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                              sortable: true, size: 200 },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,                  size: 140 },
+  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120 },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                             size: 120 },
+];
+
+function useClientSort<T>(data: T[], sort: SortState | null): T[] {
+  return useMemo(() => {
+    if (!sort) return data;
+    return [...data].sort((a, b) => {
+      const va = (a as Record<string, unknown>)[sort.columnId] as string | number;
+      const vb = (b as Record<string, unknown>)[sort.columnId] as string | number;
+      const cmp = va < vb ? -1 : va > vb ? 1 : 0;
+      return sort.direction === 'asc' ? cmp : -cmp;
+    });
+  }, [data, sort]);
+}
+
+export function Demo() {
+  const [sort, setSort] = useState<SortState | null>(null);
+  const sortedDeals = useClientSort(deals, sort);
+  const instance = useDataTable<Deal>({
+    data: sortedDeals,
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    sort,
+    onSortChange: setSort,
+    renderExpandedRow: (row) => (
+      <Stack gap="sm">
+        <p style={{ margin: 0 }}>
+          <strong>{row.name}</strong> — {row.stage} stage, owned by {row.owner}.
+        </p>
+        <p style={{ margin: 0 }}>
+          Full deal value: \${row.amount.toLocaleString()}. The detail panel is your
+          consumer-rendered JSX — drop in whatever you need: forms, tabs, charts, notes,
+          related-records lists.
+        </p>
+      </Stack>
+    ),
+  });
+  return <DataTable instance={instance} aria-label="Deals" />;
+}`}
     >
       <DataTable instance={instance} aria-label="Deals (expandable)" />
     </Example>
@@ -486,25 +865,65 @@ function PinningExample() {
     <Example
       title="Column pinning (left + right)"
       description="Pin a column declaratively with `pin: 'left'` or `pin: 'right'` on the `ColumnDef`. Pinned columns stick to their respective edges during horizontal scroll. The selection auto-column is always sticky-left at offset 0. Pinned columns are locked in position (no drag grip) but their sort still works. Equivalent: `defaultColumnPinning: { left: [...], right: [...] }` on the hook — explicit hook prop wins over `ColumnDef.pin`."
-      code={`const pinnedDealColumns: ColumnDef<Deal>[] = [
-  { id: 'name',   header: 'Deal',   cell: (r) => r.name, sortable: true, size: 200, pin: 'left' },
-  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>, size: 140 },
-  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120, pin: 'right' },
-  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner, size: 120 },
+      code={`import { useMemo, useState } from 'react';
+import { Badge, DataTable, useDataTable, type ColumnDef, type SortState } from '@eocrm/design-system';
+
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
+
+const deals: Deal[] = [
+  { id: 'd1', name: 'Acme renewal',       stage: 'Negotiation', amount: 12000, owner: 'Sara'   },
+  { id: 'd2', name: 'Globex expansion',   stage: 'Lead',        amount:  4500, owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won',         amount:  8800, owner: 'Sara'   },
+  { id: 'd4', name: 'Hooli pilot',        stage: 'Lost',        amount:     0, owner: 'Jin'    },
 ];
 
-const [sort, setSort] = useState<SortState | null>(null);
-const sortedDeals = useClientSort(deals, sort);
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger'  as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info'    as const;
+  }
+}
 
-const instance = useDataTable<Deal>({
-  data: sortedDeals,
-  columns: pinnedDealColumns,
-  getRowId: (r) => r.id,
-  enableRowSelection: true,
-  sort, onSortChange: setSort,
-});
+const pinnedDealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                              sortable: true, size: 200, pin: 'left'  },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,                  size: 140              },
+  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120, pin: 'right' },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                             size: 120              },
+];
 
-return <DataTable instance={instance} aria-label="Deals" />;`}
+function useClientSort<T>(data: T[], sort: SortState | null): T[] {
+  return useMemo(() => {
+    if (!sort) return data;
+    return [...data].sort((a, b) => {
+      const va = (a as Record<string, unknown>)[sort.columnId] as string | number;
+      const vb = (b as Record<string, unknown>)[sort.columnId] as string | number;
+      const cmp = va < vb ? -1 : va > vb ? 1 : 0;
+      return sort.direction === 'asc' ? cmp : -cmp;
+    });
+  }, [data, sort]);
+}
+
+export function Demo() {
+  const [sort, setSort] = useState<SortState | null>(null);
+  const sortedDeals = useClientSort(deals, sort);
+  const instance = useDataTable<Deal>({
+    data: sortedDeals,
+    columns: pinnedDealColumns,
+    getRowId: (r) => r.id,
+    enableRowSelection: true,
+    sort,
+    onSortChange: setSort,
+  });
+  return <DataTable instance={instance} aria-label="Deals" />;
+}`}
     >
       <DataTable instance={instance} aria-label="Deals (pinning)" />
     </Example>
@@ -650,30 +1069,88 @@ function WidePinningExample() {
     <Example
       title="Column pinning — wide table (scroll horizontally)"
       description="With ~14 columns totalling well past viewport width, the underlying `<Table>` scroll wrapper kicks in and you can drag the scrollbar horizontally. The left-pinned `Deal` column and the right-pinned `Amount` + `actions` columns stay locked while the middle scrolls. Selection auto-column is sticky-left at offset 0 — left-pinned data columns stack to the right of it. `Deal` and `Amount` are still click-to-sort."
-      code={`// 14-column WideDeal type with id, name, stage, amount, owner, region,
-// source, closeDate, contactName, contactEmail, contactPhone,
-// lastActivity, priority, nextStep, actions.
-const wideDealColumns: ColumnDef<WideDeal>[] = [
-  { id: 'name',   header: 'Deal',   cell: (r) => r.name, sortable: true, size: 220 },
-  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge ...>{r.stage}</Badge>, size: 140 },
-  /* ... 10 more middle columns ... */
-  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount}\`, align: 'end', sortable: true, size: 130 },
-  { id: 'actions', header: '', cell: (r) => r.actions, align: 'center', size: 56 },
+      code={`import { useMemo, useState } from 'react';
+import { Badge, DataTable, useDataTable, type ColumnDef, type SortState } from '@eocrm/design-system';
+
+type Deal = { stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost'; [key: string]: unknown };
+
+type WideDeal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+  region: string;
+  source: string;
+  closeDate: string;
+  contactName: string;
+  contactEmail: string;
+  contactPhone: string;
+  lastActivity: string;
+  priority: 'Low' | 'Med' | 'High';
+  nextStep: string;
+  actions: string;
+};
+
+const wideDeals: WideDeal[] = [
+  { id: 'w1', name: 'Acme renewal',       stage: 'Negotiation', amount: 12000, owner: 'Sara',   region: 'EMEA', source: 'Inbound',  closeDate: '2026-06-14', contactName: 'Wile E. Coyote', contactEmail: 'wile@acme.test',   contactPhone: '+1 555 0101', lastActivity: '2d ago', priority: 'High', nextStep: 'Send contract',      actions: '⋯' },
+  { id: 'w2', name: 'Globex expansion',   stage: 'Lead',        amount:  4500, owner: 'Marcus', region: 'NA',   source: 'Referral', closeDate: '2026-07-02', contactName: 'Hank Scorpio',   contactEmail: 'hank@globex.test', contactPhone: '+1 555 0102', lastActivity: '5h ago', priority: 'Med',  nextStep: 'Discovery call',     actions: '⋯' },
+  { id: 'w3', name: 'Initech onboarding', stage: 'Won',         amount:  8800, owner: 'Sara',   region: 'NA',   source: 'Event',    closeDate: '2026-05-30', contactName: 'Bill Lumbergh',  contactEmail: 'bill@initech.test',contactPhone: '+1 555 0103', lastActivity: '1d ago', priority: 'Med',  nextStep: 'Kickoff scheduling', actions: '⋯' },
+  { id: 'w4', name: 'Hooli pilot',        stage: 'Lost',        amount:     0, owner: 'Jin',    region: 'APAC', source: 'Outbound', closeDate: '2026-05-10', contactName: 'Gavin Belson',   contactEmail: 'gavin@hooli.test', contactPhone: '+1 555 0104', lastActivity: '3w ago', priority: 'Low',  nextStep: 'Send post-mortem',   actions: '⋯' },
 ];
 
-const [sort, setSort] = useState<SortState | null>(null);
-const sortedWideDeals = useClientSort(wideDeals, sort);
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger'  as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info'    as const;
+  }
+}
 
-const instance = useDataTable<WideDeal>({
-  data: sortedWideDeals,
-  columns: wideDealColumns,
-  getRowId: (r) => r.id,
-  enableRowSelection: true,
-  defaultColumnPinning: { left: ['name'], right: ['amount', 'actions'] },
-  sort, onSortChange: setSort,
-});
+const wideDealColumns: ColumnDef<WideDeal>[] = [
+  { id: 'name',         header: 'Deal',          cell: (r) => r.name,                                              sortable: true, size: 220, pin: 'left'  },
+  { id: 'stage',        header: 'Stage',         cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,                  size: 140              },
+  { id: 'owner',        header: 'Owner',         cell: (r) => r.owner,                                                             size: 120              },
+  { id: 'region',       header: 'Region',        cell: (r) => r.region,                                                            size: 100              },
+  { id: 'source',       header: 'Source',        cell: (r) => r.source,                                                            size: 140              },
+  { id: 'closeDate',    header: 'Close date',    cell: (r) => r.closeDate,                                                         size: 130              },
+  { id: 'contactName',  header: 'Contact',       cell: (r) => r.contactName,                                                       size: 180              },
+  { id: 'contactEmail', header: 'Email',         cell: (r) => r.contactEmail,                                                      size: 200              },
+  { id: 'contactPhone', header: 'Phone',         cell: (r) => r.contactPhone,                                                      size: 150              },
+  { id: 'lastActivity', header: 'Last activity', cell: (r) => r.lastActivity,                                                      size: 140              },
+  { id: 'priority',     header: 'Priority',      cell: (r) => r.priority,                                                          size: 100              },
+  { id: 'nextStep',     header: 'Next step',     cell: (r) => r.nextStep,                                                          size: 200              },
+  { id: 'amount',       header: 'Amount',        cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 130, pin: 'right' },
+  { id: 'actions',      header: '',              cell: (r) => r.actions,                           align: 'center',               size:  56, pin: 'right' },
+];
 
-return <DataTable instance={instance} aria-label="Wide deals" />;`}
+function useClientSort<T>(data: T[], sort: SortState | null): T[] {
+  return useMemo(() => {
+    if (!sort) return data;
+    return [...data].sort((a, b) => {
+      const va = (a as Record<string, unknown>)[sort.columnId] as string | number;
+      const vb = (b as Record<string, unknown>)[sort.columnId] as string | number;
+      const cmp = va < vb ? -1 : va > vb ? 1 : 0;
+      return sort.direction === 'asc' ? cmp : -cmp;
+    });
+  }, [data, sort]);
+}
+
+export function Demo() {
+  const [sort, setSort] = useState<SortState | null>(null);
+  const sortedWideDeals = useClientSort(wideDeals, sort);
+  const instance = useDataTable<WideDeal>({
+    data: sortedWideDeals,
+    columns: wideDealColumns,
+    getRowId: (r) => r.id,
+    enableRowSelection: true,
+    // Pinning declared on ColumnDef.pin: 'name' → left, 'amount'+'actions' → right.
+    sort,
+    onSortChange: setSort,
+  });
+  return <DataTable instance={instance} aria-label="Wide deals" />;
+}`}
     >
       <DataTable instance={instance} aria-label="Wide deals (pinning)" />
     </Example>
@@ -701,25 +1178,70 @@ function PinnedRowsExample() {
     <Example
       title="Row pinning (starred-row pattern)"
       description="Pinned rows render in a separate `<tbody>` above the main body and stay anchored across sort and pagination. Sort the `Deal` or `Amount` column — the starred row stays put while the main body reshuffles. Consumer supplies `pinnedRows` as a separate array, typically from a separate server query. Selection inside the pinned section is per-row; the header select-all only touches `data` (the current page)."
-      code={`${COLUMNS_SNIPPET}
+      code={`import { useMemo, useState } from 'react';
+import { Badge, DataTable, useDataTable, type ColumnDef, type SortState } from '@eocrm/design-system';
+
+type Deal = {
+  id: string;
+  name: string;
+  stage: 'Lead' | 'Negotiation' | 'Won' | 'Lost';
+  amount: number;
+  owner: string;
+};
+
+const deals: Deal[] = [
+  { id: 'd1', name: 'Acme renewal',       stage: 'Negotiation', amount: 12000, owner: 'Sara'   },
+  { id: 'd2', name: 'Globex expansion',   stage: 'Lead',        amount:  4500, owner: 'Marcus' },
+  { id: 'd3', name: 'Initech onboarding', stage: 'Won',         amount:  8800, owner: 'Sara'   },
+  { id: 'd4', name: 'Hooli pilot',        stage: 'Lost',        amount:     0, owner: 'Jin'    },
+];
 
 const starredDeals: Deal[] = [
   { id: 's1', name: '⭐ Starred deal', stage: 'Won', amount: 50000, owner: 'Sara' },
 ];
 
-const [sort, setSort] = useState<SortState | null>(null);
-// In real code: refetch \`data\` from the server with { sort } on change.
-const sortedDeals = useClientSort(deals, sort);
+function stageTone(stage: Deal['stage']) {
+  switch (stage) {
+    case 'Won':         return 'success' as const;
+    case 'Lost':        return 'danger'  as const;
+    case 'Negotiation': return 'warning' as const;
+    default:            return 'info'    as const;
+  }
+}
 
-const instance = useDataTable<Deal>({
-  data: sortedDeals,         // current page from server (sorted)
-  pinnedRows: starredDeals,  // separate query — stays put across sort
-  columns: dealColumns,
-  getRowId: (r) => r.id,
-  sort, onSortChange: setSort,
-});
+const dealColumns: ColumnDef<Deal>[] = [
+  { id: 'name',   header: 'Deal',   cell: (r) => r.name,                                              sortable: true, size: 200 },
+  { id: 'stage',  header: 'Stage',  cell: (r) => <Badge tone={stageTone(r.stage)}>{r.stage}</Badge>,                  size: 140 },
+  { id: 'amount', header: 'Amount', cell: (r) => \`$\${r.amount.toLocaleString()}\`, align: 'end', sortable: true, size: 120 },
+  { id: 'owner',  header: 'Owner',  cell: (r) => r.owner,                                                             size: 120 },
+];
 
-return <DataTable instance={instance} aria-label="Deals" />;`}
+function useClientSort<T>(data: T[], sort: SortState | null): T[] {
+  return useMemo(() => {
+    if (!sort) return data;
+    return [...data].sort((a, b) => {
+      const va = (a as Record<string, unknown>)[sort.columnId] as string | number;
+      const vb = (b as Record<string, unknown>)[sort.columnId] as string | number;
+      const cmp = va < vb ? -1 : va > vb ? 1 : 0;
+      return sort.direction === 'asc' ? cmp : -cmp;
+    });
+  }, [data, sort]);
+}
+
+export function Demo() {
+  const [sort, setSort] = useState<SortState | null>(null);
+  // In real code: refetch \`data\` from the server with { sort } on change.
+  const sortedDeals = useClientSort(deals, sort);
+  const instance = useDataTable<Deal>({
+    data: sortedDeals,        // current page from server (sorted)
+    pinnedRows: starredDeals, // separate query — stays put across sort
+    columns: dealColumns,
+    getRowId: (r) => r.id,
+    sort,
+    onSortChange: setSort,
+  });
+  return <DataTable instance={instance} aria-label="Deals" />;
+}`}
     >
       <DataTable instance={instance} aria-label="Deals (pinned rows)" />
     </Example>

--- a/packages/playground/src/pages/components/DatePickerDemo.tsx
+++ b/packages/playground/src/pages/components/DatePickerDemo.tsx
@@ -109,7 +109,11 @@ export function DatePickerDemoPanel() {
       <Example
         title="Uncontrolled"
         description="No `value` / `onChange` — the picker owns state. Type a date, click in the grid, or use the clear button."
-        code={`<DatePicker defaultValue={new Date()} />`}
+        code={`import { DatePicker } from '@eocrm/design-system';
+
+export function Demo() {
+  return <DatePicker defaultValue={new Date()} aria-label="Uncontrolled date" />;
+}`}
       >
         <InputExample>
           <DatePicker defaultValue={TODAY} aria-label="Uncontrolled date" />
@@ -119,8 +123,20 @@ export function DatePickerDemoPanel() {
       <Example
         title="Controlled"
         description="Consumer owns the value; useful when the form layer needs to validate or react to changes."
-        code={`const [value, setValue] = useState<Date | null>(new Date());
-<DatePicker value={value} onChange={setValue} />`}
+        code={`import { useState } from 'react';
+import { DatePicker, Stack, toDateKey } from '@eocrm/design-system';
+
+export function ControlledDemo() {
+  const [value, setValue] = useState<Date | null>(new Date());
+  return (
+    <Stack gap="xs">
+      <DatePicker value={value} onChange={setValue} aria-label="Controlled date" />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        {value ? toDateKey(value) : 'null'}
+      </code>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <ControlledDemo />
@@ -130,13 +146,21 @@ export function DatePickerDemoPanel() {
       <Example
         title="Min / max"
         description="`min` and `max` disable out-of-range cells in the grid AND reject typed input outside the window."
-        code={`const today = new Date();
+        code={`import { DatePicker } from '@eocrm/design-system';
+
+const today = new Date();
 const in90Days = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 90);
 
-<DatePicker
-  min={today}
-  max={in90Days}
-/>`}
+export function Demo() {
+  return (
+    <DatePicker
+      defaultValue={today}
+      min={today}
+      max={in90Days}
+      aria-label="Date within 90 days"
+    />
+  );
+}`}
       >
         <InputExample>
           <DatePicker
@@ -151,9 +175,16 @@ const in90Days = new Date(today.getFullYear(), today.getMonth(), today.getDate()
       <Example
         title="Disable weekends"
         description="`isDateDisabled` runs per cell and per typed-input parse. Disabled cells are non-clickable and arrow-key navigation skips them."
-        code={`<DatePicker
-  isDateDisabled={(d) => d.getDay() === 0 || d.getDay() === 6}
-/>`}
+        code={`import { DatePicker } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <DatePicker
+      aria-label="Weekday only"
+      isDateDisabled={(d) => d.getDay() === 0 || d.getDay() === 6}
+    />
+  );
+}`}
       >
         <InputExample>
           <DatePicker
@@ -166,9 +197,17 @@ const in90Days = new Date(today.getFullYear(), today.getMonth(), today.getDate()
       <Example
         title="Sizes"
         description="Three sizes — sm (24px), md (32px, default), lg (40px). The popover month grid is fixed-size; only the trigger row scales."
-        code={`<DatePicker size="sm" defaultValue={new Date()} />
-<DatePicker size="md" defaultValue={new Date()} />
-<DatePicker size="lg" defaultValue={new Date()} />`}
+        code={`import { DatePicker, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <DatePicker size="sm" defaultValue={new Date()} aria-label="Small date" />
+      <DatePicker size="md" defaultValue={new Date()} aria-label="Medium date" />
+      <DatePicker size="lg" defaultValue={new Date()} aria-label="Large date" />
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="sm">
@@ -182,7 +221,11 @@ const in90Days = new Date(today.getFullYear(), today.getMonth(), today.getDate()
       <Example
         title="Disabled"
         description="Use `disabled` when the field is unavailable in the current context (e.g., read-only stage of a workflow). The clear button is hidden when disabled."
-        code={`<DatePicker disabled defaultValue={new Date()} />`}
+        code={`import { DatePicker } from '@eocrm/design-system';
+
+export function Demo() {
+  return <DatePicker disabled defaultValue={new Date()} aria-label="Disabled date" />;
+}`}
       >
         <InputExample>
           <DatePicker disabled defaultValue={TODAY} aria-label="Disabled date" />
@@ -192,8 +235,18 @@ const in90Days = new Date(today.getFullYear(), today.getMonth(), today.getDate()
       <Example
         title="Invalid"
         description="Pair with a visible error message + aria-describedby."
-        code={`<DatePicker invalid aria-describedby="dob-error" />
-<p id="dob-error">Date is required.</p>`}
+        code={`import { DatePicker, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs">
+      <DatePicker invalid aria-label="Date of birth" aria-describedby="dob-error" />
+      <p id="dob-error" style={{ color: 'var(--color-danger)', fontSize: 'var(--font-size-xs)' }}>
+        Date is required.
+      </p>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="xs">
@@ -211,10 +264,33 @@ const in90Days = new Date(today.getFullYear(), today.getMonth(), today.getDate()
       <Example
         title="Form integration"
         description="When `name` is set, the picker renders a hidden mirror `<input>` with the ISO date so native `<form>` submission works."
-        code={`<form action="/api/dates">
-  <DatePicker name="dob" defaultValue={new Date()} />
-  <button type="submit">Submit</button>
-</form>`}
+        code={`import { useState } from 'react';
+import { Button, DatePicker, Stack } from '@eocrm/design-system';
+
+export function FormDemo() {
+  const [submitted, setSubmitted] = useState<string | null>(null);
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const fd = new FormData(e.currentTarget);
+        setSubmitted(String(fd.get('dob') ?? ''));
+      }}
+    >
+      <Stack gap="xs">
+        <DatePicker name="dob" defaultValue={new Date()} aria-label="Date of birth" />
+        <Button type="submit" size="sm">
+          Submit
+        </Button>
+        {submitted !== null && (
+          <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+            dob = {submitted || '(empty)'}
+          </code>
+        )}
+      </Stack>
+    </form>
+  );
+}`}
       >
         <InputExample>
           <FormDemo />
@@ -224,9 +300,15 @@ const in90Days = new Date(today.getFullYear(), today.getMonth(), today.getDate()
       <Example
         title="ru-RU locale"
         description="Input parses and formats as DD.MM.YYYY. UI labels (button tooltips) come from <I18nProvider locale='ru'>."
-        code={`<I18nProvider locale="ru">
-  <DatePicker defaultValue={new Date()} locale="ru-RU" />
-</I18nProvider>`}
+        code={`import { DatePicker, I18nProvider } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <I18nProvider locale="ru">
+      <DatePicker defaultValue={new Date()} locale="ru-RU" aria-label="Дата" />
+    </I18nProvider>
+  );
+}`}
       >
         <InputExample>
           <I18nProvider locale="ru">
@@ -238,14 +320,28 @@ const in90Days = new Date(today.getFullYear(), today.getMonth(), today.getDate()
       <Example
         title="Granularity: minute"
         description="`granularity='minute'` adds a manual-entry time input below the calendar grid; the trigger text becomes `MM/DD/YYYY HH:mm` (or `MM/DD/YYYY h:mm AM/PM` in 12h locales) and the hidden form mirror emits ISO local datetime (`2026-05-28T14:30`). Picking a different date preserves the existing time-of-day; picking from `null` defaults to `00:00`. The embedded `<TimeField>` also exposes a Now button in its popover footer."
-        code={`const [value, setValue] = useState<Date | null>(new Date(2026, 4, 28, 9, 0));
+        code={`import { useState } from 'react';
+import { DatePicker, Stack, toIsoDateTime } from '@eocrm/design-system';
 
-<DatePicker
-  granularity="minute"
-  value={value}
-  onChange={setValue}
-/>
-// hidden form mirror: 2026-05-28T09:00`}
+const today = new Date();
+const todayAtNine = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 0, 0, 0);
+
+export function GranularityMinuteDemo() {
+  const [value, setValue] = useState<Date | null>(todayAtNine);
+  return (
+    <Stack gap="xs">
+      <DatePicker
+        granularity="minute"
+        value={value}
+        onChange={setValue}
+        aria-label="Meeting start"
+      />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        {value ? toIsoDateTime(value) : 'null'}
+      </code>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <GranularityMinuteDemo />
@@ -255,11 +351,44 @@ const in90Days = new Date(today.getFullYear(), today.getMonth(), today.getDate()
       <Example
         title="Hour cycle (12h vs 24h)"
         description="`hourCycle` controls both the trigger text and the embedded TimeField popover. `'12'` forces a 12-hour AM/PM display; `'24'` forces 00–23. The default `'auto'` derives from locale via `Intl.DateTimeFormat` — en-US → 12h, ru-RU → 24h."
-        code={`// Forced 12-hour
-<DatePicker granularity="minute" hourCycle="12" value={v12} onChange={setV12} />
+        code={`import { useState } from 'react';
+import { DatePicker, Stack } from '@eocrm/design-system';
 
-// Forced 24-hour
-<DatePicker granularity="minute" hourCycle="24" value={v24} onChange={setV24} />`}
+const today = new Date();
+const todayAtNine = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 0, 0, 0);
+
+export function HourCycleDemo() {
+  const [v12, setV12] = useState<Date | null>(todayAtNine);
+  const [v24, setV24] = useState<Date | null>(todayAtNine);
+  return (
+    <Stack gap="md">
+      <Stack gap="xs">
+        <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+          hourCycle=&quot;12&quot;
+        </code>
+        <DatePicker
+          granularity="minute"
+          hourCycle="12"
+          value={v12}
+          onChange={setV12}
+          aria-label="12-hour datetime"
+        />
+      </Stack>
+      <Stack gap="xs">
+        <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+          hourCycle=&quot;24&quot;
+        </code>
+        <DatePicker
+          granularity="minute"
+          hourCycle="24"
+          value={v24}
+          onChange={setV24}
+          aria-label="24-hour datetime"
+        />
+      </Stack>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <HourCycleDemo />

--- a/packages/playground/src/pages/components/DateRangePickerDemo.tsx
+++ b/packages/playground/src/pages/components/DateRangePickerDemo.tsx
@@ -127,10 +127,19 @@ export function DateRangePickerDemoPanel() {
       <Example
         title="Uncontrolled"
         description="No `value` / `onChange` — the picker owns state. Click the input or the calendar button to open; pick start then end."
-        code={`const today = new Date();
+        code={`import { DateRangePicker } from '@eocrm/design-system';
+
+const today = new Date();
 const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
 
-<DateRangePicker defaultValue={{ start: today, end: in14 }} />`}
+export function Demo() {
+  return (
+    <DateRangePicker
+      defaultValue={{ start: today, end: in14 }}
+      aria-label="Uncontrolled range"
+    />
+  );
+}`}
       >
         <InputExample>
           <DateRangePicker
@@ -143,11 +152,26 @@ const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1
       <Example
         title="Controlled"
         description="Consumer owns the value via `value` + `onChange`. Useful when the form layer needs to react to changes (validation, summary panels)."
-        code={`const today = new Date();
-const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
-const [value, setValue] = useState<DateRange | null>({ start: today, end: in14 });
+        code={`import { useState } from 'react';
+import { DateRangePicker, Stack, toDateKey, type DateRange } from '@eocrm/design-system';
 
-<DateRangePicker value={value} onChange={setValue} />`}
+const today = new Date();
+const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
+
+export function ControlledDemo() {
+  const [value, setValue] = useState<DateRange | null>({
+    start: today,
+    end: in14,
+  });
+  return (
+    <Stack gap="xs">
+      <DateRangePicker value={value} onChange={setValue} aria-label="Controlled range" />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        {value ? \`\${toDateKey(value.start)} → \${toDateKey(value.end)}\` : 'null'}
+      </code>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <ControlledDemo />
@@ -157,13 +181,22 @@ const [value, setValue] = useState<DateRange | null>({ start: today, end: in14 }
       <Example
         title="Min / max"
         description="Restrict picks to a window. Out-of-range cells in the grid are non-clickable; typed input outside the window reverts."
-        code={`const today = new Date();
+        code={`import { DateRangePicker } from '@eocrm/design-system';
+
+const today = new Date();
+const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
 const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 90);
 
-<DateRangePicker
-  min={today}
-  max={in90}
-/>`}
+export function Demo() {
+  return (
+    <DateRangePicker
+      defaultValue={{ start: today, end: in14 }}
+      min={today}
+      max={in90}
+      aria-label="Range within 90 days"
+    />
+  );
+}`}
       >
         <InputExample>
           <DateRangePicker
@@ -178,9 +211,16 @@ const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 9
       <Example
         title="Disable weekends"
         description="`isDateDisabled` runs per cell and per typed-input parse. Disabled cells are non-clickable; arrow-key navigation skips them."
-        code={`<DateRangePicker
-  isDateDisabled={(d) => d.getDay() === 0 || d.getDay() === 6}
-/>`}
+        code={`import { DateRangePicker } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <DateRangePicker
+      aria-label="Weekday range only"
+      isDateDisabled={(d) => d.getDay() === 0 || d.getDay() === 6}
+    />
+  );
+}`}
       >
         <InputExample>
           <DateRangePicker
@@ -193,12 +233,20 @@ const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 9
       <Example
         title="Sizes"
         description="Three sizes — sm (24px), md (32px, default), lg (40px). The two-month popover grid is fixed-size; only the trigger row scales."
-        code={`const today = new Date();
+        code={`import { DateRangePicker, Stack } from '@eocrm/design-system';
+
+const today = new Date();
 const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
 
-<DateRangePicker size="sm" defaultValue={{ start: today, end: in14 }} />
-<DateRangePicker size="md" defaultValue={{ start: today, end: in14 }} />
-<DateRangePicker size="lg" defaultValue={{ start: today, end: in14 }} />`}
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <DateRangePicker size="sm" defaultValue={{ start: today, end: in14 }} aria-label="Small range" />
+      <DateRangePicker size="md" defaultValue={{ start: today, end: in14 }} aria-label="Medium range" />
+      <DateRangePicker size="lg" defaultValue={{ start: today, end: in14 }} aria-label="Large range" />
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="sm">
@@ -224,13 +272,20 @@ const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1
       <Example
         title="Disabled"
         description="Use `disabled` when the range is unavailable in the current context. The clear button is hidden when disabled."
-        code={`const today = new Date();
+        code={`import { DateRangePicker } from '@eocrm/design-system';
+
+const today = new Date();
 const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
 
-<DateRangePicker
-  disabled
-  defaultValue={{ start: today, end: in14 }}
-/>`}
+export function Demo() {
+  return (
+    <DateRangePicker
+      disabled
+      defaultValue={{ start: today, end: in14 }}
+      aria-label="Disabled range"
+    />
+  );
+}`}
       >
         <InputExample>
           <DateRangePicker
@@ -244,8 +299,21 @@ const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1
       <Example
         title="Invalid"
         description="Pair with a visible error message and aria-describedby pointing at it."
-        code={`<DateRangePicker invalid aria-describedby="range-error" />
-<p id="range-error">Range is required.</p>`}
+        code={`import { DateRangePicker, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs">
+      <DateRangePicker invalid aria-label="Booking dates" aria-describedby="range-error" />
+      <p
+        id="range-error"
+        style={{ color: 'var(--color-danger)', fontSize: 'var(--font-size-xs)' }}
+      >
+        Range is required.
+      </p>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="xs">
@@ -263,13 +331,45 @@ const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1
       <Example
         title="Form integration"
         description="When `nameStart` and `nameEnd` are set, the picker renders two hidden mirror `<input>`s with ISO dates so native `<form>` submission works."
-        code={`const today = new Date();
+        code={`import { useState } from 'react';
+import { Button, DateRangePicker, Stack } from '@eocrm/design-system';
+
+const today = new Date();
 const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
 
-<form action="/api/bookings">
-  <DateRangePicker nameStart="bookingStart" nameEnd="bookingEnd" defaultValue={{ start: today, end: in14 }} />
-  <button type="submit">Submit</button>
-</form>`}
+export function FormDemo() {
+  const [submitted, setSubmitted] = useState<{ start: string; end: string } | null>(null);
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const fd = new FormData(e.currentTarget);
+        setSubmitted({
+          start: String(fd.get('bookingStart') ?? ''),
+          end: String(fd.get('bookingEnd') ?? ''),
+        });
+      }}
+    >
+      <Stack gap="xs">
+        <DateRangePicker
+          nameStart="bookingStart"
+          nameEnd="bookingEnd"
+          defaultValue={{ start: today, end: in14 }}
+          aria-label="Booking dates"
+        />
+        <Button type="submit" size="sm">
+          Submit
+        </Button>
+        {submitted !== null && (
+          <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+            bookingStart = {submitted.start || '(empty)'} · bookingEnd ={' '}
+            {submitted.end || '(empty)'}
+          </code>
+        )}
+      </Stack>
+    </form>
+  );
+}`}
       >
         <InputExample>
           <FormDemo />
@@ -279,12 +379,22 @@ const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1
       <Example
         title="ru-RU locale"
         description="Input parses and formats as DD.MM.YYYY — DD.MM.YYYY. UI labels (button tooltips) come from <I18nProvider locale='ru'>."
-        code={`<I18nProvider locale="ru">
-  <DateRangePicker
-    defaultValue={{ start: today, end: in14 }}
-    locale="ru-RU"
-  />
-</I18nProvider>`}
+        code={`import { DateRangePicker, I18nProvider } from '@eocrm/design-system';
+
+const today = new Date();
+const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
+
+export function Demo() {
+  return (
+    <I18nProvider locale="ru">
+      <DateRangePicker
+        defaultValue={{ start: today, end: in14 }}
+        locale="ru-RU"
+        aria-label="Диапазон дат"
+      />
+    </I18nProvider>
+  );
+}`}
       >
         <InputExample>
           <I18nProvider locale="ru">
@@ -300,16 +410,25 @@ const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1
       <Example
         title="Granularity: minute"
         description="`granularity='minute'` adds dual start-time / end-time inputs below the two-month grid; the trigger text becomes `MM/DD/YYYY HH:mm — MM/DD/YYYY HH:mm` (or `MM/DD/YYYY h:mm AM/PM — …` in 12h locales) and the hidden form mirrors emit ISO local datetime. This example starts EMPTY (`value === null`) — open the popover and the start/end time inputs are already there, enabled and defaulting to `00:00` / `23:59`. Set the times first, then click two days: the pending times you entered are applied to the committed range (no need to seed a placeholder range). Existing times are preserved across subsequent date picks. On a same-day range, the end-time silently clamps to ≥ the start-time on every commit (try setting end-time earlier than start-time — it snaps back)."
-        code={`// Starts empty — time inputs are visible + editable before picking dates.
-const [value, setValue] = useState<DateRange | null>(null);
+        code={`import { useState } from 'react';
+import { DateRangePicker, Stack, toIsoDateTime, type DateRange } from '@eocrm/design-system';
 
-<DateRangePicker
-  granularity="minute"
-  value={value}
-  onChange={setValue}
-/>
-// Set start 09:00 / end 17:00, then pick two days →
-// hidden form mirrors: 2026-05-28T09:00, 2026-05-28T17:00`}
+export function GranularityMinuteDemo() {
+  const [value, setValue] = useState<DateRange | null>(null);
+  return (
+    <Stack gap="xs">
+      <DateRangePicker
+        granularity="minute"
+        value={value}
+        onChange={setValue}
+        aria-label="Meeting window"
+      />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        {value ? \`\${toIsoDateTime(value.start)} → \${toIsoDateTime(value.end)}\` : 'null'}
+      </code>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <GranularityMinuteDemo />
@@ -319,11 +438,45 @@ const [value, setValue] = useState<DateRange | null>(null);
       <Example
         title="Hour cycle (12h vs 24h)"
         description="`hourCycle` propagates to both the start and end TimeFields AND to the trigger text formatter. The default `'auto'` derives the cycle from locale via `Intl.DateTimeFormat`."
-        code={`// Forced 12-hour
-<DateRangePicker granularity="minute" hourCycle="12" value={v12} onChange={setV12} />
+        code={`import { useState } from 'react';
+import { DateRangePicker, Stack, type DateRange } from '@eocrm/design-system';
 
-// Forced 24-hour
-<DateRangePicker granularity="minute" hourCycle="24" value={v24} onChange={setV24} />`}
+const today = new Date();
+const today9am = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 0, 0, 0);
+const today5pm = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 17, 0, 0, 0);
+
+export function HourCycleDemo() {
+  const [v12, setV12] = useState<DateRange | null>({ start: today9am, end: today5pm });
+  const [v24, setV24] = useState<DateRange | null>({ start: today9am, end: today5pm });
+  return (
+    <Stack gap="md">
+      <Stack gap="xs">
+        <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+          hourCycle=&quot;12&quot;
+        </code>
+        <DateRangePicker
+          granularity="minute"
+          hourCycle="12"
+          value={v12}
+          onChange={setV12}
+          aria-label="12-hour range"
+        />
+      </Stack>
+      <Stack gap="xs">
+        <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+          hourCycle=&quot;24&quot;
+        </code>
+        <DateRangePicker
+          granularity="minute"
+          hourCycle="24"
+          value={v24}
+          onChange={setV24}
+          aria-label="24-hour range"
+        />
+      </Stack>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <HourCycleDemo />

--- a/packages/playground/src/pages/components/DefinitionListDemo.tsx
+++ b/packages/playground/src/pages/components/DefinitionListDemo.tsx
@@ -15,32 +15,39 @@ export function DefinitionListDemo() {
       <Example
         title="Horizontal with icons"
         description="The canonical contact-properties pattern: terms in column 1, icon + value in column 2. Term column auto-sizes to the longest label."
-        code={`<DefinitionList>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Email</DefinitionList.Term>
-    <DefinitionList.Description icon={<Mail size={14} />}>
-      ada@example.com
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Phone</DefinitionList.Term>
-    <DefinitionList.Description icon={<Phone size={14} />}>
-      +1 (415) 555-0142
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Company</DefinitionList.Term>
-    <DefinitionList.Description icon={<Building size={14} />}>
-      Globex Industries
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Location</DefinitionList.Term>
-    <DefinitionList.Description icon={<MapPin size={14} />}>
-      San Francisco, CA
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-</DefinitionList>`}
+        code={`import { Mail, Phone, Building, MapPin } from 'lucide-react';
+import { DefinitionList } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <DefinitionList>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Email</DefinitionList.Term>
+        <DefinitionList.Description icon={<Mail size={14} />}>
+          ada@example.com
+        </DefinitionList.Description>
+      </DefinitionList.Item>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Phone</DefinitionList.Term>
+        <DefinitionList.Description icon={<Phone size={14} />}>
+          +1 (415) 555-0142
+        </DefinitionList.Description>
+      </DefinitionList.Item>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Company</DefinitionList.Term>
+        <DefinitionList.Description icon={<Building size={14} />}>
+          Globex Industries
+        </DefinitionList.Description>
+      </DefinitionList.Item>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Location</DefinitionList.Term>
+        <DefinitionList.Description icon={<MapPin size={14} />}>
+          San Francisco, CA
+        </DefinitionList.Description>
+      </DefinitionList.Item>
+    </DefinitionList>
+  );
+}`}
       >
         <DefinitionList>
           <DefinitionList.Item>
@@ -73,20 +80,25 @@ export function DefinitionListDemo() {
       <Example
         title="Explicit termWidth"
         description="Override the auto-sized term column when you need consistent alignment across multiple DefinitionLists on the same screen."
-        code={`<DefinitionList termWidth="200px">
-  <DefinitionList.Item>
-    <DefinitionList.Term>Customer success manager</DefinitionList.Term>
-    <DefinitionList.Description icon={<User size={14} />}>
-      Priya Shah
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Account tier</DefinitionList.Term>
-    <DefinitionList.Description>
-      Enterprise
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-</DefinitionList>`}
+        code={`import { User } from 'lucide-react';
+import { DefinitionList } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <DefinitionList termWidth="200px">
+      <DefinitionList.Item>
+        <DefinitionList.Term>Customer success manager</DefinitionList.Term>
+        <DefinitionList.Description icon={<User size={14} />}>
+          Priya Shah
+        </DefinitionList.Description>
+      </DefinitionList.Item>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Account tier</DefinitionList.Term>
+        <DefinitionList.Description>Enterprise</DefinitionList.Description>
+      </DefinitionList.Item>
+    </DefinitionList>
+  );
+}`}
       >
         <DefinitionList termWidth="200px">
           <DefinitionList.Item>
@@ -105,26 +117,33 @@ export function DefinitionListDemo() {
       <Example
         title="With dividers"
         description="Opt in to row separators when migrating from Card.List or when the list sits inside a Card."
-        code={`<DefinitionList dividers>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Website</DefinitionList.Term>
-    <DefinitionList.Description icon={<Globe size={14} />}>
-      globex.example.com
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Industry</DefinitionList.Term>
-    <DefinitionList.Description icon={<Briefcase size={14} />}>
-      Manufacturing
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Founded</DefinitionList.Term>
-    <DefinitionList.Description icon={<Cake size={14} />}>
-      1987
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-</DefinitionList>`}
+        code={`import { Globe, Briefcase, Cake } from 'lucide-react';
+import { DefinitionList } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <DefinitionList dividers>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Website</DefinitionList.Term>
+        <DefinitionList.Description icon={<Globe size={14} />}>
+          globex.example.com
+        </DefinitionList.Description>
+      </DefinitionList.Item>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Industry</DefinitionList.Term>
+        <DefinitionList.Description icon={<Briefcase size={14} />}>
+          Manufacturing
+        </DefinitionList.Description>
+      </DefinitionList.Item>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Founded</DefinitionList.Term>
+        <DefinitionList.Description icon={<Cake size={14} />}>
+          1987
+        </DefinitionList.Description>
+      </DefinitionList.Item>
+    </DefinitionList>
+  );
+}`}
       >
         <DefinitionList dividers>
           <DefinitionList.Item>
@@ -149,9 +168,31 @@ export function DefinitionListDemo() {
       <Example
         title="Spacing variants"
         description="Vertical density per row. Default is sm (dense); bump to md or lg for roomier panels."
-        code={`<DefinitionList spacing="sm">…</DefinitionList>  {/* default — dense */}
-<DefinitionList spacing="md">…</DefinitionList>
-<DefinitionList spacing="lg">…</DefinitionList>`}
+        code={`import { DefinitionList, Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="lg">
+      {(['sm', 'md', 'lg'] as const).map((s) => (
+        <Stack gap="xs" key={s}>
+          <Text size="sm" tone="muted">
+            {\`spacing="\${s}"\${s === 'sm' ? ' (default)' : ''}\`}
+          </Text>
+          <DefinitionList spacing={s} dividers>
+            <DefinitionList.Item>
+              <DefinitionList.Term>Plan</DefinitionList.Term>
+              <DefinitionList.Description>Enterprise</DefinitionList.Description>
+            </DefinitionList.Item>
+            <DefinitionList.Item>
+              <DefinitionList.Term>Seats</DefinitionList.Term>
+              <DefinitionList.Description>120</DefinitionList.Description>
+            </DefinitionList.Item>
+          </DefinitionList>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}`}
       >
         <Stack gap="lg">
           {(['sm', 'md', 'lg'] as const).map((s) => (
@@ -177,23 +218,30 @@ export function DefinitionListDemo() {
       <Example
         title="Stacked layout"
         description="Stack each term above its description. Useful for settings pages, narrow viewports, or long descriptions that need to breathe."
-        code={`<DefinitionList layout="stacked" dividers>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Workspace name</DefinitionList.Term>
-    <DefinitionList.Description>Acme Corp</DefinitionList.Description>
-  </DefinitionList.Item>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Workspace description</DefinitionList.Term>
-    <DefinitionList.Description>
-      Internal tooling for the customer success team. Includes pipeline tracking,
-      onboarding workflows, and a shared inbox for support escalations.
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Created</DefinitionList.Term>
-    <DefinitionList.Description>March 14, 2024</DefinitionList.Description>
-  </DefinitionList.Item>
-</DefinitionList>`}
+        code={`import { DefinitionList } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <DefinitionList layout="stacked" dividers>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Workspace name</DefinitionList.Term>
+        <DefinitionList.Description>Acme Corp</DefinitionList.Description>
+      </DefinitionList.Item>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Workspace description</DefinitionList.Term>
+        <DefinitionList.Description>
+          Internal tooling for the customer success team. Includes pipeline
+          tracking, onboarding workflows, and a shared inbox for support
+          escalations.
+        </DefinitionList.Description>
+      </DefinitionList.Item>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Created</DefinitionList.Term>
+        <DefinitionList.Description>March 14, 2024</DefinitionList.Description>
+      </DefinitionList.Item>
+    </DefinitionList>
+  );
+}`}
       >
         <DefinitionList layout="stacked" dividers>
           <DefinitionList.Item>
@@ -217,32 +265,41 @@ export function DefinitionListDemo() {
       <Example
         title="Mixed content in description"
         description="The dd accepts any ReactNode. Compose with Badge, Link, Text, or anything else — useful for tags, statuses, or values that link out."
-        code={`<DefinitionList>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Status</DefinitionList.Term>
-    <DefinitionList.Description>
-      <Cluster gap="xs" align="center">
-        <Badge tone="success">Active</Badge>
-        <Text as="span" size="sm" tone="subtle">since Jan 2024</Text>
-      </Cluster>
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Website</DefinitionList.Term>
-    <DefinitionList.Description icon={<Globe size={14} />}>
-      <Link href="https://globex.example.com" target="_blank" rel="noopener noreferrer">globex.example.com</Link>
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-  <DefinitionList.Item>
-    <DefinitionList.Term>Tags</DefinitionList.Term>
-    <DefinitionList.Description>
-      <Cluster gap="xs">
-        <Badge tone="purple">Enterprise</Badge>
-        <Badge tone="info">Pipeline 2026</Badge>
-      </Cluster>
-    </DefinitionList.Description>
-  </DefinitionList.Item>
-</DefinitionList>`}
+        code={`import { Globe } from 'lucide-react';
+import { Badge, Cluster, DefinitionList, Link, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <DefinitionList>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Status</DefinitionList.Term>
+        <DefinitionList.Description>
+          <Cluster gap="xs" align="center">
+            <Badge tone="success">Active</Badge>
+            <Text as="span" size="sm" tone="subtle">since Jan 2024</Text>
+          </Cluster>
+        </DefinitionList.Description>
+      </DefinitionList.Item>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Website</DefinitionList.Term>
+        <DefinitionList.Description icon={<Globe size={14} />}>
+          <Link href="https://globex.example.com" target="_blank" rel="noopener noreferrer">
+            globex.example.com
+          </Link>
+        </DefinitionList.Description>
+      </DefinitionList.Item>
+      <DefinitionList.Item>
+        <DefinitionList.Term>Tags</DefinitionList.Term>
+        <DefinitionList.Description>
+          <Cluster gap="xs">
+            <Badge tone="purple">Enterprise</Badge>
+            <Badge tone="info">Pipeline 2026</Badge>
+          </Cluster>
+        </DefinitionList.Description>
+      </DefinitionList.Item>
+    </DefinitionList>
+  );
+}`}
       >
         <DefinitionList>
           <DefinitionList.Item>

--- a/packages/playground/src/pages/components/DemoBody.tsx
+++ b/packages/playground/src/pages/components/DemoBody.tsx
@@ -11,6 +11,8 @@ import styles from './DemoLayout.module.scss';
 export interface DemoBodyProps {
   files: ComponentFile[];
   componentName?: ComponentName;
+  /** Override for the API-table lookup key; defaults to `componentName`. */
+  apiName?: string;
   children: ReactNode;
 }
 
@@ -19,7 +21,7 @@ export interface DemoBodyProps {
  * `<DemoLayout>` — reusable inside multi-variant pages where the page
  * header is rendered once and tabs swap the body.
  */
-export function DemoBody({ files, componentName, children }: DemoBodyProps) {
+export function DemoBody({ files, componentName, apiName, children }: DemoBodyProps) {
   const [activeId, setActiveId] = useState(files[0]?.filename ?? '');
   const active = files.find((f) => f.filename === activeId) ?? files[0];
 
@@ -56,7 +58,7 @@ export function DemoBody({ files, componentName, children }: DemoBodyProps) {
       <h2 className={styles.sectionTitle}>Examples</h2>
       <div className={styles.examplesGrid}>{children}</div>
 
-      {componentName && <ComponentApi name={componentName} />}
+      {(apiName ?? componentName) && <ComponentApi name={apiName ?? componentName!} />}
       {componentName && <CrossLinks kind="component" name={componentName} />}
     </>
   );

--- a/packages/playground/src/pages/components/DemoLayout.tsx
+++ b/packages/playground/src/pages/components/DemoLayout.tsx
@@ -10,10 +10,23 @@ export interface DemoLayoutProps {
   description: string;
   files: ComponentFile[];
   componentName?: ComponentName;
+  /**
+   * Component key for the auto-generated API table when it differs from
+   * `componentName` or the component isn't in the cross-link registry (e.g.
+   * `AppLayout`). Defaults to `componentName`.
+   */
+  apiName?: string;
   children: ReactNode;
 }
 
-export function DemoLayout({ name, description, files, componentName, children }: DemoLayoutProps) {
+export function DemoLayout({
+  name,
+  description,
+  files,
+  componentName,
+  apiName,
+  children,
+}: DemoLayoutProps) {
   return (
     <Stack gap="lg">
       <header className={styles.header}>
@@ -22,7 +35,7 @@ export function DemoLayout({ name, description, files, componentName, children }
         <p className={styles.description}>{description}</p>
       </header>
 
-      <DemoBody files={files} componentName={componentName}>
+      <DemoBody files={files} componentName={componentName} apiName={apiName}>
         {children}
       </DemoBody>
     </Stack>

--- a/packages/playground/src/pages/components/DividerDemo.tsx
+++ b/packages/playground/src/pages/components/DividerDemo.tsx
@@ -14,7 +14,17 @@ export function DividerDemo() {
       <Example
         title="Horizontal default"
         description="A single thin line between two paragraphs."
-        code={`<Divider />`}
+        code={`import { Divider, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <p style={{ margin: 0 }}>First section content.</p>
+      <Divider />
+      <p style={{ margin: 0 }}>Second section content.</p>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <p style={{ margin: 0 }}>First section content.</p>
@@ -26,12 +36,20 @@ export function DividerDemo() {
       <Example
         title="Variants and sizes"
         description="Solid (default) and dashed variants. Three size tiers (sm=1px, md=2px, lg=3px)."
-        code={`<Divider size="sm" />
-<Divider size="md" />
-<Divider size="lg" />
-<Divider variant="dashed" size="sm" />
-<Divider variant="dashed" size="md" />
-<Divider variant="dashed" size="lg" />`}
+        code={`import { Divider, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Divider size="sm" />
+      <Divider size="md" />
+      <Divider size="lg" />
+      <Divider variant="dashed" size="sm" />
+      <Divider variant="dashed" size="md" />
+      <Divider variant="dashed" size="lg" />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Divider size="sm" />
@@ -46,9 +64,17 @@ export function DividerDemo() {
       <Example
         title="Labeled (auth-form pattern)"
         description="`<Divider>OR</Divider>` between two grouped actions. Switches to <div role='separator'> internally."
-        code={`<Button>Sign in with email</Button>
-<Divider>OR</Divider>
-<Button variant="secondary">Sign in with SSO</Button>`}
+        code={`import { Button, Divider, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Button>Sign in with email</Button>
+      <Divider>OR</Divider>
+      <Button variant="secondary">Sign in with SSO</Button>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Button>Sign in with email</Button>
@@ -60,13 +86,19 @@ export function DividerDemo() {
       <Example
         title="Vertical inside a Cluster (toolbar)"
         description="Use vertical dividers to separate grouped actions in a horizontal cluster."
-        code={`<Cluster gap="sm" align="center">
-  <Button variant="ghost" size="sm">Edit</Button>
-  <Divider orientation="vertical" />
-  <Button variant="ghost" size="sm">Duplicate</Button>
-  <Divider orientation="vertical" />
-  <Button variant="ghost" size="sm">Archive</Button>
-</Cluster>`}
+        code={`import { Button, Cluster, Divider } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm" align="center">
+      <Button variant="ghost" size="sm">Edit</Button>
+      <Divider orientation="vertical" />
+      <Button variant="ghost" size="sm">Duplicate</Button>
+      <Divider orientation="vertical" />
+      <Button variant="ghost" size="sm">Archive</Button>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" align="center">
           <Button variant="ghost" size="sm">
@@ -86,13 +118,19 @@ export function DividerDemo() {
       <Example
         title="Inside a Card (section break)"
         description="A header + Divider + body to clearly separate metadata from content."
-        code={`<Card padding="md">
-  <Stack gap="sm">
-    <strong>Card heading</strong>
-    <Divider />
-    <p style={{ margin: 0 }}>Card body content goes here.</p>
-  </Stack>
-</Card>`}
+        code={`import { Card, Divider, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Card padding="md">
+      <Stack gap="sm">
+        <strong>Card heading</strong>
+        <Divider />
+        <p style={{ margin: 0 }}>Card body content goes here.</p>
+      </Stack>
+    </Card>
+  );
+}`}
       >
         <Card padding="md">
           <Stack gap="sm">
@@ -106,7 +144,11 @@ export function DividerDemo() {
       <Example
         title="Dashed labeled"
         description="Combine variant + label for a softer visual break."
-        code={`<Divider variant="dashed">SECTION 2</Divider>`}
+        code={`import { Divider } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Divider variant="dashed">SECTION 2</Divider>;
+}`}
       >
         <Divider variant="dashed">SECTION 2</Divider>
       </Example>

--- a/packages/playground/src/pages/components/DotDemo.tsx
+++ b/packages/playground/src/pages/components/DotDemo.tsx
@@ -16,12 +16,24 @@ export function DotDemo() {
       <Example
         title="Semantic tones"
         description="Pass `tone` for one of the 6 semantic BadgeTones. Matches the Badge tone palette so a dot legend lines up with status badges. `neutral` is the default when neither `tone` nor `color` is set."
-        code={`<Dot tone="neutral" />
-<Dot tone="info" />
-<Dot tone="success" />
-<Dot tone="warning" />
-<Dot tone="danger" />
-<Dot tone="purple" />`}
+        code={`import { Cluster, Dot, Text } from '@eocrm/design-system';
+
+const TONES = ['neutral', 'info', 'success', 'warning', 'danger', 'purple'] as const;
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      {TONES.map((tone) => (
+        <Cluster key={tone} gap="xs" align="center">
+          <Dot tone={tone} />
+          <Text as="span" size="sm">
+            {tone}
+          </Text>
+        </Cluster>
+      ))}
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           {TONES.map((tone) => (
@@ -38,10 +50,22 @@ export function DotDemo() {
       <Example
         title="Palette colors (categorical)"
         description="Pass `color` for any of the 30 categorical PaletteColors. The dot paints with that color's saturated `--color-palette-<name>-fg` token — the same color OptionsPicker groups and palette Badges use, so a color-coded filter dot matches its source exactly. `color` wins over `tone` when both are set."
-        code={`<Dot color="violet" />
-<Dot color="teal" />
-<Dot color="amber" />
-<Dot color="rose" />`}
+        code={`import { Cluster, Dot, PALETTE_COLORS, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center" wrap>
+      {PALETTE_COLORS.map((color) => (
+        <Cluster key={color} gap="xs" align="center">
+          <Dot color={color} />
+          <Text as="span" size="sm">
+            {color}
+          </Text>
+        </Cluster>
+      ))}
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center" wrap>
           {PALETTE_COLORS.map((color) => (
@@ -58,12 +82,38 @@ export function DotDemo() {
       <Example
         title="Color-coding a filter (realistic)"
         description="The canonical use: a small leading dot beside a label to color-code a category — e.g. an audit-log event-source legend or a per-team filter row. The dot is decorative; the text is the accessible label."
-        code={`<Stack gap="xs">
-  <Cluster gap="xs" align="center"><Dot color="blue" /> Authentication</Cluster>
-  <Cluster gap="xs" align="center"><Dot color="emerald" /> Billing</Cluster>
-  <Cluster gap="xs" align="center"><Dot color="orange" /> Permissions</Cluster>
-  <Cluster gap="xs" align="center"><Dot tone="danger" /> Security alert</Cluster>
-</Stack>`}
+        code={`import { Cluster, Dot, Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs">
+      <Cluster gap="xs" align="center">
+        <Dot color="blue" />
+        <Text as="span" size="sm">
+          Authentication
+        </Text>
+      </Cluster>
+      <Cluster gap="xs" align="center">
+        <Dot color="emerald" />
+        <Text as="span" size="sm">
+          Billing
+        </Text>
+      </Cluster>
+      <Cluster gap="xs" align="center">
+        <Dot color="orange" />
+        <Text as="span" size="sm">
+          Permissions
+        </Text>
+      </Cluster>
+      <Cluster gap="xs" align="center">
+        <Dot tone="danger" />
+        <Text as="span" size="sm">
+          Security alert
+        </Text>
+      </Cluster>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="xs">
           <Cluster gap="xs" align="center">

--- a/packages/playground/src/pages/components/DrawerDemo.tsx
+++ b/packages/playground/src/pages/components/DrawerDemo.tsx
@@ -42,11 +42,29 @@ function BasicExample() {
     <Example
       title="Basic (right, md)"
       description="Default: right side, medium size. Header wires aria-labelledby. Esc + overlay click + × all dismiss. Touch users can also swipe the Header right to close."
-      code={`<Drawer open={open} onOpenChange={setOpen}>
-  <Drawer.Header>Filters</Drawer.Header>
-  <Drawer.Body>...</Drawer.Body>
-  <Drawer.Footer>...</Drawer.Footer>
-</Drawer>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Drawer } from '@eocrm/design-system';
+
+export function BasicExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Cluster>
+        <Button onClick={() => setOpen(true)}>Show filters</Button>
+      </Cluster>
+      <Drawer open={open} onOpenChange={setOpen}>
+        <Drawer.Header>Filters</Drawer.Header>
+        <Drawer.Body>Filter content here. Swipe the header to close on touch devices.</Drawer.Body>
+        <Drawer.Footer>
+          <Drawer.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Drawer.Close>
+          <Button onClick={() => setOpen(false)}>Apply</Button>
+        </Drawer.Footer>
+      </Drawer>
+    </>
+  );
+}`}
     >
       <Cluster>
         <Button onClick={() => setOpen(true)}>Show filters</Button>
@@ -71,7 +89,39 @@ function SidesExample() {
     <Example
       title="Sides"
       description="`side='left' | 'right' | 'top' | 'bottom'`. Default is 'right'."
-      code={`<Drawer side="left" ...>...</Drawer>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Drawer } from '@eocrm/design-system';
+
+export function SidesExample() {
+  const [side, setSide] = useState<null | 'left' | 'right' | 'top' | 'bottom'>(null);
+  return (
+    <>
+      <Cluster gap="sm">
+        <Button variant="secondary" size="sm" onClick={() => setSide('left')}>
+          Left
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setSide('right')}>
+          Right
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setSide('top')}>
+          Top
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setSide('bottom')}>
+          Bottom
+        </Button>
+      </Cluster>
+      <Drawer open={side !== null} onOpenChange={(n) => !n && setSide(null)} side={side ?? 'right'}>
+        <Drawer.Header>Side: {side ?? 'right'}</Drawer.Header>
+        <Drawer.Body>This drawer slid in from the {side} edge.</Drawer.Body>
+        <Drawer.Footer>
+          <Drawer.Close>
+            <Button>Close</Button>
+          </Drawer.Close>
+        </Drawer.Footer>
+      </Drawer>
+    </>
+  );
+}`}
     >
       <Cluster gap="sm">
         <Button variant="secondary" size="sm" onClick={() => setSide('left')}>
@@ -106,7 +156,31 @@ function SizesExample() {
     <Example
       title="Sizes (right side)"
       description='`size="sm"` (320px) / `"md"` (440px, default) / `"lg"` (640px). Capped to viewport - 32px on narrow viewports.'
-      code={`<Drawer size="sm" ...>...</Drawer>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Drawer } from '@eocrm/design-system';
+
+export function SizesExample() {
+  const [size, setSize] = useState<null | 'sm' | 'md' | 'lg'>(null);
+  return (
+    <>
+      <Cluster gap="sm">
+        <Button variant="secondary" size="sm" onClick={() => setSize('sm')}>
+          Small
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setSize('md')}>
+          Medium
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setSize('lg')}>
+          Large
+        </Button>
+      </Cluster>
+      <Drawer open={size !== null} onOpenChange={(n) => !n && setSize(null)} size={size ?? 'md'}>
+        <Drawer.Header>Size: {size ?? 'md'}</Drawer.Header>
+        <Drawer.Body>Width determined by the \`size\` prop.</Drawer.Body>
+      </Drawer>
+    </>
+  );
+}`}
     >
       <Cluster gap="sm">
         <Button variant="secondary" size="sm" onClick={() => setSize('sm')}>
@@ -133,7 +207,34 @@ function OverlayVariantsExample() {
     <Example
       title="Overlay variants"
       description='`overlay="solid"` (default, dim) / `"blur"` (frosted glass, backdrop-filter: blur(4px)).'
-      code={`<Drawer overlay="blur" ...>...</Drawer>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Drawer } from '@eocrm/design-system';
+
+export function OverlayVariantsExample() {
+  const [variant, setVariant] = useState<null | 'solid' | 'blur'>(null);
+  return (
+    <>
+      <Cluster gap="sm">
+        <Button variant="secondary" size="sm" onClick={() => setVariant('solid')}>
+          Solid overlay
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setVariant('blur')}>
+          Blur overlay
+        </Button>
+      </Cluster>
+      <Drawer
+        open={variant !== null}
+        onOpenChange={(n) => !n && setVariant(null)}
+        overlay={variant ?? 'solid'}
+      >
+        <Drawer.Header>{variant === 'blur' ? 'Frosted glass' : 'Solid dim'}</Drawer.Header>
+        <Drawer.Body>
+          {variant === 'blur' ? 'Backdrop is blurred.' : 'Standard dimming overlay.'}
+        </Drawer.Body>
+      </Drawer>
+    </>
+  );
+}`}
     >
       <Cluster gap="sm">
         <Button variant="secondary" size="sm" onClick={() => setVariant('solid')}>
@@ -163,7 +264,36 @@ function ForcedStepExample() {
     <Example
       title="Forced step (non-dismissible)"
       description="`disableEscapeClose + dismissOnOverlayClick={false} + dragToClose={false} + closeButton={false}` + no Close = user must use the in-drawer action."
-      code={`<Drawer disableEscapeClose dismissOnOverlayClick={false} dragToClose={false} ...>...</Drawer>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Drawer } from '@eocrm/design-system';
+
+export function ForcedStepExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Cluster>
+        <Button variant="danger" onClick={() => setOpen(true)}>
+          Trigger forced step
+        </Button>
+      </Cluster>
+      <Drawer
+        open={open}
+        onOpenChange={() => {}}
+        disableEscapeClose
+        dismissOnOverlayClick={false}
+        dragToClose={false}
+        size="sm"
+        aria-label="Confirm action"
+      >
+        <Drawer.Header closeButton={false}>Confirm action</Drawer.Header>
+        <Drawer.Body>This drawer cannot be dismissed by Esc, overlay click, or swipe.</Drawer.Body>
+        <Drawer.Footer>
+          <Button onClick={() => setOpen(false)}>Confirm</Button>
+        </Drawer.Footer>
+      </Drawer>
+    </>
+  );
+}`}
     >
       <Cluster>
         <Button variant="danger" onClick={() => setOpen(true)}>
@@ -197,17 +327,43 @@ function FormExample() {
     <Example
       title="Form drawer with initial focus"
       description="`initialFocusRef` focuses the first input on open."
-      code={`const inputRef = useRef<HTMLInputElement>(null);
-<Drawer open={open} onOpenChange={setOpen} initialFocusRef={inputRef}>
-  <Drawer.Header>Edit contact</Drawer.Header>
-  <Drawer.Body>
-    <label>
-      Company
-      <Input ref={inputRef} value={name} onChange={...} />
-    </label>
-  </Drawer.Body>
-  <Drawer.Footer>...</Drawer.Footer>
-</Drawer>`}
+      code={`import { useRef, useState } from 'react';
+import { Button, Cluster, Drawer, Input, Stack } from '@eocrm/design-system';
+
+export function FormExample() {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('Acme Inc.');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  return (
+    <>
+      <Cluster>
+        <Button onClick={() => setOpen(true)}>Edit contact</Button>
+      </Cluster>
+      <Drawer open={open} onOpenChange={setOpen} initialFocusRef={inputRef}>
+        <Drawer.Header>Edit contact</Drawer.Header>
+        <Drawer.Body>
+          <Stack gap="md">
+            <label>
+              Company
+              <Input
+                ref={inputRef}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Acme Inc."
+              />
+            </label>
+          </Stack>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Drawer.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Drawer.Close>
+          <Button onClick={() => setOpen(false)}>Save</Button>
+        </Drawer.Footer>
+      </Drawer>
+    </>
+  );
+}`}
     >
       <Cluster>
         <Button onClick={() => setOpen(true)}>Edit contact</Button>
@@ -245,12 +401,53 @@ function StackedExample() {
     <Example
       title="Stacked drawers"
       description="Open a drawer from inside another drawer. Default stackMode='overlay' keeps the parent visible; inner overlay is transparent. Esc closes the topmost."
-      code={`<Drawer open={editOpen} ...>
-  <Drawer.Footer>
-    <Button variant="danger" onClick={() => setConfirmOpen(true)}>Delete</Button>
-  </Drawer.Footer>
-</Drawer>
-<Drawer open={confirmOpen} ...>...</Drawer>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Drawer } from '@eocrm/design-system';
+
+export function StackedExample() {
+  const [editOpen, setEditOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  return (
+    <>
+      <Cluster>
+        <Button onClick={() => setEditOpen(true)}>Edit (with delete inside)</Button>
+      </Cluster>
+      <Drawer open={editOpen} onOpenChange={setEditOpen}>
+        <Drawer.Header>Edit</Drawer.Header>
+        <Drawer.Body>Content of the edit drawer.</Drawer.Body>
+        <Drawer.Footer align="space-between">
+          <Button variant="danger" onClick={() => setConfirmOpen(true)}>
+            Delete
+          </Button>
+          <Cluster gap="sm">
+            <Drawer.Close>
+              <Button variant="secondary">Cancel</Button>
+            </Drawer.Close>
+            <Button onClick={() => setEditOpen(false)}>Save</Button>
+          </Cluster>
+        </Drawer.Footer>
+      </Drawer>
+      <Drawer open={confirmOpen} onOpenChange={setConfirmOpen} size="sm">
+        <Drawer.Header>Delete?</Drawer.Header>
+        <Drawer.Body>This cannot be undone.</Drawer.Body>
+        <Drawer.Footer>
+          <Drawer.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Drawer.Close>
+          <Button
+            variant="danger"
+            onClick={() => {
+              setConfirmOpen(false);
+              setEditOpen(false);
+            }}
+          >
+            Delete
+          </Button>
+        </Drawer.Footer>
+      </Drawer>
+    </>
+  );
+}`}
     >
       <Cluster>
         <Button onClick={() => setEditOpen(true)}>Edit (with delete inside)</Button>
@@ -299,12 +496,36 @@ function ModalInteropExample() {
     <Example
       title="Modal from inside Drawer"
       description="Drawer and Modal share the same overlay registry. A Modal opened from inside a Drawer stacks on top. Esc routes to the Modal first."
-      code={`<Drawer ...>
-  <Drawer.Footer>
-    <Button onClick={() => setModalOpen(true)}>Open modal</Button>
-  </Drawer.Footer>
-</Drawer>
-<Modal open={modalOpen} ...>...</Modal>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Drawer, Modal } from '@eocrm/design-system';
+
+export function ModalInteropExample() {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  return (
+    <>
+      <Cluster>
+        <Button onClick={() => setDrawerOpen(true)}>Open drawer</Button>
+      </Cluster>
+      <Drawer open={drawerOpen} onOpenChange={setDrawerOpen}>
+        <Drawer.Header>Drawer with a modal inside</Drawer.Header>
+        <Drawer.Body>Press the button below to open a modal from inside this drawer.</Drawer.Body>
+        <Drawer.Footer>
+          <Button onClick={() => setModalOpen(true)}>Open modal</Button>
+        </Drawer.Footer>
+      </Drawer>
+      <Modal open={modalOpen} onOpenChange={setModalOpen} size="sm">
+        <Modal.Header>Hello from a modal</Modal.Header>
+        <Modal.Body>The drawer stays open underneath.</Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button>OK</Button>
+          </Modal.Close>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}`}
     >
       <Cluster>
         <Button onClick={() => setDrawerOpen(true)}>Open drawer</Button>
@@ -335,7 +556,32 @@ function NoHeaderExample() {
     <Example
       title="No Header (aria-label fallback)"
       description="Omit `<Drawer.Header>` and pass `aria-label` for the accessible name."
-      code={`<Drawer aria-label="Confirm action" ...>...</Drawer>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Drawer } from '@eocrm/design-system';
+
+export function NoHeaderExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Cluster>
+        <Button variant="secondary" onClick={() => setOpen(true)}>
+          Open (no Header)
+        </Button>
+      </Cluster>
+      <Drawer open={open} onOpenChange={setOpen} aria-label="Confirm action" size="sm">
+        <Drawer.Body>
+          <p style={{ margin: 0 }}>Are you sure?</p>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Drawer.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Drawer.Close>
+          <Button onClick={() => setOpen(false)}>Continue</Button>
+        </Drawer.Footer>
+      </Drawer>
+    </>
+  );
+}`}
     >
       <Cluster>
         <Button variant="secondary" onClick={() => setOpen(true)}>
@@ -363,36 +609,49 @@ function FloatingContentExample() {
     <Example
       title="Floating content inside a drawer"
       description="Selects, dropdown menus, and popovers opened inside a Drawer now render above it (they used to appear behind the panel)."
-      code={`<Drawer open={open} onOpenChange={setOpen}>
-  <Drawer.Header>Role settings</Drawer.Header>
-  <Drawer.Body>
-    <Stack gap="md">
-      <Text>Selects and menus opened in here now layer above the drawer.</Text>
-      <Select
-        options={[
-          { value: 'admin', label: 'Admin' },
-          { value: 'member', label: 'Member' },
-          { value: 'guest', label: 'Guest' },
-        ]}
-        placeholder="Pick a role"
-      />
-      <DropdownMenu>
-        <DropdownMenu.Trigger>
-          <Button variant="secondary">Actions</Button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content>
-          <DropdownMenu.Item onSelect={() => {}}>Rename</DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
-        </DropdownMenu.Content>
-      </DropdownMenu>
-    </Stack>
-  </Drawer.Body>
-  <Drawer.Footer>
-    <Drawer.Close>
-      <Button variant="secondary">Close</Button>
-    </Drawer.Close>
-  </Drawer.Footer>
-</Drawer>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Drawer, DropdownMenu, Select, Stack, Text } from '@eocrm/design-system';
+
+export function FloatingContentExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Cluster>
+        <Button onClick={() => setOpen(true)}>Open drawer</Button>
+      </Cluster>
+      <Drawer open={open} onOpenChange={setOpen}>
+        <Drawer.Header>Role settings</Drawer.Header>
+        <Drawer.Body>
+          <Stack gap="md">
+            <Text>Selects and menus opened in here now layer above the drawer.</Text>
+            <Select
+              options={[
+                { value: 'admin', label: 'Admin' },
+                { value: 'member', label: 'Member' },
+                { value: 'guest', label: 'Guest' },
+              ]}
+              placeholder="Pick a role"
+            />
+            <DropdownMenu>
+              <DropdownMenu.Trigger>
+                <Button variant="secondary">Actions</Button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content>
+                <DropdownMenu.Item onSelect={() => {}}>Rename</DropdownMenu.Item>
+                <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu>
+          </Stack>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Drawer.Close>
+            <Button variant="secondary">Close</Button>
+          </Drawer.Close>
+        </Drawer.Footer>
+      </Drawer>
+    </>
+  );
+}`}
     >
       <Cluster>
         <Button onClick={() => setOpen(true)}>Open drawer</Button>

--- a/packages/playground/src/pages/components/DropdownMenuDemo.tsx
+++ b/packages/playground/src/pages/components/DropdownMenuDemo.tsx
@@ -19,20 +19,26 @@ export function DropdownMenuDemo() {
       <Example
         title="Toolbar overflow"
         description={`"More" / overflow menu in a Cluster toolbar. Default align="start" anchors the menu to the trigger's left edge.`}
-        code={`<Cluster gap="sm">
-  <Button>New deal</Button>
-  <Button variant="secondary">Filter</Button>
-  <DropdownMenu>
-    <DropdownMenu.Trigger>
-      <Button variant="secondary">More ▾</Button>
-    </DropdownMenu.Trigger>
-    <DropdownMenu.Content>
-      <DropdownMenu.Item onSelect={() => {}}>Import CSV</DropdownMenu.Item>
-      <DropdownMenu.Item onSelect={() => {}}>Export</DropdownMenu.Item>
-      <DropdownMenu.Item onSelect={() => {}}>Bulk edit</DropdownMenu.Item>
-    </DropdownMenu.Content>
-  </DropdownMenu>
-</Cluster>`}
+        code={`import { Button, Cluster, DropdownMenu } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <Button>New deal</Button>
+      <Button variant="secondary">Filter</Button>
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="secondary">More ▾</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item onSelect={() => {}}>Import CSV</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => {}}>Export</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => {}}>Bulk edit</DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm">
           <Button>New deal</Button>
@@ -53,18 +59,38 @@ export function DropdownMenuDemo() {
       <Example
         title="Table row actions (kebab)"
         description={`Ghost-button kebab at the row's right edge, menu aligned to the trigger's right (align="end") so it doesn't overflow the table.`}
-        code={`<Cluster justify="between" gap="sm">
-  <span>Acme Inc.</span>
-  <DropdownMenu>
-    <DropdownMenu.Trigger>
-      <Button variant="ghost" aria-label="Row actions">⋯</Button>
-    </DropdownMenu.Trigger>
-    <DropdownMenu.Content align="end">
-      <DropdownMenu.Item onSelect={() => {}}>View</DropdownMenu.Item>
-      <DropdownMenu.Item onSelect={() => {}}>Archive</DropdownMenu.Item>
-    </DropdownMenu.Content>
-  </DropdownMenu>
-</Cluster>`}
+        code={`import { Button, Cluster, DropdownMenu, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Cluster justify="between" gap="sm">
+        <span>Acme Inc.</span>
+        <DropdownMenu>
+          <DropdownMenu.Trigger>
+            <Button variant="ghost" aria-label="Row actions">⋯</Button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content align="end">
+            <DropdownMenu.Item onSelect={() => {}}>View</DropdownMenu.Item>
+            <DropdownMenu.Item onSelect={() => {}}>Archive</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      </Cluster>
+      <Cluster justify="between" gap="sm">
+        <span>Globex Corp.</span>
+        <DropdownMenu>
+          <DropdownMenu.Trigger>
+            <Button variant="ghost" aria-label="Row actions">⋯</Button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content align="end">
+            <DropdownMenu.Item onSelect={() => {}}>View</DropdownMenu.Item>
+            <DropdownMenu.Item onSelect={() => {}}>Archive</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      </Cluster>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Cluster justify="between" gap="sm">
@@ -101,21 +127,29 @@ export function DropdownMenuDemo() {
       <Example
         title="Destructive action with separator"
         description={`Group routine actions, drop a separator, end with a tone="danger" Delete. Reserve danger for irreversible destructive operations.`}
-        code={`<DropdownMenu>
-  <DropdownMenu.Trigger>
-    <Button variant="secondary">Manage ▾</Button>
-  </DropdownMenu.Trigger>
-  <DropdownMenu.Content>
-    <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-    <DropdownMenu.Item onSelect={() => {}} shortcut="⌘D">
-      Duplicate
-    </DropdownMenu.Item>
-    <DropdownMenu.Separator />
-    <DropdownMenu.Item onSelect={() => {}} tone="danger">
-      Delete
-    </DropdownMenu.Item>
-  </DropdownMenu.Content>
-</DropdownMenu>`}
+        code={`import { Button, Cluster, DropdownMenu } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="secondary">Manage ▾</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => {}} shortcut="⌘D">
+            Duplicate
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item onSelect={() => {}} tone="danger">
+            Delete
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm">
           <DropdownMenu>
@@ -139,17 +173,25 @@ export function DropdownMenuDemo() {
       <Example
         title="Disabled item"
         description="Disabled items are skipped by keyboard nav, don't fire onSelect, and render dimmed."
-        code={`<DropdownMenu>
-  <DropdownMenu.Trigger>
-    <Button variant="secondary">Actions ▾</Button>
-  </DropdownMenu.Trigger>
-  <DropdownMenu.Content>
-    <DropdownMenu.Item onSelect={() => {}}>Available</DropdownMenu.Item>
-    <DropdownMenu.Item onSelect={() => {}} disabled>
-      Not yet permitted
-    </DropdownMenu.Item>
-  </DropdownMenu.Content>
-</DropdownMenu>`}
+        code={`import { Button, Cluster, DropdownMenu } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="secondary">Actions ▾</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item onSelect={() => {}}>Available</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => {}} disabled>
+            Not yet permitted
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm">
           <DropdownMenu>
@@ -169,22 +211,34 @@ export function DropdownMenuDemo() {
       <Example
         title="Multi-select filter (CheckboxItem)"
         description="Checkbox items toggle in place and don't close the menu by default — natural for a filter chip menu."
-        code={`<DropdownMenu>
-  <DropdownMenu.Trigger>
-    <Button variant="secondary">Filter ▾</Button>
-  </DropdownMenu.Trigger>
-  <DropdownMenu.Content>
-    <DropdownMenu.CheckboxItem checked={active} onCheckedChange={setActive}>
-      Active
-    </DropdownMenu.CheckboxItem>
-    <DropdownMenu.CheckboxItem checked={pending} onCheckedChange={setPending}>
-      Pending
-    </DropdownMenu.CheckboxItem>
-    <DropdownMenu.CheckboxItem checked={churned} onCheckedChange={setChurned}>
-      Churned
-    </DropdownMenu.CheckboxItem>
-  </DropdownMenu.Content>
-</DropdownMenu>`}
+        code={`import { useState } from 'react';
+import { Button, Cluster, DropdownMenu } from '@eocrm/design-system';
+
+export function FilterExample() {
+  const [active, setActive] = useState(true);
+  const [pending, setPending] = useState(false);
+  const [churned, setChurned] = useState(false);
+  return (
+    <Cluster gap="sm">
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="secondary">Filter ▾</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.CheckboxItem checked={active} onCheckedChange={setActive}>
+            Active
+          </DropdownMenu.CheckboxItem>
+          <DropdownMenu.CheckboxItem checked={pending} onCheckedChange={setPending}>
+            Pending
+          </DropdownMenu.CheckboxItem>
+          <DropdownMenu.CheckboxItem checked={churned} onCheckedChange={setChurned}>
+            Churned
+          </DropdownMenu.CheckboxItem>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </Cluster>
+  );
+}`}
       >
         <FilterExample />
       </Example>
@@ -192,18 +246,28 @@ export function DropdownMenuDemo() {
       <Example
         title="Single-select sort (RadioGroup)"
         description="Radio items default to close-on-select — picking a sort closes the menu."
-        code={`<DropdownMenu>
-  <DropdownMenu.Trigger>
-    <Button variant="secondary">Sort: {sort} ▾</Button>
-  </DropdownMenu.Trigger>
-  <DropdownMenu.Content>
-    <DropdownMenu.RadioGroup value={sort} onValueChange={setSort}>
-      <DropdownMenu.RadioItem value="name">Name</DropdownMenu.RadioItem>
-      <DropdownMenu.RadioItem value="date">Date</DropdownMenu.RadioItem>
-      <DropdownMenu.RadioItem value="size">Size</DropdownMenu.RadioItem>
-    </DropdownMenu.RadioGroup>
-  </DropdownMenu.Content>
-</DropdownMenu>`}
+        code={`import { useState } from 'react';
+import { Button, Cluster, DropdownMenu } from '@eocrm/design-system';
+
+export function SortExample() {
+  const [sort, setSort] = useState('name');
+  return (
+    <Cluster gap="sm">
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="secondary">Sort: {sort} ▾</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.RadioGroup value={sort} onValueChange={setSort}>
+            <DropdownMenu.RadioItem value="name">Name</DropdownMenu.RadioItem>
+            <DropdownMenu.RadioItem value="date">Date</DropdownMenu.RadioItem>
+            <DropdownMenu.RadioItem value="size">Size</DropdownMenu.RadioItem>
+          </DropdownMenu.RadioGroup>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </Cluster>
+  );
+}`}
       >
         <SortExample />
       </Example>
@@ -211,23 +275,31 @@ export function DropdownMenuDemo() {
       <Example
         title="Nested actions (Sub)"
         description={`A "More" submenu opens beside the parent. Hover to open after 100ms, or click. Use Escape to close just the sub, click outside to close everything.`}
-        code={`<DropdownMenu>
-  <DropdownMenu.Trigger>
-    <Button variant="secondary">Actions ▾</Button>
-  </DropdownMenu.Trigger>
-  <DropdownMenu.Content>
-    <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-    <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
-    <DropdownMenu.Sub>
-      <DropdownMenu.SubTrigger>Export</DropdownMenu.SubTrigger>
-      <DropdownMenu.SubContent>
-        <DropdownMenu.Item onSelect={() => {}}>CSV</DropdownMenu.Item>
-        <DropdownMenu.Item onSelect={() => {}}>JSON</DropdownMenu.Item>
-        <DropdownMenu.Item onSelect={() => {}}>PDF</DropdownMenu.Item>
-      </DropdownMenu.SubContent>
-    </DropdownMenu.Sub>
-  </DropdownMenu.Content>
-</DropdownMenu>`}
+        code={`import { Button, Cluster, DropdownMenu } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="secondary">Actions ▾</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger>Export</DropdownMenu.SubTrigger>
+            <DropdownMenu.SubContent>
+              <DropdownMenu.Item onSelect={() => {}}>CSV</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}}>JSON</DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={() => {}}>PDF</DropdownMenu.Item>
+            </DropdownMenu.SubContent>
+          </DropdownMenu.Sub>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm">
           <DropdownMenu>
@@ -253,30 +325,42 @@ export function DropdownMenuDemo() {
       <Example
         title="Grouped + labeled (Group + Label)"
         description="A combined menu — filters as checkboxes, sort as a radio group, both organized with labels. The View settings pattern."
-        code={`<DropdownMenu>
-  <DropdownMenu.Trigger>
-    <Button variant="secondary">View ▾</Button>
-  </DropdownMenu.Trigger>
-  <DropdownMenu.Content>
-    <DropdownMenu.Group>
-      <DropdownMenu.Label>Show</DropdownMenu.Label>
-      <DropdownMenu.CheckboxItem checked={active} onCheckedChange={setActive}>
-        Active
-      </DropdownMenu.CheckboxItem>
-      <DropdownMenu.CheckboxItem checked={archived} onCheckedChange={setArchived}>
-        Archived
-      </DropdownMenu.CheckboxItem>
-    </DropdownMenu.Group>
-    <DropdownMenu.Separator />
-    <DropdownMenu.Group>
-      <DropdownMenu.Label>Sort by</DropdownMenu.Label>
-      <DropdownMenu.RadioGroup value={sort} onValueChange={setSort}>
-        <DropdownMenu.RadioItem value="name">Name</DropdownMenu.RadioItem>
-        <DropdownMenu.RadioItem value="date">Date</DropdownMenu.RadioItem>
-      </DropdownMenu.RadioGroup>
-    </DropdownMenu.Group>
-  </DropdownMenu.Content>
-</DropdownMenu>`}
+        code={`import { useState } from 'react';
+import { Button, Cluster, DropdownMenu } from '@eocrm/design-system';
+
+export function ViewSettingsExample() {
+  const [active, setActive] = useState(true);
+  const [archived, setArchived] = useState(false);
+  const [sort, setSort] = useState('name');
+  return (
+    <Cluster gap="sm">
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="secondary">View ▾</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Group>
+            <DropdownMenu.Label>Show</DropdownMenu.Label>
+            <DropdownMenu.CheckboxItem checked={active} onCheckedChange={setActive}>
+              Active
+            </DropdownMenu.CheckboxItem>
+            <DropdownMenu.CheckboxItem checked={archived} onCheckedChange={setArchived}>
+              Archived
+            </DropdownMenu.CheckboxItem>
+          </DropdownMenu.Group>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Group>
+            <DropdownMenu.Label>Sort by</DropdownMenu.Label>
+            <DropdownMenu.RadioGroup value={sort} onValueChange={setSort}>
+              <DropdownMenu.RadioItem value="name">Name</DropdownMenu.RadioItem>
+              <DropdownMenu.RadioItem value="date">Date</DropdownMenu.RadioItem>
+            </DropdownMenu.RadioGroup>
+          </DropdownMenu.Group>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </Cluster>
+  );
+}`}
       >
         <ViewSettingsExample />
       </Example>
@@ -284,40 +368,67 @@ export function DropdownMenuDemo() {
       <Example
         title="Custom indicators (ItemIndicator)"
         description="Checked items already get the info-tinted row + 2px left accent for free. Use <DropdownMenu.ItemIndicator> as a direct child to add a custom glyph on top — a Pin icon, a colored dot for a label-color picker, a custom animated check, etc. Indicators only render when the parent item is checked / selected."
-        code={`<DropdownMenu>
-  <DropdownMenu.Trigger>
-    <Button variant="secondary">Label color ▾</Button>
-  </DropdownMenu.Trigger>
-  <DropdownMenu.Content>
-    <DropdownMenu.RadioGroup value={color} onValueChange={setColor}>
-      <DropdownMenu.RadioItem value="red">
-        <DropdownMenu.ItemIndicator>
-          <span style={{ width: 10, height: 10, borderRadius: 999, background: 'var(--color-danger)' }} />
-        </DropdownMenu.ItemIndicator>
-        Red
-      </DropdownMenu.RadioItem>
-      <DropdownMenu.RadioItem value="green">
-        <DropdownMenu.ItemIndicator>
-          <span style={{ width: 10, height: 10, borderRadius: 999, background: 'var(--color-success)' }} />
-        </DropdownMenu.ItemIndicator>
-        Green
-      </DropdownMenu.RadioItem>
-      <DropdownMenu.RadioItem value="blue">
-        <DropdownMenu.ItemIndicator>
-          <span style={{ width: 10, height: 10, borderRadius: 999, background: 'var(--color-accent)' }} />
-        </DropdownMenu.ItemIndicator>
-        Blue
-      </DropdownMenu.RadioItem>
-    </DropdownMenu.RadioGroup>
-    <DropdownMenu.Separator />
-    <DropdownMenu.CheckboxItem checked={pinned} onCheckedChange={setPinned}>
-      <DropdownMenu.ItemIndicator>
-        <Pin size={14} />
-      </DropdownMenu.ItemIndicator>
-      Pin to top
-    </DropdownMenu.CheckboxItem>
-  </DropdownMenu.Content>
-</DropdownMenu>`}
+        code={`import { useState } from 'react';
+import { Pin } from 'lucide-react';
+import { Button, Cluster, DropdownMenu } from '@eocrm/design-system';
+
+function ColorDot({ color }: { color: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        display: 'inline-block',
+        width: 10,
+        height: 10,
+        borderRadius: 999,
+        background: color,
+      }}
+    />
+  );
+}
+
+export function CustomIndicatorExample() {
+  const [color, setColor] = useState('blue');
+  const [pinned, setPinned] = useState(false);
+  return (
+    <Cluster gap="sm">
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="secondary">Label color ▾</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.RadioGroup value={color} onValueChange={setColor}>
+            <DropdownMenu.RadioItem value="red">
+              <DropdownMenu.ItemIndicator>
+                <ColorDot color="var(--color-danger)" />
+              </DropdownMenu.ItemIndicator>
+              Red
+            </DropdownMenu.RadioItem>
+            <DropdownMenu.RadioItem value="green">
+              <DropdownMenu.ItemIndicator>
+                <ColorDot color="var(--color-success)" />
+              </DropdownMenu.ItemIndicator>
+              Green
+            </DropdownMenu.RadioItem>
+            <DropdownMenu.RadioItem value="blue">
+              <DropdownMenu.ItemIndicator>
+                <ColorDot color="var(--color-accent)" />
+              </DropdownMenu.ItemIndicator>
+              Blue
+            </DropdownMenu.RadioItem>
+          </DropdownMenu.RadioGroup>
+          <DropdownMenu.Separator />
+          <DropdownMenu.CheckboxItem checked={pinned} onCheckedChange={setPinned}>
+            <DropdownMenu.ItemIndicator>
+              <Pin size={14} />
+            </DropdownMenu.ItemIndicator>
+            Pin to top
+          </DropdownMenu.CheckboxItem>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </Cluster>
+  );
+}`}
       >
         <CustomIndicatorExample />
       </Example>

--- a/packages/playground/src/pages/components/EmojiPickerDemo.tsx
+++ b/packages/playground/src/pages/components/EmojiPickerDemo.tsx
@@ -38,23 +38,42 @@ export function EmojiPickerDemo() {
       <Example
         title="Reaction picker in a Popover"
         description="The canonical use: an icon-only trigger opens the grid inside a Popover you control. onSelect tallies the chosen emoji into a reaction count shown as a Cluster of Badges."
-        code={`const [reactions, setReactions] = useState<Record<string, number>>({ '👍': 2, '🎉': 1 });
+        code={`import { useState } from 'react';
+import { Smile } from 'lucide-react';
+import { EmojiPicker, Popover, Button, Badge, Stack, Cluster, Text } from '@eocrm/design-system';
 
-<Cluster gap="xs" align="center">
-  {Object.entries(reactions).map(([emoji, count]) => (
-    <Badge key={emoji} tone="neutral">{emoji} {count}</Badge>
-  ))}
-  <Popover>
-    <Popover.Trigger>
-      <Button iconOnly variant="ghost" size="sm" aria-label="Add reaction">
-        <Smile size={16} />
-      </Button>
-    </Popover.Trigger>
-    <Popover.Content>
-      <EmojiPicker onSelect={(emoji) => setReactions((r) => tally(r, emoji))} />
-    </Popover.Content>
-  </Popover>
-</Cluster>`}
+function tally(reactions: Record<string, number>, emoji: string): Record<string, number> {
+  return { ...reactions, [emoji]: (reactions[emoji] ?? 0) + 1 };
+}
+
+export function Demo() {
+  const [reactions, setReactions] = useState<Record<string, number>>({ '👍': 2, '🎉': 1 });
+
+  return (
+    <Stack gap="sm">
+      <Text size="sm">
+        <strong>Maya Chen</strong> closed the Acme renewal — nice quarter.
+      </Text>
+      <Cluster gap="xs" align="center">
+        {Object.entries(reactions).map(([emoji, count]) => (
+          <Badge key={emoji} tone="neutral">
+            {emoji} {count}
+          </Badge>
+        ))}
+        <Popover>
+          <Popover.Trigger>
+            <Button iconOnly variant="ghost" size="sm" aria-label="Add reaction">
+              <Smile size={16} />
+            </Button>
+          </Popover.Trigger>
+          <Popover.Content>
+            <EmojiPicker onSelect={(emoji) => setReactions((r) => tally(r, emoji))} />
+          </Popover.Content>
+        </Popover>
+      </Cluster>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Text size="sm">
@@ -83,13 +102,22 @@ export function EmojiPickerDemo() {
       <Example
         title="EmojiPickerPopover wrapper (opens + closes for you)"
         description="The batteries-included wrapper owns the Popover and closes on select. Pass a trigger and an onSelect — here it appends the chosen emoji to a comment draft."
-        code={`<Cluster gap="sm" align="center">
-  <Text size="sm">{draft || 'Write a comment…'}</Text>
-  <EmojiPickerPopover
-    trigger={<Button variant="secondary" size="sm">Add reaction</Button>}
-    onSelect={(emoji) => setDraft((d) => d + emoji)}
-  />
-</Cluster>`}
+        code={`import { useState } from 'react';
+import { EmojiPickerPopover, Button, Cluster, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  const [draft, setDraft] = useState('Great work shipping the Q3 renewal flow ');
+
+  return (
+    <Cluster gap="sm" align="center">
+      <Text size="sm">{draft || 'Write a comment…'}</Text>
+      <EmojiPickerPopover
+        trigger={<Button variant="secondary" size="sm">Add reaction</Button>}
+        onSelect={(emoji) => setDraft((d) => d + emoji)}
+      />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" align="center">
           <Text size="sm">{draft || 'Write a comment…'}</Text>
@@ -107,12 +135,21 @@ export function EmojiPickerDemo() {
       <Example
         title="Bare grid (no Popover)"
         description="The picker surface on its own — search box + category-sectioned 8-column grid, navigable by arrow keys. Drop it into any container; here onSelect echoes the most recent pick."
-        code={`<Stack gap="sm">
-  <EmojiPicker onSelect={setLastInserted} />
-  <Text size="sm" tone="muted">
-    Last picked: {lastInserted ?? '—'}
-  </Text>
-</Stack>`}
+        code={`import { useState } from 'react';
+import { EmojiPicker, Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  const [lastInserted, setLastInserted] = useState<string | null>(null);
+
+  return (
+    <Stack gap="sm">
+      <EmojiPicker onSelect={setLastInserted} />
+      <Text size="sm" tone="muted">
+        Last picked: {lastInserted ?? '—'}
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <EmojiPicker onSelect={setLastInserted} />
@@ -125,11 +162,23 @@ export function EmojiPickerDemo() {
       <Example
         title="Recently used (recent prop)"
         description="Pass recent={[...]} to pin a 'Recently used' section at the top (shown only while not searching). The consumer owns persistence — keep the list yourself (e.g. localStorage), update it in onSelect, and pass it back. Here, picking an emoji moves it to the front of the recent row."
-        code={`const [recent, setRecent] = useState<string[]>(['👍', '🎉', '❤️', '🔥', '✅']);
-const addRecent = (emoji: string) =>
-  setRecent((r) => [emoji, ...r.filter((c) => c !== emoji)].slice(0, 16));
+        code={`import { useState } from 'react';
+import { EmojiPicker, Stack, Text } from '@eocrm/design-system';
 
-<EmojiPicker recent={recent} onSelect={addRecent} />`}
+export function Demo() {
+  const [recent, setRecent] = useState<string[]>(['👍', '🎉', '❤️', '🔥', '✅']);
+  const addRecent = (emoji: string) =>
+    setRecent((r) => [emoji, ...r.filter((c) => c !== emoji)].slice(0, 16));
+
+  return (
+    <Stack gap="sm">
+      <EmojiPicker recent={recent} onSelect={addRecent} />
+      <Text size="sm" tone="muted">
+        recent: {recent.join(' ')}
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <EmojiPicker recent={recent} onSelect={addRecent} />

--- a/packages/playground/src/pages/components/EmptyStateDemo.tsx
+++ b/packages/playground/src/pages/components/EmptyStateDemo.tsx
@@ -15,7 +15,11 @@ export function EmptyStateDemo() {
       <Example
         title="Title only"
         description="Minimal form — just a title. Works for inline contexts where a short label is enough."
-        code={`<EmptyState title="No results" />`}
+        code={`import { EmptyState } from '@eocrm/design-system';
+
+export function Demo() {
+  return <EmptyState title="No results" />;
+}`}
       >
         <EmptyState title="No results" />
       </Example>
@@ -23,7 +27,12 @@ export function EmptyStateDemo() {
       <Example
         title="With icon"
         description="An icon above the title adds visual weight and helps users orient quickly."
-        code={`<EmptyState icon={<Inbox size={32} />} title="Inbox empty" />`}
+        code={`import { Inbox } from 'lucide-react';
+import { EmptyState } from '@eocrm/design-system';
+
+export function Demo() {
+  return <EmptyState icon={<Inbox size={32} />} title="Inbox empty" />;
+}`}
       >
         <EmptyState icon={<Inbox size={32} />} title="Inbox empty" />
       </Example>
@@ -31,11 +40,18 @@ export function EmptyStateDemo() {
       <Example
         title="With icon + description"
         description="A description elaborates on why the state is empty and sets expectations."
-        code={`<EmptyState
-  icon={<Inbox size={32} />}
-  title="Inbox empty"
-  description="When you get a message, it'll show up here."
-/>`}
+        code={`import { Inbox } from 'lucide-react';
+import { EmptyState } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <EmptyState
+      icon={<Inbox size={32} />}
+      title="Inbox empty"
+      description="When you get a message, it'll show up here."
+    />
+  );
+}`}
       >
         <EmptyState
           icon={<Inbox size={32} />}
@@ -47,12 +63,19 @@ export function EmptyStateDemo() {
       <Example
         title="With icon + description + single action"
         description="One primary action guides the user to the obvious next step."
-        code={`<EmptyState
-  icon={<Users size={32} />}
-  title="No contacts yet"
-  description="Add your first contact to get started."
-  actions={<Button>Add contact</Button>}
-/>`}
+        code={`import { Users } from 'lucide-react';
+import { Button, EmptyState } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <EmptyState
+      icon={<Users size={32} />}
+      title="No contacts yet"
+      description="Add your first contact to get started."
+      actions={<Button>Add contact</Button>}
+    />
+  );
+}`}
       >
         <EmptyState
           icon={<Users size={32} />}
@@ -65,17 +88,24 @@ export function EmptyStateDemo() {
       <Example
         title="With icon + description + multiple actions"
         description="Use a Cluster to lay out two actions side-by-side. Keep one primary; make the secondary ghost."
-        code={`<EmptyState
-  icon={<SearchX size={32} />}
-  title="No results"
-  description="Try clearing filters or a different search term."
-  actions={
-    <Cluster gap="sm" justify="center">
-      <Button>Clear filters</Button>
-      <Button variant="ghost">New search</Button>
-    </Cluster>
-  }
-/>`}
+        code={`import { SearchX } from 'lucide-react';
+import { Button, Cluster, EmptyState } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <EmptyState
+      icon={<SearchX size={32} />}
+      title="No results"
+      description="Try clearing filters or a different search term."
+      actions={
+        <Cluster gap="sm" justify="center">
+          <Button>Clear filters</Button>
+          <Button variant="ghost">New search</Button>
+        </Cluster>
+      }
+    />
+  );
+}`}
       >
         <EmptyState
           icon={<SearchX size={32} />}
@@ -93,26 +123,33 @@ export function EmptyStateDemo() {
       <Example
         title="Sizes — sm / md / lg"
         description="sm for inline / popover contexts, md (default) for cards and sections, lg for hero / full-page empty states. Recommended icon sizes: sm=24, md=32, lg=48."
-        code={`<Stack gap="lg">
-  <EmptyState
-    size="sm"
-    icon={<Search size={24} />}
-    title="No matches"
-    description="Refine your search to see results."
-  />
-  <EmptyState
-    size="md"
-    icon={<Search size={32} />}
-    title="No matches"
-    description="Refine your search to see results."
-  />
-  <EmptyState
-    size="lg"
-    icon={<Search size={48} />}
-    title="No matches"
-    description="Refine your search to see results."
-  />
-</Stack>`}
+        code={`import { Search } from 'lucide-react';
+import { EmptyState, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="lg">
+      <EmptyState
+        size="sm"
+        icon={<Search size={24} />}
+        title="No matches"
+        description="Refine your search to see results."
+      />
+      <EmptyState
+        size="md"
+        icon={<Search size={32} />}
+        title="No matches"
+        description="Refine your search to see results."
+      />
+      <EmptyState
+        size="lg"
+        icon={<Search size={48} />}
+        title="No matches"
+        description="Refine your search to see results."
+      />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="lg">
           <EmptyState
@@ -139,15 +176,22 @@ export function EmptyStateDemo() {
       <Example
         title="Align start"
         description="Left-aligned variant for narrow columns where center alignment would look stranded."
-        code={`<div style={{ maxWidth: 360 }}>
-  <EmptyState
-    align="start"
-    icon={<PackageOpen size={32} />}
-    title="No shipments today"
-    description="When something's on the way, it'll appear here."
-    actions={<Button size="sm">View archive</Button>}
-  />
-</div>`}
+        code={`import { PackageOpen } from 'lucide-react';
+import { Button, EmptyState } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <EmptyState
+        align="start"
+        icon={<PackageOpen size={32} />}
+        title="No shipments today"
+        description="When something's on the way, it'll appear here."
+        actions={<Button size="sm">View archive</Button>}
+      />
+    </div>
+  );
+}`}
       >
         <div style={{ maxWidth: 360 }}>
           <EmptyState
@@ -163,15 +207,22 @@ export function EmptyStateDemo() {
       <Example
         title="Inside a Card"
         description="Wrap in a Card when the empty state occupies a defined surface area, such as a Kanban column or dashboard panel."
-        code={`<Card padding="lg">
-  <EmptyState
-    icon={<Inbox size={48} />}
-    title="Nothing here yet"
-    description="Once you add deals, they'll appear in this column."
-    actions={<Button>Add deal</Button>}
-    size="lg"
-  />
-</Card>`}
+        code={`import { Inbox } from 'lucide-react';
+import { Button, Card, EmptyState } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Card padding="lg" style={{ maxWidth: 480 }}>
+      <EmptyState
+        icon={<Inbox size={48} />}
+        title="Nothing here yet"
+        description="Once you add deals, they'll appear in this column."
+        actions={<Button>Add deal</Button>}
+        size="lg"
+      />
+    </Card>
+  );
+}`}
       >
         <Card padding="lg" style={{ maxWidth: 480 }}>
           <EmptyState
@@ -187,28 +238,35 @@ export function EmptyStateDemo() {
       <Example
         title="Inside a Table (no rows)"
         description="DataTable's 'no rows' shape: a single body row with a cell that spans every column. Use size='sm' so the empty state sits inside the row without exploding its height."
-        code={`<Table>
-  <Table.Header>
-    <Table.Row>
-      <Table.HeaderCell>Name</Table.HeaderCell>
-      <Table.HeaderCell>Email</Table.HeaderCell>
-      <Table.HeaderCell align="end">Amount</Table.HeaderCell>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.Cell colSpan={3}>
-        <EmptyState
-          size="sm"
-          icon={<SearchX size={24} />}
-          title="No matching contacts"
-          description="Try clearing the filter or searching for a different name."
-          actions={<Button size="sm">Clear filters</Button>}
-        />
-      </Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table>`}
+        code={`import { SearchX } from 'lucide-react';
+import { Button, EmptyState, Table } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Name</Table.HeaderCell>
+          <Table.HeaderCell>Email</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell colSpan={3}>
+            <EmptyState
+              size="sm"
+              icon={<SearchX size={24} />}
+              title="No matching contacts"
+              description="Try clearing the filter or searching for a different name."
+              actions={<Button size="sm">Clear filters</Button>}
+            />
+          </Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  );
+}`}
       >
         <Table>
           <Table.Header>

--- a/packages/playground/src/pages/components/ErrorStateDemo.tsx
+++ b/packages/playground/src/pages/components/ErrorStateDemo.tsx
@@ -15,17 +15,24 @@ export function ErrorStateDemo() {
       <Example
         title="Not found (neutral)"
         description="The default tone. size defaults to lg (full-page hero), headingLevel to 1."
-        code={`<ErrorState
-  icon={<Compass size={48} aria-hidden="true" />}
-  title="Page not found"
-  description="We couldn't find that page. It may have been moved or deleted."
-  actions={
-    <Cluster gap="sm" justify="center">
-      <Button>Back to dashboard</Button>
-      <Button variant="secondary">Search</Button>
-    </Cluster>
-  }
-/>`}
+        code={`import { Compass } from 'lucide-react';
+import { Button, Cluster, ErrorState } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <ErrorState
+      icon={<Compass size={48} aria-hidden="true" />}
+      title="Page not found"
+      description="We couldn't find that page. It may have been moved or deleted."
+      actions={
+        <Cluster gap="sm" justify="center">
+          <Button>Back to dashboard</Button>
+          <Button variant="secondary">Search</Button>
+        </Cluster>
+      }
+    />
+  );
+}`}
       >
         <ErrorState
           icon={<Compass size={48} aria-hidden="true" />}
@@ -43,14 +50,25 @@ export function ErrorStateDemo() {
       <Example
         title="Error (danger + extra)"
         description={`tone="danger" tints the icon red and sets role="alert"; extra holds a support reference below the actions.`}
-        code={`<ErrorState
-  tone="danger"
-  icon={<TriangleAlert size={48} aria-hidden="true" />}
-  title="Something went wrong"
-  description="An unexpected error occurred. We've logged it and our team is on it."
-  actions={<Button>Try again</Button>}
-  extra={<Text size="sm" tone="muted">Error ID: a1b2-c3d4</Text>}
-/>`}
+        code={`import { TriangleAlert } from 'lucide-react';
+import { Button, ErrorState, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <ErrorState
+      tone="danger"
+      icon={<TriangleAlert size={48} aria-hidden="true" />}
+      title="Something went wrong"
+      description="An unexpected error occurred. We've logged it and our team is on it."
+      actions={<Button>Try again</Button>}
+      extra={
+        <Text size="sm" tone="muted">
+          Error ID: a1b2-c3d4
+        </Text>
+      }
+    />
+  );
+}`}
       >
         <ErrorState
           tone="danger"
@@ -69,9 +87,18 @@ export function ErrorStateDemo() {
       <Example
         title="Sizes"
         description="sm / md / lg (default). Pair the icon size with the state size (24 / 32 / 48)."
-        code={`<ErrorState size="sm" icon={<Compass size={24} aria-hidden="true" />} title="Not found" />
-<ErrorState size="md" icon={<Compass size={32} aria-hidden="true" />} title="Not found" />
-<ErrorState size="lg" icon={<Compass size={48} aria-hidden="true" />} title="Not found" />`}
+        code={`import { Compass } from 'lucide-react';
+import { Cluster, ErrorState } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="xl" align="start">
+      <ErrorState size="sm" icon={<Compass size={24} aria-hidden="true" />} title="Not found" />
+      <ErrorState size="md" icon={<Compass size={32} aria-hidden="true" />} title="Not found" />
+      <ErrorState size="lg" icon={<Compass size={48} aria-hidden="true" />} title="Not found" />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="xl" align="start">
           <ErrorState size="sm" icon={<Compass size={24} aria-hidden="true" />} title="Not found" />

--- a/packages/playground/src/pages/components/FieldDemo.tsx
+++ b/packages/playground/src/pages/components/FieldDemo.tsx
@@ -14,13 +14,20 @@ export function FieldDemo() {
       name="Field"
       description="Labeled-control unit — wires label, help, error, the required marker, and id/aria-describedby/invalid onto any control. No validation or state of its own."
       files={getComponentFiles('Field')}
+      componentName="Field"
     >
       <Example
         title="Label + description"
         description="Label associated to the control; helper text linked via aria-describedby."
-        code={`<Field label="Work email" description="We only use this for sign-in.">
-  <Input type="email" placeholder="you@company.com" />
-</Field>`}
+        code={`import { Field, Input } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Field label="Work email" description="We only use this for sign-in.">
+      <Input type="email" placeholder="you@company.com" />
+    </Field>
+  );
+}`}
       >
         <Field label="Work email" description="We only use this for sign-in.">
           <Input type="email" placeholder="you@company.com" />
@@ -30,9 +37,25 @@ export function FieldDemo() {
       <Example
         title="Required + live error"
         description="error replaces the description, flips the control to invalid, and links the message. Type a value without an '@'."
-        code={`<Field label="Email" required error={emailError}>
-  <Input value={email} onChange={(e) => setEmail(e.target.value)} />
-</Field>`}
+        code={`import { useState } from 'react';
+import { Field, Input } from '@eocrm/design-system';
+
+export function Demo() {
+  const [email, setEmail] = useState('');
+  const emailError =
+    email.length > 0 && !email.includes('@') ? 'Enter a valid email address.' : undefined;
+
+  return (
+    <Field label="Email" required error={emailError}>
+      <Input
+        type="email"
+        placeholder="you@company.com"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+    </Field>
+  );
+}`}
       >
         <Field label="Email" required error={emailError}>
           <Input
@@ -47,9 +70,15 @@ export function FieldDemo() {
       <Example
         title="Optional + horizontal orientation"
         description="orientation='horizontal' places the label beside the control — the Settings-row layout."
-        code={`<Field label="Display name" optional orientation="horizontal">
-  <Input placeholder="Ada Lovelace" />
-</Field>`}
+        code={`import { Field, Input } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Field label="Display name" optional orientation="horizontal">
+      <Input placeholder="Ada Lovelace" />
+    </Field>
+  );
+}`}
       >
         <Field label="Display name" optional orientation="horizontal">
           <Input placeholder="Ada Lovelace" />
@@ -59,12 +88,18 @@ export function FieldDemo() {
       <Example
         title="Group mode (radio set)"
         description="asGroup renders the label as a role=group caption (no htmlFor) and wires the group's aria-labelledby / error."
-        code={`<Field asGroup label="Notify me" error="Pick one option.">
-  <RadioGroup name="notify">
-    <Radio value="all" label="All activity" />
-    <Radio value="mentions" label="Only mentions" />
-  </RadioGroup>
-</Field>`}
+        code={`import { Field, Radio, RadioGroup } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Field asGroup label="Notify me" error="Pick one option.">
+      <RadioGroup name="notify-demo">
+        <Radio value="all" label="All activity" />
+        <Radio value="mentions" label="Only mentions" />
+      </RadioGroup>
+    </Field>
+  );
+}`}
       >
         <Field asGroup label="Notify me" error="Pick one option.">
           <RadioGroup name="notify-demo">

--- a/packages/playground/src/pages/components/FileUploadDemo.tsx
+++ b/packages/playground/src/pages/components/FileUploadDemo.tsx
@@ -194,13 +194,23 @@ export function FileUploadDemo() {
       <Example
         title="Basic single-file"
         description="Default mode — at most one file. The dropzone hides once a file is present and re-appears after removal."
-        code={`function BasicSingle() {
+        code={`import { useState } from 'react';
+import { FileUpload, type FileEntry } from '@eocrm/design-system';
+
+function makeId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return \`id-\${Math.random().toString(36).slice(2)}\`;
+}
+
+export function BasicSingle() {
   const [files, setFiles] = useState<FileEntry[]>([]);
   return (
     <FileUpload
       files={files}
       onFilesAdded={(added) =>
-        setFiles(added.map((f) => ({ id: crypto.randomUUID(), file: f, status: 'pending' })))
+        setFiles(added.map((f) => ({ id: makeId(), file: f, status: 'pending' as const })))
       }
       onFileRemove={(entry) => setFiles((prev) => prev.filter((e) => e.id !== entry.id))}
     />
@@ -213,16 +223,40 @@ export function FileUploadDemo() {
       <Example
         title="Multiple with limits"
         description="multiple + maxFiles + maxSize + accept. The dropzone stays visible while the file list grows beneath."
-        code={`<FileUpload
-  multiple
-  files={files}
-  accept=".pdf,image/*"
-  maxFiles={5}
-  maxSize={10 * 1024 * 1024}
-  dropzoneHint={<>Up to 5 files, <Code>.pdf</Code> or images, 10 MB each</>}
-  onFilesAdded={…}
-  onFileRemove={…}
-/>`}
+        code={`import { useState } from 'react';
+import { Code, FileUpload, type FileEntry } from '@eocrm/design-system';
+
+function makeId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return \`id-\${Math.random().toString(36).slice(2)}\`;
+}
+
+export function MultiWithLimits() {
+  const [files, setFiles] = useState<FileEntry[]>([]);
+  return (
+    <FileUpload
+      multiple
+      files={files}
+      accept=".pdf,image/*"
+      maxFiles={5}
+      maxSize={10 * 1024 * 1024}
+      dropzoneHint={
+        <span>
+          Up to 5 files, <Code>.pdf</Code> or images, 10 MB each
+        </span>
+      }
+      onFilesAdded={(added) =>
+        setFiles((prev) => [
+          ...prev,
+          ...added.map((f) => ({ id: makeId(), file: f, status: 'pending' as const })),
+        ])
+      }
+      onFileRemove={(entry) => setFiles((prev) => prev.filter((e) => e.id !== entry.id))}
+    />
+  );
+}`}
       >
         <MultiWithLimits />
       </Example>
@@ -230,11 +264,86 @@ export function FileUploadDemo() {
       <Example
         title="Status walkthrough"
         description="Drop a file, then click 'Start upload' to walk it through pending → uploading (with progress ticking) → done. Demonstrates the consumer's full state-machine ownership."
-        code={`// Consumer's upload code transitions the entry through statuses:
-const startUpload = () => {
-  setFiles(prev => prev.map(e => e.id === id ? { ...e, status: 'uploading', progress: 0 } : e));
-  // ... tick progress, eventually set status: 'done' ...
-};`}
+        code={`import { useEffect, useRef, useState } from 'react';
+import { Button, Cluster, FileUpload, Stack, Text, type FileEntry } from '@eocrm/design-system';
+
+function makeId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return \`id-\${Math.random().toString(36).slice(2)}\`;
+}
+
+export function StatusWalkthrough() {
+  const [files, setFiles] = useState<FileEntry[]>([]);
+  const [progress, setProgress] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, []);
+
+  const startUpload = () => {
+    if (files.length === 0) return;
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    const id = files[0].id;
+    setFiles((prev) =>
+      prev.map((e) => (e.id === id ? { ...e, status: 'uploading' as const, progress: 0 } : e)),
+    );
+    setProgress(0);
+    intervalRef.current = setInterval(() => {
+      setProgress((p) => {
+        const next = Math.min(100, p + 10);
+        setFiles((prev) => prev.map((e) => (e.id === id ? { ...e, progress: next } : e)));
+        if (next === 100) {
+          if (intervalRef.current !== null) {
+            clearInterval(intervalRef.current);
+            intervalRef.current = null;
+          }
+          setTimeout(() => {
+            setFiles((prev) =>
+              prev.map((e) => (e.id === id ? { ...e, status: 'done' as const } : e)),
+            );
+          }, 200);
+        }
+        return next;
+      });
+    }, 200);
+  };
+
+  return (
+    <Stack gap="sm">
+      <FileUpload
+        files={files}
+        onFilesAdded={(added) =>
+          setFiles(added.map((f) => ({ id: makeId(), file: f, status: 'pending' as const })))
+        }
+        onFileRemove={(entry) => setFiles((prev) => prev.filter((e) => e.id !== entry.id))}
+      />
+      <Cluster gap="sm">
+        <Button
+          size="sm"
+          onClick={startUpload}
+          disabled={files.length === 0 || files[0]?.status !== 'pending'}
+        >
+          Start upload
+        </Button>
+        <Text size="sm" tone="muted">
+          Drop a file then click "Start upload" to walk through pending → uploading ({progress}%) →
+          done.
+        </Text>
+      </Cluster>
+    </Stack>
+  );
+}`}
       >
         <StatusWalkthrough />
       </Example>
@@ -242,7 +351,18 @@ const startUpload = () => {
       <Example
         title="Error state"
         description="A row with status='error' renders the error message in danger color and tints the row's border."
-        code={`<FileUpload files={[{ id: 'err-1', file, status: 'error', error: 'Server returned 500 — please retry' }]} … />`}
+        code={`import { FileUpload, type FileEntry } from '@eocrm/design-system';
+
+const file: FileEntry = {
+  id: 'err-1',
+  file: new File([new Uint8Array(1024 * 50)], 'broken.csv', { type: 'text/csv' }),
+  status: 'error',
+  error: 'Server returned 500 — please retry',
+};
+
+export function ErrorState() {
+  return <FileUpload files={[file]} onFilesAdded={() => {}} onFileRemove={() => {}} />;
+}`}
       >
         <ErrorState />
       </Example>
@@ -250,7 +370,17 @@ const startUpload = () => {
       <Example
         title="Disabled"
         description="The dropzone is grayed and non-interactive; remove buttons are disabled."
-        code={`<FileUpload disabled files={files} onFilesAdded={() => {}} onFileRemove={() => {}} />`}
+        code={`import { FileUpload, type FileEntry } from '@eocrm/design-system';
+
+const file: FileEntry = {
+  id: 'dis-1',
+  file: new File([new Uint8Array(1024 * 100)], 'locked.pdf', { type: 'application/pdf' }),
+  status: 'done',
+};
+
+export function DisabledDemo() {
+  return <FileUpload disabled files={[file]} onFilesAdded={() => {}} onFileRemove={() => {}} />;
+}`}
       >
         <DisabledDemo />
       </Example>
@@ -258,13 +388,49 @@ const startUpload = () => {
       <Example
         title="Custom validator"
         description="Reject files whose names contain 'test'. The onFileReject callback fires with reason='custom' and the validator's returned message."
-        code={`<FileUpload
-  multiple
-  files={files}
-  validator={(f) => f.name.toLowerCase().includes('test') ? 'Filenames cannot contain "test"' : null}
-  onFileReject={(file, reason, message) => toast.error(message ?? \`\${file.name}: \${reason}\`)}
-  …
-/>`}
+        code={`import { useState } from 'react';
+import { Code, FileUpload, Stack, Text, type FileEntry } from '@eocrm/design-system';
+
+function makeId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return \`id-\${Math.random().toString(36).slice(2)}\`;
+}
+
+export function CustomValidator() {
+  const [files, setFiles] = useState<FileEntry[]>([]);
+  const [rejected, setRejected] = useState<string | null>(null);
+  return (
+    <Stack gap="sm">
+      <FileUpload
+        multiple
+        files={files}
+        validator={(f) =>
+          f.name.toLowerCase().includes('test') ? 'Filenames cannot contain "test"' : null
+        }
+        dropzoneHint={
+          <Text as="span" size="sm" tone="muted">
+            Try dropping a file named <Code>test.csv</Code> to see the custom rejection.
+          </Text>
+        }
+        onFilesAdded={(added) =>
+          setFiles((prev) => [
+            ...prev,
+            ...added.map((f) => ({ id: makeId(), file: f, status: 'pending' as const })),
+          ])
+        }
+        onFileRemove={(entry) => setFiles((prev) => prev.filter((e) => e.id !== entry.id))}
+        onFileReject={(file, reason, message) => setRejected(\`\${file.name}: \${message ?? reason}\`)}
+      />
+      {rejected && (
+        <Text size="sm" tone="danger">
+          Rejected: {rejected}
+        </Text>
+      )}
+    </Stack>
+  );
+}`}
       >
         <CustomValidator />
       </Example>

--- a/packages/playground/src/pages/components/FilterChipDemo.tsx
+++ b/packages/playground/src/pages/components/FilterChipDemo.tsx
@@ -37,10 +37,31 @@ export function FilterChipDemo() {
       <Example
         title="Label + tone-dotted value + dismiss"
         description="The canonical filter-chip shape. tone='info' prefixes a 6px blue dot before the value text. The dismiss × removes the chip from local state."
-        code={`<FilterChip onDismiss={() => removeChip('event')}>
-  <FilterChip.Label>Event</FilterChip.Label>
-  <FilterChip.Value tone="info">auth.* (3)</FilterChip.Value>
-</FilterChip>`}
+        code={`import { useState } from 'react';
+import { Cluster, FilterChip } from '@eocrm/design-system';
+
+export function Demo() {
+  const [chips, setChips] = useState(['event', 'tenant']);
+  const removeChip = (id: string) =>
+    setChips((prev) => prev.filter((c) => c !== id));
+
+  return (
+    <Cluster gap="sm">
+      {chips.includes('event') && (
+        <FilterChip onDismiss={() => removeChip('event')}>
+          <FilterChip.Label>Event</FilterChip.Label>
+          <FilterChip.Value tone="info">auth.* (3)</FilterChip.Value>
+        </FilterChip>
+      )}
+      {chips.includes('tenant') && (
+        <FilterChip onDismiss={() => removeChip('tenant')}>
+          <FilterChip.Label>Tenant</FilterChip.Label>
+          <FilterChip.Value>beta</FilterChip.Value>
+        </FilterChip>
+      )}
+    </Cluster>
+  );
+}`}
       >
         <InputExample width="auto">
           <Cluster gap="sm">
@@ -63,10 +84,38 @@ export function FilterChipDemo() {
       <Example
         title="Tone variants"
         description="One chip per BadgeTone — info / success / warning / danger / purple / neutral. The dot color comes from the matching token; the pill itself stays neutral white."
-        code={`<FilterChip onDismiss={() => {}}>
-  <FilterChip.Label>Event</FilterChip.Label>
-  <FilterChip.Value tone="success">auth.login_succeeded</FilterChip.Value>
-</FilterChip>`}
+        code={`import { Cluster, FilterChip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <FilterChip onDismiss={() => {}}>
+        <FilterChip.Label>Event</FilterChip.Label>
+        <FilterChip.Value tone="info">role.assigned</FilterChip.Value>
+      </FilterChip>
+      <FilterChip onDismiss={() => {}}>
+        <FilterChip.Label>Event</FilterChip.Label>
+        <FilterChip.Value tone="success">auth.login_succeeded</FilterChip.Value>
+      </FilterChip>
+      <FilterChip onDismiss={() => {}}>
+        <FilterChip.Label>Event</FilterChip.Label>
+        <FilterChip.Value tone="warning">invitation.expired</FilterChip.Value>
+      </FilterChip>
+      <FilterChip onDismiss={() => {}}>
+        <FilterChip.Label>Event</FilterChip.Label>
+        <FilterChip.Value tone="danger">auth.login_failed</FilterChip.Value>
+      </FilterChip>
+      <FilterChip onDismiss={() => {}}>
+        <FilterChip.Label>Event</FilterChip.Label>
+        <FilterChip.Value tone="purple">deal.won</FilterChip.Value>
+      </FilterChip>
+      <FilterChip onDismiss={() => {}}>
+        <FilterChip.Label>Event</FilterChip.Label>
+        <FilterChip.Value tone="neutral">system_setting.updated</FilterChip.Value>
+      </FilterChip>
+    </Cluster>
+  );
+}`}
       >
         <InputExample width="auto">
           <Cluster gap="sm">
@@ -101,9 +150,20 @@ export function FilterChipDemo() {
       <Example
         title="Value-only (no label)"
         description="Omit the Label subcomponent for chips that don't need a category prefix — useful when the filter category is implied by surrounding context."
-        code={`<FilterChip onDismiss={() => {}}>
-  <FilterChip.Value tone="warning">Platform only</FilterChip.Value>
-</FilterChip>`}
+        code={`import { Cluster, FilterChip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <FilterChip onDismiss={() => {}}>
+        <FilterChip.Value tone="warning">Platform only</FilterChip.Value>
+      </FilterChip>
+      <FilterChip onDismiss={() => {}}>
+        <FilterChip.Value>acme</FilterChip.Value>
+      </FilterChip>
+    </Cluster>
+  );
+}`}
       >
         <InputExample width="auto">
           <Cluster gap="sm">
@@ -120,10 +180,16 @@ export function FilterChipDemo() {
       <Example
         title="Read-only (no dismiss button)"
         description="Omit onDismiss to render a static chip — useful for displaying filters that aren't user-removable."
-        code={`<FilterChip>
-  <FilterChip.Label>Status</FilterChip.Label>
-  <FilterChip.Value>Active</FilterChip.Value>
-</FilterChip>`}
+        code={`import { FilterChip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <FilterChip>
+      <FilterChip.Label>Status</FilterChip.Label>
+      <FilterChip.Value>Active</FilterChip.Value>
+    </FilterChip>
+  );
+}`}
       >
         <InputExample width="auto">
           <FilterChip>
@@ -136,17 +202,51 @@ export function FilterChipDemo() {
       <Example
         title="Interactive (editable) chip"
         description="Pass onActivate to make the chip BODY a button — for editable filters whose body re-opens an editor. Click a chip body below to 'edit' it; click the ✕ to remove it. The ✕ stops propagation, so removing never fires onActivate. In a real screen, wire onActivate to a controlled <Popover open onOpenChange> whose content is the editor (e.g. a range-picker)."
-        code={`// Editable chip — body re-opens an editor popover; ✕ removes the filter
-const [open, setOpen] = useState(false);
-<Popover open={open} onOpenChange={setOpen}>
-  <Popover.Trigger>
-    <FilterChip onActivate={() => setOpen((o) => !o)} expanded={open} onDismiss={remove}>
-      <FilterChip.Label>Range</FilterChip.Label>
-      <FilterChip.Value>Jun 1 – Jul 31</FilterChip.Value>
-    </FilterChip>
-  </Popover.Trigger>
-  <Popover.Content maxWidth={520}>{/* range picker */}</Popover.Content>
-</Popover>`}
+        code={`import { useState } from 'react';
+import { Cluster, FilterChip, Stack, Text } from '@eocrm/design-system';
+
+type EditableFilter = { id: string; label: string; value: string };
+
+const INITIAL_EDITABLE: EditableFilter[] = [
+  { id: 'range', label: 'Range', value: 'Jun 1 – Jul 31' },
+  { id: 'owner', label: 'Owner', value: 'Sarah Chen' },
+  { id: 'event', label: 'Event', value: 'auth.* (3)' },
+];
+
+export function Demo() {
+  const [editable, setEditable] = useState<EditableFilter[]>(INITIAL_EDITABLE);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const removeEditable = (id: string) => {
+    setEditable((prev) => prev.filter((f) => f.id !== id));
+    setEditingId((cur) => (cur === id ? null : cur));
+  };
+
+  return (
+    <Stack gap="sm">
+      <Cluster gap="sm">
+        {editable.map((f) => (
+          <FilterChip
+            key={f.id}
+            onActivate={() => setEditingId((cur) => (cur === f.id ? null : f.id))}
+            expanded={editingId === f.id}
+            onDismiss={() => removeEditable(f.id)}
+            dismissLabel={\`Remove \${f.label}: \${f.value} filter\`}
+          >
+            <FilterChip.Label>{f.label}</FilterChip.Label>
+            <FilterChip.Value>{f.value}</FilterChip.Value>
+          </FilterChip>
+        ))}
+      </Cluster>
+      <Text size="sm" tone="muted">
+        {editable.length === 0
+          ? 'All filters removed.'
+          : editingId
+            ? \`Editing "\${editable.find((f) => f.id === editingId)?.label}" — a real consumer would now show a Popover editor here.\`
+            : 'Click a chip body to edit it; click × to remove (× never triggers edit).'}
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <InputExample width="auto">
           <Stack gap="sm">

--- a/packages/playground/src/pages/components/FormRowDemo.tsx
+++ b/packages/playground/src/pages/components/FormRowDemo.tsx
@@ -9,14 +9,25 @@ export function FormRowDemo() {
       name="FormRow"
       description="Lays form fields side by side. Thin wrapper over Grid — responsive auto-fit by default (reflows to stacked when narrow), or a fixed column count."
       files={getComponentFiles('FormRow')}
+      componentName="FormRow"
     >
       <Example
         title="Responsive (default)"
         description="Two fields sit side by side and drop to stacked as the container narrows — resize the window to see it reflow."
-        code={`<FormRow>
-  <Field label="First name" required><Input placeholder="Ada" /></Field>
-  <Field label="Last name" required><Input placeholder="Lovelace" /></Field>
-</FormRow>`}
+        code={`import { Field, FormRow, Input } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <FormRow>
+      <Field label="First name" required>
+        <Input placeholder="Ada" />
+      </Field>
+      <Field label="Last name" required>
+        <Input placeholder="Lovelace" />
+      </Field>
+    </FormRow>
+  );
+}`}
       >
         <FormRow>
           <Field label="First name" required>
@@ -31,11 +42,23 @@ export function FormRowDemo() {
       <Example
         title="Fixed columns"
         description="columns={3} keeps an exact three-up layout at any width."
-        code={`<FormRow columns={3}>
-  <Field label="City"><Input placeholder="London" /></Field>
-  <Field label="State / Region"><Input placeholder="England" /></Field>
-  <Field label="Postcode"><Input placeholder="SW1A" /></Field>
-</FormRow>`}
+        code={`import { Field, FormRow, Input } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <FormRow columns={3}>
+      <Field label="City">
+        <Input placeholder="London" />
+      </Field>
+      <Field label="State / Region">
+        <Input placeholder="England" />
+      </Field>
+      <Field label="Postcode">
+        <Input placeholder="SW1A" />
+      </Field>
+    </FormRow>
+  );
+}`}
       >
         <FormRow columns={3}>
           <Field label="City">

--- a/packages/playground/src/pages/components/FormSectionDemo.tsx
+++ b/packages/playground/src/pages/components/FormSectionDemo.tsx
@@ -9,17 +9,30 @@ export function FormSectionDemo() {
       name="FormSection"
       description="Titled group of form fields — a heading + description over a vertical stack of fields. Consecutive sections are separated by a divider automatically."
       files={getComponentFiles('FormSection')}
+      componentName="FormSection"
     >
       <Example
         title="Titled group"
         description="Heading + description over a stack of fields (here a side-by-side pair plus a full-width Field)."
-        code={`<FormSection title="Profile" description="Basic details that appear on the contact record.">
-  <FormRow>
-    <Field label="First name" required><Input placeholder="Ada" /></Field>
-    <Field label="Last name" required><Input placeholder="Lovelace" /></Field>
-  </FormRow>
-  <Field label="Work email" required><Input type="email" placeholder="ada@example.com" /></Field>
-</FormSection>`}
+        code={`import { Field, FormRow, FormSection, Input } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <FormSection title="Profile" description="Basic details that appear on the contact record.">
+      <FormRow>
+        <Field label="First name" required>
+          <Input placeholder="Ada" />
+        </Field>
+        <Field label="Last name" required>
+          <Input placeholder="Lovelace" />
+        </Field>
+      </FormRow>
+      <Field label="Work email" required>
+        <Input type="email" placeholder="ada@example.com" />
+      </Field>
+    </FormSection>
+  );
+}`}
       >
         <FormSection title="Profile" description="Basic details that appear on the contact record.">
           <FormRow>
@@ -39,12 +52,24 @@ export function FormSectionDemo() {
       <Example
         title="Consecutive sections get a divider"
         description="Render two sections as siblings; the divider between them is automatic."
-        code={`<FormSection title="Profile" description="Public details">
-  <Field label="Display name"><Input /></Field>
-</FormSection>
-<FormSection title="Preferences" description="Defaults for this contact">
-  <Field label="Timezone" orientation="horizontal"><Input /></Field>
-</FormSection>`}
+        code={`import { Field, FormSection, Input } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <>
+      <FormSection title="Profile" description="Public details">
+        <Field label="Display name">
+          <Input placeholder="Ada Lovelace" />
+        </Field>
+      </FormSection>
+      <FormSection title="Preferences" description="Defaults for this contact">
+        <Field label="Timezone" orientation="horizontal">
+          <Input placeholder="Europe/London" />
+        </Field>
+      </FormSection>
+    </>
+  );
+}`}
       >
         <>
           <FormSection title="Profile" description="Public details">

--- a/packages/playground/src/pages/components/GridDemo.tsx
+++ b/packages/playground/src/pages/components/GridDemo.tsx
@@ -26,11 +26,22 @@ function AutoFitExample() {
     <Example
       title="Auto-fit (default)"
       description="No props set. Defaults to `minColumnWidth='240px'`. Resize your viewport to watch the columns reflow."
-      code={`<Grid gap="md">
-  <Card>...</Card>
-  <Card>...</Card>
-  ...
-</Grid>`}
+      code={`import { Card, Grid } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Grid gap="md">
+      {Array.from({ length: 6 }, (_, i) => (
+        <Card key={i}>
+          <strong>Tile {i + 1}</strong>
+          <p style={{ margin: 0, color: 'var(--color-fg-muted)' }}>
+            Auto-fitted to fill the row.
+          </p>
+        </Card>
+      ))}
+    </Grid>
+  );
+}`}
     >
       <Grid gap="md">
         {Array.from({ length: 6 }, (_, i) => (
@@ -51,17 +62,30 @@ function FixedColumnsExample() {
     <Example
       title="Fixed columns (2-column form)"
       description="`columns={2}` for exactly two equal-width columns regardless of viewport. The canonical label/field form layout."
-      code={`<Grid columns={2} gap="lg">
-  <label>
-    First name
-    <Input placeholder="Ada" />
-  </label>
-  <label>
-    Last name
-    <Input placeholder="Lovelace" />
-  </label>
-  ...
-</Grid>`}
+      code={`import { Grid, Input } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Grid columns={2} gap="lg">
+      <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        <span style={{ fontSize: 'var(--font-size-sm)', fontWeight: 500 }}>First name</span>
+        <Input placeholder="Ada" />
+      </label>
+      <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        <span style={{ fontSize: 'var(--font-size-sm)', fontWeight: 500 }}>Last name</span>
+        <Input placeholder="Lovelace" />
+      </label>
+      <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        <span style={{ fontSize: 'var(--font-size-sm)', fontWeight: 500 }}>Email</span>
+        <Input placeholder="ada@example.com" />
+      </label>
+      <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        <span style={{ fontSize: 'var(--font-size-sm)', fontWeight: 500 }}>Phone</span>
+        <Input placeholder="+1 555 0100" />
+      </label>
+    </Grid>
+  );
+}`}
     >
       <Grid columns={2} gap="lg">
         <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
@@ -90,9 +114,26 @@ function GapScaleExample() {
     <Example
       title="Gap scale"
       description="Same scale as Stack and Cluster: xs (4) / sm (8) / md (12) / lg (16) / xl (24) / 2xl (32) — all in pixels."
-      code={`<Grid columns={3} gap="xs">...</Grid>
-<Grid columns={3} gap="md">...</Grid>
-<Grid columns={3} gap="2xl">...</Grid>`}
+      code={`import { Card, Grid, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      {(['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const).map((g) => (
+        <Stack key={g} gap="xs">
+          <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+            gap=&quot;{g}&quot;
+          </div>
+          <Grid columns={3} gap={g}>
+            {Array.from({ length: 3 }, (_, i) => (
+              <Card key={i}>cell {i + 1}</Card>
+            ))}
+          </Grid>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}`}
     >
       <Stack gap="md">
         {(['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const).map((g) => (
@@ -117,9 +158,26 @@ function MinColumnWidthExample() {
     <Example
       title="minColumnWidth variants"
       description="Three grids at different minimums. Wider minColumnWidth = fewer, wider columns at the same viewport."
-      code={`<Grid minColumnWidth="200px">...</Grid>
-<Grid minColumnWidth="280px">...</Grid>
-<Grid minColumnWidth="360px">...</Grid>`}
+      code={`import { Card, Grid, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      {(['200px', '280px', '360px'] as const).map((m) => (
+        <Stack key={m} gap="xs">
+          <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+            minColumnWidth=&quot;{m}&quot;
+          </div>
+          <Grid minColumnWidth={m} gap="sm">
+            {Array.from({ length: 5 }, (_, i) => (
+              <Card key={i}>cell {i + 1}</Card>
+            ))}
+          </Grid>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}`}
     >
       <Stack gap="md">
         {(['200px', '280px', '360px'] as const).map((m) => (
@@ -144,11 +202,36 @@ function AlignmentExample() {
     <Example
       title="alignItems / justifyItems"
       description="Cells of varying intrinsic content height. alignItems=start aligns content to the top of each track; alignItems=stretch (default browser behavior) makes them all match the tallest. Try changing the value to compare."
-      code={`<Grid columns={3} gap="md" alignItems="start">
-  <Card>short</Card>
-  <Card>medium content here that takes more lines</Card>
-  <Card>short</Card>
-</Grid>`}
+      code={`import { Card, Grid, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+        alignItems=&quot;start&quot;
+      </div>
+      <Grid columns={3} gap="md" alignItems="start">
+        <Card>short</Card>
+        <Card>
+          medium content here that takes a couple of lines so the card grows taller than the
+          others
+        </Card>
+        <Card>short</Card>
+      </Grid>
+      <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+        alignItems=&quot;stretch&quot; (default)
+      </div>
+      <Grid columns={3} gap="md" alignItems="stretch">
+        <Card>short</Card>
+        <Card>
+          medium content here that takes a couple of lines so the card grows taller than the
+          others
+        </Card>
+        <Card>short</Card>
+      </Grid>
+    </Stack>
+  );
+}`}
     >
       <Stack gap="md">
         <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
@@ -183,13 +266,30 @@ function SemanticElementExample() {
     <Example
       title="Semantic elements via `as`"
       description="Render Grid as a `<section>` (landmark) or `<ul>` (list). Limited to 10 common layout/semantic elements."
-      code={`<Grid as="section" columns={2} gap="md">
-  ...
-</Grid>
+      code={`import { Card, Cluster, Grid, Stack } from '@eocrm/design-system';
 
-<Grid as="ul" minColumnWidth="200px" gap="sm">
-  <li>...</li>
-</Grid>`}
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Grid as="section" columns={2} gap="md">
+        <Card>section cell 1</Card>
+        <Card>section cell 2</Card>
+      </Grid>
+      <Cluster gap="sm">
+        <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+          Below: rendered as &lt;ul&gt; with &lt;li&gt; children.
+        </span>
+      </Cluster>
+      <Grid as="ul" minColumnWidth="160px" gap="sm" style={{ listStyle: 'none', padding: 0 }}>
+        {['Alpha', 'Bravo', 'Charlie', 'Delta'].map((label) => (
+          <li key={label}>
+            <Card>{label}</Card>
+          </li>
+        ))}
+      </Grid>
+    </Stack>
+  );
+}`}
     >
       <Stack gap="md">
         <Grid as="section" columns={2} gap="md">

--- a/packages/playground/src/pages/components/IconTileDemo.tsx
+++ b/packages/playground/src/pages/components/IconTileDemo.tsx
@@ -15,9 +15,18 @@ export function IconTileDemo() {
       <Example
         title="Palette colors"
         description="color is one of the 30 categorical Palette colors (default 'slate'). Categorical, not semantic."
-        code={`{PALETTE_COLORS.map((c) => (
-  <IconTile key={c} color={c} label={c} icon={<Shapes size={16} />} />
-))}`}
+        code={`import { Shapes } from 'lucide-react';
+import { Cluster, IconTile, PALETTE_COLORS } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      {PALETTE_COLORS.map((c) => (
+        <IconTile key={c} color={c} label={c} icon={<Shapes size={16} />} />
+      ))}
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm">
           {PALETTE_COLORS.map((c) => (
@@ -29,9 +38,18 @@ export function IconTileDemo() {
       <Example
         title="Sizes"
         description="sm 24 / md 32 / lg 40 — sizes the tile box; size your icon to match."
-        code={`<IconTile color="blue" size="sm" icon={<Shapes size={14} />} />
-<IconTile color="blue" size="md" icon={<Shapes size={16} />} />
-<IconTile color="blue" size="lg" icon={<Shapes size={20} />} />`}
+        code={`import { Shapes } from 'lucide-react';
+import { Cluster, IconTile } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      <IconTile color="blue" size="sm" icon={<Shapes size={14} />} />
+      <IconTile color="blue" size="md" icon={<Shapes size={16} />} />
+      <IconTile color="blue" size="lg" icon={<Shapes size={20} />} />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           <IconTile color="blue" size="sm" icon={<Shapes size={14} />} />
@@ -43,8 +61,17 @@ export function IconTileDemo() {
       <Example
         title="Shape"
         description="square (default) or circle."
-        code={`<IconTile color="amber" shape="square" icon={<MailPlus size={16} />} />
-<IconTile color="amber" shape="circle" icon={<MailPlus size={16} />} />`}
+        code={`import { MailPlus } from 'lucide-react';
+import { Cluster, IconTile } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      <IconTile color="amber" shape="square" icon={<MailPlus size={16} />} />
+      <IconTile color="amber" shape="circle" icon={<MailPlus size={16} />} />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           <IconTile color="amber" shape="square" icon={<MailPlus size={16} />} />
@@ -55,14 +82,22 @@ export function IconTileDemo() {
       <Example
         title="Decorative vs labelled"
         description="Decorative by default (aria-hidden) beside text; pass a label when the icon stands alone."
-        code={`// decorative — text nearby carries meaning
-<Cluster gap="sm" align="center">
-  <IconTile color="amber" shape="circle" icon={<MailPlus size={14} />} />
-  <Text>alex@acme.co</Text>
-</Cluster>
+        code={`import { Check, MailPlus } from 'lucide-react';
+import { Cluster, IconTile, Stack, Text } from '@eocrm/design-system';
 
-// standalone + meaningful → label
-<IconTile color="green" label="Verified" icon={<Check size={16} />} />`}
+export function Demo() {
+  return (
+    <Stack gap="md">
+      {/* decorative — text nearby carries meaning */}
+      <Cluster gap="sm" align="center">
+        <IconTile color="amber" shape="circle" icon={<MailPlus size={14} />} />
+        <Text>alex@acme.co</Text>
+      </Cluster>
+      {/* standalone + meaningful → label */}
+      <IconTile color="green" label="Verified" icon={<Check size={16} />} />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Cluster gap="sm" align="center">

--- a/packages/playground/src/pages/components/ImageCropDemo.tsx
+++ b/packages/playground/src/pages/components/ImageCropDemo.tsx
@@ -198,9 +198,26 @@ export function ImageCropDemo() {
       <Example
         title="Basic (square aspect)"
         description="aspectRatio={1}. The crop box is centered as a square inside the viewport. Drag the image to reposition; zoom slider scales it."
-        code={`function BasicSquare() {
+        code={`import { useState } from 'react';
+import { Code, ImageCrop, Stack, Text, type CropArea } from '@eocrm/design-system';
+
+const SAMPLE_IMAGE = 'https://picsum.photos/seed/eocrm-imagecrop/1200/800';
+
+export function BasicSquare() {
   const [crop, setCrop] = useState<CropArea | null>(null);
-  return <ImageCrop src={SAMPLE_IMAGE} value={crop} onChange={setCrop} aspectRatio={1} />;
+  return (
+    <Stack gap="sm">
+      <ImageCrop src={SAMPLE_IMAGE} value={crop} onChange={setCrop} aspectRatio={1} />
+      <Text size="sm" tone="muted">
+        Crop:{' '}
+        <Code>
+          {crop
+            ? \`\${Math.round(crop.x)}, \${Math.round(crop.y)} — \${Math.round(crop.width)}×\${Math.round(crop.height)}\`
+            : 'computing...'}
+        </Code>
+      </Text>
+    </Stack>
+  );
 }`}
       >
         <BasicSquare />
@@ -209,7 +226,15 @@ export function ImageCropDemo() {
       <Example
         title="Landscape (16:9)"
         description="aspectRatio={16/9}. Crop box matches the configured ratio inside the viewport."
-        code={`<ImageCrop src={SAMPLE_IMAGE} value={crop} onChange={setCrop} aspectRatio={16 / 9} />`}
+        code={`import { useState } from 'react';
+import { ImageCrop, type CropArea } from '@eocrm/design-system';
+
+const SAMPLE_IMAGE = 'https://picsum.photos/seed/eocrm-imagecrop/1200/800';
+
+export function Landscape() {
+  const [crop, setCrop] = useState<CropArea | null>(null);
+  return <ImageCrop src={SAMPLE_IMAGE} value={crop} onChange={setCrop} aspectRatio={16 / 9} />;
+}`}
       >
         <Landscape />
       </Example>
@@ -217,7 +242,15 @@ export function ImageCropDemo() {
       <Example
         title="Free aspect (no aspectRatio prop)"
         description="Crop box fills the entire viewport. The user controls the cropped region via zoom only (zooming in shows less of the source)."
-        code={`<ImageCrop src={SAMPLE_IMAGE} value={crop} onChange={setCrop} />`}
+        code={`import { useState } from 'react';
+import { ImageCrop, type CropArea } from '@eocrm/design-system';
+
+const SAMPLE_IMAGE = 'https://picsum.photos/seed/eocrm-imagecrop/1200/800';
+
+export function FreeAspect() {
+  const [crop, setCrop] = useState<CropArea | null>(null);
+  return <ImageCrop src={SAMPLE_IMAGE} value={crop} onChange={setCrop} />;
+}`}
       >
         <FreeAspect />
       </Example>
@@ -225,34 +258,140 @@ export function ImageCropDemo() {
       <Example
         title="FileUpload integration"
         description="The canonical pick → crop → save flow using the useCropPreview hook. Live 256×256 preview re-encodes on every drag/zoom (debounced 120ms). Toggle the format buttons (JPEG/PNG/WebP) and the encoder swaps live with a CircularProgress spinner during the re-encode. The Download button reuses the hook's previewBlob — no second encode — and saves locally; your real Save handler would POST previewBlob to your upload endpoint."
-        code={`function FileUploadIntegration() {
+        code={`import { useEffect, useState } from 'react';
+import {
+  Button,
+  CircularProgress,
+  Cluster,
+  Code,
+  FileUpload,
+  ImageCrop,
+  Stack,
+  Text,
+  useCropPreview,
+  type CropArea,
+  type FileEntry,
+} from '@eocrm/design-system';
+
+type OutputFormat = 'image/png' | 'image/jpeg' | 'image/webp';
+
+const FORMAT_EXT: Record<OutputFormat, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+};
+
+function makeId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return \`id-\${Math.random().toString(36).slice(2)}\`;
+}
+
+export function FileUploadIntegration() {
   const [files, setFiles] = useState<FileEntry[]>([]);
   const [crop, setCrop] = useState<CropArea | null>(null);
-  const pickedFile = files[0]?.file ?? null;
+  const [format, setFormat] = useState<OutputFormat>('image/jpeg');
 
-  // Live preview + Save Blob via the hook — debounced encode, race-guarded
-  // generation counter, auto-revoked object URLs.
-  const { previewUrl, previewBlob, encoding } = useCropPreview(pickedFile, crop, {
-    type: 'image/jpeg',
+  const pickedFile = files[0]?.file ?? null;
+  useEffect(() => {
+    setCrop(null);
+  }, [pickedFile]);
+
+  const { previewUrl, previewBlob, previewSize, encoding } = useCropPreview(pickedFile, crop, {
+    type: format,
     quality: 0.9,
     outputWidth: 256,
   });
 
-  const handleSave = async () => {
+  const handleSave = () => {
     if (!previewBlob) return;
-    const fd = new FormData();
-    fd.append('file', previewBlob, 'avatar.jpg');
-    await fetch('/api/upload-avatar', { method: 'POST', body: fd });
+    const downloadUrl = URL.createObjectURL(previewBlob);
+    const a = document.createElement('a');
+    a.href = downloadUrl;
+    a.download = \`cropped.\${FORMAT_EXT[format]}\`;
+    a.click();
+    URL.revokeObjectURL(downloadUrl);
   };
 
   return (
     <Stack gap="md">
-      <FileUpload files={files} onFilesAdded={...} onFileRemove={...} />
+      <FileUpload
+        files={files}
+        accept="image/*"
+        maxSize={25 * 1024 * 1024}
+        onFilesAdded={(added) =>
+          setFiles(added.map((f) => ({ id: makeId(), file: f, status: 'done' as const })))
+        }
+        onFileRemove={(entry) => setFiles((prev) => prev.filter((e) => e.id !== entry.id))}
+      />
       {pickedFile && (
         <>
           <ImageCrop src={pickedFile} value={crop} onChange={setCrop} aspectRatio={1} />
-          {previewUrl && <img src={previewUrl} style={{ opacity: encoding ? 0.5 : 1 }} />}
-          <Button onClick={handleSave} disabled={!previewBlob || encoding}>Save</Button>
+          <Cluster gap="sm" align="center">
+            <Text size="sm" tone="muted">
+              Format:
+            </Text>
+            {(['image/jpeg', 'image/png', 'image/webp'] as const).map((f) => (
+              <Button
+                key={f}
+                onClick={() => setFormat(f)}
+                variant={format === f ? 'primary' : 'secondary'}
+                size="sm"
+              >
+                {f.replace('image/', '').toUpperCase()}
+              </Button>
+            ))}
+          </Cluster>
+          <Cluster gap="sm" align="center">
+            <Text size="sm" tone="muted">
+              Live 256×256 preview:
+            </Text>
+            <div
+              style={{
+                position: 'relative',
+                width: 64,
+                height: 64,
+                borderRadius: 'var(--radius-md)',
+                overflow: 'hidden',
+                background: 'var(--color-bg-muted)',
+              }}
+            >
+              {previewUrl && (
+                <img
+                  src={previewUrl}
+                  alt="Cropped preview"
+                  style={{
+                    width: 64,
+                    height: 64,
+                    opacity: encoding ? 0.5 : 1,
+                    transition: 'opacity var(--transition-base)',
+                  }}
+                />
+              )}
+              {encoding && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    inset: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <CircularProgress size="sm" aria-label="Re-encoding preview" />
+                </div>
+              )}
+            </div>
+            {previewSize !== null && !encoding && (
+              <Text size="sm" tone="muted">
+                <Code>{(previewSize / 1024).toFixed(1)} KB</Code>
+              </Text>
+            )}
+            <Button onClick={handleSave} disabled={!previewBlob || encoding} variant="secondary">
+              Download
+            </Button>
+          </Cluster>
         </>
       )}
     </Stack>
@@ -265,7 +404,15 @@ export function ImageCropDemo() {
       <Example
         title="Disabled"
         description="Viewport is grayed (--opacity-disabled); drag and zoom both no-op."
-        code={`<ImageCrop src={SAMPLE_IMAGE} value={crop} onChange={setCrop} aspectRatio={1} disabled />`}
+        code={`import { useState } from 'react';
+import { ImageCrop, type CropArea } from '@eocrm/design-system';
+
+const SAMPLE_IMAGE = 'https://picsum.photos/seed/eocrm-imagecrop/1200/800';
+
+export function DisabledDemo() {
+  const [crop, setCrop] = useState<CropArea | null>(null);
+  return <ImageCrop src={SAMPLE_IMAGE} value={crop} onChange={setCrop} aspectRatio={1} disabled />;
+}`}
       >
         <DisabledDemo />
       </Example>

--- a/packages/playground/src/pages/components/ImageDemo.tsx
+++ b/packages/playground/src/pages/components/ImageDemo.tsx
@@ -103,7 +103,17 @@ export function ImageDemo() {
       <Example
         title="Basic"
         description="Give it an aspectRatio so the box is reserved (no layout shift). Fills its container's width."
-        code={`<Image src={url} alt="Mountain lake" aspectRatio="16 / 9" />`}
+        code={`import { Image } from '@eocrm/design-system';
+
+const PHOTO = 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=600&q=80';
+
+export function Demo() {
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <Image src={PHOTO} alt="Mountain lake at dawn" aspectRatio="16 / 9" />
+    </div>
+  );
+}`}
       >
         <div style={{ maxWidth: 360 }}>
           <Image src={PHOTO} alt="Mountain lake at dawn" aspectRatio="16 / 9" />
@@ -113,7 +123,55 @@ export function ImageDemo() {
       <Example
         title="The three states"
         description="Loading and error are handled inside `<Image>`. Reload the middle image to watch its own Skeleton placeholder fade into the loaded image; the third points at a broken URL to show the error placeholder + retry."
-        code={`<Image src={url} alt="…" aspectRatio="16 / 9" />`}
+        code={`import { useState } from 'react';
+import { Image, Stack, Cluster, Text, Button } from '@eocrm/design-system';
+
+const PHOTO = 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=600&q=80';
+const BROKEN = 'https://example.com/does-not-exist.jpg';
+
+export function ThreeStates() {
+  const [reload, setReload] = useState(0);
+  return (
+    <Stack gap="sm">
+      <Cluster gap="md" align="start">
+        <Stack gap="xs" align="center">
+          <div style={{ width: 200 }}>
+            <Image src={PHOTO} alt="Mountain lake at dawn" aspectRatio="16 / 9" />
+          </div>
+          <Text size="xs" tone="muted">
+            Loaded
+          </Text>
+        </Stack>
+        <Stack gap="xs" align="center">
+          <div style={{ width: 200 }}>
+            <Image
+              key={reload}
+              src={\`\${PHOTO}&reload=\${reload}\`}
+              alt="Reloads to show the loading skeleton"
+              aspectRatio="16 / 9"
+            />
+          </div>
+          <Text size="xs" tone="muted">
+            Loading → loaded
+          </Text>
+        </Stack>
+        <Stack gap="xs" align="center">
+          <div style={{ width: 200 }}>
+            <Image src={BROKEN} alt="A photo that fails to load" aspectRatio="16 / 9" />
+          </div>
+          <Text size="xs" tone="muted">
+            Error
+          </Text>
+        </Stack>
+      </Cluster>
+      <Cluster>
+        <Button variant="secondary" size="sm" onClick={() => setReload((n) => n + 1)}>
+          Reload the middle image
+        </Button>
+      </Cluster>
+    </Stack>
+  );
+}`}
       >
         <ThreeStates />
       </Example>
@@ -121,8 +179,37 @@ export function ImageDemo() {
       <Example
         title="object-fit"
         description="cover fills + crops; contain shows the whole image letterboxed on the muted box."
-        code={`<Image src={url} alt="…" objectFit="cover" aspectRatio="16 / 9" />
-<Image src={url} alt="…" objectFit="contain" aspectRatio="16 / 9" />`}
+        code={`import { useState } from 'react';
+import { Image, Stack, Cluster, Button } from '@eocrm/design-system';
+
+const PORTRAIT = 'https://images.unsplash.com/photo-1517849845537-4d257902454a?w=500&q=80';
+
+export function Demo() {
+  const [fit, setFit] = useState<'cover' | 'contain'>('cover');
+  return (
+    <Stack gap="sm">
+      <Cluster gap="sm">
+        <Button
+          variant={fit === 'cover' ? 'primary' : 'secondary'}
+          size="sm"
+          onClick={() => setFit('cover')}
+        >
+          cover
+        </Button>
+        <Button
+          variant={fit === 'contain' ? 'primary' : 'secondary'}
+          size="sm"
+          onClick={() => setFit('contain')}
+        >
+          contain
+        </Button>
+      </Cluster>
+      <div style={{ maxWidth: 360 }}>
+        <Image src={PORTRAIT} alt="A dog" objectFit={fit} aspectRatio="16 / 9" />
+      </div>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Cluster gap="sm">
@@ -150,9 +237,40 @@ export function ImageDemo() {
       <Example
         title="Aspect ratio"
         description="Pass a CSS ratio string or a number. The box is reserved at that ratio so there is no layout shift while the image loads."
-        code={`<Image src={url} alt="…" aspectRatio="16 / 9" />
-<Image src={url} alt="…" aspectRatio={1} />
-<Image src={url} alt="…" aspectRatio="4 / 3" />`}
+        code={`import { Image, Stack, Cluster, Text } from '@eocrm/design-system';
+
+const PHOTO = 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=600&q=80';
+
+export function Demo() {
+  return (
+    <Cluster gap="md">
+      <Stack gap="xs" align="center">
+        <div style={{ width: 220 }}>
+          <Image src={PHOTO} alt="16 / 9 ratio" aspectRatio="16 / 9" />
+        </div>
+        <Text size="xs" tone="muted">
+          16 / 9
+        </Text>
+      </Stack>
+      <Stack gap="xs" align="center">
+        <div style={{ width: 220 }}>
+          <Image src={PHOTO} alt="1:1 ratio" aspectRatio={1} />
+        </div>
+        <Text size="xs" tone="muted">
+          1
+        </Text>
+      </Stack>
+      <Stack gap="xs" align="center">
+        <div style={{ width: 220 }}>
+          <Image src={PHOTO} alt="4 / 3 ratio" aspectRatio="4 / 3" />
+        </div>
+        <Text size="xs" tone="muted">
+          4 / 3
+        </Text>
+      </Stack>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md">
           <Stack gap="xs" align="center">
@@ -185,7 +303,26 @@ export function ImageDemo() {
       <Example
         title="Radius"
         description="none / sm / md (default) / lg / full."
-        code={`<Image src={url} alt="…" radius="lg" aspectRatio="1" />`}
+        code={`import { Image, Stack, Cluster, Text } from '@eocrm/design-system';
+
+const PHOTO = 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=600&q=80';
+
+export function Demo() {
+  return (
+    <Cluster gap="md">
+      {(['none', 'sm', 'md', 'lg', 'full'] as const).map((r) => (
+        <Stack key={r} gap="xs" align="center">
+          <div style={{ width: 80 }}>
+            <Image src={PHOTO} alt="" radius={r} aspectRatio="1" />
+          </div>
+          <Text size="xs" tone="muted">
+            {r}
+          </Text>
+        </Stack>
+      ))}
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md">
           {(['none', 'sm', 'md', 'lg', 'full'] as const).map((r) => (
@@ -204,7 +341,24 @@ export function ImageDemo() {
       <Example
         title="Fixed-size thumbnail (size)"
         description="size renders a fixed square box from the --size-* scale (xs 20 / sm 24 / md 32 / lg 40 px) instead of filling the container width — for dense thumbnails like a table-row image cell. No consumer-owned fixed-width wrapper needed; it won't squish in a flex row."
-        code={`<Image src={url} alt="report.pdf preview" size="lg" objectFit="cover" />`}
+        code={`import { Image, Stack, Cluster, Text } from '@eocrm/design-system';
+
+const PHOTO = 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=600&q=80';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      {(['xs', 'sm', 'md', 'lg'] as const).map((s) => (
+        <Stack key={s} gap="xs" align="center">
+          <Image src={PHOTO} alt="" size={s} objectFit="cover" />
+          <Text size="xs" tone="muted">
+            {s}
+          </Text>
+        </Stack>
+      ))}
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           {(['xs', 'sm', 'md', 'lg'] as const).map((s) => (
@@ -221,8 +375,37 @@ export function ImageDemo() {
       <Example
         title="Interactive thumbnail (click to preview)"
         description="Set interactive (or onClick) to make the image a flush, keyboard-accessible click target — a chromeless button with a DS focus ring, no inset/border/hover paint. The canonical use is a dense table-cell thumbnail that opens a preview Modal. Tab to it and press Enter/Space."
-        code={`<Image src={url} alt="report.png" size="lg" objectFit="cover"
-  onClick={() => setOpen(true)} ariaLabel="Preview report.png" />`}
+        code={`import { useState } from 'react';
+import { Image, Modal, Button } from '@eocrm/design-system';
+
+const PHOTO = 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=600&q=80';
+
+export function InteractiveThumb() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Image
+        src={PHOTO}
+        alt="Mountain lake at dawn"
+        size="lg"
+        objectFit="cover"
+        onClick={() => setOpen(true)}
+        ariaLabel="Preview Mountain lake at dawn"
+      />
+      <Modal open={open} onOpenChange={setOpen}>
+        <Modal.Header>Mountain lake at dawn</Modal.Header>
+        <Modal.Body>
+          <Image src={PHOTO} alt="Mountain lake at dawn" aspectRatio="16 / 9" />
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Close</Button>
+          </Modal.Close>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}`}
       >
         <InteractiveThumb />
       </Example>
@@ -230,7 +413,17 @@ export function ImageDemo() {
       <Example
         title="Error + retry"
         description="A failed load shows the ImageOff placeholder with a Retry button (re-fetches the source)."
-        code={`<Image src={brokenUrl} alt="…" aspectRatio="16 / 9" />`}
+        code={`import { Image } from '@eocrm/design-system';
+
+const BROKEN = 'https://example.com/does-not-exist.jpg';
+
+export function Demo() {
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <Image src={BROKEN} alt="Intentionally broken image" aspectRatio="16 / 9" />
+    </div>
+  );
+}`}
       >
         <div style={{ maxWidth: 360 }}>
           <RetryDemo />
@@ -240,7 +433,22 @@ export function ImageDemo() {
       <Example
         title="Custom fallback"
         description="Override the default error placeholder with any node via `fallback`."
-        code={`<Image src={brokenUrl} alt="…" aspectRatio="16 / 9" fallback={<EmptyState title="Couldn't load image" />} />`}
+        code={`import { Image, EmptyState } from '@eocrm/design-system';
+
+const BROKEN = 'https://example.com/does-not-exist.jpg';
+
+export function Demo() {
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <Image
+        src={BROKEN}
+        alt="Broken with custom fallback"
+        aspectRatio="16 / 9"
+        fallback={<EmptyState size="sm" title="Couldn't load image" />}
+      />
+    </div>
+  );
+}`}
       >
         <div style={{ maxWidth: 360 }}>
           <Image
@@ -255,7 +463,24 @@ export function ImageDemo() {
       <Example
         title="In a gallery grid"
         description="Responsive grid of square thumbnails — each reserves its box and loads independently."
-        code={`<Grid minColumnWidth="160px" gap="sm">{urls.map((u) => <Image key={u} src={u} alt="" aspectRatio="1" />)}</Grid>`}
+        code={`import { Image, Grid } from '@eocrm/design-system';
+
+const GALLERY = [
+  'https://images.unsplash.com/photo-1465146344425-f00d5f5c8f07?w=400&q=80',
+  'https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=400&q=80',
+  'https://images.unsplash.com/photo-1470770841072-f978cf4d019e?w=400&q=80',
+  'https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=400&q=80',
+];
+
+export function Demo() {
+  return (
+    <Grid minColumnWidth="160px" gap="sm">
+      {GALLERY.map((u) => (
+        <Image key={u} src={u} alt="" aspectRatio="1" />
+      ))}
+    </Grid>
+  );
+}`}
       >
         <Grid minColumnWidth="160px" gap="sm">
           {GALLERY.map((u) => (

--- a/packages/playground/src/pages/components/IndentDemo.tsx
+++ b/packages/playground/src/pages/components/IndentDemo.tsx
@@ -43,11 +43,39 @@ export function IndentDemo() {
       <Example
         title="Threaded comments (level = depth)"
         description="A flat comment list rendered at known depths. level={0} is flush; each deeper reply adds one gutter. Nesting reads as hierarchy."
-        code={`{comments.map((c) => (
-  <Indent key={c.id} level={c.depth}>
-    <Card padding="sm">…</Card>
-  </Indent>
-))}`}
+        code={`import { Avatar, Card, Cluster, Indent, Stack, Text } from '@eocrm/design-system';
+
+const THREAD = [
+  { id: 'c1', depth: 0, author: 'Dana Reyes', body: 'Can we move the renewal date field above the owner?' },
+  { id: 'c2', depth: 1, author: 'Sam Cole', body: 'Agreed — it’s the first thing reps look for.' },
+  { id: 'c3', depth: 2, author: 'Dana Reyes', body: 'I’ll open a ticket for the layout change.' },
+  { id: 'c4', depth: 1, author: 'Priya Nair', body: 'Should we keep the old position for a release as a fallback?' },
+  { id: 'c5', depth: 0, author: 'Marco Diaz', body: 'Separate thought: the status chip colors need more contrast.' },
+];
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      {THREAD.map((c) => (
+        <Indent key={c.id} level={c.depth}>
+          <Card padding="sm">
+            <Cluster gap="sm" align="center">
+              <Avatar name={c.author} size="sm" />
+              <Stack gap="xs">
+                <Text size="sm" weight="semibold">
+                  {c.author}
+                </Text>
+                <Text size="sm" tone="muted">
+                  {c.body}
+                </Text>
+              </Stack>
+            </Cluster>
+          </Card>
+        </Indent>
+      ))}
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           {THREAD.map((c) => (
@@ -73,9 +101,21 @@ export function IndentDemo() {
       <Example
         title="Gutter scale"
         description="gutter sets the per-level size (xs 4 / sm 8 / md 12 / lg 16 / xl 24 / 2xl 32). Here the same level={2} at three gutters."
-        code={`<Indent level={2} gutter="sm">…</Indent>
-<Indent level={2} gutter="lg">…</Indent>
-<Indent level={2} gutter="2xl">…</Indent>`}
+        code={`import { Card, Indent, Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      {(['sm', 'lg', '2xl'] as const).map((g) => (
+        <Indent key={g} level={2} gutter={g}>
+          <Card padding="sm">
+            <Text size="sm">level=2 · gutter="{g}"</Text>
+          </Card>
+        </Indent>
+      ))}
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           {(['sm', 'lg', '2xl'] as const).map((g) => (

--- a/packages/playground/src/pages/components/InlineDatePickerDemo.tsx
+++ b/packages/playground/src/pages/components/InlineDatePickerDemo.tsx
@@ -109,7 +109,11 @@ export function InlineDatePickerDemoPanel() {
       <Example
         title="Uncontrolled"
         description="No `value` / `onChange` — the picker owns state. Click a cell to set; use the chevrons or PageUp/PageDown to navigate."
-        code={`<InlineDatePicker defaultValue={new Date()} />`}
+        code={`import { InlineDatePicker } from '@eocrm/design-system';
+
+export function Demo() {
+  return <InlineDatePicker defaultValue={new Date()} aria-label="Uncontrolled date" />;
+}`}
       >
         <InputExample width="auto">
           <InlineDatePicker defaultValue={TODAY} aria-label="Uncontrolled date" />
@@ -119,8 +123,20 @@ export function InlineDatePickerDemoPanel() {
       <Example
         title="Controlled"
         description="Consumer owns the value via `value` + `onChange`. The picker's cursor stays where the user navigated — programmatic value changes don't scroll the calendar."
-        code={`const [value, setValue] = useState<Date | null>(new Date());
-<InlineDatePicker value={value} onChange={setValue} />`}
+        code={`import { useState } from 'react';
+import { InlineDatePicker, Stack, toDateKey } from '@eocrm/design-system';
+
+export function ControlledDemo() {
+  const [value, setValue] = useState<Date | null>(new Date());
+  return (
+    <Stack gap="xs">
+      <InlineDatePicker value={value} onChange={setValue} aria-label="Controlled date" />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        {value ? toDateKey(value) : 'null'}
+      </code>
+    </Stack>
+  );
+}`}
       >
         <InputExample width="auto">
           <ControlledDemo />
@@ -130,10 +146,21 @@ export function InlineDatePickerDemoPanel() {
       <Example
         title="Min / max"
         description="Restrict picks to a window. Out-of-range cells are non-clickable; arrow nav skips them."
-        code={`const today = new Date();
+        code={`import { InlineDatePicker } from '@eocrm/design-system';
+
+const today = new Date();
 const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 90);
 
-<InlineDatePicker min={today} max={in90} />`}
+export function Demo() {
+  return (
+    <InlineDatePicker
+      defaultValue={today}
+      min={today}
+      max={in90}
+      aria-label="Date within 90 days"
+    />
+  );
+}`}
       >
         <InputExample width="auto">
           <InlineDatePicker
@@ -148,9 +175,16 @@ const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 9
       <Example
         title="Disable weekends"
         description="`isDateDisabled` runs per cell. Disabled cells are non-clickable and arrow-key navigation skips them."
-        code={`<InlineDatePicker
-  isDateDisabled={(d) => d.getDay() === 0 || d.getDay() === 6}
-/>`}
+        code={`import { InlineDatePicker } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <InlineDatePicker
+      aria-label="Weekday only"
+      isDateDisabled={(d) => d.getDay() === 0 || d.getDay() === 6}
+    />
+  );
+}`}
       >
         <InputExample width="auto">
           <InlineDatePicker
@@ -163,7 +197,11 @@ const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 9
       <Example
         title="Disabled"
         description="Use `disabled` when the calendar is unavailable in the current context. Cells / chevrons / keyboard nav all blocked; the grid mutes visually."
-        code={`<InlineDatePicker disabled defaultValue={new Date()} />`}
+        code={`import { InlineDatePicker } from '@eocrm/design-system';
+
+export function Demo() {
+  return <InlineDatePicker disabled defaultValue={new Date()} aria-label="Disabled date" />;
+}`}
       >
         <InputExample width="auto">
           <InlineDatePicker disabled defaultValue={TODAY} aria-label="Disabled date" />
@@ -173,10 +211,33 @@ const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 9
       <Example
         title="Form integration"
         description="When `name` is set, the picker renders a hidden mirror `<input>` with the ISO date so native `<form>` submission works."
-        code={`<form action="/api/dates">
-  <InlineDatePicker name="dob" defaultValue={new Date()} />
-  <button type="submit">Submit</button>
-</form>`}
+        code={`import { useState } from 'react';
+import { Button, InlineDatePicker, Stack } from '@eocrm/design-system';
+
+export function FormDemo() {
+  const [submitted, setSubmitted] = useState<string | null>(null);
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const fd = new FormData(e.currentTarget);
+        setSubmitted(String(fd.get('dob') ?? ''));
+      }}
+    >
+      <Stack gap="xs">
+        <InlineDatePicker name="dob" defaultValue={new Date()} aria-label="Date of birth" />
+        <Button type="submit" size="sm">
+          Submit
+        </Button>
+        {submitted !== null && (
+          <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+            dob = {submitted || '(empty)'}
+          </code>
+        )}
+      </Stack>
+    </form>
+  );
+}`}
       >
         <InputExample width="auto">
           <FormDemo />
@@ -186,9 +247,15 @@ const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 9
       <Example
         title="ru-RU locale"
         description="Locale-aware month + weekday labels. UI labels (chevrons) come from <I18nProvider locale='ru'>."
-        code={`<I18nProvider locale="ru">
-  <InlineDatePicker defaultValue={new Date()} locale="ru-RU" />
-</I18nProvider>`}
+        code={`import { I18nProvider, InlineDatePicker } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <I18nProvider locale="ru">
+      <InlineDatePicker defaultValue={new Date()} locale="ru-RU" aria-label="Дата" />
+    </I18nProvider>
+  );
+}`}
       >
         <InputExample width="auto">
           <I18nProvider locale="ru">
@@ -200,13 +267,28 @@ const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 9
       <Example
         title="Granularity: minute"
         description="`granularity='minute'` renders a manual-entry time input below the grid (always visible — there's no popover to gate it on). Picking a different date preserves the existing time-of-day; the time input is disabled until a date is set. The hidden form mirror emits ISO local datetime (`2026-05-28T09:00`). The embedded `<TimeField>` exposes a Now button in its popover."
-        code={`const [value, setValue] = useState<Date | null>(new Date(2026, 4, 28, 9, 0));
+        code={`import { useState } from 'react';
+import { InlineDatePicker, Stack, toIsoDateTime } from '@eocrm/design-system';
 
-<InlineDatePicker
-  granularity="minute"
-  value={value}
-  onChange={setValue}
-/>`}
+const today = new Date();
+const todayAtNine = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 0, 0, 0);
+
+export function GranularityMinuteDemo() {
+  const [value, setValue] = useState<Date | null>(todayAtNine);
+  return (
+    <Stack gap="xs">
+      <InlineDatePicker
+        granularity="minute"
+        value={value}
+        onChange={setValue}
+        aria-label="Meeting start"
+      />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        {value ? toIsoDateTime(value) : 'null'}
+      </code>
+    </Stack>
+  );
+}`}
       >
         <InputExample width="auto">
           <GranularityMinuteDemo />
@@ -216,8 +298,44 @@ const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 9
       <Example
         title="Hour cycle (12h vs 24h)"
         description="`hourCycle` forwards to the embedded TimeField. `'12'` shows a 12-hour AM/PM popover; `'24'` shows hours 00–23. Default `'auto'` derives from the active locale."
-        code={`<InlineDatePicker granularity="minute" hourCycle="12" value={v12} onChange={setV12} />
-<InlineDatePicker granularity="minute" hourCycle="24" value={v24} onChange={setV24} />`}
+        code={`import { useState } from 'react';
+import { InlineDatePicker, Stack } from '@eocrm/design-system';
+
+const today = new Date();
+const todayAtNine = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 0, 0, 0);
+
+export function HourCycleDemo() {
+  const [v12, setV12] = useState<Date | null>(todayAtNine);
+  const [v24, setV24] = useState<Date | null>(todayAtNine);
+  return (
+    <Stack gap="lg">
+      <Stack gap="xs">
+        <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+          hourCycle=&quot;12&quot;
+        </code>
+        <InlineDatePicker
+          granularity="minute"
+          hourCycle="12"
+          value={v12}
+          onChange={setV12}
+          aria-label="12-hour datetime"
+        />
+      </Stack>
+      <Stack gap="xs">
+        <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+          hourCycle=&quot;24&quot;
+        </code>
+        <InlineDatePicker
+          granularity="minute"
+          hourCycle="24"
+          value={v24}
+          onChange={setV24}
+          aria-label="24-hour datetime"
+        />
+      </Stack>
+    </Stack>
+  );
+}`}
       >
         <InputExample width="auto">
           <HourCycleDemo />

--- a/packages/playground/src/pages/components/InlineDateRangePickerDemo.tsx
+++ b/packages/playground/src/pages/components/InlineDateRangePickerDemo.tsx
@@ -124,10 +124,19 @@ export function InlineDateRangePickerDemoPanel() {
       <Example
         title="Uncontrolled"
         description="No `value` / `onChange` — the picker owns state. Click start then end; hover (or arrow-key) between clicks shows the preview range."
-        code={`const today = new Date();
+        code={`import { InlineDateRangePicker } from '@eocrm/design-system';
+
+const today = new Date();
 const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
 
-<InlineDateRangePicker defaultValue={{ start: today, end: in14 }} />`}
+export function Demo() {
+  return (
+    <InlineDateRangePicker
+      defaultValue={{ start: today, end: in14 }}
+      aria-label="Uncontrolled range"
+    />
+  );
+}`}
       >
         <InputExample width="auto">
           <InlineDateRangePicker
@@ -140,11 +149,23 @@ const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1
       <Example
         title="Controlled"
         description="Consumer owns the value via `value` + `onChange`. Useful when the form layer reacts to range changes (validation, summary panels)."
-        code={`const today = new Date();
-const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
-const [value, setValue] = useState<DateRange | null>({ start: today, end: in14 });
+        code={`import { useState } from 'react';
+import { InlineDateRangePicker, Stack, toDateKey, type DateRange } from '@eocrm/design-system';
 
-<InlineDateRangePicker value={value} onChange={setValue} />`}
+const today = new Date();
+const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
+
+export function ControlledDemo() {
+  const [value, setValue] = useState<DateRange | null>({ start: today, end: in14 });
+  return (
+    <Stack gap="xs">
+      <InlineDateRangePicker value={value} onChange={setValue} aria-label="Controlled range" />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        {value ? \`\${toDateKey(value.start)} → \${toDateKey(value.end)}\` : 'null'}
+      </code>
+    </Stack>
+  );
+}`}
       >
         <InputExample width="auto">
           <ControlledDemo />
@@ -154,10 +175,22 @@ const [value, setValue] = useState<DateRange | null>({ start: today, end: in14 }
       <Example
         title="Min / max"
         description="Out-of-range cells are non-clickable on both halves."
-        code={`const today = new Date();
+        code={`import { InlineDateRangePicker } from '@eocrm/design-system';
+
+const today = new Date();
+const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
 const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 90);
 
-<InlineDateRangePicker min={today} max={in90} />`}
+export function Demo() {
+  return (
+    <InlineDateRangePicker
+      defaultValue={{ start: today, end: in14 }}
+      min={today}
+      max={in90}
+      aria-label="Range within 90 days"
+    />
+  );
+}`}
       >
         <InputExample width="auto">
           <InlineDateRangePicker
@@ -172,9 +205,16 @@ const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 9
       <Example
         title="Disable weekends"
         description="`isDateDisabled` runs per cell on both halves and gates the boundary picks."
-        code={`<InlineDateRangePicker
-  isDateDisabled={(d) => d.getDay() === 0 || d.getDay() === 6}
-/>`}
+        code={`import { InlineDateRangePicker } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <InlineDateRangePicker
+      aria-label="Weekday range only"
+      isDateDisabled={(d) => d.getDay() === 0 || d.getDay() === 6}
+    />
+  );
+}`}
       >
         <InputExample width="auto">
           <InlineDateRangePicker
@@ -187,10 +227,20 @@ const in90 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 9
       <Example
         title="Disabled"
         description="`disabled` blocks selection and chevron navigation; the entire grid pair mutes visually."
-        code={`const today = new Date();
+        code={`import { InlineDateRangePicker } from '@eocrm/design-system';
+
+const today = new Date();
 const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
 
-<InlineDateRangePicker disabled defaultValue={{ start: today, end: in14 }} />`}
+export function Demo() {
+  return (
+    <InlineDateRangePicker
+      disabled
+      defaultValue={{ start: today, end: in14 }}
+      aria-label="Disabled range"
+    />
+  );
+}`}
       >
         <InputExample width="auto">
           <InlineDateRangePicker
@@ -204,10 +254,45 @@ const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1
       <Example
         title="Form integration"
         description="When `nameStart` and `nameEnd` are set, the picker renders two hidden mirror `<input>`s with ISO dates so native `<form>` submission works."
-        code={`<form action="/api/bookings">
-  <InlineDateRangePicker nameStart="bookingStart" nameEnd="bookingEnd" />
-  <button type="submit">Submit</button>
-</form>`}
+        code={`import { useState } from 'react';
+import { Button, InlineDateRangePicker, Stack } from '@eocrm/design-system';
+
+const today = new Date();
+const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
+
+export function FormDemo() {
+  const [submitted, setSubmitted] = useState<{ start: string; end: string } | null>(null);
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const fd = new FormData(e.currentTarget);
+        setSubmitted({
+          start: String(fd.get('bookingStart') ?? ''),
+          end: String(fd.get('bookingEnd') ?? ''),
+        });
+      }}
+    >
+      <Stack gap="xs">
+        <InlineDateRangePicker
+          nameStart="bookingStart"
+          nameEnd="bookingEnd"
+          defaultValue={{ start: today, end: in14 }}
+          aria-label="Booking dates"
+        />
+        <Button type="submit" size="sm">
+          Submit
+        </Button>
+        {submitted !== null && (
+          <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+            bookingStart = {submitted.start || '(empty)'} · bookingEnd ={' '}
+            {submitted.end || '(empty)'}
+          </code>
+        )}
+      </Stack>
+    </form>
+  );
+}`}
       >
         <InputExample width="auto">
           <FormDemo />
@@ -217,12 +302,22 @@ const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1
       <Example
         title="ru-RU locale"
         description="Locale-aware labels. UI strings (chevron tooltips) come from <I18nProvider locale='ru'>."
-        code={`<I18nProvider locale="ru">
-  <InlineDateRangePicker
-    defaultValue={{ start: today, end: in14 }}
-    locale="ru-RU"
-  />
-</I18nProvider>`}
+        code={`import { I18nProvider, InlineDateRangePicker } from '@eocrm/design-system';
+
+const today = new Date();
+const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 14);
+
+export function Demo() {
+  return (
+    <I18nProvider locale="ru">
+      <InlineDateRangePicker
+        defaultValue={{ start: today, end: in14 }}
+        locale="ru-RU"
+        aria-label="Диапазон дат"
+      />
+    </I18nProvider>
+  );
+}`}
       >
         <InputExample width="auto">
           <I18nProvider locale="ru">
@@ -238,14 +333,28 @@ const in14 = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1
       <Example
         title="Granularity: minute"
         description="`granularity='minute'` renders dual start-time / end-time inputs below the two-month grid. This example starts EMPTY (`value === null`) — the start/end time inputs are already there, enabled and defaulting to `00:00` / `23:59`, before any range is picked. Set the times first, then click two days: the pending times you entered are applied to the committed range (no need to seed a placeholder range). Existing times are preserved across subsequent date picks. On a same-day range, the end-time silently clamps to ≥ the start-time on every commit (try setting end-time earlier than start-time — it snaps back). Each embedded `<TimeField>` exposes a Now button."
-        code={`// Starts empty — time inputs are visible + editable before picking dates.
-const [value, setValue] = useState<DateRange | null>(null);
+        code={`import { useState } from 'react';
+import { InlineDateRangePicker, Stack, toIsoDateTime, type DateRange } from '@eocrm/design-system';
 
-<InlineDateRangePicker
-  granularity="minute"
-  value={value}
-  onChange={setValue}
-/>`}
+export function GranularityMinuteDemo() {
+  // Starts EMPTY (value === null) so the start/end time inputs are visible
+  // and editable below the grid before any range is picked — set the times
+  // first, then click two days and the pending times carry through.
+  const [value, setValue] = useState<DateRange | null>(null);
+  return (
+    <Stack gap="xs">
+      <InlineDateRangePicker
+        granularity="minute"
+        value={value}
+        onChange={setValue}
+        aria-label="Meeting window"
+      />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        {value ? \`\${toIsoDateTime(value.start)} → \${toIsoDateTime(value.end)}\` : 'null'}
+      </code>
+    </Stack>
+  );
+}`}
       >
         <InputExample width="auto">
           <GranularityMinuteDemo />
@@ -255,8 +364,45 @@ const [value, setValue] = useState<DateRange | null>(null);
       <Example
         title="Hour cycle (12h vs 24h)"
         description="`hourCycle` propagates to both the start and end TimeFields. Default `'auto'` derives from locale."
-        code={`<InlineDateRangePicker granularity="minute" hourCycle="12" value={v12} onChange={setV12} />
-<InlineDateRangePicker granularity="minute" hourCycle="24" value={v24} onChange={setV24} />`}
+        code={`import { useState } from 'react';
+import { InlineDateRangePicker, Stack, type DateRange } from '@eocrm/design-system';
+
+const today = new Date();
+const today9am = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 0, 0, 0);
+const today5pm = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 17, 0, 0, 0);
+
+export function HourCycleDemo() {
+  const [v12, setV12] = useState<DateRange | null>({ start: today9am, end: today5pm });
+  const [v24, setV24] = useState<DateRange | null>({ start: today9am, end: today5pm });
+  return (
+    <Stack gap="lg">
+      <Stack gap="xs">
+        <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+          hourCycle=&quot;12&quot;
+        </code>
+        <InlineDateRangePicker
+          granularity="minute"
+          hourCycle="12"
+          value={v12}
+          onChange={setV12}
+          aria-label="12-hour range"
+        />
+      </Stack>
+      <Stack gap="xs">
+        <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+          hourCycle=&quot;24&quot;
+        </code>
+        <InlineDateRangePicker
+          granularity="minute"
+          hourCycle="24"
+          value={v24}
+          onChange={setV24}
+          aria-label="24-hour range"
+        />
+      </Stack>
+    </Stack>
+  );
+}`}
       >
         <InputExample width="auto">
           <HourCycleDemo />

--- a/packages/playground/src/pages/components/InputDemo.tsx
+++ b/packages/playground/src/pages/components/InputDemo.tsx
@@ -19,14 +19,20 @@ export function InputDemo() {
       <Example
         title="Default"
         description="A standard text input. Always pair with a real <label>, never use placeholder as a label."
-        code={`<label>
-  Email
-  <Input
-    value={email}
-    onChange={(e) => setEmail(e.target.value)}
-    placeholder="you@example.com"
-  />
-</label>`}
+        code={`import { useState } from 'react';
+import { Input } from '@eocrm/design-system';
+
+export function Demo() {
+  const [email, setEmail] = useState('priya@acme.com');
+
+  return (
+    <Input
+      value={email}
+      onChange={(e) => setEmail(e.target.value)}
+      placeholder="you@example.com"
+    />
+  );
+}`}
       >
         <InputExample>
           <Input
@@ -40,9 +46,22 @@ export function InputDemo() {
       <Example
         title="Sizes"
         description="Three sizes — sm (24px), md (32px, default), lg (40px). Use sm for dense toolbars, lg for hero / mobile-friendly forms."
-        code={`<Input size="sm" placeholder="Filter…" />
-<Input size="md" placeholder="Default" />
-<Input size="lg" type="search" placeholder="Search the workspace" />`}
+        code={`import { Input, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Input size="sm" placeholder="Filter…" aria-label="Small input" />
+      <Input size="md" placeholder="Default" aria-label="Medium input" />
+      <Input
+        size="lg"
+        type="search"
+        placeholder="Search the workspace"
+        aria-label="Large input"
+      />
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="sm">
@@ -61,11 +80,20 @@ export function InputDemo() {
       <Example
         title="Invalid state"
         description="Pass invalid to toggle the error visual. Pair with an external error message and aria-describedby."
-        code={`<Input
-  invalid
-  value={value}
-  onChange={(e) => setValue(e.target.value)}
-/>`}
+        code={`import { useState } from 'react';
+import { Input } from '@eocrm/design-system';
+
+export function Demo() {
+  const [value, setValue] = useState('not-an-email');
+
+  return (
+    <Input
+      invalid
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+}`}
       >
         <InputExample>
           <Input invalid value={invalidValue} onChange={(e) => setInvalidValue(e.target.value)} />
@@ -74,8 +102,16 @@ export function InputDemo() {
 
       <Example
         title="Disabled & readonly"
-        code={`<Input value="Locked" disabled />
-<Input value="Cannot edit" readOnly />`}
+        code={`import { Input, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Input value="Locked" disabled readOnly />
+      <Input value="Cannot edit" readOnly />
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="sm">
@@ -88,9 +124,17 @@ export function InputDemo() {
       <Example
         title="Native types"
         description="Input forwards all native HTML attributes — type, inputMode, autoComplete, pattern, etc."
-        code={`<Input type="email" placeholder="Email" autoComplete="email" />
-<Input type="search" placeholder="Search" />
-<Input type="password" placeholder="Password" />`}
+        code={`import { Input, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Input type="email" placeholder="Email" autoComplete="email" />
+      <Input type="search" placeholder="Search" />
+      <Input type="password" placeholder="Password" />
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="sm">

--- a/packages/playground/src/pages/components/KanbanDemo.tsx
+++ b/packages/playground/src/pages/components/KanbanDemo.tsx
@@ -84,21 +84,87 @@ export function KanbanDemo() {
       <Example
         title="Basic board (3 columns)"
         description="Drag cards within and across columns. Empty columns are still drop targets. Watch the target column reflow as the dragged card crosses in."
-        code={`<Kanban onMove={handleMove}>
-  {(['todo', 'doing', 'done'] as const).map((colId) => (
-    <Kanban.Column key={colId} id={colId}>
-      <Cluster justify="between" align="center">
-        <Title order={3} size="sm">{COL_TITLES[colId]}</Title>
-        <Badge tone="neutral" size="sm">{board[colId].length}</Badge>
-      </Cluster>
-      {board[colId].map((card) => (
-        <Kanban.Card key={card.id} id={card.id}>
-          <Card padding="sm">{card.title}</Card>
-        </Kanban.Card>
+        code={`import { useCallback, useState } from 'react';
+import {
+  Badge,
+  Card,
+  Cluster,
+  Kanban,
+  Title,
+  type KanbanMoveEvent,
+} from '@eocrm/design-system';
+
+type ColId = 'todo' | 'doing' | 'done';
+
+interface CardData {
+  id: string;
+  title: string;
+}
+
+const COL_TITLES: Record<ColId, string> = {
+  todo: 'To do',
+  doing: 'In progress',
+  done: 'Done',
+};
+
+const INITIAL_BOARD: Record<ColId, CardData[]> = {
+  todo: [
+    { id: 'task-1', title: 'Draft Q3 OKRs' },
+    { id: 'task-2', title: 'Review pricing page mocks' },
+    { id: 'task-3', title: 'Schedule retro' },
+  ],
+  doing: [
+    { id: 'task-4', title: 'Refactor billing service' },
+    { id: 'task-5', title: 'Customer interview notes' },
+  ],
+  done: [
+    { id: 'task-6', title: 'Ship onboarding email' },
+    { id: 'task-7', title: 'Migrate logs to OTLP' },
+  ],
+};
+
+export function Demo() {
+  const [board, setBoard] = useState<Record<ColId, CardData[]>>(INITIAL_BOARD);
+
+  const handleMove = useCallback((event: KanbanMoveEvent) => {
+    const { from, to, cardId } = event;
+    setBoard((curr) => {
+      const fromCol = from.columnId as ColId;
+      const toCol = to.columnId as ColId;
+      const next: Record<ColId, CardData[]> = {
+        todo: [...curr.todo],
+        doing: [...curr.doing],
+        done: [...curr.done],
+      };
+      const sourceArr = next[fromCol];
+      const idx = sourceArr.findIndex((c) => c.id === cardId);
+      if (idx < 0) return curr;
+      const [moved] = sourceArr.splice(idx, 1);
+      const targetArr = fromCol === toCol ? sourceArr : next[toCol];
+      const insertAt = Math.min(to.index, targetArr.length);
+      targetArr.splice(insertAt, 0, moved);
+      return next;
+    });
+  }, []);
+
+  return (
+    <Kanban onMove={handleMove}>
+      {(['todo', 'doing', 'done'] as const).map((colId) => (
+        <Kanban.Column key={colId} id={colId}>
+          <Cluster justify="between" align="center">
+            <Title order={3} size="sm">{COL_TITLES[colId]}</Title>
+            <Badge tone="neutral" size="sm">{board[colId].length}</Badge>
+          </Cluster>
+          {board[colId].map((card) => (
+            <Kanban.Card key={card.id} id={card.id}>
+              <Card padding="sm">{card.title}</Card>
+            </Kanban.Card>
+          ))}
+        </Kanban.Column>
       ))}
-    </Kanban.Column>
-  ))}
-</Kanban>`}
+    </Kanban>
+  );
+}`}
       >
         <Kanban onMove={handleMoveA}>
           {(['todo', 'doing', 'done'] as const).map((colId) => (
@@ -124,41 +190,111 @@ export function KanbanDemo() {
       <Example
         title="Cards with Handle + DropdownMenu"
         description="Use Kanban.Handle when cards contain interactive elements. The grip is the only drag-initiator; the internal menu stays clickable."
-        code={`<Kanban onMove={handleMove}>
-  {(['todo', 'doing', 'done'] as const).map((colId) => (
-    <Kanban.Column key={colId} id={colId}>
-      <Cluster justify="between" align="center">
-        <Title order={3} size="sm">{COL_TITLES[colId]}</Title>
-        <Badge tone="neutral" size="sm">{board[colId].length}</Badge>
-      </Cluster>
-      {board[colId].map((card) => (
-        <Kanban.Card key={card.id} id={card.id}>
-          <Card padding="sm">
-            <Cluster justify="between" align="center">
-              <Cluster gap="sm" align="center">
-                <Kanban.Handle aria-label={\`Reorder \${card.title}\`}>
-                  <GripVertical size={14} />
-                </Kanban.Handle>
-                <Text weight="medium">{card.title}</Text>
-              </Cluster>
-              <DropdownMenu>
-                <DropdownMenu.Trigger>
-                  <Button variant="ghost" size="sm" iconOnly aria-label="More">
-                    <MoreHorizontal size={14} />
-                  </Button>
-                </DropdownMenu.Trigger>
-                <DropdownMenu.Content align="end">
-                  <DropdownMenu.Item onSelect={() => {}}>View</DropdownMenu.Item>
-                  <DropdownMenu.Item onSelect={() => {}}>Archive</DropdownMenu.Item>
-                </DropdownMenu.Content>
-              </DropdownMenu>
-            </Cluster>
-          </Card>
-        </Kanban.Card>
+        code={`import { useCallback, useState } from 'react';
+import { GripVertical, MoreHorizontal } from 'lucide-react';
+import {
+  Badge,
+  Button,
+  Card,
+  Cluster,
+  DropdownMenu,
+  Kanban,
+  Text,
+  Title,
+  type KanbanMoveEvent,
+} from '@eocrm/design-system';
+
+type ColId = 'todo' | 'doing' | 'done';
+
+interface CardData {
+  id: string;
+  title: string;
+}
+
+const COL_TITLES: Record<ColId, string> = {
+  todo: 'To do',
+  doing: 'In progress',
+  done: 'Done',
+};
+
+const INITIAL_BOARD: Record<ColId, CardData[]> = {
+  todo: [
+    { id: 'task-1', title: 'Draft Q3 OKRs' },
+    { id: 'task-2', title: 'Review pricing page mocks' },
+    { id: 'task-3', title: 'Schedule retro' },
+  ],
+  doing: [
+    { id: 'task-4', title: 'Refactor billing service' },
+    { id: 'task-5', title: 'Customer interview notes' },
+  ],
+  done: [
+    { id: 'task-6', title: 'Ship onboarding email' },
+    { id: 'task-7', title: 'Migrate logs to OTLP' },
+  ],
+};
+
+export function Demo() {
+  const [board, setBoard] = useState<Record<ColId, CardData[]>>(INITIAL_BOARD);
+
+  const handleMove = useCallback((event: KanbanMoveEvent) => {
+    const { from, to, cardId } = event;
+    setBoard((curr) => {
+      const fromCol = from.columnId as ColId;
+      const toCol = to.columnId as ColId;
+      const next: Record<ColId, CardData[]> = {
+        todo: [...curr.todo],
+        doing: [...curr.doing],
+        done: [...curr.done],
+      };
+      const sourceArr = next[fromCol];
+      const idx = sourceArr.findIndex((c) => c.id === cardId);
+      if (idx < 0) return curr;
+      const [moved] = sourceArr.splice(idx, 1);
+      const targetArr = fromCol === toCol ? sourceArr : next[toCol];
+      const insertAt = Math.min(to.index, targetArr.length);
+      targetArr.splice(insertAt, 0, moved);
+      return next;
+    });
+  }, []);
+
+  return (
+    <Kanban onMove={handleMove}>
+      {(['todo', 'doing', 'done'] as const).map((colId) => (
+        <Kanban.Column key={colId} id={colId}>
+          <Cluster justify="between" align="center">
+            <Title order={3} size="sm">{COL_TITLES[colId]}</Title>
+            <Badge tone="neutral" size="sm">{board[colId].length}</Badge>
+          </Cluster>
+          {board[colId].map((card) => (
+            <Kanban.Card key={card.id} id={card.id}>
+              <Card padding="sm">
+                <Cluster justify="between" align="center">
+                  <Cluster gap="sm" align="center">
+                    <Kanban.Handle aria-label={\`Reorder \${card.title}\`}>
+                      <GripVertical size={14} />
+                    </Kanban.Handle>
+                    <Text weight="medium">{card.title}</Text>
+                  </Cluster>
+                  <DropdownMenu>
+                    <DropdownMenu.Trigger>
+                      <Button variant="ghost" size="sm" iconOnly aria-label="More">
+                        <MoreHorizontal size={14} />
+                      </Button>
+                    </DropdownMenu.Trigger>
+                    <DropdownMenu.Content align="end">
+                      <DropdownMenu.Item onSelect={() => {}}>View</DropdownMenu.Item>
+                      <DropdownMenu.Item onSelect={() => {}}>Archive</DropdownMenu.Item>
+                    </DropdownMenu.Content>
+                  </DropdownMenu>
+                </Cluster>
+              </Card>
+            </Kanban.Card>
+          ))}
+        </Kanban.Column>
       ))}
-    </Kanban.Column>
-  ))}
-</Kanban>`}
+    </Kanban>
+  );
+}`}
       >
         <Kanban onMove={handleMoveB}>
           {(['todo', 'doing', 'done'] as const).map((colId) => (

--- a/packages/playground/src/pages/components/KbdDemo.tsx
+++ b/packages/playground/src/pages/components/KbdDemo.tsx
@@ -35,9 +35,17 @@ export function KbdDemo() {
       <Example
         title="Single key"
         description="A one-entry keys array renders a single chip with no separator. Useful for Esc / Enter / ? hints."
-        code={`<Kbd keys={['Esc']} />
-<Kbd keys={['Enter']} />
-<Kbd keys={['?']} />`}
+        code={`import { Cluster, Kbd } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm" align="center">
+      <Kbd keys={['Esc']} />
+      <Kbd keys={['Enter']} />
+      <Kbd keys={['?']} />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" align="center">
           <Kbd keys={['Esc']} />
@@ -49,8 +57,16 @@ export function KbdDemo() {
       <Example
         title="Two-key combo"
         description="Multiple entries are joined by an inline + separator. Pass the literal labels — '⌘' on macOS, 'Ctrl' elsewhere; the app layer picks."
-        code={`<Kbd keys={['⌘', 'K']} />
-<Kbd keys={['Ctrl', 'C']} />`}
+        code={`import { Cluster, Kbd } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm" align="center">
+      <Kbd keys={['⌘', 'K']} />
+      <Kbd keys={['Ctrl', 'C']} />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" align="center">
           <Kbd keys={['⌘', 'K']} />
@@ -61,8 +77,16 @@ export function KbdDemo() {
       <Example
         title="Three-key combo"
         description="Any number of keys; n − 1 separators are rendered between them."
-        code={`<Kbd keys={['Ctrl', 'Shift', 'P']} />
-<Kbd keys={['⌘', 'Shift', 'F']} />`}
+        code={`import { Cluster, Kbd } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm" align="center">
+      <Kbd keys={['Ctrl', 'Shift', 'P']} />
+      <Kbd keys={['⌘', 'Shift', 'F']} />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" align="center">
           <Kbd keys={['Ctrl', 'Shift', 'P']} />
@@ -73,8 +97,16 @@ export function KbdDemo() {
       <Example
         title="Size variants"
         description="`sm` (default, 18px tall) is the inline-chrome size — matches TopBar.Search. `md` (24px tall) is the standalone shortcut size for command-palette / shortcut-sheet UI."
-        code={`<Kbd keys={['⌘', 'K']} size="sm" />
-<Kbd keys={['⌘', 'K']} size="md" />`}
+        code={`import { Cluster, Kbd } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      <Kbd keys={['⌘', 'K']} size="sm" />
+      <Kbd keys={['⌘', 'K']} size="md" />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           <Kbd keys={['⌘', 'K']} size="sm" />
@@ -85,9 +117,15 @@ export function KbdDemo() {
       <Example
         title="Inline in prose"
         description="The wrapper is `display: inline-flex` with `vertical-align: baseline`, so a Kbd embedded inside a `<Text>` paragraph sits on the text baseline without breaking flow."
-        code={`<Text>
-  Press <Kbd keys={['⌘', 'K']} /> to open the command palette.
-</Text>`}
+        code={`import { Kbd, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Text>
+      Press <Kbd keys={['⌘', 'K']} /> to open the command palette.
+    </Text>
+  );
+}`}
       >
         <Text>
           Press <Kbd keys={['⌘', 'K']} /> to open the command palette.
@@ -97,15 +135,23 @@ export function KbdDemo() {
       <Example
         title="Inside a Tooltip"
         description="The canonical Tooltip + Kbd composition — the tooltip body labels the action, the Kbd shows the shortcut."
-        code={`<Tooltip
-  content={
-    <>
-      Save <Kbd keys={['⌘', 'S']} />
-    </>
-  }
->
-  <Button>Save</Button>
-</Tooltip>`}
+        code={`import { Button, Cluster, Kbd, Tooltip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm" align="center">
+      <Tooltip
+        content={
+          <>
+            Save <Kbd keys={['⌘', 'S']} />
+          </>
+        }
+      >
+        <Button>Save</Button>
+      </Tooltip>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm" align="center">
           <Tooltip
@@ -123,11 +169,17 @@ export function KbdDemo() {
       <Example
         title="Inside TopBar.Search"
         description="TopBar.Search renders its `hotkey` prop via <Kbd size='sm'>. Pass an array for multi-key combos; a single string is also accepted and renders as one chip."
-        code={`<TopBar>
-  <TopBar.Start>
-    <TopBar.Search placeholder="Search…" hotkey={['⌘', 'K']} />
-  </TopBar.Start>
-</TopBar>`}
+        code={`import { TopBar } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <TopBar>
+      <TopBar.Start>
+        <TopBar.Search placeholder="Search…" hotkey={['⌘', 'K']} />
+      </TopBar.Start>
+    </TopBar>
+  );
+}`}
       >
         <TopBarStage>
           <TopBar>
@@ -141,7 +193,18 @@ export function KbdDemo() {
       <Example
         title="Custom aria-label"
         description="The wrapper's default aria-label is keys.join(' + ') — fine for most shortcuts, but symbol keys read poorly. Override with a verbal description when the raw glyphs are unintuitive."
-        code={`<Kbd keys={['⌘', 'K']} aria-label="Open command palette" />`}
+        code={`import { Kbd, Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs" align="start">
+      <Kbd keys={['⌘', 'K']} aria-label="Open command palette" />
+      <Text size="sm" tone="muted">
+        Screen readers announce "Open command palette" instead of "⌘ + K".
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="xs" align="start">
           <Kbd keys={['⌘', 'K']} aria-label="Open command palette" />

--- a/packages/playground/src/pages/components/LightboxDemo.tsx
+++ b/packages/playground/src/pages/components/LightboxDemo.tsx
@@ -117,15 +117,60 @@ export function LightboxDemo() {
       <Example
         title="Gallery from thumbnails"
         description="A row of interactive Image thumbnails opens the Lightbox at the clicked index. Cycle with the chevrons, ← → keys, or the bottom strip; the caption shows below each image."
-        code={`const [open, setOpen] = useState(false);
-const [start, setStart] = useState(0);
-<Cluster gap="sm">
-  {photos.map((p, i) => (
-    <Image key={p.src} src={p.src} alt={p.alt} size="lg" objectFit="cover"
-      interactive onClick={() => { setStart(i); setOpen(true); }} ariaLabel={\`Open \${p.alt}\`} />
-  ))}
-</Cluster>
-<Lightbox open={open} onOpenChange={setOpen} items={photos} defaultIndex={start} />`}
+        code={`import { useState } from 'react';
+import { Cluster, Image, Lightbox, Stack, Text, type LightboxItem } from '@eocrm/design-system';
+
+const PHOTOS: LightboxItem[] = [
+  {
+    src: 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=1400&q=80',
+    alt: 'Mountain lake at dawn',
+    caption: 'Lakeside cabin — site survey',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1465146344425-f00d5f5c8f07?w=1400&q=80',
+    alt: 'Field of flowers',
+    caption: 'North meadow',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=1400&q=80',
+    alt: 'Sunlit ridge',
+    caption: 'Ridge access road',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1470770841072-f978cf4d019e?w=1400&q=80',
+    alt: 'Forest lake',
+  },
+];
+
+export function Gallery() {
+  const [open, setOpen] = useState(false);
+  const [start, setStart] = useState(0);
+  return (
+    <Stack gap="sm">
+      <Cluster gap="sm">
+        {PHOTOS.map((p, i) => (
+          <Image
+            key={p.src}
+            src={p.src}
+            alt={p.alt}
+            size="lg"
+            objectFit="cover"
+            interactive
+            onClick={() => {
+              setStart(i);
+              setOpen(true);
+            }}
+            ariaLabel={\`Open \${p.alt}\`}
+          />
+        ))}
+      </Cluster>
+      <Text size="sm" tone="muted">
+        Click a thumbnail — arrows / ← → cycle, the strip jumps, Esc closes.
+      </Text>
+      <Lightbox open={open} onOpenChange={setOpen} items={PHOTOS} defaultIndex={start} />
+    </Stack>
+  );
+}`}
       >
         <Gallery />
       </Example>
@@ -133,12 +178,43 @@ const [start, setStart] = useState(0);
       <Example
         title="Mixed gallery — images + PDF"
         description="Items can be documents too: pass kind: 'pdf' (or a .pdf src) and the stage renders an iframe with a download action instead of an img. A PDF without a thumbnail gets a document-icon placeholder in the strip. Image and PDF items mix freely in one gallery."
-        code={`const items = [
-  { src: photo.url, alt: 'Site photo' },
-  { src: report.url, alt: 'Site-survey report.pdf', kind: 'pdf', caption: 'Site-survey report (PDF)' },
-  { src: photo2.url, alt: 'Ridge access road' },
+        code={`import { useState } from 'react';
+import { Button, Lightbox, Stack, Text, type LightboxItem } from '@eocrm/design-system';
+
+const ATTACHMENTS: LightboxItem[] = [
+  {
+    src: 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=1400&q=80',
+    alt: 'Mountain lake at dawn',
+    caption: 'Lakeside cabin — site survey',
+  },
+  {
+    src: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
+    alt: 'Site-survey report.pdf',
+    kind: 'pdf',
+    caption: 'Site-survey report (PDF)',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=1400&q=80',
+    alt: 'Sunlit ridge',
+    caption: 'Ridge access road',
+  },
 ];
-<Lightbox open={open} onOpenChange={setOpen} items={items} />`}
+
+export function MixedGallery() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Stack gap="sm">
+      <Button variant="secondary" size="sm" onClick={() => setOpen(true)}>
+        Open attachments (images + PDF)
+      </Button>
+      <Text size="sm" tone="muted">
+        Navigate to the PDF — it previews in an iframe with a download action; the strip shows a
+        document-icon placeholder for it.
+      </Text>
+      <Lightbox open={open} onOpenChange={setOpen} items={ATTACHMENTS} />
+    </Stack>
+  );
+}`}
       >
         <MixedGallery />
       </Example>
@@ -146,7 +222,26 @@ const [start, setStart] = useState(0);
       <Example
         title="Single image"
         description="With one item the chevrons, counter, and thumbnail strip are hidden — just the image, caption (if any), and close."
-        code={`<Lightbox open={open} onOpenChange={setOpen} items={[photo]} />`}
+        code={`import { useState } from 'react';
+import { Button, Lightbox, Stack, type LightboxItem } from '@eocrm/design-system';
+
+const photo: LightboxItem = {
+  src: 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=1400&q=80',
+  alt: 'Mountain lake at dawn',
+  caption: 'Lakeside cabin — site survey',
+};
+
+export function SingleImage() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Stack gap="sm">
+      <Button variant="secondary" size="sm" onClick={() => setOpen(true)}>
+        Open single image
+      </Button>
+      <Lightbox open={open} onOpenChange={setOpen} items={[photo]} />
+    </Stack>
+  );
+}`}
       >
         <SingleImage />
       </Example>

--- a/packages/playground/src/pages/components/LinkCardDemo.tsx
+++ b/packages/playground/src/pages/components/LinkCardDemo.tsx
@@ -14,12 +14,18 @@ export function LinkCardDemo() {
       <Example
         title="As a link (default <a>)"
         description="The whole card is one anchor. Hover for the lift; tab to it for the focus ring."
-        code={`<LinkCard href="https://status.example.com">
-  <Stack gap="xs">
-    <Text weight="semibold">Status page</Text>
-    <Text size="sm" tone="muted">All systems operational.</Text>
-  </Stack>
-</LinkCard>`}
+        code={`import { LinkCard, Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <LinkCard href="https://status.example.com">
+      <Stack gap="xs">
+        <Text weight="semibold">Status page</Text>
+        <Text size="sm" tone="muted">All systems operational.</Text>
+      </Stack>
+    </LinkCard>
+  );
+}`}
       >
         <LinkCard href="https://status.example.com">
           <Stack gap="xs">
@@ -34,9 +40,15 @@ export function LinkCardDemo() {
       <Example
         title="As a button (action)"
         description={`Pass as="button" for an action instead of navigation.`}
-        code={`<LinkCard as="button" type="button" onClick={openImporter}>
-  <Text weight="semibold">Import contacts</Text>
-</LinkCard>`}
+        code={`import { LinkCard, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <LinkCard as="button" type="button" onClick={() => {}}>
+      <Text weight="semibold">Import contacts</Text>
+    </LinkCard>
+  );
+}`}
       >
         <LinkCard as="button" type="button" onClick={() => undefined}>
           <Text weight="semibold">Import contacts</Text>
@@ -46,11 +58,32 @@ export function LinkCardDemo() {
       <Example
         title="Index grid"
         description="The canonical use — a grid of cards each linking somewhere. padding + tone match Card."
-        code={`<Grid minColumnWidth="220px" gap="md">
-  <LinkCard href="#" tone="accent"><Text weight="semibold">Dashboard</Text></LinkCard>
-  <LinkCard href="#" tone="success"><Text weight="semibold">Deals</Text></LinkCard>
-  <LinkCard href="#"><Text weight="semibold">Contacts</Text></LinkCard>
-</Grid>`}
+        code={`import { Grid, LinkCard, Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Grid minColumnWidth="220px" gap="md">
+      <LinkCard href="https://example.com/dashboard" tone="accent">
+        <Stack gap="xs">
+          <Text weight="semibold">Dashboard</Text>
+          <Text size="sm" tone="muted">KPIs & pipeline.</Text>
+        </Stack>
+      </LinkCard>
+      <LinkCard href="https://example.com/deals" tone="success">
+        <Stack gap="xs">
+          <Text weight="semibold">Deals</Text>
+          <Text size="sm" tone="muted">Kanban board.</Text>
+        </Stack>
+      </LinkCard>
+      <LinkCard href="https://example.com/contacts">
+        <Stack gap="xs">
+          <Text weight="semibold">Contacts</Text>
+          <Text size="sm" tone="muted">Directory.</Text>
+        </Stack>
+      </LinkCard>
+    </Grid>
+  );
+}`}
       >
         <Grid minColumnWidth="220px" gap="md">
           <LinkCard href="https://example.com/dashboard" tone="accent">

--- a/packages/playground/src/pages/components/LinkDemo.tsx
+++ b/packages/playground/src/pages/components/LinkDemo.tsx
@@ -16,7 +16,15 @@ export function LinkDemo() {
       <Example
         title="Default — external link"
         description="No `as` prop = native <a>. Use for external URLs."
-        code={`<Link href="https://docs.example.com">Documentation</Link>`}
+        code={`import { Link } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Link href="https://example.com" target="_blank" rel="noopener noreferrer">
+      Documentation
+    </Link>
+  );
+}`}
       >
         <Link href="https://example.com" target="_blank" rel="noopener noreferrer">
           Documentation
@@ -26,9 +34,23 @@ export function LinkDemo() {
       <Example
         title="Three variants side by side"
         description="Pure visual difference. Pick by emphasis level."
-        code={`<Link href="/x">default — accent + hover-underline</Link>
-<Link href="/x" variant="muted">muted — subdued nav</Link>
-<Link href="/x" variant="subtle">subtle — fg, hover-accent + underline</Link>`}
+        code={`import { Link, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Link href="#default" onClick={(e) => e.preventDefault()}>
+        default — accent + hover-underline
+      </Link>
+      <Link href="#muted" variant="muted" onClick={(e) => e.preventDefault()}>
+        muted — subdued nav
+      </Link>
+      <Link href="#subtle" variant="subtle" onClick={(e) => e.preventDefault()}>
+        subtle — fg, hover-accent + underline
+      </Link>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Link href="#default" onClick={(e) => e.preventDefault()}>
@@ -47,8 +69,15 @@ export function LinkDemo() {
         title="SPA navigation via `as={RouterLink}`"
         description="Passes through router's `to`, `replace`, etc. with full type inference."
         code={`import { Link as RouterLink } from 'react-router-dom';
+import { Link } from '@eocrm/design-system';
 
-<Link as={RouterLink} to="/mockups/contacts">Go to Contacts</Link>`}
+export function Demo() {
+  return (
+    <Link as={RouterLink} to="/mockups/contacts">
+      Go to Contacts
+    </Link>
+  );
+}`}
       >
         <Link as={RouterLink} to="/mockups/contacts">
           Go to Contacts
@@ -58,12 +87,20 @@ export function LinkDemo() {
       <Example
         title={'Link-styled action via `as="button"`'}
         description="An action that must visually match a sibling Link but can't be a real href (a fake href is the Link anti-pattern) → render a real <button>. It inherits the link look AND the pointer cursor."
-        code={`<Cluster gap="md">
-  <Link href="/forgot-password">Forgot?</Link>
-  <Link as="button" type="button" onClick={handleChangeEmail}>
-    Change email
-  </Link>
-</Cluster>`}
+        code={`import { Cluster, Link } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md">
+      <Link href="#forgot" onClick={(e) => e.preventDefault()}>
+        Forgot?
+      </Link>
+      <Link as="button" type="button" onClick={() => {}}>
+        Change email
+      </Link>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md">
           <Link href="#forgot" onClick={(e) => e.preventDefault()}>
@@ -78,9 +115,16 @@ export function LinkDemo() {
       <Example
         title="Composed with an icon"
         description="Compose Link with whatever children you want — it's just a styled anchor."
-        code={`<Link href="https://docs.example.com" target="_blank" rel="noopener noreferrer">
-  Open docs <ExternalLink size={12} />
-</Link>`}
+        code={`import { ExternalLink } from 'lucide-react';
+import { Link } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Link href="https://example.com" target="_blank" rel="noopener noreferrer">
+      Open docs <ExternalLink size={12} />
+    </Link>
+  );
+}`}
       >
         <Link href="https://example.com" target="_blank" rel="noopener noreferrer">
           Open docs <ExternalLink size={12} />
@@ -90,9 +134,23 @@ export function LinkDemo() {
       <Example
         title="Inline in body text"
         description="Inherits font-size and color context from the surrounding paragraph."
-        code={`<p>
-  See the <Link href="/x">documentation</Link> for more info.
-</p>`}
+        code={`import { Link } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <p style={{ fontSize: 'var(--font-size-md)', color: 'var(--color-fg)', margin: 0 }}>
+      See the{' '}
+      <Link href="#docs" onClick={(e) => e.preventDefault()}>
+        documentation
+      </Link>{' '}
+      for more info, or skip to the{' '}
+      <Link href="#examples" variant="muted" onClick={(e) => e.preventDefault()}>
+        examples
+      </Link>
+      .
+    </p>
+  );
+}`}
       >
         <p style={{ fontSize: 'var(--font-size-md)', color: 'var(--color-fg)', margin: 0 }}>
           See the{' '}
@@ -110,11 +168,23 @@ export function LinkDemo() {
       <Example
         title="Cluster of links"
         description="Multiple links lay out via Cluster — no special grouping primitive needed."
-        code={`<Cluster gap="md">
-  <Link href="/a">Home</Link>
-  <Link href="/b">Features</Link>
-  <Link href="/c">Pricing</Link>
-</Cluster>`}
+        code={`import { Cluster, Link } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md">
+      <Link href="#home" onClick={(e) => e.preventDefault()}>
+        Home
+      </Link>
+      <Link href="#features" onClick={(e) => e.preventDefault()}>
+        Features
+      </Link>
+      <Link href="#pricing" onClick={(e) => e.preventDefault()}>
+        Pricing
+      </Link>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md">
           <Link href="#home" onClick={(e) => e.preventDefault()}>

--- a/packages/playground/src/pages/components/LiquidEditorDemo.tsx
+++ b/packages/playground/src/pages/components/LiquidEditorDemo.tsx
@@ -42,12 +42,43 @@ export function LiquidEditorDemo() {
       <Example
         title="With variables + live preview"
         description="Type {{ to autocomplete a variable; add | to autocomplete a filter. The preview is consumer-rendered (here a stand-in for a backend call)."
-        code={`<LiquidEditor
-  value={formula}
-  onChange={setFormula}
-  variables={VARS}
-  preview={fakeRender(formula)}
-/>`}
+        code={`import { useState } from 'react';
+import { LiquidEditor, type LiquidVariable } from '@eocrm/design-system';
+
+const VARS: LiquidVariable[] = [
+  { code: 'first_name', label: 'First name', type: 'text', group: 'Built-in fields' },
+  { code: 'last_name', label: 'Last name', type: 'text', group: 'Built-in fields' },
+  { code: 'email', label: 'Email', type: 'text', group: 'Built-in fields' },
+  { code: 'job_title', label: 'Job title', type: 'text', group: 'Custom fields' },
+  { code: 'join_date', label: 'Join date', type: 'date', group: 'Custom fields' },
+];
+
+function fakeRender(template: string): string {
+  const data: Record<string, string> = {
+    first_name: 'Ada',
+    last_name: 'Lovelace',
+    email: 'ada@example.com',
+    job_title: 'Engineer',
+    join_date: '2024-01-12',
+  };
+  return template.replace(/\{\{\s*(\w+)(\s*\|\s*upcase)?\s*\}\}/g, (_m, code, up) => {
+    const v = data[code] ?? '';
+    return up ? v.toUpperCase() : v;
+  });
+}
+
+export function Demo() {
+  const [formula, setFormula] = useState('{{ first_name }} {{ last_name | upcase }}');
+
+  return (
+    <LiquidEditor
+      value={formula}
+      onChange={setFormula}
+      variables={VARS}
+      preview={fakeRender(formula)}
+    />
+  );
+}`}
       >
         <LiquidEditor
           value={formula}
@@ -60,17 +91,35 @@ export function LiquidEditorDemo() {
       <Example
         title="Custom toolbar actions"
         description='Pass toolbarActions to add buttons (e.g. a Docs link) right-aligned in the toolbar, just before the bordered "Insert variable" button.'
-        code={`<LiquidEditor
-  value={formula}
-  onChange={setFormula}
-  variables={VARS}
-  toolbarActions={
-    <Button variant="ghost" size="sm">
-      <BookOpen size={14} />
-      Docs
-    </Button>
-  }
-/>`}
+        code={`import { useState } from 'react';
+import { BookOpen } from 'lucide-react';
+import { Button, LiquidEditor, type LiquidVariable } from '@eocrm/design-system';
+
+const VARS: LiquidVariable[] = [
+  { code: 'first_name', label: 'First name', type: 'text', group: 'Built-in fields' },
+  { code: 'last_name', label: 'Last name', type: 'text', group: 'Built-in fields' },
+  { code: 'email', label: 'Email', type: 'text', group: 'Built-in fields' },
+  { code: 'job_title', label: 'Job title', type: 'text', group: 'Custom fields' },
+  { code: 'join_date', label: 'Join date', type: 'date', group: 'Custom fields' },
+];
+
+export function Demo() {
+  const [formula, setFormula] = useState('{{ first_name }} {{ last_name | upcase }}');
+
+  return (
+    <LiquidEditor
+      value={formula}
+      onChange={setFormula}
+      variables={VARS}
+      toolbarActions={
+        <Button variant="ghost" size="sm">
+          <BookOpen size={14} />
+          Docs
+        </Button>
+      }
+    />
+  );
+}`}
       >
         <LiquidEditor
           value={formula}
@@ -88,7 +137,22 @@ export function LiquidEditorDemo() {
       <Example
         title="Unknown-variable flagging"
         description="A {{ variable }} not in the provided list is underlined and named in the footer."
-        code={`<LiquidEditor value={value} onChange={setValue} variables={VARS} />`}
+        code={`import { useState } from 'react';
+import { LiquidEditor, type LiquidVariable } from '@eocrm/design-system';
+
+const VARS: LiquidVariable[] = [
+  { code: 'first_name', label: 'First name', type: 'text', group: 'Built-in fields' },
+  { code: 'last_name', label: 'Last name', type: 'text', group: 'Built-in fields' },
+  { code: 'email', label: 'Email', type: 'text', group: 'Built-in fields' },
+  { code: 'job_title', label: 'Job title', type: 'text', group: 'Custom fields' },
+  { code: 'join_date', label: 'Join date', type: 'date', group: 'Custom fields' },
+];
+
+export function Demo() {
+  const [value, setValue] = useState('{{ first_naem }}');
+
+  return <LiquidEditor value={value} onChange={setValue} variables={VARS} />;
+}`}
       >
         <LiquidEditor value={withTypo} onChange={setWithTypo} variables={VARS} />
       </Example>
@@ -96,7 +160,27 @@ export function LiquidEditorDemo() {
       <Example
         title="External (backend) syntax error"
         description="invalid + error surface a backend Liquid parse error; independent of client unknown-variable flags."
-        code={`<LiquidEditor value={value} onChange={setValue} invalid error="Unexpected end of template" />`}
+        code={`import { LiquidEditor, type LiquidVariable } from '@eocrm/design-system';
+
+const VARS: LiquidVariable[] = [
+  { code: 'first_name', label: 'First name', type: 'text', group: 'Built-in fields' },
+  { code: 'last_name', label: 'Last name', type: 'text', group: 'Built-in fields' },
+  { code: 'email', label: 'Email', type: 'text', group: 'Built-in fields' },
+  { code: 'job_title', label: 'Job title', type: 'text', group: 'Custom fields' },
+  { code: 'join_date', label: 'Join date', type: 'date', group: 'Custom fields' },
+];
+
+export function Demo() {
+  return (
+    <LiquidEditor
+      value="{{ first_name "
+      onChange={() => {}}
+      variables={VARS}
+      invalid
+      error="Unexpected end of template"
+    />
+  );
+}`}
       >
         <LiquidEditor
           value="{{ first_name "
@@ -110,7 +194,28 @@ export function LiquidEditorDemo() {
       <Example
         title="Read-only"
         description="Selection allowed, edits blocked; highlighting + preview still render."
-        code={`<LiquidEditor value={value} onChange={() => {}} variables={VARS} readOnly />`}
+        code={`import { LiquidEditor, Stack, type LiquidVariable } from '@eocrm/design-system';
+
+const VARS: LiquidVariable[] = [
+  { code: 'first_name', label: 'First name', type: 'text', group: 'Built-in fields' },
+  { code: 'last_name', label: 'Last name', type: 'text', group: 'Built-in fields' },
+  { code: 'email', label: 'Email', type: 'text', group: 'Built-in fields' },
+  { code: 'job_title', label: 'Job title', type: 'text', group: 'Custom fields' },
+  { code: 'join_date', label: 'Join date', type: 'date', group: 'Custom fields' },
+];
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <LiquidEditor
+        value="{{ first_name }} — {{ job_title }}"
+        onChange={() => {}}
+        variables={VARS}
+        readOnly
+      />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <LiquidEditor

--- a/packages/playground/src/pages/components/LogoDemo.tsx
+++ b/packages/playground/src/pages/components/LogoDemo.tsx
@@ -16,8 +16,11 @@ export function LogoDemo() {
         title="Mark + wordmark"
         description="The common header / auth lockup — pass the mark via src and the wordmark via text."
         code={`import logo from '../assets/eocrm-logo.svg';
+import { Logo } from '@eocrm/design-system';
 
-<Logo src={logo} text="eocrm" />`}
+export function Demo() {
+  return <Logo src={logo} text="eocrm" />;
+}`}
       >
         <Logo src={eocrmLogo} text="eocrm" />
       </Example>
@@ -25,7 +28,12 @@ export function LogoDemo() {
       <Example
         title="Mark only"
         description="Omit text for just the mark. Pass label for a standalone accessible name (the image alt)."
-        code={`<Logo src={logo} label="eocrm" />`}
+        code={`import logo from '../assets/eocrm-logo.svg';
+import { Logo } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Logo src={logo} label="eocrm" />;
+}`}
       >
         <Logo src={eocrmLogo} label="eocrm" />
       </Example>
@@ -33,7 +41,12 @@ export function LogoDemo() {
       <Example
         title="Wordmark below the mark"
         description="textPlacement='bottom' stacks the wordmark under the mark, centered."
-        code={`<Logo src={logo} text="eocrm" textPlacement="bottom" />`}
+        code={`import logo from '../assets/eocrm-logo.svg';
+import { Logo } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Logo src={logo} text="eocrm" textPlacement="bottom" />;
+}`}
       >
         <Logo src={eocrmLogo} text="eocrm" textPlacement="bottom" />
       </Example>
@@ -41,7 +54,12 @@ export function LogoDemo() {
       <Example
         title="With a muted subline"
         description="subtext adds a small muted line under the wordmark — the app-shell brand lockup (name + plan)."
-        code={`<Logo src={logo} text="eocrm" subtext="Free trial" size="sm" />`}
+        code={`import logo from '../assets/eocrm-logo.svg';
+import { Logo } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Logo src={logo} text="eocrm" subtext="Free trial" size="sm" />;
+}`}
       >
         <Logo src={eocrmLogo} text="eocrm" subtext="Free trial" size="sm" />
       </Example>
@@ -49,9 +67,18 @@ export function LogoDemo() {
       <Example
         title="Sizes"
         description="sm (24) / md (32, default) / lg (40)."
-        code={`<Logo src={logo} text="eocrm" size="sm" />
-<Logo src={logo} text="eocrm" size="md" />
-<Logo src={logo} text="eocrm" size="lg" />`}
+        code={`import logo from '../assets/eocrm-logo.svg';
+import { Cluster, Logo } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="lg" align="center">
+      <Logo src={logo} text="eocrm" size="sm" />
+      <Logo src={logo} text="eocrm" size="md" />
+      <Logo src={logo} text="eocrm" size="lg" />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="lg" align="center">
           <Logo src={eocrmLogo} text="eocrm" size="sm" />

--- a/packages/playground/src/pages/components/MasonryDemo.tsx
+++ b/packages/playground/src/pages/components/MasonryDemo.tsx
@@ -47,7 +47,52 @@ export function MasonryDemo() {
       <Example
         title="Responsive"
         description="minColumnWidth sets the target column width; the column count reflows with the container. Numbers read left→right across the top row."
-        code={`<Masonry minColumnWidth="160px" gap="sm">{tiles}</Masonry>`}
+        code={`import { Masonry } from '@eocrm/design-system';
+
+const TILES = [
+  { n: 1, h: 80 },
+  { n: 2, h: 140 },
+  { n: 3, h: 100 },
+  { n: 4, h: 60 },
+  { n: 5, h: 120 },
+  { n: 6, h: 90 },
+  { n: 7, h: 160 },
+  { n: 8, h: 70 },
+  { n: 9, h: 110 },
+  { n: 10, h: 130 },
+  { n: 11, h: 95 },
+  { n: 12, h: 150 },
+];
+
+function Tile({ n, h }: { n: number; h: number }) {
+  return (
+    <div
+      style={{
+        height: h,
+        borderRadius: 'var(--radius-md)',
+        background: 'var(--color-accent-subtle-bg)',
+        color: 'var(--color-accent)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontWeight: 700,
+        fontSize: 18,
+      }}
+    >
+      {n}
+    </div>
+  );
+}
+
+export function Demo() {
+  return (
+    <Masonry minColumnWidth="160px" gap="sm">
+      {TILES.map((t) => (
+        <Tile key={t.n} n={t.n} h={t.h} />
+      ))}
+    </Masonry>
+  );
+}`}
       >
         <Masonry minColumnWidth="160px" gap="sm">
           {TILES.map((t) => (
@@ -59,7 +104,52 @@ export function MasonryDemo() {
       <Example
         title="Fixed columns"
         description="A fixed number of equal-width columns at any container width."
-        code={`<Masonry columns={3} gap="md">{tiles}</Masonry>`}
+        code={`import { Masonry } from '@eocrm/design-system';
+
+const TILES = [
+  { n: 1, h: 80 },
+  { n: 2, h: 140 },
+  { n: 3, h: 100 },
+  { n: 4, h: 60 },
+  { n: 5, h: 120 },
+  { n: 6, h: 90 },
+  { n: 7, h: 160 },
+  { n: 8, h: 70 },
+  { n: 9, h: 110 },
+  { n: 10, h: 130 },
+  { n: 11, h: 95 },
+  { n: 12, h: 150 },
+];
+
+function Tile({ n, h }: { n: number; h: number }) {
+  return (
+    <div
+      style={{
+        height: h,
+        borderRadius: 'var(--radius-md)',
+        background: 'var(--color-accent-subtle-bg)',
+        color: 'var(--color-accent)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontWeight: 700,
+        fontSize: 18,
+      }}
+    >
+      {n}
+    </div>
+  );
+}
+
+export function Demo() {
+  return (
+    <Masonry columns={3} gap="md">
+      {TILES.map((t) => (
+        <Tile key={t.n} n={t.n} h={t.h} />
+      ))}
+    </Masonry>
+  );
+}`}
       >
         <Masonry columns={3} gap="md">
           {TILES.map((t) => (
@@ -71,7 +161,26 @@ export function MasonryDemo() {
       <Example
         title="Photo wall"
         description="The canonical use: Image children of varied aspect ratios. Masonry rebalances once the images load."
-        code={`<Masonry minColumnWidth="200px" gap="sm">{photos.map(p => <Image … aspectRatio={p.r} />)}</Masonry>`}
+        code={`import { Image, Masonry } from '@eocrm/design-system';
+
+const PHOTOS = [
+  { src: 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=400&q=80', r: '4 / 3' },
+  { src: 'https://images.unsplash.com/photo-1517849845537-4d257902454a?w=400&q=80', r: '3 / 4' },
+  { src: 'https://images.unsplash.com/photo-1465146344425-f00d5f5c8f07?w=400&q=80', r: '1 / 1' },
+  { src: 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=400&q=80', r: '16 / 9' },
+  { src: 'https://images.unsplash.com/photo-1470770841072-f978cf4d019e?w=400&q=80', r: '3 / 4' },
+  { src: 'https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=400&q=80', r: '4 / 3' },
+];
+
+export function Demo() {
+  return (
+    <Masonry minColumnWidth="200px" gap="sm">
+      {PHOTOS.map((p) => (
+        <Image key={p.src} src={p.src} alt="" aspectRatio={p.r} />
+      ))}
+    </Masonry>
+  );
+}`}
       >
         <Masonry minColumnWidth="200px" gap="sm">
           {PHOTOS.map((p) => (
@@ -83,7 +192,26 @@ export function MasonryDemo() {
       <Example
         title="Card wall"
         description="Cards of differing content length pack into balanced columns."
-        code={`<Masonry minColumnWidth="240px" gap="md">{cards}</Masonry>`}
+        code={`import { Card, Masonry, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Masonry minColumnWidth="240px" gap="md">
+      {[
+        'Short note.',
+        'A medium note that runs onto a second line so its card is a bit taller than the others.',
+        'Tiny.',
+        'Another note with enough text to wrap across two or three lines and change the height meaningfully versus its neighbours.',
+        'Mid-length note here.',
+        'One more.',
+      ].map((body, i) => (
+        <Card key={i} padding="md">
+          <Text size="sm">{body}</Text>
+        </Card>
+      ))}
+    </Masonry>
+  );
+}`}
       >
         <Masonry minColumnWidth="240px" gap="md">
           {[

--- a/packages/playground/src/pages/components/MediaTileDemo.tsx
+++ b/packages/playground/src/pages/components/MediaTileDemo.tsx
@@ -89,14 +89,74 @@ export function MediaTileDemo() {
       <Example
         title="Files grid (Masonry of tiles)"
         description="Hover a tile (or Tab into it) to reveal the name + size on top and the preview / download / delete controls on the bottom, each on a gray scrim. The non-image file shows a centered icon."
-        code={`<Masonry minColumnWidth="180px" gap="sm">
-  {files.map((f) => (
-    <MediaTile key={f.id}
-      media={<Image src={f.src} alt={f.name} aspectRatio={1} objectFit="cover" />}
-      title={f.name} meta={f.size}
-      actions={<Cluster gap="xs"><Button iconOnly aria-label={\`Download \${f.name}\`}>…</Button></Cluster>} />
-  ))}
-</Masonry>`}
+        code={`import { FileText, Maximize2, Download, Trash2 } from 'lucide-react';
+import { MediaTile, Image, Masonry, Cluster, Button } from '@eocrm/design-system';
+
+interface FileItem {
+  id: string;
+  name: string;
+  size: string;
+  src?: string;
+}
+
+const files: FileItem[] = [
+  { id: 'f1', name: 'lake-survey.jpg', size: '2.4 MB', src: 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=400&q=70' },
+  { id: 'f2', name: 'north-meadow.png', size: '1.1 MB', src: 'https://images.unsplash.com/photo-1465146344425-f00d5f5c8f07?w=400&q=70' },
+  { id: 'f3', name: 'site-plan.pdf', size: '380 KB' },
+];
+
+const iconBody = (
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      aspectRatio: '1',
+      background: 'var(--color-bg-muted)',
+      color: 'var(--color-fg-muted)',
+    }}
+  >
+    <FileText size={40} />
+  </div>
+);
+
+function fileActions(name: string) {
+  return (
+    <Cluster gap="xs">
+      <Button iconOnly variant="ghost" size="sm" aria-label={\`Preview \${name}\`} onClick={() => {}}>
+        <Maximize2 size={16} />
+      </Button>
+      <Button iconOnly variant="ghost" size="sm" aria-label={\`Download \${name}\`} onClick={() => {}}>
+        <Download size={16} />
+      </Button>
+      <Button iconOnly variant="ghost" size="sm" aria-label={\`Delete \${name}\`} onClick={() => {}}>
+        <Trash2 size={16} />
+      </Button>
+    </Cluster>
+  );
+}
+
+export function Demo() {
+  return (
+    <Masonry minColumnWidth="180px" gap="sm">
+      {files.map((f) => (
+        <MediaTile
+          key={f.id}
+          media={
+            f.src ? (
+              <Image src={f.src} alt={f.name} aspectRatio={1} objectFit="cover" />
+            ) : (
+              iconBody
+            )
+          }
+          title={f.name}
+          meta={f.size}
+          actions={fileActions(f.name)}
+        />
+      ))}
+    </Masonry>
+  );
+}`}
       >
         <Masonry minColumnWidth="180px" gap="sm">
           {FILES.map((f) => (
@@ -120,9 +180,54 @@ export function MediaTileDemo() {
       <Example
         title="revealOn — hover / focus / visible"
         description="hover (default): reveal on pointer hover OR keyboard focus. focus: only on focus-within. visible: always shown."
-        code={`<MediaTile revealOn="hover" … />
-<MediaTile revealOn="focus" … />
-<MediaTile revealOn="visible" … />`}
+        code={`import { Maximize2, Download, Trash2 } from 'lucide-react';
+import { MediaTile, Image, Cluster, Stack, Text, Button, type MediaTileReveal } from '@eocrm/design-system';
+
+function fileActions(name: string) {
+  return (
+    <Cluster gap="xs">
+      <Button iconOnly variant="ghost" size="sm" aria-label={\`Preview \${name}\`} onClick={() => {}}>
+        <Maximize2 size={16} />
+      </Button>
+      <Button iconOnly variant="ghost" size="sm" aria-label={\`Download \${name}\`} onClick={() => {}}>
+        <Download size={16} />
+      </Button>
+      <Button iconOnly variant="ghost" size="sm" aria-label={\`Delete \${name}\`} onClick={() => {}}>
+        <Trash2 size={16} />
+      </Button>
+    </Cluster>
+  );
+}
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="start">
+      {(['hover', 'focus', 'visible'] as MediaTileReveal[]).map((r) => (
+        <Stack key={r} gap="xs" align="center">
+          <div style={{ width: 160 }}>
+            <MediaTile
+              revealOn={r}
+              media={
+                <Image
+                  src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=400&q=70"
+                  alt="Mountain lake"
+                  aspectRatio={1}
+                  objectFit="cover"
+                />
+              }
+              title="lake-survey.jpg"
+              meta="2.4 MB"
+              actions={fileActions('lake-survey.jpg')}
+            />
+          </div>
+          <Text size="xs" tone="muted">
+            revealOn=&quot;{r}&quot;
+          </Text>
+        </Stack>
+      ))}
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="start">
           {(['hover', 'focus', 'visible'] as MediaTileReveal[]).map((r) => (

--- a/packages/playground/src/pages/components/ModalDemo.tsx
+++ b/packages/playground/src/pages/components/ModalDemo.tsx
@@ -29,16 +29,29 @@ function BasicExample() {
     <Example
       title="Basic"
       description="Controlled open state. Header wires aria-labelledby automatically. Built-in × close button + Esc + overlay click all dismiss."
-      code={`const [open, setOpen] = useState(false);
-<Button onClick={() => setOpen(true)}>Open modal</Button>
-<Modal open={open} onOpenChange={setOpen}>
-  <Modal.Header>Hello</Modal.Header>
-  <Modal.Body>This is a modal.</Modal.Body>
-  <Modal.Footer>
-    <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
-    <Button onClick={() => setOpen(false)}>OK</Button>
-  </Modal.Footer>
-</Modal>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Modal } from '@eocrm/design-system';
+
+export function BasicExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Cluster>
+        <Button onClick={() => setOpen(true)}>Open modal</Button>
+      </Cluster>
+      <Modal open={open} onOpenChange={setOpen}>
+        <Modal.Header>Hello</Modal.Header>
+        <Modal.Body>This is a modal. Click outside, press Esc, or use the × to close.</Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button onClick={() => setOpen(false)}>OK</Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}`}
     >
       <Cluster>
         <Button onClick={() => setOpen(true)}>Open modal</Button>
@@ -63,7 +76,40 @@ function SizesExample() {
     <Example
       title="Sizes"
       description='`size="sm"` (400px) / `"md"` (560px, default) / `"lg"` (800px). Below 640px viewport width the modal goes fullscreen regardless.'
-      code={`<Modal size="sm" open={open} onOpenChange={setOpen}>...</Modal>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Modal } from '@eocrm/design-system';
+
+export function SizesExample() {
+  const [openSize, setOpenSize] = useState<'sm' | 'md' | 'lg' | null>(null);
+  return (
+    <>
+      <Cluster gap="sm">
+        <Button variant="secondary" size="sm" onClick={() => setOpenSize('sm')}>
+          Small
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setOpenSize('md')}>
+          Medium
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setOpenSize('lg')}>
+          Large
+        </Button>
+      </Cluster>
+      <Modal
+        open={openSize !== null}
+        onOpenChange={(next) => !next && setOpenSize(null)}
+        size={openSize ?? 'md'}
+      >
+        <Modal.Header>Size: {openSize ?? 'md'}</Modal.Header>
+        <Modal.Body>The width is determined by the \`size\` prop.</Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button>Close</Button>
+          </Modal.Close>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}`}
     >
       <Cluster gap="sm">
         <Button variant="secondary" size="sm" onClick={() => setOpenSize('sm')}>
@@ -99,10 +145,42 @@ function OverlayVariantsExample() {
     <Example
       title="Overlay variants"
       description='`overlay="solid"` (default) paints the standard dark dim. `overlay="blur"` paints a light frosted-glass effect (`backdrop-filter: blur(4px)`). Open both with rich content visible behind to compare.'
-      code={`<Modal open={open} onOpenChange={setOpen} overlay="blur">
-  <Modal.Header>Subtle overlay</Modal.Header>
-  <Modal.Body>The page behind is blurred instead of dimmed.</Modal.Body>
-</Modal>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Modal } from '@eocrm/design-system';
+
+export function OverlayVariantsExample() {
+  const [variant, setVariant] = useState<'solid' | 'blur' | null>(null);
+  return (
+    <>
+      <Cluster gap="sm">
+        <Button variant="secondary" size="sm" onClick={() => setVariant('solid')}>
+          Solid overlay
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => setVariant('blur')}>
+          Blur overlay
+        </Button>
+      </Cluster>
+      <Modal
+        open={variant !== null}
+        onOpenChange={(next) => !next && setVariant(null)}
+        overlay={variant ?? 'solid'}
+        size="sm"
+      >
+        <Modal.Header>{variant === 'blur' ? 'Frosted glass' : 'Solid dim'}</Modal.Header>
+        <Modal.Body>
+          {variant === 'blur'
+            ? 'Backdrop is blurred. Try opening this on a page with rich content behind to see it best.'
+            : 'Standard dark dimming. Default variant.'}
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button>Close</Button>
+          </Modal.Close>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}`}
     >
       <Cluster gap="sm">
         <Button variant="secondary" size="sm" onClick={() => setVariant('solid')}>
@@ -142,17 +220,47 @@ function FormExample() {
     <Example
       title="Form modal with initial focus"
       description="Use `initialFocusRef` to focus the first input on open. Body content stays in a Stack."
-      code={`const inputRef = useRef<HTMLInputElement>(null);
-<Modal open={open} onOpenChange={setOpen} initialFocusRef={inputRef}>
-  <Modal.Header>Edit contact</Modal.Header>
-  <Modal.Body>
-    <label>
-      Company name
-      <Input ref={inputRef} value={name} onChange={...} />
-    </label>
-  </Modal.Body>
-  <Modal.Footer>...</Modal.Footer>
-</Modal>`}
+      code={`import { useRef, useState } from 'react';
+import { Button, Cluster, Input, Modal, Stack } from '@eocrm/design-system';
+
+export function FormExample() {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('Acme Inc.');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  return (
+    <>
+      <Cluster>
+        <Button onClick={() => setOpen(true)}>Edit contact</Button>
+      </Cluster>
+      <Modal open={open} onOpenChange={setOpen} initialFocusRef={inputRef}>
+        <Modal.Header>Edit contact</Modal.Header>
+        <Modal.Body>
+          <Stack gap="md">
+            <label>
+              Company name
+              <Input
+                ref={inputRef}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Acme Inc."
+              />
+            </label>
+            <label>
+              Owner
+              <Input placeholder="Sara" />
+            </label>
+          </Stack>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button onClick={() => setOpen(false)}>Save</Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}`}
     >
       <Cluster>
         <Button onClick={() => setOpen(true)}>Edit contact</Button>
@@ -193,20 +301,37 @@ function ForcedStepExample() {
     <Example
       title="Forced step (non-dismissible)"
       description="`disableEscapeClose` + `dismissOnOverlayClick={false}` + `<Modal.Header closeButton={false}>` + no `<Modal.Close>` = the user can only resolve via the in-modal action."
-      code={`<Modal
-  open
-  onOpenChange={() => {}}
-  size="sm"
-  disableEscapeClose
-  dismissOnOverlayClick={false}
-  aria-label="Session expired"
->
-  <Modal.Header closeButton={false}>Session expired</Modal.Header>
-  <Modal.Body>Please sign in again.</Modal.Body>
-  <Modal.Footer>
-    <Button onClick={reauth}>Sign in</Button>
-  </Modal.Footer>
-</Modal>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Modal } from '@eocrm/design-system';
+
+export function ForcedStepExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Cluster>
+        <Button variant="danger" onClick={() => setOpen(true)}>
+          Trigger forced step
+        </Button>
+      </Cluster>
+      <Modal
+        open={open}
+        onOpenChange={() => {}}
+        size="sm"
+        disableEscapeClose
+        dismissOnOverlayClick={false}
+        aria-label="Session expired"
+      >
+        <Modal.Header closeButton={false}>Session expired</Modal.Header>
+        <Modal.Body>
+          This modal can&apos;t be dismissed via Esc or overlay click. Use the button below.
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={() => setOpen(false)}>Sign in again</Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}`}
     >
       <Cluster>
         <Button variant="danger" onClick={() => setOpen(true)}>
@@ -240,19 +365,63 @@ function StackedExample() {
     <Example
       title="Stacked modals (overlay mode — default)"
       description='Opening a modal from inside another stacks visually. With the default `stackMode="overlay"`, the parent stays visible underneath and the inner overlay is transparent — one effective dim layer for the whole stack, parent context stays in view. Use `stackMode="replace"` to hide the parent via `display: none` (React state preserved) — best for forced steps where parent context is irrelevant. Escape closes only the topmost; body scroll stays locked across the whole stack.'
-      code={`<Modal open={editOpen} stackMode="overlay" ...>
-  <Modal.Footer align="space-between">
-    <Button variant="danger" onClick={() => setConfirmOpen(true)}>Delete</Button>
-    ...
-  </Modal.Footer>
-</Modal>
-<Modal open={confirmOpen} stackMode="overlay" ...>
-  <Modal.Header>Delete contact?</Modal.Header>
-  <Modal.Footer>
-    <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
-    <Button variant="danger" onClick={confirmDelete}>Delete</Button>
-  </Modal.Footer>
-</Modal>`}
+      code={`import { useState } from 'react';
+import { Badge, Button, Cluster, Input, Modal, Stack } from '@eocrm/design-system';
+
+export function StackedExample() {
+  const [editOpen, setEditOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  return (
+    <>
+      <Cluster>
+        <Button onClick={() => setEditOpen(true)}>Edit (with delete inside)</Button>
+      </Cluster>
+      <Modal open={editOpen} onOpenChange={setEditOpen} size="md">
+        <Modal.Header>Edit contact</Modal.Header>
+        <Modal.Body>
+          <Stack gap="md">
+            <label>
+              Company
+              <Input defaultValue="Acme Inc." />
+            </label>
+            <Cluster gap="sm" align="center">
+              <Badge tone="success">Active</Badge>
+            </Cluster>
+          </Stack>
+        </Modal.Body>
+        <Modal.Footer align="space-between">
+          <Button variant="danger" onClick={() => setConfirmOpen(true)}>
+            Delete
+          </Button>
+          <Cluster gap="sm">
+            <Modal.Close>
+              <Button variant="secondary">Cancel</Button>
+            </Modal.Close>
+            <Button onClick={() => setEditOpen(false)}>Save</Button>
+          </Cluster>
+        </Modal.Footer>
+      </Modal>
+      <Modal open={confirmOpen} onOpenChange={setConfirmOpen} size="sm">
+        <Modal.Header>Delete contact?</Modal.Header>
+        <Modal.Body>This cannot be undone.</Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button
+            variant="danger"
+            onClick={() => {
+              setConfirmOpen(false);
+              setEditOpen(false);
+            }}
+          >
+            Delete
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}`}
     >
       <Cluster>
         <Button onClick={() => setEditOpen(true)}>Edit (with delete inside)</Button>
@@ -309,10 +478,32 @@ function NoHeaderExample() {
     <Example
       title="No Header (aria-label fallback)"
       description="Omit `<Modal.Header>` and pass `aria-label` for the dialog's accessible name."
-      code={`<Modal open={open} onOpenChange={setOpen} aria-label="Confirm action">
-  <Modal.Body>Are you sure?</Modal.Body>
-  <Modal.Footer>...</Modal.Footer>
-</Modal>`}
+      code={`import { useState } from 'react';
+import { Button, Cluster, Modal } from '@eocrm/design-system';
+
+export function NoHeaderInline() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Cluster>
+        <Button variant="secondary" onClick={() => setOpen(true)}>
+          Open (no Header)
+        </Button>
+      </Cluster>
+      <Modal open={open} onOpenChange={setOpen} aria-label="Confirm action">
+        <Modal.Body>
+          <p style={{ margin: 0 }}>Are you sure you want to continue?</p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button onClick={() => setOpen(false)}>Continue</Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}`}
     >
       <NoHeaderInline />
     </Example>

--- a/packages/playground/src/pages/components/OptionsPickerDemo.tsx
+++ b/packages/playground/src/pages/components/OptionsPickerDemo.tsx
@@ -71,12 +71,32 @@ export function OptionsPickerDemo() {
       <Example
         title="Multi-select, flat options"
         description="Default mode. Draft state buffered until Apply."
-        code={`<OptionsPicker selected={selected} onApply={setSelected}>
-  <OptionsPicker.Trigger>
-    <Button variant="secondary">Stage <ChevronDown size={14}/></Button>
-  </OptionsPicker.Trigger>
-  <OptionsPicker.Content label="Filter stage" options={flatOptions} />
-</OptionsPicker>`}
+        code={`import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Button, OptionsPicker } from '@eocrm/design-system';
+
+const flatOptions = [
+  { value: 'lead', label: 'Lead' },
+  { value: 'qualified', label: 'Qualified' },
+  { value: 'proposal', label: 'Proposal' },
+  { value: 'won', label: 'Won' },
+  { value: 'lost', label: 'Lost' },
+];
+
+export function Demo() {
+  const [selected, setSelected] = useState<string[]>(['lead']);
+
+  return (
+    <OptionsPicker selected={selected} onApply={setSelected}>
+      <OptionsPicker.Trigger>
+        <Button variant="secondary">
+          Stage ({selected.length}) <ChevronDown size={14} />
+        </Button>
+      </OptionsPicker.Trigger>
+      <OptionsPicker.Content label="Filter stage" options={flatOptions} />
+    </OptionsPicker>
+  );
+}`}
       >
         <InputExample width="auto">
           <OptionsPicker selected={multiFlat} onApply={setMultiFlat}>
@@ -93,12 +113,52 @@ export function OptionsPickerDemo() {
       <Example
         title="Multi-select, grouped with namespace hints"
         description="Each group has a colored dot, label, and a right-side hint label (e.g., auth.*). Clicking the group header toggles all options in the namespace."
-        code={`<OptionsPicker selected={selected} onApply={setSelected}>
-  <OptionsPicker.Trigger>
-    <Button variant="secondary">Events <ChevronDown size={14}/></Button>
-  </OptionsPicker.Trigger>
-  <OptionsPicker.Content label="Filter events" groups={groupedOptions} />
-</OptionsPicker>`}
+        code={`import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Button, OptionsPicker } from '@eocrm/design-system';
+
+const groupedOptions = [
+  {
+    id: 'auth',
+    label: 'Authentication',
+    color: 'blue' as const,
+    hint: 'auth.*',
+    options: [
+      { value: 'auth.login_succeeded', label: 'login_succeeded' },
+      { value: 'auth.login_failed', label: 'login_failed' },
+      { value: 'auth.logout', label: 'logout' },
+    ],
+  },
+  {
+    id: 'role',
+    label: 'Roles',
+    color: 'emerald' as const,
+    hint: 'role.*',
+    options: [
+      { value: 'role.assigned', label: 'assigned' },
+      { value: 'role.updated', label: 'updated' },
+      { value: 'role.revoked', label: 'revoked' },
+    ],
+  },
+];
+
+export function Demo() {
+  const [selected, setSelected] = useState<string[]>([
+    'auth.login_succeeded',
+    'role.assigned',
+  ]);
+
+  return (
+    <OptionsPicker selected={selected} onApply={setSelected}>
+      <OptionsPicker.Trigger>
+        <Button variant="secondary">
+          Events ({selected.length}) <ChevronDown size={14} />
+        </Button>
+      </OptionsPicker.Trigger>
+      <OptionsPicker.Content label="Filter events" groups={groupedOptions} />
+    </OptionsPicker>
+  );
+}`}
       >
         <InputExample width="auto">
           <OptionsPicker selected={multiGrouped} onApply={setMultiGrouped}>
@@ -115,12 +175,32 @@ export function OptionsPickerDemo() {
       <Example
         title="Single-select (auto-commits on click)"
         description="No Apply/Cancel footer. Each click fires onApply(value) and closes the panel. Use for single-choice filter UX (Tenant, status, etc.)."
-        code={`<OptionsPicker mode="single" selected={value} onApply={setValue}>
-  <OptionsPicker.Trigger>
-    <Button variant="secondary">Stage <ChevronDown size={14}/></Button>
-  </OptionsPicker.Trigger>
-  <OptionsPicker.Content label="Filter stage" options={flatOptions} />
-</OptionsPicker>`}
+        code={`import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Button, OptionsPicker } from '@eocrm/design-system';
+
+const flatOptions = [
+  { value: 'lead', label: 'Lead' },
+  { value: 'qualified', label: 'Qualified' },
+  { value: 'proposal', label: 'Proposal' },
+  { value: 'won', label: 'Won' },
+  { value: 'lost', label: 'Lost' },
+];
+
+export function Demo() {
+  const [value, setValue] = useState<string | null>('qualified');
+
+  return (
+    <OptionsPicker mode="single" selected={value} onApply={setValue}>
+      <OptionsPicker.Trigger>
+        <Button variant="secondary">
+          Stage: {value ?? '—'} <ChevronDown size={14} />
+        </Button>
+      </OptionsPicker.Trigger>
+      <OptionsPicker.Content label="Filter stage" options={flatOptions} />
+    </OptionsPicker>
+  );
+}`}
       >
         <InputExample width="auto">
           <OptionsPicker mode="single" selected={single} onApply={setSingle}>
@@ -137,15 +217,43 @@ export function OptionsPickerDemo() {
       <Example
         title="Controlled open state"
         description="Pass open + onOpenChange to drive the panel externally."
-        code={`<OptionsPicker
-  open={open}
-  onOpenChange={setOpen}
-  selected={selected}
-  onApply={setSelected}
->
-  <OptionsPicker.Trigger><Button>Filter</Button></OptionsPicker.Trigger>
-  <OptionsPicker.Content label="Filter" options={flatOptions} />
-</OptionsPicker>`}
+        code={`import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Button, OptionsPicker, Stack } from '@eocrm/design-system';
+
+const flatOptions = [
+  { value: 'lead', label: 'Lead' },
+  { value: 'qualified', label: 'Qualified' },
+  { value: 'proposal', label: 'Proposal' },
+  { value: 'won', label: 'Won' },
+  { value: 'lost', label: 'Lost' },
+];
+
+export function Demo() {
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  return (
+    <Stack gap="sm">
+      <OptionsPicker
+        open={open}
+        onOpenChange={setOpen}
+        selected={selected}
+        onApply={setSelected}
+      >
+        <OptionsPicker.Trigger>
+          <Button variant="secondary">
+            Filter ({selected.length}) <ChevronDown size={14} />
+          </Button>
+        </OptionsPicker.Trigger>
+        <OptionsPicker.Content label="Filter stage" options={flatOptions} />
+      </OptionsPicker>
+      <Button variant="ghost" size="sm" onClick={() => setOpen((o) => !o)}>
+        Toggle externally (currently {open ? 'open' : 'closed'})
+      </Button>
+    </Stack>
+  );
+}`}
       >
         <InputExample width="auto">
           <Stack gap="sm">

--- a/packages/playground/src/pages/components/PageDemo.tsx
+++ b/packages/playground/src/pages/components/PageDemo.tsx
@@ -23,11 +23,25 @@ export function PageDemo() {
       <Example
         title='Default — gap="lg"'
         description="The canonical CRM page rhythm: 16px between top-level sections. Matches every shipped mockup."
-        code={`<Page>
-  <PageHeader>{/* … */}</PageHeader>
-  <Card>{/* … */}</Card>
-  <Table>{/* … */}</Table>
-</Page>`}
+        code={`import { Card, Page, Text } from '@eocrm/design-system';
+
+function Stand({ children }: { children: string }) {
+  return (
+    <Card padding="md">
+      <Text>{children}</Text>
+    </Card>
+  );
+}
+
+export function Demo() {
+  return (
+    <Page>
+      <Stand>PageHeader stand-in</Stand>
+      <Stand>Card / filter row</Stand>
+      <Stand>Table / body section</Stand>
+    </Page>
+  );
+}`}
       >
         <InputExample width="auto">
           <Page>
@@ -41,9 +55,25 @@ export function PageDemo() {
       <Example
         title='Compact — gap="md"'
         description="Tighter rhythm (12px). Use for dense dashboards or pages that pack many narrow sections."
-        code={`<Page gap="md">
-  {/* … */}
-</Page>`}
+        code={`import { Card, Page, Text } from '@eocrm/design-system';
+
+function Stand({ children }: { children: string }) {
+  return (
+    <Card padding="md">
+      <Text>{children}</Text>
+    </Card>
+  );
+}
+
+export function Demo() {
+  return (
+    <Page gap="md">
+      <Stand>Section one</Stand>
+      <Stand>Section two</Stand>
+      <Stand>Section three</Stand>
+    </Page>
+  );
+}`}
       >
         <InputExample width="auto">
           <Page gap="md">
@@ -57,9 +87,25 @@ export function PageDemo() {
       <Example
         title='Spacious — gap="xl"'
         description="Looser rhythm (24px). Use for overview / hero pages with few large sections."
-        code={`<Page gap="xl">
-  {/* … */}
-</Page>`}
+        code={`import { Card, Page, Text } from '@eocrm/design-system';
+
+function Stand({ children }: { children: string }) {
+  return (
+    <Card padding="md">
+      <Text>{children}</Text>
+    </Card>
+  );
+}
+
+export function Demo() {
+  return (
+    <Page gap="xl">
+      <Stand>Section one</Stand>
+      <Stand>Section two</Stand>
+      <Stand>Section three</Stand>
+    </Page>
+  );
+}`}
       >
         <InputExample width="auto">
           <Page gap="xl">

--- a/packages/playground/src/pages/components/PageHeaderDemo.tsx
+++ b/packages/playground/src/pages/components/PageHeaderDemo.tsx
@@ -101,9 +101,15 @@ export function PageHeaderDemo() {
       <Example
         title="Minimal"
         description="The smallest useful PageHeader — just a Title. All other slots are absent and collapse to 0 height."
-        code={`<PageHeader>
-  <PageHeader.Title>Settings</PageHeader.Title>
-</PageHeader>`}
+        code={`import { PageHeader } from '@eocrm/design-system';
+
+export function MinimalDemo() {
+  return (
+    <PageHeader>
+      <PageHeader.Title>Settings</PageHeader.Title>
+    </PageHeader>
+  );
+}`}
       >
         <MinimalDemo />
       </Example>
@@ -111,13 +117,19 @@ export function PageHeaderDemo() {
       <Example
         title="With subtitle and actions"
         description="The dominant CRM list/index page pattern. Title + Subtitle on the left, a primary Action button on the right."
-        code={`<PageHeader>
-  <PageHeader.Title>Members</PageHeader.Title>
-  <PageHeader.Subtitle>Manage team access and roles.</PageHeader.Subtitle>
-  <PageHeader.Actions>
-    <Button>Invite member</Button>
-  </PageHeader.Actions>
-</PageHeader>`}
+        code={`import { Button, PageHeader } from '@eocrm/design-system';
+
+export function WithSubtitleAndActions() {
+  return (
+    <PageHeader>
+      <PageHeader.Title>Members</PageHeader.Title>
+      <PageHeader.Subtitle>Manage team access and roles.</PageHeader.Subtitle>
+      <PageHeader.Actions>
+        <Button>Invite member</Button>
+      </PageHeader.Actions>
+    </PageHeader>
+  );
+}`}
       >
         <WithSubtitleAndActions />
       </Example>
@@ -125,29 +137,37 @@ export function PageHeaderDemo() {
       <Example
         title="Full (detail page)"
         description="ContactDetail-style header. Breadcrumb + BackButton in the top row; Aside (Avatar) to the left of the title block; Title + Subtitle + Meta (Badge + Text) stacked in the center; Actions cluster on the right."
-        code={`<PageHeader>
-  <PageHeader.Breadcrumb>
-    <Breadcrumb>
-      <Breadcrumb.Item href="#">Contacts</Breadcrumb.Item>
-      <Breadcrumb.Item>Acme Corp</Breadcrumb.Item>
-    </Breadcrumb>
-  </PageHeader.Breadcrumb>
-  <PageHeader.BackButton href="#" aria-label="Back to contacts" />
-  <PageHeader.Aside>
-    <Avatar size="lg" name="Acme Corp" />
-  </PageHeader.Aside>
-  <PageHeader.Title>Acme Corporation</PageHeader.Title>
-  <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
-  <PageHeader.Meta>
-    <Badge tone="success">Active</Badge>
-    <Text size="sm" tone="muted">Last contacted 2 days ago</Text>
-  </PageHeader.Meta>
-  <PageHeader.Actions>
-    <Button variant="secondary">Email</Button>
-    <Button variant="secondary">Call</Button>
-    <Button>Edit</Button>
-  </PageHeader.Actions>
-</PageHeader>`}
+        code={`import { Avatar, Badge, Breadcrumb, Button, PageHeader, Text } from '@eocrm/design-system';
+
+export function FullDemo() {
+  return (
+    <PageHeader>
+      <PageHeader.Breadcrumb>
+        <Breadcrumb>
+          <Breadcrumb.Item href="#">Contacts</Breadcrumb.Item>
+          <Breadcrumb.Item>Acme Corp</Breadcrumb.Item>
+        </Breadcrumb>
+      </PageHeader.Breadcrumb>
+      <PageHeader.BackButton href="#" aria-label="Back to contacts" />
+      <PageHeader.Aside>
+        <Avatar size="lg" name="Acme Corp" />
+      </PageHeader.Aside>
+      <PageHeader.Title>Acme Corporation</PageHeader.Title>
+      <PageHeader.Subtitle>Founded 2014 · 230 employees</PageHeader.Subtitle>
+      <PageHeader.Meta>
+        <Badge tone="success">Active</Badge>
+        <Text size="sm" tone="muted">
+          Last contacted 2 days ago
+        </Text>
+      </PageHeader.Meta>
+      <PageHeader.Actions>
+        <Button variant="secondary">Email</Button>
+        <Button variant="secondary">Call</Button>
+        <Button>Edit</Button>
+      </PageHeader.Actions>
+    </PageHeader>
+  );
+}`}
       >
         <FullDemo />
       </Example>
@@ -155,20 +175,32 @@ export function PageHeaderDemo() {
       <Example
         title="Inline with sibling Tabs"
         description="When Tabs follows the header as a sibling, set `borderBottom={false}` so PageHeader's border doesn't duplicate Tabs' own border-bottom."
-        code={`<div>
-  <PageHeader borderBottom={false}>
-    <PageHeader.Title>Reports</PageHeader.Title>
-    <PageHeader.Actions>
-      <Button variant="secondary">Export</Button>
-      <Button>New report</Button>
-    </PageHeader.Actions>
-  </PageHeader>
-  <Tabs activeId={tab} onChange={setTab} items={[
-    { id: 'overview', label: 'Overview' },
-    { id: 'pipeline', label: 'Pipeline' },
-    { id: 'forecast', label: 'Forecast' },
-  ]} />
-</div>`}
+        code={`import { useState } from 'react';
+import { Button, PageHeader, Tabs } from '@eocrm/design-system';
+
+export function WithSiblingTabs() {
+  const [tab, setTab] = useState('overview');
+  return (
+    <div>
+      <PageHeader borderBottom={false}>
+        <PageHeader.Title>Reports</PageHeader.Title>
+        <PageHeader.Actions>
+          <Button variant="secondary">Export</Button>
+          <Button>New report</Button>
+        </PageHeader.Actions>
+      </PageHeader>
+      <Tabs
+        activeId={tab}
+        onChange={setTab}
+        items={[
+          { id: 'overview', label: 'Overview' },
+          { id: 'pipeline', label: 'Pipeline' },
+          { id: 'forecast', label: 'Forecast' },
+        ]}
+      />
+    </div>
+  );
+}`}
       >
         <WithSiblingTabs />
       </Example>
@@ -176,13 +208,19 @@ export function PageHeaderDemo() {
       <Example
         title="Section header (order={2})"
         description="Sub-page section header — renders as <h2> instead of <h1>. Useful for sub-pages within a tab or a panel where the page's <h1> lives elsewhere."
-        code={`<PageHeader>
-  <PageHeader.Title order={2}>Filters</PageHeader.Title>
-  <PageHeader.Subtitle>Narrow the dataset shown below.</PageHeader.Subtitle>
-  <PageHeader.Actions>
-    <Button variant="secondary">Reset</Button>
-  </PageHeader.Actions>
-</PageHeader>`}
+        code={`import { Button, PageHeader } from '@eocrm/design-system';
+
+export function SectionHeaderDemo() {
+  return (
+    <PageHeader>
+      <PageHeader.Title order={2}>Filters</PageHeader.Title>
+      <PageHeader.Subtitle>Narrow the dataset shown below.</PageHeader.Subtitle>
+      <PageHeader.Actions>
+        <Button variant="secondary">Reset</Button>
+      </PageHeader.Actions>
+    </PageHeader>
+  );
+}`}
       >
         <SectionHeaderDemo />
       </Example>

--- a/packages/playground/src/pages/components/PaginationDemo.tsx
+++ b/packages/playground/src/pages/components/PaginationDemo.tsx
@@ -30,8 +30,16 @@ function PaginationDemoPanel() {
       <Example
         title="Basic"
         description="Default md size. Click prev / next / a page number to update."
-        code={`const [page, setPage] = useState(1);
-<Pagination currentPage={page} pageCount={10} onPageChange={setPage} />`}
+        code={`import { useState } from 'react';
+import { Pagination } from '@eocrm/design-system';
+
+export function Demo() {
+  const [page, setPage] = useState(1);
+
+  return (
+    <Pagination currentPage={page} pageCount={10} onPageChange={setPage} />
+  );
+}`}
       >
         <Pagination currentPage={page} pageCount={10} onPageChange={setPage} />
       </Example>
@@ -39,7 +47,16 @@ function PaginationDemoPanel() {
       <Example
         title="Middle of a long list"
         description="With pageCount=20 and current=5, both ellipses appear. Total slot count stays at 7."
-        code={`<Pagination currentPage={5} pageCount={20} onPageChange={setPage} />`}
+        code={`import { useState } from 'react';
+import { Pagination } from '@eocrm/design-system';
+
+export function Demo() {
+  const [page, setPage] = useState(5);
+
+  return (
+    <Pagination currentPage={page} pageCount={20} onPageChange={setPage} />
+  );
+}`}
       >
         <Pagination currentPage={pageMid} pageCount={20} onPageChange={setPageMid} />
       </Example>
@@ -47,7 +64,13 @@ function PaginationDemoPanel() {
       <Example
         title="Single page"
         description="Edge case — pageCount=1 still renders (single disabled-current button + both prev/next disabled). Consumer doesn't have to conditionally hide it."
-        code={`<Pagination currentPage={1} pageCount={1} onPageChange={() => {}} />`}
+        code={`import { Pagination } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Pagination currentPage={1} pageCount={1} onPageChange={() => {}} />
+  );
+}`}
       >
         <Pagination currentPage={1} pageCount={1} onPageChange={() => {}} />
       </Example>
@@ -55,12 +78,21 @@ function PaginationDemoPanel() {
       <Example
         title="siblingCount=0 (tight)"
         description="For sidebar / narrow column use. Hides the sibling pages — just first, current, last + ellipses."
-        code={`<Pagination
-  currentPage={5}
-  pageCount={100}
-  onPageChange={setPage}
-  siblingCount={0}
-/>`}
+        code={`import { useState } from 'react';
+import { Pagination } from '@eocrm/design-system';
+
+export function Demo() {
+  const [page, setPage] = useState(5);
+
+  return (
+    <Pagination
+      currentPage={page}
+      pageCount={100}
+      onPageChange={setPage}
+      siblingCount={0}
+    />
+  );
+}`}
       >
         <Pagination
           currentPage={pageTight}
@@ -73,12 +105,21 @@ function PaginationDemoPanel() {
       <Example
         title="siblingCount=2 (wide)"
         description="For full-width footers. Two sibling pages on each side of current — totalSlots = 9."
-        code={`<Pagination
-  currentPage={6}
-  pageCount={20}
-  onPageChange={setPage}
-  siblingCount={2}
-/>`}
+        code={`import { useState } from 'react';
+import { Pagination } from '@eocrm/design-system';
+
+export function Demo() {
+  const [page, setPage] = useState(5);
+
+  return (
+    <Pagination
+      currentPage={page}
+      pageCount={20}
+      onPageChange={setPage}
+      siblingCount={2}
+    />
+  );
+}`}
       >
         <Pagination
           currentPage={pageWide}
@@ -91,11 +132,17 @@ function PaginationDemoPanel() {
       <Example
         title="Sizes — sm / md / lg"
         description="sm for tight footers and sidebars, md (default) for DataTable, lg for hero / standalone."
-        code={`<Stack gap="md">
-  <Pagination size="sm" currentPage={3} pageCount={10} onPageChange={setPage} />
-  <Pagination size="md" currentPage={3} pageCount={10} onPageChange={setPage} />
-  <Pagination size="lg" currentPage={3} pageCount={10} onPageChange={setPage} />
-</Stack>`}
+        code={`import { Pagination, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Pagination size="sm" currentPage={3} pageCount={10} onPageChange={() => {}} />
+      <Pagination size="md" currentPage={3} pageCount={10} onPageChange={() => {}} />
+      <Pagination size="lg" currentPage={3} pageCount={10} onPageChange={() => {}} />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Pagination size="sm" currentPage={3} pageCount={10} onPageChange={() => {}} />
@@ -107,7 +154,13 @@ function PaginationDemoPanel() {
       <Example
         title="Disabled (loading lock)"
         description="Lock the whole nav while data is refetching to prevent double-clicks."
-        code={`<Pagination currentPage={3} pageCount={10} onPageChange={setPage} disabled />`}
+        code={`import { Pagination } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Pagination currentPage={3} pageCount={10} onPageChange={() => {}} disabled />
+  );
+}`}
       >
         <Pagination currentPage={3} pageCount={10} onPageChange={() => {}} disabled />
       </Example>
@@ -115,33 +168,42 @@ function PaginationDemoPanel() {
       <Example
         title="Composed with <Select> for page size"
         description="The canonical DataTable footer shape — page-size selector on one side, pagination on the other. Pagination doesn't ship a page-size selector itself; the consumer composes it."
-        code={`const [page, setPage] = useState(1);
-const [pageSize, setPageSize] = useState('10');
-const pageSizeNum = Number(pageSize);
+        code={`import { useState } from 'react';
+import { Cluster, Pagination, Select } from '@eocrm/design-system';
 
-<Cluster justify="between" align="center" wrap>
-  <Cluster gap="sm" align="center">
-    <span>Rows per page</span>
-    <Select
-      value={pageSize}
-      onChange={(value) => {
-        setPageSize(value as string);
-        setPage(1); // reset to first page when page size changes
-      }}
-      options={[
-        { value: '10', label: '10' },
-        { value: '25', label: '25' },
-        { value: '50', label: '50' },
-      ]}
-    />
-  </Cluster>
-  <Pagination
-    currentPage={page}
-    pageCount={Math.ceil(240 / pageSizeNum)}
-    onPageChange={setPage}
-    size="sm"
-  />
-</Cluster>`}
+export function Demo() {
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState('10');
+  const pageSizeNum = Number(pageSize);
+
+  return (
+    <Cluster justify="between" align="center" wrap>
+      <Cluster gap="sm" align="center">
+        <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+          Rows per page
+        </span>
+        <Select
+          value={pageSize}
+          onChange={(value) => {
+            setPageSize(value as string);
+            setPage(1);
+          }}
+          options={[
+            { value: '10', label: '10' },
+            { value: '25', label: '25' },
+            { value: '50', label: '50' },
+          ]}
+        />
+      </Cluster>
+      <Pagination
+        currentPage={page}
+        pageCount={Math.ceil(240 / pageSizeNum)}
+        onPageChange={setPage}
+        size="sm"
+      />
+    </Cluster>
+  );
+}`}
       >
         <Cluster justify="between" align="center" wrap>
           <Cluster gap="sm" align="center">
@@ -185,12 +247,28 @@ function CursorPaginationDemoPanel() {
       <Example
         title="Basic"
         description="Both buttons enabled — has both directions to navigate."
-        code={`<CursorPagination
-  hasPrevious={hasPrev}
-  hasNext={hasNext}
-  onPrevious={loadPrevious}
-  onNext={loadNext}
-/>`}
+        code={`import { useState } from 'react';
+import { CursorPagination, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  const [cursor, setCursor] = useState(2);
+  const hasPrev = cursor > 0;
+  const hasNext = cursor < 5;
+
+  return (
+    <Stack gap="xs">
+      <CursorPagination
+        hasPrevious={hasPrev}
+        hasNext={hasNext}
+        onPrevious={() => setCursor((c) => c - 1)}
+        onNext={() => setCursor((c) => c + 1)}
+      />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        cursor = {cursor} (range 0–5)
+      </code>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="xs">
           <CursorPagination
@@ -208,12 +286,18 @@ function CursorPaginationDemoPanel() {
       <Example
         title="At the start (hasPrevious=false)"
         description="Previous is disabled. Layout doesn't shift — the button stays in the row."
-        code={`<CursorPagination
-  hasPrevious={false}
-  hasNext={true}
-  onPrevious={loadPrevious}
-  onNext={loadNext}
-/>`}
+        code={`import { CursorPagination } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <CursorPagination
+      hasPrevious={false}
+      hasNext
+      onPrevious={() => {}}
+      onNext={() => {}}
+    />
+  );
+}`}
       >
         <CursorPagination hasPrevious={false} hasNext onPrevious={() => {}} onNext={() => {}} />
       </Example>
@@ -221,12 +305,18 @@ function CursorPaginationDemoPanel() {
       <Example
         title="At the end (hasNext=false)"
         description="Next is disabled. Same layout shape."
-        code={`<CursorPagination
-  hasPrevious={true}
-  hasNext={false}
-  onPrevious={loadPrevious}
-  onNext={loadNext}
-/>`}
+        code={`import { CursorPagination } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <CursorPagination
+      hasPrevious
+      hasNext={false}
+      onPrevious={() => {}}
+      onNext={() => {}}
+    />
+  );
+}`}
       >
         <CursorPagination hasPrevious hasNext={false} onPrevious={() => {}} onNext={() => {}} />
       </Example>
@@ -234,14 +324,20 @@ function CursorPaginationDemoPanel() {
       <Example
         title="Custom labels — 'Newer' / 'Older'"
         description="For reverse-chronological feeds where 'Previous' means going to more recent items."
-        code={`<CursorPagination
-  hasPrevious={hasNewer}
-  hasNext={hasOlder}
-  onPrevious={loadNewer}
-  onNext={loadOlder}
-  previousLabel="Newer"
-  nextLabel="Older"
-/>`}
+        code={`import { CursorPagination } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <CursorPagination
+      hasPrevious
+      hasNext
+      onPrevious={() => {}}
+      onNext={() => {}}
+      previousLabel="Newer"
+      nextLabel="Older"
+    />
+  );
+}`}
       >
         <CursorPagination
           hasPrevious

--- a/packages/playground/src/pages/components/PaletteDemo.tsx
+++ b/packages/playground/src/pages/components/PaletteDemo.tsx
@@ -80,12 +80,36 @@ export function PaletteDemo() {
       <Example
         title="All 30 colors"
         description="Each swatch shows the bg fill and the fg text. Reference grid for picking colors by name."
-        code={`import { PALETTE_COLORS, paletteTokens } from '@eocrm/design-system';
+        code={`import { Grid, PALETTE_COLORS, paletteTokens, type PaletteColor } from '@eocrm/design-system';
 
-PALETTE_COLORS.map((color) => {
+function Swatch({ color }: { color: PaletteColor }) {
   const { bg, fg } = paletteTokens(color);
-  return <div style={{ background: bg, color: fg }}>{color}</div>;
-});`}
+  return (
+    <div
+      style={{
+        background: bg,
+        color: fg,
+        padding: '12px 8px',
+        borderRadius: 6,
+        fontSize: 13,
+        fontWeight: 600,
+        textAlign: 'center',
+      }}
+    >
+      {color}
+    </div>
+  );
+}
+
+export function Demo() {
+  return (
+    <Grid minColumnWidth="100px" gap="sm">
+      {PALETTE_COLORS.map((color) => (
+        <Swatch key={color} color={color} />
+      ))}
+    </Grid>
+  );
+}`}
       >
         <InputExample width="auto">
           <Grid minColumnWidth="100px" gap="sm">
@@ -99,22 +123,64 @@ PALETTE_COLORS.map((color) => {
       <Example
         title="Consumer pattern — domain → color"
         description="Consumers own the mapping. Here: each audit-event namespace gets a distinct color, and a small custom <CategoryChip /> uses paletteTokens(color) to render."
-        code={`const EVENT_NAMESPACE_COLOR: Record<string, PaletteColor> = {
+        code={`import { type ReactNode } from 'react';
+import { Stack, paletteTokens, type PaletteColor } from '@eocrm/design-system';
+
+const EVENT_NAMESPACE_COLOR: Record<string, PaletteColor> = {
   auth: 'blue',
   user: 'violet',
   role: 'amber',
   invitation: 'pink',
   contact: 'teal',
   deal: 'emerald',
+  membership: 'gold',
+  system_setting: 'slate',
 };
+
+function eventPaletteColor(event: string): PaletteColor {
+  const namespace = event.split('.')[0];
+  return EVENT_NAMESPACE_COLOR[namespace] ?? 'stone';
+}
 
 function CategoryChip({ color, children }: { color: PaletteColor; children: ReactNode }) {
   const { bg, fg } = paletteTokens(color);
-  return <span style={{ background: bg, color: fg }}>{children}</span>;
+  return (
+    <span
+      style={{
+        background: bg,
+        color: fg,
+        padding: '2px 8px',
+        borderRadius: 4,
+        fontSize: 12,
+        fontWeight: 500,
+      }}
+    >
+      {children}
+    </span>
+  );
 }
 
-const events = ['auth.login_succeeded', 'user.created', 'role.assigned', /* … */];
-events.map((e) => <CategoryChip color={eventPaletteColor(e)}>{e}</CategoryChip>);`}
+export function Demo() {
+  return (
+    <Stack gap="sm" align="start">
+      {[
+        'auth.login_succeeded',
+        'auth.login_failed',
+        'user.created',
+        'user.deleted',
+        'role.assigned',
+        'invitation.sent',
+        'contact.updated',
+        'deal.won',
+        'system_setting.changed',
+      ].map((event) => (
+        <CategoryChip key={event} color={eventPaletteColor(event)}>
+          {event}
+        </CategoryChip>
+      ))}
+    </Stack>
+  );
+}`}
       >
         <InputExample width="auto">
           <Stack gap="sm" align="start">

--- a/packages/playground/src/pages/components/PasswordInputDemo.tsx
+++ b/packages/playground/src/pages/components/PasswordInputDemo.tsx
@@ -87,7 +87,11 @@ export function PasswordInputDemo() {
       <Example
         title="Default"
         description="Uncontrolled, with a placeholder. The eye-toggle button reveals/hides the value."
-        code={`<PasswordInput placeholder="Password" />`}
+        code={`import { PasswordInput } from '@eocrm/design-system';
+
+export function Demo() {
+  return <PasswordInput placeholder="Password" />;
+}`}
       >
         <InputExample>
           <PasswordInput placeholder="Password" />
@@ -97,9 +101,17 @@ export function PasswordInputDemo() {
       <Example
         title="Sizes"
         description="Three sizes — sm / md (default) / lg. Same scale as <Input>."
-        code={`<PasswordInput size="sm" placeholder="Small" />
-<PasswordInput size="md" placeholder="Medium" />
-<PasswordInput size="lg" placeholder="Large" />`}
+        code={`import { PasswordInput, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <PasswordInput size="sm" placeholder="Small" aria-label="Small password" />
+      <PasswordInput size="md" placeholder="Medium" aria-label="Medium password" />
+      <PasswordInput size="lg" placeholder="Large" aria-label="Large password" />
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="sm">
@@ -113,12 +125,25 @@ export function PasswordInputDemo() {
       <Example
         title="Controlled"
         description="Provide `revealed` + `onRevealChange` to control the toggle externally. The handler receives the next boolean."
-        code={`const [revealed, setRevealed] = useState(false);
-<PasswordInput
-  revealed={revealed}
-  onRevealChange={setRevealed}
-  defaultValue="hunter2"
-/>`}
+        code={`import { useState } from 'react';
+import { PasswordInput, Stack } from '@eocrm/design-system';
+
+export function ControlledDemo() {
+  const [revealed, setRevealed] = useState(false);
+  return (
+    <Stack gap="xs">
+      <PasswordInput
+        revealed={revealed}
+        onRevealChange={setRevealed}
+        defaultValue="hunter2"
+        aria-label="Password"
+      />
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        revealed = {String(revealed)}
+      </code>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <ControlledDemo />
@@ -128,7 +153,11 @@ export function PasswordInputDemo() {
       <Example
         title="No toggle"
         description="Set `revealable={false}` to hide the eye button — for compliance or kiosk screens where revealing the password is forbidden."
-        code={`<PasswordInput revealable={false} placeholder="No toggle" />`}
+        code={`import { PasswordInput } from '@eocrm/design-system';
+
+export function Demo() {
+  return <PasswordInput revealable={false} placeholder="No toggle" />;
+}`}
       >
         <InputExample>
           <PasswordInput revealable={false} placeholder="No toggle" />
@@ -138,7 +167,11 @@ export function PasswordInputDemo() {
       <Example
         title="Caps-lock warning"
         description="Opt in with `capsLockWarning`. When Caps Lock is active a warning icon appears and a polite aria-live region announces it. Cleared on blur."
-        code={`<PasswordInput capsLockWarning placeholder="Try with Caps Lock on" />`}
+        code={`import { PasswordInput } from '@eocrm/design-system';
+
+export function Demo() {
+  return <PasswordInput capsLockWarning placeholder="Try with Caps Lock on" />;
+}`}
       >
         <InputExample>
           <PasswordInput capsLockWarning placeholder="Try with Caps Lock on" />
@@ -148,7 +181,16 @@ export function PasswordInputDemo() {
       <Example
         title="Wrong-layout warning"
         description="Opt in with `wrongLayoutWarning`. Detects non-ASCII keystrokes (e.g. Cyrillic from a Russian layout) and shows a warning icon + live region. Only enable when the system expects Latin-only passwords."
-        code={`<PasswordInput wrongLayoutWarning placeholder="Try typing while on a non-Latin keyboard" />`}
+        code={`import { PasswordInput } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <PasswordInput
+      wrongLayoutWarning
+      placeholder="Try typing while on a non-Latin keyboard"
+    />
+  );
+}`}
       >
         <InputExample>
           <PasswordInput
@@ -161,7 +203,11 @@ export function PasswordInputDemo() {
       <Example
         title="Both warnings"
         description="Both warnings can be active at the same time — one icon per active warning."
-        code={`<PasswordInput capsLockWarning wrongLayoutWarning placeholder="Password" />`}
+        code={`import { PasswordInput } from '@eocrm/design-system';
+
+export function Demo() {
+  return <PasswordInput capsLockWarning wrongLayoutWarning placeholder="Password" />;
+}`}
       >
         <InputExample>
           <PasswordInput capsLockWarning wrongLayoutWarning placeholder="Password" />
@@ -171,7 +217,11 @@ export function PasswordInputDemo() {
       <Example
         title="Disabled"
         description="The native `disabled` attribute is forwarded — click is blocked, the eye toggle is also disabled, and the field mutes."
-        code={`<PasswordInput disabled defaultValue="locked" />`}
+        code={`import { PasswordInput } from '@eocrm/design-system';
+
+export function Demo() {
+  return <PasswordInput disabled defaultValue="locked" />;
+}`}
       >
         <InputExample>
           <PasswordInput disabled defaultValue="locked" />
@@ -181,8 +231,21 @@ export function PasswordInputDemo() {
       <Example
         title="Invalid"
         description="`invalid` adds the danger border + sets `aria-invalid='true'`. Pair with a visible error message and `aria-describedby`."
-        code={`<PasswordInput invalid aria-describedby="pw-error" placeholder="Password" />
-<p id="pw-error">Password is required.</p>`}
+        code={`import { PasswordInput, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs">
+      <PasswordInput invalid aria-describedby="pw-error-demo" placeholder="Password" />
+      <p
+        id="pw-error-demo"
+        style={{ color: 'var(--color-danger)', fontSize: 'var(--font-size-xs)' }}
+      >
+        Password is required.
+      </p>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="xs">
@@ -200,9 +263,15 @@ export function PasswordInputDemo() {
       <Example
         title="Localized labels (ru-RU)"
         description="Wrap in <I18nProvider locale='ru'> to translate all aria-labels and live-region strings."
-        code={`<I18nProvider locale="ru">
-  <PasswordInput capsLockWarning wrongLayoutWarning placeholder="Пароль" />
-</I18nProvider>`}
+        code={`import { I18nProvider, PasswordInput } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <I18nProvider locale="ru">
+      <PasswordInput capsLockWarning wrongLayoutWarning placeholder="Пароль" />
+    </I18nProvider>
+  );
+}`}
       >
         <InputExample>
           <I18nProvider locale="ru">
@@ -214,14 +283,39 @@ export function PasswordInputDemo() {
       <Example
         title="Form integration"
         description="`name` + `required` round-trip through native FormData. The capsLockWarning is active so login-form users get a hint if they're about to fail."
-        code={`<form onSubmit={(e) => {
-  e.preventDefault();
-  const fd = new FormData(e.currentTarget);
-  console.log(fd.get('password'));
-}}>
-  <PasswordInput name="password" required capsLockWarning placeholder="Enter password" />
-  <button type="submit">Submit</button>
-</form>`}
+        code={`import { useState } from 'react';
+import { Button, PasswordInput, Stack } from '@eocrm/design-system';
+
+export function FormDemo() {
+  const [submitted, setSubmitted] = useState<string | null>(null);
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const fd = new FormData(e.currentTarget);
+        setSubmitted(fd.get('password') ? '(received — not shown)' : '(empty)');
+      }}
+    >
+      <Stack gap="sm">
+        <PasswordInput
+          name="password"
+          required
+          placeholder="Enter password"
+          aria-label="Password"
+          capsLockWarning
+        />
+        <Button type="submit" size="sm">
+          Submit
+        </Button>
+        {submitted !== null && (
+          <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+            password = {submitted}
+          </code>
+        )}
+      </Stack>
+    </form>
+  );
+}`}
       >
         <InputExample>
           <FormDemo />
@@ -231,15 +325,25 @@ export function PasswordInputDemo() {
       <Example
         title="With strength meter (composition)"
         description="Pair with <PasswordStrengthMeter> using shared controlled state and `aria-describedby` for the accessible association."
-        code={`const [pw, setPw] = useState('');
-<PasswordInput
-  value={pw}
-  onChange={(e) => setPw(e.target.value)}
-  capsLockWarning
-  wrongLayoutWarning
-  aria-describedby="strength-meter"
-/>
-<PasswordStrengthMeter id="strength-meter" value={pw} />`}
+        code={`import { useState } from 'react';
+import { PasswordInput, PasswordStrengthMeter, Stack } from '@eocrm/design-system';
+
+export function StrengthDemo() {
+  const [pw, setPw] = useState('');
+  return (
+    <Stack gap="xs">
+      <PasswordInput
+        value={pw}
+        onChange={(e) => setPw(e.target.value)}
+        capsLockWarning
+        wrongLayoutWarning
+        placeholder="Create password"
+        aria-describedby="strength-demo-meter"
+      />
+      <PasswordStrengthMeter id="strength-demo-meter" value={pw} />
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <StrengthDemo />

--- a/packages/playground/src/pages/components/PasswordStrengthMeterDemo.tsx
+++ b/packages/playground/src/pages/components/PasswordStrengthMeterDemo.tsx
@@ -57,13 +57,23 @@ export function PasswordStrengthMeterDemo() {
       <Example
         title="Live with PasswordInput"
         description="The canonical signup pattern — shared controlled state between a PasswordInput and the meter. Associate them with `aria-describedby` so screen readers announce the score."
-        code={`const [pw, setPw] = useState('');
-<PasswordInput
-  value={pw}
-  onChange={(e) => setPw(e.target.value)}
-  aria-describedby="strength-meter"
-/>
-<PasswordStrengthMeter id="strength-meter" value={pw} />`}
+        code={`import { useState } from 'react';
+import { PasswordInput, PasswordStrengthMeter, Stack } from '@eocrm/design-system';
+
+export function LiveWithInputDemo() {
+  const [pw, setPw] = useState('');
+  return (
+    <Stack gap="xs">
+      <PasswordInput
+        value={pw}
+        onChange={(e) => setPw(e.target.value)}
+        placeholder="Type a password"
+        aria-describedby="live-demo-meter"
+      />
+      <PasswordStrengthMeter id="live-demo-meter" value={pw} />
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <LiveWithInputDemo />
@@ -73,8 +83,32 @@ export function PasswordStrengthMeterDemo() {
       <Example
         title="Standalone with score prop"
         description="Pass a pre-computed `score` (0–4) when scoring is done externally (zxcvbn, server-side). The `score` prop wins over `value` when both are present."
-        code={`// score comes from zxcvbn(pw).score or similar
-<PasswordStrengthMeter score={score} />`}
+        code={`import { useState } from 'react';
+import {
+  PasswordStrengthMeter,
+  Stack,
+  type PasswordStrengthScore,
+} from '@eocrm/design-system';
+
+export function ScoreSliderDemo() {
+  const [score, setScore] = useState<PasswordStrengthScore>(0);
+  return (
+    <Stack gap="sm">
+      <label style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>
+        Score: {score}
+        <input
+          type="range"
+          min={0}
+          max={4}
+          value={score}
+          onChange={(e) => setScore(Number(e.target.value) as PasswordStrengthScore)}
+          style={{ display: 'block', width: '100%', marginTop: 'var(--space-1)' }}
+        />
+      </label>
+      <PasswordStrengthMeter score={score} />
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <ScoreSliderDemo />
@@ -84,7 +118,11 @@ export function PasswordStrengthMeterDemo() {
       <Example
         title="No label"
         description="`showLabel={false}` renders segments only — useful when space is very tight or you're showing the label text elsewhere."
-        code={`<PasswordStrengthMeter value="Hunter2!@#" showLabel={false} />`}
+        code={`import { PasswordStrengthMeter } from '@eocrm/design-system';
+
+export function Demo() {
+  return <PasswordStrengthMeter value="Hunter2!@#" showLabel={false} />;
+}`}
       >
         <InputExample>
           <PasswordStrengthMeter value="Hunter2!@#" showLabel={false} />
@@ -94,9 +132,20 @@ export function PasswordStrengthMeterDemo() {
       <Example
         title="Localized labels (ru-RU)"
         description="Wrap in <I18nProvider locale='ru'> to swap the labels. The default Russian translations come from the library; consumers may further override individual keys via `overrides`."
-        code={`<I18nProvider locale="ru">
-  <PasswordStrengthMeter value="Hunter2!@#" />
-</I18nProvider>`}
+        code={`import { I18nProvider, PasswordStrengthMeter, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <I18nProvider locale="ru">
+      <Stack gap="sm">
+        <PasswordStrengthMeter value="" />
+        <PasswordStrengthMeter value="abc" />
+        <PasswordStrengthMeter value="AbcDef12" />
+        <PasswordStrengthMeter value="Hunter2!@#" />
+      </Stack>
+    </I18nProvider>
+  );
+}`}
       >
         <InputExample>
           <I18nProvider locale="ru">

--- a/packages/playground/src/pages/components/PersonDisplayDemo.tsx
+++ b/packages/playground/src/pages/components/PersonDisplayDemo.tsx
@@ -15,9 +15,29 @@ export function PersonDisplayDemo() {
       <Example
         title="All three sizes"
         description="The same person rendered at sm, md, and lg so you can compare scale. sm is for tight table cells, md is the default, lg is the detail-page hero."
-        code={`<PersonDisplay size="sm">…</PersonDisplay>
-<PersonDisplay size="md">…</PersonDisplay>
-<PersonDisplay size="lg">…</PersonDisplay>`}
+        code={`import { PersonDisplay, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <PersonDisplay size="sm">
+        <PersonDisplay.Avatar name="Sarah Chen" />
+        <PersonDisplay.Name>Sarah Chen</PersonDisplay.Name>
+        <PersonDisplay.Description>sarah@acme.com</PersonDisplay.Description>
+      </PersonDisplay>
+      <PersonDisplay size="md">
+        <PersonDisplay.Avatar name="Sarah Chen" />
+        <PersonDisplay.Name>Sarah Chen</PersonDisplay.Name>
+        <PersonDisplay.Description>sarah@acme.com</PersonDisplay.Description>
+      </PersonDisplay>
+      <PersonDisplay size="lg">
+        <PersonDisplay.Avatar name="Sarah Chen" />
+        <PersonDisplay.Name>Sarah Chen</PersonDisplay.Name>
+        <PersonDisplay.Description>sarah@acme.com</PersonDisplay.Description>
+      </PersonDisplay>
+    </Stack>
+  );
+}`}
       >
         <InputExample width="auto">
           <Stack gap="md">
@@ -43,10 +63,16 @@ export function PersonDisplayDemo() {
       <Example
         title="Avatar + name only"
         description="The compact owner-column shape — no description line."
-        code={`<PersonDisplay size="sm">
-  <PersonDisplay.Avatar name="Avery Liu" />
-  <PersonDisplay.Name>Avery Liu</PersonDisplay.Name>
-</PersonDisplay>`}
+        code={`import { PersonDisplay } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <PersonDisplay size="sm">
+      <PersonDisplay.Avatar name="Avery Liu" />
+      <PersonDisplay.Name>Avery Liu</PersonDisplay.Name>
+    </PersonDisplay>
+  );
+}`}
       >
         <InputExample width="auto">
           <PersonDisplay size="sm">
@@ -59,11 +85,17 @@ export function PersonDisplayDemo() {
       <Example
         title="Linked name"
         description="Name renders as a real <a> when href is set. Uses Link variant=subtle so it doesn't compete with action CTAs."
-        code={`<PersonDisplay size="md">
-  <PersonDisplay.Avatar name="Sarah Chen" src="/avatars/sarah.png" />
-  <PersonDisplay.Name href="/contacts/sarah-chen">Sarah Chen</PersonDisplay.Name>
-  <PersonDisplay.Description>sarah@acme.com</PersonDisplay.Description>
-</PersonDisplay>`}
+        code={`import { PersonDisplay } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <PersonDisplay size="md">
+      <PersonDisplay.Avatar name="Sarah Chen" />
+      <PersonDisplay.Name href="#sarah-chen">Sarah Chen</PersonDisplay.Name>
+      <PersonDisplay.Description>sarah@acme.com</PersonDisplay.Description>
+    </PersonDisplay>
+  );
+}`}
       >
         <InputExample width="auto">
           <PersonDisplay size="md">
@@ -77,12 +109,18 @@ export function PersonDisplayDemo() {
       <Example
         title="Multiple description lines"
         description="Repeat <PersonDisplay.Description> for additional lines — email then role then company, etc."
-        code={`<PersonDisplay size="md">
-  <PersonDisplay.Avatar name="Marcus Vega" />
-  <PersonDisplay.Name>Marcus Vega</PersonDisplay.Name>
-  <PersonDisplay.Description>marcus@acme.com</PersonDisplay.Description>
-  <PersonDisplay.Description>Account Executive</PersonDisplay.Description>
-</PersonDisplay>`}
+        code={`import { PersonDisplay } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <PersonDisplay size="md">
+      <PersonDisplay.Avatar name="Marcus Vega" />
+      <PersonDisplay.Name>Marcus Vega</PersonDisplay.Name>
+      <PersonDisplay.Description>marcus@acme.com</PersonDisplay.Description>
+      <PersonDisplay.Description>Account Executive</PersonDisplay.Description>
+    </PersonDisplay>
+  );
+}`}
       >
         <InputExample width="auto">
           <PersonDisplay size="md">
@@ -97,11 +135,17 @@ export function PersonDisplayDemo() {
       <Example
         title="With status dot"
         description="Pass status to <PersonDisplay.Avatar> for the presence dot (online / busy / away / offline)."
-        code={`<PersonDisplay size="md">
-  <PersonDisplay.Avatar name="Priya Mehta" status="online" />
-  <PersonDisplay.Name>Priya Mehta</PersonDisplay.Name>
-  <PersonDisplay.Description>priya@acme.com</PersonDisplay.Description>
-</PersonDisplay>`}
+        code={`import { PersonDisplay } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <PersonDisplay size="md">
+      <PersonDisplay.Avatar name="Priya Mehta" status="online" />
+      <PersonDisplay.Name>Priya Mehta</PersonDisplay.Name>
+      <PersonDisplay.Description>priya@acme.com</PersonDisplay.Description>
+    </PersonDisplay>
+  );
+}`}
       >
         <InputExample width="auto">
           <PersonDisplay size="md">
@@ -115,13 +159,22 @@ export function PersonDisplayDemo() {
       <Example
         title="Description with inline Badge"
         description="Description accepts ReactNode children — inline a small Badge for context like an audit-log 'impersonating' marker."
-        code={`<PersonDisplay size="md">
-  <PersonDisplay.Avatar name="System Admin" />
-  <PersonDisplay.Name>System Admin</PersonDisplay.Name>
-  <PersonDisplay.Description>
-    admin@acme.com <Badge tone="warning" size="sm">impersonating Sarah Chen</Badge>
-  </PersonDisplay.Description>
-</PersonDisplay>`}
+        code={`import { Badge, PersonDisplay } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <PersonDisplay size="md">
+      <PersonDisplay.Avatar name="System Admin" />
+      <PersonDisplay.Name>System Admin</PersonDisplay.Name>
+      <PersonDisplay.Description>
+        admin@acme.com{' '}
+        <Badge tone="warning" size="sm">
+          impersonating Sarah Chen
+        </Badge>
+      </PersonDisplay.Description>
+    </PersonDisplay>
+  );
+}`}
       >
         <InputExample width="auto">
           <PersonDisplay size="md">
@@ -140,12 +193,28 @@ export function PersonDisplayDemo() {
       <Example
         title="Shrink-wrap for overlay triggers"
         description="Inside a STRETCHING flex/grid column (here a Stack, which stretches its children), a default PersonDisplay blockifies and stretches to the full column width — the dashed outline shows the box reaching the right edge, so a Popover/Tooltip cloned onto it anchors to that wide box and centers far right of the person. With shrink (second row) the box hugs the avatar+name, so overlays anchor to the visible person. The dashed outlines are demo-only, to make each box's width visible."
-        code={`// In a stretching column, keep the overlay trigger content-width so it anchors right
-<PersonDisplay shrink>
-  <PersonDisplay.Avatar name="Sarah Chen" />
-  <PersonDisplay.Name>Sarah Chen</PersonDisplay.Name>
-  <PersonDisplay.Description>sarah@acme.com</PersonDisplay.Description>
-</PersonDisplay>`}
+        code={`import { PersonDisplay, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <PersonDisplay style={{ outline: '1px dashed var(--color-border)' }}>
+        <PersonDisplay.Avatar name="Sarah Chen" />
+        <PersonDisplay.Name>Sarah Chen</PersonDisplay.Name>
+        <PersonDisplay.Description>
+          sarah@acme.com (default — stretches)
+        </PersonDisplay.Description>
+      </PersonDisplay>
+      <PersonDisplay shrink style={{ outline: '1px dashed var(--color-border)' }}>
+        <PersonDisplay.Avatar name="Sarah Chen" />
+        <PersonDisplay.Name>Sarah Chen</PersonDisplay.Name>
+        <PersonDisplay.Description>
+          sarah@acme.com (shrink — content-width)
+        </PersonDisplay.Description>
+      </PersonDisplay>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="md">

--- a/packages/playground/src/pages/components/PhoneInputDemo.tsx
+++ b/packages/playground/src/pages/components/PhoneInputDemo.tsx
@@ -19,8 +19,21 @@ export function PhoneInputDemo() {
       <Example
         title="Default (US)"
         description="The trigger shows just the calling code by default (compact); open the country picker — its text auto-selects — and type to search. The component emits canonical E.164; the display reconstructs from it."
-        code={`const [phone, setPhone] = useState<string | null>(null);
-<PhoneInput value={phone} onChange={setPhone} defaultCountry="US" />`}
+        code={`import { useState } from 'react';
+import { PhoneInput, isValidPhone, Stack, Text, Code } from '@eocrm/design-system';
+
+export function Demo() {
+  const [phone, setPhone] = useState<string | null>(null);
+  return (
+    <Stack gap="sm">
+      <PhoneInput value={phone} onChange={setPhone} defaultCountry="US" />
+      <Text size="sm" tone="muted">
+        E.164 → <Code>{phone ?? 'null'}</Code> · valid:{' '}
+        <Code>{String(isValidPhone(phone))}</Code>
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <PhoneInput value={phone} onChange={setPhone} defaultCountry="US" />
@@ -34,8 +47,13 @@ export function PhoneInputDemo() {
       <Example
         title="Seeded from an existing E.164 value"
         description="Pass an E.164 string and the picker + number field reconstruct from it (here a UK number)."
-        code={`const [gb, setGb] = useState<string | null>('+442071838750');
-<PhoneInput value={gb} onChange={setGb} />`}
+        code={`import { useState } from 'react';
+import { PhoneInput } from '@eocrm/design-system';
+
+export function Demo() {
+  const [gb, setGb] = useState<string | null>('+442071838750');
+  return <PhoneInput value={gb} onChange={setGb} />;
+}`}
       >
         <PhoneInput value={gb} onChange={setGb} />
       </Example>
@@ -43,10 +61,31 @@ export function PhoneInputDemo() {
       <Example
         title="Country display formats (countryDisplay)"
         description="Controls how the SELECTED country shows in the trigger — full name+code (default), ISO+code, just the code, or emoji flag+code. The dropdown rows always show the full country name and stay searchable. Note: emoji flags don't render on Windows Chrome/Edge — prefer 'iso' there."
-        code={`<PhoneInput value={v} onChange={setV} countryDisplay="name" /> // United States +1 (default)
-<PhoneInput value={v} onChange={setV} countryDisplay="iso" />  // US +1
-<PhoneInput value={v} onChange={setV} countryDisplay="code" /> // +1
-<PhoneInput value={v} onChange={setV} countryDisplay="flag" /> // 🇺🇸 +1`}
+        code={`import { useState } from 'react';
+import { PhoneInput, Stack, Cluster, Code, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  const [dv, setDv] = useState<string | null>('+12025550123');
+  return (
+    <Stack gap="sm">
+      {(['name', 'iso', 'code', 'flag'] as const).map((mode) => (
+        <Cluster key={mode} gap="sm">
+          <Code>{mode}</Code>
+          <PhoneInput
+            value={dv}
+            onChange={setDv}
+            countryDisplay={mode}
+            aria-label={\`\${mode} display\`}
+          />
+        </Cluster>
+      ))}
+      <Text size="sm" tone="muted">
+        All four share one value — editing any updates the rest, so only the trigger format
+        differs.
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           {(['name', 'iso', 'code', 'flag'] as const).map((mode) => (
@@ -70,9 +109,20 @@ export function PhoneInputDemo() {
       <Example
         title="Inside a Field (label + validation)"
         description="Field injects the label association; drive invalid chrome via isValidPhone."
-        code={`<Field label="Mobile" error={isValidPhone(phone) ? undefined : 'Enter a valid number'}>
-  <PhoneInput value={phone} onChange={setPhone} />
-</Field>`}
+        code={`import { useState } from 'react';
+import { PhoneInput, isValidPhone, Field } from '@eocrm/design-system';
+
+export function Demo() {
+  const [phone, setPhone] = useState<string | null>(null);
+  return (
+    <Field
+      label="Mobile"
+      error={phone && !isValidPhone(phone) ? 'Enter a valid number' : undefined}
+    >
+      <PhoneInput value={phone} onChange={setPhone} />
+    </Field>
+  );
+}`}
       >
         <Field
           label="Mobile"
@@ -85,7 +135,11 @@ export function PhoneInputDemo() {
       <Example
         title="Disabled"
         description="Both controls disabled."
-        code={`<PhoneInput value="+12025550123" onChange={() => {}} disabled />`}
+        code={`import { PhoneInput } from '@eocrm/design-system';
+
+export function Demo() {
+  return <PhoneInput value="+12025550123" onChange={() => {}} disabled />;
+}`}
       >
         <PhoneInput value="+12025550123" onChange={() => {}} disabled />
       </Example>

--- a/packages/playground/src/pages/components/PopoverDemo.tsx
+++ b/packages/playground/src/pages/components/PopoverDemo.tsx
@@ -24,25 +24,33 @@ export function PopoverDemo() {
       <Example
         title="Default — filter panel"
         description="The canonical popover: a button trigger, a small panel of controls, and an Apply / Cancel footer."
-        code={`<Popover>
-  <Popover.Trigger>
-    <Button variant="secondary">Filters</Button>
-  </Popover.Trigger>
-  <Popover.Content>
-    <Stack gap="sm">
-      <Popover.Heading>Filter results</Popover.Heading>
-      <div>(form controls go here)</div>
-      <Cluster justify="end" gap="sm">
-        <Popover.Close>
-          <Button variant="secondary" size="sm">Cancel</Button>
-        </Popover.Close>
-        <Popover.Close>
-          <Button size="sm">Apply</Button>
-        </Popover.Close>
-      </Cluster>
-    </Stack>
-  </Popover.Content>
-</Popover>`}
+        code={`import { Button, Cluster, Popover, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <Popover>
+        <Popover.Trigger>
+          <Button variant="secondary">Filters</Button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Stack gap="sm">
+            <Popover.Heading>Filter results</Popover.Heading>
+            <div>(form controls would go here once Checkbox lands)</div>
+            <Cluster justify="end" gap="sm">
+              <Popover.Close>
+                <Button variant="secondary" size="sm">Cancel</Button>
+              </Popover.Close>
+              <Popover.Close>
+                <Button size="sm">Apply</Button>
+              </Popover.Close>
+            </Cluster>
+          </Stack>
+        </Popover.Content>
+      </Popover>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <Popover>
@@ -72,10 +80,27 @@ export function PopoverDemo() {
       <Example
         title="Sides"
         description="Floating UI auto-flips on collision; this row pins each popover to a specific side."
-        code={`<Popover><Popover.Trigger><Button>Top</Button></Popover.Trigger><Popover.Content side="top">Top</Popover.Content></Popover>
-<Popover><Popover.Trigger><Button>Right</Button></Popover.Trigger><Popover.Content side="right">Right</Popover.Content></Popover>
-<Popover><Popover.Trigger><Button>Bottom</Button></Popover.Trigger><Popover.Content side="bottom">Bottom</Popover.Content></Popover>
-<Popover><Popover.Trigger><Button>Left</Button></Popover.Trigger><Popover.Content side="left">Left</Popover.Content></Popover>`}
+        code={`import { Button, Cluster, Popover, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+        <Popover key={side}>
+          <Popover.Trigger>
+            <Button variant="secondary">{side}</Button>
+          </Popover.Trigger>
+          <Popover.Content side={side}>
+            <Stack gap="xs">
+              <Popover.Heading>{\`Side: \${side}\`}</Popover.Heading>
+              <div>The arrow points back at the trigger.</div>
+            </Stack>
+          </Popover.Content>
+        </Popover>
+      ))}
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
@@ -97,19 +122,35 @@ export function PopoverDemo() {
       <Example
         title="Rich content with multiple Close buttons"
         description="A popover can contain any interactive content. Wrap each closing element in <Popover.Close>."
-        code={`<Popover>
-  <Popover.Trigger>
-    <Button variant="secondary">Actions</Button>
-  </Popover.Trigger>
-  <Popover.Content>
-    <Stack gap="sm">
-      <Popover.Heading>Choose</Popover.Heading>
-      <Popover.Close><Button variant="secondary" size="sm">Save and exit</Button></Popover.Close>
-      <Popover.Close><Button variant="secondary" size="sm">Discard</Button></Popover.Close>
-      <Popover.Close><Button variant="ghost" size="sm">Stay</Button></Popover.Close>
-    </Stack>
-  </Popover.Content>
-</Popover>`}
+        code={`import { Button, Cluster, Popover, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <Popover>
+        <Popover.Trigger>
+          <Button variant="secondary">Actions</Button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Stack gap="sm">
+            <Popover.Heading>Choose</Popover.Heading>
+            <Stack gap="xs">
+              <Popover.Close>
+                <Button variant="secondary" size="sm">Save and exit</Button>
+              </Popover.Close>
+              <Popover.Close>
+                <Button variant="secondary" size="sm">Discard</Button>
+              </Popover.Close>
+              <Popover.Close>
+                <Button variant="ghost" size="sm">Stay</Button>
+              </Popover.Close>
+            </Stack>
+          </Stack>
+        </Popover.Content>
+      </Popover>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <Popover>
@@ -145,33 +186,41 @@ export function PopoverDemo() {
       <Example
         title="Inside a DropdownMenu — z-index sanity"
         description="Wrap a <DropdownMenu.Item closeOnSelect={false}> as the Popover trigger. Popover's z-layer is above DropdownMenu's (--z-popover: 1050 > --z-dropdown: 1000), so the popover floats over the menu."
-        code={`<DropdownMenu>
-  <DropdownMenu.Trigger>
-    <Button variant="secondary">Actions</Button>
-  </DropdownMenu.Trigger>
-  <DropdownMenu.Content>
-    <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-    <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
-    <Popover>
-      <Popover.Trigger>
-        <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}}>
-          Move to…
-        </DropdownMenu.Item>
-      </Popover.Trigger>
-      <Popover.Content>
-        <Stack gap="xs">
-          <Popover.Heading>Move to folder</Popover.Heading>
-          <div>(folder picker)</div>
-          <Cluster justify="end">
-            <Popover.Close>
-              <Button size="sm">Done</Button>
-            </Popover.Close>
-          </Cluster>
-        </Stack>
-      </Popover.Content>
-    </Popover>
-  </DropdownMenu.Content>
-</DropdownMenu>`}
+        code={`import { Button, Cluster, DropdownMenu, Popover, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="secondary">Actions</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+          <Popover>
+            <Popover.Trigger>
+              <DropdownMenu.Item closeOnSelect={false} onSelect={() => {}}>
+                Move to…
+              </DropdownMenu.Item>
+            </Popover.Trigger>
+            <Popover.Content>
+              <Stack gap="xs">
+                <Popover.Heading>Move to folder</Popover.Heading>
+                <div>(folder picker would go here)</div>
+                <Cluster justify="end">
+                  <Popover.Close>
+                    <Button size="sm">Done</Button>
+                  </Popover.Close>
+                </Cluster>
+              </Stack>
+            </Popover.Content>
+          </Popover>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <DropdownMenu>
@@ -207,40 +256,48 @@ export function PopoverDemo() {
       <Example
         title="Nested floating surfaces"
         description="A Popover panel can host its own floating surfaces — a kebab DropdownMenu, and a ConfirmationPopover opened from a menu item. They now render ABOVE the popover panel (z --z-overlay-floating: 1190) instead of behind it, so the menu and the confirm dialog are fully interactive. Open the panel, then open the kebab menu, then click Delete."
-        code={`<Popover>
-  <Popover.Trigger>
-    <Button variant="secondary">Open panel</Button>
-  </Popover.Trigger>
-  <Popover.Content>
-    <Stack gap="sm">
-      <Cluster justify="between" align="center">
-        <Popover.Heading>Record</Popover.Heading>
-        <DropdownMenu>
-          <DropdownMenu.Trigger>
-            <Button variant="ghost" size="sm" iconOnly aria-label="Record actions">⋯</Button>
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Content align="end">
-            <DropdownMenu.Item onSelect={() => {}}>Rename</DropdownMenu.Item>
-            <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
-            <DropdownMenu.Separator />
-            <ConfirmationPopover
-              title="Delete record?"
-              description="This action cannot be undone."
-              variant="danger"
-              confirmLabel="Delete"
-              onConfirm={() => {}}
-            >
-              <DropdownMenu.Item closeOnSelect={false} tone="danger" onSelect={() => {}}>
-                Delete
-              </DropdownMenu.Item>
-            </ConfirmationPopover>
-          </DropdownMenu.Content>
-        </DropdownMenu>
-      </Cluster>
-      <div>The kebab menu and the delete confirmation float above this panel.</div>
-    </Stack>
-  </Popover.Content>
-</Popover>`}
+        code={`import { Button, Cluster, ConfirmationPopover, DropdownMenu, Popover, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <Popover>
+        <Popover.Trigger>
+          <Button variant="secondary">Open panel</Button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Stack gap="sm">
+            <Cluster justify="between" align="center">
+              <Popover.Heading>Record</Popover.Heading>
+              <DropdownMenu>
+                <DropdownMenu.Trigger>
+                  <Button variant="ghost" size="sm" iconOnly aria-label="Record actions">⋯</Button>
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Content align="end">
+                  <DropdownMenu.Item onSelect={() => {}}>Rename</DropdownMenu.Item>
+                  <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+                  <DropdownMenu.Separator />
+                  <ConfirmationPopover
+                    title="Delete record?"
+                    description="This action cannot be undone."
+                    variant="danger"
+                    confirmLabel="Delete"
+                    onConfirm={() => {}}
+                  >
+                    <DropdownMenu.Item closeOnSelect={false} tone="danger" onSelect={() => {}}>
+                      Delete
+                    </DropdownMenu.Item>
+                  </ConfirmationPopover>
+                </DropdownMenu.Content>
+              </DropdownMenu>
+            </Cluster>
+            <div>The kebab menu and the delete confirmation float above this panel.</div>
+          </Stack>
+        </Popover.Content>
+      </Popover>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <Popover>
@@ -285,13 +342,30 @@ export function PopoverDemo() {
       <Example
         title="Controlled open"
         description="Drive open externally — useful for orchestrating with other UI state."
-        code={`const [open, setOpen] = useState(false);
-<Popover open={open} onOpenChange={setOpen}>
-  <Popover.Trigger>
-    <Button onClick={() => setOpen((o) => !o)}>Toggle</Button>
-  </Popover.Trigger>
-  <Popover.Content>…</Popover.Content>
-</Popover>`}
+        code={`import { useState } from 'react';
+import { Button, Cluster, Popover, Stack } from '@eocrm/design-system';
+
+export function ControlledExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger>
+        <Button onClick={() => setOpen((o) => !o)}>{open ? 'Close' : 'Open'}</Button>
+      </Popover.Trigger>
+      <Popover.Content>
+        <Stack gap="sm">
+          <Popover.Heading>Controlled</Popover.Heading>
+          <div>This popover is driven from external state.</div>
+          <Cluster justify="end">
+            <Popover.Close>
+              <Button size="sm">Close</Button>
+            </Popover.Close>
+          </Cluster>
+        </Stack>
+      </Popover.Content>
+    </Popover>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <ControlledExample />
@@ -301,33 +375,42 @@ export function PopoverDemo() {
       <Example
         title="Anchor (controlled, no injected ARIA)"
         description="Popover.Anchor positions Content against its child but injects ONLY the floating ref — no onClick, no aria-haspopup/aria-expanded/aria-controls. Use it when the anchor already owns its toggle + ARIA. Here an interactive FilterChip (its body <button> carries aria-haspopup/aria-expanded via onActivate/expanded) drives a CONTROLLED popover: clicking the chip body opens/closes the panel, and the chip's role=group root stays free of popover ARIA. (Popover.Trigger would have redundantly stamped that ARIA onto the group root.)"
-        code={`const [open, setOpen] = useState(false);
-<Popover open={open} onOpenChange={setOpen}>
-  <Popover.Anchor>
-    <FilterChip
-      onActivate={() => setOpen((o) => !o)}
-      expanded={open}
-      onDismiss={() => {/* remove the filter */}}
-    >
-      <FilterChip.Label>Date</FilterChip.Label>
-      <FilterChip.Value>Jun 1 – Jun 13</FilterChip.Value>
-    </FilterChip>
-  </Popover.Anchor>
-  <Popover.Content maxWidth={360}>
-    <Stack gap="sm">
-      <Popover.Heading>Audit log date range</Popover.Heading>
-      <Text tone="muted">(date-range picker goes here)</Text>
-      <Cluster justify="end" gap="sm">
-        <Popover.Close>
-          <Button variant="secondary" size="sm">Cancel</Button>
-        </Popover.Close>
-        <Popover.Close>
-          <Button size="sm">Apply</Button>
-        </Popover.Close>
-      </Cluster>
-    </Stack>
-  </Popover.Content>
-</Popover>`}
+        code={`import { useState } from 'react';
+import { Button, Cluster, FilterChip, Popover, Stack, Text } from '@eocrm/design-system';
+
+export function AnchorChipExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Anchor>
+        <FilterChip
+          onActivate={() => setOpen((o) => !o)}
+          expanded={open}
+          onDismiss={() => {
+            /* a real screen would remove this filter from state */
+          }}
+        >
+          <FilterChip.Label>Date</FilterChip.Label>
+          <FilterChip.Value>Jun 1 – Jun 13</FilterChip.Value>
+        </FilterChip>
+      </Popover.Anchor>
+      <Popover.Content maxWidth={360}>
+        <Stack gap="sm">
+          <Popover.Heading>Audit log date range</Popover.Heading>
+          <Text tone="muted">(a date-range picker would render here)</Text>
+          <Cluster justify="end" gap="sm">
+            <Popover.Close>
+              <Button variant="secondary" size="sm">Cancel</Button>
+            </Popover.Close>
+            <Popover.Close>
+              <Button size="sm">Apply</Button>
+            </Popover.Close>
+          </Cluster>
+        </Stack>
+      </Popover.Content>
+    </Popover>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <AnchorChipExample />
@@ -337,17 +420,21 @@ export function PopoverDemo() {
       <Example
         title="Wide content (maxWidth)"
         description="The panel caps at 360px by default, which clips wide content like a two-column filter or a date-range calendar. Pass maxWidth to let the panel grow — here a 480px two-column layout that would otherwise overflow."
-        code={`<Popover>
-  <Popover.Trigger>
-    <Button variant="secondary">Date range filter</Button>
-  </Popover.Trigger>
-  <Popover.Content maxWidth={520}>
+        code={`import { Button, Cluster, Popover, Stack } from '@eocrm/design-system';
+
+function WideRangeBody() {
+  return (
     <Stack gap="sm">
       <Popover.Heading>Pick a date range</Popover.Heading>
       <Cluster gap="md" align="start">
-        {/* two side-by-side month grids ≈ 480px wide */}
-        <div style={{ width: 220 }}>(start month)</div>
-        <div style={{ width: 220 }}>(end month)</div>
+        <Stack gap="xs" style={{ width: 220 }}>
+          <strong>Start month</strong>
+          <div>A 31-cell month grid would render here (~220px wide).</div>
+        </Stack>
+        <Stack gap="xs" style={{ width: 220 }}>
+          <strong>End month</strong>
+          <div>The second month grid sits beside it (~220px wide).</div>
+        </Stack>
       </Cluster>
       <Cluster justify="end" gap="sm">
         <Popover.Close>
@@ -358,8 +445,31 @@ export function PopoverDemo() {
         </Popover.Close>
       </Cluster>
     </Stack>
-  </Popover.Content>
-</Popover>`}
+  );
+}
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <Popover>
+        <Popover.Trigger>
+          <Button variant="secondary">Default cap (clips at 360px)</Button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <WideRangeBody />
+        </Popover.Content>
+      </Popover>
+      <Popover>
+        <Popover.Trigger>
+          <Button variant="secondary">maxWidth=520 (fits)</Button>
+        </Popover.Trigger>
+        <Popover.Content maxWidth={520}>
+          <WideRangeBody />
+        </Popover.Content>
+      </Popover>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <Popover>

--- a/packages/playground/src/pages/components/ProgressDemo.tsx
+++ b/packages/playground/src/pages/components/ProgressDemo.tsx
@@ -38,9 +38,17 @@ export function ProgressDemo() {
       <Example
         title="Sizes"
         description="Three sizes for the track height — 4px / 8px (default) / 12px. Pick the size that matches the surrounding content density."
-        code={`<Progress size="sm" value={60} />
-<Progress size="md" value={60} />
-<Progress size="lg" value={60} />`}
+        code={`import { Progress, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Progress size="sm" value={60} />
+      <Progress size="md" value={60} />
+      <Progress size="lg" value={60} />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Progress size="sm" value={60} />
@@ -52,10 +60,18 @@ export function ProgressDemo() {
       <Example
         title="Tones"
         description="Four tones for the fill color. Use 'warning' when a metric is approaching a threshold (e.g. disk at 85%), 'danger' when over. Default is the accent blue."
-        code={`<Progress value={75} />
-<Progress value={75} tone="success" />
-<Progress value={75} tone="warning" />
-<Progress value={75} tone="danger" />`}
+        code={`import { Progress, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Progress value={75} />
+      <Progress value={75} tone="success" />
+      <Progress value={75} tone="warning" />
+      <Progress value={75} tone="danger" />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Progress value={75} />
@@ -68,8 +84,16 @@ export function ProgressDemo() {
       <Example
         title="Determinate vs indeterminate"
         description="Omit `value` for indeterminate. The animation is a 30%-wide pulse sliding right; under prefers-reduced-motion it collapses to a static accent fill."
-        code={`<Progress value={45} />
-<Progress />`}
+        code={`import { Progress, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Progress value={45} />
+      <Progress />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Progress value={45} />
@@ -80,10 +104,18 @@ export function ProgressDemo() {
       <Example
         title="Labels"
         description="`label={false}` (default), `label={true}` shows {n}% to the right (auto-suppressed when indeterminate), or pass a ReactNode for custom content."
-        code={`<Progress value={45} />
-<Progress value={45} label />
-<Progress value={3} max={10} label={'3 of 10'} />
-<Progress label="Loading…" />`}
+        code={`import { Progress, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Progress value={45} />
+      <Progress value={45} label />
+      <Progress value={3} max={10} label={'3 of 10'} />
+      <Progress label="Loading…" />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Progress value={45} />
@@ -96,13 +128,21 @@ export function ProgressDemo() {
       <Example
         title="Composed in a card — storage usage panel"
         description="The canonical 'gauge' pattern — heading + bar + supporting text. Tone shifts to warning above 80%, danger above 95%."
-        code={`<Card>
-  <Stack gap="xs">
-    <Title order={3} size="md">Storage</Title>
-    <Progress value={85} max={100} tone="warning" label />
-    <Text size="sm" tone="muted">85 GB of 100 GB used</Text>
-  </Stack>
-</Card>`}
+        code={`import { Card, Cluster, Progress, Stack, Text, Title } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="start">
+      <Card style={{ minWidth: 320 }}>
+        <Stack gap="xs">
+          <Title order={3} size="md">Storage</Title>
+          <Progress value={85} max={100} tone="warning" label />
+          <Text size="sm" tone="muted">85 GB of 100 GB used</Text>
+        </Stack>
+      </Card>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="start">
           <Card style={{ minWidth: 320 }}>
@@ -122,13 +162,23 @@ export function ProgressDemo() {
       <Example
         title="Live demo — interactive value"
         description="Drive the bar with a slider to see the transition + percentage label update in real time."
-        code={`function LiveProgress() {
+        code={`import { useState } from 'react';
+import { Progress, Stack } from '@eocrm/design-system';
+
+export function LiveProgress() {
   const [value, setValue] = useState(45);
   return (
     <Stack gap="sm">
       <Progress value={value} label />
-      <input type="range" min={0} max={100} value={value}
-        onChange={(e) => setValue(Number(e.target.value))} />
+      <input
+        type="range"
+        min={0}
+        max={100}
+        value={value}
+        onChange={(e) => setValue(Number(e.target.value))}
+        aria-label="Progress value"
+        style={{ width: '100%' }}
+      />
     </Stack>
   );
 }`}

--- a/packages/playground/src/pages/components/RadioDemo.tsx
+++ b/packages/playground/src/pages/components/RadioDemo.tsx
@@ -61,11 +61,17 @@ export function RadioDemo() {
       <Example
         title="Default — RadioGroup (preferred)"
         description="Wrap radios in `<RadioGroup>` to get fieldset/legend semantics, shared `name`, and centralized state."
-        code={`<RadioGroup name="size" defaultValue="md" label="T-shirt size">
-  <Radio value="sm" label="Small" />
-  <Radio value="md" label="Medium" />
-  <Radio value="lg" label="Large" />
-</RadioGroup>`}
+        code={`import { Radio, RadioGroup } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <RadioGroup name="size" defaultValue="md" label="T-shirt size">
+      <Radio value="sm" label="Small" />
+      <Radio value="md" label="Medium" />
+      <Radio value="lg" label="Large" />
+    </RadioGroup>
+  );
+}`}
       >
         <InputExample>
           <RadioGroup name="size-default" defaultValue="md" label="T-shirt size">
@@ -79,9 +85,26 @@ export function RadioDemo() {
       <Example
         title="Sizes"
         description="Three sizes — sm (14px) / md (16px, default) / lg (20px). Same scale as `<Checkbox>` and `<Input>`."
-        code={`<RadioGroup name="size" size="sm" defaultValue="a">...</RadioGroup>
-<RadioGroup name="size" size="md" defaultValue="a">...</RadioGroup>
-<RadioGroup name="size" size="lg" defaultValue="a">...</RadioGroup>`}
+        code={`import { Radio, RadioGroup, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <RadioGroup name="sz-sm" size="sm" defaultValue="a" orientation="horizontal">
+        <Radio value="a" label="Small A" />
+        <Radio value="b" label="Small B" />
+      </RadioGroup>
+      <RadioGroup name="sz-md" size="md" defaultValue="a" orientation="horizontal">
+        <Radio value="a" label="Medium A" />
+        <Radio value="b" label="Medium B" />
+      </RadioGroup>
+      <RadioGroup name="sz-lg" size="lg" defaultValue="a" orientation="horizontal">
+        <Radio value="a" label="Large A" />
+        <Radio value="b" label="Large B" />
+      </RadioGroup>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="md">
@@ -104,12 +127,24 @@ export function RadioDemo() {
       <Example
         title="Controlled"
         description="Provide `value` + `onChange`. The handler receives `(nextValue, event)`."
-        code={`const [plan, setPlan] = useState('free');
-<RadioGroup name="plan" value={plan} onChange={setPlan} label="Pick a plan">
-  <Radio value="free" label="Free" />
-  <Radio value="pro" label="Pro" />
-  <Radio value="enterprise" label="Enterprise" />
-</RadioGroup>`}
+        code={`import { useState } from 'react';
+import { Radio, RadioGroup, Stack } from '@eocrm/design-system';
+
+export function ControlledDemo() {
+  const [plan, setPlan] = useState('free');
+  return (
+    <Stack gap="xs">
+      <RadioGroup name="plan" value={plan} onChange={setPlan} label="Pick a plan">
+        <Radio value="free" label="Free" />
+        <Radio value="pro" label="Pro" />
+        <Radio value="enterprise" label="Enterprise" />
+      </RadioGroup>
+      <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+        plan = {plan}
+      </code>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <ControlledDemo />
@@ -119,11 +154,17 @@ export function RadioDemo() {
       <Example
         title="Horizontal orientation"
         description="`orientation='horizontal'` lays out radios in a wrapping row."
-        code={`<RadioGroup name="align" defaultValue="left" label="Text align" orientation="horizontal">
-  <Radio value="left" label="Left" />
-  <Radio value="center" label="Center" />
-  <Radio value="right" label="Right" />
-</RadioGroup>`}
+        code={`import { Radio, RadioGroup } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <RadioGroup name="align" defaultValue="left" label="Text align" orientation="horizontal">
+      <Radio value="left" label="Left" />
+      <Radio value="center" label="Center" />
+      <Radio value="right" label="Right" />
+    </RadioGroup>
+  );
+}`}
       >
         <InputExample>
           <RadioGroup name="align" defaultValue="left" label="Text align" orientation="horizontal">
@@ -137,10 +178,23 @@ export function RadioDemo() {
       <Example
         title="Disabled"
         description="`disabled` on the group disables all children. A per-child `disabled` still wins for individual options."
-        code={`<RadioGroup name="locked" defaultValue="a" disabled label="Locked group">
-  <Radio value="a" label="Option A" />
-  <Radio value="b" label="Option B" />
-</RadioGroup>`}
+        code={`import { Radio, RadioGroup, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <RadioGroup name="locked" defaultValue="a" disabled label="Locked group">
+        <Radio value="a" label="Option A" />
+        <Radio value="b" label="Option B" />
+      </RadioGroup>
+      <RadioGroup name="mixed" defaultValue="a" label="One option disabled">
+        <Radio value="a" label="Available" />
+        <Radio value="b" label="Disabled" disabled />
+        <Radio value="c" label="Available" />
+      </RadioGroup>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="md">
@@ -160,11 +214,30 @@ export function RadioDemo() {
       <Example
         title="Invalid"
         description="`invalid` on the group sets `aria-invalid` on the fieldset and applies the danger visual to every child + the legend."
-        code={`<RadioGroup name="terms" invalid required label="Accept the agreement" aria-describedby="terms-err">
-  <Radio value="yes" label="Yes" />
-  <Radio value="no" label="No" />
-</RadioGroup>
-<p id="terms-err">Please make a selection.</p>`}
+        code={`import { Radio, RadioGroup, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs">
+      <RadioGroup
+        name="terms"
+        invalid
+        required
+        label="Accept the agreement"
+        aria-describedby="terms-err"
+      >
+        <Radio value="yes" label="Yes" />
+        <Radio value="no" label="No" />
+      </RadioGroup>
+      <p
+        id="terms-err"
+        style={{ color: 'var(--color-danger)', fontSize: 'var(--font-size-xs)' }}
+      >
+        Please make a selection.
+      </p>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <Stack gap="xs">
@@ -191,16 +264,37 @@ export function RadioDemo() {
       <Example
         title="Form integration"
         description="`<RadioGroup name>` shared across children means `FormData.get(name)` returns the selected value."
-        code={`<form>
-  <RadioGroup name="size" defaultValue="md" label="T-shirt size">
-    <Radio value="sm" label="Small" />
-    <Radio value="md" label="Medium" />
-    <Radio value="lg" label="Large" />
-  </RadioGroup>
-  <button type="submit">Submit</button>
-</form>
+        code={`import { useState } from 'react';
+import { Button, Radio, RadioGroup, Stack } from '@eocrm/design-system';
 
-// On submit: new FormData(form).get('size')`}
+export function FormDemo() {
+  const [submitted, setSubmitted] = useState<string | null>(null);
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const fd = new FormData(e.currentTarget);
+        setSubmitted(String(fd.get('size') ?? '(none)'));
+      }}
+    >
+      <Stack gap="xs">
+        <RadioGroup name="size" defaultValue="md" label="T-shirt size">
+          <Radio value="sm" label="Small" />
+          <Radio value="md" label="Medium" />
+          <Radio value="lg" label="Large" />
+        </RadioGroup>
+        <Button type="submit" size="sm">
+          Submit
+        </Button>
+        {submitted !== null && (
+          <code style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-muted)' }}>
+            size = {submitted}
+          </code>
+        )}
+      </Stack>
+    </form>
+  );
+}`}
       >
         <InputExample>
           <FormDemo />

--- a/packages/playground/src/pages/components/RailDemo.tsx
+++ b/packages/playground/src/pages/components/RailDemo.tsx
@@ -97,32 +97,130 @@ export function RailDemo() {
       <Example
         title="Default — uncontrolled, with sections, items, and a group"
         description="Start with `defaultCollapsed={false}` and let the built-in CollapseToggle in the footer drive the state. Sections group related items; a Rail.Group renders inline when expanded."
-        code={`<Rail defaultCollapsed={false} aria-label="Main navigation">
-  <Rail.Header><BrandMark /></Rail.Header>
+        code={`import { type ReactNode } from 'react';
+import { Activity, Home, KanbanSquare, Settings as SettingsIcon, Users } from 'lucide-react';
+import { Badge, Cluster, Rail, Text, useRail } from '@eocrm/design-system';
 
-  <Rail.Section title="Main">
-    <Rail.Item icon={<Home size={16} />} href="#dashboard">Dashboard</Rail.Item>
-    <Rail.Item icon={<KanbanSquare size={16} />} href="#deals">Deals</Rail.Item>
-    <Rail.Item icon={<Users size={16} />} href="#contacts" badge={<Badge tone="info" size="sm">12</Badge>}>
-      Contacts
-    </Rail.Item>
-  </Rail.Section>
+function RailStage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: 480,
+        minHeight: 480,
+        display: 'flex',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+        overflow: 'hidden',
+        background: 'var(--color-bg-subtle)',
+      }}
+    >
+      {children}
+      <div
+        style={{
+          flex: '1 1 auto',
+          padding: 'var(--space-4)',
+          color: 'var(--color-fg-muted)',
+        }}
+      >
+        <Text tone="muted">Main content area — the rail is to the left.</Text>
+      </div>
+    </div>
+  );
+}
 
-  <Rail.Section title="Operations">
-    <Rail.Group icon={<SettingsIcon size={16} />} label="Settings">
-      <Rail.Item href="#settings-general">General</Rail.Item>
-      <Rail.Item href="#settings-security">Security</Rail.Item>
-      <Rail.Item href="#settings-billing">Billing</Rail.Item>
-    </Rail.Group>
-    <Rail.Item icon={<Activity size={16} />} href="#audit">Audit log</Rail.Item>
-  </Rail.Section>
+function BrandMark() {
+  const { collapsed } = useRail();
+  return (
+    <Cluster gap="sm" align="center" wrap={false} justify={collapsed ? 'center' : 'start'}>
+      <div
+        aria-hidden
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 'var(--radius-md)',
+          background: 'var(--color-accent)',
+          color: 'var(--color-accent-fg)',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontWeight: 'var(--font-weight-semibold)',
+          flexShrink: 0,
+        }}
+      >
+        R
+      </div>
+      {!collapsed && <Text weight="semibold">Railside</Text>}
+    </Cluster>
+  );
+}
 
-  <Rail.Spacer />
+export function Demo() {
+  return (
+    <RailStage>
+      <Rail defaultCollapsed={false}>
+        <Rail.Header>
+          <BrandMark />
+        </Rail.Header>
 
-  <Rail.Footer>
-    <Rail.CollapseToggle />
-  </Rail.Footer>
-</Rail>`}
+        <Rail.Section title="Main">
+          <Rail.Item
+            icon={<Home size={16} />}
+            href="#dashboard"
+            onClick={(e) => e.preventDefault()}
+          >
+            Dashboard
+          </Rail.Item>
+          <Rail.Item
+            icon={<KanbanSquare size={16} />}
+            href="#deals"
+            onClick={(e) => e.preventDefault()}
+          >
+            Deals
+          </Rail.Item>
+          <Rail.Item
+            icon={<Users size={16} />}
+            href="#contacts"
+            onClick={(e) => e.preventDefault()}
+            badge={
+              <Badge tone="info" size="sm">
+                12
+              </Badge>
+            }
+          >
+            Contacts
+          </Rail.Item>
+        </Rail.Section>
+
+        <Rail.Section title="Operations">
+          <Rail.Group icon={<SettingsIcon size={16} />} label="Settings">
+            <Rail.Item href="#settings-general" onClick={(e) => e.preventDefault()}>
+              General
+            </Rail.Item>
+            <Rail.Item href="#settings-security" onClick={(e) => e.preventDefault()}>
+              Security
+            </Rail.Item>
+            <Rail.Item href="#settings-billing" onClick={(e) => e.preventDefault()}>
+              Billing
+            </Rail.Item>
+          </Rail.Group>
+          <Rail.Item
+            icon={<Activity size={16} />}
+            href="#audit"
+            onClick={(e) => e.preventDefault()}
+          >
+            Audit log
+          </Rail.Item>
+        </Rail.Section>
+
+        <Rail.Spacer />
+
+        <Rail.Footer>
+          <Rail.CollapseToggle />
+        </Rail.Footer>
+      </Rail>
+    </RailStage>
+  );
+}`}
       >
         <RailStage>
           <Rail defaultCollapsed={false}>
@@ -192,28 +290,125 @@ export function RailDemo() {
       <Example
         title="Collapsed by default — hover a group to reveal its subitems"
         description="`defaultCollapsed` makes the rail mount in its narrow mode. Top-level items become icon-only with a tooltip on hover; hovering a group icon reveals a flyout popover containing the group's subitems."
-        code={`<Rail defaultCollapsed>
-  <Rail.Header><BrandMark /></Rail.Header>
+        code={`import { type ReactNode } from 'react';
+import { Bell, Home, Mail, Settings as SettingsIcon, ShieldCheck } from 'lucide-react';
+import { Cluster, Rail, Text, useRail } from '@eocrm/design-system';
 
-  <Rail.Section title="Main">
-    <Rail.Item icon={<Home size={16} />} href="#dashboard">Dashboard</Rail.Item>
-    <Rail.Item icon={<Bell size={16} />} href="#alerts">Alerts</Rail.Item>
-  </Rail.Section>
+function RailStage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: 480,
+        minHeight: 480,
+        display: 'flex',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+        overflow: 'hidden',
+        background: 'var(--color-bg-subtle)',
+      }}
+    >
+      {children}
+      <div
+        style={{
+          flex: '1 1 auto',
+          padding: 'var(--space-4)',
+          color: 'var(--color-fg-muted)',
+        }}
+      >
+        <Text tone="muted">Main content area — the rail is to the left.</Text>
+      </div>
+    </div>
+  );
+}
 
-  <Rail.Section title="Operations">
-    <Rail.Group icon={<SettingsIcon size={16} />} label="Settings">
-      <Rail.Item href="#settings-general">General</Rail.Item>
-      <Rail.Item href="#settings-security">Security</Rail.Item>
-      <Rail.Item href="#settings-billing">Billing</Rail.Item>
-    </Rail.Group>
-  </Rail.Section>
+function BrandMark() {
+  const { collapsed } = useRail();
+  return (
+    <Cluster gap="sm" align="center" wrap={false} justify={collapsed ? 'center' : 'start'}>
+      <div
+        aria-hidden
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 'var(--radius-md)',
+          background: 'var(--color-accent)',
+          color: 'var(--color-accent-fg)',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontWeight: 'var(--font-weight-semibold)',
+          flexShrink: 0,
+        }}
+      >
+        R
+      </div>
+      {!collapsed && <Text weight="semibold">Railside</Text>}
+    </Cluster>
+  );
+}
 
-  <Rail.Spacer />
+export function Demo() {
+  return (
+    <RailStage>
+      <Rail defaultCollapsed>
+        <Rail.Header>
+          <BrandMark />
+        </Rail.Header>
 
-  <Rail.Footer>
-    <Rail.CollapseToggle />
-  </Rail.Footer>
-</Rail>`}
+        <Rail.Section title="Main">
+          <Rail.Item
+            icon={<Home size={16} />}
+            href="#dashboard"
+            onClick={(e) => e.preventDefault()}
+          >
+            Dashboard
+          </Rail.Item>
+          <Rail.Item
+            icon={<Bell size={16} />}
+            href="#alerts"
+            onClick={(e) => e.preventDefault()}
+          >
+            Alerts
+          </Rail.Item>
+          <Rail.Item
+            icon={<Mail size={16} />}
+            href="#inbox"
+            onClick={(e) => e.preventDefault()}
+          >
+            Inbox
+          </Rail.Item>
+        </Rail.Section>
+
+        <Rail.Section title="Operations">
+          <Rail.Group icon={<SettingsIcon size={16} />} label="Settings">
+            <Rail.Item href="#settings-general" onClick={(e) => e.preventDefault()}>
+              General
+            </Rail.Item>
+            <Rail.Item href="#settings-security" onClick={(e) => e.preventDefault()}>
+              Security
+            </Rail.Item>
+            <Rail.Item href="#settings-billing" onClick={(e) => e.preventDefault()}>
+              Billing
+            </Rail.Item>
+          </Rail.Group>
+          <Rail.Item
+            icon={<ShieldCheck size={16} />}
+            href="#audit"
+            onClick={(e) => e.preventDefault()}
+          >
+            Audit
+          </Rail.Item>
+        </Rail.Section>
+
+        <Rail.Spacer />
+
+        <Rail.Footer>
+          <Rail.CollapseToggle />
+        </Rail.Footer>
+      </Rail>
+    </RailStage>
+  );
+}`}
       >
         <RailStage>
           <Rail defaultCollapsed>
@@ -278,21 +473,113 @@ export function RailDemo() {
       <Example
         title="Controlled — drive collapsed state from a sibling component"
         description="Pass `collapsed` + `onCollapsedChange` to control state externally. Useful when the rail's collapsed state is persisted to localStorage, syncs with a URL parameter, or is toggled by a button elsewhere in the page chrome."
-        code={`const [collapsed, setCollapsed] = useState(false);
+        code={`import { useState, type ReactNode } from 'react';
+import { Building2, Home, Search } from 'lucide-react';
+import { Button, Cluster, Rail, Stack, Text, useRail } from '@eocrm/design-system';
 
-<Cluster gap="sm">
-  <Button onClick={() => setCollapsed(c => !c)}>
-    {collapsed ? 'Expand' : 'Collapse'} rail
-  </Button>
-</Cluster>
+function RailStage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: 480,
+        minHeight: 480,
+        display: 'flex',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+        overflow: 'hidden',
+        background: 'var(--color-bg-subtle)',
+      }}
+    >
+      {children}
+      <div
+        style={{
+          flex: '1 1 auto',
+          padding: 'var(--space-4)',
+          color: 'var(--color-fg-muted)',
+        }}
+      >
+        <Text tone="muted">Main content area — the rail is to the left.</Text>
+      </div>
+    </div>
+  );
+}
 
-<Rail
-  collapsed={collapsed}
-  onCollapsedChange={setCollapsed}
-  aria-label="Main navigation"
->
-  …
-</Rail>`}
+function BrandMark() {
+  const { collapsed } = useRail();
+  return (
+    <Cluster gap="sm" align="center" wrap={false} justify={collapsed ? 'center' : 'start'}>
+      <div
+        aria-hidden
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 'var(--radius-md)',
+          background: 'var(--color-accent)',
+          color: 'var(--color-accent-fg)',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontWeight: 'var(--font-weight-semibold)',
+          flexShrink: 0,
+        }}
+      >
+        R
+      </div>
+      {!collapsed && <Text weight="semibold">Railside</Text>}
+    </Cluster>
+  );
+}
+
+export function Demo() {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <Stack gap="md">
+      <Cluster gap="sm" align="center">
+        <Button variant="secondary" size="sm" onClick={() => setCollapsed((c) => !c)}>
+          {collapsed ? 'Expand' : 'Collapse'} rail
+        </Button>
+        <Text tone="muted" size="sm">
+          External state controls the rail.
+        </Text>
+      </Cluster>
+      <RailStage>
+        <Rail collapsed={collapsed} onCollapsedChange={setCollapsed}>
+          <Rail.Header>
+            <BrandMark />
+          </Rail.Header>
+          <Rail.Section title="Main">
+            <Rail.Item
+              icon={<Home size={16} />}
+              href="#dashboard"
+              onClick={(e) => e.preventDefault()}
+            >
+              Dashboard
+            </Rail.Item>
+            <Rail.Item
+              icon={<Search size={16} />}
+              href="#search"
+              onClick={(e) => e.preventDefault()}
+            >
+              Search
+            </Rail.Item>
+            <Rail.Item
+              icon={<Building2 size={16} />}
+              href="#tenants"
+              onClick={(e) => e.preventDefault()}
+            >
+              Tenants
+            </Rail.Item>
+          </Rail.Section>
+          <Rail.Spacer />
+          <Rail.Footer>
+            <Rail.CollapseToggle />
+          </Rail.Footer>
+        </Rail>
+      </RailStage>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Cluster gap="sm" align="center">
@@ -348,21 +635,110 @@ export function RailDemo() {
           "anchor; Rail's CSS reads that selector and applies the active accent. " +
           'Groups auto-open when one of their subitems is the active route.'
         }
-        code={`import { NavLink } from 'react-router-dom';
+        code={`import { type ReactNode } from 'react';
+import { Cog, Home, KanbanSquare, Layers, Settings as SettingsIcon, Users } from 'lucide-react';
+import { Cluster, Rail, Text, useRail } from '@eocrm/design-system';
 
-<Rail aria-label="Main navigation">
-  <Rail.Section title="Main">
-    <Rail.Item icon={<Home />} as={NavLink} to="/" end>Dashboard</Rail.Item>
-    <Rail.Item icon={<KanbanSquare />} as={NavLink} to="/deals">Deals</Rail.Item>
-  </Rail.Section>
+function RailStage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: 480,
+        minHeight: 480,
+        display: 'flex',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+        overflow: 'hidden',
+        background: 'var(--color-bg-subtle)',
+      }}
+    >
+      {children}
+      <div
+        style={{
+          flex: '1 1 auto',
+          padding: 'var(--space-4)',
+          color: 'var(--color-fg-muted)',
+        }}
+      >
+        <Text tone="muted">Main content area — the rail is to the left.</Text>
+      </div>
+    </div>
+  );
+}
 
-  <Rail.Section title="Operations">
-    <Rail.Group icon={<SettingsIcon />} label="Settings">
-      <Rail.Item as={NavLink} to="/settings/general">General</Rail.Item>
-      <Rail.Item as={NavLink} to="/settings/security">Security</Rail.Item>
-    </Rail.Group>
-  </Rail.Section>
-</Rail>`}
+function BrandMark() {
+  const { collapsed } = useRail();
+  return (
+    <Cluster gap="sm" align="center" wrap={false} justify={collapsed ? 'center' : 'start'}>
+      <div
+        aria-hidden
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 'var(--radius-md)',
+          background: 'var(--color-accent)',
+          color: 'var(--color-accent-fg)',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontWeight: 'var(--font-weight-semibold)',
+          flexShrink: 0,
+        }}
+      >
+        R
+      </div>
+      {!collapsed && <Text weight="semibold">Railside</Text>}
+    </Cluster>
+  );
+}
+
+export function Demo() {
+  return (
+    <>
+      <RailStage>
+        <Rail>
+          <Rail.Header>
+            <BrandMark />
+          </Rail.Header>
+          <Rail.Section title="Main">
+            <Rail.Item icon={<Home size={16} />} href="#/">
+              Dashboard
+            </Rail.Item>
+            <Rail.Item icon={<KanbanSquare size={16} />} href="#/deals">
+              Deals
+            </Rail.Item>
+            <Rail.Item icon={<Users size={16} />} href="#/contacts">
+              Contacts
+            </Rail.Item>
+          </Rail.Section>
+          <Rail.Section title="Operations">
+            <Rail.Group icon={<SettingsIcon size={16} />} label="Settings">
+              <Rail.Item href="#/settings/general">General</Rail.Item>
+              <Rail.Item href="#/settings/security" aria-current="page">
+                Security
+              </Rail.Item>
+              <Rail.Item href="#/settings/billing">Billing</Rail.Item>
+            </Rail.Group>
+            <Rail.Item icon={<Cog size={16} />} href="#/integrations">
+              Integrations
+            </Rail.Item>
+          </Rail.Section>
+          <Rail.Spacer />
+          <Rail.Footer>
+            <Rail.CollapseToggle />
+          </Rail.Footer>
+        </Rail>
+      </RailStage>
+      <Cluster gap="sm" align="center">
+        <Layers size={14} aria-hidden style={{ color: 'var(--color-fg-muted)' }} />
+        <Text tone="muted" size="sm">
+          The demo starts at <code>/settings/security</code>, so the Settings group auto-opens and
+          that subitem shows the active accent.
+        </Text>
+      </Cluster>
+    </>
+  );
+}`}
       >
         <RailStage>
           <Rail>
@@ -410,28 +786,121 @@ export function RailDemo() {
       <Example
         title="Items pinned to the bottom — Rail.Spacer pushes anything after it down"
         description="Drop a `<Rail.Spacer />` between the main item list and a secondary section to keep settings / help / sign-out anchored at the rail's bottom edge. The Footer (CollapseToggle, user chip) sits below them and stays sticky when the item list overflows."
-        code={`<Rail>
-  <Rail.Header><BrandMark /></Rail.Header>
+        code={`import { type ReactNode } from 'react';
+import { Home, KanbanSquare, Search, Settings as SettingsIcon, Users } from 'lucide-react';
+import { Cluster, Rail, Text, useRail } from '@eocrm/design-system';
 
-  <Rail.Section title="Main">
-    <Rail.Item icon={<Home size={16} />} href="#dashboard">Dashboard</Rail.Item>
-    <Rail.Item icon={<KanbanSquare size={16} />} href="#deals">Deals</Rail.Item>
-    <Rail.Item icon={<Users size={16} />} href="#contacts">Contacts</Rail.Item>
-  </Rail.Section>
+function RailStage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: 480,
+        minHeight: 480,
+        display: 'flex',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+        overflow: 'hidden',
+        background: 'var(--color-bg-subtle)',
+      }}
+    >
+      {children}
+      <div
+        style={{
+          flex: '1 1 auto',
+          padding: 'var(--space-4)',
+          color: 'var(--color-fg-muted)',
+        }}
+      >
+        <Text tone="muted">Main content area — the rail is to the left.</Text>
+      </div>
+    </div>
+  );
+}
 
-  {/* Spacer eats the remaining vertical space, pushing everything below it
-      to the bottom of the rail. */}
-  <Rail.Spacer />
+function BrandMark() {
+  const { collapsed } = useRail();
+  return (
+    <Cluster gap="sm" align="center" wrap={false} justify={collapsed ? 'center' : 'start'}>
+      <div
+        aria-hidden
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 'var(--radius-md)',
+          background: 'var(--color-accent)',
+          color: 'var(--color-accent-fg)',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontWeight: 'var(--font-weight-semibold)',
+          flexShrink: 0,
+        }}
+      >
+        R
+      </div>
+      {!collapsed && <Text weight="semibold">Railside</Text>}
+    </Cluster>
+  );
+}
 
-  <Rail.Section>
-    <Rail.Item icon={<SettingsIcon size={16} />} href="#settings">Settings</Rail.Item>
-    <Rail.Item icon={<Search size={16} />} href="#help">Help & feedback</Rail.Item>
-  </Rail.Section>
+export function Demo() {
+  return (
+    <RailStage>
+      <Rail>
+        <Rail.Header>
+          <BrandMark />
+        </Rail.Header>
 
-  <Rail.Footer>
-    <Rail.CollapseToggle />
-  </Rail.Footer>
-</Rail>`}
+        <Rail.Section title="Main">
+          <Rail.Item
+            icon={<Home size={16} />}
+            href="#dashboard"
+            onClick={(e) => e.preventDefault()}
+          >
+            Dashboard
+          </Rail.Item>
+          <Rail.Item
+            icon={<KanbanSquare size={16} />}
+            href="#deals"
+            onClick={(e) => e.preventDefault()}
+          >
+            Deals
+          </Rail.Item>
+          <Rail.Item
+            icon={<Users size={16} />}
+            href="#contacts"
+            onClick={(e) => e.preventDefault()}
+          >
+            Contacts
+          </Rail.Item>
+        </Rail.Section>
+
+        <Rail.Spacer />
+
+        <Rail.Section>
+          <Rail.Item
+            icon={<SettingsIcon size={16} />}
+            href="#settings"
+            onClick={(e) => e.preventDefault()}
+          >
+            Settings
+          </Rail.Item>
+          <Rail.Item
+            icon={<Search size={16} />}
+            href="#help"
+            onClick={(e) => e.preventDefault()}
+          >
+            Help & feedback
+          </Rail.Item>
+        </Rail.Section>
+
+        <Rail.Footer>
+          <Rail.CollapseToggle />
+        </Rail.Footer>
+      </Rail>
+    </RailStage>
+  );
+}`}
       >
         <RailStage>
           <Rail>

--- a/packages/playground/src/pages/components/RichTextDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextDemo.tsx
@@ -132,7 +132,33 @@ export function RichTextDemo() {
       <Example
         title="Rendering a document"
         description="A RichDoc rendered read-only via the engine's renderer."
-        code={`<RichText value={doc} />`}
+        code={`import { RichText, createBlock, type RichDoc } from '@eocrm/design-system';
+
+const doc: RichDoc = {
+  blocks: [
+    createBlock('heading', 'Release notes', { level: 1, id: 'h' }),
+    {
+      id: 'p',
+      type: 'paragraph',
+      inlines: [
+        { text: 'We shipped ', marks: [] },
+        { text: 'bold', marks: [{ type: 'bold' }] },
+        { text: ' and ', marks: [] },
+        { text: 'italic', marks: [{ type: 'italic' }] },
+        { text: ' with a ', marks: [] },
+        { text: 'link', marks: [{ type: 'link', href: '/docs' }] },
+        { text: '.', marks: [] },
+      ],
+    },
+    createBlock('bullet_item', 'First item', { id: 'l1' }),
+    createBlock('bullet_item', 'Second item', { id: 'l2' }),
+    createBlock('blockquote', 'A quote block.', { id: 'q' }),
+  ],
+};
+
+export function Demo() {
+  return <RichText value={doc} />;
+}`}
       >
         <RichText value={SAMPLE} />
       </Example>
@@ -140,8 +166,72 @@ export function RichTextDemo() {
       <Example
         title="The engine is live"
         description="These buttons run pure engine transforms on a doc and re-render it — no editor yet, just the model + render working together."
-        code={`const r = toggleMark(doc, range, { type: 'bold' });
-setDoc(r.doc);`}
+        code={`import { useState } from 'react';
+import {
+  RichText,
+  createBlock,
+  toggleMark,
+  setBlockType,
+  Cluster,
+  Button,
+  type RichDoc,
+} from '@eocrm/design-system';
+
+const SAMPLE: RichDoc = {
+  blocks: [
+    createBlock('heading', 'Release notes', { level: 1, id: 'h' }),
+    {
+      id: 'p',
+      type: 'paragraph',
+      inlines: [
+        { text: 'We shipped ', marks: [] },
+        { text: 'bold', marks: [{ type: 'bold' }] },
+        { text: ' and ', marks: [] },
+        { text: 'italic', marks: [{ type: 'italic' }] },
+        { text: ' with a ', marks: [] },
+        { text: 'link', marks: [{ type: 'link', href: '/docs' }] },
+        { text: '.', marks: [] },
+      ],
+    },
+    createBlock('bullet_item', 'First item', { id: 'l1' }),
+    createBlock('bullet_item', 'Second item', { id: 'l2' }),
+    createBlock('blockquote', 'A quote block.', { id: 'q' }),
+  ],
+};
+
+export function Demo() {
+  const [doc, setDoc] = useState<RichDoc>(SAMPLE);
+
+  const boldHeading = () =>
+    setDoc(
+      (d) =>
+        toggleMark(
+          d,
+          { anchor: { blockId: 'h', offset: 0 }, focus: { blockId: 'h', offset: 13 } },
+          { type: 'bold' },
+        ).doc,
+    );
+  const quoteToParagraph = () =>
+    setDoc((d) => setBlockType(d, 'q', { type: 'paragraph' }).doc);
+  const reset = () => setDoc(SAMPLE);
+
+  return (
+    <>
+      <Cluster gap="sm">
+        <Button size="sm" onClick={boldHeading}>
+          Toggle bold heading
+        </Button>
+        <Button size="sm" onClick={quoteToParagraph}>
+          Quote → paragraph
+        </Button>
+        <Button size="sm" variant="secondary" onClick={reset}>
+          Reset
+        </Button>
+      </Cluster>
+      <RichText value={doc} />
+    </>
+  );
+}`}
       >
         <Cluster gap="sm">
           <Button size="sm" onClick={boldHeading}>
@@ -160,11 +250,39 @@ setDoc(r.doc);`}
       <Example
         title="Link substitution (renderLink)"
         description="Pass renderLink to swap how a link renders. Here a link to an in-space task URL (https://app.eocrm/task/123) becomes a task chip, while a plain external link stays a normal <a>. The model is unchanged — renderLink is render-time only; serialization still emits a link."
-        code={`const renderLink: RenderLink = ({ href }, fallback) => {
-  const m = /^https?:\\/\\/app\\.eocrm\\/task\\/(\\d+)/i.exec(href);
+        code={`import { RichText, Badge, type RichDoc, type RenderLink } from '@eocrm/design-system';
+
+const TASK_RE = /^https?:\\/\\/app\\.eocrm\\/task\\/(\\d+)/i;
+const renderLink: RenderLink = ({ href }, fallback) => {
+  const m = TASK_RE.exec(href);
   return m ? <Badge tone="purple">#{m[1]} · Ship the gallery</Badge> : fallback;
 };
-<RichText value={doc} renderLink={renderLink} />`}
+
+const doc: RichDoc = {
+  blocks: [
+    {
+      id: 'lr',
+      type: 'paragraph',
+      inlines: [
+        { text: 'Track ', marks: [] },
+        {
+          text: 'https://app.eocrm/task/123',
+          marks: [{ type: 'link', href: 'https://app.eocrm/task/123' }],
+        },
+        { text: ' and read more at ', marks: [] },
+        {
+          text: 'example.com',
+          marks: [{ type: 'link', href: 'https://example.com' }],
+        },
+        { text: '.', marks: [] },
+      ],
+    },
+  ],
+};
+
+export function Demo() {
+  return <RichText value={doc} renderLink={renderLink} />;
+}`}
       >
         <RichText value={LINK_DOC} renderLink={renderLink} />
       </Example>
@@ -172,21 +290,46 @@ setDoc(r.doc);`}
       <Example
         title="Mention substitution (renderMention)"
         description="Pass renderMention to swap how an @-mention renders — same contract as renderLink but for mention marks. Here each mention becomes an interactive member chip (click one). It composes with renderLink and is render-time only; serialization still emits the mention mark."
-        code={`// Render an @-mention as your own interactive, keyboard-accessible chip.
+        code={`import { RichText, Badge, type RichDoc, type RenderMention } from '@eocrm/design-system';
+
+const openMention = (id: string, label: string) => alert(\`Mentioned \${label} (\${id})\`);
 const renderMention: RenderMention = ({ id, label }) => (
   <Badge
     tone="info"
     role="button"
     tabIndex={0}
-    onClick={() => openProfile(id)}
+    title={\`Open \${label}'s profile\`}
+    onClick={() => openMention(id, label)}
     onKeyDown={(e) => {
-      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openProfile(id); }
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openMention(id, label);
+      }
     }}
   >
     @{label}
   </Badge>
 );
-<RichText value={doc} renderMention={renderMention} />`}
+
+const doc: RichDoc = {
+  blocks: [
+    {
+      id: 'mr',
+      type: 'paragraph',
+      inlines: [
+        { text: 'Assign this to ', marks: [] },
+        { text: '@Alice', marks: [{ type: 'mention', id: 'u1', label: 'Alice Nguyen' }] },
+        { text: ' and ', marks: [] },
+        { text: '@Bob', marks: [{ type: 'mention', id: 'u2', label: 'Bob Martinez' }] },
+        { text: '.', marks: [] },
+      ],
+    },
+  ],
+};
+
+export function Demo() {
+  return <RichText value={doc} renderMention={renderMention} />;
+}`}
       >
         <RichText value={MENTION_DOC} renderMention={renderMention} />
       </Example>

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -119,8 +119,37 @@ export function RichTextEditorDemo() {
       <Example
         title="Editable with toolbar"
         description='The toolbar prop adds a formatting bar above the editor. Keyboard shortcuts and toolbar buttons both work — select text to format it, or toggle a mark at a collapsed caret and then type to apply it to new text. Enter on an empty list item exits the list; Tab / Shift+Tab indent and outdent list items. Undo/redo: ⌘/Ctrl+Z and ⌘/Ctrl+Shift+Z (or the toolbar Undo/Redo buttons). Type "# ", "- ", "1. ", or "> " at the start of a line to auto-format. The toolbar also includes an emoji button that opens a searchable emoji picker and inserts the chosen emoji at the caret.'
-        code={`const [doc, setDoc] = useState(docFromText('…'));
-<RichTextEditor value={doc} onChange={setDoc} toolbar placeholder="Write a note…" />`}
+        code={`import { useState } from 'react';
+import {
+  RichTextEditor,
+  docFromText,
+  toHtml,
+  toMarkdown,
+  Code,
+  Text,
+  Stack,
+  type RichDoc,
+} from '@eocrm/design-system';
+
+export function Demo() {
+  const [doc, setDoc] = useState<RichDoc>(
+    docFromText('Type here. Select a word and press ⌘B.'),
+  );
+  return (
+    <Stack gap="sm">
+      <RichTextEditor value={doc} onChange={setDoc} toolbar placeholder="Write a note…" />
+      <Text size="sm" tone="muted">
+        Toolbar + shortcuts: ⌘/Ctrl+B bold · I italic · U underline · ⇧X strike
+      </Text>
+      <Text size="sm" tone="muted">
+        HTML → <Code>{toHtml(doc)}</Code>
+      </Text>
+      <Text size="sm" tone="muted">
+        Markdown → <Code>{toMarkdown(doc).replace(/\\n/g, '⏎')}</Code>
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <RichTextEditor value={doc} onChange={setDoc} toolbar placeholder="Write a note…" />
@@ -139,8 +168,20 @@ export function RichTextEditorDemo() {
       <Example
         title='Focus-gated toolbar (toolbar="auto")'
         description='toolbar="auto" shows the formatting bar only when the editor is focused or non-empty — ideal for a compact comment composer. Click into the empty editor below: the bar appears; click away (while still empty) and it hides. Crucially, the bar stays up while the editor’s own overlays are open — focus the empty editor, click the Link button (or ⌘/Ctrl+K): the link editor opens and the bar does NOT collapse, even though focus moved into the link popover. The editable is never remounted as the bar toggles, so there is no focus/selection loss.'
-        code={`const [doc, setDoc] = useState(docFromText(''));
-<RichTextEditor value={doc} onChange={setDoc} toolbar="auto" placeholder="Add a comment…" />`}
+        code={`import { useState } from 'react';
+import { RichTextEditor, docFromText, type RichDoc } from '@eocrm/design-system';
+
+export function Demo() {
+  const [doc, setDoc] = useState<RichDoc>(() => docFromText(''));
+  return (
+    <RichTextEditor
+      value={doc}
+      onChange={setDoc}
+      toolbar="auto"
+      placeholder="Add a comment… (toolbar appears on focus)"
+    />
+  );
+}`}
       >
         <RichTextEditor
           value={autoDoc}
@@ -153,8 +194,19 @@ export function RichTextEditorDemo() {
       <Example
         title="Block controls"
         description="Set blockControls for a per-block gutter on hover/focus: ＋ inserts a block below, ⠿ drags to reorder (subtree-aware for nested lists) and opens a menu (turn into / duplicate / move / delete). Keyboard: Shift+F10 opens the menu, ⌘/Ctrl+⇧↑/↓ move the block, ⌘/Ctrl+D duplicates. Works with or without the toolbar. Grab anywhere on the gutter to drag the whole row — it lifts and the other rows slide apart to open its slot (clamped to the editor); text stays selectable."
-        code={`const [doc, setDoc] = useState(fromMarkdown('…'));
-<RichTextEditor value={doc} onChange={setDoc} blockControls placeholder="Write…" />`}
+        code={`import { useState } from 'react';
+import { RichTextEditor, fromMarkdown, type RichDoc } from '@eocrm/design-system';
+
+export function Demo() {
+  const [doc, setDoc] = useState<RichDoc>(() =>
+    fromMarkdown(
+      '# Block controls\\n\\nHover a line for the ＋ / ⠿ gutter.\\n\\n- first item\\n- second item\\n\\n> Drag the handle to reorder, or open the menu to turn into / duplicate / delete.',
+    ),
+  );
+  return (
+    <RichTextEditor value={doc} onChange={setDoc} blockControls placeholder="Write…" />
+  );
+}`}
       >
         <RichTextEditor
           value={blockDoc}
@@ -167,8 +219,36 @@ export function RichTextEditorDemo() {
       <Example
         title="File upload"
         description="Provide upload={{ onUpload }} to enable a toolbar attach button and clipboard-file paste. Images served from a real URL render inline; other files (and object-URL uploads) show as a download chip. Uploading shows a spinner; a rejected onUpload shows Retry/Remove. Wire onUploadingChange to your submit button. (This demo uses a mock uploader that returns a local object URL.) Open any attachment's block menu (the ⠿ handle) and choose Configure to set alt text, alignment, replace the file, or open/download. The width slider appears only for an image that renders as a preview (the seeded embedded image above) — an uploaded object-URL image shows as a chip and isn't resizable. You can also drag the handle on the image's bottom-right corner to resize it directly; the image resizes live as you drag (and the whole drag is a single undo)."
-        code={`<RichTextEditor value={doc} onChange={setDoc} toolbar blockControls
-  upload={{ onUpload: (file) => uploadToServer(file) }} />`}
+        code={`import { useState } from 'react';
+import { RichTextEditor, fromHtml, type RichDoc } from '@eocrm/design-system';
+
+// Mock uploader: resolve to a local object URL after a short delay (demo only).
+const mockUpload = (file: File) =>
+  new Promise<{ url: string; mime: string; name: string }>((resolve) =>
+    setTimeout(
+      () => resolve({ url: URL.createObjectURL(file), mime: file.type, name: file.name }),
+      600,
+    ),
+  );
+
+export function Demo() {
+  const [doc, setDoc] = useState<RichDoc>(() =>
+    fromHtml(
+      '<p>Paste a screenshot, or use the toolbar button to attach a file.</p>' +
+        '<img src="https://example.com/sample.svg" width="320" alt="Embedded sample image" />',
+    ),
+  );
+  return (
+    <RichTextEditor
+      value={doc}
+      onChange={setDoc}
+      toolbar
+      blockControls
+      upload={{ onUpload: mockUpload, accept: 'image/*,.pdf' }}
+      placeholder="Write…"
+    />
+  );
+}`}
       >
         <RichTextEditor
           value={uploadDoc}
@@ -183,8 +263,20 @@ export function RichTextEditorDemo() {
       <Example
         title="Links"
         description="Select text and press ⌘/Ctrl+K (or the toolbar link button) to open the link editor; type a URL and Apply. With the caret inside a link the URL is pre-filled and Remove appears. With no selection, the URL is inserted as linked text. Esc or a click outside cancels."
-        code={`const [doc, setDoc] = useState(docFromText('…'));
-<RichTextEditor value={doc} onChange={setDoc} toolbar />`}
+        code={`import { useState } from 'react';
+import { RichTextEditor, docFromText, type RichDoc } from '@eocrm/design-system';
+
+export function Demo() {
+  const [doc, setDoc] = useState<RichDoc>(docFromText('Read the docs and visit our site.'));
+  return (
+    <RichTextEditor
+      value={doc}
+      onChange={setDoc}
+      toolbar
+      placeholder="Select text, then ⌘K…"
+    />
+  );
+}`}
       >
         <RichTextEditor
           value={linkDoc}
@@ -197,8 +289,26 @@ export function RichTextEditorDemo() {
       <Example
         title="Text & highlight color"
         description="Select text and use the toolbar's separate Text color and Highlight buttons to apply a color. Each picker is a grid of small named badges that leads with the default brand colors (gray, red, green, amber, blue), then the rest of the categorical palette. Choosing Default clears the color. With blockControls enabled, open the ⠿ block menu and choose Text color or Highlight to color the entire block at once. Colors persist in the document and round-trip through HTML serialization, but are dropped in Markdown (like alignment and width)."
-        code={`const [doc, setDoc] = useState(() => fromHtml('<p>Select a word and color it.</p>'));
-<RichTextEditor value={doc} onChange={setDoc} toolbar blockControls />`}
+        code={`import { useState } from 'react';
+import { RichTextEditor, fromHtml, type RichDoc } from '@eocrm/design-system';
+
+export function Demo() {
+  const [doc, setDoc] = useState<RichDoc>(() =>
+    fromHtml(
+      '<p>Select a word and use the toolbar <strong>Text color</strong> or <strong>Highlight</strong> button to pick a color from the palette. Each color is a small named badge; choosing Default clears the color.</p>' +
+        '<p>With block controls, open the ⠿ menu → Text color / Highlight to color the whole block at once.</p>',
+    ),
+  );
+  return (
+    <RichTextEditor
+      value={doc}
+      onChange={setDoc}
+      toolbar
+      blockControls
+      placeholder="Select text, then use the Text color / Highlight buttons…"
+    />
+  );
+}`}
       >
         <RichTextEditor
           value={colorDoc}
@@ -212,9 +322,20 @@ export function RichTextEditorDemo() {
       <Example
         title="Import (HTML / Markdown) + rich paste"
         description="Seed the editor from stored HTML or Markdown with fromHtml / fromMarkdown, and paste rich HTML (from the web, Word, Google Docs) straight into the editor — it becomes formatted content, not plain text. This editor has a toolbar but no blockControls, yet the imported image is still resizable: hover it and drag the bottom-right corner handle."
-        code={`import { fromMarkdown } from '@eocrm/design-system'; // (fromHtml too — same API)
-const [doc, setDoc] = useState(() => fromMarkdown('# Imported\\n\\n- one\\n- two'));
-<RichTextEditor value={doc} onChange={setDoc} toolbar />`}
+        code={`import { useState } from 'react';
+import { RichTextEditor, fromHtml, type RichDoc } from '@eocrm/design-system';
+
+export function Demo() {
+  const [doc, setDoc] = useState<RichDoc>(() =>
+    fromHtml(
+      '<h1>Imported</h1><p>This editor was <strong>seeded</strong> from HTML — paste rich HTML to import more. Hover the image and drag its corner to resize (no block controls needed).</p>' +
+        '<img src="https://example.com/sample.svg" width="280" alt="Imported sample image" />',
+    ),
+  );
+  return (
+    <RichTextEditor value={doc} onChange={setDoc} toolbar placeholder="Paste rich HTML here…" />
+  );
+}`}
       >
         <RichTextEditor
           value={importDoc}
@@ -227,23 +348,59 @@ const [doc, setDoc] = useState(() => fromMarkdown('# Imported\\n\\n- one\\n- two
       <Example
         title="Mentions (@-autocomplete)"
         description='Pass a mentions prop with onQuery to enable @-mentions. Type "@" then a name (e.g. "@al") to open the candidate menu; ↑/↓ to move, Enter/Tab to insert a chip, Esc to dismiss. The chip carries the id; Backspace removes the whole chip. Pass renderMention to swap the default span for an interactive member chip (click one below) — it composes with renderLink and is render-time only, so serialization keeps the mention mark.'
-        code={`// Render an @-mention as your own interactive, keyboard-accessible chip.
+        code={`import { useState } from 'react';
+import {
+  RichTextEditor,
+  docFromText,
+  Badge,
+  type RichDoc,
+  type RenderMention,
+} from '@eocrm/design-system';
+
+const TEAM = [
+  { id: 'u1', label: 'Alice Nguyen', description: 'alice@eocrm.dev' },
+  { id: 'u2', label: 'Bob Martinez', description: 'bob@eocrm.dev' },
+  { id: 'u3', label: 'Carlos Whitfield', description: 'carlos@eocrm.dev' },
+  { id: 'u4', label: 'Dana Lee', description: 'dana@eocrm.dev' },
+];
+
+const queryTeam = (q: string) =>
+  Promise.resolve(TEAM.filter((m) => m.label.toLowerCase().includes(q.toLowerCase())));
+
+const openMention = (id: string, label: string) =>
+  alert(\`Mentioned \${label} (\${id})\`);
+
 const renderMention: RenderMention = ({ id, label }) => (
   <Badge
     tone="info"
     role="button"
     tabIndex={0}
-    onClick={() => openProfile(id)}
+    title={\`Open \${label}'s profile\`}
+    onClick={() => openMention(id, label)}
     onKeyDown={(e) => {
-      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openProfile(id); }
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openMention(id, label);
+      }
     }}
   >
     @{label}
   </Badge>
 );
-<RichTextEditor value={doc} onChange={setDoc} toolbar
-  mentions={{ onQuery: (q) => searchUsers(q) }}
-  renderMention={renderMention} />`}
+
+export function Demo() {
+  const [doc, setDoc] = useState<RichDoc>(() => docFromText('Assign this to '));
+  return (
+    <RichTextEditor
+      value={doc}
+      onChange={setDoc}
+      toolbar
+      placeholder="Type @ to mention someone…"
+      mentions={{ onQuery: queryTeam }}
+      renderMention={renderMention}
+    />
+  );
+}`}
       >
         <RichTextEditor
           value={mentionDoc}
@@ -258,12 +415,45 @@ const renderMention: RenderMention = ({ id, label }) => (
       <Example
         title="Autolink + link previews"
         description="Autolink is on by default — type or paste a URL like https://app.eocrm/task/123 (add a trailing space) and it becomes a link. With renderLink, a resolvable task URL renders as an atomic task chip: the caret sits before/after it and Backspace deletes the whole chip in one step. It's render-time only — serialization still emits a plain link. A plain external URL stays an editable <a>."
-        code={`const renderLink: RenderLink = ({ href }, fallback) => {
-  const m = /^https?:\\/\\/app\\.eocrm\\/task\\/(\\d+)/i.exec(href);
+        code={`import { useState } from 'react';
+import {
+  RichTextEditor,
+  docFromText,
+  Badge,
+  Code,
+  Text,
+  Stack,
+  type RichDoc,
+  type RenderLink,
+} from '@eocrm/design-system';
+
+const TASK_RE = /^https?:\\/\\/app\\.eocrm\\/task\\/(\\d+)/i;
+
+const renderLink: RenderLink = ({ href }, fallback) => {
+  const m = TASK_RE.exec(href);
   return m ? <Badge tone="purple">#{m[1]} · Ship the gallery</Badge> : fallback;
 };
-// autolink is on by default; pass renderLink to preview resolvable links as chips
-<RichTextEditor value={doc} onChange={setDoc} toolbar renderLink={renderLink} />`}
+
+export function Demo() {
+  const [doc, setDoc] = useState<RichDoc>(() =>
+    docFromText('Type a task URL below to watch it autolink. '),
+  );
+  return (
+    <Stack gap="sm">
+      <RichTextEditor
+        value={doc}
+        onChange={setDoc}
+        toolbar
+        renderLink={renderLink}
+        placeholder="Type https://app.eocrm/task/123 then a space…"
+      />
+      <Text size="sm" tone="muted">
+        Try typing or pasting <Code>https://app.eocrm/task/123</Code> (task chip) and{' '}
+        <Code>https://example.com</Code> (plain link).
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <RichTextEditor
@@ -283,7 +473,13 @@ const renderMention: RenderMention = ({ id, label }) => (
       <Example
         title="Read-only"
         description="Same surface, non-editable (prefer <RichText> for pure display)."
-        code={`<RichTextEditor value={doc} onChange={() => {}} readOnly />`}
+        code={`import { RichTextEditor, docFromText } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <RichTextEditor value={docFromText('Read-only content.')} onChange={() => {}} readOnly />
+  );
+}`}
       >
         <RichTextEditor value={docFromText('Read-only content.')} onChange={() => {}} readOnly />
       </Example>

--- a/packages/playground/src/pages/components/ScreenDemo.tsx
+++ b/packages/playground/src/pages/components/ScreenDemo.tsx
@@ -16,14 +16,21 @@ export function ScreenDemo() {
       <Example
         title="Block fill, accent backdrop"
         description={`fill="block" fills its container (not the viewport) so it's safe to embed here. backdrop="accent" paints the soft accent wash used by the login screen.`}
-        code={`<Screen fill="block" backdrop="accent">
-  <ErrorState
-    icon={<Compass size={48} aria-hidden="true" />}
-    title="Page not found"
-    description="The page you're looking for doesn't exist or has been moved."
-    actions={<Button>Go to homepage</Button>}
-  />
-</Screen>`}
+        code={`import { Compass } from 'lucide-react';
+import { Button, ErrorState, Screen } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Screen fill="block" backdrop="accent">
+      <ErrorState
+        icon={<Compass size={48} aria-hidden="true" />}
+        title="Page not found"
+        description="The page you're looking for doesn't exist or has been moved."
+        actions={<Button>Go to homepage</Button>}
+      />
+    </Screen>
+  );
+}`}
       >
         <Screen fill="block" backdrop="accent">
           <ErrorState
@@ -38,30 +45,37 @@ export function ScreenDemo() {
       <Example
         title="Danger backdrop + header / footer slots"
         description="Header is pinned top, footer pinned bottom, main centered between."
-        code={`<Screen
-  fill="block"
-  backdrop="danger"
-  header={
-    <Cluster justify="start">
-      <Text as="span" weight="bold">eocrm</Text>
-    </Cluster>
-  }
-  footer={
-    <Cluster justify="center" gap="lg">
-      <Link href="#" variant="muted">Privacy</Link>
-      <Link href="#" variant="muted">Status</Link>
-    </Cluster>
-  }
->
-  <ErrorState
-    tone="danger"
-    icon={<TriangleAlert size={48} aria-hidden="true" />}
-    title="Something went wrong"
-    description="An unexpected error occurred."
-    actions={<Button>Reload</Button>}
-    extra={<Text size="sm" tone="muted">Error ID: a1b2-c3d4</Text>}
-  />
-</Screen>`}
+        code={`import { TriangleAlert } from 'lucide-react';
+import { Button, Cluster, ErrorState, Link, Screen, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Screen
+      fill="block"
+      backdrop="danger"
+      header={
+        <Cluster justify="start">
+          <Text as="span" weight="bold">eocrm</Text>
+        </Cluster>
+      }
+      footer={
+        <Cluster justify="center" gap="lg">
+          <Link href="#" variant="muted">Privacy</Link>
+          <Link href="#" variant="muted">Status</Link>
+        </Cluster>
+      }
+    >
+      <ErrorState
+        tone="danger"
+        icon={<TriangleAlert size={48} aria-hidden="true" />}
+        title="Something went wrong"
+        description="An unexpected error occurred."
+        actions={<Button>Reload</Button>}
+        extra={<Text size="sm" tone="muted">Error ID: a1b2-c3d4</Text>}
+      />
+    </Screen>
+  );
+}`}
       >
         <Screen
           fill="block"
@@ -102,7 +116,24 @@ export function ScreenDemo() {
       <Example
         title="Live full-viewport screens"
         description={`fill="viewport" (the default) takes over the whole window — see it in the mockups.`}
-        code={`<Screen backdrop="accent">…</Screen>  // fill defaults to "viewport"`}
+        code={`import { Link as RouterLink } from 'react-router-dom';
+import { Link, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Link as={RouterLink} to="/mockups/404-standalone" variant="default">
+        404 — standalone page →
+      </Link>
+      <Link as={RouterLink} to="/mockups/error-standalone" variant="default">
+        Error — standalone page →
+      </Link>
+      <Link as={RouterLink} to="/mockups/login" variant="default">
+        Login →
+      </Link>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Link as={RouterLink} to="/mockups/404-standalone" variant="default">

--- a/packages/playground/src/pages/components/SelectDemo.tsx
+++ b/packages/playground/src/pages/components/SelectDemo.tsx
@@ -89,20 +89,31 @@ export function SelectDemo() {
       <Example
         title="Status — single, non-searchable"
         description="The simplest case. Static options, single value, no search input."
-        code={`const STATUSES = [
+        code={`import { useState } from 'react';
+import { Badge, Select, Stack, type SelectOption } from '@eocrm/design-system';
+
+const STATUSES: SelectOption[] = [
   { value: 'active', label: 'Active' },
   { value: 'pending', label: 'Pending' },
   { value: 'archived', label: 'Archived' },
 ];
 
-const [status, setStatus] = useState('');
-
-<Select
-  options={STATUSES}
-  value={status}
-  onChange={(v) => setStatus(v as string)}
-  placeholder="Pick a status"
-/>`}
+export function StatusExample() {
+  const [status, setStatus] = useState<string>('');
+  return (
+    <Stack gap="sm" align="start">
+      <div style={{ width: 320 }}>
+        <Select
+          options={STATUSES}
+          value={status}
+          onChange={(v) => setStatus(v as string)}
+          placeholder="Pick a status"
+        />
+      </div>
+      {status ? <Badge tone="info">{status}</Badge> : <Badge tone="neutral">none</Badge>}
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <StatusExample />
@@ -112,7 +123,10 @@ const [status, setStatus] = useState('');
       <Example
         title="Country — single, searchable, grouped"
         description="Options can be nested under group labels. Type to filter; arrow keys traverse across groups."
-        code={`const COUNTRIES = [
+        code={`import { useState } from 'react';
+import { Badge, Select, Stack } from '@eocrm/design-system';
+
+const COUNTRIES = [
   {
     label: 'Americas',
     options: [
@@ -138,13 +152,23 @@ const [status, setStatus] = useState('');
   },
 ];
 
-<Select
-  searchable
-  options={COUNTRIES}
-  value={country}
-  onChange={(v) => setCountry(v as string)}
-  placeholder="Search countries…"
-/>`}
+export function CountryExample() {
+  const [country, setCountry] = useState<string>('');
+  return (
+    <Stack gap="sm" align="start">
+      <div style={{ width: 320 }}>
+        <Select
+          searchable
+          options={COUNTRIES}
+          value={country}
+          onChange={(v) => setCountry(v as string)}
+          placeholder="Search countries…"
+        />
+      </div>
+      {country ? <Badge tone="info">{country}</Badge> : <Badge tone="neutral">none</Badge>}
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <CountryExample />
@@ -154,9 +178,22 @@ const [status, setStatus] = useState('');
       <Example
         title="Assignee — single, async with custom render"
         description="Pass `loadOptions(query, signal)` to fetch on demand. `renderOption` lets the dropdown show whatever you need — avatar + name + email here."
-        code={`async function fetchUsers(query, signal) {
-  const users = await api.searchUsers(query, { signal });
-  return users.map((u) => ({
+        code={`import { useState } from 'react';
+import { Badge, PersonDisplay, Select, Stack, type SelectOption } from '@eocrm/design-system';
+
+const MOCK_USERS = [
+  { id: 'u1', name: 'Alex Rivera', email: 'alex@example.com' },
+  { id: 'u2', name: 'Bea Chen', email: 'bea@example.com' },
+  { id: 'u3', name: 'Cam Patel', email: 'cam@example.com' },
+  { id: 'u4', name: 'Dani Kowalski', email: 'dani@example.com' },
+  { id: 'u5', name: 'Eli Goldberg', email: 'eli@example.com' },
+];
+
+async function fakeFetchUsers(query: string, signal: AbortSignal): Promise<SelectOption[]> {
+  await new Promise((r) => setTimeout(r, 250));
+  if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+  const q = query.toLowerCase();
+  return MOCK_USERS.filter((u) => u.name.toLowerCase().includes(q)).map((u) => ({
     value: u.id,
     label: u.name,
     description: u.email,
@@ -164,20 +201,30 @@ const [status, setStatus] = useState('');
   }));
 }
 
-<Select
-  searchable
-  loadOptions={fetchUsers}
-  value={assignee}
-  onChange={(v) => setAssignee(v as string)}
-  placeholder="Find a user…"
-  renderOption={(opt) => (
-    <PersonDisplay size="sm">
-      <PersonDisplay.Avatar name={opt.label} />
-      <PersonDisplay.Name>{opt.label}</PersonDisplay.Name>
-      <PersonDisplay.Description>{opt.description}</PersonDisplay.Description>
-    </PersonDisplay>
-  )}
-/>`}
+export function AssigneeExample() {
+  const [assignee, setAssignee] = useState<string>('');
+  return (
+    <Stack gap="sm" align="start">
+      <div style={{ width: 320 }}>
+        <Select
+          searchable
+          loadOptions={fakeFetchUsers}
+          value={assignee}
+          onChange={(v) => setAssignee(v as string)}
+          placeholder="Find a user…"
+          renderOption={(opt) => (
+            <PersonDisplay size="sm">
+              <PersonDisplay.Avatar name={opt.label} />
+              <PersonDisplay.Name>{opt.label}</PersonDisplay.Name>
+              <PersonDisplay.Description>{opt.description}</PersonDisplay.Description>
+            </PersonDisplay>
+          )}
+        />
+      </div>
+      {assignee ? <Badge tone="info">{assignee}</Badge> : <Badge tone="neutral">none</Badge>}
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <AssigneeExample />
@@ -187,8 +234,10 @@ const [status, setStatus] = useState('');
       <Example
         title="Async + error retry"
         description="The flaky fetch fails ~50% of the time. The listbox surfaces the error with a Retry affordance."
-        code={`async function flakyFetch(query, signal) {
-  await delay(200);
+        code={`import { Select, type SelectOption } from '@eocrm/design-system';
+
+async function flakyFetch(_query: string, signal: AbortSignal): Promise<SelectOption[]> {
+  await new Promise((r) => setTimeout(r, 200));
   if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
   if (Math.random() < 0.5) {
     throw new Error('Network glitched. Try again.');
@@ -200,7 +249,11 @@ const [status, setStatus] = useState('');
   ];
 }
 
-<Select searchable loadOptions={flakyFetch} placeholder="Pick a user (may fail)" />`}
+export function Demo() {
+  return (
+    <Select searchable loadOptions={flakyFetch} placeholder="Pick a user (may fail)" />
+  );
+}`}
       >
         <InputExample>
           <Select searchable loadOptions={flakyFetch} placeholder="Pick a user (may fail)" />
@@ -210,23 +263,44 @@ const [status, setStatus] = useState('');
       <Example
         title="Status filter — multi, summary trigger"
         description="`multiple` + `triggerDisplay='summary'` shows '2 selected' in the trigger. Best for compact filter bars."
-        code={`const STATUSES = [
+        code={`import { useState } from 'react';
+import { Badge, Cluster, Select, Stack, type SelectOption } from '@eocrm/design-system';
+
+const STATUSES: SelectOption[] = [
   { value: 'active', label: 'Active' },
   { value: 'pending', label: 'Pending' },
   { value: 'archived', label: 'Archived' },
 ];
 
-const [statusFilter, setStatusFilter] = useState<string[]>([]);
-
-<Select
-  multiple
-  triggerDisplay="summary"
-  searchable
-  options={STATUSES}
-  value={statusFilter}
-  onChange={(v) => setStatusFilter(v as string[])}
-  placeholder="Filter by status"
-/>`}
+export function StatusFilterExample() {
+  const [statusFilter, setStatusFilter] = useState<string[]>([]);
+  return (
+    <Stack gap="sm" align="start">
+      <div style={{ width: 320 }}>
+        <Select
+          multiple
+          triggerDisplay="summary"
+          searchable
+          options={STATUSES}
+          value={statusFilter}
+          onChange={(v) => setStatusFilter(v as string[])}
+          placeholder="Filter by status"
+        />
+      </div>
+      <Cluster gap="xs">
+        {statusFilter.length === 0 ? (
+          <Badge tone="neutral">none</Badge>
+        ) : (
+          statusFilter.map((v) => (
+            <Badge key={v} tone="info">
+              {v}
+            </Badge>
+          ))
+        )}
+      </Cluster>
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <StatusFilterExample />
@@ -236,20 +310,45 @@ const [statusFilter, setStatusFilter] = useState<string[]>([]);
       <Example
         title="Owners — multi, chips trigger"
         description="`triggerDisplay='chips'` (the default for multi) renders each selection as a removable chip in the trigger."
-        code={`async function fetchUsers(query, signal) {
-  const users = await api.searchUsers(query, { signal });
-  return users.map((u) => ({ value: u.id, label: u.name }));
+        code={`import { useState } from 'react';
+import { Select, type SelectOption } from '@eocrm/design-system';
+
+const MOCK_USERS = [
+  { id: 'u1', name: 'Alex Rivera', email: 'alex@example.com' },
+  { id: 'u2', name: 'Bea Chen', email: 'bea@example.com' },
+  { id: 'u3', name: 'Cam Patel', email: 'cam@example.com' },
+  { id: 'u4', name: 'Dani Kowalski', email: 'dani@example.com' },
+  { id: 'u5', name: 'Eli Goldberg', email: 'eli@example.com' },
+];
+
+async function fakeFetchUsers(query: string, signal: AbortSignal): Promise<SelectOption[]> {
+  await new Promise((r) => setTimeout(r, 250));
+  if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+  const q = query.toLowerCase();
+  return MOCK_USERS.filter((u) => u.name.toLowerCase().includes(q)).map((u) => ({
+    value: u.id,
+    label: u.name,
+    description: u.email,
+    data: u,
+  }));
 }
 
-<Select
-  multiple
-  triggerDisplay="chips"
-  searchable
-  loadOptions={fetchUsers}
-  value={owners}
-  onChange={(v) => setOwners(v as string[])}
-  placeholder="Pick owners…"
-/>`}
+export function OwnersExample() {
+  const [owners, setOwners] = useState<string[]>([]);
+  return (
+    <div style={{ width: 320 }}>
+      <Select
+        multiple
+        triggerDisplay="chips"
+        searchable
+        loadOptions={fakeFetchUsers}
+        value={owners}
+        onChange={(v) => setOwners(v as string[])}
+        placeholder="Pick owners…"
+      />
+    </div>
+  );
+}`}
       >
         <InputExample>
           <OwnersExample />
@@ -259,25 +358,39 @@ const [statusFilter, setStatusFilter] = useState<string[]>([]);
       <Example
         title="Tags — multi, chips, searchable, creatable"
         description="`creatable` shows a 'Create &quot;…&quot;' row when the query has no exact match. `onCreate(label)` fires when the user picks it; you decide what to do with the new value."
-        code={`const tagOptions = [
-  { value: 'shipping', label: 'shipping' },
-  { value: 'urgent', label: 'urgent' },
-  { value: 'vip', label: 'vip' },
-];
+        code={`import { useState } from 'react';
+import { Select, Stack } from '@eocrm/design-system';
 
-const [tags, setTags] = useState<string[]>(['shipping']);
-
-<Select
-  multiple
-  searchable
-  creatable
-  triggerDisplay="chips"
-  options={tagOptions}
-  value={tags}
-  onChange={(v) => setTags(v as string[])}
-  onCreate={(label) => addTag(label)}
-  placeholder="Add tags…"
-/>`}
+export function TagsExample() {
+  const [tags, setTags] = useState<string[]>(['shipping']);
+  const [createdLog, setCreatedLog] = useState<string[]>([]);
+  return (
+    <Stack gap="sm" align="start">
+      <div style={{ width: 320 }}>
+        <Select
+          multiple
+          searchable
+          creatable
+          triggerDisplay="chips"
+          options={[
+            { value: 'shipping', label: 'shipping' },
+            { value: 'urgent', label: 'urgent' },
+            { value: 'vip', label: 'vip' },
+          ]}
+          value={tags}
+          onChange={(v) => setTags(v as string[])}
+          onCreate={(label) => setCreatedLog((log) => [...log, label])}
+          placeholder="Add tags…"
+        />
+      </div>
+      {createdLog.length > 0 && (
+        <small>
+          Created: <code>{createdLog.join(', ')}</code>
+        </small>
+      )}
+    </Stack>
+  );
+}`}
       >
         <InputExample>
           <TagsExample />
@@ -287,15 +400,29 @@ const [tags, setTags] = useState<string[]>(['shipping']);
       <Example
         title="Visual states — disabled, readOnly, invalid"
         description="`disabled` blocks all interaction. `readOnly` shows the value but blocks editing. `invalid` paints the trigger with the error ring."
-        code={`const STATUSES = [
+        code={`import { Cluster, Select, type SelectOption } from '@eocrm/design-system';
+
+const STATUSES: SelectOption[] = [
   { value: 'active', label: 'Active' },
   { value: 'pending', label: 'Pending' },
   { value: 'archived', label: 'Archived' },
 ];
 
-<Select options={STATUSES} disabled value="pending" />
-<Select options={STATUSES} readOnly value="active" />
-<Select options={STATUSES} invalid placeholder="Required" />`}
+export function Demo() {
+  return (
+    <Cluster gap="md" wrap justify="center">
+      <div style={{ width: 320 }}>
+        <Select options={STATUSES} disabled value="pending" />
+      </div>
+      <div style={{ width: 320 }}>
+        <Select options={STATUSES} readOnly value="active" />
+      </div>
+      <div style={{ width: 320 }}>
+        <Select options={STATUSES} invalid placeholder="Required" />
+      </div>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" wrap justify="center">
           <div style={{ width: 320 }}>
@@ -313,15 +440,29 @@ const [tags, setTags] = useState<string[]>(['shipping']);
       <Example
         title="Sizes — sm / md / lg"
         description="`size` controls the trigger height and font size. The listbox typography scales to match."
-        code={`const STATUSES = [
+        code={`import { Cluster, Select, type SelectOption } from '@eocrm/design-system';
+
+const STATUSES: SelectOption[] = [
   { value: 'active', label: 'Active' },
   { value: 'pending', label: 'Pending' },
   { value: 'archived', label: 'Archived' },
 ];
 
-<Select options={STATUSES} size="sm" placeholder="sm" />
-<Select options={STATUSES} size="md" placeholder="md" />
-<Select options={STATUSES} size="lg" placeholder="lg" />`}
+export function Demo() {
+  return (
+    <Cluster gap="md" wrap justify="center">
+      <div style={{ width: 320 }}>
+        <Select options={STATUSES} size="sm" placeholder="sm" />
+      </div>
+      <div style={{ width: 320 }}>
+        <Select options={STATUSES} size="md" placeholder="md" />
+      </div>
+      <div style={{ width: 320 }}>
+        <Select options={STATUSES} size="lg" placeholder="lg" />
+      </div>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" wrap justify="center">
           <div style={{ width: 320 }}>
@@ -339,27 +480,52 @@ const [tags, setTags] = useState<string[]>(['shipping']);
       <Example
         title="Form integration"
         description="`name` makes Select participate in native FormData. Single values become one entry; multi values become repeated entries. `required` blocks submit when empty."
-        code={`const STATUSES = [
+        code={`import { Button, Cluster, Select, Stack, type SelectOption } from '@eocrm/design-system';
+
+const STATUSES: SelectOption[] = [
   { value: 'active', label: 'Active' },
   { value: 'pending', label: 'Pending' },
   { value: 'archived', label: 'Archived' },
 ];
 
-const tagOptions = [
-  { value: 'a', label: 'a' },
-  { value: 'b', label: 'b' },
-];
-
-<form onSubmit={(e) => {
-  e.preventDefault();
-  const data = new FormData(e.currentTarget);
-  console.log(data.get('status'), data.getAll('tags'));
-}}>
-  <Select options={STATUSES} name="status" required placeholder="Status (required)" />
-  <Select multiple triggerDisplay="chips" searchable creatable
-    options={tagOptions} name="tags" placeholder="Tags" />
-  <Button type="submit" size="sm">Submit</Button>
-</form>`}
+export function FormExample() {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const data = new FormData(e.currentTarget);
+        alert(
+          \`status = \${data.get('status') ?? '(empty)'}\ntags = \${JSON.stringify(data.getAll('tags'))}\`,
+        );
+      }}
+    >
+      <Stack gap="md">
+        <div style={{ width: 320 }}>
+          <Select options={STATUSES} name="status" required placeholder="Status (required)" />
+        </div>
+        <div style={{ width: 320 }}>
+          <Select
+            multiple
+            triggerDisplay="chips"
+            searchable
+            creatable
+            options={[
+              { value: 'a', label: 'a' },
+              { value: 'b', label: 'b' },
+            ]}
+            name="tags"
+            placeholder="Tags"
+          />
+        </div>
+        <Cluster>
+          <Button type="submit" size="sm">
+            Submit
+          </Button>
+        </Cluster>
+      </Stack>
+    </form>
+  );
+}`}
       >
         <FormExample />
       </Example>

--- a/packages/playground/src/pages/components/SkeletonDemo.tsx
+++ b/packages/playground/src/pages/components/SkeletonDemo.tsx
@@ -14,9 +14,15 @@ export function SkeletonDemo() {
       <Example
         title="Text — inline placeholder"
         description="Default variant sits on the text baseline. Use directly inside a paragraph or label while the real value loads."
-        code={`<p style={{ margin: 0 }}>
-  Loading user name: <Skeleton width={120} />
-</p>`}
+        code={`import { Skeleton } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <p style={{ margin: 0 }}>
+      Loading user name: <Skeleton width={120} />
+    </p>
+  );
+}`}
       >
         <p style={{ margin: 0 }}>
           Loading user name: <Skeleton width={120} />
@@ -26,11 +32,17 @@ export function SkeletonDemo() {
       <Example
         title="Multi-line text"
         description="Stack several text skeletons at varied widths to mimic a paragraph or list-item copy block."
-        code={`<Stack gap="xs" style={{ width: 240 }}>
-  <Skeleton width="80%" />
-  <Skeleton width="60%" />
-  <Skeleton width="40%" />
-</Stack>`}
+        code={`import { Skeleton, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs" style={{ width: 240 }}>
+      <Skeleton width="80%" />
+      <Skeleton width="60%" />
+      <Skeleton width="40%" />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="xs" style={{ width: 240 }}>
           <Skeleton width="80%" />
@@ -42,10 +54,16 @@ export function SkeletonDemo() {
       <Example
         title="Circular — avatar placeholders"
         description='`variant="circular"` forces border-radius 50%. When only `width` is set the height matches automatically — no need to supply both.'
-        code={`<Cluster gap="md" align="center">
-  <Skeleton variant="circular" width={32} />
-  <Skeleton variant="circular" width={40} />
-</Cluster>`}
+        code={`import { Cluster, Skeleton } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="center">
+      <Skeleton variant="circular" width={32} />
+      <Skeleton variant="circular" width={40} />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="center">
           <Skeleton variant="circular" width={32} />
@@ -56,11 +74,17 @@ export function SkeletonDemo() {
       <Example
         title="Rectangular — image / button / card"
         description='`variant="rectangular"` gives a small border-radius. Always supply explicit dimensions — with no width/height the box has zero size and renders invisibly.'
-        code={`<Stack gap="sm">
-  <Skeleton variant="rectangular" width={200} height={120} />
-  <Skeleton variant="rectangular" width={80} height={32} />
-  <Skeleton variant="rectangular" width="100%" height={60} />
-</Stack>`}
+        code={`import { Skeleton, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Skeleton variant="rectangular" width={200} height={120} />
+      <Skeleton variant="rectangular" width={80} height={32} />
+      <Skeleton variant="rectangular" width="100%" height={60} />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Skeleton variant="rectangular" width={200} height={120} />
@@ -72,16 +96,22 @@ export function SkeletonDemo() {
       <Example
         title="List-row composition"
         description="Compose circular + text + rectangular skeletons inside your normal layout primitives to match the shape of the real content."
-        code={`<Card padding="md">
-  <Cluster gap="md" align="center">
-    <Skeleton variant="circular" width={32} />
-    <Stack gap="xs" style={{ flex: 1 }}>
-      <Skeleton width="60%" />
-      <Skeleton width="40%" />
-    </Stack>
-    <Skeleton variant="rectangular" width={80} height={32} />
-  </Cluster>
-</Card>`}
+        code={`import { Card, Cluster, Skeleton, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Card padding="md">
+      <Cluster gap="md" align="center">
+        <Skeleton variant="circular" width={32} />
+        <Stack gap="xs" style={{ flex: 1 }}>
+          <Skeleton width="60%" />
+          <Skeleton width="40%" />
+        </Stack>
+        <Skeleton variant="rectangular" width={80} height={32} />
+      </Cluster>
+    </Card>
+  );
+}`}
       >
         <Card padding="md">
           <Cluster gap="md" align="center">
@@ -98,11 +128,17 @@ export function SkeletonDemo() {
       <Example
         title='No animation — animation="none"'
         description='Pass `animation="none"` when rendering many skeletons at once. Simultaneous pulsing on 10+ elements is visually noisy; a static state reads more cleanly.'
-        code={`<Stack gap="xs" style={{ width: 240 }}>
-  {Array.from({ length: 5 }).map((_, i) => (
-    <Skeleton key={i} variant="rectangular" height={32} animation="none" />
-  ))}
-</Stack>`}
+        code={`import { Skeleton, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs" style={{ width: 240 }}>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <Skeleton key={i} variant="rectangular" height={32} animation="none" />
+      ))}
+    </Stack>
+  );
+}`}
       >
         <Stack gap="xs" style={{ width: 240 }}>
           {Array.from({ length: 5 }).map((_, i) => (
@@ -114,24 +150,36 @@ export function SkeletonDemo() {
       <Example
         title="Inside a Table — DataTable preview"
         description="Drop skeletons directly into Table cells to render a realistic table loading state before data arrives."
-        code={`<Table>
-  <Table.Header>
-    <Table.Row>
-      <Table.HeaderCell>Name</Table.HeaderCell>
-      <Table.HeaderCell>Status</Table.HeaderCell>
-      <Table.HeaderCell align="end">Amount</Table.HeaderCell>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    {Array.from({ length: 5 }).map((_, i) => (
-      <Table.Row key={i}>
-        <Table.Cell><Skeleton width="80%" /></Table.Cell>
-        <Table.Cell><Skeleton width={60} /></Table.Cell>
-        <Table.Cell align="end"><Skeleton width={50} /></Table.Cell>
-      </Table.Row>
-    ))}
-  </Table.Body>
-</Table>`}
+        code={`import { Skeleton, Table } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Name</Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Table.Row key={i}>
+            <Table.Cell>
+              <Skeleton width="80%" />
+            </Table.Cell>
+            <Table.Cell>
+              <Skeleton width={60} />
+            </Table.Cell>
+            <Table.Cell align="end">
+              <Skeleton width={50} />
+            </Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}`}
       >
         <Table>
           <Table.Header>

--- a/packages/playground/src/pages/components/SliderDemo.tsx
+++ b/packages/playground/src/pages/components/SliderDemo.tsx
@@ -148,10 +148,18 @@ export function SliderDemo() {
       <Example
         title="Basic single-thumb"
         description="Default props (min=0, max=100, step=1). Controlled state with one number."
-        code={`function BasicSingle() {
+        code={`import { useState } from 'react';
+import { Code, Slider, Stack, Text } from '@eocrm/design-system';
+
+export function BasicSingle() {
   const [value, setValue] = useState(50);
   return (
-    <Slider value={value} onChange={(v) => setValue(v as number)} aria-label="Volume" />
+    <Stack gap="sm">
+      <Slider value={value} onChange={(v) => setValue(v as number)} aria-label="Volume" />
+      <Text size="sm" tone="muted">
+        Current value: <Code>{value}</Code>
+      </Text>
+    </Stack>
   );
 }`}
       >
@@ -161,12 +169,28 @@ export function SliderDemo() {
       <Example
         title="Range mode (two thumbs)"
         description="Pass a [min, max] tuple as value → two thumbs. Range-clamp ensures value[0] ≤ value[1]. Formatted label."
-        code={`<Slider
-  value={[20000, 80000]}
-  min={0} max={100000} step={1000}
-  label={(v) => \`$\${v.toLocaleString()}\`}
-  onChange={(v) => setRange(v as [number, number])}
-/>`}
+        code={`import { useState } from 'react';
+import { Code, Slider, Stack, Text } from '@eocrm/design-system';
+
+export function RangeFilter() {
+  const [range, setRange] = useState<[number, number]>([20000, 80000]);
+  return (
+    <Stack gap="sm">
+      <Slider
+        value={range}
+        min={0}
+        max={100000}
+        step={1000}
+        label={(v) => \`$\${v.toLocaleString()}\`}
+        onChange={(v) => setRange(v as [number, number])}
+        aria-label="Price range"
+      />
+      <Text size="sm" tone="muted">
+        Range: <Code>\${range[0].toLocaleString()}</Code> – <Code>\${range[1].toLocaleString()}</Code>
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <RangeFilter />
       </Example>
@@ -174,9 +198,19 @@ export function SliderDemo() {
       <Example
         title="Sizes"
         description="Three sizes: sm (4/14), md (6/18, default), lg (8/22). All bound to the same controlled value."
-        code={`<Slider size="sm" value={value} onChange={…} />
-<Slider size="md" value={value} onChange={…} />
-<Slider size="lg" value={value} onChange={…} />`}
+        code={`import { useState } from 'react';
+import { Slider, Stack } from '@eocrm/design-system';
+
+export function Sizes() {
+  const [value, setValue] = useState(50);
+  return (
+    <Stack gap="md">
+      <Slider value={value} size="sm" onChange={(v) => setValue(v as number)} aria-label="sm" />
+      <Slider value={value} size="md" onChange={(v) => setValue(v as number)} aria-label="md" />
+      <Slider value={value} size="lg" onChange={(v) => setValue(v as number)} aria-label="lg" />
+    </Stack>
+  );
+}`}
       >
         <Sizes />
       </Example>
@@ -184,10 +218,40 @@ export function SliderDemo() {
       <Example
         title="Tones"
         description="Four tones for the fill color. Use warning/danger for threshold-style sliders (e.g. disk usage at 90% → danger fill)."
-        code={`<Slider tone="default" value={value} onChange={…} />
-<Slider tone="success" value={value} onChange={…} />
-<Slider tone="warning" value={value} onChange={…} />
-<Slider tone="danger" value={value} onChange={…} />`}
+        code={`import { useState } from 'react';
+import { Slider, Stack } from '@eocrm/design-system';
+
+export function Tones() {
+  const [value, setValue] = useState(75);
+  return (
+    <Stack gap="md">
+      <Slider
+        value={value}
+        tone="default"
+        onChange={(v) => setValue(v as number)}
+        aria-label="default"
+      />
+      <Slider
+        value={value}
+        tone="success"
+        onChange={(v) => setValue(v as number)}
+        aria-label="success"
+      />
+      <Slider
+        value={value}
+        tone="warning"
+        onChange={(v) => setValue(v as number)}
+        aria-label="warning"
+      />
+      <Slider
+        value={value}
+        tone="danger"
+        onChange={(v) => setValue(v as number)}
+        aria-label="danger"
+      />
+    </Stack>
+  );
+}`}
       >
         <Tones />
       </Example>
@@ -195,7 +259,20 @@ export function SliderDemo() {
       <Example
         title="Tick marks"
         description="`marks={[0, 25, 50, 75, 100]}` renders 5 ticks. Marks within the current fill range get a filled tone."
-        code={`<Slider value={value} marks={[0, 25, 50, 75, 100]} onChange={…} />`}
+        code={`import { useState } from 'react';
+import { Slider } from '@eocrm/design-system';
+
+export function Marks() {
+  const [value, setValue] = useState(50);
+  return (
+    <Slider
+      value={value}
+      marks={[0, 25, 50, 75, 100]}
+      onChange={(v) => setValue(v as number)}
+      aria-label="With marks"
+    />
+  );
+}`}
       >
         <Marks />
       </Example>
@@ -203,12 +280,26 @@ export function SliderDemo() {
       <Example
         title="Vertical orientation"
         description="Single-thumb vertical slider, 200px tall by default. Marks render to the right; label bubble appears on the right of the thumb."
-        code={`<Slider
-  value={value}
-  orientation="vertical"
-  marks={[0, 25, 50, 75, 100]}
-  onChange={(v) => setValue(v as number)}
-/>`}
+        code={`import { useState } from 'react';
+import { Cluster, Code, Slider, Text } from '@eocrm/design-system';
+
+export function Vertical() {
+  const [value, setValue] = useState(60);
+  return (
+    <Cluster gap="lg" align="center">
+      <Slider
+        value={value}
+        orientation="vertical"
+        marks={[0, 25, 50, 75, 100]}
+        onChange={(v) => setValue(v as number)}
+        aria-label="Vertical volume"
+      />
+      <Text size="sm" tone="muted">
+        Current: <Code>{value}</Code>
+      </Text>
+    </Cluster>
+  );
+}`}
       >
         <Vertical />
       </Example>
@@ -216,12 +307,28 @@ export function SliderDemo() {
       <Example
         title="Fractional step (zoom-style)"
         description="min=1, max=3, step=0.1 — the canonical ImageCrop zoom control. label=true shows the current value as a bubble."
-        code={`<Slider
-  value={zoom}
-  min={1} max={3} step={0.1}
-  label
-  onChange={(v) => setZoom(v as number)}
-/>`}
+        code={`import { useState } from 'react';
+import { Code, Slider, Stack, Text } from '@eocrm/design-system';
+
+export function FractionalStep() {
+  const [zoom, setZoom] = useState(1.5);
+  return (
+    <Stack gap="sm">
+      <Slider
+        value={zoom}
+        min={1}
+        max={3}
+        step={0.1}
+        label
+        onChange={(v) => setZoom(v as number)}
+        aria-label="Zoom"
+      />
+      <Text size="sm" tone="muted">
+        Zoom: <Code>{zoom.toFixed(1)}×</Code>
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <FractionalStep />
       </Example>
@@ -229,7 +336,11 @@ export function SliderDemo() {
       <Example
         title="Disabled"
         description="Track and thumb both grayed (via --opacity-disabled). Pointer/keyboard no-op; tabIndex=-1; aria-disabled=true."
-        code={`<Slider value={50} disabled onChange={() => {}} aria-label="Disabled" />`}
+        code={`import { Slider } from '@eocrm/design-system';
+
+export function DisabledDemo() {
+  return <Slider value={50} disabled onChange={() => {}} aria-label="Disabled" />;
+}`}
       >
         <DisabledDemo />
       </Example>

--- a/packages/playground/src/pages/components/SocialButtonDemo.tsx
+++ b/packages/playground/src/pages/components/SocialButtonDemo.tsx
@@ -14,10 +14,16 @@ export function SocialButtonDemo() {
       <Example
         title="Providers"
         description="provider picks the brand mark; label is the (consumer-supplied) text. Width comes from the parent."
-        code={`<Stack gap="sm">
-  <SocialButton provider="google" label="Continue with Google" />
-  <SocialButton provider="yandex" label="Continue with Yandex" />
-</Stack>`}
+        code={`import { SocialButton, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <SocialButton provider="google" label="Continue with Google" />
+      <SocialButton provider="yandex" label="Continue with Yandex" />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <SocialButton provider="google" label="Continue with Google" />
@@ -28,7 +34,11 @@ export function SocialButtonDemo() {
       <Example
         title="Disabled"
         description="Spreads Button props (disabled, onClick, size, …)."
-        code={`<SocialButton provider="google" label="Continue with Google" disabled />`}
+        code={`import { SocialButton } from '@eocrm/design-system';
+
+export function Demo() {
+  return <SocialButton provider="google" label="Continue with Google" disabled />;
+}`}
       >
         <SocialButton provider="google" label="Continue with Google" disabled />
       </Example>

--- a/packages/playground/src/pages/components/SortableDemo.tsx
+++ b/packages/playground/src/pages/components/SortableDemo.tsx
@@ -72,15 +72,29 @@ export function SortableDemo() {
       <Example
         title="Plain text list (no Handle)"
         description="Whole-item drag works without a Handle when the Item contains no interactive content. The 5px activation distance means short clicks still pass through to child elements."
-        code={`<Sortable
-  onReorder={({ from, to }) => setTodos((curr) => arrayMove(curr, from, to))}
->
-  {todos.map((t) => (
-    <Sortable.Item key={t.id} id={t.id}>
-      <Card padding="sm">{t.label}</Card>
-    </Sortable.Item>
-  ))}
-</Sortable>`}
+        code={`import { useState } from 'react';
+import { arrayMove } from '@dnd-kit/sortable';
+import { Card, Sortable } from '@eocrm/design-system';
+
+export function Demo() {
+  const [todos, setTodos] = useState([
+    { id: 1, label: 'Buy milk' },
+    { id: 2, label: 'Walk the dog' },
+    { id: 3, label: 'Call dentist' },
+    { id: 4, label: 'Finish design review' },
+    { id: 5, label: 'Pick up dry cleaning' },
+  ]);
+
+  return (
+    <Sortable onReorder={({ from, to }) => setTodos((curr) => arrayMove(curr, from, to))}>
+      {todos.map((t) => (
+        <Sortable.Item key={t.id} id={t.id}>
+          <Card padding="sm">{t.label}</Card>
+        </Sortable.Item>
+      ))}
+    </Sortable>
+  );
+}`}
       >
         <Sortable onReorder={({ from, to }) => setTodos((curr) => arrayMove(curr, from, to))}>
           {todos.map((t) => (
@@ -94,36 +108,62 @@ export function SortableDemo() {
       <Example
         title="Cards with Handle + DropdownMenu"
         description="When an Item contains interactive elements, use Sortable.Handle to restrict drag origin. The internal menu stays clickable."
-        code={`<Sortable
-  onReorder={({ from, to }) => setTasks((curr) => arrayMove(curr, from, to))}
->
-  {tasks.map((task) => (
-    <Sortable.Item key={task.id} id={task.id}>
-      <Card padding="sm">
-        <Cluster justify="between" align="center">
-          <Cluster gap="sm" align="center">
-            <Sortable.Handle aria-label={\`Reorder \${task.title}\`}>
-              <GripVertical size={14} />
-            </Sortable.Handle>
-            <Text weight="medium">{task.title}</Text>
-            <Badge tone={task.tone}>{task.owner}</Badge>
-          </Cluster>
-          <DropdownMenu>
-            <DropdownMenu.Trigger>
-              <Button variant="ghost" size="sm" iconOnly aria-label="More">
-                <MoreHorizontal size={14} />
-              </Button>
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content align="end">
-              <DropdownMenu.Item onSelect={() => {}}>View</DropdownMenu.Item>
-              <DropdownMenu.Item onSelect={() => {}}>Archive</DropdownMenu.Item>
-            </DropdownMenu.Content>
-          </DropdownMenu>
-        </Cluster>
-      </Card>
-    </Sortable.Item>
-  ))}
-</Sortable>`}
+        code={`import { useState } from 'react';
+import { GripVertical, MoreHorizontal } from 'lucide-react';
+import { arrayMove } from '@dnd-kit/sortable';
+import {
+  Badge,
+  Button,
+  Card,
+  Cluster,
+  DropdownMenu,
+  Sortable,
+  Text,
+} from '@eocrm/design-system';
+
+export function Demo() {
+  const [tasks, setTasks] = useState([
+    { id: 'task-1', title: 'Q3 renewal proposal', tone: 'info' as const, owner: 'Priya' },
+    { id: 'task-2', title: 'Onboarding kickoff', tone: 'success' as const, owner: 'Alex' },
+    {
+      id: 'task-3',
+      title: 'Customer interview notes',
+      tone: 'warning' as const,
+      owner: 'Maya',
+    },
+  ]);
+
+  return (
+    <Sortable onReorder={({ from, to }) => setTasks((curr) => arrayMove(curr, from, to))}>
+      {tasks.map((task) => (
+        <Sortable.Item key={task.id} id={task.id}>
+          <Card padding="sm">
+            <Cluster justify="between" align="center">
+              <Cluster gap="sm" align="center">
+                <Sortable.Handle aria-label={\`Reorder \${task.title}\`}>
+                  <GripVertical size={14} />
+                </Sortable.Handle>
+                <Text weight="medium">{task.title}</Text>
+                <Badge tone={task.tone}>{task.owner}</Badge>
+              </Cluster>
+              <DropdownMenu>
+                <DropdownMenu.Trigger>
+                  <Button variant="ghost" size="sm" iconOnly aria-label="More">
+                    <MoreHorizontal size={14} />
+                  </Button>
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Content align="end">
+                  <DropdownMenu.Item onSelect={() => {}}>View</DropdownMenu.Item>
+                  <DropdownMenu.Item onSelect={() => {}}>Archive</DropdownMenu.Item>
+                </DropdownMenu.Content>
+              </DropdownMenu>
+            </Cluster>
+          </Card>
+        </Sortable.Item>
+      ))}
+    </Sortable>
+  );
+}`}
       >
         <Sortable onReorder={({ from, to }) => setTasks((curr) => arrayMove(curr, from, to))}>
           {tasks.map((task) => (
@@ -158,20 +198,41 @@ export function SortableDemo() {
       <Example
         title="Image gallery"
         description="Drag-to-reorder visual tiles. Each tile is a Card with a colored thumbnail; the whole tile is draggable."
-        code={`<Sortable
-  onReorder={({ from, to }) => setImages((curr) => arrayMove(curr, from, to))}
->
-  {images.map((img) => (
-    <Sortable.Item key={img.id} id={img.id}>
-      <Card padding="sm">
-        <Cluster gap="sm" align="center">
-          <span style={{ width: 40, height: 40, background: img.color, borderRadius: 'var(--radius-sm)' }} />
-          <Text>{img.label}</Text>
-        </Cluster>
-      </Card>
-    </Sortable.Item>
-  ))}
-</Sortable>`}
+        code={`import { useState } from 'react';
+import { arrayMove } from '@dnd-kit/sortable';
+import { Card, Cluster, Sortable, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  const [images, setImages] = useState([
+    { id: 'img-1', label: 'Hero', color: '#3b82f6' },
+    { id: 'img-2', label: 'Logo dark', color: '#6366f1' },
+    { id: 'img-3', label: 'Pattern A', color: '#10b981' },
+    { id: 'img-4', label: 'Pattern B', color: '#f59e0b' },
+  ]);
+
+  return (
+    <Sortable onReorder={({ from, to }) => setImages((curr) => arrayMove(curr, from, to))}>
+      {images.map((img) => (
+        <Sortable.Item key={img.id} id={img.id}>
+          <Card padding="sm">
+            <Cluster gap="sm" align="center">
+              <span
+                style={{
+                  display: 'inline-block',
+                  width: 40,
+                  height: 40,
+                  background: img.color,
+                  borderRadius: 'var(--radius-sm)',
+                }}
+              />
+              <Text>{img.label}</Text>
+            </Cluster>
+          </Card>
+        </Sortable.Item>
+      ))}
+    </Sortable>
+  );
+}`}
       >
         <Sortable onReorder={({ from, to }) => setImages((curr) => arrayMove(curr, from, to))}>
           {images.map((img) => (
@@ -198,12 +259,17 @@ export function SortableDemo() {
       <Example
         title="Keyboard-only walkthrough"
         description="Tab to a Handle (or any Item without a Handle), press Space to pick up, ArrowUp/ArrowDown to move, Space to drop. Escape cancels. dnd-kit announces each step via aria-live."
-        code={`// Same JSX as "Cards with Handle" above.
-// User flow:
-//   1. Tab to a GripVertical handle.
-//   2. Space — item is picked up; aria-live announces it.
-//   3. ArrowDown — item moves; announcement updates.
-//   4. Space again — item is dropped, focus stays on the handle.`}
+        code={`import { Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Text size="sm" tone="muted">
+        Try Tab + Space + ArrowUp / ArrowDown on the cards above.
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Text size="sm" tone="muted">
@@ -215,17 +281,35 @@ export function SortableDemo() {
       <Example
         title="Long list with autoscroll"
         description="When the cursor enters the edge of the scrolling container during a drag, dnd-kit auto-scrolls. Try dragging from near the top toward the bottom."
-        code={`<div style={{ maxHeight: 280, overflowY: 'auto', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-md)' }}>
-  <Sortable
-    onReorder={({ from, to }) => setQueue((curr) => arrayMove(curr, from, to))}
-  >
-    {queue.map((q) => (
-      <Sortable.Item key={q.id} id={q.id}>
-        <Card padding="sm">{q.label}</Card>
-      </Sortable.Item>
-    ))}
-  </Sortable>
-</div>`}
+        code={`import { useState } from 'react';
+import { arrayMove } from '@dnd-kit/sortable';
+import { Card, Sortable } from '@eocrm/design-system';
+
+export function Demo() {
+  const [queue, setQueue] = useState(
+    Array.from({ length: 20 }, (_, i) => ({ id: i + 1, label: \`Ticket #\${1000 + i}\` })),
+  );
+
+  return (
+    <div
+      style={{
+        maxHeight: 280,
+        overflowY: 'auto',
+        border: '1px solid var(--color-border)',
+        borderRadius: 'var(--radius-md)',
+        padding: 'var(--space-2)',
+      }}
+    >
+      <Sortable onReorder={({ from, to }) => setQueue((curr) => arrayMove(curr, from, to))}>
+        {queue.map((q) => (
+          <Sortable.Item key={q.id} id={q.id}>
+            <Card padding="sm">{q.label}</Card>
+          </Sortable.Item>
+        ))}
+      </Sortable>
+    </div>
+  );
+}`}
       >
         <div
           style={{
@@ -249,18 +333,33 @@ export function SortableDemo() {
       <Example
         title="Async / optimistic reorder"
         description="onReorder applies the new order a tick late — as it would with an optimistic TanStack mutation's onMutate. Before this fix the dropped row kept dnd-kit's stale drag transform and animated in from ~100px off (a 'fly up then settle' glitch). The dragged item now renders in a DragOverlay that owns the drop animation, so the late state update lands smoothly. Drag a stage to feel it."
-        code={`// Order arrives a tick late, like an optimistic mutation's onMutate.
-<Sortable
-  onReorder={({ from, to }) =>
-    setTimeout(() => setStages((curr) => arrayMove(curr, from, to)), 0)
-  }
->
-  {stages.map((s) => (
-    <Sortable.Item key={s.id} id={s.id}>
-      <Card padding="sm">{s.label}</Card>
-    </Sortable.Item>
-  ))}
-</Sortable>`}
+        code={`import { useState } from 'react';
+import { arrayMove } from '@dnd-kit/sortable';
+import { Card, Sortable } from '@eocrm/design-system';
+
+export function Demo() {
+  const [stages, setStages] = useState([
+    { id: 'stage-1', label: 'Lead captured' },
+    { id: 'stage-2', label: 'Qualified' },
+    { id: 'stage-3', label: 'Proposal sent' },
+    { id: 'stage-4', label: 'Negotiation' },
+    { id: 'stage-5', label: 'Closed won' },
+  ]);
+
+  return (
+    <Sortable
+      onReorder={({ from, to }) =>
+        setTimeout(() => setStages((curr) => arrayMove(curr, from, to)), 0)
+      }
+    >
+      {stages.map((s) => (
+        <Sortable.Item key={s.id} id={s.id}>
+          <Card padding="sm">{s.label}</Card>
+        </Sortable.Item>
+      ))}
+    </Sortable>
+  );
+}`}
       >
         <Sortable
           onReorder={({ from, to }) =>
@@ -278,28 +377,57 @@ export function SortableDemo() {
       <Example
         title="Restrict drag to container (default)"
         description="By default (restrictToContainer) the dragged item is clamped to the list's bounding box — it can't be dragged off over unrelated UI. Pass restrictToContainer={false} for free-drag, where the item follows the cursor anywhere on the page. Drag a row in each list and notice how the left one stays inside its bounds while the right one doesn't."
-        code={`{/* Default: dragged item clamped to the list's bounds. */}
-<Sortable
-  onReorder={({ from, to }) => setContained((curr) => arrayMove(curr, from, to))}
->
-  {contained.map((s) => (
-    <Sortable.Item key={s.id} id={s.id}>
-      <Card padding="sm">{s.label}</Card>
-    </Sortable.Item>
-  ))}
-</Sortable>
+        code={`import { useState } from 'react';
+import { arrayMove } from '@dnd-kit/sortable';
+import { Card, Cluster, Sortable, Stack, Text } from '@eocrm/design-system';
 
-{/* Free drag: item can be dragged anywhere on the page. */}
-<Sortable
-  restrictToContainer={false}
-  onReorder={({ from, to }) => setFreeDrag((curr) => arrayMove(curr, from, to))}
->
-  {freeDrag.map((s) => (
-    <Sortable.Item key={s.id} id={s.id}>
-      <Card padding="sm">{s.label}</Card>
-    </Sortable.Item>
-  ))}
-</Sortable>`}
+export function Demo() {
+  const [contained, setContained] = useState([
+    { id: 'c-1', label: 'Discovery call' },
+    { id: 'c-2', label: 'Demo scheduled' },
+    { id: 'c-3', label: 'Contract draft' },
+  ]);
+
+  const [freeDrag, setFreeDrag] = useState([
+    { id: 'f-1', label: 'Discovery call' },
+    { id: 'f-2', label: 'Demo scheduled' },
+    { id: 'f-3', label: 'Contract draft' },
+  ]);
+
+  return (
+    <Cluster gap="lg" align="start">
+      <Stack gap="xs">
+        <Text size="sm" weight="medium">
+          Contained (default)
+        </Text>
+        <Sortable
+          onReorder={({ from, to }) => setContained((curr) => arrayMove(curr, from, to))}
+        >
+          {contained.map((s) => (
+            <Sortable.Item key={s.id} id={s.id}>
+              <Card padding="sm">{s.label}</Card>
+            </Sortable.Item>
+          ))}
+        </Sortable>
+      </Stack>
+      <Stack gap="xs">
+        <Text size="sm" weight="medium">
+          Free drag (restrictToContainer=false)
+        </Text>
+        <Sortable
+          restrictToContainer={false}
+          onReorder={({ from, to }) => setFreeDrag((curr) => arrayMove(curr, from, to))}
+        >
+          {freeDrag.map((s) => (
+            <Sortable.Item key={s.id} id={s.id}>
+              <Card padding="sm">{s.label}</Card>
+            </Sortable.Item>
+          ))}
+        </Sortable>
+      </Stack>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="lg" align="start">
           <Stack gap="xs">

--- a/packages/playground/src/pages/components/SortableGroupDemo.tsx
+++ b/packages/playground/src/pages/components/SortableGroupDemo.tsx
@@ -48,19 +48,83 @@ export function SortableGroupDemo() {
       <Example
         title="Drag fields between groups"
         description="Grab a field's handle and drag it within its group to reorder, or across into another group. onMove fires during the drag (cross-container) and on drop; moveSortableItem applies it to the per-group state."
-        code={`const [groups, setGroups] = useState(initial);
-<SortableGroup onMove={(e) => setGroups((g) => moveSortableItem(g, e))}>
-  {Object.entries(groups).map(([gid, fields]) => (
-    <SortableGroup.Container key={gid} id={gid} items={fields.map((f) => f.id)}>
-      {fields.map((f) => (
-        <Sortable.Item key={f.id} id={f.id}>
-          <Sortable.Handle><GripVertical size={14} /></Sortable.Handle>
-          {f.label}
-        </Sortable.Item>
-      ))}
-    </SortableGroup.Container>
-  ))}
-</SortableGroup>`}
+        code={`import { useState } from 'react';
+import { GripVertical } from 'lucide-react';
+import {
+  SortableGroup,
+  Sortable,
+  moveSortableItem,
+  Stack,
+  Cluster,
+  Card,
+  Text,
+  Code,
+} from '@eocrm/design-system';
+
+interface Field {
+  id: string;
+  label: string;
+}
+
+const initial: Record<string, Field[]> = {
+  contact: [
+    { id: 'first', label: 'First name' },
+    { id: 'last', label: 'Last name' },
+    { id: 'email', label: 'Email' },
+  ],
+  company: [
+    { id: 'name', label: 'Company name' },
+    { id: 'size', label: 'Headcount' },
+  ],
+  custom: [{ id: 'nps', label: 'NPS score' }],
+};
+
+const groupLabels: Record<string, string> = {
+  contact: 'Contact',
+  company: 'Company',
+  custom: 'Custom',
+};
+
+export function Demo() {
+  const [groups, setGroups] = useState<Record<string, Field[]>>(initial);
+  return (
+    <Stack gap="md">
+      <SortableGroup onMove={(e) => setGroups((g) => moveSortableItem(g, e))}>
+        <Cluster gap="md" align="start">
+          {Object.entries(groups).map(([gid, fields]) => (
+            <Card key={gid} style={{ minWidth: 200, flex: 1 }}>
+              <Stack gap="sm">
+                <Text size="sm" weight="semibold">
+                  {groupLabels[gid]}
+                </Text>
+                <SortableGroup.Container id={gid} items={fields.map((f) => f.id)}>
+                  {fields.map((f) => (
+                    <Sortable.Item key={f.id} id={f.id}>
+                      <Cluster gap="sm" align="center">
+                        <Sortable.Handle>
+                          <GripVertical size={14} />
+                        </Sortable.Handle>
+                        <Text size="sm">{f.label}</Text>
+                      </Cluster>
+                    </Sortable.Item>
+                  ))}
+                </SortableGroup.Container>
+              </Stack>
+            </Card>
+          ))}
+        </Cluster>
+      </SortableGroup>
+      <Text size="sm" tone="muted">
+        Order →{' '}
+        <Code>
+          {Object.entries(groups)
+            .map(([g, f]) => \`\${g}: [\${f.map((x) => x.id).join(', ')}]\`)
+            .join('  ·  ')}
+        </Code>
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <SortableGroup onMove={(e) => setGroups((g) => moveSortableItem(g, e))}>

--- a/packages/playground/src/pages/components/SplitDemo.tsx
+++ b/packages/playground/src/pages/components/SplitDemo.tsx
@@ -47,13 +47,57 @@ export function SplitDemo() {
       <Example
         title="Vertical Tabs rail + detail panel (canonical)"
         description="aside holds the narrow vertical Tabs rail; children is the filling detail panel. The panel sits to the right and fills remaining width at any container size — no wrapping."
-        code={`const [section, setSection] = useState('general');
+        code={`import { useState } from 'react';
+import { Activity, CreditCard, Settings, Shield } from 'lucide-react';
+import { Badge, Card, Split, Stack, Tabs, type TabItem } from '@eocrm/design-system';
 
-<Split aside={
-  <Tabs orientation="vertical" items={settingsTabs} activeId={section} onChange={setSection} />
-} gap="lg">
-  <Card padding="md">{/* detail for {section} */}</Card>
-</Split>`}
+const sections: Record<string, { title: string; body: string }> = {
+  general: { title: 'General', body: 'Workspace name, locale, and default landing page.' },
+  security: {
+    title: 'Security',
+    body: 'SSO, session timeout, and IP allow-list. Unsaved changes.',
+  },
+  activity: { title: 'Activity', body: 'Audit log of configuration changes (14 this month).' },
+  billing: { title: 'Billing', body: 'Plan, seats, and invoices.' },
+};
+
+const settingsTabs: TabItem[] = [
+  { id: 'general', label: 'General', icon: <Settings size={14} /> },
+  {
+    id: 'security',
+    label: 'Security',
+    icon: <Shield size={14} />,
+    trailing: <Badge tone="warning">Unsaved</Badge>,
+  },
+  { id: 'activity', label: 'Activity', icon: <Activity size={14} />, count: 14 },
+  { id: 'billing', label: 'Billing', icon: <CreditCard size={14} />, count: 3 },
+];
+
+export function Demo() {
+  const [section, setSection] = useState('general');
+  const active = sections[section];
+
+  return (
+    <Split
+      gap="lg"
+      aside={
+        <Tabs
+          orientation="vertical"
+          items={settingsTabs}
+          activeId={section}
+          onChange={setSection}
+        />
+      }
+    >
+      <Card padding="md" style={{ color: 'var(--color-fg-muted)' }}>
+        <Stack gap="xs">
+          <strong style={{ color: 'var(--color-fg)' }}>{active.title}</strong>
+          <span>{active.body}</span>
+        </Stack>
+      </Card>
+    </Split>
+  );
+}`}
       >
         <Split
           gap="lg"
@@ -78,9 +122,59 @@ export function SplitDemo() {
       <Example
         title="side='end' + pinned asideWidth"
         description="side='end' moves the aside to the trailing edge; asideWidth pins the rail width so the main panel doesn't reflow as the active row's adornments change."
-        code={`<Split side="end" asideWidth="200px" gap="lg" aside={<Tabs orientation="vertical" … />}>
-  <Card padding="md">{/* detail */}</Card>
-</Split>`}
+        code={`import { useState } from 'react';
+import { Activity, CreditCard, Settings, Shield } from 'lucide-react';
+import { Badge, Card, Split, Stack, Tabs, type TabItem } from '@eocrm/design-system';
+
+const sections: Record<string, { title: string; body: string }> = {
+  general: { title: 'General', body: 'Workspace name, locale, and default landing page.' },
+  security: {
+    title: 'Security',
+    body: 'SSO, session timeout, and IP allow-list. Unsaved changes.',
+  },
+  activity: { title: 'Activity', body: 'Audit log of configuration changes (14 this month).' },
+  billing: { title: 'Billing', body: 'Plan, seats, and invoices.' },
+};
+
+const settingsTabs: TabItem[] = [
+  { id: 'general', label: 'General', icon: <Settings size={14} /> },
+  {
+    id: 'security',
+    label: 'Security',
+    icon: <Shield size={14} />,
+    trailing: <Badge tone="warning">Unsaved</Badge>,
+  },
+  { id: 'activity', label: 'Activity', icon: <Activity size={14} />, count: 14 },
+  { id: 'billing', label: 'Billing', icon: <CreditCard size={14} />, count: 3 },
+];
+
+export function Demo() {
+  const [sectionEnd, setSectionEnd] = useState('general');
+  const activeEnd = sections[sectionEnd];
+
+  return (
+    <Split
+      side="end"
+      asideWidth="200px"
+      gap="lg"
+      aside={
+        <Tabs
+          orientation="vertical"
+          items={settingsTabs}
+          activeId={sectionEnd}
+          onChange={setSectionEnd}
+        />
+      }
+    >
+      <Card padding="md" style={{ color: 'var(--color-fg-muted)' }}>
+        <Stack gap="xs">
+          <strong style={{ color: 'var(--color-fg)' }}>{activeEnd.title}</strong>
+          <span>{activeEnd.body}</span>
+        </Stack>
+      </Card>
+    </Split>
+  );
+}`}
       >
         <Split
           side="end"

--- a/packages/playground/src/pages/components/StackDemo.tsx
+++ b/packages/playground/src/pages/components/StackDemo.tsx
@@ -33,9 +33,50 @@ export function StackDemo() {
       <Example
         title="Gap sizes"
         description="6 gap tokens: xs (4) | sm (8) | md (12, default) | lg (16) | xl (24) | 2xl (32). All values in pixels."
-        code={`<Stack gap="xs">…</Stack>
-<Stack gap="md">…</Stack>
-<Stack gap="lg">…</Stack>`}
+        code={`import type { ReactNode } from 'react';
+import { Cluster, Stack } from '@eocrm/design-system';
+
+const Block = ({ children }: { children: ReactNode }) => (
+  <div
+    style={{
+      padding: '10px 14px',
+      background: 'var(--color-accent-subtle-bg)',
+      color: 'var(--color-accent)',
+      borderRadius: 'var(--radius-sm)',
+      fontWeight: 500,
+    }}
+  >
+    {children}
+  </div>
+);
+
+export function Demo() {
+  return (
+    <Cluster gap="lg" align="start">
+      {(['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const).map((g) => (
+        <div key={g}>
+          <div
+            style={{
+              fontSize: 'var(--font-size-xs)',
+              color: 'var(--color-fg-subtle)',
+              marginBottom: 8,
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+              fontWeight: 600,
+            }}
+          >
+            gap={g}
+          </div>
+          <Stack gap={g}>
+            <Block>1</Block>
+            <Block>2</Block>
+            <Block>3</Block>
+          </Stack>
+        </div>
+      ))}
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="lg" align="start">
           {(['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const).map((g) => (
@@ -65,14 +106,22 @@ export function StackDemo() {
       <Example
         title="Form (the canonical use)"
         description="Stack a label/input pair vertically, with a button row at the bottom."
-        code={`<Stack gap="md">
-  <Input placeholder="Name" />
-  <Input placeholder="Email" />
-  <Cluster justify="end" gap="sm">
-    <Button variant="secondary">Cancel</Button>
-    <Button>Save</Button>
-  </Cluster>
-</Stack>`}
+        code={`import { Button, Cluster, Input, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <Stack gap="md">
+        <Input placeholder="Name" />
+        <Input placeholder="Email" />
+        <Cluster justify="end" gap="sm">
+          <Button variant="secondary">Cancel</Button>
+          <Button>Save</Button>
+        </Cluster>
+      </Stack>
+    </div>
+  );
+}`}
       >
         <div style={{ maxWidth: 360 }}>
           <Stack gap="md" className={outlineStyles.outlined}>
@@ -89,9 +138,34 @@ export function StackDemo() {
       <Example
         title="Alignment (cross-axis)"
         description="align controls horizontal alignment of children inside the stack. Default is stretch."
-        code={`<Stack align="start">…</Stack>   // left-aligned
-<Stack align="center">…</Stack>  // center
-<Stack align="end">…</Stack>     // right-aligned`}
+        code={`import { Badge, Cluster, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="lg" align="start">
+      {(['start', 'center', 'end', 'stretch'] as const).map((a) => (
+        <div key={a} style={{ width: 160 }}>
+          <div
+            style={{
+              fontSize: 'var(--font-size-xs)',
+              color: 'var(--color-fg-subtle)',
+              marginBottom: 8,
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+              fontWeight: 600,
+            }}
+          >
+            align={a}
+          </div>
+          <Stack gap="sm" align={a}>
+            <Badge tone="info">Short</Badge>
+            <Badge tone="info">Medium width</Badge>
+          </Stack>
+        </div>
+      ))}
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="lg" align="start">
           {(['start', 'center', 'end', 'stretch'] as const).map((a) => (

--- a/packages/playground/src/pages/components/StickyDemo.tsx
+++ b/packages/playground/src/pages/components/StickyDemo.tsx
@@ -30,10 +30,54 @@ export function StickyDemo() {
       <Example
         title="Detail page: sticky sidebar in a Split"
         description="Scroll inside the box — the wide main column scrolls while the sidebar pins (top='md'). align='stretch' makes the aside track full-height so the Sticky has a tall containing block to pin within."
-        code={`<Split side="end" asideWidth="220px" align="stretch"
-  aside={<Sticky top="md"><Card>…sidebar…</Card></Sticky>}>
-  <Stack gap="md">…long main column…</Stack>
-</Split>`}
+        code={`import { CSSProperties } from 'react';
+import { Card, Split, Stack, Sticky, Text, Title } from '@eocrm/design-system';
+
+const scrollBox: CSSProperties = {
+  maxHeight: 300,
+  overflowY: 'auto',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius-md)',
+  padding: 'var(--space-3)',
+};
+
+const rows = [1, 2, 3, 4, 5];
+
+export function Demo() {
+  return (
+    <div style={scrollBox}>
+      <Split
+        side="end"
+        asideWidth="220px"
+        gap="lg"
+        align="stretch"
+        aside={
+          <Sticky top="md">
+            <Card>
+              <Stack gap="xs">
+                <Title order={4} size="sm">
+                  Sidebar
+                </Title>
+                <Text size="sm" tone="muted">
+                  Owner · Tags · Linked records. Pins to the top as you scroll
+                  the main column.
+                </Text>
+              </Stack>
+            </Card>
+          </Sticky>
+        }
+      >
+        <Stack gap="md">
+          {rows.map((n) => (
+            <Card key={n}>
+              <Text>Main column row {n}</Text>
+            </Card>
+          ))}
+        </Stack>
+      </Split>
+    </div>
+  );
+}`}
       >
         <div style={scrollBox}>
           <Split
@@ -70,7 +114,48 @@ export function StickyDemo() {
       <Example
         title="Top offset"
         description="top maps to the spacing scale (none / xs / sm / md / lg / xl). none (default) pins flush (top:0); a non-zero step clears a sticky header or adds breathing room."
-        code={`<Sticky top="lg"><FilterPanel /></Sticky>`}
+        code={`import { CSSProperties } from 'react';
+import { Card, Split, Stack, Sticky, Text } from '@eocrm/design-system';
+
+const scrollBox: CSSProperties = {
+  maxHeight: 300,
+  overflowY: 'auto',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius-md)',
+  padding: 'var(--space-3)',
+};
+
+const rows = [1, 2, 3, 4, 5];
+
+export function Demo() {
+  return (
+    <div style={scrollBox}>
+      <Split
+        side="start"
+        asideWidth="160px"
+        gap="lg"
+        align="stretch"
+        aside={
+          <Sticky top="lg">
+            <Card>
+              <Text size="sm" tone="muted">
+                top=&quot;lg&quot;
+              </Text>
+            </Card>
+          </Sticky>
+        }
+      >
+        <Stack gap="md">
+          {rows.map((n) => (
+            <Card key={n}>
+              <Text>Row {n}</Text>
+            </Card>
+          ))}
+        </Stack>
+      </Split>
+    </div>
+  );
+}`}
       >
         <div style={scrollBox}>
           <Split
@@ -102,14 +187,47 @@ export function StickyDemo() {
       <Example
         title="Scroll-viewport mode: a sidebar taller than the screen"
         description="With scroll, the pinned box is capped at the viewport height (minus the top offset and an equal bottom gap) and scrolls its own content — so a sidebar with more items than fit on screen stays fully reachable instead of running off below the fold. Scroll the page: the sidebar pins, and once it hits the bottom its own scrollbar takes over (overscroll-behavior:contain keeps the page from scroll-chaining). Pair with a non-none top for breathing room."
-        code={`<Split side="end" asideWidth="240px" align="stretch"
-  aside={
-    <Sticky top="lg" scroll>
-      <Stack gap="md">{manyCards}</Stack>
-    </Sticky>
-  }>
-  <Stack gap="md">…long main column…</Stack>
-</Split>`}
+        code={`import { Card, Split, Stack, Sticky, Text, Title } from '@eocrm/design-system';
+
+const sidebarItems = Array.from({ length: 5 }, (_, i) => i + 1);
+const mainRows = [1, 2, 3, 4, 5];
+
+export function Demo() {
+  return (
+    <Split
+      side="end"
+      asideWidth="240px"
+      gap="lg"
+      align="stretch"
+      aside={
+        <Sticky top="lg" scroll>
+          <Stack gap="md">
+            {sidebarItems.map((n) => (
+              <Card key={n}>
+                <Stack gap="xs">
+                  <Title order={4} size="sm">
+                    Linked record {n}
+                  </Title>
+                  <Text size="sm" tone="muted">
+                    Account · updated {n} day{n === 1 ? '' : 's'} ago
+                  </Text>
+                </Stack>
+              </Card>
+            ))}
+          </Stack>
+        </Sticky>
+      }
+    >
+      <Stack gap="md">
+        {mainRows.map((n) => (
+          <Card key={n}>
+            <Text>Main column row {n}</Text>
+          </Card>
+        ))}
+      </Stack>
+    </Split>
+  );
+}`}
       >
         <Split
           side="end"

--- a/packages/playground/src/pages/components/SwitchDemo.tsx
+++ b/packages/playground/src/pages/components/SwitchDemo.tsx
@@ -27,7 +27,11 @@ export function SwitchDemo() {
       <Example
         title="Default + with label"
         description="Uncontrolled. Click the label or the track to toggle."
-        code={`<Switch>Enable notifications</Switch>`}
+        code={`import { Switch } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Switch>Enable notifications</Switch>;
+}`}
       >
         <Switch>Enable notifications</Switch>
       </Example>
@@ -35,9 +39,17 @@ export function SwitchDemo() {
       <Example
         title="Three sizes"
         description="Size scales track + thumb + label font together."
-        code={`<Switch size="sm">Small</Switch>
-<Switch size="md">Medium (default)</Switch>
-<Switch size="lg">Large</Switch>`}
+        code={`import { Stack, Switch } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Switch size="sm">Small</Switch>
+      <Switch size="md">Medium (default)</Switch>
+      <Switch size="lg">Large</Switch>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Switch size="sm">Small</Switch>
@@ -49,9 +61,23 @@ export function SwitchDemo() {
       <Example
         title="Three tones (all checked)"
         description="Tone only affects the checked-state track color. Unchecked is always neutral."
-        code={`<Switch defaultChecked tone="accent">Accent (default)</Switch>
-<Switch defaultChecked tone="success">Success</Switch>
-<Switch defaultChecked tone="danger">Danger</Switch>`}
+        code={`import { Stack, Switch } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Switch defaultChecked tone="accent">
+        Accent (default)
+      </Switch>
+      <Switch defaultChecked tone="success">
+        Success
+      </Switch>
+      <Switch defaultChecked tone="danger">
+        Danger
+      </Switch>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Switch defaultChecked tone="accent">
@@ -69,11 +95,18 @@ export function SwitchDemo() {
       <Example
         title="Controlled"
         description="onChange receives (nextBool, event). The component is otherwise dumb — consumer drives the state."
-        code={`const [enabled, setEnabled] = useState(false);
+        code={`import { useState } from 'react';
+import { Switch } from '@eocrm/design-system';
 
-<Switch checked={enabled} onChange={(next) => setEnabled(next)}>
-  Marketing emails
-</Switch>`}
+export function Demo() {
+  const [enabled, setEnabled] = useState(false);
+
+  return (
+    <Switch checked={enabled} onChange={(next) => setEnabled(next)}>
+      Marketing emails ({enabled ? 'ON' : 'OFF'})
+    </Switch>
+  );
+}`}
       >
         <Switch checked={controlled} onChange={(next) => setControlled(next)}>
           Marketing emails ({controlled ? 'ON' : 'OFF'})
@@ -83,19 +116,26 @@ export function SwitchDemo() {
       <Example
         title="Loading (async toggle with optimistic update)"
         description="The button fakes a 1.5s server roundtrip. The switch updates immediately (optimistic), spins while saving, and would rollback on error. loading={true} disables the input."
-        code={`const [enabled, setEnabled] = useState(false);
-const [saving, setSaving] = useState(false);
+        code={`import { useState } from 'react';
+import { Switch } from '@eocrm/design-system';
 
-const handleToggle = async (next: boolean) => {
-  setSaving(true);
-  setEnabled(next);
-  await api.save(next);  // ...with try/catch + rollback in real code
-  setSaving(false);
-};
+export function Demo() {
+  const [enabled, setEnabled] = useState(false);
+  const [saving, setSaving] = useState(false);
 
-<Switch checked={enabled} loading={saving} onChange={handleToggle}>
-  Two-factor auth
-</Switch>`}
+  const handleToggle = async (next: boolean) => {
+    setSaving(true);
+    setEnabled(next);
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    setSaving(false);
+  };
+
+  return (
+    <Switch checked={enabled} loading={saving} onChange={handleToggle} tone="success">
+      Two-factor auth ({saving ? 'saving…' : enabled ? 'ON' : 'OFF'})
+    </Switch>
+  );
+}`}
       >
         <Switch checked={asyncEnabled} loading={saving} onChange={handleAsyncToggle} tone="success">
           Two-factor auth ({saving ? 'saving…' : asyncEnabled ? 'ON' : 'OFF'})
@@ -105,12 +145,27 @@ const handleToggle = async (next: boolean) => {
       <Example
         title="Invalid state"
         description="aria-invalid + danger-tone border on the track. Use when validation has surfaced an error."
-        code={`<Switch invalid aria-describedby="terms-error">
-  I agree to the terms
-</Switch>
-<p id="terms-error" style={{ color: 'var(--color-danger)' }}>
-  You must agree to the terms before continuing.
-</p>`}
+        code={`import { Stack, Switch } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Switch invalid aria-describedby="terms-error">
+        I agree to the terms
+      </Switch>
+      <p
+        id="terms-error"
+        style={{
+          color: 'var(--color-danger)',
+          margin: 0,
+          fontSize: 'var(--font-size-sm)',
+        }}
+      >
+        You must agree to the terms before continuing.
+      </p>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Switch invalid aria-describedby="terms-error">
@@ -132,8 +187,18 @@ const handleToggle = async (next: boolean) => {
       <Example
         title="Disabled"
         description="Native disabled attribute. Unchecked and checked variants shown."
-        code={`<Switch disabled>Disabled (off)</Switch>
-<Switch disabled defaultChecked>Disabled (on)</Switch>`}
+        code={`import { Cluster, Switch } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md">
+      <Switch disabled>Disabled (off)</Switch>
+      <Switch disabled defaultChecked>
+        Disabled (on)
+      </Switch>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md">
           <Switch disabled>Disabled (off)</Switch>

--- a/packages/playground/src/pages/components/TableDemo.tsx
+++ b/packages/playground/src/pages/components/TableDemo.tsx
@@ -149,24 +149,53 @@ export function TableDemo() {
       <Example
         title="Default"
         description="Comfortable density, hover on, no stripes. Native `<table>` semantics throughout."
-        code={`<Table>
-  <Table.Header>
-    <Table.Row>
-      <Table.HeaderCell>Company</Table.HeaderCell>
-      <Table.HeaderCell>Status</Table.HeaderCell>
-      <Table.HeaderCell align="end">Amount</Table.HeaderCell>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    {rows.map((r) => (
-      <Table.Row key={r.id}>
-        <Table.Cell>{r.name}</Table.Cell>
-        <Table.Cell><Badge tone={...}>{r.status}</Badge></Table.Cell>
-        <Table.Cell align="end">\${r.amount.toLocaleString()}</Table.Cell>
-      </Table.Row>
-    ))}
-  </Table.Body>
-</Table>`}
+        code={`import { Badge, Table } from '@eocrm/design-system';
+
+interface Row {
+  id: string;
+  name: string;
+  status: 'Active' | 'Pending' | 'Archived';
+  amount: number;
+}
+
+const ROWS: Row[] = [
+  { id: 'a', name: 'Acme Corp', status: 'Active', amount: 12_500 },
+  { id: 'b', name: 'Beanstalk Ltd', status: 'Pending', amount: 4_200 },
+  { id: 'c', name: 'Cobalt Studios', status: 'Active', amount: 28_400 },
+  { id: 'd', name: 'Delta Mfg', status: 'Archived', amount: 800 },
+  { id: 'e', name: 'Echo Logistics', status: 'Active', amount: 7_900 },
+];
+
+const STATUS_TONE: Record<Row['status'], 'success' | 'warning' | 'neutral'> = {
+  Active: 'success',
+  Pending: 'warning',
+  Archived: 'neutral',
+};
+
+export function StaticTable() {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Company</Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {ROWS.map((row) => (
+          <Table.Row key={row.id}>
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell>
+              <Badge tone={STATUS_TONE[row.status]}>{row.status}</Badge>
+            </Table.Cell>
+            <Table.Cell align="end">\${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}`}
       >
         <StaticTable />
       </Example>
@@ -174,7 +203,34 @@ export function TableDemo() {
       <Example
         title="Dense"
         description="24px row, 8px cell padding, `font-size-sm`. Useful for inline tables inside cards or narrow side panels."
-        code={`<Table density="dense">{...}</Table>`}
+        code={`import { Table } from '@eocrm/design-system';
+
+const rows = [
+  { id: 'a', name: 'Acme Corp', amount: 12_500 },
+  { id: 'b', name: 'Beanstalk Ltd', amount: 4_200 },
+  { id: 'c', name: 'Cobalt Studios', amount: 28_400 },
+];
+
+export function Demo() {
+  return (
+    <Table density="dense">
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Company</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {rows.map((row) => (
+          <Table.Row key={row.id}>
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell align="end">\${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}`}
       >
         <Table density="dense">
           <Table.Header>
@@ -197,7 +253,36 @@ export function TableDemo() {
       <Example
         title="Striped + hover"
         description="Zebra stripes on even body rows + opt-in hover affordance. Both default off — use them together when the table represents a list of selectable rows."
-        code={`<Table striped hover>{...}</Table>`}
+        code={`import { Table } from '@eocrm/design-system';
+
+const rows = [
+  { id: 'a', name: 'Acme Corp', amount: 12_500 },
+  { id: 'b', name: 'Beanstalk Ltd', amount: 4_200 },
+  { id: 'c', name: 'Cobalt Studios', amount: 28_400 },
+  { id: 'd', name: 'Delta Mfg', amount: 800 },
+  { id: 'e', name: 'Echo Logistics', amount: 7_900 },
+];
+
+export function Demo() {
+  return (
+    <Table striped hover>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Company</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {rows.map((row) => (
+          <Table.Row key={row.id}>
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell align="end">\${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}`}
       >
         <Table striped hover>
           <Table.Header>
@@ -220,7 +305,46 @@ export function TableDemo() {
       <Example
         title="Bordered"
         description="Full-grid borders (outer + vertical between cells). Default is Atlassian-minimal (just row dividers + header underline); pass `bordered` for the heavier admin-screen look."
-        code={`<Table bordered>{...}</Table>`}
+        code={`import { Badge, Table } from '@eocrm/design-system';
+
+const rows = [
+  { id: 'a', name: 'Acme Corp', status: 'Active' as const, amount: 12_500 },
+  { id: 'b', name: 'Beanstalk Ltd', status: 'Pending' as const, amount: 4_200 },
+  { id: 'c', name: 'Cobalt Studios', status: 'Active' as const, amount: 28_400 },
+  { id: 'd', name: 'Delta Mfg', status: 'Archived' as const, amount: 800 },
+  { id: 'e', name: 'Echo Logistics', status: 'Active' as const, amount: 7_900 },
+];
+
+const STATUS_TONE = {
+  Active: 'success',
+  Pending: 'warning',
+  Archived: 'neutral',
+} as const;
+
+export function Demo() {
+  return (
+    <Table bordered>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Company</Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {rows.map((row) => (
+          <Table.Row key={row.id}>
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell>
+              <Badge tone={STATUS_TONE[row.status]}>{row.status}</Badge>
+            </Table.Cell>
+            <Table.Cell align="end">\${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}`}
       >
         <Table bordered>
           <Table.Header>
@@ -247,12 +371,81 @@ export function TableDemo() {
       <Example
         title="Sortable headers"
         description="`<Table.HeaderCell sortDirection>` renders the right chevron + sets `aria-sort`. The primitive only paints — wire `onClick` to your own state. Demo uses the typical 3-state cycle (unsorted → asc → desc → unsorted), but consumers can use any cycle. DataTable will compose this seam."
-        code={`<Table.HeaderCell
-  sortDirection={sortKey === 'amount' ? sortDir : 'none'}
-  onClick={() => toggleSort('amount')}
->
-  Amount
-</Table.HeaderCell>`}
+        code={`import { useState } from 'react';
+import { Badge, Table } from '@eocrm/design-system';
+
+const ROWS = [
+  { id: 'a', name: 'Acme Corp', status: 'Active' as const, amount: 12_500 },
+  { id: 'b', name: 'Beanstalk Ltd', status: 'Pending' as const, amount: 4_200 },
+  { id: 'c', name: 'Cobalt Studios', status: 'Active' as const, amount: 28_400 },
+  { id: 'd', name: 'Delta Mfg', status: 'Archived' as const, amount: 800 },
+  { id: 'e', name: 'Echo Logistics', status: 'Active' as const, amount: 7_900 },
+];
+
+const STATUS_TONE = {
+  Active: 'success',
+  Pending: 'warning',
+  Archived: 'neutral',
+} as const;
+
+type SortKey = 'name' | 'amount';
+type SortState = { key: SortKey; dir: 'asc' | 'desc' } | null;
+
+export function SortableTable() {
+  const [sort, setSort] = useState<SortState>(null);
+
+  const sorted = sort
+    ? [...ROWS].sort((a, b) => {
+        const factor = sort.dir === 'asc' ? 1 : -1;
+        if (sort.key === 'amount') return (a.amount - b.amount) * factor;
+        return a.name.localeCompare(b.name) * factor;
+      })
+    : ROWS;
+
+  function dirFor(key: SortKey) {
+    if (sort?.key !== key) return 'none' as const;
+    return sort.dir;
+  }
+
+  function toggle(key: SortKey) {
+    setSort((prev) => {
+      if (prev?.key !== key) return { key, dir: 'asc' };
+      if (prev.dir === 'asc') return { key, dir: 'desc' };
+      return null;
+    });
+  }
+
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell sortDirection={dirFor('name')} onClick={() => toggle('name')}>
+            Company
+          </Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell
+            align="end"
+            sortDirection={dirFor('amount')}
+            onClick={() => toggle('amount')}
+          >
+            Amount
+          </Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {sorted.map((row) => (
+          <Table.Row key={row.id}>
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell>
+              <Badge tone={STATUS_TONE[row.status]}>{row.status}</Badge>
+            </Table.Cell>
+            <Table.Cell align="end">\${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}`}
       >
         <SortableTable />
       </Example>
@@ -260,9 +453,44 @@ export function TableDemo() {
       <Example
         title="Selected row"
         description="`<Table.Row selected>` paints a tinted bg + sets `aria-selected`. Click any row to select it (consumer-owned state)."
-        code={`<Table.Row selected={isSelected(row.id)} onClick={() => select(row.id)}>
-  {...}
-</Table.Row>`}
+        code={`import { useState } from 'react';
+import { Table } from '@eocrm/design-system';
+
+const ROWS = [
+  { id: 'a', name: 'Acme Corp', amount: 12_500 },
+  { id: 'b', name: 'Beanstalk Ltd', amount: 4_200 },
+  { id: 'c', name: 'Cobalt Studios', amount: 28_400 },
+  { id: 'd', name: 'Delta Mfg', amount: 800 },
+  { id: 'e', name: 'Echo Logistics', amount: 7_900 },
+];
+
+export function SelectableTable() {
+  const [selectedId, setSelectedId] = useState<string | null>('c');
+
+  return (
+    <Table hover>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Company</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {ROWS.map((row) => (
+          <Table.Row
+            key={row.id}
+            selected={selectedId === row.id}
+            onClick={() => setSelectedId(row.id)}
+            style={{ cursor: 'pointer' }}
+          >
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell align="end">\${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}`}
       >
         <SelectableTable />
       </Example>
@@ -270,9 +498,45 @@ export function TableDemo() {
       <Example
         title="Sticky header"
         description="`stickyHeader` keeps the header row visible while body rows scroll. Requires a scrollable ancestor — the default outer wrapper provides one."
-        code={`<div style={{ maxHeight: 200, overflow: 'auto' }}>
-  <Table stickyHeader scroll={false}>{...}</Table>
-</div>`}
+        code={`import { Table } from '@eocrm/design-system';
+
+const rows = [
+  { id: 'a', name: 'Acme Corp', amount: 12_500 },
+  { id: 'b', name: 'Beanstalk Ltd', amount: 4_200 },
+  { id: 'c', name: 'Cobalt Studios', amount: 28_400 },
+  { id: 'd', name: 'Delta Mfg', amount: 800 },
+  { id: 'e', name: 'Echo Logistics', amount: 7_900 },
+];
+
+export function Demo() {
+  return (
+    <div
+      style={{
+        maxHeight: 200,
+        overflow: 'auto',
+        border: 'var(--border-width) solid var(--color-border)',
+        borderRadius: 'var(--radius-md)',
+      }}
+    >
+      <Table stickyHeader scroll={false}>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Company</Table.HeaderCell>
+            <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {[...rows, ...rows, ...rows].map((row, i) => (
+            <Table.Row key={\`\${row.id}-\${i}\`}>
+              <Table.Cell>{row.name}</Table.Cell>
+              <Table.Cell align="end">\${row.amount.toLocaleString()}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
+  );
+}`}
       >
         <div
           style={{
@@ -304,17 +568,56 @@ export function TableDemo() {
       <Example
         title="Footer with totals"
         description="`<Table.Footer>` (renders `<tfoot>`) is the spot for totals, summary, or pagination chrome. Same `--color-bg-muted` background as the header; doesn't participate in hover/striped."
-        code={`<Table>
-  <Table.Header>...</Table.Header>
-  <Table.Body>...</Table.Body>
-  <Table.Footer>
-    <Table.Row>
-      <Table.Cell>Total</Table.Cell>
-      <Table.Cell />
-      <Table.Cell align="end">{total}</Table.Cell>
-    </Table.Row>
-  </Table.Footer>
-</Table>`}
+        code={`import { Badge, Table } from '@eocrm/design-system';
+
+const rows = [
+  { id: 'a', name: 'Acme Corp', status: 'Active' as const, amount: 12_500 },
+  { id: 'b', name: 'Beanstalk Ltd', status: 'Pending' as const, amount: 4_200 },
+  { id: 'c', name: 'Cobalt Studios', status: 'Active' as const, amount: 28_400 },
+  { id: 'd', name: 'Delta Mfg', status: 'Archived' as const, amount: 800 },
+  { id: 'e', name: 'Echo Logistics', status: 'Active' as const, amount: 7_900 },
+];
+
+const STATUS_TONE = {
+  Active: 'success',
+  Pending: 'warning',
+  Archived: 'neutral',
+} as const;
+
+export function Demo() {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Company</Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {rows.map((row) => (
+          <Table.Row key={row.id}>
+            <Table.Cell>{row.name}</Table.Cell>
+            <Table.Cell>
+              <Badge tone={STATUS_TONE[row.status]}>{row.status}</Badge>
+            </Table.Cell>
+            <Table.Cell align="end">\${row.amount.toLocaleString()}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+      <Table.Footer>
+        <Table.Row>
+          <Table.Cell colSpan={2}>
+            <strong>Total</strong>
+          </Table.Cell>
+          <Table.Cell align="end">
+            <strong>\${rows.reduce((sum, r) => sum + r.amount, 0).toLocaleString()}</strong>
+          </Table.Cell>
+        </Table.Row>
+      </Table.Footer>
+    </Table>
+  );
+}`}
       >
         <Table>
           <Table.Header>
@@ -351,22 +654,54 @@ export function TableDemo() {
       <Example
         title="Grouped header (multi-row, colSpan + rowSpan)"
         description="Native `colSpan` / `rowSpan` work straight through on `<Table.HeaderCell>` and `<Table.Cell>`. Bordered + multi-row header is the typical 'plan vs actual per quarter' shape."
-        code={`<Table bordered>
-  <Table.Header>
-    <Table.Row>
-      <Table.HeaderCell rowSpan={2}>Region</Table.HeaderCell>
-      <Table.HeaderCell colSpan={2} align="center">Q1</Table.HeaderCell>
-      <Table.HeaderCell colSpan={2} align="center">Q2</Table.HeaderCell>
-    </Table.Row>
-    <Table.Row>
-      <Table.HeaderCell align="end">Plan</Table.HeaderCell>
-      <Table.HeaderCell align="end">Actual</Table.HeaderCell>
-      <Table.HeaderCell align="end">Plan</Table.HeaderCell>
-      <Table.HeaderCell align="end">Actual</Table.HeaderCell>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>...</Table.Body>
-</Table>`}
+        code={`import { Table } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Table bordered>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell rowSpan={2}>Region</Table.HeaderCell>
+          <Table.HeaderCell colSpan={2} align="center">
+            Q1
+          </Table.HeaderCell>
+          <Table.HeaderCell colSpan={2} align="center">
+            Q2
+          </Table.HeaderCell>
+        </Table.Row>
+        <Table.Row>
+          <Table.HeaderCell align="end">Plan</Table.HeaderCell>
+          <Table.HeaderCell align="end">Actual</Table.HeaderCell>
+          <Table.HeaderCell align="end">Plan</Table.HeaderCell>
+          <Table.HeaderCell align="end">Actual</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>North</Table.Cell>
+          <Table.Cell align="end">100</Table.Cell>
+          <Table.Cell align="end">95</Table.Cell>
+          <Table.Cell align="end">120</Table.Cell>
+          <Table.Cell align="end">130</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>South</Table.Cell>
+          <Table.Cell align="end">80</Table.Cell>
+          <Table.Cell align="end">88</Table.Cell>
+          <Table.Cell align="end">90</Table.Cell>
+          <Table.Cell align="end">92</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>West</Table.Cell>
+          <Table.Cell align="end">60</Table.Cell>
+          <Table.Cell align="end">71</Table.Cell>
+          <Table.Cell align="end">75</Table.Cell>
+          <Table.Cell align="end">68</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  );
+}`}
       >
         <Table bordered>
           <Table.Header>
@@ -415,21 +750,52 @@ export function TableDemo() {
       <Example
         title="Row grouping (rowSpan in body)"
         description="Use `rowSpan` on a body cell to label a category that owns several rows. Combine with `<th scope='row'>` on the spanning cell if it should be read as a row-header by AT."
-        code={`<Table bordered>
-  <Table.Header>...</Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.HeaderCell rowSpan={3} scope="row">Active</Table.HeaderCell>
-      <Table.Cell>Acme Corp</Table.Cell>
-      <Table.Cell align="end">$12,500</Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>Cobalt Studios</Table.Cell>
-      <Table.Cell align="end">$28,400</Table.Cell>
-    </Table.Row>
-    {/* ... */}
-  </Table.Body>
-</Table>`}
+        code={`import { Badge, Table } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Table bordered>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell>Company</Table.HeaderCell>
+          <Table.HeaderCell align="end">Amount</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.HeaderCell rowSpan={3} scope="row">
+            <Badge tone="success">Active</Badge>
+          </Table.HeaderCell>
+          <Table.Cell>Acme Corp</Table.Cell>
+          <Table.Cell align="end">$12,500</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>Cobalt Studios</Table.Cell>
+          <Table.Cell align="end">$28,400</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>Echo Logistics</Table.Cell>
+          <Table.Cell align="end">$7,900</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.HeaderCell scope="row">
+            <Badge tone="warning">Pending</Badge>
+          </Table.HeaderCell>
+          <Table.Cell>Beanstalk Ltd</Table.Cell>
+          <Table.Cell align="end">$4,200</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.HeaderCell scope="row">
+            <Badge tone="neutral">Archived</Badge>
+          </Table.HeaderCell>
+          <Table.Cell>Delta Mfg</Table.Cell>
+          <Table.Cell align="end">$800</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  );
+}`}
       >
         <Table bordered>
           <Table.Header>
@@ -476,7 +842,38 @@ export function TableDemo() {
       <Example
         title="Truncated cell"
         description="`<Table.Cell truncate>` ellipsizes overflow text. Requires a constrained cell width — set `style={{ maxWidth }}` on the cell or `<col>` width on the column."
-        code={`<Table.Cell truncate style={{ maxWidth: 180 }}>{longString}</Table.Cell>`}
+        code={`import { Badge, Table } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell style={{ width: 180 }}>Subject</Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell truncate style={{ maxWidth: 180 }}>
+            Q4 strategy: revisit the long-tail growth bets and align with platform launches
+          </Table.Cell>
+          <Table.Cell>
+            <Badge tone="warning">Pending</Badge>
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell truncate style={{ maxWidth: 180 }}>
+            Short subject
+          </Table.Cell>
+          <Table.Cell>
+            <Badge tone="success">Active</Badge>
+          </Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  );
+}`}
       >
         <Table>
           <Table.Header>

--- a/packages/playground/src/pages/components/TabsDemo.tsx
+++ b/packages/playground/src/pages/components/TabsDemo.tsx
@@ -47,18 +47,28 @@ export function TabsDemo() {
       <Example
         title="Basic"
         description="Pass items as an array of { id, label }. Track activeId in caller state. Use the active id to conditionally render the panel below."
-        code={`const [activeTab, setActiveTab] = useState('overview');
+        code={`import { useState } from 'react';
+import { Card, Stack, Tabs } from '@eocrm/design-system';
 
-<Tabs
-  items={[
-    { id: 'overview', label: 'Overview' },
-    { id: 'activity', label: 'Activity' },
-    { id: 'notes', label: 'Notes' },
-  ]}
-  activeId={activeTab}
-  onChange={setActiveTab}
-/>
-{activeTab === 'overview' && <OverviewPanel />}`}
+export function Demo() {
+  const [activeTab, setActiveTab] = useState('overview');
+  return (
+    <Stack gap="md">
+      <Tabs
+        items={[
+          { id: 'overview', label: 'Overview' },
+          { id: 'activity', label: 'Activity' },
+          { id: 'notes', label: 'Notes' },
+        ]}
+        activeId={activeTab}
+        onChange={setActiveTab}
+      />
+      <Card padding="md" style={{ color: 'var(--color-fg-muted)' }}>
+        Showing <strong>{activeTab}</strong> panel.
+      </Card>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="md">
           <Tabs
@@ -79,16 +89,24 @@ export function TabsDemo() {
       <Example
         title="With count chips"
         description="Add count to any item for a chip showing the number of records in that view. The chip color shifts when the tab is active."
-        code={`<Tabs
-  items={[
-    { id: 'all', label: 'All', count: 248 },
-    { id: 'open', label: 'Open', count: 32 },
-    { id: 'won', label: 'Won', count: 8 },
-    { id: 'lost', label: 'Lost', count: 4 },
-  ]}
-  activeId={tab}
-  onChange={setTab}
-/>`}
+        code={`import { useState } from 'react';
+import { Tabs } from '@eocrm/design-system';
+
+export function Demo() {
+  const [tab, setTab] = useState('all');
+  return (
+    <Tabs
+      items={[
+        { id: 'all', label: 'All', count: 248 },
+        { id: 'open', label: 'Open', count: 32 },
+        { id: 'won', label: 'Won', count: 8 },
+        { id: 'lost', label: 'Lost', count: 4 },
+      ]}
+      activeId={tab}
+      onChange={setTab}
+    />
+  );
+}`}
       >
         <Tabs
           items={[
@@ -105,16 +123,25 @@ export function TabsDemo() {
       <Example
         title="With leading icons"
         description="Each TabItem accepts an optional icon (typically a lucide-react glyph). The icon renders before the label and inherits the tab's color so it dims when inactive and shifts to accent when active. The icon is decorative (aria-hidden) — the label carries the accessible name."
-        code={`<Tabs
-  items={[
-    { id: 'profile', label: 'Profile', icon: <User size={14} /> },
-    { id: 'activity', label: 'Activity', icon: <Activity size={14} /> },
-    { id: 'files', label: 'Files', icon: <FileText size={14} /> },
-    { id: 'settings', label: 'Settings', icon: <Settings size={14} /> },
-  ]}
-  activeId={tab}
-  onChange={setTab}
-/>`}
+        code={`import { useState } from 'react';
+import { Activity, FileText, Settings, User } from 'lucide-react';
+import { Tabs } from '@eocrm/design-system';
+
+export function Demo() {
+  const [tab, setTab] = useState('profile');
+  return (
+    <Tabs
+      items={[
+        { id: 'profile', label: 'Profile', icon: <User size={14} /> },
+        { id: 'activity', label: 'Activity', icon: <Activity size={14} /> },
+        { id: 'files', label: 'Files', icon: <FileText size={14} /> },
+        { id: 'settings', label: 'Settings', icon: <Settings size={14} /> },
+      ]}
+      activeId={tab}
+      onChange={setTab}
+    />
+  );
+}`}
       >
         <Tabs
           items={[
@@ -131,15 +158,24 @@ export function TabsDemo() {
       <Example
         title="Icons + counts together"
         description="Icon and count can coexist — icon renders before the label, count renders after."
-        code={`<Tabs
-  items={[
-    { id: 'inbox', label: 'Inbox', icon: <Mail size={14} />, count: 12 },
-    { id: 'tasks', label: 'Tasks', icon: <Activity size={14} />, count: 3 },
-    { id: 'docs', label: 'Docs', icon: <FileText size={14} /> },
-  ]}
-  activeId={tab}
-  onChange={setTab}
-/>`}
+        code={`import { useState } from 'react';
+import { Activity, FileText, Mail } from 'lucide-react';
+import { Tabs } from '@eocrm/design-system';
+
+export function Demo() {
+  const [tab, setTab] = useState('inbox');
+  return (
+    <Tabs
+      items={[
+        { id: 'inbox', label: 'Inbox', icon: <Mail size={14} />, count: 12 },
+        { id: 'tasks', label: 'Tasks', icon: <Activity size={14} />, count: 3 },
+        { id: 'docs', label: 'Docs', icon: <FileText size={14} /> },
+      ]}
+      activeId={tab}
+      onChange={setTab}
+    />
+  );
+}`}
       >
         <Tabs
           items={[
@@ -155,31 +191,63 @@ export function TabsDemo() {
       <Example
         title="Vertical (master–detail)"
         description='orientation="vertical" renders a stacked rail of full-width rows — the active row gets a left accent bar and a subtly tinted background, and ArrowUp/ArrowDown move between rows. Place the rail in a Split beside the detail panel. Best for settings / configuration editors, where each row is a section and the panel reflects the selection.'
-        code={`const [section, setSection] = useState('general');
+        code={`import { useState } from 'react';
+import { Activity, CreditCard, Settings, Shield } from 'lucide-react';
+import { Badge, Card, Split, Stack, Tabs } from '@eocrm/design-system';
 
-<Split
-  gap="lg"
-  aside={
-    <Tabs
-      orientation="vertical"
-      items={[
-        { id: 'general', label: 'General', icon: <Settings size={14} /> },
-        {
-          id: 'security',
-          label: 'Security',
-          icon: <Shield size={14} />,
-          trailing: <Badge tone="warning">Unsaved</Badge>,
-        },
-        { id: 'activity', label: 'Activity', icon: <Activity size={14} />, count: 14 },
-        { id: 'billing', label: 'Billing', icon: <CreditCard size={14} />, count: 3 },
-      ]}
-      activeId={section}
-      onChange={setSection}
-    />
-  }
->
-  <Card padding="md">{/* panel for the active section */}</Card>
-</Split>`}
+const verticalDetail: Record<string, { title: string; body: string }> = {
+  general: {
+    title: 'General',
+    body: 'Workspace name, default currency, and time zone for this account.',
+  },
+  security: {
+    title: 'Security',
+    body: 'Password policy, two-factor enforcement, and active session management.',
+  },
+  activity: {
+    title: 'Activity log',
+    body: '14 recent events — logins, record edits, and permission changes.',
+  },
+  billing: {
+    title: 'Billing',
+    body: 'Plan, payment method, and the 3 invoices issued this quarter.',
+  },
+};
+
+export function Demo() {
+  const [section, setSection] = useState('general');
+  const active = verticalDetail[section];
+  return (
+    <Split
+      gap="lg"
+      aside={
+        <Tabs
+          orientation="vertical"
+          items={[
+            { id: 'general', label: 'General', icon: <Settings size={14} /> },
+            {
+              id: 'security',
+              label: 'Security',
+              icon: <Shield size={14} />,
+              trailing: <Badge tone="warning">Unsaved</Badge>,
+            },
+            { id: 'activity', label: 'Activity', icon: <Activity size={14} />, count: 14 },
+            { id: 'billing', label: 'Billing', icon: <CreditCard size={14} />, count: 3 },
+          ]}
+          activeId={section}
+          onChange={setSection}
+        />
+      }
+    >
+      <Card padding="md" style={{ minWidth: 280, color: 'var(--color-fg-muted)' }}>
+        <Stack gap="xs">
+          <strong style={{ color: 'var(--color-fg)' }}>{active.title}</strong>
+          <span>{active.body}</span>
+        </Stack>
+      </Card>
+    </Split>
+  );
+}`}
       >
         <Split
           gap="lg"
@@ -214,30 +282,47 @@ export function TabsDemo() {
       <Example
         title="Leading / trailing adornments"
         description="leading and trailing are free-form adornments, distinct from the decorative icon and numeric count. leading sits before the icon/label (here a colored sync-status dot); trailing sits at the end (here a Badge). Unlike icon, they are NOT aria-hidden — give meaningful adornments accessible text. The bare status dots below are marked aria-hidden because the trailing Badge already carries the status in words."
-        code={`<Tabs
-  items={[
-    {
-      id: 'lead',
-      label: 'Leads',
-      leading: <span style={{ /* token-colored dot */ }} aria-hidden />,
-      trailing: <Badge tone="info">Syncing</Badge>,
-    },
-    {
-      id: 'won',
-      label: 'Won',
-      leading: <span style={{ /* token-colored dot */ }} aria-hidden />,
-      trailing: <Badge tone="success">Live</Badge>,
-    },
-    {
-      id: 'lost',
-      label: 'Lost',
-      leading: <span style={{ /* token-colored dot */ }} aria-hidden />,
-      trailing: <Badge tone="danger">Failed</Badge>,
-    },
-  ]}
-  activeId={stage}
-  onChange={setStage}
-/>`}
+        code={`import { useState } from 'react';
+import { Badge, Tabs } from '@eocrm/design-system';
+
+function StatusDot({ color }: { color: string }) {
+  return (
+    <span
+      aria-hidden
+      style={{ width: 8, height: 8, borderRadius: '50%', background: color, display: 'block' }}
+    />
+  );
+}
+
+export function Demo() {
+  const [stage, setStage] = useState('lead');
+  return (
+    <Tabs
+      items={[
+        {
+          id: 'lead',
+          label: 'Leads',
+          leading: <StatusDot color="var(--color-info)" />,
+          trailing: <Badge tone="info">Syncing</Badge>,
+        },
+        {
+          id: 'won',
+          label: 'Won',
+          leading: <StatusDot color="var(--color-success)" />,
+          trailing: <Badge tone="success">Live</Badge>,
+        },
+        {
+          id: 'lost',
+          label: 'Lost',
+          leading: <StatusDot color="var(--color-danger)" />,
+          trailing: <Badge tone="danger">Failed</Badge>,
+        },
+      ]}
+      activeId={stage}
+      onChange={setStage}
+    />
+  );
+}`}
       >
         <Tabs
           items={[

--- a/packages/playground/src/pages/components/TextDemo.tsx
+++ b/packages/playground/src/pages/components/TextDemo.tsx
@@ -18,11 +18,19 @@ export function TextDemo() {
       <Example
         title="Sizes"
         description="Five sizes from --font-size-xs (11px) to --font-size-xl (20px). Default is `md` (14px)."
-        code={`<Text size="xs">xs — 11px, dense metadata</Text>
-<Text size="sm">sm — 12px, small body / labels</Text>
-<Text size="md">md — 14px, body (default)</Text>
-<Text size="lg">lg — 16px, large body</Text>
-<Text size="xl">xl — 20px, very large body</Text>`}
+        code={`import { Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs">
+      <Text size="xs">xs — 11px, dense metadata</Text>
+      <Text size="sm">sm — 12px, small body / labels</Text>
+      <Text size="md">md — 14px, body (default)</Text>
+      <Text size="lg">lg — 16px, large body</Text>
+      <Text size="xl">xl — 20px, very large body</Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="xs">
           <Text size="xs">xs — 11px, dense metadata</Text>
@@ -36,11 +44,21 @@ export function TextDemo() {
       <Example
         title="As variants"
         description="Constrained-as dispatch — exactly four rendered elements. <p> (block, default), <span> (inline), <div> (block, no <p> nesting constraints), <label> (pair with htmlFor)."
-        code={`<Text>Default — renders <p></Text>
-<Text as="span">as="span" — renders inline <span></Text>
-<Text as="div">as="div" — renders block <div></Text>
-<Text as="label" htmlFor="email-demo">as="label" htmlFor — renders <label></Text>
-<Input id="email-demo" placeholder="Email" />`}
+        code={`import { Input, Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm" align="start">
+      <Text>Default — renders &lt;p&gt;</Text>
+      <Text as="span">as="span" — renders inline &lt;span&gt;</Text>
+      <Text as="div">as="div" — renders block &lt;div&gt;</Text>
+      <Text as="label" htmlFor="email-demo">
+        as="label" htmlFor — renders &lt;label&gt;
+      </Text>
+      <Input id="email-demo" placeholder="Email" />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm" align="start">
           <Text>Default — renders &lt;p&gt;</Text>
@@ -56,13 +74,21 @@ export function TextDemo() {
       <Example
         title="Tones"
         description="Seven tones: default + muted + subtle (foreground variants), accent, plus state-coded danger / success / warning."
-        code={`<Text tone="default">default</Text>
-<Text tone="muted">muted</Text>
-<Text tone="subtle">subtle</Text>
-<Text tone="accent">accent</Text>
-<Text tone="danger">danger</Text>
-<Text tone="success">success</Text>
-<Text tone="warning">warning</Text>`}
+        code={`import { Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs">
+      <Text tone="default">default</Text>
+      <Text tone="muted">muted</Text>
+      <Text tone="subtle">subtle</Text>
+      <Text tone="accent">accent</Text>
+      <Text tone="danger">danger</Text>
+      <Text tone="success">success</Text>
+      <Text tone="warning">warning</Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="xs">
           <Text tone="default">default</Text>
@@ -78,10 +104,18 @@ export function TextDemo() {
       <Example
         title="Weights"
         description="Four weights. Default for Text is `regular`."
-        code={`<Text weight="regular">regular (default)</Text>
-<Text weight="medium">medium</Text>
-<Text weight="semibold">semibold</Text>
-<Text weight="bold">bold</Text>`}
+        code={`import { Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs">
+      <Text weight="regular">regular (default)</Text>
+      <Text weight="medium">medium</Text>
+      <Text weight="semibold">semibold</Text>
+      <Text weight="bold">bold</Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="xs">
           <Text weight="regular">regular (default)</Text>
@@ -94,9 +128,17 @@ export function TextDemo() {
       <Example
         title="Alignment"
         description="Text-align applied via class — left / center / right."
-        code={`<Text align="left">left aligned</Text>
-<Text align="center">center aligned</Text>
-<Text align="right">right aligned</Text>`}
+        code={`import { Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs" style={{ width: 360 }}>
+      <Text align="left">left aligned</Text>
+      <Text align="center">center aligned</Text>
+      <Text align="right">right aligned</Text>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="xs" style={{ width: 360 }}>
           <Text align="left">left aligned</Text>
@@ -108,9 +150,17 @@ export function TextDemo() {
       <Example
         title="Truncate"
         description="Single-line ellipsis. The full text remains in the accessibility tree."
-        code={`<div style={{ width: 240 }}>
-  <Text truncate>A long single line that will be ellipsed when it overflows the parent.</Text>
-</div>`}
+        code={`import { Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <div style={{ width: 240, border: '1px dashed var(--color-border)', padding: 8 }}>
+      <Text truncate>
+        A long single line that will be ellipsed when it overflows the parent.
+      </Text>
+    </div>
+  );
+}`}
       >
         <div style={{ width: 240, border: '1px dashed var(--color-border)', padding: 8 }}>
           <Text truncate>
@@ -122,12 +172,19 @@ export function TextDemo() {
       <Example
         title="Line clamp"
         description="Multi-line ellipsis via `lineClamp={N}` — uses CSS -webkit-line-clamp (the dynamic value is set inline)."
-        code={`<div style={{ width: 320 }}>
-  <Text lineClamp={2}>
-    A long paragraph that wraps onto multiple lines, but we want to ellipsis
-    after exactly two lines so the surrounding card has a predictable height.
-  </Text>
-</div>`}
+        code={`import { Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <div style={{ width: 320, border: '1px dashed var(--color-border)', padding: 8 }}>
+      <Text lineClamp={2}>
+        A long paragraph that wraps onto multiple lines, but we want to ellipsis after exactly
+        two lines so the surrounding card has a predictable height. This sentence is here just
+        to make sure the text overflows so the clamp visibly fires in the demo.
+      </Text>
+    </div>
+  );
+}`}
       >
         <div style={{ width: 320, border: '1px dashed var(--color-border)', padding: 8 }}>
           <Text lineClamp={2}>
@@ -141,8 +198,22 @@ export function TextDemo() {
       <Example
         title="Composing with <Code>"
         description="<Code> is inline by default and scales with the surrounding text (uses --font-size-code, a relative 0.92em)."
-        code={`<Text>Run <Code>npm install</Code> to add a dependency.</Text>
-<Text size="sm">In dev mode, set <Code>VITE_BASE_PATH=/</Code> to serve from root.</Text>`}
+        code={`import { Cluster, Code, Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="start">
+      <Stack gap="xs" style={{ maxWidth: 360 }}>
+        <Text>
+          Run <Code>npm install</Code> to add a dependency.
+        </Text>
+        <Text size="sm">
+          In dev mode, set <Code>VITE_BASE_PATH=/</Code> to serve from root.
+        </Text>
+      </Stack>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="start">
           <Stack gap="xs" style={{ maxWidth: 360 }}>

--- a/packages/playground/src/pages/components/TextareaDemo.tsx
+++ b/packages/playground/src/pages/components/TextareaDemo.tsx
@@ -18,7 +18,11 @@ export function TextareaDemo() {
       <Example
         title="Default"
         description="Auto-grows on input, 3 row minimum, no max. Resize handle hidden because auto-grow is on."
-        code={`<Textarea placeholder="Write something…" />`}
+        code={`import { Textarea } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Textarea placeholder="Write something…" />;
+}`}
       >
         <Textarea placeholder="Write something…" />
       </Example>
@@ -26,9 +30,17 @@ export function TextareaDemo() {
       <Example
         title="Three sizes"
         description="Size affects typography + padding only (height comes from minRows). Useful when matching Input alongside."
-        code={`<Textarea size="sm" minRows={2} placeholder="sm" />
-<Textarea size="md" minRows={2} placeholder="md" />
-<Textarea size="lg" minRows={2} placeholder="lg" />`}
+        code={`import { Stack, Textarea } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Textarea size="sm" minRows={2} placeholder="sm" />
+      <Textarea size="md" minRows={2} placeholder="md" />
+      <Textarea size="lg" minRows={2} placeholder="lg" />
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Textarea size="sm" minRows={2} placeholder="sm" />
@@ -40,13 +52,21 @@ export function TextareaDemo() {
       <Example
         title="Auto-grow in action (capped at 8 rows)"
         description="Type multiple lines — the field expands up to 8 rows, then scrolls."
-        code={`<Textarea
-  minRows={2}
-  maxRows={8}
-  value={value}
-  onChange={(e) => setValue(e.target.value)}
-  placeholder="Try multiple lines…"
-/>`}
+        code={`import { useState } from 'react';
+import { Textarea } from '@eocrm/design-system';
+
+export function Demo() {
+  const [value, setValue] = useState('');
+  return (
+    <Textarea
+      minRows={2}
+      maxRows={8}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      placeholder="Try multiple lines…"
+    />
+  );
+}`}
       >
         <Textarea
           minRows={2}
@@ -60,7 +80,11 @@ export function TextareaDemo() {
       <Example
         title="Fixed rows (no auto-grow) with resize handle"
         description="Opting out of auto-grow lets the user drag the resize handle in the bottom-right corner."
-        code={`<Textarea autoGrow={false} minRows={4} resize="vertical" />`}
+        code={`import { Textarea } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Textarea autoGrow={false} minRows={4} resize="vertical" />;
+}`}
       >
         <Textarea autoGrow={false} minRows={4} resize="vertical" />
       </Example>
@@ -68,11 +92,19 @@ export function TextareaDemo() {
       <Example
         title="Twitter-style counter"
         description="When maxLength is set, the counter appears automatically. Controlled state shown."
-        code={`<Textarea
-  maxLength={140}
-  value={tweet}
-  onChange={(e) => setTweet(e.target.value)}
-/>`}
+        code={`import { useState } from 'react';
+import { Textarea } from '@eocrm/design-system';
+
+export function Demo() {
+  const [tweet, setTweet] = useState("What's happening?");
+  return (
+    <Textarea
+      maxLength={140}
+      value={tweet}
+      onChange={(e) => setTweet(e.target.value)}
+    />
+  );
+}`}
       >
         <Textarea maxLength={140} value={tweet} onChange={(e) => setTweet(e.target.value)} />
       </Example>
@@ -80,7 +112,11 @@ export function TextareaDemo() {
       <Example
         title="Bare counter (no maxLength)"
         description="showCount={true} forces the counter even without a hard limit — shows just the running count."
-        code={`<Textarea showCount minRows={3} placeholder="Free-form…" />`}
+        code={`import { Textarea } from '@eocrm/design-system';
+
+export function Demo() {
+  return <Textarea showCount minRows={3} placeholder="Free-form…" />;
+}`}
       >
         <Textarea showCount minRows={3} placeholder="Free-form…" />
       </Example>
@@ -88,10 +124,25 @@ export function TextareaDemo() {
       <Example
         title="Error state"
         description="invalid={true} adds the red border + danger focus ring. Pair with a visible error message via aria-describedby."
-        code={`<Textarea invalid aria-describedby="bio-error" defaultValue="" />
-<p id="bio-error" style={{ color: 'var(--color-danger)' }}>
-  Bio must not be empty.
-</p>`}
+        code={`import { Stack, Textarea } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Textarea invalid aria-describedby="bio-error" defaultValue="" />
+      <p
+        id="bio-error"
+        style={{
+          color: 'var(--color-danger)',
+          margin: 0,
+          fontSize: 'var(--font-size-sm)',
+        }}
+      >
+        Bio must not be empty.
+      </p>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Textarea invalid aria-describedby="bio-error" defaultValue="" />
@@ -111,8 +162,19 @@ export function TextareaDemo() {
       <Example
         title="Disabled and readOnly"
         description="Native attributes — same visual treatment as Input."
-        code={`<Textarea disabled defaultValue="Disabled — can't focus or edit." />
-<Textarea readOnly defaultValue="Read-only — focusable, content selectable, not editable." />`}
+        code={`import { Cluster, Textarea } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <Textarea disabled defaultValue="Disabled — can't focus or edit." />
+      <Textarea
+        readOnly
+        defaultValue="Read-only — focusable, content selectable, not editable."
+      />
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="sm">
           <Textarea disabled defaultValue="Disabled — can't focus or edit." />

--- a/packages/playground/src/pages/components/ThreadDemo.tsx
+++ b/packages/playground/src/pages/components/ThreadDemo.tsx
@@ -20,38 +20,57 @@ export function ThreadDemo() {
       <Example
         title="Comment thread (nested replies)"
         description="Each item's node is a slot — an Avatar for the author. Nested <Thread.Item>s render as replies under the rail; a reply can itself have replies. Each reply branches off the rail with an elbow connector to its avatar. (The author line gets the avatar's line-height so it centers on the avatar.)"
-        code={`// center the author line on the avatar — the avatar is taller than a text line
+        code={`import { Avatar, Stack, Text, Thread } from '@eocrm/design-system';
+
 const headerLine = { lineHeight: 'var(--size-sm)' };
 
-<Thread>
-  <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
-    <Stack gap="xs">
-      <Text size="sm" style={headerLine}><strong>Maya Chen</strong> · 2h ago</Text>
-      <Text size="sm">
-        Flagged the Acme renewal — usage dropped ~30% last quarter. Worth a
-        check-in before we send the contract.
-      </Text>
-    </Stack>
-    <Thread.Item node={<Avatar name="Tom Okafor" size="sm" />}>
-      <Stack gap="xs">
-        <Text size="sm" style={headerLine}><strong>Tom Okafor</strong> · 1h ago</Text>
-        <Text size="sm">Good catch. I'll set up a call with their ops lead for Thursday.</Text>
-      </Stack>
+export function Demo() {
+  return (
+    <Thread>
       <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
         <Stack gap="xs">
-          <Text size="sm" style={headerLine}><strong>Maya Chen</strong> · 48m ago</Text>
-          <Text size="sm">Perfect — loop in Priya, she owns the technical relationship.</Text>
+          <Text size="sm" style={headerLine}>
+            <strong>Maya Chen</strong> · 2h ago
+          </Text>
+          <Text size="sm">
+            Flagged the Acme renewal — usage dropped ~30% last quarter. Worth a
+            check-in before we send the contract.
+          </Text>
         </Stack>
+        <Thread.Item node={<Avatar name="Tom Okafor" size="sm" />}>
+          <Stack gap="xs">
+            <Text size="sm" style={headerLine}>
+              <strong>Tom Okafor</strong> · 1h ago
+            </Text>
+            <Text size="sm">
+              Good catch. I'll set up a call with their ops lead for Thursday.
+            </Text>
+          </Stack>
+          <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
+            <Stack gap="xs">
+              <Text size="sm" style={headerLine}>
+                <strong>Maya Chen</strong> · 48m ago
+              </Text>
+              <Text size="sm">
+                Perfect — loop in Priya, she owns the technical relationship.
+              </Text>
+            </Stack>
+          </Thread.Item>
+        </Thread.Item>
+        <Thread.Item node={<Avatar name="Priya Nair" size="sm" />}>
+          <Stack gap="xs">
+            <Text size="sm" style={headerLine}>
+              <strong>Priya Nair</strong> · 20m ago
+            </Text>
+            <Text size="sm">
+              On it — pulling the latest usage report so we walk in prepared.
+            </Text>
+          </Stack>
+        </Thread.Item>
       </Thread.Item>
-    </Thread.Item>
-    <Thread.Item node={<Avatar name="Priya Nair" size="sm" />}>
-      <Stack gap="xs">
-        <Text size="sm" style={headerLine}><strong>Priya Nair</strong> · 20m ago</Text>
-        <Text size="sm">On it — pulling the latest usage report so we walk in prepared.</Text>
-      </Stack>
-    </Thread.Item>
-  </Thread.Item>
-</Thread>`}
+    </Thread>
+  );
+}`}
       >
         <Thread>
           <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
@@ -101,25 +120,42 @@ const headerLine = { lineHeight: 'var(--size-sm)' };
       <Example
         title="Depth cap (maxDepth)"
         description="A deep back-and-forth. With maxDepth={3}, replies stop indenting once the cap is reached — the chain past level 3 renders flat at the same indent so the thread stops marching right off the page."
-        code={`// headerLine = { lineHeight: 'var(--size-sm)' } — see the first example
-<Thread maxDepth={3}>
-  <Thread.Item node={<Avatar name="Dana Reyes" size="sm" />}>
-    <Text size="sm" style={headerLine}><strong>Dana Reyes</strong> · who's covering the EU launch demo?</Text>
-    <Thread.Item node={<Avatar name="Sam Cole" size="sm" />}>
-      <Text size="sm" style={headerLine}><strong>Sam Cole</strong> · I can — what time zone is the client in?</Text>
-      <Thread.Item node={<Avatar name="Lena Fischer" size="sm" />}>
-        <Text size="sm" style={headerLine}><strong>Lena Fischer</strong> · CET. They asked for 10:00 their time.</Text>
-        <Thread.Item node={<Avatar name="Raj Patel" size="sm" />}>
-          {/* depth 3 hits the cap → this reply and deeper render flat */}
-          <Text size="sm" style={headerLine}><strong>Raj Patel</strong> · Booked the room and sent the invite.</Text>
-          <Thread.Item node={<Avatar name="Olivia Wong" size="sm" />}>
-            <Text size="sm" style={headerLine}><strong>Olivia Wong</strong> · Added the deck link to the calendar event.</Text>
+        code={`import { Avatar, Text, Thread } from '@eocrm/design-system';
+
+const headerLine = { lineHeight: 'var(--size-sm)' };
+
+export function Demo() {
+  return (
+    <Thread maxDepth={3}>
+      <Thread.Item node={<Avatar name="Dana Reyes" size="sm" />}>
+        <Text size="sm" style={headerLine}>
+          <strong>Dana Reyes</strong> · who's covering the EU launch demo?
+        </Text>
+        <Thread.Item node={<Avatar name="Sam Cole" size="sm" />}>
+          <Text size="sm" style={headerLine}>
+            <strong>Sam Cole</strong> · I can — what time zone is the client in?
+          </Text>
+          <Thread.Item node={<Avatar name="Lena Fischer" size="sm" />}>
+            <Text size="sm" style={headerLine}>
+              <strong>Lena Fischer</strong> · CET. They asked for 10:00 their time.
+            </Text>
+            <Thread.Item node={<Avatar name="Raj Patel" size="sm" />}>
+              {/* depth 3 hits the cap → this reply and deeper render flat */}
+              <Text size="sm" style={headerLine}>
+                <strong>Raj Patel</strong> · Booked the room and sent the invite.
+              </Text>
+              <Thread.Item node={<Avatar name="Olivia Wong" size="sm" />}>
+                <Text size="sm" style={headerLine}>
+                  <strong>Olivia Wong</strong> · Added the deck link to the calendar event.
+                </Text>
+              </Thread.Item>
+            </Thread.Item>
           </Thread.Item>
         </Thread.Item>
       </Thread.Item>
-    </Thread.Item>
-  </Thread.Item>
-</Thread>`}
+    </Thread>
+  );
+}`}
       >
         <Thread maxDepth={3}>
           <Thread.Item node={<Avatar name="Dana Reyes" size="sm" />}>
@@ -154,15 +190,33 @@ const headerLine = { lineHeight: 'var(--size-sm)' };
       <Example
         title="Compact (dense sidebar thread)"
         description="compact tightens the gaps for a narrow panel — a contact-record activity sidebar. The remapped tokens cascade to every nested reply."
-        code={`// headerLine = { lineHeight: 'var(--size-sm)' } — see the first example
-<Thread compact>
-  <Thread.Item node={<Avatar name="Grace Liu" size="sm" />}>
-    <Text size="sm" style={headerLine}><strong>Grace Liu</strong> · renewed the contract</Text>
-    <Thread.Item node={<Avatar name="Marcus Bell" size="sm" />}>
-      <Text size="sm" style={headerLine}><strong>Marcus Bell</strong> · nice — invoice sent</Text>
-    </Thread.Item>
-  </Thread.Item>
-</Thread>`}
+        code={`import { Avatar, Constrain, Text, Thread } from '@eocrm/design-system';
+
+const headerLine = { lineHeight: 'var(--size-sm)' };
+
+export function Demo() {
+  return (
+    <Constrain maxWidth="xs">
+      <Thread compact>
+        <Thread.Item node={<Avatar name="Grace Liu" size="sm" />}>
+          <Text size="sm" style={headerLine}>
+            <strong>Grace Liu</strong> · renewed the contract
+          </Text>
+          <Thread.Item node={<Avatar name="Marcus Bell" size="sm" />}>
+            <Text size="sm" style={headerLine}>
+              <strong>Marcus Bell</strong> · nice — invoice sent
+            </Text>
+          </Thread.Item>
+        </Thread.Item>
+        <Thread.Item node={<Avatar name="Priya Nair" size="sm" />}>
+          <Text size="sm" style={headerLine}>
+            <strong>Priya Nair</strong> · logged a support call
+          </Text>
+        </Thread.Item>
+      </Thread>
+    </Constrain>
+  );
+}`}
       >
         <Constrain maxWidth="xs">
           <Thread compact>

--- a/packages/playground/src/pages/components/TimeFieldDemo.tsx
+++ b/packages/playground/src/pages/components/TimeFieldDemo.tsx
@@ -84,8 +84,13 @@ export function TimeFieldDemo() {
       <Example
         title="Default (auto cycle)"
         description="`hourCycle='auto'` (the default) reads the active locale via `Intl.DateTimeFormat`. In the playground (en-US) this renders as a 12-hour clock with an AM/PM column in the popover. ArrowDown on the input opens the popover; ArrowUp/Down navigate within the focused column; ArrowLeft/Right switch columns; Enter commits."
-        code={`const [time, setTime] = useState<TimeValue | null>({ hours: 9, minutes: 30 });
-<TimeField value={time} onChange={setTime} aria-label="Start time" />`}
+        code={`import { useState } from 'react';
+import { TimeField, type TimeValue } from '@eocrm/design-system';
+
+export function DefaultExample() {
+  const [time, setTime] = useState<TimeValue | null>({ hours: 9, minutes: 30 });
+  return <TimeField value={time} onChange={setTime} aria-label="Start time" />;
+}`}
       >
         <DefaultExample />
       </Example>
@@ -93,12 +98,20 @@ export function TimeFieldDemo() {
       <Example
         title="Forced 24-hour cycle"
         description="`hourCycle='24'` overrides the locale heuristic and shows hours 00–23 in the popover with no AM/PM column. Typed input still accepts both `14:30` and `2:30 PM` shapes — the cycle controls display, not parsing."
-        code={`<TimeField
-  value={time}
-  onChange={setTime}
-  hourCycle="24"
-  aria-label="Departure time"
-/>`}
+        code={`import { useState } from 'react';
+import { TimeField, type TimeValue } from '@eocrm/design-system';
+
+export function Forced24Example() {
+  const [time, setTime] = useState<TimeValue | null>({ hours: 14, minutes: 0 });
+  return (
+    <TimeField
+      value={time}
+      onChange={setTime}
+      hourCycle="24"
+      aria-label="Departure time"
+    />
+  );
+}`}
       >
         <Forced24Example />
       </Example>
@@ -106,13 +119,21 @@ export function TimeFieldDemo() {
       <Example
         title="Step = 30 minutes"
         description="`step={30}` cuts the minutes column down to two rows (`00`, `30`) AND rounds typed input on commit — `09:17` rounds to `09:30`. Use `step={1}` to disable rounding entirely."
-        code={`<TimeField
-  value={time}
-  onChange={setTime}
-  step={30}
-  hourCycle="24"
-  aria-label="Slot start"
-/>`}
+        code={`import { useState } from 'react';
+import { TimeField, type TimeValue } from '@eocrm/design-system';
+
+export function Step30Example() {
+  const [time, setTime] = useState<TimeValue | null>({ hours: 10, minutes: 0 });
+  return (
+    <TimeField
+      value={time}
+      onChange={setTime}
+      step={30}
+      hourCycle="24"
+      aria-label="Slot start"
+    />
+  );
+}`}
       >
         <Step30Example />
       </Example>
@@ -120,13 +141,21 @@ export function TimeFieldDemo() {
       <Example
         title="Hide the Now button"
         description="`hideNowButton` removes the footer row entirely. Use when 'now' isn't a meaningful default — e.g. wake-up alarms, scheduled-for-tomorrow time pickers."
-        code={`<TimeField
-  value={time}
-  onChange={setTime}
-  hideNowButton
-  hourCycle="12"
-  aria-label="Wake-up alarm"
-/>`}
+        code={`import { useState } from 'react';
+import { TimeField, type TimeValue } from '@eocrm/design-system';
+
+export function HideNowExample() {
+  const [time, setTime] = useState<TimeValue | null>({ hours: 8, minutes: 0 });
+  return (
+    <TimeField
+      value={time}
+      onChange={setTime}
+      hideNowButton
+      hourCycle="12"
+      aria-label="Wake-up alarm"
+    />
+  );
+}`}
       >
         <HideNowExample />
       </Example>
@@ -134,9 +163,20 @@ export function TimeFieldDemo() {
       <Example
         title="Controlled with live value display"
         description="The committed value is always `{ hours: 0-23, minutes: 0-59 }` regardless of display cycle. AM/PM is a presentation concern, flipped at the column boundary; internal storage stays 24-hour so consumers don't have to track period state."
-        code={`const [time, setTime] = useState<TimeValue | null>({ hours: 13, minutes: 45 });
-<TimeField value={time} onChange={setTime} hourCycle="auto" aria-label="Meeting start" />
-<Text size="sm" tone="muted">Committed value: <Code>{JSON.stringify(time)}</Code></Text>`}
+        code={`import { useState } from 'react';
+import { Code, Stack, Text, TimeField, type TimeValue } from '@eocrm/design-system';
+
+export function ControlledExample() {
+  const [time, setTime] = useState<TimeValue | null>({ hours: 13, minutes: 45 });
+  return (
+    <Stack gap="sm">
+      <TimeField value={time} onChange={setTime} hourCycle="auto" aria-label="Meeting start" />
+      <Text size="sm" tone="muted">
+        Committed value: <Code>{JSON.stringify(time)}</Code>
+      </Text>
+    </Stack>
+  );
+}`}
       >
         <ControlledExample />
       </Example>
@@ -144,13 +184,35 @@ export function TimeFieldDemo() {
       <Example
         title="Locale-driven hourCycle='auto'"
         description="With `hourCycle='auto'` the cycle follows the locale — en-US gets 12h with AM/PM, ru-RU gets 24h. Override locally with the `locale` prop or globally with `<LocaleProvider>`."
-        code={`<LocaleProvider locale="en-US">
-  <TimeField value={a} onChange={setA} aria-label="en-US time" />
-</LocaleProvider>
+        code={`import { useState } from 'react';
+import { Code, LocaleProvider, Stack, Text, TimeField, type TimeValue } from '@eocrm/design-system';
 
-<LocaleProvider locale="ru-RU">
-  <TimeField value={b} onChange={setB} aria-label="ru-RU time" />
-</LocaleProvider>`}
+export function LocaleSideBySide() {
+  const [a, setA] = useState<TimeValue | null>({ hours: 14, minutes: 30 });
+  const [b, setB] = useState<TimeValue | null>({ hours: 14, minutes: 30 });
+  return (
+    <Stack gap="md">
+      <Stack gap="xs">
+        <Text size="sm" tone="muted">
+          <Code>locale=&quot;en-US&quot;</Code> + <Code>hourCycle=&quot;auto&quot;</Code> → 12h
+          display
+        </Text>
+        <LocaleProvider locale="en-US">
+          <TimeField value={a} onChange={setA} aria-label="en-US time" />
+        </LocaleProvider>
+      </Stack>
+      <Stack gap="xs">
+        <Text size="sm" tone="muted">
+          <Code>locale=&quot;ru-RU&quot;</Code> + <Code>hourCycle=&quot;auto&quot;</Code> → 24h
+          display
+        </Text>
+        <LocaleProvider locale="ru-RU">
+          <TimeField value={b} onChange={setB} aria-label="ru-RU time" />
+        </LocaleProvider>
+      </Stack>
+    </Stack>
+  );
+}`}
       >
         <LocaleSideBySide />
       </Example>
@@ -158,7 +220,11 @@ export function TimeFieldDemo() {
       <Example
         title="Disabled (null value)"
         description="`value={null}` disables the field entirely — the input is blank, the chevron is muted, and typed input is ignored. The DatePicker family uses this to gate time selection on a date being chosen first."
-        code={`<TimeField value={null} onChange={() => {}} aria-label="Time" />`}
+        code={`import { TimeField } from '@eocrm/design-system';
+
+export function Demo() {
+  return <TimeField value={null} onChange={() => {}} aria-label="Disabled time" />;
+}`}
       >
         <TimeField value={null} onChange={() => {}} aria-label="Disabled time" />
       </Example>

--- a/packages/playground/src/pages/components/TimelineDemo.tsx
+++ b/packages/playground/src/pages/components/TimelineDemo.tsx
@@ -15,24 +15,57 @@ export function TimelineDemo() {
       <Example
         title="Activity feed (avatar / icon nodes)"
         description="Each item's node is a slot — an Avatar for a person, an IconTile for a system event, or an action like the “Add activity” composer pinned as the most-recent node at the top. The connector links consecutive nodes and stops at the last."
-        code={`<Timeline>
-  <Timeline.Item node={<IconTile icon={<Plus size={16} />} color="blue" size="sm" />}>
-    {/* center the single control to the node box */}
-    <div style={{ display: 'flex', alignItems: 'center', minHeight: 'var(--size-md)' }}>
-      <Button variant="secondary" size="sm" onClick={addActivity}>Add activity</Button>
-    </div>
-  </Timeline.Item>
-  <Timeline.Item node={<Avatar name="Dana Reyes" size="sm" />}>
-    <Stack gap="xs">
-      <Text size="sm"><strong>Dana Reyes</strong> · note · 2h ago</Text>
-      <Text size="sm" tone="muted">Called the client; renewal confirmed for Q3.</Text>
-    </Stack>
-  </Timeline.Item>
-  <Timeline.Item node={<IconTile icon={<GitCommit size={16} />} color="blue" size="sm" />}>
-    …
-  </Timeline.Item>
-  …
-</Timeline>`}
+        code={`import { GitCommit, Mail, Plus } from 'lucide-react';
+import { Avatar, Button, IconTile, Stack, Text, Timeline } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Timeline>
+      <Timeline.Item node={<IconTile icon={<Plus size={16} />} color="blue" size="sm" />}>
+        <div style={{ display: 'flex', alignItems: 'center', minHeight: 'var(--size-md)' }}>
+          <Button variant="secondary" size="sm" onClick={() => {}}>
+            Add activity
+          </Button>
+        </div>
+      </Timeline.Item>
+      <Timeline.Item node={<Avatar name="Dana Reyes" size="sm" />}>
+        <Stack gap="xs">
+          <Text size="sm">
+            <strong>Dana Reyes</strong> · note · 2h ago
+          </Text>
+          <Text size="sm" tone="muted">
+            Called the client; renewal confirmed for Q3.
+          </Text>
+        </Stack>
+      </Timeline.Item>
+      <Timeline.Item node={<IconTile icon={<GitCommit size={16} />} color="blue" size="sm" />}>
+        <Stack gap="xs">
+          <Text size="sm">
+            <strong>System</strong> · stage change · 5h ago
+          </Text>
+          <Text size="sm" tone="muted">
+            Moved to "Negotiation".
+          </Text>
+        </Stack>
+      </Timeline.Item>
+      <Timeline.Item node={<IconTile icon={<Mail size={16} />} color="slate" size="sm" />}>
+        <Stack gap="xs">
+          <Text size="sm">
+            <strong>Sam Cole</strong> · email · yesterday
+          </Text>
+          <Text size="sm" tone="muted">
+            Sent the updated proposal.
+          </Text>
+        </Stack>
+      </Timeline.Item>
+      <Timeline.Item node={<Avatar name="Priya Nair" size="sm" />}>
+        <Text size="sm">
+          <strong>Priya Nair</strong> · created · 3d ago
+        </Text>
+      </Timeline.Item>
+    </Timeline>
+  );
+}`}
       >
         <Timeline>
           {/* Composer entry as the most-recent (top) node — its connector flows into the feed below.
@@ -85,13 +118,28 @@ export function TimelineDemo() {
       <Example
         title="Compact (dot nodes — sidebar widget)"
         description="compact tightens the gutter, node box, and spacing; pair with small Dot nodes for a dense activity widget."
-        code={`<Timeline compact>
-  <Timeline.Item node={<Dot tone="info" />}>
-    <Text size="sm">Renewal confirmed</Text>
-    <Text size="xs" tone="muted">2h ago</Text>
-  </Timeline.Item>
-  …
-</Timeline>`}
+        code={`import { Dot, Text, Timeline } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <div style={{ maxWidth: 260 }}>
+      <Timeline compact>
+        <Timeline.Item node={<Dot tone="info" />}>
+          <Text size="sm">Renewal confirmed</Text>
+          <Text size="xs" tone="muted">2h ago</Text>
+        </Timeline.Item>
+        <Timeline.Item node={<Dot tone="success" />}>
+          <Text size="sm">Moved to Negotiation</Text>
+          <Text size="xs" tone="muted">5h ago</Text>
+        </Timeline.Item>
+        <Timeline.Item node={<Dot tone="purple" />}>
+          <Text size="sm">Proposal sent</Text>
+          <Text size="xs" tone="muted">yesterday</Text>
+        </Timeline.Item>
+      </Timeline>
+    </div>
+  );
+}`}
       >
         <div style={{ maxWidth: 260 }}>
           <Timeline compact>

--- a/packages/playground/src/pages/components/TitleDemo.tsx
+++ b/packages/playground/src/pages/components/TitleDemo.tsx
@@ -16,12 +16,20 @@ export function TitleDemo() {
       <Example
         title="Orders 1-6"
         description="The required `order` prop drives both the rendered element (h1-h6) and the default visual size (1→3xl, 2→2xl, 3→xl, 4→lg, 5→md, 6→sm)."
-        code={`<Title order={1}>Order 1 (h1, 3xl)</Title>
-<Title order={2}>Order 2 (h2, 2xl)</Title>
-<Title order={3}>Order 3 (h3, xl)</Title>
-<Title order={4}>Order 4 (h4, lg)</Title>
-<Title order={5}>Order 5 (h5, md)</Title>
-<Title order={6}>Order 6 (h6, sm)</Title>`}
+        code={`import { Stack, Title } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Title order={1}>Order 1 (h1, 3xl)</Title>
+      <Title order={2}>Order 2 (h2, 2xl)</Title>
+      <Title order={3}>Order 3 (h3, xl)</Title>
+      <Title order={4}>Order 4 (h4, lg)</Title>
+      <Title order={5}>Order 5 (h5, md)</Title>
+      <Title order={6}>Order 6 (h6, sm)</Title>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Title order={1}>Order 1 (h1, 3xl)</Title>
@@ -36,9 +44,17 @@ export function TitleDemo() {
       <Example
         title="Size override"
         description="Pass `size` to decouple the visual size from the semantic level. Useful when a nested section still needs the right h-level for SR but a smaller visual treatment."
-        code={`<Title order={2}>Default h2 (2xl)</Title>
-<Title order={2} size="lg">h2 with size="lg"</Title>
-<Title order={2} size="md">h2 with size="md"</Title>`}
+        code={`import { Stack, Title } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Title order={2}>Default h2 (2xl)</Title>
+      <Title order={2} size="lg">h2 with size="lg"</Title>
+      <Title order={2} size="md">h2 with size="md"</Title>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Title order={2}>Default h2 (2xl)</Title>
@@ -54,11 +70,19 @@ export function TitleDemo() {
       <Example
         title="Tones"
         description="Five tones map to --color-fg / -muted / -subtle / --color-accent / --color-danger."
-        code={`<Title order={3} tone="default">default</Title>
-<Title order={3} tone="muted">muted</Title>
-<Title order={3} tone="subtle">subtle</Title>
-<Title order={3} tone="accent">accent</Title>
-<Title order={3} tone="danger">danger</Title>`}
+        code={`import { Stack, Title } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Title order={3} tone="default">default</Title>
+      <Title order={3} tone="muted">muted</Title>
+      <Title order={3} tone="subtle">subtle</Title>
+      <Title order={3} tone="accent">accent</Title>
+      <Title order={3} tone="danger">danger</Title>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Title order={3} tone="default">
@@ -82,10 +106,18 @@ export function TitleDemo() {
       <Example
         title="Weights"
         description="Four weights. Default for Title is `semibold`."
-        code={`<Title order={3} weight="regular">regular</Title>
-<Title order={3} weight="medium">medium</Title>
-<Title order={3} weight="semibold">semibold (default)</Title>
-<Title order={3} weight="bold">bold</Title>`}
+        code={`import { Stack, Title } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="sm">
+      <Title order={3} weight="regular">regular</Title>
+      <Title order={3} weight="medium">medium</Title>
+      <Title order={3} weight="semibold">semibold (default)</Title>
+      <Title order={3} weight="bold">bold</Title>
+    </Stack>
+  );
+}`}
       >
         <Stack gap="sm">
           <Title order={3} weight="regular">
@@ -106,9 +138,19 @@ export function TitleDemo() {
       <Example
         title="Truncate"
         description="Single-line ellipsis inside a narrow container. The full text remains in the accessibility tree."
-        code={`<div style={{ width: 200 }}>
-  <Title order={3} truncate>A very long title that exceeds the container width</Title>
-</div>`}
+        code={`import { Cluster, Title } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" align="start">
+      <div style={{ width: 200, border: '1px dashed var(--color-border)', padding: 8 }}>
+        <Title order={3} truncate>
+          A very long title that exceeds the container width
+        </Title>
+      </div>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" align="start">
           <div style={{ width: 200, border: '1px dashed var(--color-border)', padding: 8 }}>

--- a/packages/playground/src/pages/components/ToastDemo.tsx
+++ b/packages/playground/src/pages/components/ToastDemo.tsx
@@ -18,11 +18,29 @@ export function ToastDemo() {
       <Example
         title="Tones"
         description="Five tones with sensible icon + accent color defaults. Error toasts use role='alert' (assertive); the others use role='status' (polite)."
-        code={`toast.info('Heads up');
-toast.success('Saved');
-toast.warning('Storage almost full');
-toast.error('Request failed');
-toast.loading('Uploading…');`}
+        code={`import { toast, Button, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <Button variant="secondary" onClick={() => toast.info('Heads up')}>
+        info
+      </Button>
+      <Button variant="secondary" onClick={() => toast.success('Saved')}>
+        success
+      </Button>
+      <Button variant="secondary" onClick={() => toast.warning('Storage almost full')}>
+        warning
+      </Button>
+      <Button variant="secondary" onClick={() => toast.error('Request failed')}>
+        error
+      </Button>
+      <Button variant="secondary" onClick={() => toast.loading('Uploading…')}>
+        loading
+      </Button>
+    </Cluster>
+  );
+}`}
       >
         <InputExample width="auto">
           <Cluster gap="sm">
@@ -48,9 +66,22 @@ toast.loading('Uploading…');`}
       <Example
         title="With a description"
         description="Description is a second line, line-clamped to 2 lines."
-        code={`toast.success('Saved', {
-  description: 'Your changes are now live.',
-});`}
+        code={`import { toast, Button } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Button
+      variant="secondary"
+      onClick={() =>
+        toast.success('Saved', {
+          description: 'Your changes are now live.',
+        })
+      }
+    >
+      Fire with description
+    </Button>
+  );
+}`}
       >
         <InputExample width="auto">
           <Button
@@ -69,12 +100,25 @@ toast.loading('Uploading…');`}
       <Example
         title="Action (Undo)"
         description="Single primary action. Clicking the button fires onClick AND dismisses the toast."
-        code={`toast.success('Item deleted', {
-  action: {
-    label: 'Undo',
-    onClick: () => toast.info('Restored'),
-  },
-});`}
+        code={`import { toast, Button } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Button
+      variant="secondary"
+      onClick={() =>
+        toast.success('Item deleted', {
+          action: {
+            label: 'Undo',
+            onClick: () => toast.info('Restored'),
+          },
+        })
+      }
+    >
+      Delete (with Undo)
+    </Button>
+  );
+}`}
       >
         <InputExample width="auto">
           <Button
@@ -96,10 +140,23 @@ toast.loading('Uploading…');`}
       <Example
         title="Programmatic update"
         description="Fire a loading toast, mutate it in place after the async op completes."
-        code={`const id = toast.loading('Uploading…');
-setTimeout(() => {
-  toast.success('Uploaded', { id });
-}, 2000);`}
+        code={`import { toast, Button } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Button
+      variant="secondary"
+      onClick={() => {
+        const id = toast.loading('Uploading…');
+        setTimeout(() => {
+          toast.success('Uploaded', { id });
+        }, 2000);
+      }}
+    >
+      Start upload
+    </Button>
+  );
+}`}
       >
         <InputExample width="auto">
           <Button
@@ -119,16 +176,32 @@ setTimeout(() => {
       <Example
         title="toast.promise (async sugar)"
         description="Pass a promise; the toast cycles loading → success/error automatically. Returns the original promise."
-        code={`toast.promise(
-  new Promise((resolve, reject) =>
-    setTimeout(() => (Math.random() > 0.5 ? resolve('done') : reject(new Error('500'))), 1500)
-  ),
-  {
-    loading: 'Working…',
-    success: 'Worked',
-    error: (e) => \`Failed: \${(e as Error).message}\`,
-  }
-);`}
+        code={`import { toast, Button } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Button
+      variant="secondary"
+      onClick={() =>
+        toast.promise(
+          new Promise((resolve, reject) =>
+            setTimeout(
+              () => (Math.random() > 0.5 ? resolve('done') : reject(new Error('500'))),
+              1500,
+            ),
+          ),
+          {
+            loading: 'Working…',
+            success: 'Worked',
+            error: (e) => \`Failed: \${(e as Error).message}\`,
+          },
+        )
+      }
+    >
+      Fire promise toast
+    </Button>
+  );
+}`}
       >
         <InputExample width="auto">
           <Button
@@ -157,7 +230,18 @@ setTimeout(() => {
       <Example
         title="Persistent error"
         description="duration: 'persistent' disables auto-dismiss. The close (×) button is force-enabled even if you pass dismissible: false."
-        code={`toast.error('Connection lost', { duration: 'persistent' });`}
+        code={`import { toast, Button } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Button
+      variant="secondary"
+      onClick={() => toast.error('Connection lost', { duration: 'persistent' })}
+    >
+      Fire persistent error
+    </Button>
+  );
+}`}
       >
         <InputExample width="auto">
           <Button
@@ -172,10 +256,38 @@ setTimeout(() => {
       <Example
         title="Per-call position override"
         description="A per-call `position` routes that toast into a different bucket. Use sparingly — mixing positions in one app is unusual UX."
-        code={`toast.info('top-right', { position: 'top-right' });
-toast.info('top-center', { position: 'top-center' });
-toast.info('bottom-left', { position: 'bottom-left' });
-toast.info('bottom-center', { position: 'bottom-center' });`}
+        code={`import { toast, Button, Cluster } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="sm">
+      <Button
+        variant="secondary"
+        onClick={() => toast.info('top-right', { position: 'top-right' })}
+      >
+        top-right
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={() => toast.info('top-center', { position: 'top-center' })}
+      >
+        top-center
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={() => toast.info('bottom-left', { position: 'bottom-left' })}
+      >
+        bottom-left
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={() => toast.info('bottom-center', { position: 'bottom-center' })}
+      >
+        bottom-center
+      </Button>
+    </Cluster>
+  );
+}`}
       >
         <InputExample width="auto">
           <Cluster gap="sm">
@@ -210,8 +322,29 @@ toast.info('bottom-center', { position: 'bottom-center' });`}
       <Example
         title="Burst + hover to expand"
         description="Fires 7 toasts in rapid succession. Only the top 3 are visible; the rest peek-collapse. Hover the stack to fan them out."
-        code={`for (let i = 1; i <= 7; i++) {
-  setTimeout(() => toast.info(\`Message #\${i}\`), i * 60);
+        code={`import { useState } from 'react';
+import { toast, Button, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  const [bursting, setBursting] = useState(false);
+
+  return (
+    <Stack gap="sm">
+      <Button
+        variant="secondary"
+        disabled={bursting}
+        onClick={() => {
+          setBursting(true);
+          for (let i = 1; i <= 7; i++) {
+            setTimeout(() => toast.info(\`Message #\${i}\`), i * 60);
+          }
+          setTimeout(() => setBursting(false), 600);
+        }}
+      >
+        Fire 7 toasts
+      </Button>
+    </Stack>
+  );
 }`}
       >
         <InputExample width="auto">

--- a/packages/playground/src/pages/components/TooltipDemo.tsx
+++ b/packages/playground/src/pages/components/TooltipDemo.tsx
@@ -16,9 +16,17 @@ export function TooltipDemo() {
       <Example
         title="Default — top + center"
         description="Wrap any trigger; tooltip opens after a short hover delay and immediately on keyboard focus."
-        code={`<Tooltip content="Save the record (⌘S)">
-  <Button>Save</Button>
-</Tooltip>`}
+        code={`import { Button, Cluster, Tooltip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <Tooltip content="Save the record (⌘S)">
+        <Button>Save</Button>
+      </Tooltip>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <Tooltip content="Save the record (⌘S)">
@@ -30,10 +38,26 @@ export function TooltipDemo() {
       <Example
         title="Sides"
         description="Floating UI auto-flips on collision; this row pins each tooltip to a specific side."
-        code={`<Tooltip content="Top" side="top"><Button>Top</Button></Tooltip>
-<Tooltip content="Right" side="right"><Button>Right</Button></Tooltip>
-<Tooltip content="Bottom" side="bottom"><Button>Bottom</Button></Tooltip>
-<Tooltip content="Left" side="left"><Button>Left</Button></Tooltip>`}
+        code={`import { Button, Cluster, Tooltip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <Tooltip content="Top" side="top">
+        <Button variant="secondary">Top</Button>
+      </Tooltip>
+      <Tooltip content="Right" side="right">
+        <Button variant="secondary">Right</Button>
+      </Tooltip>
+      <Tooltip content="Bottom" side="bottom">
+        <Button variant="secondary">Bottom</Button>
+      </Tooltip>
+      <Tooltip content="Left" side="left">
+        <Button variant="secondary">Left</Button>
+      </Tooltip>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <Tooltip content="Top" side="top">
@@ -54,9 +78,19 @@ export function TooltipDemo() {
       <Example
         title="Icon-only trigger"
         description="Trigger needs its own aria-label; tooltip is supplementary description, not the label."
-        code={`<Tooltip content="Filter results">
-  <Button variant="ghost" aria-label="Filter">⏷</Button>
-</Tooltip>`}
+        code={`import { Button, Cluster, Tooltip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <Tooltip content="Filter results">
+        <Button variant="ghost" aria-label="Filter">
+          ⏷
+        </Button>
+      </Tooltip>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <Tooltip content="Filter results">
@@ -70,19 +104,28 @@ export function TooltipDemo() {
       <Example
         title="Rich content"
         description="content is a ReactNode — combine an icon, an emphasised label, secondary copy, and an inline <kbd> shortcut. Use <Cluster> for layout so it wraps gracefully if the copy grows."
-        code={`<Tooltip
-  content={
-    <Cluster gap="xs" align="center">
-      <Sparkles size={14} aria-hidden="true" />
-      <span>
-        <strong>Smart save</strong> — autoformats
-      </span>
-      <kbd>⌘⇧S</kbd>
+        code={`import { Sparkles } from 'lucide-react';
+import { Button, Cluster, Tooltip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <Tooltip
+        content={
+          <Cluster gap="xs" align="center">
+            <Sparkles size={14} aria-hidden="true" />
+            <span>
+              <strong>Smart save</strong> — autoformats
+            </span>
+            <kbd>⌘⇧S</kbd>
+          </Cluster>
+        }
+      >
+        <Button>Smart save</Button>
+      </Tooltip>
     </Cluster>
-  }
->
-  <Button>Smart save</Button>
-</Tooltip>`}
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <Tooltip
@@ -104,9 +147,17 @@ export function TooltipDemo() {
       <Example
         title="Long content wraps"
         description="The panel has a max-width; copy wraps. Use sparingly — long copy belongs in body content, not a tooltip."
-        code={`<Tooltip content="…">
-  <Button>Long tooltip</Button>
-</Tooltip>`}
+        code={`import { Button, Cluster, Tooltip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <Tooltip content="This tooltip body is long enough to wrap onto multiple lines so you can see the chrome at its widest.">
+        <Button variant="secondary">Long tooltip</Button>
+      </Tooltip>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <Tooltip content="This tooltip body is long enough to wrap onto multiple lines so you can see the chrome at its widest.">
@@ -118,16 +169,28 @@ export function TooltipDemo() {
       <Example
         title="On a DropdownMenu item (z-index sanity)"
         description="Tooltip's z-layer is above DropdownMenu, so a tooltip on a menu item appears over the menu."
-        code={`<DropdownMenu>
-  <DropdownMenu.Trigger>
-    <Button variant="secondary">Actions</Button>
-  </DropdownMenu.Trigger>
-  <DropdownMenu.Content>
-    <DropdownMenu.Item onSelect={() => {}}>
-      <Tooltip content="Permanently remove this record"><span>Delete</span></Tooltip>
-    </DropdownMenu.Item>
-  </DropdownMenu.Content>
-</DropdownMenu>`}
+        code={`import { Button, Cluster, DropdownMenu, Tooltip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Cluster gap="md" justify="center">
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <Button variant="secondary">Actions</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => {}} tone="danger">
+            <Tooltip content="Permanently remove this record">
+              <span>Delete</span>
+            </Tooltip>
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </Cluster>
+  );
+}`}
       >
         <Cluster gap="md" justify="center">
           <DropdownMenu>
@@ -150,10 +213,19 @@ export function TooltipDemo() {
       <Example
         title="Controlled open"
         description="Drive open externally — rare, but useful for orchestrating with other UI state."
-        code={`const [open, setOpen] = useState(false);
-<Tooltip content="Controlled" open={open} onOpenChange={setOpen}>
-  <Button onClick={() => setOpen(o => !o)}>Toggle</Button>
-</Tooltip>`}
+        code={`import { useState } from 'react';
+import { Button, Cluster, Tooltip } from '@eocrm/design-system';
+
+export function ControlledExample() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Cluster gap="md" justify="center">
+      <Tooltip content="Controlled programmatically" open={open} onOpenChange={setOpen}>
+        <Button onClick={() => setOpen((prev) => !prev)}>Toggle</Button>
+      </Tooltip>
+    </Cluster>
+  );
+}`}
       >
         <ControlledExample />
       </Example>

--- a/packages/playground/src/pages/components/TopBarDemo.tsx
+++ b/packages/playground/src/pages/components/TopBarDemo.tsx
@@ -79,27 +79,58 @@ export function TopBarDemo() {
       <Example
         title="Default — search on the left, actions + avatar on the right"
         description="The canonical app-shell pattern: TopBar.Start holds TopBar.Search (with an optional ⌘K hint), TopBar.End holds two TopBar.IconButton actions and a trailing Avatar. The Bell button is `indicator` to surface unread notifications."
-        code={`const [query, setQuery] = useState('');
+        code={`import { useState, type ReactNode } from 'react';
+import { Bell, Plus } from 'lucide-react';
+import { Avatar, Text, TopBar } from '@eocrm/design-system';
 
-<TopBar>
-  <TopBar.Start>
-    <TopBar.Search
-      placeholder="Search contacts, deals…"
-      hotkey={['⌘', 'K']}
-      value={query}
-      onChange={(e) => setQuery(e.target.value)}
-    />
-  </TopBar.Start>
-  <TopBar.End>
-    <TopBar.IconButton aria-label="Create new">
-      <Plus size={16} />
-    </TopBar.IconButton>
-    <TopBar.IconButton aria-label="Notifications, 3 unread" indicator>
-      <Bell size={16} />
-    </TopBar.IconButton>
-    <Avatar name="Alex Rivera" size="sm" />
-  </TopBar.End>
-</TopBar>`}
+function TopBarStage({ children, height = 220 }: { children: ReactNode; height?: number }) {
+  return (
+    <div
+      style={{
+        height,
+        overflow: 'auto',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+        background: 'var(--color-bg-subtle)',
+      }}
+    >
+      {children}
+      <div style={{ padding: 'var(--space-4)' }}>
+        <Text tone="muted">
+          Scroll this box — the bar pins to the top. Page content goes here in a real app.
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+export function Demo() {
+  const [query, setQuery] = useState('');
+
+  return (
+    <TopBarStage>
+      <TopBar>
+        <TopBar.Start>
+          <TopBar.Search
+            placeholder="Search contacts, deals…"
+            hotkey={['⌘', 'K']}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </TopBar.Start>
+        <TopBar.End>
+          <TopBar.IconButton aria-label="Create new">
+            <Plus size={16} />
+          </TopBar.IconButton>
+          <TopBar.IconButton aria-label="Notifications, 3 unread" indicator>
+            <Bell size={16} />
+          </TopBar.IconButton>
+          <Avatar name="Alex Rivera" size="sm" />
+        </TopBar.End>
+      </TopBar>
+    </TopBarStage>
+  );
+}`}
       >
         <TopBarStage>
           <TopBar>
@@ -127,20 +158,83 @@ export function TopBarDemo() {
       <Example
         title="Brand on the left, no search"
         description="The Start cluster can hold anything — drop the search and use it for a brand mark when the bar is part of a marketing surface or a docs site. End-only is also valid: a single trailing cluster works because Start defaults to no content."
-        code={`<TopBar>
-  <TopBar.Start>
-    <BrandMark />
-  </TopBar.Start>
-  <TopBar.End>
-    <TopBar.IconButton aria-label="Help">
-      <HelpCircle size={16} />
-    </TopBar.IconButton>
-    <TopBar.IconButton aria-label="Settings">
-      <SettingsIcon size={16} />
-    </TopBar.IconButton>
-    <Avatar name="Sam Chen" size="sm" />
-  </TopBar.End>
-</TopBar>`}
+        code={`import { type ReactNode } from 'react';
+import { HelpCircle, Settings as SettingsIcon } from 'lucide-react';
+import { Avatar, Text, TopBar } from '@eocrm/design-system';
+
+function TopBarStage({ children, height = 220 }: { children: ReactNode; height?: number }) {
+  return (
+    <div
+      style={{
+        height,
+        overflow: 'auto',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+        background: 'var(--color-bg-subtle)',
+      }}
+    >
+      {children}
+      <div style={{ padding: 'var(--space-4)' }}>
+        <Text tone="muted">
+          Scroll this box — the bar pins to the top. Page content goes here in a real app.
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+function BrandMark() {
+  return (
+    <div
+      aria-hidden
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 'var(--space-2)',
+        fontWeight: 'var(--font-weight-semibold)',
+        color: 'var(--color-fg)',
+      }}
+    >
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 24,
+          height: 24,
+          borderRadius: 'var(--radius-md)',
+          background: 'var(--color-accent)',
+          color: 'var(--color-accent-fg)',
+          fontSize: 'var(--font-size-xs)',
+        }}
+      >
+        OC
+      </span>
+      Orbit CRM
+    </div>
+  );
+}
+
+export function Demo() {
+  return (
+    <TopBarStage>
+      <TopBar>
+        <TopBar.Start>
+          <BrandMark />
+        </TopBar.Start>
+        <TopBar.End>
+          <TopBar.IconButton aria-label="Help">
+            <HelpCircle size={16} />
+          </TopBar.IconButton>
+          <TopBar.IconButton aria-label="Settings">
+            <SettingsIcon size={16} />
+          </TopBar.IconButton>
+          <Avatar name="Sam Chen" size="sm" />
+        </TopBar.End>
+      </TopBar>
+    </TopBarStage>
+  );
+}`}
       >
         <TopBarStage>
           <TopBar>
@@ -163,16 +257,47 @@ export function TopBarDemo() {
       <Example
         title="Custom indicator tone"
         description="`indicatorTone` selects the dot color. Use `warning` for soft cues (a scheduled maintenance reminder), `info` for informational pings, `accent` for new-feature highlights. The default is `danger`."
-        code={`<TopBar>
-  <TopBar.End>
-    <TopBar.IconButton aria-label="Maintenance scheduled" indicator indicatorTone="warning">
-      <Wrench size={16} />
-    </TopBar.IconButton>
-    <TopBar.IconButton aria-label="What's new" indicator indicatorTone="accent">
-      <Bell size={16} />
-    </TopBar.IconButton>
-  </TopBar.End>
-</TopBar>`}
+        code={`import { type ReactNode } from 'react';
+import { Bell, Wrench } from 'lucide-react';
+import { Text, TopBar } from '@eocrm/design-system';
+
+function TopBarStage({ children, height = 220 }: { children: ReactNode; height?: number }) {
+  return (
+    <div
+      style={{
+        height,
+        overflow: 'auto',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+        background: 'var(--color-bg-subtle)',
+      }}
+    >
+      {children}
+      <div style={{ padding: 'var(--space-4)' }}>
+        <Text tone="muted">
+          Scroll this box — the bar pins to the top. Page content goes here in a real app.
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+export function Demo() {
+  return (
+    <TopBarStage>
+      <TopBar>
+        <TopBar.End>
+          <TopBar.IconButton aria-label="Maintenance scheduled" indicator indicatorTone="warning">
+            <Wrench size={16} />
+          </TopBar.IconButton>
+          <TopBar.IconButton aria-label="What's new" indicator indicatorTone="accent">
+            <Bell size={16} />
+          </TopBar.IconButton>
+        </TopBar.End>
+      </TopBar>
+    </TopBarStage>
+  );
+}`}
       >
         <TopBarStage>
           <TopBar>
@@ -195,16 +320,47 @@ export function TopBarDemo() {
       <Example
         title='Nested toolbar with as="div"'
         description='When the bar appears inside another content area where a second header landmark would be wrong (e.g. a secondary filters toolbar inside a main page), pass `as="div"` to render the same chrome without the banner role.'
-        code={`<TopBar as="div" aria-label="Filters toolbar">
-  <TopBar.Start>
-    <Text weight="medium">Filters</Text>
-  </TopBar.Start>
-  <TopBar.End>
-    <TopBar.IconButton aria-label="Reset filters">
-      <Wrench size={16} />
-    </TopBar.IconButton>
-  </TopBar.End>
-</TopBar>`}
+        code={`import { type ReactNode } from 'react';
+import { Wrench } from 'lucide-react';
+import { Text, TopBar } from '@eocrm/design-system';
+
+function TopBarStage({ children, height = 220 }: { children: ReactNode; height?: number }) {
+  return (
+    <div
+      style={{
+        height,
+        overflow: 'auto',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+        background: 'var(--color-bg-subtle)',
+      }}
+    >
+      {children}
+      <div style={{ padding: 'var(--space-4)' }}>
+        <Text tone="muted">
+          Scroll this box — the bar pins to the top. Page content goes here in a real app.
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+export function Demo() {
+  return (
+    <TopBarStage>
+      <TopBar as="div" aria-label="Filters toolbar">
+        <TopBar.Start>
+          <Text weight="medium">Filters</Text>
+        </TopBar.Start>
+        <TopBar.End>
+          <TopBar.IconButton aria-label="Reset filters">
+            <Wrench size={16} />
+          </TopBar.IconButton>
+        </TopBar.End>
+      </TopBar>
+    </TopBarStage>
+  );
+}`}
       >
         <TopBarStage>
           <TopBar as="div" aria-label="Filters toolbar">


### PR DESCRIPTION
Phase B of the demo-docs overhaul. **Playground-only** — no library files change, so no `@eocrm/design-system` release. Builds on #249.

## What this does

Rewrites **all 517 `<Example>` code blocks across 88 demos** to the self-contained convention established on `ButtonDemo` in #249:

1. **Imports first** (`react` → third-party → `@eocrm/design-system`),
2. **inline data objects** (realistic literals, not hidden module consts or `../../data/mock` imports),
3. **the example as a component** (`export function Demo()`, or the example's own named stateful component reproduced in full).

Each snippet's JSX matches its Example's live preview, so copy-paste reproduces the demo. Several **stale code/preview mismatches were fixed in passing** (e.g. DropdownMenu rows, ErrorState wrapper, Modal `stackMode`, Field `name`, Rail items).

Also adds an `apiName` escape hatch to `DemoLayout`/`DemoBody` and wires `Field`, `FormRow`, `FormSection`, and `AppLayout` so they render an API table too. Every component now has one except the `DatePickers` overview page.

## Test plan
- `make build` (typecheck + bundle, regenerates the props manifest via the Vite plugin), `make lint`, `npm run format:check` — all green.
- Swept all 517 blocks: every one leads with an `import`.
- A fresh-context reviewer audited a 10-file sample (incl. the data-heavy DataTable/Kanban and stateful Modal/Popover/Sortable): verdict **clean enough to ship**, 0 Critical / 0 Important.
- Live: Field/AppLayout now show their API table; spot-checked code blocks render.

## Known minor (cosmetic, from the review)
- Two PopoverDemo snippets omit the demo-gallery centering `<Cluster>` wrapper (treated like the demo-only `className`s we intentionally drop).
- CardDemo "Header without action" uses explicit rows vs the preview's `.map()` (identical output).
- One SelectDemo `alert()` shows a literal newline rather than `\n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)