### PR TITLE
fix: DashboardCanvas — no gestures under an open modal (portal-target guard, overlay gate, mid-gesture abort) (#362)

### DIFF
--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
@@ -1,8 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createRef } from 'react';
+import { createPortal } from 'react-dom';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { overlayStack } from '../_internal/overlay';
 import { DashboardCanvas } from './DashboardCanvas';
 import { applyMove, applyResize, reorderSection } from './engine';
 import type { DashboardCanvasValue } from './engine';
@@ -1277,5 +1279,217 @@ describe('DashboardCanvas snap-dot field (#356)', () => {
     expect(scss).toMatch(
       /background-position:\s*calc\(var\(--dashboard-canvas-gap\) \/ -2\)\s*calc\(var\(--dashboard-canvas-gap\) \/ -2\)/,
     );
+  });
+});
+
+// #362 — a Modal opened from inside renderItem portals to document.body, but
+// its events bubble through the REACT tree into the item/root handlers, so
+// without gating the canvas drags behind the open backdrop. Two layers under
+// test: the DOM-containment guard (portal-bubbled events never arm) and the
+// overlay-stack gate (no arming under an open Modal/Drawer/Lightbox, and an
+// overlay opening mid-gesture aborts it).
+describe('DashboardCanvas overlay & portal gating (#362)', () => {
+  let restoreRects: () => void;
+  beforeEach(() => {
+    restoreRects = stubCanvasRects();
+  });
+  afterEach(() => {
+    restoreRects();
+    act(() => {
+      overlayStack.unregister('test-overlay');
+    });
+  });
+
+  function renderCanvas(props: Partial<Parameters<typeof DashboardCanvas>[0]> = {}) {
+    const onChange = vi.fn();
+    const utils = render(
+      <DashboardCanvas
+        value={baseValue()}
+        onChange={onChange}
+        renderItem={renderItem}
+        columns={12}
+        {...props}
+      />,
+    );
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    return { ...utils, onChange, root };
+  }
+
+  it('a pointerdown bubbled from a portal inside renderItem never arms a drag', () => {
+    const portalRenderItem = (id: string | number) => (
+      <div data-testid={`item-${id}`}>
+        {id}
+        {id === 'b' && createPortal(<div data-testid="portal-surface" />, document.body)}
+      </div>
+    );
+    const { container, onChange, root } = renderCanvas({ renderItem: portalRenderItem });
+    fireEvent.pointerDown(screen.getByTestId('portal-surface'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).toBeNull();
+    expect(root).not.toHaveAttribute('data-dragging');
+    fireEvent.pointerUp(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('portal-bubbled moves never promote a pending press into a drag', () => {
+    const portalRenderItem = (id: string | number) => (
+      <div data-testid={`item-${id}`}>
+        {id}
+        {id === 'b' && createPortal(<div data-testid="portal-surface" />, document.body)}
+      </div>
+    );
+    const { container, onChange, root } = renderCanvas({ renderItem: portalRenderItem });
+    // Legit press on the item itself, then the move stream arrives portal-
+    // bubbled (an overlay opened on the press, before the 5px threshold).
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(screen.getByTestId('portal-surface'), {
+      clientX: 95,
+      clientY: 60,
+      pointerId: 1,
+    });
+    expect(container.querySelector('[data-dc-ghost]')).toBeNull();
+    fireEvent.pointerUp(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not arm a pointer drag while a blocking overlay is open above the canvas', () => {
+    const { container, onChange, root } = renderCanvas();
+    act(() => {
+      overlayStack.register('test-overlay', 'overlay');
+    });
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).toBeNull();
+    fireEvent.pointerUp(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not arm a keyboard pick or resize while a blocking overlay is open', () => {
+    const { container, onChange } = renderCanvas();
+    act(() => {
+      overlayStack.register('test-overlay', 'overlay');
+    });
+    const b = itemEl(container, 'b');
+    fireEvent.keyDown(b, { key: 'Enter' });
+    expect(b).not.toHaveAttribute('data-dc-picked');
+    fireEvent.keyDown(b, { key: 'ArrowRight', shiftKey: true });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('a canvas rendered INSIDE an open overlay portal keeps editing', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <div data-modal-portal-root="">
+        <DashboardCanvas
+          value={baseValue()}
+          onChange={onChange}
+          renderItem={renderItem}
+          columns={12}
+        />
+      </div>,
+    );
+    act(() => {
+      overlayStack.register('test-overlay', 'overlay');
+    });
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    fireEvent.pointerUp(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('an overlay opening mid-drag aborts the gesture without committing', () => {
+    const { container, onChange, root } = renderCanvas();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeNull();
+    act(() => {
+      overlayStack.register('test-overlay', 'overlay');
+    });
+    expect(container.querySelector('[data-dc-ghost]')).toBeNull();
+    expect(root).not.toHaveAttribute('data-dragging');
+    fireEvent.pointerUp(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not reorder a section via Shift+Arrow while a blocking overlay is open', () => {
+    const { onChange } = renderCanvas();
+    act(() => {
+      overlayStack.register('test-overlay', 'overlay');
+    });
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Collapse Section One section' }), {
+      key: 'ArrowDown',
+      shiftKey: true,
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('an overlay opening mid-pick cancels the pick', () => {
+    const { container } = renderCanvas();
+    const b = itemEl(container, 'b');
+    fireEvent.keyDown(b, { key: 'Enter' });
+    expect(b).toHaveAttribute('data-dc-picked');
+    act(() => {
+      overlayStack.register('test-overlay', 'overlay');
+    });
+    expect(itemEl(container, 'b')).not.toHaveAttribute('data-dc-picked');
+  });
+
+  it('an overlay CLOSING mid-drag does not abort the gesture', () => {
+    act(() => {
+      overlayStack.register('test-overlay', 'overlay');
+    });
+    // Canvas inside the overlay portal so editing is allowed while it's open.
+    const onChange = vi.fn();
+    const { container } = render(
+      <div data-modal-portal-root="">
+        <DashboardCanvas
+          value={baseValue()}
+          onChange={onChange}
+          renderItem={renderItem}
+          columns={12}
+        />
+      </div>,
+    );
+    const root = screen.getByRole('group', { name: 'Dashboard canvas' });
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeNull();
+    act(() => {
+      overlayStack.unregister('test-overlay');
+    });
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeNull();
+    fireEvent.pointerUp(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
@@ -10,7 +10,7 @@ import clsx from 'clsx';
 import { useTranslation } from '../../i18n/useTranslation';
 import { Accordion } from '../Accordion';
 import type { CollapseBreakpoint } from '../_internal/collapse';
-import { useFloatingSurface } from '../_internal/overlay';
+import { overlayStack, useFloatingSurface } from '../_internal/overlay';
 import { mergeAriaDescribedby, mergeRefs, sanitizeId } from '../_internal/refs';
 import {
   DASHBOARD_COLUMNS,
@@ -202,6 +202,15 @@ function capturePointer(el: Element | null, pointerId: number) {
     /* jsdom */
   }
 }
+
+/**
+ * Portal roots of the stack-registered blocking overlays (Modal / Drawer /
+ * Lightbox — the ones that inert the background). A canvas inside one of
+ * these is that overlay's CONTENT and keeps editing while it's open; a canvas
+ * outside all of them is background whenever the stack is non-empty (#362).
+ */
+const OVERLAY_HOST_SELECTOR =
+  '[data-modal-portal-root], [data-drawer-portal-root], [data-lightbox-portal-root]';
 
 // In-flight gesture bookkeeping lives in a ref (FlowCanvas precedent): the
 // pointer stream mutates it without re-render churn; `live` state below is
@@ -478,6 +487,21 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       if (section) handleToggleSection(section.id);
     };
 
+    // A Modal/Popover/DropdownMenu rendered inside renderItem portals its DOM
+    // to document.body, but its events bubble through the REACT tree into the
+    // item's and root's handlers — the press physically landed on the
+    // overlay's backdrop or panel, never the canvas (the backdrop DOES win
+    // hit-testing; FlowCanvas #290 is the same class on its background pan).
+    // A target outside the canvas root is never a gesture (#362).
+    const isPortalEvent = (event: ReactPointerEvent) =>
+      !(event.target instanceof Node) || !rootRef.current?.contains(event.target);
+
+    // A blocking overlay is open and this canvas is not inside any overlay
+    // portal — the canvas is inert background, so neither a pointer press nor
+    // a keyboard pick may arm (#362).
+    const underOpenOverlay = () =>
+      overlayStack.topDepth() > 0 && !rootRef.current?.closest(OVERLAY_HOST_SELECTOR);
+
     // --- gesture starts (single `editingEnabled` choke point: readOnly prop OR narrow width) ---
     const onMovePointerDown = (
       event: ReactPointerEvent<HTMLDivElement>,
@@ -489,6 +513,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       // the canvas until it drops or cancels. No preventDefault — clicks
       // inside item bodies pass through until the drag arms.
       if (!editingEnabled || event.button !== 0 || dragRef.current || pick) return;
+      if (isPortalEvent(event) || underOpenOverlay()) return;
       const el = event.currentTarget;
       const rect = el.getBoundingClientRect();
       dragRef.current = {
@@ -522,6 +547,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       edge: ResizeEdge,
     ) => {
       if (!editingEnabled || event.button !== 0 || dragRef.current || pick) return;
+      if (isPortalEvent(event) || underOpenOverlay()) return;
       // The handle sits inside the move-drag surface — never arm both.
       event.stopPropagation();
       dragRef.current = {
@@ -548,6 +574,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       sectionId: string | number,
     ) => {
       if (!editingEnabled || event.button !== 0 || dragRef.current || pick) return;
+      if (isPortalEvent(event) || underOpenOverlay()) return;
       // Called only from the section's dedicated grip handle (see
       // DashboardCanvasSection's remarks) — no target-based exclusion needed,
       // the toggle button and the renderSectionHeader extras never wire this.
@@ -573,9 +600,14 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
 
       if (drag.kind === 'move') {
         if (!drag.moved) {
+          // Portal-bubbled moves never ARM: an overlay opened on the press
+          // itself (before the 5px threshold) must not have its backdrop
+          // moves promote the pending drag. Once armed, capture retargets
+          // the stream to the root, so this can't misfire mid-drag.
           if (
+            isPortalEvent(event) ||
             Math.abs(event.clientX - drag.startX) + Math.abs(event.clientY - drag.startY) <
-            DRAG_ACTIVATION_PX
+              DRAG_ACTIVATION_PX
           ) {
             return;
           }
@@ -667,9 +699,11 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
 
       // Section band reorder — vertical only.
       if (!drag.moved) {
+        // Same portal-arming guard as the move branch above.
         if (
+          isPortalEvent(event) ||
           Math.abs(event.clientX - drag.startX) + Math.abs(event.clientY - drag.startY) <
-          DRAG_ACTIVATION_PX
+            DRAG_ACTIVATION_PX
         ) {
           return;
         }
@@ -875,6 +909,14 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
         }
         return;
       }
+      // A blocking overlay above the canvas gates the whole keyboard editing
+      // surface, not just the pick: `inert` already makes the cells
+      // unfocusable in the normal page case — this catches programmatic-focus
+      // edges (#362). The exemption is "inside ANY overlay host", so a canvas
+      // in a Drawer under a stacked Modal can still arm a fresh keyboard pick
+      // (pointer can't reach it; the mid-gesture abort covers post-arm opens)
+      // — deliberate residual.
+      if (underOpenOverlay()) return;
       if (activate) {
         event.preventDefault(); // Space must not scroll the page
         setPick({
@@ -918,6 +960,10 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       sectionId: string | number,
     ) => {
       if (!event.shiftKey || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) return;
+      // Same keyboard-editing gate as onItemKeyDown (#362) — the focus-reclaim
+      // effect programmatically focuses this very trigger, so inert alone
+      // can't be relied on to keep keys out.
+      if (underOpenOverlay()) return;
       // Composed onto Accordion.Trigger's own onKeyDown (it runs ours first);
       // the target is always the trigger button itself — extras and the grip
       // handle live outside it, so there's nothing to exclude here anymore.
@@ -1025,6 +1071,25 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       observer.observe(root);
       return () => observer.disconnect();
     }, [stackBelow]);
+
+    // An overlay opening mid-gesture aborts it (#362): pointer capture keeps
+    // the move stream flowing to the root even after a backdrop covers the
+    // canvas, so without this the drag would keep going under the modal.
+    // Depth is compared against the stack at gesture start, so a canvas
+    // already INSIDE an open overlay is unaffected by its own host; a close
+    // (depth shrinking) never aborts. Same restore as Escape.
+    useEffect(() => {
+      if (!dragging && !pick) return undefined;
+      const baseDepth = overlayStack.topDepth();
+      return overlayStack._subscribe(() => {
+        if (overlayStack.topDepth() <= baseDepth) return;
+        dragRef.current = null;
+        setLive(null);
+        if (pick) cancelPick();
+      });
+      // cancelPick is re-created per render but only reads current state.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [dragging, pick]);
 
     // readOnly OR the narrow-width gate flipping editing off mid-gesture
     // aborts it — same restore as Escape.

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
@@ -1,4 +1,5 @@
 import { createRef } from 'react';
+import { createPortal } from 'react-dom';
 import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { FlowCanvas } from './FlowCanvas';
@@ -474,6 +475,40 @@ describe('FlowCanvas selection & intents', () => {
     fireEvent.pointerUp(node, { pointerId: 1 });
     expect(node.getAttribute('data-selected')).toBe('true');
     expect(onSelectionChange).toHaveBeenCalledWith({ type: 'node', id: 'open' });
+  });
+
+  it('a pointerdown bubbled from a portal inside a node adornment never selects or drags (#362)', () => {
+    // A Modal/Popover opened from a node's adornment portals to document.body
+    // but bubbles through the REACT tree into the node's pointerdown handler.
+    const onSelectionChange = vi.fn();
+    const nodes: FlowCanvasNode[] = [
+      {
+        id: 'open',
+        label: 'Open',
+        position: { x: 0, y: 0 },
+        adornment: createPortal(<div data-testid="portal-surface" />, document.body),
+      },
+    ];
+    render(<FlowCanvas nodes={nodes} edges={[]} onSelectionChange={onSelectionChange} />);
+    fireEvent.pointerDown(screen.getByTestId('portal-surface'), { pointerId: 1, button: 0 });
+    fireEvent.pointerUp(screen.getByLabelText('Open'), { pointerId: 1 });
+    expect(screen.getByLabelText('Open').getAttribute('data-selected')).toBeNull();
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
+  it('a pointerdown bubbled from a portal inside an edge-label chip never selects (#362)', () => {
+    const onSelectionChange = vi.fn();
+    const edges: FlowCanvasEdge[] = [
+      {
+        id: 't1',
+        from: 'open',
+        to: 'done',
+        label: createPortal(<div data-testid="chip-portal" />, document.body),
+      },
+    ];
+    render(<FlowCanvas nodes={NODES} edges={edges} onSelectionChange={onSelectionChange} />);
+    fireEvent.pointerDown(screen.getByTestId('chip-portal'), { pointerId: 1, button: 0 });
+    expect(onSelectionChange).not.toHaveBeenCalled();
   });
 
   it('click selects an edge', () => {

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
@@ -1452,6 +1452,15 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
   const handleNodePointerDown = useCallback(
     (id: string, event: ReactPointerEvent<HTMLDivElement>) => {
       if (event.button !== 0) return;
+      // Portal-bubbled press (#290 class, #362): a Modal/Popover opened from
+      // a node's label/adornment renders into document.body but its events
+      // bubble through the REACT tree into this handler — the press landed on
+      // the overlay, not the node. Never a select/drag. Same guard on the
+      // edge/handle/endpoint handlers below and the edge-label chip. The
+      // overlay-stack arming gate + mid-gesture abort stay DashboardCanvas-
+      // only for now (#362): here, arming under an overlay is already blocked
+      // by inert + this guard.
+      if (!(event.target instanceof Node) || !rootRef.current?.contains(event.target)) return;
       event.stopPropagation();
       cancelKeyboardConnect(); // the user visibly moved on to another node
       const current = selectionRef.current;
@@ -1493,6 +1502,7 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
   const handleHandlePointerDown = useCallback(
     (id: string, event: ReactPointerEvent<HTMLElement>) => {
       if (event.button !== 0 || !canConnect) return;
+      if (!(event.target instanceof Node) || !rootRef.current?.contains(event.target)) return;
       // One draw at a time (matching the drag guard): a second pointer
       // grabbing a handle mid-draw must not hijack the first ghost. A
       // keyboard connect, by contrast, is superseded by the new draw.
@@ -1519,6 +1529,7 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
   const handleEndpointPointerDown = useCallback(
     (edgeId: string, end: 'source' | 'target', event: ReactPointerEvent<Element>) => {
       if (event.button !== 0 || !canConnect) return;
+      if (!(event.target instanceof Node) || !rootRef.current?.contains(event.target)) return;
       event.stopPropagation();
       if (connectRef.current?.mode === 'pointer') return; // one gesture at a time
       const edge = edges.find((e) => e.id === edgeId);
@@ -1545,6 +1556,7 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
   const handleEdgePointerDown = useCallback(
     (id: string, event: ReactPointerEvent<SVGPathElement>) => {
       if (event.button !== 0) return;
+      if (!(event.target instanceof Node) || !rootRef.current?.contains(event.target)) return;
       event.stopPropagation();
       cancelKeyboardConnect(); // the user visibly moved on to an edge
       const current = selectionRef.current;
@@ -1783,6 +1795,9 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
               style={{ left: geometry.midpoint.x, top: geometry.midpoint.y }}
               onPointerDown={(event) => {
                 if (event.button !== 0) return;
+                // Same portal-press guard as handleNodePointerDown (#362).
+                if (!(event.target instanceof Node) || !rootRef.current?.contains(event.target))
+                  return;
                 event.stopPropagation();
                 cancelKeyboardConnect(); // same abandon rule as handleEdgePointerDown
                 // Same re-select guard as handleEdgePointerDown.

--- a/packages/playground/src/pages/components/DashboardCanvasDemo.tsx
+++ b/packages/playground/src/pages/components/DashboardCanvasDemo.tsx
@@ -2,8 +2,12 @@ import { useState } from 'react';
 import {
   Accordion,
   Badge,
+  Button,
   Card,
+  Cluster,
   DashboardCanvas,
+  Input,
+  Modal,
   Stack,
   Text,
   Title,
@@ -96,6 +100,62 @@ const NARROW_VALUE: DashboardCanvasValue = {
   ],
 };
 
+const CONFIG_VALUE: DashboardCanvasValue = {
+  items: [
+    { id: 'revenue', x: 0, y: 0, w: 12, h: 4 },
+    { id: 'deals', x: 12, y: 0, w: 12, h: 4 },
+  ],
+  sections: [],
+};
+
+// A widget whose card hosts its own config Modal — the modal is a React child
+// of the draggable cell (its portal renders to document.body, but its events
+// bubble through the REACT tree into the cell). The canvas must not treat
+// presses inside the open modal as drag starts (#362).
+function ConfigurableWidget({ id }: { id: string }) {
+  const [open, setOpen] = useState(false);
+  const widget = WIDGETS[id];
+  if (!widget) return null;
+  return (
+    <Card style={{ height: '100%' }}>
+      <Stack gap="xs">
+        <Cluster justify="between" gap="sm">
+          <Text size="sm" tone="muted">
+            {widget.title}
+          </Text>
+          <Button size="xs" variant="ghost" onClick={() => setOpen(true)}>
+            Configure
+          </Button>
+        </Cluster>
+        <Title order={3} size="md">
+          {widget.metric}
+        </Title>
+        <Text size="sm" tone="muted">
+          {widget.sub}
+        </Text>
+      </Stack>
+      <Modal open={open} onOpenChange={setOpen} size="sm">
+        <Modal.Header>Configure “{widget.title}”</Modal.Header>
+        <Modal.Body>
+          <Stack gap="md">
+            <Input defaultValue={widget.title} aria-label="Widget title" />
+            <Text size="sm" tone="muted">
+              While this modal is open the canvas behind it must not react to pointer or keyboard
+              gestures — try dragging across the backdrop.
+            </Text>
+          </Stack>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="secondary">Cancel</Button>
+          </Modal.Close>
+          <Button onClick={() => setOpen(false)}>Save</Button>
+        </Modal.Footer>
+      </Modal>
+    </Card>
+  );
+}
+
 function renderWidget(id: string | number) {
   const widget = WIDGETS[String(id)];
   if (!widget) return null;
@@ -132,6 +192,7 @@ export function DashboardCanvasDemo() {
   const [value, setValue] = useState<DashboardCanvasValue>(INITIAL_VALUE);
   const [twelveValue, setTwelveValue] = useState<DashboardCanvasValue>(TWELVE_COL_VALUE);
   const [narrowValue, setNarrowValue] = useState<DashboardCanvasValue>(NARROW_VALUE);
+  const [configValue, setConfigValue] = useState<DashboardCanvasValue>(CONFIG_VALUE);
 
   const renderSectionHeader = (id: string | number) => (
     <Badge tone="neutral">{value.sections.find((s) => s.id === id)?.items.length ?? 0}</Badge>
@@ -264,6 +325,57 @@ export function Demo() {
           value={twelveValue}
           onChange={setTwelveValue}
           renderItem={renderWidget}
+        />
+      </Example>
+
+      <Example
+        title="Widget config modal"
+        description="The eocrm edit-mode pattern: each widget opens its own settings Modal from a button inside renderItem. The modal portals to document.body, but its React parent is the draggable cell — the canvas ignores pointer events whose DOM target lives outside it (portal-bubbled), and an overlay opening above the canvas aborts any in-flight gesture, so the dashboard is inert behind the backdrop (#362)."
+        code={`import { useState } from 'react';
+import { Button, Card, Cluster, DashboardCanvas, Input, Modal, Stack, Text, Title } from '@eocrm/design-system';
+
+function ConfigurableWidget({ id }) {
+  const [open, setOpen] = useState(false);
+  const widget = WIDGETS[id];
+  return (
+    <Card style={{ height: '100%' }}>
+      <Stack gap="xs">
+        <Cluster justify="between" gap="sm">
+          <Text size="sm" tone="muted">{widget.title}</Text>
+          <Button size="xs" variant="ghost" onClick={() => setOpen(true)}>Configure</Button>
+        </Cluster>
+        <Title order={3} size="md">{widget.metric}</Title>
+      </Stack>
+      {/* Rendered inside the draggable cell — the canvas must stay inert behind it. */}
+      <Modal open={open} onOpenChange={setOpen} size="sm">
+        <Modal.Header>Configure “{widget.title}”</Modal.Header>
+        <Modal.Body>
+          <Input defaultValue={widget.title} aria-label="Widget title" />
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close><Button variant="secondary">Cancel</Button></Modal.Close>
+          <Button onClick={() => setOpen(false)}>Save</Button>
+        </Modal.Footer>
+      </Modal>
+    </Card>
+  );
+}
+
+export function Demo() {
+  const [value, setValue] = useState(configLayout);
+  return (
+    <DashboardCanvas
+      value={value}
+      onChange={setValue}
+      renderItem={(id) => <ConfigurableWidget id={String(id)} />}
+    />
+  );
+}`}
+      >
+        <DashboardCanvas
+          value={configValue}
+          onChange={setConfigValue}
+          renderItem={(id) => <ConfigurableWidget id={String(id)} />}
         />
       </Example>
 


### PR DESCRIPTION
Addresses #362.

## Summary
- **Proven root cause (real-browser tracing)**: a Modal opened from `renderItem` portals its DOM to `document.body`, but its React synthetic events bubble through the JSX tree into the host widget's pointer handlers — backdrop presses armed real drags of the widget behind the modal (ghost + commit, modal open). The backdrop itself was never the hole.
- **Three layers in DashboardCanvas**: (1) containment guard — events whose DOM target is outside the canvas root never arm or promote a gesture (all pointerdown sites + the pre-threshold branch); (2) overlay gate — no pointer press, keyboard pick, Shift+resize, or header band-reorder while a blocking overlay (Modal/Drawer/Lightbox) is open above the canvas — a canvas rendered INSIDE an open overlay keeps editing, and non-blocking overlays (Popover/Dropdown/Select) never freeze it; (3) mid-gesture abort when overlay depth grows past the arm-time baseline (closes never abort). Escape stays with the modal (the canvas only holds a floating-surface registration during live gestures, which can no longer exist under a modal).
- **FlowCanvas shared the hole**: all five consumer-content pointerdown sites (node/edge/handle/endpoint/edge-label chip) got the same containment guard; the overlay gate/abort machinery is deliberately DashboardCanvas-only (documented in-code — FlowCanvas arming is already inert-blocked in the page case).
- Demo gains a realistic widget-config-modal example (the exact eocrm pattern). Pre-existing residuals found by review are tracked in #363.

## Test plan
- +11 tests total (real `createPortal` bubbling, real `overlayStack.register` — no mocks): portal-press/promote no-arm, pointer+keyboard+header overlay gates, canvas-inside-overlay exemption, mid-drag/mid-pick aborts, overlay-close no-abort, FlowCanvas chip+adornment guards. DC+FlowCanvas 248; full suite 4096; Modal suite untouched and green; all root gates green.
- Browser-verified: drag blocked while the config modal is open, drag works after close, Escape closes the modal with no phantom canvas cancel.
- Rule-8 adversarial review (fable): 2 Important one-liners found and fixed; second-pass expectations met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk