### PR TITLE
fix(FlowCanvas): controls-slot popovers/overlays work (portaled events no longer intercepted)

### DIFF
--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { FlowCanvas } from './FlowCanvas';
 import type { FlowCanvasEdge, FlowCanvasNode } from './types';
 import { Select } from '../Select';
+import { ConfirmationPopover } from '../ConfirmationPopover';
 import { overlayStack } from '../_internal/overlay';
 
 const NODES: FlowCanvasNode[] = [
@@ -2104,5 +2105,32 @@ describe('FlowCanvas auto-layout with pinned nodes', () => {
     );
     expect(posOf('A')).toEqual(before.a);
     expect(posOf('B')).toEqual(before.b);
+  });
+});
+
+describe('FlowCanvas controls with portaled overlays (#290)', () => {
+  it('does not treat a controls popover portaled to body as canvas background', async () => {
+    const onNodeCreate = vi.fn();
+    render(
+      <FlowCanvas
+        nodes={NODES}
+        edges={EDGES}
+        onNodeCreate={onNodeCreate}
+        controls={
+          <ConfirmationPopover title="Re-arrange?" onConfirm={() => {}}>
+            <button>Re-arrange</button>
+          </ConfirmationPopover>
+        }
+      />,
+    );
+    // Open the ConfirmationPopover — its footer renders in a portal to
+    // document.body but its events still bubble to the canvas root's handlers.
+    fireEvent.click(screen.getByRole('button', { name: 'Re-arrange' }));
+    const confirm = await screen.findByRole('button', { name: 'Confirm' });
+    // A double-click on the portaled footer must NOT be read as an empty-canvas
+    // background double-click (which would create a node). Before the fix,
+    // isBackgroundTarget returned true for the body-portaled target.
+    fireEvent.dblClick(confirm);
+    expect(onNodeCreate).not.toHaveBeenCalled();
   });
 });

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
@@ -556,7 +556,15 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
   } | null>(null);
   const isBackgroundTarget = (target: EventTarget | null): boolean => {
     const el = target as HTMLElement | null;
-    return !el?.closest?.(
+    // Events from a portaled overlay opened inside `controls` (a Popover /
+    // ConfirmationPopover / DropdownMenu whose content renders into
+    // document.body) still bubble to these React handlers — React portals
+    // bubble through the React tree, not the DOM tree — even though the DOM
+    // target lives outside the canvas. Never treat those as canvas background:
+    // doing so starts a background pan (setPointerCapture swallows the
+    // overlay's own click) or creates a node on double-click. #290
+    if (!el || !rootRef.current?.contains(el)) return false;
+    return !el.closest?.(
       '[data-flow-node], [data-flow-edge], [data-flow-chip], [data-flow-controls], [data-flow-handle]',
     );
   };

--- a/packages/playground/src/pages/components/FlowCanvasDemo.tsx
+++ b/packages/playground/src/pages/components/FlowCanvasDemo.tsx
@@ -3,6 +3,7 @@ import {
   Badge,
   Button,
   Cluster,
+  ConfirmationPopover,
   FlowCanvas,
   Stack,
   Text,
@@ -151,9 +152,18 @@ export function Demo() {
                   <Button size="sm" variant="primary" onClick={handleAddNode}>
                     Add node
                   </Button>
-                  <Button size="sm" variant="secondary" onClick={handleArrange}>
-                    Re-arrange
-                  </Button>
+                  {/* A ConfirmationPopover works from the controls slot even though
+                      its footer portals to document.body (#290). */}
+                  <ConfirmationPopover
+                    title="Re-arrange all nodes?"
+                    description="This overwrites every node's current position."
+                    confirmLabel="Re-arrange"
+                    onConfirm={handleArrange}
+                  >
+                    <Button size="sm" variant="secondary">
+                      Re-arrange
+                    </Button>
+                  </ConfirmationPopover>
                 </Cluster>
               }
               onNodeCreate={handleNodeCreate}


### PR DESCRIPTION
Closes #290.

## Bug
A `ConfirmationPopover` (or `Popover`/`DropdownMenu`) whose trigger lives in a `FlowCanvas` `controls` slot opened fine, but its footer buttons did nothing — `onConfirm`/`onCancel` never fired.

## Cause
The overlay's footer renders in a **portal to `document.body`**, but React portal events still bubble to the canvas root's handlers (React portals bubble through the React tree, not the DOM tree). `isBackgroundTarget` only checked `.closest('[data-flow-controls], …)`, which the body-portaled target fails — so it returned `true`, `handleRootPointerDown` treated the Confirm press as a background pan and `setPointerCapture` swallowed the click (and a double-click would create a node).

## Fix
`isBackgroundTarget` now returns `false` for any target not inside the canvas root — portaled overlays opened from `controls` are never treated as canvas background. One centralized guard fixes both the pan-capture and node-create paths.

## Verification
- 3731 tests pass; typecheck + stylelint clean; playground builds; tarball clean.
- New regression test (`#290`) **fails without the fix** (double-clicking the portaled footer created a node) and passes with it.
- **Browser-verified** the exact repro: a `ConfirmationPopover` in the controls slot — clicking **Confirm** now fires `onConfirm` (nodes re-arrange) and dismisses the popover; previously the click was swallowed. Demo updated to wrap "Re-arrange" in a `ConfirmationPopover`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)