### PR TITLE
fix(TimeField): clip the X axis on .timeColumn (#375)

### DIFF
--- a/packages/design-system/src/components/TimeField/TimeField.module.scss
+++ b/packages/design-system/src/components/TimeField/TimeField.module.scss
@@ -116,6 +116,13 @@
   width: var(--date-picker-time-popover-column-width);
   max-height: var(--date-picker-time-popover-max-height);
   overflow-y: auto;
+
+  // Y scrolls, X clips. Declaring only `overflow-y` leaves X at `visible`,
+  // which the spec computes to `auto` — making a 4rem listbox column
+  // horizontally scrollable. Same fix `Rail.body` and `DropdownMenu.content`
+  // carry. Nothing overflows today; this keeps it that way if the column token
+  // shrinks or rows grow (#375).
+  overflow-x: hidden;
 }
 
 .timeColumnDivider {

--- a/packages/design-system/src/components/TimeField/TimeField.test.tsx
+++ b/packages/design-system/src/components/TimeField/TimeField.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, type ReactNode, useState } from 'react';
@@ -969,5 +971,22 @@ describe('TimeField — overlay elevation (#272)', () => {
     await user.click(screen.getByRole('button', { name: /Open time list/i }));
     const hours = await screen.findByRole('listbox', { name: 'Hours' });
     expect(hours.closest('[data-timefield-popover="true"]')).not.toHaveAttribute('data-in-overlay');
+  });
+});
+
+describe('TimeField — scroll box axes (#375)', () => {
+  // jsdom never loads the compiled CSS module, so computed styles can't be
+  // asserted here. Same SCSS-source fallback DropdownMenu.test.tsx and
+  // Rail.test.tsx use for their equivalent overflow contracts.
+  const scss = readFileSync(resolve(__dirname, 'TimeField.module.scss'), 'utf8');
+
+  it('.timeColumn clips the X axis instead of scrolling it', () => {
+    // Declaring only `overflow-y: auto` leaves X at `visible`, which the spec
+    // computes to `auto` — making a 4rem listbox column horizontally
+    // scrollable. `[^}]*` bounds each match inside the .timeColumn block so a
+    // later rule's declaration can't satisfy it, and `^` anchors to the bare
+    // rule so a descendant selector can't either.
+    expect(scss).toMatch(/^\.timeColumn\s*\{[^}]*overflow-y:\s*auto/m);
+    expect(scss).toMatch(/^\.timeColumn\s*\{[^}]*overflow-x:\s*hidden/m);
   });
 });


### PR DESCRIPTION
Addresses #375.

## Summary

`.timeColumn` declared only `overflow-y: auto`. Per CSS Overflow §3 the unspecified axis then computes `visible` → `auto`, so a `4rem` listbox column was horizontally scrollable. Same shape as the Rail bug in #374, and the same one-line fix `Rail.body` and `DropdownMenu.content` already carry.

**This is hardening, not a live bug** — and the issue says so explicitly, so nobody should go hunting a repro. Today's 2-character rows leave ~23px of slack against a 54px content box, measured in Chromium:

| column | rows | scrolls Y | v-gutter | clientW | widest row | h-scrollbar |
|---|---|---|---|---|---|---|
| hour | 25 | yes | 10px | 54px | 54px | no |
| minute | 9 | no | 0 | 64px | 64px | no |
| period | 5 | no | 0 | 56px | 56px | no |

That slack is a property of the content, not the CSS. It erodes if a consumer rebinds `--date-picker-time-popover-column-width` smaller (it's a public token), if a seconds column lands, or if localized period labels get wider.

## Test plan

- Regression test asserts the contract from the SCSS source, since jsdom never loads the compiled CSS module — the established fallback used by `Rail.test.tsx` and `DropdownMenu.test.tsx`. The regex is `^`-anchored and `[^}]*`-bounded so neither a descendant rule nor a later block can satisfy it.
- **Mutation-verified:** with `overflow-x: hidden` removed the test fails on exactly that assertion; with it restored, 59/59 pass.
- Full gate: 4151 tests across 196 files, typecheck, stylelint, prettier, `npm pack --dry-run` clean.
- Pre-push review loop per Hard rule 8. It caught two things, both fixed: a `stylelint-disable` comment that was cargo-culted from `Rail` for a rule that doesn't cover `overflow-x` (verified unnecessary — the file lints clean without it), and a comment that restated the issue inline across 10 lines for a one-line change.

## Not in scope

The issue names four siblings with the same shape — `Select .listbox`, `OptionsPicker .list`, `LiquidEditor .menu`, `RichTextEditor .mentionMenu` — as worth the same audit. Deliberately left alone to keep this PR scoped to the issue; worth a follow-up. `Modal .body`, `Drawer .body` and friends are *correctly* left alone for good: they hold arbitrary consumer content where a horizontal scrollbar on a genuinely wide table is the right affordance, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk