### PR TITLE
docs(LiquidEditor): surface the existing showLineNumbers prop

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -985,6 +985,8 @@ const VARS = [
 
 **Toolbar:** the right-aligned "Insert variable" dropdown is a bordered `secondary` `sm` button. Pass `toolbarActions` (a `ReactNode`, e.g. `<Button variant="ghost" size="sm">…</Button>` for a Docs/Help link) to add extra buttons right-aligned just before it. Hidden when `showToolbar={false}`.
 
+**Gutter:** `showLineNumbers={false}` hides the line-number gutter (default `true`) — right for single-line formula inputs and dense forms; combine with `showToolbar={false}` for the most minimal chrome.
+
 When NOT to use: plain prose → `Textarea`; static read-only code → playground `CodeBlock`. Don't expect it to validate syntax (feed `error` from the backend) or to produce its own preview (preview is consumer-rendered).
 
 ### `<RichTextEditor>` — controlled rich-text editor (contentEditable)

--- a/packages/playground/src/pages/components/LiquidEditorDemo.tsx
+++ b/packages/playground/src/pages/components/LiquidEditorDemo.tsx
@@ -31,6 +31,7 @@ function fakeRender(template: string): string {
 export function LiquidEditorDemo() {
   const [formula, setFormula] = useState('{{ first_name }} {{ last_name | upcase }}');
   const [withTypo, setWithTypo] = useState('{{ first_naem }}');
+  const [compact, setCompact] = useState('{{ first_name | upcase }}');
 
   return (
     <DemoLayout
@@ -131,6 +132,40 @@ export function Demo() {
               Docs
             </Button>
           }
+        />
+      </Example>
+
+      <Example
+        title="Compact (showLineNumbers={false})"
+        description="Hide the line-number gutter for single-line formula fields and dense forms; pair with showToolbar={false} for the most minimal chrome."
+        code={`import { useState } from 'react';
+import { LiquidEditor, type LiquidVariable } from '@eocrm/design-system';
+
+const VARS: LiquidVariable[] = [
+  { code: 'first_name', label: 'First name', type: 'text', group: 'Built-in fields' },
+  { code: 'last_name', label: 'Last name', type: 'text', group: 'Built-in fields' },
+];
+
+export function Demo() {
+  const [value, setValue] = useState('{{ first_name | upcase }}');
+
+  return (
+    <LiquidEditor
+      value={value}
+      onChange={setValue}
+      variables={VARS}
+      showLineNumbers={false}
+      minRows={2}
+    />
+  );
+}`}
+      >
+        <LiquidEditor
+          value={compact}
+          onChange={setCompact}
+          variables={VARS}
+          showLineNumbers={false}
+          minRows={2}
         />
       </Example>
 


### PR DESCRIPTION
## Summary

`showLineNumbers?: boolean` (default `true`) already exists on LiquidEditor — implemented, JSDoc'd, tested, and in the published package — but was undiscoverable: no demo example exercised it and AGENTS.md's LiquidEditor section never mentioned it. A consumer asked for the feature believing it didn't exist.

- New **Compact** demo example: `showLineNumbers={false}` + `minRows={2}` (single-line formula field use case), browser-verified (gutter absent in the example, present in the default one)
- AGENTS.md: **Gutter** bullet in the LiquidEditor section

## Test plan

- `make test` (3675), typecheck, lint, format green
- Playwright check: compact example renders without gutter; default example unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)