### PR TITLE
fix: suppress duplicate Rail current markers (#415)

### DIFF
--- a/packages/design-system/src/components/Rail/Rail.test.tsx
+++ b/packages/design-system/src/components/Rail/Rail.test.tsx
@@ -992,6 +992,39 @@ describe('Rail — linkable Group (#377)', () => {
     }
   });
 
+  it('does not duplicate current-page markers into the collapsed flyout', () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <Rail defaultCollapsed>
+          <Rail.Section title="Main">
+            <Rail.Group
+              as="a"
+              href="#/deals"
+              aria-current="page"
+              icon={<span aria-hidden />}
+              label="Deals"
+            >
+              <Rail.Item href="#/deals?view=open" aria-current="page">
+                My open USD
+              </Rail.Item>
+            </Rail.Group>
+          </Rail.Section>
+        </Rail>,
+      );
+
+      const trigger = screen.getByRole('link', { name: 'Deals' });
+      act(() => fireEvent.pointerEnter(trigger));
+      act(() => vi.advanceTimersByTime(100));
+
+      const flyout = screen.getByRole('dialog', { name: 'Deals' });
+      expect(trigger).toHaveAttribute('aria-current', 'page');
+      expect(flyout.querySelectorAll('[aria-current="page"]')).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('collapsed: no chevron, hover opens the flyout, and its header is a link', () => {
     vi.useFakeTimers();
     try {

--- a/packages/design-system/src/components/Rail/Rail.test.tsx
+++ b/packages/design-system/src/components/Rail/Rail.test.tsx
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { act, createRef, useState } from 'react';
+import { act, createRef, forwardRef, useState } from 'react';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { I18nProvider } from '../../i18n/I18nProvider';
@@ -1020,6 +1020,47 @@ describe('Rail — linkable Group (#377)', () => {
       const flyout = screen.getByRole('dialog', { name: 'Deals' });
       expect(trigger).toHaveAttribute('aria-current', 'page');
       expect(flyout.querySelectorAll('[aria-current="page"]')).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('neutralizes current-page markers synthesized by router-like flyout links', () => {
+    vi.useFakeTimers();
+    try {
+      const ActiveLink = forwardRef<HTMLAnchorElement, React.ComponentPropsWithoutRef<'a'>>(
+        function ActiveLink({ 'aria-current': ariaCurrent = 'page', ...props }, ref) {
+          return <a ref={ref} aria-current={ariaCurrent} {...props} />;
+        },
+      );
+
+      render(
+        <Rail defaultCollapsed>
+          <Rail.Section title="Main">
+            <Rail.Group as={ActiveLink} href="#/deals" icon={<span aria-hidden />} label="Deals">
+              <Rail.Item as={ActiveLink} href="#/deals?view=open">
+                My open USD
+              </Rail.Item>
+            </Rail.Group>
+          </Rail.Section>
+        </Rail>,
+      );
+
+      const trigger = screen.getByRole('link', { name: 'Deals' });
+      act(() => fireEvent.pointerEnter(trigger));
+      act(() => vi.advanceTimersByTime(100));
+
+      const flyout = screen.getByRole('dialog', { name: 'Deals' });
+      expect(trigger).toHaveAttribute('aria-current', 'page');
+      expect(flyout.querySelectorAll('[aria-current="page"]')).toHaveLength(0);
+      expect(within(flyout).getByRole('link', { name: 'Deals' })).toHaveAttribute(
+        'aria-current',
+        'false',
+      );
+      expect(within(flyout).getByRole('link', { name: 'My open USD' })).toHaveAttribute(
+        'aria-current',
+        'false',
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -26,7 +26,7 @@ import {
 import clsx from 'clsx';
 import { useTranslation } from '../../i18n';
 import { useRail } from './Rail';
-import { RailGroupContext } from './RailGroupContext';
+import { RailGroupContext, RailGroupDuplicateContext } from './RailGroupContext';
 import { type PolymorphicProps } from './RailItem';
 import { overlayStack, useFloatingSurface, useInOverlay } from '../_internal/overlay';
 import styles from './Rail.module.scss';
@@ -569,10 +569,12 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
   // The flyout header is a SECOND rendering of the same destination, not a
   // second instance of the consumer's element — so it carries the navigation
   // props but not the identifying ones. A duplicated `id` is invalid HTML, and
-  // a duplicated `data-testid` makes `getByTestId` throw on "found multiple"
-  // for any consumer who tagged their group and then collapsed the rail.
+  // a duplicated `data-testid` makes `getByTestId` throw on "found multiple",
+  // while duplicated `aria-current` would expose two current destinations.
   const headerLinkProps = Object.fromEntries(
-    Object.entries(rest).filter(([key]) => key !== 'id' && !key.startsWith('data-')),
+    Object.entries(rest).filter(
+      ([key]) => key !== 'id' && key !== 'aria-current' && !key.startsWith('data-'),
+    ),
   );
 
   const chevron = (
@@ -733,7 +735,11 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
                 label
               )}
             </div>
-            <div className={styles.flyoutBody}>{groupedChildren}</div>
+            <div className={styles.flyoutBody}>
+              <RailGroupDuplicateContext.Provider value>
+                {groupedChildren}
+              </RailGroupDuplicateContext.Provider>
+            </div>
           </div>,
           document.body,
         )}

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -728,7 +728,11 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
                 only other way there. */}
             <div className={styles.flyoutHeader}>
               {isLink ? (
-                <LinkComponent className={styles.flyoutHeaderLink} {...headerLinkProps}>
+                <LinkComponent
+                  className={styles.flyoutHeaderLink}
+                  {...headerLinkProps}
+                  aria-current={false}
+                >
                   {label}
                 </LinkComponent>
               ) : (

--- a/packages/design-system/src/components/Rail/RailGroupContext.ts
+++ b/packages/design-system/src/components/Rail/RailGroupContext.ts
@@ -3,3 +3,7 @@ import { createContext } from 'react';
 // React context follows component ancestry through the collapsed flyout portal,
 // so Rail.Item can distinguish group subitems without relying on DOM ancestry.
 export const RailGroupContext = createContext(false);
+
+// The collapsed flyout repeats the group's items for presentation. Descendants
+// use this signal to suppress state that must have only one exposed owner.
+export const RailGroupDuplicateContext = createContext(false);

--- a/packages/design-system/src/components/Rail/RailItem.tsx
+++ b/packages/design-system/src/components/Rail/RailItem.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react';
 import clsx from 'clsx';
 import { useRail } from './Rail';
-import { RailGroupContext } from './RailGroupContext';
+import { RailGroupContext, RailGroupDuplicateContext } from './RailGroupContext';
 import { Tooltip } from '../Tooltip';
 import styles from './Rail.module.scss';
 
@@ -107,6 +107,7 @@ export const RailItem = forwardRef(function RailItem<C extends ElementType = 'a'
   const Component = (as ?? 'a') as ElementType;
   const { collapsed } = useRail();
   const insideGroup = useContext(RailGroupContext);
+  const duplicatePresentation = useContext(RailGroupDuplicateContext);
 
   // The polymorphic anchor / NavLink / button receives the className so the
   // CSS `:has([aria-current="page"])` selector can light it up via the
@@ -115,8 +116,17 @@ export const RailItem = forwardRef(function RailItem<C extends ElementType = 'a'
     <Component
       ref={ref}
       className={clsx(styles.item, className)}
-      // {...rest} last so consumer overrides win (Pattern A).
+      // {...rest} last so consumer overrides win (Pattern A), except that the
+      // duplicate-presentation context owns aria-current below.
       {...rest}
+      // A collapsed group's flyout repeats the real rail-side item. `false`
+      // also overrides router components that synthesize `aria-current` from
+      // active route state, so the duplicate never claims to be current.
+      aria-current={
+        duplicatePresentation
+          ? false
+          : (rest as { 'aria-current'?: React.AriaAttributes['aria-current'] })['aria-current']
+      }
     >
       {icon && (
         <span className={styles.itemIcon} aria-hidden="true">


### PR DESCRIPTION
Addresses #415.

## Summary
- keep `aria-current="page"` on the collapsed rail-side owner
- remove the marker from the duplicated flyout header
- neutralize current state on duplicated flyout subitems, including router-generated markers
- add a regression test covering a current group and current subitem together

## Test plan
- `npm test`
- `npm run typecheck`
- `npm run lint:css`
- `npm run build`
- `npm run format:check`
- `npm pack --dry-run -w @eocrm/design-system`