### PR TITLE
fix: LiquidEditor tracks {% assign %} names — no false unknown-flagging (#310)

### DIFF
--- a/packages/design-system/src/components/LiquidEditor/liquidTokenizer.test.tsx
+++ b/packages/design-system/src/components/LiquidEditor/liquidTokenizer.test.tsx
@@ -150,3 +150,26 @@ describe('for-loop variables (#304)', () => {
     expect(unknownVariables(src, KNOWN)).toEqual(['bogus']);
   });
 });
+
+describe('assign variables (#310)', () => {
+  const KNOWN = new Set(['record.associations']);
+
+  it('does not flag a variable declared by an assign tag', () => {
+    const src = '{% assign total = 3 %}{{ total }}';
+    expect(unknownVariables(src, KNOWN)).toEqual([]);
+    expect(tokenize(src, KNOWN).every((t) => t.type !== 'unknown')).toBe(true);
+  });
+
+  it('still flags {{ total }} used BEFORE the assign declares it', () => {
+    const src = '{{ total }}{% assign total = 3 %}';
+    expect(unknownVariables(src, KNOWN)).toEqual(['total']);
+  });
+
+  it('a keyword between for/assign and the name cancels the declaration capture', () => {
+    // `case` is a keyword, so `bogus` must NOT be mis-recorded as a declared
+    // name (it is the collection here) — and being the first value identifier
+    // in the tag, it is root-checked and flagged.
+    const src = '{% for case in bogus %}{{ bogus }}{% endfor %}';
+    expect(unknownVariables(src, KNOWN)).toEqual(['bogus']);
+  });
+});

--- a/packages/design-system/src/components/LiquidEditor/liquidTokenizer.test.tsx
+++ b/packages/design-system/src/components/LiquidEditor/liquidTokenizer.test.tsx
@@ -165,6 +165,11 @@ describe('assign variables (#310)', () => {
     expect(unknownVariables(src, KNOWN)).toEqual(['total']);
   });
 
+  it('assign in an OUTPUT tag does not arm declaration capture', () => {
+    // {{ assign mystery }} — output tags declare nothing; mystery is root-checked.
+    expect(unknownVariables('{{ assign mystery }}', KNOWN)).toEqual(['mystery']);
+  });
+
   it('a keyword between for/assign and the name cancels the declaration capture', () => {
     // `case` is a keyword, so `bogus` must NOT be mis-recorded as a declared
     // name (it is the collection here) — and being the first value identifier

--- a/packages/design-system/src/components/LiquidEditor/liquidTokenizer.ts
+++ b/packages/design-system/src/components/LiquidEditor/liquidTokenizer.ts
@@ -78,11 +78,13 @@ export function tokenize(source: string, knownCodes?: ReadonlySet<string>): Liqu
   // reference is checked by its root identifier only, so membership is
   // tested against the set of first dotted segments.
   const knownRoots = hasKnown ? new Set([...knownCodes!].map((c) => c.split('.')[0])) : undefined;
-  // #304: `{% for item in … %}` declares `item` — collect loop variables as the
-  // pass encounters them so later references (in tags and {{ }} bodies) aren't
-  // flagged unknown. Single forward pass: a use BEFORE its declaration stays
-  // flagged — acceptable ceiling, generated snippets always declare first.
-  const loopVars = new Set<string>();
+  // #304/#310: `{% for item in … %}` and `{% assign total = … %}` declare a
+  // name — collect declared names as the pass encounters them so later
+  // references (in tags and {{ }} bodies) aren't flagged unknown. Single
+  // forward pass: a use BEFORE its declaration stays flagged — acceptable
+  // ceiling, generated snippets always declare first. Names are not scoped
+  // to their loop/tag (lenient false negatives on out-of-scope use).
+  const declaredVars = new Set<string>();
 
   const push = (type: LiquidTokenType, start: number, end: number) => {
     if (end > start) tokens.push({ type, value: source.slice(start, end), start, end });
@@ -116,9 +118,11 @@ export function tokenize(source: string, knownCodes?: ReadonlySet<string>): Liqu
     // identifier in this tag (so only the ROOT identifier is unknown-checked).
     let expectFilter = false;
     let seenValue = false;
-    // Set right after the `for` keyword in a `{% %}` tag — the next identifier
-    // is the loop-variable declaration.
-    let expectLoopVar = false;
+    // Set right after the `for` / `assign` keyword in a `{% %}` tag — the
+    // next identifier is the declared name. Any other intervening keyword
+    // cancels the capture so a keyword-named declaration ({% for case in x %})
+    // can't mis-record the following identifier.
+    let expectDeclaration = false;
     // For `{% if … %}` the first identifier is the tag-name keyword.
 
     while (i < interiorEnd) {
@@ -159,22 +163,22 @@ export function tokenize(source: string, knownCodes?: ReadonlySet<string>): Liqu
           expectFilter = false;
         } else if (KEYWORDS.has(word)) {
           push('keyword', start, i);
-          if (!isOutput && word === 'for') expectLoopVar = true;
+          expectDeclaration = !isOutput && (word === 'for' || word === 'assign');
         } else if (isDottedProperty) {
           push('variable', start, i); // neutral property access; not unknown-checked
         } else {
-          if (expectLoopVar) loopVars.add(word);
+          if (expectDeclaration) declaredVars.add(word);
           const unknown =
             hasKnown &&
             !seenValue &&
-            !expectLoopVar &&
+            !expectDeclaration &&
             !knownRoots!.has(word) &&
-            !loopVars.has(word);
+            !declaredVars.has(word);
           // Only the leading value identifier is the "root"; subsequent ones
           // (rare) are treated as variables but not unknown-checked.
           push(unknown ? 'unknown' : 'variable', start, i);
           seenValue = true;
-          expectLoopVar = false;
+          expectDeclaration = false;
         }
         continue;
       }


### PR DESCRIPTION
Addresses #310.

## Summary
- Declaration capture in the tokenizer now triggers on `assign` as well as `for` (set renamed `loopVars` → `declaredVars`): `{% assign total = 3 %}{{ total }}` no longer flags `total`.
- Hardening from the #304 round-2 review: any OTHER intervening keyword cancels the capture, so `{% for case in bogus %}` no longer mis-records `bogus` as a declared name (it is now correctly root-checked and flagged).
- Unchanged documented ceilings: use-before-declaration still flags; names aren't scoped to their tag/loop; `{% capture %}` not tracked.

## Test plan
Four new tokenizer tests (assign declare/use, use-before-declare, output-tag guard, keyword-cancellation). Full gates green: 3803 tests, typecheck, stylelint, prettier. Adversarial review round: clean (16 node probes across tag shapes — contiguity, filters, `{% if x and y %}`, whitespace control, keyword-named assign targets — all verified unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UxNT6c6wDQ4PnpUhxandz