### PR TITLE
feat(Accordion): actionsWhenClosed — hide header actions on collapsed items (#258)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1867,6 +1867,7 @@ import { Accordion } from '@eocrm/design-system';
 - **`gap`** — `"sm"` / `"md"` / `"lg"` separates items into **collapsible cards** (each gets its own border + radius; the joined container chrome is dropped). Omit for the default joined look.
 - **`indicatorSide`** — `"right"` (default) or `"left"` to put the chevron before the title.
 - **`<Accordion.Trigger actions={…}>`** — a controls slot at the **right of the header**, rendered OUTSIDE the toggle button so its buttons/menus are clickable without toggling the section (and don't pollute the heading's accessible name). Keep it to a few small controls.
+- **`actionsWhenClosed`** — `"show"` (default) keeps `actions` always visible; `"hide"` fades them out (and drops them from focus order) while the item is collapsed — for dense sidebars of collapsed cards.
 - **Smooth animation** via CSS `grid-template-rows: 0fr → 1fr`. No JS measurement.
 - **Heading wrapping** — Trigger is wrapped in `<h3>` by default per WAI-ARIA APG. Override via `headerLevel` on Item.
 - **Keyboard**: ArrowDown/Up cycles between triggers, Home/End jumps to ends, Space/Enter toggles. Disabled items are skipped.

--- a/packages/design-system/src/components/Accordion/Accordion.module.scss
+++ b/packages/design-system/src/components/Accordion/Accordion.module.scss
@@ -8,6 +8,13 @@
   border-radius: var(--accordion-radius);
   background: var(--accordion-bg);
   overflow: hidden;
+
+  // How a closed item's `.actions` render — resolved through inherited custom props
+  // so the NEAREST accordion wins (a nested accordion with a different
+  // `actionsWhenClosed` is unaffected by an ancestor's). Default: visible.
+  --accordion-actions-closed-opacity: var(--opacity-visible);
+  --accordion-actions-closed-visibility: visible;
+  --accordion-actions-closed-pointer-events: auto;
 }
 
 // Borderless variant: strip the outer chrome. Item dividing lines also
@@ -160,6 +167,29 @@
   gap: var(--accordion-actions-gap);
   flex-shrink: 0;
   padding-inline-end: var(--accordion-trigger-padding-x-md);
+
+  // Bare-class transition (matches the reduced-motion reset's specificity so that
+  // override actually wins). Only fires when the values below change — i.e. in
+  // `actionsWhenClosed="hide"` mode as items toggle.
+  transition:
+    opacity var(--transition-fast),
+    visibility var(--transition-fast);
+}
+
+// actionsWhenClosed="hide": a closed item's actions fade out and leave the focus
+// order (visibility:hidden) — useful for dense sidebars of collapsed cards. The
+// values come from the nearest accordion's inherited props, so this also resolves
+// correctly for nested accordions. Layout space is kept (no reflow on toggle).
+.accordion[data-actions-when-closed='hide'] {
+  --accordion-actions-closed-opacity: var(--opacity-hidden);
+  --accordion-actions-closed-visibility: hidden;
+  --accordion-actions-closed-pointer-events: none;
+}
+
+.item[data-state='closed'] .actions {
+  opacity: var(--accordion-actions-closed-opacity);
+  visibility: var(--accordion-actions-closed-visibility);
+  pointer-events: var(--accordion-actions-closed-pointer-events);
 }
 
 .content {
@@ -265,7 +295,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .content,
-  .indicator {
+  .indicator,
+  .actions {
     transition: none;
   }
 }

--- a/packages/design-system/src/components/Accordion/Accordion.test.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.test.tsx
@@ -600,6 +600,46 @@ describe('<Accordion>', () => {
     );
   });
 
+  it('default actionsWhenClosed is "show"; "hide" sets the data attr on the root', () => {
+    const { container: c0 } = render(<BasicSingle />);
+    expect(container0OfRoot(c0)).toHaveAttribute('data-actions-when-closed', 'show');
+    const { container: c1 } = render(
+      <Accordion type="multiple" actionsWhenClosed="hide">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>A</Accordion.Trigger>
+          <Accordion.Content>x</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(container0OfRoot(c1)).toHaveAttribute('data-actions-when-closed', 'hide');
+  });
+
+  it('nested accordions each carry their own actionsWhenClosed (no leak via inherited vars)', () => {
+    // The hide behavior is driven by inherited CSS custom props keyed off the
+    // NEAREST [data-accordion]; this asserts each root owns its own attr so a
+    // nested 'show' inside an outer 'hide' resolves independently. (The computed
+    // opacity/visibility is covered by the Playwright pass — jsdom doesn't apply
+    // the module stylesheet.)
+    const { container } = render(
+      <Accordion type="multiple" actionsWhenClosed="hide" defaultValue={['a']}>
+        <Accordion.Item value="a">
+          <Accordion.Trigger>Outer</Accordion.Trigger>
+          <Accordion.Content>
+            <Accordion type="single">
+              <Accordion.Item value="n">
+                <Accordion.Trigger>Inner</Accordion.Trigger>
+                <Accordion.Content>z</Accordion.Content>
+              </Accordion.Item>
+            </Accordion>
+          </Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    const roots = container.querySelectorAll('[data-accordion]');
+    expect(roots[0]).toHaveAttribute('data-actions-when-closed', 'hide');
+    expect(roots[1]).toHaveAttribute('data-actions-when-closed', 'show');
+  });
+
   it('gap is absent by default and set as data-gap when provided', () => {
     const { container: c0 } = render(<BasicSingle />);
     expect(container0OfRoot(c0)).not.toHaveAttribute('data-gap');

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -45,6 +45,14 @@ export type AccordionGap = 'sm' | 'md' | 'lg';
 /** Which side the trigger indicator (chevron) sits on. Defaults to `'right'`. */
 export type AccordionIndicatorSide = 'left' | 'right';
 
+/**
+ * Whether a `<Accordion.Trigger actions>` slot stays visible when its item is
+ * collapsed. `'show'` (default) keeps controls always visible; `'hide'` fades them
+ * out (and removes them from focus order) while the item is closed — useful for a
+ * dense sidebar of collapsed blocks whose controls act on hidden body content.
+ */
+export type AccordionActionsWhenClosed = 'show' | 'hide';
+
 interface AccordionBaseProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   'defaultValue' | 'onChange'
@@ -60,6 +68,12 @@ interface AccordionBaseProps extends Omit<
   gap?: AccordionGap;
   /** Which side the chevron indicator sits on. Defaults to `'right'`. */
   indicatorSide?: AccordionIndicatorSide;
+  /**
+   * Whether `Accordion.Trigger` `actions` stay visible when the item is collapsed.
+   * Defaults to `'show'`; `'hide'` fades them out (and drops them from focus order)
+   * while closed.
+   */
+  actionsWhenClosed?: AccordionActionsWhenClosed;
   children: ReactNode;
 }
 
@@ -144,7 +158,8 @@ export type AccordionProps = AccordionBaseProps & (AccordionSingleProps | Accord
  * @example
  * // Collapsible cards: gap between items + chevron on the left + a header
  * // controls slot (rendered outside the toggle, so it doesn't toggle the section).
- * <Accordion type="multiple" gap="md" indicatorSide="left">
+ * // `actionsWhenClosed="hide"` fades the controls out on collapsed cards.
+ * <Accordion type="multiple" gap="md" indicatorSide="left" actionsWhenClosed="hide">
  *   <Accordion.Item value="billing">
  *     <Accordion.Trigger
  *       actions={
@@ -195,6 +210,7 @@ const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
       size = 'md',
       gap,
       indicatorSide = 'right',
+      actionsWhenClosed = 'show',
       children,
       className,
       ...rest
@@ -241,6 +257,7 @@ const AccordionSingleImpl = forwardRef<HTMLDivElement, SingleImplProps>(
           data-size={size}
           data-gap={gap}
           data-indicator-side={indicatorSide}
+          data-actions-when-closed={actionsWhenClosed}
           className={clsx(styles.accordion, className)}
         >
           {children}
@@ -263,6 +280,7 @@ const AccordionMultipleImpl = forwardRef<HTMLDivElement, MultipleImplProps>(
       size = 'md',
       gap,
       indicatorSide = 'right',
+      actionsWhenClosed = 'show',
       children,
       className,
       ...rest
@@ -308,6 +326,7 @@ const AccordionMultipleImpl = forwardRef<HTMLDivElement, MultipleImplProps>(
           data-size={size}
           data-gap={gap}
           data-indicator-side={indicatorSide}
+          data-actions-when-closed={actionsWhenClosed}
           className={clsx(styles.accordion, className)}
         >
           {children}

--- a/packages/design-system/src/components/Accordion/index.ts
+++ b/packages/design-system/src/components/Accordion/index.ts
@@ -7,6 +7,7 @@ export type {
   AccordionSize,
   AccordionGap,
   AccordionIndicatorSide,
+  AccordionActionsWhenClosed,
 } from './Accordion';
 export type { AccordionItemProps } from './AccordionItem';
 export type { AccordionTriggerProps } from './AccordionTrigger';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -459,6 +459,7 @@ export type {
   AccordionSize,
   AccordionGap,
   AccordionIndicatorSide,
+  AccordionActionsWhenClosed,
 } from './components/Accordion';
 
 export { Breadcrumb } from './components/Breadcrumb';

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -31,6 +31,13 @@
           "description": "Which side the chevron indicator sits on. Defaults to `'right'`."
         },
         {
+          "name": "actionsWhenClosed",
+          "type": "AccordionActionsWhenClosed",
+          "required": false,
+          "default": "",
+          "description": "Whether `Accordion.Trigger` `actions` stay visible when the item is collapsed.\nDefaults to `'show'`; `'hide'` fades them out (and drops them from focus order)\nwhile closed."
+        },
+        {
           "name": "children",
           "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
           "required": true,
@@ -4567,6 +4574,7 @@
     "AccordionSize": "\"sm\" | \"md\" | \"lg\"",
     "AccordionGap": "\"sm\" | \"md\" | \"lg\"",
     "AccordionIndicatorSide": "\"left\" | \"right\"",
+    "AccordionActionsWhenClosed": "\"show\" | \"hide\"",
     "TopBarElement": "\"div\" | \"header\"",
     "CodeTone": "\"danger\" | \"accent\" | \"default\" | \"muted\"",
     "RichDoc": "{ blocks: Block[] }",

--- a/packages/playground/src/pages/components/AccordionDemo.tsx
+++ b/packages/playground/src/pages/components/AccordionDemo.tsx
@@ -359,7 +359,7 @@ export function Demo() {
 
       <Example
         title="Collapsible cards — gap + left chevron + header actions"
-        description="gap separates the items into cards; indicatorSide='left' moves the chevron before the title; Accordion.Trigger's actions slot holds controls at the right of the header. The action buttons are outside the toggle, so clicking them edits/deletes without opening the section."
+        description="gap separates the items into cards; indicatorSide='left' moves the chevron before the title; Accordion.Trigger's actions slot holds controls at the right of the header (outside the toggle, so clicking them edits/deletes without opening the section). actionsWhenClosed='hide' fades the controls out on collapsed cards — expand 'Billing plan' vs the closed cards to see it."
         code={`import { Pencil, Trash2 } from 'lucide-react';
 import { Accordion, Button, Cluster } from '@eocrm/design-system';
 
@@ -376,7 +376,13 @@ const rowActions = (label) => (
 
 export function Demo() {
   return (
-    <Accordion type="multiple" gap="md" indicatorSide="left" defaultValue={['plan']}>
+    <Accordion
+      type="multiple"
+      gap="md"
+      indicatorSide="left"
+      actionsWhenClosed="hide"
+      defaultValue={['plan']}
+    >
       <Accordion.Item value="plan">
         <Accordion.Trigger actions={rowActions('plan')}>Billing plan</Accordion.Trigger>
         <Accordion.Content>Pro — $49/mo, renews Jul 1. 12 seats.</Accordion.Content>
@@ -393,7 +399,13 @@ export function Demo() {
   );
 }`}
       >
-        <Accordion type="multiple" gap="md" indicatorSide="left" defaultValue={['plan']}>
+        <Accordion
+          type="multiple"
+          gap="md"
+          indicatorSide="left"
+          actionsWhenClosed="hide"
+          defaultValue={['plan']}
+        >
           <Accordion.Item value="plan">
             <Accordion.Trigger
               actions={


### PR DESCRIPTION
Addresses #258.

## Summary
New root prop **`actionsWhenClosed`** (`'show' | 'hide'`, default `'show'`). In `'hide'` mode, a collapsed item's `Accordion.Trigger` `actions` fade out and leave the focus order — useful for dense sidebars of collapsed cards whose controls act on hidden body content. Default `'show'` preserves current behavior exactly.

- Closed + hide ⇒ `opacity: var(--opacity-hidden)` + `visibility: hidden` (removed from tab order) + `pointer-events: none`; fades back in on open. Layout space is kept (no reflow on toggle); reduced-motion respected.
- Driven by **inherited CSS custom properties** keyed off the nearest `.accordion`, so a nested accordion resolves independently — an outer `hide` does **not** leak into a nested `show` (and vice-versa).
- New exported type `AccordionActionsWhenClosed` (component + root `src/index.ts`).

## Test plan
- `make test` (3486, +2 Accordion tests: default/`hide` attr, nested-attr no-leak), `make build-lib`, `make lint`, `npm run format:check`, `npm pack --dry-run` (0 leak) — green.
- Two Rule 8 review passes → clean. The first caught two issues (nested cross-contamination via a descendant selector; a dead reduced-motion reset from a specificity mismatch); both fixed by the inherited-custom-property refactor.
- Live (Playwright): open item actions opacity=1/visible; closed item actions opacity=0/visibility=hidden/pointer-events=none and **not focusable**; an injected nested `show` accordion inside the outer `hide` keeps its closed actions visible (opacity=1) — confirming no leak. The cards demo now uses `actionsWhenClosed="hide"` (controls show only on the open card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)