### PR TITLE
feat: add a Card fill option (#430)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1282,6 +1282,11 @@ interface UseCropPreviewOptions extends ExtractCropOptions {
 
 ### `<Card>` — bordered container
 
+- `fill` makes the Card fill a definite-height parent (`height: 100%`) and
+  applies `min-width: 0` so it can shrink inside narrow Grid, Sortable, and
+  DashboardCanvas cells. It does not create a height by itself; bound the
+  parent (for example with `Constrain height`) when needed.
+
 ```tsx
 <Card padding="md">
   <Stack gap="md">...</Stack>

--- a/packages/design-system/src/components/Card/Card.module.scss
+++ b/packages/design-system/src/components/Card/Card.module.scss
@@ -21,6 +21,11 @@
   overflow: visible;
 }
 
+.fill {
+  height: 100%;
+  min-width: 0;
+}
+
 // Tone-coded left-stripe via inset box-shadow. Drawn inside the card on top
 // of the existing border, so untoned cards stay pixel-identical to before
 // (no layout shift, no width change). The existing --shadow-sm stays on

--- a/packages/design-system/src/components/Card/Card.test.tsx
+++ b/packages/design-system/src/components/Card/Card.test.tsx
@@ -163,6 +163,13 @@ describe('Card', () => {
     expect((container.firstChild as HTMLElement).className).toMatch(/fill/);
   });
 
+  it('does not apply or forward fill by default', () => {
+    const { container } = render(<Card>x</Card>);
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).not.toMatch(/fill/);
+    expect(card).not.toHaveAttribute('fill');
+  });
+
   it('fill owns the full-height and shrink-safe CSS contract', () => {
     const root = parse(compile(resolve(__dirname, 'Card.module.scss')).css);
     const rules: Rule[] = [];
@@ -170,18 +177,17 @@ describe('Card', () => {
       if (rule.selectors.includes('.fill')) rules.push(rule);
     });
 
-    expect(rules).toHaveLength(1);
-    expect(rules[0]?.selector).toBe('.fill');
-    expect(rules[0]?.parent?.type).toBe('root');
-    expect(rules[0]?.nodes).toHaveLength(2);
-    expect(
-      rules[0]?.nodes.map((node) =>
-        node.type === 'decl' ? [node.prop, node.value, node.important] : [node.type],
-      ),
-    ).toEqual([
-      ['height', '100%', undefined],
-      ['min-width', '0', undefined],
-    ]);
+    const declarations = new Map<string, { value: string; important: boolean | undefined }>();
+    for (const rule of rules) {
+      for (const node of rule.nodes) {
+        if (node.type === 'decl') {
+          declarations.set(node.prop, { value: node.value, important: node.important });
+        }
+      }
+    }
+
+    expect(declarations.get('height')).toEqual({ value: '100%', important: undefined });
+    expect(declarations.get('min-width')).toEqual({ value: '0', important: undefined });
   });
 });
 

--- a/packages/design-system/src/components/Card/Card.test.tsx
+++ b/packages/design-system/src/components/Card/Card.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { resolve } from 'node:path';
 import { createRef } from 'react';
-import { parse, type Rule } from 'postcss';
 import { compile } from 'sass';
 import { Card, type CardPadding, type CardTone } from './Card';
 
@@ -171,23 +170,21 @@ describe('Card', () => {
   });
 
   it('fill owns the full-height and shrink-safe CSS contract', () => {
-    const root = parse(compile(resolve(__dirname, 'Card.module.scss')).css);
-    const rules: Rule[] = [];
-    root.walkRules((rule) => {
-      if (rule.selectors.includes('.fill')) rules.push(rule);
-    });
+    const style = document.createElement('style');
+    style.textContent = compile(resolve(__dirname, 'Card.module.scss')).css;
+    const card = document.createElement('div');
+    card.className = 'card fill';
+    document.head.append(style);
+    document.body.append(card);
 
-    const declarations = new Map<string, { value: string; important: boolean | undefined }>();
-    for (const rule of rules) {
-      for (const node of rule.nodes) {
-        if (node.type === 'decl') {
-          declarations.set(node.prop, { value: node.value, important: node.important });
-        }
-      }
+    try {
+      const computed = getComputedStyle(card);
+      expect(computed.height).toBe('100%');
+      expect(computed.minWidth).toBe('0px');
+    } finally {
+      card.remove();
+      style.remove();
     }
-
-    expect(declarations.get('height')).toEqual({ value: '100%', important: undefined });
-    expect(declarations.get('min-width')).toEqual({ value: '0', important: undefined });
   });
 });
 

--- a/packages/design-system/src/components/Card/Card.test.tsx
+++ b/packages/design-system/src/components/Card/Card.test.tsx
@@ -174,15 +174,21 @@ describe('Card', () => {
     style.textContent = compile(resolve(__dirname, 'Card.module.scss')).css;
     const card = document.createElement('div');
     card.className = 'card fill';
+    const control = document.createElement('div');
+    control.className = 'card';
     document.head.append(style);
-    document.body.append(card);
+    document.body.append(card, control);
 
     try {
       const computed = getComputedStyle(card);
+      const controlComputed = getComputedStyle(control);
       expect(computed.height).toBe('100%');
       expect(computed.minWidth).toBe('0px');
+      expect(controlComputed.height).not.toBe('100%');
+      expect(controlComputed.minWidth).not.toBe('0px');
     } finally {
       card.remove();
+      control.remove();
       style.remove();
     }
   });

--- a/packages/design-system/src/components/Card/Card.test.tsx
+++ b/packages/design-system/src/components/Card/Card.test.tsx
@@ -1,5 +1,8 @@
 import { render, screen } from '@testing-library/react';
+import { resolve } from 'node:path';
 import { createRef } from 'react';
+import { parse, type Rule } from 'postcss';
+import { compile } from 'sass';
 import { Card, type CardPadding, type CardTone } from './Card';
 
 describe('Card', () => {
@@ -153,6 +156,32 @@ describe('Card', () => {
   it('overflow="hidden" explicit is equivalent to default (no modifier)', () => {
     const { container } = render(<Card overflow="hidden">x</Card>);
     expect((container.firstChild as HTMLElement).className).not.toMatch(/overflowVisible/);
+  });
+
+  it('fill adds the full-height modifier class', () => {
+    const { container } = render(<Card fill>x</Card>);
+    expect((container.firstChild as HTMLElement).className).toMatch(/fill/);
+  });
+
+  it('fill owns the full-height and shrink-safe CSS contract', () => {
+    const root = parse(compile(resolve(__dirname, 'Card.module.scss')).css);
+    const rules: Rule[] = [];
+    root.walkRules((rule) => {
+      if (rule.selectors.includes('.fill')) rules.push(rule);
+    });
+
+    expect(rules).toHaveLength(1);
+    expect(rules[0]?.selector).toBe('.fill');
+    expect(rules[0]?.parent?.type).toBe('root');
+    expect(rules[0]?.nodes).toHaveLength(2);
+    expect(
+      rules[0]?.nodes.map((node) =>
+        node.type === 'decl' ? [node.prop, node.value, node.important] : [node.type],
+      ),
+    ).toEqual([
+      ['height', '100%', undefined],
+      ['min-width', '0', undefined],
+    ]);
   });
 });
 

--- a/packages/design-system/src/components/Card/Card.tsx
+++ b/packages/design-system/src/components/Card/Card.tsx
@@ -74,6 +74,7 @@ export interface CardProps extends HTMLAttributes<HTMLDivElement> {
    * Fill the containing block's height and allow the Card to shrink within a
    * narrow grid cell. Use in stretched Grid, Sortable, or DashboardCanvas
    * cells whose wrapper already has a definite height. Defaults to `false`.
+   * @default false
    */
   fill?: boolean;
 }

--- a/packages/design-system/src/components/Card/Card.tsx
+++ b/packages/design-system/src/components/Card/Card.tsx
@@ -70,6 +70,12 @@ export interface CardProps extends HTMLAttributes<HTMLDivElement> {
    * @default 'hidden'
    */
   overflow?: CardOverflow;
+  /**
+   * Fill the containing block's height and allow the Card to shrink within a
+   * narrow grid cell. Use in stretched Grid, Sortable, or DashboardCanvas
+   * cells whose wrapper already has a definite height. Defaults to `false`.
+   */
+  fill?: boolean;
 }
 
 const paddingClass: Record<CardPadding, string> = {
@@ -147,6 +153,13 @@ function hasCompoundChildren(children: ReactNode): boolean {
  *   <Card padding="md" tone="danger">Churned</Card>
  * </Cluster>
  *
+ * @example
+ * // Fill a bounded dashboard cell without consumer CSS:
+ * <Card fill>
+ *   <Card.Header>Pipeline</Card.Header>
+ *   <Chart />
+ * </Card>
+ *
  * @remarks When NOT to use
  * - As the only child of another Card. **Never nest cards.** If you need to
  *   subdivide, use spacing or a horizontal rule inside one card.
@@ -162,6 +175,8 @@ function hasCompoundChildren(children: ReactNode): boolean {
  *   The default `hidden` exists so square-cornered children (Tables with internal
  *   scroll wrappers, images, full-bleed media) don't show a seam at the rounded
  *   corner.
+ * - ❌ `<Card style={{ height: '100%' }}>` — use `<Card fill>`. The modifier
+ *   also applies the shrink-safe minimum width required in narrow grid cells.
  * - ❌ Adding hover shadows to make Cards "interactive". If the whole card
  *   is clickable, that's a different component (`LinkCard`, not yet shipped).
  * - ❌ Cards nested in Cards. Almost always means your information
@@ -172,7 +187,7 @@ function hasCompoundChildren(children: ReactNode): boolean {
  *   compound API (`Card.Header` / `Card.List` / `Card.ListRow`) instead.
  */
 const CardRoot = forwardRef<HTMLDivElement, CardProps>(function Card(
-  { padding, tone, overflow = 'hidden', className, children, ...props },
+  { padding, tone, overflow = 'hidden', fill = false, className, children, ...props },
   ref,
 ) {
   // Compound subcomponents (Card.Header / Card.List / Card.ListRow) manage
@@ -188,6 +203,7 @@ const CardRoot = forwardRef<HTMLDivElement, CardProps>(function Card(
         styles.card,
         paddingClass[effectivePadding],
         overflow === 'visible' && styles.overflowVisible,
+        fill && styles.fill,
         className,
       )}
       data-tone={tone}

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -543,7 +543,7 @@
           "name": "fill",
           "type": "boolean",
           "required": false,
-          "default": "",
+          "default": "false",
           "description": "Fill the containing block's height and allow the Card to shrink within a\nnarrow grid cell. Use in stretched Grid, Sortable, or DashboardCanvas\ncells whose wrapper already has a definite height. Defaults to `false`."
         }
       ]

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -538,6 +538,13 @@
           "required": false,
           "default": "hidden",
           "description": "How the card clips its children at the rounded border.\n- `hidden` (default) — children are clipped to the rounded border. This\n  prevents the visible seam that appears at the corners when a child has\n  square corners (Table's internal scroll wrapper, images, full-bleed\n  media). Overlays in this library (DropdownMenu, Tooltip, Popover, Drawer,\n  Modal) portal to `document.body` and are NOT clipped by this. Focus\n  outlines use CSS `outline`, which is not affected by ancestor overflow.\n- `visible` — opt out of clipping. Use when a direct child needs to\n  overhang the card edge — decorative badges that protrude from a corner,\n  hover-lift transforms whose shadow extends past the card border, etc."
+        },
+        {
+          "name": "fill",
+          "type": "boolean",
+          "required": false,
+          "default": "",
+          "description": "Fill the containing block's height and allow the Card to shrink within a\nnarrow grid cell. Use in stretched Grid, Sortable, or DashboardCanvas\ncells whose wrapper already has a definite height. Defaults to `false`."
         }
       ]
     },

--- a/packages/playground/src/pages/components/CardDemo.tsx
+++ b/packages/playground/src/pages/components/CardDemo.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@eocrm/design-system';
 import { Avatar } from '@eocrm/design-system';
 import { Button } from '@eocrm/design-system';
 import { Link } from '@eocrm/design-system';
+import { Constrain } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import { getComponentFiles } from '../../lib/componentFiles';
@@ -55,6 +56,24 @@ export function Demo() {
             lg
           </Card>
         </Cluster>
+      </Example>
+
+      <Example
+        title="Fill a bounded cell"
+        description="Use fill when a Card should occupy the full height of a stretched Grid, Sortable, or DashboardCanvas cell. It also allows the Card to shrink safely in narrow spans."
+        code={`import { Card, Constrain } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    <Constrain height="xs" maxWidth="sm">
+      <Card fill>Full-height widget card</Card>
+    </Constrain>
+  );
+}`}
+      >
+        <Constrain height="xs" maxWidth="sm">
+          <Card fill>Full-height widget card</Card>
+        </Constrain>
       </Example>
 
       <Example


### PR DESCRIPTION
Addresses #430.

## Summary
- add a boolean `fill` prop to Card
- fill the containing block height and allow shrinking in narrow grid cells
- document the definite-height parent requirement and add a playground example

## Test plan
- Card tests cover prop/class behavior and exact emitted CSS
- full repository tests and typecheck
- CSS lint, playground build, and package dry run