### PR TITLE
feat: Tabs trailing action — button-like "+ new" pseudo-tab (#366)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -2056,6 +2056,7 @@ const [tab, setTab] = useState('overview');
 - `orientation`: `horizontal` (default — sliding underline, ArrowLeft/Right) or `vertical` (stacked master–detail rail: full-width rows, left accent bar + tinted active row, ArrowUp/Down). Put a vertical strip in a `Split`'s `aside` beside its detail panel.
 - `panelIdPrefix`: optional. When set, each tab gets `aria-controls="${prefix}-${itemId}-panel"`. Set this if you render the panels in the DOM and want assistive tech to follow the link.
 - The active-tab underline slides between tabs when `activeId` changes. Respects `prefers-reduced-motion: reduce`.
+- `action?: { label, icon?, onClick, disabled? }` renders a `+ New entity`-style button-like pseudo-tab after the tab items, inside the same strip — tab-shaped but visibly muted, NOT `role="tab"`, never selected, skipped by arrow-key roving (reachable via `Tab` instead), and the sliding indicator never targets it. It only fires `onClick`; if the click should change `activeId`, do that yourself in the handler (e.g. append + select a new tab). Known, accepted a11y tradeoff: like the `TabItem.actions` button, this leaves one non-`"tab"` child in the `role="tablist"` container (an `aria-required-children` deviation) — a real `<button>` still announces correctly to assistive tech regardless of its parent's role.
 
 ### `<Accordion>` — vertically-stacked collapsible panels
 

--- a/packages/design-system/src/components/Tabs/Tabs.module.scss
+++ b/packages/design-system/src/components/Tabs/Tabs.module.scss
@@ -53,6 +53,40 @@
   color: var(--tabs-tab-fg-active);
 }
 
+// Trailing action button (`action` prop) — sits after the tabs in the same
+// flex row so it lines up as the last item in the strip. Same rhythm as
+// `.tab` (height/padding/typography) but deliberately more muted — it's a
+// button, not a tab, and must read as visually distinct even before hover.
+.action {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tabs-tab-gap);
+  padding: var(--tabs-tab-padding-y) var(--tabs-tab-padding-x);
+  border: none;
+  background: transparent;
+  color: var(--tabs-action-fg);
+  font-family: inherit;
+  font-size: var(--tabs-tab-font-size);
+  font-weight: var(--tabs-tab-font-weight);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+
+  &:hover:not(:disabled) {
+    color: var(--tabs-tab-fg-hover);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 var(--ring-width) var(--tabs-tab-ring);
+    border-radius: var(--tabs-tab-radius);
+  }
+
+  &:disabled {
+    opacity: var(--tabs-action-opacity-disabled);
+    cursor: not-allowed;
+  }
+}
+
 .icon {
   display: inline-flex;
   align-items: center;
@@ -168,6 +202,24 @@
 
   .active {
     background: var(--tabs-vertical-tab-bg-active);
+  }
+
+  // The action button follows the same axis as the tabs: a full-width row
+  // instead of an inline flex item. Never gets the active tint — it's never
+  // selected.
+  .action {
+    width: 100%;
+    justify-content: flex-start;
+    padding: var(--tabs-vertical-tab-padding-y) var(--tabs-vertical-tab-padding-x);
+    border-radius: var(--tabs-vertical-tab-radius);
+    text-align: left;
+    transition:
+      color var(--transition-fast),
+      background var(--transition-fast);
+
+    &:hover:not(:disabled) {
+      background: var(--tabs-vertical-tab-bg-hover);
+    }
   }
 
   .indicator {

--- a/packages/design-system/src/components/Tabs/Tabs.test.tsx
+++ b/packages/design-system/src/components/Tabs/Tabs.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, useEffect, useState } from 'react';
-import { Tabs, type TabItem } from './Tabs';
+import { Tabs, type TabItem, type TabsAction } from './Tabs';
 
 const items: TabItem[] = [
   { id: 'a', label: 'Overview' },
@@ -572,5 +572,122 @@ describe('Tabs', () => {
     expect(act).toBeInTheDocument();
     expect(securityTab).not.toContainElement(act);
     expect(screen.getByRole('tablist')).toHaveAttribute('aria-orientation', 'vertical');
+  });
+});
+
+describe('Tabs action', () => {
+  const action: TabsAction = { label: 'New deal', onClick: vi.fn() };
+
+  it('renders the action as a plain button, not a tab', () => {
+    render(<Tabs items={items} activeId="a" onChange={vi.fn()} action={action} />);
+    const btn = screen.getByRole('button', { name: 'New deal' });
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toHaveAttribute('role', 'tab');
+    expect(screen.getAllByRole('tab')).toHaveLength(3);
+  });
+
+  it('sets type="button"', () => {
+    render(<Tabs items={items} activeId="a" onChange={vi.fn()} action={action} />);
+    expect(screen.getByRole('button', { name: 'New deal' })).toHaveAttribute('type', 'button');
+  });
+
+  it('renders the action after all tab items in document order', () => {
+    render(<Tabs items={items} activeId="a" onChange={vi.fn()} action={action} />);
+    const tabs = screen.getAllByRole('tab');
+    const btn = screen.getByRole('button', { name: 'New deal' });
+    const last = tabs[tabs.length - 1];
+    expect(last.compareDocumentPosition(btn) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('does not render an action button when the prop is omitted', () => {
+    render(<Tabs items={items} activeId="a" onChange={vi.fn()} />);
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+
+  it('fires action.onClick and NOT onChange when clicked', async () => {
+    const onClick = vi.fn();
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Tabs
+        items={items}
+        activeId="a"
+        onChange={onChange}
+        action={{ label: 'New deal', onClick }}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'New deal' }));
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('leaves activeId/aria-selected and the indicator untouched after clicking the action', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    const { container } = render(
+      <Tabs items={items} activeId="a" onChange={onChange} action={action} />,
+    );
+    const indicator = container.querySelector('[class*="indicator"]') as HTMLElement;
+    const before = indicator.getAttribute('style');
+    await user.click(screen.getByRole('button', { name: 'New deal' }));
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true');
+    expect(indicator.getAttribute('style')).toBe(before);
+  });
+
+  it('disables the button and blocks onClick when action.disabled is true', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Tabs
+        items={items}
+        activeId="a"
+        onChange={vi.fn()}
+        action={{ label: 'New deal', onClick, disabled: true }}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: 'New deal' });
+    expect(btn).toBeDisabled();
+    await user.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('renders the icon aria-hidden next to the label', () => {
+    render(
+      <Tabs
+        items={items}
+        activeId="a"
+        onChange={vi.fn()}
+        action={{ label: 'New deal', icon: <svg data-testid="action-icon" />, onClick: vi.fn() }}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: 'New deal' });
+    const icon = within(btn).getByTestId('action-icon');
+    expect(icon.closest('[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it('is skipped by arrow-key roving — ArrowRight from the last tab wraps to the first tab', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Tabs items={items} activeId="c" onChange={onChange} action={action} />);
+    screen.getByRole('tab', { name: 'Notes' }).focus();
+    await user.keyboard('{ArrowRight}');
+    expect(onChange).toHaveBeenLastCalledWith('a');
+    expect(document.activeElement).toBe(screen.getByRole('tab', { name: 'Overview' }));
+  });
+
+  it('is reachable via the Tab key after the active tab, outside the roving tabindex', async () => {
+    const user = userEvent.setup();
+    render(<Tabs items={items} activeId="a" onChange={vi.fn()} action={action} />);
+    screen.getByRole('tab', { name: 'Overview' }).focus();
+    await user.tab();
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'New deal' }));
+  });
+
+  it('renders in vertical orientation without becoming a tab', () => {
+    render(
+      <Tabs items={items} activeId="a" onChange={vi.fn()} orientation="vertical" action={action} />,
+    );
+    expect(screen.getByRole('button', { name: 'New deal' })).toBeInTheDocument();
+    expect(screen.getAllByRole('tab')).toHaveLength(3);
   });
 });

--- a/packages/design-system/src/components/Tabs/Tabs.tokens.scss
+++ b/packages/design-system/src/components/Tabs/Tabs.tokens.scss
@@ -20,6 +20,11 @@
   --tabs-tab-ring: var(--ring-accent);
   --tabs-tab-radius: var(--radius-sm);
 
+  // Trailing action button (`action` prop) — a button-like pseudo-tab, more
+  // muted than an idle tab since it never becomes selected.
+  --tabs-action-fg: var(--color-fg-subtle);
+  --tabs-action-opacity-disabled: var(--opacity-disabled);
+
   // Indicator
   --tabs-indicator-bg: var(--color-accent);
 

--- a/packages/design-system/src/components/Tabs/Tabs.tsx
+++ b/packages/design-system/src/components/Tabs/Tabs.tsx
@@ -52,6 +52,25 @@ export interface TabItem {
 }
 
 /**
+ * A trailing action rendered after the tab items in the same strip (e.g. a
+ * `+ New deal` pseudo-tab). Rendered as a real `<button type="button">`, NOT
+ * `role="tab"` — it has no tabpanel to control, is excluded from the
+ * arrow-key roving order, and the animated selection indicator never targets
+ * it. Reachable via the Tab key like any ordinary button, right after the
+ * currently-focusable tab.
+ */
+export interface TabsAction {
+  /** Visible label. Also the button's accessible name — no separate aria-label needed. */
+  label: string;
+  /** Optional decorative icon rendered before the label. Rendered `aria-hidden` — the label carries the accessible name. */
+  icon?: ReactNode;
+  /** Called when the button is clicked. Never changes `activeId` or fires `onChange` — wire up your own state (e.g. append a new tab) in the handler. */
+  onClick: () => void;
+  /** Disables the button (dimmed, non-interactive). Default `false`. */
+  disabled?: boolean;
+}
+
+/**
  * Determines what happens when Arrow keys move focus between tabs.
  * - `auto` (default) — focus and onChange both fire on Arrow. Best for cheap, eager-rendered panels.
  * - `manual` — Arrow only moves focus; Enter/Space activates via native button click. Best for lazy-loaded panels.
@@ -93,6 +112,16 @@ export interface TabsProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChang
    * `Split`'s `aside`, with the detail panel as the `Split`'s children beside it.
    */
   orientation?: TabsOrientation;
+  /**
+   * A trailing action rendered after the tab items, inside the same strip
+   * (e.g. `{ label: 'New deal', icon: <Plus/>, onClick: addDeal }`). Styled
+   * tab-like but visibly muted, never becomes the selected tab, and is
+   * skipped by arrow-key roving — reachable via the Tab key instead. For
+   * controls that apply to the whole bar but aren't shaped like a tab (a
+   * filter toggle), use `endContent`. For a control on a single tab, use
+   * `TabItem.actions`.
+   */
+  action?: TabsAction;
   /**
    * Controls for the whole tab bar (e.g. an "add tab" button, a filter
    * toggle), rendered at the end of the strip OUTSIDE the tablist so it never
@@ -145,6 +174,15 @@ const IS_DEV = typeof process !== 'undefined' && process.env?.NODE_ENV !== 'prod
  * <Tabs items={items} activeId={tab} onChange={setTab} activationMode="manual" />
  *
  * @example
+ * // Trailing action — a button-like pseudo-tab that never becomes selected:
+ * <Tabs
+ *   items={items}
+ *   activeId={tab}
+ *   onChange={setTab}
+ *   action={{ label: '+ New entity', icon: <Plus size={14} />, onClick: createEntity }}
+ * />
+ *
+ * @example
  * // Vertical master–detail rail with a trailing unsaved-changes badge:
  * <Split
  *   aside={
@@ -179,6 +217,8 @@ const IS_DEV = typeof process !== 'undefined' && process.env?.NODE_ENV !== 'prod
  * - ❌ Using `orientation="vertical"` as a page sidebar / primary navigation.
  *   It is for *intra-page* master–detail section switching, not route changes —
  *   use the app sidebar for navigation.
+ * - ❌ Reaching for `action` to switch views. It never sets `activeId` — if
+ *   the click should select a tab, add a `TabItem` instead.
  */
 export const Tabs = forwardRef<HTMLDivElement, TabsProps>(function Tabs(
   {
@@ -188,6 +228,7 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(function Tabs(
     panelIdPrefix,
     activationMode = 'auto',
     orientation = 'horizontal',
+    action,
     endContent,
     className,
     ...props
@@ -399,6 +440,29 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(function Tabs(
             </span>
           );
         })}
+        {action != null && (
+          // Plain button — deliberately NOT role="tab": no tabpanel to
+          // control, excluded from the arrow-key roving above (which only
+          // ever reads `items`/`tabRefs`), and never measured by the
+          // indicator effect (which only looks up `tabRefs[activeId]`).
+          // Known, accepted `aria-required-children` deviation: this leaves
+          // one non-"tab" child in a `role="tablist"` container, same as the
+          // `TabItem.actions` button above already does. A real `<button>`
+          // still announces correctly to AT regardless of its parent's role.
+          <button
+            type="button"
+            className={styles.action}
+            onClick={action.onClick}
+            disabled={action.disabled}
+          >
+            {action.icon != null && (
+              <span className={styles.icon} aria-hidden="true">
+                {action.icon}
+              </span>
+            )}
+            <span className={styles.label}>{action.label}</span>
+          </button>
+        )}
         <span ref={indicatorRef} className={styles.indicator} aria-hidden="true" />
       </div>
     </div>

--- a/packages/design-system/src/components/Tabs/index.ts
+++ b/packages/design-system/src/components/Tabs/index.ts
@@ -1,2 +1,2 @@
 export { Tabs } from './Tabs';
-export type { TabsProps, TabItem, TabsActivationMode, TabsOrientation } from './Tabs';
+export type { TabsProps, TabItem, TabsAction, TabsActivationMode, TabsOrientation } from './Tabs';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -177,7 +177,13 @@ export type {
 } from './components/PersonDisplay';
 
 export { Tabs } from './components/Tabs';
-export type { TabsProps, TabItem, TabsActivationMode, TabsOrientation } from './components/Tabs';
+export type {
+  TabsProps,
+  TabItem,
+  TabsAction,
+  TabsActivationMode,
+  TabsOrientation,
+} from './components/Tabs';
 
 export { DropdownMenu } from './components/DropdownMenu';
 export type {

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -4450,6 +4450,13 @@
           "description": "`'horizontal'` (default) — a horizontal strip with a sliding underline.\n`'vertical'` — a stacked master–detail rail: full-width rows, a left accent\nbar + tinted background on the active row, and ArrowUp/ArrowDown navigation.\nSets `aria-orientation` on the tablist accordingly. Put a vertical strip in a\n`Split`'s `aside`, with the detail panel as the `Split`'s children beside it."
         },
         {
+          "name": "action",
+          "type": "TabsAction",
+          "required": false,
+          "default": "",
+          "description": "A trailing action rendered after the tab items, inside the same strip\n(e.g. `{ label: 'New deal', icon: <Plus/>, onClick: addDeal }`). Styled\ntab-like but visibly muted, never becomes the selected tab, and is\nskipped by arrow-key roving — reachable via the Tab key instead. For\ncontrols that apply to the whole bar but aren't shaped like a tab (a\nfilter toggle), use `endContent`. For a control on a single tab, use\n`TabItem.actions`."
+        },
+        {
           "name": "endContent",
           "type": "string | number | bigint | boolean | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null",
           "required": false,

--- a/packages/playground/src/pages/components/TabsDemo.tsx
+++ b/packages/playground/src/pages/components/TabsDemo.tsx
@@ -5,6 +5,7 @@ import {
   FileText,
   Mail,
   MoreVertical,
+  Plus,
   Settings,
   Shield,
   User,
@@ -51,6 +52,22 @@ export function TabsDemo() {
 
   // Strip-level actions example.
   const [stripTab, setStripTab] = useState('board');
+
+  // Trailing action example: a stateful deal list where the action appends a
+  // new tab and selects it — the real product flow, not just a click handler.
+  const [dealTabs, setDealTabs] = useState([
+    { id: 'acme', label: 'Acme Corp' },
+    { id: 'globex', label: 'Globex' },
+  ]);
+  const [dealActive, setDealActive] = useState('acme');
+  const [dealCount, setDealCount] = useState(0);
+  const addDeal = () => {
+    const n = dealCount + 1;
+    const id = `deal-${n}`;
+    setDealTabs((prev) => [...prev, { id, label: `New deal ${n}` }]);
+    setDealCount(n);
+    setDealActive(id);
+  };
 
   const verticalDetail: Record<string, { title: string; body: string }> = {
     general: {
@@ -558,6 +575,47 @@ export function Demo() {
           activeId={stripTab}
           onChange={setStripTab}
           endContent={<Button size="sm">+ New tab</Button>}
+        />
+      </Example>
+
+      <Example
+        title="Trailing action"
+        description="action renders a button-like pseudo-tab after the tab items, in the same strip. Unlike endContent, it's styled to match the tab rhythm (just visibly muted) and sits right where the next tab would go. Clicking it never selects it — it only fires onClick, so the consumer decides what happens (here: append a new tab and select it)."
+        code={`import { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { Tabs } from '@eocrm/design-system';
+
+export function Demo() {
+  const [tabs, setTabs] = useState([
+    { id: 'acme', label: 'Acme Corp' },
+    { id: 'globex', label: 'Globex' },
+  ]);
+  const [active, setActive] = useState('acme');
+  const [count, setCount] = useState(0);
+
+  const addDeal = () => {
+    const n = count + 1;
+    const id = \`deal-\${n}\`;
+    setTabs((prev) => [...prev, { id, label: \`New deal \${n}\` }]);
+    setCount(n);
+    setActive(id);
+  };
+
+  return (
+    <Tabs
+      items={tabs}
+      activeId={active}
+      onChange={setActive}
+      action={{ label: 'New deal', icon: <Plus size={14} />, onClick: addDeal }}
+    />
+  );
+}`}
+      >
+        <Tabs
+          items={dealTabs}
+          activeId={dealActive}
+          onChange={setDealActive}
+          action={{ label: 'New deal', icon: <Plus size={14} />, onClick: addDeal }}
         />
       </Example>
     </DemoLayout>


### PR DESCRIPTION
Addresses #366.

## Summary
- New `action?: TabsAction` prop (`{ label, icon?, onClick, disabled? }`) — a real `<button type="button">` rendered as the last item in the tab strip, styled to the tabs' rhythm (slightly muted, hover like a tab).
- Deliberately NOT `role=tab` (a tab must control a panel): plain button semantics, outside the arrow-key roving order (arrows wrap across real tabs only), Tab-key reachable, `:focus-visible` ring. The animated selection indicator never targets it — clicking fires `onClick` only, no `onChange`, no selection change. Works in both orientations. `TabsAction` exported.
- The one a11y deviation (a non-tab child inside `role=tablist`) matches the component's existing documented `TabItem.actions` characteristic — noted in JSDoc + AGENTS.md.
- Demo: stateful "+ New deal" example that appends and then selects a new tab (the real product flow), Plus icon.

## Test plan
- 9 new tests (63 in the Tabs suite; 4112 repo-wide): button-not-tab role, DOM order, onClick-without-onChange, indicator/activeId untouched, disabled, aria-hidden icon, roving skip + wrap, Tab-key reachability, vertical orientation.
- All root gates + pack dry-run green; two-round rule-8 review clean; visual verification in both themes (indicator stays put on action click; moves only when the new tab is selected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk