### PR TITLE
fix(Thread): header-centered node + rail ends at the last elbow (#247, #248)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1652,7 +1652,7 @@ import { Divider } from '@eocrm/design-system';
 
 ### `<Thread>` — nested-reply threading primitive
 
-`<Thread>` + `<Thread.Item node>` — a per-level left vertical rail connecting a parent comment to its nested replies, with the leading `node` slot (`<Avatar>` / icon / `<Dot>`) as the connection point. Replies are written as nested `<Thread.Item>`s; the recursive compound detects them (by identity) and indents under the rail. Depth-capped (`maxDepth`, default `4`) so deep threads stop marching right — past the cap, replies render flat at the same indent. `<Thread compact>` tightens the gaps for dense sidebars. Semantic `<ul>`/`<li>`.
+`<Thread>` + `<Thread.Item node>` — a per-level left vertical rail connecting a parent comment to its nested replies, with the leading `node` slot (`<Avatar>` / icon / `<Dot>`) as the connection point. Replies are written as nested `<Thread.Item>`s; the recursive compound detects them (by identity) and indents under the rail. Depth-capped (`maxDepth`, default `4`) so deep threads stop marching right — past the cap, replies render flat at the same indent. `<Thread compact>` tightens the gaps for dense sidebars. The node centers on the first body line (the header) by default — pass `nodeAlign="top"` to top-align it instead. The rail terminates at the last reply's elbow, so it's surface-independent (no `--thread-surface` to keep in sync — works on tinted backgrounds). Semantic `<ul>`/`<li>`.
 
 ```tsx
 <Thread maxDepth={4}>
@@ -1672,6 +1672,7 @@ import { Divider } from '@eocrm/design-system';
 ```
 
 - `node` is a SLOT (pass `<Avatar size="sm">` / a small icon / `<Dot>`) — there's no built-in avatar. Match the node to `--thread-node-size` (default `sm` / 24px) so the rail/elbow connectors meet it cleanly; override `--thread-node-size` for a larger node. The rail branches to each reply with an elbow (`├─`/`└─`).
+- `nodeAlign` (default `header`): the node centers on the first body line — set your header (`<Avatar size="sm">` + author/timestamp) as the first child and it aligns automatically; no consumer line-height hack. **Remove any old `lineHeight: var(--size-sm)` (or similar) header override** — it now double-compensates and pushes the text off the node's centre. `nodeAlign="top"` top-aligns the node instead. If your header line-box differs from `<Text size="sm">`, override `--thread-header-line-height`.
 - Plain children are the comment body; any direct `<Thread.Item>` child is a reply. Don't wrap a reply in a Fragment / wrapper — the sort matches `Thread.Item` by identity and it won't be detected.
 - `maxDepth` (default `4`): once nesting hits the cap, deeper replies render flat (same indent) instead of marching further right. `compact` flows to every nested level via CSS vars.
 - **When NOT to use**: a flat activity feed with no parent/child nesting → `<Timeline>`; plain indentation with no connecting line → `<Indent>`.

--- a/packages/design-system/src/components/Thread/Thread.module.scss
+++ b/packages/design-system/src/components/Thread/Thread.module.scss
@@ -22,31 +22,22 @@
   row-gap: var(--thread-row-gap);
 }
 
-.gutter {
-  position: relative;
-}
-
+// Node box: its height is the alignment target. Default (`nodeAlign="header"`) it's the
+// header line-box, so a node taller than one line centers ON the first body line
+// (overflowing the box symmetrically). `.alignTop` makes it the full node height → the
+// node top-aligns with the body. Either way the node is centered within the box.
 .nodeBox {
-  height: var(--thread-node-size);
+  height: var(--thread-nodebox-height);
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-// Vertical rail from below the node to the bottom of the item — i.e. down past the
-// item's (indented) replies, so it reads as descending from the avatar. The grid
-// stretches the gutter column to the item's full height (content holds the replies),
-// so inset-block-end:0 reaches the bottom of the reply group. Decorative.
-.rail {
-  position: absolute;
-  inset-inline-start: 50%;
-  transform: translateX(-50%);
-
-  // Start a hairline below the node so the rail doesn't touch the avatar.
-  inset-block-start: calc(var(--thread-node-size) + var(--thread-node-gap));
-  inset-block-end: 0;
-  width: var(--thread-rail-width);
-  background: var(--thread-rail-color);
+// nodeAlign="top": full-height node box, top-aligned with the body (the pre-header-
+// centering behavior). Overrides the header-centering defaults from the tokens.
+.alignTop {
+  --thread-node-center: calc(var(--thread-node-size) / 2);
+  --thread-nodebox-height: var(--thread-node-size);
 }
 
 .content {
@@ -56,8 +47,32 @@
   gap: var(--thread-row-gap);
 }
 
+// `position: relative` so the parent rail (rendered as a child) anchors to the body box:
+// its bottom edge is the rail's natural terminus, independent of the surface colour or
+// the replies' height.
 .body {
+  position: relative;
   min-width: 0;
+}
+
+// The parent rail's trunk above the replies — from just below the node down to the
+// bottom of the body, extended one row-gap further so it meets the first reply's trunk
+// segment across the body→replies gap. Anchored to `.body` (not a full-height gutter),
+// so there is no overshoot to mask: the per-reply `::after` segments carry the trunk the
+// rest of the way and terminate it exactly at the last elbow. Decorative.
+.rail {
+  position: absolute;
+  inset-inline-start: calc(-1 * (var(--thread-node-size) / 2 + var(--thread-content-gap)));
+  transform: translateX(-50%);
+
+  // Start a hairline below the node (node centre + half the node), so the rail doesn't
+  // touch the avatar.
+  inset-block-start: calc(
+    var(--thread-node-center) + var(--thread-node-size) / 2 + var(--thread-node-gap)
+  );
+  inset-block-end: calc(-1 * var(--thread-row-gap));
+  width: var(--thread-rail-width);
+  background: var(--thread-rail-color);
 }
 
 // Indented replies — nested inside content (so the gutter column stretches and the
@@ -87,7 +102,7 @@
 .replies > .item::before {
   content: '';
   position: absolute;
-  inset-block-start: calc(var(--thread-node-size) / 2);
+  inset-block-start: var(--thread-node-center);
   inset-inline-start: calc(-1 * (var(--thread-node-size) / 2 + var(--thread-content-gap)));
 
   // Run from the parent rail to a hairline short of the node, so it doesn't touch the
@@ -98,20 +113,30 @@
   transform: translateY(-50%);
 }
 
-// The parent rail spans to the bottom of the whole reply group; mask its overshoot
-// below the LAST reply's elbow so the trunk ends at the final branch (└─) instead of
-// dangling past it. Painted in `--thread-surface` (the surface the thread sits on,
-// default `--color-bg`); override the token if Thread renders on a tinted surface.
-.replies > .item:last-child::after {
+// The trunk through the reply group, drawn per reply as a vertical segment so it ends
+// exactly at the last elbow — no full-height rail + surface-coloured mask, so it's
+// independent of the surface the thread sits on. Each segment starts one row-gap above
+// its item (bridging the gap to the previous segment / the body rail), giving a
+// continuous line at the parent gutter's centre.
+.replies > .item::after {
   content: '';
   position: absolute;
-  inset-block-start: calc(var(--thread-node-size) / 2);
+  inset-block-start: calc(-1 * var(--thread-row-gap));
+  inset-inline-start: calc(-1 * (var(--thread-node-size) / 2 + var(--thread-content-gap)));
+  transform: translateX(-50%);
+  width: var(--thread-rail-width);
+  background: var(--thread-rail-color);
+}
+
+// Non-last replies: run the segment to the item's bottom so it joins the next one.
+.replies > .item:not(:last-child)::after {
   inset-block-end: 0;
-  inset-inline-start: calc(
-    -1 * (var(--thread-node-size) / 2 + var(--thread-content-gap)) - var(--thread-rail-width)
-  );
-  width: calc(var(--thread-rail-width) * 3);
-  background: var(--thread-surface);
+}
+
+// Last reply: stop the trunk at this elbow (└─) — node centre + the bridged gap — so it
+// terminates at the final branch with nothing dangling below it.
+.replies > .item:last-child::after {
+  height: calc(var(--thread-row-gap) + var(--thread-node-center));
 }
 
 // Flat replies past the cap — a direct grid child spanning both columns so they are

--- a/packages/design-system/src/components/Thread/Thread.test.tsx
+++ b/packages/design-system/src/components/Thread/Thread.test.tsx
@@ -78,6 +78,24 @@ describe('Thread', () => {
     expect((container.querySelector('ul') as HTMLElement).className).toMatch(/compact/);
   });
 
+  it('defaults to header alignment (no alignTop class on the root)', () => {
+    const { container } = render(
+      <Thread>
+        <Thread.Item node={<span>A</span>}>x</Thread.Item>
+      </Thread>,
+    );
+    expect((container.querySelector('ul') as HTMLElement).className).not.toMatch(/alignTop/);
+  });
+
+  it('nodeAlign="top" adds the alignTop class to the root <ul>', () => {
+    const { container } = render(
+      <Thread nodeAlign="top">
+        <Thread.Item node={<span>A</span>}>x</Thread.Item>
+      </Thread>,
+    );
+    expect((container.querySelector('ul') as HTMLElement).className).toMatch(/alignTop/);
+  });
+
   it('forwards refs to the root <ul> and item <li>', () => {
     const ulRef = createRef<HTMLUListElement>();
     const liRef = createRef<HTMLLIElement>();

--- a/packages/design-system/src/components/Thread/Thread.tokens.scss
+++ b/packages/design-system/src/components/Thread/Thread.tokens.scss
@@ -10,10 +10,21 @@
   --thread-rail-width: var(--border-width); // hairline rail
   --thread-rail-color: var(--color-border);
   --thread-node-gap: 1px; // hairline gap between the connector lines and the node/avatar
-  // Surface the thread sits on; the last-reply trunk mask paints this to hide the
-  // rail's overshoot below the final branch. Override if Thread renders on a
-  // non-default (tinted) surface, else a faint stripe shows below the last reply.
-  --thread-surface: var(--color-bg);
+
+  // Height of the first body line (the "header" — author + timestamp). With the
+  // default `nodeAlign="header"`, the node is vertically centered against THIS line, so
+  // it should match your header text's line-box. Defaults to the line-box of
+  // `<Text size="sm">` (the canonical header) via the global primitives — if you rebrand
+  // Text's own tokens (`--text-font-size-sm`/`--text-line-height`) so they diverge, or
+  // your header line differs, override this token to match.
+  --thread-header-line-height: calc(var(--font-size-sm) * var(--line-height-normal));
+
+  // Node vertical centre (from the item top) and node-box height. Defaults center the
+  // node on the header line; the `.alignTop` class (`nodeAlign="top"`) overrides both to
+  // top-align the node with the body instead. The rail/elbow connectors derive their
+  // Y from `--thread-node-center`, so they track whichever alignment is active.
+  --thread-node-center: calc(var(--thread-header-line-height) / 2);
+  --thread-nodebox-height: var(--thread-header-line-height);
 
   --thread-node-size-compact: var(--size-sm); // 24px
   --thread-content-gap-compact: var(--space-1); // 4px

--- a/packages/design-system/src/components/Thread/Thread.tsx
+++ b/packages/design-system/src/components/Thread/Thread.tsx
@@ -21,6 +21,9 @@ interface ThreadContextValue {
 
 const ThreadContext = createContext<ThreadContextValue | null>(null);
 
+/** Where the leading `node` sits relative to the comment body. See `ThreadProps#nodeAlign`. */
+export type ThreadNodeAlign = 'header' | 'top';
+
 /**
  * Reads the surrounding thread depth/cap. Falls back to a depth-0 default so a
  * `<Thread.Item>` can render standalone (e.g. in a test) without a provider.
@@ -40,6 +43,17 @@ export interface ThreadProps extends HTMLAttributes<HTMLUListElement> {
    * every nested item via CSS custom properties. Default `false`.
    */
   compact?: boolean;
+  /**
+   * Where the leading `node` sits relative to the comment body.
+   * - `header` (default) — vertically centered on the **first body line** (the author /
+   *   timestamp header), Jira/GitHub style, so a node taller than one line (e.g. a 24px
+   *   `<Avatar>`) reads as centered against the name rather than top-aligned. Assumes the
+   *   header line-box matches `--thread-header-line-height` (defaults to `<Text size="sm">`);
+   *   override that token if your header line differs.
+   * - `top` — top-aligned with the body (the node's top meets the body's top). Use when the
+   *   node is about one line tall, or when you deliberately want top alignment.
+   */
+  nodeAlign?: ThreadNodeAlign;
   /** The `<Thread.Item>`s. */
   children: ReactNode;
 }
@@ -47,9 +61,10 @@ export interface ThreadProps extends HTMLAttributes<HTMLUListElement> {
 export interface ThreadItemProps extends HTMLAttributes<HTMLLIElement> {
   /**
    * The leading marker the rail connects to — an `<Avatar>`, icon, or `<Dot>`. Centered
-   * in a fixed node box so the rail aligns regardless of node content. It's a slot:
-   * there is no built-in avatar. Size the node to `--thread-node-size` (default `sm` /
-   * 24px) — e.g. `<Avatar size="sm">` — so the rail/elbow connectors meet it cleanly;
+   * in its node box so the rail/elbow connectors meet it cleanly regardless of node
+   * content; by default the box centers on the first body line so a taller node aligns to
+   * the header (see `Thread`'s `nodeAlign`). It's a slot: there is no built-in avatar.
+   * Size the node to `--thread-node-size` (default `sm` / 24px) — e.g. `<Avatar size="sm">`;
    * for a larger node, override `--thread-node-size` to match.
    */
   node: ReactNode;
@@ -91,15 +106,17 @@ const ThreadItem = forwardRef<HTMLLIElement, ThreadItemProps>(function ThreadIte
 
   return (
     <li className={clsx(styles.item, className)} {...rest} ref={ref}>
-      <div className={styles.gutter}>
-        <div className={styles.nodeBox}>{node}</div>
-        {hasReplies && indented && <div className={styles.rail} aria-hidden="true" />}
-      </div>
+      <div className={styles.nodeBox}>{node}</div>
       {hasReplies && indented ? (
-        // Indented: replies live inside content so the gutter column stretches to
-        // their full height and the parent rail spans alongside them. Depth +1.
+        // Indented: replies live inside content; the parent rail (anchored to the body
+        // box) bridges down to the first reply, and the per-reply trunk segments carry
+        // it the rest of the way, ending at the last elbow. Depth +1.
         <div className={styles.content}>
-          <div className={styles.body}>{body}</div>
+          <div className={styles.body}>
+            {body}
+            {/* Parent rail trunk above the replies — anchored to the body box. */}
+            <div className={styles.rail} aria-hidden="true" />
+          </div>
           <ThreadContext.Provider value={{ depth: depth + 1, maxDepth }}>
             <ul className={styles.replies}>{replies}</ul>
           </ThreadContext.Provider>
@@ -156,6 +173,11 @@ ThreadItem.displayName = 'Thread.Item';
  *   </Thread.Item>
  * </Thread>
  *
+ * @example
+ * // Node alignment: by default the avatar centers on the first body line (the header).
+ * // Pass nodeAlign="top" to top-align it with the body instead.
+ * <Thread nodeAlign="top">…</Thread>
+ *
  * @remarks When NOT to use
  * - A flat activity feed with no parent/child nesting → `<Timeline>`.
  * - Plain indentation with no connecting line → `<Indent>`.
@@ -171,11 +193,27 @@ ThreadItem.displayName = 'Thread.Item';
  * - ❌ Putting layout margins on items — spacing comes from `compact` / the row-gap token.
  */
 const ThreadRoot = forwardRef<HTMLUListElement, ThreadProps>(function Thread(
-  { maxDepth = DEFAULT_MAX_DEPTH, compact = false, className, children, ...rest },
+  {
+    maxDepth = DEFAULT_MAX_DEPTH,
+    compact = false,
+    nodeAlign = 'header',
+    className,
+    children,
+    ...rest
+  },
   ref,
 ) {
   return (
-    <ul ref={ref} className={clsx(styles.root, compact && styles.compact, className)} {...rest}>
+    <ul
+      ref={ref}
+      className={clsx(
+        styles.root,
+        compact && styles.compact,
+        nodeAlign === 'top' && styles.alignTop,
+        className,
+      )}
+      {...rest}
+    >
       <ThreadContext.Provider value={{ depth: 0, maxDepth }}>{children}</ThreadContext.Provider>
     </ul>
   );

--- a/packages/design-system/src/components/Thread/index.ts
+++ b/packages/design-system/src/components/Thread/index.ts
@@ -1,2 +1,2 @@
 export { Thread } from './Thread';
-export type { ThreadProps, ThreadItemProps } from './Thread';
+export type { ThreadProps, ThreadItemProps, ThreadNodeAlign } from './Thread';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -110,7 +110,7 @@ export { Timeline } from './components/Timeline';
 export type { TimelineProps, TimelineItemProps } from './components/Timeline';
 
 export { Thread } from './components/Thread';
-export type { ThreadProps, ThreadItemProps } from './components/Thread';
+export type { ThreadProps, ThreadItemProps, ThreadNodeAlign } from './components/Thread';
 
 export { BrandIcon } from './components/BrandIcon';
 export type { BrandIconProps, BrandName } from './components/BrandIcon';

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -4179,6 +4179,13 @@
         "description": "Tighter gaps for dense surfaces (sidebars, panels). The remapped tokens cascade to\nevery nested item via CSS custom properties. Default `false`."
       },
       {
+        "name": "nodeAlign",
+        "type": "ThreadNodeAlign",
+        "required": false,
+        "default": "header",
+        "description": "Where the leading `node` sits relative to the comment body.\n- `header` (default) — vertically centered on the **first body line** (the author /\n  timestamp header), Jira/GitHub style, so a node taller than one line (e.g. a 24px\n  `<Avatar>`) reads as centered against the name rather than top-aligned. Assumes the\n  header line-box matches `--thread-header-line-height` (defaults to `<Text size=\"sm\">`);\n  override that token if your header line differs.\n- `top` — top-aligned with the body (the node's top meets the body's top). Use when the\n  node is about one line tall, or when you deliberately want top alignment."
+      },
+      {
         "name": "children",
         "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
         "required": true,

--- a/packages/playground/src/pages/components/ThreadDemo.tsx
+++ b/packages/playground/src/pages/components/ThreadDemo.tsx
@@ -3,12 +3,6 @@ import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
 
-// Give the author/header line the avatar's line-height so its text centers on the
-// avatar's vertical centre (the avatar is taller than a default text line). This is a
-// consumer-side composition choice — Thread slots the node + content and top-aligns
-// the row; centering the header against the avatar is the page's call.
-const headerLine = { lineHeight: 'var(--size-sm)' } as const;
-
 export function ThreadDemo() {
   return (
     <DemoLayout
@@ -19,17 +13,15 @@ export function ThreadDemo() {
     >
       <Example
         title="Comment thread (nested replies)"
-        description="Each item's node is a slot — an Avatar for the author. Nested <Thread.Item>s render as replies under the rail; a reply can itself have replies. Each reply branches off the rail with an elbow connector to its avatar. (The author line gets the avatar's line-height so it centers on the avatar.)"
+        description="Each item's node is a slot — an Avatar for the author. Nested <Thread.Item>s render as replies under the rail; a reply can itself have replies, each branching off the rail with an elbow connector. The avatar centers on the first body line (the author/timestamp header) automatically — no consumer line-height tweaks needed."
         code={`import { Avatar, Stack, Text, Thread } from '@eocrm/design-system';
-
-const headerLine = { lineHeight: 'var(--size-sm)' };
 
 export function Demo() {
   return (
     <Thread>
       <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
         <Stack gap="xs">
-          <Text size="sm" style={headerLine}>
+          <Text size="sm">
             <strong>Maya Chen</strong> · 2h ago
           </Text>
           <Text size="sm">
@@ -39,7 +31,7 @@ export function Demo() {
         </Stack>
         <Thread.Item node={<Avatar name="Tom Okafor" size="sm" />}>
           <Stack gap="xs">
-            <Text size="sm" style={headerLine}>
+            <Text size="sm">
               <strong>Tom Okafor</strong> · 1h ago
             </Text>
             <Text size="sm">
@@ -48,7 +40,7 @@ export function Demo() {
           </Stack>
           <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
             <Stack gap="xs">
-              <Text size="sm" style={headerLine}>
+              <Text size="sm">
                 <strong>Maya Chen</strong> · 48m ago
               </Text>
               <Text size="sm">
@@ -59,7 +51,7 @@ export function Demo() {
         </Thread.Item>
         <Thread.Item node={<Avatar name="Priya Nair" size="sm" />}>
           <Stack gap="xs">
-            <Text size="sm" style={headerLine}>
+            <Text size="sm">
               <strong>Priya Nair</strong> · 20m ago
             </Text>
             <Text size="sm">
@@ -75,7 +67,7 @@ export function Demo() {
         <Thread>
           <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
             <Stack gap="xs">
-              <Text size="sm" style={headerLine}>
+              <Text size="sm">
                 <strong>Maya Chen</strong> · 2h ago
               </Text>
               <Text size="sm">
@@ -85,7 +77,7 @@ export function Demo() {
             </Stack>
             <Thread.Item node={<Avatar name="Tom Okafor" size="sm" />}>
               <Stack gap="xs">
-                <Text size="sm" style={headerLine}>
+                <Text size="sm">
                   <strong>Tom Okafor</strong> · 1h ago
                 </Text>
                 <Text size="sm">
@@ -94,7 +86,7 @@ export function Demo() {
               </Stack>
               <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
                 <Stack gap="xs">
-                  <Text size="sm" style={headerLine}>
+                  <Text size="sm">
                     <strong>Maya Chen</strong> · 48m ago
                   </Text>
                   <Text size="sm">
@@ -105,7 +97,7 @@ export function Demo() {
             </Thread.Item>
             <Thread.Item node={<Avatar name="Priya Nair" size="sm" />}>
               <Stack gap="xs">
-                <Text size="sm" style={headerLine}>
+                <Text size="sm">
                   <strong>Priya Nair</strong> · 20m ago
                 </Text>
                 <Text size="sm">
@@ -118,34 +110,162 @@ export function Demo() {
       </Example>
 
       <Example
+        title="On a tinted surface (no rail mask)"
+        description="The rail terminates exactly at the last reply's elbow, so it's independent of the surface the thread sits on — no faint stripe below the final branch even on a tinted background. (Earlier the trunk was drawn full-height and painted over with the page colour, which leaked on non-white surfaces.)"
+        code={`import { Avatar, Stack, Text, Thread } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <div
+      style={{
+        background: 'var(--color-bg-muted)',
+        padding: 'var(--space-4)',
+        borderRadius: 'var(--radius-md)',
+      }}
+    >
+      <Thread>
+        <Thread.Item node={<Avatar name="Dana Reyes" size="sm" />}>
+          <Stack gap="xs">
+            <Text size="sm">
+              <strong>Dana Reyes</strong> · 3h ago
+            </Text>
+            <Text size="sm">Moved the kickoff to Wednesday — does that still work?</Text>
+          </Stack>
+          <Thread.Item node={<Avatar name="Sam Cole" size="sm" />}>
+            <Text size="sm">
+              <strong>Sam Cole</strong> · works for me
+            </Text>
+          </Thread.Item>
+          <Thread.Item node={<Avatar name="Lena Fischer" size="sm" />}>
+            <Text size="sm">
+              <strong>Lena Fischer</strong> · same here, see you then
+            </Text>
+          </Thread.Item>
+        </Thread.Item>
+      </Thread>
+    </div>
+  );
+}`}
+      >
+        <div
+          style={{
+            background: 'var(--color-bg-muted)',
+            padding: 'var(--space-4)',
+            borderRadius: 'var(--radius-md)',
+          }}
+        >
+          <Thread>
+            <Thread.Item node={<Avatar name="Dana Reyes" size="sm" />}>
+              <Stack gap="xs">
+                <Text size="sm">
+                  <strong>Dana Reyes</strong> · 3h ago
+                </Text>
+                <Text size="sm">Moved the kickoff to Wednesday — does that still work?</Text>
+              </Stack>
+              <Thread.Item node={<Avatar name="Sam Cole" size="sm" />}>
+                <Text size="sm">
+                  <strong>Sam Cole</strong> · works for me
+                </Text>
+              </Thread.Item>
+              <Thread.Item node={<Avatar name="Lena Fischer" size="sm" />}>
+                <Text size="sm">
+                  <strong>Lena Fischer</strong> · same here, see you then
+                </Text>
+              </Thread.Item>
+            </Thread.Item>
+          </Thread>
+        </div>
+      </Example>
+
+      <Example
+        title="Node alignment (header vs top)"
+        description={
+          'By default the node centers on the first body line (the header), so a taller avatar reads as centered against the name (Jira/GitHub style). Pass nodeAlign="top" to top-align the node with the body instead — useful when the node is about one line tall.'
+        }
+        code={`import { Avatar, Stack, Text, Thread } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="lg">
+      {/* default: nodeAlign="header" — avatar centered on the author line */}
+      <Thread>
+        <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
+          <Stack gap="xs">
+            <Text size="sm">
+              <strong>Maya Chen</strong> · 2h ago
+            </Text>
+            <Text size="sm">Centered on the header line.</Text>
+          </Stack>
+        </Thread.Item>
+      </Thread>
+
+      {/* nodeAlign="top" — avatar top-aligned with the body */}
+      <Thread nodeAlign="top">
+        <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
+          <Stack gap="xs">
+            <Text size="sm">
+              <strong>Maya Chen</strong> · 2h ago
+            </Text>
+            <Text size="sm">Top-aligned with the body.</Text>
+          </Stack>
+        </Thread.Item>
+      </Thread>
+    </Stack>
+  );
+}`}
+      >
+        <Stack gap="lg">
+          <Thread>
+            <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
+              <Stack gap="xs">
+                <Text size="sm">
+                  <strong>Maya Chen</strong> · 2h ago
+                </Text>
+                <Text size="sm">Centered on the header line.</Text>
+              </Stack>
+            </Thread.Item>
+          </Thread>
+
+          <Thread nodeAlign="top">
+            <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
+              <Stack gap="xs">
+                <Text size="sm">
+                  <strong>Maya Chen</strong> · 2h ago
+                </Text>
+                <Text size="sm">Top-aligned with the body.</Text>
+              </Stack>
+            </Thread.Item>
+          </Thread>
+        </Stack>
+      </Example>
+
+      <Example
         title="Depth cap (maxDepth)"
         description="A deep back-and-forth. With maxDepth={3}, replies stop indenting once the cap is reached — the chain past level 3 renders flat at the same indent so the thread stops marching right off the page."
         code={`import { Avatar, Text, Thread } from '@eocrm/design-system';
-
-const headerLine = { lineHeight: 'var(--size-sm)' };
 
 export function Demo() {
   return (
     <Thread maxDepth={3}>
       <Thread.Item node={<Avatar name="Dana Reyes" size="sm" />}>
-        <Text size="sm" style={headerLine}>
+        <Text size="sm">
           <strong>Dana Reyes</strong> · who's covering the EU launch demo?
         </Text>
         <Thread.Item node={<Avatar name="Sam Cole" size="sm" />}>
-          <Text size="sm" style={headerLine}>
+          <Text size="sm">
             <strong>Sam Cole</strong> · I can — what time zone is the client in?
           </Text>
           <Thread.Item node={<Avatar name="Lena Fischer" size="sm" />}>
-            <Text size="sm" style={headerLine}>
+            <Text size="sm">
               <strong>Lena Fischer</strong> · CET. They asked for 10:00 their time.
             </Text>
             <Thread.Item node={<Avatar name="Raj Patel" size="sm" />}>
               {/* depth 3 hits the cap → this reply and deeper render flat */}
-              <Text size="sm" style={headerLine}>
+              <Text size="sm">
                 <strong>Raj Patel</strong> · Booked the room and sent the invite.
               </Text>
               <Thread.Item node={<Avatar name="Olivia Wong" size="sm" />}>
-                <Text size="sm" style={headerLine}>
+                <Text size="sm">
                   <strong>Olivia Wong</strong> · Added the deck link to the calendar event.
                 </Text>
               </Thread.Item>
@@ -159,24 +279,24 @@ export function Demo() {
       >
         <Thread maxDepth={3}>
           <Thread.Item node={<Avatar name="Dana Reyes" size="sm" />}>
-            <Text size="sm" style={headerLine}>
+            <Text size="sm">
               <strong>Dana Reyes</strong> · who's covering the EU launch demo?
             </Text>
             <Thread.Item node={<Avatar name="Sam Cole" size="sm" />}>
-              <Text size="sm" style={headerLine}>
+              <Text size="sm">
                 <strong>Sam Cole</strong> · I can — what time zone is the client in?
               </Text>
               <Thread.Item node={<Avatar name="Lena Fischer" size="sm" />}>
-                <Text size="sm" style={headerLine}>
+                <Text size="sm">
                   <strong>Lena Fischer</strong> · CET. They asked for 10:00 their time.
                 </Text>
                 <Thread.Item node={<Avatar name="Raj Patel" size="sm" />}>
                   {/* depth 3 hits the cap → this reply and deeper render flat */}
-                  <Text size="sm" style={headerLine}>
+                  <Text size="sm">
                     <strong>Raj Patel</strong> · Booked the room and sent the invite.
                   </Text>
                   <Thread.Item node={<Avatar name="Olivia Wong" size="sm" />}>
-                    <Text size="sm" style={headerLine}>
+                    <Text size="sm">
                       <strong>Olivia Wong</strong> · Added the deck link to the calendar event.
                     </Text>
                   </Thread.Item>
@@ -192,24 +312,22 @@ export function Demo() {
         description="compact tightens the gaps for a narrow panel — a contact-record activity sidebar. The remapped tokens cascade to every nested reply."
         code={`import { Avatar, Constrain, Text, Thread } from '@eocrm/design-system';
 
-const headerLine = { lineHeight: 'var(--size-sm)' };
-
 export function Demo() {
   return (
     <Constrain maxWidth="xs">
       <Thread compact>
         <Thread.Item node={<Avatar name="Grace Liu" size="sm" />}>
-          <Text size="sm" style={headerLine}>
+          <Text size="sm">
             <strong>Grace Liu</strong> · renewed the contract
           </Text>
           <Thread.Item node={<Avatar name="Marcus Bell" size="sm" />}>
-            <Text size="sm" style={headerLine}>
+            <Text size="sm">
               <strong>Marcus Bell</strong> · nice — invoice sent
             </Text>
           </Thread.Item>
         </Thread.Item>
         <Thread.Item node={<Avatar name="Priya Nair" size="sm" />}>
-          <Text size="sm" style={headerLine}>
+          <Text size="sm">
             <strong>Priya Nair</strong> · logged a support call
           </Text>
         </Thread.Item>
@@ -221,17 +339,17 @@ export function Demo() {
         <Constrain maxWidth="xs">
           <Thread compact>
             <Thread.Item node={<Avatar name="Grace Liu" size="sm" />}>
-              <Text size="sm" style={headerLine}>
+              <Text size="sm">
                 <strong>Grace Liu</strong> · renewed the contract
               </Text>
               <Thread.Item node={<Avatar name="Marcus Bell" size="sm" />}>
-                <Text size="sm" style={headerLine}>
+                <Text size="sm">
                   <strong>Marcus Bell</strong> · nice — invoice sent
                 </Text>
               </Thread.Item>
             </Thread.Item>
             <Thread.Item node={<Avatar name="Priya Nair" size="sm" />}>
-              <Text size="sm" style={headerLine}>
+              <Text size="sm">
                 <strong>Priya Nair</strong> · logged a support call
               </Text>
             </Thread.Item>


### PR DESCRIPTION
Addresses #247 and #248.

## Summary

Two Thread layout fixes (library change):

**#247 — node centers on the header line.** `<Thread.Item node>` top-aligned the node with the body, so a taller avatar sat below the header's centre. The node now vertically centers on the **first body line** (author/timestamp header) by default — Jira/GitHub style. New `nodeAlign?: 'header' | 'top'` prop on `Thread` (default `'header'`; `'top'` restores top-alignment). Driven by `--thread-node-center` / `--thread-nodebox-height`, with a new `--thread-header-line-height` token (defaults to the `<Text size="sm">` line-box; override if your header differs). Exported `ThreadNodeAlign` type.

**#248 — rail terminates at the last elbow.** The trunk was drawn full-height and the overshoot below the last elbow was painted over with `--thread-surface`, which leaked a faint stripe on any tinted surface. The rail is now a body-anchored trunk above the replies plus contiguous per-reply `::after` segments whose last segment stops exactly at the last elbow — surface-independent, no mask. The `--thread-surface` token is removed.

Also: the playground demo no longer needs the `lineHeight: var(--size-sm)` header hack (header-centering is native), and gains "On a tinted surface" + "Node alignment" examples; AGENTS.md updated (incl. a note to remove old header line-height overrides).

## Behavior note
`nodeAlign` defaults to `'header'`, which slightly changes the default rendering for existing consumers (the better, requested behavior). Documented in JSDoc + AGENTS.md + the demo.

## Test plan
- `make test` (3475, +2 new `nodeAlign` tests), `make build-lib`, `make lint`, `npm run format:check`, `npm pack --dry-run` leak check (0) — all green.
- Two fresh-context Rule 8 review passes → clean (0 Critical / 0 Important).
- Live (Playwright): avatar centre Y == header centre Y (Δ 0.1px); last-reply trunk height = row-gap + node-centre, ending exactly at the elbow on a 55px-tall item (no overshoot) on a tinted background; `nodeAlign="top"` gives a full-height top-aligned node box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)