### PR TITLE
fix: RichTextEditor post-reset autolink divergence — resolve container-level DOM carets (#321)

### DIFF
--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.controlledReset.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.controlledReset.test.tsx
@@ -1,0 +1,91 @@
+// Regression test for #321: after a parent-driven controlled reset
+// (setDoc(emptyDoc()) — no remount), the next typed URL + space must still
+// autolink into a chip and flow through onChange. Uses the REAL selection
+// layer (no readSelection mock): the DOM selection collapses to the editable
+// root when the old block element is removed, exactly like a browser.
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { RichTextEditor } from './RichTextEditor';
+import { I18nProvider } from '../../i18n';
+import type { RichDoc } from '../RichText/engine/model';
+
+const chip: React.ComponentProps<typeof RichTextEditor>['renderLink'] = ({ href }, fallback) =>
+  href.startsWith('https://chip') ? <span data-chip>{href}</span> : fallback;
+
+function typeText(editor: HTMLElement, data: string): Event {
+  const evt = new Event('beforeinput', { bubbles: true, cancelable: true });
+  Object.defineProperty(evt, 'inputType', { value: 'insertText' });
+  Object.defineProperty(evt, 'data', { value: data });
+  act(() => {
+    editor.dispatchEvent(evt);
+  });
+  return evt;
+}
+
+function emptyBlockDoc(id: string): RichDoc {
+  return { blocks: [{ id, type: 'paragraph', inlines: [{ text: '', marks: [] }] }] };
+}
+
+describe('RichTextEditor controlled external reset (#321)', () => {
+  it('autolinks and commits a URL typed after an external value reset', () => {
+    const docs: RichDoc[] = [];
+    function Harness() {
+      const [doc, setDoc] = useState<RichDoc>(() => emptyBlockDoc('a1'));
+      return (
+        <>
+          <button onClick={() => setDoc(emptyBlockDoc('a2'))}>reset</button>
+          <RichTextEditor
+            value={doc}
+            onChange={(d) => {
+              docs.push(d);
+              setDoc(d);
+            }}
+            renderLink={chip}
+          />
+        </>
+      );
+    }
+    render(
+      <I18nProvider locale="en">
+        <Harness />
+      </I18nProvider>,
+    );
+    const box = screen.getByRole('textbox', { name: 'Rich text editor' });
+    // Put the caret where a click would: inside the first (empty) paragraph.
+    const p1 = box.querySelector('[data-block-id="a1"]')!;
+    act(() => {
+      document.getSelection()!.collapse(p1, 0);
+    });
+    // First URL + space → chip (sanity: the pre-reset path works).
+    typeText(box, 'https://chip/1');
+    typeText(box, ' ');
+    expect(box.querySelector('[data-rich-link]')).not.toBeNull();
+
+    // Parent submits and resets the doc — controlled replacement, NO remount.
+    fireEvent.click(screen.getByRole('button', { name: 'reset' }));
+    expect(box.querySelector('[data-rich-link]')).toBeNull();
+    const commitsBefore = docs.length;
+
+    // The removed block took the DOM selection with it — the boundary collapsed
+    // to the editable root. Type without re-clicking (focus never left the editor).
+    const evt1 = typeText(box, 'https://chip/2');
+    const evt2 = typeText(box, ' ');
+    // The editor must keep control of the input (un-prevented default = the
+    // browser mutates the contentEditable DOM raw → duplicate text in real browsers).
+    expect(evt1.defaultPrevented).toBe(true);
+    expect(evt2.defaultPrevented).toBe(true);
+    // onChange kept flowing and the URL got linked…
+    expect(docs.length).toBeGreaterThan(commitsBefore);
+    const last = docs[docs.length - 1];
+    expect(
+      last.blocks.some((b) =>
+        b.inlines.some((r) =>
+          r.marks.some((m) => m.type === 'link' && m.href === 'https://chip/2'),
+        ),
+      ),
+    ).toBe(true);
+    // …and the DOM shows exactly ONE rendering of the URL (the chip), no raw copy.
+    expect(box.querySelector('[data-rich-link]')).not.toBeNull();
+    expect(box.textContent).toBe('https://chip/2 ');
+  });
+});

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -747,7 +747,16 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
           return;
         }
         const range = readSelection(root);
-        if (!range) return;
+        if (!range) {
+          // Unmappable selection: never cede an editing input to the browser —
+          // an un-prevented default insert/delete mutates the contentEditable
+          // DOM outside the model (permanent DOM/model divergence, #321). A
+          // dropped keystroke is recoverable; a future resolver bug surfaces
+          // as dropped keystrokes instead of DOM corruption — acceptable.
+          if (e.inputType.startsWith('insert') || e.inputType.startsWith('delete'))
+            e.preventDefault();
+          return;
+        }
         // Markdown block input rules: a marker + space at the start of a paragraph
         // converts the block (e.g. "# " → heading, "- " → bullet). The space is
         // consumed; one commit → one undo step (⌘Z reverts the conversion).

--- a/packages/design-system/src/components/RichTextEditor/selection.test.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.test.ts
@@ -286,6 +286,43 @@ describe('void-block selection', () => {
   });
 });
 
+// A caret can land ON a block container — the editor root or a <ul>/<ol> list
+// wrapper — when the block it lived in is removed (e.g. a controlled external
+// value replacement; the DOM collapses the boundary to (container, childIndex)).
+// It must resolve to an adjacent block, not null (#321).
+describe('container-level carets (root + list wrappers) — #321', () => {
+  it('root caret before a block resolves to its start (next branch)', () => {
+    const r = makeRoot('<p data-block-id="a">hi</p><p data-block-id="b">world</p>');
+    expect(pointFromDom(r, r, 1)).toEqual({ blockId: 'b', offset: 0 });
+  });
+  it('root caret past the last block resolves to the END of the last block (prev branch)', () => {
+    const r = makeRoot('<p data-block-id="a">hi</p><p data-block-id="b">world</p>');
+    expect(pointFromDom(r, r, 2)).toEqual({ blockId: 'b', offset: 5 });
+  });
+  it('prev-branch end offset is widget-corrected (data-len, not display length)', () => {
+    const r = makeRoot(
+      '<p data-block-id="b1">hi <span data-rich-link data-len="13" contenteditable="false">#1 Task</span></p>',
+    );
+    // model: "hi " (3) + widget (13) = 16, not the 10 display chars.
+    expect(pointFromDom(r, r, 1)).toEqual({ blockId: 'b1', offset: 16 });
+  });
+  it('a caret ON a <ul> wrapper resolves to the adjacent <li> item', () => {
+    const r = makeRoot('<ul><li data-block-id="l1">one</li><li data-block-id="l2">two</li></ul>');
+    const ul = r.querySelector('ul')!;
+    expect(pointFromDom(r, ul, 1)).toEqual({ blockId: 'l2', offset: 0 }); // next: start
+    expect(pointFromDom(r, ul, 2)).toEqual({ blockId: 'l2', offset: 3 }); // prev: end
+  });
+  it('root caret beside a <ul> wrapper resolves INTO its first/last item', () => {
+    const r = makeRoot('<p data-block-id="a">hi</p><ul><li data-block-id="l1">one</li></ul>');
+    expect(pointFromDom(r, r, 1)).toEqual({ blockId: 'l1', offset: 0 }); // next: into the list
+    expect(pointFromDom(r, r, 2)).toEqual({ blockId: 'l1', offset: 3 }); // prev: list item end
+  });
+  it('an empty root still returns null', () => {
+    const r = makeRoot('');
+    expect(pointFromDom(r, r, 0)).toBeNull();
+  });
+});
+
 describe('selectionRect — degenerate-selection fallback', () => {
   const rect = (top: number, left: number, width: number, height: number): DOMRect =>
     ({

--- a/packages/design-system/src/components/RichTextEditor/selection.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.ts
@@ -122,39 +122,46 @@ export function pointFromDom(root: HTMLElement, node: Node, offset: number): Poi
     // one just before it. `kids[-1]` (offset 0) is undefined → figureBlock null.
     const fig = figureBlock(kids[offset]) ?? figureBlock(kids[offset - 1]);
     if (fig) return { blockId: fig.getAttribute('data-block-id')!, offset: 0 };
-    // Root-level caret beside ORDINARY blocks. This happens when the block the
-    // selection lived in is removed from the DOM — e.g. a controlled external
-    // value replacement (parent setDoc(emptyDoc())) swaps the block elements,
-    // and the DOM collapses the live selection boundary to (root, childIndex).
-    // Resolve to the start of the next block, else the end of the previous one.
-    // Returning null here would make readSelection null, and the beforeinput
-    // handler would cede the keystroke to the browser — which then mutates the
-    // contentEditable DOM outside the model (raw text over the re-rendered
-    // content, onChange stalled). See #321.
+  }
+  const blockEl = blockElementFor(root, node);
+  if (blockEl) {
+    // A void figure block has no text — its only position is offset 0. (A caret on a
+    // figure descendant ascends to the figure via blockElementFor.)
+    if (blockEl.tagName === 'FIGURE') {
+      return { blockId: blockEl.getAttribute('data-block-id')!, offset: 0 };
+    }
+    return {
+      blockId: blockEl.getAttribute('data-block-id')!,
+      offset: offsetWithinBlock(blockEl, node, offset),
+    };
+  }
+  // Container-level caret: an element inside the editor with no block ancestor —
+  // the root itself or a <ul>/<ol> list wrapper (the only elements renderDoc puts
+  // between root and blocks). This happens when the block the selection lived in
+  // is removed from the DOM — e.g. a controlled external value replacement
+  // (parent setDoc(emptyDoc())) swaps the block elements, and the DOM collapses
+  // the live selection boundary to (container, childIndex). Resolve to the start
+  // of the next block, else the end of the previous one. Returning null here
+  // would make readSelection null, and the beforeinput handler would cede the
+  // keystroke to the browser — which then mutates the contentEditable DOM
+  // outside the model (raw text over the re-rendered content, onChange
+  // stalled). See #321.
+  if (node instanceof HTMLElement && (node === root || root.contains(node))) {
+    const kids = node.childNodes;
     const next = blockWithin(kids[offset], 'first');
     if (next) return { blockId: next.getAttribute('data-block-id')!, offset: 0 };
     const prev = blockWithin(kids[offset - 1], 'last');
     if (prev) {
+      // A figure here is unreachable (root-adjacent figures are caught by the
+      // figureBlock check above; figures never nest in list wrappers), so the
+      // end offset is always the block's widget-corrected full model length.
       return {
         blockId: prev.getAttribute('data-block-id')!,
-        // A void figure's only position is 0; a text block's end is its full
-        // model length (widget-corrected by offsetWithinBlock).
-        offset:
-          prev.tagName === 'FIGURE' ? 0 : offsetWithinBlock(prev, prev, prev.childNodes.length),
+        offset: offsetWithinBlock(prev, prev, prev.childNodes.length),
       };
     }
   }
-  const blockEl = blockElementFor(root, node);
-  if (!blockEl) return null;
-  // A void figure block has no text — its only position is offset 0. (A caret on a
-  // figure descendant ascends to the figure via blockElementFor.)
-  if (blockEl.tagName === 'FIGURE') {
-    return { blockId: blockEl.getAttribute('data-block-id')!, offset: 0 };
-  }
-  return {
-    blockId: blockEl.getAttribute('data-block-id')!,
-    offset: offsetWithinBlock(blockEl, node, offset),
-  };
+  return null;
 }
 
 /**

--- a/packages/design-system/src/components/RichTextEditor/selection.ts
+++ b/packages/design-system/src/components/RichTextEditor/selection.ts
@@ -43,6 +43,17 @@ function figureBlock(node: Node | null | undefined): HTMLElement | null {
     : null;
 }
 
+/** The first/last block element at or inside a root-level child node — the node
+ *  itself when it IS a block, else its first/last `[data-block-id]` descendant
+ *  (a `<ul>`/`<ol>` wrapper contains its `<li data-block-id>` items). Null for
+ *  text/absent nodes. */
+function blockWithin(node: Node | undefined, which: 'first' | 'last'): HTMLElement | null {
+  if (!(node instanceof HTMLElement)) return null;
+  if (node.hasAttribute('data-block-id')) return node;
+  const all = node.querySelectorAll<HTMLElement>('[data-block-id]');
+  return all.length > 0 ? all[which === 'first' ? 0 : all.length - 1] : null;
+}
+
 /**
  * Character offset within `blockEl` of the DOM position `(node, offset)`. Works
  * for both text-node boundaries (offset = char index) and element-node
@@ -111,6 +122,27 @@ export function pointFromDom(root: HTMLElement, node: Node, offset: number): Poi
     // one just before it. `kids[-1]` (offset 0) is undefined → figureBlock null.
     const fig = figureBlock(kids[offset]) ?? figureBlock(kids[offset - 1]);
     if (fig) return { blockId: fig.getAttribute('data-block-id')!, offset: 0 };
+    // Root-level caret beside ORDINARY blocks. This happens when the block the
+    // selection lived in is removed from the DOM — e.g. a controlled external
+    // value replacement (parent setDoc(emptyDoc())) swaps the block elements,
+    // and the DOM collapses the live selection boundary to (root, childIndex).
+    // Resolve to the start of the next block, else the end of the previous one.
+    // Returning null here would make readSelection null, and the beforeinput
+    // handler would cede the keystroke to the browser — which then mutates the
+    // contentEditable DOM outside the model (raw text over the re-rendered
+    // content, onChange stalled). See #321.
+    const next = blockWithin(kids[offset], 'first');
+    if (next) return { blockId: next.getAttribute('data-block-id')!, offset: 0 };
+    const prev = blockWithin(kids[offset - 1], 'last');
+    if (prev) {
+      return {
+        blockId: prev.getAttribute('data-block-id')!,
+        // A void figure's only position is 0; a text block's end is its full
+        // model length (widget-corrected by offsetWithinBlock).
+        offset:
+          prev.tagName === 'FIGURE' ? 0 : offsetWithinBlock(prev, prev, prev.childNodes.length),
+      };
+    }
   }
   const blockEl = blockElementFor(root, node);
   if (!blockEl) return null;


### PR DESCRIPTION
Addresses #321.

## Summary
- **Root cause (confirmed by adversarial review):** when a controlled reset (`setDoc(emptyDoc())`) removes the DOM block the live selection sits in, the browser collapses the selection to the editable root (or a surviving `<ul>`/`<ol>` wrapper). `pointFromDom` had no resolution for container-level carets (except a void-figure fast-path), so `readSelection` returned null and the `beforeinput` handler returned **without** `preventDefault` — the browser then inserted raw text directly into the React-owned DOM, outside the model. Result: raw URL text overlapping the chip, and `onChange` never seeing the input. Remount was the only recovery (the eocrm `key`-bump workaround).
- **Fix at the shared choke point** (`selection.ts pointFromDom`): a caret on any block-less container (editor root or list wrapper) now resolves to the start of the next block, else the widget-corrected end of the previous one (figure fast-path preserved first). Heals every `readSelection` consumer at once (beforeinput, paste, composition, selectionchange).
- **Defense in depth:** `beforeinput` now `preventDefault`s `insert*`/`delete*` input types when the selection is unresolvable (after the IME composition bail) — in a fully controlled contentEditable, an un-prevented default edit is guaranteed permanent DOM/model divergence, while a dropped keystroke is recoverable.
- Dead `prev.tagName === 'FIGURE'` guard removed with a reachability comment (figures can't nest in list wrappers; root-adjacent figures are caught by the fast-path).

The `CommentComposer` remount workaround can be removed once this ships.

## Test plan
- New regression test `RichTextEditor.controlledReset.test.tsx` drives the exact issue repro un-mocked (type URL → chip → controlled reset → second URL) and pins the mechanism (defaultPrevented + onChange resumption). Failed before the fix, passes after.
- 6 new unit tests for container-level caret resolution in `selection.test.ts` (root next/prev branches, widget-corrected offsets, list-wrapper carets, empty root).
- Full gates green: package suite 3879 tests, typecheck, `make lint`, `npm run format:check`, tarball hygiene.
- Rule-8 adversarial review confirmed the root cause independently and drove a second hardening round (list-wrapper generalization); scoped re-review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk