### PR TITLE
fix(Tabs): actions trailing inset + full-width endContent border

### DIFF
--- a/packages/design-system/src/components/Tabs/Tabs.module.scss
+++ b/packages/design-system/src/components/Tabs/Tabs.module.scss
@@ -181,9 +181,13 @@
 
   // A celled tab is the full-width row: the button fills, actions pin right.
   // `display`/`gap`/`align-items` are inherited from the base `.cell` rule.
+  // padding-inline-end insets the actions from the rail's right edge to match
+  // the button's own horizontal padding on the left (otherwise the control is
+  // glued to the edge).
   .cell {
     width: 100%;
     justify-content: space-between;
+    padding-inline-end: var(--tabs-vertical-tab-padding-x);
   }
 
   .cell > .tab {
@@ -245,6 +249,12 @@
   display: inline-flex;
   align-items: center;
   gap: var(--tabs-cell-gap);
+
+  // Trailing inset so the actions aren't glued to the tab's right edge — matches
+  // the horizontal padding a bare tab button carries. The underline spans the
+  // whole cell, so this also gives the underline the same right breathing room
+  // a bare tab's underline has. (Vertical overrides with its own padding-x.)
+  padding-inline-end: var(--tabs-tab-padding-x);
 }
 
 .tabActions {

--- a/packages/design-system/src/components/Tabs/Tabs.module.scss
+++ b/packages/design-system/src/components/Tabs/Tabs.module.scss
@@ -212,17 +212,17 @@
 }
 
 // ---- Strip-level endContent (only rendered when the prop is set) ----
-// space-between pins endContent to the far end; the scroll wrapper is allowed
-// to shrink (min-width: 0) so tabs scroll within it while endContent stays put.
-// No flex-grow / margin (Rule 4 / stylelint) — space-between + flex-shrink do it.
+// The scroll region fills the row so the tablist's bottom border spans the full
+// tab area, and endContent carries a matching border so the track runs unbroken
+// under it (full-width, not cut at the last tab). align-items: flex-end
+// bottom-aligns both so their borders — and the indicator — land on one line.
 .root {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--tabs-endcontent-gap);
+  align-items: flex-end;
 
   .scrollWrap {
-    min-width: 0;
+    flex: 1; // fill the row (shorthand, not the disallowed flex-grow longhand)
+    min-width: 0; // let the tabs overflow-scroll instead of forcing the row wider
   }
 }
 
@@ -230,14 +230,26 @@
   display: inline-flex;
   align-items: center;
   flex-shrink: 0;
+
+  // Space before the controls (a flex gap would break the border line) plus the
+  // continuation of the tablist's bottom track under endContent.
+  padding-inline-start: var(--tabs-endcontent-gap);
+  border-bottom: var(--border-width-emphasis) solid var(--tabs-border-color);
 }
 
 .rootVertical {
   flex-direction: column;
   align-items: stretch;
 
+  // Vertical has no bottom track: the rail is content-height, endContent below.
+  .scrollWrap {
+    flex: initial;
+  }
+
   .endContent {
     justify-content: flex-start;
+    padding-inline-start: 0;
+    border-bottom: none;
   }
 }
 

--- a/packages/playground/src/pages/components/TabsDemo.tsx
+++ b/packages/playground/src/pages/components/TabsDemo.tsx
@@ -1,5 +1,15 @@
 import { useState } from 'react';
-import { Activity, CreditCard, FileText, Mail, Settings, Shield, User, X } from 'lucide-react';
+import {
+  Activity,
+  CreditCard,
+  FileText,
+  Mail,
+  MoreVertical,
+  Settings,
+  Shield,
+  User,
+  X,
+} from 'lucide-react';
 import { Tabs } from '@eocrm/design-system';
 import { Badge } from '@eocrm/design-system';
 import { Button } from '@eocrm/design-system';
@@ -249,7 +259,16 @@ export function Demo() {
         <Tabs
           orientation="vertical"
           items={[
-            { id: 'general', label: 'General', icon: <Settings size={14} /> },
+            {
+              id: 'general',
+              label: 'General',
+              icon: <Settings size={14} />,
+              actions: (
+                <Button iconOnly size="xs" variant="ghost" aria-label="General options">
+                  <MoreVertical size={14} />
+                </Button>
+              ),
+            },
             {
               id: 'security',
               label: 'Security',
@@ -280,7 +299,16 @@ export function Demo() {
             <Tabs
               orientation="vertical"
               items={[
-                { id: 'general', label: 'General', icon: <Settings size={14} /> },
+                {
+                  id: 'general',
+                  label: 'General',
+                  icon: <Settings size={14} />,
+                  actions: (
+                    <Button iconOnly size="xs" variant="ghost" aria-label="General options">
+                      <MoreVertical size={14} />
+                    </Button>
+                  ),
+                },
                 {
                   id: 'security',
                   label: 'Security',


### PR DESCRIPTION
Two Tabs visual fixes reported while dogfooding v0.2.22.

## 1. Per-tab actions were glued to the tab's trailing edge (both orientations)
`actions` controls had no trailing space, unlike a bare tab's horizontal padding. Added `padding-inline-end` to the actions cell (`--tabs-tab-padding-x` horizontal, `--tabs-vertical-tab-padding-x` vertical) so the control — and the underline that spans the cell — get the same right breathing room. Also added a per-row options control to the vertical demo (that case wasn't covered).

## 2. endContent cut the tablist's bottom border at the last tab
With `endContent`, `justify-content: space-between` left the tablist border stopping at the last tab. Now the scroll region fills the row so the tablist border reaches `endContent`, and `endContent` carries a matching border so the track runs unbroken full-width; `align-items: flex-end` keeps both borders (and the sliding indicator) on one baseline. Vertical is unaffected.

## Verification
- 3730 tests pass; typecheck + stylelint clean; playground builds; tarball clean.
- **Browser-verified:** actions now 12px from the cell edge in both orientations (`gluedToRight: false`); endContent border meets the tablist border with 0 gap on the same baseline, reaches the bar's right edge, and the indicator still sits on the track.

Follow-up to v0.2.22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)