### PR TITLE
feat(styles): thin, theme-colored scrollbars on every scroller

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -126,7 +126,7 @@ The library ships a full dark palette, driven entirely by CSS. There is **no the
 </html>
 ```
 
-`color-scheme` is set automatically for each state, so native form controls, scrollbars, and the browser chrome match the theme.
+`color-scheme` is set automatically for each state, so native form controls and the browser chrome match the theme. Scrollbars go a step further: `reset.scss` applies `scrollbar-width: thin` + a token-colored `scrollbar-color` to every element, so every scroller in the app is thin and theme-colored rather than OS-default. Opt a scroller out with its own `scrollbar-width: auto` / `scrollbar-color: auto`.
 
 **What flips for free:** every component whose colors resolve through the design tokens — which is all of them. Surfaces, text, borders, the accent and semantic palettes, shadows, overlays, focus rings, Badge tones, and Tooltip all redefine under dark with zero markup changes.
 

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -52,7 +52,7 @@ import {
 Importing `@eocrm/design-system/styles/global.scss` once at your app root applies three things:
 
 1. **Tokens** — defines every `--color-*`, `--space-*`, `--radius-*`, `--font-*`, `--shadow-*` etc. on `:root`. Required.
-2. **Modern reset** — including `* { margin: 0 }`. **All default browser margins on every element are zeroed.** Headings, paragraphs, lists have no intrinsic vertical rhythm; space them via `Stack`/`Cluster` or with the parent's own margin in CSS.
+2. **Modern reset** — including `* { margin: 0 }`. **All default browser margins on every element are zeroed.** Headings, paragraphs, lists have no intrinsic vertical rhythm; space them via `Stack`/`Cluster` or with the parent's own margin in CSS. The reset also applies `scrollbar-width: thin` + a token-colored `scrollbar-color` to every element, so **every** scroll container — library components and your own — gets a thin themed scrollbar instead of the OS default. It's declared at specificity 0-0-0; opt a scroller out with its own `scrollbar-width: auto` / `scrollbar-color: auto`. Note that Chromium ignores `::-webkit-scrollbar` rules on any scroller where these standard properties are set — if you already style scrollbars that way, they'll stop applying.
 3. **Base typography** — `body` font + size, `h1`–`h4` sizes, link color. Global rules, not scoped.
 
 If you need only the tokens (you're providing your own reset), import `@eocrm/design-system/styles/tokens.scss` directly. Other available subpath imports: `./styles/reset.scss`, `./styles/typography.scss`, `./styles/mixins.scss`.

--- a/packages/design-system/src/components/Tabs/Tabs.module.scss
+++ b/packages/design-system/src/components/Tabs/Tabs.module.scss
@@ -4,9 +4,10 @@
 // instead of on .tabs means the tablist itself remains an overflow-visible
 // box, so the active-tab underline (positioned just below its baseline) is
 // never clipped by overflow-y's auto-promotion.
+// `scrollbar-width: thin` used to live here; it now comes from the universal
+// scrollbar reset in styles/reset.scss, which themes every scroller at once.
 .scrollWrap {
   overflow-x: auto;
-  scrollbar-width: thin;
 }
 
 .tabs {

--- a/packages/design-system/src/styles/reset.scss
+++ b/packages/design-system/src/styles/reset.scss
@@ -6,6 +6,23 @@
 
 * {
   margin: 0;
+
+  // Thin, theme-colored scrollbars instead of the chunky OS default, on every
+  // scroller in the library and in consumer code. The universal selector is
+  // deliberate: `scrollbar-color` inherits, `scrollbar-width` does NOT — set
+  // only on the root, nested scrollers keep a fat `auto` gutter painted in our
+  // thumb color. The color rides along on `*` rather than inheriting from the
+  // root so a subtree that retones `--color-fg-subtle` retones its scrollbars
+  // too. Specificity 0-0-0, so opt a scroller out with its own
+  // `scrollbar-width: auto` / `scrollbar-color: auto` — on the scroller itself,
+  // not an ancestor, since every descendant re-matches `*`. Unsupporting
+  // engines keep their default; overlay-scrollbar platforms (macOS) ignore the
+  // track color; forced-colors reverts the thumb to the system palette; and
+  // Chromium ignores `::-webkit-scrollbar` rules once these are set. Accepted
+  // trade-off: `thin` is a smaller drag target than the OS bar, below WCAG
+  // 2.5.8's 24px.
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-fg-subtle) transparent;
 }
 
 html,

--- a/packages/playground/src/pages/components/RailDemo.tsx
+++ b/packages/playground/src/pages/components/RailDemo.tsx
@@ -83,6 +83,28 @@ function BrandMark() {
   );
 }
 
+// Enough workspaces to overflow the 480px stage, so the scrolling-body example
+// actually shows a scrollbar rather than describing one.
+const WORKSPACES = [
+  'Acme Corp',
+  'Globex',
+  'Initech',
+  'Umbrella Health',
+  'Stark Industries',
+  'Wayne Enterprises',
+  'Soylent',
+  'Hooli',
+  'Pied Piper',
+  'Vehement Capital',
+  'Massive Dynamic',
+  'Cyberdyne',
+  'Tyrell Corp',
+  'Wonka Industries',
+  'Gringotts',
+  'Duff Brewing',
+  'Oceanic Airlines',
+];
+
 export function RailDemo() {
   // Example 3: controlled state driven by a sibling button outside the rail.
   const [controlledCollapsed, setControlledCollapsed] = useState(false);
@@ -956,6 +978,158 @@ export function Demo() {
             </Rail.Footer>
           </Rail>
         </RailStage>
+      </Example>
+
+      <Example
+        title="Overflowing item list — everything above the Footer scrolls"
+        description="Rail splits its children at the first `Rail.Footer`: everything before it renders inside one scroll box, the Footer outside it. So when the item list outgrows the rail, the Footer stays pinned at the bottom while the Header scrolls away with the items. The scrollbar is thin and theme-colored — that comes from the `scrollbar-width` / `scrollbar-color` reset in the library's `reset.scss`, not from a Rail-specific style, so every scroll container in the app looks the same."
+        code={`import { type ReactNode } from 'react';
+import { Building2, Home, Users } from 'lucide-react';
+import { Cluster, Rail, Text, useRail } from '@eocrm/design-system';
+
+// 17 entries — the list has to outgrow the stage's height to scroll at all.
+const WORKSPACES = ['Acme Corp', 'Globex', 'Initech' /* …14 more */];
+
+// The rail fills its parent's height — bound that height or nothing overflows.
+function RailStage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: 480,
+        minHeight: 480,
+        display: 'flex',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-width) solid var(--color-border)',
+        overflow: 'hidden',
+        background: 'var(--color-bg-subtle)',
+      }}
+    >
+      {children}
+      <div
+        style={{
+          flex: '1 1 auto',
+          padding: 'var(--space-4)',
+          color: 'var(--color-fg-muted)',
+        }}
+      >
+        <Text tone="muted">Main content area — the rail is to the left.</Text>
+      </div>
+    </div>
+  );
+}
+
+function BrandMark() {
+  const { collapsed } = useRail();
+  return (
+    <Cluster gap="sm" align="center" wrap={false} justify={collapsed ? 'center' : 'start'}>
+      <div
+        aria-hidden
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 'var(--radius-md)',
+          background: 'var(--color-accent)',
+          color: 'var(--color-accent-fg)',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontWeight: 'var(--font-weight-semibold)',
+          flexShrink: 0,
+        }}
+      >
+        R
+      </div>
+      {!collapsed && <Text weight="semibold">Railside</Text>}
+    </Cluster>
+  );
+}
+
+export function Demo() {
+  return (
+    <RailStage>
+      <Rail>
+        <Rail.Header>
+          <BrandMark />
+        </Rail.Header>
+
+        <Rail.Section title="Main">
+          <Rail.Item icon={<Home size={16} />} href="#dashboard">
+            Dashboard
+          </Rail.Item>
+          <Rail.Item icon={<Users size={16} />} href="#contacts">
+            Contacts
+          </Rail.Item>
+        </Rail.Section>
+
+        {/* Long enough to overflow — these scroll, the Footer below does not. */}
+        <Rail.Section title="Workspaces">
+          {WORKSPACES.map((name) => (
+            <Rail.Item
+              key={name}
+              icon={<Building2 size={16} />}
+              href={\`#/w/\${encodeURIComponent(name)}\`}
+            >
+              {name}
+            </Rail.Item>
+          ))}
+        </Rail.Section>
+
+        <Rail.Footer>
+          <Rail.CollapseToggle />
+        </Rail.Footer>
+      </Rail>
+    </RailStage>
+  );
+}`}
+      >
+        <RailStage>
+          <Rail>
+            <Rail.Header>
+              <BrandMark />
+            </Rail.Header>
+
+            <Rail.Section title="Main">
+              <Rail.Item
+                icon={<Home size={16} />}
+                href="#dashboard"
+                onClick={(e) => e.preventDefault()}
+              >
+                Dashboard
+              </Rail.Item>
+              <Rail.Item
+                icon={<Users size={16} />}
+                href="#contacts"
+                onClick={(e) => e.preventDefault()}
+              >
+                Contacts
+              </Rail.Item>
+            </Rail.Section>
+
+            <Rail.Section title="Workspaces">
+              {WORKSPACES.map((name) => (
+                <Rail.Item
+                  key={name}
+                  icon={<Building2 size={16} />}
+                  href={`#/w/${encodeURIComponent(name)}`}
+                  onClick={(e) => e.preventDefault()}
+                >
+                  {name}
+                </Rail.Item>
+              ))}
+            </Rail.Section>
+
+            <Rail.Footer>
+              <Rail.CollapseToggle />
+            </Rail.Footer>
+          </Rail>
+        </RailStage>
+        <Cluster gap="sm" align="center">
+          <Layers size={14} aria-hidden style={{ color: 'var(--color-fg-muted)' }} />
+          <Text tone="muted" size="sm">
+            Collapse the rail while scrolled — the section titles fold away, so the list shortens
+            and the thumb grows. The gutter itself stays the same thin width.
+          </Text>
+        </Cluster>
       </Example>
     </DemoLayout>
   );


### PR DESCRIPTION
Scroll containers across the library rendered the chunky OS-default scrollbar. This sets `scrollbar-width: thin` + a token-colored `scrollbar-color` once in the reset instead of per component.

```scss
// src/styles/reset.scss
* {
  margin: 0;
  scrollbar-width: thin;
  scrollbar-color: var(--color-fg-subtle) transparent;
}
```

## Why the universal selector

`scrollbar-color` is inherited; **`scrollbar-width` is not**. Declaring both on the root themes the color everywhere while leaving every nested scroller at `auto` — i.e. a fat OS gutter painted in our thumb color. Measured in Chromium before the fix: `html` computed `thin`, every `.rail .body` / `CodeBlock pre` still computed `auto` with a 15px gutter. On `*`, all of them compute `thin` at a 10px gutter, with the correct token resolved in both light and dark.

Specificity is 0-0-0, so any component or consumer rule wins — a scroller opts out with its own `scrollbar-width: auto` / `scrollbar-color: auto`.

## Accessibility

Thumb is `--color-fg-subtle`. Contrast against every surface a library scroller actually sits on (`--color-bg`, `-subtle`, `-muted`, `-sunken`, plus the Lightbox overlay): 3.54:1 worst case light, 3.97:1 worst case dark — clears WCAG 1.4.11's 3:1. `thin` is a smaller drag target than the OS bar (below 2.5.8's 24px); accepted trade-off, noted in the reset comment.

## Also in this PR

- **Tabs** — drop the now-redundant local `scrollbar-width: thin`.
- **README / AGENTS** — document the reset, the opt-out, and that Chromium ignores `::-webkit-scrollbar` rules on any scroller where these standard properties are set.
- **RailDemo** — add an "Overflowing item list" example. Every existing rail demo was 480px tall with ~8 items, so no rail in the playground had ever actually scrolled.

## Verification

- 4120 tests, typecheck, stylelint, build, `npm pack --dry-run` — all green.
- Verified live in the playground (Chromium/Linux) in both themes: every scroller `thin`, gutter 15px → 10px, thumb color resolving per theme.
- Five rounds of the `pre-push-review` loop; final verdict clean.

## Known limits

- Consumers on the tokens-only path (`import tokens.scss`, own reset) keep OS-default scrollbars — including Tabs, which previously had its own. Consistent with that path already forfeiting the margin reset and body font.
- No `scrollbar-gutter: stable`. The rail's icon column still shifts when the list crosses the overflow threshold; reserving 10px permanently is a separate call.
- macOS/Firefox overlay-scrollbar behavior is asserted from spec — only measured on Linux/Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk