### PR TITLE
test: stabilize Vitest worker concurrency

### DIFF
--- a/packages/design-system/vitest.config.ts
+++ b/packages/design-system/vitest.config.ts
@@ -4,9 +4,8 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
-    // Keep jsdom workers within the CPU/memory available to CI containers.
-    // Hosted environments can report far more logical CPUs than their quota,
-    // causing otherwise-fast interaction tests to hit Vitest's 5s timeout.
+    // Limit jsdom concurrency to prevent resource contention from causing
+    // otherwise-fast interaction tests to hit Vitest's 5s timeout.
     maxWorkers: 4,
     // Exposes describe/it/expect/vi globally and lets @testing-library/react
     // auto-cleanup between tests (no manual afterEach needed).

--- a/packages/design-system/vitest.config.ts
+++ b/packages/design-system/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
+    // Keep jsdom workers within the CPU/memory available to CI containers.
+    // Hosted environments can report far more logical CPUs than their quota,
+    // causing otherwise-fast interaction tests to hit Vitest's 5s timeout.
+    maxWorkers: 4,
     // Exposes describe/it/expect/vi globally and lets @testing-library/react
     // auto-cleanup between tests (no manual afterEach needed).
     globals: true,


### PR DESCRIPTION
## What changed

- cap Vitest's jsdom worker concurrency at four workers
- document why the cap is necessary for interaction-test stability

## Root cause

Vitest detected 32 logical CPUs in the execution environment and ran enough jsdom test files concurrently to create resource contention. Ordinary interaction tests then exceeded the default five-second timeout, producing 12 failures across 10 otherwise-unrelated component suites.

The failures were not component defects:

- both DateRangePicker files passed together: 79/79 tests
- all 10 previously failing files passed together: 296/296 tests
- the complete suite passed when invoked with `--maxWorkers=4`: 4,282/4,282 tests

Making the same cap part of `vitest.config.ts` removes the environment-dependent over-parallelization for normal `npm test` runs.

## Impact

Test execution only. Production code and package behavior are unchanged. The suite trades some maximum parallelism for deterministic execution under constrained runners.

## Validation

- root `npm test`: 198 files, 4,282/4,282 tests passed on three complete post-fix runs
- `npm run format:check`
- `npm run lint:css`
- `npm run typecheck`
- pre-push hook passed
- independent code review: ready to merge; wording-only minor addressed
