### PR TITLE
feat: Text size="inherit" — inline runs inside headings keep the parent size (#319)

### DIFF
--- a/docs/superpowers/plans/2026-07-25-text-size-inherit.md
+++ b/docs/superpowers/plans/2026-07-25-text-size-inherit.md
@@ -1,0 +1,132 @@
+# Text size="inherit" — Implementation Plan (#319)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** `<Text size="inherit">` renders with no fixed font-size — it inherits font-size AND line-height from its parent, so a muted inline run inside a heading (`<Text as="span" size="inherit" tone="muted">` inside `<PageHeader.Title>`) keeps the heading's size.
+
+**Architecture:** Purely additive: extend the `TextSize` union with `'inherit'`, map it to a new `.sizeInherit` class setting `font-size: inherit; line-height: inherit;` (line-height must inherit too — Text's base 1.5 line-height inside a tight-line-height heading would otherwise inflate the heading's line box). Tone/weight/align keep working unchanged on top.
+
+**Tech Stack:** React 18, TypeScript, SCSS modules, Vitest + RTL (globals — no describe/it/expect imports).
+
+## Global Constraints
+
+- Repo `/home/dpws/projects/design-system`, branch `feat/text-size-inherit` (already checked out).
+- Tokens-only SCSS; if stylelint's `scale-unlimited/declaration-strict-value` flags `font-size: inherit` / `line-height: inherit`, use a `// stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS-wide keyword, not a raw value` comment (mirror the `.alignLeft` pattern in Text.module.scss).
+- Full JSDoc on the changed prop/type (package CLAUDE.md rule 7).
+- Tests run from inside the package: `cd packages/design-system && npx vitest run src/components/Text/Text.test.tsx`.
+- Lint/format from repo root: `make lint`, `npm run format:check`.
+- Commit per task; do NOT push.
+
+---
+
+### Task 1: The feature (code + tests + JSDoc)
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Text/Text.tsx`
+- Modify: `packages/design-system/src/components/Text/Text.module.scss`
+- Test: `packages/design-system/src/components/Text/Text.test.tsx`
+
+**Interfaces:**
+
+- Produces: `TextSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'inherit'`; class `styles.sizeInherit`.
+
+- [ ] **Step 1: Failing tests** — append to `Text.test.tsx` (match the file's existing style — read it first):
+
+```tsx
+describe('Text size="inherit" (#319)', () => {
+  it('renders the sizeInherit class and no fixed-size class', () => {
+    render(
+      <Text as="span" size="inherit" data-testid="t">
+        ENG-5
+      </Text>,
+    );
+    const el = screen.getByTestId('t');
+    expect(el.className).toMatch(/sizeInherit/);
+    expect(el.className).not.toMatch(/sizeMd/);
+  });
+
+  it('tone and weight still apply with size="inherit"', () => {
+    render(
+      <Text as="span" size="inherit" tone="muted" weight="medium" data-testid="t">
+        ENG-5
+      </Text>,
+    );
+    const el = screen.getByTestId('t');
+    expect(el.className).toMatch(/toneMuted/);
+    expect(el.className).toMatch(/weightMedium/);
+  });
+});
+```
+
+- [ ] **Step 2: Run** `cd packages/design-system && npx vitest run src/components/Text/Text.test.tsx` — expect FAIL (type error / missing class).
+
+- [ ] **Step 3: Implement.**
+
+`Text.tsx`:
+
+- `export type TextSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'inherit';` — extend the `/** Visual size. */` JSDoc to `/** Visual size. `'inherit'` takes font-size and line-height from the parent (inline runs inside headings). */`
+- `SIZE_CLASS`: add `inherit: styles.sizeInherit,`.
+- `size` prop JSDoc: add option line:
+
+```
+   * - `inherit` — no fixed size; font-size AND line-height inherit from the
+   *   parent. For inline runs inside a heading (`as="span"` inside a
+   *   `<Title>` / `<PageHeader.Title>`) that must keep the heading's size —
+   *   e.g. a muted task-key prefix. Tone / weight still apply.
+```
+
+- Add one `@example` after the existing inline-run example:
+
+```
+ * @example
+ * // Muted inline run inside a heading — keeps the heading's font size:
+ * <Title order={1}>
+ *   <Text as="span" size="inherit" tone="muted">ENG-5</Text> Fix login
+ * </Title>
+```
+
+- Extend the `@remarks Anti-patterns` bullet about wrapping `<Title>` in `<Text>`: it stays an anti-pattern; `size="inherit"` is for runs INSIDE a heading, not around one. One sentence.
+
+`Text.module.scss` — after `.sizeXl`:
+
+```scss
+// `inherit` — no fixed size: font-size AND line-height come from the parent
+// (inline runs inside headings). Line-height must inherit too or Text's
+// base 1.5 would inflate a tight heading's line box.
+.sizeInherit {
+  font-size: inherit;
+  line-height: inherit;
+}
+```
+
+(Add the stylelint disable comments only if `make lint` flags the `inherit` keywords.)
+
+- [ ] **Step 4: Run** the Text tests (PASS), `cd packages/design-system && npm run typecheck`, root `make lint`.
+
+- [ ] **Step 5: Commit** — `feat(Text): size="inherit" — inline runs inside headings keep the parent size (#319)`
+
+---
+
+### Task 2: Docs + demo
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md` (Text section)
+- Modify: `packages/playground/src/pages/components/TextDemo.tsx`
+
+- [ ] **Step 1: AGENTS.md** — in the Text section, add one TL;DR line for `size="inherit"` (muted title prefix inside a heading; font-size + line-height inherit). Match surrounding style.
+
+- [ ] **Step 2: TextDemo.tsx** — add a demo section (match the file's existing section/Example component pattern) titled "size=\"inherit\" — inline runs inside headings": a `<Title order={2}>` containing `<Text as="span" size="inherit" tone="muted">ENG-5</Text> Fix login flow` (plus, if the file's style supports it, a contrast line showing the old wrong way with `size="sm"` rendering smaller). Imports only from `@eocrm/design-system`.
+
+- [ ] **Step 3: Verify from repo root** — `make test && make build-lib && make lint && npm run format:check && make build`. Also `npx prettier --write docs/superpowers/plans/2026-07-25-text-size-inherit.md` and commit the plan doc here.
+
+- [ ] **Step 4: Commit** — `docs: Text size="inherit" demo + AGENTS.md note (#319)`
+
+---
+
+## Self-review notes
+
+- Line-height inheritance is the one non-obvious decision; locked in (see Architecture).
+- No new component → no manifest CLUSTERS entry; props.manifest.json may regenerate during `make build` — commit if changed.
+- Not adding an inline `Title` variant — issue itself prefers the `Text size="inherit"` surface.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -196,7 +196,7 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 - `align`: `left | center | right` (default `left`).
 - `truncate`: single-line ellipsis. `lineClamp: number`: multi-line ellipsis. `lineClamp` overrides `truncate`.
 - **Use `<Text>` for every non-heading run.** No more `<span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>`.
-- **`size="inherit"`** — for a muted/toned inline run INSIDE a heading (e.g. `<Text as="span" size="inherit" tone="muted">ENG-5</Text>` before a `<Title order={1}>` task name) that must keep the heading's size instead of shrinking to `md`. Font-size AND line-height both inherit from the parent.
+- **`size="inherit"`** — for a muted/toned inline run INSIDE a heading (e.g. `<Text as="span" size="inherit" tone="muted">ENG-5</Text>` at the start of a `<Title order={1}>` task name) that must keep the heading's size instead of shrinking to `md`. Font-size AND line-height both inherit from the parent.
 
 ### `<Code>` — inline `<code>` chip
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -190,12 +190,13 @@ Each component is fully JSDoc'd. Hover any usage in your editor for inline docs 
 ```
 
 - `as: 'p' | 'span' | 'div' | 'label'` (default `'p'`). Constrained string union — no polymorphic generic.
-- `size: 'xs' | 'sm' | 'md' | 'lg' | 'xl'` (default `'md'`).
+- `size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'inherit'` (default `'md'`).
 - `tone`: `default | muted | subtle | accent | danger | success | warning`.
 - `weight`: `regular | medium | semibold | bold` (default `regular`).
 - `align`: `left | center | right` (default `left`).
 - `truncate`: single-line ellipsis. `lineClamp: number`: multi-line ellipsis. `lineClamp` overrides `truncate`.
 - **Use `<Text>` for every non-heading run.** No more `<span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-fg-muted)' }}>`.
+- **`size="inherit"`** — for a muted/toned inline run INSIDE a heading (e.g. `<Text as="span" size="inherit" tone="muted">ENG-5</Text>` before a `<Title order={1}>` task name) that must keep the heading's size instead of shrinking to `md`. Font-size AND line-height both inherit from the parent.
 
 ### `<Code>` — inline `<code>` chip
 

--- a/packages/design-system/src/components/Text/Text.module.scss
+++ b/packages/design-system/src/components/Text/Text.module.scss
@@ -29,6 +29,14 @@
   font-size: var(--text-font-size-xl);
 }
 
+// `inherit` — no fixed size: font-size AND line-height come from the parent
+// (inline runs inside headings). Line-height must inherit too or Text's
+// base 1.5 would inflate a tight heading's line box.
+.sizeInherit {
+  font-size: inherit;
+  line-height: inherit;
+}
+
 .weightRegular {
   font-weight: var(--text-font-weight-regular);
 }

--- a/packages/design-system/src/components/Text/Text.test.tsx
+++ b/packages/design-system/src/components/Text/Text.test.tsx
@@ -183,3 +183,27 @@ describe('Text', () => {
     expect(el).toHaveAttribute('for', 'email-input');
   });
 });
+
+describe('Text size="inherit" (#319)', () => {
+  it('renders the sizeInherit class and no fixed-size class', () => {
+    render(
+      <Text as="span" size="inherit" data-testid="t">
+        ENG-5
+      </Text>,
+    );
+    const el = screen.getByTestId('t');
+    expect(el.className).toMatch(/sizeInherit/);
+    expect(el.className).not.toMatch(/sizeMd/);
+  });
+
+  it('tone and weight still apply with size="inherit"', () => {
+    render(
+      <Text as="span" size="inherit" tone="muted" weight="medium" data-testid="t">
+        ENG-5
+      </Text>,
+    );
+    const el = screen.getByTestId('t');
+    expect(el.className).toMatch(/toneMuted/);
+    expect(el.className).toMatch(/weightMedium/);
+  });
+});

--- a/packages/design-system/src/components/Text/Text.tsx
+++ b/packages/design-system/src/components/Text/Text.tsx
@@ -46,7 +46,9 @@ export interface TextProps extends HTMLAttributes<HTMLElement> {
    * - `inherit` — no fixed size; font-size AND line-height inherit from the
    *   parent. For inline runs inside a heading (`as="span"` inside a
    *   `<Title>` / `<PageHeader.Title>`) that must keep the heading's size —
-   *   e.g. a muted task-key prefix. Tone / weight still apply.
+   *   e.g. a muted task-key prefix. Tone / weight still apply — font-weight
+   *   stays Text's own (default `regular`), it does NOT inherit; pass
+   *   `weight` to match the heading if needed.
    */
   size?: TextSize;
   /**

--- a/packages/design-system/src/components/Text/Text.tsx
+++ b/packages/design-system/src/components/Text/Text.tsx
@@ -10,8 +10,8 @@ import styles from './Text.module.scss';
  */
 export type TextAs = 'p' | 'span' | 'div' | 'label';
 
-/** Visual size. */
-export type TextSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+/** Visual size. `'inherit'` takes font-size and line-height from the parent (inline runs inside headings). */
+export type TextSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'inherit';
 
 /** Color tone. */
 export type TextTone = 'default' | 'muted' | 'subtle' | 'accent' | 'danger' | 'success' | 'warning';
@@ -43,6 +43,10 @@ export interface TextProps extends HTMLAttributes<HTMLElement> {
    * - `md` — 14px, body text (default)
    * - `lg` — 16px, large body / lead text
    * - `xl` — 20px, very large body (rare)
+   * - `inherit` — no fixed size; font-size AND line-height inherit from the
+   *   parent. For inline runs inside a heading (`as="span"` inside a
+   *   `<Title>` / `<PageHeader.Title>`) that must keep the heading's size —
+   *   e.g. a muted task-key prefix. Tone / weight still apply.
    */
   size?: TextSize;
   /**
@@ -84,6 +88,7 @@ const SIZE_CLASS: Record<TextSize, string> = {
   md: styles.sizeMd,
   lg: styles.sizeLg,
   xl: styles.sizeXl,
+  inherit: styles.sizeInherit,
 };
 
 const TONE_CLASS: Record<TextTone, string> = {
@@ -144,6 +149,12 @@ const ALIGN_CLASS: Record<TextAlign, string> = {
  * <Text size="sm" tone="danger">Email is required.</Text>
  *
  * @example
+ * // Muted inline run inside a heading — keeps the heading's font size:
+ * <Title order={1}>
+ *   <Text as="span" size="inherit" tone="muted">ENG-5</Text> Fix login
+ * </Title>
+ *
+ * @example
  * // Body copy under a heading, spaced with Stack — the canonical CRM-page shape:
  * <Stack gap="xs">
  *   <Title order={2}>Pipeline</Title>
@@ -162,7 +173,8 @@ const ALIGN_CLASS: Record<TextAlign, string> = {
  *   The whitelist is the contract.
  * - ❌ `<Text as="h2">` — Text doesn't accept heading tags. Use `<Title order={2}>`.
  * - ❌ Wrapping a `<Title>` in `<Text>` for tone/weight tweaks. Pass tone/weight
- *   directly to the `<Title>` instead.
+ *   directly to the `<Title>` instead. `size="inherit"` is for runs INSIDE a
+ *   heading, not for wrapping the heading itself.
  * - ❌ Nesting `<Text>` inside another `<Text>` with the default `as="p"`. The
  *   inner `<p>` renders inside the outer `<p>`, which the React DOM nesting
  *   validator warns about (and is invalid HTML). When you need a tone or

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -4299,7 +4299,7 @@
           "type": "TextSize",
           "required": false,
           "default": "",
-          "description": "Visual size. Defaults to `'md'` (body text).\n- `xs` — 11px, dense metadata / captions\n- `sm` — 12px, small body / labels\n- `md` — 14px, body text (default)\n- `lg` — 16px, large body / lead text\n- `xl` — 20px, very large body (rare)\n- `inherit` — no fixed size; font-size AND line-height inherit from the\n  parent. For inline runs inside a heading (`as=\"span\"` inside a\n  `<Title>` / `<PageHeader.Title>`) that must keep the heading's size —\n  e.g. a muted task-key prefix. Tone / weight still apply."
+          "description": "Visual size. Defaults to `'md'` (body text).\n- `xs` — 11px, dense metadata / captions\n- `sm` — 12px, small body / labels\n- `md` — 14px, body text (default)\n- `lg` — 16px, large body / lead text\n- `xl` — 20px, very large body (rare)\n- `inherit` — no fixed size; font-size AND line-height inherit from the\n  parent. For inline runs inside a heading (`as=\"span\"` inside a\n  `<Title>` / `<PageHeader.Title>`) that must keep the heading's size —\n  e.g. a muted task-key prefix. Tone / weight still apply — font-weight\n  stays Text's own (default `regular`), it does NOT inherit; pass\n  `weight` to match the heading if needed."
         },
         {
           "name": "tone",

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -4299,7 +4299,7 @@
           "type": "TextSize",
           "required": false,
           "default": "",
-          "description": "Visual size. Defaults to `'md'` (body text).\n- `xs` — 11px, dense metadata / captions\n- `sm` — 12px, small body / labels\n- `md` — 14px, body text (default)\n- `lg` — 16px, large body / lead text\n- `xl` — 20px, very large body (rare)"
+          "description": "Visual size. Defaults to `'md'` (body text).\n- `xs` — 11px, dense metadata / captions\n- `sm` — 12px, small body / labels\n- `md` — 14px, body text (default)\n- `lg` — 16px, large body / lead text\n- `xl` — 20px, very large body (rare)\n- `inherit` — no fixed size; font-size AND line-height inherit from the\n  parent. For inline runs inside a heading (`as=\"span\"` inside a\n  `<Title>` / `<PageHeader.Title>`) that must keep the heading's size —\n  e.g. a muted task-key prefix. Tone / weight still apply."
         },
         {
           "name": "tone",
@@ -4807,7 +4807,7 @@
     "RenderLink": "(link: RichTextLink, defaultNode: ReactNode) => ReactNode",
     "RenderMention": "(mention: RichTextMention, defaultNode: ReactNode) => ReactNode",
     "TextAs": "\"div\" | \"span\" | \"label\" | \"p\"",
-    "TextSize": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\"",
+    "TextSize": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\" | \"inherit\"",
     "TextTone": "\"success\" | \"warning\" | \"danger\" | \"accent\" | \"default\" | \"muted\" | \"subtle\"",
     "TextWeight": "\"regular\" | \"medium\" | \"semibold\" | \"bold\"",
     "TextAlign": "\"left\" | \"right\" | \"center\"",

--- a/packages/playground/src/pages/components/TextDemo.tsx
+++ b/packages/playground/src/pages/components/TextDemo.tsx
@@ -3,6 +3,7 @@ import { Code } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { Cluster } from '@eocrm/design-system';
 import { Input } from '@eocrm/design-system';
+import { Title } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
@@ -225,6 +226,40 @@ export function Demo() {
             </Text>
           </Stack>
         </Cluster>
+      </Example>
+
+      <Example
+        title='size="inherit" — inline runs inside headings'
+        description="No fixed size — font-size AND line-height inherit from the parent. Use for a muted inline run inside a <Title> that must keep the heading's size, instead of shrinking to Text's own default."
+        code={`import { Stack, Text, Title } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="xs">
+      <Title order={2}>
+        <Text as="span" size="inherit" tone="muted">ENG-5</Text> Fix login flow
+      </Title>
+      <Title order={2}>
+        <Text as="span" size="sm" tone="muted">ENG-5</Text> Fix login flow
+      </Title>
+    </Stack>
+  );
+}`}
+      >
+        <Stack gap="xs">
+          <Title order={2}>
+            <Text as="span" size="inherit" tone="muted">
+              ENG-5
+            </Text>{' '}
+            Fix login flow
+          </Title>
+          <Title order={2}>
+            <Text as="span" size="sm" tone="muted">
+              ENG-5
+            </Text>{' '}
+            Fix login flow
+          </Title>
+        </Stack>
       </Example>
     </DemoLayout>
   );


### PR DESCRIPTION
Addresses #319.

## Summary
- `TextSize` gains `'inherit'`: `<Text size="inherit">` stamps a `.sizeInherit` class (`font-size: inherit; line-height: inherit`) instead of a fixed size class, so a muted/toned inline run inside a heading (`<Text as="span" size="inherit" tone="muted">ENG-5</Text>` inside `<PageHeader.Title>`) keeps the heading's size.
- Line-height inherits too — Text's base 1.5 would otherwise inflate a tight heading's line box.
- JSDoc (incl. explicit note that font-weight does NOT inherit), AGENTS.md TL;DR line, playground demo section with an inherit-vs-`size="sm"` contrast, regenerated props manifest.
- Purely additive — verified no exhaustive `Record<TextSize, ...>` maps outside Text's own SIZE_CLASS (Field/PersonDisplay use TextSize in value position only).

## Test plan
- New unit tests: `sizeInherit` class stamped (and no fixed-size class); tone/weight still apply alongside.
- Full gates green locally: `make test` (3852 tests), `make build-lib`, `make lint`, `npm run format:check`, `make build`.
- Fresh-context rule-8 review: clean (two doc-polish minors found and applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk