### PR TITLE
fix(FlowCanvas): remove the stray focus box around clicked edges/nodes (+ edge toolbar at corner)

### DIFF
--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.module.scss
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.module.scss
@@ -15,8 +15,25 @@
   touch-action: none; // claim touch drags so the page doesn't scroll instead
   cursor: grab;
 
+  // Canvas keyboard-focus ring. The `focus-ring` mixin also sets `outline:
+  // none`, which kills the raw UA focus outline whenever the canvas is focused.
   &:focus-visible {
     @include focus-ring;
+  }
+
+  // Keyboard roving moves real DOM focus onto the child node/edge (which then
+  // shows its own ring/recolor), but selecting an edge by CLICK leaves focus on
+  // this root (SVG paths don't take reliable click-focus), so the ring above
+  // would wrap the WHOLE canvas in a loose rounded box that reads as a giant
+  // selection frame around the selected item. That item already shows its own
+  // highlight (node accent border / edge recolor), so drop the redundant ring
+  // whenever a selection is present. `outline: none` from the mixin still
+  // applies, so the raw UA outline never reappears either. The attribute is
+  // gated on the selection resolving to a rendered item (see FlowCanvas.tsx),
+  // so a dangling selection keeps the ring — the focused-but-empty state stays
+  // visible for keyboard users (WCAG 2.4.7).
+  &[data-flow-has-selection]:focus-visible {
+    box-shadow: none;
   }
 }
 

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.module.scss
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.module.scss
@@ -15,6 +15,12 @@
   touch-action: none; // claim touch drags so the page doesn't scroll instead
   cursor: grab;
 
+  // Never paint the UA focus outline — our indicator is the box-shadow ring
+  // below. A `:focus-visible` reset misses a plain MOUSE `:focus` (e.g. clicking
+  // empty canvas), where Chrome on Windows paints `outline: auto` around the
+  // whole role=application canvas. Suppress it in every focus state.
+  outline: none;
+
   // Canvas keyboard-focus ring. The `focus-ring` mixin also sets `outline:
   // none`, which kills the raw UA focus outline whenever the canvas is focused.
   &:focus-visible {
@@ -99,9 +105,14 @@
   // unlabeled edge below the WCAG 2.5.8 minimum.
   vector-effect: non-scaling-stroke;
 
-  &:focus-visible {
-    outline: none;
-  }
+  // Never paint the UA focus outline. This corridor is a WIDE invisible stroke,
+  // so an `outline: auto` traces a big rounded box around the edge's bounding
+  // area. A `:focus-visible`-scoped reset is NOT enough: a MOUSE click gives
+  // plain `:focus` (not `-visible`), and Chrome on Windows paints `outline:
+  // auto` in that state (macOS Chromium doesn't — hence it only reproduces on
+  // Windows). Focus/selection is shown by recoloring the visible .edgePath
+  // (below / [data-active]), so suppress the outline outright.
+  outline: none;
 }
 
 // Keyboard focus (E-key edge cycling) must stay visible even when the
@@ -175,6 +186,12 @@ g:has(> .edgeHit:focus-visible) > .edgePath {
   cursor: grab;
   user-select: none;
   touch-action: none;
+
+  // Never paint the UA focus outline — selection is the accent border
+  // ([data-selected]) and keyboard focus is the glow ring (:focus-visible). A
+  // `:focus-visible` reset misses a plain MOUSE `:focus`, where Chrome on
+  // Windows paints `outline: auto` around this role=button node.
+  outline: none;
 
   &:focus-visible {
     @include focus-ring;

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
@@ -256,6 +256,73 @@ describe('FlowCanvas viewport', () => {
     expect(screen.getByRole('status').textContent).toBe('');
   });
 
+  it('flags the root with data-flow-has-selection only while a RESOLVED item is selected (gates the canvas focus ring)', () => {
+    // The root keeps DOM focus when an edge is click-selected, so its
+    // :focus-visible ring would wrap the whole canvas. The
+    // [data-flow-has-selection] flag lets the SCSS suppress that ring once a
+    // node/edge is selected (the item's own highlight is the focus indicator
+    // then) while keeping it for the focused-but-empty state. See
+    // FlowCanvas.module.scss `.root:focus-visible`.
+    const { rerender } = render(<FlowCanvas nodes={NODES} edges={EDGES} selection={null} />);
+    const root = screen.getByRole('application');
+    expect(root).not.toHaveAttribute('data-flow-has-selection');
+
+    rerender(<FlowCanvas nodes={NODES} edges={EDGES} selection={{ type: 'node', id: 'open' }} />);
+    expect(root).toHaveAttribute('data-flow-has-selection', '');
+
+    rerender(<FlowCanvas nodes={NODES} edges={EDGES} selection={{ type: 'edge', id: 't1' }} />);
+    expect(root).toHaveAttribute('data-flow-has-selection', '');
+
+    // A selection whose id is entirely absent from the graph is already voided
+    // by the derived-selection filter, so the flag never sets.
+    rerender(<FlowCanvas nodes={NODES} edges={EDGES} selection={{ type: 'node', id: 'ghost' }} />);
+    expect(root).not.toHaveAttribute('data-flow-has-selection');
+
+    // The load-bearing case for the resolve gate: an edge that IS in `edges`
+    // (so the derived-selection filter keeps it) but references a node missing
+    // from `nodes`, so it is never rendered (resolvedEdges skips it). Here
+    // `selection != null` is true, yet nothing is highlighted — suppressing the
+    // root ring would strand a keyboard user with no visible focus (WCAG 2.4.7),
+    // so the flag must stay off. (resolvedEdges warns on the missing node.)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    rerender(
+      <FlowCanvas
+        nodes={NODES}
+        edges={[{ id: 'x', from: 'open', to: 'ghost' }]}
+        selection={{ type: 'edge', id: 'x' }}
+      />,
+    );
+    expect(root).not.toHaveAttribute('data-flow-has-selection');
+    warn.mockRestore();
+
+    rerender(<FlowCanvas nodes={NODES} edges={EDGES} selection={null} />);
+    expect(root).not.toHaveAttribute('data-flow-has-selection');
+  });
+
+  it('anchors the edge action toolbar at the edge bounding-box top-right (target edge), not the midpoint', () => {
+    // Horizontal edge open(0,0) → done(300,0): the edge's rightmost point is the
+    // target's left edge — canvas x = 300 = done's position, independent of node
+    // size — well past the midpoint (~(w+300)/2). The toolbar anchors to that
+    // top-right corner (matching how node actions anchor to a node's corner), so
+    // its screen-px left is maxX*z + tx with maxX = 300, which a midpoint anchor
+    // would not produce. Read z/tx off the stage so it's viewport-invariant.
+    const { container } = render(
+      <FlowCanvas
+        nodes={NODES}
+        edges={EDGES}
+        selection={{ type: 'edge', id: 't1' }}
+        renderEdgeActions={(id) => <button data-testid="edge-act">del {id}</button>}
+      />,
+    );
+    const toolbar = screen.getByTestId('edge-act').closest('[data-flow-controls]') as HTMLElement;
+    const done = screen.getByLabelText('Done');
+    const [, tx, , z] = getStage(container).style.transform.match(
+      /translate\(([-\d.]+)px, ([-\d.]+)px\) scale\(([-\d.]+)\)/,
+    )!;
+    const expectedLeft = parseFloat(done.style.left) * parseFloat(z) + parseFloat(tx);
+    expect(parseFloat(toolbar.style.left)).toBeCloseTo(expectedLeft, 1);
+  });
+
   it('pointercancel mid-pan drops the panning cursor class', () => {
     render(<FlowCanvas nodes={NODES} edges={[]} />);
     const root = screen.getByRole('application');

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
@@ -1573,8 +1573,13 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
       if (!resolved) return null;
       const content = renderEdgeActions(selection.id);
       if (content == null) return null;
-      const mid = resolved.geometry.midpoint;
-      return { left: mid.x * z + tx, top: mid.y * z + ty, content };
+      // Top-right corner of the edge's bounding box (endpoints + midpoint, so a
+      // bowed edge is covered), matching how node actions anchor to the node's
+      // top-right corner.
+      const { source, target, midpoint } = resolved.geometry;
+      const maxX = Math.max(source.x, target.x, midpoint.x);
+      const minY = Math.min(source.y, target.y, midpoint.y);
+      return { left: maxX * z + tx, top: minY * z + ty, content };
     }
     return null;
   })();

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
@@ -1573,9 +1573,10 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
       if (!resolved) return null;
       const content = renderEdgeActions(selection.id);
       if (content == null) return null;
-      // Top-right corner of the edge's bounding box (endpoints + midpoint, so a
-      // bowed edge is covered), matching how node actions anchor to the node's
-      // top-right corner.
+      // Approximate top-right corner of the edge — the max/min of its endpoints
+      // and midpoint (a curved edge can bow slightly past this 3-point hull via
+      // its control points, but the toolbar still lands adjacent to the edge),
+      // matching how node actions anchor to the node's top-right corner.
       const { source, target, midpoint } = resolved.geometry;
       const maxX = Math.max(source.x, target.x, midpoint.x);
       const minY = Math.min(source.y, target.y, midpoint.y);
@@ -1583,6 +1584,23 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
     }
     return null;
   })();
+
+  // Gates the root's focus ring (see .module.scss). Keyed on the selection
+  // actually resolving to a RENDERED node/edge — not merely on `selection`
+  // being non-null — so a dangling selection (e.g. the retained id after a
+  // keyboard delete, before the consumer drops it from props) does NOT suppress
+  // the ring and strand a keyboard user with no visible focus. Mirrors the
+  // dangling-selection guards in `selectionActions` above.
+  const selectionResolves =
+    selection != null &&
+    (selection.type === 'node'
+      ? // Redundant with the derived-selection filter above (a node id survives
+        // there iff it is in `rects`), kept for symmetry with `selectionActions`.
+        rects.has(selection.id)
+      : // Load-bearing: the derived filter keeps an edge whose id is in `edges`,
+        // but a dangling-endpoint edge is skipped by resolvedEdges (never
+        // rendered), so this is what withholds the flag for it.
+        resolvedEdges.some((r) => r.edge.id === selection.id));
 
   const setRootRef = useMemo(() => mergeRefs(rootRef, ref), [ref]);
 
@@ -1607,6 +1625,11 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
         className,
       )}
       data-flowcanvas-maximized={maximized ? '' : undefined}
+      // Gates the root's own focus ring (see .module.scss): a resolved
+      // selection's own highlight is the focus indicator, so the whole-canvas
+      // ring is suppressed while an item is selected and reserved for the
+      // focused-but-empty state.
+      data-flow-has-selection={selectionResolves ? '' : undefined}
       onPointerDown={handleRootPointerDown}
       onPointerMove={handleRootPointerMove}
       onPointerUp={handleRootPointerUp}

--- a/packages/playground/src/pages/components/FlowCanvasDemo.tsx
+++ b/packages/playground/src/pages/components/FlowCanvasDemo.tsx
@@ -157,14 +157,14 @@ export function Demo() {
           }
           // Floating toolbars anchored to the selected node / edge:
           renderNodeActions={(id) => (
-            <Button size="xs" iconOnly variant="ghost" aria-label="Delete node" onClick={() => deleteNode(id)}>
-              <Trash2 size={12} />
+            <Button size="sm" iconOnly variant="ghost" aria-label="Delete node" onClick={() => deleteNode(id)}>
+              <Trash2 size={16} />
             </Button>
           )}
           renderEdgeActions={(id) => (
             <ConfirmationPopover title="Delete connection?" confirmLabel="Delete" variant="danger" onConfirm={() => deleteEdge(id)}>
-              <Button size="xs" iconOnly variant="ghost" aria-label="Delete connection">
-                <Trash2 size={12} />
+              <Button size="sm" iconOnly variant="ghost" aria-label="Delete connection">
+                <Trash2 size={16} />
               </Button>
             </ConfirmationPopover>
           )}
@@ -219,13 +219,13 @@ export function Demo() {
               onSelectionChange={handleSelectionChange}
               renderNodeActions={(id) => (
                 <Button
-                  size="xs"
+                  size="sm"
                   iconOnly
                   variant="ghost"
                   aria-label="Delete node"
                   onClick={() => handleNodeDelete(id)}
                 >
-                  <Trash2 size={12} />
+                  <Trash2 size={16} />
                 </Button>
               )}
               renderEdgeActions={(id) => (
@@ -237,8 +237,8 @@ export function Demo() {
                   variant="danger"
                   onConfirm={() => handleEdgeDelete(id)}
                 >
-                  <Button size="xs" iconOnly variant="ghost" aria-label="Delete connection">
-                    <Trash2 size={12} />
+                  <Button size="sm" iconOnly variant="ghost" aria-label="Delete connection">
+                    <Trash2 size={16} />
                   </Button>
                 </ConfirmationPopover>
               )}


### PR DESCRIPTION
Two related FlowCanvas selection-UX fixes.

## 1. Edge action toolbar anchors to the edge's top-right corner
`renderEdgeActions` now floats at the top-right corner of the edge's bounding box (max of endpoints + midpoint x, min y) instead of the edge midpoint — matching how `renderNodeActions` anchors to a node's top-right corner. Demo toolbar delete icons bumped `xs`→`sm` / `12`→`16` for parity with the node toolbar.

## 2. Suppress the whole-canvas focus ring when a node/edge is selected
**Problem:** FlowCanvas keeps DOM focus on the root `[role=application]` when an edge is click-selected (SVG edge paths don't take reliable click-focus), so the root's `:focus-visible` ring (`box-shadow: 0 0 0 2px accent`) wrapped the **entire canvas** in a loose rounded box that read as a giant selection frame around the selected item — visible on plain mouse clicks, not just keyboard.

**Fix:** the root carries `data-flow-has-selection` whenever the selection resolves to a *rendered* node/edge, and the SCSS drops the ring in that state:
```scss
.root:focus-visible { @include focus-ring; }                 /* outline:none + ring */
.root[data-flow-has-selection]:focus-visible { box-shadow: none; }
```
Once an item is selected, its own highlight (node accent border / edge recolor) is the focus indicator, so the whole-canvas ring is redundant. The focused-but-nothing-selected state keeps the ring, so keyboard focus stays visible (WCAG 2.4.7). `outline: none` from the mixin still applies in both states, so the raw UA outline never reappears.

The flag is keyed on the selection **resolving** to a rendered item (not merely `selection != null`), so a dangling-endpoint edge (present in `edges` but pointing at a missing node — never rendered) keeps the ring instead of stranding a keyboard user with no visible focus.

## Verification
- Browser (Playwright): confirmed across focus/selection states — focused+empty shows the ring; focused+edge-selected → `box-shadow: none` **and** `outline: none`; the loose blue box is gone while edge selection, toolbar, and endpoint handles still work.
- Two fresh-context review rounds (repo Rule 8): round 1 caught a WCAG 2.4.7 hole (fixed via the resolve gate); round 2 verdict `clean enough to stop`, plus a hardened regression test for the dangling-endpoint-edge branch.
- Gates: 3758 tests pass (incl. new `data-flow-has-selection` gate + edge-toolbar anchor tests), typecheck, stylelint, build, `npm pack` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 3. Remove the UA focus outline on mouse-click focus (the actual user-reported box)
On **Chrome/Windows**, clicking an edge painted the browser default `outline: auto` on the focused edge hit-path (a wide invisible corridor → a big rounded box). The CSS reset was scoped to `:focus-visible` (keyboard only); a mouse click is plain `:focus`, which Windows still outlines (macOS Chromium does not — hence it never reproduced locally). Diagnosed from the user's own DevTools: `activeClass: edgeHit`, `activeOutline: rgb(153,200,255) auto 5px`. Fixed by suppressing the UA outline outright on the edge hit-path, node, and root — their focus indicators are the path recolor / box-shadow ring, so keyboard focus stays visible. Verified in-browser: focused `outline-style` is now `none` for edge, node, and empty-canvas clicks.
