### PR TITLE
feat: Cluster as prop for inline (span) use cases (#266)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1294,8 +1294,18 @@ Use this instead of `Card.List` + `Card.ListRow` whenever the data is genuinely 
     <Button>Add user</Button>
   </Cluster>
 </Cluster>
+
+// Inline, inside a <button>/<a>/<label> where a <div> is invalid HTML —
+// as="span" renders inline-flex (e.g. icon + label in a ButtonGroup.Item):
+<ButtonGroup.Item value="list">
+  <Cluster as="span" gap="xs" align="center" wrap={false}>
+    <List size={14} aria-hidden />
+    List
+  </Cluster>
+</ButtonGroup.Item>
 ```
 
+- `as`: `div` (default) / `span` / `section` / `aside`. `span` = inline-flex for phrasing-content contexts (inside `<button>`, `<a>`, `<label>`). `section`/`aside` only for genuinely standalone, labelled regions — `aside` creates a `complementary` landmark; never use it for visual grouping.
 - `gap`: same scale as Stack
 - `justify`: `start` (default) / `center` / `end` / `between`
 - `align`: `start` / `center` (default) / `end` / `baseline`

--- a/packages/design-system/src/components/Cluster/Cluster.module.scss
+++ b/packages/design-system/src/components/Cluster/Cluster.module.scss
@@ -5,6 +5,13 @@
   flex-direction: row;
 }
 
+// as="span": phrasing-content contexts (inside <button>, <a>, <label>) need
+// an inline-level box — a block flex container would break inline flow and
+// is invalid HTML there; this is the reason the span variant exists.
+.inline {
+  display: inline-flex;
+}
+
 .wrap {
   flex-wrap: wrap;
 }

--- a/packages/design-system/src/components/Cluster/Cluster.test.tsx
+++ b/packages/design-system/src/components/Cluster/Cluster.test.tsx
@@ -56,8 +56,49 @@ describe('Cluster', () => {
   });
 
   it('forwards refs to the underlying div', () => {
-    const ref = createRef<HTMLDivElement>();
+    const ref = createRef<HTMLElement>();
     render(<Cluster ref={ref}>x</Cluster>);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('renders a div by default', () => {
+    const { container } = render(<Cluster>x</Cluster>);
+    expect((container.firstChild as HTMLElement).tagName).toBe('DIV');
+  });
+
+  it.each(['span', 'section', 'aside'] as const)('renders as %s when as is set', (as) => {
+    const { container } = render(<Cluster as={as}>x</Cluster>);
+    expect((container.firstChild as HTMLElement).tagName).toBe(as.toUpperCase());
+  });
+
+  it('applies the inline class only for as="span"', () => {
+    const { container: asSpan } = render(<Cluster as="span">x</Cluster>);
+    expect((asSpan.firstChild as HTMLElement).className).toMatch(/inline/);
+    const { container: asDiv } = render(<Cluster>x</Cluster>);
+    expect((asDiv.firstChild as HTMLElement).className).not.toMatch(/inline/);
+    const { container: asSection } = render(<Cluster as="section">x</Cluster>);
+    expect((asSection.firstChild as HTMLElement).className).not.toMatch(/inline/);
+  });
+
+  it('forwards the ref to the chosen element for as="span"', () => {
+    const ref = createRef<HTMLElement>();
+    render(
+      <Cluster as="span" ref={ref}>
+        x
+      </Cluster>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+
+  it('keeps variant classes and className merging with as="span"', () => {
+    const { container } = render(
+      <Cluster as="span" gap="xs" justify="between" className="external">
+        x
+      </Cluster>,
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toMatch(/gapXs/);
+    expect(el.className).toMatch(/justifyBetween/);
+    expect(el.className).toMatch(/external/);
   });
 });

--- a/packages/design-system/src/components/Cluster/Cluster.test.tsx
+++ b/packages/design-system/src/components/Cluster/Cluster.test.tsx
@@ -80,14 +80,19 @@ describe('Cluster', () => {
     expect((asSection.firstChild as HTMLElement).className).not.toMatch(/inline/);
   });
 
-  it('forwards the ref to the chosen element for as="span"', () => {
+  it.each([
+    ['span', HTMLSpanElement],
+    ['section', HTMLElement],
+    ['aside', HTMLElement],
+  ] as const)('forwards the ref to the chosen element for as="%s"', (as, expected) => {
     const ref = createRef<HTMLElement>();
     render(
-      <Cluster as="span" ref={ref}>
+      <Cluster as={as} ref={ref}>
         x
       </Cluster>,
     );
-    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+    expect(ref.current).toBeInstanceOf(expected);
+    expect(ref.current!.tagName).toBe(as.toUpperCase());
   });
 
   it('keeps variant classes and className merging with as="span"', () => {

--- a/packages/design-system/src/components/Cluster/Cluster.test.tsx
+++ b/packages/design-system/src/components/Cluster/Cluster.test.tsx
@@ -78,6 +78,8 @@ describe('Cluster', () => {
     expect((asDiv.firstChild as HTMLElement).className).not.toMatch(/inline/);
     const { container: asSection } = render(<Cluster as="section">x</Cluster>);
     expect((asSection.firstChild as HTMLElement).className).not.toMatch(/inline/);
+    const { container: asAside } = render(<Cluster as="aside">x</Cluster>);
+    expect((asAside.firstChild as HTMLElement).className).not.toMatch(/inline/);
   });
 
   it.each([
@@ -93,6 +95,21 @@ describe('Cluster', () => {
     );
     expect(ref.current).toBeInstanceOf(expected);
     expect(ref.current!.tagName).toBe(as.toUpperCase());
+  });
+
+  it('nests validly inside a <button> with as="span" (the #266 acceptance criterion)', () => {
+    // React logs validateDOMNesting console.error for block content inside a
+    // button — the exact failure as="span" exists to avoid.
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <button type="button">
+        <Cluster as="span" gap="xs">
+          x
+        </Cluster>
+      </button>,
+    );
+    expect(error).not.toHaveBeenCalled();
+    error.mockRestore();
   });
 
   it('keeps variant classes and className merging with as="span"', () => {

--- a/packages/design-system/src/components/Cluster/Cluster.tsx
+++ b/packages/design-system/src/components/Cluster/Cluster.tsx
@@ -28,6 +28,9 @@ export interface ClusterProps extends HTMLAttributes<HTMLElement> {
    *   `aria-label`/`aria-labelledby` (an unnamed section is just a div to AT).
    * - `aside` — exposes a `complementary` landmark to screen readers; label it,
    *   and never use it for mere visual grouping.
+   *
+   * `span` is the ONLY value valid inside `<button>`/`<a>`/`<label>` —
+   * `section` and `aside` are flow content and remain invalid HTML there.
    */
   as?: ClusterAs;
   /**
@@ -143,6 +146,8 @@ export const Cluster = forwardRef<HTMLElement, ClusterProps>(function Cluster(
   // the runtime type is always correct because Component is exactly `as`.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const domRef = ref as unknown as Ref<any>;
+  // className merged via clsx so consumer classes stack with ours;
+  // {...props} last so the consumer can override anything (Pattern A).
   return (
     <Component
       ref={domRef}

--- a/packages/design-system/src/components/Cluster/Cluster.tsx
+++ b/packages/design-system/src/components/Cluster/Cluster.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type HTMLAttributes } from 'react';
+import { forwardRef, type HTMLAttributes, type Ref } from 'react';
 import clsx from 'clsx';
 import styles from './Cluster.module.scss';
 
@@ -11,7 +11,21 @@ export type ClusterJustify = 'start' | 'center' | 'end' | 'between';
 /** Cross-axis alignment. */
 export type ClusterAlign = 'start' | 'center' | 'end' | 'baseline';
 
-export interface ClusterProps extends HTMLAttributes<HTMLDivElement> {
+/**
+ * Rendered element. A small union rather than a fully generic polymorphic
+ * `as`, mirroring `TextAs`; details on the `as` prop.
+ */
+export type ClusterAs = 'div' | 'span' | 'section' | 'aside';
+
+export interface ClusterProps extends HTMLAttributes<HTMLElement> {
+  /**
+   * Element to render. Defaults to `'div'`.
+   * - `div` (default) / `section` / `aside` — block-level flex container.
+   * - `span` — renders `display: inline-flex`, for phrasing-content contexts
+   *   where a block element is invalid HTML: inside `<button>` (e.g. a
+   *   `ButtonGroup.Item` icon + label), `<a>`, or `<label>`.
+   */
+  as?: ClusterAs;
   /**
    * Gap between children, in pixels:
    * `xs` (4) / `sm` (8) / `md` (12, default) / `lg` (16) / `xl` (24) / `2xl` (32).
@@ -101,16 +115,26 @@ const alignClass: Record<ClusterAlign, string> = {
  * - ❌ Inline `style={{ marginLeft: 'auto' }}` on a child to push it right.
  *   Use `justify="between"` (with a sibling on the left) or split into two
  *   Clusters in the parent.
+ * - ❌ `as="span"` as a general styling hook. Reach for it only when block
+ *   content is invalid HTML (inside `<button>`, `<a>`, `<label>`); in normal
+ *   flow, the default block `div` is what you want.
  */
-export const Cluster = forwardRef<HTMLDivElement, ClusterProps>(function Cluster(
-  { gap = 'md', justify = 'start', align = 'center', wrap = true, className, ...props },
+export const Cluster = forwardRef<HTMLElement, ClusterProps>(function Cluster(
+  { as = 'div', gap = 'md', justify = 'start', align = 'center', wrap = true, className, ...props },
   ref,
 ) {
+  const Component = as;
+  // The rendered element type varies across the union, so the JSX ref slot
+  // expects an intersection of the element ref types. Cast like Text does —
+  // the runtime type is always correct because Component is exactly `as`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const domRef = ref as unknown as Ref<any>;
   return (
-    <div
-      ref={ref}
+    <Component
+      ref={domRef}
       className={clsx(
         styles.cluster,
+        as === 'span' && styles.inline,
         gapClass[gap],
         justifyClass[justify],
         alignClass[align],

--- a/packages/design-system/src/components/Cluster/Cluster.tsx
+++ b/packages/design-system/src/components/Cluster/Cluster.tsx
@@ -20,10 +20,14 @@ export type ClusterAs = 'div' | 'span' | 'section' | 'aside';
 export interface ClusterProps extends HTMLAttributes<HTMLElement> {
   /**
    * Element to render. Defaults to `'div'`.
-   * - `div` (default) / `section` / `aside` — block-level flex container.
+   * - `div` (default) — block-level flex container; right for nearly all uses.
    * - `span` — renders `display: inline-flex`, for phrasing-content contexts
    *   where a block element is invalid HTML: inside `<button>` (e.g. a
    *   `ButtonGroup.Item` icon + label), `<a>`, or `<label>`.
+   * - `section` — only for a genuinely standalone, nameable region; pair with
+   *   `aria-label`/`aria-labelledby` (an unnamed section is just a div to AT).
+   * - `aside` — exposes a `complementary` landmark to screen readers; label it,
+   *   and never use it for mere visual grouping.
    */
   as?: ClusterAs;
   /**
@@ -103,6 +107,16 @@ const alignClass: Record<ClusterAlign, string> = {
  * <Cluster gap="xs">
  *   {tags.map(t => <Badge key={t.id} tone={t.tone}>{t.label}</Badge>)}
  * </Cluster>
+ *
+ * @example
+ * // Inline, inside a <button> where a <div> is invalid HTML — as="span"
+ * // renders inline-flex (icon + label in a segmented ButtonGroup.Item):
+ * <ButtonGroup.Item value="list">
+ *   <Cluster as="span" gap="xs" align="center" wrap={false}>
+ *     <List size={14} aria-hidden />
+ *     List
+ *   </Cluster>
+ * </ButtonGroup.Item>
  *
  * @remarks When NOT to use
  * - For aligned columns of equal width — use `<Grid>`. Cluster wraps

--- a/packages/design-system/src/components/Cluster/index.ts
+++ b/packages/design-system/src/components/Cluster/index.ts
@@ -1,2 +1,2 @@
 export { Cluster } from './Cluster';
-export type { ClusterProps, ClusterGap, ClusterJustify, ClusterAlign } from './Cluster';
+export type { ClusterProps, ClusterAs, ClusterGap, ClusterJustify, ClusterAlign } from './Cluster';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -58,7 +58,13 @@ export { Switch } from './components/Switch';
 export type { SwitchProps, SwitchSize, SwitchTone } from './components/Switch';
 
 export { Cluster } from './components/Cluster';
-export type { ClusterProps, ClusterGap, ClusterJustify, ClusterAlign } from './components/Cluster';
+export type {
+  ClusterProps,
+  ClusterAs,
+  ClusterGap,
+  ClusterJustify,
+  ClusterAlign,
+} from './components/Cluster';
 
 export { Constrain } from './components/Constrain';
 export type { ConstrainProps, ConstrainWidth, ConstrainFlex } from './components/Constrain';

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -608,6 +608,13 @@
     "Cluster": {
       "props": [
         {
+          "name": "as",
+          "type": "ClusterAs",
+          "required": false,
+          "default": "div",
+          "description": "Element to render. Defaults to `'div'`.\n- `div` (default) / `section` / `aside` — block-level flex container.\n- `span` — renders `display: inline-flex`, for phrasing-content contexts\n  where a block element is invalid HTML: inside `<button>` (e.g. a\n  `ButtonGroup.Item` icon + label), `<a>`, or `<label>`."
+        },
+        {
           "name": "gap",
           "type": "ClusterGap",
           "required": false,
@@ -4577,6 +4584,7 @@
     "StackAlign": "\"start\" | \"end\" | \"center\" | \"stretch\"",
     "SwitchSize": "\"sm\" | \"md\" | \"lg\"",
     "SwitchTone": "\"success\" | \"danger\" | \"accent\"",
+    "ClusterAs": "\"div\" | \"span\" | \"section\" | \"aside\"",
     "ClusterGap": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\" | \"2xl\"",
     "ClusterJustify": "\"start\" | \"end\" | \"center\" | \"between\"",
     "ClusterAlign": "\"start\" | \"end\" | \"center\" | \"baseline\"",
@@ -4586,7 +4594,7 @@
     "GridGap": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\" | \"2xl\"",
     "GridAlignItems": "\"start\" | \"end\" | \"center\" | \"stretch\"",
     "GridJustifyItems": "\"start\" | \"end\" | \"center\" | \"stretch\"",
-    "GridAs": "\"article\" | \"main\" | \"div\" | \"section\" | \"ul\" | \"ol\" | \"nav\" | \"aside\" | \"header\" | \"footer\"",
+    "GridAs": "\"div\" | \"section\" | \"aside\" | \"article\" | \"main\" | \"ul\" | \"ol\" | \"nav\" | \"header\" | \"footer\"",
     "SplitSide": "\"start\" | \"end\"",
     "SplitGap": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\" | \"2xl\"",
     "SplitAlign": "\"start\" | \"center\" | \"stretch\"",
@@ -4684,7 +4692,7 @@
     "RichDoc": "{ blocks: Block[] }",
     "RenderLink": "(link: RichTextLink, defaultNode: ReactNode) => ReactNode",
     "RenderMention": "(mention: RichTextMention, defaultNode: ReactNode) => ReactNode",
-    "TextAs": "\"div\" | \"label\" | \"p\" | \"span\"",
+    "TextAs": "\"div\" | \"span\" | \"label\" | \"p\"",
     "TextSize": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\"",
     "TextTone": "\"success\" | \"warning\" | \"danger\" | \"accent\" | \"default\" | \"muted\" | \"subtle\"",
     "TextWeight": "\"regular\" | \"medium\" | \"semibold\" | \"bold\"",

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -612,7 +612,7 @@
           "type": "ClusterAs",
           "required": false,
           "default": "div",
-          "description": "Element to render. Defaults to `'div'`.\n- `div` (default) / `section` / `aside` — block-level flex container.\n- `span` — renders `display: inline-flex`, for phrasing-content contexts\n  where a block element is invalid HTML: inside `<button>` (e.g. a\n  `ButtonGroup.Item` icon + label), `<a>`, or `<label>`."
+          "description": "Element to render. Defaults to `'div'`.\n- `div` (default) — block-level flex container; right for nearly all uses.\n- `span` — renders `display: inline-flex`, for phrasing-content contexts\n  where a block element is invalid HTML: inside `<button>` (e.g. a\n  `ButtonGroup.Item` icon + label), `<a>`, or `<label>`.\n- `section` — only for a genuinely standalone, nameable region; pair with\n  `aria-label`/`aria-labelledby` (an unnamed section is just a div to AT).\n- `aside` — exposes a `complementary` landmark to screen readers; label it,\n  and never use it for mere visual grouping."
         },
         {
           "name": "gap",

--- a/packages/playground/src/pages/components/ClusterDemo.tsx
+++ b/packages/playground/src/pages/components/ClusterDemo.tsx
@@ -1,11 +1,36 @@
+import { useState } from 'react';
 import { Cluster } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { Button } from '@eocrm/design-system';
 import { Badge } from '@eocrm/design-system';
+import { ButtonGroup } from '@eocrm/design-system';
+import { Kanban, List } from 'lucide-react';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import outlineStyles from './demoOutline.module.scss';
 import { getComponentFiles } from '../../lib/componentFiles';
+
+// Live preview for the as="span" example — the issue's motivating use case:
+// icon + label inside a segmented ButtonGroup.Item, where a <div> is invalid.
+function InlineClusterExample() {
+  const [view, setView] = useState('list');
+  return (
+    <ButtonGroup value={view} onValueChange={setView} aria-label="View">
+      <ButtonGroup.Item value="list">
+        <Cluster as="span" gap="xs" align="center" wrap={false}>
+          <List size={14} />
+          List
+        </Cluster>
+      </ButtonGroup.Item>
+      <ButtonGroup.Item value="board">
+        <Cluster as="span" gap="xs" align="center" wrap={false}>
+          <Kanban size={14} />
+          Board
+        </Cluster>
+      </ButtonGroup.Item>
+    </ButtonGroup>
+  );
+}
 
 const Block = ({ children }: { children: React.ReactNode }) => (
   <div
@@ -182,6 +207,36 @@ export function Demo() {
             <Badge tone="neutral">North America</Badge>
           </Cluster>
         </div>
+      </Example>
+
+      <Example
+        title={`Inline (as="span")`}
+        description="Inside a <button>, <a>, or <label>, a block <div> is invalid HTML. as='span' renders an inline-flex <span> — here giving a segmented ButtonGroup.Item a proper icon + label with a token gap."
+        code={`import { useState } from 'react';
+import { ButtonGroup, Cluster } from '@eocrm/design-system';
+import { Kanban, List } from 'lucide-react';
+
+export function Demo() {
+  const [view, setView] = useState('list');
+  return (
+    <ButtonGroup value={view} onValueChange={setView} aria-label="View">
+      <ButtonGroup.Item value="list">
+        <Cluster as="span" gap="xs" align="center" wrap={false}>
+          <List size={14} />
+          List
+        </Cluster>
+      </ButtonGroup.Item>
+      <ButtonGroup.Item value="board">
+        <Cluster as="span" gap="xs" align="center" wrap={false}>
+          <Kanban size={14} />
+          Board
+        </Cluster>
+      </ButtonGroup.Item>
+    </ButtonGroup>
+  );
+}`}
+      >
+        <InlineClusterExample />
       </Example>
 
       <Example

--- a/packages/playground/src/pages/components/ClusterDemo.tsx
+++ b/packages/playground/src/pages/components/ClusterDemo.tsx
@@ -18,13 +18,13 @@ function InlineClusterExample() {
     <ButtonGroup value={view} onValueChange={setView} aria-label="View">
       <ButtonGroup.Item value="list">
         <Cluster as="span" gap="xs" align="center" wrap={false}>
-          <List size={14} />
+          <List size={14} aria-hidden />
           List
         </Cluster>
       </ButtonGroup.Item>
       <ButtonGroup.Item value="board">
         <Cluster as="span" gap="xs" align="center" wrap={false}>
-          <Kanban size={14} />
+          <Kanban size={14} aria-hidden />
           Board
         </Cluster>
       </ButtonGroup.Item>
@@ -222,13 +222,13 @@ export function Demo() {
     <ButtonGroup value={view} onValueChange={setView} aria-label="View">
       <ButtonGroup.Item value="list">
         <Cluster as="span" gap="xs" align="center" wrap={false}>
-          <List size={14} />
+          <List size={14} aria-hidden />
           List
         </Cluster>
       </ButtonGroup.Item>
       <ButtonGroup.Item value="board">
         <Cluster as="span" gap="xs" align="center" wrap={false}>
-          <Kanban size={14} />
+          <Kanban size={14} aria-hidden />
           Board
         </Cluster>
       </ButtonGroup.Item>


### PR DESCRIPTION
Addresses #266.

## Summary

`Cluster` gains `as?: 'div' | 'span' | 'section' | 'aside'` (default `'div'`), mirroring `Text`'s small-union polymorphism exactly (union type, `forwardRef<HTMLElement>`, same ref-cast pattern). `as="span"` renders `display: inline-flex` for phrasing-content contexts — the issue's motivating case: icon + label inside a segmented `ButtonGroup.Item`, where a block `<div>` is invalid HTML. The eocrm `InlineCluster` shim can now be retired.

- Per-value JSDoc guidance incl. `section`/`aside` landmark semantics and an explicit "span is the only inline-safe value" note; new positive `@example` + anti-pattern `@remarks`
- `ClusterAs` exported from both index surfaces; props manifest regenerated
- AGENTS.md Cluster TL;DR updated (new `as` bullet + ButtonGroup.Item snippet)
- Demo: new *Inline (as="span")* example exercising the real ButtonGroup use case, verified in a live browser (span in button, inline-flex, 4px token gap, valid DOM)
- Type note: `ClusterProps`/ref widen `HTMLDivElement` → `HTMLElement` — the same deliberate trade `Text` already made, sanctioned by the issue

## Test plan

- 12 new/updated unit tests (29 total): every `as` value renders + forwards refs, inline class scoped to span only, className/variant merging, and a validateDOMNesting test pinning the "valid inside <button>" acceptance criterion
- `make test` (3661), `make build-lib`, `make lint`, `npm run format:check`, pack-leak grep = 0
- Two-round Rule-8 adversarial review (correctness/API + a11y/tests lenses): final verdict clean, all findings incl. niceToHaves addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)