### PR TITLE
feat: graduated collapseBelow map for Grid + collapseBelow for Sortable grid (#318)

### DIFF
--- a/docs/superpowers/plans/2026-07-25-collapse-map-grid-sortable.md
+++ b/docs/superpowers/plans/2026-07-25-collapse-map-grid-sortable.md
@@ -1,0 +1,640 @@
+# Graduated collapse for Grid + collapseBelow for Sortable — Implementation Plan (#318)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `collapseBelow` on `<Grid>` and (new) on `<Sortable arrangement="grid">` accepts either the existing breakpoint string (binary collapse) or a breakpoint→columns map (graduated collapse, e.g. `{ md: 6, sm: 1 }`).
+
+**Architecture:** The map form works by (a) container-query CSS rules on new per-breakpoint "step" classes that set `grid-template-columns` from per-breakpoint inline custom properties (`--grid-columns-md` etc.) injected by the container, and (b) per-item clamped spans computed in JS — the container provides its collapse map via a React context, each Item stamps `--grid-item-span-<bp>` / `--sortable-item-span-<bp>` inline with its span clamped to the step's column count. Step blocks are declared lg → md → sm so at a narrow width the smallest matching breakpoint wins by source order. The legacy string form is untouched (Grid) / mirrored (Sortable).
+
+**Tech Stack:** React 18, TypeScript, SCSS modules, CSS container queries, Vitest + RTL (globals on — no `describe/it/expect` imports).
+
+## Global Constraints
+
+- Repo: `/home/dpws/projects/design-system`, branch `feat/collapse-map` (already checked out).
+- Tokens-only SCSS; `grid-column` needs `// stylelint-disable-next-line property-disallowed-list -- <reason>` on the line above (see existing examples in `Grid.module.scss`).
+- Every new/changed exported prop and type gets full JSDoc (package CLAUDE.md rule 7).
+- Tests: Vitest globals — do NOT import `describe/it/expect/vi`. Import `render, screen` from `@testing-library/react`.
+- Run tests from repo root: `npx vitest run packages/design-system/src/components/Grid/Grid.test.tsx` (or the Sortable path).
+- Commit after each task; conventional-commit messages.
+
+---
+
+### Task 1: Shared collapse plumbing (`_internal`)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/_internal/collapse.scss`
+- Create: `packages/design-system/src/components/_internal/collapse.ts`
+- Modify: `packages/design-system/src/components/_internal/gridSpan.ts` (add clamp resolver)
+- Modify: `packages/design-system/src/components/Grid/Grid.tokens.scss` (drop the moved SCSS vars)
+- Modify: `packages/design-system/src/components/Grid/Grid.module.scss` (repoint `tokens.$grid-collapse-*` → `bp.$collapse-*`)
+- Test: `packages/design-system/src/components/_internal/gridSpan.test.ts` (create if absent, else extend)
+
+**Interfaces:**
+
+- Produces: SCSS `$collapse-sm: 480px / $collapse-md: 640px / $collapse-lg: 768px` (namespace `bp` via `@use '../_internal/collapse' as bp;`).
+- Produces: `type CollapseBreakpoint = 'sm' | 'md' | 'lg'`, `type CollapseColumnsMap = Partial<Record<CollapseBreakpoint, number>>`, `const CollapseColumnsContext: React.Context<CollapseColumnsMap | null>`, `const COLLAPSE_BREAKPOINTS: readonly CollapseBreakpoint[]` (order `['lg','md','sm']`), `function collapseTrackTemplate(columns: number): string` → `` `repeat(${columns}, minmax(0, 1fr))` ``.
+- Produces: `function resolveCollapsedGridItemSpan(span: GridItemSpan | undefined, columns: number): string` in `gridSpan.ts`.
+
+- [ ] **Step 1: Write failing tests for the clamp resolver** — append to (or create) `gridSpan.test.ts`:
+
+```ts
+import { resolveCollapsedGridItemSpan } from './gridSpan';
+
+describe('resolveCollapsedGridItemSpan (#318)', () => {
+  it('returns auto for a span-less item', () => {
+    expect(resolveCollapsedGridItemSpan(undefined, 6)).toBe('auto');
+  });
+  it('keeps spans smaller than the step columns', () => {
+    expect(resolveCollapsedGridItemSpan(3, 6)).toBe('span 3');
+    expect(resolveCollapsedGridItemSpan('25%', 6)).toBe('span 3');
+  });
+  it('clamps spans >= step columns to the full row', () => {
+    expect(resolveCollapsedGridItemSpan(9, 6)).toBe('1 / -1');
+    expect(resolveCollapsedGridItemSpan('75%', 6)).toBe('1 / -1');
+    expect(resolveCollapsedGridItemSpan(6, 6)).toBe('1 / -1');
+  });
+  it('full-row spans and single-column steps are always 1 / -1', () => {
+    expect(resolveCollapsedGridItemSpan('100%', 6)).toBe('1 / -1');
+    expect(resolveCollapsedGridItemSpan('full', 6)).toBe('1 / -1');
+    expect(resolveCollapsedGridItemSpan(3, 1)).toBe('1 / -1');
+    expect(resolveCollapsedGridItemSpan(undefined, 1)).toBe('auto');
+  });
+});
+```
+
+- [ ] **Step 2: Run** `npx vitest run packages/design-system/src/components/_internal/gridSpan.test.ts` — expect FAIL (function not exported).
+
+- [ ] **Step 3: Implement.**
+
+`_internal/collapse.scss`:
+
+```scss
+// Container-width collapse thresholds shared by Grid's `collapseBelow` and
+// Sortable's grid-arrangement `collapseBelow`. SCSS constants (not CSS custom
+// properties): container-query conditions can't read custom properties.
+// Keep in sync with the CollapseBreakpoint JSDoc in collapse.ts.
+$collapse-sm: 480px;
+$collapse-md: 640px;
+$collapse-lg: 768px;
+```
+
+`_internal/collapse.ts`:
+
+```ts
+import { createContext } from 'react';
+
+/**
+ * Container-width threshold for `collapseBelow` on Grid / Sortable (grid
+ * arrangement). `sm` 480px / `md` 640px / `lg` 768px — measured against the
+ * grid's OWN width (container query), not the viewport.
+ */
+export type CollapseBreakpoint = 'sm' | 'md' | 'lg';
+
+/**
+ * Graduated collapse: breakpoint → column count. Below each breakpoint the
+ * grid re-templates to that many equal columns and every item's span is
+ * clamped to fit. E.g. `{ md: 6, sm: 1 }` = 12-col grid above 640px, 6-col
+ * between 480–640px, single column below 480px. When several breakpoints
+ * match, the smallest wins.
+ */
+export type CollapseColumnsMap = Partial<Record<CollapseBreakpoint, number>>;
+
+/** Largest → smallest; step CSS is declared in this order so the smallest matching breakpoint wins by source order. */
+export const COLLAPSE_BREAKPOINTS: readonly CollapseBreakpoint[] = ['lg', 'md', 'sm'];
+
+/**
+ * The container's graduated-collapse map, provided by Grid / Sortable (grid
+ * arrangement) to their Items so each can stamp per-breakpoint clamped span
+ * custom properties. `null` when the container has no map-form collapse.
+ */
+export const CollapseColumnsContext = createContext<CollapseColumnsMap | null>(null);
+
+/** Track template for a collapse step — mirrors Grid's fixed-column template. */
+export function collapseTrackTemplate(columns: number): string {
+  return `repeat(${columns}, minmax(0, 1fr))`;
+}
+```
+
+Append to `_internal/gridSpan.ts`:
+
+```ts
+/**
+ * Resolve a span against a graduated-collapse step's column count: spans that
+ * fit keep their track count, spans >= the step's columns clamp to the full
+ * row (`1 / -1`), full-row spans stay full-row, span-less stays `auto`.
+ */
+export function resolveCollapsedGridItemSpan(
+  span: GridItemSpan | undefined,
+  columns: number,
+): string {
+  if (span === undefined) return 'auto';
+  if (span === 'full' || span === '100%' || columns <= 1) return '1 / -1';
+  const tracks = typeof span === 'number' ? span : FRACTION_TRACKS[span];
+  return tracks >= columns ? '1 / -1' : `span ${tracks}`;
+}
+```
+
+In `Grid.tokens.scss`: delete the `$grid-collapse-sm/md/lg` block and its comment; leave a pointer comment `// Collapse breakpoints live in ../_internal/collapse.scss (shared with Sortable).`
+In `Grid.module.scss`: add `@use '../_internal/collapse' as bp;` at top and replace `tokens.$grid-collapse-sm|md|lg` with `bp.$collapse-sm|md|lg` in the three `@container` conditions.
+
+- [ ] **Step 4: Run** the gridSpan test (PASS) plus `npx vitest run packages/design-system/src/components/Grid/Grid.test.tsx` and `cd packages/design-system && npm run lint:css` — all green.
+
+- [ ] **Step 5: Commit** — `feat(internal): shared collapse breakpoints, map context, clamped span resolver (#318)`
+
+---
+
+### Task 2: Grid — map form of `collapseBelow`
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Grid/Grid.tsx`
+- Modify: `packages/design-system/src/components/Grid/GridItem.tsx`
+- Modify: `packages/design-system/src/components/Grid/Grid.module.scss`
+- Modify: `packages/design-system/src/components/Grid/index.ts`, `packages/design-system/src/index.ts`
+- Test: `packages/design-system/src/components/Grid/Grid.test.tsx`
+
+**Interfaces:**
+
+- Consumes: everything Task 1 produces.
+- Produces: `GridFixedColumns.collapseBelow?: GridCollapseBreakpoint | CollapseColumnsMap`; `GridCollapseBreakpoint` becomes an alias of `CollapseBreakpoint`; `CollapseColumnsMap` re-exported from `Grid/index.ts` and `src/index.ts`. Step classes `styles.stepSm/stepMd/stepLg`.
+
+- [ ] **Step 1: Write failing tests** — append to `Grid.test.tsx`:
+
+```tsx
+describe('Grid graduated collapse (#318)', () => {
+  it('map form adds collapsible + one step class per breakpoint and injects step templates', () => {
+    render(
+      <Grid columns={12} collapseBelow={{ md: 6, sm: 1 }} data-testid="grid">
+        <div>a</div>
+      </Grid>,
+    );
+    const el = screen.getByTestId('grid');
+    expect(el.className).toMatch(/collapsible/);
+    expect(el.className).toMatch(/stepMd/);
+    expect(el.className).toMatch(/stepSm/);
+    expect(el.className).not.toMatch(/stepLg/);
+    expect(el.className).not.toMatch(/collapseMd/);
+    expect(el.style.getPropertyValue('--grid-columns-md')).toBe('repeat(6, minmax(0, 1fr))');
+    expect(el.style.getPropertyValue('--grid-columns-sm')).toBe('repeat(1, minmax(0, 1fr))');
+    expect(el.style.getPropertyValue('--grid-columns-lg')).toBe('');
+  });
+
+  it('Grid.Item under a map grid stamps clamped per-breakpoint spans', () => {
+    render(
+      <Grid columns={12} collapseBelow={{ md: 6, sm: 1 }}>
+        <Grid.Item span="75%" data-testid="wide">
+          w
+        </Grid.Item>
+        <Grid.Item span={3} data-testid="narrow">
+          n
+        </Grid.Item>
+        <Grid.Item data-testid="plain">p</Grid.Item>
+      </Grid>,
+    );
+    const wide = screen.getByTestId('wide');
+    expect(wide.style.getPropertyValue('--grid-item-span')).toBe('span 9');
+    expect(wide.style.getPropertyValue('--grid-item-span-md')).toBe('1 / -1');
+    expect(wide.style.getPropertyValue('--grid-item-span-sm')).toBe('1 / -1');
+    const narrow = screen.getByTestId('narrow');
+    expect(narrow.style.getPropertyValue('--grid-item-span-md')).toBe('span 3');
+    expect(narrow.style.getPropertyValue('--grid-item-span-sm')).toBe('1 / -1');
+    const plain = screen.getByTestId('plain');
+    expect(plain.style.getPropertyValue('--grid-item-span-md')).toBe('auto');
+  });
+
+  it('Grid.Item outside a map grid stamps no per-breakpoint spans', () => {
+    render(
+      <Grid columns={12} collapseBelow="md">
+        <Grid.Item span={3} data-testid="cell">
+          c
+        </Grid.Item>
+      </Grid>,
+    );
+    expect(screen.getByTestId('cell').style.getPropertyValue('--grid-item-span-md')).toBe('');
+  });
+
+  it('TS: map form is invalid on an auto-fit grid', () => {
+    // @ts-expect-error — collapseBelow (map form included) requires `columns`.
+    const Invalid = <Grid minColumnWidth="200px" collapseBelow={{ md: 6 }} />;
+    void Invalid;
+  });
+});
+```
+
+- [ ] **Step 2: Run** `npx vitest run packages/design-system/src/components/Grid/Grid.test.tsx` — new tests FAIL.
+
+- [ ] **Step 3: Implement.**
+
+`Grid.tsx`:
+
+- Imports: `import { CollapseColumnsContext, COLLAPSE_BREAKPOINTS, collapseTrackTemplate, type CollapseBreakpoint, type CollapseColumnsMap } from '../_internal/collapse';`
+- Replace the local breakpoint type with a re-export alias (KEEP the existing JSDoc line, now extended):
+
+```ts
+/** Container-width threshold below which a fixed-column grid collapses. `sm` 480px / `md` 640px / `lg` 768px. */
+export type GridCollapseBreakpoint = CollapseBreakpoint;
+export type { CollapseColumnsMap };
+```
+
+- `GridFixedColumns.collapseBelow?: GridCollapseBreakpoint | CollapseColumnsMap;` — extend the existing JSDoc with a paragraph:
+
+```
+   * Also accepts a graduated breakpoint→columns map, e.g.
+   * `collapseBelow={{ md: 6, sm: 1 }}`: below 640px the grid re-templates to
+   * 6 columns (item spans clamp to fit — a span wider than the step becomes a
+   * full row), and below 480px to a single column. Use when jumping straight
+   * from N columns to 1 wastes tablet widths. When several breakpoints match,
+   * the smallest wins. Only `Grid.Item` children get span clamping; plain
+   * children auto-place into the step's tracks.
+```
+
+- In the component body:
+
+```ts
+const collapseMap = typeof collapseBelow === 'object' ? collapseBelow : undefined;
+const collapseKeys = collapseMap
+  ? COLLAPSE_BREAKPOINTS.filter((b) => collapseMap[b] !== undefined)
+  : [];
+const stepVars = Object.fromEntries(
+  collapseKeys.map((b) => [`--grid-columns-${b}`, collapseTrackTemplate(collapseMap![b]!)]),
+);
+```
+
+- className: replace the two `collapseBelow && …` clsx lines with:
+
+```ts
+      collapseBelow && styles.collapsible,
+      typeof collapseBelow === 'string' && collapseClass[collapseBelow],
+      ...collapseKeys.map((b) => stepClass[b]),
+```
+
+with `const stepClass: Record<CollapseBreakpoint, string> = { sm: styles.stepSm, md: styles.stepMd, lg: styles.stepLg };` next to `collapseClass`.
+
+- style: `style={{ ...(style as CSSProperties), ...stepVars, ['--grid-columns' as string]: template }}`
+- Wrap the returned `<Tag …/>` in the provider only when a map is present:
+
+```tsx
+const grid = ( <Tag …/> );
+return collapseMap ? (
+  <CollapseColumnsContext.Provider value={collapseMap}>{grid}</CollapseColumnsContext.Provider>
+) : ( grid );
+```
+
+- Add one `@example` to the Grid JSDoc (graduated dashboard: `collapseBelow={{ md: 6, sm: 1 }}`) and extend the `@remarks Grid.Item` note with one line about clamping.
+
+`GridItem.tsx`:
+
+```ts
+import { useContext } from 'react';
+import { CollapseColumnsContext } from '../_internal/collapse';
+import {
+  resolveGridItemSpan,
+  resolveCollapsedGridItemSpan,
+  type GridItemSpan,
+} from '../_internal/gridSpan';
+// in the body:
+const collapseMap = useContext(CollapseColumnsContext);
+const collapseVars = collapseMap
+  ? Object.fromEntries(
+      (Object.keys(collapseMap) as (keyof typeof collapseMap)[]).map((b) => [
+        `--grid-item-span-${b}`,
+        resolveCollapsedGridItemSpan(span, collapseMap[b]!),
+      ]),
+    )
+  : undefined;
+// style: { ...(style as CSSProperties), ...collapseVars, ['--grid-item-span' as string]: resolved ?? 'auto' }
+```
+
+(Same always-stamp rationale as `--grid-item-span`: custom properties inherit, so every map key present on the container gets stamped on every Item.)
+
+`Grid.module.scss` — append after the existing three legacy `@container` blocks (order lg → md → sm is REQUIRED; note the specificity comment):
+
+```scss
+// --- graduated (map) collapse ------------------------------------------
+// Step track templates + per-item clamped spans are computed in Grid.tsx /
+// GridItem.tsx and injected inline (--grid-columns-<bp>, --grid-item-span-<bp>).
+// Declared lg → md → sm so when several steps match at a narrow width the
+// smallest breakpoint wins by source order (equal specificity).
+@container (max-width: #{bp.$collapse-lg}) {
+  .collapsible.stepLg {
+    grid-template-columns: var(--grid-columns-lg);
+
+    > .item {
+      // stylelint-disable-next-line property-disallowed-list -- graduated collapse override is Grid's own placement mechanism, same sanction as `.item` above
+      grid-column: var(--grid-item-span-lg, auto);
+    }
+  }
+}
+
+@container (max-width: #{bp.$collapse-md}) {
+  .collapsible.stepMd {
+    grid-template-columns: var(--grid-columns-md);
+
+    > .item {
+      // stylelint-disable-next-line property-disallowed-list -- graduated collapse override is Grid's own placement mechanism, same sanction as `.item` above
+      grid-column: var(--grid-item-span-md, auto);
+    }
+  }
+}
+
+@container (max-width: #{bp.$collapse-sm}) {
+  .collapsible.stepSm {
+    grid-template-columns: var(--grid-columns-sm);
+
+    > .item {
+      // stylelint-disable-next-line property-disallowed-list -- graduated collapse override is Grid's own placement mechanism, same sanction as `.item` above
+      grid-column: var(--grid-item-span-sm, auto);
+    }
+  }
+}
+```
+
+`Grid/index.ts`: add `CollapseColumnsMap` to the type exports from `./Grid`.
+`src/index.ts`: add `CollapseColumnsMap` to the Grid type-export block.
+
+- [ ] **Step 4: Run** `npx vitest run packages/design-system/src/components/Grid/Grid.test.tsx` (PASS) and `cd packages/design-system && npm run typecheck && npm run lint:css`.
+
+- [ ] **Step 5: Commit** — `feat(Grid): graduated collapseBelow map — per-step templates + clamped item spans (#318)`
+
+---
+
+### Task 3: Sortable — `collapseBelow` (string + map)
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Sortable/Sortable.tsx`
+- Modify: `packages/design-system/src/components/Sortable/Sortable.module.scss`
+- Modify: `packages/design-system/src/index.ts` (no new Sortable type names needed — prop reuses `GridCollapseBreakpoint`/`CollapseColumnsMap`; only touch if Task 2 didn't already export `CollapseColumnsMap`)
+- Test: `packages/design-system/src/components/Sortable/Sortable.test.tsx`
+
+**Interfaces:**
+
+- Consumes: Task 1's `CollapseColumnsContext`, `COLLAPSE_BREAKPOINTS`, `collapseTrackTemplate`, `CollapseBreakpoint`, `CollapseColumnsMap`, `resolveCollapsedGridItemSpan`, SCSS `bp.$collapse-*`.
+- Produces: `SortableProps.collapseBelow?: CollapseBreakpoint | CollapseColumnsMap`.
+
+- [ ] **Step 1: Write failing tests** — append to `Sortable.test.tsx` (match the file's existing render helpers/style; a minimal grid render is `<Sortable arrangement="grid" collapseBelow=… data-testid="ol"><Sortable.Item id="a">A</Sortable.Item></Sortable>`):
+
+```tsx
+describe('Sortable collapseBelow (#318)', () => {
+  it('string form adds collapsible + collapse class on the grid <ol>', () => {
+    render(
+      <Sortable arrangement="grid" collapseBelow="md" data-testid="ol">
+        <Sortable.Item id="a">A</Sortable.Item>
+      </Sortable>,
+    );
+    const ol = screen.getByTestId('ol');
+    expect(ol.className).toMatch(/collapsible/);
+    expect(ol.className).toMatch(/collapseMd/);
+  });
+
+  it('map form adds step classes, injects step templates, items stamp clamped spans', () => {
+    render(
+      <Sortable arrangement="grid" collapseBelow={{ md: 6, sm: 1 }} data-testid="ol">
+        <Sortable.Item id="a" span="75%" data-testid="wide">
+          A
+        </Sortable.Item>
+        <Sortable.Item id="b" span={3} data-testid="narrow">
+          B
+        </Sortable.Item>
+      </Sortable>,
+    );
+    const ol = screen.getByTestId('ol');
+    expect(ol.className).toMatch(/collapsible/);
+    expect(ol.className).toMatch(/stepMd/);
+    expect(ol.className).toMatch(/stepSm/);
+    expect(ol.style.getPropertyValue('--sortable-columns-md')).toBe('repeat(6, minmax(0, 1fr))');
+    const wide = screen.getByTestId('wide');
+    expect(wide.style.getPropertyValue('--sortable-item-span-md')).toBe('1 / -1');
+    expect(wide.style.getPropertyValue('--sortable-item-span-sm')).toBe('1 / -1');
+    const narrow = screen.getByTestId('narrow');
+    expect(narrow.style.getPropertyValue('--sortable-item-span-md')).toBe('span 3');
+  });
+
+  it('collapseBelow is inert in list arrangement', () => {
+    render(
+      <Sortable collapseBelow="md" data-testid="ol">
+        <Sortable.Item id="a">A</Sortable.Item>
+      </Sortable>,
+    );
+    const ol = screen.getByTestId('ol');
+    expect(ol.className).not.toMatch(/collapsible/);
+    expect(ol.className).not.toMatch(/collapseMd/);
+  });
+});
+```
+
+- [ ] **Step 2: Run** `npx vitest run packages/design-system/src/components/Sortable/Sortable.test.tsx` — new tests FAIL.
+
+- [ ] **Step 3: Implement.**
+
+`Sortable.tsx`:
+
+- Imports: add `useContext` is already imported; add `import { CollapseColumnsContext, COLLAPSE_BREAKPOINTS, collapseTrackTemplate, type CollapseBreakpoint, type CollapseColumnsMap } from '../_internal/collapse';` and extend the gridSpan import with `resolveCollapsedGridItemSpan`.
+- `SortableProps` — add after `columns`:
+
+```ts
+  /**
+   * Responsive collapse for the grid arrangement — mirrors `Grid`'s
+   * `collapseBelow` exactly (same breakpoints, same container-query
+   * mechanism). Ignored unless `arrangement="grid"`.
+   * - `'sm' | 'md' | 'lg'` — below the container-width threshold (480 / 640 /
+   *   768px of the LIST'S OWN width) every item spans the full row: a single
+   *   visual column.
+   * - `{ lg?: n, md?: n, sm?: n }` — graduated: below each breakpoint the grid
+   *   re-templates to that many columns and item spans clamp to fit (a span
+   *   wider than the step becomes a full row). E.g. `{ md: 6, sm: 1 }`.
+   *
+   * ❌ Anti-pattern: a collapsible Sortable must get its width from its
+   * parent — `container-type: inline-size` zeroes the list's contribution to
+   * intrinsic sizing (same caveat as `Grid`'s `collapseBelow`).
+   */
+  collapseBelow?: CollapseBreakpoint | CollapseColumnsMap;
+```
+
+- In `SortableRoot` (after `const isGrid = …`):
+
+```ts
+const collapse = isGrid ? collapseBelow : undefined;
+const collapseMap = typeof collapse === 'object' ? collapse : undefined;
+const collapseKeys = collapseMap
+  ? COLLAPSE_BREAKPOINTS.filter((b) => collapseMap[b] !== undefined)
+  : [];
+```
+
+- Class maps next to the component (module scope):
+
+```ts
+const collapseClass: Record<CollapseBreakpoint, string> = {
+  sm: styles.collapseSm,
+  md: styles.collapseMd,
+  lg: styles.collapseLg,
+};
+const stepClass: Record<CollapseBreakpoint, string> = {
+  sm: styles.stepSm,
+  md: styles.stepMd,
+  lg: styles.stepLg,
+};
+```
+
+- `<ol>` className:
+
+```ts
+className={clsx(
+  isGrid ? styles.grid : styles.list,
+  collapse && styles.collapsible,
+  typeof collapse === 'string' && collapseClass[collapse],
+  ...collapseKeys.map((b) => stepClass[b]),
+  className,
+)}
+```
+
+- `<ol>` style (grid branch): merge step template vars:
+
+```ts
+style={
+  isGrid
+    ? {
+        ...style,
+        ...Object.fromEntries(
+          collapseKeys.map((b) => [
+            `--sortable-columns-${b}`,
+            collapseTrackTemplate(collapseMap![b]!),
+          ]),
+        ),
+        ['--sortable-columns' as string]: columns,
+      }
+    : style
+}
+```
+
+- Provide the map to items — wrap the ENTIRE existing JSX return (DndContext) in the provider only when `collapseMap` is set (the DragOverlay clone can keep stamping vars; they're inert outside the `<ol>`):
+
+```tsx
+const tree = ( <DndContext …>…</DndContext> );
+return collapseMap ? (
+  <CollapseColumnsContext.Provider value={collapseMap}>{tree}</CollapseColumnsContext.Provider>
+) : ( tree );
+```
+
+- `SortableItem`: read `const collapseMap = useContext(CollapseColumnsContext);` and merge into the `<li>` style object:
+
+```ts
+...(collapseMap
+  ? Object.fromEntries(
+      (Object.keys(collapseMap) as CollapseBreakpoint[]).map((b) => [
+        `--sortable-item-span-${b}`,
+        resolveCollapsedGridItemSpan(span, collapseMap[b]!),
+      ]),
+    )
+  : undefined),
+```
+
+- Extend the `@remarks Grid arrangement` JSDoc block on SortableRoot with one sentence pointing at `collapseBelow` parity, and add one `@example` variant line is NOT needed (keep the grid example, add `collapseBelow={{ md: 6, sm: 1 }}` to it).
+
+`Sortable.module.scss` — add `@use '../_internal/collapse' as bp;` at top, then append (mirrors Grid, including the specificity comments):
+
+```scss
+// --- collapseBelow (grid arrangement) ----------------------------------
+// Mirrors Grid's collapseBelow: only collapsible lists become size
+// containers, so existing lists get zero containment changes.
+.collapsible {
+  container-type: inline-size;
+}
+
+// Binary (string) collapse — below the threshold every item spans the full
+// row. Double class gives specificity (0,2,0) so the collapse beats any
+// single-class consumer grid-column rule; vs `.item` it wins by source order.
+@container (max-width: #{bp.$collapse-sm}) {
+  .collapsible.collapseSm > * {
+    // stylelint-disable-next-line property-disallowed-list -- collapse override is Sortable's own placement mechanism, mirrors Grid
+    grid-column: 1 / -1;
+  }
+}
+
+@container (max-width: #{bp.$collapse-md}) {
+  .collapsible.collapseMd > * {
+    // stylelint-disable-next-line property-disallowed-list -- collapse override is Sortable's own placement mechanism, mirrors Grid
+    grid-column: 1 / -1;
+  }
+}
+
+@container (max-width: #{bp.$collapse-lg}) {
+  .collapsible.collapseLg > * {
+    // stylelint-disable-next-line property-disallowed-list -- collapse override is Sortable's own placement mechanism, mirrors Grid
+    grid-column: 1 / -1;
+  }
+}
+
+// Graduated (map) collapse — step templates + per-item clamped spans are
+// computed in Sortable.tsx and injected inline (--sortable-columns-<bp>,
+// --sortable-item-span-<bp>). Declared lg → md → sm so the smallest matching
+// breakpoint wins by source order (equal specificity).
+@container (max-width: #{bp.$collapse-lg}) {
+  .collapsible.stepLg {
+    grid-template-columns: var(--sortable-columns-lg);
+
+    > .item {
+      // stylelint-disable-next-line property-disallowed-list -- graduated collapse override is Sortable's own placement mechanism, mirrors Grid
+      grid-column: var(--sortable-item-span-lg, auto);
+    }
+  }
+}
+
+@container (max-width: #{bp.$collapse-md}) {
+  .collapsible.stepMd {
+    grid-template-columns: var(--sortable-columns-md);
+
+    > .item {
+      // stylelint-disable-next-line property-disallowed-list -- graduated collapse override is Sortable's own placement mechanism, mirrors Grid
+      grid-column: var(--sortable-item-span-md, auto);
+    }
+  }
+}
+
+@container (max-width: #{bp.$collapse-sm}) {
+  .collapsible.stepSm {
+    grid-template-columns: var(--sortable-columns-sm);
+
+    > .item {
+      // stylelint-disable-next-line property-disallowed-list -- graduated collapse override is Sortable's own placement mechanism, mirrors Grid
+      grid-column: var(--sortable-item-span-sm, auto);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run** `npx vitest run packages/design-system/src/components/Sortable/Sortable.test.tsx` (PASS) and `cd packages/design-system && npm run typecheck && npm run lint:css`.
+
+- [ ] **Step 5: Commit** — `feat(Sortable): collapseBelow for grid arrangement — binary + graduated map (#318)`
+
+---
+
+### Task 4: Docs + playground demos
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md` (Grid + Sortable sections)
+- Modify: `packages/playground/src/pages/components/GridDemo.tsx`
+- Modify: `packages/playground/src/pages/components/SortableDemo.tsx`
+
+**Interfaces:** Consumes the public API from Tasks 2–3. Playground imports ONLY from `@eocrm/design-system`.
+
+- [ ] **Step 1: AGENTS.md** — in the Grid section, extend the `collapseBelow` mention with the map form (one sentence + a `collapseBelow={{ md: 6, sm: 1 }}` snippet line). In the Sortable section, add: `collapseBelow` (grid arrangement only) mirrors Grid — string for binary collapse, `{ md: 6, sm: 1 }` for graduated. Match the surrounding TL;DR style; read the neighboring sections first.
+
+- [ ] **Step 2: GridDemo.tsx** — after the existing "Grid.Item span + collapseBelow" section, add a sibling section "Graduated collapse (breakpoint→columns map)" reusing that section's resizable-box pattern, with `<Grid columns={12} gap="md" collapseBelow={{ md: 6, sm: 1 }}>` and the same span children; description explains: 12 cols wide, 6 cols under 640px (spans clamp), 1 col under 480px. Copy the surrounding section component's exact structure (title/description/source props).
+
+- [ ] **Step 3: SortableDemo.tsx** — extend the existing grid-arrangement section (or add a sibling section if the demo file uses one section per feature) so the grid example passes `collapseBelow={{ md: 6, sm: 1 }}` inside a resizable container mirroring GridDemo's pattern; description notes parity with Grid's collapseBelow.
+
+- [ ] **Step 4: Verify** — from repo root: `make test && make build-lib && make lint && npm run format:check` (format may require `npx prettier --write` on touched files first), then `make build` (playground typecheck+bundle).
+
+- [ ] **Step 5: Commit** — `docs: graduated collapse demos + AGENTS.md notes (#318)`
+
+---
+
+## Self-review notes
+
+- Spec coverage: issue part 1 (Sortable collapseBelow) = Task 3; part 2 (graduated map for both) = Tasks 1–3; consumer-facing docs = Task 4.
+- Deliberately NOT changing the legacy string mechanism on Grid (`> * { grid-column: 1/-1 }`) — it's more robust for plain children than a 1-column template, and existing consumers depend on its exact specificity story.
+- Deliberately NOT validating map values at runtime (garbage columns counts) — consistent with the documented-not-validated stance on `columns`/fraction spans.
+- `Card` fill prop mentioned in the issue's "Consumer status" is NOT in scope — the issue proposes no DS change for it.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -851,6 +851,8 @@ Props on the root: `onReorder?: ({ from, to, id }) => void` — fires only when 
 </Sortable>
 ```
 
+`collapseBelow` (grid arrangement only) mirrors Grid's `collapseBelow` exactly — `'sm' | 'md' | 'lg'` for a binary collapse to one column, or `{ md: 6, sm: 1 }` for a graduated step-down with item spans clamped per step.
+
 **Drag origin** (hybrid): if `<Sortable.Handle>` is present in the Item subtree, only the Handle initiates drag. If no Handle is present, the entire Item is draggable + focusable. A 5px activation distance means short clicks-without-movement on internal buttons / links pass through.
 
 **Keyboard reorder**: Tab to focus the Handle (or the Item if no Handle), press **Space** to pick up, **ArrowUp** / **ArrowDown** to move, **Space** to drop, **Escape** to cancel. dnd-kit's KeyboardSensor ships built-in `aria-live` announcements describing each move. Inside a `Modal`/`Drawer`, an in-progress drag is an Escape-consuming mode: Escape cancels the drag and the host survives that press; the next Escape closes the host (#282). Same for `DataTable` column reorder.
@@ -1493,6 +1495,12 @@ Fractions assume a 12-column grid — pair them with `columns={12}` on the paren
 **`collapseBelow` — collapse to one column below a width preset:**
 
 Only valid on a fixed-`columns` Grid (auto-fit grids already reflow). Presets: `'sm'` 480px / `'md'` 640px / `'lg'` 768px. This is a **container query on the Grid's own width, not the viewport** — it fires based on the space the Grid itself has, not the browser window, so it collapses correctly inside a narrow sidebar or split pane even on a wide screen — provided the pane gives the grid a definite width. Below the threshold every child spans the full row, `Grid.Item` spans included.
+
+Also takes a graduated breakpoint→columns map instead of a single string, for a step-down rather than straight-to-1-column collapse — `Grid.Item` spans clamp to fit each step:
+
+```tsx
+<Grid columns={12} gap="md" collapseBelow={{ md: 6, sm: 1 }}>
+```
 
 **Anti-patterns:**
 

--- a/packages/design-system/src/components/Grid/Grid.module.scss
+++ b/packages/design-system/src/components/Grid/Grid.module.scss
@@ -105,3 +105,41 @@
     grid-column: 1 / -1;
   }
 }
+
+// --- graduated (map) collapse ------------------------------------------
+// Step track templates + per-item clamped spans are computed in Grid.tsx /
+// GridItem.tsx and injected inline (--grid-columns-<bp>, --grid-item-span-<bp>).
+// Declared lg → md → sm so when several steps match at a narrow width the
+// smallest breakpoint wins by source order (equal specificity).
+@container (max-width: #{bp.$collapse-lg}) {
+  .collapsible.stepLg {
+    grid-template-columns: var(--grid-columns-lg);
+
+    > .item {
+      // stylelint-disable-next-line property-disallowed-list -- graduated collapse override is Grid's own placement mechanism, same sanction as `.item` above
+      grid-column: var(--grid-item-span-lg, auto);
+    }
+  }
+}
+
+@container (max-width: #{bp.$collapse-md}) {
+  .collapsible.stepMd {
+    grid-template-columns: var(--grid-columns-md);
+
+    > .item {
+      // stylelint-disable-next-line property-disallowed-list -- graduated collapse override is Grid's own placement mechanism, same sanction as `.item` above
+      grid-column: var(--grid-item-span-md, auto);
+    }
+  }
+}
+
+@container (max-width: #{bp.$collapse-sm}) {
+  .collapsible.stepSm {
+    grid-template-columns: var(--grid-columns-sm);
+
+    > .item {
+      // stylelint-disable-next-line property-disallowed-list -- graduated collapse override is Grid's own placement mechanism, same sanction as `.item` above
+      grid-column: var(--grid-item-span-sm, auto);
+    }
+  }
+}

--- a/packages/design-system/src/components/Grid/Grid.module.scss
+++ b/packages/design-system/src/components/Grid/Grid.module.scss
@@ -1,4 +1,5 @@
 @use './Grid.tokens' as tokens;
+@use '../_internal/collapse' as bp;
 
 .grid {
   display: grid;
@@ -84,21 +85,21 @@
 // Double class (.collapsible.collapseXx) gives specificity (0,2,0) so the
 // collapse beats any single-class consumer `grid-column` rule regardless of
 // CSS bundle emission order; vs `.item` it also still wins by source order.
-@container (max-width: #{tokens.$grid-collapse-sm}) {
+@container (max-width: #{bp.$collapse-sm}) {
   .collapsible.collapseSm > * {
     // stylelint-disable-next-line property-disallowed-list -- collapse override is Grid's own placement mechanism, same sanction as `.item` above
     grid-column: 1 / -1;
   }
 }
 
-@container (max-width: #{tokens.$grid-collapse-md}) {
+@container (max-width: #{bp.$collapse-md}) {
   .collapsible.collapseMd > * {
     // stylelint-disable-next-line property-disallowed-list -- collapse override is Grid's own placement mechanism, same sanction as `.item` above
     grid-column: 1 / -1;
   }
 }
 
-@container (max-width: #{tokens.$grid-collapse-lg}) {
+@container (max-width: #{bp.$collapse-lg}) {
   .collapsible.collapseLg > * {
     // stylelint-disable-next-line property-disallowed-list -- collapse override is Grid's own placement mechanism, same sanction as `.item` above
     grid-column: 1 / -1;

--- a/packages/design-system/src/components/Grid/Grid.test.tsx
+++ b/packages/design-system/src/components/Grid/Grid.test.tsx
@@ -252,3 +252,62 @@ describe('Grid collapseBelow (#314)', () => {
     expect((container.firstChild as HTMLElement).className).not.toMatch(/collaps/i);
   });
 });
+
+describe('Grid graduated collapse (#318)', () => {
+  it('map form adds collapsible + one step class per breakpoint and injects step templates', () => {
+    render(
+      <Grid columns={12} collapseBelow={{ md: 6, sm: 1 }} data-testid="grid">
+        <div>a</div>
+      </Grid>,
+    );
+    const el = screen.getByTestId('grid');
+    expect(el.className).toMatch(/collapsible/);
+    expect(el.className).toMatch(/stepMd/);
+    expect(el.className).toMatch(/stepSm/);
+    expect(el.className).not.toMatch(/stepLg/);
+    expect(el.className).not.toMatch(/collapseMd/);
+    expect(el.style.getPropertyValue('--grid-columns-md')).toBe('repeat(6, minmax(0, 1fr))');
+    expect(el.style.getPropertyValue('--grid-columns-sm')).toBe('repeat(1, minmax(0, 1fr))');
+    expect(el.style.getPropertyValue('--grid-columns-lg')).toBe('');
+  });
+
+  it('Grid.Item under a map grid stamps clamped per-breakpoint spans', () => {
+    render(
+      <Grid columns={12} collapseBelow={{ md: 6, sm: 1 }}>
+        <Grid.Item span="75%" data-testid="wide">
+          w
+        </Grid.Item>
+        <Grid.Item span={3} data-testid="narrow">
+          n
+        </Grid.Item>
+        <Grid.Item data-testid="plain">p</Grid.Item>
+      </Grid>,
+    );
+    const wide = screen.getByTestId('wide');
+    expect(wide.style.getPropertyValue('--grid-item-span')).toBe('span 9');
+    expect(wide.style.getPropertyValue('--grid-item-span-md')).toBe('1 / -1');
+    expect(wide.style.getPropertyValue('--grid-item-span-sm')).toBe('1 / -1');
+    const narrow = screen.getByTestId('narrow');
+    expect(narrow.style.getPropertyValue('--grid-item-span-md')).toBe('span 3');
+    expect(narrow.style.getPropertyValue('--grid-item-span-sm')).toBe('1 / -1');
+    const plain = screen.getByTestId('plain');
+    expect(plain.style.getPropertyValue('--grid-item-span-md')).toBe('auto');
+  });
+
+  it('Grid.Item outside a map grid stamps no per-breakpoint spans', () => {
+    render(
+      <Grid columns={12} collapseBelow="md">
+        <Grid.Item span={3} data-testid="cell">
+          c
+        </Grid.Item>
+      </Grid>,
+    );
+    expect(screen.getByTestId('cell').style.getPropertyValue('--grid-item-span-md')).toBe('');
+  });
+
+  it('TS: map form is invalid on an auto-fit grid', () => {
+    // @ts-expect-error — collapseBelow (map form included) requires `columns`.
+    const Invalid = <Grid minColumnWidth="200px" collapseBelow={{ md: 6 }} />;
+    void Invalid;
+  });
+});

--- a/packages/design-system/src/components/Grid/Grid.tokens.scss
+++ b/packages/design-system/src/components/Grid/Grid.tokens.scss
@@ -10,9 +10,4 @@
   --grid-gap-2xl: var(--space-8);
 }
 
-// Collapse breakpoints for `collapseBelow` — container-width thresholds.
-// SCSS constants (not CSS custom properties): query conditions can't read
-// custom properties. Keep in sync with the GridCollapseBreakpoint JSDoc.
-$grid-collapse-sm: 480px;
-$grid-collapse-md: 640px;
-$grid-collapse-lg: 768px;
+// Collapse breakpoints live in ../_internal/collapse.scss (shared with Sortable).

--- a/packages/design-system/src/components/Grid/Grid.tsx
+++ b/packages/design-system/src/components/Grid/Grid.tsx
@@ -158,7 +158,7 @@ const GridBase = forwardRef<HTMLElement, GridProps>(function Grid(
 ) {
   const template =
     columns !== undefined
-      ? `repeat(${columns}, minmax(0, 1fr))`
+      ? collapseTrackTemplate(columns)
       : `repeat(auto-fit, minmax(${minColumnWidth ?? '240px'}, 1fr))`;
 
   const collapseMap = typeof collapseBelow === 'object' ? collapseBelow : undefined;

--- a/packages/design-system/src/components/Grid/Grid.tsx
+++ b/packages/design-system/src/components/Grid/Grid.tsx
@@ -2,6 +2,13 @@ import { forwardRef, type CSSProperties, type HTMLAttributes, type ReactElement 
 import clsx from 'clsx';
 import styles from './Grid.module.scss';
 import { GridItem } from './GridItem';
+import {
+  CollapseColumnsContext,
+  COLLAPSE_BREAKPOINTS,
+  collapseTrackTemplate,
+  type CollapseBreakpoint,
+  type CollapseColumnsMap,
+} from '../_internal/collapse';
 
 /** Gap between cells. Same scale as Stack/Cluster: pixels 4/8/12/16/24/32. */
 export type GridGap = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
@@ -12,8 +19,9 @@ export type GridAlignItems = 'start' | 'center' | 'end' | 'stretch';
 /** Main-axis (horizontal within track) alignment of each cell. */
 export type GridJustifyItems = 'start' | 'center' | 'end' | 'stretch';
 
-/** Container-width threshold below which a fixed-column grid collapses to one visual column. `sm` 480px / `md` 640px / `lg` 768px. */
-export type GridCollapseBreakpoint = 'sm' | 'md' | 'lg';
+/** Container-width threshold below which a fixed-column grid collapses. `sm` 480px / `md` 640px / `lg` 768px. */
+export type GridCollapseBreakpoint = CollapseBreakpoint;
+export type { CollapseColumnsMap };
 
 /** Limited polymorphic element type. Covers the layout / semantic elements Grid is likely to render as. */
 export type GridAs =
@@ -71,8 +79,16 @@ interface GridFixedColumns extends GridBaseProps, HTMLAttributes<HTMLElement> {
    * width 0 — give the parent a concrete width instead. The grid also becomes
    * the containing block for absolutely-positioned descendants (layout
    * containment).
+   *
+   * Also accepts a graduated breakpoint→columns map, e.g.
+   * `collapseBelow={{ md: 6, sm: 1 }}`: below 640px the grid re-templates to
+   * 6 columns (item spans clamp to fit — a span wider than the step becomes a
+   * full row), and below 480px to a single column. Use when jumping straight
+   * from N columns to 1 wastes tablet widths. When several breakpoints match,
+   * the smallest wins. Only `Grid.Item` children get span clamping; plain
+   * children auto-place into the step's tracks.
    */
-  collapseBelow?: GridCollapseBreakpoint;
+  collapseBelow?: GridCollapseBreakpoint | CollapseColumnsMap;
 }
 
 interface GridAutoFit extends GridBaseProps, HTMLAttributes<HTMLElement> {
@@ -119,6 +135,12 @@ const collapseClass: Record<GridCollapseBreakpoint, string> = {
   lg: styles.collapseLg,
 };
 
+const stepClass: Record<CollapseBreakpoint, string> = {
+  sm: styles.stepSm,
+  md: styles.stepMd,
+  lg: styles.stepLg,
+};
+
 const GridBase = forwardRef<HTMLElement, GridProps>(function Grid(
   {
     gap = 'md',
@@ -139,13 +161,21 @@ const GridBase = forwardRef<HTMLElement, GridProps>(function Grid(
       ? `repeat(${columns}, minmax(0, 1fr))`
       : `repeat(auto-fit, minmax(${minColumnWidth ?? '240px'}, 1fr))`;
 
+  const collapseMap = typeof collapseBelow === 'object' ? collapseBelow : undefined;
+  const collapseKeys = collapseMap
+    ? COLLAPSE_BREAKPOINTS.filter((b) => collapseMap[b] !== undefined)
+    : [];
+  const stepVars = Object.fromEntries(
+    collapseKeys.map((b) => [`--grid-columns-${b}`, collapseTrackTemplate(collapseMap![b]!)]),
+  );
+
   // `as` is a string union of intrinsic JSX elements; cast through unknown
   // for the limited union. At runtime React just uses the element name.
   const Tag = as as unknown as 'div';
 
   // Tag is constrained at the type level via GridAs; the ref + rest casts
   // satisfy React's intrinsic-element signature without per-tag branching.
-  return (
+  const grid = (
     <Tag
       ref={ref as React.Ref<HTMLDivElement>}
       className={clsx(
@@ -154,12 +184,19 @@ const GridBase = forwardRef<HTMLElement, GridProps>(function Grid(
         alignItems && alignItemsClass[alignItems],
         justifyItems && justifyItemsClass[justifyItems],
         collapseBelow && styles.collapsible,
-        collapseBelow && collapseClass[collapseBelow],
+        typeof collapseBelow === 'string' && collapseClass[collapseBelow],
+        ...collapseKeys.map((b) => stepClass[b]),
         className,
       )}
-      style={{ ...(style as CSSProperties), ['--grid-columns' as string]: template }}
+      style={{ ...(style as CSSProperties), ...stepVars, ['--grid-columns' as string]: template }}
       {...(rest as HTMLAttributes<HTMLDivElement>)}
     />
+  );
+
+  return collapseMap ? (
+    <CollapseColumnsContext.Provider value={collapseMap}>{grid}</CollapseColumnsContext.Provider>
+  ) : (
+    grid
   );
 }) as <T extends GridProps>(props: T & { ref?: React.Ref<HTMLElement> }) => ReactElement;
 
@@ -213,6 +250,13 @@ const GridBase = forwardRef<HTMLElement, GridProps>(function Grid(
  *   <Grid.Item span="100%"><Card>Footer row</Card></Grid.Item>
  * </Grid>
  *
+ * @example
+ * // Graduated dashboard — re-templates at each step instead of jumping to 1 column.
+ * <Grid columns={12} gap="md" collapseBelow={{ md: 6, sm: 1 }}>
+ *   <Grid.Item span="25%"><Card>KPI</Card></Grid.Item>
+ *   <Grid.Item span="75%"><Card>Chart</Card></Grid.Item>
+ * </Grid>
+ *
  * @remarks When NOT to use
  * - For vertical flow with a single column — use `<Stack>`.
  * - For unaligned wrapping rows (toolbars, tag lists) — use `<Cluster>`.
@@ -231,5 +275,7 @@ const GridBase = forwardRef<HTMLElement, GridProps>(function Grid(
  * - Attach `<Grid.Item span={...}>` to a cell for an explicit column span
  *   (numeric track count or 12-col fraction). See `GridItemSpan`. Plain
  *   children remain valid Grid cells — `Grid.Item` is opt-in.
+ * - Under a map-form `collapseBelow`, each `Grid.Item`'s span clamps per
+ *   step — a span wider than the step's column count becomes a full row.
  */
 export const Grid = Object.assign(GridBase, { Item: GridItem });

--- a/packages/design-system/src/components/Grid/GridItem.tsx
+++ b/packages/design-system/src/components/Grid/GridItem.tsx
@@ -1,6 +1,11 @@
-import { forwardRef, type CSSProperties, type HTMLAttributes } from 'react';
+import { forwardRef, useContext, type CSSProperties, type HTMLAttributes } from 'react';
 import clsx from 'clsx';
-import { resolveGridItemSpan, type GridItemSpan } from '../_internal/gridSpan';
+import {
+  resolveGridItemSpan,
+  resolveCollapsedGridItemSpan,
+  type GridItemSpan,
+} from '../_internal/gridSpan';
+import { CollapseColumnsContext } from '../_internal/collapse';
 import styles from './Grid.module.scss';
 
 // The span vocabulary (type + fraction→track resolver) is shared with
@@ -51,6 +56,20 @@ export const GridItem = forwardRef<HTMLElement, GridItemProps>(function GridItem
 ) {
   const resolved = resolveGridItemSpan(span);
 
+  // Set only when a graduated (map-form) `collapseBelow` grid is an
+  // ancestor — same always-stamp rationale as `--grid-item-span`: custom
+  // properties inherit, so every map key present on the container gets
+  // stamped on every Item (see resolveCollapsedGridItemSpan for clamping).
+  const collapseMap = useContext(CollapseColumnsContext);
+  const collapseVars = collapseMap
+    ? Object.fromEntries(
+        (Object.keys(collapseMap) as (keyof typeof collapseMap)[]).map((b) => [
+          `--grid-item-span-${b}`,
+          resolveCollapsedGridItemSpan(span, collapseMap[b]!),
+        ]),
+      )
+    : undefined;
+
   const Tag = as as unknown as 'div';
   return (
     // Grid/Stack/Cluster are the layout primitives — `grid-column` via the
@@ -62,7 +81,11 @@ export const GridItem = forwardRef<HTMLElement, GridItemProps>(function GridItem
       // Always set the property — custom properties inherit, so an unset
       // span-less item nested under a spanned one would resolve the
       // ancestor's value instead of `auto`.
-      style={{ ...(style as CSSProperties), ['--grid-item-span' as string]: resolved ?? 'auto' }}
+      style={{
+        ...(style as CSSProperties),
+        ...collapseVars,
+        ['--grid-item-span' as string]: resolved ?? 'auto',
+      }}
       {...(rest as HTMLAttributes<HTMLDivElement>)}
     />
   );

--- a/packages/design-system/src/components/Grid/index.ts
+++ b/packages/design-system/src/components/Grid/index.ts
@@ -6,5 +6,6 @@ export type {
   GridJustifyItems,
   GridAs,
   GridCollapseBreakpoint,
+  CollapseColumnsMap,
 } from './Grid';
 export type { GridItemProps, GridItemSpan, GridItemAs } from './GridItem';

--- a/packages/design-system/src/components/Sortable/Sortable.module.scss
+++ b/packages/design-system/src/components/Sortable/Sortable.module.scss
@@ -1,4 +1,5 @@
 @use './Sortable.tokens';
+@use '../_internal/collapse' as bp;
 
 .list {
   // UA reset — <ol> ships with default browser margin and padding.
@@ -89,5 +90,73 @@
     // we override it under reduced motion. !important is the canonical way
     // to override inline styles with the same property at higher specificity.
     transition: none !important; // stylelint-disable-line declaration-no-important -- override dnd-kit's inline transition
+  }
+}
+
+// --- collapseBelow (grid arrangement) ----------------------------------
+// Mirrors Grid's collapseBelow: only collapsible lists become size
+// containers, so existing lists get zero containment changes.
+.collapsible {
+  container-type: inline-size;
+}
+
+// Binary (string) collapse — below the threshold every item spans the full
+// row. Double class gives specificity (0,2,0) so the collapse beats any
+// single-class consumer grid-column rule; vs `.item` it wins by source order.
+@container (max-width: #{bp.$collapse-sm}) {
+  .collapsible.collapseSm > * {
+    // stylelint-disable-next-line property-disallowed-list -- collapse override is Sortable's own placement mechanism, mirrors Grid
+    grid-column: 1 / -1;
+  }
+}
+
+@container (max-width: #{bp.$collapse-md}) {
+  .collapsible.collapseMd > * {
+    // stylelint-disable-next-line property-disallowed-list -- collapse override is Sortable's own placement mechanism, mirrors Grid
+    grid-column: 1 / -1;
+  }
+}
+
+@container (max-width: #{bp.$collapse-lg}) {
+  .collapsible.collapseLg > * {
+    // stylelint-disable-next-line property-disallowed-list -- collapse override is Sortable's own placement mechanism, mirrors Grid
+    grid-column: 1 / -1;
+  }
+}
+
+// Graduated (map) collapse — step templates + per-item clamped spans are
+// computed in Sortable.tsx and injected inline (--sortable-columns-<bp>,
+// --sortable-item-span-<bp>). Declared lg → md → sm so the smallest matching
+// breakpoint wins by source order (equal specificity).
+@container (max-width: #{bp.$collapse-lg}) {
+  .collapsible.stepLg {
+    grid-template-columns: var(--sortable-columns-lg);
+
+    > .item {
+      // stylelint-disable-next-line property-disallowed-list -- graduated collapse override is Sortable's own placement mechanism, mirrors Grid
+      grid-column: var(--sortable-item-span-lg, auto);
+    }
+  }
+}
+
+@container (max-width: #{bp.$collapse-md}) {
+  .collapsible.stepMd {
+    grid-template-columns: var(--sortable-columns-md);
+
+    > .item {
+      // stylelint-disable-next-line property-disallowed-list -- graduated collapse override is Sortable's own placement mechanism, mirrors Grid
+      grid-column: var(--sortable-item-span-md, auto);
+    }
+  }
+}
+
+@container (max-width: #{bp.$collapse-sm}) {
+  .collapsible.stepSm {
+    grid-template-columns: var(--sortable-columns-sm);
+
+    > .item {
+      // stylelint-disable-next-line property-disallowed-list -- graduated collapse override is Sortable's own placement mechanism, mirrors Grid
+      grid-column: var(--sortable-item-span-sm, auto);
+    }
   }
 }

--- a/packages/design-system/src/components/Sortable/Sortable.test.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.test.tsx
@@ -394,6 +394,53 @@ describe('Sortable grid arrangement (#316)', () => {
   });
 });
 
+describe('Sortable collapseBelow (#318)', () => {
+  it('string form adds collapsible + collapse class on the grid <ol>', () => {
+    render(
+      <Sortable arrangement="grid" collapseBelow="md" data-testid="ol">
+        <Sortable.Item id="a">A</Sortable.Item>
+      </Sortable>,
+    );
+    const ol = screen.getByTestId('ol');
+    expect(ol.className).toMatch(/collapsible/);
+    expect(ol.className).toMatch(/collapseMd/);
+  });
+
+  it('map form adds step classes, injects step templates, items stamp clamped spans', () => {
+    render(
+      <Sortable arrangement="grid" collapseBelow={{ md: 6, sm: 1 }} data-testid="ol">
+        <Sortable.Item id="a" span="75%" data-testid="wide">
+          A
+        </Sortable.Item>
+        <Sortable.Item id="b" span={3} data-testid="narrow">
+          B
+        </Sortable.Item>
+      </Sortable>,
+    );
+    const ol = screen.getByTestId('ol');
+    expect(ol.className).toMatch(/collapsible/);
+    expect(ol.className).toMatch(/stepMd/);
+    expect(ol.className).toMatch(/stepSm/);
+    expect(ol.style.getPropertyValue('--sortable-columns-md')).toBe('repeat(6, minmax(0, 1fr))');
+    const wide = screen.getByTestId('wide');
+    expect(wide.style.getPropertyValue('--sortable-item-span-md')).toBe('1 / -1');
+    expect(wide.style.getPropertyValue('--sortable-item-span-sm')).toBe('1 / -1');
+    const narrow = screen.getByTestId('narrow');
+    expect(narrow.style.getPropertyValue('--sortable-item-span-md')).toBe('span 3');
+  });
+
+  it('collapseBelow is inert in list arrangement', () => {
+    render(
+      <Sortable collapseBelow="md" data-testid="ol">
+        <Sortable.Item id="a">A</Sortable.Item>
+      </Sortable>,
+    );
+    const ol = screen.getByTestId('ol');
+    expect(ol.className).not.toMatch(/collapsible/);
+    expect(ol.className).not.toMatch(/collapseMd/);
+  });
+});
+
 describe('restrictTransformToRect', () => {
   // A 50px-tall, 100px-wide node sitting at (left:10, top:20) inside a
   // 400x300 bounding box anchored at (left:0, top:0).

--- a/packages/design-system/src/components/Sortable/Sortable.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.tsx
@@ -34,7 +34,18 @@ import { CSS, type Transform } from '@dnd-kit/utilities';
 import clsx from 'clsx';
 import { mergeRefs } from '../_internal/refs';
 import { useFloatingSurface } from '../_internal/overlay';
-import { resolveGridItemSpan, type GridItemSpan } from '../_internal/gridSpan';
+import {
+  resolveGridItemSpan,
+  resolveCollapsedGridItemSpan,
+  type GridItemSpan,
+} from '../_internal/gridSpan';
+import {
+  CollapseColumnsContext,
+  COLLAPSE_BREAKPOINTS,
+  collapseTrackTemplate,
+  type CollapseBreakpoint,
+  type CollapseColumnsMap,
+} from '../_internal/collapse';
 import styles from './Sortable.module.scss';
 
 /**
@@ -115,6 +126,22 @@ export interface SortableProps extends HTMLAttributes<HTMLOListElement> {
    * fraction (documented, not validated — same as `Grid`).
    */
   columns?: number;
+  /**
+   * Responsive collapse for the grid arrangement — mirrors `Grid`'s
+   * `collapseBelow` exactly (same breakpoints, same container-query
+   * mechanism). Ignored unless `arrangement="grid"`.
+   * - `'sm' | 'md' | 'lg'` — below the container-width threshold (480 / 640 /
+   *   768px of the LIST'S OWN width) every item spans the full row: a single
+   *   visual column.
+   * - `{ lg?: n, md?: n, sm?: n }` — graduated: below each breakpoint the grid
+   *   re-templates to that many columns and item spans clamp to fit (a span
+   *   wider than the step becomes a full row). E.g. `{ md: 6, sm: 1 }`.
+   *
+   * ❌ Anti-pattern: a collapsible Sortable must get its width from its
+   * parent — `container-type: inline-size` zeroes the list's contribution to
+   * intrinsic sizing (same caveat as `Grid`'s `collapseBelow`).
+   */
+  collapseBelow?: CollapseBreakpoint | CollapseColumnsMap;
 }
 
 export interface SortableItemProps extends Omit<HTMLAttributes<HTMLLIElement>, 'id'> {
@@ -240,6 +267,7 @@ function containsHandle(children: ReactNode): boolean {
  * <Sortable
  *   arrangement="grid"
  *   columns={12}
+ *   collapseBelow={{ md: 6, sm: 1 }}
  *   onReorder={({ from, to }) => setWidgets((w) => arrayMove(w, from, to))}
  * >
  *   {widgets.map((w) => (
@@ -256,7 +284,9 @@ function containsHandle(children: ReactNode): boolean {
  *   `span` (`Sortable.Item span="50%"` / `span={6}` / `span="100%"`) — same
  *   values as `Grid.Item`. Semantics stay order-based: a drop reorders the
  *   flow; nothing persists a grid x/y position. `restrictToContainer` still
- *   clamps the drag to the grid's bounding box.
+ *   clamps the drag to the grid's bounding box. `collapseBelow` mirrors
+ *   `Grid`'s responsive collapse exactly — same breakpoints, same
+ *   container-query mechanism, same binary/graduated distinction.
  *
  * @remarks Drag confinement
  * - By default (`restrictToContainer`) the dragged item is clamped to the
@@ -289,12 +319,24 @@ function containsHandle(children: ReactNode): boolean {
  *   `SortableContext` only tracks the ids you pass it; arbitrary children
  *   render but won't be reorderable.
  */
+const collapseClass: Record<CollapseBreakpoint, string> = {
+  sm: styles.collapseSm,
+  md: styles.collapseMd,
+  lg: styles.collapseLg,
+};
+const stepClass: Record<CollapseBreakpoint, string> = {
+  sm: styles.stepSm,
+  md: styles.stepMd,
+  lg: styles.stepLg,
+};
+
 const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function SortableRoot(
   {
     onReorder,
     restrictToContainer = true,
     arrangement = 'list',
     columns = 12,
+    collapseBelow,
     className,
     style,
     children,
@@ -303,6 +345,11 @@ const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function Sortab
   ref,
 ) {
   const isGrid = arrangement === 'grid';
+  const collapse = isGrid ? collapseBelow : undefined;
+  const collapseMap = typeof collapse === 'object' ? collapse : undefined;
+  const collapseKeys = collapseMap
+    ? COLLAPSE_BREAKPOINTS.filter((b) => collapseMap[b] !== undefined)
+    : [];
   const [activeId, setActiveId] = useState<string | number | null>(null);
   // #282: a keyboard drag is an Escape-consuming MODE (Escape cancels the
   // drag). Register it as a floating surface while active so a host Modal/Drawer
@@ -385,7 +432,7 @@ const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function Sortab
   );
   const modifiers = restrictToContainer ? [restrictModifier] : undefined;
 
-  return (
+  const tree = (
     <DndContext
       sensors={sensors}
       modifiers={modifiers}
@@ -405,11 +452,30 @@ const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function Sortab
       >
         <ol
           ref={mergeRefs(olRef, ref)}
-          className={clsx(isGrid ? styles.grid : styles.list, className)}
+          className={clsx(
+            isGrid ? styles.grid : styles.list,
+            collapse && styles.collapsible,
+            typeof collapse === 'string' && collapseClass[collapse],
+            ...collapseKeys.map((b) => stepClass[b]),
+            className,
+          )}
           // In grid mode the <ol> owns the track template; inject the column
           // count as a custom prop AFTER the consumer's style so it wins
           // (mirrors Grid's --grid-columns). List mode leaves style untouched.
-          style={isGrid ? { ...style, ['--sortable-columns' as string]: columns } : style}
+          style={
+            isGrid
+              ? {
+                  ...style,
+                  ...Object.fromEntries(
+                    collapseKeys.map((b) => [
+                      `--sortable-columns-${b}`,
+                      collapseTrackTemplate(collapseMap![b]!),
+                    ]),
+                  ),
+                  ['--sortable-columns' as string]: columns,
+                }
+              : style
+          }
           {...rest}
         >
           {children}
@@ -431,6 +497,12 @@ const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function Sortab
         ) : null}
       </DragOverlay>
     </DndContext>
+  );
+
+  return collapseMap ? (
+    <CollapseColumnsContext.Provider value={collapseMap}>{tree}</CollapseColumnsContext.Provider>
+  ) : (
+    tree
   );
 });
 SortableRoot.displayName = 'Sortable';
@@ -462,6 +534,8 @@ export const SortableItem = forwardRef<HTMLLIElement, SortableItemProps>(functio
 
   const hasHandle = useMemo(() => containsHandle(children), [children]);
 
+  const collapseMap = useContext(CollapseColumnsContext);
+
   const ctxValue = useMemo<SortableItemContextValue>(
     () => ({ listeners, attributes, setActivatorNodeRef }),
     [listeners, attributes, setActivatorNodeRef],
@@ -492,6 +566,17 @@ export const SortableItem = forwardRef<HTMLLIElement, SortableItemProps>(functio
           // ignored by the CSS in list mode (grid-column is inert on a flex
           // child). Mirrors Grid.Item.
           ['--sortable-item-span' as string]: resolveGridItemSpan(span) ?? 'auto',
+          // Per-breakpoint clamped span for a graduated (map-form)
+          // `collapseBelow` ancestor — same always-stamp rationale as
+          // `--sortable-item-span` (custom properties inherit).
+          ...(collapseMap
+            ? Object.fromEntries(
+                (Object.keys(collapseMap) as CollapseBreakpoint[]).map((b) => [
+                  `--sortable-item-span-${b}`,
+                  resolveCollapsedGridItemSpan(span, collapseMap[b]!),
+                ]),
+              )
+            : undefined),
         }}
         data-dragging={isDragging ? 'true' : undefined}
         className={clsx(styles.item, className)}

--- a/packages/design-system/src/components/Sortable/index.ts
+++ b/packages/design-system/src/components/Sortable/index.ts
@@ -10,3 +10,4 @@ export {
   type SortableItemContextValue,
   type SortableArrangement,
 } from './Sortable';
+export type { CollapseBreakpoint } from '../_internal/collapse';

--- a/packages/design-system/src/components/_internal/collapse.scss
+++ b/packages/design-system/src/components/_internal/collapse.scss
@@ -1,0 +1,7 @@
+// Container-width collapse thresholds shared by Grid's `collapseBelow` and
+// Sortable's grid-arrangement `collapseBelow`. SCSS constants (not CSS custom
+// properties): container-query conditions can't read custom properties.
+// Keep in sync with the CollapseBreakpoint JSDoc in collapse.ts.
+$collapse-sm: 480px;
+$collapse-md: 640px;
+$collapse-lg: 768px;

--- a/packages/design-system/src/components/_internal/collapse.ts
+++ b/packages/design-system/src/components/_internal/collapse.ts
@@ -1,0 +1,32 @@
+import { createContext } from 'react';
+
+/**
+ * Container-width threshold for `collapseBelow` on Grid / Sortable (grid
+ * arrangement). `sm` 480px / `md` 640px / `lg` 768px — measured against the
+ * grid's OWN width (container query), not the viewport.
+ */
+export type CollapseBreakpoint = 'sm' | 'md' | 'lg';
+
+/**
+ * Graduated collapse: breakpoint → column count. Below each breakpoint the
+ * grid re-templates to that many equal columns and every item's span is
+ * clamped to fit. E.g. `{ md: 6, sm: 1 }` = 12-col grid above 640px, 6-col
+ * between 480–640px, single column below 480px. When several breakpoints
+ * match, the smallest wins.
+ */
+export type CollapseColumnsMap = Partial<Record<CollapseBreakpoint, number>>;
+
+/** Largest → smallest; step CSS is declared in this order so the smallest matching breakpoint wins by source order. */
+export const COLLAPSE_BREAKPOINTS: readonly CollapseBreakpoint[] = ['lg', 'md', 'sm'];
+
+/**
+ * The container's graduated-collapse map, provided by Grid / Sortable (grid
+ * arrangement) to their Items so each can stamp per-breakpoint clamped span
+ * custom properties. `null` when the container has no map-form collapse.
+ */
+export const CollapseColumnsContext = createContext<CollapseColumnsMap | null>(null);
+
+/** Track template for a collapse step — mirrors Grid's fixed-column template. */
+export function collapseTrackTemplate(columns: number): string {
+  return `repeat(${columns}, minmax(0, 1fr))`;
+}

--- a/packages/design-system/src/components/_internal/gridSpan.test.ts
+++ b/packages/design-system/src/components/_internal/gridSpan.test.ts
@@ -1,0 +1,22 @@
+import { resolveCollapsedGridItemSpan } from './gridSpan';
+
+describe('resolveCollapsedGridItemSpan (#318)', () => {
+  it('returns auto for a span-less item', () => {
+    expect(resolveCollapsedGridItemSpan(undefined, 6)).toBe('auto');
+  });
+  it('keeps spans smaller than the step columns', () => {
+    expect(resolveCollapsedGridItemSpan(3, 6)).toBe('span 3');
+    expect(resolveCollapsedGridItemSpan('25%', 6)).toBe('span 3');
+  });
+  it('clamps spans >= step columns to the full row', () => {
+    expect(resolveCollapsedGridItemSpan(9, 6)).toBe('1 / -1');
+    expect(resolveCollapsedGridItemSpan('75%', 6)).toBe('1 / -1');
+    expect(resolveCollapsedGridItemSpan(6, 6)).toBe('1 / -1');
+  });
+  it('full-row spans and single-column steps are always 1 / -1', () => {
+    expect(resolveCollapsedGridItemSpan('100%', 6)).toBe('1 / -1');
+    expect(resolveCollapsedGridItemSpan('full', 6)).toBe('1 / -1');
+    expect(resolveCollapsedGridItemSpan(3, 1)).toBe('1 / -1');
+    expect(resolveCollapsedGridItemSpan(undefined, 1)).toBe('auto');
+  });
+});

--- a/packages/design-system/src/components/_internal/gridSpan.ts
+++ b/packages/design-system/src/components/_internal/gridSpan.ts
@@ -37,3 +37,18 @@ export function resolveGridItemSpan(span: GridItemSpan | undefined): string | un
   if (typeof span === 'number') return `span ${span}`;
   return `span ${FRACTION_TRACKS[span]}`;
 }
+
+/**
+ * Resolve a span against a graduated-collapse step's column count: spans that
+ * fit keep their track count, spans >= the step's columns clamp to the full
+ * row (`1 / -1`), full-row spans stay full-row, span-less stays `auto`.
+ */
+export function resolveCollapsedGridItemSpan(
+  span: GridItemSpan | undefined,
+  columns: number,
+): string {
+  if (span === undefined) return 'auto';
+  if (span === 'full' || span === '100%' || columns <= 1) return '1 / -1';
+  const tracks = typeof span === 'number' ? span : FRACTION_TRACKS[span];
+  return tracks >= columns ? '1 / -1' : `span ${tracks}`;
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -83,6 +83,7 @@ export type {
   GridJustifyItems,
   GridAs,
   GridCollapseBreakpoint,
+  CollapseColumnsMap,
   GridItemProps,
   GridItemSpan,
   GridItemAs,

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -365,6 +365,7 @@ export type {
   SortableHandleProps,
   SortableReorderEvent,
   SortableArrangement,
+  CollapseBreakpoint,
 } from './components/Sortable';
 
 export { SortableGroup, moveSortableItem } from './components/SortableGroup';

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -2094,10 +2094,10 @@
         },
         {
           "name": "collapseBelow",
-          "type": "GridCollapseBreakpoint",
+          "type": "CollapseBreakpoint | Partial<Record<CollapseBreakpoint, number>>",
           "required": false,
           "default": "",
-          "description": "Collapse to a single visual column when the GRID'S OWN width (container\nquery, not viewport) drops below the preset: `sm` 480px / `md` 640px /\n`lg` 768px. Every child spans the full row below the threshold —\n`Grid.Item` spans included. Only valid with `columns` (auto-fit grids\nalready reflow).\n\nConsumer inline `style={{ gridColumn }}` on a child still wins below the\nthreshold (inline beats any stylesheet rule) — don't do that; use\n`Grid.Item span` instead.\n\n❌ Anti-pattern: a `collapseBelow` grid must get its width from its\nparent. `container-type: inline-size` zeroes the grid's contribution to\nintrinsic sizing, so in an intrinsic-width context (`Split`'s default\n`auto` aside track, a `Cluster` item, `width: max-content`) it renders at\nwidth 0 — give the parent a concrete width instead. The grid also becomes\nthe containing block for absolutely-positioned descendants (layout\ncontainment)."
+          "description": "Collapse to a single visual column when the GRID'S OWN width (container\nquery, not viewport) drops below the preset: `sm` 480px / `md` 640px /\n`lg` 768px. Every child spans the full row below the threshold —\n`Grid.Item` spans included. Only valid with `columns` (auto-fit grids\nalready reflow).\n\nConsumer inline `style={{ gridColumn }}` on a child still wins below the\nthreshold (inline beats any stylesheet rule) — don't do that; use\n`Grid.Item span` instead.\n\n❌ Anti-pattern: a `collapseBelow` grid must get its width from its\nparent. `container-type: inline-size` zeroes the grid's contribution to\nintrinsic sizing, so in an intrinsic-width context (`Split`'s default\n`auto` aside track, a `Cluster` item, `width: max-content`) it renders at\nwidth 0 — give the parent a concrete width instead. The grid also becomes\nthe containing block for absolutely-positioned descendants (layout\ncontainment).\n\nAlso accepts a graduated breakpoint→columns map, e.g.\n`collapseBelow={{ md: 6, sm: 1 }}`: below 640px the grid re-templates to\n6 columns (item spans clamp to fit — a span wider than the step becomes a\nfull row), and below 480px to a single column. Use when jumping straight\nfrom N columns to 1 wastes tablet widths. When several breakpoints match,\nthe smallest wins. Only `Grid.Item` children get span clamping; plain\nchildren auto-place into the step's tracks."
         }
       ]
     },
@@ -4002,6 +4002,13 @@
           "required": false,
           "default": "",
           "description": "Number of equal-width grid tracks. Only applies when `arrangement=\"grid\"`\n(ignored for a list). Default `12`, matching `Grid.Item`'s 12-column\nfraction spans (`'25%'`→3 … `'75%'`→9 tracks). Set another count for a\nsimpler grid, but the named fraction spans then won't map to their\nfraction (documented, not validated — same as `Grid`)."
+        },
+        {
+          "name": "collapseBelow",
+          "type": "CollapseBreakpoint | Partial<Record<CollapseBreakpoint, number>>",
+          "required": false,
+          "default": "",
+          "description": "Responsive collapse for the grid arrangement — mirrors `Grid`'s\n`collapseBelow` exactly (same breakpoints, same container-query\nmechanism). Ignored unless `arrangement=\"grid\"`.\n- `'sm' | 'md' | 'lg'` — below the container-width threshold (480 / 640 /\n  768px of the LIST'S OWN width) every item spans the full row: a single\n  visual column.\n- `{ lg?: n, md?: n, sm?: n }` — graduated: below each breakpoint the grid\n  re-templates to that many columns and item spans clamp to fit (a span\n  wider than the step becomes a full row). E.g. `{ md: 6, sm: 1 }`.\n\n❌ Anti-pattern: a collapsible Sortable must get its width from its\nparent — `container-type: inline-size` zeroes the list's contribution to\nintrinsic sizing (same caveat as `Grid`'s `collapseBelow`)."
         }
       ]
     },
@@ -4700,7 +4707,6 @@
     "GridAlignItems": "\"start\" | \"end\" | \"center\" | \"stretch\"",
     "GridJustifyItems": "\"start\" | \"end\" | \"center\" | \"stretch\"",
     "GridAs": "\"div\" | \"section\" | \"aside\" | \"article\" | \"main\" | \"ul\" | \"ol\" | \"nav\" | \"header\" | \"footer\"",
-    "GridCollapseBreakpoint": "\"sm\" | \"md\" | \"lg\"",
     "SplitSide": "\"start\" | \"end\"",
     "SplitGap": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\" | \"2xl\"",
     "SplitAlign": "\"start\" | \"center\" | \"stretch\"",

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -4773,6 +4773,7 @@
     "SliderMark": "{ value: number; label?: string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null }",
     "SortableReorderEvent": "{ from: number; to: number; id: string | number }",
     "SortableArrangement": "\"list\" | \"grid\"",
+    "CollapseBreakpoint": "\"sm\" | \"md\" | \"lg\"",
     "SortableMoveEvent": "{ id: string | number; from: { container: string | number; index: number; }; to: { container: string | number; index: number; } }",
     "TableDensity": "\"comfortable\" | \"dense\"",
     "PaginationSize": "\"sm\" | \"md\" | \"lg\"",

--- a/packages/playground/src/pages/components/GridDemo.tsx
+++ b/packages/playground/src/pages/components/GridDemo.tsx
@@ -18,6 +18,7 @@ export function GridDemo() {
       <AlignmentExample />
       <SemanticElementExample />
       <SpanCollapseExample />
+      <GraduatedCollapseExample />
     </DemoLayout>
   );
 }
@@ -335,6 +336,48 @@ export function Demo() {
     >
       <div style={{ resize: 'horizontal', overflow: 'auto' }}>
         <Grid columns={12} gap="md" collapseBelow="md">
+          <Grid.Item span="25%">
+            <Card>KPI</Card>
+          </Grid.Item>
+          <Grid.Item span="75%">
+            <Card>Chart</Card>
+          </Grid.Item>
+          <Grid.Item span="33%">
+            <Card>List</Card>
+          </Grid.Item>
+          <Grid.Item span="67%">
+            <Card>Table</Card>
+          </Grid.Item>
+          <Grid.Item span="100%">
+            <Card>Footer row</Card>
+          </Grid.Item>
+        </Grid>
+      </div>
+    </Example>
+  );
+}
+
+function GraduatedCollapseExample() {
+  return (
+    <Example
+      title="Graduated collapse (breakpoint→columns map)"
+      description="`collapseBelow={{ md: 6, sm: 1 }}` steps down instead of jumping straight to one column: 12 columns wide, re-templates to 6 columns under 640px (spans clamp to fit), then to 1 column under 480px. Drag the box's resize handle (bottom-right corner) narrower to see both steps."
+      code={`import { Card, Grid } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Grid columns={12} gap="md" collapseBelow={{ md: 6, sm: 1 }}>
+      <Grid.Item span="25%"><Card>KPI</Card></Grid.Item>
+      <Grid.Item span="75%"><Card>Chart</Card></Grid.Item>
+      <Grid.Item span="33%"><Card>List</Card></Grid.Item>
+      <Grid.Item span="67%"><Card>Table</Card></Grid.Item>
+      <Grid.Item span="100%"><Card>Footer row</Card></Grid.Item>
+    </Grid>
+  );
+}`}
+    >
+      <div style={{ resize: 'horizontal', overflow: 'auto' }}>
+        <Grid columns={12} gap="md" collapseBelow={{ md: 6, sm: 1 }}>
           <Grid.Item span="25%">
             <Card>KPI</Card>
           </Grid.Item>

--- a/packages/playground/src/pages/components/SortableDemo.tsx
+++ b/packages/playground/src/pages/components/SortableDemo.tsx
@@ -70,6 +70,14 @@ export function SortableDemo() {
     { id: 'w-5', title: 'Activity feed', span: '100%' as const },
   ]);
 
+  const [collapsibleWidgets, setCollapsibleWidgets] = useState([
+    { id: 'cw-1', title: 'KPIs', span: '25%' as const },
+    { id: 'cw-2', title: 'Revenue', span: '75%' as const },
+    { id: 'cw-3', title: 'Recent deals', span: '33%' as const },
+    { id: 'cw-4', title: 'Pipeline', span: '67%' as const },
+    { id: 'cw-5', title: 'Activity feed', span: '100%' as const },
+  ]);
+
   return (
     <DemoLayout
       name="Sortable"
@@ -533,6 +541,75 @@ export function Demo() {
             </Sortable.Item>
           ))}
         </Sortable>
+      </Example>
+
+      <Example
+        title="Grid arrangement — graduated collapse"
+        description="collapseBelow accepts the same graduated map as Grid: {{ md: 6, sm: 1 }} re-templates the grid to 6 columns under 640px (item spans clamp to fit) and to 1 column under 480px, mirroring Grid's collapseBelow exactly. Drag the box's resize handle (bottom-right corner) narrower to see it step down."
+        code={`import { useState } from 'react';
+import { GripVertical } from 'lucide-react';
+import { arrayMove } from '@dnd-kit/sortable';
+import { Card, Cluster, Sortable, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  const [widgets, setWidgets] = useState([
+    { id: 'w-1', title: 'KPIs', span: '25%' as const },
+    { id: 'w-2', title: 'Revenue', span: '75%' as const },
+    { id: 'w-3', title: 'Recent deals', span: '33%' as const },
+    { id: 'w-4', title: 'Pipeline', span: '67%' as const },
+    { id: 'w-5', title: 'Activity feed', span: '100%' as const },
+  ]);
+
+  return (
+    <Sortable
+      arrangement="grid"
+      columns={12}
+      collapseBelow={{ md: 6, sm: 1 }}
+      onReorder={({ from, to }) => setWidgets((w) => arrayMove(w, from, to))}
+    >
+      {widgets.map((widget) => (
+        <Sortable.Item key={widget.id} id={widget.id} span={widget.span}>
+          <Card padding="sm" style={{ height: '100%' }}>
+            <Cluster gap="sm" align="center">
+              <Sortable.Handle aria-label={\`Reorder \${widget.title}\`}>
+                <GripVertical size={14} />
+              </Sortable.Handle>
+              <Text weight="medium">{widget.title}</Text>
+              <Text size="sm" tone="muted">
+                {widget.span}
+              </Text>
+            </Cluster>
+          </Card>
+        </Sortable.Item>
+      ))}
+    </Sortable>
+  );
+}`}
+      >
+        <div style={{ resize: 'horizontal', overflow: 'auto' }}>
+          <Sortable
+            arrangement="grid"
+            columns={12}
+            collapseBelow={{ md: 6, sm: 1 }}
+            onReorder={({ from, to }) => setCollapsibleWidgets((w) => arrayMove(w, from, to))}
+          >
+            {collapsibleWidgets.map((widget) => (
+              <Sortable.Item key={widget.id} id={widget.id} span={widget.span}>
+                <Card padding="sm" style={{ height: '100%' }}>
+                  <Cluster gap="sm" align="center">
+                    <Sortable.Handle aria-label={`Reorder ${widget.title}`}>
+                      <GripVertical size={14} />
+                    </Sortable.Handle>
+                    <Text weight="medium">{widget.title}</Text>
+                    <Text size="sm" tone="muted">
+                      {widget.span}
+                    </Text>
+                  </Cluster>
+                </Card>
+              </Sortable.Item>
+            ))}
+          </Sortable>
+        </div>
       </Example>
 
       <Stack gap="xs">


### PR DESCRIPTION
Addresses #318.

## Summary
- `<Sortable arrangement="grid">` gains `collapseBelow` — full parity with `Grid`: the binary string form (`'sm' | 'md' | 'lg'`, every item collapses to a full row below the container-width threshold) plus the new map form.
- `collapseBelow` on both `Grid` and `Sortable` now also accepts a graduated breakpoint→columns map, e.g. `collapseBelow={{ md: 6, sm: 1 }}`: below each breakpoint the grid re-templates to that many equal columns and item spans clamp to fit (a span wider than the step becomes a full row). Sidesteps the inline-custom-property-beats-stylesheet problem from the issue: the step templates are injected as per-breakpoint inline custom properties (`--grid-columns-<bp>`) read by static container-query rules, and clamped spans are computed in JS (container → item via a React context) rather than CSS `min()`.
- Shared plumbing in `_internal/` (breakpoint SCSS constants, `CollapseBreakpoint`/`CollapseColumnsMap` types + context, clamp resolver); new public exports `CollapseColumnsMap`, `CollapseBreakpoint`.
- AGENTS.md notes, JSDoc, playground demo sections for both components, regenerated props manifest.

Legacy string-form behavior on Grid is byte-identical (untouched CSS mechanism); Sortable list mode and non-collapsible grids are unchanged.

## Test plan
- New unit tests: clamp resolver edge cases (span == columns, columns == 1, fractions), Grid map-form classes/templates/clamped item stamps, TS-level rejection of map on auto-fit grids, Sortable string/map forms + list-mode inertness.
- Full gates green locally: `make test` (3850 tests), `make build-lib`, `make lint`, `npm run format:check`, `make build`.
- 4-round subagent review (per-task spec+quality gates) + final whole-branch adversarial review: clean; cascade order, context-leak scenarios, and legacy-behavior parity traced and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk