### PR TITLE
fix: preserve DataTable focus during refetches (#428)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -3029,6 +3029,11 @@ backgrounds → `background-image`; icons → lucide / inline SVG.
 
 ### `<DataTable>` — server-driven data table with column features
 
+- `loading` is non-destructive for populated tables: existing rows stay mounted
+  during refetches so focused controls and row-local state survive. Skeleton
+  rows are for the initial empty load only; the table exposes `aria-busy` in
+  both cases.
+
 ```tsx
 const instance = useDataTable<Deal>({
   data,

--- a/packages/design-system/src/components/DataTable/DataTable.test.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.test.tsx
@@ -92,6 +92,28 @@ describe('<DataTable>', () => {
     expect(bodyRows.length).toBe(3);
   });
 
+  it('keeps populated rows and their focused controls mounted during a refetch', () => {
+    function RefetchHarness({ loading }: { loading: boolean }) {
+      const instance = useDataTable<Row>({
+        data: rows,
+        columns: cols,
+        getRowId,
+        enableRowSelection: true,
+      });
+      return <DataTable instance={instance} aria-label="t" loading={loading} />;
+    }
+
+    const { rerender } = render(<RefetchHarness loading={false} />);
+    const checkbox = screen.getAllByRole('checkbox', { name: /select row/i })[0]!;
+    checkbox.focus();
+
+    rerender(<RefetchHarness loading />);
+
+    expect(checkbox).toHaveFocus();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByRole('table')).toHaveAttribute('aria-busy', 'true');
+  });
+
   it('renders selection auto-column when enableRowSelection is true', () => {
     render(<Harness enableRowSelection />);
     const headerRow = screen.getAllByRole('row')[0]!;

--- a/packages/design-system/src/components/DataTable/DataTable.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.tsx
@@ -52,6 +52,11 @@ export interface DataTableProps<T> {
   /** Hover highlight on body rows. Defaults TRUE (DataTable rows are usually interactive). */
   hover?: boolean;
   bordered?: boolean;
+  /**
+   * Marks the table busy. Empty tables show skeleton rows; populated tables
+   * keep their rows mounted during a refetch so focus and local row state are
+   * preserved. Defaults to `false`.
+   */
   loading?: boolean;
   /** Number of skeleton rows when `loading`. Defaults 10. */
   loadingRowCount?: number;
@@ -412,6 +417,8 @@ function DataTableInner<T>(
     (instance.enableRowSelection ? 1 : 0) +
     (instance.hasExpansion ? 1 : 0);
   const dataIsEmpty = !loading && instance.data.length === 0 && instance.pinnedRows.length === 0;
+  const hasRenderedRows = instance.data.length > 0 || instance.pinnedRows.length > 0;
+  const showSkeletonRows = loading && !hasRenderedRows;
 
   const [dragActive, setDragActive] = useState(false);
 
@@ -525,6 +532,7 @@ function DataTableInner<T>(
           density={density}
           striped={striped}
           bordered={bordered}
+          aria-busy={loading || undefined}
           aria-rowcount={instance.rowCount}
           className={clsx(styles.root, className)}
           {...rest}
@@ -597,7 +605,7 @@ function DataTableInner<T>(
           )}
 
           <Table.Body>
-            {loading ? (
+            {showSkeletonRows ? (
               <SkeletonRows count={loadingRowCount} totalColCount={totalColCount} />
             ) : dataIsEmpty ? (
               <EmptyRow totalColCount={totalColCount} content={emptyState} />

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -1081,7 +1081,7 @@
           "type": "boolean",
           "required": false,
           "default": "",
-          "description": ""
+          "description": "Marks the table busy. Empty tables show skeleton rows; populated tables\nkeep their rows mounted during a refetch so focus and local row state are\npreserved. Defaults to `false`."
         },
         {
           "name": "loadingRowCount",

--- a/packages/playground/src/pages/components/DataTableDemo.tsx
+++ b/packages/playground/src/pages/components/DataTableDemo.tsx
@@ -635,7 +635,7 @@ function LoadingExample() {
   return (
     <Example
       title="Loading"
-      description="Pass `loading` to render skeleton rows. `loadingRowCount` controls how many (default 10)."
+      description="Pass `loading` to mark the table busy. Empty tables render skeleton rows (`loadingRowCount` defaults to 10); populated tables keep their rows mounted during refetches so keyboard focus is preserved."
       code={`import { Badge, DataTable, useDataTable, type ColumnDef } from '@eocrm/design-system';
 
 type Deal = {


### PR DESCRIPTION
Addresses #428.

## Summary
- keep populated DataTable rows mounted while `loading` is true
- expose the loading state with `aria-busy`
- retain skeleton rows for empty initial loads and document the distinction

## Test plan
- regression test focuses a row checkbox and verifies focus survives a loading rerender
- full repository tests and typecheck
- CSS lint, playground build, and package dry run