### PR TITLE
feat(playground): schematic previews for the components overview

### DIFF
--- a/packages/playground/CLAUDE.md
+++ b/packages/playground/CLAUDE.md
@@ -79,7 +79,7 @@ For a new demo page to be reachable:
 
 1. `src/App.tsx` — add a `<Route path="/components/<name>" element={<<Name>Demo />} />`
 2. `src/layout/AppShell/AppShell.tsx` — add the item to the appropriate group in `componentGroups` (`Layout`, `Forms`, `Display`, `Navigation`). If none of the existing groups fit, add a new group rather than stuffing the item somewhere it doesn't belong.
-3. `src/pages/components/ComponentsIndex.tsx` — add a card to the overview grid with a small live preview
+3. `src/pages/components/ComponentsIndex.tsx` — add a card to the overview grid, plus a schematic preview in `overviewSchematics.tsx` (blueprint-accent vocabulary — tinted shapes, exactly one solid-accent focal element; see the SCHEMATICS record). Overview previews are schematics, not live renders.
 4. `src/pages/mockups/registry.ts` — if the new component is used by any mockup, add its name to that mockup's `usesComponents` list (and extend the `ComponentName` union if it's a brand-new component name)
 
 Skipping 1–3 → users can navigate to the URL but the page is unreachable through nav. Skipping 4 → the cross-link between mockups and component demos is broken.

--- a/packages/playground/src/pages/components/ComponentsIndex.module.scss
+++ b/packages/playground/src/pages/components/ComponentsIndex.module.scss
@@ -110,25 +110,3 @@
   -webkit-box-orient: vertical;
   min-height: calc(2em * var(--line-height-normal));
 }
-
-// Skeleton primitives used by Card preview
-.skeleton {
-  height: 8px;
-  background: var(--color-bg-sunken);
-  border-radius: var(--radius-sm);
-  width: 100%;
-}
-
-.bar {
-  width: 80px;
-  height: 10px;
-  background: var(--color-accent-subtle-bg);
-  border-radius: var(--radius-sm);
-}
-
-.tile {
-  width: 32px;
-  height: 32px;
-  background: var(--color-accent-subtle-bg);
-  border-radius: var(--radius-sm);
-}

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -1,1672 +1,582 @@
 import { Link } from 'react-router-dom';
-import { ArrowRight, Bell, Home, Inbox, Users } from 'lucide-react';
-import { Accordion } from '@eocrm/design-system';
-import { Alert } from '@eocrm/design-system';
-import { Avatar } from '@eocrm/design-system';
-import { Badge } from '@eocrm/design-system';
-import { Dot } from '@eocrm/design-system';
-import { Timeline } from '@eocrm/design-system';
-import { Thread } from '@eocrm/design-system';
-import { BrandIcon } from '@eocrm/design-system';
-import { Logo } from '@eocrm/design-system';
-import eocrmLogo from '../../assets/eocrm-logo.svg';
-import { Breadcrumb } from '@eocrm/design-system';
-import { Link as DSLink } from '@eocrm/design-system';
-import { LinkCard } from '@eocrm/design-system';
-import { Button } from '@eocrm/design-system';
-import { SocialButton } from '@eocrm/design-system';
-import { ButtonGroup } from '@eocrm/design-system';
-import { Card } from '@eocrm/design-system';
-import { CircularProgress } from '@eocrm/design-system';
-import { Progress } from '@eocrm/design-system';
-import { Code } from '@eocrm/design-system';
-import { RichText, createBlock } from '@eocrm/design-system';
-import { RichTextEditor, docFromText } from '@eocrm/design-system';
-import { Text } from '@eocrm/design-system';
-import { Title } from '@eocrm/design-system';
-import { Checkbox } from '@eocrm/design-system';
-import { ColorPicker } from '@eocrm/design-system';
-import { Cluster } from '@eocrm/design-system';
-import { Constrain } from '@eocrm/design-system';
-import { Indent } from '@eocrm/design-system';
-import { Divider } from '@eocrm/design-system';
-import { Grid } from '@eocrm/design-system';
-import { Split } from '@eocrm/design-system';
-import { Sticky } from '@eocrm/design-system';
-import { Masonry } from '@eocrm/design-system';
-import { Field } from '@eocrm/design-system';
-import { FormRow } from '@eocrm/design-system';
-import { FormSection } from '@eocrm/design-system';
-import { Input } from '@eocrm/design-system';
-import { LiquidEditor } from '@eocrm/design-system';
-import { Kbd } from '@eocrm/design-system';
-import { PasswordInput } from '@eocrm/design-system';
-import { PasswordStrengthMeter } from '@eocrm/design-system';
-import { PhoneInput } from '@eocrm/design-system';
-import { Select } from '@eocrm/design-system';
-import { Skeleton } from '@eocrm/design-system';
-import { Slider } from '@eocrm/design-system';
-import { Kanban } from '@eocrm/design-system';
-import { FlowCanvas } from '@eocrm/design-system';
-import { Rail } from '@eocrm/design-system';
-import { TopBar } from '@eocrm/design-system';
-import { Sortable } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
-import { Switch } from '@eocrm/design-system';
-import { Table } from '@eocrm/design-system';
-import { Tabs } from '@eocrm/design-system';
-import { Textarea } from '@eocrm/design-system';
-import { TimeField } from '@eocrm/design-system';
-import { DropdownMenu } from '@eocrm/design-system';
-import { Calendar } from '@eocrm/design-system';
-import { DatePicker } from '@eocrm/design-system';
-import { DataTable, useDataTable, type ColumnDef } from '@eocrm/design-system';
-import { DefinitionList } from '@eocrm/design-system';
-import { EmptyState } from '@eocrm/design-system';
-import { ErrorState } from '@eocrm/design-system';
-import { Screen } from '@eocrm/design-system';
-import { Compass } from 'lucide-react';
-import { FileUpload } from '@eocrm/design-system';
-import { FilterChip } from '@eocrm/design-system';
-import { IconTile } from '@eocrm/design-system';
-import { Shapes } from 'lucide-react';
-import { Image } from '@eocrm/design-system';
-import { MediaTile } from '@eocrm/design-system';
-import { ImageCrop } from '@eocrm/design-system';
-import { OptionsPicker } from '@eocrm/design-system';
-import { EmojiPickerPopover } from '@eocrm/design-system';
-import { PALETTE_COLORS, paletteTokens } from '@eocrm/design-system';
-import { Pagination } from '@eocrm/design-system';
-import { PersonDisplay } from '@eocrm/design-system';
-import { Radio, RadioGroup } from '@eocrm/design-system';
-import { Page } from '@eocrm/design-system';
-import { PageHeader } from '@eocrm/design-system';
-import { toast } from '@eocrm/design-system';
+import { ArrowRight } from 'lucide-react';
+import { SCHEMATICS } from './overviewSchematics';
 import styles from './ComponentsIndex.module.scss';
 
-type _PreviewRow = { id: string; name: string; stage: string; amount: string };
-const _previewCols: ColumnDef<_PreviewRow>[] = [
-  { id: 'name', header: 'Deal', cell: (r) => r.name, size: 120 },
-  { id: 'stage', header: 'Stage', cell: (r) => r.stage, size: 90 },
-  { id: 'amount', header: 'Amount', cell: (r) => r.amount, align: 'end', size: 80 },
-];
-const _previewData: _PreviewRow[] = [
-  { id: '1', name: 'Acme', stage: 'Won', amount: '$12k' },
-  { id: '2', name: 'Globex', stage: 'Lead', amount: '$4.5k' },
-];
-function DataTablePreview() {
-  const instance = useDataTable<_PreviewRow>({
-    data: _previewData,
-    columns: _previewCols,
-    getRowId: (r) => r.id,
-  });
-  return (
-    <div style={{ width: 220, pointerEvents: 'none' }}>
-      <DataTable instance={instance} aria-label="Preview" />
-    </div>
-  );
-}
-
+// Previews are blueprint-accent schematics (see overviewSchematics.tsx), not
+// live component renders — uniform thumbnails with no theme/portal edge cases.
+// Spec: docs/superpowers/specs/2026-07-03-overview-schematics-design.md
 const items: { to: string; name: string; description: string; preview: React.ReactNode }[] = [
   {
     to: '/components/accordion',
     name: 'Accordion',
     description: 'Stacked collapsible panels. Single-open or multi-open mode.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: '260px' }}>
-        <Accordion type="single" collapsible defaultValue="a">
-          <Accordion.Item value="a">
-            <Accordion.Trigger>Section</Accordion.Trigger>
-            <Accordion.Content>Body</Accordion.Content>
-          </Accordion.Item>
-        </Accordion>
-      </div>
-    ),
+    preview: SCHEMATICS['Accordion'],
   },
   {
     to: '/components/alert',
     name: 'Alert',
     description: 'Persistent in-flow notification with four tones.',
-    preview: <Alert tone="info" title="Synced 5 minutes ago" />,
+    preview: SCHEMATICS['Alert'],
   },
   {
     to: '/components/button',
     name: 'Button',
     description: 'Action triggers with variants and sizes.',
-    preview: (
-      <Cluster gap="sm" justify="center">
-        <Button size="sm">Primary</Button>
-        <Button size="sm" variant="secondary">
-          Secondary
-        </Button>
-      </Cluster>
-    ),
+    preview: SCHEMATICS['Button'],
   },
   {
     to: '/components/social-button',
     name: 'SocialButton',
     description: 'Provider sign-in button — brand mark + label.',
-    preview: <SocialButton provider="google" label="Continue with Google" />,
+    preview: SCHEMATICS['SocialButton'],
   },
   {
     to: '/components/button-group',
     name: 'ButtonGroup',
     description:
       'Joined Buttons (toolbar action group) or single-select segmented control with arrow-key navigation.',
-    preview: (
-      <Cluster gap="sm" justify="center">
-        <ButtonGroup aria-label="Preview">
-          <Button size="sm" variant="secondary">
-            Cut
-          </Button>
-          <Button size="sm" variant="secondary">
-            Copy
-          </Button>
-          <Button size="sm" variant="secondary">
-            Paste
-          </Button>
-        </ButtonGroup>
-      </Cluster>
-    ),
+    preview: SCHEMATICS['ButtonGroup'],
   },
   {
     to: '/components/datepickers',
     name: 'Date pickers',
     description:
       'Four variants of the same month grid — DatePicker, DateRangePicker, and inline counterparts.',
-    preview: (
-      <div style={{ width: 200 }}>
-        <DatePicker defaultValue={new Date(2026, 4, 21)} aria-label="Preview" />
-      </div>
-    ),
+    preview: SCHEMATICS['Date pickers'],
   },
   {
     to: '/components/empty-state',
     name: 'EmptyState',
     description:
       'Opinionated "nothing here" container — icon, title, description, actions. Three sizes for inline / card / hero use.',
-    preview: (
-      <EmptyState
-        size="sm"
-        icon={<Inbox size={24} />}
-        title="No results"
-        description="Try clearing filters."
-      />
-    ),
+    preview: SCHEMATICS['EmptyState'],
   },
   {
     to: '/components/error-state',
     name: 'ErrorState',
     description: 'Page-level 404 / error status block — icon, title, actions, error ID.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: '260px' }}>
-        <ErrorState
-          size="sm"
-          icon={<Compass size={24} aria-hidden="true" />}
-          title="Page not found"
-        />
-      </div>
-    ),
+    preview: SCHEMATICS['ErrorState'],
   },
   {
     to: '/components/screen',
     name: 'Screen',
     description: 'Full-bleed / centered screen layout for auth, 404, and error pages.',
-    preview: (
-      // Override the component token: fillBlock's default min-height (~500px)
-      // is meant for real pages and would bleed far past the preview box.
-      <div
-        style={
-          {
-            width: '100%',
-            maxWidth: '260px',
-            height: '96px',
-            '--screen-block-min-height': '96px',
-          } as React.CSSProperties
-        }
-      >
-        <Screen fill="block" backdrop="accent">
-          <Text size="sm" tone="muted">
-            Full-bleed screen
-          </Text>
-        </Screen>
-      </div>
-    ),
+    preview: SCHEMATICS['Screen'],
   },
   {
     to: '/components/file-upload',
     name: 'FileUpload',
     description:
       'Controlled dropzone-style file picker with built-in validation, drag/click both supported, per-row Progress for uploading status.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: 220 }}>
-        <FileUpload
-          files={[]}
-          onFilesAdded={() => {}}
-          onFileRemove={() => {}}
-          dropzoneLabel="Drop or click"
-        />
-      </div>
-    ),
+    preview: SCHEMATICS['FileUpload'],
   },
   {
     to: '/components/image-crop',
     name: 'ImageCrop',
     description:
       'Controlled image-crop primitive on <canvas>. Pattern-A drag (centered box, draggable image, slider-controlled zoom). Top-level extractCropBlob utility for the Save handler.',
-    preview: (
-      <div
-        style={{
-          width: '100%',
-          maxWidth: 220,
-          height: 120,
-          overflow: 'hidden',
-          borderRadius: 'var(--radius-md)',
-        }}
-      >
-        <ImageCrop
-          src="https://picsum.photos/seed/eocrm-card/400/300"
-          value={{ x: 50, y: 25, width: 200, height: 200 }}
-          onChange={() => {}}
-          aspectRatio={1}
-          showZoomControl={false}
-          style={{ pointerEvents: 'none' }}
-        />
-      </div>
-    ),
+    preview: SCHEMATICS['ImageCrop'],
   },
   {
     to: '/components/icon-tile',
     name: 'IconTile',
     description: 'Decorative tile framing an icon, tinted by a Palette color.',
-    preview: (
-      <Cluster gap="sm">
-        <IconTile color="blue" icon={<Shapes size={16} />} />
-        <IconTile color="amber" shape="circle" icon={<Shapes size={16} />} />
-        <IconTile color="green" icon={<Shapes size={16} />} />
-      </Cluster>
-    ),
+    preview: SCHEMATICS['IconTile'],
   },
   {
     to: '/components/image',
     name: 'Image',
     description:
       'Remote image with Skeleton loading state, fade-in on load, and an accessible broken-image placeholder with retry.',
-    preview: (
-      <div style={{ maxWidth: 180, width: '100%' }}>
-        <Image
-          src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=400&q=80"
-          alt=""
-          aspectRatio="16 / 9"
-        />
-      </div>
-    ),
+    preview: SCHEMATICS['Image'],
   },
   {
     to: '/components/media-tile',
     name: 'MediaTile',
     description: 'Media tile — image/icon body with hover-revealed name/size + controls bars.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: 110 }}>
-        <MediaTile
-          revealOn="visible"
-          media={
-            <Image
-              src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=200&q=60"
-              alt=""
-              aspectRatio={1}
-              objectFit="cover"
-            />
-          }
-          title="lake.jpg"
-          meta="2.4 MB"
-        />
-      </div>
-    ),
+    preview: SCHEMATICS['MediaTile'],
   },
   {
     to: '/components/input',
     name: 'Input',
     description: 'Single-line text field with focus + invalid states.',
-    preview: (
-      <div style={{ width: 200 }}>
-        <Input placeholder="Type here…" />
-      </div>
-    ),
+    preview: SCHEMATICS['Input'],
   },
   {
     to: '/components/liquid-editor',
     name: 'LiquidEditor',
     description: 'Liquid template editor with highlighting, autocomplete, and a preview pane.',
-    preview: (
-      <LiquidEditor
-        value="{{ first_name }}"
-        onChange={() => {}}
-        showToolbar={false}
-        showLineNumbers={false}
-        minRows={1}
-      />
-    ),
+    preview: SCHEMATICS['LiquidEditor'],
   },
   {
     to: '/components/kbd',
     name: 'Kbd',
     description:
       'Inline keyboard-shortcut chip: one <kbd> per key joined by a faint + separator. Two sizes (sm matches TopBar, md for command palettes).',
-    preview: (
-      <Cluster gap="sm" justify="center">
-        <Kbd keys={['⌘', 'K']} />
-        <Kbd keys={['Ctrl', 'Shift', 'P']} size="md" />
-      </Cluster>
-    ),
+    preview: SCHEMATICS['Kbd'],
   },
   {
     to: '/components/pagination',
     name: 'Pagination',
     description:
       'Numbered nav with windowing, plus a cursor variant for streams without total. Both controlled, no built-in page size.',
-    // pageCount kept small — the windowed 10-page control is wider than the card.
-    preview: <Pagination currentPage={2} pageCount={3} onPageChange={() => {}} size="sm" />,
+    preview: SCHEMATICS['Pagination'],
   },
   {
     to: '/components/palette',
     name: 'Palette',
     description: '30 categorical bg + fg color pairs for consumer-defined domain → color mappings.',
-    preview: (
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(10, 1fr)',
-          gap: 2,
-          width: '100%',
-        }}
-        aria-hidden
-      >
-        {PALETTE_COLORS.map((color) => {
-          const { bg } = paletteTokens(color);
-          return (
-            <div
-              key={color}
-              style={{
-                background: bg,
-                aspectRatio: '1 / 1',
-                borderRadius: 2,
-              }}
-            />
-          );
-        })}
-      </div>
-    ),
+    preview: SCHEMATICS['Palette'],
   },
   {
     to: '/components/person-display',
     name: 'PersonDisplay',
     description:
       'Avatar + name (+ optional description lines). Three sizes drive Avatar + Text scales.',
-    preview: (
-      <PersonDisplay size="md">
-        <PersonDisplay.Avatar name="Sarah Chen" />
-        <PersonDisplay.Name>Sarah Chen</PersonDisplay.Name>
-        <PersonDisplay.Description>sarah@acme.com</PersonDisplay.Description>
-      </PersonDisplay>
-    ),
+    preview: SCHEMATICS['PersonDisplay'],
   },
   {
     to: '/components/password-input',
     name: 'PasswordInput',
     description:
       'Password field with eye toggle, opt-in caps-lock + wrong-keyboard-layout warnings.',
-    preview: (
-      <div style={{ width: 200 }}>
-        <PasswordInput defaultValue="hunter2" aria-label="Preview" />
-      </div>
-    ),
+    preview: SCHEMATICS['PasswordInput'],
   },
   {
     to: '/components/password-strength-meter',
     name: 'PasswordStrengthMeter',
     description:
       '4-segment strength visualization. Default heuristic for prototypes; pass `score` for production scoring.',
-    preview: (
-      <div style={{ width: 200 }}>
-        <PasswordStrengthMeter value="Hunter2!@#" />
-      </div>
-    ),
+    preview: SCHEMATICS['PasswordStrengthMeter'],
   },
   {
     to: '/components/phone-input',
     name: 'PhoneInput',
     description: 'International phone field — country picker + national number, emitting E.164.',
-    preview: (
-      <div style={{ width: 240 }}>
-        <PhoneInput value="+12025550123" onChange={() => {}} aria-label="Preview" />
-      </div>
-    ),
+    preview: SCHEMATICS['PhoneInput'],
   },
   {
     to: '/components/progress',
     name: 'Progress',
     description:
       'Linear progress bar — determinate via value/max, indeterminate when value is omitted. Sizes / tones / optional label.',
-    preview: (
-      <Stack gap="xs">
-        <Progress value={45} />
-        <Progress value={85} tone="warning" />
-      </Stack>
-    ),
+    preview: SCHEMATICS['Progress'],
   },
   {
     to: '/components/radio',
     name: 'Radio',
     description:
       'Native-input-backed radio with custom paint, plus a RadioGroup wrapper for fieldset/legend semantics and group state propagation.',
-    preview: (
-      <RadioGroup name="preview" defaultValue="b">
-        <Radio value="a" label="Option A" />
-        <Radio value="b" label="Option B" />
-      </RadioGroup>
-    ),
+    preview: SCHEMATICS['Radio'],
   },
   {
     to: '/components/select',
     name: 'Select',
     description:
       'Value picker — single, multi (chips and summary), searchable, async, creatable. The generalist.',
-    preview: (
-      <div style={{ width: 200 }}>
-        <Select
-          options={[
-            { value: 'active', label: 'Active' },
-            { value: 'pending', label: 'Pending' },
-            { value: 'archived', label: 'Archived' },
-          ]}
-          placeholder="Pick a status"
-        />
-      </div>
-    ),
+    preview: SCHEMATICS['Select'],
   },
   {
     to: '/components/switch',
     name: 'Switch',
     description: 'Binary on/off toggle. Three tones + async loading state.',
-    preview: <Switch defaultChecked tone="success" aria-label="Preview" />,
+    preview: SCHEMATICS['Switch'],
   },
   {
     to: '/components/skeleton',
     name: 'Skeleton',
     description:
       'Placeholder rectangle for loading states. Three variants (text / circular / rectangular), pulse animation respects prefers-reduced-motion.',
-    preview: (
-      <Stack gap="xs" style={{ width: 200 }}>
-        <Skeleton width="80%" />
-        <Skeleton width="60%" />
-        <Skeleton width="40%" />
-      </Stack>
-    ),
+    preview: SCHEMATICS['Skeleton'],
   },
   {
     to: '/components/slider',
     name: 'Slider',
     description:
       'Controlled slider: single-thumb or range (two-thumb), horizontal or vertical. Custom-painted with marks + value bubble.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: 220 }}>
-        <Slider value={42} onChange={() => {}} aria-label="preview" />
-      </div>
-    ),
+    preview: SCHEMATICS['Slider'],
   },
   {
     to: '/components/kanban',
     name: 'Kanban',
     description: 'Multi-column board with live cross-column drag.',
-    preview: (
-      // Columns have a 260px min-width, so a two-column board can never fit
-      // the preview box unscaled — same scale-down trick as the Calendar card.
-      <div
-        style={{
-          width: '100%',
-          maxWidth: 230,
-          height: 118,
-          overflow: 'hidden',
-          pointerEvents: 'none',
-        }}
-      >
-        <div style={{ width: '240%', transform: 'scale(0.42)', transformOrigin: 'top left' }}>
-          <Kanban>
-            <Kanban.Column id="a">
-              <Kanban.Card id="card-a1">
-                <Card padding="sm">Call Acme</Card>
-              </Kanban.Card>
-              <Kanban.Card id="card-a2">
-                <Card padding="sm">Send quote</Card>
-              </Kanban.Card>
-            </Kanban.Column>
-            <Kanban.Column id="b">
-              <Kanban.Card id="card-b1">
-                <Card padding="sm">Demo call</Card>
-              </Kanban.Card>
-            </Kanban.Column>
-          </Kanban>
-        </div>
-      </div>
-    ),
+    preview: SCHEMATICS['Kanban'],
   },
   {
     to: '/components/flow-canvas',
     name: 'FlowCanvas',
     description: 'Pan/zoom canvas for directed node-edge diagrams.',
-    preview: (
-      // inert (not just pointerEvents: none): the canvas root is a tabIndex=0
-      // role=application widget that swallows arrow keys — a keyboard user
-      // tabbing the index grid must not land inside a decorative preview.
-      <div inert style={{ height: 120, width: '100%', pointerEvents: 'none' }}>
-        <FlowCanvas
-          readOnly
-          nodes={[
-            { id: 'a', label: 'Open', color: '#0052CC', position: { x: 0, y: 8 } },
-            { id: 'b', label: 'Done', color: '#1F845A', position: { x: 150, y: 48 } },
-          ]}
-          edges={[{ id: 'e', from: 'a', to: 'b' }]}
-        />
-      </div>
-    ),
+    preview: SCHEMATICS['FlowCanvas'],
   },
   {
     to: '/components/sortable',
     name: 'Sortable',
     description: 'Drag-to-reorder list with optional keyboard handle.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: 220, pointerEvents: 'none' }}>
-        <Sortable onReorder={() => {}}>
-          <Sortable.Item id="a">
-            <Card padding="sm">First</Card>
-          </Sortable.Item>
-          <Sortable.Item id="b">
-            <Card padding="sm">Second</Card>
-          </Sortable.Item>
-        </Sortable>
-      </div>
-    ),
+    preview: SCHEMATICS['Sortable'],
   },
   {
     to: '/components/sortable-group',
     name: 'SortableGroup',
     description:
       'Drag items between multiple sortable lists (cross-container), with a live handoff.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: 220, pointerEvents: 'none', display: 'flex', gap: 8 }}>
-        <Card padding="sm" style={{ flex: 1 }}>
-          <Stack gap="xs">
-            <Text size="sm">First</Text>
-            <Text size="sm">Second</Text>
-          </Stack>
-        </Card>
-        <Card padding="sm" style={{ flex: 1 }}>
-          <Stack gap="xs">
-            <Text size="sm">Third</Text>
-          </Stack>
-        </Card>
-      </div>
-    ),
+    preview: SCHEMATICS['SortableGroup'],
   },
   {
     to: '/components/datatable',
     name: 'DataTable',
     description: 'Tabular data with sortable / resizable / reorderable columns and row selection.',
-    preview: <DataTablePreview />,
+    preview: SCHEMATICS['DataTable'],
   },
   {
     to: '/components/definition-list',
     name: 'DefinitionList',
     description: 'Semantic key/value pairs with optional icon on the value.',
-    preview: (
-      <DefinitionList>
-        <DefinitionList.Item>
-          <DefinitionList.Term>Email</DefinitionList.Term>
-          <DefinitionList.Description>ada@example.com</DefinitionList.Description>
-        </DefinitionList.Item>
-        <DefinitionList.Item>
-          <DefinitionList.Term>Phone</DefinitionList.Term>
-          <DefinitionList.Description>+1 (415) 555-0142</DefinitionList.Description>
-        </DefinitionList.Item>
-      </DefinitionList>
-    ),
+    preview: SCHEMATICS['DefinitionList'],
   },
   {
     to: '/components/table',
     name: 'Table',
     description:
       'Tabular data primitive — compound subcomponents over native HTML semantics with density, hover, striped, and sortable-header visuals.',
-    preview: (
-      <div style={{ width: 220 }}>
-        <Table density="dense" scroll={false}>
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell>Name</Table.HeaderCell>
-              <Table.HeaderCell align="end">Total</Table.HeaderCell>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            <Table.Row>
-              <Table.Cell>Acme</Table.Cell>
-              <Table.Cell align="end">12.5K</Table.Cell>
-            </Table.Row>
-            <Table.Row>
-              <Table.Cell>Beanstalk</Table.Cell>
-              <Table.Cell align="end">4.2K</Table.Cell>
-            </Table.Row>
-          </Table.Body>
-        </Table>
-      </div>
-    ),
+    preview: SCHEMATICS['Table'],
   },
   {
     to: '/components/card',
     name: 'Card',
     description: 'Bordered container that groups related content.',
-    preview: (
-      <Card padding="md" style={{ width: 160 }}>
-        <Stack gap="xs">
-          <div className={styles.skeleton} style={{ width: '60%' }} />
-          <div className={styles.skeleton} />
-          <div className={styles.skeleton} style={{ width: '80%' }} />
-        </Stack>
-      </Card>
-    ),
+    preview: SCHEMATICS['Card'],
   },
   {
     to: '/components/checkbox',
     name: 'Checkbox',
     description:
       'Native-input-backed checkbox with custom paint — sizes, indeterminate, label, invalid, full form integration.',
-    preview: (
-      <Stack gap="xs">
-        <Checkbox defaultChecked label="Checked" />
-        <Checkbox indeterminate label="Indeterminate" />
-        <Checkbox label="Unchecked" />
-      </Stack>
-    ),
+    preview: SCHEMATICS['Checkbox'],
   },
   {
     to: '/components/field',
     name: 'Field',
     description: 'Labeled-control unit — label, help, error, required, a11y wiring.',
-    preview: (
-      <Field label="Email" description="We only use this for sign-in.">
-        <Input placeholder="you@company.com" />
-      </Field>
-    ),
+    preview: SCHEMATICS['Field'],
   },
   {
     to: '/components/form-row',
     name: 'FormRow',
     description: 'Fields side by side; reflows to stacked when narrow.',
-    preview: (
-      <FormRow>
-        <Field label="First">
-          <Input placeholder="Ada" />
-        </Field>
-        <Field label="Last">
-          <Input placeholder="Lovelace" />
-        </Field>
-      </FormRow>
-    ),
+    preview: SCHEMATICS['FormRow'],
   },
   {
     to: '/components/form-section',
     name: 'FormSection',
     description: 'Titled group of fields with heading + description.',
-    preview: (
-      <FormSection title="Profile" description="Public details">
-        <Field label="Name">
-          <Input placeholder="Ada Lovelace" />
-        </Field>
-      </FormSection>
-    ),
+    preview: SCHEMATICS['FormSection'],
   },
   {
     to: '/components/color-picker',
     name: 'ColorPicker',
     description:
       'Controlled HEX color picker with two shapes — popover trigger for form fields and an inline <ColorPicker.Panel> for theme builders. SV square + hue slider + HEX input + optional presets.',
-    preview: (
-      // The inline Panel is ~370px tall — far beyond the preview box. Show
-      // the closed popover trigger next to a preset row instead.
-      <Cluster gap="sm" justify="center">
-        <div style={{ pointerEvents: 'none' }}>
-          <ColorPicker value="#4F46E5" onChange={() => {}} />
-        </div>
-        {['#4F46E5', '#10B981', '#F59E0B', '#EF4444'].map((hex) => (
-          <span
-            key={hex}
-            style={{
-              width: 20,
-              height: 20,
-              borderRadius: 'var(--radius-sm)',
-              border: 'var(--border-width) solid var(--color-border)',
-              background: hex,
-            }}
-          />
-        ))}
-      </Cluster>
-    ),
+    preview: SCHEMATICS['ColorPicker'],
   },
   {
     to: '/components/stack',
     name: 'Stack',
     description: 'Vertical layout with consistent gap.',
-    preview: (
-      <Stack gap="xs">
-        <div className={styles.bar} />
-        <div className={styles.bar} />
-        <div className={styles.bar} />
-      </Stack>
-    ),
+    preview: SCHEMATICS['Stack'],
   },
   {
     to: '/components/cluster',
     name: 'Cluster',
     description: 'Horizontal wrapping layout with gap + alignment.',
-    preview: (
-      <Cluster gap="xs">
-        <div className={styles.tile} />
-        <div className={styles.tile} />
-        <div className={styles.tile} />
-        <div className={styles.tile} />
-      </Cluster>
-    ),
+    preview: SCHEMATICS['Cluster'],
   },
   {
     to: '/components/app-layout',
     name: 'AppLayout',
     description: 'Viewport-filling app shell — topBar + sidebar + content.',
-    preview: (
-      <Stack gap="xs">
-        <div className={styles.bar} />
-        <Cluster gap="xs" wrap={false}>
-          <div className={styles.tile} />
-          <Stack gap="xs">
-            <div className={styles.bar} />
-            <div className={styles.bar} />
-          </Stack>
-        </Cluster>
-      </Stack>
-    ),
+    preview: SCHEMATICS['AppLayout'],
   },
   {
     to: '/components/constrain',
     name: 'Constrain',
     description: 'Width / flex constraint — cap a width or fill a flex row.',
-    preview: (
-      <Stack gap="xs">
-        <Constrain maxWidth="xs">
-          <div className={styles.bar} />
-        </Constrain>
-        <Constrain maxWidth="sm">
-          <div className={styles.bar} />
-        </Constrain>
-      </Stack>
-    ),
+    preview: SCHEMATICS['Constrain'],
   },
   {
     to: '/components/indent',
     name: 'Indent',
     description:
       'Indent nested content by level × gutter — token-based, RTL-aware. For tree/thread depth.',
-    preview: (
-      <Stack gap="xs">
-        <Indent level={0}>
-          <div className={styles.bar} />
-        </Indent>
-        <Indent level={1}>
-          <div className={styles.bar} />
-        </Indent>
-        <Indent level={2}>
-          <div className={styles.bar} />
-        </Indent>
-      </Stack>
-    ),
+    preview: SCHEMATICS['Indent'],
   },
   {
     to: '/components/code',
     name: 'Code',
     description:
       'Inline <code> chip — monospace text with subtle bg. Use for inline identifiers / snippets.',
-    preview: (
-      <Cluster gap="sm" justify="center">
-        <Code>userId</Code>
-        <Code tone="danger">--no-verify</Code>
-      </Cluster>
-    ),
+    preview: SCHEMATICS['Code'],
   },
   {
     to: '/components/divider',
     name: 'Divider',
     description: 'Thin separator. Horizontal/vertical, solid/dashed, optional label.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: '200px' }}>
-        <Divider>OR</Divider>
-      </div>
-    ),
+    preview: SCHEMATICS['Divider'],
   },
   {
     to: '/components/grid',
     name: 'Grid',
     description:
       '2D layout primitive with token-driven gap, auto-fit responsive columns, and equal-width fixed columns.',
-    preview: (
-      <Grid columns={2} gap="xs">
-        <div className={styles.tile} />
-        <div className={styles.tile} />
-        <div className={styles.tile} />
-        <div className={styles.tile} />
-      </Grid>
-    ),
+    preview: SCHEMATICS['Grid'],
   },
   {
     to: '/components/split',
     name: 'Split',
     description:
       'Master–detail layout: an intrinsic-width aside beside a filling main pane (CSS grid auto 1fr). For a vertical Tabs rail + detail panel.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: 220 }}>
-        <Split gap="sm" aside={<div className={styles.tile} style={{ width: 28 }} />}>
-          <div className={styles.tile} style={{ width: '100%' }} />
-        </Split>
-      </div>
-    ),
+    preview: SCHEMATICS['Split'],
   },
   {
     to: '/components/sticky',
     name: 'Sticky',
     description:
       'Pins its box to the top of the scroll container while the page scrolls — for a record-detail sidebar that stays in view.',
-    preview: (
-      <div
-        style={{
-          width: '100%',
-          maxWidth: 220,
-          maxHeight: 88,
-          overflowY: 'auto',
-          border: '1px solid var(--color-border)',
-          borderRadius: 'var(--radius-sm)',
-          padding: 6,
-        }}
-      >
-        <Split
-          gap="sm"
-          side="end"
-          asideWidth="56px"
-          align="stretch"
-          aside={
-            <Sticky top="none">
-              <div className={styles.tile} style={{ height: 22 }} />
-            </Sticky>
-          }
-        >
-          <div style={{ display: 'grid', gap: 4 }}>
-            {[0, 1, 2, 3, 4, 5].map((i) => (
-              <div key={i} className={styles.tile} style={{ height: 16, width: '100%' }} />
-            ))}
-          </div>
-        </Split>
-      </div>
-    ),
+    preview: SCHEMATICS['Sticky'],
   },
   {
     to: '/components/masonry',
     name: 'Masonry',
     description: 'Height-balanced columns for variable-height items.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: '260px' }}>
-        <Masonry columns={3} gap="sm">
-          {[40, 64, 28, 52, 36, 48].map((h, i) => (
-            <div
-              key={i}
-              style={{
-                height: h,
-                borderRadius: 'var(--radius-sm)',
-                background: 'var(--color-accent-subtle-bg)',
-              }}
-            />
-          ))}
-        </Masonry>
-      </div>
-    ),
+    preview: SCHEMATICS['Masonry'],
   },
   {
     to: '/components/avatar',
     name: 'Avatar',
     description: 'Profile circle with image or auto-colored initials.',
-    preview: (
-      <Cluster gap="sm">
-        <Avatar name="Alex Rivera" />
-        <Avatar name="Maya Owens" />
-        <Avatar name="Sam Chen" />
-      </Cluster>
-    ),
+    preview: SCHEMATICS['Avatar'],
   },
   {
     to: '/components/badge',
     name: 'Badge',
     description: 'Small status/category pill with semantic tones.',
-    preview: (
-      <Cluster gap="xs">
-        <Badge tone="info">New</Badge>
-        <Badge tone="success">Active</Badge>
-        <Badge tone="warning">Pending</Badge>
-      </Cluster>
-    ),
+    preview: SCHEMATICS['Badge'],
   },
   {
     to: '/components/dot',
     name: 'Dot',
     description: 'Bare palette/tone colored circle for color-coding affordances.',
-    preview: (
-      <Cluster gap="sm" align="center">
-        <Dot color="violet" />
-        <Dot color="teal" />
-        <Dot tone="success" />
-        <Dot tone="danger" />
-      </Cluster>
-    ),
+    preview: SCHEMATICS['Dot'],
   },
   {
     to: '/components/timeline',
     name: 'Timeline',
     description:
       'Vertical activity feed — connector line through avatar/dot/icon nodes; compact variant.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: 200 }}>
-        <Timeline compact>
-          <Timeline.Item node={<Dot tone="info" />}>
-            <Text size="xs">Renewal confirmed</Text>
-          </Timeline.Item>
-          <Timeline.Item node={<Dot tone="success" />}>
-            <Text size="xs">Moved to Negotiation</Text>
-          </Timeline.Item>
-        </Timeline>
-      </div>
-    ),
+    preview: SCHEMATICS['Timeline'],
   },
   {
     to: '/components/thread',
     name: 'Thread',
     description:
       'Nested-reply threading — per-level left rail connecting a comment to its replies; depth-capped.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: 200 }}>
-        <Thread compact>
-          <Thread.Item node={<Avatar name="Maya Chen" size="sm" />}>
-            <Text size="xs">Renewal flagged</Text>
-            <Thread.Item node={<Avatar name="Tom Okafor" size="sm" />}>
-              <Text size="xs">On it</Text>
-            </Thread.Item>
-          </Thread.Item>
-        </Thread>
-      </div>
-    ),
+    preview: SCHEMATICS['Thread'],
   },
   {
     to: '/components/rich-text',
     name: 'RichText',
     description: 'Read-only renderer for the in-house rich-text model.',
-    preview: (
-      <RichText
-        value={{
-          blocks: [
-            createBlock('heading', 'Notes', { level: 3, id: 'pi-h' }),
-            createBlock('bullet_item', 'Rich content', { id: 'pi-l' }),
-          ],
-        }}
-      />
-    ),
+    preview: SCHEMATICS['RichText'],
   },
   {
     to: '/components/rich-text-editor',
     name: 'RichTextEditor',
     description: 'Controlled contentEditable rich-text editor over the in-house engine.',
-    preview: (
-      <RichTextEditor value={docFromText('Editable rich text')} onChange={() => {}} readOnly />
-    ),
+    preview: SCHEMATICS['RichTextEditor'],
   },
   {
     to: '/components/brand-icon',
     name: 'BrandIcon',
     description: 'Full-color brand marks (Google, Yandex) for SSO buttons.',
-    preview: (
-      <Cluster gap="md" justify="center">
-        <BrandIcon name="google" size={28} />
-        <BrandIcon name="yandex" size={28} />
-      </Cluster>
-    ),
+    preview: SCHEMATICS['BrandIcon'],
   },
   {
     to: '/components/logo',
     name: 'Logo',
     description: 'The eocrm brand logo — mark + optional wordmark.',
-    preview: <Logo src={eocrmLogo} text="eocrm" size="md" />,
+    preview: SCHEMATICS['Logo'],
   },
   {
     to: '/components/breadcrumb',
     name: 'Breadcrumb',
     description: 'Navigation trail with auto-current on the last item.',
-    preview: (
-      // as="span": real anchors would nest inside the card's <Link> (invalid HTML).
-      <Breadcrumb>
-        <Breadcrumb.Item as="span">Workspace</Breadcrumb.Item>
-        <Breadcrumb.Item as="span">Contacts</Breadcrumb.Item>
-        <Breadcrumb.Item>Acme</Breadcrumb.Item>
-      </Breadcrumb>
-    ),
+    preview: SCHEMATICS['Breadcrumb'],
   },
   {
     to: '/components/link',
     name: 'Link',
     description: 'Polymorphic styled anchor with three visual variants.',
-    preview: (
-      // as="span": a real anchor would nest inside the card's <Link> (invalid HTML).
-      <DSLink as="span">View details →</DSLink>
-    ),
+    preview: SCHEMATICS['Link'],
   },
   {
     to: '/components/link-card',
     name: 'LinkCard',
     description: 'A clickable Card — the whole surface navigates or acts.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: '220px' }}>
-        <LinkCard as="div" padding="sm">
-          <Text size="sm" weight="semibold">
-            Dashboard
-          </Text>
-        </LinkCard>
-      </div>
-    ),
+    preview: SCHEMATICS['LinkCard'],
   },
   {
     to: '/components/rail',
     name: 'Rail',
     description:
       'Collapsible left-side nav with sections, items, groups, and hover-popover for collapsed groups.',
-    preview: (
-      // as="span": real anchors here would nest inside the card's <Link>
-      // (invalid HTML); the preview is inert anyway.
-      <div style={{ width: 240, height: 118, overflow: 'hidden', pointerEvents: 'none' }}>
-        <Rail>
-          <Rail.Section title="Main">
-            <Rail.Item as="span" icon={<Home size={14} />}>
-              Dashboard
-            </Rail.Item>
-            <Rail.Item as="span" icon={<Users size={14} />} aria-current="page">
-              Contacts
-            </Rail.Item>
-          </Rail.Section>
-        </Rail>
-      </div>
-    ),
+    preview: SCHEMATICS['Rail'],
   },
   {
     to: '/components/topbar',
     name: 'TopBar',
     description:
       'Sticky application top-bar primitive. Compound API with Start/End clusters, a styled Search input, and an IconButton with optional notification dot.',
-    preview: (
-      <div
-        style={{
-          width: '100%',
-          maxWidth: 360,
-          height: 80,
-          overflow: 'hidden',
-          pointerEvents: 'none',
-          borderRadius: 'var(--radius-md)',
-          border: 'var(--border-width) solid var(--color-border)',
-        }}
-      >
-        <TopBar>
-          <TopBar.Start>
-            <TopBar.Search placeholder="Search…" hotkey={['⌘', 'K']} />
-          </TopBar.Start>
-          <TopBar.End>
-            <TopBar.IconButton aria-label="Notifications" indicator>
-              <Bell size={14} />
-            </TopBar.IconButton>
-          </TopBar.End>
-        </TopBar>
-      </div>
-    ),
+    preview: SCHEMATICS['TopBar'],
   },
   {
     to: '/components/tabs',
     name: 'Tabs',
     description: 'Horizontal tab strip with optional count chips.',
-    preview: (
-      <div style={{ width: '100%', maxWidth: 240 }}>
-        <Tabs
-          items={[
-            { id: 'a', label: 'Overview' },
-            { id: 'b', label: 'Activity', count: 4 },
-          ]}
-          activeId="a"
-          onChange={() => undefined}
-        />
-      </div>
-    ),
+    preview: SCHEMATICS['Tabs'],
   },
   {
     to: '/components/text',
     name: 'Text',
     description:
       'Body / inline text primitive with size/tone/weight/align/truncate/lineClamp props.',
-    preview: (
-      <Stack gap="xs" align="center">
-        <Text size="sm" tone="muted">
-          12 minutes ago
-        </Text>
-        <Text weight="medium">Acme Inc</Text>
-      </Stack>
-    ),
+    preview: SCHEMATICS['Text'],
   },
   {
     to: '/components/title',
     name: 'Title',
     description: 'Semantic heading primitive — renders h1-h6 from the required `order` prop.',
-    preview: (
-      <Stack gap="xs" align="center">
-        <Title order={3}>Dashboard</Title>
-        <Title order={5} tone="muted">
-          Subtitle
-        </Title>
-      </Stack>
-    ),
+    preview: SCHEMATICS['Title'],
   },
   {
     to: '/components/dropdown-menu',
     name: 'DropdownMenu',
     description: 'Action menu opened from a trigger button. Compound API.',
-    preview: (
-      <Cluster gap="sm" justify="center">
-        <DropdownMenu>
-          <DropdownMenu.Trigger>
-            <Button size="sm" variant="secondary">
-              Actions ▾
-            </Button>
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Content>
-            <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
-            <DropdownMenu.Item onSelect={() => {}}>Duplicate</DropdownMenu.Item>
-          </DropdownMenu.Content>
-        </DropdownMenu>
-      </Cluster>
-    ),
+    preview: SCHEMATICS['DropdownMenu'],
   },
   {
     to: '/components/textarea',
     name: 'Textarea',
     description: 'Multi-line text with auto-grow + character counter.',
-    preview: (
-      <Textarea minRows={2} autoGrow={false} defaultValue="Multi-line text…" aria-label="Preview" />
-    ),
+    preview: SCHEMATICS['Textarea'],
   },
   {
     to: '/components/timefield',
     name: 'TimeField',
     description:
       'Standalone time-of-day input — text + popover with hour / minute (+ AM/PM in 12h locales) lists and a Now button. Powers the picker family when granularity="minute".',
-    preview: (
-      <div style={{ width: 140 }}>
-        <TimeField value={{ hours: 9, minutes: 30 }} onChange={() => {}} aria-label="Preview" />
-      </div>
-    ),
+    preview: SCHEMATICS['TimeField'],
   },
   {
     to: '/components/toast',
     name: 'Toast',
     description: 'Imperative transient notifications.',
-    preview: (
-      <Button size="sm" onClick={() => toast.success('Saved')}>
-        Fire toast
-      </Button>
-    ),
+    preview: SCHEMATICS['Toast'],
   },
   {
     to: '/components/tooltip',
     name: 'Tooltip',
     description: 'Small floating label on hover/focus, with a pointer arrow.',
-    preview: (
-      // Static stand-in (same approach as the Modal/Drawer previews): a
-      // defaultOpen Tooltip portals to <body> and floats outside the card.
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: 6,
-          pointerEvents: 'none',
-        }}
-      >
-        <span
-          style={{
-            padding: '4px 8px',
-            background: 'var(--color-fg)',
-            color: 'var(--color-bg)',
-            borderRadius: 'var(--radius-sm)',
-            fontSize: 'var(--font-size-xs)',
-          }}
-        >
-          Save (⌘S)
-        </span>
-        <span
-          style={{
-            width: 0,
-            height: 0,
-            marginTop: -6,
-            borderLeft: '5px solid transparent',
-            borderRight: '5px solid transparent',
-            borderTop: '5px solid var(--color-fg)',
-          }}
-        />
-        <Button size="sm" variant="secondary">
-          Save
-        </Button>
-      </div>
-    ),
+    preview: SCHEMATICS['Tooltip'],
   },
   {
     to: '/components/modal',
     name: 'Modal',
     description: 'Focus-locked dialog with header / body / footer slots and overlay variants.',
-    preview: (
-      <div
-        style={{
-          width: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          pointerEvents: 'none',
-        }}
-      >
-        <div
-          style={{
-            width: 180,
-            border: '1px solid var(--color-border)',
-            borderRadius: 'var(--radius-md)',
-            background: 'var(--color-bg)',
-            boxShadow: 'var(--shadow-lg)',
-            overflow: 'hidden',
-          }}
-        >
-          <div
-            style={{
-              padding: '8px 12px',
-              borderBottom: '1px solid var(--color-border)',
-              fontWeight: 600,
-              fontSize: '0.75rem',
-            }}
-          >
-            Dialog title
-          </div>
-          <div style={{ padding: '8px 12px', fontSize: '0.7rem', color: 'var(--color-fg-muted)' }}>
-            Dialog content goes here.
-          </div>
-          <div
-            style={{
-              padding: '8px 12px',
-              borderTop: '1px solid var(--color-border)',
-              display: 'flex',
-              justifyContent: 'flex-end',
-              gap: 6,
-            }}
-          >
-            <Button size="sm" variant="secondary">
-              Cancel
-            </Button>
-            <Button size="sm">OK</Button>
-          </div>
-        </div>
-      </div>
-    ),
+    preview: SCHEMATICS['Modal'],
   },
   {
     to: '/components/lightbox',
     name: 'Lightbox',
     description: 'Full-screen image gallery overlay — large image, prev/next, thumbnails, caption.',
-    preview: (
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr',
-          gap: 4,
-          width: '100%',
-          maxWidth: 120,
-        }}
-      >
-        <Image
-          src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=120&q=60"
-          alt=""
-          size="md"
-          objectFit="cover"
-        />
-        <Image
-          src="https://images.unsplash.com/photo-1465146344425-f00d5f5c8f07?w=120&q=60"
-          alt=""
-          size="md"
-          objectFit="cover"
-        />
-      </div>
-    ),
+    preview: SCHEMATICS['Lightbox'],
   },
   {
     to: '/components/filter-chip',
     name: 'FilterChip',
     description:
       'Dismissible "active filter" pill — Label + tone-dotted Value + auto-rendered × dismiss button.',
-    preview: (
-      <div style={{ pointerEvents: 'none' }}>
-        <FilterChip onDismiss={() => {}}>
-          <FilterChip.Label>Event</FilterChip.Label>
-          <FilterChip.Value tone="info">auth.*</FilterChip.Value>
-        </FilterChip>
-      </div>
-    ),
+    preview: SCHEMATICS['FilterChip'],
   },
   {
     to: '/components/options-picker',
     name: 'OptionsPicker',
     description:
       'Filter-picker UX: popover with search, optional grouping, multi/single select, draft-then-Apply commit.',
-    preview: (
-      <div style={{ pointerEvents: 'none' }}>
-        <OptionsPicker
-          selected={['lead', 'won']}
-          onApply={() => {}}
-          open={false}
-          onOpenChange={() => {}}
-        >
-          <OptionsPicker.Trigger>
-            <Button size="sm" variant="secondary">
-              Stage (2) ▾
-            </Button>
-          </OptionsPicker.Trigger>
-          <OptionsPicker.Content
-            label="Filter stage"
-            options={[
-              { value: 'lead', label: 'Lead' },
-              { value: 'won', label: 'Won' },
-            ]}
-          />
-        </OptionsPicker>
-      </div>
-    ),
+    preview: SCHEMATICS['OptionsPicker'],
   },
   {
     to: '/components/emoji-picker',
     name: 'EmojiPicker',
     description:
       'Searchable, categorized emoji grid for reactions and everyday input — lives in a Popover, calls onSelect(emoji).',
-    preview: (
-      <div style={{ pointerEvents: 'none' }}>
-        <EmojiPickerPopover
-          trigger={
-            <Button size="sm" variant="secondary">
-              😀 React
-            </Button>
-          }
-          onSelect={() => {}}
-        />
-      </div>
-    ),
+    preview: SCHEMATICS['EmojiPicker'],
   },
   {
     to: '/components/page',
     name: 'Page',
     description:
       'Page-root layout primitive. Wraps top-level sections with the canonical CRM rhythm (gap="lg").',
-    preview: (
-      <Page>
-        <Card padding="sm">
-          <Text size="sm">Header</Text>
-        </Card>
-        <Card padding="sm">
-          <Text size="sm">Body</Text>
-        </Card>
-      </Page>
-    ),
+    preview: SCHEMATICS['Page'],
   },
   {
     to: '/components/page-header',
     name: 'PageHeader',
     description:
       'Compound layout primitive for top-of-page headers. Breadcrumb + BackButton + Aside (Avatar) + Title + Subtitle + Meta + Actions.',
-    preview: (
-      <div style={{ width: '100%', pointerEvents: 'none' }}>
-        <PageHeader borderBottom={false}>
-          <PageHeader.Title order={2}>Acme Corp</PageHeader.Title>
-          <PageHeader.Subtitle>230 employees</PageHeader.Subtitle>
-          <PageHeader.Actions>
-            <Button size="sm" variant="secondary">
-              Edit
-            </Button>
-          </PageHeader.Actions>
-        </PageHeader>
-      </div>
-    ),
+    preview: SCHEMATICS['PageHeader'],
   },
   {
     to: '/components/drawer',
     name: 'Drawer',
     description: 'Edge-anchored slide-in panel with drag-to-close on mobile.',
-    preview: (
-      <div
-        style={{
-          width: '100%',
-          display: 'flex',
-          alignItems: 'stretch',
-          justifyContent: 'flex-end',
-          height: 116,
-          pointerEvents: 'none',
-          overflow: 'hidden',
-          position: 'relative',
-          borderRadius: 'var(--radius-sm)',
-          border: 'var(--border-width) solid var(--color-border)',
-          background: 'var(--color-bg)',
-        }}
-      >
-        {/* Page content behind the drawer — gives the overlay something to
-            dim, and keeps the panel readable as a raised surface in dark
-            mode (previously the backdrop was a featureless void there). */}
-        <div
-          style={{
-            position: 'absolute',
-            inset: 0,
-            padding: 10,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 6,
-          }}
-        >
-          <div className={styles.skeleton} style={{ width: '40%' }} />
-          <div className={styles.skeleton} style={{ width: '75%' }} />
-          <div className={styles.skeleton} style={{ width: '60%' }} />
-        </div>
-        {/* Overlay */}
-        <div
-          style={{
-            position: 'absolute',
-            inset: 0,
-            background: 'var(--color-bg-overlay)',
-            opacity: 0.4,
-          }}
-        />
-        {/* Drawer panel — 160px so the footer buttons fit inside (they
-            overflowed the previous 130px panel). */}
-        <div
-          style={{
-            width: 160,
-            borderLeft: 'var(--border-width) solid var(--color-border)',
-            background: 'var(--color-bg)',
-            boxShadow: 'var(--shadow-lg)',
-            display: 'flex',
-            flexDirection: 'column',
-            position: 'relative',
-            zIndex: 1,
-          }}
-        >
-          <div
-            style={{
-              padding: '6px 12px',
-              borderBottom: 'var(--border-width) solid var(--color-border)',
-              fontWeight: 600,
-              fontSize: '0.75rem',
-            }}
-          >
-            Filters
-          </div>
-          <div
-            style={{
-              padding: '6px 12px',
-              fontSize: '0.7rem',
-              color: 'var(--color-fg-muted)',
-              flex: 1,
-            }}
-          >
-            Filter content here.
-          </div>
-          <div
-            style={{
-              padding: '6px 8px',
-              borderTop: 'var(--border-width) solid var(--color-border)',
-              display: 'flex',
-              justifyContent: 'flex-end',
-              gap: 6,
-            }}
-          >
-            <Button size="sm" variant="ghost">
-              Cancel
-            </Button>
-            <Button size="sm">Apply</Button>
-          </div>
-        </div>
-      </div>
-    ),
+    preview: SCHEMATICS['Drawer'],
   },
   {
     to: '/components/popover',
     name: 'Popover',
     description: 'Non-modal floating panel for arbitrary small surfaces.',
-    preview: (
-      // Static stand-in (same approach as the Modal/Drawer previews): a
-      // defaultOpen Popover portals to <body> and floats outside the card.
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: 6,
-          pointerEvents: 'none',
-        }}
-      >
-        <Button size="sm" variant="secondary">
-          Filters
-        </Button>
-        <div
-          style={{
-            width: 150,
-            padding: 'var(--space-3)',
-            background: 'var(--color-bg)',
-            border: 'var(--border-width) solid var(--color-border)',
-            borderRadius: 'var(--radius-md)',
-            boxShadow: 'var(--shadow-md)',
-          }}
-        >
-          <Stack gap="xs">
-            <Text size="sm" weight="semibold">
-              Filters
-            </Text>
-            <div className={styles.skeleton} />
-            <div className={styles.skeleton} style={{ width: '70%' }} />
-          </Stack>
-        </div>
-      </div>
-    ),
+    preview: SCHEMATICS['Popover'],
   },
   {
     to: '/components/calendar',
     name: 'Calendar',
     description:
       'Month view with continuous multi-day event bars, overflow chips, and locale-aware weekday grids.',
-    preview: (
-      <div
-        style={{
-          width: '100%',
-          maxWidth: 220,
-          height: 100,
-          overflow: 'hidden',
-          pointerEvents: 'none',
-        }}
-      >
-        <div
-          style={{
-            width: '250%',
-            transform: 'scale(0.4)',
-            transformOrigin: 'top left',
-          }}
-        >
-          <Calendar defaultValue={new Date(2026, 4, 15)} />
-        </div>
-      </div>
-    ),
+    preview: SCHEMATICS['Calendar'],
   },
   {
     to: '/components/circular-progress',
     name: 'CircularProgress',
     description:
       'Circular progress / loading spinner — donut shape for tracked progress, or spinning arc when value is omitted.',
-    preview: (
-      <Cluster gap="sm" justify="center">
-        <CircularProgress size="sm" />
-        <CircularProgress size="md" value={65} label />
-      </Cluster>
-    ),
+    preview: SCHEMATICS['CircularProgress'],
   },
   {
     to: '/components/confirmation-popover',
     name: 'ConfirmationPopover',
     description: '"Are you sure?" preset on top of Popover, with async-aware Confirm.',
-    preview: (
-      // Static stand-in (same approach as the Modal/Drawer previews): a
-      // defaultOpen ConfirmationPopover portals to <body> and floats outside
-      // the card.
-      <div
-        style={{
-          width: 190,
-          padding: 'var(--space-3)',
-          background: 'var(--color-bg)',
-          border: 'var(--border-width) solid var(--color-border)',
-          borderRadius: 'var(--radius-md)',
-          boxShadow: 'var(--shadow-md)',
-          pointerEvents: 'none',
-        }}
-      >
-        <Stack gap="xs">
-          <Text size="sm" weight="semibold">
-            Delete?
-          </Text>
-          <Text size="sm" tone="muted">
-            Cannot be undone.
-          </Text>
-          <Cluster gap="xs" justify="end">
-            <Button size="sm" variant="ghost">
-              Cancel
-            </Button>
-            <Button size="sm" variant="danger">
-              Delete
-            </Button>
-          </Cluster>
-        </Stack>
-      </div>
-    ),
+    preview: SCHEMATICS['ConfirmationPopover'],
   },
 ];
+
+if (import.meta.env.DEV) {
+  for (const item of items) {
+    if (!item.preview) {
+      console.warn(`[ComponentsIndex] no schematic for card "${item.name}"`);
+    }
+  }
+}
 
 export function ComponentsIndex() {
   return (

--- a/packages/playground/src/pages/components/overviewSchematics.module.scss
+++ b/packages/playground/src/pages/components/overviewSchematics.module.scss
@@ -1,0 +1,60 @@
+// Blueprint-accent schematic vocabulary for the components overview grid.
+// Every card preview is drawn from these shapes — tokens only, so light and
+// dark themes both work with no special-casing.
+
+.row {
+  display: flex;
+  align-items: center;
+}
+
+.col {
+  display: flex;
+  flex-direction: column;
+}
+
+.box {
+  flex-shrink: 0;
+  background: var(--color-accent-subtle-bg);
+  border-radius: var(--radius-sm);
+}
+
+.solid {
+  flex-shrink: 0;
+  background: var(--color-accent);
+  border-radius: var(--radius-sm);
+}
+
+.outline {
+  flex-shrink: 0;
+  background: var(--color-bg);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.panel {
+  flex-shrink: 0;
+  background: var(--color-bg);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+}
+
+.dashed {
+  flex-shrink: 0;
+
+  // 45% accent ≈ the approved mockup's dashed tint; opacity would also wash
+  // out children, so mix the border color instead.
+  border: var(--border-width) dashed color-mix(in srgb, var(--color-accent) 45%, transparent);
+  border-radius: var(--radius-sm);
+}
+
+.dot {
+  flex-shrink: 0;
+  border-radius: var(--radius-full);
+}
+
+.pill {
+  flex-shrink: 0;
+  background: var(--color-accent-subtle-bg);
+  border-radius: var(--radius-full);
+}

--- a/packages/playground/src/pages/components/overviewSchematics.tsx
+++ b/packages/playground/src/pages/components/overviewSchematics.tsx
@@ -1,0 +1,1850 @@
+import type { CSSProperties, ReactNode } from 'react';
+import styles from './overviewSchematics.module.scss';
+
+// ---------------------------------------------------------------------------
+// Vocabulary — the only building blocks schematics are drawn from.
+// Blueprint-accent language: tinted shapes sketch structure; exactly ONE
+// solid-accent element per schematic marks the component's key affordance.
+// ---------------------------------------------------------------------------
+
+type Dim = number | string;
+
+interface ShapeProps {
+  /** Width — number = px, string passthrough ('70%'). */
+  w?: Dim;
+  /** Height — number = px, string passthrough. */
+  h?: Dim;
+  /** Positional / clip-path / transform tweaks only — never colors. */
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+function dim(v: Dim | undefined): string | number | undefined {
+  return typeof v === 'number' ? v : v;
+}
+
+function shape(className: string) {
+  return function Shape({ w, h, style, children }: ShapeProps) {
+    return (
+      <span
+        className={className}
+        style={{ width: dim(w), height: dim(h), ...style }}
+        aria-hidden="true"
+      >
+        {children}
+      </span>
+    );
+  };
+}
+
+/** Tinted structural fill. */
+export const Box = shape(styles.box);
+/** Solid accent — THE focal element; exactly one per schematic. */
+export const Solid = shape(styles.solid);
+/** Plain surface (bg + neutral border) — inputs, cards, rows. */
+export const Outline = shape(styles.outline);
+/** Elevated surface (surface + shadow) — modals, popovers, menus. */
+export const Panel = shape(styles.panel);
+/** Dashed accent region — slots, columns, dropzones, layout frames. */
+export const Dashed = shape(styles.dashed);
+
+interface FlexProps {
+  gap?: number;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+/** Horizontal group. */
+export function Row({ gap = 6, style, children }: FlexProps) {
+  return (
+    <span className={styles.row} style={{ gap, ...style }} aria-hidden="true">
+      {children}
+    </span>
+  );
+}
+
+/** Vertical group. */
+export function Col({ gap = 6, style, children }: FlexProps) {
+  return (
+    <span className={styles.col} style={{ gap, ...style }} aria-hidden="true">
+      {children}
+    </span>
+  );
+}
+
+/** 5px tinted text line. */
+export function Bar({ w = 40, style }: ShapeProps) {
+  return <Box w={w} h={5} style={style} />;
+}
+
+/** 5px accent text line — counts as the focal element. */
+export function SolidBar({ w = 40, style }: ShapeProps) {
+  return <Solid w={w} h={5} style={style} />;
+}
+
+/** 8px circle; `solid` makes it the accent focal element. */
+export function Dot({
+  solid = false,
+  size = 8,
+  style,
+}: {
+  solid?: boolean;
+  size?: number;
+  style?: CSSProperties;
+}) {
+  return (
+    <span
+      className={`${styles.dot} ${solid ? styles.solid : styles.box}`}
+      style={{ width: size, height: size, borderRadius: 'var(--radius-full)', ...style }}
+      aria-hidden="true"
+    />
+  );
+}
+
+/** 16px rounded-full tinted chip. */
+export function Pill({ w = 40, style }: ShapeProps) {
+  return (
+    <span
+      className={styles.pill}
+      style={{ width: dim(w), height: 16, ...style }}
+      aria-hidden="true"
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SCHEMATICS — one drawing per overview card, keyed by the card's `name`.
+// Populated per batch; every schematic fits within 230x110.
+// ---------------------------------------------------------------------------
+
+export const SCHEMATICS: Record<string, ReactNode> = {
+  Accordion: (
+    <Col gap={4} style={{ width: 190 }}>
+      <Outline
+        w="100%"
+        h={22}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 6px',
+        }}
+      >
+        <Bar w={70} />
+        <Solid w={10} h={6} style={{ clipPath: 'polygon(0 0,100% 0,50% 100%)', borderRadius: 0 }} />
+      </Outline>
+      <Col gap={4} style={{ padding: '2px 6px' }}>
+        <Bar w={130} />
+        <Bar w={100} />
+      </Col>
+      <Outline
+        w="100%"
+        h={22}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 6px',
+        }}
+      >
+        <Bar w={54} />
+        <Box w={8} h={5} style={{ clipPath: 'polygon(0 0,100% 0,50% 100%)', borderRadius: 0 }} />
+      </Outline>
+      <Outline
+        w="100%"
+        h={22}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 6px',
+        }}
+      >
+        <Bar w={62} />
+        <Box w={8} h={5} style={{ clipPath: 'polygon(0 0,100% 0,50% 100%)', borderRadius: 0 }} />
+      </Outline>
+    </Col>
+  ),
+  Alert: (
+    <Row>
+      <Outline
+        w={200}
+        h={44}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '0 12px',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        <Solid w={4} h="100%" style={{ position: 'absolute', top: 0, left: 0, borderRadius: 0 }} />
+        <Dot size={12} />
+        <Col gap={4}>
+          <Bar w={90} />
+          <Bar w={60} />
+        </Col>
+      </Outline>
+    </Row>
+  ),
+  Button: (
+    <Row gap={8}>
+      <Solid w={64} h={26} />
+      <Outline
+        w={64}
+        h={26}
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Bar w={30} />
+      </Outline>
+      <Outline
+        w={46}
+        h={20}
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Bar w={20} />
+      </Outline>
+    </Row>
+  ),
+  SocialButton: (
+    <Row>
+      <Outline
+        w={190}
+        h={32}
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 10 }}
+      >
+        <Dot solid size={12} />
+        <Bar w={90} />
+      </Outline>
+    </Row>
+  ),
+  ButtonGroup: (
+    <Row style={{ gap: 0 }}>
+      <Solid w={48} h={24} style={{ borderRadius: '6px 0 0 6px' }} />
+      <Outline
+        w={48}
+        h={24}
+        style={{ borderRadius: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Bar w={22} />
+      </Outline>
+      <Outline
+        w={48}
+        h={24}
+        style={{
+          borderRadius: '0 6px 6px 0',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Bar w={22} />
+      </Outline>
+    </Row>
+  ),
+  'Date pickers': (
+    <Col gap={6}>
+      <Outline
+        w={118}
+        h={20}
+        style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '0 6px' }}
+      >
+        <Box w={8} h={8} />
+        <Bar w={54} />
+      </Outline>
+      <Panel w={118} style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: 8 }}>
+        <Row gap={4}>
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+        </Row>
+        <Row gap={4}>
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+          <Solid w={38} h={8} style={{ borderRadius: 999 }} />
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+        </Row>
+        <Row gap={4}>
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+          <Box w={10} h={8} />
+        </Row>
+      </Panel>
+    </Col>
+  ),
+  EmptyState: (
+    <Col gap={6} style={{ alignItems: 'center' }}>
+      <Box w={24} h={24} style={{ borderRadius: '50%' }} />
+      <Bar w={70} />
+      <Bar w={110} />
+      <Solid w={60} h={18} style={{ marginTop: 2 }} />
+    </Col>
+  ),
+  ErrorState: (
+    <Col gap={6} style={{ alignItems: 'center' }}>
+      <Dashed w={24} h={24} style={{ borderRadius: '50%' }} />
+      <Bar w={84} />
+      <Row gap={6}>
+        <Solid w={52} h={16} />
+        <Outline
+          w={52}
+          h={16}
+          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        >
+          <Bar w={24} />
+        </Outline>
+      </Row>
+      <Pill w={64} style={{ height: 10 }} />
+    </Col>
+  ),
+  Screen: (
+    <Row>
+      <Dashed
+        w={210}
+        h={100}
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Col gap={4} style={{ alignItems: 'center' }}>
+          <Bar w={64} />
+          <Bar w={44} />
+          <Solid w={44} h={12} style={{ marginTop: 4 }} />
+        </Col>
+      </Dashed>
+    </Row>
+  ),
+  FileUpload: (
+    <Col gap={6} style={{ width: 190 }}>
+      <Dashed
+        w="100%"
+        h={48}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 5,
+        }}
+      >
+        <Solid
+          w={16}
+          h={10}
+          style={{ clipPath: 'polygon(50% 0,100% 100%,0 100%)', borderRadius: 0 }}
+        />
+        <Bar w={70} />
+      </Dashed>
+      <Outline
+        w="100%"
+        h={24}
+        style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '0 6px' }}
+      >
+        <Box w={10} h={12} />
+        <Bar w={48} />
+        <Outline
+          w={48}
+          h={8}
+          style={{ display: 'flex', marginLeft: 'auto', borderRadius: 999, overflow: 'hidden' }}
+        >
+          <Box w={26} h="100%" style={{ borderRadius: 0 }} />
+        </Outline>
+      </Outline>
+    </Col>
+  ),
+  ImageCrop: (
+    <Col gap={8} style={{ alignItems: 'center' }}>
+      <Box
+        w={150}
+        h={66}
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Dashed w={40} h={40} />
+      </Box>
+      <Row style={{ gap: 0, alignItems: 'center' }}>
+        <Box w={60} h={4} style={{ borderRadius: 0 }} />
+        <Dot solid size={10} />
+        <Box w={60} h={4} style={{ borderRadius: 0 }} />
+      </Row>
+    </Col>
+  ),
+  IconTile: (
+    <Row gap={8}>
+      <Solid
+        w={32}
+        h={32}
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Outline w={12} h={12} style={{ borderRadius: '50%' }} />
+      </Solid>
+      <Box
+        w={32}
+        h={32}
+        style={{
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Outline w={12} h={12} style={{ borderRadius: '50%' }} />
+      </Box>
+      <Box
+        w={32}
+        h={32}
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Outline w={12} h={12} style={{ borderRadius: '50%' }} />
+      </Box>
+    </Row>
+  ),
+  Image: (
+    <Row>
+      <Outline w={150} h={86} style={{ position: 'relative', overflow: 'hidden' }}>
+        <Dot solid size={14} style={{ position: 'absolute', top: 12, right: 18 }} />
+        <Box
+          w={80}
+          h={44}
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 12,
+            clipPath: 'polygon(50% 0,100% 100%,0 100%)',
+            borderRadius: 0,
+          }}
+        />
+        <Box
+          w={56}
+          h={30}
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            right: 10,
+            clipPath: 'polygon(50% 0,100% 100%,0 100%)',
+            borderRadius: 0,
+          }}
+        />
+      </Outline>
+    </Row>
+  ),
+  MediaTile: (
+    <Row>
+      <Outline w={96} h={92} style={{ position: 'relative', overflow: 'hidden' }}>
+        <Box
+          w={56}
+          h={30}
+          style={{
+            position: 'absolute',
+            bottom: 26,
+            left: 20,
+            clipPath: 'polygon(50% 0,100% 100%,0 100%)',
+            borderRadius: 0,
+          }}
+        />
+        <Row gap={4} style={{ position: 'absolute', top: 7, left: 7 }}>
+          <SolidBar w={34} />
+          <Bar w={16} />
+        </Row>
+        <Row
+          gap={6}
+          style={{
+            position: 'absolute',
+            bottom: 7,
+            left: 0,
+            width: '100%',
+            justifyContent: 'center',
+          }}
+        >
+          <Dot size={7} />
+          <Dot size={7} />
+          <Dot size={7} />
+        </Row>
+      </Outline>
+    </Row>
+  ),
+  Input: (
+    <Row>
+      <Outline
+        w={180}
+        h={30}
+        style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '0 8px' }}
+      >
+        <Bar w={64} />
+        <Solid w={2} h={14} style={{ borderRadius: 0 }} />
+      </Outline>
+    </Row>
+  ),
+  LiquidEditor: (
+    <Outline w={210} style={{ display: 'flex', flexDirection: 'column', gap: 5, padding: 6 }}>
+      <Row gap={6} style={{ alignItems: 'center', width: '100%' }}>
+        <Bar w={26} />
+        <Box w={38} h={10} style={{ marginLeft: 'auto' }} />
+      </Row>
+      <Row gap={6}>
+        <Col gap={5}>
+          <Bar w={6} />
+          <Bar w={6} />
+          <Bar w={6} />
+        </Col>
+        <Col gap={5}>
+          <Row gap={4}>
+            <Bar w={28} />
+            <SolidBar w={34} />
+            <Bar w={18} />
+          </Row>
+          <Bar w={90} />
+          <Row gap={4}>
+            <Bar w={44} />
+            <Box w={26} h={5} />
+          </Row>
+        </Col>
+      </Row>
+      <Dashed w="100%" h={22} style={{ display: 'flex', alignItems: 'center', padding: 6 }}>
+        <Bar w={70} />
+      </Dashed>
+    </Outline>
+  ),
+  Kbd: (
+    <Col gap={8} style={{ alignItems: 'flex-start' }}>
+      <Row gap={4} style={{ alignItems: 'center' }}>
+        <Solid w={16} h={12} style={{ borderRadius: 3 }} />
+        <Box
+          w={7}
+          h={7}
+          style={{
+            clipPath:
+              'polygon(40% 0,60% 0,60% 40%,100% 40%,100% 60%,60% 60%,60% 100%,40% 100%,40% 60%,0 60%,0 40%,40% 40%)',
+          }}
+        />
+        <Outline w={16} h={12} />
+      </Row>
+      <Row gap={4} style={{ alignItems: 'center' }}>
+        <Outline w={24} h={17} />
+        <Box
+          w={8}
+          h={8}
+          style={{
+            clipPath:
+              'polygon(40% 0,60% 0,60% 40%,100% 40%,100% 60%,60% 60%,60% 100%,40% 100%,40% 60%,0 60%,0 40%,40% 40%)',
+          }}
+        />
+        <Outline w={24} h={17} />
+        <Box
+          w={8}
+          h={8}
+          style={{
+            clipPath:
+              'polygon(40% 0,60% 0,60% 40%,100% 40%,100% 60%,60% 60%,60% 100%,40% 100%,40% 60%,0 60%,0 40%,40% 40%)',
+          }}
+        />
+        <Outline w={30} h={17} />
+      </Row>
+    </Col>
+  ),
+  Pagination: (
+    <Row gap={6} style={{ alignItems: 'center' }}>
+      <Box w={8} h={10} style={{ clipPath: 'polygon(100% 0,100% 100%,0 50%)' }} />
+      <Outline w={20} h={20} />
+      <Solid w={20} h={20} />
+      <Outline w={20} h={20} />
+      <Dot size={3} />
+      <Dot size={3} />
+      <Dot size={3} />
+      <Outline w={20} h={20} />
+      <Box w={8} h={10} style={{ clipPath: 'polygon(0 0,0 100%,100% 50%)' }} />
+    </Row>
+  ),
+  Palette: (
+    <Col gap={4}>
+      <Row gap={4}>
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+      </Row>
+      <Row gap={4}>
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Solid w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+      </Row>
+      <Row gap={4}>
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+        <Box w={16} h={16} />
+      </Row>
+    </Col>
+  ),
+  PersonDisplay: (
+    <Row gap={8} style={{ alignItems: 'center' }}>
+      <Dot solid size={30} />
+      <Col gap={5}>
+        <Bar w={64} />
+        <Bar w={44} />
+      </Col>
+    </Row>
+  ),
+  PasswordInput: (
+    <Outline
+      w={170}
+      h={32}
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: 8 }}
+    >
+      <Row gap={4}>
+        <Dot size={5} />
+        <Dot size={5} />
+        <Dot size={5} />
+        <Dot size={5} />
+        <Dot size={5} />
+      </Row>
+      <Outline
+        w={24}
+        h={16}
+        style={{
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Dot solid size={8} />
+      </Outline>
+    </Outline>
+  ),
+  PasswordStrengthMeter: (
+    <Col gap={6} style={{ alignItems: 'flex-start' }}>
+      <Row gap={4}>
+        <Solid w={36} h={6} style={{ borderRadius: 999 }} />
+        <Box w={36} h={6} style={{ borderRadius: 999 }} />
+        <Box w={36} h={6} style={{ borderRadius: 999 }} />
+        <Outline w={36} h={6} style={{ borderRadius: 999 }} />
+      </Row>
+      <Bar w={44} />
+    </Col>
+  ),
+  PhoneInput: (
+    <Outline w={190} h={32} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: 8 }}>
+      <Solid w={20} h={13} style={{ borderRadius: 2 }} />
+      <Box w={8} h={5} style={{ clipPath: 'polygon(0 0,100% 0,50% 100%)' }} />
+      <Box w={2} h={16} />
+      <Bar w={78} />
+    </Outline>
+  ),
+  Progress: (
+    <Col gap={8} style={{ alignItems: 'flex-start' }}>
+      <Outline w={180} h={10} style={{ borderRadius: 999, overflow: 'hidden', display: 'flex' }}>
+        <Solid w="55%" h="100%" />
+      </Outline>
+      <Outline w={180} h={10} style={{ borderRadius: 999, overflow: 'hidden', display: 'flex' }}>
+        <Box w="80%" h="100%" />
+      </Outline>
+    </Col>
+  ),
+  Radio: (
+    <Col gap={8}>
+      <Row gap={6} style={{ alignItems: 'center' }}>
+        <Outline
+          w={14}
+          h={14}
+          style={{
+            borderRadius: '50%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Dot solid size={6} />
+        </Outline>
+        <Bar w={54} />
+      </Row>
+      <Row gap={6} style={{ alignItems: 'center' }}>
+        <Outline w={14} h={14} style={{ borderRadius: '50%' }} />
+        <Bar w={40} />
+      </Row>
+    </Col>
+  ),
+  Select: (
+    <Col gap={4} style={{ alignItems: 'flex-start' }}>
+      <Outline
+        w={160}
+        h={26}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: 7,
+        }}
+      >
+        <Bar w={56} />
+        <Box w={8} h={5} style={{ clipPath: 'polygon(0 0,100% 0,50% 100%)' }} />
+      </Outline>
+      <Panel w={160} style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: 7 }}>
+        <SolidBar w={92} />
+        <Bar w={70} />
+        <Bar w={82} />
+      </Panel>
+    </Col>
+  ),
+  Switch: (
+    <Row gap={10} style={{ alignItems: 'center' }}>
+      <Solid
+        w={38}
+        h={20}
+        style={{
+          borderRadius: 999,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          padding: 3,
+        }}
+      >
+        <Outline w={14} h={14} style={{ borderRadius: '50%' }} />
+      </Solid>
+      <Outline
+        w={38}
+        h={20}
+        style={{ borderRadius: 999, display: 'flex', alignItems: 'center', padding: 3 }}
+      >
+        <Box w={14} h={14} style={{ borderRadius: '50%' }} />
+      </Outline>
+    </Row>
+  ),
+  Skeleton: (
+    <Row gap={8} style={{ alignItems: 'flex-start' }}>
+      <Dot size={26} />
+      <Col gap={6}>
+        <SolidBar w={100} />
+        <Bar w={72} />
+        <Box w={120} h={34} />
+      </Col>
+    </Row>
+  ),
+  Slider: (
+    <Col gap={4} style={{ position: 'relative', alignItems: 'flex-start' }}>
+      <Panel
+        w={22}
+        h={13}
+        style={{ marginLeft: 65, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Bar w={10} />
+      </Panel>
+      <Outline w={180} h={6} style={{ borderRadius: 999, overflow: 'hidden', display: 'flex' }}>
+        <Box w="42%" h="100%" />
+      </Outline>
+      <Dot solid size={14} style={{ position: 'absolute', left: 69, top: 13 }} />
+      <Row gap={4} style={{ width: '100%', justifyContent: 'space-between' }}>
+        <Dot size={4} />
+        <Dot size={4} />
+        <Dot size={4} />
+        <Dot size={4} />
+        <Dot size={4} />
+      </Row>
+    </Col>
+  ),
+  Kanban: (
+    <Row gap={6} style={{ alignItems: 'flex-start' }}>
+      <Dashed
+        w={64}
+        h={92}
+        style={{ display: 'flex', flexDirection: 'column', gap: 5, padding: 6 }}
+      >
+        <Bar w={30} />
+        <Outline w="100%" h={18} />
+        <Outline w="100%" h={18} />
+        <Outline w="100%" h={18} />
+      </Dashed>
+      <Dashed
+        w={64}
+        h={92}
+        style={{ display: 'flex', flexDirection: 'column', gap: 5, padding: 6 }}
+      >
+        <Bar w={24} />
+        <Solid w="100%" h={18} style={{ transform: 'rotate(-5deg)' }} />
+        <Outline w="100%" h={18} />
+      </Dashed>
+      <Dashed
+        w={64}
+        h={92}
+        style={{ display: 'flex', flexDirection: 'column', gap: 5, padding: 6 }}
+      >
+        <Bar w={26} />
+        <Outline w="100%" h={18} />
+      </Dashed>
+    </Row>
+  ),
+  FlowCanvas: (
+    <Dashed w={210} h={100} style={{ display: 'block', position: 'relative' }}>
+      <Solid w={52} h={22} style={{ position: 'absolute', left: 14, top: 12 }} />
+      <Box
+        w={88}
+        h={2}
+        style={{
+          position: 'absolute',
+          left: 66,
+          top: 33,
+          transform: 'rotate(30deg)',
+          transformOrigin: '0 0',
+        }}
+      />
+      <Outline w={52} h={22} style={{ position: 'absolute', left: 140, top: 64 }} />
+      <Col style={{ position: 'absolute', left: 10, bottom: 10, gap: 3 }}>
+        <Outline w={12} h={12} />
+        <Outline w={12} h={12} />
+      </Col>
+    </Dashed>
+  ),
+  Sortable: (
+    <Col gap={6}>
+      <Outline
+        w={190}
+        h={22}
+        style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '0 8px' }}
+      >
+        <Col style={{ gap: 2 }}>
+          <Box w={9} h={2} />
+          <Box w={9} h={2} />
+        </Col>
+        <Bar w={92} />
+      </Outline>
+      <Panel
+        w={190}
+        h={22}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 7,
+          padding: '0 8px',
+          transform: 'translateX(14px) rotate(-2deg)',
+        }}
+      >
+        <Solid
+          w={9}
+          h={8}
+          style={{
+            clipPath: 'polygon(0 0, 100% 0, 100% 30%, 0 30%, 0 70%, 100% 70%, 100% 100%, 0 100%)',
+          }}
+        />
+        <Bar w={92} />
+      </Panel>
+      <Dashed w={190} h={22} />
+    </Col>
+  ),
+  SortableGroup: (
+    <Row gap={10} style={{ position: 'relative' }}>
+      <Dashed
+        w={96}
+        h={90}
+        style={{ display: 'flex', flexDirection: 'column', gap: 5, padding: 6 }}
+      >
+        <Outline w="100%" h={18} />
+        <Outline w="100%" h={18} />
+      </Dashed>
+      <Dashed
+        w={96}
+        h={90}
+        style={{ display: 'flex', flexDirection: 'column', gap: 5, padding: 6 }}
+      >
+        <Outline w="100%" h={18} />
+      </Dashed>
+      <Solid
+        w={64}
+        h={18}
+        style={{ position: 'absolute', left: 70, top: 38, transform: 'rotate(-4deg)' }}
+      />
+    </Row>
+  ),
+  DataTable: (
+    <Outline
+      w={214}
+      h={88}
+      style={{ display: 'flex', flexDirection: 'column', gap: 7, padding: 8 }}
+    >
+      <Row gap={6}>
+        <Box w={10} h={10} />
+        <Bar w={38} />
+        <Solid w={9} h={6} style={{ clipPath: 'polygon(50% 0, 100% 100%, 0 100%)' }} />
+        <Bar w={30} style={{ marginLeft: 14 }} />
+        <Bar w={34} style={{ marginLeft: 'auto' }} />
+      </Row>
+      <Box w="100%" h={2} />
+      <Row gap={6}>
+        <Box w={10} h={10} />
+        <Bar w={48} />
+        <Bar w={30} style={{ marginLeft: 'auto' }} />
+      </Row>
+      <Row gap={6}>
+        <Box w={10} h={10} />
+        <Bar w={40} />
+        <Bar w={24} style={{ marginLeft: 'auto' }} />
+      </Row>
+      <Row gap={6}>
+        <Box w={10} h={10} />
+        <Bar w={52} />
+        <Bar w={28} style={{ marginLeft: 'auto' }} />
+      </Row>
+    </Outline>
+  ),
+  DefinitionList: (
+    <Col gap={10}>
+      <Row gap={10}>
+        <Bar w={36} />
+        <Bar w={92} />
+      </Row>
+      <Row gap={10}>
+        <Bar w={36} />
+        <Row gap={4}>
+          <Dot solid size={9} />
+          <Bar w={76} />
+        </Row>
+      </Row>
+      <Row gap={10}>
+        <Bar w={36} />
+        <Bar w={64} />
+      </Row>
+    </Col>
+  ),
+  Table: (
+    <Outline
+      w={210}
+      h={82}
+      style={{ display: 'flex', flexDirection: 'column', gap: 5, padding: 6 }}
+    >
+      <Solid w="100%" h={12} />
+      <Row style={{ padding: '0 6px', height: 12 }}>
+        <Bar w={54} />
+        <Bar w={26} style={{ marginLeft: 'auto' }} />
+      </Row>
+      <Box w="100%" h={16} style={{ display: 'flex', alignItems: 'center', padding: '0 6px' }}>
+        <Bar w={44} />
+        <Bar w={30} style={{ marginLeft: 'auto' }} />
+      </Box>
+      <Row style={{ padding: '0 6px', height: 12 }}>
+        <Bar w={60} />
+        <Bar w={22} style={{ marginLeft: 'auto' }} />
+      </Row>
+    </Outline>
+  ),
+  Card: (
+    <Outline
+      w={150}
+      h={58}
+      style={{ display: 'flex', flexDirection: 'column', gap: 7, padding: 12 }}
+    >
+      <SolidBar w={64} />
+      <Bar w="100%" />
+      <Bar w="78%" />
+    </Outline>
+  ),
+  Checkbox: (
+    <Col gap={8}>
+      <Row gap={8}>
+        <Solid w={13} h={13} />
+        <Bar w={58} />
+      </Row>
+      <Row gap={8}>
+        <Outline
+          w={13}
+          h={13}
+          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        >
+          <Box w={7} h={3} />
+        </Outline>
+        <Bar w={70} />
+      </Row>
+      <Row gap={8}>
+        <Outline w={13} h={13} />
+        <Bar w={48} />
+      </Row>
+    </Col>
+  ),
+  Field: (
+    <Col style={{ gap: 5 }}>
+      <Row gap={4}>
+        <SolidBar w={38} />
+        <Dot size={5} />
+      </Row>
+      <Outline w={170} h={26} style={{ display: 'flex', alignItems: 'center', padding: '0 8px' }}>
+        <Bar w={70} />
+      </Outline>
+      <Bar w={100} />
+    </Col>
+  ),
+  FormRow: (
+    <Dashed w={202} h={50} style={{ display: 'flex', gap: 10, padding: 8 }}>
+      <Col style={{ gap: 4 }}>
+        <SolidBar w={30} />
+        <Outline w={86} h={22} />
+      </Col>
+      <Col style={{ gap: 4 }}>
+        <Bar w={30} />
+        <Outline w={86} h={22} />
+      </Col>
+    </Dashed>
+  ),
+  FormSection: (
+    <Col style={{ gap: 5 }}>
+      <SolidBar w={72} />
+      <Bar w={118} />
+      <Col style={{ gap: 3, marginTop: 5 }}>
+        <Bar w={30} />
+        <Outline w={180} h={20} />
+      </Col>
+      <Col style={{ gap: 3 }}>
+        <Bar w={42} />
+        <Outline w={180} h={20} />
+      </Col>
+    </Col>
+  ),
+  ColorPicker: (
+    <Panel w={122} h={88} style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: 8 }}>
+      <Solid w="100%" h={34} style={{ display: 'block', position: 'relative' }}>
+        <Outline
+          w={10}
+          h={10}
+          style={{ position: 'absolute', top: 6, right: 12, borderRadius: '50%' }}
+        />
+      </Solid>
+      <Box w="100%" h={7} style={{ borderRadius: 999 }} />
+      <Row gap={4}>
+        <Outline w={46} h={14} />
+        <Box w={12} h={12} />
+        <Box w={12} h={12} />
+        <Box w={12} h={12} />
+      </Row>
+    </Panel>
+  ),
+  Stack: (
+    <Col gap={8}>
+      <Solid w={110} h={16} />
+      <Box w={110} h={16} />
+      <Box w={110} h={16} />
+    </Col>
+  ),
+  Cluster: (
+    <Row gap={6} style={{ flexWrap: 'wrap', width: 150 }}>
+      <Solid w={58} h={16} />
+      <Box w={24} h={16} />
+      <Box w={44} h={16} />
+      <Box w={70} h={16} />
+      <Box w={30} h={16} />
+      <Box w={92} h={16} />
+    </Row>
+  ),
+  AppLayout: (
+    <Outline
+      w={210}
+      h={92}
+      style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+    >
+      <Solid w="100%" h={13} style={{ borderRadius: 0 }} />
+      <Row gap={5} style={{ padding: 5, alignItems: 'flex-start' }}>
+        <Box w={38} h={66} />
+        <Dashed
+          w={152}
+          h={66}
+          style={{ display: 'flex', flexDirection: 'column', gap: 7, padding: 8 }}
+        >
+          <Bar w={72} />
+          <Bar w={110} />
+          <Bar w={90} />
+        </Dashed>
+      </Row>
+    </Outline>
+  ),
+  Constrain: (
+    <Dashed w={200} style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: 8 }}>
+      <Solid w={100} h={10} />
+      <Bar w={100} />
+      <Bar w={72} />
+    </Dashed>
+  ),
+  Indent: (
+    <Col gap={6}>
+      <Bar w={90} />
+      <Bar w={80} style={{ marginLeft: 20 }} />
+      <SolidBar w={70} style={{ marginLeft: 40 }} />
+    </Col>
+  ),
+  Code: (
+    <Row gap={6}>
+      <Bar w={34} />
+      <Box h={16} style={{ display: 'flex', alignItems: 'center', padding: '0 6px' }}>
+        <SolidBar w={26} />
+      </Box>
+      <Bar w={30} />
+    </Row>
+  ),
+  Divider: (
+    <Col gap={8} style={{ width: 170, alignItems: 'center' }}>
+      <Bar w={150} />
+      <Bar w={126} />
+      <Row
+        style={{
+          position: 'relative',
+          width: '100%',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <Solid w="100%" h={2} style={{ borderRadius: 0 }} />
+        <Pill w={34} style={{ position: 'absolute', height: 10 }} />
+      </Row>
+      <Bar w={150} />
+      <Bar w={110} />
+    </Col>
+  ),
+  Grid: (
+    <Col gap={6}>
+      <Row gap={6}>
+        <Solid w={46} h={26} />
+        <Box w={46} h={26} />
+        <Box w={46} h={26} />
+      </Row>
+      <Row gap={6}>
+        <Box w={46} h={26} />
+        <Box w={46} h={26} />
+        <Box w={46} h={26} />
+      </Row>
+    </Col>
+  ),
+  Split: (
+    <Row gap={8} style={{ alignItems: 'flex-start' }}>
+      <Col gap={4}>
+        <Solid w={36} h={12} />
+        <Box w={36} h={12} />
+        <Box w={36} h={12} />
+      </Col>
+      <Dashed
+        w={144}
+        h={60}
+        style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: 8 }}
+      >
+        <Bar w={100} />
+        <Bar w={118} />
+        <Bar w={84} />
+      </Dashed>
+    </Row>
+  ),
+  Sticky: (
+    <Outline
+      w={200}
+      h={84}
+      style={{ display: 'flex', gap: 8, padding: 8, alignItems: 'flex-start', overflow: 'hidden' }}
+    >
+      <Col gap={4}>
+        <Box w={116} h={10} />
+        <Box w={116} h={10} />
+        <Box w={116} h={10} />
+        <Box w={116} h={10} />
+        <Box w={116} h={10} />
+        <Box w={116} h={10} />
+        <Box w={116} h={10} />
+      </Col>
+      <Solid w={58} h={30} />
+    </Outline>
+  ),
+  Masonry: (
+    <Row gap={6} style={{ alignItems: 'flex-start' }}>
+      <Col gap={6}>
+        <Solid w={46} h={34} />
+        <Box w={46} h={20} />
+      </Col>
+      <Col gap={6}>
+        <Box w={46} h={18} />
+        <Box w={46} h={36} />
+      </Col>
+      <Col gap={6}>
+        <Box w={46} h={26} />
+        <Box w={46} h={24} />
+      </Col>
+    </Row>
+  ),
+  Avatar: (
+    <Row gap={8}>
+      <Dot solid size={34} />
+      <Outline
+        w={34}
+        h={34}
+        style={{
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Bar w={14} />
+      </Outline>
+      <Box w={34} h={34} style={{ borderRadius: '50%' }} />
+    </Row>
+  ),
+  Badge: (
+    <Row gap={6}>
+      <Solid w={36} h={16} style={{ borderRadius: 999 }} />
+      <Pill w={44} />
+      <Pill w={32} />
+    </Row>
+  ),
+  Dot: (
+    <Row gap={10}>
+      <Row gap={4}>
+        <Dot solid size={10} />
+        <Bar w={24} />
+      </Row>
+      <Row gap={4}>
+        <Dot size={10} />
+        <Bar w={24} />
+      </Row>
+      <Row gap={4}>
+        <Dot size={10} />
+        <Bar w={24} />
+      </Row>
+    </Row>
+  ),
+  Timeline: (
+    <Row gap={8} style={{ alignItems: 'flex-start' }}>
+      <Col gap={4} style={{ alignItems: 'center' }}>
+        <Dot solid size={10} />
+        <Box w={2} h={14} />
+        <Dot size={10} />
+        <Box w={2} h={14} />
+        <Dot size={10} />
+      </Col>
+      <Col style={{ gap: 23, paddingTop: 2 }}>
+        <Bar w={70} />
+        <Bar w={56} />
+        <Bar w={64} />
+      </Col>
+    </Row>
+  ),
+  Thread: (
+    <Col gap={6}>
+      <Row gap={6}>
+        <Dot solid size={12} />
+        <Bar w={76} />
+      </Row>
+      <Row gap={8} style={{ alignItems: 'flex-start' }}>
+        <Box w={2} h={30} style={{ marginLeft: 5 }} />
+        <Col gap={10}>
+          <Row gap={6}>
+            <Dot size={10} />
+            <Bar w={54} />
+          </Row>
+          <Row gap={6}>
+            <Dot size={10} />
+            <Bar w={44} />
+          </Row>
+        </Col>
+      </Row>
+    </Col>
+  ),
+  RichText: (
+    <Col gap={6}>
+      <Solid w={80} h={9} />
+      <Row gap={4}>
+        <Bar w={40} />
+        <Box w={26} h={7} />
+        <Bar w={30} />
+      </Row>
+      <Row gap={6}>
+        <Dot size={5} />
+        <Bar w={92} />
+      </Row>
+      <Row gap={6}>
+        <Dot size={5} />
+        <Bar w={76} />
+      </Row>
+    </Col>
+  ),
+  RichTextEditor: (
+    <Outline w={200} style={{ display: 'flex', flexDirection: 'column', gap: 7, padding: 8 }}>
+      <Row gap={4}>
+        <Box w={14} h={10} />
+        <Box w={14} h={10} />
+        <Box w={14} h={10} />
+        <Box w={2} h={10} />
+        <Box w={16} h={10} />
+      </Row>
+      <Bar w={150} />
+      <Row gap={4}>
+        <Bar w={104} />
+        <Solid w={2} h={12} />
+      </Row>
+    </Outline>
+  ),
+  BrandIcon: (
+    <Row gap={10}>
+      <Dot size={22} />
+      <Dot solid size={22} />
+      <Outline w={22} h={22} style={{ borderRadius: '50%' }} />
+    </Row>
+  ),
+  Logo: (
+    <Row gap={8} style={{ alignItems: 'center' }}>
+      <Solid w={30} h={30} style={{ borderRadius: '50%' }} />
+      <Box w={72} h={14} style={{ borderRadius: 7 }} />
+    </Row>
+  ),
+  Breadcrumb: (
+    <Row gap={8} style={{ alignItems: 'center' }}>
+      <Bar w={34} />
+      <Box w={6} h={9} style={{ clipPath: 'polygon(0 0,100% 50%,0 100%)' }} />
+      <Bar w={34} />
+      <Box w={6} h={9} style={{ clipPath: 'polygon(0 0,100% 50%,0 100%)' }} />
+      <SolidBar w={42} />
+    </Row>
+  ),
+  Link: (
+    <Row gap={6} style={{ alignItems: 'center' }}>
+      <Bar w={32} />
+      <Col gap={4} style={{ alignItems: 'center' }}>
+        <SolidBar w={54} />
+        <Box w={54} h={2} />
+      </Col>
+      <Bar w={28} />
+    </Row>
+  ),
+  LinkCard: (
+    <Outline
+      w={180}
+      h={64}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '0 12px',
+      }}
+    >
+      <Col gap={6}>
+        <SolidBar w={72} />
+        <Bar w={48} />
+      </Col>
+      <Box
+        w={9}
+        h={12}
+        style={{
+          clipPath: 'polygon(25% 0,100% 50%,25% 100%,0 80%,50% 50%,0 20%)',
+          borderRadius: 0,
+        }}
+      />
+    </Outline>
+  ),
+  Rail: (
+    <Row gap={6} style={{ alignItems: 'flex-start' }}>
+      <Outline
+        w={24}
+        h={100}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 8,
+          padding: '8px 0',
+        }}
+      >
+        <Dot size={7} />
+        <Dot size={7} />
+        <Dot size={7} />
+      </Outline>
+      <Outline
+        w={90}
+        h={100}
+        style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: 8 }}
+      >
+        <Bar w={28} />
+        <Row gap={6} style={{ alignItems: 'center' }}>
+          <Dot size={7} />
+          <Bar w={36} />
+        </Row>
+        <Solid w={72} h={14} style={{ borderRadius: 4 }} />
+        <Row gap={6} style={{ alignItems: 'center' }}>
+          <Dot size={7} />
+          <Bar w={32} />
+        </Row>
+      </Outline>
+    </Row>
+  ),
+  TopBar: (
+    <Col gap={6}>
+      <Outline
+        w={214}
+        h={34}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 8px',
+        }}
+      >
+        <Outline
+          w={104}
+          h={20}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '0 6px',
+          }}
+        >
+          <Bar w={42} />
+          <Box w={16} h={12} style={{ borderRadius: 3 }} />
+        </Outline>
+        <Box w={20} h={20} style={{ position: 'relative', borderRadius: 6 }}>
+          <Dot solid size={8} style={{ position: 'absolute', top: -2, right: -2 }} />
+        </Box>
+      </Outline>
+      <Dashed w={214} h={50} />
+    </Col>
+  ),
+  Tabs: (
+    <Col style={{ position: 'relative', gap: 8, alignItems: 'flex-start' }}>
+      <Row gap={10} style={{ alignItems: 'center' }}>
+        <Bar w={38} />
+        <Row gap={4} style={{ alignItems: 'center' }}>
+          <Bar w={34} />
+          <Pill w={16} />
+        </Row>
+        <Bar w={28} />
+      </Row>
+      <Box w={180} h={2} />
+      <Solid w={38} h={4} style={{ position: 'absolute', bottom: -1, left: 0, borderRadius: 2 }} />
+    </Col>
+  ),
+  Text: (
+    <Col gap={6} style={{ alignItems: 'flex-start' }}>
+      <Bar w={150} />
+      <Bar w={142} />
+      <Row gap={4} style={{ alignItems: 'center' }}>
+        <SolidBar w={76} />
+        <Dot size={3} />
+        <Dot size={3} />
+        <Dot size={3} />
+      </Row>
+    </Col>
+  ),
+  Title: (
+    <Col gap={8} style={{ alignItems: 'flex-start' }}>
+      <Solid w={112} h={12} style={{ borderRadius: 3 }} />
+      <Box w={84} h={8} style={{ borderRadius: 2 }} />
+      <Bar w={132} />
+    </Col>
+  ),
+  DropdownMenu: (
+    <Col gap={4} style={{ alignItems: 'flex-start' }}>
+      <Outline
+        w={30}
+        h={22}
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Box w={8} h={5} style={{ clipPath: 'polygon(0 0,100% 0,50% 100%)', borderRadius: 0 }} />
+      </Outline>
+      <Panel
+        w={104}
+        h={58}
+        style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: 7 }}
+      >
+        <Solid w={90} h={11} style={{ borderRadius: 3 }} />
+        <Bar w={70} />
+        <Box w="100%" h={1} style={{ borderRadius: 0 }} />
+        <Bar w={58} />
+      </Panel>
+    </Col>
+  ),
+  Textarea: (
+    <Outline
+      w={176}
+      h={78}
+      style={{ display: 'flex', flexDirection: 'column', gap: 7, padding: 9 }}
+    >
+      <Bar w={132} />
+      <Bar w={144} />
+      <SolidBar w={70} />
+      <Bar w={22} style={{ marginTop: 'auto', alignSelf: 'flex-end' }} />
+    </Outline>
+  ),
+  TimeField: (
+    <Row gap={8} style={{ alignItems: 'flex-start' }}>
+      <Outline
+        w={82}
+        h={26}
+        style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '0 7px' }}
+      >
+        <Outline w={12} h={12} style={{ borderRadius: '50%' }} />
+        <Bar w={36} />
+      </Outline>
+      <Panel w={90} h={62} style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: 7 }}>
+        <Row gap={8}>
+          <Col gap={4}>
+            <Bar w={30} />
+            <Solid w={30} h={10} style={{ borderRadius: 3 }} />
+            <Bar w={30} />
+          </Col>
+          <Col gap={4}>
+            <Bar w={30} />
+            <Bar w={30} />
+            <Bar w={30} />
+          </Col>
+        </Row>
+        <Box w={74} h={1} />
+        <Bar w={26} />
+      </Panel>
+    </Row>
+  ),
+  Toast: (
+    <Dashed w={200} h={92} style={{ position: 'relative' }}>
+      <Panel
+        w={150}
+        h={40}
+        style={{
+          position: 'absolute',
+          right: 8,
+          bottom: 8,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '0 10px',
+        }}
+      >
+        <Dot solid size={10} />
+        <Col gap={4}>
+          <Bar w={70} />
+          <Bar w={48} />
+        </Col>
+      </Panel>
+    </Dashed>
+  ),
+  Tooltip: (
+    <Col gap={4} style={{ alignItems: 'center' }}>
+      <Solid
+        w={92}
+        h={32}
+        style={{ clipPath: 'polygon(0 0,100% 0,100% 72%,58% 72%,50% 100%,42% 72%,0 72%)' }}
+      />
+      <Outline
+        w={64}
+        h={22}
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Bar w={30} />
+      </Outline>
+    </Col>
+  ),
+  Modal: (
+    <Box
+      w={210}
+      h={100}
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+    >
+      <Panel
+        w={140}
+        h={78}
+        style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: 8 }}
+      >
+        <Bar w={54} />
+        <Bar w={104} />
+        <Bar w={84} />
+        <Row gap={4} style={{ marginTop: 'auto', justifyContent: 'flex-end', width: '100%' }}>
+          <Outline w={28} h={12} />
+          <Solid w={28} h={12} />
+        </Row>
+      </Panel>
+    </Box>
+  ),
+  Lightbox: (
+    <Col gap={6} style={{ alignItems: 'center' }}>
+      <Row gap={6} style={{ alignItems: 'center' }}>
+        <Box w={10} h={14} style={{ clipPath: 'polygon(100% 0,100% 100%,0 50%)' }} />
+        <Box w={118} h={56} />
+        <Box w={10} h={14} style={{ clipPath: 'polygon(0 0,100% 50%,0 100%)' }} />
+      </Row>
+      <Bar w={44} />
+      <Row gap={4}>
+        <Box w={20} h={14} />
+        <Solid w={20} h={14} />
+        <Box w={20} h={14} />
+        <Box w={20} h={14} />
+      </Row>
+    </Col>
+  ),
+  FilterChip: (
+    <Outline
+      w={148}
+      h={30}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '0 10px',
+        borderRadius: 999,
+      }}
+    >
+      <Bar w={28} />
+      <Dot size={7} />
+      <Bar w={40} />
+      <Solid
+        w={10}
+        h={10}
+        style={{
+          marginLeft: 'auto',
+          clipPath:
+            'polygon(20% 0,50% 30%,80% 0,100% 20%,70% 50%,100% 80%,80% 100%,50% 70%,20% 100%,0 80%,30% 50%,0 20%)',
+        }}
+      />
+    </Outline>
+  ),
+  OptionsPicker: (
+    <Row gap={8} style={{ alignItems: 'flex-start' }}>
+      <Outline
+        w={52}
+        h={16}
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Bar w={28} />
+      </Outline>
+      <Panel
+        w={118}
+        h={100}
+        style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: 6 }}
+      >
+        <Outline
+          w="100%"
+          h={14}
+          style={{ display: 'flex', alignItems: 'center', padding: '0 4px' }}
+        >
+          <Bar w={38} />
+        </Outline>
+        <Row gap={4} style={{ alignItems: 'center' }}>
+          <Box w={8} h={8} />
+          <Bar w={48} />
+        </Row>
+        <Row gap={4} style={{ alignItems: 'center' }}>
+          <Box w={8} h={8} />
+          <Bar w={36} />
+        </Row>
+        <Row gap={4} style={{ alignItems: 'center' }}>
+          <Outline w={8} h={8} />
+          <Bar w={44} />
+        </Row>
+        <Row gap={4} style={{ marginTop: 'auto', justifyContent: 'flex-end', width: '100%' }}>
+          <Outline w={26} h={12} />
+          <Solid w={26} h={12} />
+        </Row>
+      </Panel>
+    </Row>
+  ),
+  EmojiPicker: (
+    <Panel w={128} h={92} style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: 8 }}>
+      <Outline w="100%" h={14} style={{ display: 'flex', alignItems: 'center', padding: '0 4px' }}>
+        <Bar w={36} />
+      </Outline>
+      <Row gap={6}>
+        <Bar w={14} />
+        <Bar w={14} />
+        <Bar w={14} />
+        <Bar w={14} />
+      </Row>
+      <Row gap={6}>
+        <Dot size={10} />
+        <Dot size={10} />
+        <Dot size={10} />
+        <Dot size={10} />
+        <Dot size={10} />
+        <Dot size={10} />
+      </Row>
+      <Row gap={6}>
+        <Dot size={10} />
+        <Dot solid size={10} />
+        <Dot size={10} />
+        <Dot size={10} />
+        <Dot size={10} />
+        <Dot size={10} />
+      </Row>
+      <Row gap={6}>
+        <Dot size={10} />
+        <Dot size={10} />
+        <Dot size={10} />
+        <Dot size={10} />
+        <Dot size={10} />
+        <Dot size={10} />
+      </Row>
+    </Panel>
+  ),
+  Page: (
+    <Dashed
+      w={150}
+      h={100}
+      style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: 8 }}
+    >
+      <Solid w="100%" h={16} />
+      <Box w="100%" h={34} />
+      <Box w="100%" h={18} />
+    </Dashed>
+  ),
+  PageHeader: (
+    <Col gap={8}>
+      <Row gap={6} style={{ alignItems: 'center' }}>
+        <Box w={8} h={10} style={{ clipPath: 'polygon(100% 0,100% 100%,0 50%)' }} />
+        <Bar w={22} />
+        <Dot size={4} />
+        <Bar w={22} />
+        <Dot size={4} />
+        <Bar w={28} />
+      </Row>
+      <Row gap={10} style={{ alignItems: 'center' }}>
+        <Dot size={26} />
+        <Col gap={4}>
+          <Solid w={64} h={8} />
+          <Bar w={48} />
+          <Row gap={4}>
+            <Pill w={24} />
+            <Pill w={32} />
+          </Row>
+        </Col>
+        <Row gap={4} style={{ alignSelf: 'flex-start' }}>
+          <Outline w={28} h={14} />
+          <Outline w={28} h={14} />
+        </Row>
+      </Row>
+    </Col>
+  ),
+  Drawer: (
+    <Outline
+      w={200}
+      h={100}
+      style={{ display: 'flex', justifyContent: 'flex-end', overflow: 'hidden' }}
+    >
+      <Col gap={6} style={{ padding: 8, marginRight: 'auto' }}>
+        <Bar w={54} />
+        <Bar w={70} />
+        <Bar w={40} />
+      </Col>
+      <Panel w={84} h="100%" style={{ display: 'flex', gap: 6, padding: 6 }}>
+        <Solid w={4} h="100%" />
+        <Col gap={6}>
+          <Bar w={44} />
+          <Bar w={54} />
+          <Bar w={34} />
+        </Col>
+      </Panel>
+    </Outline>
+  ),
+  Popover: (
+    <Col gap={6} style={{ alignItems: 'flex-start' }}>
+      <Solid w={44} h={16} />
+      <Panel
+        w={112}
+        h={56}
+        style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: 8 }}
+      >
+        <Bar w={50} />
+        <Bar w={80} />
+        <Bar w={60} />
+      </Panel>
+    </Col>
+  ),
+  Calendar: (
+    <Col gap={4} style={{ position: 'relative' }}>
+      <Row gap={4}>
+        <Bar w={22} />
+        <Bar w={22} />
+        <Bar w={22} />
+        <Bar w={22} />
+        <Bar w={22} />
+        <Bar w={22} />
+        <Bar w={22} />
+      </Row>
+      <Row gap={4}>
+        <Outline w={22} h={24} />
+        <Outline w={22} h={24} />
+        <Outline w={22} h={24} />
+        <Outline w={22} h={24} />
+        <Outline w={22} h={24} />
+        <Outline w={22} h={24} />
+        <Outline w={22} h={24} />
+      </Row>
+      <Row gap={4}>
+        <Outline w={22} h={24} style={{ display: 'flex', alignItems: 'flex-start', padding: 3 }}>
+          <Box w={16} h={6} />
+        </Outline>
+        <Outline w={22} h={24} />
+        <Outline
+          w={22}
+          h={24}
+          style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'center', padding: 3 }}
+        >
+          <Box w={14} h={6} style={{ borderRadius: 3 }} />
+        </Outline>
+        <Outline w={22} h={24} />
+        <Outline w={22} h={24} />
+        <Outline w={22} h={24} />
+        <Outline w={22} h={24} />
+      </Row>
+      <Solid w={74} h={6} style={{ position: 'absolute', top: 14, left: 26 }} />
+    </Col>
+  ),
+  CircularProgress: (
+    <Box w={44} h={44} style={{ position: 'relative', borderRadius: '50%' }}>
+      <Solid
+        w={44}
+        h={44}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          borderRadius: '50%',
+          clipPath: 'polygon(50% 50%,50% 0,100% 0,100% 100%,0 100%,0 50%)',
+        }}
+      />
+      <Outline
+        w={30}
+        h={30}
+        style={{
+          position: 'absolute',
+          top: 7,
+          left: 7,
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Bar w={12} />
+      </Outline>
+    </Box>
+  ),
+  ConfirmationPopover: (
+    <Col gap={6} style={{ alignItems: 'flex-start' }}>
+      <Outline w={40} h={14} />
+      <Panel
+        w={124}
+        h={60}
+        style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: 8 }}
+      >
+        <Bar w={52} />
+        <Bar w={92} />
+        <Row gap={4} style={{ marginTop: 'auto', justifyContent: 'flex-end', width: '100%' }}>
+          <Outline w={28} h={12} />
+          <Solid w={28} h={12} />
+        </Row>
+      </Panel>
+    </Col>
+  ),
+};


### PR DESCRIPTION
## Summary

Per the approved spec (`docs/superpowers/specs/2026-07-03-overview-schematics-design.md`): all 87 overview cards now render **blueprint-accent schematics** instead of live components.

- New `overviewSchematics.tsx`: shared vocabulary (Box/Solid/Outline/Panel/Dashed/Bar/SolidBar/Dot/Pill + Row/Col) + the `SCHEMATICS` record — tinted shapes, exactly one solid-accent focal element per card, tokens-only colors (both themes work untouched)
- `ComponentsIndex.tsx` drops ~80 design-system imports; the page is fully static — no portals, live state, or heavy mounts (RTE/DataTable/Calendar)
- Authored via a 6-batch parallel workflow, then reviewed strip-by-strip in light AND dark by screenshot-reading agents; 13 cards redrawn for identity collisions (BrandIcon↔SocialButton, Date pickers↔EmojiPicker, Divider↔Slider) and sibling distinctness
- Playground CLAUDE.md Rule 4.3 updated: overview previews are schematics now
- Dead `.skeleton/.bar/.tile` primitives removed from the index stylesheet

Playground-only — no version bump expected.

## Test plan

- Browser-verified: 87/87 schematics render, one uniform card height, zero console errors, dev-warn guard for missing schematic keys
- Visual review loop over cropped screenshot strips in both themes until clean
- `make test` (3663), `make build`, `make lint`, `npm run format:check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)