### PR TITLE
fix: EntityChip — true inline seating, unconditional no-underline, bold hover, always-a-link semantics (#336)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1764,9 +1764,9 @@ import { Divider } from '@eocrm/design-system';
 ### `<EntityChip>` — inline entity-link chip
 
 ```tsx
-// Inline, inside a sentence:
+// Inline, inside a sentence — canonically a link to its entity:
 <Text>
-  Reassigned <EntityChip icon={<User size={14} />} label="Priya Shah" /> to this deal.
+  Reassigned <EntityChip href="/contacts/12" icon={<User size={14} />} label="Priya Shah" /> to this deal.
 </Text>
 
 // href, prefix + status:
@@ -1783,11 +1783,13 @@ import { Link as RouterLink } from 'react-router-dom';
 ```
 
 - Polymorphic inline chip: optional `icon` (rendered `aria-hidden`), optional muted `prefix` (e.g. a task key), the `label`, and an optional colored `status`. All inline `<span>`s inside one root — safe to drop directly inside a `<p>`/`<Text>`.
-- Renders `<a href>` when `href` is set, `<span>` (static, non-navigating) otherwise, or whatever `as` is passed (`RouterLink`, `'button'`, any component) — same polymorphic contract as `<Link>`.
+- **An EntityChip is always a link to its entity**: pass `href` (renders `<a href>`) or `as` (`RouterLink`, `'button'`, any component — same polymorphic contract as `<Link>`). The bare `<span>` form (no target) is for rare non-navigable contexts only.
 - `status`: `{ label, category?, color? }`. `category` (`to_do`/`in_progress`/`open`/`done`/`won`/`lost`) resolves a default palette color; `color` (a `PaletteColor`) overrides it — same category → color mapping as `<StatusMenu>`.
-- `loading`: swaps the body for an `aria-busy` ellipsis, non-interactive. `unavailable`: mutes the chip and forces a non-interactive `<span>` with `aria-disabled` — even with `href`/`as` set (entity deleted or no access).
+- `loading`: swaps the body for an `aria-busy` ellipsis. `unavailable`: mutes the chip (entity deleted or no access). Both are purely visual when the chip has a link target — it stays a live, keyboard-reachable link. Only a target-less `unavailable` chip is non-interactive with `aria-disabled`.
+- Hover affordance on link/button chips: the label bolds (width is pre-reserved — no layout shift) and the background deepens. The chip never underlines, even under aggressive consumer link CSS.
+- Chip text inherits the surrounding font size — inside a heading it renders at heading size, by design (that's what keeps the chip box symmetric around the local text in any context).
 - **When NOT to use**: plain status with no linked entity → `<Badge>`/`<StatusMenu>`; standalone navigation with no icon/prefix/status chrome → `<Link>`; removable filter pills → `<FilterChip>`.
-- **Anti-pattern**: nesting a `<Badge>` inside another `<Badge>` to fake an entity-with-status chip — `EntityChip` replaces that composition. `status.color` is a `PaletteColor` name, never a raw hex string.
+- **Anti-pattern**: nesting a `<Badge>` inside another `<Badge>` to fake an entity-with-status chip — `EntityChip` replaces that composition. `status.color` is a `PaletteColor` name, never a raw hex string. Omitting a link target (`href`/`as`) is also an anti-pattern — an EntityChip should link to its entity.
 
 ### `<StatusMenu>` — status-transition dropdown
 

--- a/packages/design-system/src/components/EntityChip/EntityChip.module.scss
+++ b/packages/design-system/src/components/EntityChip/EntityChip.module.scss
@@ -10,30 +10,41 @@
   border-radius: var(--entity-chip-radius);
   background: var(--entity-chip-bg);
   color: var(--entity-chip-fg);
+
+  // Font-size deliberately inherits (no override): the chip text runs at the
+  // surrounding text's size, which — with the tight line-height below — makes
+  // the padded box bracket the local glyph band symmetrically in any context.
+  // A fixed smaller size made the box hang ~4px below 14px body text even
+  // with perfect baseline alignment.
   font: inherit;
-  font-size: var(--entity-chip-font-size);
-  text-decoration: none;
+  line-height: var(--entity-chip-line-height);
+
+  // Consumer apps ship global link rules (`a:hover { text-decoration: … }`)
+  // that out-specify anything the chip can win by selectors alone — the chip
+  // must NEVER underline, so assert it unconditionally.
+  // stylelint-disable-next-line declaration-no-important -- global consumer link rules out-specify the chip; precedent: Sortable's reduced-motion !important
+  text-decoration: none !important;
   vertical-align: baseline;
 
-  // <a>/<button> renders are the interactive variants — everything else
-  // (a plain <span> or a blocked/unavailable chip) has no hover/focus chrome.
+  // <a>/<button> renders are the interactive variants and get hover/focus
+  // chrome even when loading/unavailable (those are purely visual states on a
+  // live link) — only a target-less <span> chip has none.
   &:is(a, button) {
     cursor: pointer;
 
     &:hover {
       background: var(--entity-chip-bg-hover);
-      color: var(--entity-chip-fg-hover);
-
-      // Re-assert over the global `a:hover { text-decoration: underline }`
-      // (typography.scss), which out-specifies the rest-state rule above.
-      text-decoration: none;
       filter: brightness(0.96);
+    }
+
+    // Hover affordance: the entity name bolds (never an underline). Scoped to
+    // the label so the muted prefix/status runs keep their weight.
+    &:hover .label {
+      font-weight: var(--entity-chip-font-weight-hover);
     }
 
     &:focus-visible {
       @include focus-ring;
-
-      text-decoration: none;
     }
   }
 }
@@ -47,6 +58,26 @@
 
 .prefix {
   color: var(--entity-chip-prefix-fg);
+}
+
+// Column-stacks the label over its invisible bold twin so the chip is always
+// as wide as the BOLD label — hover-bolding then causes zero layout shift.
+.label {
+  display: inline-flex;
+  flex-direction: column;
+}
+
+.labelGhost {
+  overflow: hidden;
+  height: 0;
+  font-weight: var(--entity-chip-font-weight-hover);
+  visibility: hidden;
+  user-select: none; // keep the twin out of rich-HTML copy/paste
+}
+
+// Keeps a loading chip's accessible name (the label) without showing it.
+.hiddenLabel {
+  @include visually-hidden;
 }
 
 .ellipsis {

--- a/packages/design-system/src/components/EntityChip/EntityChip.test.tsx
+++ b/packages/design-system/src/components/EntityChip/EntityChip.test.tsx
@@ -22,10 +22,14 @@ function StubRouterLink({
   );
 }
 
+// The chip renders an invisible aria-hidden bold twin of the label (reserves
+// the bold-on-hover width) — visible-text queries must skip it.
+const visible = { ignore: '[aria-hidden="true"], script, style' };
+
 describe('<EntityChip>', () => {
   it('renders the label', () => {
     render(<EntityChip label="ENG-5 Fix login bug" />);
-    expect(screen.getByText('ENG-5 Fix login bug')).toBeInTheDocument();
+    expect(screen.getByText('ENG-5 Fix login bug', visible)).toBeInTheDocument();
   });
 
   it('renders the icon aria-hidden', () => {
@@ -70,12 +74,15 @@ describe('<EntityChip>', () => {
 
   it('renders as <a> with href when href is set', () => {
     render(<EntityChip label="Contact" href="/contacts/1" />);
-    expect(screen.getByText('Contact').closest('a')).toHaveAttribute('href', '/contacts/1');
+    expect(screen.getByText('Contact', visible).closest('a')).toHaveAttribute(
+      'href',
+      '/contacts/1',
+    );
   });
 
   it('renders as <span> by default when no href is set', () => {
-    render(<EntityChip label="Contact" />);
-    expect(screen.getByText('Contact').closest('span')?.tagName).toBe('SPAN');
+    const { container } = render(<EntityChip label="Contact" />);
+    expect((container.firstElementChild as HTMLElement).tagName).toBe('SPAN');
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
@@ -85,7 +92,10 @@ describe('<EntityChip>', () => {
         {/* label prop still drives content */}
       </EntityChip>,
     );
-    expect(screen.getByText('Contacts')).toHaveAttribute('data-to', '/contacts');
+    expect(screen.getByText('Contacts', visible).closest('a')).toHaveAttribute(
+      'data-to',
+      '/contacts',
+    );
   });
 
   it('as="button" gets type="button"', () => {
@@ -93,20 +103,32 @@ describe('<EntityChip>', () => {
     expect(screen.getByRole('button', { name: /Pick/ })).toHaveAttribute('type', 'button');
   });
 
-  it('loading renders aria-busy, an ellipsis body, and a span (never a link)', () => {
+  it('loading + href stays a real link, aria-busy, named after the label', () => {
     render(<EntityChip label="Contact" href="/contacts/1" loading />);
     expect(screen.getByText('…')).toBeInTheDocument();
-    expect(screen.queryByRole('link')).not.toBeInTheDocument();
-    expect(screen.queryByText('Contact')).not.toBeInTheDocument();
-    const root = screen.getByText('…').closest('span[aria-busy]');
-    expect(root).toHaveAttribute('aria-busy', 'true');
+    const link = screen.getByRole('link', { name: /Contact/ });
+    expect(link).toHaveAttribute('href', '/contacts/1');
+    expect(link).toHaveAttribute('aria-busy', 'true');
+    expect(link).not.toHaveAttribute('aria-disabled');
   });
 
-  it('unavailable renders a span, aria-disabled, and the unavailable class', () => {
+  it('unavailable + href renders a live <a href> — no aria-disabled', () => {
     render(<EntityChip label="Contact" href="/contacts/1" unavailable />);
-    const chip = screen.getByText('Contact').closest('span[aria-disabled]');
-    expect(chip).toHaveAttribute('aria-disabled', 'true');
-    expect(chip?.className).toMatch(/unavailable/);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/contacts/1');
+    expect(link).not.toHaveAttribute('aria-disabled');
+    expect(link.className).toMatch(/unavailable/);
+  });
+
+  it('unavailable + custom `as` keeps the real component and its props', () => {
+    render(<EntityChip label="Task" as={StubRouterLink} to="/tasks/5" unavailable />);
+    expect(screen.getByText('Task', visible).closest('a')).toHaveAttribute('data-to', '/tasks/5');
+  });
+
+  it('bare-span loading stays a span with aria-busy', () => {
+    render(<EntityChip label="Contact" loading />);
+    const root = screen.getByText('…').closest('span[aria-busy]');
+    expect(root).toHaveAttribute('aria-busy', 'true');
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
@@ -115,12 +137,14 @@ describe('<EntityChip>', () => {
     expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
 
-  it('unavailable neuters a consumer onClick — forced span, no click handler', async () => {
+  it('bare-span unavailable keeps aria-disabled and neuters a consumer onClick', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();
-    render(<EntityChip label="Pick" as="button" onClick={onClick} unavailable />);
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
-    await user.click(screen.getByText('Pick'));
+    render(<EntityChip label="Pick" onClick={onClick} unavailable />);
+    const chip = screen.getByText('Pick', visible).closest('span[aria-disabled]');
+    expect(chip).toHaveAttribute('aria-disabled', 'true');
+    expect(chip?.className).toMatch(/unavailable/);
+    await user.click(screen.getByText('Pick', visible));
     expect(onClick).not.toHaveBeenCalled();
   });
 
@@ -145,7 +169,7 @@ describe('<EntityChip>', () => {
   });
 
   it('merges className with the internal chip class', () => {
-    render(<EntityChip label="Contact" className="external" />);
-    expect(screen.getByText('Contact').closest('span')?.className).toMatch(/external/);
+    const { container } = render(<EntityChip label="Contact" className="external" />);
+    expect(container.querySelector('.external')?.className).toMatch(/chip/);
   });
 });

--- a/packages/design-system/src/components/EntityChip/EntityChip.tokens.scss
+++ b/packages/design-system/src/components/EntityChip/EntityChip.tokens.scss
@@ -9,13 +9,19 @@
   --entity-chip-bg: #d6d0c5;
   --entity-chip-bg-hover: #d6d0c5;
   --entity-chip-fg: var(--color-palette-stone-fg);
-  --entity-chip-fg-hover: var(--color-accent-hover);
   --entity-chip-prefix-fg: var(--color-fg-muted);
   --entity-chip-radius: var(--radius-sm);
   --entity-chip-gap: var(--space-1);
   --entity-chip-padding-y: var(--space-05);
   --entity-chip-padding-x: var(--space-2);
-  --entity-chip-font-size: var(--font-size-sm);
+
+  // No font-size token: the chip inherits the surrounding text's size by
+  // design (see EntityChip.module.scss) — a tight line-height keeps the
+  // padded box hugging the glyph band instead of hanging below the baseline.
+  --entity-chip-line-height: var(--line-height-none);
+
+  // Hover affordance is bolded text (never an underline).
+  --entity-chip-font-weight-hover: var(--font-weight-bold);
   --entity-chip-unavailable-fg: var(--color-fg-muted);
 
   // Status separator dot — bigger than body text + its own right gap so it

--- a/packages/design-system/src/components/EntityChip/EntityChip.tsx
+++ b/packages/design-system/src/components/EntityChip/EntityChip.tsx
@@ -41,17 +41,17 @@ interface EntityChipOwnProps {
   /** Renders `as="a"` with this href when `as` is omitted. */
   href?: string;
   /**
-   * Loading placeholder: icon slot + `…` body, aria-busy, non-interactive.
-   * The `as` component is still forced to a plain `<span>` — any of its
-   * other props (e.g. a RouterLink's `to`/`replace`) still spread onto that
-   * span and may leave junk DOM attributes; pass them conditionally if that
-   * matters.
+   * Loading placeholder: icon slot + `…` body, aria-busy; the label stays in
+   * the DOM visually hidden so the chip keeps its accessible name. Purely
+   * visual — with a link target (`href`/`as`) the chip stays a live,
+   * keyboard-reachable link while loading.
    */
   loading?: boolean;
   /**
-   * Entity missing/no access: muted, non-interactive (renders `as` forced to
-   * 'span'), aria-disabled. Same caveat as `loading` — the `as` component's
-   * other props still spread onto the forced span.
+   * Entity missing/no access: muted styling. With a link target (`href`/`as`)
+   * the chip remains a real link — unavailable is a visual state, not a
+   * disabling one. Only a target-less chip (bare span) becomes non-interactive
+   * with aria-disabled.
    */
   unavailable?: boolean;
 }
@@ -93,9 +93,9 @@ function statusColorStyle(status: EntityChipStatus): CSSProperties {
  * Inline entity-link chip: an optional icon, an optional muted prefix (e.g.
  * a task key), the entity's name, and an optional workflow status shown in
  * its own color — all spans inside a single inline root, safe to drop
- * directly inside a `<p>`. Renders `<a>` when `href` is set, `<span>` for a
- * static (non-navigating) chip, or whatever `as` is passed for router-aware
- * navigation.
+ * directly inside a `<p>`. An EntityChip is canonically a link to its entity:
+ * pass `href` (renders `<a>`) or `as` (router-aware navigation). The bare
+ * `<span>` form is for rare non-navigable contexts only.
  *
  * @example
  * // Inline usage inside a sentence
@@ -115,9 +115,9 @@ function statusColorStyle(status: EntityChipStatus): CSSProperties {
  * />
  *
  * @example
- * // Loading / unavailable states
- * <EntityChip label="Contact" loading />
- * <EntityChip label="Deleted contact" unavailable />
+ * // Loading / unavailable states — still live links with a target
+ * <EntityChip href="/contacts/7" label="Contact" loading />
+ * <EntityChip href="/contacts/9" label="Deleted contact" unavailable />
  *
  * @remarks When NOT to use
  * - Plain status display with no linked entity → use `<Badge>` or `<StatusMenu>`.
@@ -131,6 +131,9 @@ function statusColorStyle(status: EntityChipStatus): CSSProperties {
  *   the inline-safety contract requires span-only content.
  * - ❌ Raw hex strings in `status.color`. It's a `PaletteColor` name
  *   (`'amber'`, `'violet'`, …), not a CSS color value.
+ * - ❌ Omitting a link target — an EntityChip should always link to its
+ *   entity (`href` or `as`); the span-only form is for rare non-navigable
+ *   contexts.
  */
 export const EntityChip = forwardRef(function EntityChip<C extends ElementType = 'a'>(
   {
@@ -148,11 +151,14 @@ export const EntityChip = forwardRef(function EntityChip<C extends ElementType =
   }: EntityChipProps<C>,
   ref: ForwardedRef<Element>,
 ) {
-  // unavailable/loading force a non-interactive span — never a link/button.
-  const blocked = unavailable || loading;
-  const Component = (blocked ? 'span' : (as ?? (href ? 'a' : 'span'))) as ElementType;
+  // A link target (`as` or `href`) always wins: loading/unavailable are then
+  // purely visual states on a live, keyboard-reachable link. Only a bare span
+  // (no target) becomes genuinely non-interactive when unavailable.
+  const Component = (as ?? (href ? 'a' : 'span')) as ElementType;
+  const bareSpan = !as && !href;
+  const inert = unavailable && bareSpan;
   const elementProps: { href?: string; type?: string } = {};
-  if (!blocked && Component === 'a') elementProps.href = href;
+  if (Component === 'a') elementProps.href = href;
   if (Component === 'button') elementProps.type = 'button';
 
   return (
@@ -162,14 +168,14 @@ export const EntityChip = forwardRef(function EntityChip<C extends ElementType =
       className={clsx(styles.chip, unavailable && styles.unavailable, className)}
       {...elementProps}
       {...rest}
-      // blocked (loading/unavailable) forces a non-interactive <span> — cancel
-      // any consumer onClick that {...rest} just spread on above, so it can't
+      // A target-less unavailable chip is non-interactive — cancel any
+      // consumer onClick that {...rest} just spread on above, so it can't
       // fire through a chip keyboard users have no way to reach (Pattern B).
-      {...(blocked ? { onClick: undefined } : null)}
+      {...(inert ? { onClick: undefined } : null)}
       // Component-owned ARIA state must survive whatever the consumer passes
       // via {...rest} — aria-busy/aria-disabled are the component's contract.
       aria-busy={loading || undefined}
-      aria-disabled={unavailable || undefined}
+      aria-disabled={inert || undefined}
     >
       {icon && (
         <span className={styles.icon} aria-hidden="true">
@@ -177,11 +183,25 @@ export const EntityChip = forwardRef(function EntityChip<C extends ElementType =
         </span>
       )}
       {loading ? (
-        <span className={styles.ellipsis}>…</span>
+        <>
+          <span className={styles.ellipsis} aria-hidden="true">
+            …
+          </span>
+          {/* Label stays in the DOM visually hidden so a linked loading chip
+              keeps its accessible name instead of being announced as "…". */}
+          <span className={styles.hiddenLabel}>{label}</span>
+        </>
       ) : (
         <>
           {prefix && <span className={styles.prefix}>{prefix}</span>}
-          {label}
+          {/* The hidden bold twin reserves the hover-bold width up front, so
+              bolding the label on hover can't shift the surrounding text. */}
+          <span className={styles.label}>
+            {label}
+            <span className={styles.labelGhost} aria-hidden="true">
+              {label}
+            </span>
+          </span>
           {status && (
             <span className={styles.status} style={statusColorStyle(status)}>
               <span className={styles.dot} aria-hidden="true">

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -1586,14 +1586,14 @@
           "type": "boolean",
           "required": false,
           "default": "",
-          "description": "Loading placeholder: icon slot + `…` body, aria-busy, non-interactive.\nThe `as` component is still forced to a plain `<span>` — any of its\nother props (e.g. a RouterLink's `to`/`replace`) still spread onto that\nspan and may leave junk DOM attributes; pass them conditionally if that\nmatters."
+          "description": "Loading placeholder: icon slot + `…` body, aria-busy; the label stays in\nthe DOM visually hidden so the chip keeps its accessible name. Purely\nvisual — with a link target (`href`/`as`) the chip stays a live,\nkeyboard-reachable link while loading."
         },
         {
           "name": "unavailable",
           "type": "boolean",
           "required": false,
           "default": "",
-          "description": "Entity missing/no access: muted, non-interactive (renders `as` forced to\n'span'), aria-disabled. Same caveat as `loading` — the `as` component's\nother props still spread onto the forced span."
+          "description": "Entity missing/no access: muted styling. With a link target (`href`/`as`)\nthe chip remains a real link — unavailable is a visual state, not a\ndisabling one. Only a target-less chip (bare span) becomes non-interactive\nwith aria-disabled."
         },
         {
           "name": "as",

--- a/packages/playground/src/pages/components/EntityChipDemo.tsx
+++ b/packages/playground/src/pages/components/EntityChipDemo.tsx
@@ -22,7 +22,7 @@ export function EntityChipDemo() {
     <DemoLayout
       name="EntityChip"
       componentName="EntityChip"
-      description="Inline entity-link chip — icon + muted prefix + name + colored status, all inside a single inline root safe to drop into a sentence. Renders <a>/<span>/whatever `as` is passed."
+      description="Inline chip that is always a link to its entity — icon + muted prefix + name + colored status, all inside a single inline root safe to drop into a sentence. Pass href (renders <a>) or `as` (router link); the bare <span> form is for rare non-navigable contexts."
       files={getComponentFiles('EntityChip')}
     >
       <Example
@@ -35,8 +35,9 @@ export function Demo() {
   return (
     <Text>
       Reassigned{' '}
-      <EntityChip icon={<User size={14} />} label="Priya Shah" /> to{' '}
+      <EntityChip href="/contacts/12" icon={<User size={14} />} label="Priya Shah" /> to{' '}
       <EntityChip
+        href="/deals/204"
         icon={<Building2 size={14} />}
         prefix="ACME-204"
         label="Acme Corp"
@@ -44,6 +45,7 @@ export function Demo() {
       />
       , blocked on{' '}
       <EntityChip
+        href="/tasks/5"
         icon={<CheckSquare size={14} />}
         prefix="ENG-5"
         label="Fix login bug"
@@ -55,8 +57,10 @@ export function Demo() {
 }`}
       >
         <Text>
-          Reassigned <EntityChip icon={<User size={14} />} label="Priya Shah" /> to{' '}
+          Reassigned <EntityChip href="/contacts/12" icon={<User size={14} />} label="Priya Shah" />{' '}
+          to{' '}
           <EntityChip
+            href="/deals/204"
             icon={<Building2 size={14} />}
             prefix="ACME-204"
             label="Acme Corp"
@@ -64,6 +68,7 @@ export function Demo() {
           />
           , blocked on{' '}
           <EntityChip
+            href="/tasks/5"
             icon={<CheckSquare size={14} />}
             prefix="ENG-5"
             label="Fix login bug"
@@ -153,22 +158,25 @@ export function Demo() {
 
       <Example
         title="Loading and unavailable"
-        description="`loading` swaps the body for an aria-busy ellipsis. `unavailable` mutes the chip and forces a non-interactive <span> (aria-disabled) — even with an href."
+        description="`loading` swaps the body for an aria-busy ellipsis; `unavailable` mutes the chip. Both are purely visual when the chip has a link target — it stays a live, keyboard-reachable link. Only a target-less unavailable chip goes non-interactive (aria-disabled)."
         code={`import { EntityChip } from '@eocrm/design-system';
 
 export function Demo() {
   return (
     <>
-      <EntityChip label="Contact" loading />
+      <EntityChip href="/contacts/7" label="Contact" loading />
       <EntityChip href="/contacts/9" label="Deleted contact" unavailable />
+      {/* no target — rare non-navigable case, aria-disabled */}
+      <EntityChip label="Deleted contact" unavailable />
     </>
   );
 }`}
       >
         <InputExample width="auto">
           <Cluster gap="sm">
-            <EntityChip label="Contact" loading />
+            <EntityChip href="/contacts/7" label="Contact" loading />
             <EntityChip href="/contacts/9" label="Deleted contact" unavailable />
+            <EntityChip label="Deleted contact" unavailable />
           </Cluster>
         </InputExample>
       </Example>


### PR DESCRIPTION
Addresses #336 (follow-up to #333).

## Summary
- **Inline seating, measured**: probe-span measurement showed the baselines were already 0.00px apart — the visual offset was the chip's padded box hanging 4.14px below the surrounding glyph band (12px chip font inheriting the paragraph's 1.43 line-height + symmetric padding). Fix: chip text now INHERITS the surrounding font size (`--entity-chip-font-size` token removed) with a tight `--entity-chip-line-height`. After: symmetric ±1px overhang, zero center bias, verified in body text and inside headings, both themes.
- **Underline**: `text-decoration: none !important` on the chip — consumer apps' global link rules can no longer re-underline it in any state.
- **Hover = bold label** (new `--entity-chip-font-weight-hover` token; accent fg-hover dropped). A measured 3.89px hover jitter is eliminated by an invisible aria-hidden bold twin reserving bold width (0.00px shift), with `user-select: none` so it can't leak into rich-HTML copy.
- **Always a link to its entity**: `loading`/`unavailable` no longer strip the anchor when a target exists — they're visual states on a live, keyboard-reachable link; `aria-disabled` + onClick-neutering apply only to the target-less span. Loading keeps the label as the accessible name (visually-hidden, mixin precedent) so no nameless focusable link. JSDoc/AGENTS.md/demo now present the link form as canonical.

## Test plan
- 19/19 EntityChip tests (3 rewritten for the new semantics, 3 new: live unavailable+href link, loading+href named link with aria-busy, bare-span aria-disabled); full suite 3911.
- Pixel-measured before/after baselines via Playwright; screenshots reviewed by the controller session in light + dark.
- Rule-8 loop: adversarial review found 2 Importants (nameless loading link, ghost copy leak) — fixed; scoped re-review PASS incl. single-accessible-copy verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk