### PR TITLE
fix(a11y): localize drag announcements across all six DndContext sites (#390)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -108,6 +108,21 @@ import { I18nProvider } from '@eocrm/design-system';
 4. In the component, `const t = useTranslation();` then `aria-label={t('component.key')}`. For array messages (months / weekdays), use `useTranslationArray()`.
 5. Never inline an English string — `aria-label="Close"` is a Hard rule 9 violation.
 
+**Drag-and-drop announcements** are localized too. Every drag surface (`Sortable`,
+`SortableGroup`, `Kanban`, `DataTable` column reorder, `RichTextEditor` block
+gutter) overrides dnd-kit's English defaults with the `drag.*` messages, and
+names what it drags by its **visible text** rather than its id — "Amount due,
+position 3 of 7", not "col_amount was moved over droppable area col_name". You
+get this for free; the one thing worth doing is giving each **container** an
+accessible name, since the library can't invent one:
+
+```tsx
+<Kanban.Column id="qualified" aria-label="Qualified">     {/* → "…in Qualified" */}
+<SortableGroup.Container id="review" items={ids} aria-label="In review" />
+```
+
+Without it, containers fall back to their position ("column 2 of 3").
+
 ---
 
 ## Dark theme
@@ -887,6 +902,7 @@ const [groups, setGroups] = useState<Record<string, Field[]>>(initial);
 </SortableGroup>;
 ```
 
+- Give each `Container` an `aria-label` — it names the `<ol>` for screen readers AND names the list in drag announcements ("…position 2 of 4 in In review").
 - Container ids and item ids share dnd-kit's one id namespace — keep them all unique.
 - Each `Container.items` must match its `<Sortable.Item>` child ids (it's the ordering source of truth).
 - Esc-cancel doesn't revert (moves are applied to your state optimistically) — snapshot before drag to undo.
@@ -950,6 +966,7 @@ Props on the root: `onMove?: (event: KanbanMoveEvent) => void` — fires once pe
 **Anti-patterns**
 
 - ❌ Expecting cross-column keyboard reorder. dnd-kit's stock coordinate-getter is per-`SortableContext`. v2 will ship a custom getter that bridges columns.
+- ❌ Leaving `<Kanban.Column>` without an `aria-label`. Screen-reader drag announcements name the destination column from it; without one they fall back to "column 2 of 3". A labelled column also renders as `role="group"` so the name isn't inert.
 - ❌ Interleaving non-`Kanban.Card` children with cards inside a `<Kanban.Column>`. The Root walks each column's children to extract a contiguous card block; if non-cards appear between cards, the rendering re-arranges them awkwardly. Keep header / count badges BEFORE the cards, footer / "Add card" buttons AFTER.
 - ❌ Wrapping `<Kanban.Card>` inside a custom component. The Root walks direct descendants of `<Kanban.Column>` to find cards; nested cards are invisible to it.
 - ❌ Non-stable column / card ids (e.g. array indices). Both must persist across reorders.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -111,17 +111,25 @@ import { I18nProvider } from '@eocrm/design-system';
 **Drag-and-drop announcements** are localized too. Every drag surface (`Sortable`,
 `SortableGroup`, `Kanban`, `DataTable` column reorder, `RichTextEditor` block
 gutter) overrides dnd-kit's English defaults with the `drag.*` messages, and
-names what it drags by its **visible text** rather than its id — "Amount due,
-position 3 of 7", not "col_amount was moved over droppable area col_name". You
-get this for free; the one thing worth doing is giving each **container** an
-accessible name, since the library can't invent one:
+names what it drags by its **rendered text** rather than its id — "Amount due,
+position 3 of 7", not "col_amount was moved over droppable area col_name". Text
+is read from the DOM, so a closed `DropdownMenu` / `Tooltip` / `Popover` inside
+a card contributes nothing, and `aria-hidden` decoration is skipped.
+
+Two things are worth doing yourself:
 
 ```tsx
-<Kanban.Column id="qualified" aria-label="Qualified">     {/* → "…in Qualified" */}
+{/* Name the CONTAINER — the library can't invent one. Either attribute works. */}
+<Kanban.Column id="qualified" aria-label="Qualified">          {/* → "…in Qualified" */}
+<Kanban.Column id="qualified" aria-labelledby="qualified-h">   {/* same, from the heading */}
 <SortableGroup.Container id="review" items={ids} aria-label="In review" />
+
+{/* Override a chatty ITEM. Without this the whole card is read out. */}
+<Kanban.Card id="d-1" aria-label="Acme renewal">…title, owner, due date, badges…</Kanban.Card>
+<Sortable.Item id="f-1" aria-label="Company name">…</Sortable.Item>
 ```
 
-Without it, containers fall back to their position ("column 2 of 3").
+An unnamed container falls back to its position ("column 2 of 3").
 
 ---
 
@@ -902,7 +910,7 @@ const [groups, setGroups] = useState<Record<string, Field[]>>(initial);
 </SortableGroup>;
 ```
 
-- Give each `Container` an `aria-label` — it names the `<ol>` for screen readers AND names the list in drag announcements ("…position 2 of 4 in In review").
+- Give each `Container` an `aria-label` (or `aria-labelledby`) — it names the `<ol>` for screen readers AND names the list in drag announcements ("…position 2 of 4 in In review").
 - Container ids and item ids share dnd-kit's one id namespace — keep them all unique.
 - Each `Container.items` must match its `<Sortable.Item>` child ids (it's the ordering source of truth).
 - Esc-cancel doesn't revert (moves are applied to your state optimistically) — snapshot before drag to undo.
@@ -966,7 +974,8 @@ Props on the root: `onMove?: (event: KanbanMoveEvent) => void` — fires once pe
 **Anti-patterns**
 
 - ❌ Expecting cross-column keyboard reorder. dnd-kit's stock coordinate-getter is per-`SortableContext`. v2 will ship a custom getter that bridges columns.
-- ❌ Leaving `<Kanban.Column>` without an `aria-label`. Screen-reader drag announcements name the destination column from it; without one they fall back to "column 2 of 3". A labelled column also renders as `role="group"` so the name isn't inert.
+- ❌ Leaving `<Kanban.Column>` unnamed. Screen-reader drag announcements name the destination column from its `aria-label` or `aria-labelledby`; without either they fall back to "column 2 of 3". A named column also renders as `role="group"` so the name isn't inert.
+- ❌ A content-heavy `<Kanban.Card>` with no `aria-label`. The card announces itself by its rendered text, so a card carrying title + assignee + due date + badges reads all of it on every drag step. One `aria-label` fixes it.
 - ❌ Interleaving non-`Kanban.Card` children with cards inside a `<Kanban.Column>`. The Root walks each column's children to extract a contiguous card block; if non-cards appear between cards, the rendering re-arranges them awkwardly. Keep header / count badges BEFORE the cards, footer / "Add card" buttons AFTER.
 - ❌ Wrapping `<Kanban.Card>` inside a custom component. The Root walks direct descendants of `<Kanban.Column>` to find cards; nested cards are invisible to it.
 - ❌ Non-stable column / card ids (e.g. array indices). Both must persist across reorders.

--- a/packages/design-system/src/components/DataTable/DataTable.test.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.test.tsx
@@ -872,6 +872,39 @@ describe('<DataTable> — a drop over a pinned column lands in the band (#383)',
     expect(orderOf(table)).toEqual(['mid', 'name', 'owner']);
   });
 
+  // --- and the announcement has to agree with the commit (#390) -------------
+  // The announcement resolves `over` through the SAME fallback the drop does.
+  // Reading raw `over` here emits "Released Name. Nothing moved." over each of
+  // the two reorders below — which is the #390 defect with the sign flipped.
+
+  it('announces the slot it commits when a pinned column owns the collision', () => {
+    renderWithRects(pinnedRightCols, rightRects);
+    dragTo(/drag to reorder name/i, 5000);
+    fireEvent.pointerUp(document);
+    // Band is [name, mid]; the commit put 'name' in the last band slot.
+    expect(screen.getByRole('status').textContent).toBe('Dropped Name at position 2 of 2.');
+  });
+
+  it('announces the slot it commits when the release resolves no target at all', () => {
+    renderWithRects(pinnedRightCols, rightRects);
+    dragTo(/drag to reorder name/i, 200, 5000);
+    fireEvent.pointerUp(document);
+    expect(screen.getByRole('status').textContent).toBe('Dropped Name at position 2 of 2.');
+  });
+
+  it('DOES announce "nothing moved" on the dragWholeColumn={false} path, which discards', () => {
+    // The mirror of the two above: that path keeps its discard, so the honest
+    // announcement is the one the others would have been wrong to make.
+    renderWithRects(pinnedRightCols, rightRects, { dragWholeColumn: false });
+    dragTo(/drag to reorder name/i, 200);
+    // Clear of the header row entirely: `over` goes non-null → null, which is
+    // the one transition that fires an `onDragOver` with no target at all.
+    fireEvent.pointerMove(document, { clientX: 200, clientY: 5000 });
+    expect(screen.getByRole('status').textContent).toBe('Name is not over a drop target.');
+    fireEvent.pointerUp(document);
+    expect(screen.getByRole('status').textContent).toBe('Released Name. Nothing moved.');
+  });
+
   it('does not let one drag inherit the previous drag’s target', () => {
     // The remembered slot is cleared at drag START, not at drag end, so a drag
     // that never resolves a slot of its own commits nothing.

--- a/packages/design-system/src/components/DataTable/DataTable.test.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.test.tsx
@@ -948,6 +948,12 @@ describe('<DataTable> — a drop over a pinned column lands in the band (#383)',
     fireEvent.pointerMove(document, { clientX: 160, clientY: 0 });
     fireEvent.pointerUp(document);
     expect(orderOf(table)).toEqual(['stage', 'name', 'owner']);
+    // ...and the announcement has to see it as a slot too (#390). Deciding
+    // "in band" from `sortableIds` — the SortableContext list, which excludes
+    // `enableReorder: false` — announced "Released Name. Nothing moved." over
+    // exactly this reorder. The position is 1-based in the VISIBLE unpinned
+    // band, which is the order asserted on the line above.
+    expect(screen.getByRole('status').textContent).toBe('Dropped Name at position 2 of 3.');
   });
 });
 

--- a/packages/design-system/src/components/DataTable/DataTable.test.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.test.tsx
@@ -1045,3 +1045,43 @@ describe('<DataTable> — column drag is clamped to the unpinned band (#381)', (
     expect(screen.getByRole('columnheader', { name: /mid/i })).toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Column-reorder announcements (#390)
+// ---------------------------------------------------------------------------
+describe('<DataTable> — drag announcements', () => {
+  // Ids and headers deliberately differ: dnd-kit's default would read
+  // "col_amount", which tells a listener nothing.
+  const labelledCols: ColumnDef<Row>[] = [
+    { id: 'col_name', header: 'Customer', cell: (r) => r.name },
+    { id: 'col_amount', header: 'Amount due', cell: (r) => r.amount },
+    { id: 'col_extra', header: 'Notes', cell: () => '—' },
+  ];
+
+  function Harness() {
+    const instance = useDataTable<Row>({ data: rows, columns: labelledCols, getRowId });
+    return <DataTable instance={instance} aria-label="Labelled" />;
+  }
+
+  it('announces the column header and slot, not the column id', () => {
+    render(<Harness />);
+    const table = screen.getByRole('table');
+    table.querySelectorAll('th').forEach((th, i) => {
+      th.getBoundingClientRect = () => new DOMRect(i * 120, 0, 120, 32);
+    });
+
+    const grip = screen.getByLabelText(/drag to reorder amount due/i);
+    fireEvent.pointerDown(grip, { clientX: 0, clientY: 0, button: 0, isPrimary: true });
+    fireEvent.pointerMove(document, { clientX: 30, clientY: 0 });
+    fireEvent.pointerMove(document, { clientX: -130, clientY: 0 });
+
+    const live = screen.getByRole('status').textContent ?? '';
+    expect(live).toMatch(/^Amount due, position \d of 3\.$/);
+    expect(live).not.toMatch(/col_/);
+
+    fireEvent.pointerUp(document, { clientX: -130, clientY: 0 });
+    expect(screen.getByRole('status').textContent).toMatch(
+      /^Dropped Amount due at position \d of 3\.$/,
+    );
+  });
+});

--- a/packages/design-system/src/components/DataTable/DataTable.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.tsx
@@ -36,7 +36,7 @@ import { useColumnDragShift } from './useColumnDragShift';
 import { clampX, type DragRangeX } from './columnShift';
 import { useFloatingSurface } from '../_internal/overlay';
 import {
-  sortableTarget,
+  dragLabelOf,
   useDragAccessibility,
   type DescribeDragTarget,
 } from '../_internal/dragAnnouncements';
@@ -415,29 +415,45 @@ function DataTableInner<T>(
 
   const [dragActive, setDragActive] = useState(false);
 
-  // Localized column-reorder announcements (Hard rule 9). A band member answers
-  // for itself — dnd-kit's own `data.sortable` gives the slot and `HeaderCell`
-  // publishes the rendered header text — so a drag says "Amount, position 3 of
-  // 7", not "col-amount was moved over droppable area col-name".
+  // Localized column-reorder announcements (Hard rule 9). `HeaderCell` publishes
+  // the rendered header text, so a drag says "Amount, position 3 of 7" instead
+  // of "col-amount was moved over droppable area col-name".
   //
-  // The fallback below is the announcement half of #383, and it must mirror
-  // `handleDragEnd` exactly or it lies about the drop it just described. In
-  // whole-column mode `over` can name something the drop cannot use — a sticky
-  // pinned column covering the band's last slot, or nothing at all after an
-  // auto-scroll desync — and BOTH are observed, not theoretical. `handleDragEnd`
-  // falls back to the last band slot the drag resolved and commits a real
-  // reorder; resolving the announcement from raw `over` would announce
-  // "Released Amount due. Nothing moved." over exactly that reorder, which is
-  // the defect #390 was filed about with the sign flipped.
+  // This resolves the slot exactly the way `handleDragEnd` does, in the SAME
+  // index space, and both halves of that are load-bearing:
   //
-  // No label needed on this path: the announced item name always comes from
-  // `active`, never from the drop target.
+  //  - `shiftOrderedIds`, not `sortableIds`. The two differ by the
+  //    `enableReorder: false` columns: excluded from `SortableContext` (nothing
+  //    to activate) but still droppable, still displaced, and still moved by
+  //    `reorderRespectingPins` — see the comment on `shiftOrderedIds`. Deciding
+  //    "in band" from the SortableContext list therefore calls a legal target
+  //    unusable, and announces "Nothing moved." over a drop that reordered. It
+  //    is also the set the position number belongs in: a listener is being told
+  //    where the column landed among the visible unpinned columns.
+  //  - the same `lastSlotIdRef` fallback (#383). In whole-column mode `over` can
+  //    name something the drop cannot use — a sticky pinned column covering the
+  //    band's last slot, or nothing at all after an auto-scroll desync, both
+  //    observed — and `handleDragEnd` commits the last band slot the drag
+  //    resolved rather than discarding. Announcing from raw `over` would call
+  //    that reorder "nothing", which is the defect #390 was filed about with the
+  //    sign flipped.
+  //
+  // The label is only ever read off `active`; a drop target's is unused.
   const describeColumn: DescribeDragTarget = (entry) => {
-    const inBand = sortableTarget(entry);
-    if (inBand) return inBand;
-    const slotId = dragWholeColumn ? lastSlotIdRef.current : null;
-    const slot = slotId == null ? -1 : sortableIds.indexOf(slotId);
-    return slot < 0 ? null : { index: slot + 1, total: sortableIds.length };
+    const id = entry ? String(entry.id) : null;
+    const slotId =
+      id != null && shiftOrderedIds.includes(id)
+        ? id
+        : dragWholeColumn
+          ? lastSlotIdRef.current
+          : null;
+    const slot = slotId == null ? -1 : shiftOrderedIds.indexOf(slotId);
+    if (slot < 0) return null;
+    return {
+      label: dragLabelOf(entry?.data.current),
+      index: slot + 1,
+      total: shiftOrderedIds.length,
+    };
   };
   const dragAccessibility = useDragAccessibility(describeColumn);
 

--- a/packages/design-system/src/components/DataTable/DataTable.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.tsx
@@ -35,7 +35,11 @@ import { reorderRespectingPins } from './reorderColumns';
 import { useColumnDragShift } from './useColumnDragShift';
 import { clampX, type DragRangeX } from './columnShift';
 import { useFloatingSurface } from '../_internal/overlay';
-import { sortableTarget, useDragAccessibility } from '../_internal/dragAnnouncements';
+import {
+  sortableTarget,
+  useDragAccessibility,
+  type DescribeDragTarget,
+} from '../_internal/dragAnnouncements';
 import { AUTO_CELL_WIDTH } from './pinStyle';
 import type { DataTableInstance } from './types';
 import { useTranslation } from '../../i18n/useTranslation';
@@ -411,11 +415,31 @@ function DataTableInner<T>(
 
   const [dragActive, setDragActive] = useState(false);
 
-  // Localized column-reorder announcements (Hard rule 9). Every droppable in
-  // this context is a header cell inside `SortableContext items={sortableIds}`,
-  // so dnd-kit's own `data.sortable` gives the slot and `HeaderCell` publishes
-  // the header text as `dragLabel` — "Amount, position 3 of 7", not "col-amount".
-  const dragAccessibility = useDragAccessibility(sortableTarget);
+  // Localized column-reorder announcements (Hard rule 9). A band member answers
+  // for itself — dnd-kit's own `data.sortable` gives the slot and `HeaderCell`
+  // publishes the rendered header text — so a drag says "Amount, position 3 of
+  // 7", not "col-amount was moved over droppable area col-name".
+  //
+  // The fallback below is the announcement half of #383, and it must mirror
+  // `handleDragEnd` exactly or it lies about the drop it just described. In
+  // whole-column mode `over` can name something the drop cannot use — a sticky
+  // pinned column covering the band's last slot, or nothing at all after an
+  // auto-scroll desync — and BOTH are observed, not theoretical. `handleDragEnd`
+  // falls back to the last band slot the drag resolved and commits a real
+  // reorder; resolving the announcement from raw `over` would announce
+  // "Released Amount due. Nothing moved." over exactly that reorder, which is
+  // the defect #390 was filed about with the sign flipped.
+  //
+  // No label needed on this path: the announced item name always comes from
+  // `active`, never from the drop target.
+  const describeColumn: DescribeDragTarget = (entry) => {
+    const inBand = sortableTarget(entry);
+    if (inBand) return inBand;
+    const slotId = dragWholeColumn ? lastSlotIdRef.current : null;
+    const slot = slotId == null ? -1 : sortableIds.indexOf(slotId);
+    return slot < 0 ? null : { index: slot + 1, total: sortableIds.length };
+  };
+  const dragAccessibility = useDragAccessibility(describeColumn);
 
   // The shift driver writes custom properties onto the <table> element, so we
   // need our own handle on it while still honouring the consumer's ref.

--- a/packages/design-system/src/components/DataTable/DataTable.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.tsx
@@ -35,6 +35,7 @@ import { reorderRespectingPins } from './reorderColumns';
 import { useColumnDragShift } from './useColumnDragShift';
 import { clampX, type DragRangeX } from './columnShift';
 import { useFloatingSurface } from '../_internal/overlay';
+import { sortableTarget, useDragAccessibility } from '../_internal/dragAnnouncements';
 import { AUTO_CELL_WIDTH } from './pinStyle';
 import type { DataTableInstance } from './types';
 import { useTranslation } from '../../i18n/useTranslation';
@@ -410,6 +411,12 @@ function DataTableInner<T>(
 
   const [dragActive, setDragActive] = useState(false);
 
+  // Localized column-reorder announcements (Hard rule 9). Every droppable in
+  // this context is a header cell inside `SortableContext items={sortableIds}`,
+  // so dnd-kit's own `data.sortable` gives the slot and `HeaderCell` publishes
+  // the header text as `dragLabel` — "Amount, position 3 of 7", not "col-amount".
+  const dragAccessibility = useDragAccessibility(sortableTarget);
+
   // The shift driver writes custom properties onto the <table> element, so we
   // need our own handle on it while still honouring the consumer's ref.
   const tableRef = useRef<HTMLTableElement | null>(null);
@@ -434,7 +441,12 @@ function DataTableInner<T>(
   );
 
   return (
-    <DndContext sensors={sensors} modifiers={modifiers} onDragEnd={handleDragEnd}>
+    <DndContext
+      accessibility={dragAccessibility}
+      sensors={sensors}
+      modifiers={modifiers}
+      onDragEnd={handleDragEnd}
+    >
       {/* #282: register the column-reorder drag as a floating surface while
           active so a host Modal/Drawer yields the Escape that cancels it (the
           drag cancels; the host survives). A leaf probe (not root state) so the

--- a/packages/design-system/src/components/DataTable/HeaderCell.tsx
+++ b/packages/design-system/src/components/DataTable/HeaderCell.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type KeyboardEvent } from 'react';
+import { useMemo, useRef, type KeyboardEvent } from 'react';
 import clsx from 'clsx';
 import {
   GripVertical,
@@ -16,7 +16,7 @@ import { useResizeHandle } from './useResizeHandle';
 import type { ColumnDef, DataTableInstance } from './types';
 import { getPinStyle } from './pinStyle';
 import { shiftVarName } from './columnShift';
-import { nodeText } from '../_internal/dragAnnouncements';
+
 import styles from './HeaderCell.module.scss';
 
 export interface HeaderCellProps<T> {
@@ -87,11 +87,12 @@ export function HeaderCell<T>({
   const headerContent =
     typeof column.header === 'function' ? column.header({ column, instance }) : column.header;
 
-  // Screen-reader announcements name the column by its header text, not by
-  // `column.id` (#390). Recomputed with the header itself — a render-function
-  // header is a fresh node every render, so it is keyed on the flattened text.
-  const dragLabel = nodeText(headerContent);
-  const dragData = useMemo(() => ({ dragLabel }), [dragLabel]);
+  // Screen-reader announcements name the column by its RENDERED header text,
+  // not by `column.id` (#390). The ref goes on the label span rather than the
+  // <th> so the grip and resize chrome — and any menu the header renders —
+  // stay out of it. Ref identity is stable, so the memo never re-runs.
+  const labelRef = useRef<HTMLSpanElement | null>(null);
+  const dragData = useMemo(() => ({ dragNode: labelRef }), []);
 
   const sortableResult = useSortable({
     id: column.id,
@@ -218,6 +219,7 @@ export function HeaderCell<T>({
         )}
       >
         <span
+          ref={labelRef}
           className={clsx(styles.label, sortable && styles.sortable)}
           tabIndex={sortable ? 0 : undefined}
           role={sortable ? 'button' : undefined}

--- a/packages/design-system/src/components/DataTable/HeaderCell.tsx
+++ b/packages/design-system/src/components/DataTable/HeaderCell.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent } from 'react';
+import { useMemo, type KeyboardEvent } from 'react';
 import clsx from 'clsx';
 import {
   GripVertical,
@@ -16,6 +16,7 @@ import { useResizeHandle } from './useResizeHandle';
 import type { ColumnDef, DataTableInstance } from './types';
 import { getPinStyle } from './pinStyle';
 import { shiftVarName } from './columnShift';
+import { nodeText } from '../_internal/dragAnnouncements';
 import styles from './HeaderCell.module.scss';
 
 export interface HeaderCellProps<T> {
@@ -82,8 +83,19 @@ export function HeaderCell<T>({
   // same reason a pinned column's does.
   const reorderable =
     column.enableReorder !== false && !isPinned && instance.unpinnedColumns.length > 1;
+
+  const headerContent =
+    typeof column.header === 'function' ? column.header({ column, instance }) : column.header;
+
+  // Screen-reader announcements name the column by its header text, not by
+  // `column.id` (#390). Recomputed with the header itself — a render-function
+  // header is a fresh node every render, so it is keyed on the flattened text.
+  const dragLabel = nodeText(headerContent);
+  const dragData = useMemo(() => ({ dragLabel }), [dragLabel]);
+
   const sortableResult = useSortable({
     id: column.id,
+    data: dragData,
     disabled: !reorderable,
     // Whole-column mode only: kill dnd-kit's post-drop FLIP animation. On
     // release `defaultAnimateLayoutChanges` returns true for every column whose
@@ -130,9 +142,6 @@ export function HeaderCell<T>({
       instance.setColumnSizing((prev) => ({ ...prev, [column.id]: next }));
     }
   };
-
-  const headerContent =
-    typeof column.header === 'function' ? column.header({ column, instance }) : column.header;
 
   const pinStyle = getPinStyle(column.id, instance);
   const stickyStyle = pinStyle.position

--- a/packages/design-system/src/components/Kanban/Kanban.test.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.test.tsx
@@ -8,6 +8,7 @@ import {
   type KanbanMoveEvent,
 } from './Kanban';
 import { SortableHandle } from '../Sortable/Sortable';
+import { I18nProvider } from '../../i18n';
 
 describe('Kanban', () => {
   it('renders a board region with columns and cards (role="article" only when Handle is present)', () => {
@@ -707,5 +708,145 @@ describe('Kanban — drag bounds (#373)', () => {
     // buggy form would have reported 1080.
     expect(bounds?.centerY).toBe(580);
     expect(bounds?.centerX).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Screen-reader announcements (#390)
+// ---------------------------------------------------------------------------
+// dnd-kit's defaults are hard-coded English and interpolate raw ids. The board
+// overrides them via `accessibility`, so these assert the live region's text —
+// which is what a screen-reader user actually hears.
+
+/** A board whose card text and column names differ from their ids, so an
+ *  announcement that leaked an id would be visible in the assertion. */
+function NamedBoard({ labelled = true }: { labelled?: boolean }) {
+  return (
+    <Kanban>
+      <Kanban.Column
+        id="col-a"
+        aria-label={labelled ? 'To do' : undefined}
+        data-col={0}
+        data-h={300}
+      >
+        <Kanban.Card id="task-1" data-card="task-1">
+          Draft Q3 OKRs
+        </Kanban.Card>
+        <Kanban.Card id="task-2" data-card="task-2">
+          Schedule retro
+        </Kanban.Card>
+      </Kanban.Column>
+      <Kanban.Column
+        id="col-b"
+        aria-label={labelled ? 'Done' : undefined}
+        data-col={1}
+        data-h={300}
+      >
+        <Kanban.Card id="task-3" data-card="task-3">
+          Ship onboarding email
+        </Kanban.Card>
+      </Kanban.Column>
+    </Kanban>
+  );
+}
+
+const live = () => screen.getByRole('status').textContent;
+
+/** Press a card and clear the 5px activation constraint. NOTE: the activating
+ *  move is also a drag move, so what lands in the live region is the drop
+ *  position, not the pick-up. */
+function press(cardText: string) {
+  const card = screen.getByText(cardText);
+  const r = card.getBoundingClientRect();
+  const x = r.left + COL_W / 2;
+  const y = r.top + CARD_H / 2;
+  fireEvent.pointerDown(card, { clientX: x, clientY: y, button: 0, isPrimary: true });
+  fireEvent.pointerMove(document, { clientX: x, clientY: y + 10 });
+}
+const moveTo = ([x, y]: [number, number]) =>
+  fireEvent.pointerMove(document, { clientX: x, clientY: y });
+const release = ([x, y]: [number, number]) =>
+  fireEvent.pointerUp(document, { clientX: x, clientY: y });
+
+describe('Kanban — drag announcements (#390)', () => {
+  let restore: () => void;
+  beforeEach(() => {
+    restore = stubLayout();
+  });
+  afterEach(() => restore());
+
+  it('names the card and the column, never the ids', () => {
+    render(<NamedBoard />);
+
+    // The pick-up announcement is not observable through a board: dnd-kit
+    // resolves an `over` in the same tick it starts the drag and React batches
+    // both `setAnnouncement` calls into one render, so the position message is
+    // the only text that ever paints. `RichTextBlockControls.test.tsx` asserts
+    // `drag.pickedUp` — that context registers no droppables, so nothing
+    // overwrites it.
+    press('Draft Q3 OKRs');
+    moveTo(at(1, 20));
+    expect(live()).toMatch(/^Draft Q3 OKRs, position \d of \d in Done\.$/);
+
+    release(at(1, 20));
+    expect(live()).toMatch(/^Dropped Draft Q3 OKRs at position \d of \d in Done\.$/);
+
+    // No announcement at any phase leaked a dnd-kit id or its English default.
+    expect(live()).not.toMatch(/task-|col-|droppable area/);
+  });
+
+  it('falls back to the column’s board position when it has no aria-label', () => {
+    render(<NamedBoard labelled={false} />);
+    press('Draft Q3 OKRs');
+    moveTo(at(1, 20));
+    expect(live()).toMatch(/in column 2 of 2\.$/);
+  });
+
+  it('a release outside the board announces a cancel, not a drop (#387)', () => {
+    render(<NamedBoard />);
+    press('Draft Q3 OKRs');
+    moveTo(at(1, 100)); // transit into the second column…
+    expect(live()).toMatch(/^Draft Q3 OKRs, position \d of \d in Done\.$/);
+    moveTo([600, 500]); // …carry it off the board…
+    release([600, 500]); // …and let go over unrelated page content
+    expect(live()).toBe('Move cancelled. Draft Q3 OKRs stayed where it was.');
+  });
+
+  it('announces in Russian under <I18nProvider locale="ru">', () => {
+    render(
+      <I18nProvider locale="ru">
+        <NamedBoard />
+      </I18nProvider>,
+    );
+
+    press('Draft Q3 OKRs');
+    moveTo(at(1, 20));
+    expect(live()).toMatch(/^Draft Q3 OKRs — позиция \d из \d, Done\.$/);
+
+    release(at(1, 20));
+    expect(live()).toMatch(/^Размещено: Draft Q3 OKRs, позиция \d из \d, Done\.$/);
+
+    // …and the cancel path is Russian too.
+    press('Draft Q3 OKRs');
+    moveTo([600, 500]);
+    release([600, 500]);
+    expect(live()).toBe('Перемещение отменено: Draft Q3 OKRs на прежнем месте.');
+  });
+
+  it('localizes the keyboard instructions dnd-kit points every draggable at', () => {
+    const { rerender } = render(<NamedBoard />);
+    const described = () => {
+      const card = screen.getByText('Draft Q3 OKRs');
+      const id = card.getAttribute('aria-describedby')!;
+      return document.getElementById(id)?.textContent ?? '';
+    };
+    expect(described()).toMatch(/^Press Space or Enter to pick up\./);
+
+    rerender(
+      <I18nProvider locale="ru">
+        <NamedBoard />
+      </I18nProvider>,
+    );
+    expect(described()).toMatch(/^Нажмите пробел или Enter/);
   });
 });

--- a/packages/design-system/src/components/Kanban/Kanban.test.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.test.tsx
@@ -9,6 +9,7 @@ import {
 } from './Kanban';
 import { SortableHandle } from '../Sortable/Sortable';
 import { I18nProvider } from '../../i18n';
+import { DropdownMenu } from '../DropdownMenu';
 
 describe('Kanban', () => {
   it('renders a board region with columns and cards (role="article" only when Handle is present)', () => {
@@ -795,6 +796,80 @@ describe('Kanban — drag announcements (#390)', () => {
     expect(live()).not.toMatch(/task-|col-|droppable area/);
   });
 
+  it('does not read a closed menu inside the card into the card’s name', () => {
+    // The children tree of a card with a `<DropdownMenu>` contains the menu's
+    // items; the DOM does not, because the panel is unmounted while closed.
+    // Announcing from the children tree gave "Draft Q3 OKRs View Archive" —
+    // and a listener has no way to tell that isn't part of the card's name.
+    render(
+      <Kanban>
+        <Kanban.Column id="col-a" aria-label="To do" data-col={0} data-h={300}>
+          <Kanban.Card id="task-1" data-card="task-1">
+            Draft Q3 OKRs
+            <DropdownMenu>
+              <DropdownMenu.Trigger>
+                <button type="button">More</button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content>
+                <DropdownMenu.Item onSelect={() => {}}>View</DropdownMenu.Item>
+                <DropdownMenu.Item onSelect={() => {}}>Archive</DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu>
+          </Kanban.Card>
+          <Kanban.Card id="task-2" data-card="task-2">
+            Schedule retro
+          </Kanban.Card>
+        </Kanban.Column>
+      </Kanban>,
+    );
+
+    press('Draft Q3 OKRs');
+    moveTo(at(0, 60));
+    const live_ = live() ?? '';
+    release(at(0, 60));
+    expect(live_).not.toMatch(/View|Archive/);
+    expect(live_).toMatch(/^Draft Q3 OKRs More, position \d of 2 in To do\.$/);
+  });
+
+  it('an aria-label on the card wins over its rendered text', () => {
+    render(
+      <Kanban>
+        <Kanban.Column id="col-a" aria-label="To do" data-col={0} data-h={300}>
+          <Kanban.Card id="task-1" data-card="task-1" aria-label="Q3 objectives draft">
+            Draft Q3 OKRs · Pavel · due Friday
+          </Kanban.Card>
+          <Kanban.Card id="task-2" data-card="task-2">
+            Schedule retro
+          </Kanban.Card>
+        </Kanban.Column>
+      </Kanban>,
+    );
+    press('Draft Q3 OKRs · Pavel · due Friday');
+    moveTo(at(0, 60));
+    expect(live()).toMatch(/^Q3 objectives draft, position \d of 2 in To do\.$/);
+    release(at(0, 60));
+  });
+
+  it('names a column from aria-labelledby when that is how it is labelled', () => {
+    render(
+      <Kanban>
+        <Kanban.Column id="col-a" aria-labelledby="head-a" data-col={0} data-h={300}>
+          <h3 id="head-a">Qualified</h3>
+          <Kanban.Card id="task-1" data-card="task-1">
+            Draft Q3 OKRs
+          </Kanban.Card>
+          <Kanban.Card id="task-2" data-card="task-2">
+            Schedule retro
+          </Kanban.Card>
+        </Kanban.Column>
+      </Kanban>,
+    );
+    press('Draft Q3 OKRs');
+    moveTo(at(0, 60));
+    expect(live()).toMatch(/in Qualified\.$/);
+    release(at(0, 60));
+  });
+
   it('falls back to the column’s board position when it has no aria-label', () => {
     render(<NamedBoard labelled={false} />);
     press('Draft Q3 OKRs');
@@ -821,16 +896,16 @@ describe('Kanban — drag announcements (#390)', () => {
 
     press('Draft Q3 OKRs');
     moveTo(at(1, 20));
-    expect(live()).toMatch(/^Draft Q3 OKRs — позиция \d из \d, Done\.$/);
+    expect(live()).toMatch(/^«Draft Q3 OKRs» — позиция \d из \d, «Done»\.$/);
 
     release(at(1, 20));
-    expect(live()).toMatch(/^Размещено: Draft Q3 OKRs, позиция \d из \d, Done\.$/);
+    expect(live()).toMatch(/^Размещено: «Draft Q3 OKRs», позиция \d из \d, «Done»\.$/);
 
     // …and the cancel path is Russian too.
     press('Draft Q3 OKRs');
     moveTo([600, 500]);
     release([600, 500]);
-    expect(live()).toBe('Перемещение отменено: Draft Q3 OKRs на прежнем месте.');
+    expect(live()).toBe('Перемещение отменено: «Draft Q3 OKRs» на прежнем месте.');
   });
 
   it('localizes the keyboard instructions dnd-kit points every draggable at', () => {

--- a/packages/design-system/src/components/Kanban/Kanban.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.tsx
@@ -42,7 +42,8 @@ import {
   type SortableItemContextValue,
 } from '../Sortable/Sortable';
 import {
-  nodeText,
+  containerName,
+  dragLabelOf,
   useDragAccessibility,
   type DescribeDragTarget,
 } from '../_internal/dragAnnouncements';
@@ -296,11 +297,23 @@ const clamp = (value: number, min: number, max: number) => Math.min(Math.max(val
  * If the children subtree contains a `<Kanban.Handle>`, only the Handle
  * initiates drag (the card div gets `role="article"`). Otherwise the whole
  * card is draggable (dnd-kit applies `role="button"`).
+ *
+ * @remarks
+ * Drag announcements name the card by its rendered text. Pass `aria-label` to
+ * override that — worth doing when the card renders a lot besides its title
+ * (assignee, due date, badges), since all of it otherwise gets read out.
  */
 export const KanbanCard = forwardRef<HTMLDivElement, KanbanCardProps>(function KanbanCard(
   { id, className, children, ...rest },
   ref,
 ) {
+  // Announcement label: the consumer's `aria-label`, else the card's RENDERED
+  // text (so a closed menu inside the card contributes nothing — see
+  // `dragLabelOf`). The same ref is the drag-bounds node ref below.
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const dragLabel = rest['aria-label'];
+  const dragData = useMemo(() => ({ dragLabel, dragNode: cardRef }), [dragLabel]);
+
   const {
     setNodeRef,
     setActivatorNodeRef,
@@ -311,7 +324,7 @@ export const KanbanCard = forwardRef<HTMLDivElement, KanbanCardProps>(function K
     isDragging,
     index,
     items,
-  } = useSortable({ id });
+  } = useSortable({ id, data: dragData });
 
   const hasHandle = useMemo(() => containsHandle(children), [children]);
 
@@ -357,10 +370,9 @@ export const KanbanCard = forwardRef<HTMLDivElement, KanbanCardProps>(function K
   // these lines silently reinstates the runaway — and no test can catch it,
   // because jsdom lays nothing out, so the clamp's only evidence is a manual
   // browser drag. Two inert guarded lines against a hand-only regression.
-  const nodeRef = useRef<HTMLDivElement | null>(null);
   const boundsRef = useRef<KanbanDragBounds | null>(null);
   useLayoutEffect(() => {
-    const node = nodeRef.current;
+    const node = cardRef.current;
     if (!isDragging || !node) {
       boundsRef.current = null;
       return;
@@ -371,7 +383,7 @@ export const KanbanCard = forwardRef<HTMLDivElement, KanbanCardProps>(function K
   }, [isDragging, index, items]);
 
   const setRef = (node: HTMLDivElement | null) => {
-    nodeRef.current = node;
+    cardRef.current = node;
     setNodeRef(node);
     // When no Handle is present, the Card itself is the drag activator.
     if (!hasHandle) setActivatorNodeRef(node);
@@ -420,11 +432,12 @@ KanbanCard.displayName = 'KanbanCard';
  * — keep cards as a contiguous block.
  *
  * @remarks
- * Pass `aria-label` with the column's visible heading. It names the column in
- * the drag announcements a screen reader hears ("…position 2 of 3 in
- * Qualified"); without it they fall back to "column 2 of 3". Because the label
- * is only useful if the element it sits on has a role, a labelled column
- * renders as `role="group"`.
+ * Name the column — `aria-label` with its visible heading, or `aria-labelledby`
+ * pointing at that heading's element. Either one names the column in the drag
+ * announcements a screen reader hears ("…position 2 of 3 in Qualified");
+ * without one they fall back to "column 2 of 3". Because a name is only useful
+ * if the element it sits on has a role, a named column renders as
+ * `role="group"`.
  */
 export const KanbanColumn = forwardRef<HTMLDivElement, KanbanColumnProps>(function KanbanColumn(
   { id, className, children, ...rest },
@@ -460,10 +473,12 @@ export const KanbanColumn = forwardRef<HTMLDivElement, KanbanColumnProps>(functi
       ref={setRef}
       className={clsx(styles.column, className)}
       {...rest}
-      // An aria-label on a role-less <div> is inert, so a labelled column gets
-      // a role to hang it on. AFTER {...rest} — but only when the consumer
-      // didn't already pick a role — so labelling can't silently do nothing.
-      {...(rest['aria-label'] && rest.role == null ? { role: 'group' } : {})}
+      // A name on a role-less <div> is inert, so a labelled column gets a role
+      // to hang it on. AFTER {...rest} — but only when the consumer didn't
+      // already pick a role — so labelling can't silently do nothing.
+      {...((rest['aria-label'] || rest['aria-labelledby']) && rest.role == null
+        ? { role: 'group' }
+        : {})}
     >
       <SortableContext
         items={cardIds as (string | number)[]}
@@ -991,21 +1006,20 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
   // says "Acme — 40 seats, position 2 of 3 in Qualified" rather than dnd-kit's
   // "deal-1 was moved over droppable area col-2". Slots are read from
   // `effectiveItems` — the order the user is actually looking at mid-drag.
-  const columnLabel = (colId: string | number): string => {
-    const explicit = columnElements.get(colId)?.props['aria-label'];
-    if (typeof explicit === 'string' && explicit) return explicit;
-    return t('kanban.unnamedColumn', {
+  const columnLabel = (colId: string | number): string =>
+    containerName(columnElements.get(colId)?.props ?? {}) ??
+    t('kanban.unnamedColumn', {
       index: columnOrder.indexOf(colId) + 1,
       total: columnOrder.length,
     });
-  };
   const describeDrag: DescribeDragTarget = (entry, activeId) => {
+    if (!entry) return null;
     const id = entry.id as string | number;
     const isColumn = effectiveItems.has(id);
     const colId = isColumn ? id : findContainer(id, effectiveItems);
     if (colId == null) return null;
     const cards = effectiveItems.get(colId) ?? [];
-    const label = nodeText(cardElements.get(id)?.props.children);
+    const label = dragLabelOf(entry.data.current);
     const container = columnLabel(colId);
     if (!isColumn) return { label, index: cards.indexOf(id) + 1, total: cards.length, container };
     // `over` is the column itself (empty column, or the padding below the

--- a/packages/design-system/src/components/Kanban/Kanban.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.tsx
@@ -41,6 +41,11 @@ import {
   SortableItemContext,
   type SortableItemContextValue,
 } from '../Sortable/Sortable';
+import {
+  nodeText,
+  useDragAccessibility,
+  type DescribeDragTarget,
+} from '../_internal/dragAnnouncements';
 import { useTranslation } from '../../i18n/useTranslation';
 import {
   containerAwareClosestCorners,
@@ -413,6 +418,13 @@ KanbanCard.displayName = 'KanbanCard';
  *
  * Column layout (header, footer) goes before / after `<Kanban.Card>` children
  * — keep cards as a contiguous block.
+ *
+ * @remarks
+ * Pass `aria-label` with the column's visible heading. It names the column in
+ * the drag announcements a screen reader hears ("…position 2 of 3 in
+ * Qualified"); without it they fall back to "column 2 of 3". Because the label
+ * is only useful if the element it sits on has a role, a labelled column
+ * renders as `role="group"`.
  */
 export const KanbanColumn = forwardRef<HTMLDivElement, KanbanColumnProps>(function KanbanColumn(
   { id, className, children, ...rest },
@@ -444,7 +456,15 @@ export const KanbanColumn = forwardRef<HTMLDivElement, KanbanColumnProps>(functi
   };
 
   return (
-    <div ref={setRef} className={clsx(styles.column, className)} {...rest}>
+    <div
+      ref={setRef}
+      className={clsx(styles.column, className)}
+      {...rest}
+      // An aria-label on a role-less <div> is inert, so a labelled column gets
+      // a role to hang it on. AFTER {...rest} — but only when the consumer
+      // didn't already pick a role — so labelling can't silently do nothing.
+      {...(rest['aria-label'] && rest.role == null ? { role: 'group' } : {})}
+    >
       <SortableContext
         items={cardIds as (string | number)[]}
         strategy={verticalListSortingStrategy}
@@ -964,10 +984,49 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
   }, []);
 
   // ------------------------------------------------------------------
+  // Screen-reader announcements (Hard rule 9, #390)
+  // ------------------------------------------------------------------
+  // Names a card by its own text and a column by the `aria-label` the consumer
+  // put on `<Kanban.Column>` (falling back to its board position), so a drag
+  // says "Acme — 40 seats, position 2 of 3 in Qualified" rather than dnd-kit's
+  // "deal-1 was moved over droppable area col-2". Slots are read from
+  // `effectiveItems` — the order the user is actually looking at mid-drag.
+  const columnLabel = (colId: string | number): string => {
+    const explicit = columnElements.get(colId)?.props['aria-label'];
+    if (typeof explicit === 'string' && explicit) return explicit;
+    return t('kanban.unnamedColumn', {
+      index: columnOrder.indexOf(colId) + 1,
+      total: columnOrder.length,
+    });
+  };
+  const describeDrag: DescribeDragTarget = (entry, activeId) => {
+    const id = entry.id as string | number;
+    const isColumn = effectiveItems.has(id);
+    const colId = isColumn ? id : findContainer(id, effectiveItems);
+    if (colId == null) return null;
+    const cards = effectiveItems.get(colId) ?? [];
+    const label = nodeText(cardElements.get(id)?.props.children);
+    const container = columnLabel(colId);
+    if (!isColumn) return { label, index: cards.indexOf(id) + 1, total: cards.length, container };
+    // `over` is the column itself (empty column, or the padding below the
+    // cards). If the dragged card has already been live-seated here it keeps
+    // its slot; otherwise it would be appended, so count it as one more.
+    const seated = cards.indexOf(activeId as string | number);
+    return seated >= 0
+      ? { label, index: seated + 1, total: cards.length, container }
+      : { label, index: cards.length + 1, total: cards.length + 1, container };
+  };
+  // A release outside the board is a cancel, not a drop — `over` is non-null on
+  // that path (closestCorners rejects nothing), so without this dnd-kit would
+  // announce a drop that handleDragEnd deliberately threw away (#387).
+  const accessibility = useDragAccessibility(describeDrag, () => outsideBoardRef.current);
+
+  // ------------------------------------------------------------------
   // Render
   // ------------------------------------------------------------------
   return (
     <DndContext
+      accessibility={accessibility}
       sensors={sensors}
       collisionDetection={collisionDetection}
       onDragStart={handleDragStart}

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
@@ -1,14 +1,17 @@
 // RichTextBlockControls.test.tsx
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useRef } from 'react';
 import { I18nProvider } from '../../i18n';
 import { RichTextBlockControls } from './RichTextBlockControls';
 
-function Harness(props: Partial<React.ComponentProps<typeof RichTextBlockControls>>) {
+function Harness({
+  locale = 'en',
+  ...props
+}: Partial<React.ComponentProps<typeof RichTextBlockControls>> & { locale?: 'en' | 'ru' }) {
   const rootRef = useRef<HTMLDivElement>(null);
   return (
-    <I18nProvider locale="en">
+    <I18nProvider locale={locale}>
       <div ref={rootRef} style={{ position: 'relative' }}>
         <p data-block-id="b1">hello</p>
         <RichTextBlockControls
@@ -172,4 +175,37 @@ it('re-measures the gutter position when blockOrderKey changes (post-drop / inse
     .getByRole('button', { name: 'Insert block below' })
     .closest('[contenteditable="false"]') as HTMLElement;
   expect(gutter.style.top).toBe('40px');
+});
+
+// --- drag announcements (#390) ----------------------------------------------
+// This DndContext registers no droppables — the drop slot is computed from the
+// pointer against the document flow — so `over` is always null and dnd-kit's
+// English defaults would announce "was dropped" with a raw gutter id. It is
+// also the ONE drag surface where the pick-up announcement survives: nothing
+// overwrites it, because the per-move announcement is deliberately silent.
+
+/** Grab the gutter and clear the sensor's 4px activation constraint. */
+function dragGutter(container: HTMLElement) {
+  const gutter = container.querySelector('[contenteditable="false"]') as HTMLElement;
+  fireEvent.pointerDown(gutter, { clientX: 0, clientY: 0, button: 0, isPrimary: true });
+  fireEvent.pointerMove(document, { clientX: 0, clientY: 10 });
+}
+const live = () => screen.getByRole('status').textContent;
+
+it('announces the block drag by the block’s own text, in English', () => {
+  const { container } = render(<Harness />);
+  dragGutter(container);
+  expect(live()).toBe('Picked up hello.');
+  fireEvent.pointerMove(document, { clientX: 0, clientY: 30 });
+  expect(live()).toBe('Picked up hello.'); // no droppables → no false "not over a target"
+  fireEvent.pointerUp(document, { clientX: 0, clientY: 30 });
+  expect(live()).toBe('Moved hello.');
+});
+
+it('announces the block drag in Russian under locale="ru"', () => {
+  const { container } = render(<Harness locale="ru" />);
+  dragGutter(container);
+  expect(live()).toBe('Взято: hello.');
+  fireEvent.pointerUp(document, { clientX: 0, clientY: 10 });
+  expect(live()).toBe('Перемещено: hello.');
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.test.tsx
@@ -205,7 +205,7 @@ it('announces the block drag by the block’s own text, in English', () => {
 it('announces the block drag in Russian under locale="ru"', () => {
   const { container } = render(<Harness locale="ru" />);
   dragGutter(container);
-  expect(live()).toBe('Взято: hello.');
+  expect(live()).toBe('Взято: «hello».');
   fireEvent.pointerUp(document, { clientX: 0, clientY: 10 });
-  expect(live()).toBe('Перемещено: hello.');
+  expect(live()).toBe('Перемещено: «hello».');
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextBlockControls.tsx
@@ -1,7 +1,7 @@
 // RichTextBlockControls.tsx — the per-block gutter overlay. Absolutely positioned
 // inside the editor shell (position: relative), aligned to the active block's box.
 // Lives OUTSIDE the contentEditable so it is never editable content.
-import { memo, useCallback, useEffect, useRef, type RefObject } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, type RefObject } from 'react';
 import {
   DndContext,
   PointerSensor,
@@ -22,6 +22,7 @@ import { preventSelectionLoss } from './preventSelectionLoss';
 import { computeReflow, type BlockRect, type UnitRange } from './blockReflow';
 import { gapIndexFromY } from './blockDrop';
 import { useShellRelativeRect, useDraggingReporter } from './useOverlayRect';
+import { tidy } from '../_internal/dragAnnouncements';
 import styles from './RichTextEditor.module.scss';
 
 export interface RichTextBlockControlsProps {
@@ -167,6 +168,9 @@ export const RichTextBlockControls = memo(function RichTextBlockControls({
   const draggedIdRef = useRef<string | null>(null);
   // The gutter DOM node, so the drag can translate it in lockstep with the lifted row.
   const gutterElRef = useRef<HTMLDivElement | null>(null);
+  // The dragged block's own text, captured at drag start so the announcement can
+  // name it after the reflow has been cleared.
+  const dragLabelRef = useRef('');
 
   // Reports block-drag lifecycle + fires (false) on a mid-drag unmount so nothing
   // leaks (dnd-kit fires neither end nor cancel when the controls unmount).
@@ -240,6 +244,7 @@ export const RichTextBlockControls = memo(function RichTextBlockControls({
     });
 
     draggedIdRef.current = activeBlockId;
+    dragLabelRef.current = tidy(nodes[unit.u0].textContent ?? '');
     onMenuOpenChange(false); // a drag should never leave the block menu open
     reportDragging(true);
     dragRef.current = { rects, els: nodes, unit, parentIdx };
@@ -300,10 +305,31 @@ export const RichTextBlockControls = memo(function RichTextBlockControls({
     endDrag();
   };
 
+  // Localized announcements (Hard rule 9, #390). This context deliberately does
+  // NOT go through `useDragAccessibility`: it registers no droppables (the drop
+  // slot is computed from the pointer against the document flow), so `over` is
+  // always null and the shared over-driven messages would all be wrong here.
+  // Same `drag.*` copy, three of the five callbacks.
+  const accessibility = useMemo(() => {
+    const item = () => dragLabelRef.current || t('drag.unnamed');
+    return {
+      announcements: {
+        onDragStart: () => t('drag.pickedUp', { item: item() }),
+        // Silent: with no droppables, dnd-kit's per-move announcement would be
+        // a permanent, false "not over a drop target".
+        onDragOver: () => undefined,
+        onDragEnd: () => t('drag.moved', { item: item() }),
+        onDragCancel: () => t('drag.cancelled', { item: item() }),
+      },
+      screenReaderInstructions: { draggable: t('drag.instructions') },
+    };
+  }, [t]);
+
   if (!activeBlockId || top == null) return null;
 
   return (
     <DndContext
+      accessibility={accessibility}
       sensors={sensors}
       onDragStart={handleDragStart}
       onDragMove={handleDragMove}

--- a/packages/design-system/src/components/Sortable/Sortable.test.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.test.tsx
@@ -1,5 +1,5 @@
 import { createRef, type CSSProperties } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Sortable, restrictTransformToRect } from './Sortable';
 
@@ -543,5 +543,55 @@ describe('Sortable — drag announcements', () => {
     expect(live).toBe('Call Acme about renewal, position 2 of 2.');
     expect(dropped).toBe('Dropped Call Acme about renewal at position 2 of 2.');
     expect(`${live}${dropped}`).not.toMatch(/lead-/);
+  });
+});
+
+describe('Sortable — announcements with no resolvable target', () => {
+  // Rects are NOT stubbed here, so jsdom reports every box as zero and dnd-kit's
+  // default rectIntersection matches nothing: `over` is null for the whole drag
+  // and never CHANGES, so no `onDragOver` ever fires. That makes this the one
+  // place the pick-up announcement survives to be asserted in a list component,
+  // and it exercises `drag.droppedNowhere` on release.
+  function dragNowhere(handleLabel: string) {
+    const grip = screen.getByLabelText(handleLabel);
+    fireEvent.pointerDown(grip, { clientX: 0, clientY: 0, button: 0, isPrimary: true });
+    fireEvent.pointerMove(document, { clientX: 0, clientY: 40 });
+  }
+  const live = () => screen.getByRole('status').textContent;
+
+  it('announces the pick-up, then that nothing moved', () => {
+    render(
+      <Sortable>
+        <Sortable.Item id="lead-1">
+          <Sortable.Handle aria-label="Reorder first" />
+          Call Acme about renewal
+        </Sortable.Item>
+        <Sortable.Item id="lead-2">
+          <Sortable.Handle aria-label="Reorder second" />
+          Send proposal to Globex
+        </Sortable.Item>
+      </Sortable>,
+    );
+    dragNowhere('Reorder first');
+    expect(live()).toBe('Picked up Call Acme about renewal.');
+    fireEvent.pointerUp(document, { clientX: 0, clientY: 40 });
+    expect(live()).toBe('Released Call Acme about renewal. Nothing moved.');
+  });
+
+  it('falls back to “the item” when there is no text and no aria-label', () => {
+    render(
+      <Sortable>
+        <Sortable.Item id="lead-1">
+          <Sortable.Handle aria-label="Reorder first" />
+        </Sortable.Item>
+        <Sortable.Item id="lead-2">
+          <Sortable.Handle aria-label="Reorder second" />
+        </Sortable.Item>
+      </Sortable>,
+    );
+    dragNowhere('Reorder first');
+    expect(live()).toBe('Picked up the item.');
+    fireEvent.pointerUp(document, { clientX: 0, clientY: 40 });
+    expect(live()).toBe('Released the item. Nothing moved.');
   });
 });

--- a/packages/design-system/src/components/Sortable/Sortable.test.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.test.tsx
@@ -508,3 +508,40 @@ describe('restrictTransformToRect', () => {
     expect(result.scaleY).toBe(0.75);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Drag announcements (#390)
+// ---------------------------------------------------------------------------
+describe('Sortable — drag announcements', () => {
+  it('announces the item’s own text and slot, never its id', async () => {
+    const restore = stubStackedRects();
+    const user = userEvent.setup();
+    render(
+      // Grid arrangement so dnd-kit uses closestCenter: list mode's default
+      // rectIntersection needs real overlap, which jsdom's stubbed rects can't
+      // produce (see the keyboard-reorder test above).
+      <Sortable arrangement="grid" columns={12}>
+        <Sortable.Item id="lead-1" span="50%">
+          <Sortable.Handle aria-label="Reorder first" />
+          Call Acme about renewal
+        </Sortable.Item>
+        <Sortable.Item id="lead-2" span="50%">
+          <Sortable.Handle aria-label="Reorder second" />
+          Send proposal to Globex
+        </Sortable.Item>
+      </Sortable>,
+    );
+
+    screen.getByLabelText('Reorder first').focus();
+    await user.keyboard('[Space]');
+    await user.keyboard('[ArrowDown]');
+    const live = screen.getByRole('status').textContent ?? '';
+    await user.keyboard('[Space]');
+    const dropped = screen.getByRole('status').textContent ?? '';
+    restore();
+
+    expect(live).toBe('Call Acme about renewal, position 2 of 2.');
+    expect(dropped).toBe('Dropped Call Acme about renewal at position 2 of 2.');
+    expect(`${live}${dropped}`).not.toMatch(/lead-/);
+  });
+});

--- a/packages/design-system/src/components/Sortable/Sortable.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.tsx
@@ -46,7 +46,7 @@ import {
   type CollapseBreakpoint,
   type CollapseColumnsMap,
 } from '../_internal/collapse';
-import { nodeText, sortableTarget, useDragAccessibility } from '../_internal/dragAnnouncements';
+import { sortableTarget, useDragAccessibility } from '../_internal/dragAnnouncements';
 import styles from './Sortable.module.scss';
 
 /**
@@ -435,8 +435,8 @@ const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function Sortab
 
   // Localized screen-reader announcements (Hard rule 9). Every droppable here
   // IS a sortable item, so dnd-kit's own `data.sortable` supplies the slot and
-  // `sortableTarget` needs no help; the item's text comes from `dragLabel`,
-  // published by `<Sortable.Item>` below.
+  // `sortableTarget` needs no help; the item's name comes from the `aria-label`
+  // / rendered text `<Sortable.Item>` publishes below.
   const accessibility = useDragAccessibility(sortableTarget);
 
   const tree = (
@@ -525,15 +525,23 @@ SortableRoot.displayName = 'Sortable';
  *
  * Under `<Sortable arrangement="grid">`, pass `span` for the item's column
  * span (mirrors `Grid.Item`'s `span`); it's ignored in a list.
+ *
+ * @remarks
+ * Drag announcements name the item by its rendered text. Pass `aria-label` to
+ * override that — worth doing when the item renders a lot of chrome (badges,
+ * timestamps, avatars) and only part of it is the actual name.
  */
 export const SortableItem = forwardRef<HTMLLIElement, SortableItemProps>(function SortableItem(
   { id, span, className, children, ...rest },
   ref,
 ) {
-  // Announcement label: the item's own visible text, so a drag says "Review
-  // pricing page mocks, position 2 of 3" instead of dnd-kit's raw id.
-  const dragLabel = useMemo(() => nodeText(children), [children]);
-  const data = useMemo(() => ({ dragLabel }), [dragLabel]);
+  // Announcement label: the consumer's `aria-label`, else the item's RENDERED
+  // text — so a drag says "Review pricing page mocks, position 2 of 3" instead
+  // of dnd-kit's raw id, and a collapsed menu inside the item contributes
+  // nothing (see `dragLabelOf`).
+  const liRef = useRef<HTMLLIElement | null>(null);
+  const dragLabel = rest['aria-label'];
+  const data = useMemo(() => ({ dragLabel, dragNode: liRef }), [dragLabel]);
 
   const {
     setNodeRef,
@@ -555,6 +563,7 @@ export const SortableItem = forwardRef<HTMLLIElement, SortableItemProps>(functio
   );
 
   const setRef = (node: HTMLLIElement | null) => {
+    liRef.current = node;
     setNodeRef(node);
     // When no Handle is present, the Item itself is the drag activator —
     // dnd-kit uses this ref to scope keyboard / pointer events.

--- a/packages/design-system/src/components/Sortable/Sortable.tsx
+++ b/packages/design-system/src/components/Sortable/Sortable.tsx
@@ -46,6 +46,7 @@ import {
   type CollapseBreakpoint,
   type CollapseColumnsMap,
 } from '../_internal/collapse';
+import { nodeText, sortableTarget, useDragAccessibility } from '../_internal/dragAnnouncements';
 import styles from './Sortable.module.scss';
 
 /**
@@ -432,8 +433,15 @@ const SortableRoot = forwardRef<HTMLOListElement, SortableProps>(function Sortab
   );
   const modifiers = restrictToContainer ? [restrictModifier] : undefined;
 
+  // Localized screen-reader announcements (Hard rule 9). Every droppable here
+  // IS a sortable item, so dnd-kit's own `data.sortable` supplies the slot and
+  // `sortableTarget` needs no help; the item's text comes from `dragLabel`,
+  // published by `<Sortable.Item>` below.
+  const accessibility = useDragAccessibility(sortableTarget);
+
   const tree = (
     <DndContext
+      accessibility={accessibility}
       sensors={sensors}
       modifiers={modifiers}
       // Grid: closestCenter is dnd-kit's idiomatic pairing for a 2D sortable
@@ -522,6 +530,11 @@ export const SortableItem = forwardRef<HTMLLIElement, SortableItemProps>(functio
   { id, span, className, children, ...rest },
   ref,
 ) {
+  // Announcement label: the item's own visible text, so a drag says "Review
+  // pricing page mocks, position 2 of 3" instead of dnd-kit's raw id.
+  const dragLabel = useMemo(() => nodeText(children), [children]);
+  const data = useMemo(() => ({ dragLabel }), [dragLabel]);
+
   const {
     setNodeRef,
     setActivatorNodeRef,
@@ -530,7 +543,7 @@ export const SortableItem = forwardRef<HTMLLIElement, SortableItemProps>(functio
     transform,
     transition,
     isDragging,
-  } = useSortable({ id });
+  } = useSortable({ id, data });
 
   const hasHandle = useMemo(() => containsHandle(children), [children]);
 

--- a/packages/design-system/src/components/SortableGroup/SortableGroup.test.tsx
+++ b/packages/design-system/src/components/SortableGroup/SortableGroup.test.tsx
@@ -165,6 +165,72 @@ describe('SortableGroup', () => {
     expect(onMove).not.toHaveBeenCalled();
   });
 
+  // --- announcements (#390) -------------------------------------------------
+  // Ids ('x', 'p') and item text ('Renew Acme') differ, so an announcement that
+  // leaked a dnd-kit id would be visible below.
+  function NamedGroup() {
+    return (
+      <SortableGroup>
+        <SortableGroup.Container id="a" items={['x', 'y']} aria-label="Open">
+          <Sortable.Item id="x">
+            <Sortable.Handle aria-label="Reorder first" />
+            Renew Acme
+          </Sortable.Item>
+          <Sortable.Item id="y">
+            <Sortable.Handle aria-label="Reorder second" />
+            Call Globex
+          </Sortable.Item>
+        </SortableGroup.Container>
+        <SortableGroup.Container id="b" items={['p', 'q']}>
+          <Sortable.Item id="p">
+            <Sortable.Handle aria-label="Reorder third" />
+            Invoice Initech
+          </Sortable.Item>
+          <Sortable.Item id="q">
+            <Sortable.Handle aria-label="Reorder fourth" />
+            Ping Hooli
+          </Sortable.Item>
+        </SortableGroup.Container>
+      </SortableGroup>
+    );
+  }
+
+  it('announces the item text and the container aria-label, not the ids', async () => {
+    const restore = stubStackedRects();
+    const user = userEvent.setup();
+    render(<NamedGroup />);
+
+    screen.getByLabelText('Reorder first').focus();
+    await user.keyboard('[Space]');
+    await user.keyboard('[ArrowDown]');
+    const live = screen.getByRole('status').textContent ?? '';
+    await user.keyboard('[Escape]');
+    restore();
+
+    expect(live).toBe('Renew Acme, position 2 of 2 in Open.');
+    expect(screen.getByRole('status').textContent).toBe(
+      'Move cancelled. Renew Acme stayed where it was.',
+    );
+  });
+
+  it('falls back to the container’s position when it has no aria-label', async () => {
+    // No aria-label anywhere, so every container must name itself positionally
+    // — never read out the raw container id.
+    const restore = stubStackedRects();
+    const user = userEvent.setup();
+    render(<Group />);
+
+    screen.getByLabelText('Reorder X').focus();
+    await user.keyboard('[Space]');
+    await user.keyboard('[ArrowDown]');
+    const live = screen.getByRole('status').textContent ?? '';
+    await user.keyboard('[Escape]');
+    restore();
+
+    expect(live).toMatch(/ in list \d of 2\.$/);
+    expect(live).not.toMatch(/ in [ab]\./);
+  });
+
   // NOTE: cross-container drags are NOT exercised here. dnd-kit's
   // sortableKeyboardCoordinates resolves the next droppable from real layout
   // geometry; with jsdom's synthetic stacked rects the keyboard sensor cannot

--- a/packages/design-system/src/components/SortableGroup/SortableGroup.tsx
+++ b/packages/design-system/src/components/SortableGroup/SortableGroup.tsx
@@ -37,6 +37,12 @@ import {
   type SortableItemProps,
 } from '../Sortable';
 import { containerAwareClosestCorners } from '../Sortable/containerAwareCollision';
+import {
+  sortableTarget,
+  useDragAccessibility,
+  type DescribeDragTarget,
+} from '../_internal/dragAnnouncements';
+import { useTranslation } from '../../i18n';
 import { type SortableMoveEvent } from './moveSortableItem';
 import styles from './SortableGroup.module.scss';
 
@@ -67,6 +73,8 @@ export interface SortableGroupContainerProps extends Omit<HTMLAttributes<HTMLOLi
 interface ContainerRecord {
   items: Id[];
   itemContent: Map<Id, ReactNode>;
+  /** The container's `aria-label`, used to name it in drag announcements. */
+  label?: string;
 }
 interface GroupContextValue {
   register: (containerId: Id, rec: ContainerRecord) => void;
@@ -138,6 +146,7 @@ function itemContentMap(children: ReactNode): Map<Id, ReactNode> {
  * which forwards to its `<ol>`.
  */
 const SortableGroupRoot = function SortableGroup({ onMove, children }: SortableGroupProps) {
+  const t = useTranslation();
   const [activeId, setActiveId] = useState<Id | null>(null);
   const registryRef = useRef<Map<Id, ContainerRecord>>(new Map());
   const [overlayVersion, setOverlayVersion] = useState(0);
@@ -223,6 +232,31 @@ const SortableGroupRoot = function SortableGroup({ onMove, children }: SortableG
 
   const handleDragCancel = () => setActiveId(null);
 
+  // Localized announcements (Hard rule 9, #390). Items name themselves via the
+  // `dragLabel` `<Sortable.Item>` publishes; a container names itself with its
+  // `aria-label`, falling back to its 1-based registration order.
+  const describeDrag: DescribeDragTarget = (entry, activeId) => {
+    const reg = registryRef.current;
+    const id = entry.id as Id;
+    const cid = reg.has(id) ? id : containerOf(id);
+    const rec = cid == null ? undefined : reg.get(cid);
+    if (cid == null || !rec) return null;
+    const container =
+      rec.label ??
+      t('drag.unnamedContainer', { index: [...reg.keys()].indexOf(cid) + 1, total: reg.size });
+    const base = sortableTarget(entry);
+    // An item: dnd-kit's own sortable data already carries the slot.
+    if (!reg.has(id)) return base && { ...base, container };
+    // The container itself (empty list, or the space below the items): the item
+    // keeps its slot if a cross-container handoff already seated it here, and
+    // is otherwise counted as one more at the end.
+    const seated = rec.items.indexOf(activeId as Id);
+    return seated >= 0
+      ? { index: seated + 1, total: rec.items.length, container }
+      : { index: rec.items.length + 1, total: rec.items.length + 1, container };
+  };
+  const accessibility = useDragAccessibility(describeDrag);
+
   const overlayContent = useMemo<ReactNode>(() => {
     void overlayVersion; // re-read the registry after container (re)registrations
     if (activeId == null) return null;
@@ -238,6 +272,7 @@ const SortableGroupRoot = function SortableGroup({ onMove, children }: SortableG
   return (
     <GroupContext.Provider value={ctx}>
       <DndContext
+        accessibility={accessibility}
         sensors={sensors}
         collisionDetection={containerAwareClosestCorners}
         onDragStart={handleDragStart}
@@ -265,6 +300,11 @@ SortableGroupRoot.displayName = 'SortableGroup';
  * One list inside a `<SortableGroup>`. Renders an `<ol>` (its own
  * `SortableContext`) and registers as a droppable so even an empty list accepts
  * cross-container drops. Children are `<Sortable.Item>`s for the ids in `items`.
+ *
+ * @remarks
+ * Pass `aria-label` with the list's visible heading. It names the `<ol>` for a
+ * screen reader AND names the list in drag announcements ("…position 2 of 4 in
+ * In review"); without it they fall back to "list 2 of 3".
  */
 const SortableGroupContainer = forwardRef<HTMLOListElement, SortableGroupContainerProps>(
   function SortableGroupContainer({ id, items, className, children, ...rest }, ref) {
@@ -275,10 +315,11 @@ const SortableGroupContainer = forwardRef<HTMLOListElement, SortableGroupContain
     const { setNodeRef } = useDroppable({ id });
 
     const contentMap = useMemo(() => itemContentMap(children), [children]);
+    const label = rest['aria-label'];
     useEffect(() => {
-      group.register(id, { items, itemContent: contentMap });
+      group.register(id, { items, itemContent: contentMap, label });
       return () => group.unregister(id);
-    }, [group, id, items, contentMap]);
+    }, [group, id, items, contentMap, label]);
 
     const setRefs = useCallback(
       (node: HTMLOListElement | null) => {

--- a/packages/design-system/src/components/SortableGroup/SortableGroup.tsx
+++ b/packages/design-system/src/components/SortableGroup/SortableGroup.tsx
@@ -38,6 +38,7 @@ import {
 } from '../Sortable';
 import { containerAwareClosestCorners } from '../Sortable/containerAwareCollision';
 import {
+  containerName,
   sortableTarget,
   useDragAccessibility,
   type DescribeDragTarget,
@@ -233,9 +234,11 @@ const SortableGroupRoot = function SortableGroup({ onMove, children }: SortableG
   const handleDragCancel = () => setActiveId(null);
 
   // Localized announcements (Hard rule 9, #390). Items name themselves via the
-  // `dragLabel` `<Sortable.Item>` publishes; a container names itself with its
-  // `aria-label`, falling back to its 1-based registration order.
+  // label `<Sortable.Item>` publishes; a container names itself with its
+  // `aria-label` / `aria-labelledby`, falling back to its 1-based registration
+  // order.
   const describeDrag: DescribeDragTarget = (entry, activeId) => {
+    if (!entry) return null;
     const reg = registryRef.current;
     const id = entry.id as Id;
     const cid = reg.has(id) ? id : containerOf(id);
@@ -302,9 +305,10 @@ SortableGroupRoot.displayName = 'SortableGroup';
  * cross-container drops. Children are `<Sortable.Item>`s for the ids in `items`.
  *
  * @remarks
- * Pass `aria-label` with the list's visible heading. It names the `<ol>` for a
- * screen reader AND names the list in drag announcements ("…position 2 of 4 in
- * In review"); without it they fall back to "list 2 of 3".
+ * Name the list — `aria-label` with its visible heading, or `aria-labelledby`
+ * pointing at that heading's element. Either names the `<ol>` for a screen
+ * reader AND names the list in drag announcements ("…position 2 of 4 in In
+ * review"); without one they fall back to "list 2 of 3".
  */
 const SortableGroupContainer = forwardRef<HTMLOListElement, SortableGroupContainerProps>(
   function SortableGroupContainer({ id, items, className, children, ...rest }, ref) {
@@ -315,11 +319,15 @@ const SortableGroupContainer = forwardRef<HTMLOListElement, SortableGroupContain
     const { setNodeRef } = useDroppable({ id });
 
     const contentMap = useMemo(() => itemContentMap(children), [children]);
-    const label = rest['aria-label'];
+    // Resolved in the effect, not during render: `aria-labelledby` names an
+    // element that only exists once the tree is mounted.
+    const ariaLabel = rest['aria-label'];
+    const ariaLabelledBy = rest['aria-labelledby'];
     useEffect(() => {
+      const label = containerName({ 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy });
       group.register(id, { items, itemContent: contentMap, label });
       return () => group.unregister(id);
-    }, [group, id, items, contentMap, label]);
+    }, [group, id, items, contentMap, ariaLabel, ariaLabelledBy]);
 
     const setRefs = useCallback(
       (node: HTMLOListElement | null) => {

--- a/packages/design-system/src/components/_internal/dragAnnouncements.ts
+++ b/packages/design-system/src/components/_internal/dragAnnouncements.ts
@@ -6,33 +6,82 @@
 // in the library passes `accessibility={useDragAccessibility(...)}` instead.
 //
 // Internal — not exported from `src/index.ts`.
-import { isValidElement, useMemo, useRef, type ReactNode } from 'react';
+import { useMemo, useRef, type RefObject } from 'react';
 import type { Active, Announcements, ScreenReaderInstructions } from '@dnd-kit/core';
 import { useTranslation } from '../../i18n';
-
-/**
- * Flatten a children subtree to the text a sighted user reads, so an item can
- * announce itself by name instead of by id. Walks `props.children` only —
- * text rendered by a custom component (which this cannot call) is invisible,
- * and the caller falls back to `drag.unnamed`.
- *
- * It cannot tell decorative markup apart from content, so literal text inside a
- * `<Sortable.Handle>` (`<Sortable.Handle>⠿</Sortable.Handle>`) is included. An
- * icon component — the normal case — contributes nothing, so this is only worth
- * avoiding if you put real words in a handle.
- */
-export function nodeText(node: ReactNode): string {
-  if (node == null || typeof node === 'boolean') return '';
-  if (typeof node === 'string' || typeof node === 'number') return String(node);
-  if (Array.isArray(node)) return node.map(nodeText).join(' ');
-  if (isValidElement(node)) return nodeText((node.props as { children?: ReactNode }).children);
-  return '';
-}
 
 /** Collapse whitespace and cap the length so an announcement stays listenable. */
 export function tidy(text: string): string {
   const flat = text.replace(/\s+/g, ' ').trim();
   return flat.length > 80 ? `${flat.slice(0, 79)}…` : flat;
+}
+
+/**
+ * What a draggable publishes on its dnd-kit `data` so the announcements can
+ * name it. Read with `dragLabelOf`.
+ */
+export interface DragLabelData {
+  /** Consumer's explicit `aria-label`. Wins outright when set. */
+  dragLabel?: string;
+  /** The rendered node to read text from when there is no explicit label. */
+  dragNode?: RefObject<HTMLElement | null>;
+}
+
+/**
+ * The name to announce for a draggable: the consumer's `aria-label` if there is
+ * one, else the node's rendered text.
+ *
+ * Reading the DOM rather than walking the React children is deliberate. A card
+ * with a `<DropdownMenu>` / `<Tooltip>` / `<ConfirmationPopover>` in it has the
+ * closed panel's contents in its children tree but NOT in the document, so a
+ * children walk announces "Draft Q3 OKRs View Archive" while the DOM announces
+ * "Draft Q3 OKRs". Collapsed and portalled subtrees drop out by construction.
+ */
+export function dragLabelOf(data: Record<string, unknown> | undefined): string | undefined {
+  const { dragLabel, dragNode } = (data ?? {}) as DragLabelData;
+  if (typeof dragLabel === 'string' && dragLabel.trim()) return tidy(dragLabel);
+  const node = dragNode?.current;
+  if (!node) return undefined;
+  const text = tidy(domText(node));
+  return text || undefined;
+}
+
+/**
+ * `textContent` for announcements: separates element boundaries with a space
+ * (raw `textContent` glues siblings — "Acme Corp$50,000") and skips
+ * `aria-hidden` subtrees, which are decoration a screen reader is already told
+ * to ignore.
+ */
+function domText(el: Element): string {
+  let out = '';
+  for (const child of el.childNodes) {
+    if (child.nodeType === 3) out += child.nodeValue ?? '';
+    else if (child.nodeType === 1 && (child as Element).getAttribute('aria-hidden') !== 'true')
+      out += ` ${domText(child as Element)}`;
+  }
+  return out;
+}
+
+/**
+ * The accessible name a consumer gave a container (a Kanban column, a
+ * SortableGroup list) — `aria-label`, or the text of whatever `aria-labelledby`
+ * points at, since naming a column by its visible `<Title>` is the natural
+ * choice. Returns undefined when neither is set; the caller falls back to a
+ * positional stand-in.
+ */
+export function containerName(props: {
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+}): string | undefined {
+  const label = props['aria-label'];
+  if (typeof label === 'string' && label.trim()) return tidy(label);
+  const ids = props['aria-labelledby'];
+  if (!ids || typeof document === 'undefined') return undefined;
+  const text = ids
+    .split(/\s+/)
+    .map((id) => document.getElementById(id)?.textContent ?? '')
+    .join(' ');
+  return text.trim() ? tidy(text) : undefined;
 }
 
 /** The `active` / `over` shape dnd-kit hands to an announcement callback. */
@@ -51,16 +100,16 @@ export interface DragTarget {
 }
 
 /**
- * Default `describe`: the label a component published as `data.dragLabel`, plus
- * the index / items `useSortable` already publishes under `data.sortable`.
- * Returns `null` for anything that is not a sortable item.
+ * Default `describe`: the name from `dragLabelOf`, plus the index / items
+ * `useSortable` already publishes under `data.sortable`. Returns `null` for
+ * anything that is not a sortable item (including a missing entry).
  */
-export function sortableTarget(entry: DragEntry): DragTarget | null {
-  const data = entry.data.current;
+export function sortableTarget(entry: DragEntry | null): DragTarget | null {
+  const data = entry?.data.current;
   const sortable = data?.sortable as { index: number; items: unknown[] } | undefined;
   if (!sortable || sortable.index < 0) return null;
   return {
-    label: typeof data?.dragLabel === 'string' ? data.dragLabel : undefined,
+    label: dragLabelOf(data),
     index: sortable.index + 1,
     total: sortable.items.length,
   };
@@ -70,16 +119,25 @@ export function sortableTarget(entry: DragEntry): DragTarget | null {
  * Describes the slot an `active` / `over` entry names. `activeId` is passed so
  * a container droppable can answer "where would THIS card land in me" — the
  * multi-list components need it to position a drop onto an empty column.
+ *
+ * `entry` is null when dnd-kit resolved no `over` at all. Most components
+ * return null straight back; a component whose drop has its OWN fallback for
+ * that case (DataTable's last-resolved band slot, #383) must answer with that
+ * slot here too, or it announces "nothing moved" about a real reorder.
  */
-export type DescribeDragTarget = (entry: DragEntry, activeId: Active['id']) => DragTarget | null;
+export type DescribeDragTarget = (
+  entry: DragEntry | null,
+  activeId: Active['id'],
+) => DragTarget | null;
 
 /**
  * Build the `accessibility` prop for a `<DndContext>`: localized announcements
  * for the whole drag lifecycle plus localized keyboard instructions.
  *
- * @param describe   Resolves an entry to a human slot. Return `null` when the
- *                   entry names no droppable slot — that announces "not over a
- *                   drop target" / "nothing moved".
+ * @param describe   Resolves an entry (or `null` when there is no `over`) to a
+ *                   human slot. Return `null` when nothing would land anywhere
+ *                   — that announces "not over a drop target" / "nothing
+ *                   moved".
  * @param isRejectedDrop Optional. Consulted on drag end BEFORE `over`: return
  *                   `true` when the component refuses to commit the release, so
  *                   it announces a cancel rather than a drop that never
@@ -102,7 +160,7 @@ export function useDragAccessibility(
 
   return useMemo(() => {
     const nameOf = (entry: DragEntry, activeId: Active['id']) =>
-      tidy(describeRef.current(entry, activeId)?.label ?? '') || t('drag.unnamed');
+      describeRef.current(entry, activeId)?.label || t('drag.unnamed');
 
     const at = (
       key: 'movedOver' | 'dropped',
@@ -125,13 +183,13 @@ export function useDragAccessibility(
         onDragStart: ({ active }) => t('drag.pickedUp', { item: nameOf(active, active.id) }),
         onDragOver: ({ active, over }) => {
           const item = nameOf(active, active.id);
-          const target = over ? describeRef.current(over, active.id) : null;
+          const target = describeRef.current(over, active.id);
           return target ? at('movedOver', item, target) : t('drag.movedOutside', { item });
         },
         onDragEnd: ({ active, over }) => {
           const item = nameOf(active, active.id);
           if (rejectedRef.current?.()) return t('drag.cancelled', { item });
-          const target = over ? describeRef.current(over, active.id) : null;
+          const target = describeRef.current(over, active.id);
           return target ? at('dropped', item, target) : t('drag.droppedNowhere', { item });
         },
         onDragCancel: ({ active }) => t('drag.cancelled', { item: nameOf(active, active.id) }),

--- a/packages/design-system/src/components/_internal/dragAnnouncements.ts
+++ b/packages/design-system/src/components/_internal/dragAnnouncements.ts
@@ -1,0 +1,142 @@
+// dragAnnouncements.ts — localized screen-reader copy for dnd-kit drags.
+//
+// dnd-kit's built-in announcements are hard-coded English AND interpolate raw
+// ids ("Draggable item deal-7 was moved over droppable area col-3"), which is
+// both a Hard rule 9 violation and useless to a listener. Every `<DndContext>`
+// in the library passes `accessibility={useDragAccessibility(...)}` instead.
+//
+// Internal — not exported from `src/index.ts`.
+import { isValidElement, useMemo, useRef, type ReactNode } from 'react';
+import type { Active, Announcements, ScreenReaderInstructions } from '@dnd-kit/core';
+import { useTranslation } from '../../i18n';
+
+/**
+ * Flatten a children subtree to the text a sighted user reads, so an item can
+ * announce itself by name instead of by id. Walks `props.children` only —
+ * text rendered by a custom component (which this cannot call) is invisible,
+ * and the caller falls back to `drag.unnamed`.
+ *
+ * It cannot tell decorative markup apart from content, so literal text inside a
+ * `<Sortable.Handle>` (`<Sortable.Handle>⠿</Sortable.Handle>`) is included. An
+ * icon component — the normal case — contributes nothing, so this is only worth
+ * avoiding if you put real words in a handle.
+ */
+export function nodeText(node: ReactNode): string {
+  if (node == null || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(nodeText).join(' ');
+  if (isValidElement(node)) return nodeText((node.props as { children?: ReactNode }).children);
+  return '';
+}
+
+/** Collapse whitespace and cap the length so an announcement stays listenable. */
+export function tidy(text: string): string {
+  const flat = text.replace(/\s+/g, ' ').trim();
+  return flat.length > 80 ? `${flat.slice(0, 79)}…` : flat;
+}
+
+/** The `active` / `over` shape dnd-kit hands to an announcement callback. */
+export type DragEntry = Pick<Active, 'id' | 'data'>;
+
+/** What a component knows about the slot an id occupies (or would land in). */
+export interface DragTarget {
+  /** Human name. Empty / omitted → the message says "the item" instead. */
+  label?: string;
+  /** 1-based slot within `container`. */
+  index: number;
+  /** Number of slots in `container`, counting the incoming item. */
+  total: number;
+  /** Human name of the list the slot belongs to. Omit in single-list components. */
+  container?: string;
+}
+
+/**
+ * Default `describe`: the label a component published as `data.dragLabel`, plus
+ * the index / items `useSortable` already publishes under `data.sortable`.
+ * Returns `null` for anything that is not a sortable item.
+ */
+export function sortableTarget(entry: DragEntry): DragTarget | null {
+  const data = entry.data.current;
+  const sortable = data?.sortable as { index: number; items: unknown[] } | undefined;
+  if (!sortable || sortable.index < 0) return null;
+  return {
+    label: typeof data?.dragLabel === 'string' ? data.dragLabel : undefined,
+    index: sortable.index + 1,
+    total: sortable.items.length,
+  };
+}
+
+/**
+ * Describes the slot an `active` / `over` entry names. `activeId` is passed so
+ * a container droppable can answer "where would THIS card land in me" — the
+ * multi-list components need it to position a drop onto an empty column.
+ */
+export type DescribeDragTarget = (entry: DragEntry, activeId: Active['id']) => DragTarget | null;
+
+/**
+ * Build the `accessibility` prop for a `<DndContext>`: localized announcements
+ * for the whole drag lifecycle plus localized keyboard instructions.
+ *
+ * @param describe   Resolves an entry to a human slot. Return `null` when the
+ *                   entry names no droppable slot — that announces "not over a
+ *                   drop target" / "nothing moved".
+ * @param isRejectedDrop Optional. Consulted on drag end BEFORE `over`: return
+ *                   `true` when the component refuses to commit the release, so
+ *                   it announces a cancel rather than a drop that never
+ *                   happened (Kanban's outside-the-board release, #390).
+ */
+export function useDragAccessibility(
+  describe: DescribeDragTarget,
+  isRejectedDrop?: () => boolean,
+): { announcements: Announcements; screenReaderInstructions: ScreenReaderInstructions } {
+  const t = useTranslation();
+
+  // Latched during render so the returned object can stay stable across the
+  // re-renders a live drag causes (dnd-kit re-subscribes its monitor listener
+  // whenever `announcements` changes identity). Both writes are idempotent —
+  // a StrictMode double render stores the same functions.
+  const describeRef = useRef(describe);
+  describeRef.current = describe;
+  const rejectedRef = useRef(isRejectedDrop);
+  rejectedRef.current = isRejectedDrop;
+
+  return useMemo(() => {
+    const nameOf = (entry: DragEntry, activeId: Active['id']) =>
+      tidy(describeRef.current(entry, activeId)?.label ?? '') || t('drag.unnamed');
+
+    const at = (
+      key: 'movedOver' | 'dropped',
+      item: string,
+      target: DragTarget,
+    ): string | undefined => {
+      const { index, total, container } = target;
+      return container == null
+        ? t(`drag.${key}`, { item, index, total })
+        : t(key === 'movedOver' ? 'drag.movedOverIn' : 'drag.droppedIn', {
+            item,
+            index,
+            total,
+            container,
+          });
+    };
+
+    return {
+      announcements: {
+        onDragStart: ({ active }) => t('drag.pickedUp', { item: nameOf(active, active.id) }),
+        onDragOver: ({ active, over }) => {
+          const item = nameOf(active, active.id);
+          const target = over ? describeRef.current(over, active.id) : null;
+          return target ? at('movedOver', item, target) : t('drag.movedOutside', { item });
+        },
+        onDragEnd: ({ active, over }) => {
+          const item = nameOf(active, active.id);
+          if (rejectedRef.current?.()) return t('drag.cancelled', { item });
+          const target = over ? describeRef.current(over, active.id) : null;
+          return target ? at('dropped', item, target) : t('drag.droppedNowhere', { item });
+        },
+        onDragCancel: ({ active }) => t('drag.cancelled', { item: nameOf(active, active.id) }),
+      } satisfies Announcements,
+      screenReaderInstructions: { draggable: t('drag.instructions') },
+    };
+  }, [t]);
+}

--- a/packages/design-system/src/i18n/en.ts
+++ b/packages/design-system/src/i18n/en.ts
@@ -99,6 +99,25 @@ export const en: Messages = {
     pinnedRows: 'Pinned rows',
     empty: 'No data',
   },
+  drag: {
+    instructions:
+      'Press Space or Enter to pick up. While dragging, the arrow keys move the item, Space or Enter drops it, and Escape cancels.',
+    pickedUp: ({ item }) => `Picked up ${item as string}.`,
+    movedOver: ({ item, index, total }) =>
+      `${item as string}, position ${index as number} of ${total as number}.`,
+    movedOverIn: ({ item, index, total, container }) =>
+      `${item as string}, position ${index as number} of ${total as number} in ${container as string}.`,
+    movedOutside: ({ item }) => `${item as string} is not over a drop target.`,
+    dropped: ({ item, index, total }) =>
+      `Dropped ${item as string} at position ${index as number} of ${total as number}.`,
+    droppedIn: ({ item, index, total, container }) =>
+      `Dropped ${item as string} at position ${index as number} of ${total as number} in ${container as string}.`,
+    droppedNowhere: ({ item }) => `Released ${item as string}. Nothing moved.`,
+    moved: ({ item }) => `Moved ${item as string}.`,
+    cancelled: ({ item }) => `Move cancelled. ${item as string} stayed where it was.`,
+    unnamed: 'the item',
+    unnamedContainer: ({ index, total }) => `list ${index as number} of ${total as number}`,
+  },
   dashboardCanvas: {
     canvas: 'Dashboard canvas',
     sectionCollapse: ({ title }) => `Collapse ${title as string} section`,
@@ -226,6 +245,7 @@ export const en: Messages = {
   },
   kanban: {
     board: 'Kanban board',
+    unnamedColumn: ({ index, total }) => `column ${index as number} of ${total as number}`,
   },
   modal: {
     close: 'Close dialog',

--- a/packages/design-system/src/i18n/messages.ts
+++ b/packages/design-system/src/i18n/messages.ts
@@ -162,6 +162,59 @@ export interface Messages {
     /** Default empty-state copy when no rows are rendered. */
     empty: string;
   };
+  /**
+   * Screen-reader copy for every dnd-kit drag surface in the library — Kanban,
+   * Sortable, SortableGroup, DataTable column reorder and the RichTextEditor
+   * block gutter. Passed to `<DndContext accessibility={…}>` so dnd-kit's
+   * hard-coded English defaults never reach a live region.
+   *
+   * `item` and `container` are human labels the component resolves at the call
+   * site (a card's text, a column header, a list's `aria-label`); `index` and
+   * `total` are 1-based slot positions. Nothing here bakes in data.
+   */
+  drag: {
+    /** Visually-hidden keyboard instructions, announced when a draggable takes focus. */
+    instructions: string;
+    /** Announced when a drag starts. */
+    pickedUp: (params: { item: string }) => string;
+    /** Announced when the drop slot changes, in a single-list component (Sortable, DataTable). */
+    movedOver: (params: { item: string; index: number; total: number }) => string;
+    /** Announced when the drop slot changes, in a multi-list component (Kanban, SortableGroup). */
+    movedOverIn: (params: {
+      item: string;
+      index: number;
+      total: number;
+      container: string;
+    }) => string;
+    /** Announced while the drag is over no drop target at all. */
+    movedOutside: (params: { item: string }) => string;
+    /** Announced on a committed drop in a single-list component. */
+    dropped: (params: { item: string; index: number; total: number }) => string;
+    /** Announced on a committed drop into a named list. */
+    droppedIn: (params: {
+      item: string;
+      index: number;
+      total: number;
+      container: string;
+    }) => string;
+    /** Announced when a release resolves to no slot, so nothing moved. */
+    droppedNowhere: (params: { item: string }) => string;
+    /**
+     * Announced on a committed drop by a surface that has no numbered slots to
+     * report — the RichTextEditor block gutter drags against the document flow,
+     * not a list of droppables.
+     */
+    moved: (params: { item: string }) => string;
+    /**
+     * Announced on Escape, and on a release the component itself rejects — a
+     * Kanban card let go outside the board is a cancel, not a drop.
+     */
+    cancelled: (params: { item: string }) => string;
+    /** Stand-in for `item` when the component has no human label for what is being dragged. */
+    unnamed: string;
+    /** Stand-in for `container` when a list has no accessible name; `index` is 1-based. */
+    unnamedContainer: (params: { index: number; total: number }) => string;
+  };
   dashboardCanvas: {
     /** aria-label for the canvas root region. */
     canvas: string;
@@ -367,6 +420,11 @@ export interface Messages {
   kanban: {
     /** aria-label for the Kanban scroll container (the board itself). */
     board: string;
+    /**
+     * Stand-in name for a column in drag announcements when the consumer gave
+     * `<Kanban.Column>` no `aria-label`; `index` is 1-based in board order.
+     */
+    unnamedColumn: (params: { index: number; total: number }) => string;
   };
   modal: {
     /** aria-label for the Modal header's close button. */

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -101,6 +101,25 @@ export const ru: Messages = {
     pinnedRows: 'Закреплённые строки',
     empty: 'Нет данных',
   },
+  drag: {
+    instructions:
+      'Нажмите пробел или Enter, чтобы взять элемент. Пока элемент взят, стрелки перемещают его, пробел или Enter размещает, Escape отменяет.',
+    pickedUp: ({ item }) => `Взято: ${item as string}.`,
+    movedOver: ({ item, index, total }) =>
+      `${item as string} — позиция ${index as number} из ${total as number}.`,
+    movedOverIn: ({ item, index, total, container }) =>
+      `${item as string} — позиция ${index as number} из ${total as number}, ${container as string}.`,
+    movedOutside: ({ item }) => `${item as string} — вне области размещения.`,
+    dropped: ({ item, index, total }) =>
+      `Размещено: ${item as string}, позиция ${index as number} из ${total as number}.`,
+    droppedIn: ({ item, index, total, container }) =>
+      `Размещено: ${item as string}, позиция ${index as number} из ${total as number}, ${container as string}.`,
+    droppedNowhere: ({ item }) => `Отпущено: ${item as string}. Ничего не изменилось.`,
+    moved: ({ item }) => `Перемещено: ${item as string}.`,
+    cancelled: ({ item }) => `Перемещение отменено: ${item as string} на прежнем месте.`,
+    unnamed: 'элемент',
+    unnamedContainer: ({ index, total }) => `список ${index as number} из ${total as number}`,
+  },
   dashboardCanvas: {
     canvas: 'Холст дашборда',
     sectionCollapse: ({ title }) => `Свернуть секцию «${title as string}»`,
@@ -228,6 +247,7 @@ export const ru: Messages = {
   },
   kanban: {
     board: 'Канбан-доска',
+    unnamedColumn: ({ index, total }) => `колонка ${index as number} из ${total as number}`,
   },
   modal: {
     close: 'Закрыть диалог',

--- a/packages/design-system/src/i18n/ru.ts
+++ b/packages/design-system/src/i18n/ru.ts
@@ -104,19 +104,19 @@ export const ru: Messages = {
   drag: {
     instructions:
       'Нажмите пробел или Enter, чтобы взять элемент. Пока элемент взят, стрелки перемещают его, пробел или Enter размещает, Escape отменяет.',
-    pickedUp: ({ item }) => `Взято: ${item as string}.`,
+    pickedUp: ({ item }) => `Взято: «${item as string}».`,
     movedOver: ({ item, index, total }) =>
-      `${item as string} — позиция ${index as number} из ${total as number}.`,
+      `«${item as string}» — позиция ${index as number} из ${total as number}.`,
     movedOverIn: ({ item, index, total, container }) =>
-      `${item as string} — позиция ${index as number} из ${total as number}, ${container as string}.`,
-    movedOutside: ({ item }) => `${item as string} — вне области размещения.`,
+      `«${item as string}» — позиция ${index as number} из ${total as number}, «${container as string}».`,
+    movedOutside: ({ item }) => `«${item as string}» — вне области размещения.`,
     dropped: ({ item, index, total }) =>
-      `Размещено: ${item as string}, позиция ${index as number} из ${total as number}.`,
+      `Размещено: «${item as string}», позиция ${index as number} из ${total as number}.`,
     droppedIn: ({ item, index, total, container }) =>
-      `Размещено: ${item as string}, позиция ${index as number} из ${total as number}, ${container as string}.`,
-    droppedNowhere: ({ item }) => `Отпущено: ${item as string}. Ничего не изменилось.`,
-    moved: ({ item }) => `Перемещено: ${item as string}.`,
-    cancelled: ({ item }) => `Перемещение отменено: ${item as string} на прежнем месте.`,
+      `Размещено: «${item as string}», позиция ${index as number} из ${total as number}, «${container as string}».`,
+    droppedNowhere: ({ item }) => `Отпущено: «${item as string}». Ничего не изменилось.`,
+    moved: ({ item }) => `Перемещено: «${item as string}».`,
+    cancelled: ({ item }) => `Перемещение отменено: «${item as string}» на прежнем месте.`,
     unnamed: 'элемент',
     unnamedContainer: ({ index, total }) => `список ${index as number} из ${total as number}`,
   },

--- a/packages/playground/src/pages/components/KanbanDemo.tsx
+++ b/packages/playground/src/pages/components/KanbanDemo.tsx
@@ -210,7 +210,7 @@ export function Demo() {
   return (
     <Kanban onMove={handleMove}>
       {(['todo', 'doing', 'done'] as const).map((colId) => (
-        <Kanban.Column key={colId} id={colId}>
+        <Kanban.Column key={colId} id={colId} aria-label={COL_TITLES[colId]}>
           <Cluster justify="between" align="center">
             <Title order={3} size="sm">{COL_TITLES[colId]}</Title>
             <Badge tone="neutral" size="sm">{board[colId].length}</Badge>
@@ -228,7 +228,7 @@ export function Demo() {
       >
         <Kanban onMove={handleMoveA}>
           {(['todo', 'doing', 'done'] as const).map((colId) => (
-            <Kanban.Column key={colId} id={colId}>
+            <Kanban.Column key={colId} id={colId} aria-label={COL_TITLES[colId]}>
               <Cluster justify="between" align="center">
                 <Title order={3} size="sm">
                   {COL_TITLES[colId]}
@@ -320,7 +320,7 @@ export function Demo() {
   return (
     <Kanban onMove={handleMove}>
       {(['todo', 'doing', 'done'] as const).map((colId) => (
-        <Kanban.Column key={colId} id={colId}>
+        <Kanban.Column key={colId} id={colId} aria-label={COL_TITLES[colId]}>
           <Cluster justify="between" align="center">
             <Title order={3} size="sm">{COL_TITLES[colId]}</Title>
             <Badge tone="neutral" size="sm">{board[colId].length}</Badge>
@@ -358,7 +358,7 @@ export function Demo() {
       >
         <Kanban onMove={handleMoveB}>
           {(['todo', 'doing', 'done'] as const).map((colId) => (
-            <Kanban.Column key={colId} id={colId}>
+            <Kanban.Column key={colId} id={colId} aria-label={COL_TITLES[colId]}>
               <Cluster justify="between" align="center">
                 <Title order={3} size="sm">
                   {COL_TITLES[colId]}
@@ -432,7 +432,7 @@ export function Demo() {
   return (
     <Kanban onMove={handleMove}>
       {(['backlog', 'archive'] as const).map((colId) => (
-        <Kanban.Column key={colId} id={colId}>
+        <Kanban.Column key={colId} id={colId} aria-label={colId}>
           <Cluster justify="between" align="center">
             <Title order={3} size="sm">{colId}</Title>
             <Badge tone="neutral" size="sm">{board[colId].length}</Badge>
@@ -451,7 +451,7 @@ export function Demo() {
         <Stack gap="sm">
           <Kanban onMove={handleMoveC} data-testid="uneven-board">
             {(['backlog', 'archive'] as const).map((colId) => (
-              <Kanban.Column key={colId} id={colId}>
+              <Kanban.Column key={colId} id={colId} aria-label={UNEVEN_TITLES[colId]}>
                 <Cluster justify="between" align="center">
                   <Title order={3} size="sm">
                     {UNEVEN_TITLES[colId]}
@@ -483,7 +483,7 @@ export function Demo() {
 
 <Kanban onMove={handleMove}>
   {STAGES.map(([stage, deals]) => (
-    <Kanban.Column key={stage} id={stage}>
+    <Kanban.Column key={stage} id={stage} aria-label={stage}>
       <Cluster justify="between" align="center">
         <Title order={3} size="sm">{stage}</Title>
         <Badge tone="neutral" size="sm">{deals.length}</Badge>
@@ -499,7 +499,7 @@ export function Demo() {
       >
         <Kanban onMove={handleMoveD} data-testid="wide-board">
           {PIPELINE.map(([stage]) => (
-            <Kanban.Column key={stage} id={stage}>
+            <Kanban.Column key={stage} id={stage} aria-label={stage}>
               <Cluster justify="between" align="center">
                 <Title order={3} size="sm">
                   {stage}

--- a/packages/playground/src/pages/components/SortableGroupDemo.tsx
+++ b/packages/playground/src/pages/components/SortableGroupDemo.tsx
@@ -97,7 +97,11 @@ export function Demo() {
                 <Text size="sm" weight="semibold">
                   {groupLabels[gid]}
                 </Text>
-                <SortableGroup.Container id={gid} items={fields.map((f) => f.id)}>
+                <SortableGroup.Container
+                  id={gid}
+                  items={fields.map((f) => f.id)}
+                  aria-label={groupLabels[gid]}
+                >
                   {fields.map((f) => (
                     <Sortable.Item key={f.id} id={f.id}>
                       <Cluster gap="sm" align="center">
@@ -135,7 +139,11 @@ export function Demo() {
                     <Text size="sm" weight="semibold">
                       {GROUP_LABELS[gid]}
                     </Text>
-                    <SortableGroup.Container id={gid} items={fields.map((f) => f.id)}>
+                    <SortableGroup.Container
+                      id={gid}
+                      items={fields.map((f) => f.id)}
+                      aria-label={GROUP_LABELS[gid]}
+                    >
                       {fields.map((f) => (
                         <Sortable.Item key={f.id} id={f.id}>
                           <Cluster gap="sm" align="center">


### PR DESCRIPTION
Addresses #390.

## Summary

No component overrode dnd-kit's screen-reader announcements, so every drag interaction announced in **English regardless of locale** — a Hard rule 9 violation across all six `DndContext` sites. And since #391, Kanban's default announcement claimed *"was dropped over droppable area X"* on a path that now cancels.

This localizes the drag lifecycle everywhere, names things a listener can recognize, and makes each announcement agree with what actually happened.

Before → after, on the playground:

| | before | after |
|---|---|---|
| Kanban pick up (ru) | `Draggable item deal-1 was picked up.` | `«Draft Q3 OKRs» — позиция 1 из 3, «To do».` |
| Kanban outside release | `…was dropped over droppable area in-progress.` | `Move cancelled. Review pricing page mocks stayed where it was.` |
| DataTable drop | `…was dropped over droppable area col-stage.` | `Dropped Stage at position 4 of 4.` |

## Shape

`_internal/dragAnnouncements.ts` exposes `useDragAccessibility(describe, isRejectedDrop?)`, shared by Kanban, Sortable, SortableGroup and DataTable — they announce the same lifecycle over numbered slots, and five tailored message sets would have meant five wordings drifting across two locales. `RichTextBlockControls` deliberately opts out: it registers no droppables, so every `over`-driven message would be permanently false there.

Labels come from the item's rendered DOM, with an `aria-label` override. Containers name themselves from `aria-label` or `aria-labelledby`, else positionally.

## Three bugs found in review, all the same shape

Each one was the announcement path reading a *different value* than the path that decides what happens. They looked equivalent and weren't:

1. **The first implementation read the React element tree**, so a card's collapsed overflow menu was scraped into its name. The repo's own demo board announced **"Draft Q3 OKRs View Archive, position 1 of 3 in To do."** — and a listener has no way to know those two words aren't the title. Now reads rendered DOM, so unmounted popovers drop out by construction.
2. **DataTable announced "Nothing moved" on drops that moved the column.** `handleDragEnd` resolves its target through the `lastSlotIdRef` fallback added in #383; the announcement decided from raw `over`, which is null or a pinned column on both of #383's documented trigger paths.
3. **Then the same mistake one level down:** the fix whitelisted against `sortableIds` while the commit used `shiftOrderedIds`, so dropping onto an unpinned `enableReorder: false` column moved it and still announced "Nothing moved". Both now use one index space.

Each was probe-confirmed in a browser or a runtime probe, not inferred, and each is mutation-covered: reverting any one of the three fails exactly its own tests and nothing else.

The other three components were checked for the same split and don't have it — `Sortable` and `SortableGroup` each have one array with multiple readers, and `RichTextBlockControls` announces no position at all. DataTable was the only component whose droppable set and sortable set legitimately differ, which is why it was the only one that could drift.

## Consumer-visible detail

Position numbers in tables mixing `enableReorder: false` with unpinned columns now count **all unpinned columns**, not just reorderable ones — which is what a sighted user counts looking at the band. The old denominator silently dropped non-reorderable columns.

`<Kanban.Column>` with an `aria-label` now also renders `role="group"`, so the name isn't inert in the a11y tree. Opt-in (only when labelled) and never overrides a consumer `role`.

## Test plan

- 4263 tests / 197 files, typecheck, lint, format:check, `npm pack --dry-run` clean — every gate run **unpiped with exit codes checked**.
- Announcement text asserted in **both locales**, plus the Kanban cancel, the collapsed-menu regression, the `aria-label` override, `aria-labelledby` container naming, and the `droppedNowhere` / `movedOutside` / `unnamed` fallbacks.
- Mutation-verified: removing the `accessibility` prop fails all 5 Kanban announcement tests with dnd-kit's English defaults in the diff output.
- en↔ru parity is enforced by `tsc` (`export const ru: Messages`); review additionally walked both objects invoking every function leaf and confirmed the only identical pairs are `AM`/`PM`, correctly.
- Three rounds of Hard rule 8 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mPjHz2Q2kKGv4NCN6EoHk
