### PR TITLE
fix: Select re-seeds the highlight when filtering or row shrink rebuilds the rows (#309)

### DIFF
--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -435,6 +435,25 @@ describe('Select — single, searchable (combobox input)', () => {
     );
   });
 
+  it('re-seeds when a mid-open row shrink strands the cursor out of bounds (#309)', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<Select options={STATUSES} value="archived" />);
+    const trigger = screen.getByRole('button', { name: 'Archived' });
+    await user.click(trigger);
+    // Open-seed highlights the selection (flat index 2).
+    expect(trigger).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Archived' }).id,
+    );
+    // Rows shrink under the open listbox (async results landing / options
+    // prop change) — index 2 no longer exists; the cursor must re-seed.
+    rerender(<Select options={STATUSES.slice(0, 1)} value="archived" />);
+    expect(trigger).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Active' }).id,
+    );
+  });
+
   it('Escape reverts query to selected label', async () => {
     const user = userEvent.setup();
     render(<Select searchable options={STATUSES} defaultValue="pending" />);

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -415,6 +415,26 @@ describe('Select — single, searchable (combobox input)', () => {
     expect(screen.getByRole('option', { name: 'Archived' })).toBeInTheDocument();
   });
 
+  it('filtering re-seeds the highlight to the first matching option (#309)', async () => {
+    const user = userEvent.setup();
+    render(<Select searchable options={STATUSES} value="archived" />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.click(input);
+    // Open-seed: the current selection is highlighted (flat index 2).
+    expect(input).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Archived' }).id,
+    );
+    // Type a query — rows rebuild to [Active, Archived]; the stale flat index
+    // must not survive (it would point past/at an arbitrary row). The cursor
+    // re-seeds to the first matching option.
+    await user.keyboard('a');
+    expect(input).toHaveAttribute(
+      'aria-activedescendant',
+      screen.getByRole('option', { name: 'Active' }).id,
+    );
+  });
+
   it('Escape reverts query to selected label', async () => {
     const user = userEvent.setup();
     render(<Select searchable options={STATUSES} defaultValue="pending" />);

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -514,6 +514,15 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, state.open]);
 
+  // Safety net for every OTHER row-shrink path (async results landing after
+  // arrow-key navigation, a mid-open `options` prop change): a cursor past
+  // the end of the rebuilt list is meaningless — re-seed it. Never fires for
+  // an in-bounds cursor, so it cannot steal a valid position.
+  useEffect(() => {
+    if (!state.open || activeIndex < rowsWithCreate.length) return;
+    setActiveIndex(rowsWithCreate.findIndex((r) => r.kind === 'option' && !r.option.disabled));
+  }, [state.open, activeIndex, rowsWithCreate]);
+
   const triggerRef = useRef<HTMLElement | null>(null);
   const listboxRef = useRef<HTMLUListElement | null>(null);
 

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -491,6 +491,29 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     return createRow ? [...rows, createRow] : rows;
   }, [rows, createRow]);
 
+  // #309: filtering while open rebuilds `rows`, but `activeIndex` is a flat
+  // index — keeping it points the highlight at whatever row now occupies
+  // that slot (or past the end, hiding it). Re-seed to the first selectable
+  // row whenever the QUERY changes while open. The open transition is
+  // excluded (the Listbox open-seed effect highlights the current selection
+  // there); non-query row changes (multi toggle, async refresh with the
+  // same query) keep the cursor.
+  // ponytail: in async mode this fires against the pre-fetch rows (results
+  // land after the debounce); first-selectable is almost always index 0
+  // either way. Re-seed on async arrival too if a palette with leading
+  // disabled rows ever makes this visible.
+  const prevQueryRef = useRef(query);
+  useEffect(() => {
+    if (prevQueryRef.current === query) return;
+    prevQueryRef.current = query;
+    if (!state.open) return;
+    setActiveIndex(rowsWithCreate.findIndex((r) => r.kind === 'option' && !r.option.disabled));
+    // rowsWithCreate is read fresh (it recomputes in the same render as the
+    // query) but must not itself re-trigger the reseed — non-query row
+    // changes keep the cursor (see above).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, state.open]);
+
   const triggerRef = useRef<HTMLElement | null>(null);
   const listboxRef = useRef<HTMLUListElement | null>(null);
 


### PR DESCRIPTION
Addresses #309.

## Summary
- Typing a query while the listbox is open now re-seeds `activeIndex` to the first selectable row of the rebuilt list (a `prevQueryRef`-guarded effect in `Select.tsx` — the single `setQuery` state all three search surfaces route through). Previously the stale flat index pointed the highlight at an arbitrary option, or past the end (hiding it, with the #305 scroll effect never firing since the index didn't change numerically).
- Open transitions keep the Listbox open-seed behavior (selection highlighted); non-query row changes (multi toggle) keep the cursor.
- Safety net from review: an out-of-bounds cursor after ANY row shrink (async results landing after arrow-key navigation, a mid-open `options` prop change) re-seeds instead of stranding the highlight. Never fires for an in-bounds cursor.

## Test plan
Two new tests: filtering re-seeds `aria-activedescendant` to the first match (fails without the fix — the stale index fell out of bounds), and a mid-open options shrink re-seeds. Full gates green: 3805 tests, typecheck, stylelint, prettier. Adversarial review round: clean — verified all query paths route through the one state, the Escape-revert ordering, StrictMode safety, no fight with ArrowUp-open seeding, and mutation-tested the main test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UxNT6c6wDQ4PnpUhxandz