### PR TITLE
feat(Split): responsive collapse prop (collapseBelow), like Grid (#372)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1557,7 +1557,18 @@ beside results).
 - `asideWidth`: `'auto'` (default, intrinsic) or a CSS length like `'240px'` to pin the rail.
 - `gap`: `xs`/`sm`/`md` (default)/`lg`/`xl`/`2xl` — same scale as Stack/Cluster/Grid.
 - `align`: `'start'` (default) / `'stretch'` (full-height aside) / `'center'`.
+- `collapseBelow`: `sm` (480px) / `md` (640px) / `lg` (768px) — stack the panes vertically when the SPLIT'S OWN width (container query, not viewport) drops below the preset. Same scale as `Grid`'s `collapseBelow`. Use it whenever `asideWidth` pins a rail, else the rail squeezes `main` to nothing on narrow screens.
 - `main` has `min-width: 0` — long content shrinks/scrolls instead of overflowing.
+
+```tsx
+// Settings screen: 220px vertical Tabs rail that stacks above the panel under 480px.
+<Split aside={<Tabs orientation="vertical" ... />} asideWidth="220px" collapseBelow="sm">
+  <SettingsPanel />
+</Split>
+```
+
+- Collapsed panes stack in **DOM order**: aside → main for `side="start"` (default), main → aside for `side="end"`. No CSS `order` flip — visual order stays in sync with tab order. Need the aside on top when stacked? Use `side="start"`.
+- ❌ A `collapseBelow` split in an intrinsic-width context (another `Split`'s default `auto` aside track, a `Cluster` item, `width: max-content`). `container-type: inline-size` makes it contribute zero intrinsic width, so it renders at width 0 — give the parent a concrete width instead. It also becomes the containing block for absolutely-positioned descendants (layout containment). Splits without the prop pay neither cost.
 
 When NOT to use: equal columns → `<Grid columns={2}>`; wrapping peer row → `<Cluster>`; app shell sidebar → `<AppLayout>`/`<Rail>`.
 

--- a/packages/design-system/src/components/Split/Split.module.scss
+++ b/packages/design-system/src/components/Split/Split.module.scss
@@ -1,4 +1,5 @@
 @use './Split.tokens';
+@use '../_internal/collapse' as bp;
 
 .split {
   display: grid;
@@ -63,4 +64,44 @@
 
 .alignCenter {
   align-items: center;
+}
+
+// --- collapseBelow -----------------------------------------------------
+// Only splits with `collapseBelow` become size containers, so existing splits
+// get zero containment changes (container-type: inline-size zeroes the
+// element's intrinsic-width contribution — see Split.tsx's anti-pattern note).
+.collapsible {
+  container-type: inline-size;
+}
+
+// Below the container threshold both panes span every track, so the split
+// renders as one stacked column — in DOM order (aside-then-main for
+// side="start", main-then-aside for side="end"; no `order` flip, so visual
+// order stays in sync with tab order). Same mechanism as Grid's collapseBelow:
+// the query targets the CHILDREN, because an element can never query its own
+// size container — a rule on `.collapsible` itself would resolve against the
+// nearest ANCESTOR container instead and silently never match. Spanning the
+// children also neutralizes .sideStart / .sideEnd (grid-template-columns is
+// the only thing those set) for both side values at once.
+// Double class (.collapsible.collapseXx) keeps specificity above any
+// single-class consumer rule regardless of CSS bundle emission order.
+@container (max-width: #{bp.$collapse-sm}) {
+  .collapsible.collapseSm > * {
+    // stylelint-disable-next-line property-disallowed-list -- collapse override is Split's own internal grid placement, same sanction as Grid's collapse rules
+    grid-column: 1 / -1;
+  }
+}
+
+@container (max-width: #{bp.$collapse-md}) {
+  .collapsible.collapseMd > * {
+    // stylelint-disable-next-line property-disallowed-list -- collapse override is Split's own internal grid placement, same sanction as Grid's collapse rules
+    grid-column: 1 / -1;
+  }
+}
+
+@container (max-width: #{bp.$collapse-lg}) {
+  .collapsible.collapseLg > * {
+    // stylelint-disable-next-line property-disallowed-list -- collapse override is Split's own internal grid placement, same sanction as Grid's collapse rules
+    grid-column: 1 / -1;
+  }
 }

--- a/packages/design-system/src/components/Split/Split.test.tsx
+++ b/packages/design-system/src/components/Split/Split.test.tsx
@@ -137,3 +137,63 @@ describe('Split', () => {
     expect(el).toHaveAttribute('aria-label', 'settings layout');
   });
 });
+
+// jsdom does not evaluate container queries — same as Grid's collapseBelow
+// tests (#314), the collapse contract is asserted via the emitted classes; the
+// @container rules themselves are verified in the browser.
+describe('Split collapseBelow (#372)', () => {
+  it('adds the collapsible + breakpoint classes when set', () => {
+    const { container } = render(
+      <Split aside={<i />} collapseBelow="sm">
+        x
+      </Split>,
+    );
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.className).toMatch(/collapsible/);
+    expect(el.className).toMatch(/collapseSm/);
+  });
+
+  it('adds no collapse classes when unset — no container-type on plain splits', () => {
+    const { container } = render(<Split aside={<i />}>x</Split>);
+    expect((container.firstElementChild as HTMLElement).className).not.toMatch(/collaps/i);
+  });
+
+  it('collapses on either side, keeping DOM order (aside-first only for side="start")', () => {
+    const cellOrder = (root: Element) =>
+      Array.from(root.children).map((c) =>
+        /aside/.test((c as HTMLElement).className) ? 'aside' : 'main',
+      );
+
+    const start = render(
+      <Split aside={<i />} side="start" collapseBelow="md">
+        x
+      </Split>,
+    );
+    const startRoot = start.container.firstElementChild as HTMLElement;
+    expect(startRoot.className).toMatch(/collapsible/);
+    expect(startRoot.className).toMatch(/collapseMd/);
+    expect(startRoot.className).toMatch(/sideStart/);
+    expect(cellOrder(startRoot)).toEqual(['aside', 'main']);
+
+    const end = render(
+      <Split aside={<i />} side="end" collapseBelow="md">
+        x
+      </Split>,
+    );
+    const endRoot = end.container.firstElementChild as HTMLElement;
+    expect(endRoot.className).toMatch(/collapsible/);
+    expect(endRoot.className).toMatch(/collapseMd/);
+    expect(endRoot.className).toMatch(/sideEnd/);
+    expect(cellOrder(endRoot)).toEqual(['main', 'aside']);
+  });
+
+  it('keeps the pinned aside width custom property while collapsible', () => {
+    const { container } = render(
+      <Split aside={<i />} asideWidth="220px" collapseBelow="sm">
+        x
+      </Split>,
+    );
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.getPropertyValue('--split-aside-width')).toBe('220px');
+  });
+});

--- a/packages/design-system/src/components/Split/Split.test.tsx
+++ b/packages/design-system/src/components/Split/Split.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { render, screen } from '@testing-library/react';
 import { createRef } from 'react';
 import { Split } from './Split';
@@ -195,5 +197,28 @@ describe('Split collapseBelow (#372)', () => {
     );
     const el = container.firstElementChild as HTMLElement;
     expect(el.style.getPropertyValue('--split-aside-width')).toBe('220px');
+  });
+});
+
+describe('Split collapseBelow — the container query can actually match (#372)', () => {
+  // jsdom cannot evaluate @container, so no behavioral test can reach this.
+  // The class-name tests above all pass against a BROKEN implementation: the
+  // first attempt at this feature put the collapse rule on the collapsible
+  // element itself, which can never match — an element does not query its own
+  // size container, so the rule resolves against the nearest ANCESTOR
+  // container (usually none) and silently does nothing. Same class names, same
+  // DOM order, dead CSS. Only a browser caught it.
+  //
+  // So assert the one thing that distinguishes correct from dead: the query's
+  // subject must be the CHILDREN. Same SCSS-source technique DashboardCanvas
+  // and DropdownMenu use for contracts jsdom can't reach.
+  const scss = readFileSync(resolve(__dirname, 'Split.module.scss'), 'utf8');
+
+  it.each(['Sm', 'Md', 'Lg'])('targets children, not itself, at the %s breakpoint', (bp) => {
+    expect(scss).toMatch(new RegExp(`\\.collapsible\\.collapse${bp}\\s*>\\s*\\*\\s*\\{`));
+  });
+
+  it('wraps each collapse rule in a @container query', () => {
+    expect(scss.match(/@container \(max-width:/g)).toHaveLength(3);
   });
 });

--- a/packages/design-system/src/components/Split/Split.tsx
+++ b/packages/design-system/src/components/Split/Split.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, type CSSProperties, type HTMLAttributes, type ReactNode } from 'react';
 import clsx from 'clsx';
 import styles from './Split.module.scss';
+import type { CollapseBreakpoint } from '../_internal/collapse';
 
 /** Which side the `aside` pane sits on. RTL-aware (DOM + column order flip together). */
 export type SplitSide = 'start' | 'end';
@@ -40,6 +41,28 @@ export interface SplitProps extends HTMLAttributes<HTMLDivElement> {
    * - `'center'` — panes vertically centered.
    */
   align?: SplitAlign;
+  /**
+   * Stack the two panes vertically when the SPLIT'S OWN width (container
+   * query, not viewport) drops below the preset: `sm` 480px / `md` 640px /
+   * `lg` 768px. Same scale as `Grid`'s `collapseBelow`. Without it a pinned
+   * `asideWidth` rail squeezes `main` to nothing on narrow screens.
+   *
+   * Collapsed panes stack in **DOM order**, not always aside-first: with
+   * the default `side="start"` that's aside → main; with `side="end"` it's
+   * main → aside, because that's the order the panes are in the DOM. Forcing
+   * aside-first when collapsed would need CSS `order`, which desynchronizes
+   * visual order from tab order — an a11y defect. If you need the aside on top
+   * when stacked, use `side="start"`.
+   *
+   * ❌ Anti-pattern: a `collapseBelow` split must get its width from its
+   * parent. `container-type: inline-size` zeroes the split's contribution to
+   * intrinsic sizing, so in an intrinsic-width context (another `Split`'s
+   * default `auto` aside track, a `Cluster` item, `width: max-content`) it
+   * renders at width 0 — give the parent a concrete width instead. The split
+   * also becomes the containing block for absolutely-positioned descendants
+   * (layout containment). Splits without the prop pay none of this.
+   */
+  collapseBelow?: CollapseBreakpoint;
 }
 
 const gapClass: Record<SplitGap, string> = {
@@ -49,6 +72,12 @@ const gapClass: Record<SplitGap, string> = {
   lg: styles.gapLg,
   xl: styles.gapXl,
   '2xl': styles.gap2xl,
+};
+
+const collapseClass: Record<CollapseBreakpoint, string> = {
+  sm: styles.collapseSm,
+  md: styles.collapseMd,
+  lg: styles.collapseLg,
 };
 
 const alignClass: Record<SplitAlign, string> = {
@@ -81,6 +110,12 @@ const alignClass: Record<SplitAlign, string> = {
  *   <Results />
  * </Split>
  *
+ * @example
+ * // Settings screen that stacks on narrow containers (rail on top, DOM order).
+ * <Split aside={<Tabs orientation="vertical" ... />} asideWidth="220px" collapseBelow="sm">
+ *   <SettingsPanel />
+ * </Split>
+ *
  * @remarks When NOT to use
  * - For equal-width columns — use `<Grid columns={2}>`. Split is intentionally
  *   asymmetric (intrinsic aside + filling main).
@@ -93,6 +128,11 @@ const alignClass: Record<SplitAlign, string> = {
  *   shell (`<Rail>` / `<AppLayout sidebar>`); Split's aside is intra-page.
  * - ❌ Expecting `main` to push the layout wider than its container — it has
  *   `min-width: 0`, so its content shrinks/scrolls instead of overflowing.
+ * - ❌ A `collapseBelow` split in an intrinsic-width context (another
+ *   `Split`'s default `auto` aside track, a `Cluster` item,
+ *   `width: max-content`). `container-type: inline-size` makes it contribute
+ *   zero intrinsic width, so it renders at width 0 — give the parent a
+ *   concrete width instead.
  */
 export const Split = forwardRef<HTMLDivElement, SplitProps>(function Split(
   {
@@ -102,6 +142,7 @@ export const Split = forwardRef<HTMLDivElement, SplitProps>(function Split(
     asideWidth = 'auto',
     gap = 'md',
     align = 'start',
+    collapseBelow,
     className,
     style,
     ...props
@@ -118,6 +159,8 @@ export const Split = forwardRef<HTMLDivElement, SplitProps>(function Split(
         side === 'end' ? styles.sideEnd : styles.sideStart,
         gapClass[gap],
         alignClass[align],
+        collapseBelow && styles.collapsible,
+        collapseBelow && collapseClass[collapseBelow],
         className,
       )}
       // asideWidth → custom property the SCSS grid template reads. Consumer

--- a/packages/design-system/src/components/Split/Split.tsx
+++ b/packages/design-system/src/components/Split/Split.tsx
@@ -47,6 +47,13 @@ export interface SplitProps extends HTMLAttributes<HTMLDivElement> {
    * `lg` 768px. Same scale as `Grid`'s `collapseBelow`. Without it a pinned
    * `asideWidth` rail squeezes `main` to nothing on narrow screens.
    *
+   * When stacked, both panes span the full grid, which means a pinned
+   * `asideWidth` acts as a FLOOR on their width — the panes are at least
+   * `asideWidth + gap` wide even if the container is narrower, and overflow
+   * horizontally past that point. Keep `asideWidth` comfortably below the
+   * narrowest container you expect (e.g. `asideWidth="320px"` inside a 300px
+   * drawer still overflows after collapsing).
+   *
    * Collapsed panes stack in **DOM order**, not always aside-first: with
    * the default `side="start"` that's aside → main; with `side="end"` it's
    * main → aside, because that's the order the panes are in the DOM. Forcing

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -4214,6 +4214,13 @@
           "required": false,
           "default": "'start'",
           "description": "Cross-axis (vertical) alignment of the panes.\n- `'start'` (default) — panes hug the top.\n- `'stretch'` — `aside` matches `main`'s height (full-height bordered rail).\n- `'center'` — panes vertically centered."
+        },
+        {
+          "name": "collapseBelow",
+          "type": "CollapseBreakpoint",
+          "required": false,
+          "default": "",
+          "description": "Stack the two panes vertically when the SPLIT'S OWN width (container\nquery, not viewport) drops below the preset: `sm` 480px / `md` 640px /\n`lg` 768px. Same scale as `Grid`'s `collapseBelow`. Without it a pinned\n`asideWidth` rail squeezes `main` to nothing on narrow screens.\n\nCollapsed panes stack in **DOM order**, not always aside-first: with\nthe default `side=\"start\"` that's aside → main; with `side=\"end\"` it's\nmain → aside, because that's the order the panes are in the DOM. Forcing\naside-first when collapsed would need CSS `order`, which desynchronizes\nvisual order from tab order — an a11y defect. If you need the aside on top\nwhen stacked, use `side=\"start\"`.\n\n❌ Anti-pattern: a `collapseBelow` split must get its width from its\nparent. `container-type: inline-size` zeroes the split's contribution to\nintrinsic sizing, so in an intrinsic-width context (another `Split`'s\ndefault `auto` aside track, a `Cluster` item, `width: max-content`) it\nrenders at width 0 — give the parent a concrete width instead. The split\nalso becomes the containing block for absolutely-positioned descendants\n(layout containment). Splits without the prop pay none of this."
         }
       ]
     },

--- a/packages/playground/src/pages/components/SplitDemo.tsx
+++ b/packages/playground/src/pages/components/SplitDemo.tsx
@@ -34,8 +34,12 @@ const settingsTabs: TabItem[] = [
 export function SplitDemo() {
   const [section, setSection] = useState('general');
   const [sectionEnd, setSectionEnd] = useState('general');
+  const [sectionCollapse, setSectionCollapse] = useState('general');
+  const [sectionCollapseEnd, setSectionCollapseEnd] = useState('general');
   const active = sections[section];
   const activeEnd = sections[sectionEnd];
+  const activeCollapse = sections[sectionCollapse];
+  const activeCollapseEnd = sections[sectionCollapseEnd];
 
   return (
     <DemoLayout
@@ -196,6 +200,89 @@ export function Demo() {
             </Stack>
           </Card>
         </Split>
+      </Example>
+
+      <Example
+        title="collapseBelow — stacks on narrow containers"
+        description="collapseBelow='sm' stacks the two panes into one column once the SPLIT'S OWN width (container query, not the viewport) drops below 480px — without it a pinned 220px rail squeezes the panel to nothing. Panes stack in DOM order: aside on top for side='start', main on top for side='end' (no CSS order flip, so visual order stays in sync with tab order). Drag each box's resize handle (bottom-right corner) narrower to see it collapse."
+        code={`import { useState } from 'react';
+import { Card, Split, Stack, Tabs } from '@eocrm/design-system';
+
+export function Demo() {
+  const [section, setSection] = useState('general');
+  const active = sections[section];
+
+  return (
+    <Split
+      asideWidth="220px"
+      gap="lg"
+      collapseBelow="sm"
+      aside={
+        <Tabs
+          orientation="vertical"
+          items={settingsTabs}
+          activeId={section}
+          onChange={setSection}
+        />
+      }
+    >
+      <Card padding="md" style={{ color: 'var(--color-fg-muted)' }}>
+        <Stack gap="xs">
+          <strong style={{ color: 'var(--color-fg)' }}>{active.title}</strong>
+          <span>{active.body}</span>
+        </Stack>
+      </Card>
+    </Split>
+  );
+}`}
+      >
+        <Stack gap="lg">
+          <div style={{ resize: 'horizontal', overflow: 'auto' }}>
+            <Split
+              asideWidth="220px"
+              gap="lg"
+              collapseBelow="sm"
+              aside={
+                <Tabs
+                  orientation="vertical"
+                  items={settingsTabs}
+                  activeId={sectionCollapse}
+                  onChange={setSectionCollapse}
+                />
+              }
+            >
+              <Card padding="md" style={{ color: 'var(--color-fg-muted)' }}>
+                <Stack gap="xs">
+                  <strong style={{ color: 'var(--color-fg)' }}>{activeCollapse.title}</strong>
+                  <span>{activeCollapse.body}</span>
+                </Stack>
+              </Card>
+            </Split>
+          </div>
+          <div style={{ resize: 'horizontal', overflow: 'auto' }}>
+            <Split
+              side="end"
+              asideWidth="220px"
+              gap="lg"
+              collapseBelow="sm"
+              aside={
+                <Tabs
+                  orientation="vertical"
+                  items={settingsTabs}
+                  activeId={sectionCollapseEnd}
+                  onChange={setSectionCollapseEnd}
+                />
+              }
+            >
+              <Card padding="md" style={{ color: 'var(--color-fg-muted)' }}>
+                <Stack gap="xs">
+                  <strong style={{ color: 'var(--color-fg)' }}>{activeCollapseEnd.title}</strong>
+                  <span>{activeCollapseEnd.body}</span>
+                </Stack>
+              </Card>
+            </Split>
+          </div>
+        </Stack>
       </Example>
     </DemoLayout>
   );


### PR DESCRIPTION
Addresses #372.

## Summary

`<Split>` rendered a static `grid-template-columns: var(--split-aside-width) 1fr` that never stacked, so below ~480px a pinned aside rail squeezed `main` to nothing. Adds `collapseBelow?: 'sm' | 'md' | 'lg'` — below the threshold the two panes stack into one column.

Reuses the existing `_internal/collapse` machinery that `Grid.collapseBelow` (#314) already established: same breakpoint names and pixel values (480 / 640 / 768), same container-query approach. Single value, no breakpoint→columns map — meaningless for a two-pane component.

## Three decisions worth knowing

**Panes stack in DOM order, not always aside-first.** With the default `side="start"` that's aside → main, which is what the issue asked for. With `side="end"` it's main → aside, because that's the DOM order. Forcing aside-first would need CSS `order`, which desynchronizes visual order from tab order — an a11y defect. Documented on the prop.

**`container-type: inline-size` is opt-in.** It zeroes the element's contribution to intrinsic sizing, so every Split paying that cost would be wrong. Only splits with `collapseBelow` become size containers; verified in the browser that a plain `<Split>` computes `container-type: normal`, and there's a test for it.

**A pinned `asideWidth` acts as a floor when stacked.** Spanning `1 / -1` doesn't erase the track template, so the panes are at least `asideWidth + gap` wide. `<Split asideWidth="320px" collapseBelow="lg">` in a 300px drawer collapses but still overflows. Documented rather than silently changing the uncollapsed track to `minmax(0, …)`, which would alter existing behavior.

## The bug this nearly shipped with

The first implementation reset `grid-template-columns` on the collapsible element itself. **That can never match** — an element does not query its own size container, so the rule resolved against the nearest *ancestor* container (none) and silently did nothing. Same class names, same DOM order, dead CSS. jsdom can't evaluate `@container`, so every class-name test passed; only browser measurement caught it.

It now targets the children (`> * { grid-column: 1 / -1 }`), copying Grid's technique, which also neutralizes `.sideStart`/`.sideEnd` in one rule since `grid-template-columns` is all they set.

Because that failure mode is invisible to behavioral tests, there's now a source-level guard asserting the query's subject is the children. Mutation-verified: reverting to the broken selector fails it.

## Test plan

- 4178 tests / 196 files, typecheck, lint, format:check, `npm pack --dry-run` clean.
- Browser-measured in Chrome at 600 / 481 / 479px for both `side` values: side-by-side above the threshold, `grid-column: 1 / -1` and stacked below, DOM order preserved. `align="stretch"` and `"center"` become no-ops when stacked (each pane gets its own row), which is correct.
- Pre-push review per Hard rule 8. It independently reproduced the container-query behavior in Chrome, confirmed the `stylelint-disable` comments are genuinely required (`grid-column` is in `property-disallowed-list` for component SCSS — deleting them produces 3 errors), and confirmed the doubled-class specificity matches Grid's precedent.

## Note for the consumer

The interim `CollapsibleSplit` shim in apps/web is **not** a 1:1 swap. This is a container query on the split's own width; the shim used `matchMedia` on the viewport. A narrow split inside a wide viewport now also collapses — better behavior, but different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk
