### PR TITLE
fix: EntityChip — consumer color prop (palette), cyan default, drop bold-on-hover, status-colored dot (#345)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1801,16 +1801,20 @@ import { Divider } from '@eocrm/design-system';
 // RouterLink via `as`, or a status color override:
 import { Link as RouterLink } from 'react-router-dom';
 <EntityChip as={RouterLink} to="/deals/9" label="Acme Corp" status={{ label: 'At risk', color: 'amber' }} />
+
+// Chip fill override (categorical, independent of status):
+<EntityChip href="/deals/9" label="Acme Corp" color="violet" />
 ```
 
 - Polymorphic inline chip: optional `icon` (rendered `aria-hidden`), optional muted `prefix` (e.g. a task key), the `label`, and an optional colored `status`. All inline `<span>`s inside one root — safe to drop directly inside a `<p>`/`<Text>`.
 - **An EntityChip is always a link to its entity**: pass `href` (renders `<a href>`) or `as` (`RouterLink`, `'button'`, any component — same polymorphic contract as `<Link>`). The bare `<span>` form (no target) is for rare non-navigable contexts only.
-- `status`: `{ label, category?, color? }`. `category` (`to_do`/`in_progress`/`open`/`done`/`won`/`lost`) resolves a default palette color; `color` (a `PaletteColor`) overrides it — same category → color mapping as `<StatusMenu>`.
+- Default chip fill is cyan. `color?: PaletteColor` overrides the fill (same inline-injection contract as `Badge color`) — independent of `status`, which keeps its own resolved color. `unavailable` still mutes the label/status/dot over any `color`.
+- `status`: `{ label, category?, color? }`. `category` (`to_do`/`in_progress`/`open`/`done`/`won`/`lost`) resolves a default palette color; `color` (a `PaletteColor`) overrides it — same category → color mapping as `<StatusMenu>`. The separator dot between name and status takes the status's resolved color too (reads as one unit with the status label).
 - `loading`: swaps the body for an `aria-busy` ellipsis. `unavailable`: mutes the chip (entity deleted or no access). Both are purely visual when the chip has a link target — it stays a live, keyboard-reachable link. Only a target-less `unavailable` chip is non-interactive with `aria-disabled`.
-- Hover affordance on link/button chips: the label thickens via text-stroke (fake bold — glyph widths don't change, so nothing reflows) and the background deepens. The chip never underlines, even under aggressive consumer link CSS.
+- Hover affordance on link/button chips: the background deepens a step plus a brightness dip. Never a weight change, never an underline, even under aggressive consumer link CSS.
 - Chip text inherits the surrounding font size — inside a heading it renders at heading size, by design (that's what keeps the chip box symmetric around the local text in any context).
 - **When NOT to use**: plain status with no linked entity → `<Badge>`/`<StatusMenu>`; standalone navigation with no icon/prefix/status chrome → `<Link>`; removable filter pills → `<FilterChip>`.
-- **Anti-pattern**: nesting a `<Badge>` inside another `<Badge>` to fake an entity-with-status chip — `EntityChip` replaces that composition. `status.color` is a `PaletteColor` name, never a raw hex string. Omitting a link target (`href`/`as`) is also an anti-pattern — an EntityChip should link to its entity.
+- **Anti-pattern**: nesting a `<Badge>` inside another `<Badge>` to fake an entity-with-status chip — `EntityChip` replaces that composition. `status.color` and the chip's own `color` are `PaletteColor` names, never raw hex strings. Omitting a link target (`href`/`as`) is also an anti-pattern — an EntityChip should link to its entity.
 
 ### `<StatusMenu>` — status-transition dropdown
 

--- a/packages/design-system/src/components/EntityChip/EntityChip.module.scss
+++ b/packages/design-system/src/components/EntityChip/EntityChip.module.scss
@@ -32,17 +32,12 @@
   &:is(a, button) {
     cursor: pointer;
 
+    // Hover affordance: bg deepens a step + a brightness dip. Never an
+    // underline, never a weight change (a fake-bold text-stroke used to live
+    // here — dropped, see #345).
     &:hover {
       background: var(--entity-chip-bg-hover);
       filter: brightness(0.96);
-    }
-
-    // Hover affordance: the entity name thickens via text-stroke — a fake
-    // bold that doesn't change glyph advance widths, so nothing reflows (real
-    // bold shifted the rest of the sentence). Never an underline. Scoped to
-    // the label so the muted prefix/status runs keep their weight.
-    &:hover .label {
-      -webkit-text-stroke-width: var(--entity-chip-hover-stroke);
     }
 
     &:focus-visible {
@@ -75,13 +70,16 @@
   color: var(--entity-chip-status-fg);
 }
 
+// Colored via --entity-chip-status-fg (set on the chip root when `status` is
+// present, see EntityChip.tsx) so the dot reads as one unit with the status
+// label instead of a neutral separator.
 .dot {
   flex-shrink: 0;
   width: var(--entity-chip-dot-size);
   height: var(--entity-chip-dot-size);
   border-radius: var(--radius-full);
   background: currentcolor;
-  color: var(--entity-chip-prefix-fg);
+  color: var(--entity-chip-status-fg);
   // stylelint-disable-next-line property-disallowed-list -- internal child of the chip's OWN flex row, centering the circle on the line while the chip itself aligns on text baseline
   align-self: center;
 }

--- a/packages/design-system/src/components/EntityChip/EntityChip.test.tsx
+++ b/packages/design-system/src/components/EntityChip/EntityChip.test.tsx
@@ -49,32 +49,50 @@ describe('<EntityChip>', () => {
     expect(dot.parentElement).toBe(container.firstElementChild); // direct flex item of the chip root
   });
 
-  it('resolves the status color from category', () => {
-    render(<EntityChip label="Task" status={{ label: 'In progress', category: 'in_progress' }} />);
-    const status = screen.getByText('In progress').closest('span');
-    expect(status?.style.getPropertyValue('--entity-chip-status-fg')).toBe(
+  it('resolves the status color from category, injected on the chip root (so the dot sees it too)', () => {
+    const { container } = render(
+      <EntityChip label="Task" status={{ label: 'In progress', category: 'in_progress' }} />,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.getPropertyValue('--entity-chip-status-fg')).toBe(
       'var(--color-palette-blue-fg)',
     );
   });
 
   it('an explicit status color wins over category', () => {
-    render(
+    const { container } = render(
       <EntityChip
         label="Task"
         status={{ label: 'Blocked', category: 'in_progress', color: 'red' }}
       />,
     );
-    const status = screen.getByText('Blocked').closest('span');
-    expect(status?.style.getPropertyValue('--entity-chip-status-fg')).toBe(
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.getPropertyValue('--entity-chip-status-fg')).toBe(
       'var(--color-palette-red-fg)',
     );
   });
 
   it('falls back to slate with no category and no color', () => {
-    render(<EntityChip label="Task" status={{ label: 'Mystery' }} />);
-    const status = screen.getByText('Mystery').closest('span');
-    expect(status?.style.getPropertyValue('--entity-chip-status-fg')).toBe(
+    const { container } = render(<EntityChip label="Task" status={{ label: 'Mystery' }} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.getPropertyValue('--entity-chip-status-fg')).toBe(
       'var(--color-palette-slate-fg)',
+    );
+  });
+
+  it('the separator dot takes the status color via currentcolor (CSS reads --entity-chip-status-fg from the root)', () => {
+    const { container } = render(
+      <EntityChip label="Task" status={{ label: 'Done', category: 'done' }} />,
+    );
+    // jsdom doesn't resolve CSS Modules, so this asserts the wiring: the dot
+    // has no per-element color override and the fg custom property lives on
+    // the shared root ancestor the .dot/.status CSS rules both read from.
+    const dot = container.querySelector('[class*="dot"]') as HTMLElement;
+    const root = container.firstElementChild as HTMLElement;
+    expect(dot.style.getPropertyValue('--entity-chip-status-fg')).toBe('');
+    expect(root.contains(dot)).toBe(true);
+    expect(root.style.getPropertyValue('--entity-chip-status-fg')).toBe(
+      'var(--color-palette-green-fg)',
     );
   });
 
@@ -118,6 +136,52 @@ describe('<EntityChip>', () => {
     expect(link).toHaveAttribute('href', '/contacts/1');
     expect(link).not.toHaveAttribute('aria-disabled');
     expect(link.className).toMatch(/unavailable/);
+  });
+
+  it('`color` injects the palette bg/fg pair, and bg-hover matches bg so the hover filter works on any color', () => {
+    const { container } = render(<EntityChip label="Acme Corp" href="/deals/9" color="violet" />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.getPropertyValue('--entity-chip-bg')).toBe('var(--color-palette-violet-bg)');
+    expect(root.style.getPropertyValue('--entity-chip-fg')).toBe('var(--color-palette-violet-fg)');
+    expect(root.style.getPropertyValue('--entity-chip-bg-hover')).toBe(
+      'var(--color-palette-violet-bg)',
+    );
+  });
+
+  it('without `color`, no chip-fill custom properties are injected — the default cyan tokens apply', () => {
+    const { container } = render(<EntityChip label="Contact" href="/contacts/1" />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.getPropertyValue('--entity-chip-bg')).toBe('');
+    expect(root.style.getPropertyValue('--entity-chip-fg')).toBe('');
+  });
+
+  it('`color` and `status` inject independently — the status color does not leak into the chip fill', () => {
+    const { container } = render(
+      <EntityChip
+        label="Fix login bug"
+        href="/tasks/5"
+        color="teal"
+        status={{ label: 'In progress', category: 'in_progress' }}
+      />,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.getPropertyValue('--entity-chip-bg')).toBe('var(--color-palette-teal-bg)');
+    expect(root.style.getPropertyValue('--entity-chip-status-fg')).toBe(
+      'var(--color-palette-blue-fg)',
+    );
+  });
+
+  it("unavailable + `color`: the muted fg override still wins (the `.unavailable` class rule beats `.chip`'s color regardless of the injected --entity-chip-fg)", () => {
+    const { container } = render(
+      <EntityChip label="Deleted contact" href="/contacts/9" color="violet" unavailable />,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    // The chip fill's own custom property IS still injected (unavailable
+    // doesn't touch the background) — only the text color is muted, by a
+    // `.unavailable { color: ... }` rule declared after `.chip`'s in the
+    // stylesheet, independent of what --entity-chip-fg resolves to.
+    expect(root.style.getPropertyValue('--entity-chip-fg')).toBe('var(--color-palette-violet-fg)');
+    expect(root.className).toMatch(/unavailable/);
   });
 
   it('unavailable + custom `as` keeps the real component and its props', () => {

--- a/packages/design-system/src/components/EntityChip/EntityChip.tokens.scss
+++ b/packages/design-system/src/components/EntityChip/EntityChip.tokens.scss
@@ -1,14 +1,16 @@
-// EntityChip.tokens.scss — Component-scoped tokens for <EntityChip>. Stone
+// EntityChip.tokens.scss — Component-scoped tokens for <EntityChip>. Cyan
 // chip chrome + a muted prefix run + an unavailable-state override.
-// --entity-chip-bg is a literal-hex exception (same pattern as Badge/Tooltip
-// in dark.scss): the raw --color-palette-stone-bg reads too close to the
-// page/card canvas to register as a distinct chip, so it's deepened a step
-// here (and again, separately, in dark.scss) rather than changing the shared
-// palette token every other stone consumer (Badge, Palette) relies on.
+// --entity-chip-bg AND --entity-chip-fg are literal-hex exceptions (same
+// pattern as Badge/Tooltip in dark.scss): the raw --color-palette-cyan-bg/-fg
+// pair reads too faint here — the raw bg is too close to the page/card
+// canvas to register as a distinct chip, and the raw fg misses the 4.5:1
+// label-contrast bar once the bg is deepened enough to register — so both
+// are tuned a step here (and again, separately, in dark.scss) rather than
+// changing the shared palette tokens every other cyan consumer relies on.
 :root {
-  --entity-chip-bg: #d6d0c5;
-  --entity-chip-bg-hover: #d6d0c5;
-  --entity-chip-fg: var(--color-palette-stone-fg);
+  --entity-chip-bg: #87d9e8;
+  --entity-chip-bg-hover: #87d9e8;
+  --entity-chip-fg: #005466;
   --entity-chip-prefix-fg: var(--color-fg-muted);
   --entity-chip-radius: var(--radius-sm);
   --entity-chip-gap: var(--space-1);
@@ -20,10 +22,6 @@
   // padded box hugging the glyph band instead of hanging below the baseline.
   --entity-chip-line-height: var(--line-height-none);
 
-  // Hover affordance: the label thickens via text-stroke (fake bold — glyph
-  // advance widths don't change, so the chip and the surrounding sentence
-  // never reflow on hover). Never an underline.
-  --entity-chip-hover-stroke: 0.04em;
   --entity-chip-unavailable-fg: var(--color-fg-muted);
 
   // Status separator dot — DIAMETER of the solid circle rendered between the

--- a/packages/design-system/src/components/EntityChip/EntityChip.tsx
+++ b/packages/design-system/src/components/EntityChip/EntityChip.tsx
@@ -38,6 +38,16 @@ interface EntityChipOwnProps {
   prefix?: ReactNode;
   /** Inline workflow status, separated by a small dot and rendered in the status's own color. */
   status?: EntityChipStatus;
+  /**
+   * Optional categorical palette color for the chip fill. When set, takes
+   * precedence over the default cyan chip tokens: the chip fills with the
+   * matching `--color-palette-<name>-bg/-fg` pair (same contract as `Badge
+   * color` — picking a readable pair is the consumer's call). Omit for the
+   * default cyan fill. The `status` run keeps its own resolved color
+   * independent of this prop, and `unavailable` still mutes the label/status
+   * text over any `color`.
+   */
+  color?: PaletteColor;
   /** Renders `as="a"` with this href when `as` is omitted. */
   href?: string;
   /**
@@ -89,6 +99,36 @@ function statusColorStyle(status: EntityChipStatus): CSSProperties {
   return { '--entity-chip-status-fg': fg } as CSSProperties;
 }
 
+/** Injectable custom-properties for a consumer `color` override — same
+ * inline-injection contract as `Badge color`. Points bg-hover at the same
+ * bg so the hover brightness filter works on any palette color. */
+function colorStyle(color: PaletteColor): CSSProperties {
+  return {
+    '--entity-chip-bg': `var(--color-palette-${color}-bg)`,
+    '--entity-chip-fg': `var(--color-palette-${color}-fg)`,
+    '--entity-chip-bg-hover': `var(--color-palette-${color}-bg)`,
+  } as CSSProperties;
+}
+
+/**
+ * Merged inline style for the chip root: the `color` prop's palette
+ * injection, the `status`'s resolved color (read by both `.status` and
+ * `.dot` — set on the root, not the `.status` span, so the dot — a sibling,
+ * not a descendant of `.status` — can see it too), then the consumer's own
+ * `style` last so it wins on a collision.
+ */
+function rootStyle(
+  color: PaletteColor | undefined,
+  status: EntityChipStatus | undefined,
+  consumerStyle: CSSProperties | undefined,
+): CSSProperties | undefined {
+  const colorVars = color ? colorStyle(color) : undefined;
+  const statusVars = status ? statusColorStyle(status) : undefined;
+  return colorVars || statusVars || consumerStyle
+    ? { ...colorVars, ...statusVars, ...consumerStyle }
+    : undefined;
+}
+
 /**
  * Inline entity-link chip: an optional icon, an optional muted prefix (e.g.
  * a task key), the entity's name, and an optional workflow status shown in
@@ -119,6 +159,10 @@ function statusColorStyle(status: EntityChipStatus): CSSProperties {
  * <EntityChip href="/contacts/7" label="Contact" loading />
  * <EntityChip href="/contacts/9" label="Deleted contact" unavailable />
  *
+ * @example
+ * // Categorical `color` override — the chip fill itself, independent of `status`
+ * <EntityChip href="/deals/9" label="Acme Corp" color="violet" />
+ *
  * @remarks When NOT to use
  * - Plain status display with no linked entity → use `<Badge>` or `<StatusMenu>`.
  * - Standalone navigation with no entity chrome (icon/prefix/status) → use `<Link>`.
@@ -129,8 +173,8 @@ function statusColorStyle(status: EntityChipStatus): CSSProperties {
  *   chip — that composition is exactly what `EntityChip` replaces.
  * - ❌ Putting block-level children (e.g. a `<div>`) inside `label`/`prefix` —
  *   the inline-safety contract requires span-only content.
- * - ❌ Raw hex strings in `status.color`. It's a `PaletteColor` name
- *   (`'amber'`, `'violet'`, …), not a CSS color value.
+ * - ❌ Raw hex strings in `status.color` or the chip's own `color`. Both are
+ *   `PaletteColor` names (`'amber'`, `'violet'`, …), not CSS color values.
  * - ❌ Omitting a link target — an EntityChip should always link to its
  *   entity (`href` or `as`); the span-only form is for rare non-navigable
  *   contexts.
@@ -142,6 +186,7 @@ export const EntityChip = forwardRef(function EntityChip<C extends ElementType =
     label,
     prefix,
     status,
+    color,
     href,
     loading = false,
     unavailable = false,
@@ -164,7 +209,7 @@ export const EntityChip = forwardRef(function EntityChip<C extends ElementType =
   return (
     <Component
       ref={ref}
-      style={style}
+      style={rootStyle(color, status, style)}
       className={clsx(styles.chip, unavailable && styles.unavailable, className)}
       {...elementProps}
       {...rest}
@@ -194,17 +239,19 @@ export const EntityChip = forwardRef(function EntityChip<C extends ElementType =
       ) : (
         <>
           {prefix && <span className={styles.prefix}>{prefix}</span>}
-          {/* Wrapper scopes the hover fake-bold to the entity name only. */}
+          {/* Wrapper keeps the name a single flex item (matters when `label`
+              is itself multiple nodes — e.g. a fragment) so the chip's `gap`
+              doesn't insert extra space inside the name. No longer scopes
+              hover styling (the fake-bold rule was dropped, see #345). */}
           <span className={styles.label}>{label}</span>
           {status && (
             <>
               {/* Separator dot is its own flex item so the chip's `gap` spaces
                   it symmetrically between name and status. A solid circle, not
-                  a font glyph — exact size, no line-box inflation. */}
+                  a font glyph — exact size, no line-box inflation. Colored via
+                  --entity-chip-status-fg, set on the chip root above (rootStyle). */}
               <span className={styles.dot} aria-hidden="true" />
-              <span className={styles.status} style={statusColorStyle(status)}>
-                {status.label}
-              </span>
+              <span className={styles.status}>{status.label}</span>
             </>
           )}
         </>

--- a/packages/design-system/src/styles/dark.scss
+++ b/packages/design-system/src/styles/dark.scss
@@ -88,10 +88,15 @@
   --tooltip-arrow-bg: #39424b;
 
   // EntityChip — literal-hex exception (EntityChip.tokens.scss), same reason
-  // as the light override: the raw stone palette bg reads too close to the
-  // dark page/card canvas, so it's deepened a step to stay a distinct chip.
-  --entity-chip-bg: #514d45;
-  --entity-chip-bg-hover: #514d45;
+  // as the light override: the raw cyan palette bg reads too close to the
+  // dark page/card canvas, so it's lightened a step to stay a distinct chip.
+  // fg is pinned to the (already dark-tuned) --color-palette-cyan-fg value —
+  // it clears the 4.5:1 bar against this bg as-is, but it's set explicitly
+  // here (not left to inherit) because the light default above is a literal
+  // that would otherwise leak into dark mode unchanged.
+  --entity-chip-bg: #255e6a;
+  --entity-chip-bg-hover: #255e6a;
+  --entity-chip-fg: var(--color-palette-cyan-fg);
 
   // Categorical palette — the 30 named colors (a bg + fg pair each). Same hue
   // as light, lightness flipped (dark tinted bg + light vivid fg), saturation

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -1621,6 +1621,13 @@
           "description": "Inline workflow status, separated by a small dot and rendered in the status's own color."
         },
         {
+          "name": "color",
+          "type": "PaletteColor",
+          "required": false,
+          "default": "",
+          "description": "Optional categorical palette color for the chip fill. When set, takes\nprecedence over the default cyan chip tokens: the chip fills with the\nmatching `--color-palette-<name>-bg/-fg` pair (same contract as `Badge\ncolor` — picking a readable pair is the consumer's call). Omit for the\ndefault cyan fill. The `status` run keeps its own resolved color\nindependent of this prop, and `unavailable` still mutes the label/status\ntext over any `color`."
+        },
+        {
           "name": "href",
           "type": "string",
           "required": false,

--- a/packages/playground/src/pages/components/EntityChipDemo.tsx
+++ b/packages/playground/src/pages/components/EntityChipDemo.tsx
@@ -128,6 +128,44 @@ export function Demo() {
       </Example>
 
       <Example
+        title="Chip fill: default cyan vs `color` override"
+        description="The chip fills cyan by default. `color` (a PaletteColor) overrides the fill, independent of any `status` — same inline-injection contract as `Badge color`."
+        code={`import { EntityChip } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <>
+      <EntityChip href="/contacts/12" label="Priya Shah" />
+      <EntityChip href="/deals/9" label="Acme Corp" color="violet" />
+      <EntityChip href="/deals/14" label="Globex" color="amber" />
+      <EntityChip
+        href="/tasks/5"
+        prefix="ENG-5"
+        label="Fix login bug"
+        color="teal"
+        status={{ label: 'In progress', category: 'in_progress' }}
+      />
+    </>
+  );
+}`}
+      >
+        <InputExample width="auto">
+          <Cluster gap="sm">
+            <EntityChip href="/contacts/12" label="Priya Shah" />
+            <EntityChip href="/deals/9" label="Acme Corp" color="violet" />
+            <EntityChip href="/deals/14" label="Globex" color="amber" />
+            <EntityChip
+              href="/tasks/5"
+              prefix="ENG-5"
+              label="Fix login bug"
+              color="teal"
+              status={{ label: 'In progress', category: 'in_progress' }}
+            />
+          </Cluster>
+        </InputExample>
+      </Example>
+
+      <Example
         title="Polymorphic: link, custom `as`, button"
         description="No `as` + href renders <a>. `as={RouterLink-like}` forwards router props (to, replace, ...) with full type inference. `as` set to 'button' + onClick makes the chip an action."
         code={`import { EntityChip } from '@eocrm/design-system';


### PR DESCRIPTION
Addresses #345.

## Summary
- **New `color?: PaletteColor` prop** — consumer-configurable chip fill, Badge-precedent inline injection of the palette pair (`--entity-chip-bg/-fg/-bg-hover`). Readability of a chosen pair is the consumer's call (same contract as `Badge color`); `unavailable` still mutes text over any color; the status run's own color is fully independent.
- **Default fill is now cyan** (was stone): the raw palette cyan pair measured too faint (1.13:1 / 1.44:1), so tuned cyan literals in the token files (the #333 pattern) — light `#87d9e8`/`#005466` (1.60:1 vs white, label 5.33:1), dark `#255e6a` + palette cyan-fg (2.23:1 vs page, label 5.25:1). Reviewer independently recomputed all four ratios.
- **Bold-on-hover removed** — text-stroke rule + token deleted (zero occurrences in the built CSS); hover stays bg + brightness.
- **Status dot now takes the status's color** — the `--entity-chip-status-fg` injection moved to the chip root so the sibling dot inherits it (verified only `.status`/`.dot` consume it; `unavailable` overrides intact). Dot centering measured already exact (0.000px) — no change.

## Test plan
- EntityChip 25/25 (color injection, color+status independence, unavailable-over-color, dot color wiring); package suite 4054; typecheck/stylelint/prettier/build/pack all green (run in an isolated worktree).
- Visual validation in both themes incl. color overrides; contrast measured from real computed styles.
- Rule-8 fresh-context review: clean, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk