### PR TITLE
fix: DashboardCanvas — dots mark both cell-edge lattices; demo widgets fill their cells (#356)

### DIFF
--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.module.scss
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.module.scss
@@ -41,20 +41,32 @@
   cursor: grab;
 }
 
-// Edit-mode snap grid: one dot per cell corner, so a drag/resize's snapped
-// destination is visible before you commit to it. Horizontal pitch is
+// Edit-mode snap grid (#356): dots on BOTH cell-edge lattices per axis —
+// cell STARTS (k·pitch) and cell ENDS ((k+1)·pitch − gap) — so all four
+// corners of a snapped widget land exactly on dots. Horizontal pitch is
 // fr-based — a column's outer edge repeats every (100% + gap) / N (N
 // columns, N-1 gaps between them: container width = N·colWidth + (N-1)·gap,
 // and colWidth + gap is exactly that expression / N). Vertical pitch is the
-// row unit + gap. `radial-gradient(circle at 0 0, …)` puts the dot at
-// each tile's own (0,0) corner rather than its center, so instances land
-// exactly on cell corners instead of cell centers.
-.canvas:not([data-readonly], [data-narrow]) .container {
-  background-image: radial-gradient(
-    circle at 0 0,
+// row unit + gap. One tile therefore holds FOUR dots (start/end × both
+// axes), and the whole field is shifted by −gap/2 (background-position) so
+// every dot center sits half a gap inside its tile — full circles, never
+// clipped on tile seams (`circle at 0 0` used to quarter-clip every dot).
+// Within a tile, cell start = gap/2 and cell end = 100% − gap/2.
+@function dc-dot($x, $y) {
+  @return radial-gradient(
+    circle at #{$x} #{$y},
     var(--dashboard-canvas-dot-color) var(--dashboard-canvas-dot-size),
     transparent var(--dashboard-canvas-dot-size)
   );
+}
+
+.canvas:not([data-readonly], [data-narrow]) .container {
+  $start: calc(var(--dashboard-canvas-gap) / 2);
+  $end: calc(100% - var(--dashboard-canvas-gap) / 2);
+
+  background-image:
+    dc-dot($start, $start), dc-dot($end, $start), dc-dot($start, $end), dc-dot($end, $end);
+  background-position: calc(var(--dashboard-canvas-gap) / -2) calc(var(--dashboard-canvas-gap) / -2);
   background-size: calc((100% + var(--dashboard-canvas-gap)) / var(--dc-cols, 24))
     calc(var(--dc-row-unit) + var(--dashboard-canvas-gap));
 }

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { createRef } from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -1250,5 +1252,30 @@ describe('DashboardCanvas empty sections (#353)', () => {
       />,
     );
     expect(screen.queryByText('Drop widgets here')).not.toBeInTheDocument();
+  });
+});
+
+// --- snap-dot field wiring (#356) ------------------------------------------
+// jsdom never computes CSS-module styles, so the both-lattices dot field is
+// asserted at the source level: four gradient layers (start/end × both axes)
+// plus the −gap/2 field shift that keeps every dot an unclipped full circle.
+describe('DashboardCanvas snap-dot field (#356)', () => {
+  const scss = readFileSync(resolve(import.meta.dirname, './DashboardCanvas.module.scss'), 'utf8');
+  const dotRule = /background-image:[^;]+;/.exec(scss)?.[0] ?? '';
+
+  it('paints four dot layers: cell start and cell end on both axes', () => {
+    expect(dotRule.match(/dc-dot\(/g)).toHaveLength(4);
+    expect(scss).toContain('$start: calc(var(--dashboard-canvas-gap) / 2)');
+    expect(scss).toContain('$end: calc(100% - var(--dashboard-canvas-gap) / 2)');
+    expect(dotRule).toContain('dc-dot($start, $start)');
+    expect(dotRule).toContain('dc-dot($end, $start)');
+    expect(dotRule).toContain('dc-dot($start, $end)');
+    expect(dotRule).toContain('dc-dot($end, $end)');
+  });
+
+  it('shifts the field by -gap/2 so lattice dots align with cell edges', () => {
+    expect(scss).toMatch(
+      /background-position:\s*calc\(var\(--dashboard-canvas-gap\) \/ -2\)\s*calc\(var\(--dashboard-canvas-gap\) \/ -2\)/,
+    );
   });
 });

--- a/packages/playground/src/pages/components/DashboardCanvasDemo.tsx
+++ b/packages/playground/src/pages/components/DashboardCanvasDemo.tsx
@@ -99,8 +99,11 @@ const NARROW_VALUE: DashboardCanvasValue = {
 function renderWidget(id: string | number) {
   const widget = WIDGETS[String(id)];
   if (!widget) return null;
+  // height: '100%' fills the grid cell — the "size the content to the cell"
+  // pattern from DashboardCanvas's renderItem JSDoc (#344): the widget's own
+  // edges ARE the cell edges, so resize/drag reads WYSIWYG against the dots.
   return (
-    <Card>
+    <Card style={{ height: '100%' }}>
       <Stack gap="xs">
         <Text size="sm" tone="muted">
           {widget.title}
@@ -164,8 +167,10 @@ const RECENT_EVENTS = [
 
 function renderWidget(id) {
   const w = WIDGETS[id];
+  // height: '100%' fills the grid cell (renderItem JSDoc's "size the content
+  // to the cell" pattern) — widget edges == cell edges, resizing is WYSIWYG.
   return (
-    <Card>
+    <Card style={{ height: '100%' }}>
       <Stack gap="xs">
         <Text size="sm" tone="muted">{w.title}</Text>
         <Title order={3} size="md">{w.metric}</Title>


### PR DESCRIPTION
Addresses #356.

## Summary
- **Dots on widget corners**: the dot field now paints BOTH cell-edge lattices (cell starts AND ends) via four radial-gradient layers, with the whole field shifted −gap/2 so no dot sits on a tile seam — every dot renders as a full circle (the old `circle at 0 0` quarter-clipped all of them). Every corner of every snapped widget lands on a dot: measured ≤0.042px across widths, both column counts, top-level and section bodies — against real (filled) widget edges. The gap-apart dot pairs read as structured corner ticks, not noise (both themes, 100% zoom).
- **Demo WYSIWYG resize (user request)**: the demo's shared renderWidget fills each Card to its cell (`height: 100%`, demo-side only — DS `Card` deliberately keeps no fill prop), so resizing is visible edge-to-edge and gaps stay clean; readOnly/12-col/stack examples inherit; comment points at the #344 size-to-cell guidance.

## Test plan
- +2 SCSS-wiring tests pinning the 4 layers and the −gap/2 shift; DC suite 165; full suite 4085; all gates green (reviewer re-ran independently).
- Rule-8 review: clean — the 4-layer lattice math verified by hand, tarball clean, demo commit provably playground-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk