### PR TITLE
fix(DropdownMenu): stale hover-intent timer re-opens a Sub after a pick closes it

### DIFF
--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1,8 +1,8 @@
-import { act, configure, render, screen } from '@testing-library/react';
+import { act, configure, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { createRef, type ReactNode } from 'react';
+import { createRef, useState, type ReactNode } from 'react';
 import { DropdownMenu } from './DropdownMenu';
 
 beforeEach(() => {
@@ -1892,5 +1892,56 @@ describe('DropdownMenu — overlay elevation', () => {
     for (const panel of panels) {
       expect(panel).toHaveAttribute('data-in-overlay', '');
     }
+  });
+});
+
+describe('DropdownMenu — Sub stale hover-intent timer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function ControlledSub() {
+    const [subOpen, setSubOpen] = useState(false);
+    return (
+      <DropdownMenu open onOpenChange={() => {}}>
+        <DropdownMenu.Trigger>
+          <button type="button">Open</button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Sub open={subOpen} onOpenChange={setSubOpen}>
+            <DropdownMenu.SubTrigger>Colors</DropdownMenu.SubTrigger>
+            <DropdownMenu.SubContent>
+              {/* Mirrors RichTextColorMenu's pick: a plain button that closes
+                  the controlled sub. */}
+              <button type="button" onClick={() => setSubOpen(false)}>
+                Pick
+              </button>
+            </DropdownMenu.SubContent>
+          </DropdownMenu.Sub>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    );
+  }
+
+  it('a click-opened sub closed by a pick stays closed past the hover window', () => {
+    render(<ControlledSub />);
+    const trigger = screen.getByRole('menuitem', { name: 'Colors' });
+    // Hover starts the 100ms hover-intent open timer…
+    fireEvent.pointerEnter(trigger);
+    // …the click opens immediately (and must supersede the pending timer)…
+    fireEvent.click(trigger);
+    // …the pick closes the sub within the hover window.
+    fireEvent.click(screen.getByRole('button', { name: 'Pick' }));
+    expect(screen.queryByRole('button', { name: 'Pick' })).toBeNull();
+    // Cross the hover window: a stale open timer would re-open the sub here —
+    // the exact sequence that intermittently broke CI (and reproduces in real
+    // browsers as hover → click → pick within 100ms).
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByRole('button', { name: 'Pick' })).toBeNull();
   });
 });

--- a/packages/design-system/src/components/DropdownMenu/Sub.tsx
+++ b/packages/design-system/src/components/DropdownMenu/Sub.tsx
@@ -258,6 +258,24 @@ export const SubTrigger = forwardRef<HTMLDivElement, DropdownMenuSubTriggerProps
       };
     }, [closeTimerRef]);
 
+    // Any open-state transition supersedes pending hover intent. Critically:
+    // a CLOSE while the 100ms hover-open timer is still pending (hover →
+    // click-open → pick-close, all inside the window) must cancel that timer,
+    // or it re-opens the sub right after the pick — an intermittent CI
+    // failure and a real-browser bug (fast hover+click+pick). Clearing the
+    // shared close timer on transitions is the symmetric guard (e.g. a
+    // keyboard re-open racing a pending hover-close).
+    useEffect(() => {
+      if (openTimerRef.current) {
+        clearTimeout(openTimerRef.current);
+        openTimerRef.current = null;
+      }
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+    }, [subCtx.open, closeTimerRef]);
+
     const handlePointerEnter = useCallback(() => {
       if (disabled) return;
       // Cancel any pending close.

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockMenu.test.tsx
@@ -100,6 +100,19 @@ it('closes the color submenu after a pick but leaves the main menu open', async 
   expect(screen.getByRole('menuitem', { name: 'Text color' })).toBeInTheDocument();
 });
 
+it('the pick-closed submenu stays closed past the hover-intent window (stale timer regression)', async () => {
+  const onColor = vi.fn();
+  setup({ onColor });
+  await userEvent.click(screen.getByRole('menuitem', { name: 'Text color' }));
+  await userEvent.click(await screen.findByRole('button', { name: 'Green' }));
+  await waitFor(() => expect(screen.queryByRole('button', { name: 'Green' })).toBeNull());
+  // Cross the SubTrigger's 100ms hover-intent window with real time: a stale
+  // open timer (hover scheduled it; the click opened without clearing it)
+  // re-opened the palette here — the intermittent CI failure's root cause.
+  await new Promise((r) => setTimeout(r, 150));
+  expect(screen.queryByRole('button', { name: 'Green' })).toBeNull();
+});
+
 it('reopens the color submenu after a pick (close-on-pick does not latch it shut)', async () => {
   const onColor = vi.fn();
   setup({ onColor });


### PR DESCRIPTION
## Summary

Root cause of the intermittent `RichTextBlockMenu` failures that broke two merge runs (the `waitFor` band-aid in #271 treated a symptom). Systematic debugging found a deterministic defect:

`SubTrigger`'s `pointerenter` schedules a **100ms hover-intent open timer**; `handleClick` opens the sub **without clearing it**. With per-call pointer state (userEvent's direct API — or a real user hovering and clicking quickly) no `pointerleave` ever clears it, so the stale timer **re-opens the submenu after a pick already closed it**. On fast machines the reopen lands after the test's first assertion poll (silent false pass); under CI load the pick lands inside the 60–100ms band and the reopen defeats any `waitFor`. Reproduced 100% deterministically with a probe (pick, wait 150ms, submenu is back).

Fix: any `subCtx.open` transition clears both pending hover timers — an actual open/close supersedes hover intent; clearing the shared close timer is the symmetric guard (keyboard re-open racing a pending hover-close).

## Test plan

- New deterministic regressions at two levels: fake-timer `DropdownMenu` unit test (hover → click → pick → advance 300ms → still closed) and the real-time `RichTextBlockMenu` sequence that flaked CI (pick → sleep 150ms → still closed) — both red before the fix, green after
- `make test` (3675), typecheck, lint, format all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)