### PR TITLE
feat: DashboardCanvas — Datadog-style 2D snap-grid dashboard (drag + resize + collapsible sections) (#337)

### DIFF
--- a/docs/superpowers/plans/2026-07-26-dashboard-canvas.md
+++ b/docs/superpowers/plans/2026-07-26-dashboard-canvas.md
@@ -1,0 +1,239 @@
+# DashboardCanvas — Implementation Plan (#337)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** New library component `<DashboardCanvas>` — Datadog-style 2D snap-grid dashboard: items with `(x, y, w, h)` on a 12-column grid with a fixed row unit; drag-to-move with push-down collision + vertical compaction; E/S/SE resize handles; full-width collapsible sections (own sub-grids, header-drag band reorder, cross-container item moves incl. top level); controlled `value` + one `onChange` per completed gesture; `readOnly` mode; keyboard parity + live-region announcements; single stacked column below the `md` container width with editing disabled.
+
+**Authority:** Issue #337 + the approved consumer design (Part A) at `/home/dpws/projects/eocrm/docs/superpowers/specs/2026-07-26-dashboard-grid-canvas-design.md` (read-only reference; lives in the consumer repo).
+
+**Architecture (locked):**
+
+- **Raw pointer events, NOT dnd-kit** — FlowCanvas's architecture (pointer capture, dragState in refs, live in-flight state discarded on cancel, commit on pointerup). Deviation from the issue's literal "on dnd-kit" wording, justified: the issue's operative constraint is "no react-grid-layout-class dependency"; FlowCanvas (cited in the issue as the precedent) is raw-pointer; dnd-kit's sortable abstractions don't fit snap-grid push-down physics; and dnd-kit pointer drags are untestable in jsdom (SortableGroup's own tests document this) while FlowCanvas-style `fireEvent.pointer*` sequences fully exercise gestures. State the deviation in the PR body.
+- **Pure engine modules + one orchestrator** (FlowCanvas file-layout precedent): all geometry/physics in `engine.ts` (headless, exhaustively unit-tested); `DashboardCanvas.tsx` wires pointer/keyboard events to it.
+- **CSS grid placement via injected custom properties** (Grid/#318 precedent): each container is `display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); grid-auto-rows: var(--dashboard-canvas-row)`; items stamp `--dc-col: <x+1> / span <w>` and `--dc-row: <y+1> / span <h>` inline; class rules consume them. Below-`md` container query re-templates to one column and overrides item placement at higher specificity (the #318 step mechanism) — stacking order = DOM order, so containers render their items sorted by `(y, x)`.
+- **Live region + i18n**: FlowCanvas's nonce-keyed `announce()` pattern; full `dashboardCanvas` namespace in messages.ts with en + ru (no dnd-kit announcer to lean on).
+- **Escape-consuming keyboard drag** registers `useFloatingSurface` (Sortable/FlowCanvas precedent).
+- Editing gate below `md` uses a ResizeObserver width check (JS mirror of the CSS container query; FlowCanvas has ResizeObserver fallback precedent), with jsdom-safe fallback (no RO / zero width → editing allowed so tests can exercise gestures).
+
+**Tech Stack:** React 18, TypeScript, SCSS modules, raw Pointer Events, Vitest + RTL (globals — no describe/it/expect imports; jsdom drags via inline `fireEvent.pointerDown/Move/Up` sequences with explicit `clientX/clientY/pointerId`, FlowCanvas.test.tsx:173-175 pattern; stub `getBoundingClientRect` where geometry is needed, Sortable.test.tsx:218-252 `stubStackedRects` convention).
+
+## Global Constraints
+
+- Repo `/home/dpws/projects/design-system`, branch `feat/dashboard-canvas` (already checked out).
+- NEW component → FULL core invariant (package CLAUDE.md + root CLAUDE.md): tests, playground demo + 4-point wiring + mockups registry union, `src/index.ts` re-exports, JSDoc rule 7 incl. `@remarks` When-NOT-to-use/anti-patterns, AGENTS.md TL;DR, CLUSTERS in BOTH manifest maps (`DashboardCanvas: 'Display'` — FlowCanvas precedent) + `npm run build:manifest`.
+- Hard rules 1–9: tokens-only SCSS; `:focus-visible` only; layout-owning exception applies ONLY to the canvas's own internal placement (grid-column/grid-row on its items need the sanctioned stylelint-disable comments, GridItem precedent); forwardRef + spread with pattern comments; i18n via `useTranslation` for EVERY user-facing string (aria-labels, instructions, announcements) in en AND ru.
+- Tests run from inside the package (`cd packages/design-system && npx vitest run src/components/DashboardCanvas`); gates from repo root. Commit per task; do NOT push.
+- Public API names below are LOCKED — later tasks and the consumer spec depend on them verbatim.
+
+## Public API (locked)
+
+```ts
+/** One placed item: grid units within its container. */
+export interface DashboardPlacement {
+  id: string | number;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface DashboardSection {
+  id: string | number;
+  title: string;
+  collapsed: boolean;
+  items: DashboardPlacement[];
+}
+
+/** Controlled value. Section array order = band order; top-level items render above the first section. */
+export interface DashboardCanvasValue {
+  items: DashboardPlacement[];
+  sections: DashboardSection[];
+}
+
+/** Per-item size constraints, by item id. */
+export interface DashboardItemConstraints {
+  minW?: number;
+  minH?: number;
+  maxH?: number;
+}
+
+export interface DashboardCanvasProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  value: DashboardCanvasValue;
+  /** Fires ONCE per completed gesture (drop, resize-end, collapse toggle, section reorder, cross-container move) with the whole next value. */
+  onChange?: (next: DashboardCanvasValue) => void;
+  /** Render the body of an item by id. */
+  renderItem: (id: string | number) => ReactNode;
+  /** Optional extras for a section header (title editor, menus) by section id. */
+  renderSectionHeader?: (id: string | number) => ReactNode;
+  /** Constraints lookup; missing entry → minW 1, minH 1, no maxH. */
+  constraints?:
+    | Record<string, DashboardItemConstraints>
+    | ((id: string | number) => DashboardItemConstraints | undefined);
+  /** View mode: identical geometry, zero drag/resize wiring; collapse toggles stay active. */
+  readOnly?: boolean;
+}
+```
+
+Engine (all pure, exported for tests; `engine.ts`):
+
+```ts
+export const DASHBOARD_COLUMNS = 12;
+export function clampPlacement(
+  p: DashboardPlacement,
+  c: DashboardItemConstraints | undefined,
+): DashboardPlacement; // bounds: 0≤x, x+w≤12, w≥minW≥1, h≥minH≥1, h≤maxH if set
+export function collides(a: DashboardPlacement, b: DashboardPlacement): boolean;
+export function compact(items: DashboardPlacement[]): DashboardPlacement[]; // pull every item up to the lowest free y, stable (y,x) processing order
+export function placeWithPushDown(
+  items: DashboardPlacement[],
+  moved: DashboardPlacement,
+): DashboardPlacement[]; // moved item claims its dropped spot for collision resolution (colliding items push down, chains recursively), then the WHOLE layout — moved included — compacts vertically (full Datadog behavior; a drop into free space below content rises back up immediately, no floating placements)
+export function applyMove(
+  value: DashboardCanvasValue,
+  from: ContainerRef,
+  to: ContainerRef,
+  id: string | number,
+  x: number,
+  y: number,
+): DashboardCanvasValue;
+export function applyResize(
+  value: DashboardCanvasValue,
+  container: ContainerRef,
+  id: string | number,
+  w: number,
+  h: number,
+  c?: DashboardItemConstraints,
+): DashboardCanvasValue;
+export function toggleSection(
+  value: DashboardCanvasValue,
+  sectionId: string | number,
+): DashboardCanvasValue;
+export function reorderSection(
+  value: DashboardCanvasValue,
+  sectionId: string | number,
+  toIndex: number,
+): DashboardCanvasValue;
+export type ContainerRef = { kind: 'top' } | { kind: 'section'; id: string | number };
+export function stackOrder(
+  value: DashboardCanvasValue,
+): { container: ContainerRef; id: string | number }[]; // (container-band order, then y, then x) — the below-md order
+export function cellFromPoint(
+  px: number,
+  py: number,
+  containerRect: DOMRect,
+  colWidth: number,
+  rowHeight: number,
+  gap: number,
+): { x: number; y: number }; // snap helper
+```
+
+---
+
+### Task 1: Engine (pure geometry + exhaustive tests)
+
+**Files:**
+
+- Create: `packages/design-system/src/components/DashboardCanvas/engine.ts`
+- Create: `packages/design-system/src/components/DashboardCanvas/engine.test.ts`
+
+**Interfaces:** exactly the engine block above. All functions immutable (never mutate inputs), deterministic, stable ordering.
+
+- [ ] **Step 1 (TDD):** write failing tests FIRST covering at minimum: clamp bounds (x<0, x+w>12, minW/minH/maxH); collides truth table (touching edges do NOT collide); compact pulls items up past gaps, preserves x, stable for ties; placeWithPushDown — drop onto an occupied cell pushes the occupant (and chains) down exactly enough, moved item keeps its dropped spot, non-colliding items compact upward, idempotent when dropped on free space; applyMove within container / cross-container (removed from source, source compacts; inserted+pushed in target) / to empty container; applyResize grows pushing neighbors down, shrink compacts, respects constraints; toggleSection flips only `collapsed`; reorderSection moves band, clamps index; stackOrder (top-level first, then sections in band order; within container by y then x); cellFromPoint snapping incl. gap arithmetic and negative/overshoot clamping.
+- [ ] **Step 2:** RED, then implement, then GREEN. No React imports in engine.ts.
+- [ ] **Step 3:** `cd packages/design-system && npm run typecheck`; root `make lint` (n/a for .ts but run anyway) + `npm run format:check`.
+- [ ] **Step 4:** Commit — `feat(DashboardCanvas): pure 2D grid engine — compaction, push-down, moves, resize, sections (#337)`
+
+---
+
+### Task 2: Component core — rendering, sections, collapse, readOnly, tokens (no gestures)
+
+**Files:**
+
+- Create: `DashboardCanvas.tsx` (orchestrator; public types + JSDoc), `DashboardCanvasItem.tsx`, `DashboardCanvasSection.tsx` (internal child components), `DashboardCanvas.module.scss`, `DashboardCanvas.tokens.scss`, `index.ts`
+- Modify: `src/index.ts` (component + ALL public types), `src/i18n/messages.ts` + `en.ts` + `ru.ts` (initial keys: `dashboardCanvas.canvas` region label, `sectionCollapse`/`sectionExpand` toggle labels — more keys come in Task 4)
+- Modify: `src/_meta/manifest.ts` + `scripts/generate-manifest.mjs` (CLUSTERS `DashboardCanvas: 'Display'`) + `npm run build:manifest` (commit regenerated output)
+- Test: `DashboardCanvas.test.tsx`
+
+**Spec:**
+
+- Root `<div role="group" aria-label={t('dashboardCanvas.canvas')}>` (forwardRef, Pattern A spread with comment). Top-level container grid, then one band per section in array order.
+- Container grid CSS: `display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); grid-auto-rows: var(--dashboard-canvas-row); gap: var(--dashboard-canvas-gap);`. Items render sorted by (y, x) (stacking-order requirement) and stamp `--dc-col: ${x + 1} / span ${w}`, `--dc-row: ${y + 1} / span ${h}` inline; `.item { grid-column: var(--dc-col); grid-row: var(--dc-row); overflow: auto; }` with the sanctioned stylelint-disable comments (Grid.Item precedent).
+- Tokens (`DashboardCanvas.tokens.scss`, all defaulting to primitives): `--dashboard-canvas-row: var(--space-12)` (48px row unit — the spec's "~48px + gap"), `--dashboard-canvas-gap: var(--space-3)`, item surface (`--dashboard-canvas-item-bg: var(--color-bg)`, border/radius/shadow), section band surface + header tokens, drop-preview + ghost tokens (used in Task 3; define now).
+- Section band: full-width; header row (collapse toggle `<button>` with `aria-expanded`, i18n'd accessible label incl. section title interpolation; the title text; `renderSectionHeader?.(id)` slot), body = the section's own container grid; `collapsed` hides the body (body unmounted — geometry preserved in value). Collapse toggle click → `onChange(toggleSection(value, id))` — works in readOnly too.
+- `readOnly`: no gesture wiring (Task 3 gates on it), no resize handles rendered, items not focusable-for-editing; collapse toggles active. Identical geometry.
+- Tests: renders items with correct inline custom props; items DOM-sorted (y,x); sections in band order with titles; collapse toggle fires onChange with toggled value (and in readOnly); renderItem called per id; renderSectionHeader slot renders; ref forwarded; className merged; region label from i18n.
+- [ ] TDD → implement → package tests + typecheck + root lint/format → Commit — `feat(DashboardCanvas): rendering core — grids, sections, collapse, readOnly, tokens (#337)`
+
+---
+
+### Task 3: Pointer gestures — move, resize, cross-container, section reorder
+
+**Files:** Modify `DashboardCanvas.tsx` / `DashboardCanvasItem.tsx` / `DashboardCanvasSection.tsx` / SCSS; extend `DashboardCanvas.test.tsx`.
+
+**Spec (FlowCanvas gesture architecture — dragState in refs, live preview in state, commit once on pointerup, discard on cancel/Escape):**
+
+- **Move:** pointerdown on item body (edit mode, primary button, 5px activation distance before drag arms — Sortable precedent) → capture pointer; live ghost follows cursor (transform, original cell dims); snapped **drop preview** cell computed via `cellFromPoint` against the container under the pointer + `placeWithPushDown` preview of the target container (preview state renders neighbors in their pushed positions — this is the Datadog live-reflow feel); pointerup commits `onChange(applyMove(...))` once; no-op drop (same container+cell) fires nothing; pointercancel/Escape restores.
+- **Cross-container:** containers (top + each expanded section body) register their DOMRects in a ref map (re-measured per dragmove via `getBoundingClientRect` — cheap enough at pointermove granularity); the container whose rect contains the pointer is the drop target; dragging over a collapsed section's band does NOT drop into it (bands auto-fit; no hover-to-expand in v1 — document).
+- **Resize:** E / S / SE handles (small `<button>`-free divs with `role="presentation"`, pointer-only — keyboard resize is Task 4; handles hidden in readOnly; hit target ≥ WCAG comment, FlowCanvas token precedent); pointerdown on handle → live preview of snapped w/h (clamped by constraints + 12-col bound), neighbors preview-pushed; pointerup commits `applyResize` once.
+- **Section reorder:** pointerdown on the section header's drag zone (not the collapse button / not header-extras) → vertical drag; live band-gap indicator at the insertion index; pointerup commits `reorderSection`.
+- Cursor states, `data-dragging` attrs, ghost/preview styled via the Task-2 tokens; `touch-action: none` on draggable surfaces (Sortable precedent).
+- **Tests (jsdom, FlowCanvas inline-pointer-sequence style + getBoundingClientRect stubbing for container rects):** move commits applyMove result once (assert onChange payload equals engine result); drop on same cell → no onChange; Escape mid-drag → no onChange; resize commits once with clamped dims; cross-container move (stub two container rects, drag from one into the other) commits with target container placement; section header drag commits reorderSection; readOnly wires nothing (pointerdown does not start a drag); activation distance respected (4px move → click passes through, no drag).
+- [ ] TDD → implement → tests/typecheck/lint/format → Commit — `feat(DashboardCanvas): pointer gestures — snap move with push-down preview, E/S/SE resize, cross-container drag, band reorder (#337)`
+
+---
+
+### Task 4: Keyboard + a11y + i18n
+
+**Files:** Modify component files + `messages.ts`/`en.ts`/`ru.ts`; extend tests.
+
+**Spec (FlowCanvas keyboard/announce architecture):**
+
+- Edit mode: each item gets `tabIndex={0}` + `role="button"` semantics documented (or `aria-roledescription` — match what FlowCanvas nodes do; read it first). Focused item: **Enter/Space = pick up**; while picked: **arrows = move one cell** (live preview, same engine path as pointer), **Enter/Space = drop (commit once)**, **Escape = cancel** (restore, `useFloatingSurface(picked != null)` so host modals yield Escape). **Without pickup: Shift+arrows = resize one cell** (commit per keypress like FlowCanvas nudges — or pickup-style? LOCKED: Shift+arrows commit per keypress via `applyResize`, simplest and matches FlowCanvas's nudge-commits). Cross-container keyboard move: while picked, ArrowUp/Down past a container's edge moves the item into the adjacent band at the nearest x — engine's applyMove handles it; announce the container change.
+- Section header: collapse toggle is a real button (Task 2); the header drag-zone gets keyboard band reorder: focused header + Shift+ArrowUp/Down = reorderSection (commit per keypress + announce).
+- Live region: nonce `announce()` + `role="status"` sr-only span (FlowCanvas.tsx:568/1902 pattern). Announcements (all i18n'd, en+ru, typed params): picked up, moved (x/y in human terms: t('dashboardCanvas.movedTo', {x, y, container})), dropped, cancelled, resized (w×h), section collapsed/expanded, section moved, item entered section/top level.
+- Visually-hidden instructions block wired via `aria-describedby` (edit mode; shorter readOnly variant) — FlowCanvas precedent.
+- Tests: full keyboard move cycle (focus → Enter → ArrowRight → Enter → onChange once with engine-equal payload); Escape cancels (no onChange); Shift+ArrowRight resizes (+1 w, commit); announcements appear in the status region (assert textContent); aria-expanded on collapse toggles; instructions present; readOnly: items not tabbable for editing, toggles still work.
+- [ ] TDD → implement → tests/typecheck/lint/format → Commit — `feat(DashboardCanvas): keyboard parity, live-region announcements, i18n en+ru (#337)`
+
+---
+
+### Task 5: Below-md stacking + editing gate
+
+**Files:** Modify component files + SCSS; extend tests.
+
+**Spec:**
+
+- Root gets `container-type: inline-size` ONLY always? NO — mirror #318: the canvas is inherently responsive per the spec, so the root is always `.canvas` with containment ON (document the intrinsic-sizing caveat in JSDoc like Grid's collapseBelow anti-pattern note). `@container (max-width: #{bp.$collapse-md})` (shared `_internal/collapse.scss` breakpoint): containers re-template to one column (`grid-template-columns: repeat(1, minmax(0, 1fr))`), items override to `grid-column: 1 / -1; grid-row: auto;` at (0,3,0)+ specificity over the custom-prop rules (the #318 step mechanism — item rule reads nothing inline below md). DOM order already = stack order (Task 2 sorts (y,x); bands in order) → correct (section, y, x) stacking for free. Item height below md: `grid-auto-rows: auto` with a min-height token? LOCKED: rows keep `var(--dashboard-canvas-row)` auto-rows and items keep their h via `grid-row: span h`? NO — spec says single stacked column; keep each item's height = `span h` rows (content-true) — simplest: keep `--dc-row` span but `grid-row: auto / span var(--dc-h)`… simplest correct: stamp `--dc-h-span: span ${h}` inline in Task 2 and below-md rule uses `grid-row: var(--dc-h-span)`. (Implementer: verify visually in Task 6's demo; adjust with a comment if heights look wrong.)
+- Editing gate: ResizeObserver on root sets `isNarrow` when width < 640 (same value as `$collapse-md`; hardcode 640 with a comment pointing at collapse.scss — SCSS constants aren't readable from TS; add a meta-test? NO — one comment each side, keep in sync manually like the existing JSDoc/SCSS pairs). `isNarrow` → gestures + keyboard editing disabled, handles hidden (readOnly-like), collapse toggles active. jsdom: no RO / 0 width → treat as wide (tests keep working).
+- Tests: below-md class present; narrow gate (mock RO or call the handler) disables pointerdown drag; collapse toggle still fires when narrow.
+- [ ] TDD → implement → tests/typecheck/lint/format → Commit — `feat(DashboardCanvas): below-md single-column stacking + narrow editing gate (#337)`
+
+---
+
+### Task 6: Demo, wiring, docs, gates
+
+**Files:**
+
+- Create: `packages/playground/src/pages/components/DashboardCanvasDemo.tsx`
+- Modify: `App.tsx` (route `/components/dashboard-canvas`), `navItems.ts` (**Display** group, distinct lucide icon e.g. `LayoutDashboard`), `ComponentsIndex.tsx` + `overviewSchematics.tsx` (`SCHEMATICS['DashboardCanvas']` — bands + mixed-size tiles blueprint), `pages/mockups/registry.ts` (ComponentName union)
+- Modify: `packages/design-system/AGENTS.md` (TL;DR section near FlowCanvas/Sortable: model, per-gesture onChange, readOnly, below-md, when NOT to use — flow reorder → Sortable; kanban columns → Kanban; free-form node graphs → FlowCanvas)
+- JSDoc final pass on DashboardCanvas.tsx: 3+ @examples (edit-mode dashboard with sections + constraints; readOnly view; controlled persistence pattern), @remarks When-NOT-to-use + anti-patterns (❌ uncontrolled usage; ❌ nesting canvases; ❌ using it for simple ordered lists).
+
+**Demo sections:** (1) stateful edit-mode canvas: ~6 widgets in top-level + two sections, mixed sizes, constraints on a couple of items, onChange wired to local state with the current value JSON shown collapsibly; (2) readOnly twin of the same value; (3) a narrow-container frame (resizable box, #318 demo pattern) showing the below-md stack.
+
+- [ ] Implement; `npx prettier --write docs/superpowers/plans/2026-07-26-dashboard-canvas.md` and include the plan doc; full gates `make test && make build-lib && make lint && npm run format:check && make build` (commit regenerated manifests).
+- [ ] Commit — `docs(DashboardCanvas): playground demo + wiring + AGENTS.md TL;DR (#337)`
+
+---
+
+### Task 7 (controller-run): visual validation + final review + ship
+
+Playwright on :8091 — real drag/resize/section gestures in the browser, both themes, narrow frame; screenshots to scratchpad. Then whole-branch rule-8 review (most capable model), fix loop, push/PR/merge/release/close per implement-issue.
+
+## Self-review notes
+
+- Raw-pointer over dnd-kit is the plan's one deliberate deviation from the issue's wording — flagged in the PR body; every other decision traces to the issue or the approved consumer spec.
+- `placeWithPushDown` semantics ("moved wins, others push down, rest compacts") is THE product-defining algorithm — Task 1's tests are the contract; Task 3 must render ITS results, never invent parallel geometry.
+- Keyboard resize commits per keypress (no resize "mode") — FlowCanvas nudge precedent, keeps the state machine small.
+- Collapsed sections don't accept drops in v1 (documented); hover-to-expand is future work.
+- Row unit 48px = `--space-12`; consumers theme via the component token.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1012,6 +1012,27 @@ When NOT to use: >100-node graphs (no virtualization); list/column reordering (u
 Kanban/Sortable); undirected/free-form drawing; as the only editing surface for complex
 attributes (anchor your own modals via the open callbacks — keep a form-based fallback).
 
+### `<DashboardCanvas>` — 2D snap-grid dashboard
+
+Datadog-style 2D snap-grid dashboard. `value` is `{ items: DashboardPlacement[], sections: DashboardSection[] }` — top-level items plus an ordered array of full-width collapsible sections, each with its own 12-column sub-grid. Always controlled, no uncontrolled mode: `onChange(next)` fires once per completed gesture (a drop, a resize end, a collapse toggle, a band reorder, a cross-container move) with the whole engine-computed next value; omit it for a static layout — drags still preview live but nothing persists past pointerup. `renderItem(id)` renders every visible item's body (called once more for the drag ghost mid-gesture, so keep it pure). `renderSectionHeader(id)` adds small extras (a title editor, a `DropdownMenu` trigger) to the right of a section's title — pointer presses inside it never start a band-reorder drag. `constraints` — a `Record<id, { minW?, minH?, maxH? }>` or a `(id) => constraints | undefined` function — clamps resize gestures per item; unlisted items default to `minW: 1`, `minH: 1`, no `maxH`.
+
+Gestures: drag-to-move with push-down collision + live compaction preview, E/S/SE resize handles, cross-container drag (top level ↔ any expanded section), and vertical band reorder by dragging a section header. Full keyboard: Tab to an item, Enter/Space picks it up, arrows move it (crossing a container's edge moves it into the next band), Shift+arrows resize, Enter/Space drops, Escape cancels; Shift+arrows on a focused section header reorders bands.
+
+```tsx
+const [value, setValue] = useState<DashboardCanvasValue>(initialLayout);
+
+<DashboardCanvas
+  value={value}
+  onChange={setValue}
+  renderItem={(id) => <Card>{widgets[id].title}</Card>}
+  constraints={{ kpi: { minW: 2, maxH: 4 } }}
+/>;
+```
+
+`readOnly` turns off all editing (no handles, no keyboard editing) while section collapse toggles keep working — collapse is navigation, not editing. Independent of `readOnly`, below 640px of the canvas's OWN width (a CSS container query, not the viewport) every container automatically re-templates to one column and editing turns off the same way — a `ResizeObserver` mirrors the breakpoint so a gesture can never half-start below it.
+
+When NOT to use: a single ordered list (priority queue, simple reordering) — use `Sortable`; fixed kanban-style columns — use `Kanban`; a free-form node/edge graph — use `FlowCanvas`. The canvas is ALWAYS a size container (`container-type: inline-size`, unconditionally) — give it a parent with a concrete width; an intrinsic-width context (a `Cluster` item, `width: max-content`) renders it at width 0, same caveat as Grid's `collapseBelow`.
+
 ### `<LiquidEditor>` — Liquid template editor
 
 Liquid template editor: syntax highlighting, line-number gutter, variable-insert menu, caret autocomplete, client-side unknown-variable flagging, and a controlled preview pane. Controlled only (`value` + `onChange`). It never parses or renders Liquid — backend syntax errors arrive via `invalid`/`error`; the rendered preview arrives via `preview`/`previewStatus`.

--- a/packages/design-system/scripts/generate-manifest.mjs
+++ b/packages/design-system/scripts/generate-manifest.mjs
@@ -84,6 +84,7 @@ const CLUSTERS = {
   CircularProgress: 'Display',
   Code: 'Display',
   CursorPagination: 'Display',
+  DashboardCanvas: 'Display',
   DataTable: 'Display',
   EmptyState: 'Display',
   ErrorState: 'Display',

--- a/packages/design-system/src/_meta/manifest.ts
+++ b/packages/design-system/src/_meta/manifest.ts
@@ -106,6 +106,7 @@ const CLUSTERS: Record<string, string> = {
   CircularProgress: 'Display',
   Code: 'Display',
   CursorPagination: 'Display',
+  DashboardCanvas: 'Display',
   DataTable: 'Display',
   EmptyState: 'Display',
   ErrorState: 'Display',

--- a/packages/design-system/src/components.manifest.json
+++ b/packages/design-system/src/components.manifest.json
@@ -177,6 +177,12 @@
     ],
     "composedBy": []
   },
+  "DashboardCanvas": {
+    "tier": "primitive",
+    "cluster": "Display",
+    "composes": [],
+    "composedBy": []
+  },
   "DataTable": {
     "tier": "composition",
     "cluster": "Display",

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.module.scss
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.module.scss
@@ -1,0 +1,85 @@
+@use './DashboardCanvas.tokens' as tokens;
+
+// Root stacks its own children — the top-level container grid, then one band
+// per section, top to bottom. This is the component's own internal
+// composition (Stack/Cluster precedent), not layout imposed on a parent.
+.canvas {
+  display: flex;
+  flex-direction: column;
+  gap: var(--dashboard-canvas-gap);
+}
+
+// One container grid — used for both the top-level items and each section's
+// body. Below-md re-templating to a single column lands in Task 5.
+.container {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  grid-auto-rows: var(--dashboard-canvas-row);
+  gap: var(--dashboard-canvas-gap);
+}
+
+// Item placement — the value is resolved in DashboardCanvasItem.tsx and
+// injected as inline custom properties (Grid.Item precedent: per-cell
+// placement is this layout family's own prop, not consumer layout).
+.item {
+  // stylelint-disable-next-line property-disallowed-list -- DashboardCanvasItem's sanctioned job: per-cell grid placement (Grid.Item precedent), not consumer layout (Rule 4 exemption)
+  grid-column: var(--dc-col);
+  // stylelint-disable-next-line property-disallowed-list -- see grid-column comment above
+  grid-row: var(--dc-row);
+  overflow: auto;
+  background: var(--dashboard-canvas-item-bg);
+  border: var(--border-width) solid var(--dashboard-canvas-item-border);
+  border-radius: var(--dashboard-canvas-item-radius);
+  box-shadow: var(--dashboard-canvas-item-shadow);
+}
+
+// Full-width collapsible band.
+.section {
+  background: var(--dashboard-canvas-section-bg);
+  border: var(--border-width) solid var(--dashboard-canvas-section-border);
+  border-radius: var(--dashboard-canvas-section-radius);
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--dashboard-canvas-gap);
+}
+
+.sectionToggle {
+  display: flex;
+  align-items: center;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--dashboard-canvas-section-header-bg-hover);
+  }
+
+  &:focus-visible {
+    outline: var(--border-width-emphasis) solid var(--color-accent);
+  }
+}
+
+.sectionIndicator {
+  flex-shrink: 0;
+  color: var(--dashboard-canvas-section-indicator-fg);
+  transition: transform var(--transition-fast);
+}
+
+// Chevron points down when expanded (default), rotates to point right when
+// the section is collapsed — aria-expanded is the single source of truth.
+.sectionToggle[aria-expanded='false'] .sectionIndicator {
+  transform: rotate(-90deg);
+}
+
+.sectionTitle {
+  color: var(--dashboard-canvas-section-header-fg);
+  font-weight: var(--font-weight-medium);
+}
+
+.sectionActions {
+  display: flex;
+  align-items: center;
+}

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.module.scss
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.module.scss
@@ -4,9 +4,25 @@
 // per section, top to bottom. This is the component's own internal
 // composition (Stack/Cluster precedent), not layout imposed on a parent.
 .canvas {
+  // Relative only as the anchor for the internal drag ghost (Rule 4's
+  // sanctioned internal-child-anchor use).
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--dashboard-canvas-gap);
+}
+
+// Edit-mode drag surfaces: whole item bodies and section headers start drags,
+// so the browser must not claim their touch gestures (Sortable precedent).
+.canvas:not([data-readonly]) .item,
+.canvas:not([data-readonly]) .sectionHeader {
+  touch-action: none;
+  cursor: grab;
+}
+
+.canvas[data-dragging] {
+  cursor: grabbing;
+  user-select: none;
 }
 
 // One container grid — used for both the top-level items and each section's
@@ -26,11 +42,102 @@
   grid-column: var(--dc-col);
   // stylelint-disable-next-line property-disallowed-list -- see grid-column comment above
   grid-row: var(--dc-row);
+  position: relative; // anchor for the internal resize handles
   overflow: auto;
   background: var(--dashboard-canvas-item-bg);
   border: var(--border-width) solid var(--dashboard-canvas-item-border);
   border-radius: var(--dashboard-canvas-item-radius);
   box-shadow: var(--dashboard-canvas-item-shadow);
+}
+
+// The dragged item's cell renders the snapped drop preview — the ghost
+// carries the content, so the cell shows only the highlighted slot.
+.item[data-dc-drop-preview] {
+  background: var(--dashboard-canvas-drop-preview-bg);
+  border-color: var(--dashboard-canvas-drop-preview-border);
+  border-style: dashed;
+  box-shadow: none;
+
+  > * {
+    visibility: hidden;
+  }
+}
+
+.item[data-dc-resizing] {
+  border-color: var(--dashboard-canvas-drop-preview-border);
+}
+
+// Cursor-following drag ghost: the moved item's content at its original px
+// size, translated per pointermove in canvas-relative coordinates.
+.ghost {
+  position: absolute;
+  top: 0;
+  left: 0;
+  overflow: hidden;
+  pointer-events: none;
+  opacity: var(--dashboard-canvas-ghost-opacity);
+  background: var(--dashboard-canvas-item-bg);
+  border: var(--border-width) solid var(--dashboard-canvas-drop-preview-border);
+  border-radius: var(--dashboard-canvas-item-radius);
+  box-shadow: var(--dashboard-canvas-item-shadow-dragging);
+}
+
+// Resize handles — pointer-only edge/corner corridors (keyboard resize is
+// Task 4). 24px hit targets (WCAG 2.5.8, FlowCanvas token precedent); the
+// only visible affordance is the cursor plus the SE corner glyph on hover.
+.handleE,
+.handleS,
+.handleSE {
+  position: absolute;
+  touch-action: none;
+}
+
+.handleE {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: var(--dashboard-canvas-handle-hit);
+  cursor: ew-resize;
+}
+
+.handleS {
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: var(--dashboard-canvas-handle-hit);
+  cursor: ns-resize;
+}
+
+.handleSE {
+  right: 0;
+  bottom: 0;
+  width: var(--dashboard-canvas-handle-hit);
+  height: var(--dashboard-canvas-handle-hit);
+  cursor: nwse-resize;
+}
+
+.handleSE::after {
+  content: '';
+  position: absolute;
+  right: var(--space-1);
+  bottom: var(--space-1);
+  width: var(--space-2);
+  height: var(--space-2);
+  border-right: var(--border-width-emphasis) solid var(--dashboard-canvas-handle-fg);
+  border-bottom: var(--border-width-emphasis) solid var(--dashboard-canvas-handle-fg);
+  border-bottom-right-radius: var(--radius-sm);
+  visibility: hidden;
+}
+
+.item:hover .handleSE::after {
+  visibility: visible;
+}
+
+// Live insertion indicator between section bands during a band-reorder drag.
+.bandIndicator {
+  height: var(--space-1);
+  border-radius: var(--radius-full);
+  background: var(--dashboard-canvas-drop-indicator);
 }
 
 // Full-width collapsible band.

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.module.scss
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.module.scss
@@ -1,9 +1,14 @@
 @use './DashboardCanvas.tokens' as tokens;
 @use '../../styles/mixins' as *;
+@use '../_internal/collapse' as bp;
 
 // Root stacks its own children — the top-level container grid, then one band
 // per section, top to bottom. This is the component's own internal
 // composition (Stack/Cluster precedent), not layout imposed on a parent.
+// ALWAYS a size container (unconditional, unlike Grid's opt-in
+// `collapseBelow`) — the below-md single-column stack (Task 5, bottom of
+// this file) depends on it. See DashboardCanvas.tsx's JSDoc ❌ anti-pattern
+// paragraph for the intrinsic-sizing caveat this carries.
 .canvas {
   // Relative only as the anchor for the internal drag ghost (Rule 4's
   // sanctioned internal-child-anchor use).
@@ -11,12 +16,15 @@
   display: flex;
   flex-direction: column;
   gap: var(--dashboard-canvas-gap);
+  container-type: inline-size;
 }
 
 // Edit-mode drag surfaces: whole item bodies and section headers start drags,
 // so the browser must not claim their touch gestures (Sortable precedent).
-.canvas:not([data-readonly]) .item,
-.canvas:not([data-readonly]) .sectionHeader {
+// Narrow width disables editing exactly like readOnly (DashboardCanvas.tsx's
+// `editingEnabled` gate) — excluded here too so the cursor doesn't lie.
+.canvas:not([data-readonly], [data-narrow]) .item,
+.canvas:not([data-readonly], [data-narrow]) .sectionHeader {
   touch-action: none;
   cursor: grab;
 }
@@ -27,7 +35,8 @@
 }
 
 // One container grid — used for both the top-level items and each section's
-// body. Below-md re-templating to a single column lands in Task 5.
+// body. Below-md re-templating to a single column: see the
+// `@container (max-width: $collapse-md)` block at the bottom of this file.
 .container {
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
@@ -207,4 +216,34 @@
 // Keyboard instructions + live announcement region.
 .srOnly {
   @include visually-hidden;
+}
+
+// --- below-md single-column stacking (Task 5) --------------------------
+// Below the shared $collapse-md breakpoint (`_internal/collapse.scss`,
+// 640px — kept in sync by hand with DashboardCanvas.tsx's NARROW_PX, the
+// same JS/CSS pairing the editing gate uses), every container grid
+// re-templates to one column and each item spans the full row at its own
+// height. DOM order is ALREADY (container band order, y, x) —
+// DashboardCanvasItem.tsx's `sortByPosition`, load-bearing exactly for this
+// — so the correct (section, y, x) stack order falls out for free; no JS
+// re-render needed for the reflow itself, only for the editing gate
+// (DashboardCanvas.tsx's `isNarrow`/`editingEnabled`).
+// Specificity: the base `.item` rule above (`grid-column: var(--dc-col);
+// grid-row: var(--dc-row);`) is one class = (0,1,0). `.canvas .item` below
+// is two classes = (0,2,0), which beats (0,1,0) unconditionally — no
+// reliance on this file's own source order surviving bundling (#318
+// precedent; same reasoning as Grid's `.collapsible.collapseXx` double
+// class). Same math for `.canvas .container` vs the one-class `.container`
+// base rule.
+@container (max-width: #{bp.$collapse-md}) {
+  .canvas .container {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .canvas .item {
+    // stylelint-disable-next-line property-disallowed-list -- below-md override is DashboardCanvas's own placement mechanism, same sanction as the base .item rule above
+    grid-column: 1 / -1;
+    // stylelint-disable-next-line property-disallowed-list -- see grid-column comment above
+    grid-row: var(--dc-h-span);
+  }
 }

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.module.scss
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.module.scss
@@ -1,4 +1,5 @@
 @use './DashboardCanvas.tokens' as tokens;
+@use '../../styles/mixins' as *;
 
 // Root stacks its own children — the top-level container grid, then one band
 // per section, top to bottom. This is the component's own internal
@@ -65,6 +66,18 @@
 
 .item[data-dc-resizing] {
   border-color: var(--dashboard-canvas-drop-preview-border);
+}
+
+// Keyboard editing: the cell itself is the focusable editing surface.
+.item:focus-visible {
+  outline: var(--border-width-emphasis) solid var(--color-accent);
+}
+
+// A keyboard-picked item travels with the engine preview — mark it like an
+// armed drag (content stays visible; there is no ghost on the keyboard path).
+.item[data-dc-picked] {
+  border-color: var(--dashboard-canvas-drop-preview-border);
+  box-shadow: var(--dashboard-canvas-item-shadow-dragging);
 }
 
 // Cursor-following drag ghost: the moved item's content at its original px
@@ -189,4 +202,9 @@
 .sectionActions {
   display: flex;
   align-items: center;
+}
+
+// Keyboard instructions + live announcement region.
+.srOnly {
+  @include visually-hidden;
 }

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
@@ -1,7 +1,8 @@
 import { createRef } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DashboardCanvas } from './DashboardCanvas';
+import { applyMove, applyResize, reorderSection } from './engine';
 import type { DashboardCanvasValue } from './engine';
 
 function baseValue(): DashboardCanvasValue {
@@ -148,5 +149,419 @@ describe('DashboardCanvas section collapse', () => {
       'aria-expanded',
       'false',
     );
+  });
+});
+
+// --- pointer gestures (Task 3) ---------------------------------------------
+// jsdom reports zero-size rects everywhere, so gesture tests hand every canvas
+// surface a deterministic box (Sortable.test.tsx stubStackedRects convention).
+// In jsdom the computed grid gap resolves to 0 and the row unit falls back to
+// 48px, so a 480px-wide container yields exact 40px columns: cell x =
+// floor(px / 40), cell y = floor(py / 48). Containers are found via their
+// data-dc-container attribute, section bands via data-dc-section, and items
+// derive their box from the inline --dc-col/--dc-row custom properties.
+const CONTAINER_RECTS: Record<
+  string,
+  { left: number; top: number; width: number; height: number }
+> = {
+  top: { left: 0, top: 0, width: 480, height: 480 },
+  s1: { left: 0, top: 600, width: 480, height: 240 },
+};
+const BAND_RECTS: Record<string, { left: number; top: number; width: number; height: number }> = {
+  s1: { left: 0, top: 560, width: 480, height: 280 }, // midpoint y=700
+  s2: { left: 0, top: 850, width: 480, height: 40 }, // midpoint y=870
+};
+const COL_PX = 40;
+const ROW_PX = 48;
+
+function toRect(r: { left: number; top: number; width: number; height: number }): DOMRect {
+  return {
+    x: r.left,
+    y: r.top,
+    top: r.top,
+    left: r.left,
+    right: r.left + r.width,
+    bottom: r.top + r.height,
+    width: r.width,
+    height: r.height,
+    toJSON() {},
+  } as DOMRect;
+}
+
+function stubCanvasRects(): () => void {
+  const orig = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function () {
+    const el = this as HTMLElement;
+    const item = el.closest?.('[data-dc-item]') as HTMLElement | null;
+    if (item) {
+      const key = item.closest('[data-dc-container]')?.getAttribute('data-dc-container') ?? 'top';
+      const base = CONTAINER_RECTS[key] ?? CONTAINER_RECTS.top;
+      const col = /^(\d+) \/ span (\d+)$/.exec(item.style.getPropertyValue('--dc-col'));
+      const row = /^(\d+) \/ span (\d+)$/.exec(item.style.getPropertyValue('--dc-row'));
+      const x = Number(col?.[1] ?? 1) - 1;
+      const w = Number(col?.[2] ?? 1);
+      const y = Number(row?.[1] ?? 1) - 1;
+      const h = Number(row?.[2] ?? 1);
+      return toRect({
+        left: base.left + x * COL_PX,
+        top: base.top + y * ROW_PX,
+        width: w * COL_PX,
+        height: h * ROW_PX,
+      });
+    }
+    const containerKey = el.getAttribute?.('data-dc-container');
+    if (containerKey && CONTAINER_RECTS[containerKey]) {
+      return toRect(CONTAINER_RECTS[containerKey]);
+    }
+    const bandKey = el.getAttribute?.('data-dc-section');
+    if (bandKey && BAND_RECTS[bandKey]) return toRect(BAND_RECTS[bandKey]);
+    return toRect({ left: 0, top: 0, width: 1000, height: 1000 });
+  };
+  return () => {
+    Element.prototype.getBoundingClientRect = orig;
+  };
+}
+
+function itemEl(container: HTMLElement, id: string): HTMLElement {
+  return container.querySelector(`[data-dc-item="${id}"]`) as HTMLElement;
+}
+
+describe('DashboardCanvas pointer gestures', () => {
+  let restoreRects: () => void;
+  beforeEach(() => {
+    restoreRects = stubCanvasRects();
+  });
+  afterEach(() => {
+    restoreRects();
+  });
+
+  function renderCanvas(props: Partial<Parameters<typeof DashboardCanvas>[0]> = {}) {
+    const onChange = vi.fn();
+    const value = baseValue();
+    const utils = render(
+      <DashboardCanvas value={value} onChange={onChange} renderItem={renderItem} {...props} />,
+    );
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    return { ...utils, onChange, value, root };
+  }
+
+  it('a snapped move commits onChange once with the engine applyMove result', () => {
+    const { container, onChange, value, root } = renderCanvas();
+    // 'b' sits at (0,0,2,1) → rect (0,0,80,48); grab it at (10,10).
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    // Ghost origin = pointer - grab offset = (85,50) → cell (2,1).
+    fireEvent.pointerMove(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    fireEvent.pointerUp(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(
+      applyMove(value, { kind: 'top' }, { kind: 'top' }, 'b', 2, 1),
+    );
+  });
+
+  it('mid-drag renders the engine preview (neighbors reflow) plus a ghost; Escape cancels', () => {
+    const { container, onChange, root } = renderCanvas();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    // Origin (165,5) → cell (4,0): 'b' vacates column 0, so 'a' compacts up.
+    fireEvent.pointerMove(root, { clientX: 175, clientY: 15, pointerId: 1 });
+    expect(itemEl(container, 'a').style.getPropertyValue('--dc-row')).toBe('1 / span 1');
+    expect(itemEl(container, 'b')).toHaveAttribute('data-dc-drop-preview');
+    expect(container.querySelector('[data-dc-ghost]')).toBeInTheDocument();
+    expect(root).toHaveAttribute('data-dragging');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(itemEl(container, 'a').style.getPropertyValue('--dc-row')).toBe('2 / span 1');
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeInTheDocument();
+    fireEvent.pointerUp(root, { clientX: 175, clientY: 15, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('a drop back on the dragged item’s own cell fires no onChange', () => {
+    const { container, onChange, root } = renderCanvas();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    // 7px right arms the drag, but origin (7,0) still snaps to b's own (0,0).
+    fireEvent.pointerMove(root, { clientX: 17, clientY: 10, pointerId: 1 });
+    fireEvent.pointerUp(root, { clientX: 17, clientY: 10, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('a sub-5px pointer move never arms a drag (clicks pass through)', () => {
+    const { container, onChange, root } = renderCanvas();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 14, clientY: 10, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeInTheDocument();
+    expect(root).not.toHaveAttribute('data-dragging');
+    fireEvent.pointerUp(root, { clientX: 14, clientY: 10, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('dragging into a section body commits applyMove into that section', () => {
+    const { container, onChange, value, root } = renderCanvas();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    // Pointer (55,615) is inside s1's body (top 600); origin (45,605) → cell (1,0).
+    fireEvent.pointerMove(root, { clientX: 55, clientY: 615, pointerId: 1 });
+    fireEvent.pointerUp(root, { clientX: 55, clientY: 615, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(
+      applyMove(value, { kind: 'top' }, { kind: 'section', id: 's1' }, 'b', 1, 0),
+    );
+  });
+
+  it('a collapsed section’s band is not a drop target', () => {
+    const { container, onChange, root } = renderCanvas();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    // (50,860) sits on collapsed s2's band — no registered container there, so
+    // the drop target stays the container the drag last hovered (top).
+    fireEvent.pointerMove(root, { clientX: 50, clientY: 860, pointerId: 1 });
+    fireEvent.pointerUp(root, { clientX: 50, clientY: 860, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0][0] as DashboardCanvasValue;
+    expect(next.sections.find((s) => s.id === 's2')?.items.map((i) => i.id)).toEqual(['d']);
+    expect(next.items.map((i) => i.id)).toContain('b');
+  });
+
+  it('an SE resize previews live and commits once with the clamped engine result', () => {
+    const { container, onChange, value, root } = renderCanvas({
+      constraints: { a: { maxH: 1 } },
+    });
+    const se = container.querySelector('[data-dc-item="a"] [data-dc-resize="se"]') as HTMLElement;
+    fireEvent.pointerDown(se, { clientX: 80, clientY: 96, pointerId: 1, button: 0 });
+    // +85px → +2 columns, +55px → +1 row: requested 4×2, maxH clamps to 4×1.
+    fireEvent.pointerMove(root, { clientX: 165, clientY: 151, pointerId: 1 });
+    expect(itemEl(container, 'a').style.getPropertyValue('--dc-col')).toBe('1 / span 4');
+    fireEvent.pointerUp(root, { clientX: 165, clientY: 151, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(
+      applyResize(value, { kind: 'top' }, 'a', 4, 2, { maxH: 1 }),
+    );
+  });
+
+  it('an E resize changes width only and honors function-form constraints', () => {
+    const { container, onChange, value, root } = renderCanvas({
+      constraints: (id: string | number) => (id === 'a' ? { minW: 3 } : undefined),
+    });
+    const e = container.querySelector('[data-dc-item="a"] [data-dc-resize="e"]') as HTMLElement;
+    fireEvent.pointerDown(e, { clientX: 80, clientY: 70, pointerId: 1, button: 0 });
+    // -80px → -2 columns (requested w=0); vertical travel is ignored on E.
+    fireEvent.pointerMove(root, { clientX: 0, clientY: 130, pointerId: 1 });
+    fireEvent.pointerUp(root, { clientX: 0, clientY: 130, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(
+      applyResize(value, { kind: 'top' }, 'a', 0, 1, { minW: 3 }),
+    );
+  });
+
+  it('a resize that snaps back to the original size fires nothing', () => {
+    const { container, onChange, root } = renderCanvas();
+    const se = container.querySelector('[data-dc-item="a"] [data-dc-resize="se"]') as HTMLElement;
+    fireEvent.pointerDown(se, { clientX: 80, clientY: 96, pointerId: 1, button: 0 });
+    fireEvent.pointerMove(root, { clientX: 83, clientY: 98, pointerId: 1 }); // rounds to ±0 cells
+    fireEvent.pointerUp(root, { clientX: 83, clientY: 98, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('resize handles never start a move drag (no ghost while resizing)', () => {
+    const { container, root } = renderCanvas();
+    const se = container.querySelector('[data-dc-item="a"] [data-dc-resize="se"]') as HTMLElement;
+    fireEvent.pointerDown(se, { clientX: 80, clientY: 96, pointerId: 1, button: 0 });
+    fireEvent.pointerMove(root, { clientX: 165, clientY: 151, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeInTheDocument();
+    fireEvent.pointerUp(root, { clientX: 165, clientY: 151, pointerId: 1 });
+  });
+
+  it('dragging a section header shows an insertion indicator and commits reorderSection', () => {
+    const { container, onChange, value, root } = renderCanvas();
+    fireEvent.pointerDown(screen.getByText('Section One'), {
+      clientX: 100,
+      clientY: 570,
+      pointerId: 1,
+      button: 0,
+    });
+    // y=900 is past both band midpoints (700, 870) → insertion slot 2 → index 1.
+    fireEvent.pointerMove(root, { clientX: 100, clientY: 900, pointerId: 1 });
+    expect(container.querySelector('[data-dc-band-indicator]')).toBeInTheDocument();
+    expect(container.querySelector('[data-dc-section="s1"]')).toHaveAttribute('data-dragging');
+    fireEvent.pointerUp(root, { clientX: 100, clientY: 900, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(reorderSection(value, 's1', 1));
+  });
+
+  it('a band drag dropped back at its own slot fires nothing', () => {
+    const { container, onChange, root } = renderCanvas();
+    fireEvent.pointerDown(screen.getByText('Section One'), {
+      clientX: 100,
+      clientY: 570,
+      pointerId: 1,
+      button: 0,
+    });
+    // Armed (6px) but still above s1's own midpoint → slot 0 = its own index.
+    fireEvent.pointerMove(root, { clientX: 100, clientY: 576, pointerId: 1 });
+    expect(container.querySelector('[data-dc-band-indicator]')).not.toBeInTheDocument();
+    fireEvent.pointerUp(root, { clientX: 100, clientY: 576, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('pointerdown on the collapse toggle never starts a band drag', () => {
+    const { container, onChange, root } = renderCanvas();
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Collapse Section One section' }), {
+      clientX: 10,
+      clientY: 570,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 10, clientY: 900, pointerId: 1 });
+    expect(container.querySelector('[data-dc-band-indicator]')).not.toBeInTheDocument();
+    fireEvent.pointerUp(root, { clientX: 10, clientY: 900, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('readOnly renders no resize handles and wires no gestures', () => {
+    const { container, onChange, root } = renderCanvas({ readOnly: true });
+    expect(container.querySelector('[data-dc-resize]')).not.toBeInTheDocument();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeInTheDocument();
+    fireEvent.pointerUp(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('captures on the never-remounted ROOT once armed, so an outside pointerup after a cross-container move still commits exactly once', () => {
+    // jsdom has no setPointerCapture at all — install one to observe receivers.
+    const spy = vi.fn();
+    (HTMLElement.prototype as { setPointerCapture?: unknown }).setPointerCapture = spy;
+    const { container, onChange, value, root } = renderCanvas();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    // No capture before arming — clicks inside item bodies must pass through.
+    expect(spy).not.toHaveBeenCalled();
+    // Arms + crosses into s1's body: the item element REMOUNTS here, which
+    // would implicitly release capture had it been set on the item.
+    fireEvent.pointerMove(root, { clientX: 55, clientY: 615, pointerId: 1 });
+    expect(spy.mock.instances).toEqual([root]);
+    // Root capture retargets an outside-the-canvas pointerup to the root.
+    fireEvent.pointerUp(root, { clientX: 5000, clientY: 5000, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(
+      applyMove(value, { kind: 'top' }, { kind: 'section', id: 's1' }, 'b', 1, 0),
+    );
+    expect(root).not.toHaveAttribute('data-dragging');
+    delete (HTMLElement.prototype as { setPointerCapture?: unknown }).setPointerCapture;
+  });
+
+  it('a controlled value update mid-drag is honored at commit (no cached-preview revert)', () => {
+    const onChange = vi.fn();
+    const value = baseValue();
+    const { container, rerender } = render(
+      <DashboardCanvas value={value} onChange={onChange} renderItem={renderItem} />,
+    );
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 175, clientY: 15, pointerId: 1 }); // cell (4,0)
+    const updated: DashboardCanvasValue = {
+      ...value,
+      items: [...value.items, { id: 'e', x: 6, y: 0, w: 2, h: 1 }],
+    };
+    rerender(<DashboardCanvas value={updated} onChange={onChange} renderItem={renderItem} />);
+    fireEvent.pointerUp(root, { clientX: 175, clientY: 15, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(
+      applyMove(updated, { kind: 'top' }, { kind: 'top' }, 'b', 4, 0),
+    );
+    expect((onChange.mock.calls[0][0] as DashboardCanvasValue).items.map((i) => i.id)).toContain(
+      'e',
+    );
+  });
+
+  it('a resize whose clamp resolves back to the current size fires nothing', () => {
+    const { container, onChange, root } = renderCanvas({ constraints: { a: { minW: 2 } } });
+    const e = container.querySelector('[data-dc-item="a"] [data-dc-resize="e"]') as HTMLElement;
+    fireEvent.pointerDown(e, { clientX: 80, clientY: 70, pointerId: 1, button: 0 });
+    // Requested w=0, but minW clamps it right back to the current 2 columns.
+    fireEvent.pointerMove(root, { clientX: 0, clientY: 70, pointerId: 1 });
+    fireEvent.pointerUp(root, { clientX: 0, clientY: 70, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('flipping readOnly on mid-drag aborts the gesture', () => {
+    const onChange = vi.fn();
+    const value = baseValue();
+    const { container, rerender } = render(
+      <DashboardCanvas value={value} onChange={onChange} renderItem={renderItem} />,
+    );
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 175, clientY: 15, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).toBeInTheDocument();
+    rerender(
+      <DashboardCanvas value={value} onChange={onChange} renderItem={renderItem} readOnly />,
+    );
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeInTheDocument();
+    fireEvent.pointerUp(root, { clientX: 175, clientY: 15, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('pointercancel restores the layout without committing', () => {
+    const { container, onChange, root } = renderCanvas();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 175, clientY: 15, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).toBeInTheDocument();
+    fireEvent.pointerCancel(root, { pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeInTheDocument();
+    expect(itemEl(container, 'a').style.getPropertyValue('--dc-row')).toBe('2 / span 1');
+    fireEvent.pointerUp(root, { clientX: 175, clientY: 15, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
@@ -565,3 +565,243 @@ describe('DashboardCanvas pointer gestures', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 });
+
+// --- keyboard editing + announcements (Task 4) ------------------------------
+// Pure engine math — no getBoundingClientRect stubs needed: the keyboard paths
+// never measure pixels, they step grid cells directly.
+describe('DashboardCanvas keyboard editing', () => {
+  function renderCanvas(props: Partial<Parameters<typeof DashboardCanvas>[0]> = {}) {
+    const onChange = vi.fn();
+    const value = baseValue();
+    const utils = render(
+      <DashboardCanvas value={value} onChange={onChange} renderItem={renderItem} {...props} />,
+    );
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    return { ...utils, onChange, value, root, status: screen.getByRole('status') };
+  }
+
+  it('edit-mode items are focusable with button semantics and a localized roledescription', () => {
+    const { container } = renderCanvas();
+    const b = itemEl(container, 'b');
+    expect(b).toHaveAttribute('tabindex', '0');
+    expect(b).toHaveAttribute('role', 'button');
+    expect(b).toHaveAttribute('aria-roledescription', 'widget');
+    expect(b.getAttribute('aria-describedby')).toBeTruthy();
+  });
+
+  it('a full keyboard move cycle commits once with the engine-equal payload', () => {
+    const { container, onChange, value, status } = renderCanvas();
+    const b = itemEl(container, 'b');
+    b.focus();
+    fireEvent.keyDown(b, { key: 'Enter' });
+    expect(status).toHaveTextContent('Picked up');
+    expect(b).toHaveAttribute('data-dc-picked');
+    fireEvent.keyDown(b, { key: 'ArrowRight' });
+    expect(status).toHaveTextContent('Moved to column 2, row 1');
+    fireEvent.keyDown(b, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(
+      applyMove(value, { kind: 'top' }, { kind: 'top' }, 'b', 1, 0),
+    );
+    expect(status).toHaveTextContent('Dropped');
+    expect(itemEl(container, 'b')).not.toHaveAttribute('data-dc-picked');
+  });
+
+  it('arrow moves while picked render the live engine preview', () => {
+    const { container } = renderCanvas();
+    const b = itemEl(container, 'b');
+    fireEvent.keyDown(b, { key: 'Enter' });
+    fireEvent.keyDown(b, { key: 'ArrowRight' });
+    // The preview IS applyMove's result: b snaps to column 2, a stays put.
+    expect(itemEl(container, 'b').style.getPropertyValue('--dc-col')).toBe('2 / span 2');
+    expect(itemEl(container, 'a').style.getPropertyValue('--dc-row')).toBe('2 / span 1');
+  });
+
+  it('Escape cancels the pick, restores the layout, and fires nothing', () => {
+    const { container, onChange, status } = renderCanvas();
+    const b = itemEl(container, 'b');
+    fireEvent.keyDown(b, { key: 'Enter' });
+    fireEvent.keyDown(b, { key: 'ArrowRight' });
+    expect(itemEl(container, 'b').style.getPropertyValue('--dc-col')).toBe('2 / span 2');
+    fireEvent.keyDown(b, { key: 'Escape' });
+    expect(itemEl(container, 'b').style.getPropertyValue('--dc-col')).toBe('1 / span 2');
+    expect(itemEl(container, 'b')).not.toHaveAttribute('data-dc-picked');
+    expect(status).toHaveTextContent('Move cancelled');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('dropping back on the home cell fires nothing (Space pickup and drop)', () => {
+    const { container, onChange } = renderCanvas();
+    const b = itemEl(container, 'b');
+    fireEvent.keyDown(b, { key: ' ' });
+    fireEvent.keyDown(b, { key: 'ArrowRight' });
+    fireEvent.keyDown(b, { key: 'ArrowLeft' });
+    fireEvent.keyDown(b, { key: ' ' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('Shift+ArrowRight resizes one column per keypress, committing each time', () => {
+    const { container, onChange, value, status } = renderCanvas();
+    const a = itemEl(container, 'a');
+    fireEvent.keyDown(a, { key: 'ArrowRight', shiftKey: true });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(applyResize(value, { kind: 'top' }, 'a', 3, 1));
+    expect(status).toHaveTextContent('Resized to 3 by 1');
+    fireEvent.keyDown(itemEl(container, 'a'), { key: 'ArrowRight', shiftKey: true });
+    // Controlled value never re-rendered, so the second press re-requests 3×1.
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('a Shift+arrow resize clamped back to the current size commits nothing but announces the limit', () => {
+    const { container, onChange, status } = renderCanvas({ constraints: { a: { minW: 2 } } });
+    fireEvent.keyDown(itemEl(container, 'a'), { key: 'ArrowLeft', shiftKey: true });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(status).toHaveTextContent('Resized to 2 by 1');
+  });
+
+  it('ArrowDown past the container bottom carries the pick into the next expanded section', () => {
+    const { container, onChange, value, status } = renderCanvas();
+    const a = itemEl(container, 'a');
+    a.focus();
+    fireEvent.keyDown(a, { key: 'Enter' });
+    // a sits at (0,1); the only other top-level item ends at row 1, so one
+    // ArrowDown steps past the bottom and enters Section One at y=0.
+    fireEvent.keyDown(a, { key: 'ArrowDown' });
+    expect(status).toHaveTextContent('Entered the Section One section');
+    // The cross-container preview remounts the item — focus is reclaimed.
+    expect(document.activeElement).toBe(itemEl(container, 'a'));
+    fireEvent.keyDown(itemEl(container, 'a'), { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(
+      applyMove(value, { kind: 'top' }, { kind: 'section', id: 's1' }, 'a', 0, 0),
+    );
+  });
+
+  it('ArrowUp at the top row carries the pick into the container above, entering at its bottom', () => {
+    const { container, onChange, value, status } = renderCanvas();
+    const c = itemEl(container, 'c');
+    fireEvent.keyDown(c, { key: 'Enter' });
+    fireEvent.keyDown(c, { key: 'ArrowUp' });
+    expect(status).toHaveTextContent('Moved to the top level');
+    fireEvent.keyDown(itemEl(container, 'c'), { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    // Top-level content ends at row 2 (item a), so c enters at y=2.
+    expect(onChange.mock.calls[0][0]).toEqual(
+      applyMove(value, { kind: 'section', id: 's1' }, { kind: 'top' }, 'c', 0, 2),
+    );
+  });
+
+  it('ArrowDown with only a collapsed section below clamps instead of entering it', () => {
+    const { container, onChange, status } = renderCanvas();
+    const c = itemEl(container, 'c');
+    fireEvent.keyDown(c, { key: 'Enter' });
+    // s2 (below s1) is collapsed — not a keyboard target, mirroring pointer.
+    fireEvent.keyDown(c, { key: 'ArrowDown' });
+    expect(status).toHaveTextContent('Moved to column 1, row 1');
+    expect(status).not.toHaveTextContent('Entered');
+    fireEvent.keyDown(c, { key: 'Enter' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('Shift+ArrowDown on a section toggle commits reorderSection and announces the new position', () => {
+    const { onChange, value, status } = renderCanvas();
+    const toggle = screen.getByRole('button', { name: 'Collapse Section One section' });
+    toggle.focus();
+    fireEvent.keyDown(toggle, { key: 'ArrowDown', shiftKey: true });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(reorderSection(value, 's1', 1));
+    expect(status).toHaveTextContent('Section One section moved to position 2');
+  });
+
+  it('Shift+ArrowUp on the first band is a clamped no-op', () => {
+    const { onChange, status } = renderCanvas();
+    const toggle = screen.getByRole('button', { name: 'Collapse Section One section' });
+    fireEvent.keyDown(toggle, { key: 'ArrowUp', shiftKey: true });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(status).toHaveTextContent('');
+  });
+
+  it('wires the visually-hidden instructions via aria-describedby, merging a consumer value', () => {
+    const { container, root, rerender, onChange, value } = renderCanvas({
+      'aria-describedby': 'ext',
+    });
+    const ids = (root.getAttribute('aria-describedby') ?? '').split(' ');
+    expect(ids).toContain('ext');
+    const instructionsEl = document.getElementById(ids.find((id) => id !== 'ext') as string);
+    expect(instructionsEl).toHaveTextContent('pick it up');
+    // Items reference the same instructions block.
+    expect(itemEl(container, 'b')).toHaveAttribute('aria-describedby', instructionsEl?.id);
+    rerender(
+      <DashboardCanvas value={value} onChange={onChange} renderItem={renderItem} readOnly />,
+    );
+    expect(instructionsEl).not.toHaveTextContent('pick it up');
+  });
+
+  it('an external value change mid-pick cancels the pick and keeps the canvas editable', () => {
+    const onChange = vi.fn();
+    const value = baseValue();
+    const { container, rerender } = render(
+      <DashboardCanvas value={value} onChange={onChange} renderItem={renderItem} />,
+    );
+    const b = itemEl(container, 'b');
+    fireEvent.keyDown(b, { key: 'Enter' });
+    fireEvent.keyDown(b, { key: 'ArrowRight' });
+    expect(itemEl(container, 'b').style.getPropertyValue('--dc-col')).toBe('2 / span 2');
+    // The consumer deletes the picked item out from under the pick.
+    const updated: DashboardCanvasValue = {
+      ...value,
+      items: value.items.filter((item) => item.id !== 'b'),
+    };
+    rerender(<DashboardCanvas value={updated} onChange={onChange} renderItem={renderItem} />);
+    // No stale preview: the deleted item is gone, the pick is cancelled...
+    expect(container.querySelector('[data-dc-item="b"]')).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Move cancelled');
+    // ...and the canvas is not locked: another item can be picked up.
+    fireEvent.keyDown(itemEl(container, 'a'), { key: 'Enter' });
+    expect(itemEl(container, 'a')).toHaveAttribute('data-dc-picked');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('focus leaving the picked item cancels the pick', () => {
+    const { container, onChange, status } = renderCanvas();
+    const b = itemEl(container, 'b');
+    b.focus();
+    fireEvent.keyDown(b, { key: 'Enter' });
+    fireEvent.keyDown(b, { key: 'ArrowRight' });
+    fireEvent.blur(b); // Tab-away
+    expect(itemEl(container, 'b')).not.toHaveAttribute('data-dc-picked');
+    expect(itemEl(container, 'b').style.getPropertyValue('--dc-col')).toBe('1 / span 2');
+    expect(status).toHaveTextContent('Move cancelled');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('pointer gestures are inert while an item is picked', () => {
+    const { container, onChange, root } = renderCanvas();
+    fireEvent.keyDown(itemEl(container, 'b'), { key: 'Enter' });
+    fireEvent.pointerDown(itemEl(container, 'a'), {
+      clientX: 10,
+      clientY: 60,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 200, clientY: 200, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeInTheDocument();
+    expect(root).not.toHaveAttribute('data-dragging');
+    fireEvent.pointerUp(root, { clientX: 200, clientY: 200, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('readOnly items are not keyboard-editable, but collapse toggles keep working', async () => {
+    const user = userEvent.setup();
+    const { container, onChange } = renderCanvas({ readOnly: true });
+    const b = itemEl(container, 'b');
+    expect(b).not.toHaveAttribute('tabindex');
+    expect(b).not.toHaveAttribute('role');
+    fireEvent.keyDown(b, { key: 'Enter' });
+    expect(b).not.toHaveAttribute('data-dc-picked');
+    fireEvent.keyDown(b, { key: 'ArrowRight', shiftKey: true });
+    expect(onChange).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Collapse Section One section' }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
@@ -1,0 +1,152 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DashboardCanvas } from './DashboardCanvas';
+import type { DashboardCanvasValue } from './engine';
+
+function baseValue(): DashboardCanvasValue {
+  return {
+    items: [
+      { id: 'a', x: 0, y: 1, w: 2, h: 1 },
+      { id: 'b', x: 0, y: 0, w: 2, h: 1 },
+    ],
+    sections: [
+      {
+        id: 's1',
+        title: 'Section One',
+        collapsed: false,
+        items: [{ id: 'c', x: 0, y: 0, w: 1, h: 1 }],
+      },
+      {
+        id: 's2',
+        title: 'Section Two',
+        collapsed: true,
+        items: [{ id: 'd', x: 0, y: 0, w: 1, h: 1 }],
+      },
+    ],
+  };
+}
+
+const renderItem = (id: string | number) => <div data-testid={`item-${id}`}>{id}</div>;
+
+describe('DashboardCanvas rendering', () => {
+  it('stamps each item with the correct inline grid custom properties', () => {
+    render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
+    const a = screen.getByTestId('item-a').parentElement as HTMLElement;
+    expect(a.style.getPropertyValue('--dc-col')).toBe('1 / span 2');
+    expect(a.style.getPropertyValue('--dc-row')).toBe('2 / span 1');
+    expect(a.style.getPropertyValue('--dc-h-span')).toBe('span 1');
+  });
+
+  it('renders top-level items DOM-sorted by (y, then x), independent of value order', () => {
+    const { container } = render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
+    const ids = Array.from(container.querySelectorAll('[data-dc-item]')).map((el) =>
+      el.getAttribute('data-dc-item'),
+    );
+    // a: y=1, b: y=0 → b renders before a even though it's second in value.items.
+    // c/d live inside their sections and come after.
+    expect(ids).toEqual(['b', 'a', 'c']); // s2 is collapsed, so 'd' is unmounted.
+  });
+
+  it('calls renderItem exactly once per visible item id', () => {
+    render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
+    expect(screen.getByTestId('item-a')).toBeInTheDocument();
+    expect(screen.getByTestId('item-b')).toBeInTheDocument();
+    expect(screen.getByTestId('item-c')).toBeInTheDocument();
+    // 'd' belongs to the collapsed section — its body is unmounted.
+    expect(screen.queryByTestId('item-d')).not.toBeInTheDocument();
+  });
+
+  it('renders sections in band (array) order with their titles', () => {
+    const { container } = render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
+    const sections = Array.from(container.querySelectorAll('[data-dc-section]'));
+    expect(sections.map((s) => s.getAttribute('data-dc-section'))).toEqual(['s1', 's2']);
+    expect(screen.getByText('Section One')).toBeInTheDocument();
+    expect(screen.getByText('Section Two')).toBeInTheDocument();
+  });
+
+  it('renders the renderSectionHeader slot per section id', () => {
+    render(
+      <DashboardCanvas
+        value={baseValue()}
+        renderItem={renderItem}
+        renderSectionHeader={(id) => <button type="button">extra-{id}</button>}
+      />,
+    );
+    expect(screen.getByText('extra-s1')).toBeInTheDocument();
+    expect(screen.getByText('extra-s2')).toBeInTheDocument();
+  });
+
+  it('exposes the canvas as a labeled group from i18n', () => {
+    render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
+    expect(screen.getByRole('group', { name: 'Dashboard canvas' })).toBeInTheDocument();
+  });
+
+  it('forwards ref to the root element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<DashboardCanvas ref={ref} value={baseValue()} renderItem={renderItem} />);
+    expect(ref.current).toBe(screen.getByRole('group', { name: 'Dashboard canvas' }));
+  });
+
+  it('merges a consumer className with the root class', () => {
+    render(<DashboardCanvas value={baseValue()} renderItem={renderItem} className="custom" />);
+    expect(screen.getByRole('group', { name: 'Dashboard canvas' }).className).toContain('custom');
+  });
+});
+
+describe('DashboardCanvas section collapse', () => {
+  it('a collapse click fires onChange with the section toggled, geometry untouched', async () => {
+    const user = userEvent.setup();
+    const value = baseValue();
+    const onChange = vi.fn();
+    render(<DashboardCanvas value={value} onChange={onChange} renderItem={renderItem} />);
+
+    await user.click(screen.getByRole('button', { name: 'Collapse Section One section' }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0][0] as DashboardCanvasValue;
+    expect(next.sections.find((s) => s.id === 's1')?.collapsed).toBe(true);
+    // Item geometry is preserved even though the body unmounts.
+    expect(next.sections.find((s) => s.id === 's1')?.items).toEqual(value.sections[0].items);
+    expect(next.items).toEqual(value.items);
+  });
+
+  it('an expand click on a collapsed section fires onChange with collapsed: false', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<DashboardCanvas value={baseValue()} onChange={onChange} renderItem={renderItem} />);
+
+    await user.click(screen.getByRole('button', { name: 'Expand Section Two section' }));
+
+    const next = onChange.mock.calls[0][0] as DashboardCanvasValue;
+    expect(next.sections.find((s) => s.id === 's2')?.collapsed).toBe(false);
+  });
+
+  it('collapse toggles fire onChange even in readOnly', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <DashboardCanvas value={baseValue()} onChange={onChange} renderItem={renderItem} readOnly />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Collapse Section One section' }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(
+      (onChange.mock.calls[0][0] as DashboardCanvasValue).sections.find((s) => s.id === 's1')
+        ?.collapsed,
+    ).toBe(true);
+  });
+
+  it('the collapse button reports aria-expanded matching section state', () => {
+    render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
+    expect(screen.getByRole('button', { name: 'Collapse Section One section' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'Expand Section Two section' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+});

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
@@ -50,12 +50,15 @@ describe('DashboardCanvas rendering', () => {
   });
 
   it('calls renderItem exactly once per visible item id', () => {
-    render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
+    const spy = vi.fn(renderItem);
+    render(<DashboardCanvas value={baseValue()} renderItem={spy} />);
     expect(screen.getByTestId('item-a')).toBeInTheDocument();
     expect(screen.getByTestId('item-b')).toBeInTheDocument();
     expect(screen.getByTestId('item-c')).toBeInTheDocument();
     // 'd' belongs to the collapsed section — its body is unmounted.
     expect(screen.queryByTestId('item-d')).not.toBeInTheDocument();
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy.mock.calls.map((call) => call[0]).sort()).toEqual(['a', 'b', 'c']);
   });
 
   it('renders sections in band (array) order with their titles', () => {
@@ -885,12 +888,12 @@ describe('DashboardCanvas below-md editing gate', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('a width of exactly 640px stays wide (the threshold is exclusive)', () => {
+  it('a width of exactly 640px goes narrow (matches the CSS max-width: 640px, inclusive)', () => {
     const observers = stubResizeObserver();
     render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
     const root = screen.getByRole('group', { name: 'Dashboard canvas' });
     fireWidth(observers, root, 640);
-    expect(root).not.toHaveAttribute('data-narrow');
+    expect(root).toHaveAttribute('data-narrow');
   });
 
   it('a zero-width report (unmeasured/hidden mount) stays wide, not narrow', () => {

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
@@ -1,5 +1,5 @@
 import { createRef } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DashboardCanvas } from './DashboardCanvas';
 import { applyMove, applyResize, reorderSection } from './engine';
@@ -803,5 +803,157 @@ describe('DashboardCanvas keyboard editing', () => {
     expect(onChange).not.toHaveBeenCalled();
     await user.click(screen.getByRole('button', { name: 'Collapse Section One section' }));
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- below-md single-column stacking + narrow editing gate (Task 5) --------
+// The @container reflow itself is browser-land (jsdom doesn't evaluate
+// container queries) — validated visually in Task 7. These tests cover the
+// JS-side editing gate: a ResizeObserver mirror of the CSS breakpoint
+// (FlowCanvas ResizeObserver-mock precedent, FlowCanvas.test.tsx:928-940).
+describe('DashboardCanvas below-md editing gate', () => {
+  interface ObserverEntry {
+    cb: ResizeObserverCallback;
+    targets: Element[];
+  }
+
+  function stubResizeObserver(): ObserverEntry[] {
+    const observers: ObserverEntry[] = [];
+    class MockResizeObserver {
+      private entry: ObserverEntry;
+      constructor(cb: ResizeObserverCallback) {
+        this.entry = { cb, targets: [] };
+        observers.push(this.entry);
+      }
+      observe(el: Element) {
+        this.entry.targets.push(el);
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    return observers;
+  }
+
+  function fireWidth(observers: ObserverEntry[], root: Element, width: number) {
+    act(() => {
+      for (const o of observers.filter((entry) => entry.targets.includes(root))) {
+        o.cb(
+          [{ contentRect: { width } } as ResizeObserverEntry],
+          null as unknown as ResizeObserver,
+        );
+      }
+    });
+  }
+
+  let restoreRects: () => void;
+  beforeEach(() => {
+    restoreRects = stubCanvasRects();
+  });
+  afterEach(() => {
+    restoreRects();
+    vi.unstubAllGlobals();
+  });
+
+  it('carries the always-on container class on the root regardless of width', () => {
+    render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    // container-type: inline-size lives on `.canvas` itself, unconditionally.
+    expect(root.className).toMatch(/canvas/);
+  });
+
+  it('a width below 640px sets data-narrow and turns off pointer editing', () => {
+    const observers = stubResizeObserver();
+    const onChange = vi.fn();
+    const { container } = render(
+      <DashboardCanvas value={baseValue()} onChange={onChange} renderItem={renderItem} />,
+    );
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    expect(root).not.toHaveAttribute('data-narrow');
+    fireWidth(observers, root, 400);
+    expect(root).toHaveAttribute('data-narrow');
+    expect(container.querySelector('[data-dc-resize]')).not.toBeInTheDocument();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeInTheDocument();
+    fireEvent.pointerUp(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('a width of exactly 640px stays wide (the threshold is exclusive)', () => {
+    const observers = stubResizeObserver();
+    render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    fireWidth(observers, root, 640);
+    expect(root).not.toHaveAttribute('data-narrow');
+  });
+
+  it('a zero-width report (unmeasured/hidden mount) stays wide, not narrow', () => {
+    const observers = stubResizeObserver();
+    render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    fireWidth(observers, root, 0);
+    expect(root).not.toHaveAttribute('data-narrow');
+  });
+
+  it('collapse toggles still fire onChange while narrow', async () => {
+    const user = userEvent.setup();
+    const observers = stubResizeObserver();
+    const onChange = vi.fn();
+    render(<DashboardCanvas value={baseValue()} onChange={onChange} renderItem={renderItem} />);
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    fireWidth(observers, root, 400);
+    await user.click(screen.getByRole('button', { name: 'Collapse Section One section' }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('going narrow mid-drag aborts the gesture without committing', () => {
+    const observers = stubResizeObserver();
+    const onChange = vi.fn();
+    const { container } = render(
+      <DashboardCanvas value={baseValue()} onChange={onChange} renderItem={renderItem} />,
+    );
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 175, clientY: 15, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).toBeInTheDocument();
+    fireWidth(observers, root, 400);
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeInTheDocument();
+    fireEvent.pointerUp(root, { clientX: 175, clientY: 15, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('narrow items are not keyboard-editable, and the instructions switch to the readOnly variant', () => {
+    const observers = stubResizeObserver();
+    const { container } = render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    const ids = (root.getAttribute('aria-describedby') ?? '').split(' ');
+    const instructionsEl = document.getElementById(ids[0]);
+    expect(instructionsEl).toHaveTextContent('pick it up');
+    fireWidth(observers, root, 400);
+    const b = itemEl(container, 'b');
+    expect(b).not.toHaveAttribute('tabindex');
+    expect(b).not.toHaveAttribute('role');
+    expect(instructionsEl).not.toHaveTextContent('pick it up');
+  });
+
+  it('widening back past 640px re-enables pointer editing', () => {
+    const observers = stubResizeObserver();
+    const { container } = render(<DashboardCanvas value={baseValue()} renderItem={renderItem} />);
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    fireWidth(observers, root, 400);
+    fireWidth(observers, root, 800);
+    expect(root).not.toHaveAttribute('data-narrow');
+    expect(container.querySelector('[data-dc-resize]')).not.toBeNull();
   });
 });

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tokens.scss
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tokens.scss
@@ -28,4 +28,11 @@
   --dashboard-canvas-item-shadow-dragging: var(--shadow-lg);
   --dashboard-canvas-drop-preview-bg: var(--color-accent-bg-subtle);
   --dashboard-canvas-drop-preview-border: var(--color-accent);
+
+  // Resize handles: 24px pointer corridor (WCAG 2.5.8) + hover glyph color.
+  --dashboard-canvas-handle-hit: var(--space-6);
+  --dashboard-canvas-handle-fg: var(--color-fg-subtle);
+
+  // Band-reorder insertion indicator.
+  --dashboard-canvas-drop-indicator: var(--color-accent);
 }

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tokens.scss
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tokens.scss
@@ -1,0 +1,31 @@
+// DashboardCanvas.tokens.scss — component-scoped tokens for <DashboardCanvas>.
+// Every token defaults to a primitive so the resolved values match the
+// global theme; consumers retheme by overriding these custom properties.
+:root {
+  // Grid geometry — row unit is the spec's "~48px + gap" (--space-12).
+  --dashboard-canvas-row: var(--space-12);
+  --dashboard-canvas-gap: var(--space-3);
+
+  // Item surface
+  --dashboard-canvas-item-bg: var(--color-bg);
+  --dashboard-canvas-item-border: var(--color-border);
+  --dashboard-canvas-item-radius: var(--radius-md);
+  --dashboard-canvas-item-shadow: var(--shadow-sm);
+
+  // Section band surface
+  --dashboard-canvas-section-bg: var(--color-bg-subtle);
+  --dashboard-canvas-section-border: var(--color-border);
+  --dashboard-canvas-section-radius: var(--radius-md);
+
+  // Section header
+  --dashboard-canvas-section-header-fg: var(--color-fg);
+  --dashboard-canvas-section-header-bg-hover: var(--color-bg-muted);
+  --dashboard-canvas-section-indicator-fg: var(--color-fg-subtle);
+
+  // Drag ghost + snapped drop-preview surfaces — Task 3 (pointer gestures)
+  // wires these; defined now per the plan so the token surface is stable.
+  --dashboard-canvas-ghost-opacity: 0.6;
+  --dashboard-canvas-item-shadow-dragging: var(--shadow-lg);
+  --dashboard-canvas-drop-preview-bg: var(--color-accent-bg-subtle);
+  --dashboard-canvas-drop-preview-border: var(--color-accent);
+}

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
@@ -70,8 +70,11 @@ export interface DashboardCanvasProps extends Omit<HTMLAttributes<HTMLDivElement
   constraints?: DashboardCanvasConstraintsProp;
   /**
    * View-only mode: identical geometry, but no drag/resize wiring, no resize
-   * handles, and no keyboard editing (Task 4) — the canvas renders `value`
-   * and lets section collapse toggles keep working. @default false
+   * handles, and no keyboard editing — the canvas renders `value` and lets
+   * section collapse toggles keep working. The canvas also disables editing
+   * on its own, without this prop, once its own width drops below 640px
+   * (below-md single-column stack) — `readOnly` is for a consumer-chosen
+   * view mode, the width gate is automatic. @default false
    */
   readOnly?: boolean;
 }
@@ -116,6 +119,15 @@ const DRAG_ACTIVATION_PX = 5;
  * when `grid-auto-rows` doesn't resolve to a px length (jsdom).
  */
 const FALLBACK_ROW_PX = 48;
+
+/**
+ * Editing-gate width threshold (px) — JS mirror of the `@container
+ * (max-width: $collapse-md)` rule in DashboardCanvas.module.scss
+ * (`_internal/collapse.scss`, 640px). SCSS constants aren't readable from
+ * TS, so this literal and that one are kept in sync by hand, same as the
+ * `FALLBACK_ROW_PX`/`--dashboard-canvas-row` pairing above.
+ */
+const NARROW_PX = 640;
 
 /** Live px geometry of one container grid, re-measured per pointermove. */
 function measureGrid(el: HTMLElement) {
@@ -241,6 +253,18 @@ type LiveState =
  * hover-to-expand). Escape or a pointer cancel mid-gesture restores the
  * current `value` without firing `onChange`.
  *
+ * ❌ Anti-pattern: the canvas is ALWAYS a size container (`container-type:
+ * inline-size` on the root, unconditionally — the below-md single-column
+ * stack depends on it) — give it a parent with a concrete width. In an
+ * intrinsic-width context (a `Cluster` item, `width: max-content`, a
+ * `Split` aside's default `auto` track) it renders at width 0 (Grid
+ * `collapseBelow` precedent — same caveat, same cause). Below 640px
+ * (`_internal/collapse.scss`'s `$collapse-md`) every container re-templates
+ * to one column and pointer + keyboard editing turns off (handles hidden,
+ * items not editing-focusable) — a `ResizeObserver` on the root mirrors the
+ * CSS breakpoint so a gesture can never half-start below it; section
+ * collapse toggles keep working regardless of width.
+ *
  * @example
  * // Static/read-only layout — no onChange, geometry only.
  * <DashboardCanvas
@@ -288,6 +312,12 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
     const dragRef = useRef<DragState | null>(null);
     const [live, setLive] = useState<LiveState | null>(null);
     const [pick, setPick] = useState<KeyboardPick | null>(null);
+    // Below-md editing gate. Starts wide: jsdom has no ResizeObserver, and a
+    // freshly-mounted (possibly still-hidden) root reports 0 width — both
+    // stay wide so existing gesture tests keep exercising the full surface
+    // (FlowCanvas's "no RO / zero size -> untrustworthy" precedent).
+    const [isNarrow, setIsNarrow] = useState(false);
+    const editingEnabled = !readOnly && !isNarrow;
     const uid = sanitizeId(useId());
     const instructionsId = `dashboard-instructions-${uid}`;
 
@@ -329,11 +359,12 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
     };
 
     const handleToggleSection = (sectionId: string | number) => {
-      // Collapse stays active in readOnly — it's navigation, not editing.
+      // Collapse stays active in readOnly AND below the narrow-editing
+      // threshold — it's navigation, not editing.
       commit(toggleSection(value, sectionId));
     };
 
-    // --- gesture starts (single readOnly choke point; Task 5 adds the narrow gate here) ---
+    // --- gesture starts (single `editingEnabled` choke point: readOnly prop OR narrow width) ---
     const onMovePointerDown = (
       event: ReactPointerEvent<HTMLDivElement>,
       placement: DashboardPlacement,
@@ -343,7 +374,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       // overwrite the state (FlowCanvas discipline), and a keyboard pick owns
       // the canvas until it drops or cancels. No preventDefault — clicks
       // inside item bodies pass through until the drag arms.
-      if (readOnly || event.button !== 0 || dragRef.current || pick) return;
+      if (!editingEnabled || event.button !== 0 || dragRef.current || pick) return;
       const el = event.currentTarget;
       const rect = el.getBoundingClientRect();
       dragRef.current = {
@@ -376,7 +407,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       container: ContainerRef,
       edge: ResizeEdge,
     ) => {
-      if (readOnly || event.button !== 0 || dragRef.current || pick) return;
+      if (!editingEnabled || event.button !== 0 || dragRef.current || pick) return;
       // The handle sits inside the move-drag surface — never arm both.
       event.stopPropagation();
       dragRef.current = {
@@ -402,7 +433,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       event: ReactPointerEvent<HTMLDivElement>,
       sectionId: string | number,
     ) => {
-      if (readOnly || event.button !== 0 || dragRef.current || pick) return;
+      if (!editingEnabled || event.button !== 0 || dragRef.current || pick) return;
       // The drag zone is the header row MINUS the collapse button and the
       // renderSectionHeader extras — those keep their own interactions.
       if ((event.target as HTMLElement).closest('button, [data-dc-section-actions]')) return;
@@ -844,18 +875,37 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       // cancelPick is re-created per render but only reads current state.
     }, [dragging, pick]);
 
-    // readOnly flipping on mid-gesture aborts it — same restore as Escape.
+    // JS mirror of the CSS `@container (max-width: $collapse-md)` rule —
+    // width alone gates editing (below it, gestures + keyboard editing turn
+    // off; collapse toggles are unaffected). typeof-guard for jsdom; a
+    // reported 0 width means the root isn't laid out yet (hidden mount),
+    // which stays wide for the same reason FlowCanvas's node ResizeObserver
+    // treats 0×0 as unmeasured rather than "small."
     useEffect(() => {
-      if (!readOnly) return;
+      const root = rootRef.current;
+      if (!root || typeof ResizeObserver === 'undefined') return undefined;
+      const observer = new ResizeObserver((entries) => {
+        const width = entries[0]?.contentRect.width ?? 0;
+        setIsNarrow(width > 0 && width < NARROW_PX);
+      });
+      observer.observe(root);
+      return () => observer.disconnect();
+    }, []);
+
+    // readOnly OR the narrow-width gate flipping editing off mid-gesture
+    // aborts it — same restore as Escape.
+    useEffect(() => {
+      if (editingEnabled) return;
       dragRef.current = null;
       setLive(null);
       if (pick) {
         setPick(null);
         announce(t('dashboardCanvas.cancelled'));
       }
-      // Deliberately keyed on readOnly alone; the closure is from the
-      // render where it flipped, so `pick` is current.
-    }, [readOnly]);
+      // Deliberately keyed on the two raw gate inputs (not the derived
+      // `editingEnabled`, recomputed every render); the closure is from the
+      // render where either flipped, so `pick` is current.
+    }, [readOnly, isNarrow]);
 
     // An external value change mid-pick invalidates the pick's home/from
     // coordinates (and can delete the picked item outright, which would
@@ -878,7 +928,10 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
     const shown =
       live != null && live.kind !== 'section' ? live.value : pick != null ? pick.preview : value;
     const gestures: CanvasGestures = {
-      readOnly,
+      // The item/section internals only care whether editing is off, not
+      // WHY — readOnly and narrow-width both render identically (no
+      // handles, not editing-focusable, gestures inert).
+      readOnly: !editingEnabled,
       movingId: live?.kind === 'move' ? live.id : null,
       resizingId: live?.kind === 'resize' ? live.id : null,
       pickedId: pick?.id ?? null,
@@ -910,6 +963,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
         aria-describedby={mergeAriaDescribedby(ariaDescribedby, instructionsId)}
         className={clsx(styles.canvas, className)}
         data-readonly={readOnly ? '' : undefined}
+        data-narrow={isNarrow ? '' : undefined}
         data-dragging={dragging ? '' : undefined}
         onPointerMove={handleRootPointerMove}
         onPointerUp={handleRootPointerUp}
@@ -967,7 +1021,11 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
           </div>
         )}
         <div id={instructionsId} className={styles.srOnly}>
-          {t(readOnly ? 'dashboardCanvas.instructionsReadOnly' : 'dashboardCanvas.instructions')}
+          {t(
+            editingEnabled
+              ? 'dashboardCanvas.instructions'
+              : 'dashboardCanvas.instructionsReadOnly',
+          )}
         </div>
         <div role="status" className={styles.srOnly}>
           <span key={announcement.nonce}>{announcement.text}</span>

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
@@ -253,35 +253,69 @@ type LiveState =
  * hover-to-expand). Escape or a pointer cancel mid-gesture restores the
  * current `value` without firing `onChange`.
  *
- * ❌ Anti-pattern: the canvas is ALWAYS a size container (`container-type:
- * inline-size` on the root, unconditionally — the below-md single-column
- * stack depends on it) — give it a parent with a concrete width. In an
- * intrinsic-width context (a `Cluster` item, `width: max-content`, a
- * `Split` aside's default `auto` track) it renders at width 0 (Grid
- * `collapseBelow` precedent — same caveat, same cause). Below 640px
- * (`_internal/collapse.scss`'s `$collapse-md`) every container re-templates
- * to one column and pointer + keyboard editing turns off (handles hidden,
- * items not editing-focusable) — a `ResizeObserver` on the root mirrors the
- * CSS breakpoint so a gesture can never half-start below it; section
- * collapse toggles keep working regardless of width.
+ * When NOT to use:
+ * - A single ordered list (priority queue, todo list, simple reordering) —
+ *   use `<Sortable>`; no 2D geometry or push-down collision is needed for 1D
+ *   reordering.
+ * - Fixed kanban-style columns — use `<Kanban>`.
+ * - A free-form node/edge graph (workflow builder) — use `<FlowCanvas>`.
+ *
+ * Anti-patterns:
+ * - ❌ Treating `value` as uncontrolled — passing it once with no `onChange`.
+ *   Drags and resizes still preview live, but nothing persists past
+ *   pointerup: the canvas is always controlled, so the next render snaps the
+ *   item back to the stale `value`.
+ * - ❌ Nesting a `DashboardCanvas` inside another one's `renderItem`.
+ *   Root-level pointer capture and the single in-flight-gesture guard
+ *   (`dragRef`/`pick`) assume exactly one canvas owns the pointer stream — a
+ *   nested canvas fights its parent for capture and Escape handling.
+ * - ❌ Using it for a simple ordered list — see "When NOT to use" above.
+ * - ❌ The canvas is ALWAYS a size container (`container-type: inline-size`
+ *   on the root, unconditionally — the below-md single-column stack depends
+ *   on it) — give it a parent with a concrete width. In an intrinsic-width
+ *   context (a `Cluster` item, `width: max-content`, a `Split` aside's
+ *   default `auto` track) it renders at width 0 (Grid `collapseBelow`
+ *   precedent — same caveat, same cause). Below 640px
+ *   (`_internal/collapse.scss`'s `$collapse-md`) every container
+ *   re-templates to one column and pointer + keyboard editing turns off
+ *   (handles hidden, items not editing-focusable) — a `ResizeObserver` on
+ *   the root mirrors the CSS breakpoint so a gesture can never half-start
+ *   below it; section collapse toggles keep working regardless of width.
  *
  * @example
- * // Static/read-only layout — no onChange, geometry only.
+ * // Edit-mode dashboard: top-level KPIs + a collapsible section, one
+ * // constrained item, and a persistence pattern — onChange keeps the canvas
+ * // controlled AND fires a save; debounce/fire-and-forget is the caller's job.
+ * const [value, setValue] = useState<DashboardCanvasValue>(initialLayout);
+ * const handleChange = (next: DashboardCanvasValue) => {
+ *   setValue(next);
+ *   saveDashboardLayout(dashboardId, next);
+ * };
  * <DashboardCanvas
- *   value={{ items: [{ id: 'kpi', x: 0, y: 0, w: 4, h: 2 }], sections: [] }}
- *   renderItem={(id) => <Card>{id}</Card>}
+ *   value={value}
+ *   onChange={handleChange}
+ *   renderItem={(id) => <Card>{widgets[id].title}</Card>}
+ *   constraints={{ kpi: { minW: 2, maxH: 4 } }}
+ * />
+ *
+ * @example
+ * // Read-only record view — same value shape, no editing affordances.
+ * <DashboardCanvas
+ *   value={savedLayout}
+ *   renderItem={(id) => <Card>{widgets[id].title}</Card>}
  *   readOnly
  * />
  *
  * @example
- * // Controlled layout with a section; onChange persists drags, resizes,
- * // band reorders, and collapse toggles.
- * const [value, setValue] = useState<DashboardCanvasValue>(initialLayout);
+ * // Constraints as a function — computed from data instead of a static map,
+ * // e.g. locking size for widget kinds with a fixed aspect ratio.
  * <DashboardCanvas
  *   value={value}
  *   onChange={setValue}
  *   renderItem={(id) => <Card>{widgets[id].title}</Card>}
- *   constraints={{ kpi: { minW: 2, maxH: 4 } }}
+ *   constraints={(id) =>
+ *     widgets[id]?.kind === 'chart' ? { minW: 4, minH: 3, maxH: 6 } : undefined
+ *   }
  * />
  */
 export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
@@ -123,8 +123,10 @@ const FALLBACK_ROW_PX = 48;
 /**
  * Editing-gate width threshold (px) — JS mirror of the `@container
  * (max-width: $collapse-md)` rule in DashboardCanvas.module.scss
- * (`_internal/collapse.scss`, 640px). SCSS constants aren't readable from
- * TS, so this literal and that one are kept in sync by hand, same as the
+ * (`_internal/collapse.scss`, 640px). `max-width` is INCLUSIVE, so a width
+ * exactly at this value already single-columns — the gate below must match
+ * with `<=`, not `<`. SCSS constants aren't readable from TS, so this
+ * literal and that one are kept in sync by hand, same as the
  * `FALLBACK_ROW_PX`/`--dashboard-canvas-row` pairing above.
  */
 const NARROW_PX = 640;
@@ -920,7 +922,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       if (!root || typeof ResizeObserver === 'undefined') return undefined;
       const observer = new ResizeObserver((entries) => {
         const width = entries[0]?.contentRect.width ?? 0;
-        setIsNarrow(width > 0 && width < NARROW_PX);
+        setIsNarrow(width > 0 && width <= NARROW_PX);
       });
       observer.observe(root);
       return () => observer.disconnect();

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
@@ -1,9 +1,15 @@
-import { Fragment, forwardRef, useCallback, useEffect, useRef, useState } from 'react';
-import type { HTMLAttributes, PointerEvent as ReactPointerEvent, ReactNode } from 'react';
+import { Fragment, forwardRef, useCallback, useEffect, useId, useRef, useState } from 'react';
+import type {
+  FocusEvent as ReactFocusEvent,
+  HTMLAttributes,
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+  ReactNode,
+} from 'react';
 import clsx from 'clsx';
 import { useTranslation } from '../../i18n/useTranslation';
 import { useFloatingSurface } from '../_internal/overlay';
-import { mergeRefs } from '../_internal/refs';
+import { mergeAriaDescribedby, mergeRefs, sanitizeId } from '../_internal/refs';
 import {
   DASHBOARD_COLUMNS,
   applyMove,
@@ -75,6 +81,27 @@ const TOP_CONTAINER: ContainerRef = { kind: 'top' };
 /** Stable registry key for a container (object identity is per-render). */
 function containerKey(cref: ContainerRef): string {
   return cref.kind === 'top' ? 'top' : `s:${String(cref.id)}`;
+}
+
+/** The items of one container within a value (engine's private lookup, re-derived). */
+function itemsOf(value: DashboardCanvasValue, cref: ContainerRef): DashboardPlacement[] {
+  return (
+    (cref.kind === 'top'
+      ? value.items
+      : value.sections.find((section) => section.id === cref.id)?.items) ?? []
+  );
+}
+
+/** Last occupied row end (max `y + h`) of a container, `excludeId` left out. */
+function bottomOf(
+  value: DashboardCanvasValue,
+  cref: ContainerRef,
+  excludeId?: string | number,
+): number {
+  return itemsOf(value, cref).reduce(
+    (max, p) => (p.id === excludeId ? max : Math.max(max, p.y + p.h)),
+    0,
+  );
 }
 
 /**
@@ -166,6 +193,28 @@ interface SectionDrag {
 }
 type DragState = MoveDrag | ResizeDrag | SectionDrag;
 
+/**
+ * Keyboard pick-up state (Enter/Space on a focused item). `x`/`y` track the
+ * REQUESTED cell exactly like a pointer drag tracks the cursor cell — the
+ * engine's compaction may render the item elsewhere, but requested tracking
+ * is what lets repeated ArrowDown presses tunnel past the compaction pull
+ * and reach the next container. Committed via the same applyMove call and
+ * `commit` choke point as the pointer path.
+ */
+interface KeyboardPick {
+  id: string | number;
+  from: ContainerRef;
+  homeX: number;
+  homeY: number;
+  /** Item dims, for clamping the requested x against the 12-column bound. */
+  w: number;
+  container: ContainerRef;
+  x: number;
+  y: number;
+  /** Engine preview of dropping right now — the rendered layout while picked. */
+  preview: DashboardCanvasValue;
+}
+
 /** Render-facing gesture projection: the engine preview IS the rendered layout. */
 type LiveState =
   | {
@@ -221,10 +270,12 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       constraints,
       readOnly = false,
       className,
+      'aria-describedby': ariaDescribedby,
       onPointerMove: onPointerMoveProp,
       onPointerUp: onPointerUpProp,
       onPointerCancel: onPointerCancelProp,
       onLostPointerCapture: onLostPointerCaptureProp,
+      onBlur: onBlurProp,
       ...rest
     },
     ref,
@@ -236,6 +287,25 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
     const bandsRef = useRef(new Map<string | number, HTMLElement>());
     const dragRef = useRef<DragState | null>(null);
     const [live, setLive] = useState<LiveState | null>(null);
+    const [pick, setPick] = useState<KeyboardPick | null>(null);
+    const uid = sanitizeId(useId());
+    const instructionsId = `dashboard-instructions-${uid}`;
+
+    // Nonce-keyed live region (FlowCanvas precedent): the nonce forces a DOM
+    // mutation for back-to-back identical messages, and keys a child <span>
+    // so the region node itself stays stable across announcements.
+    const [announcement, setAnnouncement] = useState({ text: '', nonce: 0 });
+    const announce = useCallback(
+      (message: string) => setAnnouncement((prev) => ({ text: message, nonce: prev.nonce + 1 })),
+      [],
+    );
+
+    // A keyboard step can remount or DOM-reorder the focused element (a
+    // cross-container move re-parents the item; a band reorder re-orders the
+    // section nodes), silently dropping focus to <body> and stranding the
+    // keyboard user. Handlers flag what to re-focus; the post-commit effect
+    // below restores it (FlowCanvas focus-reclaim precedent).
+    const reclaimRef = useRef<{ kind: 'item' | 'section'; id: string | number } | null>(null);
 
     const setContainerEl = useCallback((cref: ContainerRef, el: HTMLElement | null) => {
       const key = containerKey(cref);
@@ -270,9 +340,10 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       container: ContainerRef,
     ) => {
       // One gesture at a time: a second pointer going down mid-drag must not
-      // overwrite the state (FlowCanvas discipline). No preventDefault —
-      // clicks inside item bodies pass through until the drag arms.
-      if (readOnly || event.button !== 0 || dragRef.current) return;
+      // overwrite the state (FlowCanvas discipline), and a keyboard pick owns
+      // the canvas until it drops or cancels. No preventDefault — clicks
+      // inside item bodies pass through until the drag arms.
+      if (readOnly || event.button !== 0 || dragRef.current || pick) return;
       const el = event.currentTarget;
       const rect = el.getBoundingClientRect();
       dragRef.current = {
@@ -305,7 +376,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       container: ContainerRef,
       edge: ResizeEdge,
     ) => {
-      if (readOnly || event.button !== 0 || dragRef.current) return;
+      if (readOnly || event.button !== 0 || dragRef.current || pick) return;
       // The handle sits inside the move-drag surface — never arm both.
       event.stopPropagation();
       dragRef.current = {
@@ -331,7 +402,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       event: ReactPointerEvent<HTMLDivElement>,
       sectionId: string | number,
     ) => {
-      if (readOnly || event.button !== 0 || dragRef.current) return;
+      if (readOnly || event.button !== 0 || dragRef.current || pick) return;
       // The drag zone is the header row MINUS the collapse button and the
       // renderSectionHeader extras — those keep their own interactions.
       if ((event.target as HTMLElement).closest('button, [data-dc-section-actions]')) return;
@@ -486,6 +557,8 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
         return;
       }
       if (drag.kind === 'resize') {
+        // Requested dims unchanged → bail before applyResize, so a no-op
+        // gesture can't commit a compaction of an untouched value.
         if (drag.lastW === drag.startW && drag.lastH === drag.startH) return;
         commit(
           applyResize(
@@ -526,38 +599,293 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       setLive(null);
     };
 
-    // Escape cancels an armed gesture and restores the current value. An
-    // armed drag is an Escape-consuming mode — registering it as a floating
-    // surface makes a host Modal/Drawer yield that Escape (FlowCanvas #282).
-    const dragging = live != null;
-    useFloatingSurface(dragging);
+    // --- keyboard editing — same engine calls + commit choke point as pointer ---
+
+    const cancelPick = () => {
+      setPick(null);
+      announce(t('dashboardCanvas.cancelled'));
+    };
+
+    /** One arrow step of a picked item; crossing a container edge moves bands. */
+    const stepPick = (current: KeyboardPick, key: string) => {
+      const dx = key === 'ArrowRight' ? 1 : key === 'ArrowLeft' ? -1 : 0;
+      const dy = key === 'ArrowDown' ? 1 : key === 'ArrowUp' ? -1 : 0;
+      // Keyboard targets = expanded containers in band order; collapsed
+      // sections are skipped (pointer drop-target parity).
+      const order: ContainerRef[] = [
+        TOP_CONTAINER,
+        ...value.sections
+          .filter((section) => !section.collapsed)
+          .map((section): ContainerRef => ({ kind: 'section', id: section.id })),
+      ];
+      const idx = order.findIndex((cref) => containerKey(cref) === containerKey(current.container));
+      let container = current.container;
+      let crossed: ContainerRef | null = null;
+      const x = Math.min(Math.max(current.x + dx, 0), DASHBOARD_COLUMNS - current.w);
+      let y = current.y + dy;
+      if (idx !== -1 && dy > 0 && y > bottomOf(current.preview, container, current.id)) {
+        // Below the container's last occupied row: enter the next band at its
+        // top, or clamp at the bottom when there is none.
+        const next = order[idx + 1];
+        if (next) {
+          container = next;
+          crossed = next;
+          y = 0;
+        } else {
+          y = bottomOf(current.preview, container, current.id);
+        }
+      } else if (idx !== -1 && dy < 0 && y < 0) {
+        // Above the top row: enter the previous band at its bottom.
+        const prev = order[idx - 1];
+        if (prev) {
+          container = prev;
+          crossed = prev;
+          y = bottomOf(current.preview, prev, current.id);
+        } else {
+          y = 0;
+        }
+      } else {
+        y = Math.max(y, 0);
+      }
+      const preview = applyMove(value, current.from, container, current.id, x, y);
+      reclaimRef.current = { kind: 'item', id: current.id };
+      setPick({ ...current, container, x, y, preview });
+      if (crossed) {
+        announce(
+          crossed.kind === 'top'
+            ? t('dashboardCanvas.enteredTopLevel')
+            : t('dashboardCanvas.enteredSection', {
+                title:
+                  value.sections.find((section) => section.id === crossed.id)?.title ??
+                  String(crossed.id),
+              }),
+        );
+      } else {
+        announce(
+          t('dashboardCanvas.movedTo', {
+            x: x + 1,
+            y: y + 1,
+            container:
+              container.kind === 'section'
+                ? value.sections.find((section) => section.id === container.id)?.title
+                : undefined,
+          }),
+        );
+      }
+    };
+
+    const onItemKeyDown = (
+      event: ReactKeyboardEvent<HTMLDivElement>,
+      placement: DashboardPlacement,
+      container: ContainerRef,
+    ) => {
+      // Only keys aimed at the cell itself — interactive widget content keeps
+      // its own keystrokes (FlowCanvas key-target discipline).
+      if (event.target !== event.currentTarget) return;
+      const { key } = event;
+      const activate = key === 'Enter' || key === ' ';
+      if (pick) {
+        if (pick.id !== placement.id) return; // one pick at a time
+        if (key === 'Escape') {
+          // Layered dismiss: this Escape ends the pick, never a host modal.
+          event.preventDefault();
+          event.stopPropagation();
+          cancelPick();
+          return;
+        }
+        if (activate) {
+          event.preventDefault();
+          setPick(null);
+          // Same-cell drop mirrors the pointer no-op guard: nothing changed,
+          // even if committing would compact an uncompacted value.
+          if (
+            !(
+              containerKey(pick.from) === containerKey(pick.container) &&
+              pick.x === pick.homeX &&
+              pick.y === pick.homeY
+            )
+          ) {
+            commit(applyMove(value, pick.from, pick.container, pick.id, pick.x, pick.y));
+          }
+          announce(t('dashboardCanvas.dropped'));
+          return;
+        }
+        if (key.startsWith('Arrow')) {
+          event.preventDefault();
+          stepPick(pick, key);
+        }
+        return;
+      }
+      if (activate) {
+        event.preventDefault(); // Space must not scroll the page
+        setPick({
+          id: placement.id,
+          from: container,
+          container,
+          homeX: placement.x,
+          homeY: placement.y,
+          w: placement.w,
+          x: placement.x,
+          y: placement.y,
+          preview: value,
+        });
+        announce(t('dashboardCanvas.pickedUp'));
+        return;
+      }
+      if (event.shiftKey && key.startsWith('Arrow')) {
+        event.preventDefault();
+        const w = placement.w + (key === 'ArrowRight' ? 1 : key === 'ArrowLeft' ? -1 : 0);
+        const h = placement.h + (key === 'ArrowDown' ? 1 : key === 'ArrowUp' ? -1 : 0);
+        // Committed per keypress — no resize mode (FlowCanvas nudge precedent).
+        const next = applyResize(
+          value,
+          container,
+          placement.id,
+          w,
+          h,
+          constraintsFor(placement.id),
+        );
+        commit(next);
+        // Announce the engine-clamped size: at a constraint the layout does
+        // not change, but the user still needs the "you're at the limit" echo.
+        const result = itemsOf(next, container).find((p) => p.id === placement.id) ?? placement;
+        announce(t('dashboardCanvas.resized', { w: result.w, h: result.h }));
+      }
+    };
+
+    const onHeaderKeyDown = (
+      event: ReactKeyboardEvent<HTMLDivElement>,
+      sectionId: string | number,
+    ) => {
+      if (!event.shiftKey || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) return;
+      // Extras keep their keys (same exclusion as the pointer drag zone).
+      if ((event.target as HTMLElement).closest('[data-dc-section-actions]')) return;
+      const fromIndex = value.sections.findIndex((section) => section.id === sectionId);
+      if (fromIndex === -1) return;
+      event.preventDefault();
+      const next = reorderSection(
+        value,
+        sectionId,
+        fromIndex + (event.key === 'ArrowDown' ? 1 : -1),
+      );
+      if (next === value) return; // clamped at the edge — nothing moved
+      reclaimRef.current = { kind: 'section', id: sectionId };
+      commit(next);
+      announce(
+        t('dashboardCanvas.sectionMoved', {
+          title: value.sections[fromIndex].title,
+          position: next.sections.findIndex((section) => section.id === sectionId) + 1,
+        }),
+      );
+    };
+
+    // Focus reclaim. No dependency array — the flag is only ever raised
+    // alongside a state update, and the check costs a ref read. When focus
+    // survived (same element, still connected) this is a no-op.
     useEffect(() => {
-      if (!dragging) return undefined;
+      const target = reclaimRef.current;
+      if (!target) return;
+      reclaimRef.current = null;
+      const root = rootRef.current;
+      if (!root) return;
+      const active = document.activeElement;
+      if (
+        active &&
+        active !== document.body &&
+        active !== document.documentElement &&
+        active.isConnected &&
+        root.contains(active)
+      ) {
+        return;
+      }
+      // Attribute-value scan instead of a selector: ids are consumer strings
+      // and CSS-escaping them buys nothing at this element count.
+      const el =
+        target.kind === 'item'
+          ? Array.from(root.querySelectorAll<HTMLElement>('[data-dc-item]')).find(
+              (node) => node.getAttribute('data-dc-item') === String(target.id),
+            )
+          : Array.from(root.querySelectorAll<HTMLElement>('[data-dc-section]'))
+              .find((node) => node.getAttribute('data-dc-section') === String(target.id))
+              ?.querySelector<HTMLElement>('button[aria-expanded]');
+      el?.focus({ preventScroll: true });
+    });
+
+    // Focus leaving the picked item cancels the pick — Tab is never trapped
+    // (WCAG 2.1.2) and an unfocused pick would be uncancellable (Escape is
+    // handled on the item). The reclaim flag distinguishes the transient
+    // blur of a mid-step remount/reorder from a real departure.
+    const handleRootBlur = (event: ReactFocusEvent<HTMLDivElement>) => {
+      onBlurProp?.(event);
+      if (!pick || reclaimRef.current) return;
+      const target = event.target as HTMLElement;
+      if (target.getAttribute?.('data-dc-item') === String(pick.id)) cancelPick();
+    };
+
+    // Escape cancels an armed gesture and restores the current value. An
+    // armed drag or keyboard pick is an Escape-consuming mode — registering
+    // it as a floating surface makes a host Modal/Drawer yield that Escape
+    // (FlowCanvas #282). The pick's own Escape lands on the focused item.
+    const dragging = live != null;
+    useFloatingSurface(dragging || pick != null);
+    // Window-level Escape: cancels a pointer drag wherever focus sits, and
+    // is the belt-and-braces exit for a pick whose item lost focus (the
+    // item-level handler consumes Escape first when focused).
+    useEffect(() => {
+      if (!dragging && !pick) return undefined;
       const onKeyDown = (event: KeyboardEvent) => {
         if (event.key !== 'Escape') return;
         dragRef.current = null;
         setLive(null);
+        if (pick) cancelPick();
       };
       window.addEventListener('keydown', onKeyDown);
       return () => window.removeEventListener('keydown', onKeyDown);
-    }, [dragging]);
+      // cancelPick is re-created per render but only reads current state.
+    }, [dragging, pick]);
 
     // readOnly flipping on mid-gesture aborts it — same restore as Escape.
     useEffect(() => {
       if (!readOnly) return;
       dragRef.current = null;
       setLive(null);
+      if (pick) {
+        setPick(null);
+        announce(t('dashboardCanvas.cancelled'));
+      }
+      // Deliberately keyed on readOnly alone; the closure is from the
+      // render where it flipped, so `pick` is current.
     }, [readOnly]);
+
+    // An external value change mid-pick invalidates the pick's home/from
+    // coordinates (and can delete the picked item outright, which would
+    // strand the canvas: every pointerdown is gated on `pick` and the
+    // Escape handler lives on the now-gone item) — abort, same discipline
+    // as the readOnly flip. Identity-guarded, no dependency array: a drop
+    // clears `pick` before onChange in the same batch, so our own commits
+    // never trip this.
+    const prevValueRef = useRef(value);
+    useEffect(() => {
+      if (prevValueRef.current === value) return;
+      prevValueRef.current = value;
+      if (!pick) return;
+      setPick(null);
+      announce(t('dashboardCanvas.cancelled'));
+    });
 
     // Render EXACTLY what the engine returned for the in-flight gesture —
     // never parallel geometry. Section band order only changes on commit.
-    const shown = live != null && live.kind !== 'section' ? live.value : value;
+    const shown =
+      live != null && live.kind !== 'section' ? live.value : pick != null ? pick.preview : value;
     const gestures: CanvasGestures = {
       readOnly,
       movingId: live?.kind === 'move' ? live.id : null,
       resizingId: live?.kind === 'resize' ? live.id : null,
+      pickedId: pick?.id ?? null,
+      instructionsId,
       onMovePointerDown,
       onResizePointerDown,
+      onItemKeyDown,
     };
 
     // Band insertion indicator position (slot among N+1 gaps), suppressed
@@ -579,6 +907,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
         ref={mergeRefs(ref, rootRef)}
         role="group"
         aria-label={t('dashboardCanvas.canvas')}
+        aria-describedby={mergeAriaDescribedby(ariaDescribedby, instructionsId)}
         className={clsx(styles.canvas, className)}
         data-readonly={readOnly ? '' : undefined}
         data-dragging={dragging ? '' : undefined}
@@ -586,6 +915,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
         onPointerUp={handleRootPointerUp}
         onPointerCancel={handleRootPointerCancel}
         onLostPointerCapture={handleLostPointerCapture}
+        onBlur={handleRootBlur}
         {...rest}
       >
         <div
@@ -615,6 +945,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
               gestures={gestures}
               dragging={live?.kind === 'section' && live.id === section.id}
               onHeaderPointerDown={onHeaderPointerDown}
+              onHeaderKeyDown={onHeaderKeyDown}
               setContainerEl={setContainerEl}
               setBandEl={setBandEl}
             />
@@ -635,6 +966,12 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
             {renderItem(live.id)}
           </div>
         )}
+        <div id={instructionsId} className={styles.srOnly}>
+          {t(readOnly ? 'dashboardCanvas.instructionsReadOnly' : 'dashboardCanvas.instructions')}
+        </div>
+        <div role="status" className={styles.srOnly}>
+          <span key={announcement.nonce}>{announcement.text}</span>
+        </div>
       </div>
     );
   },

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
@@ -1,0 +1,132 @@
+import { forwardRef, useCallback } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
+import clsx from 'clsx';
+import { useTranslation } from '../../i18n/useTranslation';
+import { toggleSection } from './engine';
+import type { DashboardCanvasValue, DashboardItemConstraints } from './engine';
+import { DashboardCanvasItem, sortByPosition } from './DashboardCanvasItem';
+import { DashboardCanvasSection } from './DashboardCanvasSection';
+import styles from './DashboardCanvas.module.scss';
+
+/**
+ * Per-item size constraints lookup passed to {@link DashboardCanvas}. Either a
+ * plain record keyed by item id, or a function for computed/dynamic limits.
+ * An item with no entry (and no matching key) gets `minW: 1`, `minH: 1`, no
+ * `maxH`.
+ */
+export type DashboardCanvasConstraintsProp =
+  | Record<string, DashboardItemConstraints>
+  | ((id: string | number) => DashboardItemConstraints | undefined);
+
+export interface DashboardCanvasProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  /**
+   * The controlled layout: top-level items plus an ordered array of
+   * collapsible sections. `DashboardCanvas` never mutates this value — every
+   * change flows out through `onChange`.
+   */
+  value: DashboardCanvasValue;
+  /**
+   * Fires once per completed gesture — a drop, a resize end, a collapse
+   * toggle, a section reorder, or a cross-container move — with the whole
+   * next `value`. Omit for a read-only or fully static canvas; without it,
+   * collapse toggles (and, from Task 3 on, drags/resizes) have no effect.
+   */
+  onChange?: (next: DashboardCanvasValue) => void;
+  /** Renders the body of an item by id. Called once per visible item, every render. */
+  renderItem: (id: string | number) => ReactNode;
+  /**
+   * Optional extra controls in a section's header (a title editor, a
+   * `DropdownMenu` trigger) rendered by section id, to the right of the
+   * title. Keep it small — the header row is not a general-purpose toolbar.
+   */
+  renderSectionHeader?: (id: string | number) => ReactNode;
+  /** Per-item size constraints, consulted by resize gestures (Task 3) and keyboard resize (Task 4). */
+  constraints?: DashboardCanvasConstraintsProp;
+  /**
+   * View-only mode: identical geometry, but no drag/resize wiring (Task 3)
+   * and no keyboard editing (Task 4) — the canvas renders `value` and lets
+   * section collapse toggles keep working. @default false
+   */
+  readOnly?: boolean;
+}
+
+/**
+ * Datadog-style 2D snap-grid dashboard: items placed on a 12-column grid with
+ * a fixed row unit, full-width collapsible sections with their own
+ * sub-grids, drag-to-move with push-down collision + compaction, and E/S/SE
+ * resize (Task 3). Always controlled — there is no uncontrolled mode.
+ *
+ * @example
+ * // Static/read-only layout — no onChange, geometry only.
+ * <DashboardCanvas
+ *   value={{ items: [{ id: 'kpi', x: 0, y: 0, w: 4, h: 2 }], sections: [] }}
+ *   renderItem={(id) => <Card>{id}</Card>}
+ *   readOnly
+ * />
+ *
+ * @example
+ * // Controlled layout with a section; onChange persists collapse toggles
+ * // now, and drag/resize/reorder once Task 3 lands.
+ * const [value, setValue] = useState<DashboardCanvasValue>(initialLayout);
+ * <DashboardCanvas
+ *   value={value}
+ *   onChange={setValue}
+ *   renderItem={(id) => <Card>{widgets[id].title}</Card>}
+ * />
+ */
+export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
+  function DashboardCanvas(
+    {
+      value,
+      onChange,
+      renderItem,
+      renderSectionHeader,
+      // Resolved for resize clamping starting in Task 3; the props interface
+      // (locked API) carries it from Task 2 on.
+      constraints: _constraints,
+      readOnly = false,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    const t = useTranslation();
+
+    const handleToggleSection = useCallback(
+      (sectionId: string | number) => {
+        // Collapse stays active in readOnly — it's navigation, not editing.
+        onChange?.(toggleSection(value, sectionId));
+      },
+      [value, onChange],
+    );
+
+    return (
+      // {...rest} last so consumer overrides win (Pattern A).
+      <div
+        ref={ref}
+        role="group"
+        aria-label={t('dashboardCanvas.canvas')}
+        className={clsx(styles.canvas, className)}
+        data-readonly={readOnly ? '' : undefined}
+        {...rest}
+      >
+        <div className={styles.container}>
+          {sortByPosition(value.items).map((item) => (
+            <DashboardCanvasItem key={item.id} placement={item}>
+              {renderItem(item.id)}
+            </DashboardCanvasItem>
+          ))}
+        </div>
+        {value.sections.map((section) => (
+          <DashboardCanvasSection
+            key={section.id}
+            section={section}
+            renderItem={renderItem}
+            renderSectionHeader={renderSectionHeader}
+            onToggle={() => handleToggleSection(section.id)}
+          />
+        ))}
+      </div>
+    );
+  },
+);

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
@@ -1,10 +1,25 @@
-import { forwardRef, useCallback } from 'react';
-import type { HTMLAttributes, ReactNode } from 'react';
+import { Fragment, forwardRef, useCallback, useEffect, useRef, useState } from 'react';
+import type { HTMLAttributes, PointerEvent as ReactPointerEvent, ReactNode } from 'react';
 import clsx from 'clsx';
 import { useTranslation } from '../../i18n/useTranslation';
-import { toggleSection } from './engine';
-import type { DashboardCanvasValue, DashboardItemConstraints } from './engine';
+import { useFloatingSurface } from '../_internal/overlay';
+import { mergeRefs } from '../_internal/refs';
+import {
+  DASHBOARD_COLUMNS,
+  applyMove,
+  applyResize,
+  cellFromPoint,
+  reorderSection,
+  toggleSection,
+} from './engine';
+import type {
+  ContainerRef,
+  DashboardCanvasValue,
+  DashboardItemConstraints,
+  DashboardPlacement,
+} from './engine';
 import { DashboardCanvasItem, sortByPosition } from './DashboardCanvasItem';
+import type { CanvasGestures, ResizeEdge } from './DashboardCanvasItem';
 import { DashboardCanvasSection } from './DashboardCanvasSection';
 import styles from './DashboardCanvas.module.scss';
 
@@ -29,32 +44,153 @@ export interface DashboardCanvasProps extends Omit<HTMLAttributes<HTMLDivElement
    * Fires once per completed gesture — a drop, a resize end, a collapse
    * toggle, a section reorder, or a cross-container move — with the whole
    * next `value`. Omit for a read-only or fully static canvas; without it,
-   * collapse toggles (and, from Task 3 on, drags/resizes) have no effect.
+   * drags preview live but nothing persists on drop.
    */
   onChange?: (next: DashboardCanvasValue) => void;
-  /** Renders the body of an item by id. Called once per visible item, every render. */
+  /**
+   * Renders the body of an item by id. Called for every visible item on
+   * every render — and once more for the dragged item mid-gesture (the
+   * cursor-following ghost) — so keep it pure.
+   */
   renderItem: (id: string | number) => ReactNode;
   /**
    * Optional extra controls in a section's header (a title editor, a
    * `DropdownMenu` trigger) rendered by section id, to the right of the
    * title. Keep it small — the header row is not a general-purpose toolbar.
+   * Pointer presses inside the slot never start a band-reorder drag.
    */
   renderSectionHeader?: (id: string | number) => ReactNode;
-  /** Per-item size constraints, consulted by resize gestures (Task 3) and keyboard resize (Task 4). */
+  /** Per-item size constraints, consulted when clamping resize gestures. */
   constraints?: DashboardCanvasConstraintsProp;
   /**
-   * View-only mode: identical geometry, but no drag/resize wiring (Task 3)
-   * and no keyboard editing (Task 4) — the canvas renders `value` and lets
-   * section collapse toggles keep working. @default false
+   * View-only mode: identical geometry, but no drag/resize wiring, no resize
+   * handles, and no keyboard editing (Task 4) — the canvas renders `value`
+   * and lets section collapse toggles keep working. @default false
    */
   readOnly?: boolean;
 }
 
+const TOP_CONTAINER: ContainerRef = { kind: 'top' };
+
+/** Stable registry key for a container (object identity is per-render). */
+function containerKey(cref: ContainerRef): string {
+  return cref.kind === 'top' ? 'top' : `s:${String(cref.id)}`;
+}
+
+/**
+ * Screen-px a pointer must travel before a press arms as a drag (Sortable's
+ * activation-distance precedent) — presses and clicks inside item bodies and
+ * section headers pass through untouched below it.
+ */
+const DRAG_ACTIVATION_PX = 5;
+
+/**
+ * Mirrors the `--dashboard-canvas-row` default (`--space-12`, 48px). Used only
+ * when `grid-auto-rows` doesn't resolve to a px length (jsdom).
+ */
+const FALLBACK_ROW_PX = 48;
+
+/** Live px geometry of one container grid, re-measured per pointermove. */
+function measureGrid(el: HTMLElement) {
+  const rect = el.getBoundingClientRect();
+  const style = getComputedStyle(el);
+  const gap = Number.parseFloat(style.columnGap) || 0;
+  const rowHeight = Number.parseFloat(style.gridAutoRows) || FALLBACK_ROW_PX;
+  const colWidth = (rect.width - gap * (DASHBOARD_COLUMNS - 1)) / DASHBOARD_COLUMNS;
+  return { rect, colWidth, rowHeight, gap };
+}
+
+/**
+ * Capture always targets the ROOT: item elements REMOUNT when a preview moves
+ * them across containers, and a remount implicitly releases their capture —
+ * the pointerup would then never arrive and the drag would stick (FlowCanvas
+ * root-capture precedent). jsdom throws on inactive pointers, hence the guard.
+ */
+function capturePointer(el: Element | null, pointerId: number) {
+  try {
+    el?.setPointerCapture(pointerId);
+  } catch {
+    /* jsdom */
+  }
+}
+
+// In-flight gesture bookkeeping lives in a ref (FlowCanvas precedent): the
+// pointer stream mutates it without re-render churn; `live` state below is
+// the render-facing projection, discarded wholesale on cancel.
+interface MoveDrag {
+  kind: 'move';
+  pointerId: number;
+  id: string | number;
+  from: ContainerRef;
+  homeX: number;
+  homeY: number;
+  startX: number;
+  startY: number;
+  /** Pointer offset inside the item at pointerdown — keeps the ghost under the grab point. */
+  grabDX: number;
+  grabDY: number;
+  ghostW: number;
+  ghostH: number;
+  moved: boolean;
+  target: ContainerRef;
+  targetKey: string;
+  cell: { x: number; y: number } | null;
+  previewKey: string | null;
+  preview: DashboardCanvasValue | null;
+}
+interface ResizeDrag {
+  kind: 'resize';
+  pointerId: number;
+  id: string | number;
+  container: ContainerRef;
+  containerKey: string;
+  edge: ResizeEdge;
+  startX: number;
+  startY: number;
+  startW: number;
+  startH: number;
+  lastW: number;
+  lastH: number;
+  preview: DashboardCanvasValue | null;
+}
+interface SectionDrag {
+  kind: 'section';
+  pointerId: number;
+  id: string | number;
+  fromIndex: number;
+  startX: number;
+  startY: number;
+  moved: boolean;
+  /** Insertion slot among ALL bands (0..N), indicator position. */
+  slot: number;
+}
+type DragState = MoveDrag | ResizeDrag | SectionDrag;
+
+/** Render-facing gesture projection: the engine preview IS the rendered layout. */
+type LiveState =
+  | {
+      kind: 'move';
+      id: string | number;
+      value: DashboardCanvasValue;
+      /** Canvas-relative px box for the cursor-following ghost. */
+      ghost: { left: number; top: number; width: number; height: number };
+    }
+  | { kind: 'resize'; id: string | number; value: DashboardCanvasValue }
+  | { kind: 'section'; id: string | number; slot: number };
+
 /**
  * Datadog-style 2D snap-grid dashboard: items placed on a 12-column grid with
- * a fixed row unit, full-width collapsible sections with their own
- * sub-grids, drag-to-move with push-down collision + compaction, and E/S/SE
- * resize (Task 3). Always controlled — there is no uncontrolled mode.
+ * a fixed row unit, full-width collapsible sections with their own sub-grids,
+ * drag-to-move with push-down collision + live compaction preview, E/S/SE
+ * resize handles, cross-container drags (top level ↔ any expanded section),
+ * and vertical band reorder by dragging a section header. Always controlled —
+ * there is no uncontrolled mode; every completed gesture fires `onChange`
+ * exactly once with the engine-computed next value.
+ *
+ * @remarks
+ * A collapsed section's band is NOT a drop target — expand it first (v1; no
+ * hover-to-expand). Escape or a pointer cancel mid-gesture restores the
+ * current `value` without firing `onChange`.
  *
  * @example
  * // Static/read-only layout — no onChange, geometry only.
@@ -65,13 +201,14 @@ export interface DashboardCanvasProps extends Omit<HTMLAttributes<HTMLDivElement
  * />
  *
  * @example
- * // Controlled layout with a section; onChange persists collapse toggles
- * // now, and drag/resize/reorder once Task 3 lands.
+ * // Controlled layout with a section; onChange persists drags, resizes,
+ * // band reorders, and collapse toggles.
  * const [value, setValue] = useState<DashboardCanvasValue>(initialLayout);
  * <DashboardCanvas
  *   value={value}
  *   onChange={setValue}
  *   renderItem={(id) => <Card>{widgets[id].title}</Card>}
+ *   constraints={{ kpi: { minW: 2, maxH: 4 } }}
  * />
  */
 export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
@@ -81,51 +218,423 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       onChange,
       renderItem,
       renderSectionHeader,
-      // Resolved for resize clamping starting in Task 3; the props interface
-      // (locked API) carries it from Task 2 on.
-      constraints: _constraints,
+      constraints,
       readOnly = false,
       className,
+      onPointerMove: onPointerMoveProp,
+      onPointerUp: onPointerUpProp,
+      onPointerCancel: onPointerCancelProp,
+      onLostPointerCapture: onLostPointerCaptureProp,
       ...rest
     },
     ref,
   ) {
     const t = useTranslation();
 
-    const handleToggleSection = useCallback(
-      (sectionId: string | number) => {
-        // Collapse stays active in readOnly — it's navigation, not editing.
-        onChange?.(toggleSection(value, sectionId));
-      },
-      [value, onChange],
+    const rootRef = useRef<HTMLDivElement | null>(null);
+    const containersRef = useRef(new Map<string, { el: HTMLElement; cref: ContainerRef }>());
+    const bandsRef = useRef(new Map<string | number, HTMLElement>());
+    const dragRef = useRef<DragState | null>(null);
+    const [live, setLive] = useState<LiveState | null>(null);
+
+    const setContainerEl = useCallback((cref: ContainerRef, el: HTMLElement | null) => {
+      const key = containerKey(cref);
+      if (el) containersRef.current.set(key, { el, cref });
+      else containersRef.current.delete(key);
+    }, []);
+    const setBandEl = useCallback((id: string | number, el: HTMLElement | null) => {
+      if (el) bandsRef.current.set(id, el);
+      else bandsRef.current.delete(id);
+    }, []);
+
+    const constraintsFor = (id: string | number): DashboardItemConstraints | undefined =>
+      typeof constraints === 'function' ? constraints(id) : constraints?.[String(id)];
+
+    // Single choke point for EVERY gesture commit: the engine ops return
+    // `value` by reference when the gesture resolves to the current layout
+    // (clamped resize, unmoved band, vanished id), so one identity check
+    // kills every no-op onChange.
+    const commit = (next: DashboardCanvasValue) => {
+      if (next !== value) onChange?.(next);
+    };
+
+    const handleToggleSection = (sectionId: string | number) => {
+      // Collapse stays active in readOnly — it's navigation, not editing.
+      commit(toggleSection(value, sectionId));
+    };
+
+    // --- gesture starts (single readOnly choke point; Task 5 adds the narrow gate here) ---
+    const onMovePointerDown = (
+      event: ReactPointerEvent<HTMLDivElement>,
+      placement: DashboardPlacement,
+      container: ContainerRef,
+    ) => {
+      // One gesture at a time: a second pointer going down mid-drag must not
+      // overwrite the state (FlowCanvas discipline). No preventDefault —
+      // clicks inside item bodies pass through until the drag arms.
+      if (readOnly || event.button !== 0 || dragRef.current) return;
+      const el = event.currentTarget;
+      const rect = el.getBoundingClientRect();
+      dragRef.current = {
+        kind: 'move',
+        pointerId: event.pointerId,
+        id: placement.id,
+        from: container,
+        homeX: placement.x,
+        homeY: placement.y,
+        startX: event.clientX,
+        startY: event.clientY,
+        grabDX: event.clientX - rect.left,
+        grabDY: event.clientY - rect.top,
+        ghostW: rect.width,
+        ghostH: rect.height,
+        moved: false,
+        target: container,
+        targetKey: containerKey(container),
+        cell: null,
+        previewKey: null,
+        preview: null,
+      };
+      // No capture yet — capture retargets the eventual click to the root,
+      // so it must wait until the drag arms (clicks pass through until then).
+    };
+
+    const onResizePointerDown = (
+      event: ReactPointerEvent<HTMLDivElement>,
+      placement: DashboardPlacement,
+      container: ContainerRef,
+      edge: ResizeEdge,
+    ) => {
+      if (readOnly || event.button !== 0 || dragRef.current) return;
+      // The handle sits inside the move-drag surface — never arm both.
+      event.stopPropagation();
+      dragRef.current = {
+        kind: 'resize',
+        pointerId: event.pointerId,
+        id: placement.id,
+        container,
+        containerKey: containerKey(container),
+        edge,
+        startX: event.clientX,
+        startY: event.clientY,
+        startW: placement.w,
+        startH: placement.h,
+        lastW: placement.w,
+        lastH: placement.h,
+        preview: null,
+      };
+      // Handles have no click semantics — capture immediately (on the root).
+      capturePointer(rootRef.current, event.pointerId);
+    };
+
+    const onHeaderPointerDown = (
+      event: ReactPointerEvent<HTMLDivElement>,
+      sectionId: string | number,
+    ) => {
+      if (readOnly || event.button !== 0 || dragRef.current) return;
+      // The drag zone is the header row MINUS the collapse button and the
+      // renderSectionHeader extras — those keep their own interactions.
+      if ((event.target as HTMLElement).closest('button, [data-dc-section-actions]')) return;
+      const fromIndex = value.sections.findIndex((section) => section.id === sectionId);
+      if (fromIndex === -1) return;
+      dragRef.current = {
+        kind: 'section',
+        pointerId: event.pointerId,
+        id: sectionId,
+        fromIndex,
+        startX: event.clientX,
+        startY: event.clientY,
+        moved: false,
+        slot: fromIndex,
+      };
+    };
+
+    // --- pointer stream (root-level; capture retargeting still bubbles here) ---
+    const handleRootPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+      onPointerMoveProp?.(event);
+      const drag = dragRef.current;
+      if (!drag || event.pointerId !== drag.pointerId) return;
+
+      if (drag.kind === 'move') {
+        if (!drag.moved) {
+          if (
+            Math.abs(event.clientX - drag.startX) + Math.abs(event.clientY - drag.startY) <
+            DRAG_ACTIVATION_PX
+          ) {
+            return;
+          }
+          drag.moved = true;
+          capturePointer(rootRef.current, event.pointerId);
+        }
+        // Drop target = the registered container grid under the pointer.
+        // Collapsed section bodies are unmounted hence unregistered, so their
+        // bands can't be targets; in dead zones (headers, gaps, outside) the
+        // last hovered container keeps the drop.
+        for (const entry of containersRef.current.values()) {
+          const r = entry.el.getBoundingClientRect();
+          if (
+            event.clientX >= r.left &&
+            event.clientX <= r.right &&
+            event.clientY >= r.top &&
+            event.clientY <= r.bottom
+          ) {
+            drag.target = entry.cref;
+            drag.targetKey = containerKey(entry.cref);
+            break;
+          }
+        }
+        const entry = containersRef.current.get(drag.targetKey);
+        if (!entry) return;
+        const { rect, colWidth, rowHeight, gap } = measureGrid(entry.el);
+        // Snap by the ghost's origin (pointer minus grab offset), not the
+        // pointer itself — grabbing a wide item mid-body must not yank its
+        // left edge to the cursor column.
+        const originX = event.clientX - drag.grabDX;
+        const originY = event.clientY - drag.grabDY;
+        const cell = cellFromPoint(originX, originY, rect, colWidth, rowHeight, gap);
+        if (
+          !drag.preview ||
+          drag.previewKey !== drag.targetKey ||
+          drag.cell?.x !== cell.x ||
+          drag.cell?.y !== cell.y
+        ) {
+          // The preview IS the engine result of the hypothetical drop — the
+          // exact value a pointerup right now would commit.
+          drag.preview = applyMove(value, drag.from, drag.target, drag.id, cell.x, cell.y);
+          drag.previewKey = drag.targetKey;
+          drag.cell = cell;
+        }
+        const rootRect = rootRef.current?.getBoundingClientRect();
+        setLive({
+          kind: 'move',
+          id: drag.id,
+          value: drag.preview,
+          ghost: {
+            left: originX - (rootRect?.left ?? 0),
+            top: originY - (rootRect?.top ?? 0),
+            width: drag.ghostW,
+            height: drag.ghostH,
+          },
+        });
+        return;
+      }
+
+      if (drag.kind === 'resize') {
+        const entry = containersRef.current.get(drag.containerKey);
+        if (!entry) return;
+        const { colWidth, rowHeight, gap } = measureGrid(entry.el);
+        const dw =
+          drag.edge === 's' ? 0 : Math.round((event.clientX - drag.startX) / (colWidth + gap));
+        const dh =
+          drag.edge === 'e' ? 0 : Math.round((event.clientY - drag.startY) / (rowHeight + gap));
+        const w = drag.startW + dw;
+        const h = drag.startH + dh;
+        if (!drag.preview || w !== drag.lastW || h !== drag.lastH) {
+          drag.lastW = w;
+          drag.lastH = h;
+          drag.preview = applyResize(value, drag.container, drag.id, w, h, constraintsFor(drag.id));
+        }
+        setLive({ kind: 'resize', id: drag.id, value: drag.preview });
+        return;
+      }
+
+      // Section band reorder — vertical only.
+      if (!drag.moved) {
+        if (
+          Math.abs(event.clientX - drag.startX) + Math.abs(event.clientY - drag.startY) <
+          DRAG_ACTIVATION_PX
+        ) {
+          return;
+        }
+        drag.moved = true;
+        capturePointer(rootRef.current, event.pointerId);
+      }
+      // Insertion slot = how many band midpoints the pointer has passed.
+      let slot = 0;
+      for (const section of value.sections) {
+        const el = bandsRef.current.get(section.id);
+        if (!el) continue;
+        const r = el.getBoundingClientRect();
+        if (event.clientY > r.top + r.height / 2) slot += 1;
+      }
+      drag.slot = slot;
+      setLive({ kind: 'section', id: drag.id, slot });
+    };
+
+    const handleRootPointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+      onPointerUpProp?.(event);
+      const drag = dragRef.current;
+      if (!drag || event.pointerId !== drag.pointerId) return;
+      // End-of-gesture cleanup ALWAYS runs (FlowCanvas precedent) so a drag
+      // can never get stuck; the commit below is the conditional part.
+      dragRef.current = null;
+      setLive(null);
+      // Commits recompute from the CURRENT `value` closure, never the cached
+      // preview — a controlled update mid-gesture must not be reverted.
+      if (drag.kind === 'move') {
+        if (!drag.moved || !drag.cell) return;
+        // No-op drop: same container, same cell → the gesture changed
+        // nothing, even if committing would compact an uncompacted value.
+        if (
+          containerKey(drag.from) === drag.targetKey &&
+          drag.cell.x === drag.homeX &&
+          drag.cell.y === drag.homeY
+        ) {
+          return;
+        }
+        commit(applyMove(value, drag.from, drag.target, drag.id, drag.cell.x, drag.cell.y));
+        return;
+      }
+      if (drag.kind === 'resize') {
+        if (drag.lastW === drag.startW && drag.lastH === drag.startH) return;
+        commit(
+          applyResize(
+            value,
+            drag.container,
+            drag.id,
+            drag.lastW,
+            drag.lastH,
+            constraintsFor(drag.id),
+          ),
+        );
+        return;
+      }
+      if (!drag.moved) return;
+      // Slot counts ALL bands including the dragged one, so slots past it
+      // shift down by one when it's spliced out.
+      const toIndex = drag.slot > drag.fromIndex ? drag.slot - 1 : drag.slot;
+      commit(reorderSection(value, drag.id, toIndex));
+    };
+
+    const handleRootPointerCancel = (event: ReactPointerEvent<HTMLDivElement>) => {
+      onPointerCancelProp?.(event);
+      const drag = dragRef.current;
+      if (!drag || event.pointerId !== drag.pointerId) return;
+      // The system aborted the gesture — restore `value`, commit nothing.
+      dragRef.current = null;
+      setLive(null);
+    };
+
+    const handleLostPointerCapture = (event: ReactPointerEvent<HTMLDivElement>) => {
+      onLostPointerCaptureProp?.(event);
+      // Safety net: a normal release fires this AFTER pointerup already
+      // cleared the state; still holding a drag here means the capture died
+      // unexpectedly — abandon the gesture instead of leaving it stuck.
+      const drag = dragRef.current;
+      if (!drag || event.pointerId !== drag.pointerId) return;
+      dragRef.current = null;
+      setLive(null);
+    };
+
+    // Escape cancels an armed gesture and restores the current value. An
+    // armed drag is an Escape-consuming mode — registering it as a floating
+    // surface makes a host Modal/Drawer yield that Escape (FlowCanvas #282).
+    const dragging = live != null;
+    useFloatingSurface(dragging);
+    useEffect(() => {
+      if (!dragging) return undefined;
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key !== 'Escape') return;
+        dragRef.current = null;
+        setLive(null);
+      };
+      window.addEventListener('keydown', onKeyDown);
+      return () => window.removeEventListener('keydown', onKeyDown);
+    }, [dragging]);
+
+    // readOnly flipping on mid-gesture aborts it — same restore as Escape.
+    useEffect(() => {
+      if (!readOnly) return;
+      dragRef.current = null;
+      setLive(null);
+    }, [readOnly]);
+
+    // Render EXACTLY what the engine returned for the in-flight gesture —
+    // never parallel geometry. Section band order only changes on commit.
+    const shown = live != null && live.kind !== 'section' ? live.value : value;
+    const gestures: CanvasGestures = {
+      readOnly,
+      movingId: live?.kind === 'move' ? live.id : null,
+      resizingId: live?.kind === 'resize' ? live.id : null,
+      onMovePointerDown,
+      onResizePointerDown,
+    };
+
+    // Band insertion indicator position (slot among N+1 gaps), suppressed
+    // when dropping there would be a no-op.
+    let bandSlot: number | null = null;
+    if (live?.kind === 'section') {
+      const fromIndex = value.sections.findIndex((section) => section.id === live.id);
+      const toIndex = live.slot > fromIndex ? live.slot - 1 : live.slot;
+      if (toIndex !== fromIndex) bandSlot = live.slot;
+    }
+    const bandIndicator = (
+      <div className={styles.bandIndicator} data-dc-band-indicator aria-hidden="true" />
     );
 
     return (
-      // {...rest} last so consumer overrides win (Pattern A).
+      // {...rest} last so consumer overrides win (Pattern A); the pointer
+      // handlers are extracted above and re-invoked inside ours.
       <div
-        ref={ref}
+        ref={mergeRefs(ref, rootRef)}
         role="group"
         aria-label={t('dashboardCanvas.canvas')}
         className={clsx(styles.canvas, className)}
         data-readonly={readOnly ? '' : undefined}
+        data-dragging={dragging ? '' : undefined}
+        onPointerMove={handleRootPointerMove}
+        onPointerUp={handleRootPointerUp}
+        onPointerCancel={handleRootPointerCancel}
+        onLostPointerCapture={handleLostPointerCapture}
         {...rest}
       >
-        <div className={styles.container}>
-          {sortByPosition(value.items).map((item) => (
-            <DashboardCanvasItem key={item.id} placement={item}>
+        <div
+          className={styles.container}
+          data-dc-container="top"
+          ref={(el) => setContainerEl(TOP_CONTAINER, el)}
+        >
+          {sortByPosition(shown.items).map((item) => (
+            <DashboardCanvasItem
+              key={item.id}
+              placement={item}
+              container={TOP_CONTAINER}
+              gestures={gestures}
+            >
               {renderItem(item.id)}
             </DashboardCanvasItem>
           ))}
         </div>
-        {value.sections.map((section) => (
-          <DashboardCanvasSection
-            key={section.id}
-            section={section}
-            renderItem={renderItem}
-            renderSectionHeader={renderSectionHeader}
-            onToggle={() => handleToggleSection(section.id)}
-          />
+        {shown.sections.map((section, index) => (
+          <Fragment key={section.id}>
+            {bandSlot === index && bandIndicator}
+            <DashboardCanvasSection
+              section={section}
+              renderItem={renderItem}
+              renderSectionHeader={renderSectionHeader}
+              onToggle={() => handleToggleSection(section.id)}
+              gestures={gestures}
+              dragging={live?.kind === 'section' && live.id === section.id}
+              onHeaderPointerDown={onHeaderPointerDown}
+              setContainerEl={setContainerEl}
+              setBandEl={setBandEl}
+            />
+          </Fragment>
         ))}
+        {bandSlot === shown.sections.length && bandIndicator}
+        {live?.kind === 'move' && (
+          <div
+            className={styles.ghost}
+            data-dc-ghost
+            aria-hidden="true"
+            style={{
+              width: live.ghost.width,
+              height: live.ghost.height,
+              transform: `translate(${live.ghost.left}px, ${live.ghost.top}px)`,
+            }}
+          >
+            {renderItem(live.id)}
+          </div>
+        )}
       </div>
     );
   },

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvasItem.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvasItem.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react';
+import type { DashboardPlacement } from './engine';
+import styles from './DashboardCanvas.module.scss';
+
+/**
+ * Stable (y, then x) render order — matches the engine's own processing
+ * order (`compact`/`placeWithPushDown`/`stackOrder`), so DOM order always
+ * agrees with visual stacking order (load-bearing below the md breakpoint,
+ * Task 5, where DOM order becomes the single-column stack order).
+ */
+export function sortByPosition(items: readonly DashboardPlacement[]): DashboardPlacement[] {
+  return [...items].sort((a, b) => a.y - b.y || a.x - b.x);
+}
+
+interface DashboardCanvasItemProps {
+  placement: DashboardPlacement;
+  children: ReactNode;
+}
+
+/**
+ * Internal — one grid cell. Stamps the placement as inline custom properties
+ * consumed by `.item` in DashboardCanvas.module.scss (Grid.Item precedent).
+ * `data-dc-item` is a stable hook for tests/consumers' CSS, independent of
+ * the hashed-in-production module class name.
+ */
+export function DashboardCanvasItem({ placement, children }: DashboardCanvasItemProps) {
+  const { id, x, y, w, h } = placement;
+  return (
+    <div
+      className={styles.item}
+      data-dc-item={String(id)}
+      style={{
+        ['--dc-col' as string]: `${x + 1} / span ${w}`,
+        ['--dc-row' as string]: `${y + 1} / span ${h}`,
+        // Task 5's below-md single-column rule reads this to keep the
+        // item's own height once `--dc-row` stops being consumed.
+        ['--dc-h-span' as string]: `span ${h}`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvasItem.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvasItem.tsx
@@ -1,6 +1,33 @@
-import type { ReactNode } from 'react';
-import type { DashboardPlacement } from './engine';
+import type { PointerEvent as ReactPointerEvent, ReactNode } from 'react';
+import type { ContainerRef, DashboardPlacement } from './engine';
 import styles from './DashboardCanvas.module.scss';
+
+/** Which resize handle a resize gesture started from. */
+export type ResizeEdge = 'e' | 's' | 'se';
+
+/**
+ * Gesture wiring handed down from DashboardCanvas to every item, top-level or
+ * inside a section. One bag instead of five props so DashboardCanvasSection
+ * forwards it untouched.
+ */
+export interface CanvasGestures {
+  readOnly: boolean;
+  /** Item currently being moved — its cell renders the drop-preview style. */
+  movingId: string | number | null;
+  /** Item currently being resized — its cell renders the resize affordance. */
+  resizingId: string | number | null;
+  onMovePointerDown: (
+    event: ReactPointerEvent<HTMLDivElement>,
+    placement: DashboardPlacement,
+    container: ContainerRef,
+  ) => void;
+  onResizePointerDown: (
+    event: ReactPointerEvent<HTMLDivElement>,
+    placement: DashboardPlacement,
+    container: ContainerRef,
+    edge: ResizeEdge,
+  ) => void;
+}
 
 /**
  * Stable (y, then x) render order — matches the engine's own processing
@@ -14,6 +41,8 @@ export function sortByPosition(items: readonly DashboardPlacement[]): DashboardP
 
 interface DashboardCanvasItemProps {
   placement: DashboardPlacement;
+  container: ContainerRef;
+  gestures: CanvasGestures;
   children: ReactNode;
 }
 
@@ -22,13 +51,26 @@ interface DashboardCanvasItemProps {
  * consumed by `.item` in DashboardCanvas.module.scss (Grid.Item precedent).
  * `data-dc-item` is a stable hook for tests/consumers' CSS, independent of
  * the hashed-in-production module class name.
+ *
+ * In edit mode the whole cell is the move-drag surface, and E/S/SE resize
+ * handles overlay the edges. The handles are pointer-only `aria-hidden` divs
+ * (not focusable) — keyboard resize arrives in Task 4 via Shift+arrows on the
+ * focused item, so exposing the handles to AT would only add noise.
  */
-export function DashboardCanvasItem({ placement, children }: DashboardCanvasItemProps) {
+export function DashboardCanvasItem({
+  placement,
+  container,
+  gestures,
+  children,
+}: DashboardCanvasItemProps) {
   const { id, x, y, w, h } = placement;
+  const { readOnly, movingId, resizingId, onMovePointerDown, onResizePointerDown } = gestures;
   return (
     <div
       className={styles.item}
       data-dc-item={String(id)}
+      data-dc-drop-preview={movingId === id ? '' : undefined}
+      data-dc-resizing={resizingId === id ? '' : undefined}
       style={{
         ['--dc-col' as string]: `${x + 1} / span ${w}`,
         ['--dc-row' as string]: `${y + 1} / span ${h}`,
@@ -36,8 +78,31 @@ export function DashboardCanvasItem({ placement, children }: DashboardCanvasItem
         // item's own height once `--dc-row` stops being consumed.
         ['--dc-h-span' as string]: `span ${h}`,
       }}
+      onPointerDown={readOnly ? undefined : (e) => onMovePointerDown(e, placement, container)}
     >
       {children}
+      {!readOnly && (
+        <>
+          <div
+            className={styles.handleE}
+            data-dc-resize="e"
+            aria-hidden="true"
+            onPointerDown={(e) => onResizePointerDown(e, placement, container, 'e')}
+          />
+          <div
+            className={styles.handleS}
+            data-dc-resize="s"
+            aria-hidden="true"
+            onPointerDown={(e) => onResizePointerDown(e, placement, container, 's')}
+          />
+          <div
+            className={styles.handleSE}
+            data-dc-resize="se"
+            aria-hidden="true"
+            onPointerDown={(e) => onResizePointerDown(e, placement, container, 'se')}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvasItem.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvasItem.tsx
@@ -1,4 +1,9 @@
-import type { PointerEvent as ReactPointerEvent, ReactNode } from 'react';
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+  ReactNode,
+} from 'react';
+import { useTranslation } from '../../i18n/useTranslation';
 import type { ContainerRef, DashboardPlacement } from './engine';
 import styles from './DashboardCanvas.module.scss';
 
@@ -16,6 +21,10 @@ export interface CanvasGestures {
   movingId: string | number | null;
   /** Item currently being resized — its cell renders the resize affordance. */
   resizingId: string | number | null;
+  /** Item currently keyboard-picked — its cell renders the picked style. */
+  pickedId: string | number | null;
+  /** id of the visually-hidden keyboard instructions block (aria-describedby). */
+  instructionsId: string;
   onMovePointerDown: (
     event: ReactPointerEvent<HTMLDivElement>,
     placement: DashboardPlacement,
@@ -26,6 +35,11 @@ export interface CanvasGestures {
     placement: DashboardPlacement,
     container: ContainerRef,
     edge: ResizeEdge,
+  ) => void;
+  onItemKeyDown: (
+    event: ReactKeyboardEvent<HTMLDivElement>,
+    placement: DashboardPlacement,
+    container: ContainerRef,
   ) => void;
 }
 
@@ -54,8 +68,10 @@ interface DashboardCanvasItemProps {
  *
  * In edit mode the whole cell is the move-drag surface, and E/S/SE resize
  * handles overlay the edges. The handles are pointer-only `aria-hidden` divs
- * (not focusable) — keyboard resize arrives in Task 4 via Shift+arrows on the
- * focused item, so exposing the handles to AT would only add noise.
+ * (not focusable) — keyboard resize is Shift+arrows on the focused cell, so
+ * exposing the handles to AT would only add noise. The cell itself is the
+ * keyboard editing surface: role=button (named by the widget's own content,
+ * FlowNode precedent) with a localized "widget" roledescription.
  */
 export function DashboardCanvasItem({
   placement,
@@ -63,14 +79,29 @@ export function DashboardCanvasItem({
   gestures,
   children,
 }: DashboardCanvasItemProps) {
+  const t = useTranslation();
   const { id, x, y, w, h } = placement;
-  const { readOnly, movingId, resizingId, onMovePointerDown, onResizePointerDown } = gestures;
+  const {
+    readOnly,
+    movingId,
+    resizingId,
+    pickedId,
+    instructionsId,
+    onMovePointerDown,
+    onResizePointerDown,
+    onItemKeyDown,
+  } = gestures;
   return (
     <div
       className={styles.item}
       data-dc-item={String(id)}
       data-dc-drop-preview={movingId === id ? '' : undefined}
       data-dc-resizing={resizingId === id ? '' : undefined}
+      data-dc-picked={pickedId === id ? '' : undefined}
+      role={readOnly ? undefined : 'button'}
+      tabIndex={readOnly ? undefined : 0}
+      aria-roledescription={readOnly ? undefined : t('dashboardCanvas.itemRole')}
+      aria-describedby={readOnly ? undefined : instructionsId}
       style={{
         ['--dc-col' as string]: `${x + 1} / span ${w}`,
         ['--dc-row' as string]: `${y + 1} / span ${h}`,
@@ -79,6 +110,7 @@ export function DashboardCanvasItem({
         ['--dc-h-span' as string]: `span ${h}`,
       }}
       onPointerDown={readOnly ? undefined : (e) => onMovePointerDown(e, placement, container)}
+      onKeyDown={readOnly ? undefined : (e) => onItemKeyDown(e, placement, container)}
     >
       {children}
       {!readOnly && (

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvasSection.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvasSection.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { useTranslation } from '../../i18n/useTranslation';
+import type { DashboardSection } from './engine';
+import { DashboardCanvasItem, sortByPosition } from './DashboardCanvasItem';
+import styles from './DashboardCanvas.module.scss';
+
+interface DashboardCanvasSectionProps {
+  section: DashboardSection;
+  renderItem: (id: string | number) => ReactNode;
+  renderSectionHeader?: (id: string | number) => ReactNode;
+  /** Fires the toggle — always active, including in `readOnly` (Task 2 spec). */
+  onToggle: () => void;
+}
+
+/**
+ * Internal — one full-width collapsible band: a header (collapse toggle +
+ * title + optional `renderSectionHeader` slot) and a body that is the
+ * section's own container grid. Collapsing unmounts the body; the section's
+ * item geometry stays in `value` untouched.
+ */
+export function DashboardCanvasSection({
+  section,
+  renderItem,
+  renderSectionHeader,
+  onToggle,
+}: DashboardCanvasSectionProps) {
+  const t = useTranslation();
+  const { id, title, collapsed, items } = section;
+
+  return (
+    <div className={styles.section} data-dc-section={String(id)}>
+      <div className={styles.sectionHeader}>
+        <button
+          type="button"
+          aria-expanded={!collapsed}
+          aria-label={t(
+            collapsed ? 'dashboardCanvas.sectionExpand' : 'dashboardCanvas.sectionCollapse',
+            { title },
+          )}
+          onClick={onToggle}
+          className={styles.sectionToggle}
+        >
+          <ChevronDown size={16} aria-hidden="true" className={styles.sectionIndicator} />
+        </button>
+        <span className={styles.sectionTitle}>{title}</span>
+        {renderSectionHeader != null && (
+          <div className={styles.sectionActions}>{renderSectionHeader(id)}</div>
+        )}
+      </div>
+      {!collapsed && (
+        <div className={styles.container}>
+          {sortByPosition(items).map((item) => (
+            <DashboardCanvasItem key={item.id} placement={item}>
+              {renderItem(item.id)}
+            </DashboardCanvasItem>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvasSection.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvasSection.tsx
@@ -1,8 +1,9 @@
-import type { ReactNode } from 'react';
+import type { PointerEvent as ReactPointerEvent, ReactNode } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { useTranslation } from '../../i18n/useTranslation';
-import type { DashboardSection } from './engine';
+import type { ContainerRef, DashboardSection } from './engine';
 import { DashboardCanvasItem, sortByPosition } from './DashboardCanvasItem';
+import type { CanvasGestures } from './DashboardCanvasItem';
 import styles from './DashboardCanvas.module.scss';
 
 interface DashboardCanvasSectionProps {
@@ -11,26 +12,56 @@ interface DashboardCanvasSectionProps {
   renderSectionHeader?: (id: string | number) => ReactNode;
   /** Fires the toggle — always active, including in `readOnly` (Task 2 spec). */
   onToggle: () => void;
+  gestures: CanvasGestures;
+  /** True while this band is being pointer-reordered (styling hook). */
+  dragging: boolean;
+  /**
+   * Band-reorder drag zone: the header row, minus the collapse button and any
+   * `renderSectionHeader` extras (the handler itself excludes them by target).
+   */
+  onHeaderPointerDown: (
+    event: ReactPointerEvent<HTMLDivElement>,
+    sectionId: string | number,
+  ) => void;
+  /** Registers the body grid in the cross-container drop-target registry. */
+  setContainerEl: (cref: ContainerRef, el: HTMLElement | null) => void;
+  /** Registers the band root for reorder insertion-index hit-testing. */
+  setBandEl: (id: string | number, el: HTMLElement | null) => void;
 }
 
 /**
  * Internal — one full-width collapsible band: a header (collapse toggle +
  * title + optional `renderSectionHeader` slot) and a body that is the
  * section's own container grid. Collapsing unmounts the body; the section's
- * item geometry stays in `value` untouched.
+ * item geometry stays in `value` untouched. A collapsed body is therefore
+ * never registered as a drop target — dragging an item over a collapsed
+ * band cannot drop into it (v1; no hover-to-expand).
  */
 export function DashboardCanvasSection({
   section,
   renderItem,
   renderSectionHeader,
   onToggle,
+  gestures,
+  dragging,
+  onHeaderPointerDown,
+  setContainerEl,
+  setBandEl,
 }: DashboardCanvasSectionProps) {
   const t = useTranslation();
   const { id, title, collapsed, items } = section;
 
   return (
-    <div className={styles.section} data-dc-section={String(id)}>
-      <div className={styles.sectionHeader}>
+    <div
+      className={styles.section}
+      data-dc-section={String(id)}
+      data-dragging={dragging ? '' : undefined}
+      ref={(el) => setBandEl(id, el)}
+    >
+      <div
+        className={styles.sectionHeader}
+        onPointerDown={gestures.readOnly ? undefined : (e) => onHeaderPointerDown(e, id)}
+      >
         <button
           type="button"
           aria-expanded={!collapsed}
@@ -45,13 +76,24 @@ export function DashboardCanvasSection({
         </button>
         <span className={styles.sectionTitle}>{title}</span>
         {renderSectionHeader != null && (
-          <div className={styles.sectionActions}>{renderSectionHeader(id)}</div>
+          <div className={styles.sectionActions} data-dc-section-actions>
+            {renderSectionHeader(id)}
+          </div>
         )}
       </div>
       {!collapsed && (
-        <div className={styles.container}>
+        <div
+          className={styles.container}
+          data-dc-container={String(id)}
+          ref={(el) => setContainerEl({ kind: 'section', id }, el)}
+        >
           {sortByPosition(items).map((item) => (
-            <DashboardCanvasItem key={item.id} placement={item}>
+            <DashboardCanvasItem
+              key={item.id}
+              placement={item}
+              container={{ kind: 'section', id }}
+              gestures={gestures}
+            >
               {renderItem(item.id)}
             </DashboardCanvasItem>
           ))}

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvasSection.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvasSection.tsx
@@ -1,4 +1,8 @@
-import type { PointerEvent as ReactPointerEvent, ReactNode } from 'react';
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+  ReactNode,
+} from 'react';
 import { ChevronDown } from 'lucide-react';
 import { useTranslation } from '../../i18n/useTranslation';
 import type { ContainerRef, DashboardSection } from './engine';
@@ -23,6 +27,11 @@ interface DashboardCanvasSectionProps {
     event: ReactPointerEvent<HTMLDivElement>,
     sectionId: string | number,
   ) => void;
+  /**
+   * Keyboard band reorder: Shift+ArrowUp/Down anywhere in the header row —
+   * in practice on the focused collapse toggle, the header's tab stop.
+   */
+  onHeaderKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>, sectionId: string | number) => void;
   /** Registers the body grid in the cross-container drop-target registry. */
   setContainerEl: (cref: ContainerRef, el: HTMLElement | null) => void;
   /** Registers the band root for reorder insertion-index hit-testing. */
@@ -45,6 +54,7 @@ export function DashboardCanvasSection({
   gestures,
   dragging,
   onHeaderPointerDown,
+  onHeaderKeyDown,
   setContainerEl,
   setBandEl,
 }: DashboardCanvasSectionProps) {
@@ -61,6 +71,7 @@ export function DashboardCanvasSection({
       <div
         className={styles.sectionHeader}
         onPointerDown={gestures.readOnly ? undefined : (e) => onHeaderPointerDown(e, id)}
+        onKeyDown={gestures.readOnly ? undefined : (e) => onHeaderKeyDown(e, id)}
       >
         <button
           type="button"

--- a/packages/design-system/src/components/DashboardCanvas/engine.test.ts
+++ b/packages/design-system/src/components/DashboardCanvas/engine.test.ts
@@ -586,3 +586,67 @@ describe('no-op gestures return the input reference', () => {
     expect(applyResize(value, { kind: 'top' }, 'a', 0, 1, { minW: 2 })).toBe(value);
   });
 });
+
+describe('engine property test (seeded, #337 review)', () => {
+  // ponytail: fixed-seed mulberry32 — deterministic in CI, not a real fuzz-test
+  // dependency. Upgrade to fast-check only if a seed stops finding regressions.
+  function mulberry32(seed: number) {
+    let a = seed;
+    return () => {
+      a = (a + 0x6d2b79f5) | 0;
+      let t = Math.imul(a ^ (a >>> 15), 1 | a);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+  const rand = mulberry32(20260726);
+  const randInt = (max: number) => Math.floor(rand() * max);
+  const randomLayout = (): DashboardPlacement[] =>
+    Array.from({ length: 2 + randInt(6) }, (_, i) => {
+      const w = 1 + randInt(4);
+      return {
+        id: `p${i}`,
+        x: randInt(DASHBOARD_COLUMNS - w + 1),
+        y: randInt(8),
+        w,
+        h: 1 + randInt(3),
+      };
+    });
+  const expectBounds = (items: DashboardPlacement[]) => {
+    for (const item of items) {
+      expect(item.x).toBeGreaterThanOrEqual(0);
+      expect(item.x + item.w).toBeLessThanOrEqual(DASHBOARD_COLUMNS);
+    }
+  };
+
+  it('holds no-overlap, bounds, and full-compaction invariants across 200 random layouts', () => {
+    for (let i = 0; i < 200; i += 1) {
+      const compacted = compact(randomLayout());
+      expectNoOverlaps(compacted);
+      expectBounds(compacted);
+      expect(compact(compacted)).toEqual(compacted); // already fully compacted
+
+      const dropped = clampPlacement(
+        { ...compacted[randInt(compacted.length)], x: randInt(DASHBOARD_COLUMNS), y: randInt(8) },
+        undefined,
+      );
+      const pushed = placeWithPushDown(compacted, dropped);
+      expectNoOverlaps(pushed);
+      expectBounds(pushed);
+      const out = pushed.find((item) => item.id === dropped.id)!;
+      expect(out.x).toBe(dropped.x);
+      expect(out.w).toBe(dropped.w);
+      expect(out.h).toBe(dropped.h);
+
+      const resized = applyResize(
+        value(compacted),
+        { kind: 'top' },
+        dropped.id,
+        dropped.w + 1,
+        dropped.h + 1,
+      );
+      expectNoOverlaps(resized.items);
+      expectBounds(resized.items);
+    }
+  });
+});

--- a/packages/design-system/src/components/DashboardCanvas/engine.test.ts
+++ b/packages/design-system/src/components/DashboardCanvas/engine.test.ts
@@ -1,0 +1,570 @@
+import {
+  DASHBOARD_COLUMNS,
+  applyMove,
+  applyResize,
+  cellFromPoint,
+  clampPlacement,
+  collides,
+  compact,
+  placeWithPushDown,
+  reorderSection,
+  stackOrder,
+  toggleSection,
+} from './engine';
+import type { DashboardCanvasValue, DashboardPlacement } from './engine';
+
+const p = (id: string, x: number, y: number, w: number, h: number): DashboardPlacement => ({
+  id,
+  x,
+  y,
+  w,
+  h,
+});
+
+const byId = (items: DashboardPlacement[], id: string): DashboardPlacement =>
+  items.find((item) => item.id === id)!;
+
+/** Asserts no two placements in the list overlap. */
+const expectNoOverlaps = (items: DashboardPlacement[]): void => {
+  for (let i = 0; i < items.length; i += 1) {
+    for (let j = i + 1; j < items.length; j += 1) {
+      expect(
+        collides(items[i], items[j]),
+        `${String(items[i].id)} overlaps ${String(items[j].id)}`,
+      ).toBe(false);
+    }
+  }
+};
+
+const value = (
+  items: DashboardPlacement[],
+  sections: DashboardCanvasValue['sections'] = [],
+): DashboardCanvasValue => ({ items, sections });
+
+describe('DASHBOARD_COLUMNS', () => {
+  it('is 12', () => {
+    expect(DASHBOARD_COLUMNS).toBe(12);
+  });
+});
+
+describe('clampPlacement', () => {
+  it('clamps negative x and y to 0', () => {
+    expect(clampPlacement(p('a', -3, -2, 2, 2), undefined)).toEqual(p('a', 0, 0, 2, 2));
+  });
+
+  it('pulls x back so x + w fits in 12 columns', () => {
+    expect(clampPlacement(p('a', 10, 0, 4, 1), undefined)).toEqual(p('a', 8, 0, 4, 1));
+  });
+
+  it('caps w at 12 columns and resets x to 0 when oversized', () => {
+    expect(clampPlacement(p('a', 3, 0, 20, 1), undefined)).toEqual(p('a', 0, 0, 12, 1));
+  });
+
+  it('enforces w >= 1 and h >= 1 without constraints', () => {
+    expect(clampPlacement(p('a', 0, 0, 0, 0), undefined)).toEqual(p('a', 0, 0, 1, 1));
+  });
+
+  it('raises w to minW and h to minH', () => {
+    expect(clampPlacement(p('a', 0, 0, 1, 1), { minW: 3, minH: 2 })).toEqual(p('a', 0, 0, 3, 2));
+  });
+
+  it('lowers h to maxH', () => {
+    expect(clampPlacement(p('a', 0, 0, 2, 9), { maxH: 4 })).toEqual(p('a', 0, 0, 2, 4));
+  });
+
+  it('does not mutate the input', () => {
+    const input = p('a', -1, 0, 2, 2);
+    clampPlacement(input, undefined);
+    expect(input).toEqual(p('a', -1, 0, 2, 2));
+  });
+});
+
+describe('collides', () => {
+  it('detects overlapping rects', () => {
+    expect(collides(p('a', 0, 0, 4, 2), p('b', 2, 1, 4, 2))).toBe(true);
+  });
+
+  it('detects full containment', () => {
+    expect(collides(p('a', 0, 0, 6, 6), p('b', 2, 2, 2, 2))).toBe(true);
+  });
+
+  it('detects identical rects', () => {
+    expect(collides(p('a', 1, 1, 2, 2), p('b', 1, 1, 2, 2))).toBe(true);
+  });
+
+  it('does NOT collide on touching vertical edges', () => {
+    expect(collides(p('a', 0, 0, 4, 2), p('b', 4, 0, 4, 2))).toBe(false);
+  });
+
+  it('does NOT collide on touching horizontal edges', () => {
+    expect(collides(p('a', 0, 0, 4, 2), p('b', 0, 2, 4, 2))).toBe(false);
+  });
+
+  it('does not collide when fully disjoint', () => {
+    expect(collides(p('a', 0, 0, 2, 2), p('b', 6, 6, 2, 2))).toBe(false);
+  });
+});
+
+describe('compact', () => {
+  it('pulls a lone item up to y 0', () => {
+    expect(compact([p('a', 3, 5, 2, 2)])).toEqual([p('a', 3, 0, 2, 2)]);
+  });
+
+  it('closes gaps in a same-column stack', () => {
+    const out = compact([p('a', 0, 0, 2, 2), p('b', 0, 5, 2, 2)]);
+    expect(byId(out, 'a').y).toBe(0);
+    expect(byId(out, 'b').y).toBe(2);
+  });
+
+  it('never changes x', () => {
+    const out = compact([p('a', 4, 7, 3, 1), p('b', 9, 3, 3, 2)]);
+    expect(byId(out, 'a').x).toBe(4);
+    expect(byId(out, 'b').x).toBe(9);
+  });
+
+  it('compacts independent columns independently', () => {
+    const out = compact([p('a', 0, 3, 2, 1), p('b', 6, 5, 2, 1)]);
+    expect(byId(out, 'a').y).toBe(0);
+    expect(byId(out, 'b').y).toBe(0);
+  });
+
+  it('slots a small item into a gap it fits, but not one it does not', () => {
+    // a: rows 0-2 at x 0-2; wide blocker b compacts onto a (rows 2-4).
+    // c (h=2) fits the 2-row space above b at x 4-6; d (h=3) does not.
+    const out = compact([
+      p('a', 0, 0, 2, 2),
+      p('b', 0, 5, 12, 2),
+      p('c', 4, 9, 2, 2),
+      p('d', 8, 9, 2, 3),
+    ]);
+    expect(byId(out, 'b').y).toBe(2); // b itself compacts onto a
+    expect(byId(out, 'c').y).toBe(0); // fits above b at its own span
+    expect(byId(out, 'd').y).toBe(4); // h=3 cannot fit above b, lands below it
+  });
+
+  it('is stable for identical (y, x): input order wins, second stacks below', () => {
+    const out = compact([p('first', 0, 0, 2, 2), p('second', 0, 0, 2, 2)]);
+    expect(byId(out, 'first').y).toBe(0);
+    expect(byId(out, 'second').y).toBe(2);
+  });
+
+  it('keeps a wide item below the narrow items it rests on (L-shaped stack)', () => {
+    const out = compact([p('tall', 0, 0, 2, 4), p('short', 4, 0, 2, 1), p('wide', 0, 6, 8, 2)]);
+    expect(byId(out, 'tall').y).toBe(0);
+    expect(byId(out, 'short').y).toBe(0);
+    expect(byId(out, 'wide').y).toBe(4); // blocked by tall, not by short
+    expectNoOverlaps(out);
+  });
+
+  it('preserves the input array order in the output', () => {
+    const out = compact([p('b', 0, 5, 2, 1), p('a', 0, 0, 2, 1)]);
+    expect(out.map((item) => item.id)).toEqual(['b', 'a']);
+  });
+
+  it('is idempotent', () => {
+    const once = compact([p('a', 0, 3, 4, 2), p('b', 2, 8, 4, 2), p('c', 8, 1, 2, 5)]);
+    expect(compact(once)).toEqual(once);
+  });
+
+  it('does not mutate the input array or its items', () => {
+    const items = [p('a', 0, 5, 2, 2)];
+    compact(items);
+    expect(items).toEqual([p('a', 0, 5, 2, 2)]);
+  });
+
+  it('returns an empty array for no items', () => {
+    expect(compact([])).toEqual([]);
+  });
+});
+
+describe('placeWithPushDown', () => {
+  it('drops onto an occupied cell: occupant is pushed down exactly enough', () => {
+    const out = placeWithPushDown([p('a', 0, 0, 2, 2)], p('m', 0, 0, 2, 2));
+    expect(byId(out, 'm')).toEqual(p('m', 0, 0, 2, 2));
+    expect(byId(out, 'a')).toEqual(p('a', 0, 2, 2, 2));
+  });
+
+  it('pushes a chain down recursively', () => {
+    const out = placeWithPushDown(
+      [p('a', 0, 0, 2, 2), p('b', 0, 2, 2, 2), p('c', 0, 4, 2, 2)],
+      p('m', 0, 0, 2, 3),
+    );
+    expect(byId(out, 'a').y).toBe(3);
+    expect(byId(out, 'b').y).toBe(5);
+    expect(byId(out, 'c').y).toBe(7);
+    expectNoOverlaps(out);
+  });
+
+  it('a wide moved item pushes items in several columns, each keeping its x', () => {
+    const items = [p('a', 0, 0, 3, 2), p('b', 5, 0, 3, 1), p('c', 9, 0, 3, 3)];
+    const out = placeWithPushDown(items, p('m', 0, 0, 12, 1));
+    expect(byId(out, 'a')).toEqual(p('a', 0, 1, 3, 2));
+    expect(byId(out, 'b')).toEqual(p('b', 5, 1, 3, 1));
+    expect(byId(out, 'c')).toEqual(p('c', 9, 1, 3, 3));
+    expectNoOverlaps(out);
+  });
+
+  it('a drop into free space rises with the compaction — no floating placements', () => {
+    const out = placeWithPushDown([p('a', 6, 0, 2, 2)], p('m', 0, 4, 2, 2));
+    expect(byId(out, 'm')).toEqual(p('m', 0, 0, 2, 2));
+    expect(byId(out, 'a')).toEqual(p('a', 6, 0, 2, 2));
+  });
+
+  it('a drop at y 10 over an empty canvas settles at y 0 in the same gesture', () => {
+    expect(placeWithPushDown([], p('m', 3, 10, 4, 2))).toEqual([p('m', 3, 0, 4, 2)]);
+  });
+
+  it('equals compact([...others, moved]) when the drop is collision-free', () => {
+    const others = [p('a', 0, 0, 4, 2), p('b', 4, 3, 4, 2)];
+    const moved = p('m', 8, 6, 4, 2);
+    expect(placeWithPushDown(others, moved)).toEqual(compact([...others, moved]));
+  });
+
+  it('non-colliding items compact upward around the drop', () => {
+    const out = placeWithPushDown([p('a', 6, 5, 2, 2)], p('m', 0, 0, 2, 2));
+    expect(byId(out, 'a').y).toBe(0);
+  });
+
+  it('an evicted item cannot land back under the moved item, it goes below', () => {
+    // m takes rows 0-3 at x 0-4; a (same span) has no free rows above m.
+    const out = placeWithPushDown([p('a', 0, 0, 4, 2)], p('m', 0, 0, 4, 4));
+    expect(byId(out, 'a').y).toBe(4);
+    expectNoOverlaps(out);
+  });
+
+  it('moved and its evictee compact as a stack with moved on top', () => {
+    // m dropped onto a at row 2 with rows 0-1 free: m claims the spot (a goes
+    // below), then the whole stack compacts to the top.
+    const out = placeWithPushDown([p('a', 0, 2, 2, 2)], p('m', 0, 2, 2, 3));
+    expect(byId(out, 'm')).toEqual(p('m', 0, 0, 2, 3));
+    expect(byId(out, 'a')).toEqual(p('a', 0, 3, 2, 2));
+    expectNoOverlaps(out);
+  });
+
+  it('replaces an existing entry with the same id (move within container)', () => {
+    const out = placeWithPushDown([p('m', 0, 0, 2, 2), p('a', 6, 0, 2, 2)], p('m', 6, 0, 2, 2));
+    expect(out.filter((item) => item.id === 'm')).toEqual([p('m', 6, 0, 2, 2)]);
+    expect(byId(out, 'a').y).toBe(2);
+    expectNoOverlaps(out);
+  });
+
+  it('is idempotent when dropped on free space', () => {
+    const items = [p('a', 0, 0, 4, 2), p('b', 4, 0, 4, 2)];
+    const once = placeWithPushDown(items, p('m', 8, 0, 4, 2));
+    const twice = placeWithPushDown(
+      once.filter((item) => item.id !== 'm'),
+      byId(once, 'm'),
+    );
+    expect(twice).toEqual(once);
+  });
+
+  it('partial-overlap push: only the overlapped column chain moves', () => {
+    // m overlaps a (x 4-6 of its 0-6 span); b sits at x 0-2 under a and may rise.
+    const out = placeWithPushDown([p('a', 0, 0, 6, 1), p('b', 0, 1, 2, 1)], p('m', 4, 0, 4, 2));
+    expect(byId(out, 'm')).toEqual(p('m', 4, 0, 4, 2));
+    expect(byId(out, 'a').y).toBe(2); // pushed below m, x unchanged
+    expect(byId(out, 'a').x).toBe(0);
+    expect(byId(out, 'b').y).toBe(0); // compacts into the vacated row
+    expectNoOverlaps(out);
+  });
+
+  it('never overlaps anything in a dense mixed layout', () => {
+    const items = [
+      p('a', 0, 0, 4, 2),
+      p('b', 4, 0, 4, 2),
+      p('c', 8, 0, 4, 2),
+      p('d', 0, 2, 6, 2),
+      p('e', 6, 2, 6, 2),
+      p('f', 0, 4, 12, 1),
+    ];
+    const out = placeWithPushDown(items, p('m', 2, 1, 8, 2));
+    // m displaces the whole top row, then the emptied row 0 compacts away.
+    expect(byId(out, 'm')).toEqual(p('m', 2, 0, 8, 2));
+    expect(byId(out, 'a').y).toBeGreaterThan(byId(out, 'm').y); // displaced items stay below m
+    expectNoOverlaps(out);
+    expect(compact(out)).toEqual(out); // fully compacted — no floating placements
+  });
+
+  it('does not mutate its inputs', () => {
+    const items = [p('a', 0, 0, 2, 2)];
+    const moved = p('m', 0, 0, 2, 2);
+    placeWithPushDown(items, moved);
+    expect(items).toEqual([p('a', 0, 0, 2, 2)]);
+    expect(moved).toEqual(p('m', 0, 0, 2, 2));
+  });
+});
+
+describe('applyMove', () => {
+  const top = { kind: 'top' } as const;
+  const sec = (id: string) => ({ kind: 'section', id }) as const;
+
+  it('moves within the top-level container and pushes the occupant', () => {
+    const v = value([p('a', 0, 0, 2, 2), p('b', 6, 0, 2, 2)]);
+    const next = applyMove(v, top, top, 'a', 6, 0);
+    expect(byId(next.items, 'a')).toEqual(p('a', 6, 0, 2, 2));
+    expect(byId(next.items, 'b').y).toBe(2);
+    expectNoOverlaps(next.items);
+  });
+
+  it('same-cell move of a floating item compacts it upward', () => {
+    const v = value([p('a', 0, 3, 2, 2)]);
+    const next = applyMove(v, top, top, 'a', 0, 3);
+    expect(byId(next.items, 'a')).toEqual(p('a', 0, 0, 2, 2));
+  });
+
+  it('the vacated spot backfills deterministically after a move away', () => {
+    const v = value([p('a', 0, 0, 2, 2), p('b', 0, 2, 2, 2)]);
+    const next = applyMove(v, top, top, 'a', 6, 0);
+    expect(byId(next.items, 'a')).toEqual(p('a', 6, 0, 2, 2));
+    expect(byId(next.items, 'b')).toEqual(p('b', 0, 0, 2, 2));
+  });
+
+  it('clamps the drop coordinates to the grid', () => {
+    const v = value([p('a', 0, 0, 4, 2)]);
+    const next = applyMove(v, top, top, 'a', 20, -5);
+    expect(byId(next.items, 'a')).toEqual(p('a', 8, 0, 4, 2));
+  });
+
+  it('cross-container: removes from source, source compacts', () => {
+    const v = value(
+      [],
+      [
+        {
+          id: 's1',
+          title: 'One',
+          collapsed: false,
+          items: [p('a', 0, 0, 2, 2), p('b', 0, 2, 2, 2)],
+        },
+      ],
+    );
+    const next = applyMove(v, sec('s1'), top, 'a', 0, 0);
+    const s1 = next.sections[0].items;
+    expect(s1.map((item) => item.id)).toEqual(['b']);
+    expect(byId(s1, 'b').y).toBe(0);
+    expect(byId(next.items, 'a')).toEqual(p('a', 0, 0, 2, 2));
+  });
+
+  it('cross-container: pushes down in the target', () => {
+    const v = value(
+      [p('t', 0, 0, 2, 2)],
+      [{ id: 's1', title: 'One', collapsed: false, items: [p('a', 0, 0, 2, 2)] }],
+    );
+    const next = applyMove(v, sec('s1'), top, 'a', 0, 0);
+    expect(byId(next.items, 'a')).toEqual(p('a', 0, 0, 2, 2));
+    expect(byId(next.items, 't').y).toBe(2);
+    expectNoOverlaps(next.items);
+  });
+
+  it('moves into an empty section', () => {
+    const v = value(
+      [p('a', 0, 0, 2, 2)],
+      [{ id: 's1', title: 'One', collapsed: false, items: [] }],
+    );
+    const next = applyMove(v, top, sec('s1'), 'a', 4, 0);
+    expect(next.items).toEqual([]);
+    expect(next.sections[0].items).toEqual([p('a', 4, 0, 2, 2)]);
+  });
+
+  it('returns the value unchanged when the id is not in the source container', () => {
+    const v = value([p('a', 0, 0, 2, 2)]);
+    expect(applyMove(v, top, top, 'nope', 0, 0)).toBe(v);
+  });
+
+  it('returns the value unchanged when the target section does not exist', () => {
+    const v = value([p('a', 0, 0, 2, 2)]);
+    expect(applyMove(v, top, sec('ghost'), 'a', 0, 0)).toBe(v);
+  });
+
+  it('does not mutate the input value', () => {
+    const items = [p('a', 0, 0, 2, 2), p('b', 6, 0, 2, 2)];
+    const v = value(items);
+    applyMove(v, top, top, 'a', 6, 0);
+    expect(v.items).toBe(items);
+    expect(items[0]).toEqual(p('a', 0, 0, 2, 2));
+  });
+});
+
+describe('applyResize', () => {
+  const top = { kind: 'top' } as const;
+
+  it('growing h pushes the neighbor below down', () => {
+    const v = value([p('a', 0, 0, 2, 2), p('b', 0, 2, 2, 2)]);
+    const next = applyResize(v, top, 'a', 2, 4);
+    expect(byId(next.items, 'a')).toEqual(p('a', 0, 0, 2, 4));
+    expect(byId(next.items, 'b').y).toBe(4);
+  });
+
+  it('growing w pushes a same-row right neighbor down (x never changes)', () => {
+    const v = value([p('a', 0, 0, 2, 2), p('b', 2, 0, 2, 2)]);
+    const next = applyResize(v, top, 'a', 4, 2);
+    expect(byId(next.items, 'b')).toEqual(p('b', 2, 2, 2, 2));
+    expectNoOverlaps(next.items);
+  });
+
+  it('shrinking h compacts the stack below (double compaction chain)', () => {
+    const v = value([p('a', 0, 0, 2, 4), p('b', 0, 4, 2, 2), p('c', 0, 6, 2, 2)]);
+    const next = applyResize(v, top, 'a', 2, 2);
+    expect(byId(next.items, 'b').y).toBe(2);
+    expect(byId(next.items, 'c').y).toBe(4);
+  });
+
+  it('keeps the resized item at its x and y', () => {
+    // blocker pins rows 0-2 at x 4-6 so a's y is held by geometry, not floating.
+    const v = value([p('blocker', 4, 0, 2, 3), p('a', 4, 3, 2, 2)]);
+    const next = applyResize(v, top, 'a', 6, 3);
+    expect(byId(next.items, 'a')).toEqual(p('a', 4, 3, 6, 3));
+  });
+
+  it('floors w at 1 even for an out-of-grid x from an invalid controlled value', () => {
+    const v = value([p('a', 12, 0, 2, 2)]);
+    const next = applyResize(v, top, 'a', 5, 2);
+    expect(byId(next.items, 'a').w).toBe(1);
+  });
+
+  it('clamps w to the remaining columns at the item x', () => {
+    const v = value([p('a', 8, 0, 2, 2)]);
+    const next = applyResize(v, top, 'a', 10, 2);
+    expect(byId(next.items, 'a').w).toBe(4);
+  });
+
+  it('respects minW, minH and maxH constraints', () => {
+    const v = value([p('a', 0, 0, 4, 4)]);
+    const next = applyResize(v, top, 'a', 1, 9, { minW: 3, minH: 2, maxH: 6 });
+    expect(byId(next.items, 'a').w).toBe(3);
+    expect(byId(next.items, 'a').h).toBe(6);
+  });
+
+  it('resizes inside a section container', () => {
+    const v = value(
+      [],
+      [{ id: 's1', title: 'One', collapsed: false, items: [p('a', 0, 0, 2, 2)] }],
+    );
+    const next = applyResize(v, { kind: 'section', id: 's1' }, 'a', 4, 3);
+    expect(next.sections[0].items).toEqual([p('a', 0, 0, 4, 3)]);
+  });
+
+  it('returns the value unchanged for an unknown id', () => {
+    const v = value([p('a', 0, 0, 2, 2)]);
+    expect(applyResize(v, top, 'nope', 4, 4)).toBe(v);
+  });
+});
+
+describe('toggleSection', () => {
+  const v = value(
+    [],
+    [
+      { id: 's1', title: 'One', collapsed: false, items: [p('a', 0, 0, 2, 2)] },
+      { id: 's2', title: 'Two', collapsed: true, items: [] },
+    ],
+  );
+
+  it('flips only the target section collapsed flag', () => {
+    const next = toggleSection(v, 's1');
+    expect(next.sections[0].collapsed).toBe(true);
+    expect(next.sections[0].items).toBe(v.sections[0].items);
+    expect(next.sections[1]).toBe(v.sections[1]);
+    expect(next.items).toBe(v.items);
+  });
+
+  it('round-trips back to the original state', () => {
+    expect(toggleSection(toggleSection(v, 's2'), 's2').sections[1].collapsed).toBe(true);
+  });
+
+  it('returns the value unchanged for an unknown id', () => {
+    expect(toggleSection(v, 'ghost')).toBe(v);
+  });
+});
+
+describe('reorderSection', () => {
+  const section = (id: string) => ({ id, title: id, collapsed: false, items: [] });
+  const v = value([], [section('a'), section('b'), section('c')]);
+
+  it('moves a band to the target index', () => {
+    expect(reorderSection(v, 'c', 0).sections.map((s) => s.id)).toEqual(['c', 'a', 'b']);
+    expect(reorderSection(v, 'a', 2).sections.map((s) => s.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('clamps the index into range', () => {
+    expect(reorderSection(v, 'c', -5).sections.map((s) => s.id)).toEqual(['c', 'a', 'b']);
+    expect(reorderSection(v, 'a', 99).sections.map((s) => s.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('is a no-op object when the index does not change', () => {
+    expect(reorderSection(v, 'b', 1)).toBe(v);
+  });
+
+  it('returns the value unchanged for an unknown id', () => {
+    expect(reorderSection(v, 'ghost', 0)).toBe(v);
+  });
+
+  it('does not touch top-level items', () => {
+    const withItems = value([p('x', 0, 0, 2, 2)], [section('a'), section('b')]);
+    expect(reorderSection(withItems, 'b', 0).items).toBe(withItems.items);
+  });
+});
+
+describe('stackOrder', () => {
+  it('lists top-level items (y, then x) before sections in band order', () => {
+    const v = value(
+      [p('t2', 4, 0, 2, 2), p('t1', 0, 0, 2, 2), p('t3', 0, 2, 2, 2)],
+      [
+        {
+          id: 's1',
+          title: 'One',
+          collapsed: false,
+          items: [p('b', 0, 1, 2, 1), p('a', 0, 0, 2, 1)],
+        },
+        { id: 's2', title: 'Two', collapsed: true, items: [p('c', 0, 0, 2, 1)] },
+      ],
+    );
+    expect(stackOrder(v)).toEqual([
+      { container: { kind: 'top' }, id: 't1' },
+      { container: { kind: 'top' }, id: 't2' },
+      { container: { kind: 'top' }, id: 't3' },
+      { container: { kind: 'section', id: 's1' }, id: 'a' },
+      { container: { kind: 'section', id: 's1' }, id: 'b' },
+      { container: { kind: 'section', id: 's2' }, id: 'c' },
+    ]);
+  });
+
+  it('breaks same-y ties by x', () => {
+    const v = value([p('right', 6, 0, 2, 1), p('left', 0, 0, 2, 1)]);
+    expect(stackOrder(v).map((entry) => entry.id)).toEqual(['left', 'right']);
+  });
+
+  it('returns an empty list for an empty value', () => {
+    expect(stackOrder(value([]))).toEqual([]);
+  });
+});
+
+describe('cellFromPoint', () => {
+  const rect = { left: 100, top: 50 } as DOMRect;
+  // 60px columns, 48px rows, 12px gap → 72px column pitch, 60px row pitch.
+  const at = (px: number, py: number) => cellFromPoint(px, py, rect, 60, 48, 12);
+
+  it('maps the container origin to cell (0, 0)', () => {
+    expect(at(100, 50)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('steps one cell per column/row pitch (cell width + gap)', () => {
+    expect(at(100 + 72, 50)).toEqual({ x: 1, y: 0 });
+    expect(at(100, 50 + 60)).toEqual({ x: 0, y: 1 });
+    expect(at(100 + 3 * 72 + 30, 50 + 2 * 60 + 10)).toEqual({ x: 3, y: 2 });
+  });
+
+  it('a point inside the trailing gap belongs to the cell before it', () => {
+    expect(at(100 + 65, 50)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('clamps negative overshoot to 0', () => {
+    expect(at(20, -100)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('clamps x overshoot to the last column but leaves y unbounded', () => {
+    expect(at(100 + 40 * 72, 50 + 40 * 60)).toEqual({ x: DASHBOARD_COLUMNS - 1, y: 40 });
+  });
+
+  it('guards zero-size cells (jsdom) without producing NaN', () => {
+    expect(cellFromPoint(500, 500, rect, 0, 0, 0)).toEqual({ x: 0, y: 0 });
+  });
+});

--- a/packages/design-system/src/components/DashboardCanvas/engine.test.ts
+++ b/packages/design-system/src/components/DashboardCanvas/engine.test.ts
@@ -568,3 +568,21 @@ describe('cellFromPoint', () => {
     expect(cellFromPoint(500, 500, rect, 0, 0, 0)).toEqual({ x: 0, y: 0 });
   });
 });
+
+describe('no-op gestures return the input reference', () => {
+  const value: DashboardCanvasValue = {
+    items: [
+      { id: 'a', x: 0, y: 0, w: 2, h: 1 },
+      { id: 'b', x: 0, y: 1, w: 2, h: 1 },
+    ],
+    sections: [],
+  };
+
+  it('applyMove: a same-cell drop in an already-compacted layout', () => {
+    expect(applyMove(value, { kind: 'top' }, { kind: 'top' }, 'a', 0, 0)).toBe(value);
+  });
+
+  it('applyResize: clamping that resolves to the current dimensions', () => {
+    expect(applyResize(value, { kind: 'top' }, 'a', 0, 1, { minW: 2 })).toBe(value);
+  });
+});

--- a/packages/design-system/src/components/DashboardCanvas/engine.ts
+++ b/packages/design-system/src/components/DashboardCanvas/engine.ts
@@ -1,0 +1,290 @@
+/**
+ * Pure geometry engine for DashboardCanvas: 12-column snap-grid placement with
+ * Datadog-style push-down collision and vertical compaction. No React, no DOM
+ * mutation — every function is deterministic and returns fresh objects,
+ * never mutating its inputs.
+ */
+
+/** One placed item: grid units within its container. */
+export interface DashboardPlacement {
+  id: string | number;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** A full-width collapsible band with its own sub-grid of items. */
+export interface DashboardSection {
+  id: string | number;
+  title: string;
+  collapsed: boolean;
+  items: DashboardPlacement[];
+}
+
+/** Controlled value. Section array order = band order; top-level items render above the first section. */
+export interface DashboardCanvasValue {
+  items: DashboardPlacement[];
+  sections: DashboardSection[];
+}
+
+/** Per-item size constraints, by item id. */
+export interface DashboardItemConstraints {
+  minW?: number;
+  minH?: number;
+  maxH?: number;
+}
+
+/** Identifies a placement container: the top-level canvas or one section's sub-grid. */
+export type ContainerRef = { kind: 'top' } | { kind: 'section'; id: string | number };
+
+/** Fixed column count of every container grid. */
+export const DASHBOARD_COLUMNS = 12;
+
+/**
+ * Clamps a placement into the grid: `w`/`h` at least 1 (and `minW`/`minH` when
+ * set), `h` capped at `maxH`, `w` capped at 12 columns, then `x` pulled back so
+ * `x + w <= 12` and `x`/`y` floored at 0.
+ */
+export function clampPlacement(
+  p: DashboardPlacement,
+  c: DashboardItemConstraints | undefined,
+): DashboardPlacement {
+  const w = Math.min(Math.max(p.w, c?.minW ?? 1, 1), DASHBOARD_COLUMNS);
+  let h = Math.max(p.h, c?.minH ?? 1, 1);
+  if (c?.maxH !== undefined) h = Math.max(Math.min(h, c.maxH), 1);
+  const x = Math.min(Math.max(p.x, 0), DASHBOARD_COLUMNS - w);
+  const y = Math.max(p.y, 0);
+  return { ...p, x, y, w, h };
+}
+
+/** True when the two rects overlap; rects that merely touch edges do NOT collide. */
+export function collides(a: DashboardPlacement, b: DashboardPlacement): boolean {
+  return a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+}
+
+/** Stable (y, then x) processing order; ties keep input order (Array.sort is stable). */
+function sortByPosition(items: readonly DashboardPlacement[]): DashboardPlacement[] {
+  return [...items].sort((a, b) => a.y - b.y || a.x - b.x);
+}
+
+/**
+ * Core packing pass: settles `items` (in stable (y, x) order) each to the
+ * lowest collision-free y at its own x-span, treating `obstacles` as fixed.
+ * With `fromCurrentY`, an item never rises — it only moves down when it
+ * collides (the push-down phase); without it, items drop to the lowest free y
+ * (the compaction phase). Returns new placements keyed by id.
+ */
+function settle(
+  items: readonly DashboardPlacement[],
+  obstacles: DashboardPlacement[],
+  fromCurrentY = false,
+): Map<string | number, DashboardPlacement> {
+  const placed = [...obstacles];
+  const settled = new Map<string | number, DashboardPlacement>();
+  for (const item of sortByPosition(items)) {
+    let y = fromCurrentY ? item.y : 0;
+    for (;;) {
+      const probe = { ...item, y };
+      const hit = placed.find((other) => collides(probe, other));
+      if (!hit) break;
+      y = hit.y + hit.h; // just below the collider; y strictly grows, so this terminates
+    }
+    const next = { ...item, y };
+    placed.push(next);
+    settled.set(item.id, next);
+  }
+  return settled;
+}
+
+/**
+ * Pulls every item up to the lowest free y at its own x-span. Stable (y, then
+ * x) processing; never changes x; also resolves any pre-existing overlaps
+ * deterministically (later item in processing order lands below). Output
+ * preserves the input array order.
+ */
+export function compact(items: DashboardPlacement[]): DashboardPlacement[] {
+  const settled = settle(items, []);
+  return items.map((item) => settled.get(item.id)!);
+}
+
+/**
+ * Datadog push-down drop: `moved` claims its dropped cell for collision
+ * resolution — colliding items are pushed down just enough (chains
+ * recursively), never sideways — and then the WHOLE layout, `moved` included,
+ * compacts vertically, so no placement ever floats over free space. When the
+ * drop is collision-free this equals `compact([...others, moved])`. An
+ * existing item with `moved.id` is replaced in place; otherwise `moved` is
+ * appended.
+ */
+export function placeWithPushDown(
+  items: DashboardPlacement[],
+  moved: DashboardPlacement,
+): DashboardPlacement[] {
+  const rest = items.filter((item) => item.id !== moved.id);
+  const pushed = settle(rest, [moved], true);
+  const intermediate = items.map((item) =>
+    item.id === moved.id ? { ...moved } : pushed.get(item.id)!,
+  );
+  if (!items.some((item) => item.id === moved.id)) intermediate.push({ ...moved });
+  return compact(intermediate);
+}
+
+/** Item ids must be unique per container; duplicate ids produce undefined layouts. */
+function containerItems(
+  value: DashboardCanvasValue,
+  ref: ContainerRef,
+): DashboardPlacement[] | undefined {
+  if (ref.kind === 'top') return value.items;
+  return value.sections.find((section) => section.id === ref.id)?.items;
+}
+
+/** Item ids must be unique per container; duplicate ids produce undefined layouts. */
+function withContainerItems(
+  value: DashboardCanvasValue,
+  ref: ContainerRef,
+  items: DashboardPlacement[],
+): DashboardCanvasValue {
+  if (ref.kind === 'top') return { ...value, items };
+  return {
+    ...value,
+    sections: value.sections.map((section) =>
+      section.id === ref.id ? { ...section, items } : section,
+    ),
+  };
+}
+
+function sameContainer(a: ContainerRef, b: ContainerRef): boolean {
+  return a.kind === 'top' ? b.kind === 'top' : b.kind === 'section' && a.id === b.id;
+}
+
+/**
+ * Moves an item to cell (x, y) of the `to` container (which may equal `from`).
+ * The source compacts after removal; the item is push-down-placed in the
+ * target with its coordinates clamped to the grid. Unknown item or missing
+ * target container returns the value unchanged.
+ */
+export function applyMove(
+  value: DashboardCanvasValue,
+  from: ContainerRef,
+  to: ContainerRef,
+  id: string | number,
+  x: number,
+  y: number,
+): DashboardCanvasValue {
+  const source = containerItems(value, from);
+  const item = source?.find((candidate) => candidate.id === id);
+  if (!source || !item || containerItems(value, to) === undefined) return value;
+  const dropped = clampPlacement({ ...item, x, y }, undefined);
+  if (sameContainer(from, to)) {
+    return withContainerItems(value, from, placeWithPushDown(source, dropped));
+  }
+  const removed = withContainerItems(
+    value,
+    from,
+    compact(source.filter((candidate) => candidate.id !== id)),
+  );
+  return withContainerItems(removed, to, placeWithPushDown(containerItems(removed, to)!, dropped));
+}
+
+/**
+ * Resizes an item in place (`x` is kept, `y` moves only through the shared
+ * vertical compaction): `w`/`h` are clamped by the constraints and by the
+ * columns remaining right of `x`, then the layout resettles around it —
+ * growing pushes neighbors down, shrinking lets them compact back up.
+ * Unknown item returns the value unchanged.
+ */
+export function applyResize(
+  value: DashboardCanvasValue,
+  container: ContainerRef,
+  id: string | number,
+  w: number,
+  h: number,
+  c?: DashboardItemConstraints,
+): DashboardCanvasValue {
+  const items = containerItems(value, container);
+  const item = items?.find((candidate) => candidate.id === id);
+  if (!items || !item) return value;
+  // Outermost floor: an invalid controlled x >= 12 must not yield w <= 0.
+  const nextW = Math.max(1, Math.min(Math.max(w, c?.minW ?? 1), DASHBOARD_COLUMNS - item.x));
+  let nextH = Math.max(h, c?.minH ?? 1, 1);
+  if (c?.maxH !== undefined) nextH = Math.max(Math.min(nextH, c.maxH), 1);
+  return withContainerItems(
+    value,
+    container,
+    placeWithPushDown(items, { ...item, w: nextW, h: nextH }),
+  );
+}
+
+/** Flips one section's `collapsed` flag; everything else is untouched (same refs). */
+export function toggleSection(
+  value: DashboardCanvasValue,
+  sectionId: string | number,
+): DashboardCanvasValue {
+  if (!value.sections.some((section) => section.id === sectionId)) return value;
+  return {
+    ...value,
+    sections: value.sections.map((section) =>
+      section.id === sectionId ? { ...section, collapsed: !section.collapsed } : section,
+    ),
+  };
+}
+
+/** Moves a section band to `toIndex` (clamped into range). Unknown id or no-op index returns the value unchanged. */
+export function reorderSection(
+  value: DashboardCanvasValue,
+  sectionId: string | number,
+  toIndex: number,
+): DashboardCanvasValue {
+  const fromIndex = value.sections.findIndex((section) => section.id === sectionId);
+  if (fromIndex === -1) return value;
+  const target = Math.min(Math.max(toIndex, 0), value.sections.length - 1);
+  if (target === fromIndex) return value;
+  const sections = [...value.sections];
+  const [moved] = sections.splice(fromIndex, 1);
+  sections.splice(target, 0, moved);
+  return { ...value, sections };
+}
+
+/**
+ * Flattened below-`md` stacking order: top-level items first, then each
+ * section's items in band order; within a container by (y, then x). Collapsed
+ * sections are included — the renderer decides whether to show their bodies.
+ */
+export function stackOrder(
+  value: DashboardCanvasValue,
+): { container: ContainerRef; id: string | number }[] {
+  const out: { container: ContainerRef; id: string | number }[] = [];
+  for (const item of sortByPosition(value.items)) {
+    out.push({ container: { kind: 'top' }, id: item.id });
+  }
+  for (const section of value.sections) {
+    for (const item of sortByPosition(section.items)) {
+      out.push({ container: { kind: 'section', id: section.id }, id: item.id });
+    }
+  }
+  return out;
+}
+
+/**
+ * Snaps a viewport point to a grid cell of the container: each cell owns its
+ * trailing gap, x is clamped to [0, 11], y is floored at 0 but unbounded above
+ * (the grid grows downward). Zero/negative cell sizes (jsdom) yield cell 0.
+ */
+export function cellFromPoint(
+  px: number,
+  py: number,
+  containerRect: DOMRect,
+  colWidth: number,
+  rowHeight: number,
+  gap: number,
+): { x: number; y: number } {
+  const colPitch = colWidth + gap;
+  const rowPitch = rowHeight + gap;
+  const rawX = colPitch > 0 ? Math.floor((px - containerRect.left) / colPitch) : 0;
+  const rawY = rowPitch > 0 ? Math.floor((py - containerRect.top) / rowPitch) : 0;
+  return {
+    x: Math.min(Math.max(rawX, 0), DASHBOARD_COLUMNS - 1),
+    y: Math.max(rawY, 0),
+  };
+}

--- a/packages/design-system/src/components/DashboardCanvas/engine.ts
+++ b/packages/design-system/src/components/DashboardCanvas/engine.ts
@@ -159,10 +159,29 @@ function sameContainer(a: ContainerRef, b: ContainerRef): boolean {
 }
 
 /**
+ * Index-wise placement equality — lets `applyMove`/`applyResize` return their
+ * input by reference when a gesture resolves to the current layout, so
+ * callers can gate commits on `next !== value` alone.
+ */
+function samePlacements(
+  a: readonly DashboardPlacement[],
+  b: readonly DashboardPlacement[],
+): boolean {
+  return (
+    a.length === b.length &&
+    a.every((p, i) => {
+      const q = b[i];
+      return p.id === q.id && p.x === q.x && p.y === q.y && p.w === q.w && p.h === q.h;
+    })
+  );
+}
+
+/**
  * Moves an item to cell (x, y) of the `to` container (which may equal `from`).
  * The source compacts after removal; the item is push-down-placed in the
- * target with its coordinates clamped to the grid. Unknown item or missing
- * target container returns the value unchanged.
+ * target with its coordinates clamped to the grid. Unknown item, missing
+ * target container, or a same-container move that resolves to the current
+ * layout returns the value unchanged (same reference).
  */
 export function applyMove(
   value: DashboardCanvasValue,
@@ -177,7 +196,8 @@ export function applyMove(
   if (!source || !item || containerItems(value, to) === undefined) return value;
   const dropped = clampPlacement({ ...item, x, y }, undefined);
   if (sameContainer(from, to)) {
-    return withContainerItems(value, from, placeWithPushDown(source, dropped));
+    const placed = placeWithPushDown(source, dropped);
+    return samePlacements(source, placed) ? value : withContainerItems(value, from, placed);
   }
   const removed = withContainerItems(
     value,
@@ -192,7 +212,8 @@ export function applyMove(
  * vertical compaction): `w`/`h` are clamped by the constraints and by the
  * columns remaining right of `x`, then the layout resettles around it —
  * growing pushes neighbors down, shrinking lets them compact back up.
- * Unknown item returns the value unchanged.
+ * Unknown item, or a resize whose clamped dimensions resolve to the current
+ * layout, returns the value unchanged (same reference).
  */
 export function applyResize(
   value: DashboardCanvasValue,
@@ -209,11 +230,8 @@ export function applyResize(
   const nextW = Math.max(1, Math.min(Math.max(w, c?.minW ?? 1), DASHBOARD_COLUMNS - item.x));
   let nextH = Math.max(h, c?.minH ?? 1, 1);
   if (c?.maxH !== undefined) nextH = Math.max(Math.min(nextH, c.maxH), 1);
-  return withContainerItems(
-    value,
-    container,
-    placeWithPushDown(items, { ...item, w: nextW, h: nextH }),
-  );
+  const placed = placeWithPushDown(items, { ...item, w: nextW, h: nextH });
+  return samePlacements(items, placed) ? value : withContainerItems(value, container, placed);
 }
 
 /** Flips one section's `collapsed` flag; everything else is untouched (same refs). */

--- a/packages/design-system/src/components/DashboardCanvas/index.ts
+++ b/packages/design-system/src/components/DashboardCanvas/index.ts
@@ -1,0 +1,8 @@
+export { DashboardCanvas } from './DashboardCanvas';
+export type { DashboardCanvasProps, DashboardCanvasConstraintsProp } from './DashboardCanvas';
+export type {
+  DashboardPlacement,
+  DashboardSection,
+  DashboardCanvasValue,
+  DashboardItemConstraints,
+} from './engine';

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -103,6 +103,24 @@ export const en: Messages = {
     canvas: 'Dashboard canvas',
     sectionCollapse: ({ title }) => `Collapse ${title as string} section`,
     sectionExpand: ({ title }) => `Expand ${title as string} section`,
+    itemRole: 'widget',
+    instructions:
+      'Press Enter or Space on a widget to pick it up. While picked, the arrow keys move it one cell — past a container edge they carry it into the next section — Enter or Space drops it, Escape cancels. Shift plus an arrow key resizes a widget. On a section’s toggle button, Shift plus ArrowUp or ArrowDown moves the section.',
+    instructionsReadOnly: 'Use the section toggle buttons to collapse or expand sections.',
+    pickedUp: 'Picked up. Use the arrow keys to move, Enter or Space to drop, Escape to cancel.',
+    movedTo: ({ x, y, container }) =>
+      container
+        ? `Moved to column ${x as number}, row ${y as number} in the ${container as string} section`
+        : `Moved to column ${x as number}, row ${y as number}`,
+    dropped: 'Dropped',
+    cancelled: 'Move cancelled',
+    resized: ({ w, h }) => `Resized to ${w as number} by ${h as number}`,
+    sectionMoved: ({ title, position }) =>
+      position != null
+        ? `${title as string} section moved to position ${position as number}`
+        : `${title as string} section moved`,
+    enteredSection: ({ title }) => `Entered the ${title as string} section`,
+    enteredTopLevel: 'Moved to the top level',
   },
   optionsPicker: {
     filter: 'Filter…',

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -99,6 +99,11 @@ export const en: Messages = {
     pinnedRows: 'Pinned rows',
     empty: 'No data',
   },
+  dashboardCanvas: {
+    canvas: 'Dashboard canvas',
+    sectionCollapse: ({ title }) => `Collapse ${title as string} section`,
+    sectionExpand: ({ title }) => `Expand ${title as string} section`,
+  },
   optionsPicker: {
     filter: 'Filter…',
     apply: 'Apply',

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -162,6 +162,14 @@ export interface Messages {
     /** Default empty-state copy when no rows are rendered. */
     empty: string;
   };
+  dashboardCanvas: {
+    /** aria-label for the canvas root region. */
+    canvas: string;
+    /** aria-label on a section's collapse toggle when expanded (click collapses it); interpolates the section title. */
+    sectionCollapse: (params: { title: string }) => string;
+    /** aria-label on a section's collapse toggle when collapsed (click expands it); interpolates the section title. */
+    sectionExpand: (params: { title: string }) => string;
+  };
   optionsPicker: {
     /** Placeholder and aria-label for the filter (search) input. */
     filter: string;

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -169,6 +169,28 @@ export interface Messages {
     sectionCollapse: (params: { title: string }) => string;
     /** aria-label on a section's collapse toggle when collapsed (click expands it); interpolates the section title. */
     sectionExpand: (params: { title: string }) => string;
+    /** aria-roledescription for item cells in edit mode. */
+    itemRole: string;
+    /** Visually-hidden keyboard instructions referenced by aria-describedby (edit mode). */
+    instructions: string;
+    /** Instructions variant for readOnly canvases — collapse toggles are the only interaction. */
+    instructionsReadOnly: string;
+    /** Live announcement when an item is picked up for a keyboard move. */
+    pickedUp: string;
+    /** Live announcement after a picked item steps one cell (1-based column/row); `container` names the section while moving inside one. */
+    movedTo: (params: { x: number; y: number; container?: string }) => string;
+    /** Live announcement when a picked item is dropped. */
+    dropped: string;
+    /** Live announcement when a keyboard move is cancelled. */
+    cancelled: string;
+    /** Live announcement after a Shift+arrow resize (the engine-clamped size, in grid units). */
+    resized: (params: { w: number; h: number }) => string;
+    /** Live announcement after a section band moves (1-based position). */
+    sectionMoved: (params: { title: string; position?: number }) => string;
+    /** Live announcement when a picked item crosses into a section. */
+    enteredSection: (params: { title: string }) => string;
+    /** Live announcement when a picked item crosses into the top-level grid. */
+    enteredTopLevel: string;
   };
   optionsPicker: {
     /** Placeholder and aria-label for the filter (search) input. */

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -105,6 +105,24 @@ export const ru: Messages = {
     canvas: 'Холст дашборда',
     sectionCollapse: ({ title }) => `Свернуть секцию «${title as string}»`,
     sectionExpand: ({ title }) => `Развернуть секцию «${title as string}»`,
+    itemRole: 'виджет',
+    instructions:
+      'Нажмите Enter или пробел на виджете, чтобы взять его. Пока виджет взят, стрелки перемещают его на одну ячейку — за границей контейнера он переходит в соседнюю секцию, — Enter или пробел размещает его, Escape отменяет перемещение. Shift со стрелкой изменяет размер виджета. Shift со стрелкой вверх или вниз на кнопке секции перемещает секцию.',
+    instructionsReadOnly: 'Кнопки секций сворачивают и разворачивают их.',
+    pickedUp: 'Виджет взят. Стрелки — перемещение, Enter или пробел — разместить, Escape — отмена.',
+    movedTo: ({ x, y, container }) =>
+      container
+        ? `Колонка ${x as number}, строка ${y as number}, секция «${container as string}»`
+        : `Колонка ${x as number}, строка ${y as number}`,
+    dropped: 'Виджет размещён',
+    cancelled: 'Перемещение отменено',
+    resized: ({ w, h }) => `Размер: ${w as number} на ${h as number}`,
+    sectionMoved: ({ title, position }) =>
+      position != null
+        ? `Секция «${title as string}» перемещена на позицию ${position as number}`
+        : `Секция «${title as string}» перемещена`,
+    enteredSection: ({ title }) => `Перемещено в секцию «${title as string}»`,
+    enteredTopLevel: 'Перемещено на верхний уровень',
   },
   optionsPicker: {
     filter: 'Фильтр…',

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -101,6 +101,11 @@ export const ru: Messages = {
     pinnedRows: 'Закреплённые строки',
     empty: 'Нет данных',
   },
+  dashboardCanvas: {
+    canvas: 'Холст дашборда',
+    sectionCollapse: ({ title }) => `Свернуть секцию «${title as string}»`,
+    sectionExpand: ({ title }) => `Развернуть секцию «${title as string}»`,
+  },
   optionsPicker: {
     filter: 'Фильтр…',
     apply: 'Применить',

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -708,3 +708,13 @@ export type { FormSectionProps } from './components/FormSection';
 
 export { FormRow } from './components/FormRow';
 export type { FormRowProps } from './components/FormRow';
+
+export { DashboardCanvas } from './components/DashboardCanvas';
+export type {
+  DashboardCanvasProps,
+  DashboardCanvasConstraintsProp,
+  DashboardPlacement,
+  DashboardSection,
+  DashboardCanvasValue,
+  DashboardItemConstraints,
+} from './components/DashboardCanvas';

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -94,6 +94,7 @@ import { ScreenDemo } from './pages/components/ScreenDemo';
 import { FileUploadDemo } from './pages/components/FileUploadDemo';
 import { FilterChipDemo } from './pages/components/FilterChipDemo';
 import { FlowCanvasDemo } from './pages/components/FlowCanvasDemo';
+import { DashboardCanvasDemo } from './pages/components/DashboardCanvasDemo';
 import { PersonDisplayDemo } from './pages/components/PersonDisplayDemo';
 import { IconTileDemo } from './pages/components/IconTileDemo';
 import { ImageDemo } from './pages/components/ImageDemo';
@@ -217,6 +218,7 @@ export default function App() {
             <Route path="/components/file-upload" element={<FileUploadDemo />} />
             <Route path="/components/filter-chip" element={<FilterChipDemo />} />
             <Route path="/components/flow-canvas" element={<FlowCanvasDemo />} />
+            <Route path="/components/dashboard-canvas" element={<DashboardCanvasDemo />} />
             <Route path="/components/icon-tile" element={<IconTileDemo />} />
             <Route path="/components/image" element={<ImageDemo />} />
             <Route path="/components/media-tile" element={<MediaTileDemo />} />

--- a/packages/playground/src/layout/AppShell/navItems.ts
+++ b/packages/playground/src/layout/AppShell/navItems.ts
@@ -224,6 +224,12 @@ export const componentGroups: { heading: string; items: NavItem[] }[] = [
       { to: '/components/error-state', label: 'ErrorState', icon: TriangleAlert, end: false },
       { to: '/components/filter-chip', label: 'FilterChip', icon: Filter, end: false },
       { to: '/components/flow-canvas', label: 'FlowCanvas', icon: Workflow, end: false },
+      {
+        to: '/components/dashboard-canvas',
+        label: 'DashboardCanvas',
+        icon: LayoutDashboard,
+        end: false,
+      },
       { to: '/components/icon-tile', label: 'IconTile', icon: Shapes, end: false },
       { to: '/components/image', label: 'Image', icon: ImageIcon, end: false },
       { to: '/components/media-tile', label: 'MediaTile', icon: GalleryThumbnails, end: false },

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -958,6 +958,52 @@
         }
       ]
     },
+    "DashboardCanvas": {
+      "props": [
+        {
+          "name": "value",
+          "type": "DashboardCanvasValue",
+          "required": true,
+          "default": "",
+          "description": "The controlled layout: top-level items plus an ordered array of\ncollapsible sections. `DashboardCanvas` never mutates this value — every\nchange flows out through `onChange`."
+        },
+        {
+          "name": "onChange",
+          "type": "((next: DashboardCanvasValue) => void)",
+          "required": false,
+          "default": "",
+          "description": "Fires once per completed gesture — a drop, a resize end, a collapse\ntoggle, a section reorder, or a cross-container move — with the whole\nnext `value`. Omit for a read-only or fully static canvas; without it,\ndrags preview live but nothing persists on drop."
+        },
+        {
+          "name": "renderItem",
+          "type": "(id: string | number) => ReactNode",
+          "required": true,
+          "default": "",
+          "description": "Renders the body of an item by id. Called for every visible item on\nevery render — and once more for the dragged item mid-gesture (the\ncursor-following ghost) — so keep it pure."
+        },
+        {
+          "name": "renderSectionHeader",
+          "type": "((id: string | number) => ReactNode)",
+          "required": false,
+          "default": "",
+          "description": "Optional extra controls in a section's header (a title editor, a\n`DropdownMenu` trigger) rendered by section id, to the right of the\ntitle. Keep it small — the header row is not a general-purpose toolbar.\nPointer presses inside the slot never start a band-reorder drag."
+        },
+        {
+          "name": "constraints",
+          "type": "DashboardCanvasConstraintsProp",
+          "required": false,
+          "default": "",
+          "description": "Per-item size constraints, consulted when clamping resize gestures."
+        },
+        {
+          "name": "readOnly",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "View-only mode: identical geometry, but no drag/resize wiring, no resize\nhandles, and no keyboard editing — the canvas renders `value` and lets\nsection collapse toggles keep working. The canvas also disables editing\non its own, without this prop, once its own width drops below 640px\n(below-md single-column stack) — `readOnly` is for a consumer-chosen\nview mode, the width gate is automatic."
+        }
+      ]
+    },
     "DataTable": {
       "props": [
         {
@@ -4942,6 +4988,8 @@
     "HourCycle": "\"auto\" | \"12\" | \"24\"",
     "FieldOrientation": "\"horizontal\" | \"vertical\"",
     "FieldSize": "\"sm\" | \"md\" | \"lg\"",
-    "FieldRenderProps": "{ id: string; aria-describedby: string; aria-labelledby: string; aria-invalid: boolean; invalid: boolean; required: boolean; labelId: string }"
+    "FieldRenderProps": "{ id: string; aria-describedby: string; aria-labelledby: string; aria-invalid: boolean; invalid: boolean; required: boolean; labelId: string }",
+    "DashboardCanvasConstraintsProp": "Record<string, DashboardItemConstraints> | ((id: string | number) => DashboardItemConstraints)",
+    "DashboardCanvasValue": "{ items: DashboardPlacement[]; sections: DashboardSection[] }"
   }
 }

--- a/packages/playground/src/pages/components/ComponentsIndex.tsx
+++ b/packages/playground/src/pages/components/ComponentsIndex.tsx
@@ -218,6 +218,13 @@ const items: { to: string; name: string; description: string; preview: React.Rea
     preview: SCHEMATICS['FlowCanvas'],
   },
   {
+    to: '/components/dashboard-canvas',
+    name: 'DashboardCanvas',
+    description:
+      '2D snap-grid dashboard — drag-to-move, resize, collapsible sections, band reorder.',
+    preview: SCHEMATICS['DashboardCanvas'],
+  },
+  {
     to: '/components/sortable',
     name: 'Sortable',
     description: 'Drag-to-reorder list with optional keyboard handle.',

--- a/packages/playground/src/pages/components/DashboardCanvasDemo.tsx
+++ b/packages/playground/src/pages/components/DashboardCanvasDemo.tsx
@@ -1,0 +1,238 @@
+import { useState } from 'react';
+import {
+  Accordion,
+  Badge,
+  Card,
+  DashboardCanvas,
+  Stack,
+  Text,
+  Title,
+  type DashboardCanvasValue,
+} from '@eocrm/design-system';
+import { DemoLayout } from './DemoLayout';
+import { Example } from './Example';
+import { getComponentFiles } from '../../lib/componentFiles';
+
+interface Widget {
+  title: string;
+  metric: string;
+  sub: string;
+}
+
+const WIDGETS: Record<string, Widget> = {
+  revenue: { title: 'Revenue (MTD)', metric: '$128,400', sub: '+12% vs last month' },
+  deals: { title: 'Open deals', metric: '34', sub: '9 closing this week' },
+  activity: { title: 'Recent activity', metric: '212 events', sub: 'Last 24 hours' },
+  leaderboard: { title: 'Top reps', metric: 'A. Chen — $41,200', sub: 'Q3 leaderboard' },
+  quota: { title: 'Quota attainment', metric: '87%', sub: 'Team average' },
+  exports: { title: 'Scheduled exports', metric: '3 reports', sub: 'Next run: tomorrow 6am' },
+};
+
+const INITIAL_VALUE: DashboardCanvasValue = {
+  items: [
+    { id: 'revenue', x: 0, y: 0, w: 4, h: 2 },
+    { id: 'deals', x: 4, y: 0, w: 4, h: 2 },
+    { id: 'activity', x: 8, y: 0, w: 4, h: 4 },
+  ],
+  sections: [
+    {
+      id: 'team',
+      title: 'Team performance',
+      collapsed: false,
+      items: [
+        { id: 'leaderboard', x: 0, y: 0, w: 6, h: 3 },
+        { id: 'quota', x: 6, y: 0, w: 6, h: 3 },
+      ],
+    },
+    {
+      id: 'reports',
+      title: 'Reports',
+      collapsed: true,
+      items: [{ id: 'exports', x: 0, y: 0, w: 12, h: 2 }],
+    },
+  ],
+};
+
+// revenue: locked to a KPI-sized footprint. quota: never allowed to shrink
+// narrower than half the section (a bar needs room to read).
+const CONSTRAINTS = {
+  revenue: { minW: 2, maxH: 2 },
+  quota: { minW: 3 },
+};
+
+const NARROW_VALUE: DashboardCanvasValue = {
+  items: [
+    { id: 'revenue', x: 0, y: 0, w: 6, h: 2 },
+    { id: 'deals', x: 6, y: 0, w: 6, h: 2 },
+  ],
+  sections: [
+    {
+      id: 'team',
+      title: 'Team performance',
+      collapsed: false,
+      items: [{ id: 'quota', x: 0, y: 0, w: 12, h: 2 }],
+    },
+  ],
+};
+
+function renderWidget(id: string | number) {
+  const widget = WIDGETS[String(id)];
+  if (!widget) return null;
+  return (
+    <Card>
+      <Stack gap="xs">
+        <Text size="sm" tone="muted">
+          {widget.title}
+        </Text>
+        <Title order={3} size="md">
+          {widget.metric}
+        </Title>
+        <Text size="sm" tone="muted">
+          {widget.sub}
+        </Text>
+      </Stack>
+    </Card>
+  );
+}
+
+export function DashboardCanvasDemo() {
+  const [value, setValue] = useState<DashboardCanvasValue>(INITIAL_VALUE);
+  const [narrowValue, setNarrowValue] = useState<DashboardCanvasValue>(NARROW_VALUE);
+
+  const renderSectionHeader = (id: string | number) => (
+    <Badge tone="neutral">{value.sections.find((s) => s.id === id)?.items.length ?? 0}</Badge>
+  );
+
+  return (
+    <DemoLayout
+      name="DashboardCanvas"
+      componentName="DashboardCanvas"
+      description="Datadog-style 2D snap-grid dashboard — drag-to-move with push-down collision, E/S/SE resize, collapsible full-width sections with their own sub-grids, cross-container drag, and band reorder. Always controlled: every completed gesture fires onChange once with the whole next value."
+      files={getComponentFiles('DashboardCanvas')}
+    >
+      <Example
+        title="Edit mode"
+        description="Drag a widget to move it (push-down collision + live compaction preview). Drag its right / bottom / corner edge to resize. Drag a section header to reorder bands, or click the chevron to collapse. Keyboard: Tab to a widget, Enter/Space to pick it up, arrows to move (crossing a band's edge moves it between containers), Shift+arrows to resize, Enter/Space to drop, Escape to cancel. `revenue` and `quota` carry constraints (min size / max height) via the `constraints` prop. The current value is shown below, collapsibly."
+        code={`import { useState } from 'react';
+import { Badge, Card, DashboardCanvas, Stack, Text, Title, type DashboardCanvasValue } from '@eocrm/design-system';
+
+const WIDGETS = {
+  revenue: { title: 'Revenue (MTD)', metric: '$128,400', sub: '+12% vs last month' },
+  deals: { title: 'Open deals', metric: '34', sub: '9 closing this week' },
+  activity: { title: 'Recent activity', metric: '212 events', sub: 'Last 24 hours' },
+  leaderboard: { title: 'Top reps', metric: 'A. Chen — $41,200', sub: 'Q3 leaderboard' },
+  quota: { title: 'Quota attainment', metric: '87%', sub: 'Team average' },
+  exports: { title: 'Scheduled exports', metric: '3 reports', sub: 'Next run: tomorrow 6am' },
+};
+
+function renderWidget(id) {
+  const w = WIDGETS[id];
+  return (
+    <Card>
+      <Stack gap="xs">
+        <Text size="sm" tone="muted">{w.title}</Text>
+        <Title order={3} size="md">{w.metric}</Title>
+        <Text size="sm" tone="muted">{w.sub}</Text>
+      </Stack>
+    </Card>
+  );
+}
+
+export function Demo() {
+  const [value, setValue] = useState<DashboardCanvasValue>({
+    items: [
+      { id: 'revenue', x: 0, y: 0, w: 4, h: 2 },
+      { id: 'deals', x: 4, y: 0, w: 4, h: 2 },
+      { id: 'activity', x: 8, y: 0, w: 4, h: 4 },
+    ],
+    sections: [
+      {
+        id: 'team',
+        title: 'Team performance',
+        collapsed: false,
+        items: [
+          { id: 'leaderboard', x: 0, y: 0, w: 6, h: 3 },
+          { id: 'quota', x: 6, y: 0, w: 6, h: 3 },
+        ],
+      },
+      {
+        id: 'reports',
+        title: 'Reports',
+        collapsed: true,
+        items: [{ id: 'exports', x: 0, y: 0, w: 12, h: 2 }],
+      },
+    ],
+  });
+
+  return (
+    <DashboardCanvas
+      value={value}
+      onChange={setValue}
+      constraints={{ revenue: { minW: 2, maxH: 2 }, quota: { minW: 3 } }}
+      renderItem={renderWidget}
+      renderSectionHeader={(id) => (
+        <Badge tone="neutral">{value.sections.find((s) => s.id === id)?.items.length ?? 0}</Badge>
+      )}
+    />
+  );
+}`}
+      >
+        <Stack gap="md">
+          <DashboardCanvas
+            value={value}
+            onChange={setValue}
+            constraints={CONSTRAINTS}
+            renderItem={renderWidget}
+            renderSectionHeader={renderSectionHeader}
+          />
+          <Accordion type="single" collapsible>
+            <Accordion.Item value="json">
+              <Accordion.Trigger>Current value (JSON)</Accordion.Trigger>
+              <Accordion.Content>
+                <pre style={{ margin: 0, fontSize: 'var(--font-size-sm)', overflow: 'auto' }}>
+                  {JSON.stringify(value, null, 2)}
+                </pre>
+              </Accordion.Content>
+            </Accordion.Item>
+          </Accordion>
+        </Stack>
+      </Example>
+
+      <Example
+        title="Read-only"
+        description="Same value as the edit-mode canvas above, rendered with readOnly: no drag/resize wiring, no handles, no keyboard editing. Section collapse toggles keep working — collapse is navigation, not editing. Suits a dashboard record page or a permission-gated view."
+        code={`import { DashboardCanvas } from '@eocrm/design-system';
+
+export function Demo() {
+  return <DashboardCanvas value={savedLayout} renderItem={renderWidget} readOnly />;
+}`}
+      >
+        <DashboardCanvas value={value} renderItem={renderWidget} readOnly />
+      </Example>
+
+      <Example
+        title="Below-md single-column stack"
+        description="Drag the box's resize handle (bottom-right corner) narrower than 640px. Every container — top level and the section — re-templates to one column, and pointer + keyboard editing turns off automatically; this width gate is independent of the readOnly prop. Widen it back past 640px to see editing return."
+        code={`import { useState } from 'react';
+import { DashboardCanvas, type DashboardCanvasValue } from '@eocrm/design-system';
+
+export function Demo() {
+  const [value, setValue] = useState<DashboardCanvasValue>(narrowLayout);
+  return (
+    <div style={{ resize: 'horizontal', overflow: 'auto', width: 480 }}>
+      <DashboardCanvas value={value} onChange={setValue} renderItem={renderWidget} />
+    </div>
+  );
+}`}
+      >
+        <div style={{ resize: 'horizontal', overflow: 'auto', width: 480 }}>
+          <DashboardCanvas
+            value={narrowValue}
+            onChange={setNarrowValue}
+            renderItem={renderWidget}
+          />
+        </div>
+      </Example>
+    </DemoLayout>
+  );
+}

--- a/packages/playground/src/pages/components/overviewSchematics.tsx
+++ b/packages/playground/src/pages/components/overviewSchematics.tsx
@@ -839,6 +839,27 @@ export const SCHEMATICS: Record<string, ReactNode> = {
       </Dashed>
     </Row>
   ),
+  DashboardCanvas: (
+    <Col gap={6}>
+      <Row gap={6} style={{ alignItems: 'flex-start' }}>
+        <Solid w={54} h={40} />
+        <Col gap={6}>
+          <Box w={40} h={17} />
+          <Box w={40} h={17} />
+        </Col>
+        <Box w={30} h={40} />
+      </Row>
+      <Dashed
+        w={128}
+        h={30}
+        style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '0 6px' }}
+      >
+        <Box w={22} h={16} />
+        <Box w={22} h={16} />
+        <Box w={22} h={16} />
+      </Dashed>
+    </Col>
+  ),
   FlowCanvas: (
     <Dashed w={210} h={100} style={{ display: 'block', position: 'relative' }}>
       <Solid w={52} h={22} style={{ position: 'absolute', left: 14, top: 12 }} />

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -20,6 +20,7 @@ export type ComponentName =
   | 'ConfirmationPopover'
   | 'Constrain'
   | 'CursorPagination'
+  | 'DashboardCanvas'
   | 'DataTable'
   | 'DatePicker'
   | 'DateRangePicker'


### PR DESCRIPTION
Addresses #337 (Part A of the approved eocrm dashboard-grid-canvas design).

## Summary
New `<DashboardCanvas>` — the largest primitive in the library:
- **Model:** controlled `value: { items, sections }` with `Placement = { id, x, y, w, h }` on a 12-column grid, fixed row unit (`--dashboard-canvas-row` = 48px token), sections as full-width auto-fit collapsible bands; `onChange` fires exactly once per completed gesture (drop, resize-end, collapse toggle, band reorder, cross-container move) — a single commit choke point with a reference-equality no-op guard.
- **Engine:** pure, headless `engine.ts` — vertical compaction + Datadog push-down (`placeWithPushDown` = push-down settle then whole-layout compaction), moves, resizes, section ops, stacking order. 77 deterministic tests + a committed seeded property test; independently fuzz-verified twice during review (~22k iterations total, zero invariant violations).
- **Gestures:** drag-to-move with cursor ghost + snapped drop preview that renders the live engine result (real push-down reflow mid-drag), E/S/SE snap resize with per-item `constraints` (minW/minH/maxH, record or function form), cross-container drag (top level ↔ sections), section-header band reorder with insertion indicator. Pointer capture on the never-remounting root; commits recompute from the current controlled value at pointerup.
- **Keyboard parity + a11y:** Enter/Space pickup, arrows move (crossing band edges = cross-container), Shift+arrows resize, Escape cancel (registered as an Escape-consuming surface), Shift+arrows on section headers reorder bands; nonce live-region announcements + instructions, fully i18n'd (en + ru). Mid-pick invalidation on external value changes; focus reclaim after cross-container remounts.
- **readOnly** (identical geometry, zero wiring, collapse stays active) and **below-md single-column stacking** in (section, y, x) order via container query, with a matching JS editing gate (inclusive 640px boundary).
- Full core invariant: 134 component+engine tests, playground demo (edit + readOnly + resizable narrow frame), all 5 wiring surfaces, manifest CLUSTERS, AGENTS.md TL;DR, complete JSDoc.

## Deliberate deviation from the issue's wording
The issue says "hand-rolled on dnd-kit"; this ships on **raw pointer events** (FlowCanvas's architecture — the precedent the issue itself cites). dnd-kit's sortable abstractions don't fit snap-grid push-down physics, and its pointer drags are untestable in jsdom (SortableGroup's tests document this), while raw-pointer gestures are fully exercised in this suite. The issue's operative constraint — no react-grid-layout-class dependency — holds.

## Test plan
- 134 DashboardCanvas tests (engine incl. seeded property test; gestures via real pointer-event sequences incl. capture-loss, mid-gesture value change, Escape/cancel, cross-container; keyboard cycles; narrow gate); package suite 4049.
- Six adversarial review gates (one per task) + fix rounds caught and fixed: full-Datadog compaction semantics, cross-container capture loss, stale-preview commits, spurious clamped-resize onChange, mid-pick lockout, 640px boundary mismatch.
- Live browser validation (Playwright): real drag with ghost + preview + push-down, SE resize with maxH clamp, band reorder, full keyboard cycle with announcements, JSON state fidelity, both themes, below-md stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk