### PR TITLE
fix: announce Kanban pointer outside board (#397)

### DIFF
--- a/packages/design-system/src/components/Kanban/Kanban.test.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.test.tsx
@@ -883,6 +883,7 @@ describe('Kanban — drag announcements (#390)', () => {
     moveTo(at(1, 100)); // transit into the second column…
     expect(live()).toMatch(/^Draft Q3 OKRs, position \d of \d in Done\.$/);
     moveTo([600, 500]); // …carry it off the board…
+    expect(live()).toBe('Draft Q3 OKRs is not over a drop target.');
     release([600, 500]); // …and let go over unrelated page content
     expect(live()).toBe('Move cancelled. Draft Q3 OKRs stayed where it was.');
   });

--- a/packages/design-system/src/components/Kanban/Kanban.test.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.test.tsx
@@ -877,14 +877,14 @@ describe('Kanban — drag announcements (#390)', () => {
     expect(live()).toMatch(/in column 2 of 2\.$/);
   });
 
-  it('a release outside the board announces a cancel, not a drop (#387)', () => {
+  it('announces leaving the board before an outside release cancels (#397)', () => {
     render(<NamedBoard />);
     press('Draft Q3 OKRs');
-    moveTo(at(1, 100)); // transit into the second column…
-    expect(live()).toMatch(/^Draft Q3 OKRs, position \d of \d in Done\.$/);
-    moveTo([600, 500]); // …carry it off the board…
+    moveTo(at(0, 20)); // resolve the first card as the nearest target…
+    expect(live()).toMatch(/^Draft Q3 OKRs, position \d of \d in To do\.$/);
+    moveTo([COL_W / 2, -50]); // …leave directly above it, so it stays nearest…
     expect(live()).toBe('Draft Q3 OKRs is not over a drop target.');
-    release([600, 500]); // …and let go over unrelated page content
+    release([COL_W / 2, -50]); // …and let go over unrelated page content
     expect(live()).toBe('Move cancelled. Draft Q3 OKRs stayed where it was.');
   });
 

--- a/packages/design-system/src/components/Kanban/Kanban.tsx
+++ b/packages/design-system/src/components/Kanban/Kanban.tsx
@@ -767,7 +767,12 @@ const KanbanRoot = forwardRef<HTMLDivElement, KanbanProps>(function KanbanRoot(
   // render under StrictMode writes the same value.
   const outsideBoardRef = useRef(false);
   const collisionDetection = useCallback<CollisionDetection>((args) => {
-    outsideBoardRef.current = isPointerOutsideContainers(args);
+    const isOutsideBoard = isPointerOutsideContainers(args);
+    outsideBoardRef.current = isOutsideBoard;
+    // Force an `over` transition to null at the board boundary. dnd-kit's
+    // announcement callback only runs when `over.id` changes, so retaining the
+    // nearest collision here would leave screen readers naming a stale column.
+    if (isOutsideBoard) return [];
     return containerAwareClosestCorners(args);
   }, []);
 

--- a/packages/design-system/src/components/_internal/dragAnnouncements.ts
+++ b/packages/design-system/src/components/_internal/dragAnnouncements.ts
@@ -138,11 +138,10 @@ export type DescribeDragTarget = (
  *                   human slot. Return `null` when nothing would land anywhere
  *                   — that announces "not over a drop target" / "nothing
  *                   moved".
- * @param isRejectedDrop Optional. Consulted before describing `over` and again
- *                   on drag end: return `true` when the component refuses to
- *                   commit the current target, so it announces that the item
- *                   is outside during the drag and cancels on release
- *                   (Kanban's outside-the-board release, #390).
+ * @param isRejectedDrop Optional. Consulted on drag end BEFORE `over`: return
+ *                   `true` when the component refuses to commit the release, so
+ *                   it announces a cancel rather than a drop that never
+ *                   happened (Kanban's outside-the-board release, #390).
  */
 export function useDragAccessibility(
   describe: DescribeDragTarget,
@@ -184,7 +183,6 @@ export function useDragAccessibility(
         onDragStart: ({ active }) => t('drag.pickedUp', { item: nameOf(active, active.id) }),
         onDragOver: ({ active, over }) => {
           const item = nameOf(active, active.id);
-          if (rejectedRef.current?.()) return t('drag.movedOutside', { item });
           const target = describeRef.current(over, active.id);
           return target ? at('movedOver', item, target) : t('drag.movedOutside', { item });
         },

--- a/packages/design-system/src/components/_internal/dragAnnouncements.ts
+++ b/packages/design-system/src/components/_internal/dragAnnouncements.ts
@@ -138,10 +138,11 @@ export type DescribeDragTarget = (
  *                   human slot. Return `null` when nothing would land anywhere
  *                   — that announces "not over a drop target" / "nothing
  *                   moved".
- * @param isRejectedDrop Optional. Consulted on drag end BEFORE `over`: return
- *                   `true` when the component refuses to commit the release, so
- *                   it announces a cancel rather than a drop that never
- *                   happened (Kanban's outside-the-board release, #390).
+ * @param isRejectedDrop Optional. Consulted before describing `over` and again
+ *                   on drag end: return `true` when the component refuses to
+ *                   commit the current target, so it announces that the item
+ *                   is outside during the drag and cancels on release
+ *                   (Kanban's outside-the-board release, #390).
  */
 export function useDragAccessibility(
   describe: DescribeDragTarget,
@@ -183,6 +184,7 @@ export function useDragAccessibility(
         onDragStart: ({ active }) => t('drag.pickedUp', { item: nameOf(active, active.id) }),
         onDragOver: ({ active, over }) => {
           const item = nameOf(active, active.id);
+          if (rejectedRef.current?.()) return t('drag.movedOutside', { item });
           const target = describeRef.current(over, active.id);
           return target ? at('movedOver', item, target) : t('drag.movedOutside', { item });
         },


### PR DESCRIPTION
Addresses #397.

## Summary

- make rejected Kanban hover targets announce the existing localized `drag.movedOutside` message immediately
- retain the existing cancelled announcement when the pointer is released outside the board
- add a regression assertion for the live-region state before pointer release

## Root cause

Kanban's collision detector recorded that the pointer was outside all columns, but the shared drag announcement helper consulted that rejection state only on drag end. During drag-over it continued describing dnd-kit's nearest retained collision target.

## Test plan

- `make test`
- `make build-lib`
- `make lint`
- `npm run format:check`
- `npm pack --workspace @eocrm/design-system --dry-run`
- Playwright + system Chrome against `/components/kanban`: drag `Draft Q3 OKRs` outside the board and assert the live region reads `Draft Q3 OKRs is not over a drop target.` before release
