### PR TITLE
fix(RichTextEditor): de-flake BlockMenu submenu-collapse assertions

### DIFF
--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.test.tsx
@@ -1,5 +1,5 @@
 // RichTextBlockMenu.test.tsx
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { I18nProvider } from '../../i18n';
 import { RichTextBlockMenu } from './RichTextBlockMenu';
@@ -91,8 +91,10 @@ it('closes the color submenu after a pick but leaves the main menu open', async 
   setup({ onColor });
   await userEvent.click(screen.getByRole('menuitem', { name: 'Text color' }));
   await userEvent.click(await screen.findByRole('button', { name: 'Green' }));
-  // Submenu collapsed: its swatches are gone.
-  expect(screen.queryByRole('button', { name: 'Green' })).toBeNull();
+  // Submenu collapsed: its swatches are gone. waitFor: the collapse can land
+  // a tick after the click under load (observed flaking on CI) — poll instead
+  // of asserting synchronously.
+  await waitFor(() => expect(screen.queryByRole('button', { name: 'Green' })).toBeNull());
   // Main menu still open: its items + the color trigger remain, ready for another pick.
   expect(screen.getByRole('menuitem', { name: /delete/i })).toBeInTheDocument();
   expect(screen.getByRole('menuitem', { name: 'Text color' })).toBeInTheDocument();
@@ -103,7 +105,7 @@ it('reopens the color submenu after a pick (close-on-pick does not latch it shut
   setup({ onColor });
   await userEvent.click(screen.getByRole('menuitem', { name: 'Text color' }));
   await userEvent.click(await screen.findByRole('button', { name: 'Green' }));
-  expect(screen.queryByRole('button', { name: 'Green' })).toBeNull(); // collapsed
+  await waitFor(() => expect(screen.queryByRole('button', { name: 'Green' })).toBeNull()); // collapsed
   // Reopen the same submenu → the palette is back.
   await userEvent.click(screen.getByRole('menuitem', { name: 'Text color' }));
   expect(await screen.findByRole('button', { name: 'Green' })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Main went red on run 28655478818 (post-merge of the playground-only #270) with `RichTextBlockMenu.test.tsx:106` failing — the identical content was green on the PR head and locally, and the rerun passed: a flake. The two close-on-pick tests assert the submenu collapse synchronously after `userEvent.click`; under CI load the collapse can land a tick later. Converted both assertions to `waitFor` polling.

Test-only change (trivial-change escape hatch per CLAUDE.md Rule 8).

## Test plan

- `npx vitest run src/components/RichTextEditor/RichTextBlockMenu.test.tsx` — 12/12
- Quality gate on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)