### PR TITLE
fix(Kanban): commit the released slot on a cross-column drop, not the entry slot (#376)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -939,6 +939,8 @@ Props on the root: `onMove?: (event: KanbanMoveEvent) => void` — fires once pe
 
 **Cross-column drag is LIVE**: as the dragged card crosses into a new column, cards in the target column shift to make room in real time. `onMove` still fires only once on release. This is driven by internal Kanban state — consumer's state is untouched until drop, so re-renders are scoped to the Kanban subtree (avoids the measureRect cascade that would happen if mid-drag mutations went through consumer setState).
 
+**Drop slot** = the slot the preview showed at release, for the whole drag — the destination index re-evaluates as the cursor moves inside the target column, not only when it crosses the boundary (#376). Safe to send `to.index` straight to a ranking API.
+
 **Keyboard reorder** works WITHIN a column (Tab to Card/Handle, Space pick up, Arrow keys move, Space drop). Cross-column keyboard moves are NOT supported in v1.
 
 **Anti-patterns**

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -939,7 +939,7 @@ Props on the root: `onMove?: (event: KanbanMoveEvent) => void` — fires once pe
 
 **Cross-column drag is LIVE**: as the dragged card crosses into a new column, cards in the target column shift to make room in real time. `onMove` still fires only once on release. This is driven by internal Kanban state — consumer's state is untouched until drop, so re-renders are scoped to the Kanban subtree (avoids the measureRect cascade that would happen if mid-drag mutations went through consumer setState).
 
-**Drop slot** = the slot the preview showed at release, for the whole drag — the destination index re-evaluates as the cursor moves inside the target column, not only when it crosses the boundary (#376). Safe to send `to.index` straight to a ranking API.
+**Drop slot**: `to.index` is the slot the preview showed at release — it re-evaluates as the cursor moves inside the target column, not only when the card crosses the boundary (#376). Caveat on `to.columnId`: releasing outside the board is not a cancel; the nearest column wins, so a drop flung past the last column still commits somewhere.
 
 **Keyboard reorder** works WITHIN a column (Tab to Card/Handle, Space pick up, Arrow keys move, Space drop). Cross-column keyboard moves are NOT supported in v1.
 

--- a/packages/design-system/src/components/Kanban/Kanban.test.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.test.tsx
@@ -255,10 +255,35 @@ describe('Kanban — drop position', () => {
   });
   afterEach(() => restore());
 
+  it('#376 reproduction: enters at the top, releases ON the last card, commits that card’s slot', () => {
+    // The exact gesture from the issue: cross the boundary near the top of a
+    // three-card column, travel DOWN, release over a sibling. Before the fix
+    // the slot froze at the crossing and this committed index 0 while the
+    // preview showed the gap further down. `at(1, 140)` sits on b2 in the
+    // live list [a1, b1, b2, b3], so both preview and commit are index 2.
+    const onMove = vi.fn();
+    render(
+      <Board
+        onMove={onMove}
+        columns={[
+          ['a', ['a1', 'a2']],
+          ['b', ['b1', 'b2', 'b3']],
+        ]}
+      />,
+    );
+
+    drag('a1', [at(1, 5), at(1, 140)]);
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onMove.mock.calls[0][0]).toEqual({
+      cardId: 'a1',
+      from: { columnId: 'a', index: 0 },
+      to: { columnId: 'b', index: 2 },
+    });
+  });
+
   it('commits the slot the card was RELEASED on, not the one it entered the column at (#376)', () => {
-    // Enter "b" at the very top (slot 0), then travel down to the last card
-    // and release there. Before #376 the slot froze at the boundary crossing
-    // and this committed index 0 while the preview showed the bottom slot.
+    // Same crossing, but released past the last card — the append path.
     const onMove = vi.fn();
     render(
       <Board
@@ -358,6 +383,32 @@ describe('Kanban — drop position', () => {
     drag('a1', [at(0, 30)]);
 
     expect(onMove).not.toHaveBeenCalled();
+  });
+
+  it('after a round trip, a sibling’s LIVE index wins over its pre-drag index', () => {
+    // a1 → b → back into a, seated at the end, released over a4. a4's pre-drag
+    // index is 3; its index in the live column (a1 removed from the front, then
+    // re-appended) is 2 — and 2 is what the strategy previews. Resolving the
+    // sibling against the pre-drag order would commit 3.
+    const onMove = vi.fn();
+    render(
+      <Board
+        onMove={onMove}
+        columns={[
+          ['a', ['a1', 'a2', 'a3', 'a4']],
+          ['b', ['b1']],
+        ]}
+      />,
+    );
+
+    drag('a1', [at(1, 5), at(0, 140)]);
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onMove.mock.calls[0][0]).toEqual({
+      cardId: 'a1',
+      from: { columnId: 'a', index: 0 },
+      to: { columnId: 'a', index: 2 },
+    });
   });
 
   it('commits the released slot after a round trip back to the origin column', () => {

--- a/packages/design-system/src/components/Kanban/Kanban.test.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.test.tsx
@@ -1,6 +1,6 @@
 import { createRef } from 'react';
-import { render } from '@testing-library/react';
-import { Kanban } from './Kanban';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Kanban, type KanbanMoveEvent } from './Kanban';
 import { SortableHandle } from '../Sortable/Sortable';
 
 describe('Kanban', () => {
@@ -165,5 +165,221 @@ describe('Kanban', () => {
     expect(consoleWarn).not.toHaveBeenCalled();
     consoleError.mockRestore();
     consoleWarn.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drop position (#376)
+// ---------------------------------------------------------------------------
+// jsdom lays nothing out — every getBoundingClientRect is 0×0, which leaves
+// dnd-kit unable to resolve ANY drop target. `stubLayout` below fakes a real
+// board: columns side by side, cards stacked inside them, rects derived from
+// each element's CURRENT position in the DOM so a live reorder re-measures the
+// way a browser would. With that in place a real pointer drag (jsdom 29
+// implements PointerEvent, so the PointerSensor activates for real) runs
+// through Kanban's own DndContext.
+
+const COL_W = 100;
+const COL_GAP = 20;
+const CARD_H = 50;
+
+/** Column i occupies x [i*(COL_W+COL_GAP), +COL_W], y [0, height]. Card n
+ *  inside it occupies that x band, y [n*CARD_H, +CARD_H]. */
+function stubLayout(): () => void {
+  const orig = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function (this: Element) {
+    const column = this.closest('[data-col]');
+    if (!column) return orig.call(this);
+    const colIdx = Number(column.getAttribute('data-col'));
+    const left = colIdx * (COL_W + COL_GAP);
+    if (this === column) {
+      const height = Number(column.getAttribute('data-h') ?? 300);
+      return new DOMRect(left, 0, COL_W, height);
+    }
+    const card = this.closest('[data-card]');
+    if (card !== this) return orig.call(this);
+    const idx = Array.from(column.querySelectorAll('[data-card]')).indexOf(this);
+    return new DOMRect(left, idx * CARD_H, COL_W, CARD_H);
+  };
+  return () => {
+    Element.prototype.getBoundingClientRect = orig;
+  };
+}
+
+interface BoardProps {
+  onMove?: (event: KanbanMoveEvent) => void;
+  columns: [string, string[]][];
+  /** Column height — a tall column with few cards has drop-able padding. */
+  height?: number;
+}
+
+function Board({ onMove, columns, height = 300 }: BoardProps) {
+  return (
+    <Kanban onMove={onMove}>
+      {columns.map(([colId, cards], i) => (
+        <Kanban.Column key={colId} id={colId} data-col={i} data-h={height}>
+          {cards.map((cardId) => (
+            <Kanban.Card key={cardId} id={cardId} data-card={cardId}>
+              {cardId}
+            </Kanban.Card>
+          ))}
+        </Kanban.Column>
+      ))}
+    </Kanban>
+  );
+}
+
+/** Presses the card, walks the pointer through `path`, releases at the last
+ *  point. Coordinates are in the stubbed layout's space. The first move only
+ *  trips the sensor's 5px activation constraint — the drag proper starts at
+ *  `path[0]`, which keeps every delta measured from the press point. */
+function drag(cardId: string, path: [number, number][]) {
+  const card = screen.getByText(cardId);
+  const from = card.getBoundingClientRect();
+  const startX = from.left + COL_W / 2;
+  const startY = from.top + CARD_H / 2;
+  fireEvent.pointerDown(card, { clientX: startX, clientY: startY, button: 0, isPrimary: true });
+  fireEvent.pointerMove(document, { clientX: startX, clientY: startY + 10 });
+  for (const [clientX, clientY] of path) fireEvent.pointerMove(document, { clientX, clientY });
+  const [lastX, lastY] = path[path.length - 1];
+  fireEvent.pointerUp(document, { clientX: lastX, clientY: lastY });
+}
+
+/** Centre of column i, at vertical offset y. */
+const at = (col: number, y: number): [number, number] => [col * (COL_W + COL_GAP) + COL_W / 2, y];
+
+describe('Kanban — drop position', () => {
+  let restore: () => void;
+  beforeEach(() => {
+    restore = stubLayout();
+  });
+  afterEach(() => restore());
+
+  it('commits the slot the card was RELEASED on, not the one it entered the column at (#376)', () => {
+    // Enter "b" at the very top (slot 0), then travel down to the last card
+    // and release there. Before #376 the slot froze at the boundary crossing
+    // and this committed index 0 while the preview showed the bottom slot.
+    const onMove = vi.fn();
+    render(
+      <Board
+        onMove={onMove}
+        columns={[
+          ['a', ['a1', 'a2']],
+          ['b', ['b1', 'b2', 'b3']],
+        ]}
+      />,
+    );
+
+    drag('a1', [at(1, 5), at(1, 190)]);
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onMove.mock.calls[0][0]).toEqual({
+      cardId: 'a1',
+      from: { columnId: 'a', index: 0 },
+      to: { columnId: 'b', index: 3 },
+    });
+  });
+
+  it('re-evaluates upward too: enters at the bottom, releases on the top card', () => {
+    const onMove = vi.fn();
+    render(
+      <Board
+        onMove={onMove}
+        columns={[
+          ['a', ['a1', 'a2']],
+          ['b', ['b1', 'b2', 'b3']],
+        ]}
+      />,
+    );
+
+    drag('a1', [at(1, 190), at(1, 5)]);
+
+    expect(onMove.mock.calls[0][0].to).toEqual({ columnId: 'b', index: 0 });
+  });
+
+  it('appends when released in a sparse column’s padding below the last card', () => {
+    // Tall column, three cards: below them `over` resolves to the column
+    // itself, which the sortable strategy renders with no displacement — so
+    // the card must already be sitting at the end of the live list.
+    const onMove = vi.fn();
+    render(
+      <Board
+        onMove={onMove}
+        height={1000}
+        columns={[
+          ['a', ['a1', 'a2']],
+          ['b', ['b1', 'b2', 'b3']],
+        ]}
+      />,
+    );
+
+    drag('a1', [at(1, 5), at(1, 980)]);
+
+    expect(onMove.mock.calls[0][0].to).toEqual({ columnId: 'b', index: 3 });
+  });
+
+  it('drops into an empty column at index 0', () => {
+    const onMove = vi.fn();
+    render(
+      <Board
+        onMove={onMove}
+        columns={[
+          ['a', ['a1', 'a2']],
+          ['b', []],
+        ]}
+      />,
+    );
+
+    drag('a1', [at(1, 100)]);
+
+    expect(onMove.mock.calls[0][0].to).toEqual({ columnId: 'b', index: 0 });
+  });
+
+  it('a same-column reorder still uses arrayMove semantics (no oscillation)', () => {
+    // The dragOver early-return exists for exactly this path — the slot is
+    // resolved once, at dragEnd, from `over`.
+    const onMove = vi.fn();
+    render(<Board onMove={onMove} columns={[['a', ['a1', 'a2', 'a3']]]} />);
+
+    drag('a1', [at(0, 90), at(0, 140)]);
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onMove.mock.calls[0][0]).toEqual({
+      cardId: 'a1',
+      from: { columnId: 'a', index: 0 },
+      to: { columnId: 'a', index: 2 },
+    });
+  });
+
+  it('does not fire onMove for a drag that never leaves its own slot', () => {
+    const onMove = vi.fn();
+    render(<Board onMove={onMove} columns={[['a', ['a1', 'a2', 'a3']]]} />);
+
+    drag('a1', [at(0, 30)]);
+
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  it('commits the released slot after a round trip back to the origin column', () => {
+    const onMove = vi.fn();
+    render(
+      <Board
+        onMove={onMove}
+        columns={[
+          ['a', ['a1', 'a2', 'a3']],
+          ['b', ['b1']],
+        ]}
+      />,
+    );
+
+    // a1 → column b → back into a, released below a3 (the last card).
+    drag('a1', [at(1, 5), at(0, 140)]);
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onMove.mock.calls[0][0]).toEqual({
+      cardId: 'a1',
+      from: { columnId: 'a', index: 0 },
+      to: { columnId: 'a', index: 2 },
+    });
   });
 });

--- a/packages/design-system/src/components/Kanban/Kanban.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.tsx
@@ -8,6 +8,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type HTMLAttributes,
   type ReactElement,
@@ -306,22 +307,37 @@ KanbanColumn.displayName = 'KanbanColumn';
  * </Kanban>
  *
  * @remarks Drop position semantics
- * - Cross-column drop on a sibling card → the active card lands at that
- *   card's slot if the cursor crossed the column boundary above the over
- *   card's midpoint, or after it if the cursor was past the midpoint
- *   (cursor-position-vs-over-card-midpoint isBelow detection at the moment
- *   of transit). Subsequent within-target-column cursor movement does NOT
- *   re-evaluate the slot — only the cross-boundary moment matters.
+ * The committed `to.index` is the slot the preview showed at the moment of
+ * release — the two cannot drift, because both are read off the same
+ * `over`. `verticalListSortingStrategy` renders a column as
+ * `arrayMove(cards, activeIndex, overIndex)` where
+ * `overIndex = cards.indexOf(over.id)`, so the gap the user sees sits at
+ * `overIndex`; `onMove` commits that same index. Where `over` is not a card
+ * (`overIndex === -1`) the strategy displaces nothing, so the preview is the
+ * card's live slot and that is what gets committed. Concretely:
+ * - Drop on a sibling card → the active card lands at that card's slot in
+ *   the destination as rendered mid-drag. The slot re-evaluates as the
+ *   cursor moves, for the whole drag — not only at the column boundary
+ *   (fixed in #376; before that a cross-column drop committed the entry
+ *   slot while the preview kept tracking the cursor).
  * - Cross-column drop onto an empty column → index 0 of the destination.
  * - Cross-column drop in the column's padding past the last card → appended
- *   to the end of the destination.
+ *   to the end of the destination, re-appended as long as the cursor stays
+ *   in the padding.
  * - Within-column reorder onto a sibling card → arrayMove semantics: the
- *   active card ends at the over card's pre-move index (`from.index` →
- *   `to.index`, where `to.index = initialItems[col].indexOf(overId)`).
+ *   active card ends at the over card's index in the column as currently
+ *   rendered (for a drag that never left its column that's the card's
+ *   pre-move index, since nothing re-seated it).
  * - Within-column drop on the source column's own padding past all cards →
- *   appended to the end of the source column.
- * - Release outside any droppable → cancel + snap back; `onMove` does NOT
- *   fire.
+ *   appended to the end of the source column. This is the one deliberate
+ *   deviation from "commit === preview": `over` is the column, so the
+ *   strategy shows the card in its original slot, but snapping a
+ *   dragged-to-the-bottom card back to where it started reads as a dropped
+ *   drag, so the commit appends instead.
+ * - Release without moving (cursor never left the card's own slot) or Escape
+ *   → snap back; `onMove` does NOT fire. Note that releasing *outside* the
+ *   board is not a cancel: `closestCorners` still resolves the nearest
+ *   column, so the card commits there.
  *
  * @remarks When NOT to use
  * - Single-column drag-to-reorder — use `<Sortable>` instead. It's simpler
@@ -463,14 +479,19 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
   // ------------------------------------------------------------------
   // Drag handlers
   // ------------------------------------------------------------------
+  const originRef = useRef<string | number | null>(null);
   const handleDragStart = useCallback(
-    (_event: DragStartEvent) => {
+    (event: DragStartEvent) => {
+      // The column the card started in. Used by handleDragOver to tell a
+      // genuine same-column reorder apart from "already transited, still
+      // moving inside the destination".
+      originRef.current = findContainer(event.active.id as string | number, initialItems);
       // Snapshot: shallow-copy each cards array so mutations don't leak into initialItems.
       const snapshot = new Map<string | number, (string | number)[]>();
       for (const [colId, cards] of initialItems) snapshot.set(colId, [...cards]);
       setLiveItems(snapshot);
     },
-    [initialItems],
+    [initialItems, findContainer],
   );
 
   const handleDragOver = useCallback(
@@ -486,15 +507,30 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
         const activeContainer = findContainer(activeId, prev);
         const overContainer = findContainer(overId, prev);
         if (activeContainer == null || overContainer == null) return prev;
-        // Within-column reorder is finalized at dragEnd. Updating liveItems
-        // every dragOver here would oscillate when the cursor stays over a
-        // single sibling (the arrayMove would flip the card back and forth).
-        // useSortable's strategy handles the visual reflow during drag.
-        if (activeContainer === overContainer) return prev;
+
+        const isTransit = activeContainer !== overContainer;
+        // Pointer in the padding of the column the card has already transited
+        // into (no card under it). `over` is the column, so the sortable
+        // strategy computes overIndex === -1 and applies NO displacement —
+        // re-appending here is therefore stable (it can't fight a transform)
+        // and it's exactly what the user sees. Cheap to keep in sync.
+        const isForeignAppend =
+          !isTransit && overId === overContainer && overContainer !== originRef.current;
+        // Everything else with active and over in the same column is finalized
+        // at dragEnd from `over` (see handleDragEnd). Re-seating the card here
+        // on every dragOver would oscillate: the insertion re-measures the
+        // rects, which changes `over`, which re-fires this handler — and the
+        // strategy would still displace siblings on top of the new order, so
+        // the commit would drift from the preview again.
+        if (!isTransit && !isForeignAppend) return prev;
 
         const activeCards = prev.get(activeContainer) ?? [];
-        const overCards = prev.get(overContainer) ?? [];
         if (!activeCards.includes(activeId)) return prev;
+        if (isForeignAppend && activeCards[activeCards.length - 1] === activeId) return prev;
+
+        // Slot math runs against the destination WITHOUT the active card, so
+        // the card's own slot is never counted (off-by-one when moving down).
+        const overCards = (prev.get(overContainer) ?? []).filter((id) => id !== activeId);
 
         // Resolve the target slot inside overContainer:
         //   - over.id is a sibling card → use that card's index, plus 1 if
@@ -517,10 +553,12 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
         }
 
         const next = new Map(prev);
-        next.set(
-          activeContainer,
-          activeCards.filter((id) => id !== activeId),
-        );
+        if (isTransit) {
+          next.set(
+            activeContainer,
+            activeCards.filter((id) => id !== activeId),
+          );
+        }
         const newOver = [...overCards];
         newOver.splice(insertAt, 0, activeId);
         next.set(overContainer, newOver);
@@ -564,15 +602,16 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
         return;
       }
 
-      // Where does active currently live in liveItems? handleDragOver moves
-      // it cross-column only (with isBelow detection determining the slot at
-      // the moment of transit), so:
-      //   - liveColumn !== fromColumn → cross-column drop. The live slot IS
-      //     the drop slot — useSortable's verticalListSortingStrategy renders
-      //     the active card at exactly that slot (no within-target visual
-      //     reflow when overId === activeId), so live === visual === commit.
-      //   - liveColumn === fromColumn → within-column drop. Finalize via
-      //     arrayMove semantics using over.id below.
+      // Where does active currently live in liveItems? handleDragOver seats
+      // it in the destination on transit; the exact slot is resolved HERE,
+      // from `over`, because that's what the user was looking at:
+      // `verticalListSortingStrategy` renders each column as
+      // `arrayMove(liveItems[col], activeIndex, overIndex)` with
+      // `overIndex = liveItems[col].indexOf(over.id)`, so the previewed slot
+      // is `overIndex` whenever `over` is a sibling card, and the card's live
+      // slot when it isn't (`overIndex === -1` → the strategy displaces
+      // nothing). Committing the live slot alone would pin the drop to the
+      // boundary-crossing point (#376).
       let liveColumn: string | number | null = null;
       let liveIdx = -1;
       for (const [colId, cards] of finalItems) {
@@ -588,10 +627,11 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
       let toIndex: number;
 
       if (liveColumn != null && liveColumn !== fromColumn) {
-        // Cross-column drop: live slot wins. Keeps the commit consistent with
-        // the visual preview the user saw during drag.
+        // Cross-column drop: the previewed slot wins (see the comment above).
         toColumn = liveColumn;
-        toIndex = liveIdx;
+        const destCards = finalItems.get(liveColumn) ?? [];
+        const overIdx = overId === activeId ? -1 : destCards.indexOf(overId);
+        toIndex = overIdx >= 0 ? overIdx : liveIdx;
       } else if (initialItems.has(overId)) {
         // Within-source-column drop on the column's padding (no card target).
         // Default to "drop at end" so the card lands where the user dragged
@@ -600,19 +640,25 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
         const fromCol = initialItems.get(fromColumn) ?? [];
         toIndex = fromCol.length - 1;
       } else if (overId === activeId) {
-        // Cursor still over the active card — barely-moved drag, no real
-        // target. Cancel.
-        setLiveItems(null);
-        return;
+        // Cursor over the dragged card itself. The strategy displaces nothing
+        // (overIndex === activeIndex), so the preview IS the live order —
+        // commit that. A barely-moved drag resolves to its own starting index
+        // and gets dropped by the no-op guard below; a card that came back to
+        // its origin column lands where the preview put it.
+        toColumn = fromColumn;
+        toIndex = liveIdx;
       } else {
         // Within-column drop on a sibling card. arrayMove semantics:
-        //   toIndex = sibling's index in the consumer's pre-move state.
-        // For cross-column drops where the cross-column transit didn't
-        // commit (rare stale-closure case at the very first dragOver), the
-        // sibling may live in a different column — handle that by resolving
-        // the column from initialItems.
+        //   toIndex = sibling's index in the live column — same rule as the
+        // cross-column branch. For a plain same-column drag liveItems is
+        // untouched, so this is the sibling's index in the consumer's
+        // pre-move state; if the card visited another column and came back,
+        // the live order is what the preview showed, so it wins.
+        // For cross-column drops where the transit didn't commit (rare
+        // stale-closure case at the very first dragOver), the sibling may
+        // live in a different column — resolve the column from the card.
         let overCol: string | number | null = null;
-        for (const [colId, cards] of initialItems) {
+        for (const [colId, cards] of finalItems) {
           if (cards.includes(overId)) {
             overCol = colId;
             break;
@@ -623,7 +669,7 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
           return;
         }
         toColumn = overCol;
-        toIndex = (initialItems.get(toColumn) ?? []).indexOf(overId);
+        toIndex = (finalItems.get(toColumn) ?? []).indexOf(overId);
       }
 
       setLiveItems(null);

--- a/packages/design-system/src/components/Kanban/Kanban.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.tsx
@@ -330,10 +330,12 @@ KanbanColumn.displayName = 'KanbanColumn';
  *   pre-move index, since nothing re-seated it).
  * - Within-column drop on the source column's own padding past all cards →
  *   appended to the end of the source column. This is the one deliberate
- *   deviation from "commit === preview": `over` is the column, so the
- *   strategy shows the card in its original slot, but snapping a
- *   dragged-to-the-bottom card back to where it started reads as a dropped
- *   drag, so the commit appends instead.
+ *   deviation from "commit === preview": `over` is the column, so the strategy
+ *   displaces nothing and previews the card at whatever slot it currently
+ *   occupies (its original one, or — if it visited another column and came
+ *   back — wherever the return seated it, which can be several slots off).
+ *   The commit appends anyway: snapping a dragged-to-the-bottom card back up
+ *   reads as a dropped drag.
  * - Release without moving (cursor never left the card's own slot) or Escape
  *   → snap back; `onMove` does NOT fire. Note that releasing *outside* the
  *   board is not a cancel: `closestCorners` still resolves the nearest
@@ -537,6 +539,15 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
         //     the cursor is past the over card's vertical midpoint (active's
         //     translated rect tracks the cursor centered around it).
         //   - over.id is the column itself (empty drop / padding) → append
+        //
+        // The `isBelow` +1 rarely survives to the commit: the strategy
+        // immediately re-renders the card at `overIndex` and dragEnd commits
+        // from `over`, so both sides of the +1 produce the same drop. It still
+        // decides the seeded slot the frame after transit (while dnd-kit has
+        // transforms disabled to re-measure), and dragEnd's fallbacks — `over`
+        // resolving to the column or to the dragged card itself — commit that
+        // seeded slot verbatim. Keep it; without it the card visibly jumps a
+        // slot on entry.
         let insertAt: number;
         if (overCards.includes(overId)) {
           const overIdx = overCards.indexOf(overId);
@@ -573,10 +584,11 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
       const { active, over } = event;
       const activeId = active.id as string | number;
 
-      // Release outside any droppable → cancel + snap back. dnd-kit fires
-      // onDragEnd with over=null when the cursor leaves all droppable areas
-      // before release. Treat that as a cancellation (matches Sortable
-      // semantics and Trello convention).
+      // `over` is null only when the collision detection returned nothing at
+      // all — i.e. no droppable was measured. It is NOT "released outside the
+      // board": `containerAwareClosestCorners` falls back to `closestCorners`,
+      // which ranks every measured droppable and always yields one, so a
+      // release far away from the columns still resolves to the nearest.
       if (!over) {
         setLiveItems(null);
         return;


### PR DESCRIPTION
Addresses #376.

## Summary

On a cross-column drag, Kanban committed the slot where the pointer **entered** the destination column, not where it was released. The visual gap meanwhile kept tracking the cursor, so preview and commit disagreed — and since the consumer sends the committed `to.index` straight to a board-rank API, the wrong index was **persisted**, not just previewed.

Measured on the demo board, dragging into a 3-card column crossing at the top then moving down to the last card:

| | entry slot | gap the preview last showed | committed `to.index` |
|---|---|---|---|
| before | 0 | 2 | **0** ← bug |
| after | 0 | 2 | **2** ✓ |

## Not the fix the issue suggested — and here's why

The issue proposed keeping the slot re-resolving in `handleDragOver` while `overContainer !== origin`. That cannot work, and both the implementer and the reviewer confirmed it independently against dnd-kit's source.

The preview is not the live order. `verticalListSortingStrategy` renders `arrayMove(items, activeIndex, overIndex)` **on top of** `liveItems`, and for the active card `defaultNewIndexGetter` reduces to exactly `overIndex` — so re-seating the card at slot *k* still draws the gap at `overIndex`. Concretely, with items `[X,A,Y,Z]`, re-seating `A` at slot 3 with `over = Z` gives `arrayMove([X,Y,Z,A],3,2) = [X,Y,A,Z]`: gap at 2, live index 3. Slot 3 is a **fixed point** of the midpoint rule, so it never converges — a permanent off-by-one. Re-measuring would also re-fire `dragOver`, the very loop the early return exists to stop.

So the slot is resolved at `dragEnd` from `over`, using dnd-kit's own newIndex rule, which makes commit == preview *by construction* rather than by keeping two paths in agreement. Two narrow supports come with it, both mutation-verified as load-bearing:

- `dragOver` re-appends while the pointer is in a **foreign** column's padding (the displacement-free case);
- `over === active` at `dragEnd` commits the live slot instead of cancelling — the A→B→A round trip, which previously previewed a move and committed nothing.

The issue warned that a `dragEnd`-only recompute leaves `liveItems` stale for anything reading it mid-drag. Checked: it has exactly two consumers — the rendered card order and each column's `SortableContext.items` — and both are the *input* the strategy displaces on top of. No third reader.

## Test plan

- 4219 tests / 197 files, typecheck, lint, format:check, `npm pack --dry-run` clean.
- Seven real pointer-drag tests. Every behavioral change is mutation-verified: reverting the cross-column `toIndex` fails 3 tests including the issue's own reproduction; reverting the `finalItems` reads fails exactly 1; removing the foreign-padding re-append fails its test; restoring the old `over === active` cancel fails the round-trip test.
- Browser-verified before *and* after on the demo board, plus empty-destination, append-below and travel-upward cases — every commit equalled the previewed gap.
- Pre-push review per Hard rule 8, two rounds. The second round's mutation battery found that the headline case wasn't actually asserted (the existing test hit the padding/append path, not "released on a sibling card") and that one change had zero coverage. Both now pinned.

## Docblock corrections

`KanbanRoot`'s `@remarks Drop position semantics` claimed "live === visual === commit", which #376 disproved, and "release outside any droppable → cancel", which has been false since #367 — `containerAwareClosestCorners` falls back to plain `closestCorners`, which pushes a collision for every measured droppable, so `over` is never null. Both corrected, along with an inline comment 240 lines below that repeated the second claim.

`AGENTS.md`'s "safe to send `to.index` straight to a ranking API" is now scoped: the index matches the preview, but `to.columnId` can be a column the user never aimed at.

## Follow-up filed

**#387** — releasing a card outside the board commits it into the nearest column instead of cancelling. Pre-existing; this PR only makes the documentation honest about it. That one silently reassigns a card's stage, so it's worth doing next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk
