### PR TITLE
feat: add a Constrain height axis (#429)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3013,9 +3013,9 @@
       "link": true
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4810,6 +4810,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "jsdom": "^29.1.1",
+        "postcss": "^8.5.25",
         "sass-embedded": "^1.100.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.7"

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1432,10 +1432,12 @@ Use this instead of `Card.List` + `Card.ListRow` whenever the data is genuinely 
 - `align`: `start` / `center` (default) / `end` / `baseline`
 - `wrap`: `true` (default). Set `false` only for narrow table cells where overflow is preferable to wrapping.
 
-### `<Constrain>` — width / flex constraint
+### `<Constrain>` — size / flex constraint
 
 ```tsx
 <Constrain maxWidth="sm"><Input placeholder="Search…" /></Constrain>
+
+<Constrain height="lg" maxHeight="viewport"><FlowCanvas /></Constrain>
 
 <Cluster wrap={false} gap="sm">
   <Constrain flex="grow"><Progress value={x} max={y} /></Constrain>
@@ -1443,8 +1445,9 @@ Use this instead of `Card.List` + `Card.ListRow` whenever the data is genuinely 
 </Cluster>
 ```
 
-- The one place width/flex sizing lives — `Stack`/`Cluster`/`Grid` are spacing-only (Rule 4). Constrain sizes its **own** box; it does not arrange children (put a `Cluster`/`Stack` inside).
+- The one place width/height/flex sizing lives — `Stack`/`Cluster`/`Grid` are spacing-only (Rule 4). Constrain sizes its **own** box; it does not arrange children (put a `Cluster`/`Stack` inside).
 - `width` / `minWidth` / `maxWidth`: a named scale `'xs'` (200) / `'sm'` (320) / `'md'` (448) / `'lg'` (640) / `'xl'` (800) / `'full'` (100%), via `--measure-*` tokens.
+- `height` / `minHeight` / `maxHeight`: the same named scale plus `'viewport'` (100dvh). Combine a fixed `height` with `maxHeight="viewport"` to keep a fill-parent child comfortably sized without exceeding the dynamic viewport.
 - `flex`: `'grow'` (fill remaining space) / `'auto'` / `'shrink'` (no grow, may shrink — the CSS flex default) / `'none'` (fixed). Omitting `flex` applies no class; the element behaves as its flex container dictates. Use `flex="grow"` to let a child fill a `Cluster` row.
 - No padding/border/background — for those use `<Card>`; for a full-bleed shell use `<Screen>`.
 

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -130,7 +130,7 @@ Grouped for navigation. Every prop and variant is JSDoc'd at the source — hove
 - `Cluster` — horizontal layout that wraps
 - `Grid` — 2D layout primitive
 - `Masonry` — height-balanced masonry layout
-- `Constrain` — width / flex constraint
+- `Constrain` — width / height / flex constraint
 - `Divider` — separator primitive
 - `Page` — page-root layout primitive
 - `Screen` — full-bleed / centered screen layout

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -46,10 +46,10 @@
     "react-dom": "^19.0.0"
   },
   "dependencies": {
-    "@eocrm/design-tokens": "0.0.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@eocrm/design-tokens": "0.0.0",
     "@floating-ui/react-dom": "^2.1.8",
     "clsx": "^2.1.1",
     "libphonenumber-js": "^1.13.7"
@@ -61,6 +61,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "jsdom": "^29.1.1",
+    "postcss": "^8.5.25",
     "sass-embedded": "^1.100.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"

--- a/packages/design-system/src/components/Constrain/Constrain.module.scss
+++ b/packages/design-system/src/components/Constrain/Constrain.module.scss
@@ -48,14 +48,17 @@
 }
 
 .h-viewport {
+  height: 100vh;
   height: 100dvh;
 }
 
 .minH-viewport {
+  min-height: 100vh;
   min-height: 100dvh;
 }
 
 .maxH-viewport {
+  max-height: 100vh;
   max-height: 100dvh;
 }
 

--- a/packages/design-system/src/components/Constrain/Constrain.module.scss
+++ b/packages/design-system/src/components/Constrain/Constrain.module.scss
@@ -12,6 +12,15 @@
   .maxW-#{$name} {
     max-width: var(--measure-#{$name});
   }
+  .h-#{$name} {
+    height: var(--measure-#{$name});
+  }
+  .minH-#{$name} {
+    min-height: var(--measure-#{$name});
+  }
+  .maxH-#{$name} {
+    max-height: var(--measure-#{$name});
+  }
 }
 
 .w-full {
@@ -24,6 +33,30 @@
 
 .maxW-full {
   max-width: 100%;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.minH-full {
+  min-height: 100%;
+}
+
+.maxH-full {
+  max-height: 100%;
+}
+
+.h-viewport {
+  height: 100dvh;
+}
+
+.minH-viewport {
+  min-height: 100dvh;
+}
+
+.maxH-viewport {
+  max-height: 100dvh;
 }
 
 .flex-grow {

--- a/packages/design-system/src/components/Constrain/Constrain.test.tsx
+++ b/packages/design-system/src/components/Constrain/Constrain.test.tsx
@@ -1,25 +1,22 @@
 import { render } from '@testing-library/react';
-import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createRef } from 'react';
+import { compile } from 'sass';
 import { Constrain } from './Constrain';
 import type { ConstrainHeight, ConstrainWidth } from './Constrain';
 
 describe('Constrain', () => {
   it('falls back to static viewport units before dynamic viewport units', () => {
-    const scss = readFileSync(resolve(__dirname, 'Constrain.module.scss'), 'utf8');
+    const css = compile(resolve(__dirname, 'Constrain.module.scss')).css;
 
     for (const [selector, property] of [
       ['h-viewport', 'height'],
       ['minH-viewport', 'min-height'],
       ['maxH-viewport', 'max-height'],
     ] as const) {
-      expect(scss).toMatch(
-        new RegExp(
-          `^\\.${selector} \\{\\n  ${property}: 100vh;\\n  ${property}: 100dvh;\\n\\}$`,
-          'm',
-        ),
-      );
+      const rules = [...css.matchAll(new RegExp(`^\\.${selector} \\{([^}]*)\\}`, 'gm'))];
+      expect(rules).toHaveLength(1);
+      expect(rules[0]?.[1]?.trim()).toBe(`${property}: 100vh;\n  ${property}: 100dvh;`);
     }
   });
 

--- a/packages/design-system/src/components/Constrain/Constrain.test.tsx
+++ b/packages/design-system/src/components/Constrain/Constrain.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import { resolve } from 'node:path';
 import { createRef } from 'react';
+import { parse, type Rule } from 'postcss';
 import { compile } from 'sass';
 import { Constrain } from './Constrain';
 import type { ConstrainHeight, ConstrainWidth } from './Constrain';
@@ -8,15 +9,30 @@ import type { ConstrainHeight, ConstrainWidth } from './Constrain';
 describe('Constrain', () => {
   it('falls back to static viewport units before dynamic viewport units', () => {
     const css = compile(resolve(__dirname, 'Constrain.module.scss')).css;
+    const root = parse(css);
 
     for (const [selector, property] of [
       ['h-viewport', 'height'],
       ['minH-viewport', 'min-height'],
       ['maxH-viewport', 'max-height'],
     ] as const) {
-      const rules = [...css.matchAll(new RegExp(`^\\.${selector} \\{([^}]*)\\}`, 'gm'))];
+      const className = new RegExp(`(?:^|[^\\w-])\\.${selector}(?![\\w-])`);
+      const rules: Rule[] = [];
+      root.walkRules((rule) => {
+        if (rule.selectors.some((candidate) => className.test(candidate))) rules.push(rule);
+      });
+
       expect(rules).toHaveLength(1);
-      expect(rules[0]?.[1]?.trim()).toBe(`${property}: 100vh;\n  ${property}: 100dvh;`);
+      expect(rules[0]?.selector).toBe(`.${selector}`);
+      expect(rules[0]?.nodes).toHaveLength(2);
+      expect(
+        rules[0]?.nodes.map((node) =>
+          node.type === 'decl' ? [node.prop, node.value] : [node.type],
+        ),
+      ).toEqual([
+        [property, '100vh'],
+        [property, '100dvh'],
+      ]);
     }
   });
 

--- a/packages/design-system/src/components/Constrain/Constrain.test.tsx
+++ b/packages/design-system/src/components/Constrain/Constrain.test.tsx
@@ -1,9 +1,22 @@
 import { render } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { createRef } from 'react';
 import { Constrain } from './Constrain';
 import type { ConstrainHeight, ConstrainWidth } from './Constrain';
 
 describe('Constrain', () => {
+  it('falls back to static viewport units before dynamic viewport units', () => {
+    const scss = readFileSync(resolve(__dirname, 'Constrain.module.scss'), 'utf8');
+
+    for (const property of ['height', 'min-height', 'max-height']) {
+      expect(scss.indexOf(`${property}: 100vh;`)).toBeGreaterThan(-1);
+      expect(scss.indexOf(`${property}: 100dvh;`)).toBeGreaterThan(
+        scss.indexOf(`${property}: 100vh;`),
+      );
+    }
+  });
+
   it('renders children in a <div> and forwards ref', () => {
     const ref = createRef<HTMLDivElement>();
     const { container } = render(

--- a/packages/design-system/src/components/Constrain/Constrain.test.tsx
+++ b/packages/design-system/src/components/Constrain/Constrain.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { createRef } from 'react';
 import { Constrain } from './Constrain';
-import type { ConstrainWidth } from './Constrain';
+import type { ConstrainHeight, ConstrainWidth } from './Constrain';
 
 describe('Constrain', () => {
   it('renders children in a <div> and forwards ref', () => {
@@ -26,6 +26,30 @@ describe('Constrain', () => {
     (w) => {
       const { container } = render(<Constrain width={w}>x</Constrain>);
       expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(`w-${w}`));
+    },
+  );
+
+  it.each<ConstrainHeight>(['xs', 'sm', 'md', 'lg', 'xl', 'full', 'viewport'])(
+    'height="%s" applies the h- class',
+    (height) => {
+      const { container } = render(<Constrain height={height}>x</Constrain>);
+      expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(`h-${height}`));
+    },
+  );
+
+  it.each<ConstrainHeight>(['xs', 'sm', 'md', 'lg', 'xl', 'full', 'viewport'])(
+    'minHeight="%s" applies the minH- class',
+    (height) => {
+      const { container } = render(<Constrain minHeight={height}>x</Constrain>);
+      expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(`minH-${height}`));
+    },
+  );
+
+  it.each<ConstrainHeight>(['xs', 'sm', 'md', 'lg', 'xl', 'full', 'viewport'])(
+    'maxHeight="%s" applies the maxH- class',
+    (height) => {
+      const { container } = render(<Constrain maxHeight={height}>x</Constrain>);
+      expect((container.firstChild as HTMLElement).className).toMatch(new RegExp(`maxH-${height}`));
     },
   );
 

--- a/packages/design-system/src/components/Constrain/Constrain.test.tsx
+++ b/packages/design-system/src/components/Constrain/Constrain.test.tsx
@@ -14,8 +14,12 @@ describe('Constrain', () => {
       ['minH-viewport', 'min-height'],
       ['maxH-viewport', 'max-height'],
     ] as const) {
-      const block = scss.match(new RegExp(`\\.${selector} \\{([^}]*)\\}`))?.[1];
-      expect(block).toContain(`${property}: 100vh;\n  ${property}: 100dvh;`);
+      expect(scss).toMatch(
+        new RegExp(
+          `^\\.${selector} \\{\\n  ${property}: 100vh;\\n  ${property}: 100dvh;\\n\\}$`,
+          'm',
+        ),
+      );
     }
   });
 

--- a/packages/design-system/src/components/Constrain/Constrain.test.tsx
+++ b/packages/design-system/src/components/Constrain/Constrain.test.tsx
@@ -24,14 +24,15 @@ describe('Constrain', () => {
 
       expect(rules).toHaveLength(1);
       expect(rules[0]?.selector).toBe(`.${selector}`);
+      expect(rules[0]?.parent?.type).toBe('root');
       expect(rules[0]?.nodes).toHaveLength(2);
       expect(
         rules[0]?.nodes.map((node) =>
-          node.type === 'decl' ? [node.prop, node.value] : [node.type],
+          node.type === 'decl' ? [node.prop, node.value, node.important] : [node.type],
         ),
       ).toEqual([
-        [property, '100vh'],
-        [property, '100dvh'],
+        [property, '100vh', undefined],
+        [property, '100dvh', undefined],
       ]);
     }
   });

--- a/packages/design-system/src/components/Constrain/Constrain.test.tsx
+++ b/packages/design-system/src/components/Constrain/Constrain.test.tsx
@@ -9,11 +9,13 @@ describe('Constrain', () => {
   it('falls back to static viewport units before dynamic viewport units', () => {
     const scss = readFileSync(resolve(__dirname, 'Constrain.module.scss'), 'utf8');
 
-    for (const property of ['height', 'min-height', 'max-height']) {
-      expect(scss.indexOf(`${property}: 100vh;`)).toBeGreaterThan(-1);
-      expect(scss.indexOf(`${property}: 100dvh;`)).toBeGreaterThan(
-        scss.indexOf(`${property}: 100vh;`),
-      );
+    for (const [selector, property] of [
+      ['h-viewport', 'height'],
+      ['minH-viewport', 'min-height'],
+      ['maxH-viewport', 'max-height'],
+    ] as const) {
+      const block = scss.match(new RegExp(`\\.${selector} \\{([^}]*)\\}`))?.[1];
+      expect(block).toContain(`${property}: 100vh;\n  ${property}: 100dvh;`);
     }
   });
 

--- a/packages/design-system/src/components/Constrain/Constrain.tsx
+++ b/packages/design-system/src/components/Constrain/Constrain.tsx
@@ -5,6 +5,9 @@ import styles from './Constrain.module.scss';
 /** Named width step → a `--measure-*` token; `'full'` = 100%. */
 export type ConstrainWidth = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
 
+/** Named height step → a `--measure-*` token; relative steps fill their containing block or viewport. */
+export type ConstrainHeight = ConstrainWidth | 'viewport';
+
 /** How the box behaves as a flex child (`Cluster`/`Stack` item). */
 export type ConstrainFlex = 'grow' | 'shrink' | 'auto' | 'none';
 
@@ -15,6 +18,12 @@ export interface ConstrainProps extends HTMLAttributes<HTMLDivElement> {
   minWidth?: ConstrainWidth;
   /** Maximum width cap — the common case (e.g. a search input at `'sm'`). */
   maxWidth?: ConstrainWidth;
+  /** Fixed height — a named measure, `'full'` (100%), or `'viewport'` (100dvh). */
+  height?: ConstrainHeight;
+  /** Minimum height floor — a named measure, `'full'`, or `'viewport'`. */
+  minHeight?: ConstrainHeight;
+  /** Maximum height cap — a named measure, `'full'`, or `'viewport'`. */
+  maxHeight?: ConstrainHeight;
   /**
    * Flex behavior as a child of a flex row/column.
    * - `'grow'` — fill remaining space (`flex: 1 1 0`) and shrink below content
@@ -29,7 +38,7 @@ export interface ConstrainProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * Width / flex constraint primitive. The one place layout-sizing props live —
+ * Size / flex constraint primitive. The one place layout-sizing props live —
  * `Stack`/`Cluster`/`Grid` are spacing-only by design, so when you need to cap a
  * search input's width, floor a column, or let a box fill a flex row, wrap it in
  * `<Constrain>`.
@@ -50,6 +59,12 @@ export interface ConstrainProps extends HTMLAttributes<HTMLDivElement> {
  *   <Button>Upgrade plan</Button>
  * </Cluster>
  *
+ * @example
+ * // Bound a fill-parent canvas without consumer CSS:
+ * <Constrain height="lg" maxHeight="viewport">
+ *   <FlowCanvas nodes={nodes} edges={edges} />
+ * </Constrain>
+ *
  * @remarks When NOT to use
  * - Spacing / arranging children → `<Stack>` / `<Cluster>` / `<Grid>`. Constrain
  *   sizes its own box; it doesn't arrange what's inside.
@@ -57,13 +72,13 @@ export interface ConstrainProps extends HTMLAttributes<HTMLDivElement> {
  * - A full-bleed page shell → `<Screen>`.
  *
  * @remarks Anti-patterns
- * - ❌ Reaching for Constrain to add `margin`/`padding` — it carries width/flex
+ * - ❌ Reaching for Constrain to add `margin`/`padding` — it carries size/flex
  *   only. Spacing comes from the parent layout primitive.
  */
 // `children` is destructured out of `rest` and rendered once below (Stack/Cluster
 // pass children via {...props} instead — both are correct; this is explicit).
 export const Constrain = forwardRef<HTMLDivElement, ConstrainProps>(function Constrain(
-  { width, minWidth, maxWidth, flex, className, children, ...rest },
+  { width, minWidth, maxWidth, height, minHeight, maxHeight, flex, className, children, ...rest },
   ref,
 ) {
   // {...rest} last so consumer overrides win (Pattern A) — Constrain locks no attrs.
@@ -74,6 +89,9 @@ export const Constrain = forwardRef<HTMLDivElement, ConstrainProps>(function Con
         width && styles[`w-${width}`],
         minWidth && styles[`minW-${minWidth}`],
         maxWidth && styles[`maxW-${maxWidth}`],
+        height && styles[`h-${height}`],
+        minHeight && styles[`minH-${minHeight}`],
+        maxHeight && styles[`maxH-${maxHeight}`],
         flex && styles[`flex-${flex}`],
         className,
       )}

--- a/packages/design-system/src/components/Constrain/Constrain.tsx
+++ b/packages/design-system/src/components/Constrain/Constrain.tsx
@@ -5,7 +5,7 @@ import styles from './Constrain.module.scss';
 /** Named width step → a `--measure-*` token; `'full'` = 100%. */
 export type ConstrainWidth = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
 
-/** Named height step → a `--measure-*` token; relative steps fill their containing block or viewport. */
+/** Fixed named measure, `'full'` (containing block), or `'viewport'` (dynamic viewport). */
 export type ConstrainHeight = ConstrainWidth | 'viewport';
 
 /** How the box behaves as a flex child (`Cluster`/`Stack` item). */

--- a/packages/design-system/src/components/Constrain/index.ts
+++ b/packages/design-system/src/components/Constrain/index.ts
@@ -1,2 +1,2 @@
 export { Constrain } from './Constrain';
-export type { ConstrainProps, ConstrainWidth, ConstrainFlex } from './Constrain';
+export type { ConstrainProps, ConstrainWidth, ConstrainHeight, ConstrainFlex } from './Constrain';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -67,7 +67,12 @@ export type {
 } from './components/Cluster';
 
 export { Constrain } from './components/Constrain';
-export type { ConstrainProps, ConstrainWidth, ConstrainFlex } from './components/Constrain';
+export type {
+  ConstrainProps,
+  ConstrainWidth,
+  ConstrainHeight,
+  ConstrainFlex,
+} from './components/Constrain';
 
 export { Indent } from './components/Indent';
 export type { IndentProps, IndentGutter } from './components/Indent';

--- a/packages/design-tokens/test/package-boundary.test.mjs
+++ b/packages/design-tokens/test/package-boundary.test.mjs
@@ -29,7 +29,7 @@ test('preserves the design-system package and TypeScript export surfaces', async
   });
   assert.equal(
     createHash('sha256').update(indexSource).digest('hex'),
-    '3848cfd793a230d4f3cacf13d8e84460dadc83d4a609e54eea6bd1d8a97142e9',
+    '83eb3ecc40ce0cc7436c5316731f559f96969f63bc3a4c8b0d302ab107a6db5c',
   );
 });
 

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -897,6 +897,27 @@
           "description": "Maximum width cap — the common case (e.g. a search input at `'sm'`)."
         },
         {
+          "name": "height",
+          "type": "ConstrainHeight",
+          "required": false,
+          "default": "",
+          "description": "Fixed height — a named measure, `'full'` (100%), or `'viewport'` (100dvh)."
+        },
+        {
+          "name": "minHeight",
+          "type": "ConstrainHeight",
+          "required": false,
+          "default": "",
+          "description": "Minimum height floor — a named measure, `'full'`, or `'viewport'`."
+        },
+        {
+          "name": "maxHeight",
+          "type": "ConstrainHeight",
+          "required": false,
+          "default": "",
+          "description": "Maximum height cap — a named measure, `'full'`, or `'viewport'`."
+        },
+        {
           "name": "flex",
           "type": "ConstrainFlex",
           "required": false,
@@ -4958,6 +4979,7 @@
     "ClusterJustify": "\"start\" | \"end\" | \"center\" | \"between\"",
     "ClusterAlign": "\"start\" | \"end\" | \"baseline\" | \"center\"",
     "ConstrainWidth": "\"sm\" | \"md\" | \"lg\" | \"xl\" | \"xs\" | \"full\"",
+    "ConstrainHeight": "ConstrainWidth | \"viewport\"",
     "ConstrainFlex": "\"none\" | \"grow\" | \"shrink\" | \"auto\"",
     "IndentGutter": "\"sm\" | \"md\" | \"lg\" | \"xl\" | \"xs\" | \"2xl\"",
     "GridGap": "\"sm\" | \"md\" | \"lg\" | \"xl\" | \"xs\" | \"2xl\"",

--- a/packages/playground/src/pages/components/ConstrainDemo.tsx
+++ b/packages/playground/src/pages/components/ConstrainDemo.tsx
@@ -8,7 +8,7 @@ export function ConstrainDemo() {
     <DemoLayout
       name="Constrain"
       componentName="Constrain"
-      description="Width / flex constraint primitive — the one place layout-sizing props live (Stack/Cluster/Grid are spacing-only). Caps widths and lets a box fill a flex row."
+      description="Size / flex constraint primitive — the one place layout-sizing props live (Stack/Cluster/Grid are spacing-only). Caps either axis and lets a box fill a flex row."
       files={getComponentFiles('Constrain')}
     >
       <Example
@@ -43,6 +43,24 @@ export function Demo() {
             <Input placeholder="maxWidth md (448)" />
           </Constrain>
         </Stack>
+      </Example>
+
+      <Example
+        title="Height bounds"
+        description="The height axis mirrors the named measure scale and adds a dynamic viewport step. Combine height with maxHeight='viewport' to bound fill-parent children without raw CSS."
+        code={`import { Constrain, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Constrain height="xs" maxHeight="viewport">
+      <Text>A child that fills its parent is bounded to 200px, or the viewport when smaller.</Text>
+    </Constrain>
+  );
+}`}
+      >
+        <Constrain height="xs" maxHeight="viewport">
+          <Text>A fill-parent child can use this bounded box without consumer CSS.</Text>
+        </Constrain>
       </Example>
 
       <Example


### PR DESCRIPTION
Addresses #429.

## Summary
- add `height`, `minHeight`, and `maxHeight` to Constrain
- mirror the named measure scale and add a dynamic `viewport` step
- export the new type and update guidance, playground docs, generated metadata, and the package-surface contract

## Test plan
- Constrain tests cover every height prop and step
- full repository tests and typecheck
- CSS lint, playground build, and package dry run