### PR TITLE
fix(Accordion): fill gapped items with the card surface (#256)

### DIFF
--- a/packages/design-system/src/components/Accordion/Accordion.module.scss
+++ b/packages/design-system/src/components/Accordion/Accordion.module.scss
@@ -52,6 +52,11 @@
 }
 
 .accordion[data-gap] .item {
+  // Fill each card with the accordion surface so gapped items read as real cards
+  // on a tinted page background — not transparent outlined boxes. (The joined root
+  // carries this fill normally; in gap mode the root is transparent, so it moves
+  // to the items.)
+  background: var(--accordion-bg);
   border: var(--border-width) solid var(--accordion-item-border-color);
   border-radius: var(--accordion-radius);
   overflow: hidden;


### PR DESCRIPTION
Addresses #256.

## Summary
When `<Accordion gap="sm|md|lg">` is set, the root drops its chrome and each item becomes a bordered + rounded card — but the items had **no background fill**, so on a tinted page background they read as transparent outlined boxes instead of filled cards. This fills gapped items with the accordion surface (`background: var(--accordion-bg)`), so `gap` blocks look like real cards on any page background. One-line, token-based; the joined (non-gap) look is unchanged.

## Test plan
- `make test` (3484), `make build-lib`, `make lint`, `npm run format:check`, `npm pack --dry-run` (0 leak) — green.
- Live (Playwright): a gapped item's computed `background-color` is now `rgb(255,255,255)` (matches `--color-bg`), while the root stays transparent (chrome dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)