### PR TITLE
fix: preserve Pagination focus on page changes (#426)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -3073,7 +3073,7 @@ const [page, setPage] = useState(1);
 
 - Controlled-only — consumer owns `currentPage`. No internal state.
 - Sibling windowing — `siblingCount` (default `1`) controls how many pages on each side of current. Boundary fixed at 1 (first + last always shown). Slot count stays constant once ellipses kick in (`siblingCount * 2 + 5`) — the row's width doesn't jump as the user clicks.
-- Current page is rendered as a disabled `<button>` with `aria-current="page"` (the W3C ARIA APG pattern for "current item, not actionable").
+- Current page stays focusable and carries `aria-current="page"`; activating it is a no-op. Keeping it enabled preserves keyboard focus when controlled `currentPage` updates after a page change.
 - Sizes: `'sm'` (24px) / `'md'` (32px, default) / `'lg'` (40px) — tracks the Button / Input scale so Pagination sits cleanly next to a `<Button>` in a Cluster.
 - Out-of-range `currentPage` / `pageCount` clamp at render time (defensive — same precedent as `<EmptyState>`'s `clampHeading`).
 - **Not bundled**: page-size selector, count caption ("Showing 11–20 of 240"). Compose those with `<Select>` and text — keeps Pagination focused on navigation. `<DataTable>` (coming) owns its own footer.

--- a/packages/design-system/src/components/Pagination/Pagination.module.scss
+++ b/packages/design-system/src/components/Pagination/Pagination.module.scss
@@ -56,9 +56,9 @@
   padding: 0 var(--pagination-nav-button-padding-x-md);
 }
 
-// Current-page button — accent palette. Override the `.button` defaults
-// AND `:disabled` (since current is rendered as disabled, but should look
-// "selected," not "unavailable").
+// Current-page button — accent palette. Override the `.button` defaults.
+// The `:disabled` override preserves the selected treatment when the whole
+// Pagination is disabled, rather than making the current page look unavailable.
 .current {
   background: var(--pagination-current-bg);
   border-color: var(--pagination-current-border-color);

--- a/packages/design-system/src/components/Pagination/Pagination.test.tsx
+++ b/packages/design-system/src/components/Pagination/Pagination.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createRef } from 'react';
+import { createRef, useState } from 'react';
 import { Pagination } from './Pagination';
 
 describe('Pagination', () => {
@@ -85,6 +85,23 @@ describe('Pagination', () => {
     render(<Pagination currentPage={1} pageCount={5} onPageChange={onPageChange} />);
     await user.click(screen.getByRole('button', { name: 'Go to page 3' }));
     expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
+  it('preserves focus when a controlled update makes the activated page current', async () => {
+    const user = userEvent.setup();
+
+    function ControlledPagination() {
+      const [page, setPage] = useState(1);
+      return <Pagination currentPage={page} pageCount={5} onPageChange={setPage} />;
+    }
+
+    render(<ControlledPagination />);
+    const pageTwo = screen.getByRole('button', { name: 'Go to page 2' });
+    await user.click(pageTwo);
+
+    expect(pageTwo).toHaveFocus();
+    expect(pageTwo).not.toBeDisabled();
+    expect(pageTwo).toHaveAttribute('aria-current', 'page');
   });
 
   it('clicking prev fires onPageChange(currentPage - 1)', async () => {

--- a/packages/design-system/src/components/Pagination/Pagination.test.tsx
+++ b/packages/design-system/src/components/Pagination/Pagination.test.tsx
@@ -50,11 +50,11 @@ describe('Pagination', () => {
     }
   });
 
-  it('marks the current page with aria-current="page" and disables it', () => {
+  it('marks the current page with aria-current="page" and keeps it enabled', () => {
     render(<Pagination currentPage={3} pageCount={5} onPageChange={() => {}} />);
     const current = screen.getByRole('button', { name: /Page 3, current page/ });
     expect(current).toHaveAttribute('aria-current', 'page');
-    expect(current).toBeDisabled();
+    expect(current).not.toBeDisabled();
   });
 
   it('disables prev on page 1', () => {
@@ -103,7 +103,7 @@ describe('Pagination', () => {
     expect(onPageChange).toHaveBeenCalledWith(4);
   });
 
-  it('clicking the (disabled) current page does not fire onPageChange', async () => {
+  it('clicking the current page does not fire onPageChange', async () => {
     const user = userEvent.setup();
     const onPageChange = vi.fn();
     render(<Pagination currentPage={3} pageCount={5} onPageChange={onPageChange} />);

--- a/packages/design-system/src/components/Pagination/Pagination.tsx
+++ b/packages/design-system/src/components/Pagination/Pagination.tsx
@@ -18,8 +18,9 @@ export interface PaginationProps extends Omit<HTMLAttributes<HTMLElement>, 'onCh
 
   /**
    * Total number of pages. Values `< 1` clamp to `1`. The component still
-   * renders when `pageCount === 1` (single disabled-current button + both
-   * prev/next disabled) so consumers don't have to conditionally hide it.
+   * renders when `pageCount === 1` (single enabled current-page button +
+   * both prev/next disabled) so consumers don't have to conditionally hide
+   * it. The `disabled` prop still disables all three controls.
    */
   pageCount: number;
 

--- a/packages/design-system/src/components/Pagination/Pagination.tsx
+++ b/packages/design-system/src/components/Pagination/Pagination.tsx
@@ -25,8 +25,7 @@ export interface PaginationProps extends Omit<HTMLAttributes<HTMLElement>, 'onCh
 
   /**
    * Called with the new 1-indexed page when the user clicks prev, next,
-   * or a page number. Not fired when the user clicks the current page
-   * (the button is `disabled`).
+   * or a page number. Not fired when the user clicks the current page.
    */
   onPageChange: (page: number) => void;
 
@@ -111,9 +110,9 @@ function clampSiblings(siblingCount: number): number {
  * @remarks A11y
  * - Wrapper is `<nav aria-label="Pagination">` (override via `aria-label`
  *   when multiple paginations sit on the same page).
- * - The current page is rendered as a disabled `<button>` with
- *   `aria-current="page"` — the W3C ARIA APG pattern for
- *   "current item, not actionable."
+ * - The current page stays focusable and is marked with
+ *   `aria-current="page"`. Activating it is a no-op, so changing pages
+ *   does not disable the focused control and discard keyboard focus.
  * - Prev/next chevron icons get `aria-hidden`; the buttons carry
  *   `aria-label="Previous page" / "Next page"` for screen readers.
  * - Ellipses are decorative `<span aria-hidden>` — not focusable.
@@ -172,10 +171,10 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(function Pagi
             key={item}
             type="button"
             className={clsx(styles.button, styles.pageButton, isCurrent && styles.current)}
-            onClick={() => onPageChange(item)}
-            // Current page is disabled — keeps the button-shaped slot in
-            // the layout AND prevents the no-op same-page click. ARIA APG.
-            disabled={disabled || isCurrent}
+            onClick={() => {
+              if (!isCurrent) onPageChange(item);
+            }}
+            disabled={disabled}
             aria-current={isCurrent ? 'page' : undefined}
             aria-label={
               isCurrent

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -3154,7 +3154,7 @@
           "type": "number",
           "required": true,
           "default": "",
-          "description": "Total number of pages. Values `< 1` clamp to `1`. The component still\nrenders when `pageCount === 1` (single disabled-current button + both\nprev/next disabled) so consumers don't have to conditionally hide it."
+          "description": "Total number of pages. Values `< 1` clamp to `1`. The component still\nrenders when `pageCount === 1` (single enabled current-page button +\nboth prev/next disabled) so consumers don't have to conditionally hide\nit. The `disabled` prop still disables all three controls."
         },
         {
           "name": "onPageChange",

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -3161,7 +3161,7 @@
           "type": "(page: number) => void",
           "required": true,
           "default": "",
-          "description": "Called with the new 1-indexed page when the user clicks prev, next,\nor a page number. Not fired when the user clicks the current page\n(the button is `disabled`)."
+          "description": "Called with the new 1-indexed page when the user clicks prev, next,\nor a page number. Not fired when the user clicks the current page."
         },
         {
           "name": "siblingCount",

--- a/packages/playground/src/pages/components/PaginationDemo.tsx
+++ b/packages/playground/src/pages/components/PaginationDemo.tsx
@@ -63,7 +63,7 @@ export function Demo() {
 
       <Example
         title="Single page"
-        description="Edge case — pageCount=1 still renders (single disabled-current button + both prev/next disabled). Consumer doesn't have to conditionally hide it."
+        description="Edge case — pageCount=1 still renders (single enabled current-page button + both prev/next disabled). Consumer doesn't have to conditionally hide it; the current button becomes disabled only when Pagination itself is disabled."
         code={`import { Pagination } from '@eocrm/design-system';
 
 export function Demo() {


### PR DESCRIPTION
Addresses #426.

## Summary
- keep the current-page button enabled and focusable while retaining aria-current=page
- make current-page activation a no-op without disabling the control
- update regression coverage, JSDoc, agent guidance, and generated playground prop docs

## Root cause
Pagination disabled whichever numbered button matched the controlled currentPage. After a keyboard user activated another page and the parent updated currentPage, the focused button became disabled, causing browsers to discard focus.

## Test plan
- Pagination regression suite
- full library suite: 198 files / 4,318 tests passed
- design-token suite: 77 passed, 1 environment-skipped
- typecheck, stylelint, playground build, package dry-run
- Husky pre-push checks