### PR TITLE
fix(RichTextEditor): guard void/attachment blocks with no inlines (#261)

### DIFF
--- a/packages/design-system/src/components/RichText/engine/blockUnit.ts
+++ b/packages/design-system/src/components/RichText/engine/blockUnit.ts
@@ -73,7 +73,13 @@ export function moveBlockUnit(
 
 /** Clone a block with a fresh id (inline runs copied so marks aren't shared). */
 function cloneBlock(b: Block): Block {
-  return { ...b, id: nextId(), inlines: b.inlines.map((r) => ({ ...r, marks: r.marks.slice() })) };
+  // `?? []` so duplicating a void block (an `attachment` carries no `inlines`)
+  // can't crash on undefined.
+  return {
+    ...b,
+    id: nextId(),
+    inlines: (b.inlines ?? []).map((r) => ({ ...r, marks: r.marks.slice() })),
+  };
 }
 
 /**

--- a/packages/design-system/src/components/RichText/engine/inlines.test.ts
+++ b/packages/design-system/src/components/RichText/engine/inlines.test.ts
@@ -12,6 +12,13 @@ describe('inlines', () => {
     expect(runsLength([plain('ab'), b('cd')])).toBe(4);
   });
 
+  it('runsText / runsLength tolerate a missing inlines (void/attachment block)', () => {
+    // A void block (e.g. `attachment`) can carry no `inlines`; the helpers must treat
+    // it as zero text instead of throwing on `.map`/`.reduce` of undefined.
+    expect(runsText(undefined)).toBe('');
+    expect(runsLength(undefined)).toBe(0);
+  });
+
   it('normalizeInlines merges adjacent equal-mark runs and drops empties', () => {
     expect(normalizeInlines([plain('a'), plain(''), plain('b')])).toEqual([plain('ab')]);
     expect(normalizeInlines([plain('a'), b('b'), b('c')])).toEqual([plain('a'), b('bc')]);

--- a/packages/design-system/src/components/RichText/engine/inlines.ts
+++ b/packages/design-system/src/components/RichText/engine/inlines.ts
@@ -2,14 +2,22 @@
 import type { Inline, Mark } from './model';
 import { marksEqual } from './marks';
 
-/** Concatenate the text of all inline runs, discarding mark information. */
-export function runsText(inlines: Inline[]): string {
-  return inlines.map((r) => r.text).join('');
+/**
+ * Concatenate the text of all inline runs, discarding mark information. Tolerates a
+ * missing `inlines` (a void block like `attachment` carries none) — a block with no
+ * runs contributes no text.
+ */
+export function runsText(inlines: Inline[] | undefined): string {
+  return (inlines ?? []).map((r) => r.text).join('');
 }
 
-/** Total character count across all inline runs (sum of run text lengths). */
-export function runsLength(inlines: Inline[]): number {
-  return inlines.reduce((n, r) => n + r.text.length, 0);
+/**
+ * Total character count across all inline runs (sum of run text lengths). Tolerates a
+ * missing `inlines` (void blocks like `attachment` carry none) → length 0, so the
+ * caret/length math never crashes on an attachment-containing doc.
+ */
+export function runsLength(inlines: Inline[] | undefined): number {
+  return (inlines ?? []).reduce((n, r) => n + r.text.length, 0);
 }
 
 /** Canonical form: adjacent equal-mark runs merged, empty runs dropped, ≥1 run. */

--- a/packages/design-system/src/components/RichText/engine/position.test.ts
+++ b/packages/design-system/src/components/RichText/engine/position.test.ts
@@ -21,6 +21,15 @@ describe('position', () => {
     expect(blockLength(doc.blocks[0])).toBe(5);
   });
 
+  it('blockLength is 0 for a void block with no inlines (attachment) — never throws', () => {
+    // External / image-attachment docs can carry an attachment block with no
+    // `inlines`. blockLength (→ runsLength) must treat it as zero, not crash — this
+    // is the render/caret-recompute path that previously threw on such docs.
+    const attachment = { id: 'img', type: 'attachment', src: 'x.png' } as RichDoc['blocks'][number];
+    expect(() => blockLength(attachment)).not.toThrow();
+    expect(blockLength(attachment)).toBe(0);
+  });
+
   it('findBlockIndex returns index or -1', () => {
     expect(findBlockIndex(doc, 'b')).toBe(1);
     expect(findBlockIndex(doc, 'zzz')).toBe(-1);

--- a/packages/design-system/src/components/RichText/engine/position.ts
+++ b/packages/design-system/src/components/RichText/engine/position.ts
@@ -51,7 +51,7 @@ export function marksBeforeCaret(doc: RichDoc, point: Point): Mark[] {
   const idx = findBlockIndex(doc, point.blockId);
   if (idx === -1 || point.offset <= 0) return [];
   let pos = 0;
-  for (const run of doc.blocks[idx].inlines) {
+  for (const run of doc.blocks[idx].inlines ?? []) {
     const end = pos + run.text.length;
     if (point.offset - 1 >= pos && point.offset - 1 < end) return run.marks;
     pos = end;

--- a/packages/design-system/src/components/RichText/engine/transforms.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.ts
@@ -27,7 +27,7 @@ function replaceBlock(doc: RichDoc, index: number, block: Block): RichDoc {
 /** Bounds of the mention run strictly containing `offset`, or null. */
 function mentionRunBoundsAt(block: Block, offset: number): { start: number; end: number } | null {
   let pos = 0;
-  for (const run of block.inlines) {
+  for (const run of block.inlines ?? []) {
     const s = pos;
     const e = pos + run.text.length;
     pos = e;

--- a/packages/design-system/src/components/RichTextEditor/commands.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/commands.test.ts
@@ -46,6 +46,21 @@ describe('activeMarks', () => {
     const doc: RichDoc = { blocks: [para('a', [{ text: 'ab', marks: [] }])] };
     expect(activeMarks(doc, span(at('a', 0), at('a', 0)), [bold])).toEqual(['bold']);
   });
+
+  // Issue #261: an external attachment block can omit `inlines` entirely. The
+  // toolbar derives pressed-state from a selection that may span such a block —
+  // the zero-length void slice must be skipped, not iterated.
+  it('does not throw over a selection spanning an attachment with no inlines', () => {
+    const attachment = {
+      id: 'img',
+      type: 'attachment',
+      src: 'x.png',
+    } as RichDoc['blocks'][number];
+    const doc: RichDoc = { blocks: [para('a', [{ text: 'ab', marks: [bold] }]), attachment] };
+    const range = span(at('a', 0), at('img', 0));
+    expect(() => activeMarks(doc, range, null)).not.toThrow();
+    expect(activeMarks(doc, range, null)).toEqual(['bold']);
+  });
 });
 
 describe('activeColors', () => {
@@ -99,6 +114,20 @@ describe('activeColors', () => {
       textColor: 'red',
       bgColor: 'blue',
     });
+  });
+
+  // Issue #261: mirror of the activeMarks guard — a selection that runs into a
+  // void attachment block (no `inlines`) must not crash the color derivation.
+  it('does not throw over a selection spanning an attachment with no inlines', () => {
+    const attachment = {
+      id: 'img',
+      type: 'attachment',
+      src: 'x.png',
+    } as RichDoc['blocks'][number];
+    const doc: RichDoc = { blocks: [para('a', [{ text: 'ab', marks: [red] }]), attachment] };
+    const range = span(at('a', 0), at('img', 0));
+    expect(() => activeColors(doc, range, null)).not.toThrow();
+    expect(activeColors(doc, range, null)).toEqual({ textColor: 'red' });
   });
 });
 

--- a/packages/design-system/src/components/RichTextEditor/commands.ts
+++ b/packages/design-system/src/components/RichTextEditor/commands.ts
@@ -68,8 +68,13 @@ export function activeMarks(doc: RichDoc, range: Range, pending: Mark[] | null):
       const block = doc.blocks[i];
       const from = i === si ? start.offset : 0;
       const to = i === ei ? end.offset : blockLength(block);
+      // Skip a zero-length slice — incl. a void `attachment` (no `inlines`), which
+      // would otherwise crash iterating undefined. Mirrors the transforms guard.
+      if (to <= from) continue;
       let pos = 0;
-      for (const run of block.inlines) {
+      // `?? []` so the iteration is safe even if a caller hands a void block a
+      // non-zero end offset (the `to <= from` skip already covers the editor path).
+      for (const run of block.inlines ?? []) {
         const rs = pos;
         const re = pos + run.text.length;
         pos = re;
@@ -144,8 +149,13 @@ export function activeColors(doc: RichDoc, range: Range, pending: Mark[] | null)
       const block = doc.blocks[i];
       const from = i === si ? start.offset : 0;
       const to = i === ei ? end.offset : blockLength(block);
+      // Skip a zero-length slice — incl. a void `attachment` (no `inlines`), which
+      // would otherwise crash iterating undefined. Mirrors the transforms guard.
+      if (to <= from) continue;
       let pos = 0;
-      for (const run of block.inlines) {
+      // `?? []` so the iteration is safe even if a caller hands a void block a
+      // non-zero end offset (the `to <= from` skip already covers the editor path).
+      for (const run of block.inlines ?? []) {
         const rs = pos;
         const re = pos + run.text.length;
         pos = re;

--- a/packages/design-system/src/components/RichTextEditor/links.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/links.test.ts
@@ -137,3 +137,24 @@ describe('setLink', () => {
     expect(r.doc.blocks[0].inlines).toEqual([{ text: 'hi', marks: [] }]);
   });
 });
+
+describe('linkAt — void blocks (issue #261)', () => {
+  // An external / image-attachment doc can carry an attachment block with NO
+  // `inlines` field at all. The toolbar recomputes the active link from the caret
+  // block on every selection change, so linkAt must resolve "no link" for a void
+  // block instead of crashing on `block.inlines` being undefined.
+  const attachment = { id: 'img', type: 'attachment', src: 'x.png' } as RichDoc['blocks'][number];
+
+  it('returns null (does not throw) for a point on an attachment with no inlines', () => {
+    const doc: RichDoc = { blocks: [attachment] };
+    expect(() => linkAt(doc, at('img', 0))).not.toThrow();
+    expect(linkAt(doc, at('img', 0))).toBeNull();
+  });
+
+  it('still resolves links in sibling text blocks when an attachment is present', () => {
+    const doc: RichDoc = {
+      blocks: [attachment, para('a', [{ text: 'home', marks: [link('/home')] }])],
+    };
+    expect(linkAt(doc, at('a', 2))).toEqual({ href: '/home', range: span(at('a', 0), at('a', 4)) });
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/links.ts
+++ b/packages/design-system/src/components/RichTextEditor/links.ts
@@ -23,6 +23,9 @@ export function linkAt(doc: RichDoc, point: Point): LinkAtResult | null {
   if (idx === -1) return null;
   const block = doc.blocks[idx];
   const len = blockLength(block);
+  // A zero-length block (empty, or a void `attachment` that carries no `inlines`)
+  // can't host a link — bail before iterating (block.inlines may be undefined).
+  if (len === 0) return null;
   // Per-character link href across the block (null where no link).
   const hrefs: (string | null)[] = [];
   for (const run of block.inlines) {


### PR DESCRIPTION
Addresses #261.

## Summary

`<RichTextEditor>` crashed with a `TypeError` whenever a document contained an attachment / image block that carries **no `inlines` field**. External / consumer-authored docs omit `inlines` on void blocks (the runtime `Block` type declares it required, but void blocks never populate it). Engine helpers that iterated `block.inlines` raw threw on `undefined` — both at load time and whenever the selection moved onto/across the attachment (the toolbar recomputes active marks/colors/link from the caret block on every selection change).

The fix guards **every reachable raw `block.inlines` iteration site** engine-wide, rather than only the leaf helpers:

- `RichText/engine/inlines.ts` — `runsText` / `runsLength` accept `Inline[] | undefined` and coalesce with `?? []`
- `RichText/engine/position.ts` — `marksBeforeCaret`
- `RichText/engine/transforms.ts` — `mentionRunBoundsAt`
- `RichText/engine/blockUnit.ts` — `cloneBlock`
- `RichTextEditor/links.ts` — `linkAt` early-returns `null` for a zero-length block
- `RichTextEditor/commands.ts` — `activeMarks` / `activeColors` skip zero-length slices and iterate `block.inlines ?? []`

The serializers (`toHtml` / `toMarkdown`) and the read-only renderer were verified already-safe — their `attachment` branches return before the generic inline path.

## Test plan

- Added regression tests in `inlines.test.ts`, `position.test.ts`, `links.test.ts`, `commands.test.ts` that construct an attachment block with `inlines` **genuinely absent** (not `inlines: []`), so they exercise the undefined path. Confirmed (by reverting source) that these fail against the pre-fix code with the exact `TypeError`, and pass with the fix.
- `make test` — 3494 passed
- `make build-lib` (typecheck), `make lint` (stylelint), `npm run format:check` — all clean
- `npm pack --dry-run` — 0 test/internal files in the tarball
- Hard-Rule-8 fresh-context adversarial review: 0 Critical / 0 Important, verdict "clean enough to stop" (its two nice-to-haves were applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)