### PR TITLE
fix: make collapsed Rail groups keyboard reachable (#401)

### DIFF
--- a/packages/design-system/src/components/Rail/Rail.test.tsx
+++ b/packages/design-system/src/components/Rail/Rail.test.tsx
@@ -1030,7 +1030,8 @@ describe('Rail — linkable Group (#377)', () => {
     trigger.focus();
     await user.tab();
     const flyout = await screen.findByRole('dialog', { name: 'Settings' });
-    expect(within(flyout).getByRole('link', { name: 'General' })).toHaveFocus();
+    const finalItem = within(flyout).getByRole('link', { name: 'General' });
+    expect(finalItem).toHaveFocus();
 
     await user.tab();
 
@@ -1073,5 +1074,31 @@ describe('Rail — linkable Group (#377)', () => {
 
     expect(document.body).toHaveFocus();
     expect(screen.queryByRole('dialog', { name: 'Empty' })).toBeNull();
+  });
+
+  it('collapsed nonempty final group exits the flyout instead of cycling within it', async () => {
+    const user = userEvent.setup();
+    render(
+      <Rail defaultCollapsed>
+        <Rail.Section title="Main">
+          <Rail.Group icon={<span aria-hidden />} label="Settings">
+            <Rail.Item href="#/general">General</Rail.Item>
+          </Rail.Group>
+        </Rail.Section>
+      </Rail>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Settings' });
+    trigger.focus();
+    await user.tab();
+    const flyout = await screen.findByRole('dialog', { name: 'Settings' });
+    const finalItem = within(flyout).getByRole('link', { name: 'General' });
+    expect(finalItem).toHaveFocus();
+    // No external destination exists, so the component must leave this Tab
+    // uncancelled and let the browser advance beyond the document.
+    expect(fireEvent.keyDown(finalItem, { key: 'Tab' })).toBe(true);
+
+    await user.tab();
+
+    expect(document.body).toHaveFocus();
   });
 });

--- a/packages/design-system/src/components/Rail/Rail.test.tsx
+++ b/packages/design-system/src/components/Rail/Rail.test.tsx
@@ -960,4 +960,30 @@ describe('Rail — linkable Group (#377)', () => {
       vi.useRealTimers();
     }
   });
+
+  it('collapsed: Tab from the focused group trigger enters the portalled flyout', async () => {
+    const user = userEvent.setup();
+    render(
+      <Rail defaultCollapsed>
+        <Rail.Section title="Main">
+          <Rail.Item href="#/companies" icon={<span aria-hidden />}>
+            Companies
+          </Rail.Item>
+          <Rail.Group as="a" href="#/deals" icon={<span aria-hidden />} label="Deals">
+            <Rail.Item href="#/deals?view=open">My open USD</Rail.Item>
+          </Rail.Group>
+          <Rail.Item href="#/projects" icon={<span aria-hidden />}>
+            Projects
+          </Rail.Item>
+        </Rail.Section>
+      </Rail>,
+    );
+
+    const trigger = screen.getByRole('link', { name: 'Deals' });
+    trigger.focus();
+    await user.tab();
+
+    const flyout = await screen.findByRole('dialog', { name: 'Deals' });
+    expect(within(flyout).getByRole('link', { name: 'Deals' })).toHaveFocus();
+  });
 });

--- a/packages/design-system/src/components/Rail/Rail.test.tsx
+++ b/packages/design-system/src/components/Rail/Rail.test.tsx
@@ -961,7 +961,7 @@ describe('Rail — linkable Group (#377)', () => {
     }
   });
 
-  it('collapsed: Tab from the focused group trigger enters the portalled flyout', async () => {
+  it('collapsed: Tab traverses the portalled flyout then rejoins Rail order', async () => {
     const user = userEvent.setup();
     render(
       <Rail defaultCollapsed>
@@ -985,5 +985,64 @@ describe('Rail — linkable Group (#377)', () => {
 
     const flyout = await screen.findByRole('dialog', { name: 'Deals' });
     expect(within(flyout).getByRole('link', { name: 'Deals' })).toHaveFocus();
+    await user.tab();
+    expect(within(flyout).getByRole('link', { name: 'My open USD' })).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole('link', { name: 'Projects' })).toHaveFocus();
+  });
+
+  it('collapsed: Shift+Tab from the first flyout item returns to the trigger', async () => {
+    const user = userEvent.setup();
+    renderLinkGroup({ collapsed: true });
+    const trigger = screen.getByRole('link', { name: 'Deals' });
+    trigger.focus();
+    await user.tab();
+    const flyout = await screen.findByRole('dialog', { name: 'Deals' });
+    expect(within(flyout).getByRole('link', { name: 'Deals' })).toHaveFocus();
+
+    await user.tab({ shift: true });
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it('collapsed toggle-only group follows the same trigger → children → next-item order', async () => {
+    const user = userEvent.setup();
+    render(
+      <Rail defaultCollapsed>
+        <Rail.Section title="Main">
+          <Rail.Group icon={<span aria-hidden />} label="Settings">
+            <Rail.Item href="#/general">General</Rail.Item>
+          </Rail.Group>
+          <Rail.Item href="#/projects" icon={<span aria-hidden />}>
+            Projects
+          </Rail.Item>
+        </Rail.Section>
+      </Rail>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Settings' });
+    trigger.focus();
+    await user.tab();
+    const flyout = await screen.findByRole('dialog', { name: 'Settings' });
+    expect(within(flyout).getByRole('link', { name: 'General' })).toHaveFocus();
+
+    await user.tab();
+
+    expect(screen.getByRole('link', { name: 'Projects' })).toHaveFocus();
+  });
+
+  it('collapsed: Escape closes the flyout, restores focus, and does not reopen it', async () => {
+    const user = userEvent.setup();
+    renderLinkGroup({ collapsed: true });
+    const trigger = screen.getByRole('link', { name: 'Deals' });
+    trigger.focus();
+    await user.tab();
+    expect(await screen.findByRole('dialog', { name: 'Deals' })).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    expect(trigger).toHaveFocus();
+    expect(screen.queryByRole('dialog', { name: 'Deals' })).toBeNull();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(screen.queryByRole('dialog', { name: 'Deals' })).toBeNull();
   });
 });

--- a/packages/design-system/src/components/Rail/Rail.test.tsx
+++ b/packages/design-system/src/components/Rail/Rail.test.tsx
@@ -975,6 +975,9 @@ describe('Rail — linkable Group (#377)', () => {
           <Rail.Item href="#/projects" icon={<span aria-hidden />} tabIndex={-1}>
             Projects
           </Rail.Item>
+          <Rail.Item href="#/stalled" icon={<span aria-hidden />}>
+            Stalled
+          </Rail.Item>
           <Rail.Item href="#/reports" icon={<span aria-hidden />}>
             Reports
           </Rail.Item>
@@ -983,6 +986,7 @@ describe('Rail — linkable Group (#377)', () => {
     );
 
     const trigger = screen.getByRole('link', { name: 'Deals' });
+    vi.spyOn(screen.getByRole('link', { name: 'Stalled' }), 'focus').mockImplementation(() => {});
     trigger.focus();
     await user.tab();
 

--- a/packages/design-system/src/components/Rail/Rail.test.tsx
+++ b/packages/design-system/src/components/Rail/Rail.test.tsx
@@ -1049,26 +1049,25 @@ describe('Rail — linkable Group (#377)', () => {
     expect(screen.queryByRole('dialog', { name: 'Deals' })).toBeNull();
   });
 
-  it('collapsed empty final group preserves native Tab traversal', async () => {
+  it('collapsed hidden-only final group does not trap focus on its trigger', async () => {
     const user = userEvent.setup();
     render(
-      <>
-        <Rail defaultCollapsed>
-          <Rail.Section title="Main">
-            <Rail.Group icon={<span aria-hidden />} label="Empty">
-              {null}
-            </Rail.Group>
-          </Rail.Section>
-        </Rail>
-        <button type="button">After navigation</button>
-      </>,
+      <Rail defaultCollapsed>
+        <Rail.Section title="Main">
+          <Rail.Group icon={<span aria-hidden />} label="Empty">
+            <Rail.Item href="#/hidden" style={{ display: 'none' }}>
+              Hidden
+            </Rail.Item>
+          </Rail.Group>
+        </Rail.Section>
+      </Rail>,
     );
     const trigger = screen.getByRole('button', { name: 'Empty' });
     trigger.focus();
 
     await user.tab();
 
-    expect(screen.getByRole('button', { name: 'After navigation' })).toHaveFocus();
+    expect(document.body).toHaveFocus();
     expect(screen.queryByRole('dialog', { name: 'Empty' })).toBeNull();
   });
 });

--- a/packages/design-system/src/components/Rail/Rail.test.tsx
+++ b/packages/design-system/src/components/Rail/Rail.test.tsx
@@ -972,8 +972,11 @@ describe('Rail — linkable Group (#377)', () => {
           <Rail.Group as="a" href="#/deals" icon={<span aria-hidden />} label="Deals">
             <Rail.Item href="#/deals?view=open">My open USD</Rail.Item>
           </Rail.Group>
-          <Rail.Item href="#/projects" icon={<span aria-hidden />}>
+          <Rail.Item href="#/projects" icon={<span aria-hidden />} tabIndex={-1}>
             Projects
+          </Rail.Item>
+          <Rail.Item href="#/reports" icon={<span aria-hidden />}>
+            Reports
           </Rail.Item>
         </Rail.Section>
       </Rail>,
@@ -988,7 +991,7 @@ describe('Rail — linkable Group (#377)', () => {
     await user.tab();
     expect(within(flyout).getByRole('link', { name: 'My open USD' })).toHaveFocus();
     await user.tab();
-    expect(screen.getByRole('link', { name: 'Projects' })).toHaveFocus();
+    expect(screen.getByRole('link', { name: 'Reports' })).toHaveFocus();
   });
 
   it('collapsed: Shift+Tab from the first flyout item returns to the trigger', async () => {
@@ -1044,5 +1047,28 @@ describe('Rail — linkable Group (#377)', () => {
     expect(screen.queryByRole('dialog', { name: 'Deals' })).toBeNull();
     await new Promise((resolve) => setTimeout(resolve, 100));
     expect(screen.queryByRole('dialog', { name: 'Deals' })).toBeNull();
+  });
+
+  it('collapsed empty final group preserves native Tab traversal', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <Rail defaultCollapsed>
+          <Rail.Section title="Main">
+            <Rail.Group icon={<span aria-hidden />} label="Empty">
+              {null}
+            </Rail.Group>
+          </Rail.Section>
+        </Rail>
+        <button type="button">After navigation</button>
+      </>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Empty' });
+    trigger.focus();
+
+    await user.tab();
+
+    expect(screen.getByRole('button', { name: 'After navigation' })).toHaveFocus();
+    expect(screen.queryByRole('dialog', { name: 'Empty' })).toBeNull();
   });
 });

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -351,36 +351,35 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
     );
   }, [isLink, isSequentiallyFocusable]);
 
-  const findNextFocusTarget = useCallback(() => {
+  const findNextFocusTargets = useCallback(() => {
     const trigger = triggerRef.current;
     const group = groupRef.current;
-    if (!trigger || !group) return null;
+    if (!trigger || !group) return [];
     const candidates = Array.from(document.querySelectorAll<HTMLElement>('*'));
     const triggerIndex = candidates.indexOf(trigger);
-    return (
-      candidates.slice(triggerIndex + 1).find((candidate) => {
-        if (group.contains(candidate)) return false;
-        return isSequentiallyFocusable(candidate);
-      }) ?? null
-    );
+    return candidates.slice(triggerIndex + 1).filter((candidate) => {
+      if (group.contains(candidate)) return false;
+      return isSequentiallyFocusable(candidate);
+    });
   }, [isSequentiallyFocusable]);
 
-  const focusFirstFlyoutItem = useCallback(() => {
-    for (const candidate of getFlyoutFocusableItems()) {
+  const focusFirstAvailable = useCallback((candidates: HTMLElement[]) => {
+    for (const candidate of candidates) {
       candidate.focus({ preventScroll: true });
-      if (document.activeElement === candidate) return;
+      if (document.activeElement === candidate) return true;
     }
+    return false;
+  }, []);
+
+  const focusFirstFlyoutItem = useCallback(() => {
+    if (focusFirstAvailable(getFlyoutFocusableItems())) return;
     setPopoverOpen(false);
-    const nextTarget = findNextFocusTarget();
-    if (nextTarget) {
-      nextTarget.focus({ preventScroll: true });
-      if (document.activeElement === nextTarget) return;
-    }
+    if (focusFirstAvailable(findNextFocusTargets())) return;
     // Tab was already cancelled to enter the portal. If no valid destination
     // remains (for example a hidden-only final group), release focus rather
     // than trapping it on the trigger.
     triggerRef.current?.blur();
-  }, [getFlyoutFocusableItems, findNextFocusTarget]);
+  }, [getFlyoutFocusableItems, findNextFocusTargets, focusFirstAvailable]);
 
   // A portalled panel sits after #root in DOM order, so native Tab traversal
   // cannot move from the trigger into it. When keyboard interaction opens the
@@ -530,18 +529,24 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
         return;
       }
       if (!e.shiftKey && target === items.at(-1)) {
-        const nextTarget = findNextFocusTarget();
+        const nextTargets = findNextFocusTargets();
         // If the group is the final page control, preserve native Tab so the
         // browser can move beyond the document instead of trapping focus.
-        if (!nextTarget) return;
+        if (nextTargets.length === 0) return;
         e.preventDefault();
         clearOpenTimer();
         clearCloseTimer();
         setPopoverOpen(false);
-        nextTarget.focus({ preventScroll: true });
+        if (!focusFirstAvailable(nextTargets)) triggerRef.current?.blur();
       }
     },
-    [getFlyoutFocusableItems, findNextFocusTarget, clearOpenTimer, clearCloseTimer],
+    [
+      getFlyoutFocusableItems,
+      findNextFocusTargets,
+      focusFirstAvailable,
+      clearOpenTimer,
+      clearCloseTimer,
+    ],
   );
 
   // Compose the consumer ref with our internal ref so consumers can still

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -89,9 +89,9 @@ interface RailGroupOwnProps {
  * except `className` and `ref`, which stay on the wrapper `<div>` in both
  * shapes, as they always have.
  *
- * Your `onPointerEnter` / `onPointerLeave` / `onFocus` / `onBlur` / `onClick`
+ * Your `onPointerEnter` / `onPointerLeave` / `onFocus` / `onBlur` / `onClick` / `onKeyDown`
  * on a linkable group are **composed** with the group's own handlers (yours
- * runs first), not replaced by them: those five are what open the
+ * runs first), not replaced by them: those six are what open the
  * collapsed-mode flyout, and overriding them would make the subitems
  * unreachable while the rail is collapsed.
  */
@@ -247,6 +247,7 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
   useFloatingSurface(popoverOpen);
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const focusFlyoutOnOpenRef = useRef(false);
 
   const clearOpenTimer = useCallback(() => {
     if (openTimerRef.current) {
@@ -320,6 +321,24 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
   // popovers (#272); its base z sits at --z-popover otherwise.
   const inOverlay = useInOverlay(triggerRef, popoverOpen);
 
+  const focusFirstFlyoutItem = useCallback(() => {
+    refs.floating.current
+      ?.querySelector<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      )
+      ?.focus({ preventScroll: true });
+  }, [refs.floating]);
+
+  // A portalled panel sits after #root in DOM order, so native Tab traversal
+  // cannot move from the trigger into it. When keyboard interaction opens the
+  // flyout, move focus to its first interactive element after the portal has
+  // mounted. Escape already restores focus to the trigger below.
+  useEffect(() => {
+    if (!popoverOpen || !focusFlyoutOnOpenRef.current) return;
+    focusFlyoutOnOpenRef.current = false;
+    focusFirstFlyoutItem();
+  }, [popoverOpen, focusFirstFlyoutItem]);
+
   // Close on Escape (a11y).
   useEffect(() => {
     if (!popoverOpen) return;
@@ -365,17 +384,29 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
   }, [collapsed, toggleOpen]);
 
   const handleTriggerKeyDown = useCallback(
-    (e: ReactKeyboardEvent<HTMLButtonElement>) => {
+    (e: ReactKeyboardEvent<HTMLElement>) => {
+      if (collapsed && e.key === 'Tab' && !e.shiftKey) {
+        e.preventDefault();
+        clearOpenTimer();
+        clearCloseTimer();
+        if (popoverOpen) {
+          focusFirstFlyoutItem();
+        } else {
+          focusFlyoutOnOpenRef.current = true;
+          setPopoverOpen(true);
+        }
+        return;
+      }
       // In collapsed mode the trigger acts like a popup-haspopup button
       // (Enter / Space opens the popover); in expanded mode native button
       // semantics already cover Enter/Space toggling.
-      if (collapsed && (e.key === 'Enter' || e.key === ' ')) {
+      if (!isLink && collapsed && (e.key === 'Enter' || e.key === ' ')) {
         e.preventDefault();
         clearCloseTimer();
         setPopoverOpen((prev) => !prev);
       }
     },
-    [collapsed, clearCloseTimer],
+    [collapsed, isLink, popoverOpen, focusFirstFlyoutItem, clearOpenTimer, clearCloseTimer],
   );
 
   const handlePointerEnter = useCallback(
@@ -483,6 +514,10 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
             onFocus={composeHandlers(rest.onFocus, collapsed ? scheduleOpen : undefined)}
             onBlur={composeHandlers(rest.onBlur, collapsed ? scheduleClose : undefined)}
             onClick={composeHandlers(rest.onClick, collapsed ? handleFlyoutClick : undefined)}
+            onKeyDown={composeHandlers(
+              rest.onKeyDown,
+              collapsed ? handleTriggerKeyDown : undefined,
+            )}
           >
             <span className={styles.itemIcon} aria-hidden="true">
               {icon}

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -324,11 +324,33 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
   // popovers (#272); its base z sits at --z-popover otherwise.
   const inOverlay = useInOverlay(triggerRef, popoverOpen);
 
+  const isSequentiallyFocusable = useCallback((candidate: HTMLElement, checkVisible = true) => {
+    if (candidate.tabIndex < 0) return false;
+    if (candidate.closest('[hidden], [inert]')) return false;
+    if (!checkVisible) return true;
+    const style = window.getComputedStyle(candidate);
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+    const layoutUnavailable = document.documentElement.getClientRects().length === 0;
+    return layoutUnavailable || candidate.getClientRects().length > 0;
+  }, []);
+
   const getFlyoutFocusableItems = useCallback(
     () =>
-      Array.from(refs.floating.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? []),
-    [refs.floating],
+      Array.from(
+        refs.floating.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? [],
+      ).filter((candidate) => isSequentiallyFocusable(candidate)),
+    [refs.floating, isSequentiallyFocusable],
   );
+
+  const hasFlyoutFocusTarget = useCallback(() => {
+    if (isLink && triggerRef.current && isSequentiallyFocusable(triggerRef.current, false)) {
+      return true;
+    }
+    const inlineSubitems = groupRef.current?.querySelector(`.${styles.subitems}`);
+    return Array.from(inlineSubitems?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? []).some(
+      (candidate) => isSequentiallyFocusable(candidate, false),
+    );
+  }, [isLink, isSequentiallyFocusable]);
 
   const findNextFocusTarget = useCallback(() => {
     const trigger = triggerRef.current;
@@ -336,15 +358,13 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
     if (!trigger || !group) return null;
     const candidates = Array.from(document.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
     const triggerIndex = candidates.indexOf(trigger);
-    const layoutUnavailable = document.documentElement.getClientRects().length === 0;
     return (
       candidates.slice(triggerIndex + 1).find((candidate) => {
         if (group.contains(candidate)) return false;
-        if (candidate.closest('[hidden]')) return false;
-        return layoutUnavailable || candidate.getClientRects().length > 0;
+        return isSequentiallyFocusable(candidate);
       }) ?? null
     );
-  }, []);
+  }, [isSequentiallyFocusable]);
 
   const focusFirstFlyoutItem = useCallback(() => {
     const first = getFlyoutFocusableItems()[0];
@@ -414,6 +434,7 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
   const handleTriggerKeyDown = useCallback(
     (e: ReactKeyboardEvent<HTMLElement>) => {
       if (collapsed && e.key === 'Tab' && !e.shiftKey) {
+        if (!hasFlyoutFocusTarget()) return;
         e.preventDefault();
         clearOpenTimer();
         clearCloseTimer();
@@ -434,7 +455,15 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
         setPopoverOpen((prev) => !prev);
       }
     },
-    [collapsed, isLink, popoverOpen, focusFirstFlyoutItem, clearOpenTimer, clearCloseTimer],
+    [
+      collapsed,
+      isLink,
+      popoverOpen,
+      focusFirstFlyoutItem,
+      hasFlyoutFocusTarget,
+      clearOpenTimer,
+      clearCloseTimer,
+    ],
   );
 
   const handlePointerEnter = useCallback(
@@ -495,11 +524,15 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
         return;
       }
       if (!e.shiftKey && target === items.at(-1)) {
+        const nextTarget = findNextFocusTarget();
+        // If the group is the final page control, preserve native Tab so the
+        // browser can move beyond the document instead of trapping focus.
+        if (!nextTarget) return;
         e.preventDefault();
         clearOpenTimer();
         clearCloseTimer();
         setPopoverOpen(false);
-        findNextFocusTarget()?.focus({ preventScroll: true });
+        nextTarget.focus({ preventScroll: true });
       }
     },
     [getFlyoutFocusableItems, findNextFocusTarget, clearOpenTimer, clearCloseTimer],

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -51,6 +51,8 @@ function composeHandlers<E>(
 const OPEN_DELAY_MS = 80;
 /** Close-grace so the cursor has time to traverse from trigger to flyout. */
 const CLOSE_GRACE_MS = 200;
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 interface RailGroupOwnProps {
   /**
@@ -248,6 +250,7 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const focusFlyoutOnOpenRef = useRef(false);
+  const suppressNextTriggerFocusOpenRef = useRef(false);
 
   const clearOpenTimer = useCallback(() => {
     if (openTimerRef.current) {
@@ -321,13 +324,37 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
   // popovers (#272); its base z sits at --z-popover otherwise.
   const inOverlay = useInOverlay(triggerRef, popoverOpen);
 
+  const getFlyoutFocusableItems = useCallback(
+    () =>
+      Array.from(refs.floating.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? []),
+    [refs.floating],
+  );
+
+  const findNextFocusTarget = useCallback(() => {
+    const trigger = triggerRef.current;
+    const group = groupRef.current;
+    if (!trigger || !group) return null;
+    const candidates = Array.from(document.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+    const triggerIndex = candidates.indexOf(trigger);
+    const layoutUnavailable = document.documentElement.getClientRects().length === 0;
+    return (
+      candidates.slice(triggerIndex + 1).find((candidate) => {
+        if (group.contains(candidate)) return false;
+        if (candidate.closest('[hidden]')) return false;
+        return layoutUnavailable || candidate.getClientRects().length > 0;
+      }) ?? null
+    );
+  }, []);
+
   const focusFirstFlyoutItem = useCallback(() => {
-    refs.floating.current
-      ?.querySelector<HTMLElement>(
-        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      )
-      ?.focus({ preventScroll: true });
-  }, [refs.floating]);
+    const first = getFlyoutFocusableItems()[0];
+    if (first) {
+      first.focus({ preventScroll: true });
+      return;
+    }
+    setPopoverOpen(false);
+    findNextFocusTarget()?.focus({ preventScroll: true });
+  }, [getFlyoutFocusableItems, findNextFocusTarget]);
 
   // A portalled panel sits after #root in DOM order, so native Tab traversal
   // cannot move from the trigger into it. When keyboard interaction opens the
@@ -349,6 +376,7 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
         clearOpenTimer();
         clearCloseTimer();
         setPopoverOpen(false);
+        suppressNextTriggerFocusOpenRef.current = true;
         triggerRef.current?.focus({ preventScroll: true });
       }
     };
@@ -425,6 +453,14 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
     [collapsed, scheduleClose],
   );
 
+  const handleTriggerFocus = useCallback(() => {
+    if (suppressNextTriggerFocusOpenRef.current) {
+      suppressNextTriggerFocusOpenRef.current = false;
+      return;
+    }
+    scheduleOpen();
+  }, [scheduleOpen]);
+
   const handleFlyoutPointerEnter = useCallback(() => {
     if (!collapsed) return;
     clearCloseTimer();
@@ -444,6 +480,30 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
     clearCloseTimer();
     setPopoverOpen(false);
   }, [collapsed, clearOpenTimer, clearCloseTimer]);
+
+  const handleFlyoutKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== 'Tab') return;
+      const items = getFlyoutFocusableItems();
+      if (items.length === 0) return;
+      const target = e.target as HTMLElement;
+      if (e.shiftKey && target === items[0]) {
+        e.preventDefault();
+        clearCloseTimer();
+        suppressNextTriggerFocusOpenRef.current = true;
+        triggerRef.current?.focus({ preventScroll: true });
+        return;
+      }
+      if (!e.shiftKey && target === items.at(-1)) {
+        e.preventDefault();
+        clearOpenTimer();
+        clearCloseTimer();
+        setPopoverOpen(false);
+        findNextFocusTarget()?.focus({ preventScroll: true });
+      }
+    },
+    [getFlyoutFocusableItems, findNextFocusTarget, clearOpenTimer, clearCloseTimer],
+  );
 
   // Compose the consumer ref with our internal ref so consumers can still
   // attach refs to the group's wrapping <div>.
@@ -511,7 +571,7 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
             {...rest}
             onPointerEnter={composeHandlers(rest.onPointerEnter, handlePointerEnter)}
             onPointerLeave={composeHandlers(rest.onPointerLeave, handlePointerLeave)}
-            onFocus={composeHandlers(rest.onFocus, collapsed ? scheduleOpen : undefined)}
+            onFocus={composeHandlers(rest.onFocus, collapsed ? handleTriggerFocus : undefined)}
             onBlur={composeHandlers(rest.onBlur, collapsed ? scheduleClose : undefined)}
             onClick={composeHandlers(rest.onClick, collapsed ? handleFlyoutClick : undefined)}
             onKeyDown={composeHandlers(
@@ -554,7 +614,7 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
           onKeyDown={handleTriggerKeyDown}
           onPointerEnter={handlePointerEnter}
           onPointerLeave={handlePointerLeave}
-          onFocus={collapsed ? scheduleOpen : undefined}
+          onFocus={collapsed ? handleTriggerFocus : undefined}
           onBlur={collapsed ? scheduleClose : undefined}
         >
           <span className={styles.itemIcon} aria-hidden="true">
@@ -599,6 +659,7 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
             onPointerEnter={handleFlyoutPointerEnter}
             onPointerLeave={handleFlyoutPointerLeave}
             onClick={handleFlyoutClick}
+            onKeyDown={handleFlyoutKeyDown}
             // Keyboard-tab traversal from the trigger into a subitem fires the
             // trigger's onBlur. Without these handlers, the 200ms close timer
             // would fire and unmount the flyout mid-tab. onFocus on the panel

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -359,9 +359,10 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
     const triggerIndex = candidates.indexOf(trigger);
     return candidates.slice(triggerIndex + 1).filter((candidate) => {
       if (group.contains(candidate)) return false;
+      if (refs.floating.current?.contains(candidate)) return false;
       return isSequentiallyFocusable(candidate);
     });
-  }, [isSequentiallyFocusable]);
+  }, [refs.floating, isSequentiallyFocusable]);
 
   const focusFirstAvailable = useCallback((candidates: HTMLElement[]) => {
     for (const candidate of candidates) {

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -51,8 +51,6 @@ function composeHandlers<E>(
 const OPEN_DELAY_MS = 80;
 /** Close-grace so the cursor has time to traverse from trigger to flyout. */
 const CLOSE_GRACE_MS = 200;
-const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 interface RailGroupOwnProps {
   /**
@@ -326,6 +324,7 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
 
   const isSequentiallyFocusable = useCallback((candidate: HTMLElement, checkVisible = true) => {
     if (candidate.tabIndex < 0) return false;
+    if (candidate.matches(':disabled')) return false;
     if (candidate.closest('[hidden], [inert]')) return false;
     if (!checkVisible) return true;
     const style = window.getComputedStyle(candidate);
@@ -336,9 +335,9 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
 
   const getFlyoutFocusableItems = useCallback(
     () =>
-      Array.from(
-        refs.floating.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? [],
-      ).filter((candidate) => isSequentiallyFocusable(candidate)),
+      Array.from(refs.floating.current?.querySelectorAll<HTMLElement>('*') ?? []).filter(
+        (candidate) => isSequentiallyFocusable(candidate),
+      ),
     [refs.floating, isSequentiallyFocusable],
   );
 
@@ -347,8 +346,8 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
       return true;
     }
     const inlineSubitems = groupRef.current?.querySelector(`.${styles.subitems}`);
-    return Array.from(inlineSubitems?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? []).some(
-      (candidate) => isSequentiallyFocusable(candidate, false),
+    return Array.from(inlineSubitems?.querySelectorAll<HTMLElement>('*') ?? []).some((candidate) =>
+      isSequentiallyFocusable(candidate, false),
     );
   }, [isLink, isSequentiallyFocusable]);
 
@@ -356,7 +355,7 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
     const trigger = triggerRef.current;
     const group = groupRef.current;
     if (!trigger || !group) return null;
-    const candidates = Array.from(document.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+    const candidates = Array.from(document.querySelectorAll<HTMLElement>('*'));
     const triggerIndex = candidates.indexOf(trigger);
     return (
       candidates.slice(triggerIndex + 1).find((candidate) => {
@@ -367,13 +366,20 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
   }, [isSequentiallyFocusable]);
 
   const focusFirstFlyoutItem = useCallback(() => {
-    const first = getFlyoutFocusableItems()[0];
-    if (first) {
-      first.focus({ preventScroll: true });
-      return;
+    for (const candidate of getFlyoutFocusableItems()) {
+      candidate.focus({ preventScroll: true });
+      if (document.activeElement === candidate) return;
     }
     setPopoverOpen(false);
-    findNextFocusTarget()?.focus({ preventScroll: true });
+    const nextTarget = findNextFocusTarget();
+    if (nextTarget) {
+      nextTarget.focus({ preventScroll: true });
+      if (document.activeElement === nextTarget) return;
+    }
+    // Tab was already cancelled to enter the portal. If no valid destination
+    // remains (for example a hidden-only final group), release focus rather
+    // than trapping it on the trigger.
+    triggerRef.current?.blur();
   }, [getFlyoutFocusableItems, findNextFocusTarget]);
 
   // A portalled panel sits after #root in DOM order, so native Tab traversal


### PR DESCRIPTION
Addresses #401.

## Summary

- intercept forward Tab from a focused collapsed `Rail.Group` trigger
- open the portalled flyout immediately and move focus to its first interactive element
- compose linkable groups' consumer `onKeyDown` handlers while preserving Enter navigation
- add a regression test for the trigger-to-portal focus transition

## Root cause

The flyout is portalled after `#root`, so browser sequential focus order cannot move from the trigger into the panel. The existing panel focus/blur guards therefore never receive focus.

## Test plan

- `make test build-lib lint`
- `npm run format:check`
- `npm pack --workspace @eocrm/design-system --dry-run --json` (607 files, zero test/internal leaks)
- Playwright/Chrome: collapsed linkable group → Tab enters flyout header → Tab reaches first subitem → Escape closes and restores trigger focus
