### PR TITLE
feat(FlowCanvas): `refitKey` prop for programmatic re-fit without a remount (#292)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -958,7 +958,12 @@ R / Shift+R rewire the selected edge's target / source, Shift+arrows nudge, +/�
 Ctrl+arrows pan, Delete deletes, Enter opens. Pass `controls` (a
 `ReactNode`) to render your own buttons top-left; a built-in Maximize toggle (top-right / `F`
 key, Escape to restore) expands the canvas in place to fill the viewport. `maximizeControl={false}`
-hides the toggle if you drive `maximized` yourself.
+hides the toggle if you drive `maximized` yourself. The canvas fits-to-content once on mount; to
+re-center afterward — on a maximize toggle, a viewport resize, or a programmatic re-arrange that
+moves every node — change the **`refitKey`** prop (any `string | number | boolean`): a new value
+re-runs the fit **without a remount**, preserving viewport/selection/focus. Don't force a re-fit
+with a changing React `key` — that remounts and drops focus to `<body>`. Bind `refitKey={maximized}`
+to re-fit on maximize enter/exit, or bump a counter after a re-arrange.
 
 ```tsx
 const [nodes, setNodes] = useState<FlowCanvasNode[]>([

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
@@ -187,6 +187,81 @@ describe('FlowCanvas viewport', () => {
     fireEvent.keyDown(root, { key: '0' }); // zero-sized root → fit is a no-op, must not throw
   });
 
+  it('refitKey change re-fits the viewport (re-centers) without a remount', () => {
+    // fitTo no-ops on a zero-sized root (the jsdom default), so give the root a
+    // real size to make the fit observable.
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 400,
+      height: 300,
+      top: 0,
+      left: 0,
+      right: 400,
+      bottom: 300,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+    try {
+      const { container, rerender } = render(
+        <FlowCanvas
+          nodes={NODES}
+          edges={EDGES}
+          refitKey={0}
+          defaultSelection={{ type: 'node', id: 'open' }}
+        />,
+      );
+      const root = screen.getByRole('application');
+      const fitTransform = getStage(container).style.transform;
+      // Zoom away from the fit.
+      root.focus();
+      fireEvent.keyDown(root, { key: '+' });
+      expect(getStage(container).style.transform).not.toBe(fitTransform);
+      // Bump refitKey → re-fits back to the framed view.
+      rerender(
+        <FlowCanvas
+          nodes={NODES}
+          edges={EDGES}
+          refitKey={1}
+          defaultSelection={{ type: 'node', id: 'open' }}
+        />,
+      );
+      expect(getStage(container).style.transform).toBe(fitTransform);
+      // No remount: the selection survived (a `key` remount would have reset it).
+      expect(screen.getByLabelText('Open')).toHaveAttribute('data-selected');
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('refitKey does not re-fit on a re-render that leaves it unchanged', () => {
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 400,
+      height: 300,
+      top: 0,
+      left: 0,
+      right: 400,
+      bottom: 300,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+    try {
+      const { container, rerender } = render(
+        <FlowCanvas nodes={NODES} edges={EDGES} refitKey={7} />,
+      );
+      const root = screen.getByRole('application');
+      root.focus();
+      fireEvent.keyDown(root, { key: '+' }); // zoom away from the fit
+      const zoomed = getStage(container).style.transform;
+      // Re-render with the SAME refitKey (and an unrelated prop change) → the
+      // manual zoom is preserved; only a refitKey CHANGE re-fits.
+      rerender(<FlowCanvas nodes={NODES} edges={EDGES} refitKey={7} readOnly />);
+      expect(getStage(container).style.transform).toBe(zoomed);
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
   it('ctrl+arrows pan', () => {
     const { container } = render(<FlowCanvas nodes={NODES} edges={[]} />);
     const root = screen.getByRole('application');

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
@@ -1,4 +1,13 @@
-import { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type {
   FocusEvent as ReactFocusEvent,
   HTMLAttributes,
@@ -122,6 +131,21 @@ export interface FlowCanvasProps extends HTMLAttributes<HTMLDivElement> {
   defaultMaximized?: boolean;
   /** Fires whenever maximize is toggled (button, `F` key, or Escape). */
   onMaximizedChange?: (maximized: boolean) => void;
+  /**
+   * Re-fit signal. Whenever this value CHANGES, the canvas re-runs its
+   * fit-to-content — the same fit as the Fit control / `0` key — re-centering
+   * and re-zooming to frame all content. It does this WITHOUT remounting, so the
+   * viewport, selection, keyboard focus, and the built-in maximize focus
+   * management are all preserved (unlike forcing a re-fit with a changing React
+   * `key`, which remounts and drops focus to `<body>`).
+   *
+   * Bind it to whatever should trigger a re-center: `refitKey={maximized}` to
+   * re-fit on maximize enter/exit (the container resizes), or bump a counter
+   * after a programmatic re-arrange that moves every node. The FIRST value never
+   * fits on its own — the mount fit handles the first frame — so any initial
+   * value is safe. @default none
+   */
+  refitKey?: string | number | boolean;
 }
 
 /**
@@ -230,6 +254,7 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
     maximized: maximizedProp,
     defaultMaximized = false,
     onMaximizedChange,
+    refitKey,
     className,
     'aria-describedby': ariaDescribedby,
     onPointerDown,
@@ -650,6 +675,28 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
     observer.observe(el);
     return () => observer.disconnect();
   }, [contentBounds, fitTo, hasMeasuredSizes]);
+
+  // Programmatic re-fit: when `refitKey` CHANGES, re-frame content without a
+  // remount. `fitTo`/`contentBounds` are read through refs so this fires ONLY on
+  // a refitKey change — depending on them directly would re-fit on every node
+  // move (which changes contentBounds). The first value is skipped: the mount
+  // fit above owns the first frame. useLayoutEffect (not useEffect) so a
+  // maximize-driven re-fit lands before paint — the container has already
+  // resized to its new bounds, so we frame the new size with no flash.
+  const fitToRef = useRef(fitTo);
+  fitToRef.current = fitTo;
+  const contentBoundsRef = useRef(contentBounds);
+  contentBoundsRef.current = contentBounds;
+  // Compare the previous value (not a mounted flag) so the first render AND a
+  // StrictMode double-invoked mount both no-op — only a real refitKey CHANGE
+  // fits. The mount fit above owns the first frame.
+  const prevRefitKeyRef = useRef(refitKey);
+  useLayoutEffect(() => {
+    if (prevRefitKeyRef.current === refitKey) return;
+    prevRefitKeyRef.current = refitKey;
+    const bounds = contentBoundsRef.current;
+    if (bounds) fitToRef.current(bounds);
+  }, [refitKey]);
 
   const zoomIn = useCallback(() => {
     zoomBy(ZOOM_STEP);

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -1974,6 +1974,13 @@
           "required": false,
           "default": "",
           "description": "Fires whenever maximize is toggled (button, `F` key, or Escape)."
+        },
+        {
+          "name": "refitKey",
+          "type": "string | number | boolean",
+          "required": false,
+          "default": "none",
+          "description": "Re-fit signal. Whenever this value CHANGES, the canvas re-runs its\nfit-to-content — the same fit as the Fit control / `0` key — re-centering\nand re-zooming to frame all content. It does this WITHOUT remounting, so the\nviewport, selection, keyboard focus, and the built-in maximize focus\nmanagement are all preserved (unlike forcing a re-fit with a changing React\n`key`, which remounts and drops focus to `<body>`).\n\nBind it to whatever should trigger a re-center: `refitKey={maximized}` to\nre-fit on maximize enter/exit (the container resizes), or bump a counter\nafter a programmatic re-arrange that moves every node. The FIRST value never\nfits on its own — the mount fit handles the first frame — so any initial\nvalue is safe."
         }
       ]
     },

--- a/packages/playground/src/pages/components/FlowCanvasDemo.tsx
+++ b/packages/playground/src/pages/components/FlowCanvasDemo.tsx
@@ -39,6 +39,8 @@ export function FlowCanvasDemo() {
   const [lastEvent, setLastEvent] = useState('—');
   const [allowConnections, setAllowConnections] = useState(true);
   const [confineNodesToView, setConfineNodesToView] = useState(false);
+  // Bumping this re-centers the canvas (fit-to-content) without a remount.
+  const [refitKey, setRefitKey] = useState(0);
 
   const handleNodeCreate = useCallback((position: { x: number; y: number }) => {
     const id = `state-${nextId++}`;
@@ -93,6 +95,7 @@ export function FlowCanvasDemo() {
   }, [nodes.length]);
   const handleArrange = useCallback(() => {
     setNodes((prev) => arrangeNodes(prev, edges));
+    setRefitKey((k) => k + 1); // re-center on the freshly laid-out nodes
     setLastEvent('controls: re-arrange');
   }, [edges]);
 
@@ -105,7 +108,7 @@ export function FlowCanvasDemo() {
     >
       <Example
         title="Workflow builder"
-        description="Drag nodes, drag from a node's edge handle to connect, double-click empty space to add a state, Delete to remove the selection. Select an edge and drag either endpoint handle onto another node — or press R (Shift+R for the source) — to rewire it via onEdgeReconnect. Selecting a node or edge floats an action toolbar (renderNodeActions / renderEdgeActions) with a delete button; the edge toolbar guards its delete behind a ConfirmationPopover. Toggle Allow connections to gate all create/rewire, and Confine nodes to view to clamp dragged cards to the visible area. Custom controls (top-left) and a Maximize toggle (top-right) — press F or Escape to toggle fullscreen. Full keyboard support: arrows rove, E cycles edges, C connects, R / Shift+R rewire, Shift+arrows nudge."
+        description="Drag nodes, drag from a node's edge handle to connect, double-click empty space to add a state, Delete to remove the selection. Select an edge and drag either endpoint handle onto another node — or press R (Shift+R for the source) — to rewire it via onEdgeReconnect. Selecting a node or edge floats an action toolbar (renderNodeActions / renderEdgeActions) with a delete button; the edge toolbar guards its delete behind a ConfirmationPopover. Toggle Allow connections to gate all create/rewire, and Confine nodes to view to clamp dragged cards to the visible area. Custom controls (top-left) and a Maximize toggle (top-right) — press F or Escape to toggle fullscreen. Full keyboard support: arrows rove, E cycles edges, C connects, R / Shift+R rewire, Shift+arrows nudge. Re-arrange bumps `refitKey` to re-center on the new layout without a remount."
         code={`import { useState } from 'react';
 import { Badge, Button, ConfirmationPopover, Cluster, FlowCanvas, Switch, type FlowCanvasEdge, type FlowCanvasNode } from '@eocrm/design-system';
 import { Trash2 } from 'lucide-react';
@@ -187,6 +190,7 @@ export function Demo() {
             <FlowCanvas
               nodes={nodes}
               edges={edges}
+              refitKey={refitKey}
               allowConnections={allowConnections}
               confineNodesToView={confineNodesToView}
               controls={


### PR DESCRIPTION
Addresses #292.

## Summary
FlowCanvas fits-to-content only once (on mount) and exposed no way to re-fit afterward, so consumers had to remount via a changing React `key` to re-center (on maximize enter/exit, or after a re-arrange that moves every node) — which drops focus to `<body>` (the maximize trigger lives inside the canvas) and resets internal state.

New **`refitKey?: string | number | boolean`** prop: whenever its value CHANGES, a `useLayoutEffect` re-runs the existing `fitTo(contentBounds)` — the same fit as the Fit control / `0` key — **without remounting**, preserving viewport / selection / focus / maximize focus-management.

- `fitTo`/`contentBounds` are read via refs so it fires ONLY on a refitKey change, not on every node move.
- Guarded by a previous-value comparison so the first render AND a StrictMode double-invoked mount both no-op (the mount fit owns the first frame).
- `useLayoutEffect` lands a maximize-driven re-fit before paint (reads the already-resized root size → frames the new size, no flash).

Bind `refitKey={maximized}` to re-fit on maximize enter/exit, or bump a counter after a re-arrange (as the demo does).

## Test plan
- refitKey change re-fits + preserves the selection (proving no remount); an unchanged refitKey does NOT re-fit. (jsdom mocks the root size since `fitTo` no-ops on a zero-sized root.)
- Browser-verified the re-center on Re-arrange: fit `scale(0.86)` → zoom `scale(1.24)` → re-arrange re-fit `scale(0.72)`.
- Demo re-centers after Re-arrange; AGENTS.md + regenerated props table document the prop.
- Gates: 3764 tests, typecheck, stylelint, format, full playground build, `npm pack` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)