### PR TITLE
fix(Sticky): separate scroll-cap bottom gap (#399)

### DIFF
--- a/docs/superpowers/plans/2026-07-31-sticky-scroll-bottom-gap.md
+++ b/docs/superpowers/plans/2026-07-31-sticky-scroll-bottom-gap.md
@@ -1,0 +1,66 @@
+# Sticky Scroll Bottom Gap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Sticky's scroll cap use a small bottom gap independently of a top offset that includes pinned chrome clearance.
+
+**Architecture:** Keep the existing selected top offset in `--sticky-offset`. Update both viewport cap declarations to subtract that once plus an optional `--sticky-bottom-gap`, falling back to `--sticky-offset` for complete backward compatibility.
+
+**Tech Stack:** SCSS modules/custom properties, React/TypeScript JSDoc, Vitest source-contract tests, Playwright/Chrome.
+
+## Global Constraints
+
+- Existing consumers that do not set `--sticky-bottom-gap` must retain symmetric cap behavior.
+- Both `100vh` fallback and `100dvh` declarations must use the separated formula.
+- Add no React prop, dependency, user-facing string, or raw spacing value.
+- Document the opt-in custom property and validate the measured 72px top / 16px bottom case.
+
+---
+
+### Task 1: Add a failing CSS contract test
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Sticky/Sticky.test.tsx`
+
+**Interfaces:**
+
+- Produces: source-level protection for both viewport-unit declarations and the backward-compatible fallback.
+
+- [ ] Add a test that reads `Sticky.module.scss` and expects both cap declarations to subtract `var(--sticky-offset, 0px)` plus `var(--sticky-bottom-gap, var(--sticky-offset, 0px))`.
+- [ ] Run `npm test --workspace @eocrm/design-system -- Sticky/Sticky.test.tsx` and confirm failure against the current doubled-offset formula.
+
+### Task 2: Separate the bottom gap and document it
+
+**Files:**
+
+- Modify: `packages/design-system/src/components/Sticky/Sticky.module.scss`
+- Modify: `packages/design-system/src/components/Sticky/Sticky.tsx`
+- Modify: `packages/design-system/AGENTS.md`
+- Modify: `packages/playground/src/pages/components/StickyDemo.tsx`
+
+**Interfaces:**
+
+- Consumes: optional CSS custom property `--sticky-bottom-gap`.
+- Produces: symmetric fallback when unset and independent bottom spacing when set.
+
+- [ ] Replace both doubled-offset cap declarations with the top-offset-plus-bottom-gap formula.
+- [ ] Update `scroll` JSDoc with default/fallback behavior and the pinned-chrome override example.
+- [ ] Update Sticky consumer guidance and the playground scroll example to demonstrate a separate bottom gap.
+- [ ] Run the focused Sticky suite and expect all tests to pass.
+- [ ] Commit with `fix(Sticky): separate scroll bottom gap`.
+
+### Task 3: Verify, review, and ship
+
+**Files:**
+
+- No further production files expected.
+
+**Interfaces:**
+
+- Produces: PR, CI, release, and browser evidence for issue #399.
+
+- [ ] Run full tests, typecheck, stylelint, formatting, playground build, and package dry-run audit.
+- [ ] In Playwright at 1400×700, set a 72px top token and 16px bottom gap, then assert computed top `72px`, max-height `612px`, and 16px remaining viewport gap; also verify unset fallback remains symmetric.
+- [ ] Open a draft PR and run the mandatory two-reviewer full-branch review loop until a same-round clean verdict.
+- [ ] Wait for CI, squash-merge, verify the exact release tag and deployed playground, comment the shipped version on #399, and close it.

--- a/docs/superpowers/specs/2026-07-31-sticky-scroll-bottom-gap-design.md
+++ b/docs/superpowers/specs/2026-07-31-sticky-scroll-bottom-gap-design.md
@@ -1,0 +1,24 @@
+# Sticky Scroll Bottom Gap Design
+
+## Problem
+
+`Sticky` currently uses its top offset twice when `scroll` caps the pinned box: `100dvh - (2 * offset)`. That is correct for a symmetric visual gap, but consumers now encode pinned top-bar clearance in `--sticky-top-*`. A 72px top offset made from a 56px bar plus a 16px gap therefore creates an unwanted 72px bottom gap and loses 56px of usable height.
+
+## Design
+
+Add `--sticky-bottom-gap` as an optional component custom-property override. The scroll cap subtracts the top offset once and then subtracts `var(--sticky-bottom-gap, var(--sticky-offset, 0px))`.
+
+When the new property is unset, the fallback equals the selected top offset and reproduces the existing symmetric calculation for every `top` size. A consumer clearing pinned chrome can set the bottom gap independently, for example:
+
+```css
+.recordAside {
+  --sticky-top-lg: calc(var(--topbar-height) + var(--space-4));
+  --sticky-bottom-gap: var(--space-4);
+}
+```
+
+At a 700px viewport this produces `700 - 72 - 16 = 612px` instead of `556px`.
+
+## Scope and verification
+
+Update both the `vh` fallback and `dvh` declaration, the `scroll` JSDoc, consumer guidance, and the Sticky playground example. Unit/source tests protect the exact fallback contract. Playwright measures computed `top`, `max-height`, and remaining bottom gap in a 1400×700 browser viewport.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1632,7 +1632,7 @@ Pins its box to the top of the scroll container while the page scrolls past — 
 ```
 
 - `top`: `none` (default, `top:0`) / `xs` / `sm` / `md` / `lg` / `xl` — offset from the top (spacing scale); use a non-zero step to clear a sticky header.
-- `scroll`: cap the pinned box at the viewport height with internal `overflow-y:auto` + `overscroll-behavior:contain` — for a sidebar taller than the screen (pair with a non-`none` `top`).
+- `scroll`: cap the pinned box at the viewport height with internal `overflow-y:auto` + `overscroll-behavior:contain` — for a sidebar taller than the screen (pair with a non-`none` `top`). The bottom gap defaults to the selected top offset. If `--sticky-top-*` also includes pinned chrome clearance, set `--sticky-bottom-gap: var(--space-4)` on the Sticky so that chrome height is subtracted only at the top.
 - Inside a `<Split>` aside, pair with `align="stretch"` (else the content-height aside track gives nowhere to pin).
 
 When NOT to use: arranging children → `<Stack>`/`<Cluster>`; a fixed overlay above content → `position: fixed` chrome (`Popover`/`Modal`/app bar); the split itself → `<Split>`. Note: `position: sticky` breaks if a clipping ancestor (`overflow: hidden/auto`) isn't the intended scroll container.

--- a/packages/design-system/src/components/Sticky/Sticky.module.scss
+++ b/packages/design-system/src/components/Sticky/Sticky.module.scss
@@ -47,14 +47,20 @@
 
 // Scroll-viewport mode (Rule 4: <Sticky> is a layout primitive — capping its own
 // pinned box + internal overflow is its job, like position:sticky itself). Caps
-// at the dynamic viewport height minus the top offset and an equal bottom gap, so
-// a column taller than the screen scrolls within itself. `overscroll-behavior:
-// contain` stops the page from scroll-chaining when the box hits its end.
+// at the dynamic viewport height minus the top offset and a bottom gap. The
+// bottom gap defaults to the top offset for backward-compatible symmetry, but
+// consumers can override `--sticky-bottom-gap` when the top offset also contains
+// pinned-chrome clearance. `overscroll-behavior: contain` stops the page from
+// scroll-chaining when the box hits its end.
 .scroll {
   // 100vh first as a fallback for browsers without dvh (Safari < 15.4), then the
   // dynamic-viewport unit — mirrors the Modal/Drawer convention.
-  max-height: calc(100vh - (2 * var(--sticky-offset, 0px)));
-  max-height: calc(100dvh - (2 * var(--sticky-offset, 0px)));
+  max-height: calc(
+    100vh - var(--sticky-offset, 0px) - var(--sticky-bottom-gap, var(--sticky-offset, 0px))
+  );
+  max-height: calc(
+    100dvh - var(--sticky-offset, 0px) - var(--sticky-bottom-gap, var(--sticky-offset, 0px))
+  );
   overflow-y: auto;
   overscroll-behavior: contain;
 }

--- a/packages/design-system/src/components/Sticky/Sticky.test.tsx
+++ b/packages/design-system/src/components/Sticky/Sticky.test.tsx
@@ -1,9 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { render } from '@testing-library/react';
 import { createRef } from 'react';
 import { Sticky } from './Sticky';
 import type { StickyTop } from './Sticky';
 
 describe('Sticky', () => {
+  const scss = readFileSync(resolve(__dirname, 'Sticky.module.scss'), 'utf8');
+
   it('renders children in a <div> and forwards ref', () => {
     const ref = createRef<HTMLDivElement>();
     const { container } = render(
@@ -45,6 +49,20 @@ describe('Sticky', () => {
       </Sticky>,
     );
     expect((container.firstChild as HTMLElement).className).toMatch(/scroll/);
+  });
+
+  it('lets the scroll cap override its bottom gap without changing the symmetric default', () => {
+    const normalizedScss = scss
+      .replace(/\s+/g, ' ')
+      .replaceAll('calc( ', 'calc(')
+      .replaceAll(' );', ');');
+    const bottomGap = 'var(--sticky-bottom-gap, var(--sticky-offset, 0px))';
+    expect(normalizedScss).toContain(
+      `max-height: calc(100vh - var(--sticky-offset, 0px) - ${bottomGap});`,
+    );
+    expect(normalizedScss).toContain(
+      `max-height: calc(100dvh - var(--sticky-offset, 0px) - ${bottomGap});`,
+    );
   });
 
   it('merges className and spreads other attrs', () => {

--- a/packages/design-system/src/components/Sticky/Sticky.tsx
+++ b/packages/design-system/src/components/Sticky/Sticky.tsx
@@ -19,10 +19,13 @@ export interface StickyProps extends HTMLAttributes<HTMLDivElement> {
    * Cap the pinned box at the viewport height and scroll its content internally,
    * so a column TALLER than the screen stays fully reachable (the overflow scrolls
    * within the box instead of below the fold). Sets `max-height` to
-   * `calc(100dvh - top offset - an equal bottom gap)`, `overflow-y: auto`, and
-   * `overscroll-behavior: contain` (page scroll doesn't chain from the box).
-   * Default `false`. Pair with a non-`none` `top` to leave breathing room. The cap
-   * is viewport-relative (`dvh`), so this assumes the page (or a viewport-tall
+   * `calc(100dvh - top offset - bottom gap)`, `overflow-y: auto`, and
+   * `overscroll-behavior: contain` (page scroll doesn't chain from the box). The
+   * bottom gap defaults to the selected top offset. When that offset also clears
+   * pinned chrome, set `--sticky-bottom-gap` on this element (for example,
+   * `var(--space-4)`) so the chrome height is not subtracted twice. Default
+   * `false`. Pair with a non-`none` `top` to leave breathing room. The cap is
+   * viewport-relative (`dvh`), so this assumes the page (or a viewport-tall
    * ancestor) is the scroll context — not a short fixed-height scroll container.
    */
   scroll?: boolean;

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -4323,7 +4323,7 @@
           "type": "boolean",
           "required": false,
           "default": "",
-          "description": "Cap the pinned box at the viewport height and scroll its content internally,\nso a column TALLER than the screen stays fully reachable (the overflow scrolls\nwithin the box instead of below the fold). Sets `max-height` to\n`calc(100dvh - top offset - an equal bottom gap)`, `overflow-y: auto`, and\n`overscroll-behavior: contain` (page scroll doesn't chain from the box).\nDefault `false`. Pair with a non-`none` `top` to leave breathing room. The cap\nis viewport-relative (`dvh`), so this assumes the page (or a viewport-tall\nancestor) is the scroll context — not a short fixed-height scroll container."
+          "description": "Cap the pinned box at the viewport height and scroll its content internally,\nso a column TALLER than the screen stays fully reachable (the overflow scrolls\nwithin the box instead of below the fold). Sets `max-height` to\n`calc(100dvh - top offset - bottom gap)`, `overflow-y: auto`, and\n`overscroll-behavior: contain` (page scroll doesn't chain from the box). The\nbottom gap defaults to the selected top offset. When that offset also clears\npinned chrome, set `--sticky-bottom-gap` on this element (for example,\n`var(--space-4)`) so the chrome height is not subtracted twice. Default\n`false`. Pair with a non-`none` `top` to leave breathing room. The cap is\nviewport-relative (`dvh`), so this assumes the page (or a viewport-tall\nancestor) is the scroll context — not a short fixed-height scroll container."
         },
         {
           "name": "children",

--- a/packages/playground/src/pages/components/StickyDemo.tsx
+++ b/packages/playground/src/pages/components/StickyDemo.tsx
@@ -186,7 +186,7 @@ export function Demo() {
 
       <Example
         title="Scroll-viewport mode: a sidebar taller than the screen"
-        description="With scroll, the pinned box is capped at the viewport height (minus the top offset and an equal bottom gap) and scrolls its own content — so a sidebar with more items than fit on screen stays fully reachable instead of running off below the fold. Scroll the page: the sidebar pins, and once it hits the bottom its own scrollbar takes over (overscroll-behavior:contain keeps the page from scroll-chaining). Pair with a non-none top for breathing room."
+        description="With scroll, the pinned box is capped at the viewport height (minus the top offset and a bottom gap) and scrolls its own content — so a sidebar with more items than fit on screen stays fully reachable instead of running off below the fold. The bottom gap defaults to the top offset; set --sticky-bottom-gap when that top offset also includes pinned chrome clearance. Scroll the page: the sidebar pins, and once it hits the bottom its own scrollbar takes over (overscroll-behavior:contain keeps the page from scroll-chaining)."
         code={`import { Card, Split, Stack, Sticky, Text, Title } from '@eocrm/design-system';
 
 const sidebarItems = Array.from({ length: 5 }, (_, i) => i + 1);

--- a/packages/playground/src/pages/components/StickyDemo.tsx
+++ b/packages/playground/src/pages/components/StickyDemo.tsx
@@ -193,7 +193,8 @@ export function Demo() {
       <Example
         title="Scroll-viewport mode: a sidebar taller than the screen"
         description="With scroll, the pinned box is capped at the viewport height (minus the top offset and a bottom gap) and scrolls its own content — so a sidebar with more items than fit on screen stays fully reachable instead of running off below the fold. The bottom gap defaults to the top offset; set --sticky-bottom-gap when that top offset also includes pinned chrome clearance. Scroll the page: the sidebar pins, and once it hits the bottom its own scrollbar takes over (overscroll-behavior:contain keeps the page from scroll-chaining)."
-        code={`import { Card, Split, Stack, Sticky, Text, Title } from '@eocrm/design-system';
+        code={`import type { CSSProperties } from 'react';
+import { Card, Split, Stack, Sticky, Text, Title } from '@eocrm/design-system';
 
 const sidebarItems = Array.from({ length: 5 }, (_, i) => i + 1);
 const mainRows = [1, 2, 3, 4, 5];

--- a/packages/playground/src/pages/components/StickyDemo.tsx
+++ b/packages/playground/src/pages/components/StickyDemo.tsx
@@ -9,6 +9,12 @@ const MAIN_ROWS = Array.from({ length: 14 }, (_, i) => i + 1);
 // something to scroll internally (the box caps at the viewport height).
 const SIDEBAR_ITEMS = Array.from({ length: 20 }, (_, i) => i + 1);
 
+const chromeAwareStickyStyle: React.CSSProperties &
+  Record<'--sticky-top-lg' | '--sticky-bottom-gap', string> = {
+  '--sticky-top-lg': 'calc(var(--topbar-height) + var(--space-4))',
+  '--sticky-bottom-gap': 'var(--space-4)',
+};
+
 // A bordered, internally-scrolling box so the sticky behaviour is visible inside
 // the demo (the box is the scroll container the aside pins within).
 const scrollBox: React.CSSProperties = {
@@ -191,6 +197,11 @@ export function Demo() {
 
 const sidebarItems = Array.from({ length: 5 }, (_, i) => i + 1);
 const mainRows = [1, 2, 3, 4, 5];
+const chromeAwareStickyStyle: CSSProperties &
+  Record<'--sticky-top-lg' | '--sticky-bottom-gap', string> = {
+  '--sticky-top-lg': 'calc(var(--topbar-height) + var(--space-4))',
+  '--sticky-bottom-gap': 'var(--space-4)',
+};
 
 export function Demo() {
   return (
@@ -200,7 +211,7 @@ export function Demo() {
       gap="lg"
       align="stretch"
       aside={
-        <Sticky top="lg" scroll>
+        <Sticky top="lg" scroll style={chromeAwareStickyStyle}>
           <Stack gap="md">
             {sidebarItems.map((n) => (
               <Card key={n}>
@@ -235,7 +246,7 @@ export function Demo() {
           gap="lg"
           align="stretch"
           aside={
-            <Sticky top="lg" scroll>
+            <Sticky top="lg" scroll style={chromeAwareStickyStyle}>
               <Stack gap="md">
                 {SIDEBAR_ITEMS.map((n) => (
                   <Card key={n}>


### PR DESCRIPTION
Addresses #399.\n\n## Summary\n- separate Sticky's scroll-cap bottom gap from a top offset that may include pinned chrome clearance\n- preserve existing symmetric behavior when --sticky-bottom-gap is unset\n- document the override and protect both vh/dvh formulas with a regression test\n\n## Test plan\n- npm test (4,302 design-system tests; 78 token tests)\n- npm run typecheck\n- npm run lint:css\n- npm run build\n- npm run format:check\n- npm pack --dry-run -w @eocrm/design-system (608 entries; zero test/internal leaks)\n- Playwright/Chrome at 1400x700: 72px top + 16px bottom => 612px cap; unset override => 556px symmetric fallback