### PR TITLE
fix: Escape closes the innermost floating surface first (#274)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -2362,7 +2362,7 @@ const [open, setOpen] = useState(false);
 - **`<Modal.Footer>` defaults to right-aligned actions.** Use `align="space-between"` to split a danger action away from save/cancel.
 - **`<Modal.Close>`** wraps a clickable child and fires `onOpenChange(false)` on click. Chains with the child's existing `onClick`.
 - **Forced step:** combine `disableEscapeClose`, `dismissOnOverlayClick={false}`, omit `<Modal.Close>`, and pass `<Modal.Header closeButton={false}>` to lock the user into the modal until they resolve it programmatically.
-- **Stacked modals.** Default `stackMode="overlay"`: the parent stays visible underneath and the inner overlay paints transparent so the parent's dim shows through (one effective dim layer for the stack). Use `stackMode="replace"` to hide the parent via `display: none` (React state preserved) — best for forced steps where the parent context is irrelevant. Escape still closes only the topmost; body scroll stays locked across the whole stack.
+- **Stacked modals.** Default `stackMode="overlay"`: the parent stays visible underneath and the inner overlay paints transparent so the parent's dim shows through (one effective dim layer for the stack). Use `stackMode="replace"` to hide the parent via `display: none` (React state preserved) — best for forced steps where the parent context is irrelevant. Escape still closes only the topmost — and yields to any open floating surface first (Select/Popover/menu/date-time popover: the first press closes the surface, the next closes the modal); body scroll stays locked across the whole stack.
 - **Initial focus:** pass `initialFocusRef` to focus a specific element (e.g. the first input). Otherwise the dialog container receives focus and the focus trap takes over.
 
 **Anti-patterns:**
@@ -2420,7 +2420,7 @@ const [open, setOpen] = useState(false);
 - **Three sizes:** `sm` (320px), `md` (440px, default), `lg` (640px). Capped to `viewport - 32px` on narrow viewports; always edge-anchored, never fullscreen.
 - **Drag-to-close** on mobile: swipe the Header in the dismiss direction (right drawer → swipe right, bottom → swipe down, etc.). Threshold: 40% of drawer size or 0.5 px/ms velocity. Opt out with `dragToClose={false}`.
 - **Overlay variants:** `overlay="solid"` (default) or `overlay="blur"` (frosted-glass with `backdrop-filter: blur(4px)`).
-- **Stacks with Modal.** Both share one overlay registry — a Drawer can open from inside a Modal (and vice versa). Escape closes the topmost regardless of type; body scroll lock is shared.
+- **Stacks with Modal.** Both share one overlay registry — a Drawer can open from inside a Modal (and vice versa). Escape closes the topmost regardless of type — after yielding to any open floating surface (innermost-first: the first press closes the surface, the next closes the host); body scroll lock is shared.
 - **Forced step:** combine `disableEscapeClose + dismissOnOverlayClick={false} + dragToClose={false}` + `<Drawer.Header closeButton={false}>` + omit `<Drawer.Close>`.
 
 **Anti-patterns:**

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -2392,7 +2392,7 @@ const [start, setStart] = useState(0);
 - Each `LightboxItem` is `{ src, alt, kind?, caption?, thumbnail? }` — `alt` is required.
 - `items` accept `kind: 'pdf'` (or a `.pdf` src) → rendered in an `<iframe>` with a download action; mixed image+PDF galleries supported. A PDF without a `thumbnail` shows a document-icon placeholder in the strip; unsafe (non-http(s)) doc srcs show a "Preview unavailable" message.
 - Single item → chevrons, counter, and strip auto-hide. Empty `items` → renders nothing.
-- Reuses the DS overlay machinery (focus-trap, scroll-lock, Esc, stacking above modals).
+- Reuses the DS overlay machinery (focus-trap, scroll-lock, Esc — yielding to open floating surfaces first like Modal/Drawer, stacking above modals).
 
 ### `<Drawer>` — edge-anchored slide-in panel
 

--- a/packages/design-system/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/design-system/src/components/DatePicker/DatePicker.test.tsx
@@ -561,3 +561,28 @@ describe('DatePicker — Escape from anywhere while open (#274)', () => {
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 });
+
+describe('DatePicker — Escape cascade with the embedded clock (#274)', () => {
+  it('three presses: clock -> calendar -> (host would be next); calendar defers to the open clock', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker
+        aria-label="Due"
+        granularity="minute"
+        value={new Date(2026, 5, 15, 14, 30)}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open calendar' }));
+    await user.click(screen.getByRole('button', { name: /Open time list/i }));
+    expect(document.querySelector('[data-timefield-popover="true"]')).not.toBeNull();
+    // Press 1: closes ONLY the clock — the calendar's document listener
+    // defers to [data-timefield-popover].
+    await user.keyboard('{Escape}');
+    expect(document.querySelector('[data-timefield-popover="true"]')).toBeNull();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    // Press 2: closes the calendar.
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});

--- a/packages/design-system/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/design-system/src/components/DatePicker/DatePicker.test.tsx
@@ -547,3 +547,17 @@ describe('DatePicker — overlay elevation (#272)', () => {
     expect(clock).toHaveAttribute('data-in-overlay', '');
   });
 });
+
+describe('DatePicker — Escape from anywhere while open (#274)', () => {
+  it('Escape closes the calendar when focus is inside the grid (not the input)', async () => {
+    const user = userEvent.setup();
+    render(<DatePicker aria-label="Due" value={new Date(2026, 5, 15)} onChange={() => {}} />);
+    await user.click(screen.getByRole('button', { name: 'Open calendar' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    // Move real focus into the month grid, then Escape from there.
+    const cell = screen.getAllByRole('gridcell', { name: /15/ })[0].querySelector('button');
+    (cell ?? screen.getByRole('dialog')).focus();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});

--- a/packages/design-system/src/components/DatePicker/DatePicker.tsx
+++ b/packages/design-system/src/components/DatePicker/DatePicker.tsx
@@ -318,6 +318,9 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(function
         setOpen(false);
       }
       if (e.key === 'Escape' && open) {
+        // Already handled by an inner surface's capture listener on this
+        // same press (the embedded clock) — one layer per press (#274).
+        if (overlayStack.wasEscapeConsumed(e.nativeEvent)) return;
         e.preventDefault();
         setOpen(false);
         inputRef.current?.focus();

--- a/packages/design-system/src/components/DatePicker/DatePicker.tsx
+++ b/packages/design-system/src/components/DatePicker/DatePicker.tsx
@@ -11,7 +11,7 @@ import {
   type MouseEvent,
 } from 'react';
 import { createPortal } from 'react-dom';
-import { useInOverlay } from '../_internal/overlay';
+import { useFloatingSurface, useInOverlay } from '../_internal/overlay';
 import clsx from 'clsx';
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react-dom';
 import { Calendar as CalendarIcon, X } from 'lucide-react';
@@ -326,6 +326,27 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(function
     [commit, draft, open],
   );
 
+  // #274: Escape must close the calendar from ANYWHERE while open — the
+  // input-scoped handler above is dead once focus moves into the grid via
+  // ArrowDown (a pre-existing gap), and hosts now yield Escape to open
+  // floating surfaces, which would otherwise leave the press doing nothing.
+  // Capture phase to beat focused widgets (matches TimeField). Defers to an
+  // open embedded TimeField clock: the clock's own (later-registered)
+  // listener must close it first — closing the calendar would unmount the
+  // clock mid-press.
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: globalThis.KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      if (document.querySelector('[data-timefield-popover="true"]')) return;
+      e.preventDefault();
+      setOpen(false);
+      inputRef.current?.focus();
+    }
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [open]);
+
   const handleSelect = useCallback(
     (next: Date) => {
       let withTime = next;
@@ -394,6 +415,9 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(function
   // --z-modal) paints it behind the host — elevate when the trigger sits in
   // an overlay, exactly like Select/Popover/DropdownMenu.
   const inOverlay = useInOverlay(wrapperRef, open);
+  // #274: hosts yield Escape while we're open — our own capture/element
+  // handler closes us on the same press instead of the Modal/Drawer.
+  useFloatingSurface(open);
 
   const showClear = clearable && value != null && !disabled;
 

--- a/packages/design-system/src/components/DatePicker/DatePicker.tsx
+++ b/packages/design-system/src/components/DatePicker/DatePicker.tsx
@@ -11,7 +11,7 @@ import {
   type MouseEvent,
 } from 'react';
 import { createPortal } from 'react-dom';
-import { useFloatingSurface, useInOverlay } from '../_internal/overlay';
+import { overlayStack, useFloatingSurface, useInOverlay } from '../_internal/overlay';
 import clsx from 'clsx';
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react-dom';
 import { Calendar as CalendarIcon, X } from 'lucide-react';
@@ -340,6 +340,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(function
       if (e.key !== 'Escape') return;
       if (document.querySelector('[data-timefield-popover="true"]')) return;
       e.preventDefault();
+      overlayStack.consumeEscape(e); // hosts yield even if we ran first (#274)
       setOpen(false);
       inputRef.current?.focus();
     }

--- a/packages/design-system/src/components/DatePicker/DatePicker.tsx
+++ b/packages/design-system/src/components/DatePicker/DatePicker.tsx
@@ -341,6 +341,8 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(function
     if (!open) return;
     function onKeyDown(e: globalThis.KeyboardEvent) {
       if (e.key !== 'Escape') return;
+      // Another surface already closed on this press — one layer per press.
+      if (overlayStack.wasEscapeConsumed(e)) return;
       if (document.querySelector('[data-timefield-popover="true"]')) return;
       e.preventDefault();
       overlayStack.consumeEscape(e); // hosts yield even if we ran first (#274)

--- a/packages/design-system/src/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/design-system/src/components/DateRangePicker/DateRangePicker.test.tsx
@@ -822,8 +822,18 @@ describe('DateRangePicker — Escape from anywhere while open (#274)', () => {
     await user.keyboard('{Escape}');
     expect(screen.queryByRole('dialog')).toBeNull();
     expect(screen.getByRole('textbox')).toHaveFocus();
-    // Reopen: no stale in-flight selection (no range preview persists).
+    // Reopen: the in-flight selection was reset — no cell carries the
+    // in-range/selection-preview state.
     await user.click(screen.getByRole('button', { name: 'Open calendar' }));
     expect(screen.getByRole('dialog')).toBeInTheDocument();
+    const marked = screen
+      .getAllByRole('gridcell')
+      .filter(
+        (c) =>
+          c.getAttribute('aria-selected') === 'true' ||
+          c.getAttribute('data-in-range') === 'true' ||
+          c.getAttribute('data-range-start') === 'true',
+      );
+    expect(marked).toHaveLength(0);
   });
 });

--- a/packages/design-system/src/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/design-system/src/components/DateRangePicker/DateRangePicker.test.tsx
@@ -808,3 +808,22 @@ describe('DateRangePicker — overlay elevation (#272)', () => {
     expect(clock).toHaveAttribute('data-in-overlay', '');
   });
 });
+
+describe('DateRangePicker — Escape from anywhere while open (#274)', () => {
+  it('Escape with focus in the grid closes the popover, resets in-flight selection, refocuses the input', async () => {
+    const user = userEvent.setup();
+    render(<DateRangePicker aria-label="Range" value={null} onChange={() => {}} />);
+    await user.click(screen.getByRole('button', { name: 'Open calendar' }));
+    // Start a range selection (first click sets selectionStart)…
+    const fives = screen.getAllByRole('gridcell', { name: /^5$/ });
+    await user.click(fives[0]);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    // …then Escape from grid/document scope (not the input).
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(screen.getByRole('textbox')).toHaveFocus();
+    // Reopen: no stale in-flight selection (no range preview persists).
+    await user.click(screen.getByRole('button', { name: 'Open calendar' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/packages/design-system/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/design-system/src/components/DateRangePicker/DateRangePicker.tsx
@@ -11,7 +11,7 @@ import {
   type MouseEvent,
 } from 'react';
 import { createPortal } from 'react-dom';
-import { useInOverlay } from '../_internal/overlay';
+import { useFloatingSurface, useInOverlay } from '../_internal/overlay';
 import clsx from 'clsx';
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react-dom';
 import { ChevronLeft, ChevronRight, Calendar as CalendarIcon, X } from 'lucide-react';
@@ -281,6 +281,8 @@ export const DateRangePicker = forwardRef<HTMLInputElement, DateRangePickerProps
 
     // #272: same overlay elevation as DatePicker.
     const inOverlay = useInOverlay(wrapperRef, open);
+    // #274: hosts yield Escape while we're open.
+    useFloatingSurface(open);
 
     const commit = useCallback(
       (raw: string) => {
@@ -384,6 +386,23 @@ export const DateRangePicker = forwardRef<HTMLInputElement, DateRangePickerProps
     }, [focusGridTick, open, refs.floating]);
 
     // Click-1 → click-2 → commit dance.
+    // #274: Escape from anywhere while open — mirrors DatePicker; see there
+    // for the rationale and the embedded-clock deferral.
+    useEffect(() => {
+      if (!open) return;
+      function onKeyDown(e: globalThis.KeyboardEvent) {
+        if (e.key !== 'Escape') return;
+        if (document.querySelector('[data-timefield-popover="true"]')) return;
+        e.preventDefault();
+        setOpen(false);
+        setSelectionStart(null);
+        setHoverDate(null);
+        inputRef.current?.focus();
+      }
+      document.addEventListener('keydown', onKeyDown, true);
+      return () => document.removeEventListener('keydown', onKeyDown, true);
+    }, [open]);
+
     const handleGridSelect = useCallback(
       (date: Date) => {
         if (selectionStart == null) {

--- a/packages/design-system/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/design-system/src/components/DateRangePicker/DateRangePicker.tsx
@@ -394,6 +394,8 @@ export const DateRangePicker = forwardRef<HTMLInputElement, DateRangePickerProps
       if (!open) return;
       function onKeyDown(e: globalThis.KeyboardEvent) {
         if (e.key !== 'Escape') return;
+        // Another surface already closed on this press — one layer per press.
+        if (overlayStack.wasEscapeConsumed(e)) return;
         if (document.querySelector('[data-timefield-popover="true"]')) return;
         e.preventDefault();
         overlayStack.consumeEscape(e); // hosts yield even if we ran first (#274)

--- a/packages/design-system/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/design-system/src/components/DateRangePicker/DateRangePicker.tsx
@@ -11,7 +11,7 @@ import {
   type MouseEvent,
 } from 'react';
 import { createPortal } from 'react-dom';
-import { useFloatingSurface, useInOverlay } from '../_internal/overlay';
+import { overlayStack, useFloatingSurface, useInOverlay } from '../_internal/overlay';
 import clsx from 'clsx';
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react-dom';
 import { ChevronLeft, ChevronRight, Calendar as CalendarIcon, X } from 'lucide-react';
@@ -394,6 +394,7 @@ export const DateRangePicker = forwardRef<HTMLInputElement, DateRangePickerProps
         if (e.key !== 'Escape') return;
         if (document.querySelector('[data-timefield-popover="true"]')) return;
         e.preventDefault();
+        overlayStack.consumeEscape(e); // hosts yield even if we ran first (#274)
         setOpen(false);
         setSelectionStart(null);
         setHoverDate(null);

--- a/packages/design-system/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/design-system/src/components/DateRangePicker/DateRangePicker.tsx
@@ -364,6 +364,8 @@ export const DateRangePicker = forwardRef<HTMLInputElement, DateRangePickerProps
           setHoverDate(null);
         }
         if (e.key === 'Escape' && open) {
+          // Already handled by the embedded clock on this press (#274).
+          if (overlayStack.wasEscapeConsumed(e.nativeEvent)) return;
           e.preventDefault();
           setOpen(false);
           setSelectionStart(null);

--- a/packages/design-system/src/components/Drawer/Content.tsx
+++ b/packages/design-system/src/components/Drawer/Content.tsx
@@ -32,8 +32,10 @@ export function Content({ children, className, style }: ContentProps) {
       if (e.key !== 'Escape') return;
       if (!overlayStack.isTop(ctx.drawerId)) return;
       // #274: an open floating surface (Select/Popover/menu/date-time popover/
-      // Rail flyout) wins this press — its own capture listener, which runs
-      // later in the same keydown, closes it. The next press reaches us.
+      // Rail flyout) wins this press — its own Escape handling (a capture
+      // listener or an element-scoped handler) closes it on this same press;
+      // wasEscapeConsumed covers a surface whose listener already ran. The
+      // next press reaches us.
       if (overlayStack.hasOpenFloating() || overlayStack.wasEscapeConsumed(e)) return;
       if (ctx.disableEscapeClose) return;
       e.preventDefault();

--- a/packages/design-system/src/components/Drawer/Content.tsx
+++ b/packages/design-system/src/components/Drawer/Content.tsx
@@ -34,7 +34,7 @@ export function Content({ children, className, style }: ContentProps) {
       // #274: an open floating surface (Select/Popover/menu/date-time popover/
       // Rail flyout) wins this press — its own capture listener, which runs
       // later in the same keydown, closes it. The next press reaches us.
-      if (overlayStack.hasOpenFloating()) return;
+      if (overlayStack.hasOpenFloating() || overlayStack.wasEscapeConsumed(e)) return;
       if (ctx.disableEscapeClose) return;
       e.preventDefault();
       ctx.setOpen(false);

--- a/packages/design-system/src/components/Drawer/Content.tsx
+++ b/packages/design-system/src/components/Drawer/Content.tsx
@@ -31,6 +31,10 @@ export function Content({ children, className, style }: ContentProps) {
     function onKeyDown(e: KeyboardEvent) {
       if (e.key !== 'Escape') return;
       if (!overlayStack.isTop(ctx.drawerId)) return;
+      // #274: an open floating surface (Select/Popover/menu/date-time popover/
+      // Rail flyout) wins this press — its own capture listener, which runs
+      // later in the same keydown, closes it. The next press reaches us.
+      if (overlayStack.hasOpenFloating()) return;
       if (ctx.disableEscapeClose) return;
       e.preventDefault();
       ctx.setOpen(false);

--- a/packages/design-system/src/components/Drawer/Drawer.test.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.test.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, type ComponentProps, type RefObject } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Drawer } from './Drawer';
+import { Select } from '../Select';
 import { overlayStack } from '../_internal/overlay';
 
 function Harness(props: Partial<ComponentProps<typeof Drawer>>) {
@@ -375,5 +376,34 @@ describe('<Drawer>', () => {
     const overlay = document.querySelector('[data-drawer-portal-root]') as HTMLElement;
     await user.click(overlay);
     expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('Drawer — Escape yields to open floating surfaces (#274)', () => {
+  function DrawerWithSelect() {
+    const [open, setOpen] = useState(true);
+    return (
+      <Drawer open={open} onOpenChange={setOpen} aria-label="Filters">
+        <Select
+          aria-label="Status"
+          options={[
+            { value: 'a', label: 'Active' },
+            { value: 'b', label: 'Archived' },
+          ]}
+        />
+      </Drawer>
+    );
+  }
+
+  it('first Escape closes only the open Select; the second closes the Drawer', async () => {
+    const user = userEvent.setup();
+    render(<DrawerWithSelect />);
+    await user.click(screen.getByRole('button', { name: 'Status' }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).toBeNull();
   });
 });

--- a/packages/design-system/src/components/DropdownMenu/Content.tsx
+++ b/packages/design-system/src/components/DropdownMenu/Content.tsx
@@ -18,6 +18,7 @@ import {
 } from '@floating-ui/react-dom';
 import clsx from 'clsx';
 import { useDropdownMenuContext } from './context';
+import { overlayStack } from '../_internal/overlay';
 import { mergeRefs } from '../_internal/refs';
 import styles from './DropdownMenu.module.scss';
 
@@ -149,6 +150,7 @@ export const Content = forwardRef<HTMLDivElement, DropdownMenuContentProps>(func
     const onKeyDown = (e: globalThis.KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
+        overlayStack.consumeEscape(e); // hosts yield even if we ran first (#274)
         // Only handle Escape for this level if focus is inside this panel or
         // no deeper sub is open. A deeper sub (higher depth) will have
         // registered its own capture listener and should handle Escape first.

--- a/packages/design-system/src/components/DropdownMenu/Root.tsx
+++ b/packages/design-system/src/components/DropdownMenu/Root.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from 'react';
 import { DropdownMenuContext, type DropdownMenuContextValue, type RegisteredItem } from './context';
 import { sanitizeId } from '../_internal/refs';
-import { useInOverlay } from '../_internal/overlay';
+import { useFloatingSurface, useInOverlay } from '../_internal/overlay';
 
 export interface DropdownMenuProps {
   /** Must contain exactly one `<DropdownMenu.Trigger>` and one `<DropdownMenu.Content>`. */
@@ -98,6 +98,9 @@ export function DropdownMenuRoot({
 
   const triggerRef = useRef<HTMLElement | null>(null);
   const inOverlay = useInOverlay(triggerRef, open);
+  // #274: hosts yield Escape while the menu (any level) is open — the
+  // menu's own capture listeners peel one level per press instead.
+  useFloatingSurface(open);
   const reactId = useId();
   const contentId = `dropdown-menu-${sanitizeId(reactId)}`;
 

--- a/packages/design-system/src/components/Lightbox/Lightbox.test.tsx
+++ b/packages/design-system/src/components/Lightbox/Lightbox.test.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { overlayStack } from '../_internal/overlay';
 import { Lightbox, type LightboxItem, type LightboxProps } from './Lightbox';
 
 const ITEMS: LightboxItem[] = [
@@ -247,5 +248,22 @@ describe('Lightbox', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: 'Close gallery' }));
     expect(trigger).toHaveFocus();
+  });
+});
+
+describe('Lightbox — Escape yields to open floating surfaces (#274)', () => {
+  afterEach(() => {
+    overlayStack._reset();
+  });
+
+  it('does not close while a floating surface is registered; closes after', () => {
+    const onOpenChange = vi.fn();
+    open({ onOpenChange });
+    overlayStack.registerFloating('probe-surface');
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onOpenChange).not.toHaveBeenCalled();
+    overlayStack.unregisterFloating('probe-surface');
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/design-system/src/components/Lightbox/Lightbox.tsx
+++ b/packages/design-system/src/components/Lightbox/Lightbox.tsx
@@ -16,7 +16,7 @@ import { Image } from '../Image';
 import { Skeleton } from '../Skeleton';
 import { useFocusTrap } from '../_internal/overlay/useFocusTrap';
 import { useScrollLock } from '../_internal/overlay/useScrollLock';
-import { useOverlayStack } from '../_internal/overlay';
+import { overlayStack, useOverlayStack } from '../_internal/overlay';
 import { useTranslation } from '../../i18n/useTranslation';
 import styles from './Lightbox.module.scss';
 
@@ -214,6 +214,8 @@ export function Lightbox({
   useEffect(() => {
     if (!open || !isTop) return;
     function onKeyDown(e: KeyboardEvent) {
+      // #274: yield to an open floating surface — see Modal/Content.tsx.
+      if (e.key === 'Escape' && overlayStack.hasOpenFloating()) return;
       if (e.key === 'Escape') {
         e.stopPropagation();
         close();

--- a/packages/design-system/src/components/Lightbox/Lightbox.tsx
+++ b/packages/design-system/src/components/Lightbox/Lightbox.tsx
@@ -215,7 +215,11 @@ export function Lightbox({
     if (!open || !isTop) return;
     function onKeyDown(e: KeyboardEvent) {
       // #274: yield to an open floating surface — see Modal/Content.tsx.
-      if (e.key === 'Escape' && overlayStack.hasOpenFloating()) return;
+      if (
+        e.key === 'Escape' &&
+        (overlayStack.hasOpenFloating() || overlayStack.wasEscapeConsumed(e))
+      )
+        return;
       if (e.key === 'Escape') {
         e.stopPropagation();
         close();

--- a/packages/design-system/src/components/LiquidEditor/AutocompleteMenu.tsx
+++ b/packages/design-system/src/components/LiquidEditor/AutocompleteMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
+import { useFloatingSurface } from '../_internal/overlay';
 import { createPortal } from 'react-dom';
 import { useFloating, autoUpdate, flip, shift, offset } from '@floating-ui/react-dom';
 import clsx from 'clsx';
@@ -31,6 +32,10 @@ export function AutocompleteMenu({
   listboxId,
   onSelect,
 }: AutocompleteMenuProps) {
+  // #274: mounted only while open — register as a floating surface so
+  // Modal/Drawer/Lightbox yield Escape to us (our own Escape handling closes
+  // us; without registration one press would close the host too).
+  useFloatingSurface(true);
   const t = useTranslation();
 
   // A Floating UI virtual element: only `getBoundingClientRect` is required.

--- a/packages/design-system/src/components/Modal/Content.tsx
+++ b/packages/design-system/src/components/Modal/Content.tsx
@@ -42,8 +42,10 @@ export function Content({ children, className, style }: ContentProps) {
       if (e.key !== 'Escape') return;
       if (!modalStack.isTop(ctx.modalId)) return;
       // #274: an open floating surface (Select/Popover/menu/date-time popover/
-      // Rail flyout) wins this press — its own capture listener, which runs
-      // later in the same keydown, closes it. The next press reaches us.
+      // Rail flyout) wins this press — its own Escape handling (a capture
+      // listener or an element-scoped handler) closes it on this same press;
+      // wasEscapeConsumed covers a surface whose listener already ran. The
+      // next press reaches us.
       if (modalStack.hasOpenFloating() || modalStack.wasEscapeConsumed(e)) return;
       if (ctx.disableEscapeClose) return;
       e.preventDefault();

--- a/packages/design-system/src/components/Modal/Content.tsx
+++ b/packages/design-system/src/components/Modal/Content.tsx
@@ -44,7 +44,7 @@ export function Content({ children, className, style }: ContentProps) {
       // #274: an open floating surface (Select/Popover/menu/date-time popover/
       // Rail flyout) wins this press — its own capture listener, which runs
       // later in the same keydown, closes it. The next press reaches us.
-      if (modalStack.hasOpenFloating()) return;
+      if (modalStack.hasOpenFloating() || modalStack.wasEscapeConsumed(e)) return;
       if (ctx.disableEscapeClose) return;
       e.preventDefault();
       ctx.setOpen(false);

--- a/packages/design-system/src/components/Modal/Content.tsx
+++ b/packages/design-system/src/components/Modal/Content.tsx
@@ -41,6 +41,10 @@ export function Content({ children, className, style }: ContentProps) {
     function onKeyDown(e: KeyboardEvent) {
       if (e.key !== 'Escape') return;
       if (!modalStack.isTop(ctx.modalId)) return;
+      // #274: an open floating surface (Select/Popover/menu/date-time popover/
+      // Rail flyout) wins this press — its own capture listener, which runs
+      // later in the same keydown, closes it. The next press reaches us.
+      if (modalStack.hasOpenFloating()) return;
       if (ctx.disableEscapeClose) return;
       e.preventDefault();
       ctx.setOpen(false);

--- a/packages/design-system/src/components/Modal/Modal.test.tsx
+++ b/packages/design-system/src/components/Modal/Modal.test.tsx
@@ -589,3 +589,38 @@ describe('Modal — Escape yields to open floating surfaces (#274)', () => {
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 });
+
+describe('Modal — Escape yield is order-independent (consumed events, #274)', () => {
+  it('survives when a surface listener runs BEFORE the modal and consumes the press', async () => {
+    // Re-render churn can re-register a surface's document-capture listener
+    // ahead of the host's; the surface then closes + unregisters within the
+    // same press. The host must still yield to the consumed event.
+    const user = userEvent.setup();
+    const surfaceListener = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      // Simulate the surface: it is no longer registered (already closed by
+      // the time the host's listener runs) but marked the event consumed.
+      overlayStack.consumeEscape(e);
+    };
+    document.addEventListener('keydown', surfaceListener, true);
+    try {
+      function Host() {
+        const [open, setOpen] = useState(true);
+        return (
+          <Modal open={open} onOpenChange={setOpen} aria-label="Filters">
+            <button type="button">Body</button>
+          </Modal>
+        );
+      }
+      render(<Host />);
+      await user.keyboard('{Escape}');
+      // Consumed press: the modal must NOT close.
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      document.removeEventListener('keydown', surfaceListener, true);
+      await user.keyboard('{Escape}');
+      expect(screen.queryByRole('dialog')).toBeNull();
+    } finally {
+      document.removeEventListener('keydown', surfaceListener, true);
+    }
+  });
+});

--- a/packages/design-system/src/components/Modal/Modal.test.tsx
+++ b/packages/design-system/src/components/Modal/Modal.test.tsx
@@ -7,6 +7,7 @@ import { useRef, useState, type ComponentProps, type RefObject } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Modal } from './Modal';
+import { Select } from '../Select';
 import { overlayStack } from '../_internal/overlay';
 
 function Harness(props: Partial<ComponentProps<typeof Modal>>) {
@@ -548,5 +549,43 @@ describe('<Modal>', () => {
     await user.keyboard('{Escape}');
     // Focus should land somewhere sensible; document.body is fine for jsdom.
     expect(document.activeElement).toBeDefined();
+  });
+});
+
+describe('Modal — Escape yields to open floating surfaces (#274)', () => {
+  function ModalWithSelect() {
+    const [open, setOpen] = useState(true);
+    return (
+      <Modal open={open} onOpenChange={setOpen} aria-label="Filters">
+        <Select
+          aria-label="Status"
+          options={[
+            { value: 'a', label: 'Active' },
+            { value: 'b', label: 'Archived' },
+          ]}
+        />
+      </Modal>
+    );
+  }
+
+  it('first Escape closes only the open Select; the second closes the Modal', async () => {
+    const user = userEvent.setup();
+    render(<ModalWithSelect />);
+    await user.click(screen.getByRole('button', { name: 'Status' }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    // Inner surface closed, host survived.
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('Escape with no surface open still closes the Modal directly', async () => {
+    const user = userEvent.setup();
+    render(<ModalWithSelect />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).toBeNull();
   });
 });

--- a/packages/design-system/src/components/Popover/Content.tsx
+++ b/packages/design-system/src/components/Popover/Content.tsx
@@ -12,7 +12,7 @@ import {
 import clsx from 'clsx';
 import { usePopoverContext } from './context';
 import { mergeRefs } from '../_internal/refs';
-import { useInOverlay } from '../_internal/overlay';
+import { useFloatingSurface, useInOverlay } from '../_internal/overlay';
 import styles from './Popover.module.scss';
 
 /** Which side of the trigger the popover prefers. Floating UI auto-flips if it doesn't fit. */
@@ -63,6 +63,9 @@ export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function 
 ) {
   const ctx = usePopoverContext('Content');
   const inOverlay = useInOverlay(ctx.triggerRef, ctx.open);
+  // #274: hosts yield Escape while we're open — our capture listener
+  // closes us (or one menu level) on the same press instead.
+  useFloatingSurface(ctx.open);
   const arrowRef = useRef<HTMLSpanElement | null>(null);
 
   const placement: Placement = (align === 'center' ? side : `${side}-${align}`) as Placement;

--- a/packages/design-system/src/components/Popover/Content.tsx
+++ b/packages/design-system/src/components/Popover/Content.tsx
@@ -12,7 +12,7 @@ import {
 import clsx from 'clsx';
 import { usePopoverContext } from './context';
 import { mergeRefs } from '../_internal/refs';
-import { useFloatingSurface, useInOverlay } from '../_internal/overlay';
+import { overlayStack, useFloatingSurface, useInOverlay } from '../_internal/overlay';
 import styles from './Popover.module.scss';
 
 /** Which side of the trigger the popover prefers. Floating UI auto-flips if it doesn't fit. */
@@ -102,6 +102,7 @@ export const Content = forwardRef<HTMLDivElement, PopoverContentProps>(function 
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
+        overlayStack.consumeEscape(e); // hosts yield even if we ran first (#274)
         ctx.closeAll();
       }
     };

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -22,6 +22,7 @@ import {
 } from '@floating-ui/react-dom';
 import clsx from 'clsx';
 import { useRail } from './Rail';
+import { useFloatingSurface } from '../_internal/overlay';
 import styles from './Rail.module.scss';
 
 /** Open-delay for hover-intent before opening the collapsed-mode flyout. */
@@ -140,6 +141,9 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupProps>(function Rai
 
   // ─── Hover-driven popover state (used when rail is collapsed) ────────
   const [popoverOpen, setPopoverOpen] = useState(false);
+  // #274: hosts yield Escape while the flyout is open — our own capture
+  // listener closes it on the same press instead of the Modal/Drawer.
+  useFloatingSurface(popoverOpen);
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -22,7 +22,7 @@ import {
 } from '@floating-ui/react-dom';
 import clsx from 'clsx';
 import { useRail } from './Rail';
-import { useFloatingSurface } from '../_internal/overlay';
+import { overlayStack, useFloatingSurface } from '../_internal/overlay';
 import styles from './Rail.module.scss';
 
 /** Open-delay for hover-intent before opening the collapsed-mode flyout. */
@@ -217,6 +217,8 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupProps>(function Rai
     if (!popoverOpen) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        e.preventDefault(); // consistency with every other floating surface
+        overlayStack.consumeEscape(e); // hosts yield even if we ran first (#274)
         clearOpenTimer();
         clearCloseTimer();
         setPopoverOpen(false);

--- a/packages/design-system/src/components/RichTextEditor/RichTextAttachmentConfig.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextAttachmentConfig.tsx
@@ -6,6 +6,7 @@
 // preview (a safe, fetchable src — an embed); an uploaded object-URL image is a
 // chip, so it gets no width. Non-image chips get replace/open/download.
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useFloatingSurface } from '../_internal/overlay';
 import { createPortal } from 'react-dom';
 import { Button } from '../Button';
 import { Input } from '../Input';
@@ -79,6 +80,10 @@ export function RichTextAttachmentConfig({
   onReplace,
   onClose,
 }: RichTextAttachmentConfigProps) {
+  // #274: mounted only while open — register as a floating surface so
+  // Modal/Drawer/Lightbox yield Escape to us (our own Escape handling closes
+  // us; without registration one press would close the host too).
+  useFloatingSurface(true);
   const t = useTranslation();
   const isImage = attachmentIsImage(block);
   const popRef = useRef<HTMLDivElement | null>(null);

--- a/packages/design-system/src/components/RichTextEditor/RichTextAttachmentConfig.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextAttachmentConfig.tsx
@@ -6,7 +6,7 @@
 // preview (a safe, fetchable src — an embed); an uploaded object-URL image is a
 // chip, so it gets no width. Non-image chips get replace/open/download.
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useFloatingSurface } from '../_internal/overlay';
+import { overlayStack, useFloatingSurface } from '../_internal/overlay';
 import { createPortal } from 'react-dom';
 import { Button } from '../Button';
 import { Input } from '../Input';
@@ -111,7 +111,22 @@ export function RichTextAttachmentConfig({
   );
 
   // Dismiss on a pointerdown outside the popover.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
   useDismissOnOutsidePointerDown(popRef, onClose);
+
+  // #274: Escape from anywhere — see RichTextLinkEditor for the rationale
+  // (focus trap can hold focus outside this body-portaled popover).
+  useEffect(() => {
+    const onKeyDown = (e: globalThis.KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      overlayStack.consumeEscape(e);
+      onCloseRef.current();
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, []);
 
   // Move focus into the popover on open so the Escape handler (on the container)
   // works without the trigger keeping focus — mirrors RichTextLinkEditor focusing
@@ -134,6 +149,7 @@ export function RichTextAttachmentConfig({
       className={styles.configPopover}
       style={floatingStyles}
       role="group"
+      data-rte-overlay=""
       aria-label={t('richTextEditor.attachmentConfigure')}
       onKeyDown={(e) => {
         if (e.key === 'Escape') {

--- a/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
@@ -5,6 +5,7 @@
 // LiquidEditor's AutocompleteMenu, so it escapes the editor's overflow and any
 // Drawer/Modal ancestor). Enter applies, Esc / click-outside cancels.
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useFloatingSurface } from '../_internal/overlay';
 import { createPortal } from 'react-dom';
 import { Button } from '../Button';
 import { Input } from '../Input';
@@ -52,6 +53,10 @@ export function RichTextLinkEditor({
   onRemove,
   onCancel,
 }: RichTextLinkEditorProps) {
+  // #274: mounted only while open — register as a floating surface so
+  // Modal/Drawer/Lightbox yield Escape to us (our own Escape handling closes
+  // us; without registration one press would close the host too).
+  useFloatingSurface(true);
   const t = useTranslation();
   const [value, setValue] = useState(href);
   const inputRef = useRef<HTMLInputElement | null>(null);

--- a/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextLinkEditor.tsx
@@ -5,7 +5,7 @@
 // LiquidEditor's AutocompleteMenu, so it escapes the editor's overflow and any
 // Drawer/Modal ancestor). Enter applies, Esc / click-outside cancels.
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useFloatingSurface } from '../_internal/overlay';
+import { overlayStack, useFloatingSurface } from '../_internal/overlay';
 import { createPortal } from 'react-dom';
 import { Button } from '../Button';
 import { Input } from '../Input';
@@ -74,7 +74,25 @@ export function RichTextLinkEditor({
   }, [editing]);
 
   // Dismiss on a pointerdown outside the bubble.
+  const onCancelRef = useRef(onCancel);
+  onCancelRef.current = onCancel;
   useDismissOnOutsidePointerDown(bubbleRef, onCancel);
+
+  // #274: Escape must close the bubble from ANYWHERE — inside a Modal the
+  // focus trap can hold focus on the dialog, so the container-scoped
+  // onKeyDown below never fires; without this the registered bubble makes
+  // the host yield and the press goes dead. Capture + consume so the host
+  // (and the editor) treat the press as handled.
+  useEffect(() => {
+    const onKeyDown = (e: globalThis.KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      overlayStack.consumeEscape(e);
+      onCancelRef.current();
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, []);
 
   const setRefs = useCallback(
     (node: HTMLDivElement | null) => {
@@ -99,6 +117,7 @@ export function RichTextLinkEditor({
     >
       <form
         role="group"
+        data-rte-overlay=""
         aria-label={t('richTextEditor.linkEditorLabel')}
         onSubmit={(e) => {
           e.preventDefault();

--- a/packages/design-system/src/components/RichTextEditor/RichTextMentionMenu.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextMentionMenu.tsx
@@ -4,6 +4,7 @@
 // the caret rect via a Floating UI virtual element (same portal+virtual-anchor
 // pattern as RichTextLinkEditor). Not exported from the package.
 import { createPortal } from 'react-dom';
+import { useFloatingSurface } from '../_internal/overlay';
 import { Avatar } from '../Avatar';
 import { Text } from '../Text';
 import type { MentionItem } from './mentions';
@@ -44,6 +45,10 @@ export function RichTextMentionMenu({
   onSelect,
   onHover,
 }: RichTextMentionMenuProps) {
+  // #274: mounted only while open — register as a floating surface so
+  // Modal/Drawer/Lightbox yield Escape to us (our own Escape handling closes
+  // us; without registration one press would close the host too).
+  useFloatingSurface(true);
   const { refs, floatingStyles } = useAnchoredFloating(anchorRect, getAnchorRect, { offset: 4 });
 
   return createPortal(

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -11,7 +11,7 @@ import {
 import clsx from 'clsx';
 import { useSelectContext, type SelectContextValue } from './context';
 import { mergeRefs } from '../_internal/refs';
-import { useInOverlay } from '../_internal/overlay';
+import { useFloatingSurface, useInOverlay } from '../_internal/overlay';
 import type { SelectOption } from './utils-types';
 import { isCreateRow } from './utils';
 import { Empty } from './Empty';
@@ -33,6 +33,9 @@ import styles from './Select.module.scss';
 export function Listbox() {
   const ctx = useSelectContext('Listbox');
   const inOverlay = useInOverlay(ctx.triggerRef, ctx.open);
+  // #274: hosts yield Escape while we're open — our own capture/element
+  // handler closes us on the same press instead of the Modal/Drawer.
+  useFloatingSurface(ctx.open);
 
   const { refs, floatingStyles } = useFloating({
     open: ctx.open,

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -11,7 +11,7 @@ import {
 import clsx from 'clsx';
 import { useSelectContext, type SelectContextValue } from './context';
 import { mergeRefs } from '../_internal/refs';
-import { useFloatingSurface, useInOverlay } from '../_internal/overlay';
+import { overlayStack, useFloatingSurface, useInOverlay } from '../_internal/overlay';
 import type { SelectOption } from './utils-types';
 import { isCreateRow } from './utils';
 import { Empty } from './Empty';
@@ -97,6 +97,7 @@ export function Listbox() {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
+        overlayStack.consumeEscape(e); // hosts yield even if we ran first (#274)
         ctx.closeAndFocusTrigger();
       }
     };

--- a/packages/design-system/src/components/TimeField/TimeField.tsx
+++ b/packages/design-system/src/components/TimeField/TimeField.tsx
@@ -10,7 +10,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
 import { createPortal } from 'react-dom';
-import { useInOverlay } from '../_internal/overlay';
+import { useFloatingSurface, useInOverlay } from '../_internal/overlay';
 import clsx from 'clsx';
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react-dom';
 import { Check, ChevronDown } from 'lucide-react';
@@ -290,6 +290,9 @@ export const TimeField = forwardRef<HTMLDivElement, TimeFieldProps>(function Tim
   // #272: elevate the clock above Modal/Drawer hosts — and, transitively,
   // above an elevated DatePicker calendar this field may be embedded in.
   const inOverlay = useInOverlay(wrapperRef, open);
+  // #274: hosts yield Escape while we're open — our own capture/element
+  // handler closes us on the same press instead of the Modal/Drawer.
+  useFloatingSurface(open);
 
   const handleToggle = useCallback(() => {
     if (isDisabled) return;

--- a/packages/design-system/src/components/TimeField/TimeField.tsx
+++ b/packages/design-system/src/components/TimeField/TimeField.tsx
@@ -10,7 +10,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
 import { createPortal } from 'react-dom';
-import { useFloatingSurface, useInOverlay } from '../_internal/overlay';
+import { overlayStack, useFloatingSurface, useInOverlay } from '../_internal/overlay';
 import clsx from 'clsx';
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react-dom';
 import { Check, ChevronDown } from 'lucide-react';
@@ -328,6 +328,7 @@ export const TimeField = forwardRef<HTMLDivElement, TimeFieldProps>(function Tim
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
+        overlayStack.consumeEscape(e); // hosts yield even if we ran first (#274)
         setOpen(false);
         inputRef.current?.focus();
       }

--- a/packages/design-system/src/components/_internal/overlay/escapeYield.test.tsx
+++ b/packages/design-system/src/components/_internal/overlay/escapeYield.test.tsx
@@ -1,7 +1,8 @@
 // #274 — parametrized host-yield contract: with a floating surface open
 // inside a Modal, the FIRST Escape closes only the surface and the SECOND
 // closes the host. Deleting any surface's useFloatingSurface registration
-// (or its consumeEscape call) fails its case here.
+// (or its consumeEscape call) fails its case here. (Select's case lives in
+// Modal.test.tsx / Drawer.test.tsx.)
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState, type ReactNode } from 'react';
@@ -9,11 +10,16 @@ import { Modal } from '../../Modal';
 import { Popover } from '../../Popover';
 import { DropdownMenu } from '../../DropdownMenu';
 import { DatePicker } from '../../DatePicker';
+import { DateRangePicker } from '../../DateRangePicker';
 import { TimeField } from '../../TimeField';
 import { Rail } from '../../Rail';
 import { Button } from '../../Button';
+import { LiquidEditor } from '../../LiquidEditor';
 import { LocaleProvider } from '../../../i18n/LocaleProvider';
 import { RichTextLinkEditor } from '../../RichTextEditor/RichTextLinkEditor';
+import { RichTextMentionMenu } from '../../RichTextEditor/RichTextMentionMenu';
+import { RichTextAttachmentConfig } from '../../RichTextEditor/RichTextAttachmentConfig';
+import type { Block } from '../../RichText/engine/model';
 import { overlayStack } from './index';
 
 function Host({ children }: { children: ReactNode }) {
@@ -169,6 +175,141 @@ describe('Escape yield contract per surface (#274)', () => {
     render(<LinkHost />);
     expect(screen.getByRole('group')).toBeInTheDocument();
     // The modal's focus trap must NOT steal focus from the bubble.
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('group')).toBeNull();
+    expect(dialogOpen()).toBe(true);
+    await user.keyboard('{Escape}');
+    expect(dialogOpen()).toBe(false);
+  });
+
+  it('DateRangePicker: first Escape closes the calendar, second the modal', async () => {
+    const user = userEvent.setup();
+    render(
+      <Host>
+        <DateRangePicker aria-label="Period" value={null} onChange={() => {}} />
+      </Host>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open calendar' }));
+    // Two dialogs open: the modal + the calendar popover.
+    expect(screen.getAllByRole('dialog').length).toBe(2);
+    await user.keyboard('{Escape}');
+    expect(screen.getAllByRole('dialog').length).toBe(1);
+    await user.keyboard('{Escape}');
+    expect(dialogOpen()).toBe(false);
+  });
+
+  it('LiquidEditor autocomplete: first Escape closes the menu, second the modal', async () => {
+    const user = userEvent.setup();
+    function LiquidHost() {
+      const [open, setOpen] = useState(true);
+      const [value, setValue] = useState('');
+      return (
+        <Modal open={open} onOpenChange={setOpen} aria-label="Host">
+          <LiquidEditor
+            value={value}
+            onChange={setValue}
+            variables={[{ code: 'first_name', label: 'First name', type: 'text' }]}
+          />
+        </Modal>
+      );
+    }
+    render(<LiquidHost />);
+    const ta = screen.getByRole('combobox');
+    await user.click(ta);
+    // `{{{{ fir` types the literal `{{ fir` (userEvent escapes `{` by doubling).
+    await user.type(ta, '{{{{ fir');
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(dialogOpen()).toBe(true);
+    await user.keyboard('{Escape}');
+    expect(dialogOpen()).toBe(false);
+  });
+
+  it('RTE mention menu: first Escape closes the menu, second the modal', async () => {
+    const user = userEvent.setup();
+    function MentionHost() {
+      const [open, setOpen] = useState(true);
+      const [menu, setMenu] = useState(true);
+      return (
+        <Modal open={open} onOpenChange={setOpen} aria-label="Host">
+          {/* The real editor closes the menu from its own element-scoped
+              keydown — mirror that here; the menu itself only registers. */}
+          <div onKeyDown={(e) => e.key === 'Escape' && setMenu(false)}>
+            <Button>Editor stand-in</Button>
+          </div>
+          {menu ? (
+            <RichTextMentionMenu
+              items={[{ id: 'u1', label: 'Alice' }]}
+              activeIndex={0}
+              anchorRect={{ top: 10, left: 10, width: 0, height: 16 }}
+              listboxId="lb"
+              getOptionId={(i) => `opt-${i}`}
+              label="Mentions"
+              emptyLabel="No matches"
+              onSelect={() => {}}
+              onHover={() => {}}
+            />
+          ) : null}
+        </Modal>
+      );
+    }
+    render(<MentionHost />);
+    expect(screen.getByRole('listbox', { name: 'Mentions' })).toBeInTheDocument();
+    // The real editor owns focus while the menu is open — mirror that, else
+    // the element-scoped close handler never sees the press. Click (not bare
+    // .focus()): the Modal's initial-focus microtask is still pending at the
+    // first await and would steal a synchronously-set focus.
+    await user.click(screen.getByRole('button', { name: 'Editor stand-in' }));
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(dialogOpen()).toBe(true);
+    await user.keyboard('{Escape}');
+    expect(dialogOpen()).toBe(false);
+  });
+
+  it('RTE attachment config: Escape with focus OUTSIDE the popover closes it, second press the modal', async () => {
+    const user = userEvent.setup();
+    const block: Block = {
+      id: 'a',
+      type: 'attachment',
+      status: 'ready',
+      src: 'http://u/p.png',
+      mime: 'image/png',
+      name: 'p.png',
+      alt: 'Chart',
+      inlines: [],
+    };
+    function ConfigHost() {
+      const [open, setOpen] = useState(true);
+      const [cfg, setCfg] = useState(true);
+      return (
+        <Modal open={open} onOpenChange={setOpen} aria-label="Host">
+          <Button>Elsewhere</Button>
+          {cfg ? (
+            <RichTextAttachmentConfig
+              block={block}
+              anchorRect={{ top: 10, left: 10, width: 200, height: 120 }}
+              maxWidth={600}
+              onAltChange={() => {}}
+              onAlignChange={() => {}}
+              onWidthChange={() => {}}
+              onWidthReset={() => {}}
+              onReplace={() => {}}
+              onClose={() => setCfg(false)}
+            />
+          ) : null}
+        </Modal>
+      );
+    }
+    render(<ConfigHost />);
+    expect(screen.getByRole('group')).toBeInTheDocument();
+    // Focus OUTSIDE the popover: only the document-capture listener sees this
+    // press (the container onKeyDown is dead) — pins that listener specifically.
+    // No click (pointerdown-outside would dismiss the popover); flush the
+    // Modal's pending initial-focus microtask first so bare .focus() sticks.
+    await act(async () => {});
+    screen.getByRole('button', { name: 'Elsewhere' }).focus();
     await user.keyboard('{Escape}');
     expect(screen.queryByRole('group')).toBeNull();
     expect(dialogOpen()).toBe(true);

--- a/packages/design-system/src/components/_internal/overlay/escapeYield.test.tsx
+++ b/packages/design-system/src/components/_internal/overlay/escapeYield.test.tsx
@@ -1,0 +1,178 @@
+// #274 — parametrized host-yield contract: with a floating surface open
+// inside a Modal, the FIRST Escape closes only the surface and the SECOND
+// closes the host. Deleting any surface's useFloatingSurface registration
+// (or its consumeEscape call) fails its case here.
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState, type ReactNode } from 'react';
+import { Modal } from '../../Modal';
+import { Popover } from '../../Popover';
+import { DropdownMenu } from '../../DropdownMenu';
+import { DatePicker } from '../../DatePicker';
+import { TimeField } from '../../TimeField';
+import { Rail } from '../../Rail';
+import { Button } from '../../Button';
+import { LocaleProvider } from '../../../i18n/LocaleProvider';
+import { RichTextLinkEditor } from '../../RichTextEditor/RichTextLinkEditor';
+import { overlayStack } from './index';
+
+function Host({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <LocaleProvider locale="en-US">
+      <Modal open={open} onOpenChange={setOpen} aria-label="Host">
+        {children}
+      </Modal>
+    </LocaleProvider>
+  );
+}
+
+afterEach(() => {
+  overlayStack._reset();
+});
+
+const dialogOpen = () => screen.queryAllByRole('dialog').length > 0;
+
+describe('Escape yield contract per surface (#274)', () => {
+  it('Popover: first Escape closes the popover, second the modal', async () => {
+    const user = userEvent.setup();
+    render(
+      <Host>
+        <Popover defaultOpen>
+          <Popover.Trigger>
+            <Button>Filters</Button>
+          </Popover.Trigger>
+          <Popover.Content>
+            <div>Panel body</div>
+          </Popover.Content>
+        </Popover>
+      </Host>,
+    );
+    expect(screen.getByText('Panel body')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByText('Panel body')).toBeNull();
+    expect(dialogOpen()).toBe(true);
+    await user.keyboard('{Escape}');
+    expect(dialogOpen()).toBe(false);
+  });
+
+  it('DropdownMenu: first Escape closes the menu, second the modal', async () => {
+    const user = userEvent.setup();
+    render(
+      <Host>
+        <DropdownMenu defaultOpen>
+          <DropdownMenu.Trigger>
+            <Button>Actions</Button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item onSelect={() => {}}>Edit</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      </Host>,
+    );
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('menu')).toBeNull();
+    expect(dialogOpen()).toBe(true);
+    await user.keyboard('{Escape}');
+    expect(dialogOpen()).toBe(false);
+  });
+
+  it('TimeField: first Escape closes the clock, second the modal', async () => {
+    const user = userEvent.setup();
+    render(
+      <Host>
+        <TimeField aria-label="Time" value={{ hours: 9, minutes: 30 }} onChange={() => {}} />
+      </Host>,
+    );
+    await user.click(screen.getByRole('button', { name: /Open time list/i }));
+    expect(document.querySelector('[data-timefield-popover="true"]')).not.toBeNull();
+    await user.keyboard('{Escape}');
+    expect(document.querySelector('[data-timefield-popover="true"]')).toBeNull();
+    expect(dialogOpen()).toBe(true);
+    await user.keyboard('{Escape}');
+    expect(dialogOpen()).toBe(false);
+  });
+
+  it('DatePicker: first Escape closes the calendar, second the modal', async () => {
+    const user = userEvent.setup();
+    render(
+      <Host>
+        <DatePicker aria-label="Due" value={null} onChange={() => {}} />
+      </Host>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open calendar' }));
+    // Two dialogs open: the modal + the calendar popover.
+    expect(screen.getAllByRole('dialog').length).toBe(2);
+    await user.keyboard('{Escape}');
+    expect(screen.getAllByRole('dialog').length).toBe(1);
+    await user.keyboard('{Escape}');
+    expect(dialogOpen()).toBe(false);
+  });
+
+  it('Rail flyout: first Escape closes the flyout, second the modal', () => {
+    vi.useFakeTimers();
+    try {
+      function RailHost() {
+        const [open, setOpen] = useState(true);
+        return (
+          <Modal open={open} onOpenChange={setOpen} aria-label="Host">
+            <Rail defaultCollapsed>
+              <Rail.Section title="Ops">
+                <Rail.Group icon={<span aria-hidden />} label="Settings">
+                  <Rail.Item as="span">Sub A</Rail.Item>
+                </Rail.Group>
+              </Rail.Section>
+            </Rail>
+          </Modal>
+        );
+      }
+      render(<RailHost />);
+      const trigger = screen.getByRole('button', { name: /Settings/ });
+      act(() => {
+        fireEvent.pointerEnter(trigger);
+      });
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      // Flyout (role=dialog) + modal both open.
+      expect(screen.getAllByRole('dialog').length).toBe(2);
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(screen.getAllByRole('dialog').length).toBe(1);
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(screen.queryAllByRole('dialog').length).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('RTE link editor: first Escape cancels the bubble, second closes the modal', async () => {
+    const user = userEvent.setup();
+    function LinkHost() {
+      const [open, setOpen] = useState(true);
+      const [bubble, setBubble] = useState(true);
+      return (
+        <Modal open={open} onOpenChange={setOpen} aria-label="Host">
+          {bubble ? (
+            <RichTextLinkEditor
+              href=""
+              editing={false}
+              anchorRect={{ top: 10, left: 10, width: 10, height: 10 }}
+              onApply={() => {}}
+              onRemove={() => {}}
+              onCancel={() => setBubble(false)}
+            />
+          ) : null}
+        </Modal>
+      );
+    }
+    render(<LinkHost />);
+    expect(screen.getByRole('group')).toBeInTheDocument();
+    // The modal's focus trap must NOT steal focus from the bubble.
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('group')).toBeNull();
+    expect(dialogOpen()).toBe(true);
+    await user.keyboard('{Escape}');
+    expect(dialogOpen()).toBe(false);
+  });
+});

--- a/packages/design-system/src/components/_internal/overlay/escapeYield.test.tsx
+++ b/packages/design-system/src/components/_internal/overlay/escapeYield.test.tsx
@@ -156,9 +156,12 @@ describe('Escape yield contract per surface (#274)', () => {
     const user = userEvent.setup();
     function LinkHost() {
       const [open, setOpen] = useState(true);
-      const [bubble, setBubble] = useState(true);
+      // Mounted after the modal (via the Add link click) so the modal's
+      // capture listener runs first — see the attachment-config case.
+      const [bubble, setBubble] = useState(false);
       return (
         <Modal open={open} onOpenChange={setOpen} aria-label="Host">
+          <Button onClick={() => setBubble(true)}>Add link</Button>
           {bubble ? (
             <RichTextLinkEditor
               href=""
@@ -173,6 +176,7 @@ describe('Escape yield contract per surface (#274)', () => {
       );
     }
     render(<LinkHost />);
+    await user.click(screen.getByRole('button', { name: 'Add link' }));
     expect(screen.getByRole('group')).toBeInTheDocument();
     // The modal's focus trap must NOT steal focus from the bubble.
     await user.keyboard('{Escape}');
@@ -282,9 +286,16 @@ describe('Escape yield contract per surface (#274)', () => {
     };
     function ConfigHost() {
       const [open, setOpen] = useState(true);
-      const [cfg, setCfg] = useState(true);
+      // Mounted AFTER the modal (via the Configure click) so listener order
+      // matches production: the modal's capture listener registered first and
+      // runs first — ONLY the useFloatingSurface registration saves the host.
+      // Mounting both in one commit would register the config's listener
+      // first (child effects run before parent effects) and consumeEscape
+      // would mask a deleted registration.
+      const [cfg, setCfg] = useState(false);
       return (
         <Modal open={open} onOpenChange={setOpen} aria-label="Host">
+          <Button onClick={() => setCfg(true)}>Configure</Button>
           <Button>Elsewhere</Button>
           {cfg ? (
             <RichTextAttachmentConfig
@@ -303,12 +314,14 @@ describe('Escape yield contract per surface (#274)', () => {
       );
     }
     render(<ConfigHost />);
+    await user.click(screen.getByRole('button', { name: 'Configure' }));
     expect(screen.getByRole('group')).toBeInTheDocument();
+    expect(overlayStack.hasOpenFloating()).toBe(true);
     // Focus OUTSIDE the popover: only the document-capture listener sees this
     // press (the container onKeyDown is dead) — pins that listener specifically.
-    // No click (pointerdown-outside would dismiss the popover); flush the
-    // Modal's pending initial-focus microtask first so bare .focus() sticks.
-    await act(async () => {});
+    // No click (pointerdown-outside would dismiss the popover); bare .focus()
+    // is safe here — the Modal's initial-focus microtask flushed during the
+    // Configure click.
     screen.getByRole('button', { name: 'Elsewhere' }).focus();
     await user.keyboard('{Escape}');
     expect(screen.queryByRole('group')).toBeNull();

--- a/packages/design-system/src/components/_internal/overlay/index.ts
+++ b/packages/design-system/src/components/_internal/overlay/index.ts
@@ -2,6 +2,7 @@ export { useFocusTrap } from './useFocusTrap';
 export { useInOverlay } from './useInOverlay';
 export { useScrollLock } from './useScrollLock';
 export {
+  useFloatingSurface,
   useOverlayStack,
   overlayStack,
   type OverlayStackMode,

--- a/packages/design-system/src/components/_internal/overlay/useFocusTrap.ts
+++ b/packages/design-system/src/components/_internal/overlay/useFocusTrap.ts
@@ -18,6 +18,9 @@ const FOCUSABLE_SELECTOR = [
 // removing that entry would re-trap their keyboard users (#272).
 const FLOATING_BYPASS_SELECTOR = [
   '[data-popover-content]',
+  // RTE link-editor / attachment-config bubbles: form-like, hold their own
+  // focus while open inside a Modal (#274).
+  '[data-rte-overlay]',
   '[data-dropdown-menu-content]',
   '[role="tooltip"]',
   '[role="menu"]',

--- a/packages/design-system/src/components/_internal/overlay/useOverlayStack.test.ts
+++ b/packages/design-system/src/components/_internal/overlay/useOverlayStack.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { useOverlayStack, overlayStack } from './useOverlayStack';
+import { useFloatingSurface, useOverlayStack, overlayStack } from './useOverlayStack';
 
 describe('overlayStack singleton', () => {
   afterEach(() => {
@@ -101,5 +101,38 @@ describe('useOverlayStack', () => {
     expect(overlayStack.depthOf('a')).toBe(0);
     unmount();
     expect(overlayStack.depthOf('a')).toBe(-1);
+  });
+});
+
+describe('floating-surface registry (#274)', () => {
+  afterEach(() => {
+    overlayStack._reset();
+  });
+
+  it('hasOpenFloating reflects register/unregister', () => {
+    expect(overlayStack.hasOpenFloating()).toBe(false);
+    overlayStack.registerFloating('a');
+    overlayStack.registerFloating('b');
+    expect(overlayStack.hasOpenFloating()).toBe(true);
+    overlayStack.unregisterFloating('a');
+    expect(overlayStack.hasOpenFloating()).toBe(true);
+    overlayStack.unregisterFloating('b');
+    expect(overlayStack.hasOpenFloating()).toBe(false);
+  });
+
+  it('useFloatingSurface registers while open and cleans up on unmount', () => {
+    const { rerender, unmount } = renderHook(
+      ({ open }: { open: boolean }) => useFloatingSurface(open),
+      { initialProps: { open: false } },
+    );
+    expect(overlayStack.hasOpenFloating()).toBe(false);
+    rerender({ open: true });
+    expect(overlayStack.hasOpenFloating()).toBe(true);
+    rerender({ open: false });
+    expect(overlayStack.hasOpenFloating()).toBe(false);
+    rerender({ open: true });
+    expect(overlayStack.hasOpenFloating()).toBe(true);
+    unmount();
+    expect(overlayStack.hasOpenFloating()).toBe(false);
   });
 });

--- a/packages/design-system/src/components/_internal/overlay/useOverlayStack.ts
+++ b/packages/design-system/src/components/_internal/overlay/useOverlayStack.ts
@@ -11,6 +11,12 @@ interface Entry {
 const stack: Entry[] = [];
 const listeners = new Set<() => void>();
 const floating = new Set<string>();
+// Escape events already handled (surface closed on them). Order-independent
+// complement to the registry: a re-render can re-register a surface's
+// document-capture listener AHEAD of its host's (effects re-fire child-
+// first), so the surface may close + unregister within the same press —
+// the host must still yield to a consumed event. WeakSet: no leaks.
+const consumedEscapes = new WeakSet<Event>();
 
 // Open floating surfaces (Select listbox, Popover, DropdownMenu levels,
 // date/time popovers, Rail flyout). Hosts' Escape handlers yield while any
@@ -83,6 +89,14 @@ export const overlayStack = {
   /** True while any floating surface is open — hosts yield Escape to it. */
   hasOpenFloating(): boolean {
     return floating.size > 0;
+  },
+  /** A closing surface marks its Escape so hosts yield even when the
+   *  surface's listener ran first (registration order is not stable). */
+  consumeEscape(e: Event): void {
+    consumedEscapes.add(e);
+  },
+  wasEscapeConsumed(e: Event): boolean {
+    return consumedEscapes.has(e);
   },
   /** Subscribe to register/unregister notifications. Returns unsubscribe. */
   _subscribe(fn: () => void): () => void {

--- a/packages/design-system/src/components/_internal/overlay/useOverlayStack.ts
+++ b/packages/design-system/src/components/_internal/overlay/useOverlayStack.ts
@@ -21,8 +21,10 @@ const consumedEscapes = new WeakSet<Event>();
 // Open floating surfaces (Select listbox, Popover, DropdownMenu levels,
 // date/time popovers, Rail flyout). Hosts' Escape handlers yield while any
 // is open so a single press closes the innermost surface, not the host too
-// (#274). A Set of ids — surfaces have no meaningful order; their own
-// (later-registered) capture listeners close them innermost-first already.
+// (#274). A Set of ids — hosts only need "is anything open". Surface-vs-
+// surface ordering is NOT guaranteed here (a Select inside a Popover still
+// closes with it on one press); only two hardcoded pairs defer today:
+// DropdownMenu sub->parent and TimeField clock->calendar. See #280.
 
 function notify() {
   for (const fn of listeners) fn();

--- a/packages/design-system/src/components/_internal/overlay/useOverlayStack.ts
+++ b/packages/design-system/src/components/_internal/overlay/useOverlayStack.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from 'react';
+import { useId, useLayoutEffect, useState } from 'react';
 
 export type OverlayStackMode = 'replace' | 'overlay';
 
@@ -10,6 +10,13 @@ interface Entry {
 // Internal ordered list of open overlay entries, most-recently-registered last.
 const stack: Entry[] = [];
 const listeners = new Set<() => void>();
+const floating = new Set<string>();
+
+// Open floating surfaces (Select listbox, Popover, DropdownMenu levels,
+// date/time popovers, Rail flyout). Hosts' Escape handlers yield while any
+// is open so a single press closes the innermost surface, not the host too
+// (#274). A Set of ids — surfaces have no meaningful order; their own
+// (later-registered) capture listeners close them innermost-first already.
 
 function notify() {
   for (const fn of listeners) fn();
@@ -66,6 +73,17 @@ export const overlayStack = {
     return topEntry()?.mode ?? null;
   },
   depthOf,
+  /** Register an open floating surface (Escape-yield participant, #274). */
+  registerFloating(id: string): void {
+    floating.add(id);
+  },
+  unregisterFloating(id: string): void {
+    floating.delete(id);
+  },
+  /** True while any floating surface is open — hosts yield Escape to it. */
+  hasOpenFloating(): boolean {
+    return floating.size > 0;
+  },
   /** Subscribe to register/unregister notifications. Returns unsubscribe. */
   _subscribe(fn: () => void): () => void {
     listeners.add(fn);
@@ -77,6 +95,7 @@ export const overlayStack = {
   _reset(): void {
     stack.length = 0;
     listeners.clear();
+    floating.clear();
   },
 };
 
@@ -147,4 +166,23 @@ export function useOverlayStack(
   }, [id, active, mode]);
 
   return state;
+}
+
+/**
+ * Register this floating surface in the Escape-yield registry while `open`
+ * (#274). Hosts (Modal/Drawer/Lightbox) skip their Escape-close while any
+ * surface is registered, so the surface's own capture listener — which runs
+ * later in the same keydown (registration order) — closes it instead; the
+ * next press reaches the host. Layout effect: the registration must be
+ * observable before the browser can deliver the next keydown.
+ */
+export function useFloatingSurface(open: boolean): void {
+  const id = useId();
+  useLayoutEffect(() => {
+    if (!open) return;
+    overlayStack.registerFloating(id);
+    return () => {
+      overlayStack.unregisterFloating(id);
+    };
+  }, [id, open]);
 }

--- a/packages/design-system/src/components/_internal/overlay/useOverlayStack.ts
+++ b/packages/design-system/src/components/_internal/overlay/useOverlayStack.ts
@@ -26,8 +26,10 @@ const consumedEscapes = new WeakSet<Event>();
 // closes with it on one press); only two hardcoded pairs defer today:
 // DropdownMenu sub->parent and TimeField clock->calendar. See #280. The
 // registry is also global, not host-scoped: any host yields to any open
-// surface, even one belonging to a lower overlay (unreachable in practice —
-// outside-pointerdown dismissal closes surfaces before a new host can open).
+// surface, even one belonging to a lower overlay — rare but reachable (e.g.
+// a modal opened from a control inside a Popover: the popover dismisses only
+// on outside pointerdown, so it stays open and registered underneath, and
+// the modal's first Escape press yields to it).
 
 function notify() {
   for (const fn of listeners) fn();

--- a/packages/design-system/src/components/_internal/overlay/useOverlayStack.ts
+++ b/packages/design-system/src/components/_internal/overlay/useOverlayStack.ts
@@ -24,7 +24,10 @@ const consumedEscapes = new WeakSet<Event>();
 // (#274). A Set of ids — hosts only need "is anything open". Surface-vs-
 // surface ordering is NOT guaranteed here (a Select inside a Popover still
 // closes with it on one press); only two hardcoded pairs defer today:
-// DropdownMenu sub->parent and TimeField clock->calendar. See #280.
+// DropdownMenu sub->parent and TimeField clock->calendar. See #280. The
+// registry is also global, not host-scoped: any host yields to any open
+// surface, even one belonging to a lower overlay (unreachable in practice —
+// outside-pointerdown dismissal closes surfaces before a new host can open).
 
 function notify() {
   for (const fn of listeners) fn();
@@ -187,9 +190,10 @@ export function useOverlayStack(
 /**
  * Register this floating surface in the Escape-yield registry while `open`
  * (#274). Hosts (Modal/Drawer/Lightbox) skip their Escape-close while any
- * surface is registered, so the surface's own capture listener — which runs
- * later in the same keydown (registration order) — closes it instead; the
- * next press reaches the host. Layout effect: the registration must be
+ * surface is registered, so the surface's own Escape handling — a document-
+ * capture listener for most surfaces, an element-scoped handler for the
+ * editor-owned menus (Liquid autocomplete, RTE mentions) — closes it instead;
+ * the next press reaches the host. Layout effect: the registration must be
  * observable before the browser can deliver the next keydown.
  */
 export function useFloatingSurface(open: boolean): void {


### PR DESCRIPTION
Addresses #274.

## Summary

One Escape press with a floating surface open inside a Modal/Drawer/Lightbox used to close BOTH the surface and its host (hosts' document-capture listeners fire first in registration order and checked nothing about inner surfaces). Now each press closes exactly one layer, innermost first.

**Mechanism** (`_internal/overlay/useOverlayStack.ts`):
- **Floating-surface registry** — `registerFloating`/`unregisterFloating`/`hasOpenFloating` + a `useFloatingSurface(open)` hook (layout effect, internal `useId`). Hosts yield Escape while anything is registered.
- **Order-independent consumption** — `consumeEscape(e)`/`wasEscapeConsumed(e)` via a `WeakSet<Event>`: registration order is NOT stable across re-renders (effect identity churn can re-register a surface's listener ahead of its host's), so a closing surface marks the event and hosts yield to a consumed press even when the surface's listener ran first.
- **Host guards** — one check in Modal/Drawer/Lightbox Escape handlers.
- **Registrations (11 surfaces)** — Select listbox, Popover (covers ConfirmationPopover incl. pending-hold), DropdownMenu (root-level; spans all Sub levels), TimeField, DatePicker, DateRangePicker, Rail flyout, RTE link editor, RTE attachment config, RTE mention menu, LiquidEditor autocomplete.
- **DatePicker/DateRangePicker Escape upgrade** — input-scoped → document-capture-while-open (fixes the pre-existing dead press with focus in the calendar grid), deferring to an open embedded TimeField clock; input handlers guard on `wasEscapeConsumed`.
- **RTE bubbles in Modals** — the link editor/attachment config close paths were dead inside Modals (focus trap held focus outside the body-portaled bubbles); they now close from a document-capture listener, and `data-rte-overlay` joins the focus-trap bypass so the bubbles are actually usable inside Modals.

## Review history (Rule 8, five rounds)

- R1–R2: registration-order race found → the WeakSet consumption hardening.
- R3: picker double-close with focus-on-input + open clock; RTE dead-Escape in Modals; per-surface contract harness added (`escapeYield.test.tsx`).
- R4: 4 of 11 registrations unpinned by tests → cases added; symmetric consumed-press guards in the picker capture handlers.
- R5: mutation testing exposed the RTE cases as vacuously passing (surface mounted in the same commit as the modal registers its listener first, so `consumeEscape` masked a deleted registration) → cases re-mounted in production order; **all mutation checks now kill their registration** (verified per surface).

## Follow-ups filed (documented skips)

- #280 — surface-in-surface Escape ordering isn't guaranteed (e.g. Select inside Popover); registry is global, not host-scoped.
- #281 — Tooltip stays unregistered (hover-transient; deliberate scope-out).
- #282 — Escape-consuming *modes* (dnd-kit keyboard drag, FlowCanvas) predate the registry.

## Test plan

- `escapeYield.test.tsx`: parametrized two-press host-yield contract for 10 surfaces (Select covered in Modal/Drawer suites) — first press closes only the surface, second the host; mutation-verified so deleting any `useFloatingSurface` call fails a test.
- Registry unit tests; inverted-registration-order regression (consumed event); Lightbox registry probe; DatePicker/DateRangePicker grid-focus Escape + three-press cascade (clock → calendar → modal); DateRangePicker selection-reset pin.
- Full suite: 186 files / 3,695 tests green; typecheck, stylelint, prettier, tarball-leak grep all pass.