### PR TITLE
feat(FlowCanvas): float the edge selection toolbar above the middle of the edge

### DIFF
--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.module.scss
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.module.scss
@@ -297,12 +297,19 @@ g:has(> .edgeHit:focus-visible) > .edgePath {
   align-items: center;
   gap: var(--space-1);
 
-  // The anchor point is a node corner / edge midpoint; nudge the toolbar just
-  // outside it so it doesn't sit on top of the selection.
+  // Node anchor = the node's top-right corner; nudge the toolbar just outside
+  // it (up-right) so it doesn't sit on top of the node.
   transform: translate(
     var(--flow-selection-actions-offset-x),
     var(--flow-selection-actions-offset-y)
   );
+}
+
+// Edge anchor = the edge's MIDPOINT. Center the toolbar horizontally on it and
+// lift the whole bar above the edge by a small gap, so it floats "by the
+// middle" of the edge without covering the line itself.
+.selectionActions[data-flow-selection-edge] {
+  transform: translate(-50%, calc(-100% - var(--space-2)));
 }
 
 .srOnly {

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
@@ -374,28 +374,39 @@ describe('FlowCanvas viewport', () => {
     expect(root).not.toHaveAttribute('data-flow-has-selection');
   });
 
-  it('anchors the edge action toolbar at the edge bounding-box top-right (target edge), not the midpoint', () => {
-    // Horizontal edge open(0,0) → done(300,0): the edge's rightmost point is the
-    // target's left edge — canvas x = 300 = done's position, independent of node
-    // size — well past the midpoint (~(w+300)/2). The toolbar anchors to that
-    // top-right corner (matching how node actions anchor to a node's corner), so
-    // its screen-px left is maxX*z + tx with maxX = 300, which a midpoint anchor
-    // would not produce. Read z/tx off the stage so it's viewport-invariant.
+  it('anchors the edge action toolbar at the edge midpoint (floats above the middle, not the corner)', () => {
+    // The toolbar anchors at the edge's MIDPOINT (CSS then centers it and lifts
+    // it above the line via [data-flow-selection-edge]). The edge label chip is
+    // anchored at the SAME midpoint but in CANVAS coords (it lives inside the
+    // transformed stage), so the toolbar's screen-px left/top equal the chip's
+    // canvas coords × the viewport. It is NOT the old bbox top-right anchor
+    // (the target's edge, x=300), which sits well past the midpoint.
     const { container } = render(
       <FlowCanvas
         nodes={NODES}
-        edges={EDGES}
+        edges={EDGES} // t1 has a label → a chip anchored at the midpoint
         selection={{ type: 'edge', id: 't1' }}
         renderEdgeActions={(id) => <button data-testid="edge-act">del {id}</button>}
       />,
     );
     const toolbar = screen.getByTestId('edge-act').closest('[data-flow-controls]') as HTMLElement;
-    const done = screen.getByLabelText('Done');
-    const [, tx, , z] = getStage(container).style.transform.match(
+    const chip = container.querySelector('[data-flow-chip]') as HTMLElement;
+    const [, tx, ty, z] = getStage(container).style.transform.match(
       /translate\(([-\d.]+)px, ([-\d.]+)px\) scale\(([-\d.]+)\)/,
     )!;
-    const expectedLeft = parseFloat(done.style.left) * parseFloat(z) + parseFloat(tx);
-    expect(parseFloat(toolbar.style.left)).toBeCloseTo(expectedLeft, 1);
+    expect(parseFloat(toolbar.style.left)).toBeCloseTo(
+      parseFloat(chip.style.left) * parseFloat(z) + parseFloat(tx),
+      1,
+    );
+    expect(parseFloat(toolbar.style.top)).toBeCloseTo(
+      parseFloat(chip.style.top) * parseFloat(z) + parseFloat(ty),
+      1,
+    );
+    // And it's the midpoint, strictly left of the old top-right anchor (done's x).
+    const done = screen.getByLabelText('Done');
+    expect(parseFloat(toolbar.style.left)).toBeLessThan(
+      parseFloat(done.style.left) * parseFloat(z) + parseFloat(tx),
+    );
   });
 
   it('pointercancel mid-pan drops the panning cursor class', () => {

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
@@ -1631,14 +1631,12 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
       if (!resolved) return null;
       const content = renderEdgeActions(selection.id);
       if (content == null) return null;
-      // Approximate top-right corner of the edge — the max/min of its endpoints
-      // and midpoint (a curved edge can bow slightly past this 3-point hull via
-      // its control points, but the toolbar still lands adjacent to the edge),
-      // matching how node actions anchor to the node's top-right corner.
-      const { source, target, midpoint } = resolved.geometry;
-      const maxX = Math.max(source.x, target.x, midpoint.x);
-      const minY = Math.min(source.y, target.y, midpoint.y);
-      return { left: maxX * z + tx, top: minY * z + ty, content };
+      // The edge's midpoint. CSS (`.selectionActions[data-flow-selection-edge]`)
+      // centers the toolbar horizontally on this point and lifts it above the
+      // edge, so it floats "by the middle" of the edge without sitting on the
+      // line itself.
+      const { midpoint } = resolved.geometry;
+      return { left: midpoint.x * z + tx, top: midpoint.y * z + ty, content };
     }
     return null;
   })();
@@ -1888,6 +1886,9 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
         <div
           className={styles.selectionActions}
           data-flow-controls=""
+          // Edge toolbar anchors at the edge midpoint; the attribute switches
+          // its transform to centered-above (vs the node's up-right corner).
+          data-flow-selection-edge={selection?.type === 'edge' ? '' : undefined}
           style={{ left: selectionActions.left, top: selectionActions.top }}
         >
           {selectionActions.content}


### PR DESCRIPTION
## Summary
The `renderEdgeActions` toolbar anchored at the edge's bounding-box top-right corner. Move it to the edge **midpoint** and, via CSS (`.selectionActions[data-flow-selection-edge]`), center it horizontally on that point and lift it above the line by an 8px gap — so it floats "by the middle" of the edge without sitting on it. Node actions are unchanged (still the node's top-right corner).

## Test plan
- Browser-verified across a horizontal edge (toolbar center `283` == midpoint `283`; bottom `752` clears the line at `760`) and a bowed edge (center `447` == midpoint `447`; bottom clears the edge's top).
- Unit test rewritten to assert the midpoint anchor (toolbar screen-px left/top == the edge label chip's canvas-coord midpoint × the viewport), strictly left of the old top-right anchor.
- Gates: 3772 tests, typecheck, stylelint, format, `npm pack` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)