### PR TITLE
fix(Rail): suppress duplicate group subitem tooltips (#400)

### DIFF
--- a/docs/superpowers/plans/2026-07-31-rail-group-subitem-tooltip.md
+++ b/docs/superpowers/plans/2026-07-31-rail-group-subitem-tooltip.md
@@ -1,0 +1,106 @@
+# Rail Group Subitem Tooltip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent collapsed Rail group subitems from rendering a redundant automatic Tooltip while preserving standalone collapsed item tooltips.
+
+**Architecture:** Introduce an internal boolean React context in the Rail component folder. `RailGroup` provides the group boundary around children, including children later rendered through the portal; `RailItem` reads it when deciding whether to wrap itself in `Tooltip`.
+
+**Tech Stack:** React 19 context and portals, TypeScript, Vitest, Testing Library, Playwright/Chrome.
+
+## Global Constraints
+
+- Preserve the public `Rail` API and existing JSDoc contract.
+- Keep standalone collapsed string-labelled item tooltips unchanged.
+- Suppress only the automatic Tooltip for items under `RailGroup`.
+- Add no dependencies, user-facing strings, styling, or public exports.
+- Validate both unit behavior and the real collapsed flyout in Playwright.
+
+---
+
+### Task 1: Lock the tooltip boundary with regression tests
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Rail/Rail.test.tsx`
+
+**Interfaces:**
+
+- Consumes: existing `Rail`, `Rail.Group`, `Rail.Item`, and `Tooltip` DOM behavior.
+- Produces: regression coverage for grouped suppression and standalone preservation.
+
+- [ ] **Step 1: Write a failing grouped-item test**
+
+Render a controlled collapsed rail with a group and string-labelled subitem, open the flyout, hover the subitem, advance timers past the Tooltip delay, and assert no element with `role="tooltip"` appears while the visible subitem label remains.
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run: `npm test --workspace @eocrm/design-system -- Rail/Rail.test.tsx`
+
+Expected: FAIL because the current grouped item opens a tooltip containing the same label.
+
+- [ ] **Step 3: Add the preservation assertion**
+
+Render a standalone collapsed string-labelled item, hover it, advance timers, and assert its tooltip still appears. This guards against disabling collapsed Rail tooltips globally.
+
+### Task 2: Add the private group context and minimal fix
+
+**Files:**
+
+- Create: `packages/design-system/src/components/Rail/RailGroupContext.ts`
+- Modify: `packages/design-system/src/components/Rail/RailGroup.tsx`
+- Modify: `packages/design-system/src/components/Rail/RailItem.tsx`
+
+**Interfaces:**
+
+- Produces: `RailGroupContext`, an internal `Context<boolean>` defaulting to `false`.
+- Consumes: `useContext(RailGroupContext)` in `RailItem`; `<RailGroupContext.Provider value>` in `RailGroup`.
+
+- [ ] **Step 1: Define the internal context**
+
+Create `RailGroupContext.ts` with `createContext(false)` and an internal comment explaining that React context crosses the collapsed flyout portal.
+
+- [ ] **Step 2: Provide the boundary once around group children**
+
+Wrap the shared group children at their logical ownership point so both expanded inline rendering and collapsed portal rendering inherit `true`, without cloning children or exporting the context publicly.
+
+- [ ] **Step 3: Gate automatic Tooltip creation**
+
+Read `insideGroup` in `RailItem` and change the wrapper condition to `collapsed && typeof children === 'string' && !insideGroup`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `npm test --workspace @eocrm/design-system -- Rail/Rail.test.tsx`
+
+Expected: all Rail tests pass.
+
+- [ ] **Step 5: Commit the tested implementation**
+
+Commit message: `fix(Rail): suppress group subitem tooltips`
+
+### Task 3: Browser and repository verification
+
+**Files:**
+
+- No production files expected.
+
+**Interfaces:**
+
+- Consumes: the completed Rail fix.
+- Produces: verification evidence for PR #400.
+
+- [ ] **Step 1: Run the full baseline gates**
+
+Run `npm test`, `npm run typecheck`, `npm run lint:css`, `npm run build`, and `npm pack --dry-run -w @eocrm/design-system`; verify the tarball contains no tests or internal-only paths.
+
+- [ ] **Step 2: Validate in Playwright**
+
+Start the playground, open the Rail component route in Chrome, collapse the rail, open a group flyout, hover and focus a subitem, and assert exactly one visible label and zero tooltip surfaces for that subitem. Also hover a standalone collapsed item and assert its tooltip still opens.
+
+- [ ] **Step 3: Run the mandatory draft-PR review loop**
+
+Open a draft PR, have two independent fresh-context reviewers inspect the complete branch diff, fix all Critical/Important findings, and repeat scoped reviews until both reviewers in the same round return `clean enough to stop`.
+
+- [ ] **Step 4: Complete CI, merge, and release**
+
+Mark the PR ready only after review and gates are clean, wait for required CI, squash-merge, verify the exact release tag and playground deployment, then comment the shipped version on issue #400 and close it.

--- a/docs/superpowers/specs/2026-07-31-rail-group-subitem-tooltip-design.md
+++ b/docs/superpowers/specs/2026-07-31-rail-group-subitem-tooltip-design.md
@@ -1,0 +1,23 @@
+# Rail Group Subitem Tooltip Design
+
+## Problem
+
+`RailItem` automatically wraps string-labelled items in `Tooltip` whenever the rail is collapsed. `RailGroup` renders the same items in a collapsed flyout where their labels are already visible, so hovering a grouped item duplicates its label. This contradicts the existing `RailItem` documentation.
+
+## Design
+
+Add a private boolean React context owned by the Rail component folder. `RailGroup` provides `true` around its children in both inline and flyout render paths. `RailItem` reads the context and retains its automatic collapsed Tooltip only when it is not inside a group.
+
+The context is internal and has no public export or consumer-facing API. It follows React ancestry through the flyout portal, unlike DOM-ancestry detection, and does not require cloning or restricting valid React children.
+
+## Compatibility and boundaries
+
+- Standalone collapsed `RailItem` instances with string children keep their Tooltip.
+- Grouped `RailItem` instances never add the automatic collapsed Tooltip; the flyout's visible label remains the discoverability surface.
+- Expanded behavior and non-string children remain unchanged.
+- Both toggle-only and linkable groups receive the same provider boundary.
+- Nested groups remain unsupported per the existing public contract.
+
+## Verification
+
+Add regression tests that first demonstrate the redundant tooltip and then prove the grouped/standalone boundary. Run the focused Rail test suite, all repository quality gates, package-content audit, and a real-browser Playwright scenario that opens the collapsed group flyout and hovers/focuses a subitem without producing a second tooltip.

--- a/packages/design-system/src/components/Rail/Rail.test.tsx
+++ b/packages/design-system/src/components/Rail/Rail.test.tsx
@@ -422,6 +422,62 @@ describe('Rail', () => {
       vi.useRealTimers();
     }
   });
+
+  it('does not repeat a collapsed group subitem label in an automatic Tooltip', () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <Rail defaultCollapsed>
+          <Rail.Section title="Ops">
+            <Rail.Group icon={<span aria-hidden />} label="Settings">
+              <Rail.Item href="/profile">Profile</Rail.Item>
+            </Rail.Group>
+          </Rail.Section>
+        </Rail>,
+      );
+
+      fireEvent.pointerEnter(screen.getByRole('button', { name: /Settings/ }));
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      const flyout = screen.getByRole('dialog', { name: 'Settings' });
+      const subitem = within(flyout).getByRole('link', { name: 'Profile' });
+      expect(subitem).toBeVisible();
+      fireEvent.pointerEnter(subitem);
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(screen.queryByRole('tooltip')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the automatic Tooltip for a standalone collapsed item', () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <Rail defaultCollapsed>
+          <Rail.Section title="Main">
+            <Rail.Item icon={<span aria-hidden />} href="/dashboard">
+              Dashboard
+            </Rail.Item>
+          </Rail.Section>
+        </Rail>,
+      );
+
+      fireEvent.pointerEnter(screen.getByRole('link', { name: 'Dashboard' }));
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Dashboard');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('Rail — Group flyout overlay elevation (#273)', () => {

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -26,6 +26,7 @@ import {
 import clsx from 'clsx';
 import { useTranslation } from '../../i18n';
 import { useRail } from './Rail';
+import { RailGroupContext } from './RailGroupContext';
 import { type PolymorphicProps } from './RailItem';
 import { overlayStack, useFloatingSurface, useInOverlay } from '../_internal/overlay';
 import styles from './Rail.module.scss';
@@ -582,6 +583,8 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
     />
   );
 
+  const groupedChildren = <RailGroupContext.Provider value>{children}</RailGroupContext.Provider>;
+
   return (
     <div
       ref={setGroupRef}
@@ -686,7 +689,7 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
         // handles the visual hide while keeping the DOM intact for `:has`.
         hidden={!collapsed && !open}
       >
-        {children}
+        {groupedChildren}
       </div>
 
       {/* Collapsed-mode flyout popover. Portaled to document.body, positioned
@@ -730,7 +733,7 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
                 label
               )}
             </div>
-            <div className={styles.flyoutBody}>{children}</div>
+            <div className={styles.flyoutBody}>{groupedChildren}</div>
           </div>,
           document.body,
         )}

--- a/packages/design-system/src/components/Rail/RailGroupContext.ts
+++ b/packages/design-system/src/components/Rail/RailGroupContext.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+// React context follows component ancestry through the collapsed flyout portal,
+// so Rail.Item can distinguish group subitems without relying on DOM ancestry.
+export const RailGroupContext = createContext(false);

--- a/packages/design-system/src/components/Rail/RailItem.tsx
+++ b/packages/design-system/src/components/Rail/RailItem.tsx
@@ -1,5 +1,6 @@
 import {
   forwardRef,
+  useContext,
   type ComponentPropsWithRef,
   type ComponentPropsWithoutRef,
   type ElementType,
@@ -9,6 +10,7 @@ import {
 } from 'react';
 import clsx from 'clsx';
 import { useRail } from './Rail';
+import { RailGroupContext } from './RailGroupContext';
 import { Tooltip } from '../Tooltip';
 import styles from './Rail.module.scss';
 
@@ -104,6 +106,7 @@ export const RailItem = forwardRef(function RailItem<C extends ElementType = 'a'
 ) {
   const Component = (as ?? 'a') as ElementType;
   const { collapsed } = useRail();
+  const insideGroup = useContext(RailGroupContext);
 
   // The polymorphic anchor / NavLink / button receives the className so the
   // CSS `:has([aria-current="page"])` selector can light it up via the
@@ -129,7 +132,7 @@ export const RailItem = forwardRef(function RailItem<C extends ElementType = 'a'
   // string — only then can we project the label onto the tooltip surface
   // safely. Non-string children (icons, complex nodes) are ignored;
   // consumers can always wrap their item in their own <Tooltip> when needed.
-  if (collapsed && typeof children === 'string') {
+  if (collapsed && typeof children === 'string' && !insideGroup) {
     return (
       <Tooltip content={children} side="right">
         {inner}


### PR DESCRIPTION
Addresses #400.\n\n## Summary\n- add an internal Rail group ancestry context that follows subitems through the collapsed flyout portal\n- suppress the automatic collapsed Tooltip only for Rail.Group subitems\n- preserve standalone collapsed Rail.Item tooltips with regression coverage\n\n## Test plan\n- npm test (4,301 design-system tests; 78 token tests)\n- npm run typecheck\n- npm run lint:css\n- npm run build\n- npm run format:check\n- npm pack --dry-run -w @eocrm/design-system (608 entries; zero test/internal-path leaks)\n- Playwright/Chrome: grouped flyout subitem shows one visible label and zero tooltips; standalone collapsed item retains its tooltip