### PR TITLE
fix: constrain dropdown menus to viewport (#420)

### DIFF
--- a/packages/design-system/src/components/DropdownMenu/Content.tsx
+++ b/packages/design-system/src/components/DropdownMenu/Content.tsx
@@ -88,13 +88,16 @@ export const Content = forwardRef<HTMLDivElement, DropdownMenuContentProps>(func
       flip(),
       shift({ padding: 8 }),
       size({
-        apply({ availableHeight, rects, elements }) {
+        apply({ availableHeight, availableWidth, rects, elements }) {
+          const viewportWidth = Math.max(0, availableWidth);
+          const requestedMinWidth =
+            typeof minWidth === 'number'
+              ? `${minWidth}px`
+              : ((minWidth as string | undefined) ?? `${rects.reference.width}px`);
           Object.assign(elements.floating.style, {
             maxHeight: `${availableHeight}px`,
-            minWidth:
-              typeof minWidth === 'number'
-                ? `${minWidth}px`
-                : ((minWidth as string | undefined) ?? `${rects.reference.width}px`),
+            maxWidth: `${viewportWidth}px`,
+            minWidth: `min(${requestedMinWidth}, ${viewportWidth}px)`,
           });
         },
         padding: 8,

--- a/packages/design-system/src/components/DropdownMenu/Content.tsx
+++ b/packages/design-system/src/components/DropdownMenu/Content.tsx
@@ -55,7 +55,10 @@ export interface DropdownMenuContentProps extends HTMLAttributes<HTMLDivElement>
   align?: DropdownMenuAlign;
   /** Gap in px between trigger and menu. Default `4`. */
   sideOffset?: number;
-  /** Minimum width in px or any CSS length. Defaults to the trigger's width. */
+  /**
+   * Preferred minimum width in px or any CSS length. Defaults to the trigger's
+   * width and is reduced when necessary to keep the menu within the viewport.
+   */
   minWidth?: number | string;
 }
 

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
@@ -125,6 +125,7 @@
 
 .itemLabel {
   flex: 1 1 auto;
+  overflow-wrap: anywhere;
 }
 
 .shortcut {

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -237,6 +237,77 @@ describe('DropdownMenu — Content', () => {
     expect(scss).toMatch(/\.content\s*\{[^}]*overflow-y:\s*auto/);
     expect(scss).toMatch(/\.content\s*\{[^}]*overflow-x:\s*hidden/);
   });
+
+  it('caps the content panel to Floating UI available width', async () => {
+    const innerWidthDescriptor = Object.getOwnPropertyDescriptor(window, 'innerWidth');
+    const clientWidthDescriptor = Object.getOwnPropertyDescriptor(
+      document.documentElement,
+      'clientWidth',
+    );
+    const clientHeightDescriptor = Object.getOwnPropertyDescriptor(
+      document.documentElement,
+      'clientHeight',
+    );
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 400 });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      configurable: true,
+      value: 800,
+    });
+
+    try {
+      const user = userEvent.setup();
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger>
+            <button type="button">Open</button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content minWidth={500}>
+            <DropdownMenu.Item onSelect={() => {}}>{'V'.repeat(255)}</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>,
+      );
+      const trigger = screen.getByRole('button', { name: 'Open' });
+      trigger.getBoundingClientRect = () =>
+        ({
+          x: 8,
+          y: 8,
+          top: 8,
+          left: 8,
+          right: 64,
+          bottom: 48,
+          width: 56,
+          height: 40,
+          toJSON: () => undefined,
+        }) as DOMRect;
+
+      await user.click(trigger);
+      const menu = screen.getByRole('menu');
+      await waitFor(() => expect(menu.style.maxWidth).toBe('384px'));
+      expect(menu.style.minWidth).toBe('calc(384px)');
+    } finally {
+      if (innerWidthDescriptor) Object.defineProperty(window, 'innerWidth', innerWidthDescriptor);
+      if (clientWidthDescriptor) {
+        Object.defineProperty(document.documentElement, 'clientWidth', clientWidthDescriptor);
+      } else {
+        delete (document.documentElement as unknown as { clientWidth?: number }).clientWidth;
+      }
+      if (clientHeightDescriptor) {
+        Object.defineProperty(document.documentElement, 'clientHeight', clientHeightDescriptor);
+      } else {
+        delete (document.documentElement as unknown as { clientHeight?: number }).clientHeight;
+      }
+    }
+  });
+
+  it('allows unbroken item labels to wrap within a width-clamped panel', () => {
+    const scssPath = resolve(__dirname, 'DropdownMenu.module.scss');
+    const scss = readFileSync(scssPath, 'utf8');
+    expect(scss).toMatch(/\.itemLabel\s*\{[^}]*overflow-wrap:\s*anywhere/);
+  });
 });
 
 describe('DropdownMenu — Item / Separator', () => {


### PR DESCRIPTION
Addresses #420.

## Summary
- clamp DropdownMenu content width to Floating UI’s available viewport width
- clamp requested minimum widths so they cannot override the viewport bound
- allow unbroken item labels to wrap anywhere

## Test plan
- regression test at a 400px viewport with a 255-character unbroken label and a 500px requested minimum
- full monorepo test, build, lint, format, and package-content gates