### PR TITLE
chore: revert release BUMP to patch after the 0.3.0 minor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ permissions:
   id-token: write # forwarded to the chained deploy-playground job
 
 env:
-  BUMP: minor
+  BUMP: patch
 
 jobs:
   quality:


### PR DESCRIPTION
One-line follow-up to #351: `BUMP` back to `patch` now that the 0.3.0 minor (DashboardCanvas columns/squares) has shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk