### PR TITLE
fix: DashboardCanvas/FlowCanvas — clear stale pending presses (pointerId-gated); guard dblclick open intents (#363)

### DIFF
--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.test.tsx
@@ -1362,6 +1362,65 @@ describe('DashboardCanvas overlay & portal gating (#362)', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it('a pointerup swallowed outside the React tree clears a pending press (#363)', () => {
+    const { container, onChange, root } = renderCanvas();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    // The release lands on an out-of-tree overlay — the root handlers never
+    // see it; only the window-capture listener does.
+    fireEvent.pointerUp(document.body, { pointerId: 1 });
+    // A buttonless hover must not resume the stale press (a mouse reuses
+    // its pointerId)…
+    fireEvent.pointerMove(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+    // …and the next real press arms normally.
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerMove(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeNull();
+    fireEvent.pointerUp(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("a second pointer's release does not discard another pointer's pending press (#363)", () => {
+    const { container, onChange, root } = renderCanvas();
+    fireEvent.pointerDown(itemEl(container, 'b'), {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    });
+    // Stray touch/palm taps and releases elsewhere.
+    fireEvent.pointerUp(document.body, { pointerId: 2 });
+    // Pointer 1 is still down — its move past the threshold must arm.
+    fireEvent.pointerMove(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(container.querySelector('[data-dc-ghost]')).not.toBeNull();
+    fireEvent.pointerUp(root, { clientX: 95, clientY: 60, pointerId: 1 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('a swallowed release also clears a pending section press (#363)', () => {
+    const { container, root } = renderCanvas();
+    fireEvent.pointerDown(sectionHandle(container, 's1'), {
+      clientX: 80,
+      clientY: 70,
+      pointerId: 1,
+      button: 0,
+    });
+    fireEvent.pointerUp(document.body, { pointerId: 1 });
+    fireEvent.pointerMove(root, { clientX: 80, clientY: 200, pointerId: 1 });
+    expect(root).not.toHaveAttribute('data-dragging');
+  });
+
   it('does not arm a pointer drag while a blocking overlay is open above the canvas', () => {
     const { container, onChange, root } = renderCanvas();
     act(() => {

--- a/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
+++ b/packages/design-system/src/components/DashboardCanvas/DashboardCanvas.tsx
@@ -502,6 +502,30 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
     const underOpenOverlay = () =>
       overlayStack.topDepth() > 0 && !rootRef.current?.closest(OVERLAY_HOST_SELECTOR);
 
+    // A pending press has no capture (capture waits for the 5px arm), so a
+    // pointerup swallowed by an overlay OUTSIDE the React tree never reaches
+    // the root handlers and would leave dragRef stale — hijacking later
+    // hovers into a buttonless drag (a mouse reuses its pointerId) or
+    // blocking arming outright (touch ids retire) (#363). Window CAPTURE
+    // listeners see the physical release before any stopPropagation below;
+    // clearing an UNMOVED press is behavior-preserving (unmoved presses
+    // commit nothing), and a moved drag is capture-owned — its own root
+    // handlers clear the ref before this check could matter.
+    const armPendingRelease = (drag: MoveDrag | SectionDrag) => {
+      const release = (event: PointerEvent) => {
+        // Only the press's OWN pointer resolves it — a stray second pointer
+        // (palm/touch) releasing elsewhere must neither clear a still-live
+        // press nor detach these listeners (that would reopen the swallowed-
+        // release hole for the own pointer).
+        if (event.pointerId !== drag.pointerId) return;
+        window.removeEventListener('pointerup', release, true);
+        window.removeEventListener('pointercancel', release, true);
+        if (dragRef.current === drag && !drag.moved) dragRef.current = null;
+      };
+      window.addEventListener('pointerup', release, true);
+      window.addEventListener('pointercancel', release, true);
+    };
+
     // --- gesture starts (single `editingEnabled` choke point: readOnly prop OR narrow width) ---
     const onMovePointerDown = (
       event: ReactPointerEvent<HTMLDivElement>,
@@ -516,7 +540,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       if (isPortalEvent(event) || underOpenOverlay()) return;
       const el = event.currentTarget;
       const rect = el.getBoundingClientRect();
-      dragRef.current = {
+      const drag: MoveDrag = {
         kind: 'move',
         pointerId: event.pointerId,
         id: placement.id,
@@ -536,6 +560,8 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
         previewKey: null,
         preview: null,
       };
+      dragRef.current = drag;
+      armPendingRelease(drag);
       // No capture yet — capture retargets the eventual click to the root,
       // so it must wait until the drag arms (clicks pass through until then).
     };
@@ -580,7 +606,7 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
       // the toggle button and the renderSectionHeader extras never wire this.
       const fromIndex = value.sections.findIndex((section) => section.id === sectionId);
       if (fromIndex === -1) return;
-      dragRef.current = {
+      const drag: SectionDrag = {
         kind: 'section',
         pointerId: event.pointerId,
         id: sectionId,
@@ -590,6 +616,8 @@ export const DashboardCanvas = forwardRef<HTMLDivElement, DashboardCanvasProps>(
         moved: false,
         slot: fromIndex,
       };
+      dragRef.current = drag;
+      armPendingRelease(drag);
     };
 
     // --- pointer stream (root-level; capture retargeting still bubbles here) ---

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
@@ -511,6 +511,36 @@ describe('FlowCanvas selection & intents', () => {
     expect(onSelectionChange).not.toHaveBeenCalled();
   });
 
+  it('a double-click bubbled from a portal inside a node adornment never fires onNodeOpen (#363)', () => {
+    const onNodeOpen = vi.fn();
+    const nodes: FlowCanvasNode[] = [
+      {
+        id: 'open',
+        label: 'Open',
+        position: { x: 0, y: 0 },
+        adornment: createPortal(<div data-testid="portal-surface" />, document.body),
+      },
+    ];
+    render(<FlowCanvas nodes={nodes} edges={[]} onNodeOpen={onNodeOpen} />);
+    fireEvent.doubleClick(screen.getByTestId('portal-surface'));
+    expect(onNodeOpen).not.toHaveBeenCalled();
+  });
+
+  it('a double-click bubbled from a portal inside an edge-label chip never fires onEdgeOpen (#363)', () => {
+    const onEdgeOpen = vi.fn();
+    const edges: FlowCanvasEdge[] = [
+      {
+        id: 't1',
+        from: 'open',
+        to: 'done',
+        label: createPortal(<div data-testid="chip-portal" />, document.body),
+      },
+    ];
+    render(<FlowCanvas nodes={NODES} edges={edges} onEdgeOpen={onEdgeOpen} />);
+    fireEvent.doubleClick(screen.getByTestId('chip-portal'));
+    expect(onEdgeOpen).not.toHaveBeenCalled();
+  });
+
   it('click selects an edge', () => {
     render(<FlowCanvas nodes={NODES} edges={EDGES} />);
     const edge = screen.getByLabelText('From Open to Done');

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.tsx
@@ -1565,8 +1565,23 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
     },
     [setSelection, cancelKeyboardConnect],
   );
-  const handleNodeDoubleClick = useCallback((id: string) => onNodeOpen?.(id), [onNodeOpen]);
-  const handleEdgeDoubleClick = useCallback((id: string) => onEdgeOpen?.(id), [onEdgeOpen]);
+  // Same portal-press guard as the pointerdown handlers above (#362/#363): a
+  // backdrop double-click on a modal opened from a node adornment / edge
+  // label bubbles React-wise into these — never an open intent.
+  const handleNodeDoubleClick = useCallback(
+    (id: string, event: ReactMouseEvent<Element>) => {
+      if (!(event.target instanceof Node) || !rootRef.current?.contains(event.target)) return;
+      onNodeOpen?.(id);
+    },
+    [onNodeOpen],
+  );
+  const handleEdgeDoubleClick = useCallback(
+    (id: string, event: ReactMouseEvent<Element>) => {
+      if (!(event.target instanceof Node) || !rootRef.current?.contains(event.target)) return;
+      onEdgeOpen?.(id);
+    },
+    [onEdgeOpen],
+  );
 
   /** Client (screen) coordinates → canvas coordinates, inverting the viewport transform. */
   const toCanvasPoint = useCallback(
@@ -1806,7 +1821,7 @@ export const FlowCanvas = forwardRef<HTMLDivElement, FlowCanvasProps>(function F
               }}
               onDoubleClick={(event) => {
                 event.stopPropagation();
-                onEdgeOpen?.(edge.id);
+                handleEdgeDoubleClick(edge.id, event);
               }}
             >
               {edge.label}

--- a/packages/design-system/src/components/FlowCanvas/FlowEdge.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowEdge.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import type { PointerEvent as ReactPointerEvent } from 'react';
+import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
 import type { EdgeGeometry } from './edgePath';
 import type { FlowCanvasEdge } from './types';
 import styles from './FlowCanvas.module.scss';
@@ -14,7 +14,7 @@ interface FlowEdgeProps {
   roleDescription: string;
   registerEl: (id: string, el: SVGPathElement | null) => void;
   onEdgePointerDown: (id: string, event: ReactPointerEvent<SVGPathElement>) => void;
-  onEdgeDoubleClick: (id: string) => void;
+  onEdgeDoubleClick: (id: string, event: ReactMouseEvent<SVGPathElement>) => void;
 }
 
 /** Internal: one edge — visible path plus a wide transparent hit/focus path. */
@@ -50,7 +50,7 @@ export const FlowEdge = memo(function FlowEdge({
         onPointerDown={(event) => onEdgePointerDown(edge.id, event)}
         onDoubleClick={(event) => {
           event.stopPropagation();
-          onEdgeDoubleClick(edge.id);
+          onEdgeDoubleClick(edge.id, event);
         }}
       />
     </g>

--- a/packages/design-system/src/components/FlowCanvas/FlowNode.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowNode.tsx
@@ -1,5 +1,9 @@
 import { memo } from 'react';
-import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
+import type {
+  CSSProperties,
+  MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
+} from 'react';
 import type { FlowCanvasNode, FlowCanvasPoint } from './types';
 import styles from './FlowCanvas.module.scss';
 
@@ -14,7 +18,7 @@ interface FlowNodeProps {
   roleDescription: string;
   registerEl: (id: string, el: HTMLDivElement | null) => void;
   onNodePointerDown: (id: string, event: ReactPointerEvent<HTMLDivElement>) => void;
-  onNodeDoubleClick: (id: string) => void;
+  onNodeDoubleClick: (id: string, event: ReactMouseEvent<HTMLDivElement>) => void;
   onHandlePointerDown: (id: string, event: ReactPointerEvent<HTMLElement>) => void;
 }
 
@@ -51,7 +55,7 @@ export const FlowNode = memo(function FlowNode({
       onPointerDown={(event) => onNodePointerDown(node.id, event)}
       onDoubleClick={(event) => {
         event.stopPropagation();
-        onNodeDoubleClick(node.id);
+        onNodeDoubleClick(node.id, event);
       }}
     >
       <span className={styles.nodeLabel}>{node.label}</span>


### PR DESCRIPTION
Addresses #363 (the pre-existing residuals surfaced by #362's review).

## Summary
- **Stale pending press**: a sub-threshold press holds no pointer capture, so a release swallowed by an out-of-tree overlay left `dragRef` stale — hijacking later hovers into a buttonless drag (mouse pointer-ID reuse, browser-reproduced) or blocking arming (touch). Fix: window-CAPTURE `pointerup`/`pointercancel` listeners armed only while a pending press exists, self-removing on the press's OWN pointer's release (pointerId-gated — a stray second pointer neither clears the press nor detaches the listeners), clearing only the identical unmoved drag object (moved drags are capture-owned). Browser-proven on both sides of the fix. FlowCanvas audited: exempt — every gesture captures at pointerdown (or stores no pending state).
- **Unguarded dblclick**: FlowCanvas node/edge/chip `onDoubleClick` open intents now carry the #362 portal-containment guard.

## Test plan
- +5 tests (swallowed-own-release clears move + section presses; cross-pointer release does NOT clear a live press and the drag still arms — the reviewer-reproduced Critical; portal dblclick on node adornment + edge chip). DC+FC 253; full suite 4101; all root gates green.
- Rule-8 review: one Critical (missing pointerId filter) found via independent reproduction, fixed with the reviewer-specified gate + regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk