### PR TITLE
fix(DataTable): clamp column reorder drag to the table's horizontal bounds (#381)

### DIFF
--- a/packages/design-system/src/components/DataTable/DataTable.test.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.test.tsx
@@ -12,7 +12,7 @@
  * covered here is the styling contract (which cells carry a shift transform,
  * which must never, and which columns the driver is told about).
  */
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useRef } from 'react';
 import { DataTable } from './DataTable';
@@ -510,10 +510,19 @@ describe('<DataTable> — whole-column drag preview', () => {
   // PointerSensor (jsdom 29 implements PointerEvent, so `pointerdown` +
   // `pointermove` activate the sensor for real); the others assert the static
   // wiring around it.
+  // Three columns, one pinned — so the two unpinned ones have somewhere to go.
+  // With a single unpinned column the drag clamp (#381) correctly pins it in
+  // place, which would make the shift assertions below vacuous.
+  const pinnedCols: ColumnDef<Row>[] = [
+    { id: 'name', header: 'Name', cell: (r) => r.name },
+    { id: 'amount', header: 'Amount', cell: (r) => r.amount },
+    { id: 'extra', header: 'Extra', cell: () => '—' },
+  ];
+
   function PinnedHarness({ dragWholeColumn }: { dragWholeColumn?: boolean }) {
     const instance = useDataTable<Row>({
       data: rows,
-      columns: cols,
+      columns: pinnedCols,
       getRowId,
       defaultColumnPinning: { left: ['name'], right: [] },
     });
@@ -525,6 +534,20 @@ describe('<DataTable> — whole-column drag preview', () => {
   // All passed for reasons unrelated to their names. The real-drag tests below
   // cover the same ground meaningfully: default-true, the `false` opt-out, and
   // the "transform only on unpinned cells" invariant.)
+
+  /**
+   * Give every header cell a real rect, `width` px wide and laid left to right.
+   *
+   * Mandatory for any drag assertion since #381: the clamp measures the header
+   * cells' RENDERED geometry at drag start, and jsdom reports every rect as
+   * zero — which the clamp correctly reads as "nowhere to go", pinning the
+   * column and making the assertion vacuous.
+   */
+  function stubHeaderRects(table: HTMLElement, width = 120) {
+    table.querySelectorAll('th').forEach((th, i) => {
+      th.getBoundingClientRect = () => new DOMRect(i * width, 0, width, 32);
+    });
+  }
 
   it('exposes the table element to the shift driver via the forwarded ref', () => {
     function RefHarness() {
@@ -556,10 +579,12 @@ describe('<DataTable> — whole-column drag preview', () => {
 
   it('during a real drag, shifts unpinned cells and leaves pinned cells alone', () => {
     render(<PinnedHarness />);
+    const table = screen.getByRole('table');
+    // Unpinned band is ['amount', 'extra'] at x=120 and x=240, so 'amount' may
+    // travel 0..+120 — the 60px drag below lands inside it.
+    stubHeaderRects(table);
     // 'name' is pinned left (no grip); 'amount' is the reorderable column.
     dragAmountColumn();
-
-    const table = screen.getByRole('table');
     // The driver published the offset onto the <table>, never onto an ancestor
     // of a sticky cell as a transform.
     expect(table.style.getPropertyValue(shiftVarName('amount'))).toBe('60px');
@@ -619,23 +644,23 @@ describe('<DataTable> — whole-column drag preview', () => {
     // the active column's offset, which would make this assertion vacuous.
     // Give the header cells real rects (each 120px wide, matching the default
     // column size) so collision detection has something to hit.
-    table.querySelectorAll('th').forEach((th, i) => {
-      th.getBoundingClientRect = () => new DOMRect(i * 120, 0, 120, 32);
-    });
+    stubHeaderRects(table);
 
     const grip = screen.getByLabelText(/drag to reorder name/i);
     fireEvent.pointerDown(grip, { clientX: 0, clientY: 0, button: 0, isPrimary: true });
     // First move clears the 6px activation constraint; the second lands the
     // dragged column squarely on 'owner', two positions to the right.
     fireEvent.pointerMove(document, { clientX: 20, clientY: 0 });
-    fireEvent.pointerMove(document, { clientX: 240, clientY: 0 });
+    fireEvent.pointerMove(document, { clientX: 200, clientY: 0 });
     // Third move because dnd-kit's `over` lags one frame: the collision found
-    // on the previous move is what the monitor sees on this one.
-    fireEvent.pointerMove(document, { clientX: 250, clientY: 0 });
+    // on the previous move is what the monitor sees on this one. Both moves
+    // stay under the 240px clamp ceiling (#381) — past it the delta stops
+    // changing, dnd-kit emits no further move, and `over` never resolves.
+    fireEvent.pointerMove(document, { clientX: 230, clientY: 0 });
 
     // Sanity: the drag really did resolve a target two columns over, so the
     // displacement assertions below are not vacuous.
-    expect(table.style.getPropertyValue(shiftVarName('name'))).toBe('250px');
+    expect(table.style.getPropertyValue(shiftVarName('name'))).toBe('230px');
     expect(table.style.getPropertyValue(shiftVarName('owner'))).toBe('-120px');
     // The point of the test — the skipped-over non-reorderable column moves by
     // exactly the same amount. With `sortableIds` this reads ''.
@@ -650,9 +675,10 @@ describe('<DataTable> — whole-column drag preview', () => {
     // and no body cell may be transformed. Only the dragged header moves —
     // dnd-kit's historical behavior.
     render(<PinnedHarness dragWholeColumn={false} />);
+    const table = screen.getByRole('table');
+    stubHeaderRects(table);
     dragAmountColumn();
 
-    const table = screen.getByRole('table');
     expect(table.style.getPropertyValue(shiftVarName('amount'))).toBe('');
     expect(table.style.getPropertyValue(shiftVarName('name'))).toBe('');
     expect(screen.getByText('10').closest('td')!.style.transform).toBe('');
@@ -663,5 +689,133 @@ describe('<DataTable> — whole-column drag preview', () => {
     }
 
     fireEvent.pointerUp(document);
+  });
+});
+
+describe('<DataTable> — column drag is clamped to the unpinned band (#381)', () => {
+  // Two clamps, one measured range (taken from the header rects at drag start):
+  //  - `useColumnDragShift` clamps `event.delta.x`, which is what the shift
+  //    variables — and therefore the whole-column preview — are built from.
+  //  - a `DndContext` modifier clamps `modifiedTranslate`, which is the
+  //    collision rect AND the transform the header-only path rides.
+  const threeCols: ColumnDef<Row>[] = [
+    { id: 'name', header: 'Name', cell: (r) => r.name },
+    { id: 'mid', header: 'Mid', cell: () => '—' },
+    { id: 'owner', header: 'Owner', cell: (r) => r.amount },
+  ];
+
+  function ThreeHarness({ dragWholeColumn }: { dragWholeColumn?: boolean }) {
+    const instance = useDataTable<Row>({ data: rows, columns: threeCols, getRowId });
+    return <DataTable instance={instance} aria-label="Three" dragWholeColumn={dragWholeColumn} />;
+  }
+
+  /**
+   * Render with header cells RENDERED 200px wide while their DECLARED size is
+   * the 120px default.
+   *
+   * That gap is the whole point. `table-layout: fixed; width: max-content;
+   * min-width: 100%` makes the table stretch to fill its scroll wrap, so real
+   * columns are wider than the `<col>` elements claim. A clamp built on
+   * declared widths stops the first column at 240px — short of the last slot,
+   * which it can then never reach.
+   */
+  function renderStretched(props: { dragWholeColumn?: boolean } = {}) {
+    render(<ThreeHarness {...props} />);
+    const table = screen.getByRole('table');
+    table.querySelectorAll('th').forEach((th, i) => {
+      th.getBoundingClientRect = () => new DOMRect(i * 200, 0, 200, 32);
+    });
+    return table;
+  }
+
+  /** Drag `columnLabel`'s grip to `clientX`, leaving the pointer down. */
+  function dragTo(columnLabel: RegExp, clientX: number) {
+    const grip = screen.getByLabelText(columnLabel);
+    fireEvent.pointerDown(grip, { clientX: 0, clientY: 0, button: 0, isPrimary: true });
+    fireEvent.pointerMove(document, { clientX: clientX > 0 ? 20 : -20, clientY: 0 });
+    fireEvent.pointerMove(document, { clientX, clientY: 0 });
+  }
+
+  /**
+   * Assert the column did not move, and that the drag was genuinely running
+   * when it didn't. A fully-clamped drag publishes NO variable rather than
+   * '0px': dnd-kit's move effect is keyed on the (already clamped) translate,
+   * so a translate pinned at 0 emits nothing after the start. Without the
+   * liveness anchor this would also pass if the drag had never activated.
+   */
+  function expectPinnedInPlace(table: HTMLElement, columnId: string, cellText: string) {
+    const published = table.style.getPropertyValue(shiftVarName(columnId));
+    expect(['', '0px']).toContain(published);
+    // Liveness: cells only carry the shift transform while a drag is active.
+    const cell = screen.getAllByText(cellText)[0]!.closest('td')!;
+    expect(cell.style.transform).toBe(`translateX(var(${shiftVarName(columnId)}, 0px))`);
+  }
+
+  it('stops the first column at the LAST slot, measured from rendered widths', () => {
+    // The regression guard for the declared-width clamp: 'name' must travel the
+    // full 400px to reach the last slot. Summing the declared 120px sizes gives
+    // 240 — third of three, with the last slot unreachable.
+    const table = renderStretched();
+    dragTo(/drag to reorder name/i, 5000);
+    expect(table.style.getPropertyValue(shiftVarName('name'))).toBe('400px');
+    fireEvent.pointerUp(document);
+  });
+
+  it('does not let the first column travel left at all', () => {
+    const table = renderStretched();
+    dragTo(/drag to reorder name/i, -5000);
+    expectPinnedInPlace(table, 'name', 'Alpha');
+    fireEvent.pointerUp(document);
+  });
+
+  it('does not let the last column travel right at all', () => {
+    const table = renderStretched();
+    dragTo(/drag to reorder owner/i, 5000);
+    expectPinnedInPlace(table, 'owner', '10');
+    fireEvent.pointerUp(document);
+  });
+
+  it('bounds a middle column by the rendered geometry on each side', () => {
+    const table = renderStretched();
+    dragTo(/drag to reorder mid/i, -5000);
+    expect(table.style.getPropertyValue(shiftVarName('mid'))).toBe('-200px');
+    fireEvent.pointerUp(document);
+
+    cleanup();
+    const table2 = renderStretched();
+    dragTo(/drag to reorder mid/i, 5000);
+    expect(table2.style.getPropertyValue(shiftVarName('mid'))).toBe('200px');
+    fireEvent.pointerUp(document);
+  });
+
+  it('clamps the header transform on the dragWholeColumn={false} path too', () => {
+    // There the header rides dnd-kit's own transform, so the modifier — not the
+    // delta clamp — is what bounds it. Same measured range either way.
+    renderStretched({ dragWholeColumn: false });
+    dragTo(/drag to reorder name/i, 5000);
+    const header = screen.getByRole('columnheader', { name: /name/i });
+    expect(header.style.transform).toContain('400px');
+    expect(header.style.transform).not.toContain('5000px');
+    fireEvent.pointerUp(document);
+  });
+
+  it('hides the grip on a lone unpinned column — it has nowhere to be dropped', () => {
+    // With every other column pinned, `reorderRespectingPins` would reject any
+    // drop this column could reach and the measured range is zero, so the drag
+    // could only ever snap back. A grip that visibly does nothing is worse than
+    // no grip — pinned columns already hide theirs for the same reason.
+    function LoneHarness() {
+      const instance = useDataTable<Row>({
+        data: rows,
+        columns: threeCols,
+        getRowId,
+        defaultColumnPinning: { left: ['name'], right: ['owner'] },
+      });
+      return <DataTable instance={instance} aria-label="Lone" />;
+    }
+    render(<LoneHarness />);
+    expect(screen.queryByLabelText(/drag to reorder mid/i)).toBeNull();
+    // Sanity: the column still renders, it just cannot be picked up.
+    expect(screen.getByRole('columnheader', { name: /mid/i })).toBeInTheDocument();
   });
 });

--- a/packages/design-system/src/components/DataTable/DataTable.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.tsx
@@ -17,6 +17,7 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
+  type Modifier,
 } from '@dnd-kit/core';
 import {
   SortableContext,
@@ -32,6 +33,7 @@ import { HeaderCell } from './HeaderCell';
 import { BodyRow } from './BodyRow';
 import { reorderRespectingPins } from './reorderColumns';
 import { useColumnDragShift } from './useColumnDragShift';
+import { clampX, type DragRangeX } from './columnShift';
 import { useFloatingSurface } from '../_internal/overlay';
 import { AUTO_CELL_WIDTH } from './pinStyle';
 import type { DataTableInstance } from './types';
@@ -175,15 +177,17 @@ function ColumnShiftDriver({
   enabled,
   orderedIds,
   widths,
+  dragRangeRef,
   onDragActiveChange,
 }: {
   rootRef: RefObject<HTMLElement | null>;
   enabled: boolean;
   orderedIds: string[];
   widths: Record<string, number>;
+  dragRangeRef: RefObject<DragRangeX | null>;
   onDragActiveChange: (active: boolean) => void;
 }) {
-  useColumnDragShift({ rootRef, enabled, orderedIds, widths, onDragActiveChange });
+  useColumnDragShift({ rootRef, enabled, orderedIds, widths, dragRangeRef, onDragActiveChange });
   return null;
 }
 
@@ -223,6 +227,11 @@ function DataTableInner<T>(
   // their per-column `useSortable({ disabled })` blocks drag activation, but
   // their presence in the items list still makes horizontalListSortingStrategy
   // shift them during another column's drag.
+  // Note this deliberately does NOT mirror HeaderCell's "hide the grip when
+  // there is only one unpinned column" rule. A lone unpinned column stays in
+  // this list while its own `useSortable({ disabled })` blocks activation —
+  // a single-item sorting context is a no-op, and keeping the lists derived
+  // from one filter each is clearer than keeping two conditions in sync.
   const sortableIds = useMemo(
     () => instance.unpinnedColumns.filter((c) => c.enableReorder !== false).map((c) => c.id),
     [instance.unpinnedColumns],
@@ -240,6 +249,41 @@ function DataTableInner<T>(
     () => instance.unpinnedColumns.map((c) => c.id),
     [instance.unpinnedColumns],
   );
+
+  // Travel available to the column being dragged, measured from real header
+  // rects when the drag starts (see `measureDragRangeX`). One measurement, two
+  // readers: `useColumnDragShift` clamps the delta it publishes, and the
+  // modifier below clamps `modifiedTranslate`. Null when no drag is active.
+  const dragRangeRef = useRef<DragRangeX | null>(null);
+
+  // Keep the dragged column inside the unpinned band. Without a clamp the
+  // pointer delta is applied raw, so a column can be dragged past the first or
+  // last slot and off the table entirely — and since `dragWholeColumn` defaults
+  // to true, that drags a full column of body cells over unrelated page content
+  // (#381).
+  //
+  // This modifier covers two things the delta clamp in `useColumnDragShift`
+  // cannot:
+  //  - the COLLISION RECT. dnd-kit derives it as
+  //    `getAdjustedRect(draggingNodeRect, modifiedTranslate)`, so clamping here
+  //    keeps `over` resolving to the last reachable column instead of going
+  //    null once the pointer leaves the table.
+  //  - the HEADER-ONLY path (`dragWholeColumn={false}`), where the header rides
+  //    `useSortable`'s own transform — which is `modifiedTranslate` — and never
+  //    touches this component's shift variables.
+  //
+  // Known residual, deliberately not papered over: on the header-only path this
+  // modifier can still be exceeded by dnd-kit's horizontal auto-scroll, because
+  // `scrollAdjustedTranslate = add(modifiedTranslate, scrollAdjustment)` adds
+  // the scroll adjustment AFTER modifiers run. The default whole-column path is
+  // unaffected — it clamps `delta`, which is already post-adjustment. Fixing
+  // the opt-out path too would mean overriding dnd-kit's auto-scroll.
+  const clampToUnpinnedBand = useCallback<Modifier>(({ transform, active }) => {
+    const range = dragRangeRef.current;
+    if (!active || !range) return transform;
+    return { ...transform, x: clampX(transform.x, range) };
+  }, []);
+  const modifiers = useMemo(() => [clampToUnpinnedBand], [clampToUnpinnedBand]);
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
@@ -302,7 +346,7 @@ function DataTableInner<T>(
   );
 
   return (
-    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+    <DndContext sensors={sensors} modifiers={modifiers} onDragEnd={handleDragEnd}>
       {/* #282: register the column-reorder drag as a floating surface while
           active so a host Modal/Drawer yields the Escape that cancels it (the
           drag cancels; the host survives). A leaf probe (not root state) so the
@@ -313,6 +357,7 @@ function DataTableInner<T>(
         enabled={dragWholeColumn}
         orderedIds={shiftOrderedIds}
         widths={instance.columnSizesPx}
+        dragRangeRef={dragRangeRef}
         onDragActiveChange={setDragActive}
       />
       <SortableContext

--- a/packages/design-system/src/components/DataTable/HeaderCell.tsx
+++ b/packages/design-system/src/components/DataTable/HeaderCell.tsx
@@ -75,8 +75,13 @@ export function HeaderCell<T>({
     sortDir === 'asc' ? ChevronUp : sortDir === 'desc' ? ChevronDown : ChevronsUpDown;
 
   // dnd-kit sortable — column is its own sortable item. Pinned columns are
-  // locked in place (see the isPinned comment above).
-  const reorderable = column.enableReorder !== false && !isPinned;
+  // locked in place (see the isPinned comment above), and so is a LONE unpinned
+  // column: with no sibling in its band, `reorderRespectingPins` rejects every
+  // drop it could reach, so the drag clamp correctly pins it at zero travel. A
+  // grip that visibly does nothing is worse than no grip, so it hides for the
+  // same reason a pinned column's does.
+  const reorderable =
+    column.enableReorder !== false && !isPinned && instance.unpinnedColumns.length > 1;
   const sortableResult = useSortable({
     id: column.id,
     disabled: !reorderable,
@@ -152,6 +157,10 @@ export function HeaderCell<T>({
     // preserved without the visual side-effect.
     <Table.HeaderCell
       align={column.align ?? 'start'}
+      // Addressable by column id so a drag can measure this cell's REAL
+      // rendered rect (see `measureDragRangeX`). Declared `<col>` widths are
+      // not a substitute — the table stretches past them to fill its wrap.
+      data-dt-column-id={column.id}
       aria-sort={sortDir != null ? sortAriaMap[sortDir] : undefined}
       onClick={sortable ? () => instance.toggleSort(column.id) : undefined}
       className={clsx(

--- a/packages/design-system/src/components/DataTable/columnShift.test.ts
+++ b/packages/design-system/src/components/DataTable/columnShift.test.ts
@@ -1,4 +1,4 @@
-import { computeColumnShifts, cssIdent, shiftVarName } from './columnShift';
+import { clampX, computeColumnShifts, cssIdent, shiftVarName } from './columnShift';
 
 const orderedIds = ['a', 'b', 'c', 'd'];
 const widths = { a: 100, b: 120, c: 80, d: 60 };
@@ -155,5 +155,26 @@ describe('shiftVarName', () => {
   it('builds a --dt-shift- prefixed custom property name', () => {
     expect(shiftVarName('name')).toBe(`--dt-shift-${cssIdent('name')}`);
     expect(shiftVarName('name').startsWith('--dt-shift-')).toBe(true);
+  });
+});
+
+describe('clampX', () => {
+  const range = { min: -220, max: 60 };
+
+  it('passes through a value inside the range', () => {
+    expect(clampX(-10, range)).toBe(-10);
+  });
+
+  it('clamps an overshoot to the left', () => {
+    expect(clampX(-9999, range)).toBe(-220);
+  });
+
+  it('clamps an overshoot to the right', () => {
+    expect(clampX(9999, range)).toBe(60);
+  });
+
+  it('holds a zero-width range at zero in both directions', () => {
+    expect(clampX(500, { min: 0, max: 0 })).toBe(0);
+    expect(clampX(-500, { min: 0, max: 0 })).toBe(0);
   });
 });

--- a/packages/design-system/src/components/DataTable/columnShift.ts
+++ b/packages/design-system/src/components/DataTable/columnShift.ts
@@ -66,6 +66,32 @@ export function computeColumnShifts({
 }
 
 /**
+ * How far the active column may travel left and right, in px, relative to
+ * where it started. Produced by `measureDragRangeX` in `useColumnDragShift`
+ * from real header rects — NOT from declared column widths, which understate
+ * the rendered ones whenever the table stretches to fill its scroll wrap.
+ */
+export interface DragRangeX {
+  /**
+   * Lower bound for the x translation, in px. Non-positive under normal
+   * left-to-right layout, where the first slot sits at or left of the active
+   * column's own position.
+   */
+  min: number;
+  /**
+   * Upper bound for the x translation, in px. Non-negative under normal
+   * left-to-right layout, where the last slot sits at or right of the active
+   * column's own position.
+   */
+  max: number;
+}
+
+/** Clamp an x translation into `range`. */
+export function clampX(x: number, range: DragRangeX): number {
+  return Math.min(range.max, Math.max(range.min, x));
+}
+
+/**
  * Turn an arbitrary column id into a fragment that is legal inside a CSS
  * custom-property name. Column ids are consumer-supplied and routinely contain
  * dots, spaces, or non-ASCII text, none of which are safe to interpolate.

--- a/packages/design-system/src/components/DataTable/useColumnDragShift.test.ts
+++ b/packages/design-system/src/components/DataTable/useColumnDragShift.test.ts
@@ -1,8 +1,27 @@
 import { createElement, useRef, type RefObject } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { DndContext, useDraggable, MouseSensor, useSensor, useSensors } from '@dnd-kit/core';
-import { applyColumnShifts, useColumnDragShift } from './useColumnDragShift';
-import { shiftVarName } from './columnShift';
+import { applyColumnShifts, measureDragRangeX, useColumnDragShift } from './useColumnDragShift';
+import { shiftVarName, type DragRangeX } from './columnShift';
+
+/**
+ * Build a detached `<table>` whose header cells carry `data-dt-column-id` and the
+ * given rects. jsdom lays nothing out, so the rects have to be stubbed — which
+ * is exactly the point: `measureDragRangeX` must read rendered geometry, never
+ * the declared `<col>` widths.
+ */
+function tableWithHeaderRects(cells: { id: string; left: number; width: number }[]) {
+  const table = document.createElement('table');
+  const row = document.createElement('tr');
+  for (const { id, left, width } of cells) {
+    const th = document.createElement('th');
+    th.setAttribute('data-dt-column-id', id);
+    th.getBoundingClientRect = () => new DOMRect(left, 0, width, 32);
+    row.appendChild(th);
+  }
+  table.appendChild(row);
+  return table;
+}
 
 describe('applyColumnShifts', () => {
   function makeRoot() {
@@ -63,6 +82,86 @@ describe('applyColumnShifts', () => {
   });
 });
 
+describe('measureDragRangeX', () => {
+  // Three columns rendered 200px wide each, starting at x=0.
+  const cells = [
+    { id: 'a', left: 0, width: 200 },
+    { id: 'b', left: 200, width: 200 },
+    { id: 'c', left: 400, width: 200 },
+  ];
+  const orderedIds = ['a', 'b', 'c'];
+
+  it('gives the first column no room to travel left and the full band to its right', () => {
+    expect(measureDragRangeX(tableWithHeaderRects(cells), orderedIds, 'a')).toEqual({
+      min: 0,
+      max: 400,
+    });
+  });
+
+  it('gives the last column no room to travel right', () => {
+    expect(measureDragRangeX(tableWithHeaderRects(cells), orderedIds, 'c')).toEqual({
+      min: -400,
+      max: 0,
+    });
+  });
+
+  it('bounds a middle column by the real geometry on each side', () => {
+    expect(measureDragRangeX(tableWithHeaderRects(cells), orderedIds, 'b')).toEqual({
+      min: -200,
+      max: 200,
+    });
+  });
+
+  it('reads RENDERED width, not the declared column size', () => {
+    // The regression this function exists for: `table-layout: fixed;
+    // width: max-content; min-width: 100%` stretches columns past their
+    // declared `<col>` width, so a declared-width sum would have stopped 'a'
+    // at 240 (2 x the 120px default) instead of the real 400 — leaving the
+    // last slot unreachable.
+    const range = measureDragRangeX(tableWithHeaderRects(cells), orderedIds, 'a');
+    expect(range.max).toBe(400);
+    expect(range.max).toBeGreaterThan(240);
+  });
+
+  it('measures correctly regardless of where the wrap is scrolled', () => {
+    // Same table, scrolled 1000px left: every rect shifts by the same amount,
+    // so the differences — which is all the range is — are unchanged.
+    const scrolled = cells.map((c) => ({ ...c, left: c.left - 1000 }));
+    expect(measureDragRangeX(tableWithHeaderRects(scrolled), orderedIds, 'a')).toEqual({
+      min: 0,
+      max: 400,
+    });
+  });
+
+  it('pins in place when the active column has no header cell', () => {
+    expect(measureDragRangeX(tableWithHeaderRects(cells), orderedIds, 'zzz')).toEqual({
+      min: 0,
+      max: 0,
+    });
+  });
+
+  it('pins in place on a null root or an empty column list', () => {
+    expect(measureDragRangeX(null, orderedIds, 'a')).toEqual({ min: 0, max: 0 });
+    expect(measureDragRangeX(tableWithHeaderRects(cells), [], 'a')).toEqual({ min: 0, max: 0 });
+  });
+
+  it('handles a column id that would break an unescaped selector', () => {
+    // Column ids are consumer-supplied: dots, spaces and quotes all appear in
+    // real schemas and all are selector metacharacters.
+    const hostile = [
+      { id: 'deal.owner name', left: 0, width: 100 },
+      { id: 'a"b', left: 100, width: 100 },
+    ];
+    expect(
+      measureDragRangeX(
+        tableWithHeaderRects(hostile),
+        ['deal.owner name', 'a"b'],
+        'deal.owner name',
+      ),
+    ).toEqual({ min: 0, max: 100 });
+  });
+});
+
 describe('useColumnDragShift', () => {
   // A draggable handle registered with dnd-kit so a real MouseSensor drag
   // sequence (mousedown -> mousemove -> mouseup) drives actual
@@ -81,6 +180,7 @@ describe('useColumnDragShift', () => {
   function Monitor(props: {
     enabled: boolean;
     rootRef: RefObject<HTMLElement | null>;
+    dragRangeRef: RefObject<DragRangeX | null>;
     onDragActiveChange: (active: boolean) => void;
   }) {
     useColumnDragShift({
@@ -88,6 +188,7 @@ describe('useColumnDragShift', () => {
       enabled: props.enabled,
       orderedIds: ['a', 'b'],
       widths: { a: 50, b: 50 },
+      dragRangeRef: props.dragRangeRef,
       onDragActiveChange: props.onDragActiveChange,
     });
     return null;
@@ -101,17 +202,63 @@ describe('useColumnDragShift', () => {
     onDragActiveChange: (active: boolean) => void;
   }) {
     const rootRef = useRef<HTMLElement | null>(null);
+    const dragRangeRef = useRef<DragRangeX | null>(null);
     // distance: 0 so the sensor activates on the first pointer move instead
     // of requiring a real drag-distance threshold jsdom can't produce.
     const sensors = useSensors(useSensor(MouseSensor, { activationConstraint: { distance: 0 } }));
     return createElement(
       DndContext,
       { sensors },
-      createElement('table', { ref: rootRef, 'data-testid': 'table' }),
-      createElement(Monitor, { rootRef, enabled, onDragActiveChange }),
+      createElement(
+        'table',
+        { ref: rootRef, 'data-testid': 'table' },
+        createElement(
+          'tbody',
+          null,
+          createElement(
+            'tr',
+            null,
+            createElement('th', { 'data-dt-column-id': 'a' }),
+            createElement('th', { 'data-dt-column-id': 'b' }),
+          ),
+        ),
+      ),
+      createElement(Monitor, { rootRef, enabled, dragRangeRef, onDragActiveChange }),
       createElement(Handle),
     );
   }
+
+  /**
+   * jsdom lays nothing out, so without stubbed rects `measureDragRangeX` would
+   * (correctly) report zero travel and every published shift would be 0px.
+   * Two columns, 50px each: 'a' may travel 0..+50.
+   */
+  function stubRects(table: HTMLElement) {
+    table.querySelectorAll('th').forEach((th, i) => {
+      th.getBoundingClientRect = () => new DOMRect(i * 50, 0, 50, 32);
+    });
+  }
+
+  it('clamps the published delta to the measured range', () => {
+    const { getByTestId } = render(
+      createElement(Harness, { enabled: true, onDragActiveChange: () => {} }),
+    );
+    const handle = getByTestId('handle');
+    const table = getByTestId('table');
+    stubRects(table);
+
+    fireEvent.mouseDown(handle, { clientX: 0, clientY: 0, button: 0 });
+    fireEvent.mouseMove(document, { clientX: 5, clientY: 0 });
+    fireEvent.mouseMove(document, { clientX: 30, clientY: 0 });
+    // Inside the range — published verbatim.
+    expect(table.style.getPropertyValue(shiftVarName('a'))).toBe('30px');
+
+    fireEvent.mouseMove(document, { clientX: 5000, clientY: 0 });
+    // Past it — held at the last slot rather than following the pointer.
+    expect(table.style.getPropertyValue(shiftVarName('a'))).toBe('50px');
+
+    fireEvent.mouseUp(document);
+  });
 
   it('cleans up and reports drag-inactive even when `enabled` flips to false mid-drag', () => {
     // Reproduces the bug: onDragEnd/onDragCancel used to be gated on
@@ -124,6 +271,7 @@ describe('useColumnDragShift', () => {
     );
     const handle = getByTestId('handle');
     const table = getByTestId('table');
+    stubRects(table);
 
     fireEvent.mouseDown(handle, { clientX: 0, clientY: 0, button: 0 });
     // First move activates the sensor (baseline); the second produces delta.

--- a/packages/design-system/src/components/DataTable/useColumnDragShift.ts
+++ b/packages/design-system/src/components/DataTable/useColumnDragShift.ts
@@ -1,6 +1,50 @@
 import { useRef, type RefObject } from 'react';
 import { useDndMonitor } from '@dnd-kit/core';
-import { computeColumnShifts, shiftVarName } from './columnShift';
+import { clampX, computeColumnShifts, shiftVarName, type DragRangeX } from './columnShift';
+
+/**
+ * Measure how far the active column may travel, in px, from the REAL rendered
+ * geometry of the header cells inside `root`.
+ *
+ * Declared widths (`columnSizingPx` / the `<col>` elements) cannot be used for
+ * this. `DataTable.module.scss` sets `table-layout: fixed; width: max-content;
+ * min-width: 100%`, so whenever the column sum is narrower than the scroll wrap
+ * the table stretches and every rendered column is WIDER than declared. Summing
+ * declared widths then under-reports the travel and makes the last slot
+ * unreachable — the exact regression this replaced.
+ *
+ * The bound is the unpinned band, not the table: pinned columns are excluded
+ * from reordering and `reorderRespectingPins` rejects a drop across a pin
+ * boundary, so travelling over a pin would take the column somewhere it can
+ * never land. `orderedIds` is therefore the unpinned columns only.
+ *
+ * All three rects are read in the same instant from the same scrolling
+ * container, so the differences are correct table-space offsets no matter where
+ * the wrap happens to be scrolled.
+ *
+ * Returns a zeroed range (pin in place) when `root` or any of the three header
+ * cells cannot be found — an unmeasurable drag must not be an unbounded one.
+ */
+export function measureDragRangeX(
+  root: HTMLElement | null,
+  orderedIds: string[],
+  activeId: string,
+): DragRangeX {
+  const zero = { min: 0, max: 0 };
+  if (!root || orderedIds.length === 0) return zero;
+
+  // Column ids are consumer-supplied and routinely contain dots, spaces, or
+  // non-ASCII text — CSS.escape is what keeps them legal in a selector.
+  const rectOf = (id: string) =>
+    root.querySelector(`th[data-dt-column-id=${CSS.escape(id)}]`)?.getBoundingClientRect();
+
+  const active = rectOf(activeId);
+  const first = rectOf(orderedIds[0]);
+  const last = rectOf(orderedIds[orderedIds.length - 1]);
+  if (!active || !first || !last) return zero;
+
+  return { min: first.left - active.left, max: last.right - active.right };
+}
 
 /**
  * Write one custom property per shifted column onto `root`, and remove the
@@ -48,6 +92,13 @@ export interface ColumnDragShiftArgs {
   orderedIds: string[];
   /** Rendered width per column id, px. */
   widths: Record<string, number>;
+  /**
+   * Caller-owned slot for the travel range measured at drag start, so the
+   * `DndContext` modifier (which lives in the PARENT of this hook and therefore
+   * cannot read a return value from it) clamps against the same numbers.
+   * Written on drag start, nulled on drag end/cancel.
+   */
+  dragRangeRef: RefObject<DragRangeX | null>;
   /** Called once at drag start (true) and once at drag end/cancel (false). */
   onDragActiveChange: (active: boolean) => void;
 }
@@ -66,17 +117,27 @@ export function useColumnDragShift({
   enabled,
   orderedIds,
   widths,
+  dragRangeRef,
   onDragActiveChange,
 }: ColumnDragShiftArgs): void {
   const writtenRef = useRef<string[]>([]);
 
   const clear = () => {
     writtenRef.current = applyColumnShifts(rootRef.current, {}, writtenRef.current);
+    dragRangeRef.current = null;
     onDragActiveChange(false);
   };
 
   useDndMonitor({
-    onDragStart() {
+    onDragStart(event) {
+      // Measured even when `enabled` is false: the header-only path does not
+      // use this hook's shift variables, but its DndContext modifier reads the
+      // very same range out of `dragRangeRef`.
+      dragRangeRef.current = measureDragRangeX(
+        rootRef.current,
+        orderedIds,
+        String(event.active.id),
+      );
       if (!enabled) return;
       onDragActiveChange(true);
     },
@@ -87,7 +148,19 @@ export function useColumnDragShift({
         activeId: String(event.active.id),
         overId: event.over ? String(event.over.id) : null,
         widths,
-        deltaX: event.delta.x,
+        // Clamping HERE, not only in the modifier, is what actually bounds the
+        // column. dnd-kit computes `delta` as
+        // `scrollAdjustedTranslate = add(modifiedTranslate, scrollAdjustment)`
+        // — the scroll adjustment is added AFTER modifiers run, so a
+        // modifier-only clamp is escaped by horizontal auto-scroll. Worse, it
+        // ran away: the translated header inflated `scrollWidth`, which let
+        // `scrollLeft` grow, which grew `scrollAdjustment`. `delta` is the
+        // post-adjustment value, so clamping it is authoritative and the
+        // feedback loop cannot start.
+        // Fail CLOSED: an unmeasurable drag is a pinned one, never an
+        // unbounded one. Unreachable today (onDragStart always sets the ref)
+        // but the `??` keeps the guarantee if that ever stops being true.
+        deltaX: clampX(event.delta.x, dragRangeRef.current ?? { min: 0, max: 0 }),
       });
       writtenRef.current = applyColumnShifts(rootRef.current, shifts, writtenRef.current);
     },


### PR DESCRIPTION
Addresses #381.

## Summary

A column-reorder drag applied the pointer delta unclamped, so a column could travel past the first or last slot and off the table. Since `dragWholeColumn` defaults to `true` (#379), that dragged a whole column of body cells over unrelated page content.

Two things had to be right, and the first attempt got both wrong — caught by review, measured in a real browser:

**1. Bound by measured geometry, not declared widths.** `DataTable.module.scss` sets `table-layout: fixed; width: max-content; min-width: 100%`, so when the column sum is narrower than the scroll wrap the table stretches and real widths exceed `columnSizesPx`. On the basic demo, declared `200/140/120/120` renders as `288/202/174/173`. A declared-width clamp capped the drag at 380px where 611px was needed — **making the last slot unreachable**, a regression in the common case. The range is now three `getBoundingClientRect()` reads at drag start (active, first, last unpinned header), taken in one synchronous pass so their differences are valid table-space offsets at any scroll position.

**2. Clamp `delta`, not just the modifier.** In dnd-kit, `scrollAdjustedTranslate = add(modifiedTranslate, scrollAdjustment)` — the scroll adjustment is applied *after* modifiers. So a modifier-only clamp was bypassed entirely by horizontal auto-scroll, and it ran away: the translated header inflates `scrollWidth`, `scrollLeft` grows, the adjustment grows. The clamp now lands on `event.delta.x`, which is post-adjustment. Because whole-column mode has the header reading the same `--dt-shift-*` variable as its body cells, clamping the delta clamps both.

Measured on the wide demo table, pointer held at the wrap edge with auto-scroll engaged for 3.5s:

| | transform | scrollWidth |
|---|---|---|
| before | 1461 → 2371 → … → **6991px, still climbing** | 2007 → **7351** |
| after | **flat at 1461px** | **constant 2007** |

1461px is exactly the unpinned band, so it correctly refuses to travel over the right-pinned columns.

## Also in this PR

- **The grip is hidden when a table has a single unpinned column.** It can never be dropped anywhere (`reorderRespectingPins` rejects every drop it could reach), so the grip could only ever do nothing. Follows the existing precedent for pinned columns. This is a user-visible change beyond the bug.
- Header cells now carry `data-dt-column-id` — needed to measure by column id, and shipped DOM.

## Known residual, deliberately not papered over

On the **opt-out** path (`dragWholeColumn={false}`) the header uses dnd-kit's own transform, which only the modifier can reach — so auto-scroll can still exceed the clamp there. Measured: the overshoot is bounded by the container's scroll distance rather than unbounded, and the runaway feedback loop is absent because the small ghost header doesn't inflate `scrollWidth` the way a whole column did. Closing it means overriding dnd-kit's auto-scroll. Documented in a code comment.

## Test plan

- 4170 tests / 196 files, typecheck, stylelint, prettier, `npm pack --dry-run` clean.
- New tests target the two regressions specifically: one stubs header rects wider than the declared `<col>` widths, so both the declared-width clamp (240px) and jsdom's zero rects (0px) fail it; another pins the *delta* clamp in a bare `DndContext` with no modifiers, so removing `clampX` from the delta fails it.
- Browser-verified in Chromium on both demo tables, before and after, with the numbers above. The reviewer reproduced the A/B independently against `main`.
- Pre-push review loop per Hard rule 8, two rounds.

## Follow-up found while verifying (not this PR)

Dropping a column while the pointer sits over a **right-pinned** column is a no-op — `useSortable({disabled})` disables droppable as well as draggable, so `over` is null and `handleDragEnd` bails. Pre-existing on `main`, but the clamp makes it more conspicuous: the preview now convincingly parks the column at the last unpinned slot and the release discards it. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk
