### PR TITLE
feat(Accordion): left chevron + gap (card look) + header actions slot

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1864,6 +1864,9 @@ import { Accordion } from '@eocrm/design-system';
 - **`type="multiple"`** — any combination.
 - **`variant`** — `"bordered"` (default; outer border + radius + item dividers) or `"borderless"` (no chrome; for nesting inside Cards or as a quiet section divider).
 - **`size`** — `"sm"` / `"md"` (default) / `"lg"` controls trigger font-size + padding (and content padding).
+- **`gap`** — `"sm"` / `"md"` / `"lg"` separates items into **collapsible cards** (each gets its own border + radius; the joined container chrome is dropped). Omit for the default joined look.
+- **`indicatorSide`** — `"right"` (default) or `"left"` to put the chevron before the title.
+- **`<Accordion.Trigger actions={…}>`** — a controls slot at the **right of the header**, rendered OUTSIDE the toggle button so its buttons/menus are clickable without toggling the section (and don't pollute the heading's accessible name). Keep it to a few small controls.
 - **Smooth animation** via CSS `grid-template-rows: 0fr → 1fr`. No JS measurement.
 - **Heading wrapping** — Trigger is wrapped in `<h3>` by default per WAI-ARIA APG. Override via `headerLevel` on Item.
 - **Keyboard**: ArrowDown/Up cycles between triggers, Home/End jumps to ends, Space/Enter toggles. Disabled items are skipped.

--- a/packages/design-system/src/components/Accordion/Accordion.module.scss
+++ b/packages/design-system/src/components/Accordion/Accordion.module.scss
@@ -31,9 +31,54 @@
   border-bottom: 0;
 }
 
+// ─── Gap → separated "card" look ─────────────────────────────────────────
+// When `gap` is set, drop the joined container chrome and give each item its own
+// border + radius, separated vertically by the gap. Placed AFTER the variant
+// rules so it wins on equal specificity → cards regardless of `variant`.
+.accordion[data-gap] {
+  gap: var(--accordion-gap-md);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  overflow: visible;
+}
+
+.accordion[data-gap='sm'] {
+  gap: var(--accordion-gap-sm);
+}
+
+.accordion[data-gap='lg'] {
+  gap: var(--accordion-gap-lg);
+}
+
+.accordion[data-gap] .item {
+  border: var(--border-width) solid var(--accordion-item-border-color);
+  border-radius: var(--accordion-radius);
+  overflow: hidden;
+}
+
+// Header ROW: the heading (toggle button) and an optional actions slot, side by
+// side, separated by a gap (no-op when there's no actions slot).
 .header {
+  display: flex;
+  align-items: center;
+  column-gap: var(--accordion-header-gap);
+  transition: background var(--transition-fast);
+}
+
+// Hover highlights the FULL header row — including the actions area — even when an
+// actions slot makes the toggle button itself shorter. Skipped for disabled items.
+.item:not([data-disabled]) .header:hover {
+  background: var(--accordion-trigger-bg-hover);
+}
+
+// The heading element (h2–h6) wrapping the toggle button. Grows to fill the row,
+// leaving the actions slot its intrinsic width on the right.
+.heading {
   // stylelint-disable-next-line property-disallowed-list -- native heading margin reset
   margin: 0;
+  flex: 1;
+  min-width: 0;
   font-weight: var(--accordion-header-font-weight);
   font-size: var(--accordion-header-font-size);
 }
@@ -54,12 +99,9 @@
   color: var(--accordion-trigger-fg);
   cursor: pointer;
   text-align: left;
-  transition: background var(--transition-fast);
 
-  &:hover:not(:disabled) {
-    background: var(--accordion-trigger-bg-hover);
-  }
-
+  // Hover background lives on `.header` (the full row) so it spans full width even
+  // when an actions slot shortens this button. The trigger stays transparent.
   &:focus-visible {
     outline: none;
     box-shadow: inset 0 0 0 var(--ring-width) var(--accordion-trigger-ring);
@@ -76,6 +118,14 @@
   min-width: 0;
 }
 
+// Wraps the indicator icon so its SIDE is controlled purely by CSS (root
+// data-indicator-side flips `order`), working for a custom `icon` too.
+.indicatorSlot {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
 .indicator {
   flex-shrink: 0;
   transition: transform var(--transition-fast);
@@ -84,6 +134,27 @@
 
 .item[data-state='open'] .indicator {
   transform: rotate(180deg);
+}
+
+// Indicator on the LEFT: pack the trigger to the start and move the icon slot
+// ahead of the label (a gap separates them). Default is right (space-between).
+.accordion[data-indicator-side='left'] .trigger {
+  justify-content: flex-start;
+  gap: var(--accordion-indicator-gap);
+}
+
+.accordion[data-indicator-side='left'] .indicatorSlot {
+  order: -1;
+}
+
+// Controls slot at the right of the header, OUTSIDE the toggle button. Its
+// inline-end padding mirrors the trigger's so controls align to the content edge.
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--accordion-actions-gap);
+  flex-shrink: 0;
+  padding-inline-end: var(--accordion-trigger-padding-x-md);
 }
 
 .content {
@@ -133,10 +204,10 @@
 
 // ─── Size variants ─────────────────────────────────────────────────────
 // Drive both the trigger padding+font-size and the content padding from a
-// single data-size on the root. .header also inherits font-size for the
+// single data-size on the root. .heading also inherits font-size for the
 // heading element.
 
-.accordion[data-size='sm'] .header {
+.accordion[data-size='sm'] .heading {
   font-size: var(--accordion-header-font-size-sm);
 }
 
@@ -150,7 +221,7 @@
   font-size: var(--accordion-content-font-size-sm);
 }
 
-.accordion[data-size='md'] .header {
+.accordion[data-size='md'] .heading {
   font-size: var(--accordion-header-font-size-md);
 }
 
@@ -163,7 +234,7 @@
   padding: var(--accordion-content-padding-y-md) var(--accordion-content-padding-x-md);
 }
 
-.accordion[data-size='lg'] .header {
+.accordion[data-size='lg'] .heading {
   font-size: var(--accordion-header-font-size-lg);
 }
 
@@ -175,6 +246,16 @@
 .accordion[data-size='lg'] .body {
   padding: var(--accordion-content-padding-y-lg) var(--accordion-content-padding-x-lg);
   font-size: var(--accordion-content-font-size-lg);
+}
+
+// Actions inline-end padding tracks the trigger's so controls stay aligned to
+// the content edge across sizes (md is the base on `.actions`).
+.accordion[data-size='sm'] .actions {
+  padding-inline-end: var(--accordion-trigger-padding-x-sm);
+}
+
+.accordion[data-size='lg'] .actions {
+  padding-inline-end: var(--accordion-trigger-padding-x-lg);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/design-system/src/components/Accordion/Accordion.test.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.test.tsx
@@ -59,7 +59,7 @@ describe('<Accordion>', () => {
 
   it('renders items in DOM order', () => {
     const { container } = render(<BasicSingle />);
-    const triggers = container.querySelectorAll('button[aria-expanded]');
+    const triggers = container.querySelectorAll('button[data-accordion-trigger]');
     expect(triggers[0]).toHaveTextContent('A trigger');
     expect(triggers[1]).toHaveTextContent('B trigger');
     expect(triggers[2]).toHaveTextContent('C trigger');
@@ -574,4 +574,112 @@ describe('<Accordion>', () => {
     await user.keyboard('{ArrowDown}');
     expect(screen.getByRole('button', { name: 'Outer B' })).toHaveFocus();
   });
+
+  // ─── indicatorSide + gap + header actions ────────────────────────────────
+
+  it('default indicatorSide is "right" (data-indicator-side attr)', () => {
+    const { container } = render(<BasicSingle />);
+    expect(container.querySelector('[data-accordion]')!).toHaveAttribute(
+      'data-indicator-side',
+      'right',
+    );
+  });
+
+  it('indicatorSide="left" sets data-indicator-side on the root', () => {
+    const { container } = render(
+      <Accordion type="single" indicatorSide="left">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(container.querySelector('[data-accordion]')!).toHaveAttribute(
+      'data-indicator-side',
+      'left',
+    );
+  });
+
+  it('gap is absent by default and set as data-gap when provided', () => {
+    const { container: c0 } = render(<BasicSingle />);
+    expect(container0OfRoot(c0)).not.toHaveAttribute('data-gap');
+    const { container: c1 } = render(
+      <Accordion type="multiple" gap="md">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(container0OfRoot(c1)).toHaveAttribute('data-gap', 'md');
+  });
+
+  it('header actions render outside the toggle button and clicking them does not toggle', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    render(
+      <Accordion type="single" collapsible>
+        <Accordion.Item value="a">
+          <Accordion.Trigger
+            actions={
+              <button type="button" onClick={onEdit}>
+                Edit
+              </button>
+            }
+          >
+            A trigger
+          </Accordion.Trigger>
+          <Accordion.Content>A content</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    const content = document.querySelector('[role="region"]')!;
+    expect(content).toHaveAttribute('data-state', 'closed');
+
+    const edit = screen.getByRole('button', { name: 'Edit' });
+    const toggle = screen.getByRole('button', { name: 'A trigger' });
+    // Action lives OUTSIDE the toggle button (valid HTML, independently clickable).
+    expect(toggle.contains(edit)).toBe(false);
+    // The heading's accessible name is just the title, not the action label.
+    expect(screen.getByRole('heading', { name: 'A trigger' })).toBeInTheDocument();
+
+    await user.click(edit);
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    // Section stayed closed — the action click did not toggle it.
+    expect(content).toHaveAttribute('data-state', 'closed');
+  });
+
+  it('arrow-nav cycles only triggers, skipping an aria-expanded control in actions', async () => {
+    const user = userEvent.setup();
+    render(
+      <Accordion type="multiple">
+        <Accordion.Item value="a">
+          <Accordion.Trigger
+            actions={
+              // Mimics a DropdownMenu/Select trigger in the slot — it carries
+              // aria-expanded but must NOT be a keyboard-nav stop for the accordion.
+              <button type="button" aria-expanded="false" aria-label="row menu">
+                ⋯
+              </button>
+            }
+          >
+            A
+          </Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="b">
+          <Accordion.Trigger>B</Accordion.Trigger>
+          <Accordion.Content>y</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    screen.getByRole('button', { name: 'A' }).focus();
+    await user.keyboard('{ArrowDown}');
+    // Lands on trigger B, NOT the "row menu" action control.
+    expect(screen.getByRole('button', { name: 'B' })).toHaveFocus();
+  });
 });
+
+function container0OfRoot(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-accordion]') as HTMLElement;
+}

--- a/packages/design-system/src/components/Accordion/Accordion.tokens.scss
+++ b/packages/design-system/src/components/Accordion/Accordion.tokens.scss
@@ -23,6 +23,19 @@
   // Indicator (chevron)
   --accordion-indicator-fg: var(--color-fg-muted);
 
+  // Gap between the indicator and the label when the indicator sits on the left.
+  --accordion-indicator-gap: var(--space-2);
+
+  // Header actions slot — gap between the trigger and the controls, and between
+  // adjacent action controls.
+  --accordion-header-gap: var(--space-3);
+  --accordion-actions-gap: var(--space-1);
+
+  // Gap between items when `gap` is set (separated "card" look).
+  --accordion-gap-sm: var(--space-2);
+  --accordion-gap-md: var(--space-3);
+  --accordion-gap-lg: var(--space-4);
+
   // Size: sm
   --accordion-header-font-size-sm: var(--font-size-sm);
   --accordion-trigger-padding-y-sm: var(--space-2);

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -34,6 +34,17 @@ export type AccordionVariant = 'bordered' | 'borderless';
  */
 export type AccordionSize = 'sm' | 'md' | 'lg';
 
+/**
+ * Spacing between items. When set, items render as separated **cards** (each gets
+ * its own border + radius) and the joined container chrome (outer border + item
+ * dividers) is dropped. Omit for the default joined look. `'sm'`/`'md'`/`'lg'`
+ * step the gap. Applies regardless of `variant`.
+ */
+export type AccordionGap = 'sm' | 'md' | 'lg';
+
+/** Which side the trigger indicator (chevron) sits on. Defaults to `'right'`. */
+export type AccordionIndicatorSide = 'left' | 'right';
+
 interface AccordionBaseProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   'defaultValue' | 'onChange'
@@ -42,6 +53,13 @@ interface AccordionBaseProps extends Omit<
   variant?: AccordionVariant;
   /** Trigger size (font + padding). Defaults to `'md'`. */
   size?: AccordionSize;
+  /**
+   * Gap between items → separated "card" look (each item gets its own border +
+   * radius; the outer container chrome is dropped). Omit for the joined default.
+   */
+  gap?: AccordionGap;
+  /** Which side the chevron indicator sits on. Defaults to `'right'`. */
+  indicatorSide?: AccordionIndicatorSide;
   children: ReactNode;
 }
 
@@ -123,6 +141,24 @@ export type AccordionProps = AccordionBaseProps & (AccordionSingleProps | Accord
  *   ...
  * </Accordion>
  *
+ * @example
+ * // Collapsible cards: gap between items + chevron on the left + a header
+ * // controls slot (rendered outside the toggle, so it doesn't toggle the section).
+ * <Accordion type="multiple" gap="md" indicatorSide="left">
+ *   <Accordion.Item value="billing">
+ *     <Accordion.Trigger
+ *       actions={
+ *         <Button iconOnly size="xs" variant="ghost" aria-label="Edit billing">
+ *           <Pencil size={14} />
+ *         </Button>
+ *       }
+ *     >
+ *       Billing
+ *     </Accordion.Trigger>
+ *     <Accordion.Content>…</Accordion.Content>
+ *   </Accordion.Item>
+ * </Accordion>
+ *
  * @remarks When NOT to use
  * - Mutually-exclusive view switchers → `<Tabs>`.
  * - Single show/hide toggle → `<Button>` + conditional render.
@@ -132,6 +168,9 @@ export type AccordionProps = AccordionBaseProps & (AccordionSingleProps | Accord
  * - ❌ Nesting `<Accordion.Trigger>` inside a heading the consumer also renders. Trigger wraps itself in a heading.
  * - ❌ Manually setting `aria-expanded` on the Trigger via `{...props}`. The component owns the ARIA contract.
  * - ❌ Using `headerLevel="h1"`. There should only be one `<h1>` per page; Accordion lives below it.
+ * - ❌ Putting bulky or primary content in the Trigger `actions` slot. It's for a
+ *   few small header controls (an icon `<Button>`, a `<DropdownMenu>` trigger, a
+ *   `<Switch>`) — the section's real content belongs in `<Accordion.Content>`.
  */
 const AccordionRoot = forwardRef<HTMLDivElement, AccordionProps>(
   function AccordionRoot(props, ref) {
@@ -154,6 +193,8 @@ const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
       collapsible = false,
       variant = 'bordered',
       size = 'md',
+      gap,
+      indicatorSide = 'right',
       children,
       className,
       ...rest
@@ -198,6 +239,8 @@ const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
           data-accordion=""
           data-variant={variant}
           data-size={size}
+          data-gap={gap}
+          data-indicator-side={indicatorSide}
           className={clsx(styles.accordion, className)}
         >
           {children}
@@ -218,6 +261,8 @@ const AccordionMultipleImpl = forwardRef<HTMLDivElement, MultipleImplProps>(
       onValueChange,
       variant = 'bordered',
       size = 'md',
+      gap,
+      indicatorSide = 'right',
       children,
       className,
       ...rest
@@ -261,6 +306,8 @@ const AccordionMultipleImpl = forwardRef<HTMLDivElement, MultipleImplProps>(
           data-accordion=""
           data-variant={variant}
           data-size={size}
+          data-gap={gap}
+          data-indicator-side={indicatorSide}
           className={clsx(styles.accordion, className)}
         >
           {children}

--- a/packages/design-system/src/components/Accordion/AccordionTrigger.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionTrigger.tsx
@@ -18,6 +18,13 @@ export interface AccordionTriggerProps extends Omit<
    * Pass `null` to suppress the icon entirely. Default: `<ChevronDown />`.
    */
   icon?: ReactNode | null;
+  /**
+   * Controls rendered at the **right of the header**, OUTSIDE the toggle button —
+   * so their buttons/menus are clickable without toggling the section, and the
+   * heading's accessible name stays just the title. Keep it to a few small
+   * controls (`<Button iconOnly>`, a `<DropdownMenu>` trigger, a `<Switch>`).
+   */
+  actions?: ReactNode;
   children: ReactNode;
 }
 
@@ -30,7 +37,7 @@ interface ItemContextWithHeaderLevel extends AccordionItemContextValue {
  * `<ChevronDown>` icon that rotates 180° when open.
  */
 export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerProps>(
-  function AccordionTrigger({ icon, children, className, onKeyDown, ...props }, ref) {
+  function AccordionTrigger({ icon, actions, children, className, onKeyDown, ...props }, ref) {
     const { toggle } = useAccordionContext('Trigger');
     const itemCtx = useAccordionItemContext('Trigger') as ItemContextWithHeaderLevel;
     const { value, disabled, isOpen, triggerId, contentId, headerLevel } = itemCtx;
@@ -45,13 +52,13 @@ export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerPr
       const root = e.currentTarget.closest<HTMLElement>('[data-accordion]');
       if (!root) return;
 
-      // querySelectorAll matches all descendants — including triggers in a
-      // NESTED Accordion inside an open Content. Scope keyboard nav to the
-      // current root by filtering to triggers whose nearest accordion ancestor
-      // IS this root. Without this, ArrowDown from an outer trigger jumps into
-      // the inner accordion.
+      // Match ONLY accordion toggle buttons (the `data-accordion-trigger` marker),
+      // never an `aria-expanded` control a consumer put in the `actions` slot (a
+      // DropdownMenu/Select trigger). Then scope to THIS root by filtering to
+      // triggers whose nearest accordion ancestor is this root — so ArrowDown from
+      // an outer trigger doesn't jump into a nested Accordion inside open Content.
       const triggers = Array.from(
-        root.querySelectorAll<HTMLButtonElement>('button[aria-expanded]:not(:disabled)'),
+        root.querySelectorAll<HTMLButtonElement>('button[data-accordion-trigger]:not(:disabled)'),
       ).filter((btn) => btn.closest('[data-accordion]') === root);
       if (triggers.length === 0) return;
 
@@ -76,26 +83,39 @@ export const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerPr
     const Heading = headerLevel as 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
     return (
-      <Heading className={styles.header}>
-        {/* Pattern B — {...props} first so component-owned id/aria-expanded/
-            aria-controls/disabled/onClick/onKeyDown/className win and the ARIA
-            contract can't be overridden by a consumer. */}
-        <button
-          {...props}
-          ref={ref}
-          type="button"
-          id={triggerId}
-          aria-expanded={isOpen}
-          aria-controls={contentId}
-          disabled={disabled}
-          onClick={() => toggle(value)}
-          onKeyDown={handleKeyDown}
-          className={clsx(styles.trigger, className)}
-        >
-          <span className={styles.label}>{children}</span>
-          {renderedIcon}
-        </button>
-      </Heading>
+      // Header ROW: the heading (toggle button) + an optional actions slot. Actions
+      // live OUTSIDE the heading/button so they're independently clickable (no
+      // toggle), valid HTML (no nested buttons), and don't pollute the heading's
+      // accessible name.
+      <div className={styles.header}>
+        <Heading className={styles.heading}>
+          {/* Pattern B — {...props} first so component-owned id/aria-expanded/
+              aria-controls/disabled/onClick/onKeyDown/className win and the ARIA
+              contract can't be overridden by a consumer. */}
+          <button
+            {...props}
+            ref={ref}
+            type="button"
+            id={triggerId}
+            // Stable marker so keyboard arrow-nav targets ONLY accordion toggles,
+            // never an aria-expanded control in the `actions` slot.
+            data-accordion-trigger=""
+            aria-expanded={isOpen}
+            aria-controls={contentId}
+            disabled={disabled}
+            onClick={() => toggle(value)}
+            onKeyDown={handleKeyDown}
+            className={clsx(styles.trigger, className)}
+          >
+            <span className={styles.label}>{children}</span>
+            {/* Icon wrapped in a slot so its side is controlled purely by CSS
+                (root data-indicator-side flips its `order`) — works for a custom
+                `icon` too, not just the default chevron. */}
+            {renderedIcon !== null && <span className={styles.indicatorSlot}>{renderedIcon}</span>}
+          </button>
+        </Heading>
+        {actions != null && <div className={styles.actions}>{actions}</div>}
+      </div>
     );
   },
 );

--- a/packages/design-system/src/components/Accordion/index.ts
+++ b/packages/design-system/src/components/Accordion/index.ts
@@ -5,6 +5,8 @@ export type {
   AccordionHeaderLevel,
   AccordionVariant,
   AccordionSize,
+  AccordionGap,
+  AccordionIndicatorSide,
 } from './Accordion';
 export type { AccordionItemProps } from './AccordionItem';
 export type { AccordionTriggerProps } from './AccordionTrigger';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -457,6 +457,8 @@ export type {
   AccordionHeaderLevel,
   AccordionVariant,
   AccordionSize,
+  AccordionGap,
+  AccordionIndicatorSide,
 } from './components/Accordion';
 
 export { Breadcrumb } from './components/Breadcrumb';

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -17,6 +17,20 @@
           "description": "Trigger size (font + padding). Defaults to `'md'`."
         },
         {
+          "name": "gap",
+          "type": "AccordionGap",
+          "required": false,
+          "default": "",
+          "description": "Gap between items → separated \"card\" look (each item gets its own border +\nradius; the outer container chrome is dropped). Omit for the joined default."
+        },
+        {
+          "name": "indicatorSide",
+          "type": "AccordionIndicatorSide",
+          "required": false,
+          "default": "",
+          "description": "Which side the chevron indicator sits on. Defaults to `'right'`."
+        },
+        {
           "name": "children",
           "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
           "required": true,
@@ -768,7 +782,7 @@
         },
         {
           "name": "side",
-          "type": "\"top\" | \"bottom\" | \"right\" | \"left\"",
+          "type": "\"left\" | \"right\" | \"top\" | \"bottom\"",
           "required": false,
           "default": "",
           "description": "Preferred side. Default `'top'` — confirmations anchor above the trigger by convention."
@@ -4494,7 +4508,7 @@
     "ErrorStateHeadingLevel": "1 | 2 | 3 | 4 | 5 | 6",
     "IconTileSize": "\"sm\" | \"md\" | \"lg\"",
     "IconTileShape": "\"square\" | \"circle\"",
-    "TooltipSide": "\"top\" | \"bottom\" | \"right\" | \"left\"",
+    "TooltipSide": "\"left\" | \"right\" | \"top\" | \"bottom\"",
     "TooltipAlign": "\"start\" | \"end\" | \"center\"",
     "ConfirmationVariant": "\"danger\" | \"default\"",
     "ModalSize": "\"sm\" | \"md\" | \"lg\"",
@@ -4503,7 +4517,7 @@
     "ScreenFill": "\"viewport\" | \"block\"",
     "ScreenBackdrop": "\"danger\" | \"none\" | \"accent\" | \"plain\"",
     "ScreenAlign": "\"start\" | \"center\"",
-    "DrawerSide": "\"top\" | \"bottom\" | \"right\" | \"left\"",
+    "DrawerSide": "\"left\" | \"right\" | \"top\" | \"bottom\"",
     "DrawerSize": "\"sm\" | \"md\" | \"lg\"",
     "DrawerOverlayVariant": "\"solid\" | \"blur\"",
     "RadioSize": "\"sm\" | \"md\" | \"lg\"",
@@ -4534,7 +4548,7 @@
     "TextareaResize": "\"none\" | \"vertical\" | \"both\"",
     "LiquidVariable": "{ code: string; label?: string; type?: string; group?: string }",
     "LiquidPreviewStatus": "\"error\" | \"loading\" | \"idle\"",
-    "LiquidPreviewPlacement": "\"bottom\" | \"right\"",
+    "LiquidPreviewPlacement": "\"right\" | \"bottom\"",
     "MentionsConfig": "{ onQuery: (query: string) => MentionItem[] | Promise<MentionItem[]>; trigger?: string }",
     "UploadConfig": "{ onUpload: (file: File) => Promise<UploadResult>; accept?: string; onUploadingChange?: ((uploading: boolean) => void) }",
     "FileEntry": "{ id: string; file: File; status: \"error\" | \"done\" | \"pending\" | \"uploading\"; progress?: number; error?: string }",
@@ -4551,6 +4565,8 @@
     "LinkVariant": "\"default\" | \"muted\" | \"subtle\"",
     "AccordionVariant": "\"bordered\" | \"borderless\"",
     "AccordionSize": "\"sm\" | \"md\" | \"lg\"",
+    "AccordionGap": "\"sm\" | \"md\" | \"lg\"",
+    "AccordionIndicatorSide": "\"left\" | \"right\"",
     "TopBarElement": "\"div\" | \"header\"",
     "CodeTone": "\"danger\" | \"accent\" | \"default\" | \"muted\"",
     "RichDoc": "{ blocks: Block[] }",
@@ -4560,7 +4576,7 @@
     "TextSize": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\"",
     "TextTone": "\"success\" | \"warning\" | \"danger\" | \"accent\" | \"default\" | \"muted\" | \"subtle\"",
     "TextWeight": "\"regular\" | \"medium\" | \"semibold\" | \"bold\"",
-    "TextAlign": "\"center\" | \"right\" | \"left\"",
+    "TextAlign": "\"left\" | \"right\" | \"center\"",
     "TitleOrder": "1 | 2 | 3 | 4 | 5 | 6",
     "TitleSize": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\" | \"2xl\" | \"3xl\"",
     "TitleTone": "\"danger\" | \"accent\" | \"default\" | \"muted\" | \"subtle\"",

--- a/packages/playground/src/pages/components/AccordionDemo.tsx
+++ b/packages/playground/src/pages/components/AccordionDemo.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { Plus } from 'lucide-react';
-import { Accordion, Stack } from '@eocrm/design-system';
+import { Plus, Pencil, Trash2 } from 'lucide-react';
+import { Accordion, Button, Cluster, Stack } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
@@ -353,6 +353,97 @@ export function Demo() {
           <Accordion.Item value="security">
             <Accordion.Trigger>Security</Accordion.Trigger>
             <Accordion.Content>2FA, active sessions, API keys.</Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Example>
+
+      <Example
+        title="Collapsible cards — gap + left chevron + header actions"
+        description="gap separates the items into cards; indicatorSide='left' moves the chevron before the title; Accordion.Trigger's actions slot holds controls at the right of the header. The action buttons are outside the toggle, so clicking them edits/deletes without opening the section."
+        code={`import { Pencil, Trash2 } from 'lucide-react';
+import { Accordion, Button, Cluster } from '@eocrm/design-system';
+
+const rowActions = (label) => (
+  <Cluster gap="xs">
+    <Button iconOnly size="xs" variant="ghost" aria-label={\`Edit \${label}\`}>
+      <Pencil size={14} />
+    </Button>
+    <Button iconOnly size="xs" variant="ghost" aria-label={\`Delete \${label}\`}>
+      <Trash2 size={14} />
+    </Button>
+  </Cluster>
+);
+
+export function Demo() {
+  return (
+    <Accordion type="multiple" gap="md" indicatorSide="left" defaultValue={['plan']}>
+      <Accordion.Item value="plan">
+        <Accordion.Trigger actions={rowActions('plan')}>Billing plan</Accordion.Trigger>
+        <Accordion.Content>Pro — $49/mo, renews Jul 1. 12 seats.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="payment">
+        <Accordion.Trigger actions={rowActions('payment method')}>Payment method</Accordion.Trigger>
+        <Accordion.Content>Visa ending 4242, expires 08/27.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="invoices">
+        <Accordion.Trigger actions={rowActions('invoices')}>Invoices</Accordion.Trigger>
+        <Accordion.Content>Download past invoices as PDF.</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}`}
+      >
+        <Accordion type="multiple" gap="md" indicatorSide="left" defaultValue={['plan']}>
+          <Accordion.Item value="plan">
+            <Accordion.Trigger
+              actions={
+                <Cluster gap="xs">
+                  <Button iconOnly size="xs" variant="ghost" aria-label="Edit plan">
+                    <Pencil size={14} />
+                  </Button>
+                  <Button iconOnly size="xs" variant="ghost" aria-label="Delete plan">
+                    <Trash2 size={14} />
+                  </Button>
+                </Cluster>
+              }
+            >
+              Billing plan
+            </Accordion.Trigger>
+            <Accordion.Content>Pro — $49/mo, renews Jul 1. 12 seats.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="payment">
+            <Accordion.Trigger
+              actions={
+                <Cluster gap="xs">
+                  <Button iconOnly size="xs" variant="ghost" aria-label="Edit payment method">
+                    <Pencil size={14} />
+                  </Button>
+                  <Button iconOnly size="xs" variant="ghost" aria-label="Delete payment method">
+                    <Trash2 size={14} />
+                  </Button>
+                </Cluster>
+              }
+            >
+              Payment method
+            </Accordion.Trigger>
+            <Accordion.Content>Visa ending 4242, expires 08/27.</Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="invoices">
+            <Accordion.Trigger
+              actions={
+                <Cluster gap="xs">
+                  <Button iconOnly size="xs" variant="ghost" aria-label="Edit invoices">
+                    <Pencil size={14} />
+                  </Button>
+                  <Button iconOnly size="xs" variant="ghost" aria-label="Delete invoices">
+                    <Trash2 size={14} />
+                  </Button>
+                </Cluster>
+              }
+            >
+              Invoices
+            </Accordion.Trigger>
+            <Accordion.Content>Download past invoices as PDF.</Accordion.Content>
           </Accordion.Item>
         </Accordion>
       </Example>


### PR DESCRIPTION
## Summary

Three Accordion enhancements (+ two follow-up polish fixes), all requested:

1. **`indicatorSide`** (`'left' | 'right'`, default `'right'`) — place the chevron before the title.
2. **`gap`** (`'sm' | 'md' | 'lg'`) — separate items into **collapsible cards**: each item gets its own border + radius and the joined container chrome is dropped. Works regardless of `variant`.
3. **`<Accordion.Trigger actions={…}>`** — a controls slot at the **right of the header**, rendered OUTSIDE the toggle button (and outside the heading): its buttons/menus are independently clickable without toggling the section, it's valid HTML (no nested buttons), and it doesn't pollute the heading's accessible name.

Follow-ups:
- **Full-width hover** — the hover background now spans the whole header row while the toggle button stays shorter when an actions slot is present.
- **Gap between trigger and controls** so they don't touch.

## Implementation notes
- Header restructured to `.header` (flex row) → `.heading` (`<h3>`, the toggle) + `.actions` sibling. Chevron wrapped in `.indicatorSlot` so `indicatorSide` works for a custom `icon` too (pure CSS `order`/`justify` via `data-indicator-side`). `gap` via `data-gap` → spaced flex column + per-item card borders (placed after the variant rules to win on equal specificity).
- **Keyboard nav** now targets a dedicated `data-accordion-trigger` marker instead of `button[aria-expanded]`, so an `aria-expanded` control (DropdownMenu/Select) in the `actions` slot isn't captured into the arrow-key cycle.
- New exported types `AccordionGap`, `AccordionIndicatorSide` (component + root `src/index.ts`). New tokens for the gaps.

## Test plan
- `make test` (3484, +5 Accordion tests: indicatorSide, gap, actions-don't-toggle, arrow-nav-skips-actions-control), `make build`, `make lint`, `npm run format:check`, `npm pack --dry-run` (0 leak) — green.
- Two Rule 8 review passes → clean (the first caught the keyboard-nav/actions-slot bug, fixed + tested).
- Live (Playwright) on the new "Collapsible cards" demo: data-gap=md + indicatorSide=left, each item bordered+rounded, chevron left of title, trigger (324px) shorter than header (396px), actions outside the toggle, clicking an action doesn't open the section, 12px gap between trigger and controls, and the `.header:hover` rule resolves to the hover-bg token (full-width).

🤖 Generated with [Claude Code](https://claude.com/claude-code)