### PR TITLE
feat: add Skeleton delay and minimum duration (#427)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -2923,11 +2923,13 @@ rendering existing reaction counts (the consumer builds that display).
 <Skeleton width={120} />                                    // text line
 <Skeleton variant="circular" width={32} />                  // avatar
 <Skeleton variant="rectangular" width="100%" height={120} /> // image
+<Skeleton loading={isFetching} delay={200} minDuration={300} /> // no flash
 ```
 
 - Three variants: `text` (default, inline, `height=1em`), `circular` (avatar / icon, square when only one dim set), `rectangular` (image / card / button, block).
 - `width` / `height` flow to inline style — `number` becomes `px`, `string` passes through (`'60%'`, `'12rem'`).
 - `animation`: `'pulse'` (default, opacity cycle) / `'none'` (static).
+- Timed visibility: keep Skeleton mounted, drive `loading`, and use `delay` to suppress fast-load flashes plus `minDuration` to prevent a just-shown placeholder from vanishing immediately. All three preserve legacy behavior by default (`loading=true`, both durations `0`). Do not conditionally unmount a timed Skeleton — unmounting bypasses `minDuration`.
 - Pulse is **automatically suppressed** when the user has `prefers-reduced-motion: reduce`.
 - `aria-hidden='true'` by default — Skeleton is decorative. Communicate "loading" from a parent live region (e.g., `aria-busy='true'` on the section being filled).
 - Composes — for a list-row placeholder, render `<Skeleton variant='circular' />` + 2–3 text skeletons + a button-shaped rectangular in a Cluster.

--- a/packages/design-system/src/components/Skeleton/Skeleton.test.tsx
+++ b/packages/design-system/src/components/Skeleton/Skeleton.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { createRef } from 'react';
 import { Skeleton } from './Skeleton';
 
@@ -89,5 +89,59 @@ describe('Skeleton', () => {
     const el = container.firstChild as HTMLElement;
     expect(el.style.width).toBe('100px');
     expect(el.style.marginTop).toBe('4px');
+  });
+
+  it('renders nothing while loading=false', () => {
+    const { container } = render(<Skeleton loading={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('waits for delay before rendering', () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = render(<Skeleton delay={200} />);
+      expect(container).toBeEmptyDOMElement();
+
+      act(() => vi.advanceTimersByTime(199));
+      expect(container).toBeEmptyDOMElement();
+
+      act(() => vi.advanceTimersByTime(1));
+      expect(container.firstChild).toBeInstanceOf(HTMLSpanElement);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('never renders when loading finishes inside the delay window', () => {
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(<Skeleton loading delay={200} />);
+      act(() => vi.advanceTimersByTime(100));
+      rerender(<Skeleton loading={false} delay={200} />);
+      act(() => vi.advanceTimersByTime(200));
+
+      expect(container).toBeEmptyDOMElement();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stays rendered for minDuration after becoming visible', () => {
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(<Skeleton loading delay={100} minDuration={300} />);
+      act(() => vi.advanceTimersByTime(100));
+      expect(container.firstChild).toBeInstanceOf(HTMLSpanElement);
+
+      act(() => vi.advanceTimersByTime(50));
+      rerender(<Skeleton loading={false} delay={100} minDuration={300} />);
+      act(() => vi.advanceTimersByTime(249));
+      expect(container.firstChild).toBeInstanceOf(HTMLSpanElement);
+
+      act(() => vi.advanceTimersByTime(1));
+      expect(container).toBeEmptyDOMElement();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/design-system/src/components/Skeleton/Skeleton.test.tsx
+++ b/packages/design-system/src/components/Skeleton/Skeleton.test.tsx
@@ -144,4 +144,27 @@ describe('Skeleton', () => {
       vi.useRealTimers();
     }
   });
+
+  it('settles zero-duration loading transitions during rerender', () => {
+    const { container, rerender } = render(<Skeleton loading={false} />);
+
+    rerender(<Skeleton loading />);
+    expect(container.firstChild).toBeInstanceOf(HTMLSpanElement);
+
+    rerender(<Skeleton loading={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('measures a changed delay from the start of the current load', () => {
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(<Skeleton delay={1000} />);
+      act(() => vi.advanceTimersByTime(900));
+
+      rerender(<Skeleton delay={500} />);
+      expect(container.firstChild).toBeInstanceOf(HTMLSpanElement);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/design-system/src/components/Skeleton/Skeleton.tsx
+++ b/packages/design-system/src/components/Skeleton/Skeleton.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, type CSSProperties, type HTMLAttributes } from 'react';
+import {
+  forwardRef,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type HTMLAttributes,
+} from 'react';
 import clsx from 'clsx';
 import styles from './Skeleton.module.scss';
 
@@ -39,11 +46,73 @@ export interface SkeletonProps extends HTMLAttributes<HTMLSpanElement> {
    * `prefers-reduced-motion: reduce`.
    */
   animation?: SkeletonAnimation;
+
+  /**
+   * Whether the loading placeholder is needed. Defaults to `true`.
+   * Keep Skeleton mounted and drive this prop when using `minDuration`, so
+   * the component can finish its visibility window after loading completes.
+   */
+  loading?: boolean;
+
+  /**
+   * Milliseconds to wait before rendering the placeholder. Defaults to `0`.
+   * A load that finishes inside this window never displays the Skeleton.
+   */
+  delay?: number;
+
+  /**
+   * Minimum milliseconds to remain visible after the placeholder renders.
+   * Defaults to `0`. Prevents a Skeleton that appears just after `delay`
+   * from disappearing again within a frame or two.
+   */
+  minDuration?: number;
 }
 
 function toCssSize(value: number | string | undefined): string | undefined {
   if (value === undefined) return undefined;
   return typeof value === 'number' ? `${value}px` : value;
+}
+
+function normalizeDuration(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function useTimedVisibility(loading: boolean, delay: number, minDuration: number): boolean {
+  const normalizedDelay = normalizeDuration(delay);
+  const normalizedMinDuration = normalizeDuration(minDuration);
+  const [visible, setVisible] = useState(() => loading && normalizedDelay === 0);
+  const shownAt = useRef<number | null>(visible ? Date.now() : null);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    if (loading) {
+      if (!visible) {
+        const show = () => {
+          shownAt.current = Date.now();
+          setVisible(true);
+        };
+        if (normalizedDelay === 0) show();
+        else timer = setTimeout(show, normalizedDelay);
+      }
+    } else if (visible) {
+      const elapsed =
+        shownAt.current === null ? normalizedMinDuration : Date.now() - shownAt.current;
+      const remaining = Math.max(0, normalizedMinDuration - elapsed);
+      const hide = () => {
+        shownAt.current = null;
+        setVisible(false);
+      };
+      if (remaining === 0) hide();
+      else timer = setTimeout(hide, remaining);
+    }
+
+    return () => {
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, [loading, normalizedDelay, normalizedMinDuration, visible]);
+
+  return visible;
 }
 
 /**
@@ -66,14 +135,19 @@ function toCssSize(value: number | string | undefined): string | undefined {
  * </Cluster>
  *
  * @example
- * // Many rows — disable animation to avoid motion overload:
- * {Array.from({ length: 20 }).map((_, i) => (
- *   <Skeleton key={i} variant="rectangular" height={32} animation="none" />
- * ))}
+ * // Avoid flashes during quick refetches while guaranteeing a deliberate
+ * // visible window for slower loads. Keep the component mounted:
+ * <Skeleton
+ *   loading={isFetching}
+ *   delay={200}
+ *   minDuration={300}
+ *   variant="rectangular"
+ *   height={32}
+ * />
  *
  * @remarks When NOT to use
- * - When loading takes < 200ms — flashing a skeleton then content jitters
- *   the layout. Render the real content directly.
+ * - For loads expected to resolve quickly, do not show an immediate
+ *   placeholder. Use `delay` so fast loads never display the Skeleton.
  * - For empty states ("No contacts yet"). Use `<EmptyState>` (not yet
  *   shipped) — a skeleton implies "loading," not "nothing here."
  *
@@ -82,11 +156,27 @@ function toCssSize(value: number | string | undefined): string | undefined {
  *   primitive is a leaf — don't pass children.
  * - ❌ Omitting all dimensions on `rectangular`. With no `width`/`height`,
  *   the box has zero size and renders invisibly. Always size it.
+ * - ❌ Conditionally unmounting a timed Skeleton with
+ *   `{loading && <Skeleton minDuration={300} />}`. React removes it before
+ *   the minimum can finish. Keep it mounted and pass `loading={loading}`.
  */
 export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(function Skeleton(
-  { variant = 'text', width, height, animation = 'pulse', className, style, ...props },
+  {
+    variant = 'text',
+    width,
+    height,
+    animation = 'pulse',
+    loading = true,
+    delay = 0,
+    minDuration = 0,
+    className,
+    style,
+    ...props
+  },
   ref,
 ) {
+  const visible = useTimedVisibility(loading, delay, minDuration);
+
   // Default height: text → 1em (sits on baseline), circular → matches width
   // (square), rectangular → undefined (consumer must size).
   let resolvedHeight: string | undefined = toCssSize(height);
@@ -113,7 +203,7 @@ export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(function Skel
   // style live AFTER {...props} so the component's class composition +
   // dimension style win over any consumer-supplied raw className / style
   // (consumer composes via the prop, not by replacing).
-  return (
+  return visible ? (
     <span
       ref={ref}
       aria-hidden="true"
@@ -126,5 +216,5 @@ export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(function Skel
       )}
       style={mergedStyle}
     />
-  );
+  ) : null;
 });

--- a/packages/design-system/src/components/Skeleton/Skeleton.tsx
+++ b/packages/design-system/src/components/Skeleton/Skeleton.tsx
@@ -1,6 +1,6 @@
 import {
   forwardRef,
-  useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type CSSProperties,
@@ -81,19 +81,27 @@ function useTimedVisibility(loading: boolean, delay: number, minDuration: number
   const normalizedDelay = normalizeDuration(delay);
   const normalizedMinDuration = normalizeDuration(minDuration);
   const [visible, setVisible] = useState(() => loading && normalizedDelay === 0);
-  const shownAt = useRef<number | null>(visible ? Date.now() : null);
+  const now = Date.now();
+  const shownAt = useRef<number | null>(visible ? now : null);
+  const loadingStartedAt = useRef<number | null>(loading ? now : null);
+  const wasLoading = useRef(loading);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     let timer: ReturnType<typeof setTimeout> | undefined;
 
     if (loading) {
+      if (!wasLoading.current || loadingStartedAt.current === null) {
+        loadingStartedAt.current = Date.now();
+      }
       if (!visible) {
         const show = () => {
           shownAt.current = Date.now();
           setVisible(true);
         };
-        if (normalizedDelay === 0) show();
-        else timer = setTimeout(show, normalizedDelay);
+        const elapsed = Date.now() - loadingStartedAt.current;
+        const remaining = Math.max(0, normalizedDelay - elapsed);
+        if (remaining === 0) show();
+        else timer = setTimeout(show, remaining);
       }
     } else if (visible) {
       const elapsed =
@@ -105,7 +113,11 @@ function useTimedVisibility(loading: boolean, delay: number, minDuration: number
       };
       if (remaining === 0) hide();
       else timer = setTimeout(hide, remaining);
+    } else {
+      loadingStartedAt.current = null;
     }
+
+    wasLoading.current = loading;
 
     return () => {
       if (timer !== undefined) clearTimeout(timer);

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -4019,6 +4019,27 @@
           "required": false,
           "default": "",
           "description": "Animation. Defaults to `'pulse'`.\n- `'pulse'` — opacity 1 → 0.6 → 1, 1.5s ease-in-out infinite.\n- `'none'` — static. Use when stacking many skeletons to avoid motion\n  overload.\n\nRegardless of this prop, animation is suppressed when the user has\n`prefers-reduced-motion: reduce`."
+        },
+        {
+          "name": "loading",
+          "type": "boolean",
+          "required": false,
+          "default": "",
+          "description": "Whether the loading placeholder is needed. Defaults to `true`.\nKeep Skeleton mounted and drive this prop when using `minDuration`, so\nthe component can finish its visibility window after loading completes."
+        },
+        {
+          "name": "delay",
+          "type": "number",
+          "required": false,
+          "default": "",
+          "description": "Milliseconds to wait before rendering the placeholder. Defaults to `0`.\nA load that finishes inside this window never displays the Skeleton."
+        },
+        {
+          "name": "minDuration",
+          "type": "number",
+          "required": false,
+          "default": "",
+          "description": "Minimum milliseconds to remain visible after the placeholder renders.\nDefaults to `0`. Prevents a Skeleton that appears just after `delay`\nfrom disappearing again within a frame or two."
         }
       ]
     },

--- a/packages/playground/src/pages/components/SkeletonDemo.tsx
+++ b/packages/playground/src/pages/components/SkeletonDemo.tsx
@@ -1,7 +1,35 @@
-import { Card, Cluster, Skeleton, Stack, Table } from '@eocrm/design-system';
+import { useEffect, useRef, useState } from 'react';
+import { Button, Card, Cluster, Skeleton, Stack, Table } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
+
+function TimedVisibilityExample() {
+  const [loading, setLoading] = useState(false);
+  const timerRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => () => window.clearTimeout(timerRef.current), []);
+
+  const simulateLoad = (duration: number) => {
+    window.clearTimeout(timerRef.current);
+    setLoading(true);
+    timerRef.current = window.setTimeout(() => setLoading(false), duration);
+  };
+
+  return (
+    <Stack gap="md">
+      <Cluster gap="sm">
+        <Button size="sm" onClick={() => simulateLoad(100)} disabled={loading}>
+          Fast load (100ms)
+        </Button>
+        <Button size="sm" onClick={() => simulateLoad(900)} disabled={loading}>
+          Slow load (900ms)
+        </Button>
+      </Cluster>
+      <Skeleton loading={loading} delay={200} minDuration={300} width={200} />
+    </Stack>
+  );
+}
 
 export function SkeletonDemo() {
   return (
@@ -49,6 +77,36 @@ export function Demo() {
           <Skeleton width="60%" />
           <Skeleton width="40%" />
         </Stack>
+      </Example>
+
+      <Example
+        title="Delayed appearance and minimum duration"
+        description="Keep Skeleton mounted and drive loading. The 100ms load finishes inside delay, so nothing flashes; the 900ms load shows after 200ms and remains visible for at least 300ms."
+        code={`import { useState } from 'react';
+import { Button, Skeleton, Stack } from '@eocrm/design-system';
+
+export function Demo() {
+  const [loading, setLoading] = useState(false);
+
+  const simulateLoad = (duration) => {
+    setLoading(true);
+    window.setTimeout(() => setLoading(false), duration);
+  };
+
+  return (
+    <Stack gap="md">
+      <Button onClick={() => simulateLoad(900)}>Simulate load</Button>
+      <Skeleton
+        loading={loading}
+        delay={200}
+        minDuration={300}
+        width={200}
+      />
+    </Stack>
+  );
+}`}
+      >
+        <TimedVisibilityExample />
       </Example>
 
       <Example


### PR DESCRIPTION
Addresses #427.

## Summary
- add controlled `loading`, `delay`, and `minDuration` behavior to Skeleton
- prevent flashes for fast loads while preserving a minimum visible interval
- document the mounted-state requirement and add an interactive playground example

## Test plan
- Skeleton unit tests cover delayed display, fast completion, and minimum duration
- full repository tests and typecheck
- CSS lint, playground build, and package dry run