### PR TITLE
fix(Tooltip): yield Escape to a host Modal/Drawer instead of closing it (#281)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -2205,7 +2205,7 @@ import { Bell, Plus } from 'lucide-react';
 - `side` (`'top'` default) / `align` (`'center'` default) / `sideOffset` (default `6`) — Floating UI auto-flips on collision.
 - `delay` — ms before hover opens. Default `400`. Keyboard focus is always immediate (a11y); close is always immediate.
 - `open` / `onOpenChange` / `defaultOpen` — controlled mode, same shape as DropdownMenu.
-- Dismissal: `pointerleave`, `blur`, document `pointerdown`, `Escape`. Tooltip never owns focus.
+- Dismissal: `pointerleave`, `blur`, document `pointerdown`, `Escape`. Tooltip never owns focus. On `Escape` (WCAG 1.4.13) the tooltip registers as a floating surface, so inside a `Modal`/`Drawer` the dismiss press closes only the tooltip — the host survives; the next `Escape` closes the host.
 - Touch devices: no tap-to-open. Tooltips are progressive enhancement for pointer + keyboard users; rely on the trigger's accessible name on touch.
 - Opens with a short scale-fade (140 ms) from the trigger side. Closes instantly. Respects `prefers-reduced-motion: reduce`.
 - Z-layer `--z-tooltip: 1300` is above modal and toast, so tooltips inside any host UI remain visible.

--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -23,6 +23,7 @@ import {
   type Placement,
 } from '@floating-ui/react-dom';
 import { chain, mergeAriaDescribedby, mergeRefs, sanitizeId } from '../_internal/refs';
+import { overlayStack, useFloatingSurface } from '../_internal/overlay';
 import styles from './Tooltip.module.scss';
 
 /** Which side of the trigger the tooltip prefers. Floating UI auto-flips if it doesn't fit. */
@@ -253,10 +254,22 @@ export function Tooltip({
     return () => document.removeEventListener('pointerdown', onPointerDown, true);
   }, [open, cancelPendingOpen, setOpen]);
 
+  // Register as an open floating surface so a host Modal/Drawer yields the
+  // Escape that dismisses this tooltip (#281). The host's capture Escape
+  // listener runs first (it opened first), so `hasOpenFloating()` — not
+  // `consumeEscape` alone — is what actually saves the host on this press.
+  useFloatingSurface(open);
+
   useEffect(() => {
     if (!open) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        // WCAG 1.4.13: Escape dismisses the tooltip. preventDefault + consume
+        // (contract symmetry with the other floating surfaces) so a host that
+        // already ran its listener still yields the press (the reverse-order
+        // fallback; the registration above covers the common order).
+        e.preventDefault();
+        overlayStack.consumeEscape(e);
         cancelPendingOpen();
         setOpen(false);
       }

--- a/packages/design-system/src/components/_internal/overlay/escapeYield.test.tsx
+++ b/packages/design-system/src/components/_internal/overlay/escapeYield.test.tsx
@@ -8,6 +8,7 @@ import userEvent from '@testing-library/user-event';
 import { useState, type ReactNode } from 'react';
 import { Modal } from '../../Modal';
 import { Popover } from '../../Popover';
+import { Tooltip } from '../../Tooltip';
 import { DropdownMenu } from '../../DropdownMenu';
 import { DatePicker } from '../../DatePicker';
 import { DateRangePicker } from '../../DateRangePicker';
@@ -59,6 +60,32 @@ describe('Escape yield contract per surface (#274)', () => {
     expect(screen.queryByText('Panel body')).toBeNull();
     expect(dialogOpen()).toBe(true);
     await user.keyboard('{Escape}');
+    expect(dialogOpen()).toBe(false);
+  });
+
+  it('Tooltip: first Escape dismisses the tooltip, second closes the modal (#281)', () => {
+    render(
+      <Host>
+        <Tooltip content="Tip" delay={0}>
+          <Button>Info</Button>
+        </Tooltip>
+      </Host>,
+    );
+    // Open via hover (delay 0) — avoids the :focus-visible gate; the Escape
+    // handling under test is identical however it opened.
+    act(() => {
+      fireEvent.pointerEnter(screen.getByRole('button', { name: 'Info' }));
+    });
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Tip');
+    // First Escape: the host's capture listener runs first but yields because
+    // the tooltip is a registered floating surface (useFloatingSurface) — so the
+    // tooltip dismisses and the modal survives. (Deleting the registration would
+    // close the modal here.)
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(dialogOpen()).toBe(true);
+    // Second Escape: nothing floating left → the modal closes.
+    fireEvent.keyDown(document, { key: 'Escape' });
     expect(dialogOpen()).toBe(false);
   });
 


### PR DESCRIPTION
Addresses #281.

## Summary
A Tooltip's Escape dismiss (WCAG 1.4.13) is a document-capture keydown that didn't participate in the #274 Escape-yield registry, so dismissing a focus/hover tooltip inside a `Modal`/`Drawer` closed the **host** on the same press.

Fix: the Tooltip now registers as a floating surface while open (`useFloatingSurface(open)`) and `consumeEscape`s its dismiss — the same contract every other surface (Popover / Select / DropdownMenu / date-time popovers / …) follows.

**Why registration, not the issue's "consume without registering":** the host's capture Escape listener runs first (it opened first), so `hasOpenFloating()` — not `consumeEscape` alone — is what makes the host yield; `consumeEscape` is only the reverse-order fallback. Verified: the new contract test **fails** when the `useFloatingSurface` registration is removed.

Net: the first Escape dismisses the tooltip and the host survives; the next Escape closes the host. (Trade-off, per the resolved product decision: a focus/hover tooltip that's incidentally showing intercepts the host's first Escape — which is the WCAG 1.4.13 behavior.)

## Test plan
- Added the `Tooltip` case to the #274 escape-yield contract suite (`escapeYield.test.tsx`): first Escape dismisses the tooltip + host survives; second closes the host. Confirmed it fails if the registration is deleted.
- Gates: 3765 tests, typecheck, stylelint, format, `npm pack` all clean. AGENTS.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)