### PR TITLE
fix: EntityChip polish — no underline, true baseline, bigger status dot, stone bg (#333)

### DIFF
--- a/packages/design-system/src/components/EntityChip/EntityChip.module.scss
+++ b/packages/design-system/src/components/EntityChip/EntityChip.module.scss
@@ -3,7 +3,7 @@
 
 .chip {
   display: inline-flex;
-  align-items: center;
+  align-items: baseline;
   gap: var(--entity-chip-gap);
   padding: var(--entity-chip-padding-y) var(--entity-chip-padding-x);
   border: none;
@@ -23,10 +23,17 @@
     &:hover {
       background: var(--entity-chip-bg-hover);
       color: var(--entity-chip-fg-hover);
+
+      // Re-assert over the global `a:hover { text-decoration: underline }`
+      // (typography.scss), which out-specifies the rest-state rule above.
+      text-decoration: none;
+      filter: brightness(0.96);
     }
 
     &:focus-visible {
       @include focus-ring;
+
+      text-decoration: none;
     }
   }
 }
@@ -34,6 +41,8 @@
 .icon {
   display: inline-flex;
   align-items: center;
+  // stylelint-disable-next-line property-disallowed-list -- internal child of the chip's OWN flex row, opting the icon glyph back to vertical centering while the chip itself aligns on text baseline
+  align-self: center;
 }
 
 .prefix {
@@ -49,7 +58,9 @@
 }
 
 .dot {
+  padding-right: var(--entity-chip-dot-gap);
   color: var(--entity-chip-prefix-fg);
+  font-size: var(--entity-chip-dot-size);
 }
 
 // Specificity 0,2,0 (.unavailable .status) beats the plain .status rule

--- a/packages/design-system/src/components/EntityChip/EntityChip.tokens.scss
+++ b/packages/design-system/src/components/EntityChip/EntityChip.tokens.scss
@@ -1,10 +1,14 @@
-// EntityChip.tokens.scss — Component-scoped tokens for <EntityChip>. Subtle
-// neutral chip chrome (mirrors Badge's neutral fill primitive) + a muted
-// prefix run + an unavailable-state override.
+// EntityChip.tokens.scss — Component-scoped tokens for <EntityChip>. Stone
+// chip chrome + a muted prefix run + an unavailable-state override.
+// --entity-chip-bg is a literal-hex exception (same pattern as Badge/Tooltip
+// in dark.scss): the raw --color-palette-stone-bg reads too close to the
+// page/card canvas to register as a distinct chip, so it's deepened a step
+// here (and again, separately, in dark.scss) rather than changing the shared
+// palette token every other stone consumer (Badge, Palette) relies on.
 :root {
-  --entity-chip-bg: var(--color-bg-muted);
-  --entity-chip-bg-hover: var(--color-bg-sunken);
-  --entity-chip-fg: var(--color-fg);
+  --entity-chip-bg: #d6d0c5;
+  --entity-chip-bg-hover: #d6d0c5;
+  --entity-chip-fg: var(--color-palette-stone-fg);
   --entity-chip-fg-hover: var(--color-accent-hover);
   --entity-chip-prefix-fg: var(--color-fg-muted);
   --entity-chip-radius: var(--radius-sm);
@@ -13,4 +17,9 @@
   --entity-chip-padding-x: var(--space-2);
   --entity-chip-font-size: var(--font-size-sm);
   --entity-chip-unavailable-fg: var(--color-fg-muted);
+
+  // Status separator dot — bigger than body text + its own right gap so it
+  // reads as a deliberate divider, not a stray period.
+  --entity-chip-dot-size: var(--font-size-lg);
+  --entity-chip-dot-gap: var(--space-2);
 }

--- a/packages/design-system/src/styles/dark.scss
+++ b/packages/design-system/src/styles/dark.scss
@@ -87,6 +87,12 @@
   --tooltip-fg: #f0f3f6;
   --tooltip-arrow-bg: #39424b;
 
+  // EntityChip — literal-hex exception (EntityChip.tokens.scss), same reason
+  // as the light override: the raw stone palette bg reads too close to the
+  // dark page/card canvas, so it's deepened a step to stay a distinct chip.
+  --entity-chip-bg: #514d45;
+  --entity-chip-bg-hover: #514d45;
+
   // Categorical palette — the 30 named colors (a bg + fg pair each). Same hue
   // as light, lightness flipped (dark tinted bg + light vivid fg), saturation
   // preserved so muted colors (slate / stone / charcoal / taupe) stay muted.


### PR DESCRIPTION
Addresses #333.

## Summary
- **No underline ever**: the global `a:hover` underline rule (0,1,1) was out-specifying the chip's base `text-decoration: none` (0,1,0) — the chip's own hover/focus rules now re-assert it at (0,2,1).
- **True baseline alignment**: `.chip` switches `align-items: center` → `baseline`, so prefix/label/status share one baseline AND the chip's outer baseline aligns with surrounding paragraph text (with `center`, no flex item participated in baseline alignment and the chip's baseline fell to its box edge). The icon opts back to vertical centering via a sanctioned internal `align-self`.
- **Status dot**: new `--entity-chip-dot-size` (font-size-lg) + `--entity-chip-dot-gap` (space-2 as padding-right) tokens.
- **Contrast**: chip fill is now stone-hued with real presence — light `#d6d0c5` (1.53:1 vs white, label 5.82:1) and a dark.scss override `#514d45` (1.93:1 vs page, label 4.99:1), following the existing Badge/Tooltip literal-hex dark-override pattern. Hover keeps the fill + brightness cue.

## Test plan
- Visually validated in a real browser (Playwright, playground on :8091): light + dark themes, inline-in-paragraph baseline, hover/focus computed styles, chip-vs-card contrast. Screenshots reviewed by the controller session; dark theme required and got a second contrast iteration.
- EntityChip suite 17/17 (re-run independently by the reviewer); scoped stylelint clean; root `make lint` + `npm run format:check` clean.
- Rule-8 fresh-context review: clean (specificity math, contrast math, rule-4 exceptions, and the Badge/Tooltip precedent all independently verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk