### PR TITLE
feat: Badge align="middle" — center a badge on a heading's line box (#327)

### DIFF
--- a/docs/superpowers/plans/2026-07-25-badge-align.md
+++ b/docs/superpowers/plans/2026-07-25-badge-align.md
@@ -1,0 +1,95 @@
+# Badge align — Implementation Plan (#327)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** `<Badge align="middle">` vertically centers an inline Badge on the surrounding line box, so a status badge beside large heading text (`<PageHeader.Title>`, `<Title>`) sits visually centered instead of riding the baseline. Default `align="baseline"` = current behavior, zero visual change for existing usage.
+
+**Architecture:** One new prop + one CSS declaration. Badge is already `display: inline-flex` (an inline-level box), so `vertical-align: middle` on the badge itself is the whole mechanism — exactly what the eocrm `InlineMiddle` shim does. `vertical-align` is inline-flow self-alignment, not parent-owned layout (Rule 4 lists margin/position/offsets/flex-grow/width/grid-\*; EntityChip already uses `vertical-align: baseline`).
+
+**Tech Stack:** React 18, TypeScript, SCSS modules, Vitest + RTL (globals — no describe/it/expect imports).
+
+## Global Constraints
+
+- Repo `/home/dpws/projects/design-system`, branch `feat/badge-align` (already checked out).
+- Full JSDoc on the new prop + exported type (rule 7). Vitest globals. Tests from inside the package; gates from repo root. Commit per task; do NOT push.
+- If stylelint objects to the `vertical-align` keywords, mirror the `.alignLeft` disable pattern in Text.module.scss (`scale-unlimited/declaration-strict-value -- keyword, not a raw value`).
+
+---
+
+### Task 1: The prop (code + tests + JSDoc)
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Badge/Badge.tsx`
+- Modify: `packages/design-system/src/components/Badge/Badge.module.scss`
+- Modify: `packages/design-system/src/components/Badge/index.ts` + `packages/design-system/src/index.ts` (export `BadgeAlign`)
+- Test: `packages/design-system/src/components/Badge/Badge.test.tsx`
+
+**Interfaces:**
+
+```ts
+/** Vertical alignment of the Badge on the surrounding line box. */
+export type BadgeAlign = 'baseline' | 'middle';
+// BadgeProps:
+  /**
+   * Vertical alignment within the surrounding line of text.
+   * - `baseline` (default) — rides the text baseline; right for body-size text.
+   * - `middle` — centers the badge on the line box; use for a badge inside a
+   *   heading line (`<Title>` / `<PageHeader.Title>`), where baseline riding
+   *   makes the badge look sunken next to large text.
+   */
+  align?: BadgeAlign;
+```
+
+- [ ] **Step 1: Failing tests** — append to Badge.test.tsx (read it first, match style):
+
+```tsx
+describe('Badge align (#327)', () => {
+  it('align="middle" adds the alignMiddle class', () => {
+    render(<Badge align="middle">To Do</Badge>);
+    expect(screen.getByText('To Do').className).toMatch(/alignMiddle/);
+  });
+  it('no align class by default (baseline = current behavior)', () => {
+    render(<Badge>To Do</Badge>);
+    expect(screen.getByText('To Do').className).not.toMatch(/alignMiddle/);
+  });
+});
+```
+
+- [ ] **Step 2:** `cd packages/design-system && npx vitest run src/components/Badge/Badge.test.tsx` — FAIL.
+- [ ] **Step 3: Implement.** `align = 'baseline'` in destructure; clsx adds `align === 'middle' && styles.alignMiddle` (no class for baseline — the UA default; keeps existing DOM identical). SCSS after the base `.badge` block:
+
+```scss
+// align="middle" — center the badge on the surrounding LINE BOX instead of
+// riding the text baseline. For badges inside a heading line (Title /
+// PageHeader.Title), where baseline riding looks sunken next to large text.
+.alignMiddle {
+  vertical-align: middle;
+}
+```
+
+Add one `@example` to Badge's JSDoc (badge inside `<Title order={1}>` beside a `<Text size="inherit">` run — the #319 + #327 pairing) and, if Badge has a "When NOT to use"/anti-patterns remark about headings, reconcile it. Export `BadgeAlign` from Badge/index.ts and src/index.ts.
+
+- [ ] **Step 4:** Tests PASS; `npm run typecheck`; root `make lint`.
+- [ ] **Step 5:** Commit — `feat(Badge): align="middle" — center a badge on a heading's line box (#327)`
+
+---
+
+### Task 2: Docs + demo + gates
+
+**Files:**
+
+- Modify: `packages/design-system/AGENTS.md` (Badge section: one line — `align="middle"` for badges inside heading lines; pairs with `Text size="inherit"`)
+- Modify: `packages/playground/src/pages/components/BadgeDemo.tsx` (new example: `<Title order={2}>` line with prefix + name + `<Badge align="middle">` vs default baseline badge for contrast — mirror the file's Example pattern)
+
+- [ ] **Step 1:** Read both files; implement.
+- [ ] **Step 2:** `npx prettier --write docs/superpowers/plans/2026-07-25-badge-align.md`; include plan doc in commit.
+- [ ] **Step 3:** Full gates: `make test && make build-lib && make lint && npm run format:check && make build`; commit regenerated props.manifest.json if changed.
+- [ ] **Step 4:** Commit — `docs(Badge): align demo + AGENTS.md note (#327)`
+
+---
+
+## Self-review notes
+
+- No Title-side slot component — the Badge prop is the smallest surface and matches the proven shim; a heading slot would be a second API for the same pixel.
+- `middle` (not a numeric offset): aligns badge middle to baseline + half x-height — the standard visually-centered-enough choice at heading sizes, and exactly what the retired shim used.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1757,6 +1757,7 @@ import { Divider } from '@eocrm/design-system';
 - `size`: `md` (20, default) / `sm` (16). `md` is the uppercase tracked "loud label" pill. `sm` drops the uppercase + tracking and renders case as-typed — use it for dense table cells, compact toolbars, or anywhere the uppercase treatment shouts next to body copy.
 - `variant`: `filled` (default) / `stripe`. `filled` is the standard pill. `stripe` renders a rectangular block with a tone-colored 3px left stripe and a softly tinted body — no uppercase or letter-spacing. Use for category markers or sidebar labels where pill emphasis is too loud. Composes with both `tone` (6 semantic) and `color` (30 palette).
 - `dot`: `start` / `end` — adds a small filled circle in the badge's text color before or after the content. Use for Slack/GitHub-style status indicators (`<Badge tone="success" dot="start">Online</Badge>`). Decorative only (`aria-hidden`); the text is still the accessible label.
+- `align`: `baseline` (default) / `middle`. Use `align="middle"` for a badge inside a heading line (`<Title>` / `<PageHeader.Title>`) — pairs with `<Text size="inherit">` — so it centers on the line box instead of riding the heading's baseline and looking sunken next to large text.
 - **Non-interactive.** If it's clickable, use `<Button>` instead.
 - Doesn't auto-add `role="status"`. Wrap in `aria-live` if a state change should be announced.
 

--- a/packages/design-system/src/components/Badge/Badge.module.scss
+++ b/packages/design-system/src/components/Badge/Badge.module.scss
@@ -58,6 +58,13 @@
   color: var(--badge-fg-purple);
 }
 
+// align="middle" — center the badge on the surrounding LINE BOX instead of
+// riding the text baseline. For badges inside a heading line (Title /
+// PageHeader.Title), where baseline riding looks sunken next to large text.
+.alignMiddle {
+  vertical-align: middle;
+}
+
 .dot {
   width: var(--size-badge-dot);
   height: var(--size-badge-dot);

--- a/packages/design-system/src/components/Badge/Badge.test.tsx
+++ b/packages/design-system/src/components/Badge/Badge.test.tsx
@@ -155,3 +155,14 @@ describe('Badge', () => {
     expect((container.firstElementChild as HTMLElement).style.background).toBe('red');
   });
 });
+
+describe('Badge align (#327)', () => {
+  it('align="middle" adds the alignMiddle class', () => {
+    render(<Badge align="middle">To Do</Badge>);
+    expect(screen.getByText('To Do').className).toMatch(/alignMiddle/);
+  });
+  it('no align class by default (baseline = current behavior)', () => {
+    render(<Badge>To Do</Badge>);
+    expect(screen.getByText('To Do').className).not.toMatch(/alignMiddle/);
+  });
+});

--- a/packages/design-system/src/components/Badge/Badge.tsx
+++ b/packages/design-system/src/components/Badge/Badge.tsx
@@ -24,6 +24,9 @@ export type BadgeSize = 'sm' | 'md';
 /** Position of the optional status dot relative to the badge content. */
 export type BadgeDot = 'start' | 'end';
 
+/** Vertical alignment of the Badge on the surrounding line box. */
+export type BadgeAlign = 'baseline' | 'middle';
+
 export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   /**
    * Semantic tone.
@@ -74,6 +77,14 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
    * left-border picks up the palette `fg` token.
    */
   color?: PaletteColor;
+  /**
+   * Vertical alignment within the surrounding line of text.
+   * - `baseline` (default) — rides the text baseline; right for body-size text.
+   * - `middle` — centers the badge on the line box; use for a badge inside a
+   *   heading line (`<Title>` / `<PageHeader.Title>`), where baseline riding
+   *   makes the badge look sunken next to large text.
+   */
+  align?: BadgeAlign;
 }
 
 const toneClass: Record<BadgeTone, string> = {
@@ -125,10 +136,21 @@ const sizeClass: Record<BadgeSize, string> = {
  *   <Badge variant="stripe" tone="success">Active</Badge>
  * </Cluster>
  *
+ * @example
+ * // Inside a heading line — align="middle" so the badge doesn't ride the
+ * // heading's baseline (paired with Text size="inherit" for the muted run):
+ * <Title order={1}>
+ *   <Text as="span" size="inherit" tone="muted">ENG-5</Text> Fix login flow{' '}
+ *   <Badge align="middle" tone="warning">In progress</Badge>
+ * </Title>
+ *
  * @remarks When NOT to use
  * - As a button. Badges are non-interactive labels. If it's clickable, use
  *   a `Button` or `Link`.
  * - For long-form text. Badges should be 1-2 words max.
+ * - `align="middle"` outside a heading line. It's a fix for the
+ *   baseline-vs-line-box mismatch next to large text — leave the default
+ *   `baseline` for badges next to body-size text.
  *
  * @example
  * // Categorical palette color (not a semantic tone) — for tag-like labels
@@ -155,6 +177,7 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
     dot,
     variant = 'filled',
     color,
+    align = 'baseline',
     className,
     children,
     style,
@@ -192,6 +215,7 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
         toneClass[tone],
         sizeClass[size],
         variant === 'stripe' && styles.stripe,
+        align === 'middle' && styles.alignMiddle,
         className,
       )}
       style={mergedStyle}

--- a/packages/design-system/src/components/Badge/index.ts
+++ b/packages/design-system/src/components/Badge/index.ts
@@ -1,2 +1,2 @@
 export { Badge } from './Badge';
-export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot, BadgeVariant } from './Badge';
+export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot, BadgeVariant, BadgeAlign } from './Badge';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -112,7 +112,14 @@ export { Avatar, AvatarGroup, avatarColorIndex } from './components/Avatar';
 export type { AvatarProps, AvatarSize, AvatarStatus, AvatarGroupProps } from './components/Avatar';
 
 export { Badge } from './components/Badge';
-export type { BadgeProps, BadgeTone, BadgeSize, BadgeDot, BadgeVariant } from './components/Badge';
+export type {
+  BadgeProps,
+  BadgeTone,
+  BadgeSize,
+  BadgeDot,
+  BadgeVariant,
+  BadgeAlign,
+} from './components/Badge';
 
 export { Dot } from './components/Dot';
 export type { DotProps } from './components/Dot';

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -234,6 +234,13 @@
           "required": false,
           "default": "",
           "description": "Optional categorical palette color. When set, takes precedence over\n`tone`: the badge fills with the matching `--color-palette-<name>-bg/fg`\ntokens. Use for non-semantic categorical labels (e.g., audit event\nnamespaces, tag colors) where the 6 semantic tones aren't enough.\n\nBoth filled and stripe variants are supported; for stripe the\nleft-border picks up the palette `fg` token."
+        },
+        {
+          "name": "align",
+          "type": "BadgeAlign",
+          "required": false,
+          "default": "baseline",
+          "description": "Vertical alignment within the surrounding line of text.\n- `baseline` (default) — rides the text baseline; right for body-size text.\n- `middle` — centers the badge on the line box; use for a badge inside a\n  heading line (`<Title>` / `<PageHeader.Title>`), where baseline riding\n  makes the badge look sunken next to large text."
         }
       ]
     },
@@ -4805,7 +4812,7 @@
     "ClusterAs": "\"div\" | \"span\" | \"section\" | \"aside\"",
     "ClusterGap": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\" | \"2xl\"",
     "ClusterJustify": "\"start\" | \"end\" | \"center\" | \"between\"",
-    "ClusterAlign": "\"start\" | \"end\" | \"center\" | \"baseline\"",
+    "ClusterAlign": "\"start\" | \"end\" | \"baseline\" | \"center\"",
     "ConstrainWidth": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\" | \"full\"",
     "ConstrainFlex": "\"none\" | \"grow\" | \"shrink\" | \"auto\"",
     "IndentGutter": "\"sm\" | \"md\" | \"lg\" | \"xs\" | \"xl\" | \"2xl\"",
@@ -4828,6 +4835,7 @@
     "BadgeSize": "\"sm\" | \"md\"",
     "BadgeDot": "\"start\" | \"end\"",
     "BadgeVariant": "\"filled\" | \"stripe\"",
+    "BadgeAlign": "\"baseline\" | \"middle\"",
     "EntityChipStatus": "{ label: string; category?: StatusCategory; color?: PaletteColor }",
     "StatusMenuStatus": "{ id: string | number; name: string; category?: StatusCategory; color?: PaletteColor }",
     "ThreadNodeAlign": "\"top\" | \"header\"",

--- a/packages/playground/src/pages/components/BadgeDemo.tsx
+++ b/packages/playground/src/pages/components/BadgeDemo.tsx
@@ -1,6 +1,8 @@
 import { Badge, PALETTE_COLORS } from '@eocrm/design-system';
 import { Cluster } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
+import { Text } from '@eocrm/design-system';
+import { Title } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
@@ -346,6 +348,45 @@ export function Demo() {
               <Badge tone="danger">Lost</Badge>
             </Cluster>
           </div>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Alignment in headings"
+        description={`align="middle" centers the badge on the line box instead of riding the text baseline. Compare the default (baseline, sunken next to the heading) against align="middle" (centered) — pairs with Text size="inherit" for the muted prefix run.`}
+        code={`import { Badge, Stack, Text, Title } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Stack gap="md">
+      <Title order={2}>
+        <Text as="span" size="inherit" tone="muted">ENG-5</Text> Fix login flow{' '}
+        <Badge tone="warning">In progress</Badge>
+      </Title>
+      <Title order={2}>
+        <Text as="span" size="inherit" tone="muted">ENG-5</Text> Fix login flow{' '}
+        <Badge align="middle" tone="warning">In progress</Badge>
+      </Title>
+    </Stack>
+  );
+}`}
+      >
+        <Stack gap="md">
+          <Title order={2}>
+            <Text as="span" size="inherit" tone="muted">
+              ENG-5
+            </Text>{' '}
+            Fix login flow <Badge tone="warning">In progress</Badge>
+          </Title>
+          <Title order={2}>
+            <Text as="span" size="inherit" tone="muted">
+              ENG-5
+            </Text>{' '}
+            Fix login flow{' '}
+            <Badge align="middle" tone="warning">
+              In progress
+            </Badge>
+          </Title>
         </Stack>
       </Example>
 


### PR DESCRIPTION
Addresses #327.

## Summary
- New `align` prop on `<Badge>` (`BadgeAlign = 'baseline' | 'middle'`, default `baseline`): `middle` stamps `vertical-align: middle` so a badge inside a heading line (`<Title>` / `<PageHeader.Title>`) centers on the line box instead of riding the baseline and looking sunken beside large text. Same mechanism as the retired eocrm `InlineMiddle` shim.
- Default is byte-identical DOM (no class stamped) — zero change for existing usage. No interaction with `dot`/`stripe`/`size` variants (verified in review).
- JSDoc `@example` pairing with `Text size="inherit"` (the #319 companion), anti-pattern bullet, AGENTS.md line, BadgeDemo heading example with middle-vs-baseline contrast, `BadgeAlign` exported.

## Test plan
- 2 new unit tests (class stamped for middle; nothing stamped by default); Badge suite 29/29.
- Full gates green locally: `make test` (3907 tests), `make build-lib`, `make lint`, `npm run format:check`, `make build`.
- Fresh-context rule-8 review: clean (independently re-ran tests + stylelint; confirmed the props.manifest `ClusterAlign` union reorder is a cosmetic generator artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk