### PR TITLE
fix(Tabs): active underline spans the whole tab cell (label + actions)

### DIFF
--- a/packages/design-system/src/components/Tabs/Tabs.tsx
+++ b/packages/design-system/src/components/Tabs/Tabs.tsx
@@ -235,15 +235,22 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(function Tabs(
     }
     indicator.style.opacity = '1';
 
+    // When the active tab is wrapped in a per-tab `actions` cell
+    // (role="presentation"), measure the CELL so the underline spans the whole
+    // tab — label AND its controls — instead of just the button. Bare tabs
+    // (no actions) measure the button, unchanged.
+    const cell = node.parentElement;
+    const measureNode = cell && cell.getAttribute('role') === 'presentation' ? cell : node;
+
     const vertical = orientation === 'vertical';
     const write = () => {
       if (vertical) {
-        indicator.style.transform = `translateY(${node.offsetTop}px)`;
-        indicator.style.height = `${node.offsetHeight}px`;
+        indicator.style.transform = `translateY(${measureNode.offsetTop}px)`;
+        indicator.style.height = `${measureNode.offsetHeight}px`;
         indicator.style.width = ''; // CSS owns the bar thickness in vertical
       } else {
-        indicator.style.transform = `translateX(${node.offsetLeft}px)`;
-        indicator.style.width = `${node.offsetWidth}px`;
+        indicator.style.transform = `translateX(${measureNode.offsetLeft}px)`;
+        indicator.style.width = `${measureNode.offsetWidth}px`;
         indicator.style.height = ''; // CSS owns the bar thickness in horizontal
       }
     };


### PR DESCRIPTION
When a tab has per-tab `actions`, the animated blue underline now spans the whole tab — the label **and** its controls — instead of stopping at the label.

## How
The indicator's `useLayoutEffect` measured the `<button role="tab">`. Now, when the active tab is wrapped in a per-tab `actions` cell (the `role="presentation"` wrapper), it measures the **cell** instead, so `translateX`/`width` cover the button + its controls. Bare tabs (no `actions`) still measure the button — unchanged.

Works for both orientations (horizontal underline width, vertical accent-bar height).

## Verification
- 3730 tests pass; typecheck + stylelint clean; tarball clean. (jsdom can't measure layout, so this is browser-verified.)
- **Browser-verified:** active "Automation" tab → indicator width 132px == cell width (covers the Switch), vs button 100px; active "Accounts" closeable tab underlines label + ✕; a bare active tab still matches its button (79px == 79px); strip-level `endContent` ("+ New tab") stays un-underlined (it's outside the tablist).

Follow-up to v0.2.21 (Tabs per-tab actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)