### PR TITLE
Fix release validation after version sync

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,6 +33,7 @@ jobs:
           cache: "gradle"
           cache-dependency-path: |
             packages/design-tokens/compose/**/*.gradle*
+            packages/design-tokens/compose/gradle.properties
             packages/design-tokens/compose/**/gradle-wrapper.properties
 
       - name: Setup Android SDK

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "21"
+          cache: "gradle"
+          cache-dependency-path: |
+            packages/design-tokens/compose/**/*.gradle*
+            packages/design-tokens/compose/**/gradle-wrapper.properties
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: "npm"
           # This writes .npmrc with the @eocrm scope pointed at GitHub Packages
           # and wires NODE_AUTH_TOKEN for the publish step below.
           registry-url: "https://npm.pkg.github.com"
@@ -94,6 +95,10 @@ jobs:
         with:
           distribution: temurin
           java-version: "21"
+          cache: "gradle"
+          cache-dependency-path: |
+            packages/design-tokens/compose/**/*.gradle*
+            packages/design-tokens/compose/**/gradle-wrapper.properties
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -223,13 +228,14 @@ jobs:
             echo "- Tag: \`v${{ steps.version.outputs.value }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Re-deploy the playground so the live site always reflects main. Runs whenever
-  # quality passed — regardless of the publish result (success / skipped /
-  # failure) — so the demo stays current even on playground-only changes and
-  # even if a publish hiccups.
+  # Re-deploy the playground so the live site reflects a successfully released
+  # main, or a main change where publishing was intentionally skipped.
   deploy-playground:
     needs: [quality, publish]
-    if: always() && needs.quality.result == 'success'
+    if: >-
+      always() &&
+      needs.quality.result == 'success' &&
+      (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     uses: ./.github/workflows/deploy-playground.yml
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,8 @@ name: Release
 #   packages/design-system/CLAUDE.md is excluded too — it is the one file in
 #   that package that never reaches the tarball (AGENTS.md, README.md, and
 #   src/components/TODO.md all ship, so those DO warrant a release).
-# - deploy-playground runs whenever quality passed (regardless of the publish
-#   result) — so the live demo always reflects main, even on playground-only
-#   changes.
+# - deploy-playground runs after a successful quality and publish, or when the
+#   change detector succeeds and intentionally skips publishing.
 #
 # To force a major/minor bump, edit BUMP below on a branch and merge — there
 # is no manual UI by design.
@@ -98,6 +97,7 @@ jobs:
           cache: "gradle"
           cache-dependency-path: |
             packages/design-tokens/compose/**/*.gradle*
+            packages/design-tokens/compose/gradle.properties
             packages/design-tokens/compose/**/gradle-wrapper.properties
 
       - name: Setup Android SDK
@@ -231,11 +231,14 @@ jobs:
   # Re-deploy the playground so the live site reflects a successfully released
   # main, or a main change where publishing was intentionally skipped.
   deploy-playground:
-    needs: [quality, publish]
+    needs: [quality, detect-library-changes, publish]
     if: >-
       always() &&
       needs.quality.result == 'success' &&
-      (needs.publish.result == 'success' || needs.publish.result == 'skipped')
+      needs.detect-library-changes.result == 'success' &&
+      (needs.publish.result == 'success' ||
+      (needs.publish.result == 'skipped' &&
+      needs.detect-library-changes.outputs.changed == 'false'))
     uses: ./.github/workflows/deploy-playground.yml
     permissions:
       contents: read

--- a/packages/design-tokens/test/determinism.test.mjs
+++ b/packages/design-tokens/test/determinism.test.mjs
@@ -114,10 +114,10 @@ test('drift check reports the relative name of every changed generated file', as
   try {
     await generate({ outputRoot: expectedRoot });
     const manifestPath = join(expectedRoot, 'manifest.json');
-    const manifest = await readFile(manifestPath, 'utf8');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
     await writeFile(
       manifestPath,
-      manifest.replace('"contractVersion": "0.0.0"', '"contractVersion": "9.9.9"'),
+      `${JSON.stringify({ ...manifest, contractVersion: '9.9.9-drift' }, null, 2)}\n`,
     );
 
     assert.deepEqual(await checkGenerated({ expectedRoot }), ['manifest.json']);

--- a/packages/design-tokens/test/generate.test.mjs
+++ b/packages/design-tokens/test/generate.test.mjs
@@ -50,6 +50,7 @@ test('generates web artifacts and a stable publication manifest', async () => {
   const outputRoot = await mkdtemp(join(tmpdir(), 'eocrm-token-output-'));
 
   try {
+    const document = await validateTokenSource(tokenSourcePath);
     await generate({ outputRoot });
 
     const [tokensScss, darkScss, manifest] = await Promise.all([
@@ -62,7 +63,7 @@ test('generates web artifacts and a stable publication manifest', async () => {
     assert.match(darkScss, /^\/\/ GENERATED FILE — DO NOT EDIT\.\n/);
     assert.deepEqual(JSON.parse(manifest), {
       schemaVersion: 1,
-      contractVersion: '0.0.0',
+      contractVersion: document.contractVersion,
       artifacts: {
         npm: '@eocrm/design-tokens',
         maven: 'com.eocrm.design:design-tokens-compose',

--- a/packages/design-tokens/test/package-boundary.test.mjs
+++ b/packages/design-tokens/test/package-boundary.test.mjs
@@ -45,11 +45,12 @@ test('packed Sass entry points resolve through the installed token package', asy
     ]);
     const tokenTarball = await pack(tokenRoot, packDirectory);
     const designSystemTarball = await pack(designSystemRoot, packDirectory);
-    const designSystemPackage = JSON.parse(
-      await readFile(join(designSystemRoot, 'package.json'), 'utf8'),
-    );
+    const [designSystemPackage, tokenPackage] = await Promise.all([
+      readFile(join(designSystemRoot, 'package.json'), 'utf8').then(JSON.parse),
+      readFile(join(tokenRoot, 'package.json'), 'utf8').then(JSON.parse),
+    ]);
 
-    assert.equal(designSystemPackage.dependencies['@eocrm/design-tokens'], '0.0.0');
+    assert.equal(designSystemPackage.dependencies['@eocrm/design-tokens'], tokenPackage.version);
 
     await writeFile(
       join(fixture, 'package.json'),

--- a/packages/design-tokens/test/release-change-detection.test.mjs
+++ b/packages/design-tokens/test/release-change-detection.test.mjs
@@ -16,6 +16,7 @@ const stableTagScriptPath = join(
   'packages/design-tokens/scripts/latest-stable-release-tag.mjs',
 );
 const workflowPath = join(repositoryRoot, '.github/workflows/release.yml');
+const qualityWorkflowPath = join(repositoryRoot, '.github/workflows/quality.yml');
 
 test('detects a library change earlier in a multi-commit push', async () => {
   const fixture = await createRepository();
@@ -289,6 +290,31 @@ test('stages Compose publications locally and repairs every Maven file', async (
   assert.match(composeStep, /-Dmaven\.repo\.local="\$RUNNER_TEMP\/compose-maven"/);
   assert.match(composeStep, /repair-compose-publication\.mjs/);
   assert.doesNotMatch(composeStep, /grep -qiE '409/);
+});
+
+test('deploys the playground only after publish succeeds or is skipped', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+  const deployJob = workflow.slice(workflow.indexOf('  deploy-playground:'));
+
+  assert.match(deployJob, /needs\.quality\.result == 'success'/);
+  assert.match(deployJob, /needs\.publish\.result == 'success'/);
+  assert.match(deployJob, /needs\.publish\.result == 'skipped'/);
+});
+
+test('caches npm and Gradle dependencies in quality and release jobs', async () => {
+  const [qualityWorkflow, releaseWorkflow] = await Promise.all([
+    readFile(qualityWorkflowPath, 'utf8'),
+    readFile(workflowPath, 'utf8'),
+  ]);
+
+  for (const workflow of [qualityWorkflow, releaseWorkflow]) {
+    assert.match(workflow, /uses: actions\/setup-node@v4[\s\S]*?cache: "npm"/);
+    assert.match(workflow, /uses: actions\/setup-java@v4[\s\S]*?cache: "gradle"/);
+    assert.match(
+      workflow,
+      /cache-dependency-path: \|[\s\S]*?packages\/design-tokens\/compose\/\*\*\/\*\.gradle\*/,
+    );
+  }
 });
 
 async function createRepository() {

--- a/packages/design-tokens/test/release-change-detection.test.mjs
+++ b/packages/design-tokens/test/release-change-detection.test.mjs
@@ -292,13 +292,15 @@ test('stages Compose publications locally and repairs every Maven file', async (
   assert.doesNotMatch(composeStep, /grep -qiE '409/);
 });
 
-test('deploys the playground only after publish succeeds or is skipped', async () => {
+test('deploys the playground only after publish succeeds or an intentional no-change skip', async () => {
   const workflow = await readFile(workflowPath, 'utf8');
   const deployJob = workflow.slice(workflow.indexOf('  deploy-playground:'));
+  const normalizedJob = deployJob.replace(/\s+/g, ' ');
 
-  assert.match(deployJob, /needs\.quality\.result == 'success'/);
-  assert.match(deployJob, /needs\.publish\.result == 'success'/);
-  assert.match(deployJob, /needs\.publish\.result == 'skipped'/);
+  assert.match(
+    normalizedJob,
+    /needs: \[quality, detect-library-changes, publish\] if: >- always\(\) && needs\.quality\.result == 'success' && needs\.detect-library-changes\.result == 'success' && \(needs\.publish\.result == 'success' \|\| \(needs\.publish\.result == 'skipped' && needs\.detect-library-changes\.outputs\.changed == 'false'\)\)/,
+  );
 });
 
 test('caches npm and Gradle dependencies in quality and release jobs', async () => {
@@ -308,14 +310,27 @@ test('caches npm and Gradle dependencies in quality and release jobs', async () 
   ]);
 
   for (const workflow of [qualityWorkflow, releaseWorkflow]) {
-    assert.match(workflow, /uses: actions\/setup-node@v4[\s\S]*?cache: "npm"/);
-    assert.match(workflow, /uses: actions\/setup-java@v4[\s\S]*?cache: "gradle"/);
-    assert.match(
-      workflow,
-      /cache-dependency-path: \|[\s\S]*?packages\/design-tokens\/compose\/\*\*\/\*\.gradle\*/,
-    );
+    const nodeStep = extractWorkflowStep(workflow, 'Setup Node');
+    const javaStep = extractWorkflowStep(workflow, 'Setup Java');
+    const androidStep = extractWorkflowStep(workflow, 'Setup Android SDK');
+
+    assert.match(nodeStep, /uses: actions\/setup-node@v4/);
+    assert.match(nodeStep, /cache: "npm"/);
+    assert.match(javaStep, /uses: actions\/setup-java@v4/);
+    assert.match(javaStep, /cache: "gradle"/);
+    assert.match(javaStep, /packages\/design-tokens\/compose\/\*\*\/\*\.gradle\*/);
+    assert.match(javaStep, /packages\/design-tokens\/compose\/gradle\.properties/);
+    assert.match(javaStep, /packages\/design-tokens\/compose\/\*\*\/gradle-wrapper\.properties/);
+    assert.doesNotMatch(androidStep, /cache/i);
   }
 });
+
+function extractWorkflowStep(workflow, name) {
+  const start = workflow.indexOf(`      - name: ${name}`);
+  const next = workflow.indexOf('\n      - name:', start + 1);
+  assert.notEqual(start, -1, `missing workflow step: ${name}`);
+  return workflow.slice(start, next === -1 ? undefined : next);
+}
 
 async function createRepository() {
   const fixture = await mkdtemp(join(tmpdir(), 'eocrm-release-diff-'));


### PR DESCRIPTION
## What changed

- make token tests derive expected contract versions from the synced package/source state
- cache npm dependencies in Release and Gradle dependencies in Quality and Release
- deploy the playground only when publishing succeeds or is intentionally skipped
- add regression coverage for release gating and workflow caches

## Root cause

The release job synchronizes package and token contract versions before verification. Three tests still asserted the development placeholder version (`0.0.0`), so the first real shared-token release failed before publishing. The playground deployment condition used `always()` with only the Quality result, so a failed publish still deployed.

## Impact

Release validation now works with the dynamically selected release version, dependency setup is cached in both workflows, and the playground cannot deploy after a failed publish.

## Verification

- simulated release sync to `0.3.27`: 26/26 affected tests passed
- `npm run tokens:check`
- `npm test`
- `npm run typecheck`
- `npm run lint:css`
- `npm run build`
- `npm run format:check`
- `git diff --check`
