### PR TITLE
feat(Sortable): grid arrangement — 2D rect sorting, item column-spans, equal-height cells (#316)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -837,7 +837,19 @@ const [items, setItems] = useState([
 </Sortable>;
 ```
 
-Props on the root: `onReorder?: ({ from, to, id }) => void` — fires only when the drop position differs from the source. Consumer owns the items array and re-renders with the new order. `arrayMove` is shipped by `@dnd-kit/sortable` (the library is already a dep) — import it from there. Items must have a stable `id` prop (`string | number`). `restrictToContainer?: boolean` (default `true`) — clamps the drag to the list's bounding box so the dragged item can't leave the `<ol>`; pass `false` for free-drag (item follows the cursor anywhere on the page).
+Props on the root: `onReorder?: ({ from, to, id }) => void` — fires only when the drop position differs from the source. Consumer owns the items array and re-renders with the new order. `arrayMove` is shipped by `@dnd-kit/sortable` (the library is already a dep) — import it from there. Items must have a stable `id` prop (`string | number`). `restrictToContainer?: boolean` (default `true`) — clamps the drag to the list's bounding box so the dragged item can't leave the `<ol>`; pass `false` for free-drag (item follows the cursor anywhere on the page). `arrangement?: 'list' | 'grid'` (default `'list'`) + `columns?: number` (grid only, default 12) — see **Grid arrangement** below.
+
+**Grid arrangement** (`arrangement="grid"`): re-lays the `<ol>` as a `columns`-track CSS grid (`columns?: number`, default 12) driven by dnd-kit's `rectSortingStrategy`, so siblings reflow in **2D** during a drag instead of shifting only vertically. Give each item a span via `<Sortable.Item span="50%">` (or `span={6}` / `span="100%"`) — **same values as `Grid.Item`** (`25%`→3 … `75%`→9 tracks of 12; `100%`/`full`→whole row). Rows are equal-height (`align-items: stretch`). Semantics stay order-based: a drop reorders the flow — nothing persists a grid x/y position. `restrictToContainer` still clamps the drag to the grid box. Default `arrangement="list"` is unchanged (single vertical column). Canonical use: a WYSIWYG dashboard customize view where edit mode mirrors view mode's 12-col widget grid.
+
+```tsx
+<Sortable arrangement="grid" columns={12} onReorder={handle}>
+  {widgets.map((w) => (
+    <Sortable.Item key={w.id} id={w.id} span={w.span}>
+      <Card style={{ height: '100%' }}>{w.title}</Card>
+    </Sortable.Item>
+  ))}
+</Sortable>
+```
 
 **Drag origin** (hybrid): if `<Sortable.Handle>` is present in the Item subtree, only the Handle initiates drag. If no Handle is present, the entire Item is draggable + focusable. A 5px activation distance means short clicks-without-movement on internal buttons / links pass through.
 

--- a/packages/design-system/src/components/Grid/GridItem.tsx
+++ b/packages/design-system/src/components/Grid/GridItem.tsx
@@ -1,27 +1,16 @@
 import { forwardRef, type CSSProperties, type HTMLAttributes } from 'react';
 import clsx from 'clsx';
+import { resolveGridItemSpan, type GridItemSpan } from '../_internal/gridSpan';
 import styles from './Grid.module.scss';
 
-/**
- * Column span for a `Grid.Item`. Numbers span that many tracks of whatever
- * `columns` the parent Grid declares. Fraction strings assume a 12-column
- * grid (`columns={12}`): `'25%'`→3, `'33%'`→4, `'50%'`→6, `'67%'`→8,
- * `'75%'`→9 tracks. `'100%'` / `'full'` span the entire row (`1 / -1`) and
- * are safe in ANY grid, including auto-fit.
- */
-export type GridItemSpan = number | 'full' | '25%' | '33%' | '50%' | '67%' | '75%' | '100%';
+// The span vocabulary (type + fraction→track resolver) is shared with
+// Sortable.Item's grid arrangement; it lives in _internal/gridSpan so neither
+// component imports the other. Re-exported here so `GridItemSpan` stays part of
+// Grid's public type surface.
+export type { GridItemSpan };
 
 /** Elements `Grid.Item` can render as. `'li'` pairs with `<Grid as="ul">`. */
 export type GridItemAs = 'div' | 'li' | 'section' | 'article' | 'aside';
-
-/** Fraction → 12-col track count. 100%/full handled separately (1 / -1). */
-const FRACTION_TRACKS: Record<Exclude<GridItemSpan, number | 'full' | '100%'>, number> = {
-  '25%': 3,
-  '33%': 4,
-  '50%': 6,
-  '67%': 8,
-  '75%': 9,
-};
 
 export interface GridItemProps extends HTMLAttributes<HTMLElement> {
   /**
@@ -60,14 +49,7 @@ export const GridItem = forwardRef<HTMLElement, GridItemProps>(function GridItem
   { span, as = 'div', className, style, ...rest },
   ref,
 ) {
-  const resolved =
-    span === undefined
-      ? undefined
-      : span === 'full' || span === '100%'
-        ? '1 / -1'
-        : typeof span === 'number'
-          ? `span ${span}`
-          : `span ${FRACTION_TRACKS[span]}`;
+  const resolved = resolveGridItemSpan(span);
 
   const Tag = as as unknown as 'div';
   return (

--- a/packages/design-system/src/components/Sortable/Sortable.module.scss
+++ b/packages/design-system/src/components/Sortable/Sortable.module.scss
@@ -12,8 +12,31 @@
   gap: var(--sortable-list-gap);
 }
 
+// Grid arrangement (arrangement="grid"). The <ol> owns the track template;
+// the column count is injected inline as --sortable-columns (default 12).
+// `align-items: stretch` (the grid default, stated for intent) makes every
+// item in a row match its tallest sibling — equal-height cells, consistent
+// with <Grid>. Per-cell spans ride on `.item`'s grid-column below.
+.grid {
+  // stylelint-disable-next-line property-disallowed-list -- UA reset for <ol> default margin
+  margin: 0;
+  // stylelint-disable-next-line property-disallowed-list -- UA reset for <ol> default padding (bullet gutter)
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(var(--sortable-columns, 12), minmax(0, 1fr));
+  gap: var(--sortable-grid-gap);
+  align-items: stretch;
+}
+
 .item {
   position: relative;
+
+  // Per-cell column span for the grid arrangement — resolved in Sortable.tsx
+  // and injected inline as --sortable-item-span (span N / 1 / -1 / auto).
+  // Inert on a flex child (list mode), active when the parent <ol> is .grid.
+  // stylelint-disable-next-line property-disallowed-list -- Sortable's sanctioned grid-arrangement placement, mirrors Grid.Item (see Sortable.tsx)
+  grid-column: var(--sortable-item-span, auto);
 
   // Required for no-Handle whole-item drag on mobile. dnd-kit's PointerSensor
   // can't initiate drag if the browser claims the touch gesture for scroll.

--- a/packages/design-system/src/components/Sortable/Sortable.test.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.test.tsx
@@ -1,5 +1,6 @@
-import { createRef } from 'react';
-import { render } from '@testing-library/react';
+import { createRef, type CSSProperties } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Sortable, restrictTransformToRect } from './Sortable';
 
 describe('Sortable', () => {
@@ -203,6 +204,193 @@ describe('Sortable', () => {
       </Sortable>,
     );
     expect(ref.current?.tagName).toBe('OL');
+  });
+});
+
+// dnd-kit's KeyboardSensor + sortableKeyboardCoordinates resolve the next drop
+// target from each item's bounding rect. jsdom reports zero-size rects, so the
+// sensor can't find a neighbour. Hand each <li> a STABLE box derived from its
+// DOM index (a vertical stack) — stable per element, because rectSortingStrategy
+// re-measures every item and a stateful counter would return a different rect on
+// each call for the same node. Descendants (the Handle button) inherit their
+// <li>'s rect; everything else gets a large container rect. Coordinate
+// resolution is strategy-independent, so ArrowDown resolves the same in a grid.
+function stubStackedRects(): () => void {
+  const orig = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function () {
+    const li = (this as Element).closest?.('li');
+    if (li?.parentElement) {
+      const i = Array.prototype.indexOf.call(li.parentElement.children, li);
+      const top = i * 50;
+      return {
+        x: 0,
+        y: top,
+        top,
+        left: 0,
+        right: 100,
+        bottom: top + 40,
+        width: 100,
+        height: 40,
+        toJSON() {},
+      } as DOMRect;
+    }
+    return {
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 1000,
+      bottom: 1000,
+      width: 1000,
+      height: 1000,
+      toJSON() {},
+    } as DOMRect;
+  };
+  return () => {
+    Element.prototype.getBoundingClientRect = orig;
+  };
+}
+
+describe('Sortable grid arrangement (#316)', () => {
+  it('defaults to the list arrangement (backward-compatible)', () => {
+    const { container } = render(
+      <Sortable>
+        <Sortable.Item id="a">A</Sortable.Item>
+      </Sortable>,
+    );
+    const ol = container.querySelector('ol')!;
+    expect(ol.className).toMatch(/list/);
+    expect(ol.className).not.toMatch(/grid/);
+    // No column template injected in list mode.
+    expect(ol.style.getPropertyValue('--sortable-columns')).toBe('');
+  });
+
+  it('arrangement="grid" swaps the <ol> to the grid class and injects 12 columns by default', () => {
+    const { container } = render(
+      <Sortable arrangement="grid">
+        <Sortable.Item id="a">A</Sortable.Item>
+      </Sortable>,
+    );
+    const ol = container.querySelector('ol')!;
+    expect(ol.className).toMatch(/grid/);
+    expect(ol.className).not.toMatch(/list/);
+    expect(ol.style.getPropertyValue('--sortable-columns')).toBe('12');
+  });
+
+  it('columns overrides the injected track count', () => {
+    const { container } = render(
+      <Sortable arrangement="grid" columns={4}>
+        <Sortable.Item id="a">A</Sortable.Item>
+      </Sortable>,
+    );
+    expect(
+      (container.querySelector('ol') as HTMLElement).style.getPropertyValue('--sortable-columns'),
+    ).toBe('4');
+  });
+
+  it('merges consumer style with --sortable-columns; the injected value wins', () => {
+    const { container } = render(
+      <Sortable
+        arrangement="grid"
+        columns={6}
+        style={{ backgroundColor: 'red', ['--sortable-columns' as string]: '99' } as CSSProperties}
+      >
+        <Sortable.Item id="a">A</Sortable.Item>
+      </Sortable>,
+    );
+    const ol = container.querySelector('ol') as HTMLElement;
+    expect(ol.style.backgroundColor).toBe('red');
+    expect(ol.style.getPropertyValue('--sortable-columns')).toBe('6');
+  });
+
+  it.each([
+    [undefined, 'auto'],
+    [2, 'span 2'],
+    ['25%', 'span 3'],
+    ['33%', 'span 4'],
+    ['50%', 'span 6'],
+    ['67%', 'span 8'],
+    ['75%', 'span 9'],
+    ['100%', '1 / -1'],
+    ['full', '1 / -1'],
+  ] as const)('Item span=%s stamps --sortable-item-span: %s on the <li>', (span, expected) => {
+    const { container } = render(
+      <Sortable arrangement="grid">
+        <Sortable.Item id="a" span={span}>
+          A
+        </Sortable.Item>
+      </Sortable>,
+    );
+    expect(
+      (container.querySelector('li') as HTMLElement).style.getPropertyValue('--sortable-item-span'),
+    ).toBe(expected);
+  });
+
+  it('a span-less Item stamps auto so it never inherits a spanned ancestor', () => {
+    const { container } = render(
+      <Sortable arrangement="grid">
+        <Sortable.Item id="a">A</Sortable.Item>
+      </Sortable>,
+    );
+    expect(
+      (container.querySelector('li') as HTMLElement).style.getPropertyValue('--sortable-item-span'),
+    ).toBe('auto');
+  });
+
+  it('keeps handle-only drag semantics in grid mode (<li> gets no dnd-kit role/tabIndex)', () => {
+    const { container } = render(
+      <Sortable arrangement="grid">
+        <Sortable.Item id="a" span="50%">
+          <Sortable.Handle>h</Sortable.Handle>
+        </Sortable.Item>
+      </Sortable>,
+    );
+    const li = container.querySelector('li');
+    expect(li?.getAttribute('tabIndex')).toBeNull();
+    expect(li?.getAttribute('role')).toBeNull();
+    // The Handle still wires the drag activator.
+    expect(container.querySelector('[data-sortable-handle="true"]')).not.toBeNull();
+  });
+
+  it('without a Handle the grid <li> is keyboard-focusable (tabIndex=0)', () => {
+    const { container } = render(
+      <Sortable arrangement="grid">
+        <Sortable.Item id="a" span="50%">
+          A
+        </Sortable.Item>
+      </Sortable>,
+    );
+    expect(container.querySelector('li')?.getAttribute('tabIndex')).toBe('0');
+  });
+
+  it('fires onReorder with the correct from/to for a keyboard drag in a grid', async () => {
+    // Two items so the drop target is unambiguous (the only neighbour is
+    // index 1) — dnd-kit's closestCenter picks it deterministically. The
+    // from/to mapping is `itemIds.indexOf`, identical to list mode; this
+    // asserts it still resolves under the grid strategy + closestCenter.
+    const restore = stubStackedRects();
+    const onReorder = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Sortable arrangement="grid" columns={12} onReorder={onReorder}>
+        <Sortable.Item id="a" span="50%">
+          <Sortable.Handle aria-label="Reorder A">ha</Sortable.Handle>A
+        </Sortable.Item>
+        <Sortable.Item id="b" span="50%">
+          <Sortable.Handle aria-label="Reorder B">hb</Sortable.Handle>B
+        </Sortable.Item>
+      </Sortable>,
+    );
+
+    screen.getByLabelText('Reorder A').focus();
+    await user.keyboard('[Space]'); // pick up "a"
+    await user.keyboard('[ArrowDown]'); // move past "b"
+    await user.keyboard('[Space]'); // drop
+
+    restore();
+
+    expect(onReorder).toHaveBeenCalledTimes(1);
+    expect(onReorder).toHaveBeenCalledWith({ id: 'a', from: 0, to: 1 });
   });
 });
 

--- a/packages/design-system/src/components/Sortable/Sortable.tokens.scss
+++ b/packages/design-system/src/components/Sortable/Sortable.tokens.scss
@@ -3,6 +3,11 @@
   // List
   --sortable-list-gap: var(--space-2);
 
+  // Grid arrangement — gap between grid cells. Defaults to the list gap so the
+  // two arrangements match out of the box; overridable independently (a
+  // dashboard grid often wants a roomier gutter than a dense list).
+  --sortable-grid-gap: var(--sortable-list-gap);
+
   // Item (dragging state)
   --sortable-item-shadow-dragging: var(--shadow-lg);
 

--- a/packages/design-system/src/components/Sortable/Sortable.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.tsx
@@ -12,6 +12,7 @@ import {
   type ReactNode,
 } from 'react';
 import {
+  closestCenter,
   DndContext,
   DragOverlay,
   KeyboardSensor,
@@ -24,6 +25,7 @@ import {
 } from '@dnd-kit/core';
 import {
   SortableContext,
+  rectSortingStrategy,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
@@ -32,7 +34,16 @@ import { CSS, type Transform } from '@dnd-kit/utilities';
 import clsx from 'clsx';
 import { mergeRefs } from '../_internal/refs';
 import { useFloatingSurface } from '../_internal/overlay';
+import { resolveGridItemSpan, type GridItemSpan } from '../_internal/gridSpan';
 import styles from './Sortable.module.scss';
+
+/**
+ * Layout arrangement of the sortable items.
+ * - `'list'` (default) — a single vertical column (`verticalListSortingStrategy`).
+ * - `'grid'` — a `columns`-track CSS grid where items carry column spans and
+ *   siblings reflow in 2D during a drag (`rectSortingStrategy`).
+ */
+export type SortableArrangement = 'list' | 'grid';
 
 /**
  * Payload fired by `onReorder` after a successful drag-drop or keyboard move.
@@ -87,6 +98,23 @@ export interface SortableProps extends HTMLAttributes<HTMLOListElement> {
    * constrains the drag vertically to the list's extent.
    */
   restrictToContainer?: boolean;
+  /**
+   * Layout arrangement of the items.
+   * - `'list'` (default) — single vertical column; existing behavior unchanged.
+   * - `'grid'` — the `<ol>` becomes a `columns`-track CSS grid. Items carry
+   *   column spans (`Sortable.Item span`), rows are equal-height, and siblings
+   *   reflow in 2D during a drag. Reorder semantics stay order-based (a drop
+   *   reorders the flow; nothing here persists an x/y position).
+   */
+  arrangement?: SortableArrangement;
+  /**
+   * Number of equal-width grid tracks. Only applies when `arrangement="grid"`
+   * (ignored for a list). Default `12`, matching `Grid.Item`'s 12-column
+   * fraction spans (`'25%'`→3 … `'75%'`→9 tracks). Set another count for a
+   * simpler grid, but the named fraction spans then won't map to their
+   * fraction (documented, not validated — same as `Grid`).
+   */
+  columns?: number;
 }
 
 export interface SortableItemProps extends Omit<HTMLAttributes<HTMLLIElement>, 'id'> {
@@ -97,6 +125,15 @@ export interface SortableItemProps extends Omit<HTMLAttributes<HTMLLIElement>, '
   id: string | number;
   /** Item content — typically a `<Card>` or a row of text + icons. */
   children: ReactNode;
+  /**
+   * Column span, only meaningful under `<Sortable arrangement="grid">`
+   * (ignored in a list). Mirrors `Grid.Item`'s `span` exactly:
+   * - number — `span N` of the grid's `columns`.
+   * - `'25%' | '33%' | '50%' | '67%' | '75%'` — fractions of a 12-column grid.
+   * - `'100%'` / `'full'` — the entire row (`1 / -1`); safe with any `columns`.
+   * Omit for a single track (auto placement).
+   */
+  span?: GridItemSpan;
 }
 
 export interface SortableHandleProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -196,6 +233,31 @@ function containsHandle(children: ReactNode): boolean {
  *   ))}
  * </Sortable>
  *
+ * @example
+ * // Grid arrangement — a 12-column dashboard of widgets with mixed spans.
+ * // Items reflow in 2D during a drag; a drop reorders the flow (order-based,
+ * // no persisted x/y). Rows are equal-height.
+ * <Sortable
+ *   arrangement="grid"
+ *   columns={12}
+ *   onReorder={({ from, to }) => setWidgets((w) => arrayMove(w, from, to))}
+ * >
+ *   {widgets.map((w) => (
+ *     <Sortable.Item key={w.id} id={w.id} span={w.span}>
+ *       <Card>{w.title}</Card>
+ *     </Sortable.Item>
+ *   ))}
+ * </Sortable>
+ *
+ * @remarks Grid arrangement
+ * - `arrangement="grid"` re-lays the `<ol>` as a `columns`-track CSS grid
+ *   (default 12) using dnd-kit's `rectSortingStrategy`, so siblings reflow in
+ *   2D during a drag instead of shifting only vertically. Give each item a
+ *   `span` (`Sortable.Item span="50%"` / `span={6}` / `span="100%"`) — same
+ *   values as `Grid.Item`. Semantics stay order-based: a drop reorders the
+ *   flow; nothing persists a grid x/y position. `restrictToContainer` still
+ *   clamps the drag to the grid's bounding box.
+ *
  * @remarks Drag confinement
  * - By default (`restrictToContainer`) the dragged item is clamped to the
  *   list's bounding box and can't be dragged off over unrelated UI. Pass
@@ -228,9 +290,19 @@ function containsHandle(children: ReactNode): boolean {
  *   render but won't be reorderable.
  */
 const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function SortableRoot(
-  { onReorder, restrictToContainer = true, className, children, ...rest },
+  {
+    onReorder,
+    restrictToContainer = true,
+    arrangement = 'list',
+    columns = 12,
+    className,
+    style,
+    children,
+    ...rest
+  },
   ref,
 ) {
+  const isGrid = arrangement === 'grid';
   const [activeId, setActiveId] = useState<string | number | null>(null);
   // #282: a keyboard drag is an Escape-consuming MODE (Escape cancels the
   // drag). Register it as a floating surface while active so a host Modal/Drawer
@@ -317,12 +389,29 @@ const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function Sortab
     <DndContext
       sensors={sensors}
       modifiers={modifiers}
+      // Grid: closestCenter is dnd-kit's idiomatic pairing for a 2D sortable
+      // grid — the dragged cell reflows to the nearest slot without needing to
+      // physically overlap it (the default rectIntersection requires overlap,
+      // which reads as sticky/unpredictable when cells vary in span). List
+      // keeps the default (undefined) so its behavior is unchanged.
+      collisionDetection={isGrid ? closestCenter : undefined}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
-        <ol ref={mergeRefs(olRef, ref)} className={clsx(styles.list, className)} {...rest}>
+      <SortableContext
+        items={itemIds}
+        strategy={isGrid ? rectSortingStrategy : verticalListSortingStrategy}
+      >
+        <ol
+          ref={mergeRefs(olRef, ref)}
+          className={clsx(isGrid ? styles.grid : styles.list, className)}
+          // In grid mode the <ol> owns the track template; inject the column
+          // count as a custom prop AFTER the consumer's style so it wins
+          // (mirrors Grid's --grid-columns). List mode leaves style untouched.
+          style={isGrid ? { ...style, ['--sortable-columns' as string]: columns } : style}
+          {...rest}
+        >
           {children}
         </ol>
       </SortableContext>
@@ -353,9 +442,12 @@ SortableRoot.displayName = 'Sortable';
  * If the children subtree contains a `<Sortable.Handle>`, only the Handle
  * initiates drag. Otherwise the whole Item is draggable (and focusable for
  * keyboard reorder).
+ *
+ * Under `<Sortable arrangement="grid">`, pass `span` for the item's column
+ * span (mirrors `Grid.Item`'s `span`); it's ignored in a list.
  */
 export const SortableItem = forwardRef<HTMLLIElement, SortableItemProps>(function SortableItem(
-  { id, className, children, ...rest },
+  { id, span, className, children, ...rest },
   ref,
 ) {
   const {
@@ -395,6 +487,11 @@ export const SortableItem = forwardRef<HTMLLIElement, SortableItemProps>(functio
           // is an invisible placeholder so it never carries a stale drag/drop
           // transform when onReorder commits the new order asynchronously (#165).
           opacity: isDragging ? 0 : undefined,
+          // Grid-arrangement column span. Always stamped (default 'auto') so a
+          // span-less item never inherits a spanned ancestor's custom property;
+          // ignored by the CSS in list mode (grid-column is inert on a flex
+          // child). Mirrors Grid.Item.
+          ['--sortable-item-span' as string]: resolveGridItemSpan(span) ?? 'auto',
         }}
         data-dragging={isDragging ? 'true' : undefined}
         className={clsx(styles.item, className)}

--- a/packages/design-system/src/components/Sortable/index.ts
+++ b/packages/design-system/src/components/Sortable/index.ts
@@ -8,4 +8,5 @@ export {
   type SortableHandleProps,
   type SortableReorderEvent,
   type SortableItemContextValue,
+  type SortableArrangement,
 } from './Sortable';

--- a/packages/design-system/src/components/_internal/gridSpan.ts
+++ b/packages/design-system/src/components/_internal/gridSpan.ts
@@ -1,0 +1,39 @@
+/**
+ * Column-span vocabulary shared by `Grid.Item` and `Sortable.Item` (grid
+ * arrangement). Lives in `_internal` so both components reference one source of
+ * the fraction→track mapping without either importing the other (which would
+ * imply a render-composition edge in the component manifest that doesn't exist).
+ */
+
+/**
+ * Column span for a grid cell. Numbers span that many tracks of whatever
+ * `columns` the parent grid declares. Fraction strings assume a 12-column
+ * grid (`columns={12}`): `'25%'`→3, `'33%'`→4, `'50%'`→6, `'67%'`→8,
+ * `'75%'`→9 tracks. `'100%'` / `'full'` span the entire row (`1 / -1`) and
+ * are safe in ANY grid, including auto-fit.
+ */
+export type GridItemSpan = number | 'full' | '25%' | '33%' | '50%' | '67%' | '75%' | '100%';
+
+/** Fraction → 12-col track count. 100%/full handled separately (1 / -1). */
+const FRACTION_TRACKS: Record<Exclude<GridItemSpan, number | 'full' | '100%'>, number> = {
+  '25%': 3,
+  '33%': 4,
+  '50%': 6,
+  '67%': 8,
+  '75%': 9,
+};
+
+/**
+ * Resolve a `GridItemSpan` to a CSS `grid-column` value (or `undefined` when
+ * no span is set; callers substitute `'auto'`).
+ * - `undefined` → `undefined`
+ * - `'full'` / `'100%'` → `'1 / -1'`
+ * - number → `'span N'`
+ * - fraction → `'span <tracks>'`
+ */
+export function resolveGridItemSpan(span: GridItemSpan | undefined): string | undefined {
+  if (span === undefined) return undefined;
+  if (span === 'full' || span === '100%') return '1 / -1';
+  if (typeof span === 'number') return `span ${span}`;
+  return `span ${FRACTION_TRACKS[span]}`;
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -363,6 +363,7 @@ export type {
   SortableItemProps,
   SortableHandleProps,
   SortableReorderEvent,
+  SortableArrangement,
 } from './components/Sortable';
 
 export { SortableGroup, moveSortableItem } from './components/SortableGroup';

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -3988,6 +3988,20 @@
           "required": false,
           "default": "true",
           "description": "When `true` (default), the dragged item is clamped to the list's bounding\nbox — it can't be dragged outside the `<ol>`. Set `false` for free-drag\n(the item can be dragged anywhere on the page). For a vertical list this\nconstrains the drag vertically to the list's extent."
+        },
+        {
+          "name": "arrangement",
+          "type": "SortableArrangement",
+          "required": false,
+          "default": "'list'",
+          "description": "Layout arrangement of the items.\n- `'list'` (default) — single vertical column; existing behavior unchanged.\n- `'grid'` — the `<ol>` becomes a `columns`-track CSS grid. Items carry\n  column spans (`Sortable.Item span`), rows are equal-height, and siblings\n  reflow in 2D during a drag. Reorder semantics stay order-based (a drop\n  reorders the flow; nothing here persists an x/y position)."
+        },
+        {
+          "name": "columns",
+          "type": "number",
+          "required": false,
+          "default": "",
+          "description": "Number of equal-width grid tracks. Only applies when `arrangement=\"grid\"`\n(ignored for a list). Default `12`, matching `Grid.Item`'s 12-column\nfraction spans (`'25%'`→3 … `'75%'`→9 tracks). Set another count for a\nsimpler grid, but the named fraction spans then won't map to their\nfraction (documented, not validated — same as `Grid`)."
         }
       ]
     },
@@ -4752,6 +4766,7 @@
     "SliderOrientation": "\"horizontal\" | \"vertical\"",
     "SliderMark": "{ value: number; label?: string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null }",
     "SortableReorderEvent": "{ from: number; to: number; id: string | number }",
+    "SortableArrangement": "\"list\" | \"grid\"",
     "SortableMoveEvent": "{ id: string | number; from: { container: string | number; index: number; }; to: { container: string | number; index: number; } }",
     "TableDensity": "\"comfortable\" | \"dense\"",
     "PaginationSize": "\"sm\" | \"md\" | \"lg\"",

--- a/packages/playground/src/pages/components/SortableDemo.tsx
+++ b/packages/playground/src/pages/components/SortableDemo.tsx
@@ -62,6 +62,14 @@ export function SortableDemo() {
     { id: 'f-3', label: 'Contract draft' },
   ]);
 
+  const [widgets, setWidgets] = useState([
+    { id: 'w-1', title: 'KPIs', span: '25%' as const },
+    { id: 'w-2', title: 'Revenue', span: '75%' as const },
+    { id: 'w-3', title: 'Recent deals', span: '33%' as const },
+    { id: 'w-4', title: 'Pipeline', span: '67%' as const },
+    { id: 'w-5', title: 'Activity feed', span: '100%' as const },
+  ]);
+
   return (
     <DemoLayout
       name="Sortable"
@@ -462,15 +470,81 @@ export function Demo() {
         </Cluster>
       </Example>
 
+      <Example
+        title="Grid arrangement (dashboard widgets)"
+        description="arrangement='grid' re-lays the <ol> as a 12-column grid (columns default 12). Each Sortable.Item carries a span (same values as Grid.Item: 25%/33%/50%/67%/75%/100%), rows are equal-height, and dnd-kit's rectSortingStrategy reflows siblings in 2D during a drag. A drop reorders the flow — order-based, no persisted x/y. Drag a widget's grip to any position."
+        code={`import { useState } from 'react';
+import { GripVertical } from 'lucide-react';
+import { arrayMove } from '@dnd-kit/sortable';
+import { Card, Cluster, Sortable, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  const [widgets, setWidgets] = useState([
+    { id: 'w-1', title: 'KPIs', span: '25%' as const },
+    { id: 'w-2', title: 'Revenue', span: '75%' as const },
+    { id: 'w-3', title: 'Recent deals', span: '33%' as const },
+    { id: 'w-4', title: 'Pipeline', span: '67%' as const },
+    { id: 'w-5', title: 'Activity feed', span: '100%' as const },
+  ]);
+
+  return (
+    <Sortable
+      arrangement="grid"
+      columns={12}
+      onReorder={({ from, to }) => setWidgets((w) => arrayMove(w, from, to))}
+    >
+      {widgets.map((widget) => (
+        <Sortable.Item key={widget.id} id={widget.id} span={widget.span}>
+          <Card padding="sm" style={{ height: '100%' }}>
+            <Cluster gap="sm" align="center">
+              <Sortable.Handle aria-label={\`Reorder \${widget.title}\`}>
+                <GripVertical size={14} />
+              </Sortable.Handle>
+              <Text weight="medium">{widget.title}</Text>
+              <Text size="sm" tone="muted">
+                {widget.span}
+              </Text>
+            </Cluster>
+          </Card>
+        </Sortable.Item>
+      ))}
+    </Sortable>
+  );
+}`}
+      >
+        <Sortable
+          arrangement="grid"
+          columns={12}
+          onReorder={({ from, to }) => setWidgets((w) => arrayMove(w, from, to))}
+        >
+          {widgets.map((widget) => (
+            <Sortable.Item key={widget.id} id={widget.id} span={widget.span}>
+              <Card padding="sm" style={{ height: '100%' }}>
+                <Cluster gap="sm" align="center">
+                  <Sortable.Handle aria-label={`Reorder ${widget.title}`}>
+                    <GripVertical size={14} />
+                  </Sortable.Handle>
+                  <Text weight="medium">{widget.title}</Text>
+                  <Text size="sm" tone="muted">
+                    {widget.span}
+                  </Text>
+                </Cluster>
+              </Card>
+            </Sortable.Item>
+          ))}
+        </Sortable>
+      </Example>
+
       <Stack gap="xs">
         <Title order={3} size="md">
           Implementation notes
         </Title>
         <Text size="sm" tone="muted">
           Thin wrapper over @dnd-kit/sortable. PointerSensor with 5px activation distance;
-          KeyboardSensor with sortableKeyboardCoordinates; vertical list strategy. Hybrid drag
-          origin via containsHandle children walk. dnd-kit ships built-in aria-live announcements
-          and autoscroll.
+          KeyboardSensor with sortableKeyboardCoordinates. arrangement='list' (default) uses the
+          vertical list strategy; arrangement='grid' uses rectSortingStrategy on a columns-track CSS
+          grid with per-item spans (Sortable.Item span). Hybrid drag origin via containsHandle
+          children walk. dnd-kit ships built-in aria-live announcements and autoscroll.
         </Text>
       </Stack>
     </DemoLayout>


### PR DESCRIPTION
Closes #316.

## What

Adds an opt-in **grid arrangement** to `<Sortable>`, which was list-only (hardcoded `verticalListSortingStrategy` + a flex-column `<ol>`).

- **`arrangement?: 'list' | 'grid'`** (default `'list'`) — existing consumers untouched; list behavior is byte-identical (same class, strategy, and default collision detection).
- **Grid mode**: the `<ol>` becomes a `columns`-track CSS grid (**`columns?: number`**, default `12`) owned by the DS `module.scss` (`grid-template-columns: repeat(var(--sortable-columns,12), minmax(0,1fr))`, gap via a new `--sortable-grid-gap` token defaulting to the list gap). Driven by dnd-kit's **`rectSortingStrategy`** so siblings reflow in **2D** during a drag. **`closestCenter`** collision is scoped to grid mode (idiomatic for a spanned sortable grid; list keeps the default). `align-items: stretch` gives **equal-height cells**.
- **Per-item span**: **`span?: GridItemSpan`** on `Sortable.Item` mirrors `Grid.Item` (#314) exactly — `25%`/`33%`/`50%`/`67%`/`75%`/`100%`/`full`/number. The span vocabulary (type + resolver) is extracted to `src/components/_internal/gridSpan.ts` so `Grid.Item` and `Sortable.Item` share one source **without either importing the other** (no false composition edge in the manifest; `GridItemSpan` stays re-exported from Grid's public surface).

All existing behavior preserved: `containsHandle` walk, handle-only vs whole-item drag, keyboard sensor + coordinate getter, `DragOverlay` clone (dnd-kit measures the span'd node, so the clone width matches the span — the issue's rough edge #2), `onReorder` contract, `restrictToContainer` clamp (now clamps in 2D). The issue's rough edge #1 (sibling-shift using vertical math) is fixed by `rectSortingStrategy`.

## Why

Serves the eocrm tenant-dashboard WYSIWYG customize view (issue's D12). The dashboard currently ships a shim (`apps/web/src/shared/ds-shims/DashboardGrid.tsx`) that re-lays the `<ol>` as a grid via a more-specific selector; this lands it natively so the shim's edit-mode `<ol>` override can be dropped.

> Note for the de-shim: #316 delivers 2D reflow + spans but **not** responsive column collapse (scoped out, mirroring Grid #314 which also doesn't collapse). The dashboard's media-query collapse still needs a `className`/inline override until a responsive-span story lands — the same limitation view-mode Grid has.

## Tests / gates

- Extended `Sortable.test.tsx`: default arrangement unchanged; grid renders the grid class + `--sortable-columns`; `columns` override; consumer-style merge (injected wins); item `span` → `--sortable-item-span` on the `<li>` (full span matrix incl. `auto`); handle detection in grid mode; grid `<li>` keyboard-focusable; `onReorder` fires with correct `from`/`to` for a keyboard drag under the grid strategy + `closestCenter`.
- Playground: new **grid dashboard demo** in `SortableDemo` (12-col, mixed spans, handles).
- AGENTS.md TL;DR + JSDoc updated; `SortableArrangement` exported.
- Green: `typecheck`, full `vitest` (3839), `lint:css`, `build`, `npm pack --dry-run` (no test files leak).
- Two fresh-Opus pre-PR review passes: 0 Critical, 0 Important, both `clean enough to stop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)