### PR TITLE
fix(RichTextEditor): block color menu closes palette on pick + no whole-block selection

### DIFF
--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.test.tsx
@@ -85,3 +85,26 @@ it('fires onColor("bgColor", key) from the Highlight submenu', async () => {
   await userEvent.click(await screen.findByRole('button', { name: 'Blue' }));
   expect(onColor).toHaveBeenCalledWith('bgColor', 'blue');
 });
+
+it('closes the color submenu after a pick but leaves the main menu open', async () => {
+  const onColor = vi.fn();
+  setup({ onColor });
+  await userEvent.click(screen.getByRole('menuitem', { name: 'Text color' }));
+  await userEvent.click(await screen.findByRole('button', { name: 'Green' }));
+  // Submenu collapsed: its swatches are gone.
+  expect(screen.queryByRole('button', { name: 'Green' })).toBeNull();
+  // Main menu still open: its items + the color trigger remain, ready for another pick.
+  expect(screen.getByRole('menuitem', { name: /delete/i })).toBeInTheDocument();
+  expect(screen.getByRole('menuitem', { name: 'Text color' })).toBeInTheDocument();
+});
+
+it('reopens the color submenu after a pick (close-on-pick does not latch it shut)', async () => {
+  const onColor = vi.fn();
+  setup({ onColor });
+  await userEvent.click(screen.getByRole('menuitem', { name: 'Text color' }));
+  await userEvent.click(await screen.findByRole('button', { name: 'Green' }));
+  expect(screen.queryByRole('button', { name: 'Green' })).toBeNull(); // collapsed
+  // Reopen the same submenu → the palette is back.
+  await userEvent.click(screen.getByRole('menuitem', { name: 'Text color' }));
+  expect(await screen.findByRole('button', { name: 'Green' })).toBeInTheDocument();
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.tsx
@@ -1,7 +1,7 @@
 // RichTextBlockMenu.tsx — internal block actions menu (DropdownMenu wrapper). The
 // `⠿` handle is the trigger; open is controlled by the editor so a keyboard
 // Shift+F10 can open the SAME menu anchored to the active block's handle.
-import { forwardRef } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import { Button } from '../Button';
 import { DropdownMenu } from '../DropdownMenu';
 import { useTranslation } from '../../i18n';
@@ -45,6 +45,18 @@ export const RichTextBlockMenu = forwardRef<HTMLButtonElement, RichTextBlockMenu
     ref,
   ) {
     const t = useTranslation();
+    // Which color submenu is open. Controlled so picking a color can collapse the
+    // submenu (back to the still-open main menu) instead of leaving the palette up.
+    const [openColorSub, setOpenColorSub] = useState<'textColor' | 'bgColor' | null>(null);
+    // Reset when the whole menu closes so it doesn't reopen a palette next time.
+    useEffect(() => {
+      if (!open) setOpenColorSub(null);
+    }, [open]);
+    const colorSubProps = (which: 'textColor' | 'bgColor') => ({
+      open: openColorSub === which,
+      onOpenChange: (next: boolean) =>
+        setOpenColorSub((prev) => (next ? which : prev === which ? null : prev)),
+    });
     return (
       <DropdownMenu open={open} onOpenChange={onOpenChange}>
         <DropdownMenu.Trigger>
@@ -69,18 +81,31 @@ export const RichTextBlockMenu = forwardRef<HTMLButtonElement, RichTextBlockMenu
           )}
           {onColor && (
             <>
-              <DropdownMenu.Sub>
+              <DropdownMenu.Sub {...colorSubProps('textColor')}>
                 <DropdownMenu.SubTrigger>{t('richTextEditor.textColor')}</DropdownMenu.SubTrigger>
                 <DropdownMenu.SubContent>
                   {/* The block menu doesn't reflect an active color — omit `active`. The
-                      badges are plain buttons (pointer-first), not registered menu items. */}
-                  <RichTextColorMenu type="textColor" onPick={(key) => onColor('textColor', key)} />
+                      badges are plain buttons (pointer-first), not registered menu items.
+                      Picking one collapses this submenu but leaves the main menu open. */}
+                  <RichTextColorMenu
+                    type="textColor"
+                    onPick={(key) => {
+                      onColor('textColor', key);
+                      setOpenColorSub(null);
+                    }}
+                  />
                 </DropdownMenu.SubContent>
               </DropdownMenu.Sub>
-              <DropdownMenu.Sub>
+              <DropdownMenu.Sub {...colorSubProps('bgColor')}>
                 <DropdownMenu.SubTrigger>{t('richTextEditor.highlight')}</DropdownMenu.SubTrigger>
                 <DropdownMenu.SubContent>
-                  <RichTextColorMenu type="bgColor" onPick={(key) => onColor('bgColor', key)} />
+                  <RichTextColorMenu
+                    type="bgColor"
+                    onPick={(key) => {
+                      onColor('bgColor', key);
+                      setOpenColorSub(null);
+                    }}
+                  />
                 </DropdownMenu.SubContent>
               </DropdownMenu.Sub>
             </>

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -483,7 +483,20 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     }, []);
 
     const commit = useCallback(
-      (result: { doc: RichDoc; selection: Range }, kind: EditKind = 'other') => {
+      (
+        result: { doc: RichDoc; selection: Range },
+        kind: EditKind = 'other',
+        options?: {
+          /**
+           * Keep the DOM selection as-is — do NOT writeSelection on the re-render.
+           * Used by edits applied from a floating UI that owns focus (e.g. the ⠿
+           * block-color submenu): writing `result.selection` would both yank focus
+           * out of the open menu and visibly select the whole block. `result.selection`
+           * is still recorded in history so undo lands somewhere sensible.
+           */
+          keepSelection?: boolean;
+        },
+      ) => {
         // No-op transforms (e.g. Backspace at the very start of the document)
         // return the SAME doc reference — skip so we don't fire onChange or leave a
         // stale pending selection that React would never consume (no re-render).
@@ -495,7 +508,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           Date.now(),
         );
         syncHistoryFlags();
-        pendingSelectionRef.current = result.selection;
+        if (!options?.keepSelection) pendingSelectionRef.current = result.selection;
         liveDocRef.current = result.doc;
         latest.current.onChange(result.doc);
       },
@@ -1320,12 +1333,17 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         commit(moveBlockUnitToIndex(latest.current.value, id, targetIndex), 'other'),
       [commit],
     );
-    // Whole-block color from the ⠿ menu's Color submenu. Computes the block's full
-    // range and routes through the same setColorMark path the toolbar uses.
+    // Whole-block color from the ⠿ menu's Color submenu. Colors the block's full
+    // range via the shared setColorMark path, but commits with `keepSelection` so it
+    // does NOT writeSelection: the block menu owns focus and stays open, and the block
+    // isn't left visibly fully-selected after the pick.
     const onBlockColor = useCallback(
       (id: string, type: 'textColor' | 'bgColor', key: string | null) => {
         const r = wholeBlockRange(latest.current.value, id);
-        if (r) commit({ doc: setColorMark(latest.current.value, r, type, key), selection: r });
+        if (r)
+          commit({ doc: setColorMark(latest.current.value, r, type, key), selection: r }, 'other', {
+            keepSelection: true,
+          });
       },
       [commit],
     );


### PR DESCRIPTION
## Summary

Two UX fixes for the ⠿ block-controls **Text color** / **Highlight** submenus:

1. **Pick closes the palette, main menu stays open.** Picking a color used to leave the palette submenu up. The two color `DropdownMenu.Sub`s are now controlled; `onPick` applies the color and collapses the submenu back to the still-open main ⠿ menu — so you can immediately pick another color/action. (Reopen still works; the "Turn into" sub is unchanged. Reset on whole-menu close.)
2. **No whole-block selection after a block color.** Applying a block color used to leave the entire block visually selected (and yank focus from the menu). `commit` gained a `keepSelection` option that skips the DOM selection write; `onBlockColor` uses it, so the menu keeps focus and nothing is highlighted. The block range is still recorded in history so undo lands sensibly.

## Test plan
- `make test` (3479, +2 block-menu tests: close-on-pick-keeps-main-open, reopen-after-pick), `make build-lib`, `make lint`, `npm run format:check` — green.
- Two Rule 8 review passes → clean (cross-sub hover guard + `keepSelection` invariant verified).
- Live (Playwright) on the block editor: after picking a color the submenu closes, the main menu stays open with the color trigger present, the block is colored, and the selection is empty (not the 168-char block).

Known minor (acceptable): **redo** (⌘⇧Z) of a block color reselects the block range — redo is a deliberate action and showing the affected range is reasonable; it's inherent to recording that range in history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)