### PR TITLE
fix: constrain Rail flyouts to viewport (#417)

### DIFF
--- a/packages/design-system/src/components/Rail/Rail.test.tsx
+++ b/packages/design-system/src/components/Rail/Rail.test.tsx
@@ -424,30 +424,84 @@ describe('Rail', () => {
   });
 
   it('caps a collapsed Group flyout to Floating UI available width', async () => {
+    const innerWidthDescriptor = Object.getOwnPropertyDescriptor(window, 'innerWidth');
+    const clientWidthDescriptor = Object.getOwnPropertyDescriptor(
+      document.documentElement,
+      'clientWidth',
+    );
+    const clientHeightDescriptor = Object.getOwnPropertyDescriptor(
+      document.documentElement,
+      'clientHeight',
+    );
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 420 });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      configurable: true,
+      value: 420,
+    });
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      configurable: true,
+      value: 800,
+    });
     vi.useFakeTimers();
     try {
       render(
         <Rail defaultCollapsed>
           <Rail.Section title="Main">
             <Rail.Group icon={<span aria-hidden />} label="Saved views">
-              <Rail.Item href="/long">A very long saved view name</Rail.Item>
+              <Rail.Item href="/long">{'V'.repeat(150)}</Rail.Item>
             </Rail.Group>
           </Rail.Section>
         </Rail>,
       );
 
-      act(() => fireEvent.pointerEnter(screen.getByRole('button', { name: 'Saved views' })));
+      const trigger = screen.getByRole('button', { name: 'Saved views' });
+      trigger.getBoundingClientRect = () =>
+        ({
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          right: 56,
+          bottom: 40,
+          width: 56,
+          height: 40,
+          toJSON: () => undefined,
+        }) as DOMRect;
+
+      act(() => fireEvent.pointerEnter(trigger));
       await act(async () => {
         vi.advanceTimersByTime(100);
         await Promise.resolve();
       });
 
-      // jsdom exposes a zero-width collision viewport. The exact value is less
-      // important than proving the real size middleware projects Floating UI's
-      // available width onto the panel (without it this style is empty).
-      expect(screen.getByRole('dialog', { name: 'Saved views' }).style.maxWidth).toBe('0px');
+      const flyout = screen.getByRole('dialog', { name: 'Saved views' });
+      expect(flyout.style.maxWidth).toBe('348px');
+      expect(flyout.style.minWidth).toBe('min(var(--rail-flyout-min-width), 348px)');
+
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 180 });
+      Object.defineProperty(document.documentElement, 'clientWidth', {
+        configurable: true,
+        value: 180,
+      });
+      await act(async () => {
+        window.dispatchEvent(new Event('resize'));
+        await Promise.resolve();
+      });
+      expect(flyout.style.maxWidth).toBe('108px');
+      expect(flyout.style.minWidth).toBe('min(var(--rail-flyout-min-width), 108px)');
     } finally {
       vi.useRealTimers();
+      if (innerWidthDescriptor) Object.defineProperty(window, 'innerWidth', innerWidthDescriptor);
+      if (clientWidthDescriptor) {
+        Object.defineProperty(document.documentElement, 'clientWidth', clientWidthDescriptor);
+      } else {
+        delete (document.documentElement as unknown as { clientWidth?: number }).clientWidth;
+      }
+      if (clientHeightDescriptor) {
+        Object.defineProperty(document.documentElement, 'clientHeight', clientHeightDescriptor);
+      } else {
+        delete (document.documentElement as unknown as { clientHeight?: number }).clientHeight;
+      }
     }
   });
 

--- a/packages/design-system/src/components/Rail/Rail.test.tsx
+++ b/packages/design-system/src/components/Rail/Rail.test.tsx
@@ -423,6 +423,34 @@ describe('Rail', () => {
     }
   });
 
+  it('caps a collapsed Group flyout to Floating UI available width', async () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <Rail defaultCollapsed>
+          <Rail.Section title="Main">
+            <Rail.Group icon={<span aria-hidden />} label="Saved views">
+              <Rail.Item href="/long">A very long saved view name</Rail.Item>
+            </Rail.Group>
+          </Rail.Section>
+        </Rail>,
+      );
+
+      act(() => fireEvent.pointerEnter(screen.getByRole('button', { name: 'Saved views' })));
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+        await Promise.resolve();
+      });
+
+      // jsdom exposes a zero-width collision viewport. The exact value is less
+      // important than proving the real size middleware projects Floating UI's
+      // available width onto the panel (without it this style is empty).
+      expect(screen.getByRole('dialog', { name: 'Saved views' }).style.maxWidth).toBe('0px');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not repeat a collapsed group subitem label in an automatic Tooltip', () => {
     vi.useFakeTimers();
     try {

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -320,7 +320,11 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
       shift({ padding: 8 }),
       size({
         apply({ availableWidth, elements }) {
-          elements.floating.style.maxWidth = `${Math.max(0, availableWidth)}px`;
+          const width = Math.max(0, availableWidth);
+          Object.assign(elements.floating.style, {
+            maxWidth: `${width}px`,
+            minWidth: `min(var(--rail-flyout-min-width), ${width}px)`,
+          });
         },
         padding: 8,
       }),

--- a/packages/design-system/src/components/Rail/RailGroup.tsx
+++ b/packages/design-system/src/components/Rail/RailGroup.tsx
@@ -20,6 +20,7 @@ import {
   flip,
   offset,
   shift,
+  size,
   useFloating,
   type Placement,
 } from '@floating-ui/react-dom';
@@ -313,7 +314,17 @@ export const RailGroup = forwardRef<HTMLDivElement, RailGroupImplProps>(function
     open: popoverOpen,
     placement,
     transform: false,
-    middleware: [offset(8), flip(), shift({ padding: 8 })],
+    middleware: [
+      offset(8),
+      flip(),
+      shift({ padding: 8 }),
+      size({
+        apply({ availableWidth, elements }) {
+          elements.floating.style.maxWidth = `${Math.max(0, availableWidth)}px`;
+        },
+        padding: 8,
+      }),
+    ],
     whileElementsMounted: autoUpdate,
     elements: { reference: triggerRef.current },
   });


### PR DESCRIPTION
Addresses #417.

## Summary
- add Floating UI size middleware to collapsed Rail.Group flyouts
- cap the panel to the collision-aware available width
- add a regression test proving the cap is projected onto the flyout

## Test plan
- `make test`
- `make build-lib`
- `make lint`
- `npm run format:check`
- `npm run build`
- package dry-run forbidden-path check