### PR TITLE
fix: expose Select required state to assistive tech (#419)

### DIFF
--- a/packages/design-system/src/components/Drawer/Drawer.test.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.test.tsx
@@ -398,7 +398,7 @@ describe('Drawer — Escape yields to open floating surfaces (#274)', () => {
   it('first Escape closes only the open Select; the second closes the Drawer', async () => {
     const user = userEvent.setup();
     render(<DrawerWithSelect />);
-    await user.click(screen.getByRole('button', { name: 'Status' }));
+    await user.click(screen.getByRole('combobox', { name: 'Status' }));
     expect(screen.getByRole('listbox')).toBeInTheDocument();
     await user.keyboard('{Escape}');
     expect(screen.queryByRole('listbox')).toBeNull();

--- a/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
+++ b/packages/design-system/src/components/FlowCanvas/FlowCanvas.test.tsx
@@ -2308,7 +2308,7 @@ describe('FlowCanvas maximize elevation', () => {
       />,
     );
     // Open the Select — its listbox portals to document.body.
-    fireEvent.click(screen.getByRole('button', { name: 'Node type' }));
+    fireEvent.click(screen.getByRole('combobox', { name: 'Node type' }));
     const listbox = await screen.findByRole('listbox');
     // Registered against [data-flowcanvas-maximized] via OVERLAY_PORTAL_SELECTOR,
     // so it stamps data-in-overlay and elevates above the fixed maximized canvas.

--- a/packages/design-system/src/components/Modal/Modal.test.tsx
+++ b/packages/design-system/src/components/Modal/Modal.test.tsx
@@ -571,7 +571,7 @@ describe('Modal — Escape yields to open floating surfaces (#274)', () => {
   it('first Escape closes only the open Select; the second closes the Modal', async () => {
     const user = userEvent.setup();
     render(<ModalWithSelect />);
-    await user.click(screen.getByRole('button', { name: 'Status' }));
+    await user.click(screen.getByRole('combobox', { name: 'Status' }));
     expect(screen.getByRole('listbox')).toBeInTheDocument();
     await user.keyboard('{Escape}');
     // Inner surface closed, host survived.

--- a/packages/design-system/src/components/Select/HiddenInputs.tsx
+++ b/packages/design-system/src/components/Select/HiddenInputs.tsx
@@ -10,8 +10,8 @@ export interface HiddenInputsProps {
 /**
  * Renders the hidden `<input>`(s) so native `FormData` picks up the Select's
  * value. Single mode renders one input. Multi mode renders one per selected
- * value; or, when empty and required, a single empty required input so native
- * validation blocks submit.
+ * value. Hidden inputs are barred from native constraint validation, so
+ * `required` is mirrored as form metadata only; consumers validate separately.
  */
 export function HiddenInputs(props: HiddenInputsProps) {
   if (!props.name) return null;

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -32,7 +32,7 @@ import styles from './Select.module.scss';
  */
 export function Listbox() {
   const ctx = useSelectContext('Listbox');
-  const inOverlay = useInOverlay(ctx.triggerRef, ctx.open);
+  const inOverlay = useInOverlay(ctx.triggerRootRef, ctx.open);
   // #274: hosts yield Escape while we're open — our own capture/element
   // handler closes us on the same press instead of the Modal/Drawer.
   const floatingId = useFloatingSurface(ctx.open);
@@ -65,7 +65,7 @@ export function Listbox() {
       }),
     ],
     whileElementsMounted: autoUpdate,
-    elements: { reference: ctx.triggerRef.current },
+    elements: { reference: ctx.triggerRootRef.current },
   });
 
   // Outside-click closes. Capture-phase pointerdown fires before any
@@ -80,14 +80,14 @@ export function Listbox() {
       const target = e.target as Node | null;
       if (!target) return;
       const panel = ctx.listboxRef.current;
-      const trigger = ctx.triggerRef.current;
+      const trigger = ctx.triggerRootRef.current;
       if (panel && panel.contains(target)) return;
       if (trigger && trigger.contains(target)) return;
       ctx.setOpen(false);
     };
     document.addEventListener('pointerdown', onPointerDown, true);
     return () => document.removeEventListener('pointerdown', onPointerDown, true);
-  }, [ctx.open, ctx.listboxRef, ctx.triggerRef, ctx.setOpen]);
+  }, [ctx.open, ctx.listboxRef, ctx.triggerRootRef, ctx.setOpen]);
 
   // Escape closes and returns focus to the trigger. Capture-phase so a
   // future in-panel input (Phase 5/6 search input) can't stop the event

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -165,13 +165,8 @@ export function Listbox() {
   }, [ctx.open, isPositioned, ctx.activeIndex]);
 
   return createPortal(
-    <ul
-      ref={mergeRefs<HTMLUListElement>(ctx.listboxRef, refs.setFloating)}
-      id={ctx.listboxId}
-      role="listbox"
-      aria-multiselectable={ctx.multiple || undefined}
-      aria-labelledby={ctx.triggerId}
-      tabIndex={-1}
+    <div
+      ref={mergeRefs<HTMLDivElement>(ctx.listboxRef, refs.setFloating)}
       data-in-overlay={inOverlay ? '' : undefined}
       className={clsx(styles.listbox)}
       style={floatingStyles}
@@ -179,11 +174,21 @@ export function Listbox() {
       {/* In-panel search for multi-summary-searchable mode. Single-mode
           searchable Select keeps the search input AS the trigger
           (ComboboxInputTrigger) since there's no second trigger to compete
-          with; multi-summary needs the trigger to remain a button that
-          shows the summary, so the search input lives inside the panel. */}
+          with; multi-summary keeps a select-only combobox trigger that shows
+          the summary, so this filter is its sibling inside the panel. */}
       {ctx.multiple && ctx.triggerDisplay === 'summary' && ctx.searchable && <InPanelSearchInput />}
-      {renderListboxBody(ctx)}
-    </ul>,
+      <ul
+        id={ctx.listboxId}
+        role="listbox"
+        aria-multiselectable={ctx.multiple || undefined}
+        aria-labelledby={ctx.triggerId}
+        tabIndex={-1}
+        data-in-overlay={inOverlay ? '' : undefined}
+        className={styles.listboxBody}
+      >
+        {renderListboxBody(ctx)}
+      </ul>
+    </div>,
     document.body,
   );
 }
@@ -380,10 +385,10 @@ function renderOptionRow<T>(
 }
 
 /**
- * Search input rendered inside the listbox panel for the multi-summary-
- * searchable variant. The trigger remains a button that shows the
- * comma-joined selection summary; the input lives in the popover so the
- * user can filter without losing the selection summary.
+ * Search input rendered beside the listbox inside the panel for the
+ * multi-summary-searchable variant. The trigger remains a select-only
+ * combobox that shows the comma-joined selection summary; this sibling
+ * searchbox filters without becoming an invalid child of the listbox.
  *
  * Owns its own keyboard handling: ArrowUp/Down cycle the active option,
  * Enter toggles selection, Escape closes and returns focus to the trigger.
@@ -413,7 +418,6 @@ function InPanelSearchInput() {
       ref={ref}
       type="text"
       role="searchbox"
-      aria-expanded="true"
       aria-controls={ctx.listboxId}
       aria-activedescendant={activeOptionId}
       aria-autocomplete="list"

--- a/packages/design-system/src/components/Select/Listbox.tsx
+++ b/packages/design-system/src/components/Select/Listbox.tsx
@@ -412,7 +412,7 @@ function InPanelSearchInput() {
     <input
       ref={ref}
       type="text"
-      role="combobox"
+      role="searchbox"
       aria-expanded="true"
       aria-controls={ctx.listboxId}
       aria-activedescendant={activeOptionId}

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -41,6 +41,12 @@
     box-shadow: 0 0 0 var(--ring-width) var(--select-trigger-ring-focus);
   }
 
+  &:has(> .chipsInput:focus-visible) {
+    outline: none;
+    border-color: var(--select-trigger-border-color-focus);
+    box-shadow: 0 0 0 var(--ring-width) var(--select-trigger-ring-focus);
+  }
+
   &[disabled] {
     color: var(--select-trigger-fg-disabled);
     background: var(--select-trigger-bg-disabled);

--- a/packages/design-system/src/components/Select/Select.module.scss
+++ b/packages/design-system/src/components/Select/Select.module.scss
@@ -168,6 +168,11 @@
   z-index: var(--z-overlay-floating);
 }
 
+.listboxBody {
+  padding: 0;
+  list-style: none;
+}
+
 @keyframes select-open {
   from {
     opacity: var(--select-listbox-anim-opacity-from);

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -696,6 +696,9 @@ describe('Select — multi-chips, non-searchable', () => {
     const wrapper = screen.getByRole('combobox').parentElement!;
     await user.click(wrapper);
     expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    await user.click(wrapper);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
 
   it('keeps the listbox open when a chip is removed', async () => {

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -27,16 +27,16 @@ describe('Select — Phase 1 scaffold', () => {
 });
 
 describe('Select — single, non-searchable, sync', () => {
-  it('renders a button trigger with placeholder when no value', () => {
+  it('renders a select-only combobox trigger with placeholder when no value', () => {
     render(<Select options={STATUSES} placeholder="Pick one" />);
-    expect(screen.getByRole('button')).toHaveTextContent('Pick one');
+    expect(screen.getByRole('combobox')).toHaveTextContent('Pick one');
   });
 
   it('renders the selected label when value is set', () => {
     render(<Select options={STATUSES} value="pending" />);
     // Two buttons in the DOM once `value` is set: the main trigger and the
     // overlay clear ✕. Filter by accessible name so the trigger is unambiguous.
-    expect(screen.getByRole('button', { name: 'Pending' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Pending' })).toBeInTheDocument();
   });
 });
 
@@ -45,7 +45,7 @@ describe('Select — open/close', () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} placeholder="Pick" />);
     expect(screen.queryByRole('listbox')).toBeNull();
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     expect(screen.getByRole('listbox')).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Active' })).toBeInTheDocument();
   });
@@ -53,7 +53,7 @@ describe('Select — open/close', () => {
   it('listbox renders in a portal at document.body level', async () => {
     const user = userEvent.setup();
     const { container } = render(<Select options={STATUSES} />);
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     const listbox = screen.getByRole('listbox');
     expect(container.contains(listbox)).toBe(false);
   });
@@ -61,7 +61,7 @@ describe('Select — open/close', () => {
   it('closes on second click of trigger', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} />);
-    const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('combobox');
     await user.click(trigger);
     expect(screen.queryByRole('listbox')).toBeInTheDocument();
     await user.click(trigger);
@@ -71,7 +71,7 @@ describe('Select — open/close', () => {
   it('aria-expanded reflects open state', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} />);
-    const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('combobox');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     await user.click(trigger);
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
@@ -80,7 +80,7 @@ describe('Select — open/close', () => {
   it('aria-controls points at the listbox id when open', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} />);
-    const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('combobox');
     await user.click(trigger);
     const listbox = screen.getByRole('listbox');
     expect(trigger.getAttribute('aria-controls')).toBe(listbox.id);
@@ -92,7 +92,7 @@ describe('Select — selection (single)', () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(<Select options={STATUSES} onChange={onChange} />);
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     await user.click(screen.getByRole('option', { name: 'Pending' }));
     expect(onChange).toHaveBeenCalledWith('pending', STATUSES[1]);
     expect(screen.queryByRole('listbox')).toBeNull();
@@ -113,11 +113,11 @@ describe('Select — selection (single)', () => {
     };
     render(<Wrapper />);
     // Closed + no value → only one button (the trigger w/ placeholder text).
-    expect(screen.getByRole('button')).toHaveTextContent('Pick');
-    await user.click(screen.getByRole('button'));
+    expect(screen.getByRole('combobox')).toHaveTextContent('Pick');
+    await user.click(screen.getByRole('combobox'));
     await user.click(screen.getByRole('option', { name: 'Archived' }));
     // After selection, the clear ✕ also renders, so name-filter the trigger.
-    expect(screen.getByRole('button', { name: 'Archived' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Archived' })).toBeInTheDocument();
   });
 
   it('clicking a disabled option does nothing', async () => {
@@ -128,7 +128,7 @@ describe('Select — selection (single)', () => {
       { value: 'b', label: 'B', disabled: true },
     ];
     render(<Select options={opts} onChange={onChange} />);
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     await user.click(screen.getByRole('option', { name: 'B' }));
     expect(onChange).not.toHaveBeenCalled();
     expect(screen.queryByRole('listbox')).toBeInTheDocument();
@@ -139,7 +139,7 @@ describe('Select — keyboard (single, non-searchable)', () => {
   it('ArrowDown on closed trigger opens with first option active', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} />);
-    const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('combobox');
     trigger.focus();
     await user.keyboard('{ArrowDown}');
     expect(screen.getByRole('listbox')).toBeInTheDocument();
@@ -150,7 +150,7 @@ describe('Select — keyboard (single, non-searchable)', () => {
   it('ArrowUp on closed trigger opens with last option active', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} />);
-    const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('combobox');
     trigger.focus();
     await user.keyboard('{ArrowUp}');
     expect(screen.getByRole('listbox')).toBeInTheDocument();
@@ -161,7 +161,7 @@ describe('Select — keyboard (single, non-searchable)', () => {
   it('Enter on closed trigger opens', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} />);
-    screen.getByRole('button').focus();
+    screen.getByRole('combobox').focus();
     await user.keyboard('{Enter}');
     expect(screen.getByRole('listbox')).toBeInTheDocument();
   });
@@ -169,9 +169,9 @@ describe('Select — keyboard (single, non-searchable)', () => {
   it('ArrowDown moves active row +1', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} />);
-    screen.getByRole('button').focus();
+    screen.getByRole('combobox').focus();
     await user.keyboard('{ArrowDown}{ArrowDown}');
-    expect(screen.getByRole('button')).toHaveAttribute(
+    expect(screen.getByRole('combobox')).toHaveAttribute(
       'aria-activedescendant',
       screen.getByRole('option', { name: 'Pending' }).id,
     );
@@ -189,7 +189,7 @@ describe('Select — keyboard (single, non-searchable)', () => {
     try {
       const user = userEvent.setup();
       render(<Select options={STATUSES} />);
-      screen.getByRole('button').focus();
+      screen.getByRole('combobox').focus();
       await user.keyboard('{ArrowDown}'); // open → first option active
       // The open-path scroll waits for Floating UI's isPositioned (scrolling
       // earlier would target the panel while it still sits at the document
@@ -209,14 +209,14 @@ describe('Select — keyboard (single, non-searchable)', () => {
   it('Home jumps to first, End jumps to last', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} />);
-    screen.getByRole('button').focus();
+    screen.getByRole('combobox').focus();
     await user.keyboard('{ArrowDown}{End}');
-    expect(screen.getByRole('button')).toHaveAttribute(
+    expect(screen.getByRole('combobox')).toHaveAttribute(
       'aria-activedescendant',
       screen.getByRole('option', { name: 'Archived' }).id,
     );
     await user.keyboard('{Home}');
-    expect(screen.getByRole('button')).toHaveAttribute(
+    expect(screen.getByRole('combobox')).toHaveAttribute(
       'aria-activedescendant',
       screen.getByRole('option', { name: 'Active' }).id,
     );
@@ -226,7 +226,7 @@ describe('Select — keyboard (single, non-searchable)', () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(<Select options={STATUSES} onChange={onChange} />);
-    screen.getByRole('button').focus();
+    screen.getByRole('combobox').focus();
     await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
     expect(onChange).toHaveBeenCalledWith('pending', STATUSES[1]);
     expect(screen.queryByRole('listbox')).toBeNull();
@@ -238,7 +238,7 @@ describe('Select — keyboard (single, non-searchable)', () => {
     render(<Select options={STATUSES} value="active" onChange={onChange} />);
     // `value="active"` triggers the clear ✕ overlay, so filter by name to
     // get only the main trigger.
-    const trigger = screen.getByRole('button', { name: 'Active' });
+    const trigger = screen.getByRole('combobox', { name: 'Active' });
     trigger.focus();
     await user.keyboard('{Enter}{ArrowDown}{Escape}');
     expect(screen.queryByRole('listbox')).toBeNull();
@@ -249,7 +249,7 @@ describe('Select — keyboard (single, non-searchable)', () => {
   it('Tab closes and commits', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} />);
-    screen.getByRole('button').focus();
+    screen.getByRole('combobox').focus();
     await user.keyboard('{Enter}{Tab}');
     expect(screen.queryByRole('listbox')).toBeNull();
   });
@@ -262,9 +262,9 @@ describe('Select — keyboard (single, non-searchable)', () => {
       { value: 'c', label: 'C' },
     ];
     render(<Select options={opts} />);
-    screen.getByRole('button').focus();
+    screen.getByRole('combobox').focus();
     await user.keyboard('{ArrowDown}{ArrowDown}');
-    expect(screen.getByRole('button')).toHaveAttribute(
+    expect(screen.getByRole('combobox')).toHaveAttribute(
       'aria-activedescendant',
       screen.getByRole('option', { name: 'C' }).id,
     );
@@ -297,10 +297,10 @@ describe('Select — typeahead (non-searchable)', () => {
   it('typing a letter jumps active row to first option starting with it', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     render(<Select options={STATUSES} />);
-    screen.getByRole('button').focus();
+    screen.getByRole('combobox').focus();
     await user.keyboard('{ArrowDown}');
     await user.keyboard('p');
-    expect(screen.getByRole('button')).toHaveAttribute(
+    expect(screen.getByRole('combobox')).toHaveAttribute(
       'aria-activedescendant',
       screen.getByRole('option', { name: 'Pending' }).id,
     );
@@ -314,10 +314,10 @@ describe('Select — typeahead (non-searchable)', () => {
       { value: '3', label: 'Antelope' },
     ];
     render(<Select options={opts} />);
-    screen.getByRole('button').focus();
+    screen.getByRole('combobox').focus();
     await user.keyboard('{ArrowDown}');
     await user.keyboard('al');
-    expect(screen.getByRole('button')).toHaveAttribute(
+    expect(screen.getByRole('combobox')).toHaveAttribute(
       'aria-activedescendant',
       screen.getByRole('option', { name: 'Albatross' }).id,
     );
@@ -330,12 +330,12 @@ describe('Select — typeahead (non-searchable)', () => {
       { value: '2', label: 'Banana' },
     ];
     render(<Select options={opts} />);
-    screen.getByRole('button').focus();
+    screen.getByRole('combobox').focus();
     await user.keyboard('{ArrowDown}');
     await user.keyboard('a');
     vi.advanceTimersByTime(600);
     await user.keyboard('b');
-    expect(screen.getByRole('button')).toHaveAttribute(
+    expect(screen.getByRole('combobox')).toHaveAttribute(
       'aria-activedescendant',
       screen.getByRole('option', { name: 'Banana' }).id,
     );
@@ -349,10 +349,10 @@ describe('Select — typeahead (non-searchable)', () => {
       { value: '3', label: 'Cherry' },
     ];
     render(<Select options={opts} />);
-    screen.getByRole('button').focus();
+    screen.getByRole('combobox').focus();
     // From CLOSED state, typing 'a' must land on Apple (index 0), not skip past it
     await user.keyboard('a');
-    expect(screen.getByRole('button')).toHaveAttribute(
+    expect(screen.getByRole('combobox')).toHaveAttribute(
       'aria-activedescendant',
       screen.getByRole('option', { name: 'Apple' }).id,
     );
@@ -438,7 +438,7 @@ describe('Select — single, searchable (combobox input)', () => {
   it('re-seeds when a mid-open row shrink strands the cursor out of bounds (#309)', async () => {
     const user = userEvent.setup();
     const { rerender } = render(<Select options={STATUSES} value="archived" />);
-    const trigger = screen.getByRole('button', { name: 'Archived' });
+    const trigger = screen.getByRole('combobox', { name: 'Archived' });
     await user.click(trigger);
     // Open-seed highlights the selection (flat index 2).
     expect(trigger).toHaveAttribute(
@@ -521,7 +521,7 @@ describe('Select — grouped options', () => {
   it('renders group headers in order before their options', async () => {
     const user = userEvent.setup();
     render(<Select options={GROUPED} />);
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     const listbox = screen.getByRole('listbox');
     const headers = listbox.querySelectorAll('[data-group-header]');
     expect(headers).toHaveLength(2);
@@ -532,7 +532,7 @@ describe('Select — grouped options', () => {
   it('group is wrapped in role=group with aria-labelledby to the header id', async () => {
     const user = userEvent.setup();
     render(<Select options={GROUPED} />);
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     const groups = screen.getAllByRole('group');
     expect(groups).toHaveLength(2);
     const header0 = screen.getByText('Active');
@@ -542,9 +542,9 @@ describe('Select — grouped options', () => {
   it('ArrowDown skips group headers', async () => {
     const user = userEvent.setup();
     render(<Select options={GROUPED} />);
-    screen.getByRole('button').focus();
+    screen.getByRole('combobox').focus();
     await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}'); // open + 2 steps
-    expect(screen.getByRole('button')).toHaveAttribute(
+    expect(screen.getByRole('combobox')).toHaveAttribute(
       'aria-activedescendant',
       screen.getByRole('option', { name: 'Baz' }).id,
     );
@@ -560,19 +560,19 @@ describe('Select — multi, summary, non-searchable', () => {
 
   it('placeholder shown when nothing selected', () => {
     render(<Select multiple triggerDisplay="summary" options={OWNERS} placeholder="Owners" />);
-    expect(screen.getByRole('button')).toHaveTextContent('Owners');
+    expect(screen.getByRole('combobox')).toHaveTextContent('Owners');
   });
 
   it('renders comma-joined labels when selections exist', () => {
     render(<Select multiple triggerDisplay="summary" options={OWNERS} value={['a', 'c']} />);
-    expect(screen.getByRole('button')).toHaveTextContent('Alex, Cam');
+    expect(screen.getByRole('combobox')).toHaveTextContent('Alex, Cam');
   });
 
   it('clicking a row toggles selection and does NOT close', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(<Select multiple triggerDisplay="summary" options={OWNERS} onChange={onChange} />);
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     await user.click(screen.getByRole('option', { name: 'Alex' }));
     expect(onChange).toHaveBeenCalledWith(['a'], [OWNERS[0]]);
     expect(screen.getByRole('listbox')).toBeInTheDocument();
@@ -592,7 +592,7 @@ describe('Select — multi, summary, non-searchable', () => {
         onChange={onChange}
       />,
     );
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     await user.click(screen.getByRole('option', { name: 'Alex' }));
     expect(onChange).toHaveBeenCalledWith([], []);
   });
@@ -600,7 +600,7 @@ describe('Select — multi, summary, non-searchable', () => {
   it('aria-multiselectable=true on the listbox', async () => {
     const user = userEvent.setup();
     render(<Select multiple triggerDisplay="summary" options={OWNERS} />);
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     expect(screen.getByRole('listbox')).toHaveAttribute('aria-multiselectable', 'true');
   });
 });
@@ -613,7 +613,7 @@ describe('Select — multi-summary aria-label', () => {
 
   it('aria-label carries the full label list when summary is truncated visually', () => {
     render(<Select multiple triggerDisplay="summary" options={OPTS} value={['a', 'b']} />);
-    const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('combobox');
     expect(trigger.getAttribute('aria-label')).toContain('Alex');
     expect(trigger.getAttribute('aria-label')).toContain('Bea');
   });
@@ -628,7 +628,7 @@ describe('Select — multi-summary aria-label', () => {
         aria-label="Owners filter"
       />,
     );
-    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Owners filter');
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-label', 'Owners filter');
   });
 });
 
@@ -642,17 +642,15 @@ describe('Select — multi-summary-searchable', () => {
   it('renders a search input inside the popover when multi+summary+searchable', async () => {
     const user = userEvent.setup();
     render(<Select multiple triggerDisplay="summary" searchable options={OPTS} />);
-    await user.click(screen.getByRole('button'));
-    const inputs = screen.getAllByRole('combobox');
-    expect(inputs).toHaveLength(1);
-    expect(inputs[0].tagName).toBe('INPUT');
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
   });
 
   it('typing into the popover search filters options', async () => {
     const user = userEvent.setup();
     render(<Select multiple triggerDisplay="summary" searchable options={OPTS} />);
-    await user.click(screen.getByRole('button'));
-    const input = screen.getByRole('combobox');
+    await user.click(screen.getByRole('combobox'));
+    const input = screen.getByRole('searchbox');
     await user.type(input, 'be');
     expect(screen.queryByRole('option', { name: 'Alex' })).toBeNull();
     expect(screen.getByRole('option', { name: 'Bea' })).toBeInTheDocument();
@@ -664,8 +662,8 @@ describe('Select — multi-summary-searchable', () => {
     render(
       <Select multiple triggerDisplay="summary" searchable options={OPTS} onChange={onChange} />,
     );
-    await user.click(screen.getByRole('button'));
-    const input = screen.getByRole('combobox');
+    await user.click(screen.getByRole('combobox'));
+    const input = screen.getByRole('searchbox');
     await user.type(input, 'al');
     await user.click(screen.getByRole('option', { name: 'Alex' }));
     expect(screen.getByRole('listbox')).toBeInTheDocument();
@@ -1065,10 +1063,10 @@ describe('Select — form integration (single)', () => {
   });
 
   it.each([
-    ['single button', {}, 'button'],
+    ['single select-only combobox', {}, 'combobox'],
     ['single searchable input', { searchable: true }, 'combobox'],
     ['multi searchable input', { multiple: true, searchable: true }, 'combobox'],
-    ['multi chips button', { multiple: true }, 'button'],
+    ['multi chips combobox', { multiple: true }, 'combobox'],
   ] as const)('exposes required state on the %s trigger', (_name, triggerProps, role) => {
     const { container } = render(<Select options={STATUSES} required {...triggerProps} />);
 
@@ -1076,11 +1074,16 @@ describe('Select — form integration (single)', () => {
     expect(container.firstElementChild).not.toHaveAttribute('aria-required');
   });
 
-  it('routes an explicit aria-required value to the trigger instead of the roleless wrapper', () => {
-    const { container } = render(<Select options={STATUSES} aria-required="true" />);
+  it('routes explicit aria-required to the combobox instead of the roleless wrapper', () => {
+    const { container, rerender } = render(
+      <Select searchable options={STATUSES} aria-required="true" />,
+    );
 
-    expect(screen.getByRole('button')).toHaveAttribute('aria-required', 'true');
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-required', 'true');
     expect(container.firstElementChild).not.toHaveAttribute('aria-required');
+
+    rerender(<Select searchable options={STATUSES} required aria-required="false" />);
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-required', 'true');
   });
 
   it('FormData picks up the value on submit', () => {
@@ -1168,14 +1171,14 @@ describe('Select — visual states', () => {
 
   it('invalid sets aria-invalid on the trigger and adds the invalid class', () => {
     const { container } = render(<Select options={STATUSES} invalid />);
-    expect(screen.getByRole('button')).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
     expect(container.firstElementChild!.className).toMatch(/invalid/);
   });
 
   it('disabled disables the trigger and prevents opening', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} disabled />);
-    const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('combobox');
     expect(trigger).toBeDisabled();
     await user.click(trigger);
     expect(screen.queryByRole('listbox')).toBeNull();
@@ -1184,7 +1187,7 @@ describe('Select — visual states', () => {
   it('readOnly prevents opening on click', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} readOnly value="pending" />);
-    const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('combobox');
     expect(trigger).toHaveAttribute('aria-readonly', 'true');
     await user.click(trigger);
     expect(screen.queryByRole('listbox')).toBeNull();
@@ -1260,7 +1263,7 @@ describe('Select — clearable', () => {
   it('clear ✕ button is focusable via keyboard', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} defaultValue="active" clearable />);
-    const trigger = screen.getByRole('button', { name: /Active/i });
+    const trigger = screen.getByRole('combobox', { name: /Active/i });
     trigger.focus();
     await user.tab(); // moves to next focusable
     const clearBtn = screen.getByRole('button', { name: /clear selection/i });
@@ -1293,7 +1296,7 @@ describe('Select — render escape hatches', () => {
         value="pending"
       />,
     );
-    await user.click(screen.getByRole('button', { name: /Pending/i }));
+    await user.click(screen.getByRole('combobox', { name: /Pending/i }));
     expect(screen.getByTestId('opt-pending')).toHaveTextContent('Pending★');
     expect(screen.getByTestId('opt-active')).toHaveTextContent('Active☆');
   });
@@ -1302,7 +1305,7 @@ describe('Select — render escape hatches', () => {
     render(
       <Select options={STATUSES} value="pending" renderValue={(opt) => <em>~~{opt.label}~~</em>} />,
     );
-    expect(screen.getByRole('button', { name: /~~Pending~~/ })).toHaveTextContent('~~Pending~~');
+    expect(screen.getByRole('combobox', { name: /Pending/ })).toHaveTextContent('~~Pending~~');
   });
 
   it('renderTag replaces chip rendering', () => {
@@ -1342,14 +1345,14 @@ describe('Select — overlay elevation', () => {
         <Select options={STATUSES} aria-label="Status" />
       </div>,
     );
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     expect(screen.getByRole('listbox')).toHaveAttribute('data-in-overlay', '');
   });
 
   it('does not elevate the listbox at page level', async () => {
     const user = userEvent.setup();
     render(<Select options={STATUSES} aria-label="Status" />);
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     expect(screen.getByRole('listbox')).not.toHaveAttribute('data-in-overlay');
   });
 });
@@ -1366,6 +1369,6 @@ describe('Select — Field label integration', () => {
         />
       </Field>,
     );
-    expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Status' })).toBeInTheDocument();
   });
 });

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -689,6 +689,24 @@ describe('Select — multi-chips, non-searchable', () => {
     expect(combobox).not.toContainElement(screen.getByRole('button', { name: /clear selection/i }));
   });
 
+  it('opens from the full chips wrapper, not only the inline combobox input', async () => {
+    const user = userEvent.setup();
+    render(<Select multiple options={OPTS} value={['a']} />);
+
+    const wrapper = screen.getByRole('combobox').parentElement!;
+    await user.click(wrapper);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('keeps the listbox open when a chip is removed', async () => {
+    const user = userEvent.setup();
+    render(<Select multiple options={OPTS} value={['a']} />);
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('button', { name: 'Remove Alpha' }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
   it('renders chips for each selected option inside the trigger', () => {
     render(<Select multiple triggerDisplay="chips" options={OPTS} value={['a', 'b']} />);
     const chips = screen.getAllByRole('button', { name: /Remove/ });

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -701,6 +701,21 @@ describe('Select — multi-chips, non-searchable', () => {
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
 
+  it('notifies once per toggle when the inline combobox input is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<Select multiple options={OPTS} value={['a']} onOpenChange={onOpenChange} />);
+
+    const combobox = screen.getByRole('combobox');
+    await user.click(combobox);
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    await user.click(combobox);
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
   it('keeps the listbox open when a chip is removed', async () => {
     const user = userEvent.setup();
     render(<Select multiple options={OPTS} value={['a']} />);

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -643,7 +643,10 @@ describe('Select — multi-summary-searchable', () => {
     const user = userEvent.setup();
     render(<Select multiple triggerDisplay="summary" searchable options={OPTS} />);
     await user.click(screen.getByRole('combobox'));
-    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    const searchbox = screen.getByRole('searchbox');
+    expect(searchbox).toBeInTheDocument();
+    expect(searchbox).not.toHaveAttribute('aria-expanded');
+    expect(screen.getByRole('listbox')).not.toContainElement(searchbox);
   });
 
   it('typing into the popover search filters options', async () => {
@@ -676,6 +679,15 @@ describe('Select — multi-chips, non-searchable', () => {
     { value: 'a', label: 'Alpha' },
     { value: 'b', label: 'Beta' },
   ];
+
+  it('keeps chip actions outside the dedicated combobox focus owner', () => {
+    render(<Select multiple options={OPTS} value={['a']} clearable />);
+
+    const combobox = screen.getByRole('combobox');
+    expect(combobox.tagName).toBe('INPUT');
+    expect(combobox).not.toContainElement(screen.getByRole('button', { name: 'Remove Alpha' }));
+    expect(combobox).not.toContainElement(screen.getByRole('button', { name: /clear selection/i }));
+  });
 
   it('renders chips for each selected option inside the trigger', () => {
     render(<Select multiple triggerDisplay="chips" options={OPTS} value={['a', 'b']} />);

--- a/packages/design-system/src/components/Select/Select.test.tsx
+++ b/packages/design-system/src/components/Select/Select.test.tsx
@@ -1064,6 +1064,25 @@ describe('Select — form integration (single)', () => {
     expect(hidden!.required).toBe(true);
   });
 
+  it.each([
+    ['single button', {}, 'button'],
+    ['single searchable input', { searchable: true }, 'combobox'],
+    ['multi searchable input', { multiple: true, searchable: true }, 'combobox'],
+    ['multi chips button', { multiple: true }, 'button'],
+  ] as const)('exposes required state on the %s trigger', (_name, triggerProps, role) => {
+    const { container } = render(<Select options={STATUSES} required {...triggerProps} />);
+
+    expect(screen.getByRole(role)).toHaveAttribute('aria-required', 'true');
+    expect(container.firstElementChild).not.toHaveAttribute('aria-required');
+  });
+
+  it('routes an explicit aria-required value to the trigger instead of the roleless wrapper', () => {
+    const { container } = render(<Select options={STATUSES} aria-required="true" />);
+
+    expect(screen.getByRole('button')).toHaveAttribute('aria-required', 'true');
+    expect(container.firstElementChild).not.toHaveAttribute('aria-required');
+  });
+
   it('FormData picks up the value on submit', () => {
     let captured: FormData | null = null;
     render(

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -227,8 +227,8 @@ export interface SelectProps<T = unknown> extends Omit<
    */
   name?: string;
   /**
-   * Marks the field as required for native form validation. When `true`, an empty
-   * selection blocks submit.
+   * Marks the field as required. The trigger exposes `aria-required="true"` to
+   * assistive technology, and an empty named selection blocks native form submit.
    */
   required?: boolean;
   /** `form` attribute forwarded to the hidden `<input>` elements. */
@@ -317,6 +317,7 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     name,
     required,
     form,
+    'aria-required': ariaRequired,
     renderOption,
     renderValue,
     renderTag,
@@ -598,6 +599,7 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
           aria-label={props['aria-label']}
           aria-labelledby={props['aria-labelledby']}
           aria-describedby={props['aria-describedby']}
+          aria-required={required ? true : ariaRequired}
         />
         {state.open && <Listbox />}
         <HiddenInputs

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -527,7 +527,7 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
   }, [state.open, activeIndex, rowsWithCreate]);
 
   const triggerRef = useRef<HTMLElement | null>(null);
-  const listboxRef = useRef<HTMLUListElement | null>(null);
+  const listboxRef = useRef<HTMLDivElement | null>(null);
 
   // `clearable` is opt-in: the ✕ clear button defaults OFF and only shows when a
   // consumer explicitly sets `clearable`. `disabled` / `readOnly` always suppress it

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -527,6 +527,7 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
   }, [state.open, activeIndex, rowsWithCreate]);
 
   const triggerRef = useRef<HTMLElement | null>(null);
+  const triggerRootRef = useRef<HTMLElement | null>(null);
   const listboxRef = useRef<HTMLDivElement | null>(null);
 
   // `clearable` is opt-in: the ✕ clear button defaults OFF and only shows when a
@@ -565,6 +566,7 @@ const SelectImpl = forwardRef<HTMLDivElement, SelectProps>(function Select(
     getOptionId,
     getGroupHeaderId,
     triggerRef,
+    triggerRootRef,
     listboxRef,
     closeAndFocusTrigger,
     retry: asyncResult.retry,

--- a/packages/design-system/src/components/Select/Select.tsx
+++ b/packages/design-system/src/components/Select/Select.tsx
@@ -228,7 +228,9 @@ export interface SelectProps<T = unknown> extends Omit<
   name?: string;
   /**
    * Marks the field as required. The trigger exposes `aria-required="true"` to
-   * assistive technology, and an empty named selection blocks native form submit.
+   * assistive technology. Hidden inputs still serialize named values, but they do
+   * not participate in native constraint validation; validate the selection in
+   * your form layer.
    */
   required?: boolean;
   /** `form` attribute forwarded to the hidden `<input>` elements. */

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -26,6 +26,7 @@ export interface TriggerProps {
   'aria-label'?: string;
   'aria-labelledby'?: string;
   'aria-describedby'?: string;
+  'aria-required'?: boolean | 'true' | 'false';
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -429,6 +430,7 @@ function ButtonTrigger(props: TriggerProps) {
         aria-label={computedAriaLabel}
         aria-labelledby={props['aria-labelledby']}
         aria-describedby={props['aria-describedby']}
+        aria-required={props['aria-required']}
         aria-invalid={props.invalid || undefined}
         aria-readonly={props.readOnly || undefined}
         disabled={props.disabled}
@@ -569,6 +571,7 @@ function ComboboxInputTrigger(props: TriggerProps) {
         aria-label={props['aria-label']}
         aria-labelledby={props['aria-labelledby']}
         aria-describedby={props['aria-describedby']}
+        aria-required={props['aria-required']}
         aria-invalid={props.invalid || undefined}
         aria-readonly={props.readOnly || undefined}
         autoComplete="off"
@@ -719,6 +722,7 @@ function ChipsInputTrigger(props: TriggerProps) {
         aria-label={props['aria-label']}
         aria-labelledby={props['aria-labelledby']}
         aria-describedby={props['aria-describedby']}
+        aria-required={props['aria-required']}
         aria-invalid={props.invalid || undefined}
         disabled={props.disabled}
         readOnly={props.readOnly}
@@ -821,6 +825,7 @@ function ChipsButtonTrigger(props: TriggerProps) {
       aria-label={computedAriaLabel}
       aria-labelledby={props['aria-labelledby']}
       aria-describedby={props['aria-describedby']}
+      aria-required={props['aria-required']}
       aria-invalid={props.invalid || undefined}
       aria-readonly={props.readOnly || undefined}
       aria-disabled={props.disabled || undefined}

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -417,7 +417,7 @@ function ButtonTrigger(props: TriggerProps) {
   })();
 
   return (
-    <div className={styles.triggerWrap}>
+    <div ref={ctx.triggerRootRef as Ref<HTMLDivElement>} className={styles.triggerWrap}>
       <button
         type="button"
         role="combobox"
@@ -555,7 +555,7 @@ function ComboboxInputTrigger(props: TriggerProps) {
   const showClear = props.clearable && selectHasValue(ctx.value, ctx.multiple);
 
   return (
-    <div className={styles.triggerWrap}>
+    <div ref={ctx.triggerRootRef as Ref<HTMLDivElement>} className={styles.triggerWrap}>
       <input
         type="text"
         id={ctx.triggerId}
@@ -612,8 +612,8 @@ function ComboboxInputTrigger(props: TriggerProps) {
  * Chips trigger with an inline `role="combobox"` input. Wrapper is a plain
  * `<div>` (no role) because the input IS the WAI-ARIA combobox; assigning
  * `role="button"` to the wrapper would create two competing focus targets.
- * Outside-click detection still works — `ctx.triggerRef` points at the
- * wrapper, and `wrapper.contains(input) === true` and `wrapper.contains(chip) === true`.
+ * The visual wrapper owns positioning and outside-click containment while
+ * the input remains the semantic combobox and focus-restoration target.
  *
  * Backspace behaviour: removes the trailing chip ONLY when `ctx.query === ''`.
  * On non-empty input it falls through to the browser's native text-deletion.
@@ -684,15 +684,11 @@ function ChipsInputTrigger(props: TriggerProps) {
     }
   };
 
-  // `ctx.triggerRef` is the wrapper div, NOT the input. This is correct
-  // for outside-click detection (everything inside the wrapper — chips,
-  // ✕ buttons, the input — is "inside the trigger"). The input gets its
-  // own local ref for focus management.
-  const wrapperRef = ctx.triggerRef as Ref<HTMLDivElement>;
+  const inputRefHolder = ctx.triggerRef as MutableRefObject<HTMLInputElement | null>;
 
   return (
     <div
-      ref={wrapperRef}
+      ref={ctx.triggerRootRef as Ref<HTMLDivElement>}
       className={clsx(styles.trigger, styles.triggerChips, styles.triggerChipsInput)}
       onClick={handleWrapperClick}
       onPointerDown={handleWrapperPointerDown}
@@ -711,7 +707,10 @@ function ChipsInputTrigger(props: TriggerProps) {
         return <Chip key={o.value} label={o.label} disabled={props.disabled} onRemove={remove} />;
       })}
       <input
-        ref={inputRef}
+        ref={(node) => {
+          inputRef.current = node;
+          inputRefHolder.current = node;
+        }}
         type="text"
         id={ctx.triggerId}
         role="combobox"
@@ -745,16 +744,15 @@ function ChipsInputTrigger(props: TriggerProps) {
 
 // ────────────────────────────────────────────────────────────────────────────
 // ChipsButtonTrigger — multi + chips + !searchable. Renders selected options
-// as removable inline chips inside a div with role="combobox". Cannot be a
-// native <button> because chip ✕ buttons nest inside it (no <button> in
-// <button>). Outside-click detection still works because Listbox tests
-// `triggerRef.contains(target)` and the wrapper IS the triggerRef.
+// as removable inline chips around a read-only combobox input. The visual
+// wrapper is also the floating anchor and outside-click boundary.
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * Chips trigger for multi-select without inline search. Wrapper is a
- * keyboard-focusable `<div role="combobox">` (so the chips' own ✕ buttons
- * can nest). Chip resolution walks `ctx.allRows`, not `ctx.rows`, so the
+ * Chips trigger for multi-select without inline search. A dedicated read-only
+ * input owns combobox semantics and keyboard focus so chip remove buttons are
+ * siblings rather than descendants of the combobox. Chip resolution walks
+ * `ctx.allRows`, not `ctx.rows`, so the
  * chip list stays stable even if a future hover-search filters the
  * popover — unselected options never show as chips, but selected ones
  * never disappear.
@@ -812,8 +810,18 @@ function ChipsButtonTrigger(props: TriggerProps) {
     props['aria-label'] ??
     (selectedOptions.length > 0 ? `Selected: ${labelForAria}` : 'Open select');
 
+  const handleWrapperClick = () => {
+    if (props.disabled || props.readOnly) return;
+    ctx.triggerRef.current?.focus();
+    if (!ctx.open) ctx.setOpen(true);
+  };
+
   return (
-    <div className={clsx(styles.trigger, styles.triggerChips)}>
+    <div
+      ref={ctx.triggerRootRef as Ref<HTMLDivElement>}
+      className={clsx(styles.trigger, styles.triggerChips)}
+      onClick={handleWrapperClick}
+    >
       {selectedOptions.map((o) => {
         const remove = () => {
           if (props.disabled || props.readOnly) return;

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -789,7 +789,7 @@ function ChipsButtonTrigger(props: TriggerProps) {
     (v) => optionByValue.get(v) ?? { value: v, label: v },
   );
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (props.disabled || props.readOnly) return;
     if (handleNavKey(e)) return;
     if (e.key === ' ') {
@@ -813,29 +813,7 @@ function ChipsButtonTrigger(props: TriggerProps) {
     (selectedOptions.length > 0 ? `Selected: ${labelForAria}` : 'Open select');
 
   return (
-    <div
-      ref={ctx.triggerRef as Ref<HTMLDivElement>}
-      id={ctx.triggerId}
-      role="combobox"
-      tabIndex={props.disabled ? -1 : 0}
-      className={clsx(styles.trigger, styles.triggerChips)}
-      aria-haspopup="listbox"
-      aria-expanded={ctx.open}
-      aria-controls={ctx.open ? ctx.listboxId : undefined}
-      aria-activedescendant={activeOptionId}
-      aria-label={computedAriaLabel}
-      aria-labelledby={props['aria-labelledby']}
-      aria-describedby={props['aria-describedby']}
-      aria-required={props['aria-required']}
-      aria-invalid={props.invalid || undefined}
-      aria-readonly={props.readOnly || undefined}
-      aria-disabled={props.disabled || undefined}
-      onClick={() => {
-        if (props.disabled || props.readOnly) return;
-        ctx.setOpen(!ctx.open);
-      }}
-      onKeyDown={handleKeyDown}
-    >
+    <div className={clsx(styles.trigger, styles.triggerChips)}>
       {selectedOptions.map((o) => {
         const remove = () => {
           if (props.disabled || props.readOnly) return;
@@ -847,8 +825,37 @@ function ChipsButtonTrigger(props: TriggerProps) {
         return <Chip key={o.value} label={o.label} disabled={props.disabled} onRemove={remove} />;
       })}
       {selectedOptions.length === 0 && (
-        <span className={styles.placeholder}>{props.placeholder ?? ''}</span>
+        <span aria-hidden="true" className={styles.placeholder}>
+          {props.placeholder ?? ''}
+        </span>
       )}
+      <input
+        ref={ctx.triggerRef as Ref<HTMLInputElement>}
+        id={ctx.triggerId}
+        type="text"
+        role="combobox"
+        readOnly
+        tabIndex={props.disabled ? -1 : 0}
+        className={styles.chipsInput}
+        aria-haspopup="listbox"
+        aria-expanded={ctx.open}
+        aria-controls={ctx.open ? ctx.listboxId : undefined}
+        aria-activedescendant={activeOptionId}
+        aria-label={computedAriaLabel}
+        aria-labelledby={props['aria-labelledby']}
+        aria-describedby={props['aria-describedby']}
+        aria-required={props['aria-required']}
+        aria-invalid={props.invalid || undefined}
+        aria-readonly={props.readOnly || undefined}
+        aria-disabled={props.disabled || undefined}
+        value=""
+        onChange={() => undefined}
+        onClick={() => {
+          if (props.disabled || props.readOnly) return;
+          ctx.setOpen(!ctx.open);
+        }}
+        onKeyDown={handleKeyDown}
+      />
       {props.clearable && selectedOptions.length > 0 && <ClearButton variant="inline" />}
     </div>
   );

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -858,10 +858,6 @@ function ChipsButtonTrigger(props: TriggerProps) {
         aria-disabled={props.disabled || undefined}
         value=""
         onChange={() => undefined}
-        onClick={() => {
-          if (props.disabled || props.readOnly) return;
-          ctx.setOpen(!ctx.open);
-        }}
         onKeyDown={handleKeyDown}
       />
       {props.clearable && selectedOptions.length > 0 && <ClearButton variant="inline" />}

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -813,7 +813,7 @@ function ChipsButtonTrigger(props: TriggerProps) {
   const handleWrapperClick = () => {
     if (props.disabled || props.readOnly) return;
     ctx.triggerRef.current?.focus();
-    if (!ctx.open) ctx.setOpen(true);
+    ctx.setOpen(!ctx.open);
   };
 
   return (

--- a/packages/design-system/src/components/Select/Trigger.tsx
+++ b/packages/design-system/src/components/Select/Trigger.tsx
@@ -351,7 +351,7 @@ function ButtonTrigger(props: TriggerProps) {
   const computedAriaLabel = (() => {
     if (props['aria-label']) return props['aria-label'];
     if (ctx.multiple && label) return `Selected: ${label}`;
-    return undefined;
+    return label || props.placeholder || undefined;
   })();
 
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
@@ -420,6 +420,7 @@ function ButtonTrigger(props: TriggerProps) {
     <div className={styles.triggerWrap}>
       <button
         type="button"
+        role="combobox"
         id={ctx.triggerId}
         ref={ctx.triggerRef as Ref<HTMLButtonElement>}
         className={clsx(styles.trigger, styles.triggerButton, !hasValue && styles.placeholder)}
@@ -744,7 +745,7 @@ function ChipsInputTrigger(props: TriggerProps) {
 
 // ────────────────────────────────────────────────────────────────────────────
 // ChipsButtonTrigger — multi + chips + !searchable. Renders selected options
-// as removable inline chips inside a div with role="button". Cannot be a
+// as removable inline chips inside a div with role="combobox". Cannot be a
 // native <button> because chip ✕ buttons nest inside it (no <button> in
 // <button>). Outside-click detection still works because Listbox tests
 // `triggerRef.contains(target)` and the wrapper IS the triggerRef.
@@ -752,7 +753,7 @@ function ChipsInputTrigger(props: TriggerProps) {
 
 /**
  * Chips trigger for multi-select without inline search. Wrapper is a
- * keyboard-focusable `<div role="button">` (so the chips' own ✕ buttons
+ * keyboard-focusable `<div role="combobox">` (so the chips' own ✕ buttons
  * can nest). Chip resolution walks `ctx.allRows`, not `ctx.rows`, so the
  * chip list stays stable even if a future hover-search filters the
  * popover — unselected options never show as chips, but selected ones
@@ -815,7 +816,7 @@ function ChipsButtonTrigger(props: TriggerProps) {
     <div
       ref={ctx.triggerRef as Ref<HTMLDivElement>}
       id={ctx.triggerId}
-      role="button"
+      role="combobox"
       tabIndex={props.disabled ? -1 : 0}
       className={clsx(styles.trigger, styles.triggerChips)}
       aria-haspopup="listbox"
@@ -878,6 +879,6 @@ export function Trigger(props: TriggerProps) {
     return ctx.searchable ? <ChipsInputTrigger {...props} /> : <ChipsButtonTrigger {...props} />;
   }
   // Multi-summary (both searchable + non-searchable) renders as the
-  // comma-joined button trigger.
+  // comma-joined select-only combobox trigger.
   return <ButtonTrigger {...props} />;
 }

--- a/packages/design-system/src/components/Select/context.ts
+++ b/packages/design-system/src/components/Select/context.ts
@@ -59,6 +59,7 @@ export interface SelectContextValue<T = unknown> {
 
   // ─── refs ─────────────────────────────────────────────────────────────────
   triggerRef: RefObject<HTMLElement | null>;
+  triggerRootRef: RefObject<HTMLElement | null>;
   listboxRef: RefObject<HTMLDivElement | null>;
 
   // ─── imperative ───────────────────────────────────────────────────────────

--- a/packages/design-system/src/components/Select/context.ts
+++ b/packages/design-system/src/components/Select/context.ts
@@ -59,7 +59,7 @@ export interface SelectContextValue<T = unknown> {
 
   // ─── refs ─────────────────────────────────────────────────────────────────
   triggerRef: RefObject<HTMLElement | null>;
-  listboxRef: RefObject<HTMLUListElement | null>;
+  listboxRef: RefObject<HTMLDivElement | null>;
 
   // ─── imperative ───────────────────────────────────────────────────────────
   closeAndFocusTrigger: () => void;

--- a/packages/design-system/src/components/_internal/overlay/escapeYield.test.tsx
+++ b/packages/design-system/src/components/_internal/overlay/escapeYield.test.tsx
@@ -383,7 +383,7 @@ describe('Surface-in-surface Escape ordering (#280)', () => {
     );
     expect(screen.getByText('panel body')).toBeInTheDocument();
     // Open the Select nested inside the popover.
-    await user.click(screen.getByRole('button', { name: 'Pick' }));
+    await user.click(screen.getByRole('combobox', { name: 'Pick' }));
     expect(screen.getByRole('listbox')).toBeInTheDocument();
     // First Escape: only the INNERMOST surface (the Select) closes; the popover
     // survives. Before #280 both closed on this one press.

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -3916,7 +3916,7 @@
           "type": "boolean",
           "required": false,
           "default": "",
-          "description": "Marks the field as required. The trigger exposes `aria-required=\"true\"` to\nassistive technology, and an empty named selection blocks native form submit."
+          "description": "Marks the field as required. The trigger exposes `aria-required=\"true\"` to\nassistive technology. Hidden inputs still serialize named values, but they do\nnot participate in native constraint validation; validate the selection in\nyour form layer."
         },
         {
           "name": "form",

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -3916,7 +3916,7 @@
           "type": "boolean",
           "required": false,
           "default": "",
-          "description": "Marks the field as required for native form validation. When `true`, an empty\nselection blocks submit."
+          "description": "Marks the field as required. The trigger exposes `aria-required=\"true\"` to\nassistive technology, and an empty named selection blocks native form submit."
         },
         {
           "name": "form",


### PR DESCRIPTION
Addresses #419.

## Summary

- expose `aria-required` on every Select trigger variant when `required` is set
- route an explicit `aria-required` override to the semantic trigger instead of the roleless wrapper
- preserve hidden-input native form validation and update the generated prop manifest
- add regression coverage for all four trigger shapes

## Root cause

`Select` forwarded unknown ARIA attributes to its root `<div>`, while `required` was used only by hidden form inputs. The actual button/combobox trigger therefore never exposed the required state to assistive technology.

## Test plan

- `npm test --workspace @eocrm/design-system -- --run src/components/Select/Select.test.tsx`
- `make test`
- `make build-lib`
- `make lint`
- `npm run format:check`
- `npm run build`
- `npm pack --dry-run -w @eocrm/design-system`
