### PR TITLE
fix(FlowCanvas): pinned nodes ignore auto-layout + arrangeNodes API

### DIFF
--- a/docs/superpowers/plans/2026-07-04-flowcanvas-arrange-nodes.md
+++ b/docs/superpowers/plans/2026-07-04-flowcanvas-arrange-nodes.md
@@ -1,0 +1,494 @@
+# FlowCanvas arrange-nodes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop pinned (explicitly-positioned) nodes from perturbing FlowCanvas auto-layout, and add a pure `arrangeNodes(nodes, edges)` export for consumer-driven "re-arrange".
+
+**Architecture:** Two changes to `layout.ts`: (1) `computeLayout` filters to the `position === undefined` subset so pinned nodes are invisible to ranking/placement/centering; the existing unknown-node edge guard skips edges touching pinned nodes for free. (2) a new pure `arrangeNodes` that strips all positions, runs `computeLayout`, and returns the nodes with fresh `position`s. Events-only — no new props, no built-in UI; the consumer wires their own button.
+
+**Tech Stack:** TypeScript, Vitest + React Testing Library (`globals: true`).
+
+**Reference spec:** `docs/superpowers/specs/2026-07-04-flowcanvas-arrange-nodes-design.md`
+**Working branch:** `feat/flowcanvas-arrange-nodes` (already created).
+
+## Conventions
+
+- Tests: `npm test -w @eocrm/design-system -- <pattern> --run` (Vitest globals — do NOT import `describe`/`it`/`expect`/`vi`).
+- Typecheck: `npm run typecheck -w @eocrm/design-system`. Lint SCSS (root): `npm run lint:css`. Prettier: `npm run format` before pushing.
+- `layout.test.ts` already defines helpers: `const n = (id) => ({ id, label: id })` and `const e = (from, to) => ({ id: \`${from}-${to}\`, from, to })`. Reuse them; write pinned nodes as inline literals with a `position`.
+- Commit per task. Do NOT push until Task 6.
+
+---
+
+## Task 1: `computeLayout` ignores pinned nodes
+
+**Files:**
+- Modify: `packages/design-system/src/components/FlowCanvas/layout.ts` (the `computeLayout` function + its JSDoc)
+- Test: `packages/design-system/src/components/FlowCanvas/layout.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the existing `describe('computeLayout', () => { ... })` block in `layout.test.ts`:
+
+```ts
+  it('ignores pinned nodes (explicit position) — absent from the result', () => {
+    const pos = computeLayout(
+      [n('a'), n('b'), { id: 'pinned', label: 'P', position: { x: 5, y: 5 } }],
+      [e('a', 'b')],
+    );
+    expect(pos.has('pinned')).toBe(false);
+    expect(pos.has('a')).toBe(true);
+    expect(pos.has('b')).toBe(true);
+  });
+
+  it('lays out auto nodes independently of pinned nodes', () => {
+    const autoOnly = computeLayout([n('a'), n('b'), n('c')], [e('a', 'b'), e('b', 'c')]);
+    const withPinned = computeLayout(
+      [n('a'), n('b'), n('c'), { id: 'd', label: 'D', position: { x: 9, y: 9 } }],
+      [e('a', 'b'), e('b', 'c')],
+    );
+    expect(withPinned.get('a')).toEqual(autoOnly.get('a'));
+    expect(withPinned.get('b')).toEqual(autoOnly.get('b'));
+    expect(withPinned.get('c')).toEqual(autoOnly.get('c'));
+  });
+
+  it('treats an auto node fed only by a pinned node as a source (edge to pinned skipped)', () => {
+    const pos = computeLayout(
+      [{ id: 'p', label: 'P', position: { x: 0, y: 0 } }, n('b')],
+      [e('p', 'b')],
+    );
+    expect(pos.has('p')).toBe(false);
+    expect(pos.get('b')!.x).toBe(0); // rank-0 source, no incoming
+  });
+
+  it('returns an empty map when every node is pinned', () => {
+    const pos = computeLayout(
+      [
+        { id: 'a', label: 'A', position: { x: 0, y: 0 } },
+        { id: 'b', label: 'B', position: { x: 1, y: 1 } },
+      ],
+      [e('a', 'b')],
+    );
+    expect(pos.size).toBe(0);
+  });
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm test -w @eocrm/design-system -- layout --run`
+Expected: FAIL — pinned nodes currently ARE in the result and DO shift the auto nodes.
+
+- [ ] **Step 3: Implement — filter to auto nodes**
+
+In `layout.ts`, make these edits to `computeLayout` (the body operates on `autoNodes` instead of `nodes`; the edge loop is unchanged).
+
+(a) Right after `if (nodes.length === 0) return result;`, insert:
+
+```ts
+  // Only nodes WITHOUT an explicit position participate in auto-layout. Pinned
+  // nodes are placed by the consumer and must not perturb the others' ranking
+  // or centering; edges touching a pinned node fall through the unknown-node
+  // guard below (the pinned id is absent from `ids`).
+  const autoNodes = nodes.filter((node) => node.position === undefined);
+  if (autoNodes.length === 0) return result;
+```
+
+(b) Change the `ids` line from `new Set(nodes.map(...))` to:
+
+```ts
+  const ids = new Set(autoNodes.map((node) => node.id));
+```
+
+(c) The init loop `for (const node of nodes) {` that sets `out`/`incoming`/`indegree` → change to `for (const node of autoNodes) {`.
+
+(d) The sources line and fallback:
+
+```ts
+  const sources = autoNodes.filter((node) => indegree.get(node.id) === 0);
+  for (const source of sources.length > 0 ? sources : [autoNodes[0]]) visit(source.id, 0);
+```
+
+(e) The unranked-cycle seed line → `for (const node of autoNodes) if (!rank.has(node.id)) visit(node.id, 0);`
+
+(f) The rank-bucketing loop `for (const node of nodes) {` (the one doing `(ranks[r] ??= []).push(node)`) → `for (const node of autoNodes) {`.
+
+Leave the edge loop, ranking, barycenter, and placement code unchanged — they already key off `ids`/`ranks`, now auto-only.
+
+- [ ] **Step 4: Update the `computeLayout` JSDoc**
+
+Append to the JSDoc block above `computeLayout` (after the "Self-loops and edges to unknown nodes are ignored." sentence):
+
+```
+ * Only nodes without an explicit `position` are laid out; a node WITH a
+ * `position` is pinned by the consumer and is ignored here — it neither
+ * occupies layout space nor anchors edges, so it never shifts the others.
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `npm test -w @eocrm/design-system -- layout --run`
+Expected: PASS — the 4 new tests plus all pre-existing `computeLayout` tests (all-auto behavior unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/design-system/src/components/FlowCanvas/layout.ts packages/design-system/src/components/FlowCanvas/layout.test.ts
+git commit -m "fix(FlowCanvas): computeLayout ignores pinned nodes"
+```
+
+---
+
+## Task 2: `arrangeNodes` export + tests
+
+**Files:**
+- Modify: `packages/design-system/src/components/FlowCanvas/layout.ts` (add `arrangeNodes`)
+- Modify: `packages/design-system/src/components/FlowCanvas/index.ts` (export)
+- Modify: `packages/design-system/src/index.ts` (export)
+- Test: `packages/design-system/src/components/FlowCanvas/layout.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `layout.test.ts`, importing `arrangeNodes` — change the top import line from `import { computeLayout, ESTIMATED_NODE_SIZE } from './layout';` to:
+
+```ts
+import { arrangeNodes, computeLayout, ESTIMATED_NODE_SIZE } from './layout';
+```
+
+Then add a new describe block at the end of the file (before the final `});` closes nothing — it's a top-level describe):
+
+```ts
+describe('arrangeNodes', () => {
+  it('gives every node a position and lays the graph out left → right', () => {
+    const result = arrangeNodes([n('a'), n('b'), n('c')], [e('a', 'b'), e('b', 'c')]);
+    expect(result.every((node) => node.position !== undefined)).toBe(true);
+    const x = (id: string) => result.find((node) => node.id === id)!.position!.x;
+    expect(x('a')).toBeLessThan(x('b'));
+    expect(x('b')).toBeLessThan(x('c'));
+  });
+
+  it('overwrites existing (pinned) positions — it re-flows ALL nodes', () => {
+    const result = arrangeNodes(
+      [{ id: 'a', label: 'A', position: { x: 999, y: 999 } }, n('b')],
+      [e('a', 'b')],
+    );
+    expect(result.find((node) => node.id === 'a')!.position).not.toEqual({ x: 999, y: 999 });
+    expect(result.find((node) => node.id === 'b')!.position).toBeDefined();
+  });
+
+  it('preserves all other node fields', () => {
+    const result = arrangeNodes([{ id: 'a', label: 'A', color: '#123456', adornment: 'x' }], []);
+    const a = result.find((node) => node.id === 'a')!;
+    expect(a.label).toBe('A');
+    expect(a.color).toBe('#123456');
+    expect(a.adornment).toBe('x');
+  });
+
+  it('is deterministic', () => {
+    const nodes = [n('a'), n('b'), n('c')];
+    const edges = [e('a', 'b')];
+    expect(arrangeNodes(nodes, edges)).toEqual(arrangeNodes(nodes, edges));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm test -w @eocrm/design-system -- layout --run`
+Expected: FAIL — `arrangeNodes` is not exported (import error / not a function).
+
+- [ ] **Step 3: Implement `arrangeNodes`**
+
+In `layout.ts`, after the `computeLayout` function, add:
+
+```ts
+/**
+ * Lay out every node into the layered left→right auto-layout and return the
+ * nodes with `position` filled in — for a consumer-driven "re-arrange / tidy"
+ * action. Unlike {@link computeLayout} (which only places nodes without an
+ * explicit `position`), this re-flows ALL nodes, overwriting any existing
+ * `position`. Pure and deterministic; every other node field is preserved.
+ *
+ * Uses estimated node sizes, so vertical centering can differ by a few pixels
+ * from the live in-canvas layout (a standalone function cannot measure the
+ * rendered DOM). Fine for a tidy action.
+ *
+ * @example
+ * // A "Re-arrange" button in your own UI (e.g. the FlowCanvas `controls` slot):
+ * <Button onClick={() => setNodes((prev) => arrangeNodes(prev, edges))}>Re-arrange</Button>
+ */
+export function arrangeNodes(
+  nodes: FlowCanvasNode[],
+  edges: FlowCanvasEdge[],
+): FlowCanvasNode[] {
+  // Strip positions so the whole graph is treated as auto and re-laid-out.
+  const layout = computeLayout(
+    nodes.map((node) => ({ ...node, position: undefined })),
+    edges,
+  );
+  return nodes.map((node) => {
+    const position = layout.get(node.id);
+    return position ? { ...node, position } : node;
+  });
+}
+```
+
+- [ ] **Step 4: Export from the FlowCanvas barrel**
+
+In `packages/design-system/src/components/FlowCanvas/index.ts`, add after the `FlowCanvas` export line:
+
+```ts
+export { FlowCanvas } from './FlowCanvas';
+export { arrangeNodes } from './layout';
+export type { FlowCanvasProps } from './FlowCanvas';
+export type { FlowCanvasPoint, FlowCanvasNode, FlowCanvasEdge, FlowCanvasSelection } from './types';
+```
+
+- [ ] **Step 5: Export from the package root**
+
+In `packages/design-system/src/index.ts`, the FlowCanvas export currently reads `export { FlowCanvas } from './components/FlowCanvas';`. Change it to:
+
+```ts
+export { FlowCanvas, arrangeNodes } from './components/FlowCanvas';
+```
+
+(Leave the adjacent `export type { FlowCanvasProps, FlowCanvasNode, ... }` block unchanged.)
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `npm test -w @eocrm/design-system -- layout --run && npm run typecheck -w @eocrm/design-system`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/design-system/src/components/FlowCanvas/layout.ts packages/design-system/src/components/FlowCanvas/layout.test.ts packages/design-system/src/components/FlowCanvas/index.ts packages/design-system/src/index.ts
+git commit -m "feat(FlowCanvas): arrangeNodes API for consumer-driven re-arrange"
+```
+
+---
+
+## Task 3: FlowCanvas integration test — added pinned node moves nothing
+
+**Files:**
+- Test: `packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx`
+
+- [ ] **Step 1: Write the failing/guard test**
+
+`FlowCanvas.test.tsx` already imports `FlowCanvas` and `import type { FlowCanvasEdge, FlowCanvasNode } from './types';`. Append this describe block:
+
+```tsx
+describe('FlowCanvas auto-layout with pinned nodes', () => {
+  it('adding a pinned node does not move the auto-laid-out nodes', () => {
+    const auto: FlowCanvasNode[] = [
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+    ];
+    const edges: FlowCanvasEdge[] = [{ id: 'ab', from: 'a', to: 'b' }];
+    const { rerender } = render(<FlowCanvas nodes={auto} edges={edges} />);
+    const posOf = (label: string) => {
+      const el = screen.getByLabelText(label);
+      return { left: el.style.left, top: el.style.top };
+    };
+    const before = { a: posOf('A'), b: posOf('B') };
+    rerender(
+      <FlowCanvas
+        nodes={[...auto, { id: 'p', label: 'Pinned', position: { x: 500, y: 500 } }]}
+        edges={edges}
+      />,
+    );
+    expect(posOf('A')).toEqual(before.a);
+    expect(posOf('B')).toEqual(before.b);
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `npm test -w @eocrm/design-system -- FlowCanvas --run`
+Expected: PASS (Task 1 already fixed the underlying behavior; jsdom uses `ESTIMATED_NODE_SIZE`, so positions are deterministic). If it FAILS, Task 1's filter is incomplete — revisit before proceeding.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
+git commit -m "test(FlowCanvas): adding a pinned node leaves auto nodes in place"
+```
+
+---
+
+## Task 4: Playground demo — Reset → Re-arrange
+
+**Files:**
+- Modify: `packages/playground/src/pages/components/FlowCanvasDemo.tsx`
+
+- [ ] **Step 1: Import `arrangeNodes`**
+
+Change the `@eocrm/design-system` import to add `arrangeNodes`:
+
+```tsx
+import {
+  Badge,
+  Button,
+  Cluster,
+  FlowCanvas,
+  Stack,
+  Text,
+  Title,
+  arrangeNodes,
+  type FlowCanvasEdge,
+  type FlowCanvasNode,
+} from '@eocrm/design-system';
+```
+
+- [ ] **Step 2: Replace `handleReset` with `handleArrange`**
+
+Change the `handleReset` callback to:
+
+```tsx
+  const handleArrange = useCallback(() => {
+    setNodes((prev) => arrangeNodes(prev, edges));
+    setLastEvent('controls: re-arrange');
+  }, [edges]);
+```
+
+- [ ] **Step 3: Swap the live button**
+
+In the interactive `<FlowCanvas>` `controls` prop, change the second button from Reset to Re-arrange:
+
+```tsx
+              controls={
+                <Cluster gap="xs">
+                  <Button size="sm" variant="primary" onClick={handleAddNode}>
+                    Add node
+                  </Button>
+                  <Button size="sm" variant="secondary" onClick={handleArrange}>
+                    Re-arrange
+                  </Button>
+                </Cluster>
+              }
+```
+
+- [ ] **Step 4: Update the displayed code snippet**
+
+In the `code={\`...\`}` template string, change the snippet import line to include `Cluster` and `arrangeNodes`:
+
+```
+import { Badge, Button, Cluster, FlowCanvas, arrangeNodes, type FlowCanvasEdge, type FlowCanvasNode } from '@eocrm/design-system';
+```
+
+and change the snippet's `controls={...}` (the single Add-node button) to show both actions:
+
+```
+        controls={
+          <Cluster gap="xs">
+            <Button size="sm" onClick={() => setNodes((prev) => [...prev, { id: crypto.randomUUID(), label: 'New state', position: { x: 40, y: 40 } }])}>Add node</Button>
+            <Button size="sm" variant="secondary" onClick={() => setNodes((prev) => arrangeNodes(prev, edges))}>Re-arrange</Button>
+          </Cluster>
+        }
+```
+
+(No literal `${` — it's inside a template literal. `crypto.randomUUID()`, arrow functions, and `arrangeNodes(prev, edges)` contain none.)
+
+- [ ] **Step 5: Note it in the example description**
+
+Append to the "Workflow builder" `Example`'s `description` string: ` The top-left controls show a custom Add-node button and a Re-arrange button wired to arrangeNodes().`
+
+- [ ] **Step 6: Typecheck / build the playground**
+
+Run: `npm run build -w playground`
+Expected: PASS (the playground workspace name is `playground`, not `@eocrm/playground`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/playground/src/pages/components/FlowCanvasDemo.tsx
+git commit -m "docs(FlowCanvas): demo Re-arrange via arrangeNodes"
+```
+
+---
+
+## Task 5: Docs — node `position` JSDoc + AGENTS.md
+
+**Files:**
+- Modify: `packages/design-system/src/components/FlowCanvas/types.ts` (the `position` field on `FlowCanvasNode`)
+- Modify: `packages/design-system/AGENTS.md` (the `### <FlowCanvas>` section)
+
+- [ ] **Step 1: Update the `position` prop JSDoc**
+
+In `types.ts`, find the `position?` field of `FlowCanvasNode` and append to its JSDoc a sentence:
+
+```
+   * A node with an explicit `position` is *pinned*: it stays where you place it
+   * and does not participate in — or perturb — the auto-layout of the other
+   * nodes. Use `arrangeNodes(nodes, edges)` to re-flow the whole graph.
+```
+
+(Match the file's existing comment style/indentation.)
+
+- [ ] **Step 2: Update AGENTS.md**
+
+In `packages/design-system/AGENTS.md`, find the `### \`<FlowCanvas>\`` section. Add a sentence to its prose:
+
+> Nodes with an explicit `position` are pinned and don't affect the auto-layout of the others (nodes without a `position` are auto-laid-out). `arrangeNodes(nodes, edges)` (exported) re-flows the whole graph and returns the nodes with fresh positions — wire it to your own "Re-arrange" button.
+
+- [ ] **Step 3: Typecheck (JSDoc shouldn't break it, confirm)**
+
+Run: `npm run typecheck -w @eocrm/design-system`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/design-system/src/components/FlowCanvas/types.ts packages/design-system/AGENTS.md
+git commit -m "docs(FlowCanvas): document pinned nodes + arrangeNodes"
+```
+
+---
+
+## Task 6: Gates, review, browser-verify, PR
+
+- [ ] **Step 1: Full gates**
+
+```bash
+npm test -w @eocrm/design-system
+npm run typecheck -w @eocrm/design-system
+npm run lint:css
+npm run build -w playground
+npm pack --dry-run -w @eocrm/design-system
+npm run format:check
+```
+All must pass; `npm pack --dry-run` shows no test/internal files. If `format:check` flags files, run `npm run format` and amend/commit.
+
+- [ ] **Step 2: Browser-verify** (playground on http://localhost:8080)
+
+Open `/components/flow-canvas`. Confirm: clicking "Add node" no longer nudges the existing nodes; clicking "Re-arrange" tidies all nodes (including any you dragged/added) into the layered layout. Capture a before/after if useful.
+
+- [ ] **Step 3: Fresh-context review** (CLAUDE.md Rule 8)
+
+Spawn a `general-purpose` reviewer scoped to `git diff main...HEAD` for `packages/design-system` + the demo, briefed on the 10 categories. Fix Critical/Important; document skips; re-run gates; re-review until `clean enough to stop`.
+
+- [ ] **Step 4: Push + PR**
+
+```bash
+git push -u origin feat/flowcanvas-arrange-nodes
+gh pr create --title "fix(FlowCanvas): pinned nodes ignore auto-layout + arrangeNodes API" --body "$(cat <<'EOF'
+- `computeLayout` now lays out only nodes without an explicit `position`; pinned nodes no longer perturb the auto-laid-out ones (fixes the reflow observed when adding a positioned node).
+- New pure export `arrangeNodes(nodes, edges): FlowCanvasNode[]` — re-flows the whole graph and returns nodes with fresh positions, for a consumer-driven "Re-arrange" button (no built-in UI). Demo's controls now show it.
+
+Spec: docs/superpowers/specs/2026-07-04-flowcanvas-arrange-nodes-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5:** Wait for `Quality / check` to pass. Merging is a HUMAN-authorized step (auto-publish on merge) — confirm with the user before merging.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** computeLayout filter (T1) · arrangeNodes + exports (T2) · integration test (T3) · demo (T4) · position JSDoc + AGENTS.md (T5) · computeLayout JSDoc (T1 Step 4) · arrangeNodes JSDoc (T2 Step 3) · gates/review/PR (T6). All spec sections mapped.
+- **No new props / no manifest change** — `arrangeNodes` is a function export, so `props.manifest.json` and the CLUSTERS manifest are untouched.
+- **Type consistency:** `arrangeNodes(nodes: FlowCanvasNode[], edges: FlowCanvasEdge[]): FlowCanvasNode[]`, `autoNodes`, `node.position === undefined` used identically across tasks.
+- **Merge is gated on human approval** (T6 Step 5) — the auto-publish makes it outward-facing.

--- a/docs/superpowers/plans/2026-07-04-flowcanvas-arrange-nodes.md
+++ b/docs/superpowers/plans/2026-07-04-flowcanvas-arrange-nodes.md
@@ -23,6 +23,7 @@
 ## Task 1: `computeLayout` ignores pinned nodes
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/FlowCanvas/layout.ts` (the `computeLayout` function + its JSDoc)
 - Test: `packages/design-system/src/components/FlowCanvas/layout.test.ts`
 
@@ -31,46 +32,46 @@
 Append inside the existing `describe('computeLayout', () => { ... })` block in `layout.test.ts`:
 
 ```ts
-  it('ignores pinned nodes (explicit position) — absent from the result', () => {
-    const pos = computeLayout(
-      [n('a'), n('b'), { id: 'pinned', label: 'P', position: { x: 5, y: 5 } }],
-      [e('a', 'b')],
-    );
-    expect(pos.has('pinned')).toBe(false);
-    expect(pos.has('a')).toBe(true);
-    expect(pos.has('b')).toBe(true);
-  });
+it('ignores pinned nodes (explicit position) — absent from the result', () => {
+  const pos = computeLayout(
+    [n('a'), n('b'), { id: 'pinned', label: 'P', position: { x: 5, y: 5 } }],
+    [e('a', 'b')],
+  );
+  expect(pos.has('pinned')).toBe(false);
+  expect(pos.has('a')).toBe(true);
+  expect(pos.has('b')).toBe(true);
+});
 
-  it('lays out auto nodes independently of pinned nodes', () => {
-    const autoOnly = computeLayout([n('a'), n('b'), n('c')], [e('a', 'b'), e('b', 'c')]);
-    const withPinned = computeLayout(
-      [n('a'), n('b'), n('c'), { id: 'd', label: 'D', position: { x: 9, y: 9 } }],
-      [e('a', 'b'), e('b', 'c')],
-    );
-    expect(withPinned.get('a')).toEqual(autoOnly.get('a'));
-    expect(withPinned.get('b')).toEqual(autoOnly.get('b'));
-    expect(withPinned.get('c')).toEqual(autoOnly.get('c'));
-  });
+it('lays out auto nodes independently of pinned nodes', () => {
+  const autoOnly = computeLayout([n('a'), n('b'), n('c')], [e('a', 'b'), e('b', 'c')]);
+  const withPinned = computeLayout(
+    [n('a'), n('b'), n('c'), { id: 'd', label: 'D', position: { x: 9, y: 9 } }],
+    [e('a', 'b'), e('b', 'c')],
+  );
+  expect(withPinned.get('a')).toEqual(autoOnly.get('a'));
+  expect(withPinned.get('b')).toEqual(autoOnly.get('b'));
+  expect(withPinned.get('c')).toEqual(autoOnly.get('c'));
+});
 
-  it('treats an auto node fed only by a pinned node as a source (edge to pinned skipped)', () => {
-    const pos = computeLayout(
-      [{ id: 'p', label: 'P', position: { x: 0, y: 0 } }, n('b')],
-      [e('p', 'b')],
-    );
-    expect(pos.has('p')).toBe(false);
-    expect(pos.get('b')!.x).toBe(0); // rank-0 source, no incoming
-  });
+it('treats an auto node fed only by a pinned node as a source (edge to pinned skipped)', () => {
+  const pos = computeLayout(
+    [{ id: 'p', label: 'P', position: { x: 0, y: 0 } }, n('b')],
+    [e('p', 'b')],
+  );
+  expect(pos.has('p')).toBe(false);
+  expect(pos.get('b')!.x).toBe(0); // rank-0 source, no incoming
+});
 
-  it('returns an empty map when every node is pinned', () => {
-    const pos = computeLayout(
-      [
-        { id: 'a', label: 'A', position: { x: 0, y: 0 } },
-        { id: 'b', label: 'B', position: { x: 1, y: 1 } },
-      ],
-      [e('a', 'b')],
-    );
-    expect(pos.size).toBe(0);
-  });
+it('returns an empty map when every node is pinned', () => {
+  const pos = computeLayout(
+    [
+      { id: 'a', label: 'A', position: { x: 0, y: 0 } },
+      { id: 'b', label: 'B', position: { x: 1, y: 1 } },
+    ],
+    [e('a', 'b')],
+  );
+  expect(pos.size).toBe(0);
+});
 ```
 
 - [ ] **Step 2: Run to verify they fail**
@@ -85,18 +86,18 @@ In `layout.ts`, make these edits to `computeLayout` (the body operates on `autoN
 (a) Right after `if (nodes.length === 0) return result;`, insert:
 
 ```ts
-  // Only nodes WITHOUT an explicit position participate in auto-layout. Pinned
-  // nodes are placed by the consumer and must not perturb the others' ranking
-  // or centering; edges touching a pinned node fall through the unknown-node
-  // guard below (the pinned id is absent from `ids`).
-  const autoNodes = nodes.filter((node) => node.position === undefined);
-  if (autoNodes.length === 0) return result;
+// Only nodes WITHOUT an explicit position participate in auto-layout. Pinned
+// nodes are placed by the consumer and must not perturb the others' ranking
+// or centering; edges touching a pinned node fall through the unknown-node
+// guard below (the pinned id is absent from `ids`).
+const autoNodes = nodes.filter((node) => node.position === undefined);
+if (autoNodes.length === 0) return result;
 ```
 
 (b) Change the `ids` line from `new Set(nodes.map(...))` to:
 
 ```ts
-  const ids = new Set(autoNodes.map((node) => node.id));
+const ids = new Set(autoNodes.map((node) => node.id));
 ```
 
 (c) The init loop `for (const node of nodes) {` that sets `out`/`incoming`/`indegree` → change to `for (const node of autoNodes) {`.
@@ -104,8 +105,8 @@ In `layout.ts`, make these edits to `computeLayout` (the body operates on `autoN
 (d) The sources line and fallback:
 
 ```ts
-  const sources = autoNodes.filter((node) => indegree.get(node.id) === 0);
-  for (const source of sources.length > 0 ? sources : [autoNodes[0]]) visit(source.id, 0);
+const sources = autoNodes.filter((node) => indegree.get(node.id) === 0);
+for (const source of sources.length > 0 ? sources : [autoNodes[0]]) visit(source.id, 0);
 ```
 
 (e) The unranked-cycle seed line → `for (const node of autoNodes) if (!rank.has(node.id)) visit(node.id, 0);`
@@ -141,6 +142,7 @@ git commit -m "fix(FlowCanvas): computeLayout ignores pinned nodes"
 ## Task 2: `arrangeNodes` export + tests
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/FlowCanvas/layout.ts` (add `arrangeNodes`)
 - Modify: `packages/design-system/src/components/FlowCanvas/index.ts` (export)
 - Modify: `packages/design-system/src/index.ts` (export)
@@ -216,10 +218,7 @@ In `layout.ts`, after the `computeLayout` function, add:
  * // A "Re-arrange" button in your own UI (e.g. the FlowCanvas `controls` slot):
  * <Button onClick={() => setNodes((prev) => arrangeNodes(prev, edges))}>Re-arrange</Button>
  */
-export function arrangeNodes(
-  nodes: FlowCanvasNode[],
-  edges: FlowCanvasEdge[],
-): FlowCanvasNode[] {
+export function arrangeNodes(nodes: FlowCanvasNode[], edges: FlowCanvasEdge[]): FlowCanvasNode[] {
   // Strip positions so the whole graph is treated as auto and re-laid-out.
   const layout = computeLayout(
     nodes.map((node) => ({ ...node, position: undefined })),
@@ -270,6 +269,7 @@ git commit -m "feat(FlowCanvas): arrangeNodes API for consumer-driven re-arrange
 ## Task 3: FlowCanvas integration test — added pinned node moves nothing
 
 **Files:**
+
 - Test: `packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx`
 
 - [ ] **Step 1: Write the failing/guard test**
@@ -319,6 +319,7 @@ git commit -m "test(FlowCanvas): adding a pinned node leaves auto nodes in place
 ## Task 4: Playground demo — Reset → Re-arrange
 
 **Files:**
+
 - Modify: `packages/playground/src/pages/components/FlowCanvasDemo.tsx`
 
 - [ ] **Step 1: Import `arrangeNodes`**
@@ -345,10 +346,10 @@ import {
 Change the `handleReset` callback to:
 
 ```tsx
-  const handleArrange = useCallback(() => {
-    setNodes((prev) => arrangeNodes(prev, edges));
-    setLastEvent('controls: re-arrange');
-  }, [edges]);
+const handleArrange = useCallback(() => {
+  setNodes((prev) => arrangeNodes(prev, edges));
+  setLastEvent('controls: re-arrange');
+}, [edges]);
 ```
 
 - [ ] **Step 3: Swap the live button**
@@ -370,7 +371,7 @@ In the interactive `<FlowCanvas>` `controls` prop, change the second button from
 
 - [ ] **Step 4: Update the displayed code snippet**
 
-In the `code={\`...\`}` template string, change the snippet import line to include `Cluster` and `arrangeNodes`:
+In the `code={\`...\`}`template string, change the snippet import line to include`Cluster`and`arrangeNodes`:
 
 ```
 import { Badge, Button, Cluster, FlowCanvas, arrangeNodes, type FlowCanvasEdge, type FlowCanvasNode } from '@eocrm/design-system';
@@ -410,6 +411,7 @@ git commit -m "docs(FlowCanvas): demo Re-arrange via arrangeNodes"
 ## Task 5: Docs — node `position` JSDoc + AGENTS.md
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/FlowCanvas/types.ts` (the `position` field on `FlowCanvasNode`)
 - Modify: `packages/design-system/AGENTS.md` (the `### <FlowCanvas>` section)
 
@@ -457,6 +459,7 @@ npm run build -w playground
 npm pack --dry-run -w @eocrm/design-system
 npm run format:check
 ```
+
 All must pass; `npm pack --dry-run` shows no test/internal files. If `format:check` flags files, run `npm run format` and amend/commit.
 
 - [ ] **Step 2: Browser-verify** (playground on http://localhost:8080)

--- a/docs/superpowers/specs/2026-07-04-flowcanvas-arrange-nodes-design.md
+++ b/docs/superpowers/specs/2026-07-04-flowcanvas-arrange-nodes-design.md
@@ -1,0 +1,136 @@
+# FlowCanvas — pinned nodes ignore auto-layout + `arrangeNodes` API
+
+**Date:** 2026-07-04
+**Component:** `packages/design-system/src/components/FlowCanvas/`
+**Status:** Approved design, ready for planning
+**Follows:** the maximize + `controls` work (v0.2.19) which surfaced the reflow via a controls-slot "Add node" button.
+
+## Summary
+
+Two related, events-only changes to FlowCanvas's layout:
+
+1. **Fix — `computeLayout` ignores pinned nodes.** Only nodes without an explicit `position` ("auto") participate in ranking/placement/centering. A pinned node no longer perturbs the auto-laid-out nodes.
+2. **API — `arrangeNodes(nodes, edges)`.** A pure exported function that lays out **all** nodes into the layered layout and returns them with `position` set, for consumer-driven "re-arrange." No built-in button — the consumer wires their own (e.g. in the `controls` slot).
+
+No new props, no new component. `FlowCanvas`'s events-only contract (it never mutates data) is preserved.
+
+## Motivation
+
+After v0.2.19 shipped a `controls` slot, an "Add node" button that inserts a node with an explicit `position` made the existing auto-laid-out nodes visibly shift. Root cause: `computeLayout` ranks and vertically-centers **every** node — so a pinned node (e.g. an edge-less one at rank 0) inflates its rank's height and re-centers the others. (The width-jitter component of the same symptom was already fixed by #284's `width: max-content`.) Separately, consumers want a one-click "tidy the whole graph" action, but the canvas owns no state.
+
+## Decisions locked during brainstorming
+
+- **Pinned = invisible to layout** (not "ranked but unplaced", not "obstacle avoidance"). Simplest, predictable: you place pinned nodes; auto nodes lay out among themselves; the two don't interact.
+- **Re-arrange = a pure exported function**, `arrangeNodes(nodes, edges): FlowCanvasNode[]` — NOT a built-in button and NOT an imperative ref method. The consumer adds their own button and applies the result.
+- **Return `FlowCanvasNode[]`** (drop-in `setNodes((prev) => arrangeNodes(prev, edges))`), name **`arrangeNodes`**.
+- `arrangeNodes` uses `ESTIMATED_NODE_SIZE` (a standalone function can't see the live canvas's `ResizeObserver` measurements) — documented caveat; the marginal accuracy gain of a ref-based measured variant isn't worth the extra API surface (YAGNI).
+
+## Design
+
+### Part 1 — `computeLayout` ignores pinned nodes (`layout.ts`)
+
+`computeLayout(nodes, edges, sizes)` keeps its signature and return type (`Map<string, FlowCanvasPoint>`). The only change: it operates on the **auto** subset.
+
+- After the `nodes.length === 0` guard, add:
+  ```ts
+  const autoNodes = nodes.filter((node) => node.position === undefined);
+  if (autoNodes.length === 0) return result;
+  ```
+- Everywhere the algorithm currently iterates `nodes`, iterate `autoNodes` instead:
+  - `const ids = new Set(autoNodes.map((node) => node.id));`
+  - the `out`/`incoming`/`indegree` init loop: `for (const node of autoNodes)`
+  - `const sources = autoNodes.filter((node) => indegree.get(node.id) === 0);` and the source fallback `[autoNodes[0]]`
+  - the unranked-cycle seed loop: `for (const node of autoNodes) if (!rank.has(node.id)) ...`
+  - the rank-bucketing loop: `for (const node of autoNodes) { const r = rank.get(node.id)!; (ranks[r] ??= []).push(node); }`
+- The edge loop is **unchanged**: its existing guard `if (!ids.has(edge.from) || !ids.has(edge.to) || edge.from === edge.to) continue` now also skips any edge touching a pinned node, because pinned ids are no longer in `ids`. This is the same code path already used for edges to unknown nodes.
+- The returned Map therefore contains positions only for auto nodes. `positionOf` (in `FlowCanvas.tsx`) is unchanged — it already prefers an explicit `position` for pinned nodes and falls back to the computed map for auto nodes; pinned nodes' computed positions were never read.
+
+**JSDoc:** update `computeLayout`'s doc to state it lays out only nodes without an explicit `position`; pinned nodes are placed by the consumer and are ignored (they neither occupy layout space nor anchor edges).
+
+**Out of scope:** a *dragged* auto node (its `position` is still `undefined`; its live position lives in the canvas's separate `dragOverrides` map) remains "auto" and still participates — that is pre-existing behavior unrelated to this bug. Keyed strictly off `node.position !== undefined`.
+
+### Part 2 — `arrangeNodes(nodes, edges)` (`layout.ts`, exported)
+
+```ts
+/**
+ * Lay out every node into the layered left→right auto-layout and return the
+ * nodes with `position` filled in — for a consumer-driven "re-arrange / tidy"
+ * action. Unlike the internal auto-layout (which only places nodes without an
+ * explicit `position`), this re-flows ALL nodes, overwriting any existing
+ * `position`. Pure and deterministic; every other node field is preserved.
+ *
+ * Uses estimated node sizes, so vertical centering can differ by a few pixels
+ * from the live in-canvas layout (a standalone function can't measure the
+ * rendered DOM). Fine for a tidy action.
+ *
+ * @example
+ * // A "Re-arrange" button in the consumer's UI (e.g. the FlowCanvas `controls` slot):
+ * <Button onClick={() => setNodes((prev) => arrangeNodes(prev, edges))}>Re-arrange</Button>
+ */
+export function arrangeNodes(
+  nodes: FlowCanvasNode[],
+  edges: FlowCanvasEdge[],
+): FlowCanvasNode[] {
+  // Strip positions so the whole graph is treated as auto and re-laid-out.
+  const layout = computeLayout(
+    nodes.map((node) => ({ ...node, position: undefined })),
+    edges,
+  );
+  return nodes.map((node) => {
+    const position = layout.get(node.id);
+    return position ? { ...node, position } : node;
+  });
+}
+```
+
+Because every node is stripped to `position: undefined`, `computeLayout` treats all of them as auto and returns a position for each, so every node comes back with a fresh `position`. The `? : node` fallback is defensive (a node computeLayout somehow omitted keeps its prior value) and never triggers in practice.
+
+### Exports
+
+- `packages/design-system/src/components/FlowCanvas/index.ts`: `export { arrangeNodes } from './layout';`
+- `packages/design-system/src/index.ts`: add `arrangeNodes` to the existing FlowCanvas export line. (`FlowCanvasNode`/`FlowCanvasEdge` types are already exported.)
+
+## Testing
+
+### `layout.test.ts` — `computeLayout` fix
+- **Pinned excluded from result:** a mixed graph (some nodes with `position`, some without) → the result Map has keys only for the auto nodes.
+- **Auto layout is pinned-independent:** the auto nodes' computed positions equal `computeLayout(<only the auto nodes>, edges)` byte-for-byte.
+- **Reported repro:** given auto nodes A/B/C with edges, `computeLayout([A,B,C], e)` and `computeLayout([A,B,C, {id:'D', label:'D', position:{x:9,y:9}}], e)` return identical positions for A/B/C.
+- **Edge to a pinned node is skipped:** an auto node whose only incoming edge comes from a pinned node is treated as a source (rank 0), no crash.
+- **All-pinned → empty Map.**
+- Existing all-auto tests must still pass unchanged.
+
+### `layout.test.ts` — `arrangeNodes`
+- Returns every input node with a `position` set (including nodes that were pinned — their old position is overwritten).
+- Preserves other fields (`label`, `color`, `adornment`, `id`).
+- Deterministic (two calls → equal output).
+- Layered order sane (a source is left of its target: `x` ascending along an edge).
+
+### `FlowCanvas.test.tsx` — integration
+- Render auto nodes, capture each rendered node's `style.left`/`style.top`, rerender with an **added pinned node**, assert the pre-existing nodes' `left`/`top` are unchanged (jsdom uses `ESTIMATED_NODE_SIZE`, so positions are deterministic).
+
+## Demo
+
+`packages/playground/src/pages/components/FlowCanvasDemo.tsx`: in the "Workflow builder" example, change the second controls-slot button from **"Reset"** to **"Re-arrange"**, wired to `arrangeNodes`:
+```tsx
+<Button size="sm" variant="secondary" onClick={() => setNodes((prev) => arrangeNodes(prev, edges))}>
+  Re-arrange
+</Button>
+```
+Update the displayed `code` snippet and the imports (`arrangeNodes`) to match. Keep "Add node".
+
+## Documentation
+
+- `arrangeNodes` JSDoc as above (description + `@example` + the estimated-size caveat).
+- `computeLayout` JSDoc updated (Part 1).
+- `FlowCanvasNode.position` prop JSDoc (`types.ts`): add a sentence that a node with an explicit `position` is pinned and does not affect the auto-layout of the other nodes.
+- `AGENTS.md` `### <FlowCanvas>`: one line noting pinned nodes don't perturb auto-layout, and that `arrangeNodes(nodes, edges)` re-flows the whole graph for a consumer "re-arrange" button.
+
+Not a new component, so no `_meta/manifest.ts` CLUSTERS entry and no `props.manifest.json` change (no new props).
+
+## Out of scope (YAGNI)
+
+- A built-in re-arrange button (explicitly rejected — consumer adds their own).
+- An imperative ref method / measured-size variant of `arrangeNodes`.
+- Obstacle-avoidance layout around pinned nodes.
+- Any change to the drag / `dragOverrides` behavior.

--- a/docs/superpowers/specs/2026-07-04-flowcanvas-arrange-nodes-design.md
+++ b/docs/superpowers/specs/2026-07-04-flowcanvas-arrange-nodes-design.md
@@ -47,7 +47,7 @@ After v0.2.19 shipped a `controls` slot, an "Add node" button that inserts a nod
 
 **JSDoc:** update `computeLayout`'s doc to state it lays out only nodes without an explicit `position`; pinned nodes are placed by the consumer and are ignored (they neither occupy layout space nor anchor edges).
 
-**Out of scope:** a *dragged* auto node (its `position` is still `undefined`; its live position lives in the canvas's separate `dragOverrides` map) remains "auto" and still participates — that is pre-existing behavior unrelated to this bug. Keyed strictly off `node.position !== undefined`.
+**Out of scope:** a _dragged_ auto node (its `position` is still `undefined`; its live position lives in the canvas's separate `dragOverrides` map) remains "auto" and still participates — that is pre-existing behavior unrelated to this bug. Keyed strictly off `node.position !== undefined`.
 
 ### Part 2 — `arrangeNodes(nodes, edges)` (`layout.ts`, exported)
 
@@ -67,10 +67,7 @@ After v0.2.19 shipped a `controls` slot, an "Add node" button that inserts a nod
  * // A "Re-arrange" button in the consumer's UI (e.g. the FlowCanvas `controls` slot):
  * <Button onClick={() => setNodes((prev) => arrangeNodes(prev, edges))}>Re-arrange</Button>
  */
-export function arrangeNodes(
-  nodes: FlowCanvasNode[],
-  edges: FlowCanvasEdge[],
-): FlowCanvasNode[] {
+export function arrangeNodes(nodes: FlowCanvasNode[], edges: FlowCanvasEdge[]): FlowCanvasNode[] {
   // Strip positions so the whole graph is treated as auto and re-laid-out.
   const layout = computeLayout(
     nodes.map((node) => ({ ...node, position: undefined })),
@@ -93,6 +90,7 @@ Because every node is stripped to `position: undefined`, `computeLayout` treats 
 ## Testing
 
 ### `layout.test.ts` — `computeLayout` fix
+
 - **Pinned excluded from result:** a mixed graph (some nodes with `position`, some without) → the result Map has keys only for the auto nodes.
 - **Auto layout is pinned-independent:** the auto nodes' computed positions equal `computeLayout(<only the auto nodes>, edges)` byte-for-byte.
 - **Reported repro:** given auto nodes A/B/C with edges, `computeLayout([A,B,C], e)` and `computeLayout([A,B,C, {id:'D', label:'D', position:{x:9,y:9}}], e)` return identical positions for A/B/C.
@@ -101,22 +99,26 @@ Because every node is stripped to `position: undefined`, `computeLayout` treats 
 - Existing all-auto tests must still pass unchanged.
 
 ### `layout.test.ts` — `arrangeNodes`
+
 - Returns every input node with a `position` set (including nodes that were pinned — their old position is overwritten).
 - Preserves other fields (`label`, `color`, `adornment`, `id`).
 - Deterministic (two calls → equal output).
 - Layered order sane (a source is left of its target: `x` ascending along an edge).
 
 ### `FlowCanvas.test.tsx` — integration
+
 - Render auto nodes, capture each rendered node's `style.left`/`style.top`, rerender with an **added pinned node**, assert the pre-existing nodes' `left`/`top` are unchanged (jsdom uses `ESTIMATED_NODE_SIZE`, so positions are deterministic).
 
 ## Demo
 
 `packages/playground/src/pages/components/FlowCanvasDemo.tsx`: in the "Workflow builder" example, change the second controls-slot button from **"Reset"** to **"Re-arrange"**, wired to `arrangeNodes`:
+
 ```tsx
 <Button size="sm" variant="secondary" onClick={() => setNodes((prev) => arrangeNodes(prev, edges))}>
   Re-arrange
 </Button>
 ```
+
 Update the displayed `code` snippet and the imports (`arrangeNodes`) to match. Keep "Add node".
 
 ## Documentation

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -939,7 +939,10 @@ Props on the root: `onMove?: (event: KanbanMoveEvent) => void` — fires once pe
 Pan/zoom canvas for directed node-edge diagrams (workflow builders). Events-only: you own
 `nodes`/`edges`; the canvas emits intents (`onNodeCreate`, `onNodeMove`, `onNodeOpen`,
 `onNodeDelete`, `onEdgeCreate`, `onEdgeOpen`, `onEdgeDelete`) and never mutates data. Nodes
-without `position` auto-layout left → right and stay draggable for the session. Selection is
+without `position` auto-layout left → right and stay draggable for the session. Nodes with an
+explicit `position` are pinned and don't affect the auto-layout of the others (nodes without a
+`position` are auto-laid-out). `arrangeNodes(nodes, edges)` (exported) re-flows the whole graph
+and returns the nodes with fresh positions — wire it to your own "Re-arrange" button. Selection is
 single (`selection`/`defaultSelection`/`onSelectionChange`); `readOnly` disables editing but
 keeps select/open. Validation of new connections via `isValidConnection` (default: no
 self-loops, no duplicate pairs). The canvas fills its parent — give the wrapper a height.

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
@@ -2082,3 +2082,27 @@ describe('FlowCanvas maximize elevation', () => {
     expect(listbox).toHaveAttribute('data-in-overlay');
   });
 });
+
+describe('FlowCanvas auto-layout with pinned nodes', () => {
+  it('adding a pinned node does not move the auto-laid-out nodes', () => {
+    const auto: FlowCanvasNode[] = [
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+    ];
+    const edges: FlowCanvasEdge[] = [{ id: 'ab', from: 'a', to: 'b' }];
+    const { rerender } = render(<FlowCanvas nodes={auto} edges={edges} />);
+    const posOf = (label: string) => {
+      const el = screen.getByLabelText(label);
+      return { left: el.style.left, top: el.style.top };
+    };
+    const before = { a: posOf('A'), b: posOf('B') };
+    rerender(
+      <FlowCanvas
+        nodes={[...auto, { id: 'p', label: 'Pinned', position: { x: 500, y: 500 } }]}
+        edges={edges}
+      />,
+    );
+    expect(posOf('A')).toEqual(before.a);
+    expect(posOf('B')).toEqual(before.b);
+  });
+});

--- a/packages/design-system/src/components/FlowCanvas/index.ts
+++ b/packages/design-system/src/components/FlowCanvas/index.ts
@@ -1,3 +1,4 @@
 export { FlowCanvas } from './FlowCanvas';
+export { arrangeNodes } from './layout';
 export type { FlowCanvasProps } from './FlowCanvas';
 export type { FlowCanvasPoint, FlowCanvasNode, FlowCanvasEdge, FlowCanvasSelection } from './types';

--- a/packages/design-system/src/components/FlowCanvas/layout.test.ts
+++ b/packages/design-system/src/components/FlowCanvas/layout.test.ts
@@ -90,4 +90,45 @@ describe('computeLayout', () => {
     );
     expect(ESTIMATED_NODE_SIZE.width).toBeGreaterThan(0);
   });
+
+  it('ignores pinned nodes (explicit position) — absent from the result', () => {
+    const pos = computeLayout(
+      [n('a'), n('b'), { id: 'pinned', label: 'P', position: { x: 5, y: 5 } }],
+      [e('a', 'b')],
+    );
+    expect(pos.has('pinned')).toBe(false);
+    expect(pos.has('a')).toBe(true);
+    expect(pos.has('b')).toBe(true);
+  });
+
+  it('lays out auto nodes independently of pinned nodes', () => {
+    const autoOnly = computeLayout([n('a'), n('b'), n('c')], [e('a', 'b'), e('b', 'c')]);
+    const withPinned = computeLayout(
+      [n('a'), n('b'), n('c'), { id: 'd', label: 'D', position: { x: 9, y: 9 } }],
+      [e('a', 'b'), e('b', 'c')],
+    );
+    expect(withPinned.get('a')).toEqual(autoOnly.get('a'));
+    expect(withPinned.get('b')).toEqual(autoOnly.get('b'));
+    expect(withPinned.get('c')).toEqual(autoOnly.get('c'));
+  });
+
+  it('treats an auto node fed only by a pinned node as a source (edge to pinned skipped)', () => {
+    const pos = computeLayout(
+      [{ id: 'p', label: 'P', position: { x: 0, y: 0 } }, n('b')],
+      [e('p', 'b')],
+    );
+    expect(pos.has('p')).toBe(false);
+    expect(pos.get('b')!.x).toBe(0); // rank-0 source, no incoming
+  });
+
+  it('returns an empty map when every node is pinned', () => {
+    const pos = computeLayout(
+      [
+        { id: 'a', label: 'A', position: { x: 0, y: 0 } },
+        { id: 'b', label: 'B', position: { x: 1, y: 1 } },
+      ],
+      [e('a', 'b')],
+    );
+    expect(pos.size).toBe(0);
+  });
 });

--- a/packages/design-system/src/components/FlowCanvas/layout.test.ts
+++ b/packages/design-system/src/components/FlowCanvas/layout.test.ts
@@ -1,4 +1,4 @@
-import { computeLayout, ESTIMATED_NODE_SIZE } from './layout';
+import { arrangeNodes, computeLayout, ESTIMATED_NODE_SIZE } from './layout';
 import type { FlowCanvasEdge, FlowCanvasNode } from './types';
 
 const n = (id: string): FlowCanvasNode => ({ id, label: id });
@@ -130,5 +130,38 @@ describe('computeLayout', () => {
       [e('a', 'b')],
     );
     expect(pos.size).toBe(0);
+  });
+});
+
+describe('arrangeNodes', () => {
+  it('gives every node a position and lays the graph out left → right', () => {
+    const result = arrangeNodes([n('a'), n('b'), n('c')], [e('a', 'b'), e('b', 'c')]);
+    expect(result.every((node) => node.position !== undefined)).toBe(true);
+    const x = (id: string) => result.find((node) => node.id === id)!.position!.x;
+    expect(x('a')).toBeLessThan(x('b'));
+    expect(x('b')).toBeLessThan(x('c'));
+  });
+
+  it('overwrites existing (pinned) positions — it re-flows ALL nodes', () => {
+    const result = arrangeNodes(
+      [{ id: 'a', label: 'A', position: { x: 999, y: 999 } }, n('b')],
+      [e('a', 'b')],
+    );
+    expect(result.find((node) => node.id === 'a')!.position).not.toEqual({ x: 999, y: 999 });
+    expect(result.find((node) => node.id === 'b')!.position).toBeDefined();
+  });
+
+  it('preserves all other node fields', () => {
+    const result = arrangeNodes([{ id: 'a', label: 'A', color: '#123456', adornment: 'x' }], []);
+    const a = result.find((node) => node.id === 'a')!;
+    expect(a.label).toBe('A');
+    expect(a.color).toBe('#123456');
+    expect(a.adornment).toBe('x');
+  });
+
+  it('is deterministic', () => {
+    const nodes = [n('a'), n('b'), n('c')];
+    const edges = [e('a', 'b')];
+    expect(arrangeNodes(nodes, edges)).toEqual(arrangeNodes(nodes, edges));
   });
 });

--- a/packages/design-system/src/components/FlowCanvas/layout.ts
+++ b/packages/design-system/src/components/FlowCanvas/layout.ts
@@ -132,7 +132,10 @@ export function computeLayout(
  * // A "Re-arrange" button in your own UI (e.g. the FlowCanvas `controls` slot):
  * <Button onClick={() => setNodes((prev) => arrangeNodes(prev, edges))}>Re-arrange</Button>
  */
-export function arrangeNodes(nodes: FlowCanvasNode[], edges: FlowCanvasEdge[]): FlowCanvasNode[] {
+export function arrangeNodes(
+  nodes: readonly FlowCanvasNode[],
+  edges: readonly FlowCanvasEdge[],
+): FlowCanvasNode[] {
   // Strip positions so the whole graph is treated as auto and re-laid-out.
   const layout = computeLayout(
     nodes.map((node) => ({ ...node, position: undefined })),

--- a/packages/design-system/src/components/FlowCanvas/layout.ts
+++ b/packages/design-system/src/components/FlowCanvas/layout.ts
@@ -116,3 +116,33 @@ export function computeLayout(
   }
   return result;
 }
+
+/**
+ * Lay out every node into the layered left→right auto-layout and return the
+ * nodes with `position` filled in — for a consumer-driven "re-arrange / tidy"
+ * action. Unlike {@link computeLayout} (which only places nodes without an
+ * explicit `position`), this re-flows ALL nodes, overwriting any existing
+ * `position`. Pure and deterministic; every other node field is preserved.
+ *
+ * Uses estimated node sizes, so vertical centering can differ by a few pixels
+ * from the live in-canvas layout (a standalone function cannot measure the
+ * rendered DOM). Fine for a tidy action.
+ *
+ * @example
+ * // A "Re-arrange" button in your own UI (e.g. the FlowCanvas `controls` slot):
+ * <Button onClick={() => setNodes((prev) => arrangeNodes(prev, edges))}>Re-arrange</Button>
+ */
+export function arrangeNodes(
+  nodes: FlowCanvasNode[],
+  edges: FlowCanvasEdge[],
+): FlowCanvasNode[] {
+  // Strip positions so the whole graph is treated as auto and re-laid-out.
+  const layout = computeLayout(
+    nodes.map((node) => ({ ...node, position: undefined })),
+    edges,
+  );
+  return nodes.map((node) => {
+    const position = layout.get(node.id);
+    return position ? { ...node, position } : node;
+  });
+}

--- a/packages/design-system/src/components/FlowCanvas/layout.ts
+++ b/packages/design-system/src/components/FlowCanvas/layout.ts
@@ -18,6 +18,9 @@ const NODE_GAP = 32; // vertical gap between nodes within a rank
  * crossings; ranks are vertically centered against the tallest rank.
  * Pure, deterministic, and cycle-safe (back-edges to on-stack nodes are
  * skipped). Self-loops and edges to unknown nodes are ignored.
+ * Only nodes without an explicit `position` are laid out; a node WITH a
+ * `position` is pinned by the consumer and is ignored here — it neither
+ * occupies layout space nor anchors edges, so it never shifts the others.
  */
 export function computeLayout(
   nodes: readonly FlowCanvasNode[],
@@ -27,11 +30,18 @@ export function computeLayout(
   const result = new Map<string, FlowCanvasPoint>();
   if (nodes.length === 0) return result;
 
-  const ids = new Set(nodes.map((node) => node.id));
+  // Only nodes WITHOUT an explicit position participate in auto-layout. Pinned
+  // nodes are placed by the consumer and must not perturb the others' ranking
+  // or centering; edges touching a pinned node fall through the unknown-node
+  // guard below (the pinned id is absent from `ids`).
+  const autoNodes = nodes.filter((node) => node.position === undefined);
+  if (autoNodes.length === 0) return result;
+
+  const ids = new Set(autoNodes.map((node) => node.id));
   const out = new Map<string, string[]>();
   const incoming = new Map<string, string[]>();
   const indegree = new Map<string, number>();
-  for (const node of nodes) {
+  for (const node of autoNodes) {
     out.set(node.id, []);
     incoming.set(node.id, []);
     indegree.set(node.id, 0);
@@ -55,15 +65,15 @@ export function computeLayout(
     for (const next of out.get(id)!) visit(next, r + 1);
     onStack.delete(id);
   };
-  const sources = nodes.filter((node) => indegree.get(node.id) === 0);
-  for (const source of sources.length > 0 ? sources : [nodes[0]]) visit(source.id, 0);
+  const sources = autoNodes.filter((node) => indegree.get(node.id) === 0);
+  for (const source of sources.length > 0 ? sources : [autoNodes[0]]) visit(source.id, 0);
   // Cycle components unreachable from any source: seed a DFS from each still-
   // unranked node so their internal edges keep flowing left → right.
-  for (const node of nodes) if (!rank.has(node.id)) visit(node.id, 0);
+  for (const node of autoNodes) if (!rank.has(node.id)) visit(node.id, 0);
 
   // Bucket by rank in input order.
   const ranks: FlowCanvasNode[][] = [];
-  for (const node of nodes) {
+  for (const node of autoNodes) {
     const r = rank.get(node.id)!;
     (ranks[r] ??= []).push(node);
   }

--- a/packages/design-system/src/components/FlowCanvas/layout.ts
+++ b/packages/design-system/src/components/FlowCanvas/layout.ts
@@ -132,10 +132,7 @@ export function computeLayout(
  * // A "Re-arrange" button in your own UI (e.g. the FlowCanvas `controls` slot):
  * <Button onClick={() => setNodes((prev) => arrangeNodes(prev, edges))}>Re-arrange</Button>
  */
-export function arrangeNodes(
-  nodes: FlowCanvasNode[],
-  edges: FlowCanvasEdge[],
-): FlowCanvasNode[] {
+export function arrangeNodes(nodes: FlowCanvasNode[], edges: FlowCanvasEdge[]): FlowCanvasNode[] {
   // Strip positions so the whole graph is treated as auto and re-laid-out.
   const layout = computeLayout(
     nodes.map((node) => ({ ...node, position: undefined })),

--- a/packages/design-system/src/components/FlowCanvas/types.ts
+++ b/packages/design-system/src/components/FlowCanvas/types.ts
@@ -25,6 +25,9 @@ export interface FlowCanvasNode {
   /**
    * Position in canvas coordinates. When omitted the node is auto-laid-out
    * (layered, left → right) and remains user-draggable for the session.
+   * A node with an explicit `position` is *pinned*: it stays where you place it
+   * and does not participate in — or perturb — the auto-layout of the other
+   * nodes. Use `arrangeNodes(nodes, edges)` to re-flow the whole graph.
    */
   position?: FlowCanvasPoint;
   /**

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -131,7 +131,7 @@ export type {
   FilterChipValueProps,
 } from './components/FilterChip';
 
-export { FlowCanvas } from './components/FlowCanvas';
+export { FlowCanvas, arrangeNodes } from './components/FlowCanvas';
 export type {
   FlowCanvasProps,
   FlowCanvasNode,

--- a/packages/playground/src/pages/components/FlowCanvasDemo.tsx
+++ b/packages/playground/src/pages/components/FlowCanvasDemo.tsx
@@ -7,6 +7,7 @@ import {
   Stack,
   Text,
   Title,
+  arrangeNodes,
   type FlowCanvasEdge,
   type FlowCanvasNode,
 } from '@eocrm/design-system';
@@ -81,11 +82,10 @@ export function FlowCanvasDemo() {
     ]);
     setLastEvent('controls: add node');
   }, [nodes.length]);
-  const handleReset = useCallback(() => {
-    setNodes(WORKFLOW_NODES);
-    setEdges(WORKFLOW_EDGES);
-    setLastEvent('controls: reset');
-  }, []);
+  const handleArrange = useCallback(() => {
+    setNodes((prev) => arrangeNodes(prev, edges));
+    setLastEvent('controls: re-arrange');
+  }, [edges]);
 
   return (
     <DemoLayout
@@ -96,9 +96,9 @@ export function FlowCanvasDemo() {
     >
       <Example
         title="Workflow builder"
-        description="Drag nodes, drag from a node's edge handle to connect, double-click empty space to add a state, Delete to remove the selection. Custom controls (top-left) and a Maximize toggle (top-right) — press F or Escape to toggle fullscreen. Full keyboard support: arrows rove, E cycles edges, C connects, Shift+arrows nudge."
+        description="Drag nodes, drag from a node's edge handle to connect, double-click empty space to add a state, Delete to remove the selection. Custom controls (top-left) and a Maximize toggle (top-right) — press F or Escape to toggle fullscreen. Full keyboard support: arrows rove, E cycles edges, C connects, Shift+arrows nudge. The top-left controls show a custom Add-node button and a Re-arrange button wired to arrangeNodes()."
         code={`import { useState } from 'react';
-import { Badge, Button, FlowCanvas, type FlowCanvasEdge, type FlowCanvasNode } from '@eocrm/design-system';
+import { Badge, Button, Cluster, FlowCanvas, arrangeNodes, type FlowCanvasEdge, type FlowCanvasNode } from '@eocrm/design-system';
 
 export function Demo() {
   const [nodes, setNodes] = useState<FlowCanvasNode[]>([
@@ -113,7 +113,12 @@ export function Demo() {
       <FlowCanvas
         nodes={nodes}
         edges={edges}
-        controls={<Button size="sm" onClick={() => setNodes((prev) => [...prev, { id: crypto.randomUUID(), label: 'New state', position: { x: 40, y: 40 } }])}>Add node</Button>}
+        controls={
+          <Cluster gap="xs">
+            <Button size="sm" onClick={() => setNodes((prev) => [...prev, { id: crypto.randomUUID(), label: 'New state', position: { x: 40, y: 40 } }])}>Add node</Button>
+            <Button size="sm" variant="secondary" onClick={() => setNodes((prev) => arrangeNodes(prev, edges))}>Re-arrange</Button>
+          </Cluster>
+        }
         onNodeCreate={(pos) =>
           setNodes((prev) => [...prev, { id: crypto.randomUUID(), label: 'New state', position: pos }])
         }
@@ -146,8 +151,8 @@ export function Demo() {
                   <Button size="sm" variant="primary" onClick={handleAddNode}>
                     Add node
                   </Button>
-                  <Button size="sm" variant="secondary" onClick={handleReset}>
-                    Reset
+                  <Button size="sm" variant="secondary" onClick={handleArrange}>
+                    Re-arrange
                   </Button>
                 </Cluster>
               }


### PR DESCRIPTION
Two related, events-only changes to FlowCanvas layout (follows the maximize + `controls` work in v0.2.19, which surfaced the reflow).

## Fix: pinned nodes no longer perturb auto-layout
`computeLayout` now lays out only nodes **without** an explicit `position`. A pinned node (e.g. one added via a controls-slot "Add node" button) no longer joins a rank and inflates its height, so the auto-laid-out nodes stay put. The existing unknown-node edge guard skips edges touching a pinned node for free.

## Feature: `arrangeNodes(nodes, edges)` — consumer-driven re-arrange
New pure export:
```ts
arrangeNodes(nodes: readonly FlowCanvasNode[], edges: readonly FlowCanvasEdge[]): FlowCanvasNode[]
```
It re-flows the **whole** graph (strips positions → `computeLayout` → returns nodes with fresh `position`s), preserving every other field. No built-in button — the consumer wires their own (e.g. in the `controls` slot):
```tsx
<Button onClick={() => setNodes((prev) => arrangeNodes(prev, edges))}>Re-arrange</Button>
```
The playground demo's controls now show it (Add node + Re-arrange).

## Verification
- **3723 tests pass** (8 new layout tests + 1 FlowCanvas integration test proving an added pinned node moves nothing); typecheck + stylelint clean; `npm pack --dry-run` clean.
- **Browser-verified:** "Add node" leaves the four seed nodes byte-for-byte in place (previously "Open" jumped); "Re-arrange" re-flows all nodes (including a previously-pinned one) into the layered layout.
- Fresh-context review → `clean enough to stop` (no Critical/Important).

Spec: docs/superpowers/specs/2026-07-04-flowcanvas-arrange-nodes-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)