### PR TITLE
fix(DropdownMenu): Escape closes one sub level per press for sub-in-sub nesting (#279)

### DIFF
--- a/packages/design-system/src/components/DropdownMenu/Content.tsx
+++ b/packages/design-system/src/components/DropdownMenu/Content.tsx
@@ -151,29 +151,22 @@ export const Content = forwardRef<HTMLDivElement, DropdownMenuContentProps>(func
       if (e.key === 'Escape') {
         e.preventDefault();
         overlayStack.consumeEscape(e); // hosts yield even if we ran first (#274)
-        // Only handle Escape for this level if focus is inside this panel or
-        // no deeper sub is open. A deeper sub (higher depth) will have
-        // registered its own capture listener and should handle Escape first.
-        // Since deeper subs register their listener AFTER this one (they mount
-        // later), and both listeners are on document in capture phase, this
-        // listener fires BEFORE the sub's listener. Skip here if a deeper
-        // panel is open — the sub's listener will handle it and stop propagation.
-        if (ctx.depth === 0) {
-          const deeperPanels = document.querySelectorAll(
-            `[data-dropdown-menu-content][data-dropdown-depth]`,
-          );
-          let hasDeeper = false;
-          for (const panel of deeperPanels) {
-            const depth = Number(panel.getAttribute('data-dropdown-depth') ?? '0');
-            if (depth > ctx.depth) {
-              hasDeeper = true;
-              break;
-            }
-          }
-          if (hasDeeper) return;
+        // Defer to any DEEPER open dropdown panel: only the single innermost
+        // panel (no deeper panel in the DOM) closes, so one Escape peels exactly
+        // one level. This is purely DOM-based — it does NOT rely on listener
+        // registration order (the keydown effect re-registers every render, so
+        // that order isn't guaranteed). Applies at EVERY depth (#279): a depth-1
+        // sub must defer to a depth-2 sub, not only depth-0 to depth-1.
+        const deeperPanels = document.querySelectorAll(
+          `[data-dropdown-menu-content][data-dropdown-depth]`,
+        );
+        for (const panel of deeperPanels) {
+          const depth = Number(panel.getAttribute('data-dropdown-depth') ?? '0');
+          if (depth > ctx.depth) return;
         }
         if (ctx.depth > 0) {
-          // Stop propagation so the parent Content's listener does not fire.
+          // Stop propagation so no later document listener double-handles this
+          // press. Shallower ancestor listeners already fired and deferred.
           e.stopImmediatePropagation();
         }
         ctx.setOpen(false);

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1619,6 +1619,44 @@ describe('DropdownMenu — SubContent', () => {
     expect(screen.queryAllByRole('menu')).toHaveLength(1);
   });
 
+  it('Escape closes exactly ONE level per press for sub-in-sub nesting (#279)', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu>
+        <DropdownMenu.Trigger>
+          <button type="button">Open</button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger>Export</DropdownMenu.SubTrigger>
+            <DropdownMenu.SubContent>
+              <DropdownMenu.Sub>
+                <DropdownMenu.SubTrigger>More</DropdownMenu.SubTrigger>
+                <DropdownMenu.SubContent>
+                  <DropdownMenu.Item onSelect={() => {}}>Deep</DropdownMenu.Item>
+                </DropdownMenu.SubContent>
+              </DropdownMenu.Sub>
+            </DropdownMenu.SubContent>
+          </DropdownMenu.Sub>
+        </DropdownMenu.Content>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('menuitem', { name: /Export/ })); // opens depth-1
+    await user.click(screen.getByRole('menuitem', { name: /More/ })); // opens depth-2
+    expect(screen.getAllByRole('menu')).toHaveLength(3);
+    // Before #279, a depth-1 listener would stopImmediatePropagation + close,
+    // taking the depth-2 panel with it (two levels per press). Now each press
+    // closes exactly the innermost level.
+    screen.getAllByRole('menu')[2].focus();
+    await user.keyboard('{Escape}'); // closes only depth-2
+    expect(screen.getAllByRole('menu')).toHaveLength(2);
+    await user.keyboard('{Escape}'); // closes depth-1
+    expect(screen.getAllByRole('menu')).toHaveLength(1);
+    await user.keyboard('{Escape}'); // closes the root
+    expect(screen.queryAllByRole('menu')).toHaveLength(0);
+  });
+
   it('SubContent opens to the right of SubTrigger by default', async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
Addresses #279.

## Summary
`DropdownMenu/Content.tsx` applied the has-deeper-panel Escape deferral **only at depth 0**, so with sub-in-sub nesting a depth-1 listener `stopImmediatePropagation`'d and closed itself — unmounting the open depth-2 panel in the same press (two menu levels per Escape).

Fix: apply the deferral at **every depth** — a panel yields to any open *deeper* panel (whose later-registered capture listener handles the press and stops propagation), so one Escape closes exactly the innermost level. The `depth > ctx.depth` comparison was already depth-relative; only the `if (ctx.depth === 0)` gate around it was wrong.

Matches the "Escape is level-only" contract already documented for subs in AGENTS.md. (The root menu survives, so hosts were never affected — this is purely menu-internal, one layer down from #274.)

## Test plan
- Added a 3-level nested-menu test: Escape closes exactly one level per press (depth-2 → depth-1 → root). Confirmed it **fails** on the old code (collapses depth-1 + depth-2 together — 1 menu left instead of 2).
- Gates: 3765 tests, typecheck, stylelint, format, `npm pack` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)