### PR TITLE
fix: Select scrolls the active option into view in the clamped listbox (#305)

### DIFF
--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -37,7 +37,7 @@ export function Listbox() {
   // handler closes us on the same press instead of the Modal/Drawer.
   const floatingId = useFloatingSurface(ctx.open);
 
-  const { refs, floatingStyles } = useFloating({
+  const { refs, floatingStyles, isPositioned } = useFloating({
     open: ctx.open,
     placement: 'bottom-start',
     // `transform: false` — emit `top` / `left` positioning instead of an
@@ -138,6 +138,31 @@ export function Listbox() {
     // the user's keyboard / mouse navigation).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ctx.open]);
+
+  // #305: keep the active option visible inside the height-clamped panel.
+  // aria-activedescendant means DOM focus never enters the listbox, so
+  // nothing scrolls it natively — with >~8 options the active row moves
+  // below the fold and the highlight disappears. One effect here covers
+  // every setActiveIndex source (trigger keyboard, typeahead, in-panel
+  // search, open seeding). Gated on isPositioned: before Floating UI
+  // places the portaled panel it sits at the document origin, where
+  // scrollIntoView would scroll the WINDOW to the top (see the identical
+  // fix in DropdownMenu/Content.tsx, #303) — and the size clamp hasn't
+  // been applied yet anyway. `block: 'nearest'` no-ops for
+  // already-visible rows, so mouse-hover activation causes no jumps.
+  // Guarded — jsdom has no scrollIntoView.
+  useEffect(() => {
+    if (!ctx.open || !isPositioned || ctx.activeIndex < 0) return;
+    const row = ctx.rows[ctx.activeIndex];
+    if (!row || row.kind !== 'option') return;
+    document
+      .getElementById(ctx.getOptionId(row.option.value))
+      ?.scrollIntoView?.({ block: 'nearest' });
+    // ctx.rows is read fresh but intentionally not a dep: a mid-open rows
+    // identity change (async load, filtering) must not re-scroll a row the
+    // user has already scrolled away from.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ctx.open, isPositioned, ctx.activeIndex]);
 
   return createPortal(
     <ul

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -149,6 +149,11 @@
 .listbox {
   z-index: var(--z-popover);
   overflow-y: auto;
+
+  // Don't chain wheel/touch scrolling past the panel's edge to the page —
+  // the listbox stays open while the page shifts underneath otherwise.
+  // Matches DropdownMenu `.content`.
+  overscroll-behavior: contain;
   padding: var(--select-listbox-padding);
   background: var(--select-listbox-bg);
   border: var(--border-width) solid var(--select-listbox-border-color);

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -195,11 +195,11 @@ describe('Select — keyboard (single, non-searchable)', () => {
       // earlier would target the panel while it still sits at the document
       // origin and yank the window).
       await waitFor(() => expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' }));
-      expect(scrollSpy.mock.instances[0]).toBe(screen.getByRole('option', { name: 'Active' }));
+      expect(scrollSpy.mock.contexts[0]).toBe(screen.getByRole('option', { name: 'Active' }));
       scrollSpy.mockClear();
       await user.keyboard('{ArrowDown}'); // move within the open listbox
       await waitFor(() => expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' }));
-      expect(scrollSpy.mock.instances[0]).toBe(screen.getByRole('option', { name: 'Pending' }));
+      expect(scrollSpy.mock.contexts[0]).toBe(screen.getByRole('option', { name: 'Pending' }));
     } finally {
       if (original) proto.scrollIntoView = original;
       else delete proto.scrollIntoView;

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -177,6 +177,35 @@ describe('Select — keyboard (single, non-searchable)', () => {
     );
   });
 
+  it('scrolls the active option into view as keyboard nav moves it (#305)', async () => {
+    // jsdom has no scrollIntoView, so define a spy (the component calls it
+    // optionally). aria-activedescendant means DOM focus never enters the
+    // clamped, scrollable listbox — the explicit scrollIntoView is the only
+    // thing keeping the active option visible.
+    const scrollSpy = vi.fn();
+    const proto = HTMLElement.prototype as unknown as { scrollIntoView?: () => void };
+    const original = proto.scrollIntoView;
+    proto.scrollIntoView = scrollSpy;
+    try {
+      const user = userEvent.setup();
+      render(<Select options={STATUSES} />);
+      screen.getByRole('button').focus();
+      await user.keyboard('{ArrowDown}'); // open → first option active
+      // The open-path scroll waits for Floating UI's isPositioned (scrolling
+      // earlier would target the panel while it still sits at the document
+      // origin and yank the window).
+      await waitFor(() => expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' }));
+      expect(scrollSpy.mock.instances[0]).toBe(screen.getByRole('option', { name: 'Active' }));
+      scrollSpy.mockClear();
+      await user.keyboard('{ArrowDown}'); // move within the open listbox
+      await waitFor(() => expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' }));
+      expect(scrollSpy.mock.instances[0]).toBe(screen.getByRole('option', { name: 'Pending' }));
+    } finally {
+      if (original) proto.scrollIntoView = original;
+      else delete proto.scrollIntoView;
+    }
+  });
+
   it('Home jumps to first, End jumps to last', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} />);


### PR DESCRIPTION
Addresses #305.

## Summary
- New effect in `Listbox.tsx` keyed on `[ctx.open, isPositioned, ctx.activeIndex]`: scrolls the active option (`getElementById` + guarded `scrollIntoView({ block: 'nearest' })`) once Floating UI has positioned the panel. Select uses `aria-activedescendant`, so DOM focus never enters the scrollable listbox and nothing scrolled it natively — the highlight vanished below the 320px clamp with >~8 options. One effect covers every `setActiveIndex` source (trigger keyboard incl. PageUp/PageDown/typeahead, ArrowUp-open seeding, in-panel search, mouse hover — `nearest` no-ops for visible rows).
- `isPositioned` gate prevents the pre-position window-yank found during the #303 review (panel sits at the document origin until positioned).
- `overscroll-behavior: contain` on `.listbox`, matching DropdownMenu.

## Test plan
- New keyboard test with a `scrollIntoView` prototype spy: open-path scroll after positioning (`waitFor`) and ArrowDown scroll, pinned to the exact option elements via `mock.contexts`.
- Full gates green: 3775 tests, typecheck, stylelint, prettier, tarball clean. Adversarial review round 1: clean (mutation-checked the new test; verified the ArrowUp-open microtask race, mouseEnter feedback bound, and `isPositioned` reset semantics against the installed Floating UI source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UxNT6c6wDQ4PnpUhxandz