### PR TITLE
fix: DropdownMenu.Content scrolls when height-clamped instead of clipping (#303)

### DIFF
--- a/packages/design-system/src/components/DropdownMenu/Content.tsx
+++ b/packages/design-system/src/components/DropdownMenu/Content.tsx
@@ -27,6 +27,17 @@ export type DropdownMenuSide = 'top' | 'bottom' | 'left' | 'right';
 /** Which edge of the menu aligns to the corresponding trigger edge. */
 export type DropdownMenuAlign = 'start' | 'center' | 'end';
 
+// Focus an item without scrolling the page (the portaled panel starts at the
+// document origin until Floating UI positions it — see the preventScroll note
+// in the open effect), then explicitly scroll the item into view WITHIN the
+// panel: `.content` is height-clamped by the size middleware and scrolls
+// (#303), and preventScroll suppresses that scroll too. Guarded — jsdom has
+// no scrollIntoView.
+const focusItem = (el: HTMLElement | null | undefined) => {
+  el?.focus({ preventScroll: true });
+  el?.scrollIntoView?.({ block: 'nearest' });
+};
+
 /**
  * Content props.
  *
@@ -219,7 +230,7 @@ export const Content = forwardRef<HTMLDivElement, DropdownMenuContentProps>(func
     const target = ctx.openIntent === 'last' ? enabled[enabled.length - 1] : enabled[0];
     const idx = ctx.itemsRef.current.findIndex((x) => x.id === target.id);
     ctx.setActiveIndex(idx);
-    queueMicrotask(() => target.ref.current?.focus({ preventScroll: true }));
+    queueMicrotask(() => focusItem(target.ref.current));
     ctx.setOpenIntent(null);
     // Depend only on ctx.open so this fires exactly when the menu transitions
     // to open. openIntent is read but not re-fired on its own.
@@ -285,7 +296,7 @@ export const Content = forwardRef<HTMLDivElement, DropdownMenuContentProps>(func
 
     const focusAt = (registryIndex: number) => {
       ctx.setActiveIndex(registryIndex);
-      queueMicrotask(() => items[registryIndex].ref.current?.focus({ preventScroll: true }));
+      queueMicrotask(() => focusItem(items[registryIndex].ref.current));
     };
 
     switch (e.key) {
@@ -334,8 +345,7 @@ export const Content = forwardRef<HTMLDivElement, DropdownMenuContentProps>(func
       );
       if (match !== -1) {
         e.preventDefault();
-        ctx.setActiveIndex(match);
-        queueMicrotask(() => items[match].ref.current?.focus({ preventScroll: true }));
+        focusAt(match);
       }
       return;
     }

--- a/packages/design-system/src/components/DropdownMenu/Content.tsx
+++ b/packages/design-system/src/components/DropdownMenu/Content.tsx
@@ -27,12 +27,13 @@ export type DropdownMenuSide = 'top' | 'bottom' | 'left' | 'right';
 /** Which edge of the menu aligns to the corresponding trigger edge. */
 export type DropdownMenuAlign = 'start' | 'center' | 'end';
 
-// Focus an item without scrolling the page (the portaled panel starts at the
-// document origin until Floating UI positions it — see the preventScroll note
-// in the open effect), then explicitly scroll the item into view WITHIN the
-// panel: `.content` is height-clamped by the size middleware and scrolls
-// (#303), and preventScroll suppresses that scroll too. Guarded — jsdom has
-// no scrollIntoView.
+// Focus an item without scrolling the page, then explicitly scroll it into
+// view WITHIN the panel: `.content` is height-clamped by the size middleware
+// and scrolls (#303), and preventScroll suppresses that scroll too.
+// ONLY for the keydown paths, where the panel is already positioned — at
+// open time the panel still sits at the document origin and scrollIntoView
+// would yank the page (the open effect defers to the isPositioned effect
+// instead). Guarded — jsdom has no scrollIntoView.
 const focusItem = (el: HTMLElement | null | undefined) => {
   el?.focus({ preventScroll: true });
   el?.scrollIntoView?.({ block: 'nearest' });
@@ -76,6 +77,7 @@ export const Content = forwardRef<HTMLDivElement, DropdownMenuContentProps>(func
   const {
     refs,
     floatingStyles,
+    isPositioned,
     placement: resolvedPlacement,
   } = useFloating({
     open: ctx.open,
@@ -230,12 +232,30 @@ export const Content = forwardRef<HTMLDivElement, DropdownMenuContentProps>(func
     const target = ctx.openIntent === 'last' ? enabled[enabled.length - 1] : enabled[0];
     const idx = ctx.itemsRef.current.findIndex((x) => x.id === target.id);
     ctx.setActiveIndex(idx);
-    queueMicrotask(() => focusItem(target.ref.current));
+    queueMicrotask(() => target.ref.current?.focus({ preventScroll: true }));
     ctx.setOpenIntent(null);
     // Depend only on ctx.open so this fires exactly when the menu transitions
     // to open. openIntent is read but not re-fired on its own.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ctx.open]);
+
+  // #303 (open path): once Floating UI has positioned the panel — and the
+  // size middleware has clamped its maxHeight — bring the active item into
+  // view. The open-intent focus above runs BEFORE positioning, while the
+  // portaled panel still sits at the document origin: scrollIntoView there
+  // would scroll the WINDOW to the top of the document, and the not-yet-
+  // clamped panel has nothing to scroll anyway (ArrowUp-open focuses the
+  // last item, which sits below the fold once the clamp lands). isPositioned
+  // resets to false on close, so this fires once per open.
+  useEffect(() => {
+    if (!ctx.open || !isPositioned) return;
+    if (ctx.activeIndex < 0) return;
+    const active = ctx.itemsRef.current[ctx.activeIndex];
+    active?.ref.current?.scrollIntoView?.({ block: 'nearest' });
+    // Mid-open activeIndex changes are scrolled by focusItem in the keydown
+    // path; this effect only covers the positioning transition.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ctx.open, isPositioned]);
 
   const handleKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Escape') {

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
@@ -10,6 +10,12 @@
   flex-direction: column;
   gap: var(--dropdown-menu-gap);
   min-width: var(--dropdown-menu-min-width);
+
+  // #303: Floating UI's size middleware inline-clamps maxHeight to the
+  // available viewport space; without these the clamped panel clips its
+  // items with no way to reach them.
+  overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--dropdown-menu-padding);
   background: var(--dropdown-menu-bg);
   border: var(--border-width) solid var(--dropdown-menu-border-color);

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
@@ -16,6 +16,10 @@
   // items with no way to reach them.
   overflow-y: auto;
   overflow-x: hidden;
+
+  // Don't chain wheel/touch scrolling past the panel's edge to the page —
+  // the menu stays open while the page shifts underneath otherwise.
+  overscroll-behavior: contain;
   padding: var(--dropdown-menu-padding);
   background: var(--dropdown-menu-bg);
   border: var(--border-width) solid var(--dropdown-menu-border-color);

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -224,6 +224,17 @@ describe('DropdownMenu — Content', () => {
     // a bare substring match would miss.
     expect(scss).toMatch(/\.content[^{]*\{[\s\S]{0,500}?@starting-style/);
   });
+
+  it('content panel scrolls when height-clamped (overflow-y on .content)', () => {
+    // #303: Floating UI's size middleware sets an inline maxHeight on the
+    // panel; without overflow-y the clamped panel clips its items with no
+    // scrollbar. Same SCSS-source fallback as the @starting-style test above
+    // (jsdom never loads the compiled stylesheet).
+    const scssPath = resolve(__dirname, 'DropdownMenu.module.scss');
+    const scss = readFileSync(scssPath, 'utf8');
+    expect(scss).toMatch(/\.content\s*\{[\s\S]{0,500}?overflow-y:\s*auto/);
+    expect(scss).toMatch(/\.content\s*\{[\s\S]{0,500}?overflow-x:\s*hidden/);
+  });
 });
 
 describe('DropdownMenu — Item / Separator', () => {

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1,4 +1,4 @@
-import { act, configure, fireEvent, render, screen } from '@testing-library/react';
+import { act, configure, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -504,19 +504,23 @@ describe('DropdownMenu — item navigation', () => {
     // scrollIntoView is what keeps keyboard-focused items visible.
     const scrollSpy = vi.fn();
     const proto = HTMLElement.prototype as unknown as { scrollIntoView?: () => void };
-    const had = 'scrollIntoView' in proto;
+    const original = proto.scrollIntoView;
     proto.scrollIntoView = scrollSpy;
     try {
       const { user } = renderMenu();
       const trigger = screen.getByRole('button', { name: 'Open' });
       trigger.focus();
       await user.keyboard('{ArrowDown}'); // keyboard-open → focus first item
-      expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' });
+      // The open-path scroll waits for Floating UI's isPositioned (scrolling
+      // at focus time would target the panel while it still sits at the
+      // document origin and yank the window).
+      await waitFor(() => expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' }));
       scrollSpy.mockClear();
       await user.keyboard('{ArrowDown}'); // move within the open menu
       expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' });
     } finally {
-      if (!had) delete proto.scrollIntoView;
+      if (original) proto.scrollIntoView = original;
+      else delete proto.scrollIntoView;
     }
   });
 

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -232,8 +232,10 @@ describe('DropdownMenu — Content', () => {
     // (jsdom never loads the compiled stylesheet).
     const scssPath = resolve(__dirname, 'DropdownMenu.module.scss');
     const scss = readFileSync(scssPath, 'utf8');
-    expect(scss).toMatch(/\.content\s*\{[\s\S]{0,500}?overflow-y:\s*auto/);
-    expect(scss).toMatch(/\.content\s*\{[\s\S]{0,500}?overflow-x:\s*hidden/);
+    // [^}]* bounds the match inside the .content block — an overflow-y in a
+    // LATER rule must not satisfy this.
+    expect(scss).toMatch(/\.content\s*\{[^}]*overflow-y:\s*auto/);
+    expect(scss).toMatch(/\.content\s*\{[^}]*overflow-x:\s*hidden/);
   });
 });
 
@@ -493,6 +495,29 @@ describe('DropdownMenu — item navigation', () => {
     trigger.focus();
     await user.keyboard('{ArrowDown}');
     expect(screen.getByRole('menuitem', { name: 'Alpha' })).toHaveFocus();
+  });
+
+  it('scrolls the focused item into view as keyboard nav moves it (#303)', async () => {
+    // jsdom has no scrollIntoView, so define a spy (the component calls it
+    // optionally). Item focus uses preventScroll (page-yank guard), which also
+    // suppresses scrolling of the height-clamped panel — the explicit
+    // scrollIntoView is what keeps keyboard-focused items visible.
+    const scrollSpy = vi.fn();
+    const proto = HTMLElement.prototype as unknown as { scrollIntoView?: () => void };
+    const had = 'scrollIntoView' in proto;
+    proto.scrollIntoView = scrollSpy;
+    try {
+      const { user } = renderMenu();
+      const trigger = screen.getByRole('button', { name: 'Open' });
+      trigger.focus();
+      await user.keyboard('{ArrowDown}'); // keyboard-open → focus first item
+      expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' });
+      scrollSpy.mockClear();
+      await user.keyboard('{ArrowDown}'); // move within the open menu
+      expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' });
+    } finally {
+      if (!had) delete proto.scrollIntoView;
+    }
   });
 
   it('last enabled item is active on open via ArrowUp', async () => {

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -515,9 +515,13 @@ describe('DropdownMenu — item navigation', () => {
       // at focus time would target the panel while it still sits at the
       // document origin and yank the window).
       await waitFor(() => expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' }));
+      // Pin WHICH element scrolled — a refactor that scrolls the panel (or
+      // scrolls at pre-position focus time) must not pass.
+      expect(scrollSpy.mock.instances[0]).toBe(screen.getByRole('menuitem', { name: 'Alpha' }));
       scrollSpy.mockClear();
-      await user.keyboard('{ArrowDown}'); // move within the open menu
+      await user.keyboard('{ArrowDown}'); // move within the open menu → Gamma
       expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' });
+      expect(scrollSpy.mock.instances[0]).toBe(screen.getByRole('menuitem', { name: 'Gamma' }));
     } finally {
       if (original) proto.scrollIntoView = original;
       else delete proto.scrollIntoView;


### PR DESCRIPTION
Addresses #303.

## Summary
- `.content` now scrolls when Floating UI's `size` middleware clamps its `maxHeight`: `overflow-y: auto; overflow-x: hidden; overscroll-behavior: contain` (contain stops wheel-past-the-edge from scrolling the page under the open menu).
- Keyboard path: item focus uses `preventScroll` (page-yank guard), which also suppressed the panel's new scrolling — so a `focusItem` helper follows each keydown-path focus with a guarded `scrollIntoView({ block: 'nearest' })`, and the open path defers its scroll to a new effect keyed on Floating UI's `isPositioned` (at open-focus time the portaled panel still sits at the document origin, so an immediate `scrollIntoView` would scroll the window to the top; the clamp also hasn't been applied yet, which matters for ArrowUp-open focusing the last item).

## Test plan
- New SCSS-source regression test asserting the overflow declarations inside the `.content` block.
- New keyboard test: prototype spy on `scrollIntoView`, asserting the open path scrolls the first item after positioning (`waitFor`) and ArrowDown scrolls the next focused item — pinned to the exact menuitem elements.
- Full gates green: 3774 tests, typecheck, stylelint, prettier. Three-round adversarial review loop (round 1 caught the preventScroll keyboard gap, round 2 caught the pre-position window-yank, round 3: clean). Review also surfaced the sibling bug in Select → filed as #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UxNT6c6wDQ4PnpUhxandz