### PR TITLE
docs: add root agent guidance pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent guidance
+
+This is a Claude-first repository. Before doing any work, read and follow the root [`CLAUDE.md`](./CLAUDE.md).
+
+When working inside a package, also read and follow the nearest package-level `CLAUDE.md`.
+
+Inspect [`.claude/skills/`](./.claude/skills/) and load every skill relevant to the current task before acting.
+
+The Claude guidance and skills are authoritative. Keep this file as a short compatibility pointer rather than duplicating their rules here.

--- a/docs/superpowers/plans/2026-07-30-root-agents-pointer.md
+++ b/docs/superpowers/plans/2026-07-30-root-agents-pointer.md
@@ -19,11 +19,13 @@
 ### Task 1: Add the root compatibility pointer
 
 **Files:**
+
 - Create: `AGENTS.md`
 - Read: `CLAUDE.md`
 - Read: `.claude/skills/`
 
 **Interfaces:**
+
 - Consumes: Existing root and package-level Claude instructions and repository-local Claude skills.
 - Produces: A root discovery file for agents that automatically load `AGENTS.md`.
 

--- a/docs/superpowers/plans/2026-07-30-root-agents-pointer.md
+++ b/docs/superpowers/plans/2026-07-30-root-agents-pointer.md
@@ -1,0 +1,75 @@
+# Root AGENTS.md Pointer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a root agent-discovery file that points to the repository's authoritative Claude guidance and skills.
+
+**Architecture:** A single root `AGENTS.md` acts as a compatibility entry point. It contains navigation and precedence guidance only, leaving all substantive rules in the existing Claude files.
+
+**Tech Stack:** Markdown repository documentation
+
+## Global Constraints
+
+- Identify the repository as Claude-first.
+- Keep `CLAUDE.md`, package-level `CLAUDE.md` files, and `.claude/skills/` authoritative.
+- Do not duplicate implementation or package rules.
+
+---
+
+### Task 1: Add the root compatibility pointer
+
+**Files:**
+- Create: `AGENTS.md`
+- Read: `CLAUDE.md`
+- Read: `.claude/skills/`
+
+**Interfaces:**
+- Consumes: Existing root and package-level Claude instructions and repository-local Claude skills.
+- Produces: A root discovery file for agents that automatically load `AGENTS.md`.
+
+- [ ] **Step 1: Confirm every referenced guidance path exists**
+
+Run:
+
+```bash
+test -f CLAUDE.md
+find packages -mindepth 2 -maxdepth 2 -name CLAUDE.md -print
+find .claude/skills -mindepth 2 -maxdepth 2 -name SKILL.md -print
+```
+
+Expected: all commands exit successfully; the latter two commands list the package guidance and repository-local skill files.
+
+- [ ] **Step 2: Create the root pointer**
+
+Create `AGENTS.md` with:
+
+```markdown
+# Agent guidance
+
+This is a Claude-first repository. Before doing any work, read and follow the root [`CLAUDE.md`](./CLAUDE.md).
+
+When working inside a package, also read and follow the nearest package-level `CLAUDE.md`.
+
+Inspect [`.claude/skills/`](./.claude/skills/) and load every skill relevant to the current task before acting.
+
+The Claude guidance and skills are authoritative. Keep this file as a short compatibility pointer rather than duplicating their rules here.
+```
+
+- [ ] **Step 3: Verify the pointer**
+
+Run:
+
+```bash
+test -f AGENTS.md
+rg -n 'CLAUDE\.md|\.claude/skills|authoritative' AGENTS.md
+git diff --check
+```
+
+Expected: `AGENTS.md` exists, all three pointer concepts are found, and `git diff --check` exits successfully with no output.
+
+- [ ] **Step 4: Commit the documentation**
+
+```bash
+git add AGENTS.md docs/superpowers/plans/2026-07-30-root-agents-pointer.md
+git commit -m "docs: add root agent guidance pointer"
+```

--- a/docs/superpowers/specs/2026-07-30-root-agents-pointer-design.md
+++ b/docs/superpowers/specs/2026-07-30-root-agents-pointer-design.md
@@ -1,0 +1,26 @@
+# Root AGENTS.md Pointer Design
+
+## Purpose
+
+Add a small compatibility entry point for coding agents that discover `AGENTS.md`
+but do not automatically discover Claude-specific repository guidance.
+
+## Design
+
+Create a root `AGENTS.md` that:
+
+- identifies the repository as Claude-first;
+- directs agents to read the root `CLAUDE.md` before working;
+- directs agents working within a package to read that package's nearest
+  `CLAUDE.md`;
+- directs agents to inspect `.claude/skills/` and load skills relevant to the
+  current task; and
+- states that the linked Claude files remain authoritative.
+
+The file will not duplicate implementation rules or package guidance. Keeping it
+as pointers prevents parallel instruction sets from drifting apart.
+
+## Verification
+
+Confirm that every referenced path exists and that the new `AGENTS.md` contains
+only navigation and precedence guidance.


### PR DESCRIPTION
## What changed

- add a root `AGENTS.md` compatibility entry point
- direct agents to the authoritative root and package-level `CLAUDE.md` files
- direct agents to load relevant repository-local skills from `.claude/skills/`
- document the small design and implementation plan

## Why

This is a Claude-first repository, but some coding agents discover `AGENTS.md` automatically and do not discover Claude-specific guidance. The pointer makes those agents load the existing source of truth without duplicating rules that could drift.

## Impact

Documentation and agent discovery only. No runtime, package, or build behavior changes.

## Validation

- `git diff --check origin/main..HEAD`
- pre-push hook: Prettier, Stylelint, and TypeScript checks passed
- focused pointer/path checks passed
- task-scoped and whole-change agent reviews reported no findings

The full component test suite was also run before this PR and exposed 12 pre-existing/unrelated failures; those are intentionally excluded from this documentation PR and will be investigated separately.
