### PR TITLE
feat(Select): clearable defaults to false (opt-in ✕ clear button)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -2442,6 +2442,7 @@ const [open, setOpen] = useState(false);
 - **Async**: pass `loadOptions(query, signal)`. Debounce (250ms default, configurable via `searchDebounceMs`) and `AbortSignal` cancellation are built-in. Do NOT debounce externally.
 - **Tag input pattern** = `multiple + searchable + creatable + triggerDisplay='chips'`. There is no separate `<Tags>` component.
 - **Form integration**: pass `name` (and `required`/`form` if needed). Hidden inputs render so `new FormData(form)` works. Multi mode renders one hidden input per selected value; `FormData.getAll(name)` returns the array.
+- **`clearable`** is opt-in (default `false`) — pass it to show the ✕ clear button once there's a value. Always suppressed when `disabled`/`readOnly`.
 - **`onChange` signature** is `(value, option | options | null)` — the second arg is the matched option(s), saving you a lookup.
 - **Render escape hatches**: `renderOption`, `renderValue`, `renderTag`, `renderEmpty`, `renderLoading`, `renderError`. Use when defaults don't suffice; default rendering is always token-correct.
 - For **action menus** (Edit/Delete/Duplicate buttons), use `<DropdownMenu>` — Select is for value selection, not actions.

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1106,26 +1106,38 @@ describe('Select — visual states', () => {
 });
 
 describe('Select — clearable', () => {
-  it('shows ✕ button when single + clearable + has value (default behavior, not required)', () => {
+  it('does NOT show ✕ by default — clearable is opt-in', () => {
     render(<Select options={STATUSES} value="pending" />);
+    expect(screen.queryByRole('button', { name: /clear selection/i })).toBeNull();
+  });
+
+  it('shows ✕ button when single + clearable + has value', () => {
+    render(<Select options={STATUSES} value="pending" clearable />);
     expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument();
   });
 
   it('clicking ✕ clears the selection', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    render(<Select options={STATUSES} defaultValue="pending" onChange={onChange} />);
+    render(<Select options={STATUSES} defaultValue="pending" clearable onChange={onChange} />);
     await user.click(screen.getByRole('button', { name: /clear selection/i }));
     expect(onChange).toHaveBeenCalledWith('', null);
   });
 
-  it('does NOT show ✕ when required', () => {
-    render(<Select options={STATUSES} value="pending" required name="x" />);
+  it('explicit clearable shows ✕ even on a required field (required does not suppress opt-in)', () => {
+    render(<Select options={STATUSES} value="pending" required name="x" clearable />);
+    expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument();
+  });
+
+  it('does NOT show ✕ when clearable but no value', () => {
+    render(<Select options={STATUSES} clearable />);
     expect(screen.queryByRole('button', { name: /clear selection/i })).toBeNull();
   });
 
-  it('does NOT show ✕ when no value', () => {
-    render(<Select options={STATUSES} />);
+  it('clearable is suppressed when disabled or readOnly', () => {
+    const { rerender } = render(<Select options={STATUSES} value="pending" clearable disabled />);
+    expect(screen.queryByRole('button', { name: /clear selection/i })).toBeNull();
+    rerender(<Select options={STATUSES} value="pending" clearable readOnly />);
     expect(screen.queryByRole('button', { name: /clear selection/i })).toBeNull();
   });
 
@@ -1160,7 +1172,7 @@ describe('Select — clearable', () => {
 
   it('clear ✕ button is focusable via keyboard', async () => {
     const user = userEvent.setup();
-    render(<Select options={STATUSES} defaultValue="active" />);
+    render(<Select options={STATUSES} defaultValue="active" clearable />);
     const trigger = screen.getByRole('button', { name: /Active/i });
     trigger.focus();
     await user.tab(); // moves to next focusable
@@ -1171,7 +1183,7 @@ describe('Select — clearable', () => {
   it('Enter on focused clear ✕ clears the selection', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    render(<Select options={STATUSES} defaultValue="pending" onChange={onChange} />);
+    render(<Select options={STATUSES} defaultValue="pending" clearable onChange={onChange} />);
     const clearBtn = screen.getByRole('button', { name: /clear selection/i });
     clearBtn.focus();
     await user.keyboard('{Enter}');

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -201,9 +201,8 @@ export interface SelectProps<T = unknown> extends Omit<
    */
   placeholder?: string;
   /**
-   * Shows a `✕` button in the trigger that clears the selection. Default
-   * is `true` in single mode (when not `required`), `false` in multi mode.
-   * Forced `false` when `disabled` or `readOnly`.
+   * Shows a `✕` button in the trigger that clears the selection. Opt-in:
+   * defaults to `false`. Always forced `false` when `disabled` or `readOnly`.
    */
   clearable?: boolean;
 
@@ -228,8 +227,8 @@ export interface SelectProps<T = unknown> extends Omit<
    */
   name?: string;
   /**
-   * Marks the field as required for native form validation. When `true`,
-   * `clearable` defaults to `false` and an empty selection blocks submit.
+   * Marks the field as required for native form validation. When `true`, an empty
+   * selection blocks submit.
    */
   required?: boolean;
   /** `form` attribute forwarded to the hidden `<input>` elements. */
@@ -495,15 +494,10 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
   const triggerRef = useRef<HTMLElement | null>(null);
   const listboxRef = useRef<HTMLUListElement | null>(null);
 
-  // `clearable` default depends on cardinality + `required`. Single-mode
-  // pickers usually want a clear button (the only way for a user to reach
-  // the empty state without typing); multi-mode users typically clear chip
-  // by chip and a "clear all" affordance is opt-in. `required` forces the
-  // ✕ off — a required field with no other selection escape would be a
-  // form-validation foot-gun. `disabled` / `readOnly` also suppress because
-  // the trigger is non-interactive in those states.
-  const effectiveClearable =
-    (clearable === undefined ? !multiple && !required : clearable) && !disabled && !readOnly;
+  // `clearable` is opt-in: the ✕ clear button defaults OFF and only shows when a
+  // consumer explicitly sets `clearable`. `disabled` / `readOnly` always suppress it
+  // (the trigger is non-interactive in those states).
+  const effectiveClearable = (clearable ?? false) && !disabled && !readOnly;
 
   // Defined inline rather than via useCallback because it captures the
   // current `setOpen` and `triggerRef` — both stable identities — and is

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -3519,7 +3519,7 @@
           "type": "boolean",
           "required": false,
           "default": "",
-          "description": "Shows a `✕` button in the trigger that clears the selection. Default\nis `true` in single mode (when not `required`), `false` in multi mode.\nForced `false` when `disabled` or `readOnly`."
+          "description": "Shows a `✕` button in the trigger that clears the selection. Opt-in:\ndefaults to `false`. Always forced `false` when `disabled` or `readOnly`."
         },
         {
           "name": "disabled",
@@ -3547,7 +3547,7 @@
           "type": "boolean",
           "required": false,
           "default": "",
-          "description": "Marks the field as required for native form validation. When `true`,\n`clearable` defaults to `false` and an empty selection blocks submit."
+          "description": "Marks the field as required for native form validation. When `true`, an empty\nselection blocks submit."
         },
         {
           "name": "form",

--- a/packages/playground/src/pages/components/SelectDemo.tsx
+++ b/packages/playground/src/pages/components/SelectDemo.tsx
@@ -121,6 +121,38 @@ export function StatusExample() {
       </Example>
 
       <Example
+        title="Clearable (opt-in)"
+        description="The ✕ clear button is opt-in — pass clearable to show it once there's a value. (It's suppressed when disabled/readOnly.)"
+        code={`import { useState } from 'react';
+import { Select, type SelectOption } from '@eocrm/design-system';
+
+const STATUSES: SelectOption[] = [
+  { value: 'active', label: 'Active' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'archived', label: 'Archived' },
+];
+
+export function ClearableExample() {
+  const [status, setStatus] = useState<string>('pending');
+  return (
+    <div style={{ width: 320 }}>
+      <Select
+        options={STATUSES}
+        value={status}
+        onChange={(v) => setStatus(v as string)}
+        clearable
+        placeholder="Pick a status"
+      />
+    </div>
+  );
+}`}
+      >
+        <InputExample>
+          <ClearableExample />
+        </InputExample>
+      </Example>
+
+      <Example
         title="Country — single, searchable, grouped"
         description="Options can be nested under group labels. Type to filter; arrow keys traverse across groups."
         code={`import { useState } from 'react';
@@ -549,6 +581,21 @@ function StatusExample() {
       </div>
       {status ? <Badge tone="info">{status}</Badge> : <Badge tone="neutral">none</Badge>}
     </Stack>
+  );
+}
+
+function ClearableExample() {
+  const [status, setStatus] = useState<string>('pending');
+  return (
+    <div style={{ width: 320 }}>
+      <Select
+        options={STATUSES}
+        value={status}
+        onChange={(v) => setStatus(v as string)}
+        clearable
+        placeholder="Pick a status"
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
`Select`'s `clearable` prop now **defaults to `false`** — the ✕ clear button is opt-in. Previously it defaulted ON for an optional single-select. Pass `clearable` to show it (it appears once there's a value, and is still suppressed when `disabled`/`readOnly`).

```diff
- effectiveClearable = (clearable === undefined ? !multiple && !required : clearable) && !disabled && !readOnly
+ effectiveClearable = (clearable ?? false) && !disabled && !readOnly
```

**⚠️ Behavior change:** consumers that relied on the automatic clear button on single selects must now pass `clearable`. `PhoneInput` (the only internal `<Select>` consumer) already sets `clearable={false}`, so it's unaffected. (`DatePicker`/`DateRangePicker` have their own separate `clearable` props — unchanged.)

## Test plan
- `make test` (3487), `make build`, `make lint`, `npm run format:check` — green.
- Updated the clearable tests: new "does NOT show ✕ by default — clearable is opt-in", "explicit clearable shows ✕ even on a required field", and "clearable suppressed when disabled/readOnly"; the opt-in / keyboard tests now pass `clearable`.
- Updated JSDoc (`clearable`, `required`), AGENTS.md, and added a "Clearable (opt-in)" demo example.
- One Rule 8 review pass → clean (0 Critical/Important); verified no other internal consumer relied on the old default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)