### PR TITLE
fix(RichTextEditor): key inline runs by mark signature to stop contentEditable text orphaning

### DIFF
--- a/packages/design-system/src/components/RichText/engine/marks.test.ts
+++ b/packages/design-system/src/components/RichText/engine/marks.test.ts
@@ -1,4 +1,4 @@
-import { marksEqual, hasMark, withMark, withoutMark, toggleMark } from './marks';
+import { marksEqual, hasMark, withMark, withoutMark, toggleMark, marksSignature } from './marks';
 import type { Mark } from './model';
 
 const bold: Mark = { type: 'bold' };
@@ -9,6 +9,21 @@ describe('marks', () => {
     expect(marksEqual([bold, italic], [italic, bold])).toBe(true);
     expect(marksEqual([bold], [bold, italic])).toBe(false);
     expect(marksEqual([], [])).toBe(true);
+  });
+
+  it('marksSignature is order-insensitive, empty for no marks, and distinguishes formatting', () => {
+    expect(marksSignature([])).toBe('');
+    // Same set in any order → same signature.
+    expect(marksSignature([bold, italic])).toBe(marksSignature([italic, bold]));
+    // A structural change (adding a mark) → a different signature, so React keys differ.
+    expect(marksSignature([bold])).not.toBe(marksSignature([bold, italic]));
+    // Color value and link href are part of the signature.
+    expect(marksSignature([{ type: 'textColor', color: 'red' }])).not.toBe(
+      marksSignature([{ type: 'textColor', color: 'blue' }]),
+    );
+    expect(marksSignature([{ type: 'link', href: '/a' }])).not.toBe(
+      marksSignature([{ type: 'link', href: '/b' }]),
+    );
   });
 
   it('marksEqual distinguishes link href', () => {

--- a/packages/design-system/src/components/RichText/engine/marks.ts
+++ b/packages/design-system/src/components/RichText/engine/marks.ts
@@ -26,6 +26,24 @@ function markKey(m: Mark): string {
   return m.type;
 }
 
+/**
+ * Order-insensitive string signature of a mark SET. Two runs with the same
+ * signature carry identical formatting. Used by the editor's renderer to fold the
+ * run's formatting into its React key, so that when a run's MARK STRUCTURE changes
+ * (e.g. bold/italic/underline added over an already-colored run) React replaces
+ * the run's subtree cleanly instead of surgically re-wrapping an existing
+ * `contentEditable` text node in place — which can orphan the node (stray leftover
+ * text) or re-point its color span.
+ */
+export function marksSignature(marks: Mark[]): string {
+  if (marks.length === 0) return '';
+  // Sorted so order doesn't matter. A theoretical separator collision (a mark key can
+  // embed free-form href/label text) is harmless: this signature is only ever combined
+  // with the run's index in a React key, which already guarantees uniqueness — at worst
+  // a collision would miss a remount (the pre-fix behavior), never break rendering.
+  return marks.map(markKey).sort().join(' ');
+}
+
 /** Order-insensitive set equality (link href included). */
 export function marksEqual(a: Mark[], b: Mark[]): boolean {
   if (a === b) return true;

--- a/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.test.tsx
@@ -676,4 +676,37 @@ describe('renderDoc per-block memoization', () => {
     const b2 = createBlock('bullet_item', 'b', { id: 'l2', depth: 0 });
     expect(html({ blocks: [a, b2, c] })).toBe('<ul><li>a</li><li>b<ul><li>c</li></ul></li></ul>');
   });
+
+  it('inline run keys fold in the mark signature (clean remount on a formatting change)', () => {
+    // Two runs that differ only by formatting. Their React keys must carry the mark
+    // signature, not just the array index — so when a run gains/loses a mark in the
+    // editor, React replaces its subtree instead of re-wrapping a live
+    // contentEditable text node in place (the cause of stray leftover text / colors
+    // resetting on numeric content).
+    const doc: RichDoc = {
+      blocks: [
+        {
+          id: 'b1',
+          type: 'paragraph',
+          inlines: [
+            { text: '42', marks: [{ type: 'bold' }] },
+            { text: '43', marks: [] },
+          ],
+        },
+      ],
+    };
+    const out = renderDoc(doc, { editable: true }) as ReactElement<{
+      children: ReactElement[];
+    }>[];
+    const runs = out[0].props.children;
+    expect(runs.map((r) => r.key)).toEqual(['0:bold', '1:']);
+    // Same run text but different marks ⇒ a different key (forces remount).
+    const colored = renderDoc(
+      { blocks: [{ id: 'b1', type: 'paragraph', inlines: [{ text: '42', marks: [] }] }] },
+      { editable: true },
+    ) as ReactElement<{ children: ReactElement[] }>[];
+    const plainKey = colored[0].props.children[0].key;
+    expect(plainKey).toBe('0:');
+    expect(plainKey).not.toBe('0:bold');
+  });
 });

--- a/packages/design-system/src/components/RichText/engine/renderDoc.tsx
+++ b/packages/design-system/src/components/RichText/engine/renderDoc.tsx
@@ -6,7 +6,7 @@ import { runsText, runsLength } from './inlines';
 import { safeHref } from './safeHref';
 import { textColorVar, bgColorVar } from './colorMarks';
 import { isListItem, effectiveDepths } from './listDepths';
-import { MARK_ORDER } from './marks';
+import { MARK_ORDER, marksSignature } from './marks';
 import type { RenderLink } from './renderLink';
 import type { RenderMention } from './renderMention';
 import { RichTextAttachment } from '../../RichTextEditor/RichTextAttachment';
@@ -132,7 +132,7 @@ function wrapMark(type: MarkType, mark: Mark, child: ReactNode): ReactNode {
   }
 }
 
-function renderRun(run: Inline, key: number): ReactNode {
+function renderRun(run: Inline, key: string): ReactNode {
   const present = MARK_ORDER.filter((t) => run.marks.some((m) => m.type === t));
   let node: ReactNode = run.text;
   // Wrap innermost-first so present[0] (link) ends up outermost.
@@ -172,13 +172,14 @@ function renderInlines(inlines: Inline[], opts: ResolvedOptions): ReactNode {
       if (custom !== fallback) {
         // Substituted: one node for the whole span. In the editor it's an atomic,
         // non-editable widget tagged with the span's MODEL length (`data-len`).
+        const mkey = `m${i}:${mention.id}:${mention.label}`;
         out.push(
           opts.editable ? (
-            <span key={i} data-rich-mention data-len={text.length} contentEditable={false}>
+            <span key={mkey} data-rich-mention data-len={text.length} contentEditable={false}>
               {custom}
             </span>
           ) : (
-            <Fragment key={i}>{custom}</Fragment>
+            <Fragment key={mkey}>{custom}</Fragment>
           ),
         );
         i = j;
@@ -210,13 +211,14 @@ function renderInlines(inlines: Inline[], opts: ResolvedOptions): ReactNode {
       if (custom !== fallback) {
         // Substituted: one node for the whole span. In the editor it's an atomic,
         // non-editable widget tagged with the span's MODEL length (`data-len`).
+        const lkey = `l${i}:${linkHref}`;
         out.push(
           opts.editable ? (
-            <span key={i} data-rich-link data-len={text.length} contentEditable={false}>
+            <span key={lkey} data-rich-link data-len={text.length} contentEditable={false}>
               {custom}
             </span>
           ) : (
-            <Fragment key={i}>{custom}</Fragment>
+            <Fragment key={lkey}>{custom}</Fragment>
           ),
         );
         i = j;
@@ -224,7 +226,10 @@ function renderInlines(inlines: Inline[], opts: ResolvedOptions): ReactNode {
       }
       // Consumer declined → fall through to normal per-run rendering (default <a>).
     }
-    out.push(renderRun(run, i));
+    // Key folds in the run's mark signature (not just its index): when a run's
+    // formatting changes, React replaces its subtree cleanly instead of re-wrapping
+    // a live contentEditable text node in place (which orphaned text / reset colors).
+    out.push(renderRun(run, `${i}:${marksSignature(run.marks)}`));
     i += 1;
   }
   return out;


### PR DESCRIPTION
## Problem

In the block editor, typing digits then applying overlapping marks — purple text+highlight over the whole block, **bold** over a middle span, *italic* over a narrower one, underline over the narrowest — produced **stray leftover text** ("extra numbers at the end") and **some colors resetting**. Reported as reproducible with numbers + the block editor.

## Root cause

The pure model layer (`transforms`/`inlines`/`marks`/`colorMarks`) is **provably correct and content-agnostic** — the op sequence yields exactly the typed characters with the right nested marks. The fault is **React ⇄ contentEditable reconciliation**: inline runs were keyed by **array index** (`key={i}`). When a run's *mark structure* changes at a given index, React reconciles the old run into the new one **in place** — re-wrapping a live `contentEditable` text node with new tags and rewriting its text — which can orphan that text node (leftover characters) and re-point its color span.

## Fix

Fold each run's **mark signature** into its React key (`${i}:${marksSignature(run.marks)}`), so a formatting change at a fixed index produces a **different key → clean subtree remount** instead of an in-place re-wrap. Plain typing (marks unchanged) keeps a **stable key**, so the cheap text-node mutation path — and the caret — are preserved. Mention/link widget keys fold in their identity too. **Rendered output is unchanged** (keys aren't observable in the DOM), so read-only `<RichText>` and all existing tests are byte-identical.

- `marks.ts`: new exported `marksSignature(marks)`.
- `renderDoc.tsx`: run + widget keys carry the signature/identity; `renderRun` key is now a string.
- Tests: `marksSignature` unit tests + a renderDoc test asserting run keys carry the signature and change when marks change.

## Test plan
- `make test` (3477, +2), `make build-lib`, `make lint`, `npm run format:check`, `npm pack --dry-run` leak check (0) — all green.
- Two Rule 8 review passes (the second on the run-key change) → clean; confirmed no typing-path regression and identical read-only output.

## ⚠️ Verification note
I could **not** reproduce/verify this end-to-end in browser automation: the demo editor is a controlled component and Playwright couldn't drive the model through repeated commits without desync. This is a **best-effort fix targeting the strongest root cause** (explicitly chosen over further repro attempts). Please verify the exact sequence in the block editor; if any stray text/color-reset remains, I'll dig further with a screen recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)