### PR TITLE
fix: DashboardCanvas — empty sections keep a droppable row + drop affordance; visible snap dots (#353, #354)

### DIFF
--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.module.scss
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.module.scss
@@ -86,6 +86,36 @@
   gap: var(--dashboard-canvas-gap);
 }
 
+// #353: an EMPTY container has no rows, so its rect collapses to zero height
+// and the pointer hit-test can never land in it — an empty, expanded body
+// keeps droppable height while editing is on: one row unit, floored at
+// --space-12 (a square row shrinks with width; ~18px is too thin a target
+// and too short for the drop-hint text). Any pointer y in the strip
+// resolves to some cell and the engine compacts the drop to y 0. `[inert]`
+// excludes collapsed section bodies (never drop targets, and their Accordion
+// collapse must still animate to zero); the readOnly/narrow gate matches the
+// other edit-only affordances, so view mode shows no blank strips.
+// `position: relative` is the internal anchor for `.dropHint` (Rule 4's
+// sanctioned use), which fills the whole strip independent of row geometry.
+.canvas:not([data-readonly], [data-narrow]) .container[data-dc-empty]:not([inert]) {
+  position: relative;
+  min-height: max(var(--dc-row-unit), var(--space-12));
+}
+
+// #353 drop affordance: rendered by DashboardCanvasSection inside an empty
+// body only while a move (drag or keyboard pick) is in flight.
+.dropHint {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: var(--border-width) dashed var(--dashboard-canvas-drop-preview-border);
+  border-radius: var(--radius-md);
+  color: var(--dashboard-canvas-handle-fg);
+  font-size: var(--font-size-sm);
+}
+
 // Item placement — the value is resolved in DashboardCanvasItem.tsx and
 // injected as inline custom properties (Grid.Item precedent: per-cell
 // placement is this layout family's own prop, not consumer layout). The cell

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
@@ -1123,3 +1123,132 @@ describe('DashboardCanvas below-md editing gate', () => {
     expect(root).toHaveAttribute('data-narrow');
   });
 });
+
+// --- empty sections: droppable body + drop affordance (#353) ---------------
+describe('DashboardCanvas empty sections (#353)', () => {
+  function emptyValue(): DashboardCanvasValue {
+    return {
+      items: [
+        { id: 'a', x: 0, y: 1, w: 2, h: 1 },
+        { id: 'b', x: 0, y: 0, w: 2, h: 1 },
+      ],
+      sections: [{ id: 's1', title: 'Section One', collapsed: false, items: [] }],
+    };
+  }
+
+  let restoreRects: () => void;
+  beforeEach(() => {
+    restoreRects = stubCanvasRects();
+  });
+  afterEach(() => {
+    restoreRects();
+  });
+
+  function renderCanvas(props: Partial<Parameters<typeof DashboardCanvas>[0]> = {}) {
+    const onChange = vi.fn();
+    const value = emptyValue();
+    const utils = render(
+      <DashboardCanvas
+        value={value}
+        onChange={onChange}
+        renderItem={renderItem}
+        columns={12}
+        {...props}
+      />,
+    );
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    return { ...utils, onChange, value, root };
+  }
+
+  it('stamps data-dc-empty on an empty container, not on a populated one', () => {
+    const { container } = renderCanvas();
+    expect(container.querySelector('[data-dc-container="s1"]')).toHaveAttribute('data-dc-empty');
+    expect(container.querySelector('[data-dc-container="top"]')).not.toHaveAttribute(
+      'data-dc-empty',
+    );
+  });
+
+  it('a single-jump pointer drag into the empty section commits applyMove into it', () => {
+    const { container, onChange, value, root } = renderCanvas();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    // Pointer (55,615) is inside s1's body rect; origin (45,605) → cell (1,0).
+    fireEvent.pointerMove(root, { clientX: 55, clientY: 615, pointerId: 1 });
+    fireEvent.pointerUp(root, { clientX: 55, clientY: 615, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(
+      applyMove(value, { kind: 'top' }, { kind: 'section', id: 's1' }, 'b', 1, 0),
+    );
+  });
+
+  it('a slow multi-step drag into the empty section commits the same move', () => {
+    const { container, onChange, value, root } = renderCanvas();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    for (const y of [60, 200, 400, 590, 615]) {
+      fireEvent.pointerMove(root, { clientX: 55, clientY: y, pointerId: 1 });
+    }
+    fireEvent.pointerUp(root, { clientX: 55, clientY: 615, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(
+      applyMove(value, { kind: 'top' }, { kind: 'section', id: 's1' }, 'b', 1, 0),
+    );
+  });
+
+  it('keyboard arrow-crossing enters the empty section and drops into it', () => {
+    const { container, onChange, value } = renderCanvas();
+    const a = itemEl(container, 'a');
+    a.focus();
+    fireEvent.keyDown(a, { key: 'Enter' });
+    // a sits at (0,1); the other top item ends at row 1, so one ArrowDown
+    // steps past the bottom and enters the empty Section One at y=0.
+    fireEvent.keyDown(a, { key: 'ArrowDown' });
+    expect(screen.getByRole('status')).toHaveTextContent('Entered the Section One section');
+    fireEvent.keyDown(itemEl(container, 'a'), { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(
+      applyMove(value, { kind: 'top' }, { kind: 'section', id: 's1' }, 'a', 0, 0),
+    );
+  });
+
+  it('shows the drop hint in the empty section only while a move drag is armed', () => {
+    const { container, root } = renderCanvas();
+    expect(screen.queryByText('Drop widgets here')).not.toBeInTheDocument();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 95, clientY: 60, pointerId: 1 }); // arms, stays in top
+    expect(screen.getByText('Drop widgets here')).toBeInTheDocument();
+    fireEvent.pointerUp(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(screen.queryByText('Drop widgets here')).not.toBeInTheDocument();
+  });
+
+  it('shows the drop hint during a keyboard pick, and never in readOnly', () => {
+    const { container, rerender, onChange, value } = renderCanvas();
+    fireEvent.keyDown(itemEl(container, 'b'), { key: 'Enter' });
+    expect(screen.getByText('Drop widgets here')).toBeInTheDocument();
+    fireEvent.keyDown(itemEl(container, 'b'), { key: 'Escape' });
+    expect(screen.queryByText('Drop widgets here')).not.toBeInTheDocument();
+    rerender(
+      <DashboardCanvas
+        value={value}
+        onChange={onChange}
+        renderItem={renderItem}
+        columns={12}
+        readOnly
+      />,
+    );
+    expect(screen.queryByText('Drop widgets here')).not.toBeInTheDocument();
+  });
+});

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tokens.scss
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tokens.scss
@@ -40,7 +40,9 @@
 
   // Edit-mode snap-grid dots (#344) — one dot per cell corner, hidden in
   // readOnly/narrow (DashboardCanvas.module.scss's `:not([data-readonly],
-  // [data-narrow])` gate, same one the drag cursor uses).
-  --dashboard-canvas-dot-color: var(--color-border-strong);
-  --dashboard-canvas-dot-size: 1px;
+  // [data-narrow])` gate, same one the drag cursor uses). #354: 1px
+  // border-strong dots were invisible at 100% zoom — 1.5px fg-subtle reads
+  // at arm's length in both themes while staying quieter than content.
+  --dashboard-canvas-dot-color: var(--color-fg-subtle);
+  --dashboard-canvas-dot-size: 1.5px;
 }

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
@@ -1117,6 +1117,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
           <div
             className={styles.container}
             data-dc-container="top"
+            data-dc-empty={shown.items.length === 0 ? '' : undefined}
             ref={(el) => setContainerEl(TOP_CONTAINER, el)}
           >
             {sortByPosition(shown.items).map((item) => (

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvasSection.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvasSection.tsx
@@ -80,6 +80,15 @@ export function DashboardCanvasSection({
   // draggable, not resizable, not keyboard-editable. `inert` below covers
   // consumer-rendered content too; this covers our own item chrome/wiring.
   const itemGestures: CanvasGestures = collapsed ? { ...gestures, readOnly: true } : gestures;
+  // #353: while a move (pointer drag or keyboard pick) is in flight, an empty
+  // expanded body advertises itself as a drop target. When the drag preview
+  // hovers this section the previewed item mounts here, `items` stops being
+  // empty, and the hint yields to the regular drop-preview cell.
+  const showDropHint =
+    !collapsed &&
+    items.length === 0 &&
+    !gestures.readOnly &&
+    (gestures.movingId != null || gestures.pickedId != null);
 
   return (
     <Accordion.Item
@@ -123,6 +132,7 @@ export function DashboardCanvasSection({
           <div
             className={styles.container}
             data-dc-container={String(id)}
+            data-dc-empty={items.length === 0 ? '' : undefined}
             inert={collapsed}
             ref={(el) => setContainerEl(containerRef, el)}
           >
@@ -136,6 +146,11 @@ export function DashboardCanvasSection({
                 {renderItem(item.id)}
               </DashboardCanvasItem>
             ))}
+            {showDropHint && (
+              <div className={styles.dropHint} data-dc-drop-hint aria-hidden="true">
+                {t('dashboardCanvas.dropHint')}
+              </div>
+            )}
           </div>
         </div>
       </Accordion.Content>

--- a/packages/design-system/src/components/DashboardCanvas/engine.test.ts
+++ b/packages/design-system/src/components/DashboardCanvas/engine.test.ts
@@ -390,6 +390,15 @@ describe('applyMove', () => {
     expect(next.sections[0].items).toEqual([p('a', 4, 0, 2, 2)]);
   });
 
+  it('a drop deep into an empty section compacts to y 0 (#353)', () => {
+    const v = value(
+      [p('a', 0, 0, 2, 2)],
+      [{ id: 's1', title: 'One', collapsed: false, items: [] }],
+    );
+    const next = applyMove(v, top, sec('s1'), 'a', 4, 7);
+    expect(next.sections[0].items).toEqual([p('a', 4, 0, 2, 2)]);
+  });
+
   it('returns the value unchanged when the id is not in the source container', () => {
     const v = value([p('a', 0, 0, 2, 2)]);
     expect(applyMove(v, top, top, 'nope', 0, 0)).toBe(v);

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -121,6 +121,7 @@ export const en: Messages = {
         : `${title as string} section moved`,
     enteredSection: ({ title }) => `Entered the ${title as string} section`,
     enteredTopLevel: 'Moved to the top level',
+    dropHint: 'Drop widgets here',
   },
   optionsPicker: {
     filter: 'Filter…',

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -191,6 +191,8 @@ export interface Messages {
     enteredSection: (params: { title: string }) => string;
     /** Live announcement when a picked item crosses into the top-level grid. */
     enteredTopLevel: string;
+    /** Hint inside an empty section body while a move (drag or keyboard pick) is in flight. */
+    dropHint: string;
   };
   optionsPicker: {
     /** Placeholder and aria-label for the filter (search) input. */

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -123,6 +123,7 @@ export const ru: Messages = {
         : `Секция «${title as string}» перемещена`,
     enteredSection: ({ title }) => `Перемещено в секцию «${title as string}»`,
     enteredTopLevel: 'Перемещено на верхний уровень',
+    dropHint: 'Перетащите виджеты сюда',
   },
   optionsPicker: {
     filter: 'Фильтр…',


### PR DESCRIPTION
Addresses #353 and #354.

## Summary
- **#353 (eocrm adoption blocker)** — root cause was the pointer path: an empty section body had a 0-height rect, so the drop hit-test could never resolve it (keyboard crossing was in fact working — proven live and in tests). Empty expanded containers (sections AND an empty top level) now stamp `data-dc-empty` and keep `min-height: max(var(--dc-row-unit), var(--space-12))` in edit mode (not readOnly/narrow, not collapsed/inert bodies), so there's always a real target. While a drag or keyboard pick is live, empty section bodies show a dashed i18n'd hint ("Drop widgets here", en+ru). The empty flag derives from the live preview projection, so the strip/hint flip correctly mid-gesture.
- **#354** — snap dots were near-invisible (1px `#c1c7d0`): now `1.5px` `var(--color-fg-subtle)` (theme-aware), A/B'd at 100% zoom in both themes — visible at arm's length, still quieter than content.

## Test plan
- +7 tests (single-jump + slow pointer drops into an empty section, keyboard cross+drop, empty-stamp, hint gating ×2, engine y-clamp); suite 4083. All root gates green.
- Real-browser evidence: mid-drag screenshot with the dashed empty-section target + commit into it; dot visibility judged at real scale in both themes (the original specks only read in zoomed crops — that's how they slipped review).
- Rule-8 review: clean (registered-element/hit-test chain independently traced; jsdom-limitation of the geometry fix explicitly noted — the browser screenshot is the proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk