### PR TITLE
feat: EntityChip — inline entity-link chip with status in its own color (#322)

### DIFF
--- a/docs/superpowers/plans/2026-07-25-entity-chip.md
+++ b/docs/superpowers/plans/2026-07-25-entity-chip.md
@@ -1,0 +1,141 @@
+# EntityChip — Implementation Plan (#322)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** New library component `<EntityChip>` — an inline-safe (span-only, valid inside `<p>`) entity-reference chip: icon + optional muted prefix (task key) + name + optional inline workflow status rendered in the status's OWN color; polymorphic (`a`/RouterLink/`button`/`span`); loading and unavailable states.
+
+**Architecture:** Span-only single component. Status colors reuse the exact model StatusMenu shipped in #320: `category` (6 workflow categories) → `PaletteColor` default, `color?: PaletteColor` override. The category→palette mapping moves from StatusMenu into `_internal/statusColor.ts` (shared vocabulary, no cross-component import — same precedent as `_internal/gridSpan.ts`); StatusMenu is refactored to consume it with ZERO public-API/behavior change. Status text color injected as an inline `var(--color-palette-<c>-fg)` custom property (Badge/Dot/StatusMenu precedent). Polymorphism follows the repo's constrained-`as` dispatch pattern (like `Text`), plus render-prop-free `as` component support for RouterLink (mirror how `Link` does polymorphic `as` — read it first and copy its approach exactly).
+
+**Tech Stack:** React 18, TypeScript, SCSS modules, palette infra, Vitest + RTL (globals — no describe/it/expect imports).
+
+## Global Constraints
+
+- Repo `/home/dpws/projects/design-system`, branch `feat/entity-chip` (already checked out).
+- NEW component → FULL core invariant: tests, playground demo + wiring (route/nav/index/schematics/registry), `src/index.ts` re-export, JSDoc `@remarks`, AGENTS.md TL;DR, manifest CLUSTERS in BOTH maps + `npm run build:manifest`.
+- Package Hard rules 1–9. Tokens-only SCSS (palette custom-property references inline are the sanctioned pattern). `:focus-visible` only. No layout props. i18n rule 9: no fixed English strings — the "…" loading glyph is punctuation (fine); everything else renders consumer-provided text; if ANY fixed string sneaks in (e.g. an aria-label), it goes through `useTranslation` with en+ru.
+- StatusMenu refactor must be behavior-neutral: its tests must pass unchanged.
+- Tests from inside the package; full gates from repo root. Commit per task; do NOT push.
+
+---
+
+### Task 1: Shared status color + EntityChip component (code + tests + exports)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/_internal/statusColor.ts`
+- Modify: `packages/design-system/src/components/StatusMenu/StatusMenu.tsx` (consume shared mapping; re-export `StatusMenuCategory` as alias of the shared type; NO public API change)
+- Create: `packages/design-system/src/components/EntityChip/EntityChip.tsx`
+- Create: `packages/design-system/src/components/EntityChip/EntityChip.module.scss`
+- Create: `packages/design-system/src/components/EntityChip/EntityChip.tokens.scss`
+- Create: `packages/design-system/src/components/EntityChip/EntityChip.test.tsx`
+- Create: `packages/design-system/src/components/EntityChip/index.ts`
+- Modify: `packages/design-system/src/index.ts`
+
+**Interfaces (public API — exact):**
+
+```ts
+// _internal/statusColor.ts
+/** Workflow status category — maps to a default palette color. Shared by StatusMenu and EntityChip. */
+export type StatusCategory = 'to_do' | 'in_progress' | 'open' | 'done' | 'won' | 'lost';
+export const STATUS_CATEGORY_COLOR: Record<StatusCategory, PaletteColor> = {
+  to_do: 'slate',
+  in_progress: 'blue',
+  open: 'violet',
+  done: 'green',
+  won: 'green',
+  lost: 'red',
+};
+/** `color` wins, then category default, then slate. */
+export function resolveStatusColor(s: {
+  category?: StatusCategory;
+  color?: PaletteColor;
+}): PaletteColor;
+
+// StatusMenu.tsx — keep the public name:
+export type StatusMenuCategory = StatusCategory; // JSDoc preserved
+
+// EntityChip.tsx
+/** Elements EntityChip can render as. All inline-safe phrasing content. */
+export type EntityChipAs = 'a' | 'span' | 'button' | ElementType; // read Link.tsx's polymorphic pattern and mirror it — if Link constrains differently, follow Link.
+
+export interface EntityChipStatus {
+  /** Status label, rendered inside the chip in the status's own color. */
+  label: string;
+  category?: StatusCategory;
+  /** Wins over `category` (per-state custom colors). */
+  color?: PaletteColor;
+}
+
+export interface EntityChipProps extends HTMLAttributes<HTMLElement> {
+  /** Leading icon — consumer passes the element (e.g. a lucide icon). Rendered aria-hidden. */
+  icon?: ReactNode;
+  /** Entity name. */
+  label: ReactNode;
+  /** Muted leading run before the name (e.g. task key `ENG-5`). */
+  prefix?: ReactNode;
+  /** Inline workflow status, shown as `· <label>` in the status's own color. */
+  status?: EntityChipStatus;
+  /** Renders `as="a"` with this href when `as` is omitted. */
+  href?: string;
+  /** Polymorphic element/component (RouterLink etc.). Default: `'a'` when `href` set, else `'span'`. */
+  as?: EntityChipAs;
+  /** Loading placeholder: icon slot + `…` body, aria-busy, non-interactive. */
+  loading?: boolean;
+  /** Entity missing/no access: muted, non-interactive (renders `as` forced to 'span'), aria-disabled. */
+  unavailable?: boolean;
+}
+```
+
+**Behavior spec:**
+
+- Element resolution: `unavailable || loading` → `'span'` (never a link/button); else `as ?? (href ? 'a' : 'span')`. When rendering `'a'`, pass `href`. When `'button'`, `type="button"` (rule 6).
+- Status run: `<span className={styles.status} style={{ '--entity-chip-status-fg': 'var(--color-palette-<c>-fg)' }}>` containing a separator `·` (aria-hidden, `styles.dot`) + the label. Color resolved via `resolveStatusColor`.
+- Prefix run: `<span className={styles.prefix}>` muted (`--entity-chip-prefix-fg: var(--color-fg-muted)` token).
+- Icon: wrapped in `<span className={styles.icon} aria-hidden="true">`.
+- Loading: replaces prefix/label/status body with `…` (`<span className={styles.ellipsis}>…</span>`), sets `aria-busy="true"`, keeps the icon slot if provided.
+- Unavailable: adds `styles.unavailable` (muted fg for the WHOLE chip incl. status run — unavailable overrides status color), `aria-disabled="true"`.
+- `forwardRef<HTMLElement>`; className merged; spread order Pattern A (props last, consumer wins) EXCEPT the ARIA state attrs (aria-busy/aria-disabled) which follow rule-7's Pattern B reasoning — put `{...rest}` before the component-owned ARIA attrs, with the required inline comment.
+- Everything is spans inside one root inline element — must be valid inside `<p>` (test asserts no div/block tags render).
+
+**SCSS spec:**
+
+- Tokens (`EntityChip.tokens.scss`): `--entity-chip-bg: var(--color-bg-muted)` (subtle neutral chip bg — check what Badge neutral uses and pick the closest primitive), `--entity-chip-fg: var(--color-fg)`, `--entity-chip-fg-hover`/link hover accent if Link has one, `--entity-chip-prefix-fg: var(--color-fg-muted)`, `--entity-chip-radius: var(--radius-sm)`, paddings/gap via space tokens, `--entity-chip-font-size: var(--font-size-sm)`, `--entity-chip-unavailable-fg: var(--color-fg-muted)`.
+- `.chip`: `display: inline-flex; align-items: center;` gap/padding/radius/bg/fg; `vertical-align: baseline` (inline flow). Interactive variants (`a`/`button` rendering): hover bg shift + `:focus-visible` ring (rule 3a). `<button>` UA resets (border/font/background) with stylelint disables as needed — mirror how an existing inline button-ish component resets.
+- `.status { color: var(--entity-chip-status-fg); }`; `.unavailable`, `.unavailable .status { color: var(--entity-chip-unavailable-fg); }` (specificity: make sure the unavailable override beats `.status` — nest or double-class as needed with a one-line comment).
+- No layout props (rule 4); `display: inline-flex` on own root is fine (intrinsic, not layout).
+
+**JSDoc:** full, 3+ examples (comment-text inline usage inside a `<p>` sentence; RouterLink via `as`; status + custom color; loading/unavailable), `@remarks When NOT to use` (plain status without entity → Badge/StatusMenu; standalone navigation → Link; removable filter chips → FilterChip) + `@remarks Anti-patterns` (❌ Badge-in-Badge composition this replaces; ❌ block children inside the chip — inline-safe contract; ❌ raw hex for status color — PaletteColor names).
+
+**Tests (rule 1 + behavior):** renders label; icon aria-hidden; prefix muted class; status run carries resolved `--entity-chip-status-fg` (category default + color override + slate fallback); `href` → `<a href>`; `as` component (dummy RouterLink fn component) receives props; `as="button"` gets type="button"; loading → aria-busy, `…` body, renders span not a; unavailable → span, aria-disabled, unavailable class; valid-inside-`<p>` (render inside a p, assert container.querySelector('div') is null); ref forwarded; className merged. StatusMenu suite still green (refactor neutrality).
+
+- [ ] **Step 1:** Read Link.tsx (polymorphic pattern), Badge.tsx, StatusMenu.tsx, FilterChip (inline chip SCSS patterns), one test file. Write failing tests.
+- [ ] **Step 2:** Confirm RED (module missing).
+- [ ] **Step 3:** Implement (incl. the `_internal/statusColor.ts` extraction + StatusMenu refactor).
+- [ ] **Step 4:** EntityChip + StatusMenu + full package suite pass; typecheck; root `make lint`.
+- [ ] **Step 5:** Commit — `feat(EntityChip): inline entity-link chip — icon + prefix + name + status in its own color (#322)`
+
+---
+
+### Task 2: Wiring (demo, nav, manifest, AGENTS.md) + gates
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/EntityChipDemo.tsx`
+- Modify: `packages/playground/src/App.tsx` (route `/components/entity-chip`), `packages/playground/src/layout/AppShell/navItems.ts` (**Display** group, distinct lucide icon), `ComponentsIndex.tsx` (grid entry) + `overviewSchematics.tsx` (`SCHEMATICS['EntityChip']`), `packages/playground/src/pages/mockups/registry.ts` (ComponentName union — required by DemoLayout typing)
+- Modify: `packages/design-system/src/_meta/manifest.ts` AND `scripts/generate-manifest.mjs` (CLUSTERS: `EntityChip: 'Display'`) + `npm run build:manifest`, commit regenerated output
+- Modify: `packages/design-system/AGENTS.md` (TL;DR section near Badge)
+
+**Demo sections:** (1) inline in flowing comment text inside a `<Text>` paragraph — icon + prefix + name + status, several chips mid-sentence; (2) statuses: categories vs custom `color` override; (3) polymorphic: href link, `as` custom component (fake RouterLink), button variant with onClick; (4) loading + unavailable side by side.
+
+- [ ] **Step 1:** Read wiring files; implement all.
+- [ ] **Step 2:** `npx prettier --write docs/superpowers/plans/2026-07-25-entity-chip.md`; include plan doc in commit.
+- [ ] **Step 3:** Full gates: `make test && make build-lib && make lint && npm run format:check && make build`; commit regenerated props.manifest.json if changed.
+- [ ] **Step 4:** Commit — `docs(EntityChip): playground demo + wiring + AGENTS.md TL;DR (#322)`
+
+---
+
+## Self-review notes
+
+- Raw hex status colors (issue mentions per-state hex in eocrm) are deliberately NOT accepted — `PaletteColor` only, same contract as StatusMenu #320; the consumer maps hex→palette on their side. Consistency beats flexibility here.
+- `StatusCategory` becomes the shared public name via EntityChip's exports; `StatusMenuCategory` stays as an alias — no breaking change.
+- No i18n keys expected (no fixed English strings); the rule-9 check still runs in review.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1759,6 +1759,34 @@ import { Divider } from '@eocrm/design-system';
 - **Non-interactive.** If it's clickable, use `<Button>` instead.
 - Doesn't auto-add `role="status"`. Wrap in `aria-live` if a state change should be announced.
 
+### `<EntityChip>` — inline entity-link chip
+
+```tsx
+// Inline, inside a sentence:
+<Text>
+  Reassigned <EntityChip icon={<User size={14} />} label="Priya Shah" /> to this deal.
+</Text>
+
+// href, prefix + status:
+<EntityChip
+  href="/tasks/5"
+  prefix="ENG-5"
+  label="Fix login bug"
+  status={{ label: 'In progress', category: 'in_progress' }}
+/>
+
+// RouterLink via `as`, or a status color override:
+import { Link as RouterLink } from 'react-router-dom';
+<EntityChip as={RouterLink} to="/deals/9" label="Acme Corp" status={{ label: 'At risk', color: 'amber' }} />
+```
+
+- Polymorphic inline chip: optional `icon` (rendered `aria-hidden`), optional muted `prefix` (e.g. a task key), the `label`, and an optional colored `status`. All inline `<span>`s inside one root — safe to drop directly inside a `<p>`/`<Text>`.
+- Renders `<a href>` when `href` is set, `<span>` (static, non-navigating) otherwise, or whatever `as` is passed (`RouterLink`, `'button'`, any component) — same polymorphic contract as `<Link>`.
+- `status`: `{ label, category?, color? }`. `category` (`to_do`/`in_progress`/`open`/`done`/`won`/`lost`) resolves a default palette color; `color` (a `PaletteColor`) overrides it — same category → color mapping as `<StatusMenu>`.
+- `loading`: swaps the body for an `aria-busy` ellipsis, non-interactive. `unavailable`: mutes the chip and forces a non-interactive `<span>` with `aria-disabled` — even with `href`/`as` set (entity deleted or no access).
+- **When NOT to use**: plain status with no linked entity → `<Badge>`/`<StatusMenu>`; standalone navigation with no icon/prefix/status chrome → `<Link>`; removable filter pills → `<FilterChip>`.
+- **Anti-pattern**: nesting a `<Badge>` inside another `<Badge>` to fake an entity-with-status chip — `EntityChip` replaces that composition. `status.color` is a `PaletteColor` name, never a raw hex string.
+
 ### `<StatusMenu>` — status-transition dropdown
 
 ```tsx

--- a/packages/design-system/scripts/generate-manifest.mjs
+++ b/packages/design-system/scripts/generate-manifest.mjs
@@ -74,6 +74,7 @@ const CLUSTERS = {
   MediaTile: 'Display',
   Badge: 'Display',
   Dot: 'Display',
+  EntityChip: 'Display',
   Timeline: 'Display',
   Thread: 'Display',
   BrandIcon: 'Display',

--- a/packages/design-system/src/_meta/manifest.ts
+++ b/packages/design-system/src/_meta/manifest.ts
@@ -96,6 +96,7 @@ const CLUSTERS: Record<string, string> = {
   MediaTile: 'Display',
   Badge: 'Display',
   Dot: 'Display',
+  EntityChip: 'Display',
   Timeline: 'Display',
   Thread: 'Display',
   BrandIcon: 'Display',

--- a/packages/design-system/src/components.manifest.json
+++ b/packages/design-system/src/components.manifest.json
@@ -270,6 +270,12 @@
       "DataTable"
     ]
   },
+  "EntityChip": {
+    "tier": "primitive",
+    "cluster": "Display",
+    "composes": [],
+    "composedBy": []
+  },
   "ErrorState": {
     "tier": "primitive",
     "cluster": "Display",

--- a/packages/design-system/src/components/EntityChip/EntityChip.module.scss
+++ b/packages/design-system/src/components/EntityChip/EntityChip.module.scss
@@ -27,8 +27,6 @@
 
     &:focus-visible {
       @include focus-ring;
-
-      outline: none;
     }
   }
 }

--- a/packages/design-system/src/components/EntityChip/EntityChip.module.scss
+++ b/packages/design-system/src/components/EntityChip/EntityChip.module.scss
@@ -1,0 +1,66 @@
+@use '../../styles/mixins' as *;
+@use './EntityChip.tokens';
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--entity-chip-gap);
+  padding: var(--entity-chip-padding-y) var(--entity-chip-padding-x);
+  border: none;
+  border-radius: var(--entity-chip-radius);
+  background: var(--entity-chip-bg);
+  color: var(--entity-chip-fg);
+  font: inherit;
+  font-size: var(--entity-chip-font-size);
+  text-decoration: none;
+  vertical-align: baseline;
+
+  // <a>/<button> renders are the interactive variants — everything else
+  // (a plain <span> or a blocked/unavailable chip) has no hover/focus chrome.
+  &:is(a, button) {
+    cursor: pointer;
+
+    &:hover {
+      background: var(--entity-chip-bg-hover);
+      color: var(--entity-chip-fg-hover);
+    }
+
+    &:focus-visible {
+      @include focus-ring;
+
+      outline: none;
+    }
+  }
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.prefix {
+  color: var(--entity-chip-prefix-fg);
+}
+
+.ellipsis {
+  color: var(--entity-chip-prefix-fg);
+}
+
+.status {
+  color: var(--entity-chip-status-fg);
+}
+
+.dot {
+  color: var(--entity-chip-prefix-fg);
+}
+
+// Specificity 0,2,0 (.unavailable .status) beats the plain .status rule
+// (0,1,0) so the unavailable muted color wins over any resolved status color.
+.unavailable {
+  color: var(--entity-chip-unavailable-fg);
+
+  .status,
+  .dot {
+    color: var(--entity-chip-unavailable-fg);
+  }
+}

--- a/packages/design-system/src/components/EntityChip/EntityChip.test.tsx
+++ b/packages/design-system/src/components/EntityChip/EntityChip.test.tsx
@@ -1,0 +1,136 @@
+import { createRef, type ComponentProps, type ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { EntityChip } from './EntityChip';
+
+// A stub component used to verify polymorphic `as` forwarding. Looks like
+// react-router-dom's <Link> — accepts `to`, optionally `replace`, etc.
+function StubRouterLink({
+  to,
+  replace,
+  children,
+  ...rest
+}: {
+  to: string;
+  replace?: boolean;
+  children?: ReactNode;
+} & ComponentProps<'a'>) {
+  return (
+    <a data-to={to} data-replace={replace ? 'true' : undefined} {...rest}>
+      {children}
+    </a>
+  );
+}
+
+describe('<EntityChip>', () => {
+  it('renders the label', () => {
+    render(<EntityChip label="ENG-5 Fix login bug" />);
+    expect(screen.getByText('ENG-5 Fix login bug')).toBeInTheDocument();
+  });
+
+  it('renders the icon aria-hidden', () => {
+    render(<EntityChip label="Task" icon={<svg data-testid="icon" />} />);
+    const icon = screen.getByTestId('icon');
+    expect(icon.parentElement).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders the prefix with the muted class', () => {
+    render(<EntityChip label="Fix login bug" prefix="ENG-5" />);
+    expect(screen.getByText('ENG-5').className).toMatch(/prefix/);
+  });
+
+  it('resolves the status color from category', () => {
+    render(<EntityChip label="Task" status={{ label: 'In progress', category: 'in_progress' }} />);
+    const status = screen.getByText('In progress').closest('span');
+    expect(status?.style.getPropertyValue('--entity-chip-status-fg')).toBe(
+      'var(--color-palette-blue-fg)',
+    );
+  });
+
+  it('an explicit status color wins over category', () => {
+    render(
+      <EntityChip
+        label="Task"
+        status={{ label: 'Blocked', category: 'in_progress', color: 'red' }}
+      />,
+    );
+    const status = screen.getByText('Blocked').closest('span');
+    expect(status?.style.getPropertyValue('--entity-chip-status-fg')).toBe(
+      'var(--color-palette-red-fg)',
+    );
+  });
+
+  it('falls back to slate with no category and no color', () => {
+    render(<EntityChip label="Task" status={{ label: 'Mystery' }} />);
+    const status = screen.getByText('Mystery').closest('span');
+    expect(status?.style.getPropertyValue('--entity-chip-status-fg')).toBe(
+      'var(--color-palette-slate-fg)',
+    );
+  });
+
+  it('renders as <a> with href when href is set', () => {
+    render(<EntityChip label="Contact" href="/contacts/1" />);
+    expect(screen.getByText('Contact').closest('a')).toHaveAttribute('href', '/contacts/1');
+  });
+
+  it('renders as <span> by default when no href is set', () => {
+    render(<EntityChip label="Contact" />);
+    expect(screen.getByText('Contact').closest('span')?.tagName).toBe('SPAN');
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders the element passed via `as`, forwarding extra props', () => {
+    render(
+      <EntityChip label="Contacts" as={StubRouterLink} to="/contacts">
+        {/* label prop still drives content */}
+      </EntityChip>,
+    );
+    expect(screen.getByText('Contacts')).toHaveAttribute('data-to', '/contacts');
+  });
+
+  it('as="button" gets type="button"', () => {
+    render(<EntityChip label="Pick" as="button" onClick={() => {}} />);
+    expect(screen.getByRole('button', { name: /Pick/ })).toHaveAttribute('type', 'button');
+  });
+
+  it('loading renders aria-busy, an ellipsis body, and a span (never a link)', () => {
+    render(<EntityChip label="Contact" href="/contacts/1" loading />);
+    expect(screen.getByText('…')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.queryByText('Contact')).not.toBeInTheDocument();
+    const root = screen.getByText('…').closest('span[aria-busy]');
+    expect(root).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('unavailable renders a span, aria-disabled, and the unavailable class', () => {
+    render(<EntityChip label="Contact" href="/contacts/1" unavailable />);
+    const chip = screen.getByText('Contact').closest('span[aria-disabled]');
+    expect(chip).toHaveAttribute('aria-disabled', 'true');
+    expect(chip?.className).toMatch(/unavailable/);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('is valid inline content — no div/block tags render', () => {
+    const { container } = render(
+      <p>
+        <EntityChip
+          label="Contact"
+          prefix="ENG-5"
+          icon={<svg />}
+          status={{ label: 'Done', category: 'done' }}
+        />
+      </p>,
+    );
+    expect(container.querySelector('div')).toBeNull();
+  });
+
+  it('forwards ref to the underlying element', () => {
+    const ref = createRef<HTMLAnchorElement>();
+    render(<EntityChip label="Contact" href="/x" ref={ref} />);
+    expect(ref.current?.tagName).toBe('A');
+  });
+
+  it('merges className with the internal chip class', () => {
+    render(<EntityChip label="Contact" className="external" />);
+    expect(screen.getByText('Contact').closest('span')?.className).toMatch(/external/);
+  });
+});

--- a/packages/design-system/src/components/EntityChip/EntityChip.test.tsx
+++ b/packages/design-system/src/components/EntityChip/EntityChip.test.tsx
@@ -1,5 +1,6 @@
 import { createRef, type ComponentProps, type ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { EntityChip } from './EntityChip';
 
 // A stub component used to verify polymorphic `as` forwarding. Looks like
@@ -107,6 +108,20 @@ describe('<EntityChip>', () => {
     expect(chip).toHaveAttribute('aria-disabled', 'true');
     expect(chip?.className).toMatch(/unavailable/);
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('loading keeps the icon slot', () => {
+    render(<EntityChip label="Task" icon={<svg data-testid="icon" />} loading />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('unavailable neuters a consumer onClick — forced span, no click handler', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<EntityChip label="Pick" as="button" onClick={onClick} unavailable />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    await user.click(screen.getByText('Pick'));
+    expect(onClick).not.toHaveBeenCalled();
   });
 
   it('is valid inline content — no div/block tags render', () => {

--- a/packages/design-system/src/components/EntityChip/EntityChip.tokens.scss
+++ b/packages/design-system/src/components/EntityChip/EntityChip.tokens.scss
@@ -1,0 +1,16 @@
+// EntityChip.tokens.scss — Component-scoped tokens for <EntityChip>. Subtle
+// neutral chip chrome (mirrors Badge's neutral fill primitive) + a muted
+// prefix run + an unavailable-state override.
+:root {
+  --entity-chip-bg: var(--color-bg-muted);
+  --entity-chip-bg-hover: var(--color-bg-sunken);
+  --entity-chip-fg: var(--color-fg);
+  --entity-chip-fg-hover: var(--color-accent-hover);
+  --entity-chip-prefix-fg: var(--color-fg-muted);
+  --entity-chip-radius: var(--radius-sm);
+  --entity-chip-gap: var(--space-1);
+  --entity-chip-padding-y: var(--space-05);
+  --entity-chip-padding-x: var(--space-2);
+  --entity-chip-font-size: var(--font-size-sm);
+  --entity-chip-unavailable-fg: var(--color-fg-muted);
+}

--- a/packages/design-system/src/components/EntityChip/EntityChip.tsx
+++ b/packages/design-system/src/components/EntityChip/EntityChip.tsx
@@ -1,0 +1,183 @@
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ComponentPropsWithRef,
+  type CSSProperties,
+  type ElementType,
+  type ForwardedRef,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+import { paletteTokens, type PaletteColor } from '../../palette';
+import { resolveStatusColor, type StatusCategory } from '../_internal/statusColor';
+import styles from './EntityChip.module.scss';
+
+/** Elements EntityChip can render as. All inline-safe phrasing content. */
+export type EntityChipAs = ElementType;
+
+export interface EntityChipStatus {
+  /** Status label, rendered inside the chip in the status's own color. */
+  label: string;
+  /** Semantic category → default color: to_do slate / in_progress blue / open violet / done green / won green / lost red. */
+  category?: StatusCategory;
+  /** Explicit palette color — wins over `category` (per-state custom colors). */
+  color?: PaletteColor;
+}
+
+interface EntityChipOwnProps {
+  /** Leading icon — consumer passes the element (e.g. a lucide icon). Rendered aria-hidden. */
+  icon?: ReactNode;
+  /**
+   * Entity name. Optional at the type level only to satisfy the polymorphic
+   * `forwardRef` generic (same workaround `<Rail.Item>` documents on its
+   * `children`); in practice every chip needs a label.
+   */
+  label?: ReactNode;
+  /** Muted leading run before the name (e.g. task key `ENG-5`). */
+  prefix?: ReactNode;
+  /** Inline workflow status, shown as `· <label>` in the status's own color. */
+  status?: EntityChipStatus;
+  /** Renders `as="a"` with this href when `as` is omitted. */
+  href?: string;
+  /** Loading placeholder: icon slot + `…` body, aria-busy, non-interactive. */
+  loading?: boolean;
+  /** Entity missing/no access: muted, non-interactive (renders `as` forced to 'span'), aria-disabled. */
+  unavailable?: boolean;
+}
+
+/**
+ * Polymorphic props helper. Intersects the component's own props with the
+ * underlying element's props (minus what we own), plus the `as` selector.
+ * Mirrors `<Link>`'s `PolymorphicProps`.
+ */
+type PolymorphicProps<C extends ElementType, P> = P & { as?: C } & Omit<
+    ComponentPropsWithoutRef<C>,
+    keyof P | 'as'
+  >;
+
+/**
+ * Public EntityChip prop type. Generic `C` defaults to `'a'`. When the
+ * consumer passes `as={SomeComponent}`, all of SomeComponent's props become
+ * available with full TypeScript inference (including `to`, `replace`,
+ * `state`, etc. for `react-router-dom`'s `<Link>`).
+ */
+export type EntityChipProps<C extends ElementType = 'a'> = PolymorphicProps<C, EntityChipOwnProps>;
+
+/**
+ * Internal ref type for the polymorphic generic. React's `forwardRef` strips
+ * the generic from the returned component, so we re-attach it via the
+ * `EntityChipComponent` cast on the export below.
+ */
+type EntityChipComponent = <C extends ElementType = 'a'>(
+  props: EntityChipProps<C> & { ref?: ComponentPropsWithRef<C>['ref'] },
+) => ReactElement | null;
+
+/** Injectable custom-property for a status's resolved color. */
+function statusColorStyle(status: EntityChipStatus): CSSProperties {
+  const { fg } = paletteTokens(resolveStatusColor(status));
+  return { '--entity-chip-status-fg': fg } as CSSProperties;
+}
+
+/**
+ * Inline entity-link chip: an optional icon, an optional muted prefix (e.g.
+ * a task key), the entity's name, and an optional workflow status shown in
+ * its own color — all spans inside a single inline root, safe to drop
+ * directly inside a `<p>`. Renders `<a>` when `href` is set, `<span>` for a
+ * static (non-navigating) chip, or whatever `as` is passed for router-aware
+ * navigation.
+ *
+ * @example
+ * // Inline usage inside a sentence
+ * <p>Reassigned <EntityChip icon={<UserIcon />} label="Priya Shah" /> to this deal.</p>
+ *
+ * @example
+ * // RouterLink via `as`
+ * import { Link as RouterLink } from 'react-router-dom';
+ * <EntityChip as={RouterLink} to="/tasks/5" prefix="ENG-5" label="Fix login bug" />
+ *
+ * @example
+ * // Status + custom color override
+ * <EntityChip
+ *   href="/deals/9"
+ *   label="Acme Corp"
+ *   status={{ label: 'At risk', color: 'amber' }}
+ * />
+ *
+ * @example
+ * // Loading / unavailable states
+ * <EntityChip label="Contact" loading />
+ * <EntityChip label="Deleted contact" unavailable />
+ *
+ * @remarks When NOT to use
+ * - Plain status display with no linked entity → use `<Badge>` or `<StatusMenu>`.
+ * - Standalone navigation with no entity chrome (icon/prefix/status) → use `<Link>`.
+ * - Removable filter pills → use `<FilterChip>`.
+ *
+ * @remarks Anti-patterns
+ * - ❌ Composing a `<Badge>` inside another `<Badge>` to fake an entity-with-status
+ *   chip — that composition is exactly what `EntityChip` replaces.
+ * - ❌ Putting block-level children (e.g. a `<div>`) inside `label`/`prefix` —
+ *   the inline-safety contract requires span-only content.
+ * - ❌ Raw hex strings in `status.color`. It's a `PaletteColor` name
+ *   (`'amber'`, `'violet'`, …), not a CSS color value.
+ */
+export const EntityChip = forwardRef(function EntityChip<C extends ElementType = 'a'>(
+  {
+    as,
+    icon,
+    label,
+    prefix,
+    status,
+    href,
+    loading = false,
+    unavailable = false,
+    className,
+    style,
+    ...rest
+  }: EntityChipProps<C>,
+  ref: ForwardedRef<Element>,
+) {
+  // unavailable/loading force a non-interactive span — never a link/button.
+  const blocked = unavailable || loading;
+  const Component = (blocked ? 'span' : (as ?? (href ? 'a' : 'span'))) as ElementType;
+  const elementProps: { href?: string; type?: string } = {};
+  if (!blocked && Component === 'a') elementProps.href = href;
+  if (Component === 'button') elementProps.type = 'button';
+
+  return (
+    <Component
+      ref={ref}
+      style={style}
+      className={clsx(styles.chip, unavailable && styles.unavailable, className)}
+      {...elementProps}
+      {...rest}
+      // Component-owned ARIA state must survive whatever the consumer passes
+      // via {...rest} — aria-busy/aria-disabled are the component's contract.
+      aria-busy={loading || undefined}
+      aria-disabled={unavailable || undefined}
+    >
+      {icon && (
+        <span className={styles.icon} aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      {loading ? (
+        <span className={styles.ellipsis}>…</span>
+      ) : (
+        <>
+          {prefix && <span className={styles.prefix}>{prefix}</span>}
+          {label}
+          {status && (
+            <span className={styles.status} style={statusColorStyle(status)}>
+              <span className={styles.dot} aria-hidden="true">
+                ·
+              </span>
+              {status.label}
+            </span>
+          )}
+        </>
+      )}
+    </Component>
+  );
+}) as EntityChipComponent;

--- a/packages/design-system/src/components/EntityChip/EntityChip.tsx
+++ b/packages/design-system/src/components/EntityChip/EntityChip.tsx
@@ -40,9 +40,19 @@ interface EntityChipOwnProps {
   status?: EntityChipStatus;
   /** Renders `as="a"` with this href when `as` is omitted. */
   href?: string;
-  /** Loading placeholder: icon slot + `…` body, aria-busy, non-interactive. */
+  /**
+   * Loading placeholder: icon slot + `…` body, aria-busy, non-interactive.
+   * The `as` component is still forced to a plain `<span>` — any of its
+   * other props (e.g. a RouterLink's `to`/`replace`) still spread onto that
+   * span and may leave junk DOM attributes; pass them conditionally if that
+   * matters.
+   */
   loading?: boolean;
-  /** Entity missing/no access: muted, non-interactive (renders `as` forced to 'span'), aria-disabled. */
+  /**
+   * Entity missing/no access: muted, non-interactive (renders `as` forced to
+   * 'span'), aria-disabled. Same caveat as `loading` — the `as` component's
+   * other props still spread onto the forced span.
+   */
   unavailable?: boolean;
 }
 
@@ -152,6 +162,10 @@ export const EntityChip = forwardRef(function EntityChip<C extends ElementType =
       className={clsx(styles.chip, unavailable && styles.unavailable, className)}
       {...elementProps}
       {...rest}
+      // blocked (loading/unavailable) forces a non-interactive <span> — cancel
+      // any consumer onClick that {...rest} just spread on above, so it can't
+      // fire through a chip keyboard users have no way to reach (Pattern B).
+      {...(blocked ? { onClick: undefined } : null)}
       // Component-owned ARIA state must survive whatever the consumer passes
       // via {...rest} — aria-busy/aria-disabled are the component's contract.
       aria-busy={loading || undefined}

--- a/packages/design-system/src/components/EntityChip/index.ts
+++ b/packages/design-system/src/components/EntityChip/index.ts
@@ -1,0 +1,2 @@
+export { EntityChip } from './EntityChip';
+export type { EntityChipProps, EntityChipAs, EntityChipStatus } from './EntityChip';

--- a/packages/design-system/src/components/EntityChip/index.ts
+++ b/packages/design-system/src/components/EntityChip/index.ts
@@ -1,2 +1,3 @@
 export { EntityChip } from './EntityChip';
 export type { EntityChipProps, EntityChipAs, EntityChipStatus } from './EntityChip';
+export type { StatusCategory } from '../_internal/statusColor';

--- a/packages/design-system/src/components/StatusMenu/StatusMenu.tsx
+++ b/packages/design-system/src/components/StatusMenu/StatusMenu.tsx
@@ -3,10 +3,11 @@ import clsx from 'clsx';
 import { DropdownMenu } from '../DropdownMenu';
 import { paletteTokens, type PaletteColor } from '../../palette';
 import { useTranslation } from '../../i18n/useTranslation';
+import { resolveStatusColor, type StatusCategory } from '../_internal/statusColor';
 import styles from './StatusMenu.module.scss';
 
 /** Workflow status category — maps to a default palette color. */
-export type StatusMenuCategory = 'to_do' | 'in_progress' | 'open' | 'done' | 'won' | 'lost';
+export type StatusMenuCategory = StatusCategory;
 
 /** One status: current value or a transition target. */
 export interface StatusMenuStatus {
@@ -37,23 +38,9 @@ export interface StatusMenuProps extends Omit<HTMLAttributes<HTMLElement>, 'onSe
   busy?: boolean;
 }
 
-const CATEGORY_COLOR: Record<StatusMenuCategory, PaletteColor> = {
-  to_do: 'slate',
-  in_progress: 'blue',
-  open: 'violet',
-  done: 'green',
-  won: 'green',
-  lost: 'red',
-};
-
-/** `color` wins; otherwise fall back to the category's default; otherwise slate. */
-function resolveColor(status: StatusMenuStatus): PaletteColor {
-  return status.color ?? (status.category && CATEGORY_COLOR[status.category]) ?? 'slate';
-}
-
 /** Injectable custom-property pair for a status's resolved color. */
 function statusColorStyle(status: StatusMenuStatus): CSSProperties {
-  const { bg, fg } = paletteTokens(resolveColor(status));
+  const { bg, fg } = paletteTokens(resolveStatusColor(status));
   return { '--status-menu-bg': bg, '--status-menu-fg': fg } as CSSProperties;
 }
 

--- a/packages/design-system/src/components/_internal/statusColor.test.ts
+++ b/packages/design-system/src/components/_internal/statusColor.test.ts
@@ -1,0 +1,26 @@
+import { STATUS_CATEGORY_COLOR, resolveStatusColor } from './statusColor';
+
+describe('_internal/statusColor', () => {
+  it('maps every category to its documented default color', () => {
+    expect(STATUS_CATEGORY_COLOR).toEqual({
+      to_do: 'slate',
+      in_progress: 'blue',
+      open: 'violet',
+      done: 'green',
+      won: 'green',
+      lost: 'red',
+    });
+  });
+
+  it('resolves the category default when no color is set', () => {
+    expect(resolveStatusColor({ category: 'in_progress' })).toBe('blue');
+  });
+
+  it('an explicit color wins over category', () => {
+    expect(resolveStatusColor({ category: 'in_progress', color: 'purple' })).toBe('purple');
+  });
+
+  it('falls back to slate with no category and no color', () => {
+    expect(resolveStatusColor({})).toBe('slate');
+  });
+});

--- a/packages/design-system/src/components/_internal/statusColor.ts
+++ b/packages/design-system/src/components/_internal/statusColor.ts
@@ -1,0 +1,26 @@
+import { type PaletteColor } from '../../palette';
+
+/**
+ * Workflow status category — maps to a default palette color. Shared by
+ * `StatusMenu` and `EntityChip` so both resolve the same category → color
+ * mapping.
+ */
+export type StatusCategory = 'to_do' | 'in_progress' | 'open' | 'done' | 'won' | 'lost';
+
+/** Category → default palette color: to_do slate / in_progress blue / open violet / done green / won green / lost red. */
+export const STATUS_CATEGORY_COLOR: Record<StatusCategory, PaletteColor> = {
+  to_do: 'slate',
+  in_progress: 'blue',
+  open: 'violet',
+  done: 'green',
+  won: 'green',
+  lost: 'red',
+};
+
+/** `color` wins; otherwise fall back to the category's default; otherwise slate. */
+export function resolveStatusColor(status: {
+  category?: StatusCategory;
+  color?: PaletteColor;
+}): PaletteColor {
+  return status.color ?? (status.category && STATUS_CATEGORY_COLOR[status.category]) ?? 'slate';
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -117,6 +117,9 @@ export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot, BadgeVariant } from '.
 export { Dot } from './components/Dot';
 export type { DotProps } from './components/Dot';
 
+export { EntityChip } from './components/EntityChip';
+export type { EntityChipProps, EntityChipAs, EntityChipStatus } from './components/EntityChip';
+
 export { StatusMenu } from './components/StatusMenu';
 export type {
   StatusMenuProps,

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -118,7 +118,12 @@ export { Dot } from './components/Dot';
 export type { DotProps } from './components/Dot';
 
 export { EntityChip } from './components/EntityChip';
-export type { EntityChipProps, EntityChipAs, EntityChipStatus } from './components/EntityChip';
+export type {
+  EntityChipProps,
+  EntityChipAs,
+  EntityChipStatus,
+  StatusCategory,
+} from './components/EntityChip';
 
 export { StatusMenu } from './components/StatusMenu';
 export type {

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -65,6 +65,7 @@ import { StackDemo } from './pages/components/StackDemo';
 import { ClusterDemo } from './pages/components/ClusterDemo';
 import { AvatarDemo } from './pages/components/AvatarDemo';
 import { BadgeDemo } from './pages/components/BadgeDemo';
+import { EntityChipDemo } from './pages/components/EntityChipDemo';
 import { DotDemo } from './pages/components/DotDemo';
 import { BrandIconDemo } from './pages/components/BrandIconDemo';
 import { LogoDemo } from './pages/components/LogoDemo';
@@ -187,6 +188,7 @@ export default function App() {
             <Route path="/components/cluster" element={<ClusterDemo />} />
             <Route path="/components/avatar" element={<AvatarDemo />} />
             <Route path="/components/badge" element={<BadgeDemo />} />
+            <Route path="/components/entity-chip" element={<EntityChipDemo />} />
             <Route path="/components/dot" element={<DotDemo />} />
             <Route path="/components/brand-icon" element={<BrandIconDemo />} />
             <Route path="/components/logo" element={<LogoDemo />} />

--- a/packages/playground/src/layout/AppShell/navItems.ts
+++ b/packages/playground/src/layout/AppShell/navItems.ts
@@ -24,6 +24,7 @@ import {
   CircleUser,
   Circle,
   Tag,
+  IdCard,
   PanelTop,
   PanelsTopLeft,
   List,
@@ -206,6 +207,7 @@ export const componentGroups: { heading: string; items: NavItem[] }[] = [
     items: [
       { to: '/components/avatar', label: 'Avatar', icon: CircleUser, end: false },
       { to: '/components/badge', label: 'Badge', icon: Tag, end: false },
+      { to: '/components/entity-chip', label: 'EntityChip', icon: IdCard, end: false },
       { to: '/components/dot', label: 'Dot', icon: Circle, end: false },
       { to: '/components/brand-icon', label: 'BrandIcon', icon: Fingerprint, end: false },
       { to: '/components/logo', label: 'Logo', icon: Hexagon, end: false },

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -1572,14 +1572,14 @@
           "type": "boolean",
           "required": false,
           "default": "",
-          "description": "Loading placeholder: icon slot + `…` body, aria-busy, non-interactive."
+          "description": "Loading placeholder: icon slot + `…` body, aria-busy, non-interactive.\nThe `as` component is still forced to a plain `<span>` — any of its\nother props (e.g. a RouterLink's `to`/`replace`) still spread onto that\nspan and may leave junk DOM attributes; pass them conditionally if that\nmatters."
         },
         {
           "name": "unavailable",
           "type": "boolean",
           "required": false,
           "default": "",
-          "description": "Entity missing/no access: muted, non-interactive (renders `as` forced to 'span'), aria-disabled."
+          "description": "Entity missing/no access: muted, non-interactive (renders `as` forced to\n'span'), aria-disabled. Same caveat as `loading` — the `as` component's\nother props still spread onto the forced span."
         },
         {
           "name": "as",

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -1530,6 +1530,66 @@
         }
       ]
     },
+    "EntityChip": {
+      "props": [
+        {
+          "name": "icon",
+          "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+          "required": false,
+          "default": "",
+          "description": "Leading icon — consumer passes the element (e.g. a lucide icon). Rendered aria-hidden."
+        },
+        {
+          "name": "label",
+          "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+          "required": false,
+          "default": "",
+          "description": "Entity name. Optional at the type level only to satisfy the polymorphic\n`forwardRef` generic (same workaround `<Rail.Item>` documents on its\n`children`); in practice every chip needs a label."
+        },
+        {
+          "name": "prefix",
+          "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
+          "required": false,
+          "default": "",
+          "description": "Muted leading run before the name (e.g. task key `ENG-5`)."
+        },
+        {
+          "name": "status",
+          "type": "EntityChipStatus",
+          "required": false,
+          "default": "",
+          "description": "Inline workflow status, shown as `· <label>` in the status's own color."
+        },
+        {
+          "name": "href",
+          "type": "string",
+          "required": false,
+          "default": "",
+          "description": "Renders `as=\"a\"` with this href when `as` is omitted."
+        },
+        {
+          "name": "loading",
+          "type": "boolean",
+          "required": false,
+          "default": "",
+          "description": "Loading placeholder: icon slot + `…` body, aria-busy, non-interactive."
+        },
+        {
+          "name": "unavailable",
+          "type": "boolean",
+          "required": false,
+          "default": "",
+          "description": "Entity missing/no access: muted, non-interactive (renders `as` forced to 'span'), aria-disabled."
+        },
+        {
+          "name": "as",
+          "type": "C",
+          "required": false,
+          "default": "",
+          "description": ""
+        }
+      ]
+    },
     "ErrorState": {
       "props": [
         {
@@ -4745,7 +4805,7 @@
     "GridGap": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\" | \"2xl\"",
     "GridAlignItems": "\"start\" | \"end\" | \"center\" | \"stretch\"",
     "GridJustifyItems": "\"start\" | \"end\" | \"center\" | \"stretch\"",
-    "GridAs": "\"div\" | \"section\" | \"aside\" | \"article\" | \"main\" | \"ul\" | \"ol\" | \"nav\" | \"header\" | \"footer\"",
+    "GridAs": "\"div\" | \"section\" | \"aside\" | \"article\" | \"footer\" | \"header\" | \"main\" | \"nav\" | \"ol\" | \"ul\"",
     "SplitSide": "\"start\" | \"end\"",
     "SplitGap": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\" | \"2xl\"",
     "SplitAlign": "\"start\" | \"center\" | \"stretch\"",
@@ -4761,7 +4821,8 @@
     "BadgeSize": "\"sm\" | \"md\"",
     "BadgeDot": "\"start\" | \"end\"",
     "BadgeVariant": "\"filled\" | \"stripe\"",
-    "StatusMenuStatus": "{ id: string | number; name: string; category?: StatusMenuCategory; color?: PaletteColor }",
+    "EntityChipStatus": "{ label: string; category?: StatusCategory; color?: PaletteColor }",
+    "StatusMenuStatus": "{ id: string | number; name: string; category?: StatusCategory; color?: PaletteColor }",
     "ThreadNodeAlign": "\"top\" | \"header\"",
     "LogoSize": "\"sm\" | \"md\" | \"lg\"",
     "LogoTextPlacement": "\"end\" | \"bottom\"",
@@ -4778,7 +4839,7 @@
     "ErrorStateTone": "\"neutral\" | \"danger\"",
     "ErrorStateHeadingLevel": "1 | 2 | 3 | 4 | 5 | 6",
     "IconTileSize": "\"sm\" | \"md\" | \"lg\"",
-    "IconTileShape": "\"square\" | \"circle\"",
+    "IconTileShape": "\"circle\" | \"square\"",
     "TooltipSide": "\"left\" | \"right\" | \"top\" | \"bottom\"",
     "TooltipAlign": "\"start\" | \"end\" | \"center\"",
     "ConfirmationVariant": "\"danger\" | \"default\"",

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -371,6 +371,13 @@ const items: { to: string; name: string; description: string; preview: React.Rea
     preview: SCHEMATICS['Badge'],
   },
   {
+    to: '/components/entity-chip',
+    name: 'EntityChip',
+    description:
+      'Inline entity-link chip — icon + muted prefix + name + colored status, safe inside a sentence. Polymorphic: <a>, <span>, <button>, or a custom `as`.',
+    preview: SCHEMATICS['EntityChip'],
+  },
+  {
     to: '/components/dot',
     name: 'Dot',
     description: 'Bare palette/tone colored circle for color-coding affordances.',

--- a/packages/playground/src/pages/components/EntityChipDemo.tsx
+++ b/packages/playground/src/pages/components/EntityChipDemo.tsx
@@ -1,0 +1,177 @@
+import type { ReactNode } from 'react';
+import { Building2, CheckSquare, User } from 'lucide-react';
+import { Cluster, EntityChip, Text } from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import { InputExample } from './InputExample';
+import { getComponentFiles } from '../../lib/componentFiles';
+
+// Looks like react-router-dom's <Link> — accepts `to`, renders an <a>. Stands
+// in for a real router Link to show `as` accepts ANY component, not just
+// react-router's (see <LinkDemo> for the real-RouterLink integration).
+function FakeRouterLink({ to, children, ...rest }: { to: string; children?: ReactNode }) {
+  return (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  );
+}
+
+export function EntityChipDemo() {
+  return (
+    <DemoLayout
+      name="EntityChip"
+      componentName="EntityChip"
+      description="Inline entity-link chip — icon + muted prefix + name + colored status, all inside a single inline root safe to drop into a sentence. Renders <a>/<span>/whatever `as` is passed."
+      files={getComponentFiles('EntityChip')}
+    >
+      <Example
+        title="Inline in flowing text"
+        description="The chip is inline-safe — drop it mid-sentence inside a <Text> paragraph exactly like a name or a link."
+        code={`import { Building2, CheckSquare, User } from 'lucide-react';
+import { EntityChip, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Text>
+      Reassigned{' '}
+      <EntityChip icon={<User size={14} />} label="Priya Shah" /> to{' '}
+      <EntityChip
+        icon={<Building2 size={14} />}
+        prefix="ACME-204"
+        label="Acme Corp"
+        status={{ label: 'Open', category: 'open' }}
+      />
+      , blocked on{' '}
+      <EntityChip
+        icon={<CheckSquare size={14} />}
+        prefix="ENG-5"
+        label="Fix login bug"
+        status={{ label: 'In progress', category: 'in_progress' }}
+      />
+      .
+    </Text>
+  );
+}`}
+      >
+        <Text>
+          Reassigned <EntityChip icon={<User size={14} />} label="Priya Shah" /> to{' '}
+          <EntityChip
+            icon={<Building2 size={14} />}
+            prefix="ACME-204"
+            label="Acme Corp"
+            status={{ label: 'Open', category: 'open' }}
+          />
+          , blocked on{' '}
+          <EntityChip
+            icon={<CheckSquare size={14} />}
+            prefix="ENG-5"
+            label="Fix login bug"
+            status={{ label: 'In progress', category: 'in_progress' }}
+          />
+          .
+        </Text>
+      </Example>
+
+      <Example
+        title="Status: categories vs custom color"
+        description="`status.category` (to_do/in_progress/open/done/won/lost) resolves a default palette color. `status.color` is an explicit PaletteColor override — it wins over category, same contract as StatusMenu."
+        code={`import { EntityChip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <>
+      <EntityChip prefix="ENG-5" label="Fix login bug" status={{ label: 'To do', category: 'to_do' }} />
+      <EntityChip prefix="ENG-6" label="Add pagination" status={{ label: 'In progress', category: 'in_progress' }} />
+      <EntityChip prefix="ACME-1" label="Acme Corp" status={{ label: 'Won', category: 'won' }} />
+      <EntityChip prefix="ACME-2" label="Globex" status={{ label: 'Lost', category: 'lost' }} />
+      {/* color overrides the category's default green */}
+      <EntityChip prefix="ACME-3" label="Initech" status={{ label: 'At risk', category: 'won', color: 'amber' }} />
+    </>
+  );
+}`}
+      >
+        <InputExample width="auto">
+          <Cluster gap="sm">
+            <EntityChip
+              prefix="ENG-5"
+              label="Fix login bug"
+              status={{ label: 'To do', category: 'to_do' }}
+            />
+            <EntityChip
+              prefix="ENG-6"
+              label="Add pagination"
+              status={{ label: 'In progress', category: 'in_progress' }}
+            />
+            <EntityChip
+              prefix="ACME-1"
+              label="Acme Corp"
+              status={{ label: 'Won', category: 'won' }}
+            />
+            <EntityChip
+              prefix="ACME-2"
+              label="Globex"
+              status={{ label: 'Lost', category: 'lost' }}
+            />
+            <EntityChip
+              prefix="ACME-3"
+              label="Initech"
+              status={{ label: 'At risk', category: 'won', color: 'amber' }}
+            />
+          </Cluster>
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Polymorphic: link, custom `as`, button"
+        description="No `as` + href renders <a>. `as={RouterLink-like}` forwards router props (to, replace, ...) with full type inference. `as` set to 'button' + onClick makes the chip an action."
+        code={`import { EntityChip } from '@eocrm/design-system';
+
+// Stands in for react-router-dom's <Link> — \`as\` accepts any component.
+function FakeRouterLink({ to, children, ...rest }) {
+  return <a href={to} {...rest}>{children}</a>;
+}
+
+export function Demo() {
+  return (
+    <>
+      <EntityChip href="/contacts/1" label="Priya Shah" />
+      <EntityChip as={FakeRouterLink} to="/tasks/5" prefix="ENG-5" label="Fix login bug" />
+      <EntityChip as="button" label="Assign to me" onClick={() => alert('Assigned')} />
+    </>
+  );
+}`}
+      >
+        <InputExample width="auto">
+          <Cluster gap="sm">
+            <EntityChip href="/contacts/1" label="Priya Shah" />
+            <EntityChip as={FakeRouterLink} to="/tasks/5" prefix="ENG-5" label="Fix login bug" />
+            <EntityChip as="button" label="Assign to me" onClick={() => alert('Assigned')} />
+          </Cluster>
+        </InputExample>
+      </Example>
+
+      <Example
+        title="Loading and unavailable"
+        description="`loading` swaps the body for an aria-busy ellipsis. `unavailable` mutes the chip and forces a non-interactive <span> (aria-disabled) — even with an href."
+        code={`import { EntityChip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <>
+      <EntityChip label="Contact" loading />
+      <EntityChip href="/contacts/9" label="Deleted contact" unavailable />
+    </>
+  );
+}`}
+      >
+        <InputExample width="auto">
+          <Cluster gap="sm">
+            <EntityChip label="Contact" loading />
+            <EntityChip href="/contacts/9" label="Deleted contact" unavailable />
+          </Cluster>
+        </InputExample>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/components/overviewSchematics.tsx
+++ b/packages/playground/src/pages/components/overviewSchematics.tsx
@@ -763,6 +763,19 @@ export const SCHEMATICS: Record<string, ReactNode> = {
       </Panel>
     </Col>
   ),
+  EntityChip: (
+    <Outline
+      w={168}
+      h={26}
+      style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '0 10px', borderRadius: 6 }}
+    >
+      <Dot solid size={9} />
+      <Bar w={20} style={{ height: 4 }} />
+      <Bar w={44} />
+      <Dot size={6} />
+      <Bar w={30} style={{ height: 4 }} />
+    </Outline>
+  ),
   Skeleton: (
     <Row gap={8} style={{ alignItems: 'flex-start' }}>
       <Dot size={26} />

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -30,6 +30,7 @@ export type ComponentName =
   | 'DropdownMenu'
   | 'EmojiPicker'
   | 'EmptyState'
+  | 'EntityChip'
   | 'ErrorState'
   | 'Field'
   | 'FileUpload'


### PR DESCRIPTION
Addresses #322.

## Summary
- New `<EntityChip>`: inline-safe (span-only, valid inside `<p>`) entity-reference chip — `icon` (aria-hidden) + muted `prefix` (task key) + `label` + optional `status={{ label, category?, color? }}` rendered in the status's OWN palette color. Replaces the hand-rolled Badge-in-Badge composition.
- Status colors reuse the exact #320 StatusMenu model: `category` (`to_do|in_progress|open|done|won|lost`) → palette default, `color: PaletteColor` override. The mapping is extracted to shared `_internal/statusColor.ts` and `StatusCategory` is now a public export; StatusMenu refactored onto it with zero API/behavior change (its tests untouched and green).
- Polymorphic via the Link.tsx `PolymorphicProps` pattern: `href` → `<a>`, `as={RouterLink}` fully typed, `as="button"` (auto `type="button"`), default `<span>`. `loading` (aria-busy, `…`, keeps icon slot) and `unavailable` (muted incl. status run, aria-disabled) both force a non-interactive span and neuter consumer `onClick`.
- Light+dark contrast of palette fg on the chip bg verified in review (≥ 4.5:1). Full core invariant: 17 unit tests + 4 shared-resolver tests, playground demo (inline-in-paragraph, statuses, polymorphism, loading/unavailable), route/nav/index/schematic/registry wiring, CLUSTERS in both manifest maps, AGENTS.md TL;DR, full JSDoc with anti-patterns.

## Test plan
- EntityChip 17/17 (incl. inline-safety no-div assertion, polymorphic ref forwarding, blocked-chip onClick neutering, palette var injection/override/fallback), statusColor 4/4, StatusMenu 18/18 unchanged.
- Full gates green locally: `make test` (3902 tests), `make build-lib`, `make lint`, `npm run format:check`, `make build`.
- Rule-8 loop: per-task review + final whole-branch review (2 Important findings fixed: public `StatusCategory` export, blocked-chip handler leak) + scoped re-review PASS.

Known deferred (non-blocking): non-onClick handlers (e.g. `onMouseDown`) still spread onto blocked chips; JSDoc documents the custom-`as` prop-leak caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk