### PR TITLE
feat: add Button selected state (#442)

### DIFF
--- a/docs/superpowers/plans/2026-08-09-button-selected-state.md
+++ b/docs/superpowers/plans/2026-08-09-button-selected-state.md
@@ -4,15 +4,15 @@
 
 **Goal:** Add an accessible persistent selected state to secondary and ghost Buttons and demonstrate it in the playground.
 
-**Architecture:** `Button` remains controlled and stateless. A boolean `selected` prop derives `aria-pressed` and a CSS-module modifier; selectors constrain selected paint to secondary and ghost variants, with component tokens wrapping existing accent primitives.
+**Architecture:** `Button` remains controlled and stateless. A boolean `selected` prop adds only a CSS-module modifier; consumers opt into native `aria-pressed` explicitly for genuine toggle buttons. Selectors constrain selected paint to secondary and ghost variants, with component tokens wrapping existing color primitives.
 
 **Tech Stack:** React 19, TypeScript, CSS Modules/SCSS, Vitest, Testing Library, Vite playground.
 
 ## Global Constraints
 
 - Selected paint applies only to `secondary` and `ghost`; intent variants retain their existing paint.
-- Omitting `selected` must preserve the current DOM by omitting `aria-pressed`.
-- Explicit native `aria-pressed` wins through Button's props-last spread contract.
+- `selected` never derives ARIA semantics.
+- Explicit native `aria-pressed` passes through Button's props-last spread contract.
 - Use Button component tokens in SCSS; do not add raw colors, spacing, radii, or layout ownership.
 - Button owns no selected state and does not toggle itself on click.
 - Any mockup JSX continues to use only exports from `@eocrm/design-system`.
@@ -35,29 +35,16 @@
 
 - [ ] **Step 1: Add failing accessibility and class-scope tests**
 
-Add focused cases to `Button.test.tsx` that render selected secondary, ghost, and primary Buttons. Assert that secondary and ghost class names contain `selected`, primary does not, `selected={true}` yields `aria-pressed="true"`, `selected={false}` yields `aria-pressed="false"`, omission yields no attribute, an explicit `aria-pressed="mixed"` overrides `selected`, and a selected disabled Button remains disabled.
+Add focused cases to `Button.test.tsx` that render every selected variant. Assert that secondary and ghost class names contain `selected`, primary/danger/success do not, `selected={false}` removes selected paint, selected alone does not add `aria-pressed`, an explicit native `aria-pressed` value passes through, and a selected disabled Button remains disabled.
 
 ```tsx
-it('maps the controlled selected prop to aria-pressed', () => {
-  const { rerender } = render(
+it('keeps selected paint separate from native toggle-button semantics', () => {
+  render(
     <Button variant="secondary" selected>
       Owner: Ada
     </Button>,
   );
-  expect(screen.getByRole('button', { name: 'Owner: Ada' })).toHaveAttribute(
-    'aria-pressed',
-    'true',
-  );
-
-  rerender(
-    <Button variant="secondary" selected={false}>
-      Owner: Ada
-    </Button>,
-  );
-  expect(screen.getByRole('button', { name: 'Owner: Ada' })).toHaveAttribute(
-    'aria-pressed',
-    'false',
-  );
+  expect(screen.getByRole('button', { name: 'Owner: Ada' })).not.toHaveAttribute('aria-pressed');
 });
 ```
 
@@ -67,9 +54,9 @@ Run: `npm test --workspace @eocrm/design-system -- Button/Button.test.tsx`
 
 Expected: TypeScript/runtime assertions fail because `selected` is not yet consumed and no selected class is applied.
 
-- [ ] **Step 3: Implement the minimal controlled prop and ARIA derivation**
+- [ ] **Step 3: Implement the minimal controlled paint prop**
 
-Add fully documented `selected?: boolean` to `ButtonProps`. Destructure it without a default so omission can be distinguished from explicit false. Derive ARIA before the props-last spread and restrict the selected class to the approved variants.
+Add fully documented `selected?: boolean` to `ButtonProps`. Destructure it without a default and restrict the selected class to the approved variants. Do not derive ARIA; explicit native attributes continue through the props-last spread.
 
 ```tsx
 const paintsSelected = selected && (variant === 'secondary' || variant === 'ghost');
@@ -77,7 +64,6 @@ const paintsSelected = selected && (variant === 'secondary' || variant === 'ghos
 <button
   ref={ref}
   type={type}
-  aria-pressed={selected === undefined ? undefined : selected}
   className={clsx(
     styles.button,
     styles[variant],
@@ -94,7 +80,7 @@ Keep the existing props-last contract and add the required explanatory JSX comme
 
 - [ ] **Step 4: Add component tokens and scoped selected selectors**
 
-In `Button.tokens.scss`, map selected state tokens to existing accent primitives. In `Button.module.scss`, apply the tokens only to compound selectors so intent variants cannot acquire selected paint.
+In `Button.tokens.scss`, map selected state tokens to existing primitives with AA-safe text and distinct resting/hover backgrounds. In `Button.module.scss`, apply the tokens only to compound selectors so intent variants cannot acquire selected paint.
 
 ```scss
 .secondary.selected,
@@ -142,12 +128,12 @@ git commit -m "feat(Button): add selected state (#442)"
 Add a canonical example and bullets to the existing Button section:
 
 ```tsx
-<Button variant="secondary" size="sm" selected={owner !== 'all'}>
+<Button variant="secondary" size="sm" selected={ownerApplied} aria-pressed={ownerApplied}>
   Owner: {ownerLabel}
 </Button>
 ```
 
-State that `selected` is controlled, adds `aria-pressed`, paints only secondary/ghost, and is for durable applied values rather than transient success or mutually exclusive ButtonGroup choices.
+State that `selected` is controlled paint only, paints secondary/ghost, and is for durable applied values rather than transient success or mutually exclusive ButtonGroup choices. Consumers add native `aria-pressed` only when Button activation toggles the state; menu/disclosure triggers keep their existing semantics.
 
 - [ ] **Step 2: Add an interactive selected-state demo**
 
@@ -158,6 +144,7 @@ const [statusApplied, setStatusApplied] = useState(true);
 <Button
   variant="secondary"
   selected={statusApplied}
+  aria-pressed={statusApplied}
   onClick={() => setStatusApplied((value) => !value)}
 >
   Status: Active
@@ -166,7 +153,7 @@ const [statusApplied, setStatusApplied] = useState(true);
 
 - [ ] **Step 3: Dogfood selected state in the Contacts mockup**
 
-Pass `selected={statusFilter !== 'all'}` and `selected={ownerFilter !== 'all'}` to the corresponding existing secondary Buttons. Do not add raw HTML, inline styles, CSS Modules, or registry changes.
+Pass `selected={statusFilter !== 'all'}` and `selected={ownerFilter !== 'all'}` to the corresponding existing secondary menu Buttons without `aria-pressed`. Filter the displayed rows/count by both values and render the library `EmptyState` for zero matches. Add `EmptyState` to the registry. Do not add raw HTML, inline styles, or CSS Modules.
 
 - [ ] **Step 4: Run formatting and relevant typechecks**
 

--- a/docs/superpowers/plans/2026-08-09-button-selected-state.md
+++ b/docs/superpowers/plans/2026-08-09-button-selected-state.md
@@ -1,0 +1,215 @@
+# Button Selected State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an accessible persistent selected state to secondary and ghost Buttons and demonstrate it in the playground.
+
+**Architecture:** `Button` remains controlled and stateless. A boolean `selected` prop derives `aria-pressed` and a CSS-module modifier; selectors constrain selected paint to secondary and ghost variants, with component tokens wrapping existing accent primitives.
+
+**Tech Stack:** React 19, TypeScript, CSS Modules/SCSS, Vitest, Testing Library, Vite playground.
+
+## Global Constraints
+
+- Selected paint applies only to `secondary` and `ghost`; intent variants retain their existing paint.
+- Omitting `selected` must preserve the current DOM by omitting `aria-pressed`.
+- Explicit native `aria-pressed` wins through Button's props-last spread contract.
+- Use Button component tokens in SCSS; do not add raw colors, spacing, radii, or layout ownership.
+- Button owns no selected state and does not toggle itself on click.
+- Any mockup JSX continues to use only exports from `@eocrm/design-system`.
+
+---
+
+### Task 1: Button selected API, semantics, and paint
+
+**Files:**
+- Modify: `packages/design-system/src/components/Button/Button.test.tsx`
+- Modify: `packages/design-system/src/components/Button/Button.tsx`
+- Modify: `packages/design-system/src/components/Button/Button.module.scss`
+- Modify: `packages/design-system/src/components/Button/Button.tokens.scss`
+
+**Interfaces:**
+- Consumes: React's native `ButtonHTMLAttributes<HTMLButtonElement>` including `aria-pressed`.
+- Produces: `ButtonProps.selected?: boolean`; selected CSS modifier; `--button-bg-selected`, `--button-bg-selected-hover`, `--button-fg-selected`, and `--button-border-color-selected` tokens.
+
+- [ ] **Step 1: Add failing accessibility and class-scope tests**
+
+Add focused cases to `Button.test.tsx` that render selected secondary, ghost, and primary Buttons. Assert that secondary and ghost class names contain `selected`, primary does not, `selected={true}` yields `aria-pressed="true"`, `selected={false}` yields `aria-pressed="false"`, omission yields no attribute, an explicit `aria-pressed="mixed"` overrides `selected`, and a selected disabled Button remains disabled.
+
+```tsx
+it('maps the controlled selected prop to aria-pressed', () => {
+  const { rerender } = render(
+    <Button variant="secondary" selected>
+      Owner: Ada
+    </Button>,
+  );
+  expect(screen.getByRole('button', { name: 'Owner: Ada' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+
+  rerender(
+    <Button variant="secondary" selected={false}>
+      Owner: Ada
+    </Button>,
+  );
+  expect(screen.getByRole('button', { name: 'Owner: Ada' })).toHaveAttribute(
+    'aria-pressed',
+    'false',
+  );
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run: `npm test --workspace @eocrm/design-system -- Button/Button.test.tsx`
+
+Expected: TypeScript/runtime assertions fail because `selected` is not yet consumed and no selected class is applied.
+
+- [ ] **Step 3: Implement the minimal controlled prop and ARIA derivation**
+
+Add fully documented `selected?: boolean` to `ButtonProps`. Destructure it without a default so omission can be distinguished from explicit false. Derive ARIA before the props-last spread and restrict the selected class to the approved variants.
+
+```tsx
+const paintsSelected = selected && (variant === 'secondary' || variant === 'ghost');
+
+<button
+  ref={ref}
+  type={type}
+  aria-pressed={selected === undefined ? undefined : selected}
+  className={clsx(
+    styles.button,
+    styles[variant],
+    styles[size],
+    iconOnly && styles.iconOnly,
+    paintsSelected && styles.selected,
+    className,
+  )}
+  {...props}
+/>
+```
+
+Keep the existing props-last contract and add the required explanatory JSX comment. Expand component examples and `@remarks` to establish selected filter triggers as valid and internal toggle state as invalid.
+
+- [ ] **Step 4: Add component tokens and scoped selected selectors**
+
+In `Button.tokens.scss`, map selected state tokens to existing accent primitives. In `Button.module.scss`, apply the tokens only to compound selectors so intent variants cannot acquire selected paint.
+
+```scss
+.secondary.selected,
+.ghost.selected {
+  background: var(--button-bg-selected);
+  color: var(--button-fg-selected);
+  border-color: var(--button-border-color-selected);
+
+  &:hover:not(:disabled) {
+    background: var(--button-bg-selected-hover);
+  }
+}
+```
+
+- [ ] **Step 5: Run focused tests and stylesheet lint to confirm GREEN**
+
+Run: `npm test --workspace @eocrm/design-system -- Button/Button.test.tsx`
+
+Run: `npm run lint:css`
+
+Expected: Button tests and stylelint pass.
+
+- [ ] **Step 6: Commit the Button API slice**
+
+```bash
+git add packages/design-system/src/components/Button
+git commit -m "feat(Button): add selected state (#442)"
+```
+
+### Task 2: Consumer guidance and demonstrations
+
+**Files:**
+- Modify: `packages/design-system/AGENTS.md`
+- Modify: `packages/playground/src/pages/components/ButtonDemo.tsx`
+- Modify: `packages/playground/src/pages/mockups/Contacts/Contacts.tsx`
+
+**Interfaces:**
+- Consumes: `ButtonProps.selected?: boolean` from Task 1.
+- Produces: Canonical selected-filter documentation, an interactive demo, and realistic Contacts filter usage.
+
+- [ ] **Step 1: Add the Button guidance contract**
+
+Add a canonical example and bullets to the existing Button section:
+
+```tsx
+<Button variant="secondary" size="sm" selected={owner !== 'all'}>
+  Owner: {ownerLabel}
+</Button>
+```
+
+State that `selected` is controlled, adds `aria-pressed`, paints only secondary/ghost, and is for durable applied values rather than transient success or mutually exclusive ButtonGroup choices.
+
+- [ ] **Step 2: Add an interactive selected-state demo**
+
+In `ButtonDemo.tsx`, add a small local component with independent Status and Owner booleans. Render both secondary and ghost examples with `selected` driven by state and include a code sample showing consumer-owned toggling.
+
+```tsx
+const [statusApplied, setStatusApplied] = useState(true);
+<Button
+  variant="secondary"
+  selected={statusApplied}
+  onClick={() => setStatusApplied((value) => !value)}
+>
+  Status: Active
+</Button>;
+```
+
+- [ ] **Step 3: Dogfood selected state in the Contacts mockup**
+
+Pass `selected={statusFilter !== 'all'}` and `selected={ownerFilter !== 'all'}` to the corresponding existing secondary Buttons. Do not add raw HTML, inline styles, CSS Modules, or registry changes.
+
+- [ ] **Step 4: Run formatting and relevant typechecks**
+
+Run: `npx prettier --check packages/design-system/AGENTS.md packages/playground/src/pages/components/ButtonDemo.tsx packages/playground/src/pages/mockups/Contacts/Contacts.tsx`
+
+Run: `npm run typecheck --workspaces --if-present`
+
+Expected: formatting and all workspace typechecks pass.
+
+- [ ] **Step 5: Commit guidance and demos**
+
+```bash
+git add packages/design-system/AGENTS.md packages/playground/src/pages/components/ButtonDemo.tsx packages/playground/src/pages/mockups/Contacts/Contacts.tsx
+git commit -m "docs(Button): demonstrate selected filter triggers (#442)"
+```
+
+### Task 3: Repository gates and publication readiness
+
+**Files:**
+- Verify: all files changed since `origin/main`
+
+**Interfaces:**
+- Consumes: completed Button API and demonstrations from Tasks 1-2.
+- Produces: a gate-clean branch ready for the mandatory pre-push review workflow.
+
+- [ ] **Step 1: Run all repository gates**
+
+Run: `make test && make build-lib && make lint && npm run format:check`
+
+Expected: every command exits 0.
+
+- [ ] **Step 2: Verify the package tarball excludes development files**
+
+Run:
+
+```bash
+npm pack --workspace @eocrm/design-system --dry-run 2>&1 | grep -cE '\.test\.(t|j)sx?|\.spec\.|/types/|CLAUDE\.md|tsconfig'
+```
+
+Expected: output `0` (the pipeline exit may be `1` because grep found zero matches).
+
+- [ ] **Step 3: Invoke the repository `pre-push-review` skill**
+
+Because the diff touches both `packages/design-system/**` and a mockup, run the skill's applicable library and mockup review requirements. Fix every Critical/Important finding and repeat its required clean-review cycle.
+
+- [ ] **Step 4: Re-run final verification after review fixes**
+
+Run: `make test && make build-lib && make lint && npm run format:check`
+
+Expected: every command exits 0 on the final reviewed head.

--- a/docs/superpowers/plans/2026-08-09-button-selected-state.md
+++ b/docs/superpowers/plans/2026-08-09-button-selected-state.md
@@ -22,12 +22,14 @@
 ### Task 1: Button selected API, semantics, and paint
 
 **Files:**
+
 - Modify: `packages/design-system/src/components/Button/Button.test.tsx`
 - Modify: `packages/design-system/src/components/Button/Button.tsx`
 - Modify: `packages/design-system/src/components/Button/Button.module.scss`
 - Modify: `packages/design-system/src/components/Button/Button.tokens.scss`
 
 **Interfaces:**
+
 - Consumes: React's native `ButtonHTMLAttributes<HTMLButtonElement>` including `aria-pressed`.
 - Produces: `ButtonProps.selected?: boolean`; selected CSS modifier; `--button-bg-selected`, `--button-bg-selected-hover`, `--button-fg-selected`, and `--button-border-color-selected` tokens.
 
@@ -85,7 +87,7 @@ const paintsSelected = selected && (variant === 'secondary' || variant === 'ghos
     className,
   )}
   {...props}
-/>
+/>;
 ```
 
 Keep the existing props-last contract and add the required explanatory JSX comment. Expand component examples and `@remarks` to establish selected filter triggers as valid and internal toggle state as invalid.
@@ -125,11 +127,13 @@ git commit -m "feat(Button): add selected state (#442)"
 ### Task 2: Consumer guidance and demonstrations
 
 **Files:**
+
 - Modify: `packages/design-system/AGENTS.md`
 - Modify: `packages/playground/src/pages/components/ButtonDemo.tsx`
 - Modify: `packages/playground/src/pages/mockups/Contacts/Contacts.tsx`
 
 **Interfaces:**
+
 - Consumes: `ButtonProps.selected?: boolean` from Task 1.
 - Produces: Canonical selected-filter documentation, an interactive demo, and realistic Contacts filter usage.
 
@@ -182,9 +186,11 @@ git commit -m "docs(Button): demonstrate selected filter triggers (#442)"
 ### Task 3: Repository gates and publication readiness
 
 **Files:**
+
 - Verify: all files changed since `origin/main`
 
 **Interfaces:**
+
 - Consumes: completed Button API and demonstrations from Tasks 1-2.
 - Produces: a gate-clean branch ready for the mandatory pre-push review workflow.
 

--- a/docs/superpowers/specs/2026-08-09-button-selected-state-design.md
+++ b/docs/superpowers/specs/2026-08-09-button-selected-state-design.md
@@ -1,0 +1,59 @@
+# Button selected state design
+
+## Problem
+
+Standalone filter and toolbar Buttons cannot show that they currently carry an
+applied value. Existing Button variants describe action intent, while
+ButtonGroup's selected treatment implies a mutually exclusive radio group.
+Consumers therefore cannot make several independent applied filters scannable
+without custom paint.
+
+## Public API and semantics
+
+Add `selected?: boolean` to `ButtonProps`, defaulting to `false`. A selected
+Button exposes `aria-pressed="true"`; an explicitly supplied native
+`aria-pressed` value continues to win through Button's existing props-last
+spread contract. An unselected Button exposes `aria-pressed="false"` only when
+the `selected` prop was explicitly supplied, preserving today's DOM for callers
+that do not opt into the state.
+
+`selected` is controlled paint and semantics only. Button does not keep state
+or change it on click.
+
+## Visual treatment
+
+Selected paint applies only to `secondary` and `ghost` Buttons. Both use a
+shared persistent accent treatment: subtle accent background, accent
+foreground, accent border, and a selected hover surface. New Button component
+tokens wrap the existing shared color primitives so consumers can theme the
+state without overriding selectors.
+
+`primary`, `danger`, and `success` retain their normal intent paint even when
+`selected` is supplied, while still receiving the requested `aria-pressed`
+state. Disabled Buttons retain the selected cue under the component's existing
+disabled opacity.
+
+## Documentation and demonstration
+
+Document `selected` on `ButtonProps`, add a canonical applied-filter example
+and anti-pattern guidance to Button's JSDoc, and update the Button section in
+`packages/design-system/AGENTS.md`. Expand the existing Button playground demo
+with selected secondary and ghost controls. Update the Contacts mockup filter
+triggers to pass `selected` from their current filter values so the realistic
+consumer example uses the shipped pattern.
+
+## Testing
+
+Button unit tests will verify:
+
+- selected secondary and ghost Buttons receive selected paint;
+- primary, danger, and success Buttons do not receive selected paint;
+- explicit `selected={true}` and `selected={false}` map to matching
+  `aria-pressed` values;
+- omitting `selected` omits `aria-pressed`;
+- an explicit native `aria-pressed` value overrides the derived value;
+- selected and disabled states compose without changing native disabled
+  behavior.
+
+The full repository gates and required library/mockup review cycle will run
+before publication.

--- a/docs/superpowers/specs/2026-08-09-button-selected-state-design.md
+++ b/docs/superpowers/specs/2026-08-09-button-selected-state-design.md
@@ -10,37 +10,36 @@ without custom paint.
 
 ## Public API and semantics
 
-Add `selected?: boolean` to `ButtonProps`, defaulting to `false`. A selected
-Button exposes `aria-pressed="true"`; an explicitly supplied native
-`aria-pressed` value continues to win through Button's existing props-last
-spread contract. An unselected Button exposes `aria-pressed="false"` only when
-the `selected` prop was explicitly supplied, preserving today's DOM for callers
-that do not opt into the state.
+Add `selected?: boolean` to `ButtonProps`, defaulting to `false`. It controls
+paint only and does not derive `aria-pressed` or any other semantics. Consumers
+pass the native `aria-pressed` attribute explicitly only when activating the
+Button itself toggles the state. Menu and disclosure triggers retain their own
+ARIA contract while still using selected paint to expose an applied value.
 
-`selected` is controlled paint and semantics only. Button does not keep state
-or change it on click.
+`selected` is controlled paint only. Button does not keep state or change it on
+click.
 
 ## Visual treatment
 
 Selected paint applies only to `secondary` and `ghost` Buttons. Both use a
-shared persistent accent treatment: subtle accent background, accent
-foreground, accent border, and a selected hover surface. New Button component
-tokens wrap the existing shared color primitives so consumers can theme the
-state without overriding selectors.
+shared persistent accent treatment: subtle accent background, AA-safe
+foreground, accent border, and a visibly distinct selected hover surface. New
+Button component tokens wrap existing shared color primitives so consumers can
+theme the state without overriding selectors.
 
 `primary`, `danger`, and `success` retain their normal intent paint even when
-`selected` is supplied, while still receiving the requested `aria-pressed`
-state. Disabled Buttons retain the selected cue under the component's existing
-disabled opacity.
+`selected` is supplied. Disabled Buttons retain the selected cue under the
+component's existing disabled opacity.
 
 ## Documentation and demonstration
 
 Document `selected` on `ButtonProps`, add a canonical applied-filter example
 and anti-pattern guidance to Button's JSDoc, and update the Button section in
 `packages/design-system/AGENTS.md`. Expand the existing Button playground demo
-with selected secondary and ghost controls. Update the Contacts mockup filter
-triggers to pass `selected` from their current filter values so the realistic
-consumer example uses the shipped pattern.
+with selected secondary and ghost controls that explicitly add `aria-pressed`
+because their activation toggles state. Update the Contacts mockup menu triggers
+to pass `selected` from their current filter values without toggle-button ARIA,
+and make those filters update the visible rows, count, and empty state.
 
 ## Testing
 
@@ -48,10 +47,9 @@ Button unit tests will verify:
 
 - selected secondary and ghost Buttons receive selected paint;
 - primary, danger, and success Buttons do not receive selected paint;
-- explicit `selected={true}` and `selected={false}` map to matching
-  `aria-pressed` values;
-- omitting `selected` omits `aria-pressed`;
-- an explicit native `aria-pressed` value overrides the derived value;
+- `selected={false}` removes selected paint;
+- `selected` alone does not add `aria-pressed`;
+- an explicit native `aria-pressed` value passes through for a genuine toggle;
 - selected and disabled states compose without changing native disabled
   behavior.
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -289,11 +289,15 @@ When NOT to use: plain text → `Text`. For editing → `<RichTextEditor>`. The 
 <Button onClick={save}>Save</Button>
 <Button variant="danger" size="sm">Delete</Button>
 <Button variant="secondary" disabled>Cancel</Button>
+<Button variant="secondary" size="sm" selected={owner !== 'all'}>
+  Owner: {ownerLabel}
+</Button>
 ```
 
 - `variant`: `primary` (default — one per section) / `secondary` / `ghost` / `danger` / `success`
 - `size`: `xs` / `sm` / `md` (default) / `lg` — use `xs` for icon-only or dense inline actions; pass `aria-label` when icon-only.
 - `iconOnly`: boolean. Renders a square icon-only button (`aspect-ratio: 1`, tight 4px padding). Width tracks the size's height token. **Always pair with `aria-label`** — there's no other accessible name.
+- `selected`: controlled boolean for a durable applied filter or independent toolbar value. It adds `aria-pressed`; selected paint applies only to `secondary` and `ghost` variants. Keep the state in the consumer. Do not use it for transient success feedback or mutually exclusive `<ButtonGroup>` choices.
 - Always renders `<button type="button">` unless you pass `type="submit"`.
 - `variant="success"` is a **transient confirmation state**, not an action intent. Flip to it for ~1.5s after the action resolves, then flip back to `primary`. The timer is the consumer's responsibility — Button stays stateless. Never render a button as `success` on initial mount. Track the timer in a `useRef` and clear on unmount + on rapid re-clicks so the flash doesn't outlive the component or get cut short.
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -289,7 +289,12 @@ When NOT to use: plain text → `Text`. For editing → `<RichTextEditor>`. The 
 <Button onClick={save}>Save</Button>
 <Button variant="danger" size="sm">Delete</Button>
 <Button variant="secondary" disabled>Cancel</Button>
-<Button variant="secondary" size="sm" selected={owner !== 'all'}>
+<Button
+  variant="secondary"
+  size="sm"
+  selected={ownerApplied}
+  aria-pressed={ownerApplied}
+>
   Owner: {ownerLabel}
 </Button>
 ```
@@ -297,7 +302,7 @@ When NOT to use: plain text → `Text`. For editing → `<RichTextEditor>`. The 
 - `variant`: `primary` (default — one per section) / `secondary` / `ghost` / `danger` / `success`
 - `size`: `xs` / `sm` / `md` (default) / `lg` — use `xs` for icon-only or dense inline actions; pass `aria-label` when icon-only.
 - `iconOnly`: boolean. Renders a square icon-only button (`aspect-ratio: 1`, tight 4px padding). Width tracks the size's height token. **Always pair with `aria-label`** — there's no other accessible name.
-- `selected`: controlled boolean for a durable applied filter or independent toolbar value. It adds `aria-pressed`; selected paint applies only to `secondary` and `ghost` variants. Keep the state in the consumer. Do not use it for transient success feedback or mutually exclusive `<ButtonGroup>` choices.
+- `selected`: controlled paint for a durable applied filter or independent toolbar value. It paints only `secondary` and `ghost` variants and adds no ARIA semantics. If activating the Button itself toggles that value, also pass the matching native `aria-pressed`; menu/disclosure triggers keep their existing semantics. Keep state in the consumer. Do not use it for transient success feedback or mutually exclusive `<ButtonGroup>` choices.
 - Always renders `<button type="button">` unless you pass `type="submit"`.
 - `variant="success"` is a **transient confirmation state**, not an action intent. Flip to it for ~1.5s after the action resolves, then flip back to `primary`. The timer is the consumer's responsibility — Button stays stateless. Never render a button as `success` on initial mount. Track the timer in a `useRef` and clear on unmount + on rapid re-clicks so the flash doesn't outlive the component or get cut short.
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -294,6 +294,7 @@ When NOT to use: plain text → `Text`. For editing → `<RichTextEditor>`. The 
   size="sm"
   selected={ownerApplied}
   aria-pressed={ownerApplied}
+  onClick={() => setOwnerApplied((value) => !value)}
 >
   Owner: {ownerLabel}
 </Button>

--- a/packages/design-system/src/components/Button/Button.module.scss
+++ b/packages/design-system/src/components/Button/Button.module.scss
@@ -90,6 +90,17 @@
   }
 }
 
+.secondary.selected,
+.ghost.selected {
+  background: var(--button-bg-selected);
+  color: var(--button-fg-selected);
+  border-color: var(--button-border-color-selected);
+
+  &:hover:not(:disabled) {
+    background: var(--button-bg-selected-hover);
+  }
+}
+
 .danger {
   background: var(--button-bg-danger);
   color: var(--button-fg-danger);

--- a/packages/design-system/src/components/Button/Button.test.tsx
+++ b/packages/design-system/src/components/Button/Button.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { Button } from './Button';
 
 describe('Button', () => {
@@ -47,42 +49,55 @@ describe('Button', () => {
         <Button variant="primary" selected>
           Save
         </Button>
+        <Button variant="danger" selected>
+          Delete
+        </Button>
+        <Button variant="success" selected>
+          Saved
+        </Button>
       </>,
     );
 
     expect(screen.getByRole('button', { name: 'Owner: Ada' }).className).toMatch(/selected/);
     expect(screen.getByRole('button', { name: 'Assignee: Lin' }).className).toMatch(/selected/);
     expect(screen.getByRole('button', { name: 'Save' }).className).not.toMatch(/selected/);
+    expect(screen.getByRole('button', { name: 'Delete' }).className).not.toMatch(/selected/);
+    expect(screen.getByRole('button', { name: 'Saved' }).className).not.toMatch(/selected/);
   });
 
-  it('maps the controlled selected prop to aria-pressed', () => {
+  it('removes selected paint when selected is false', () => {
     const { rerender } = render(
       <Button variant="secondary" selected>
         Owner: Ada
       </Button>,
     );
-    expect(screen.getByRole('button', { name: 'Owner: Ada' })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    );
+    expect(screen.getByRole('button', { name: 'Owner: Ada' }).className).toMatch(/selected/);
 
     rerender(
       <Button variant="secondary" selected={false}>
         Owner: Ada
       </Button>,
     );
-    expect(screen.getByRole('button', { name: 'Owner: Ada' })).toHaveAttribute(
-      'aria-pressed',
-      'false',
+    expect(screen.getByRole('button', { name: 'Owner: Ada' }).className).not.toMatch(/selected/);
+  });
+
+  it('keeps selected paint separate from native toggle-button semantics', () => {
+    render(
+      <>
+        <Button variant="secondary" selected>
+          Filter
+        </Button>
+        <Button variant="secondary" selected aria-pressed>
+          Toggle
+        </Button>
+      </>,
     );
+
+    expect(screen.getByRole('button', { name: 'Filter' })).not.toHaveAttribute('aria-pressed');
+    expect(screen.getByRole('button', { name: 'Toggle' })).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('omits aria-pressed when selected is not specified', () => {
-    render(<Button>Save</Button>);
-    expect(screen.getByRole('button', { name: 'Save' })).not.toHaveAttribute('aria-pressed');
-  });
-
-  it('allows an explicit aria-pressed value to override selected', () => {
+  it('passes through an explicit mixed aria-pressed value', () => {
     render(
       <Button selected aria-pressed="mixed">
         Owner: Ada
@@ -101,6 +116,14 @@ describe('Button', () => {
       </Button>,
     );
     expect(screen.getByRole('button', { name: 'Owner: Ada' })).toBeDisabled();
+  });
+
+  it('uses distinct hover paint and an AA-safe foreground primitive for selected buttons', () => {
+    const tokens = readFileSync(resolve(__dirname, 'Button.tokens.scss'), 'utf8');
+
+    expect(tokens).toContain('--button-bg-selected: var(--color-accent-bg-subtle);');
+    expect(tokens).toContain('--button-bg-selected-hover: var(--color-info-bg-subtle);');
+    expect(tokens).toContain('--button-fg-selected: var(--color-fg);');
   });
 
   it('merges the className prop with internal classes', () => {

--- a/packages/design-system/src/components/Button/Button.test.tsx
+++ b/packages/design-system/src/components/Button/Button.test.tsx
@@ -118,11 +118,13 @@ describe('Button', () => {
     expect(screen.getByRole('button', { name: 'Owner: Ada' })).toBeDisabled();
   });
 
-  it('uses distinct hover paint and an AA-safe foreground primitive for selected buttons', () => {
+  it('derives selected hover paint from the selected accent tokens', () => {
     const tokens = readFileSync(resolve(__dirname, 'Button.tokens.scss'), 'utf8');
 
     expect(tokens).toContain('--button-bg-selected: var(--color-accent-bg-subtle);');
-    expect(tokens).toContain('--button-bg-selected-hover: var(--color-info-bg-subtle);');
+    expect(tokens).toMatch(
+      /--button-bg-selected-hover:\s*color-mix\(\s*in srgb,\s*var\(--button-bg-selected\),\s*var\(--button-border-color-selected\) 12%\s*\);/s,
+    );
     expect(tokens).toContain('--button-fg-selected: var(--color-fg);');
   });
 

--- a/packages/design-system/src/components/Button/Button.test.tsx
+++ b/packages/design-system/src/components/Button/Button.test.tsx
@@ -35,6 +35,74 @@ describe('Button', () => {
     expect(screen.getByRole('button', { name: 'Saved!' }).className).toMatch(/success/);
   });
 
+  it('applies selected paint only to secondary and ghost variants', () => {
+    render(
+      <>
+        <Button variant="secondary" selected>
+          Owner: Ada
+        </Button>
+        <Button variant="ghost" selected>
+          Assignee: Lin
+        </Button>
+        <Button variant="primary" selected>
+          Save
+        </Button>
+      </>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Owner: Ada' }).className).toMatch(/selected/);
+    expect(screen.getByRole('button', { name: 'Assignee: Lin' }).className).toMatch(/selected/);
+    expect(screen.getByRole('button', { name: 'Save' }).className).not.toMatch(/selected/);
+  });
+
+  it('maps the controlled selected prop to aria-pressed', () => {
+    const { rerender } = render(
+      <Button variant="secondary" selected>
+        Owner: Ada
+      </Button>,
+    );
+    expect(screen.getByRole('button', { name: 'Owner: Ada' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    rerender(
+      <Button variant="secondary" selected={false}>
+        Owner: Ada
+      </Button>,
+    );
+    expect(screen.getByRole('button', { name: 'Owner: Ada' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('omits aria-pressed when selected is not specified', () => {
+    render(<Button>Save</Button>);
+    expect(screen.getByRole('button', { name: 'Save' })).not.toHaveAttribute('aria-pressed');
+  });
+
+  it('allows an explicit aria-pressed value to override selected', () => {
+    render(
+      <Button selected aria-pressed="mixed">
+        Owner: Ada
+      </Button>,
+    );
+    expect(screen.getByRole('button', { name: 'Owner: Ada' })).toHaveAttribute(
+      'aria-pressed',
+      'mixed',
+    );
+  });
+
+  it('keeps a selected button disabled', () => {
+    render(
+      <Button variant="secondary" selected disabled>
+        Owner: Ada
+      </Button>,
+    );
+    expect(screen.getByRole('button', { name: 'Owner: Ada' })).toBeDisabled();
+  });
+
   it('merges the className prop with internal classes', () => {
     render(<Button className="external">Hi</Button>);
     const btn = screen.getByRole('button', { name: 'Hi' });

--- a/packages/design-system/src/components/Button/Button.test.tsx
+++ b/packages/design-system/src/components/Button/Button.test.tsx
@@ -115,7 +115,9 @@ describe('Button', () => {
         Owner: Ada
       </Button>,
     );
-    expect(screen.getByRole('button', { name: 'Owner: Ada' })).toBeDisabled();
+    const button = screen.getByRole('button', { name: 'Owner: Ada' });
+    expect(button).toBeDisabled();
+    expect(button.className).toMatch(/selected/);
   });
 
   it('derives selected hover paint from the selected accent tokens', () => {

--- a/packages/design-system/src/components/Button/Button.tokens.scss
+++ b/packages/design-system/src/components/Button/Button.tokens.scss
@@ -56,7 +56,11 @@
 
   // Selected (secondary and ghost only)
   --button-bg-selected: var(--color-accent-bg-subtle);
-  --button-bg-selected-hover: var(--color-info-bg-subtle);
+  --button-bg-selected-hover: color-mix(
+    in srgb,
+    var(--button-bg-selected),
+    var(--button-border-color-selected) 12%
+  );
   --button-fg-selected: var(--color-fg);
   --button-border-color-selected: var(--color-accent);
 

--- a/packages/design-system/src/components/Button/Button.tokens.scss
+++ b/packages/design-system/src/components/Button/Button.tokens.scss
@@ -56,8 +56,8 @@
 
   // Selected (secondary and ghost only)
   --button-bg-selected: var(--color-accent-bg-subtle);
-  --button-bg-selected-hover: var(--color-accent-subtle-bg);
-  --button-fg-selected: var(--color-accent);
+  --button-bg-selected-hover: var(--color-info-bg-subtle);
+  --button-fg-selected: var(--color-fg);
   --button-border-color-selected: var(--color-accent);
 
   // Variant: ghost

--- a/packages/design-system/src/components/Button/Button.tokens.scss
+++ b/packages/design-system/src/components/Button/Button.tokens.scss
@@ -54,6 +54,12 @@
   --button-fg-secondary: var(--color-fg);
   --button-border-color-secondary: var(--color-border-strong);
 
+  // Selected (secondary and ghost only)
+  --button-bg-selected: var(--color-accent-bg-subtle);
+  --button-bg-selected-hover: var(--color-accent-subtle-bg);
+  --button-fg-selected: var(--color-accent);
+  --button-border-color-selected: var(--color-accent);
+
   // Variant: ghost
   --button-bg-ghost: transparent;
   --button-bg-ghost-hover: var(--color-bg-muted);

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -46,6 +46,16 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    * button will lay out as a normal rectangle with the existing gap.
    */
   iconOnly?: boolean;
+  /**
+   * Controlled persistent state for an independent filter or toolbar trigger.
+   * When supplied, exposes the matching `aria-pressed` value (`true` or
+   * `false`); omit it for ordinary action Buttons so no toggle state is
+   * announced. Selected paint applies only to `secondary` and `ghost` Buttons;
+   * `primary`, `danger`, and `success` retain their intent paint. The consumer
+   * owns the state and updates it from `onClick`; Button never toggles itself.
+   * Defaults to `undefined` (no `aria-pressed` attribute).
+   */
+  selected?: boolean;
 }
 
 /**
@@ -76,6 +86,17 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  * </Cluster>
  *
  * @example
+ * // Persistent filter trigger — state belongs to the consumer.
+ * const [ownerApplied, setOwnerApplied] = useState(false);
+ * <Button
+ *   variant="secondary"
+ *   selected={ownerApplied}
+ *   onClick={() => setOwnerApplied((value) => !value)}
+ * >
+ *   Owner: Ada
+ * </Button>
+ *
+ * @example
  * // Transient success confirmation (~1.5s). The timer is the consumer's
  * // responsibility — the variant is just paint. Track the timer in a ref so
  * // you can clear it on unmount (prevents a setState-after-unmount warning)
@@ -101,6 +122,9 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  *
  * @remarks When NOT to use
  * - Navigation to another URL → use a router-aware `<Link>` (not yet shipped).
+ * - A persistent independent filter or toolbar trigger → use controlled
+ *   `selected` on a `secondary` or `ghost` Button; keep that state in the
+ *   consumer, not inside Button.
  * - Toggle state (on/off) → use `Switch` or `Checkbox` (not yet shipped), not
  *   a Button with internal state.
  * - A clickable table row → make the row itself the interactive surface;
@@ -129,20 +153,33 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  *   `iconOnly` with `aria-label="…"`.
  */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { variant = 'primary', size = 'md', iconOnly = false, className, type = 'button', ...props },
+  {
+    variant = 'primary',
+    size = 'md',
+    iconOnly = false,
+    selected,
+    className,
+    type = 'button',
+    ...props
+  },
   ref,
 ) {
+  const paintsSelected = selected && (variant === 'secondary' || variant === 'ghost');
+
   return (
     <button
       ref={ref}
       type={type}
+      aria-pressed={selected === undefined ? undefined : selected}
       className={clsx(
         styles.button,
         styles[variant],
         styles[size],
         iconOnly && styles.iconOnly,
+        paintsSelected && styles.selected,
         className,
       )}
+      // {...props} last so consumers can override native attributes such as aria-pressed.
       {...props}
     />
   );

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -47,13 +47,13 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    */
   iconOnly?: boolean;
   /**
-   * Controlled persistent state for an independent filter or toolbar trigger.
-   * When supplied, exposes the matching `aria-pressed` value (`true` or
-   * `false`); omit it for ordinary action Buttons so no toggle state is
-   * announced. Selected paint applies only to `secondary` and `ghost` Buttons;
-   * `primary`, `danger`, and `success` retain their intent paint. The consumer
-   * owns the state and updates it from `onClick`; Button never toggles itself.
-   * Defaults to `undefined` (no `aria-pressed` attribute).
+   * Controlled persistent paint for an applied filter or toolbar value.
+   * Selected paint applies only to `secondary` and `ghost` Buttons;
+   * `primary`, `danger`, and `success` retain their intent paint. This prop is
+   * visual only and does not add toggle-button semantics. Pass native
+   * `aria-pressed` explicitly only when activating the Button itself toggles
+   * the selected state; menu and disclosure triggers keep their own semantics.
+   * The consumer owns the state. Defaults to `undefined` (not selected).
    */
   selected?: boolean;
 }
@@ -91,6 +91,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  * <Button
  *   variant="secondary"
  *   selected={ownerApplied}
+ *   aria-pressed={ownerApplied}
  *   onClick={() => setOwnerApplied((value) => !value)}
  * >
  *   Owner: Ada
@@ -122,11 +123,10 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  *
  * @remarks When NOT to use
  * - Navigation to another URL → use a router-aware `<Link>` (not yet shipped).
- * - A persistent independent filter or toolbar trigger → use controlled
- *   `selected` on a `secondary` or `ghost` Button; keep that state in the
- *   consumer, not inside Button.
  * - Toggle state (on/off) → use `Switch` or `Checkbox` (not yet shipped), not
  *   a Button with internal state.
+ * - Mutually exclusive choices → use `<ButtonGroup>`, which supplies the
+ *   group-level selection semantics.
  * - A clickable table row → make the row itself the interactive surface;
  *   don't nest a button.
  * - On touch-first surfaces, prefer `size="sm"` or larger. `xs` (20px×~28px, or
@@ -151,6 +151,9 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  * - ❌ `<Button iconOnly><X /></Button>` without `aria-label`. The button has
  *   no accessible name; screen readers announce nothing. Always pair
  *   `iconOnly` with `aria-label="…"`.
+ * - ❌ Assuming `selected` adds toggle semantics. It is paint only. Pass
+ *   `aria-pressed` explicitly when activating the Button toggles that state;
+ *   do not add it to menu or disclosure triggers.
  */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   {
@@ -170,7 +173,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     <button
       ref={ref}
       type={type}
-      aria-pressed={selected === undefined ? undefined : selected}
       className={clsx(
         styles.button,
         styles[variant],
@@ -179,7 +181,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
         paintsSelected && styles.selected,
         className,
       )}
-      // {...props} last so consumers can override native attributes such as aria-pressed.
+      // {...props} last so consumers can supply native semantics such as aria-pressed.
       {...props}
     />
   );

--- a/packages/design-system/src/components/SocialButton/SocialButton.tsx
+++ b/packages/design-system/src/components/SocialButton/SocialButton.tsx
@@ -4,7 +4,7 @@ import { BrandIcon, type BrandName } from '../BrandIcon';
 
 const ICON_SIZE: Record<ButtonSize, number> = { xs: 14, sm: 16, md: 18, lg: 20 };
 
-export interface SocialButtonProps extends Omit<ButtonProps, 'children' | 'iconOnly'> {
+export interface SocialButtonProps extends Omit<ButtonProps, 'children' | 'iconOnly' | 'selected'> {
   /**
    * Which provider's brand mark to show. Tied to `<BrandIcon>`'s set, so it
    * grows as BrandIcon does (today: `'google'` / `'yandex'`).

--- a/packages/playground/src/lib/props.manifest.json
+++ b/packages/playground/src/lib/props.manifest.json
@@ -344,6 +344,13 @@
           "required": false,
           "default": "",
           "description": "Render the button as a square icon-only target — `aspect-ratio` is forced\nto 1 so width tracks the size's `height` token (`xs` → 20×20, `sm` → 24×24,\n`md` → 32×32, `lg` → 40×40) and `padding` is tightened to a small inset\n(4px) so the icon has breathing room without changing the outer shape.\n\n**Always pass `aria-label`** when `iconOnly` is set, otherwise the button\nhas no accessible name. Pass a single icon as `children`.\n\nUse for inline density (row controls, chip-adjacent actions, toolbar\naffordances). For an icon + short text label, leave `iconOnly` off — the\nbutton will lay out as a normal rectangle with the existing gap."
+        },
+        {
+          "name": "selected",
+          "type": "boolean",
+          "required": false,
+          "default": "",
+          "description": "Controlled persistent paint for an applied filter or toolbar value.\nSelected paint applies only to `secondary` and `ghost` Buttons;\n`primary`, `danger`, and `success` retain their intent paint. This prop is\nvisual only and does not add toggle-button semantics. Pass native\n`aria-pressed` explicitly only when activating the Button itself toggles\nthe selected state; menu and disclosure triggers keep their own semantics.\nThe consumer owns the state. Defaults to `undefined` (not selected)."
         }
       ]
     },

--- a/packages/playground/src/pages/components/ButtonDemo.tsx
+++ b/packages/playground/src/pages/components/ButtonDemo.tsx
@@ -37,6 +37,30 @@ function SaveWithSuccessFlash() {
   );
 }
 
+function AppliedFilters() {
+  const [statusApplied, setStatusApplied] = useState(true);
+  const [ownerApplied, setOwnerApplied] = useState(false);
+
+  return (
+    <Cluster gap="sm">
+      <Button
+        variant="secondary"
+        selected={statusApplied}
+        onClick={() => setStatusApplied((value) => !value)}
+      >
+        Status: Active
+      </Button>
+      <Button
+        variant="ghost"
+        selected={ownerApplied}
+        onClick={() => setOwnerApplied((value) => !value)}
+      >
+        Owner: Alex Rivera
+      </Button>
+    </Cluster>
+  );
+}
+
 export function ButtonDemo() {
   return (
     <DemoLayout
@@ -111,6 +135,39 @@ export function SaveWithSuccessFlash() {
 }`}
       >
         <SaveWithSuccessFlash />
+      </Example>
+
+      <Example
+        title="Applied filters (persistent state)"
+        description="Use selected for a durable, independently applied filter value. It is controlled by the consumer, adds aria-pressed, and paints secondary and ghost Buttons when applied. Click either filter to try it. For transient success feedback use the success variant; for mutually exclusive choices use ButtonGroup."
+        code={`import { useState } from 'react';
+import { Button, Cluster } from '@eocrm/design-system';
+
+export function AppliedFilters() {
+  const [statusApplied, setStatusApplied] = useState(true);
+  const [ownerApplied, setOwnerApplied] = useState(false);
+
+  return (
+    <Cluster gap="sm">
+      <Button
+        variant="secondary"
+        selected={statusApplied}
+        onClick={() => setStatusApplied((value) => !value)}
+      >
+        Status: Active
+      </Button>
+      <Button
+        variant="ghost"
+        selected={ownerApplied}
+        onClick={() => setOwnerApplied((value) => !value)}
+      >
+        Owner: Alex Rivera
+      </Button>
+    </Cluster>
+  );
+}`}
+      >
+        <AppliedFilters />
       </Example>
 
       <Example

--- a/packages/playground/src/pages/components/ButtonDemo.tsx
+++ b/packages/playground/src/pages/components/ButtonDemo.tsx
@@ -46,6 +46,7 @@ function AppliedFilters() {
       <Button
         variant="secondary"
         selected={statusApplied}
+        aria-pressed={statusApplied}
         onClick={() => setStatusApplied((value) => !value)}
       >
         Status: Active
@@ -53,6 +54,7 @@ function AppliedFilters() {
       <Button
         variant="ghost"
         selected={ownerApplied}
+        aria-pressed={ownerApplied}
         onClick={() => setOwnerApplied((value) => !value)}
       >
         Owner: Alex Rivera
@@ -139,7 +141,7 @@ export function SaveWithSuccessFlash() {
 
       <Example
         title="Applied filters (persistent state)"
-        description="Use selected for a durable, independently applied filter value. It is controlled by the consumer, adds aria-pressed, and paints secondary and ghost Buttons when applied. Click either filter to try it. For transient success feedback use the success variant; for mutually exclusive choices use ButtonGroup."
+        description="Use selected for durable applied-value paint on secondary and ghost Buttons. It is visual only; these examples also pass aria-pressed because clicking each Button directly toggles its state. Menu and disclosure triggers keep their own semantics. For transient success feedback use the success variant; for mutually exclusive choices use ButtonGroup."
         code={`import { useState } from 'react';
 import { Button, Cluster } from '@eocrm/design-system';
 
@@ -152,6 +154,7 @@ export function AppliedFilters() {
       <Button
         variant="secondary"
         selected={statusApplied}
+        aria-pressed={statusApplied}
         onClick={() => setStatusApplied((value) => !value)}
       >
         Status: Active
@@ -159,6 +162,7 @@ export function AppliedFilters() {
       <Button
         variant="ghost"
         selected={ownerApplied}
+        aria-pressed={ownerApplied}
         onClick={() => setOwnerApplied((value) => !value)}
       >
         Owner: Alex Rivera

--- a/packages/playground/src/pages/mockups/Contacts/Contacts.tsx
+++ b/packages/playground/src/pages/mockups/Contacts/Contacts.tsx
@@ -63,7 +63,7 @@ export function Contacts() {
           <Cluster gap="sm" wrap={false}>
             <DropdownMenu>
               <DropdownMenu.Trigger>
-                <Button variant="secondary" size="sm">
+                <Button variant="secondary" size="sm" selected={statusFilter !== 'all'}>
                   Status: {statusFilterLabel[statusFilter]} <ChevronDown size={12} />
                 </Button>
               </DropdownMenu.Trigger>
@@ -78,7 +78,7 @@ export function Contacts() {
             </DropdownMenu>
             <DropdownMenu>
               <DropdownMenu.Trigger>
-                <Button variant="secondary" size="sm">
+                <Button variant="secondary" size="sm" selected={ownerFilter !== 'all'}>
                   Owner: {ownerFilter === 'all' ? 'All' : ownerFilter} <ChevronDown size={12} />
                 </Button>
               </DropdownMenu.Trigger>

--- a/packages/playground/src/pages/mockups/Contacts/Contacts.tsx
+++ b/packages/playground/src/pages/mockups/Contacts/Contacts.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Link as RouterLink } from 'react-router';
 import { Plus, Filter, ChevronDown } from 'lucide-react';
 import {
@@ -34,6 +34,7 @@ const owners = ['all', 'Alex Rivera', 'Jordan Park', 'Sam Chen', 'Maya Owens'];
 export function Contacts() {
   const [statusFilter, setStatusFilter] = useState('all');
   const [ownerFilter, setOwnerFilter] = useState('all');
+  const statusFilterTriggerRef = useRef<HTMLButtonElement>(null);
   const filteredContacts = contacts.filter(
     (contact) =>
       (statusFilter === 'all' || contact.status === statusFilter) &&
@@ -45,7 +46,7 @@ export function Contacts() {
       <PageHeader>
         <PageHeader.Title>Contacts</PageHeader.Title>
         <PageHeader.Meta>
-          <Text size="sm" tone="muted">
+          <Text size="sm" tone="muted" role="status" aria-live="polite">
             {filteredContacts.length} {filteredContacts.length === 1 ? 'contact' : 'contacts'}
           </Text>
         </PageHeader.Meta>
@@ -69,7 +70,12 @@ export function Contacts() {
           <Cluster gap="sm" wrap={false}>
             <DropdownMenu>
               <DropdownMenu.Trigger>
-                <Button variant="secondary" size="sm" selected={statusFilter !== 'all'}>
+                <Button
+                  ref={statusFilterTriggerRef}
+                  variant="secondary"
+                  size="sm"
+                  selected={statusFilter !== 'all'}
+                >
                   Status: {statusFilterLabel[statusFilter]} <ChevronDown size={12} />
                 </Button>
               </DropdownMenu.Trigger>
@@ -106,6 +112,7 @@ export function Contacts() {
         {filteredContacts.length === 0 ? (
           <EmptyState
             title="No contacts match your filters"
+            headingLevel={2}
             description="Try a different status or owner, or clear the applied filters."
             actions={
               <Button
@@ -113,6 +120,7 @@ export function Contacts() {
                 onClick={() => {
                   setStatusFilter('all');
                   setOwnerFilter('all');
+                  requestAnimationFrame(() => statusFilterTriggerRef.current?.focus());
                 }}
               >
                 Clear filters

--- a/packages/playground/src/pages/mockups/Contacts/Contacts.tsx
+++ b/packages/playground/src/pages/mockups/Contacts/Contacts.tsx
@@ -9,6 +9,7 @@ import {
   Cluster,
   Constrain,
   DropdownMenu,
+  EmptyState,
   Input,
   Link,
   Page,
@@ -33,6 +34,11 @@ const owners = ['all', 'Alex Rivera', 'Jordan Park', 'Sam Chen', 'Maya Owens'];
 export function Contacts() {
   const [statusFilter, setStatusFilter] = useState('all');
   const [ownerFilter, setOwnerFilter] = useState('all');
+  const filteredContacts = contacts.filter(
+    (contact) =>
+      (statusFilter === 'all' || contact.status === statusFilter) &&
+      (ownerFilter === 'all' || contact.owner === ownerFilter),
+  );
 
   return (
     <Page>
@@ -40,7 +46,7 @@ export function Contacts() {
         <PageHeader.Title>Contacts</PageHeader.Title>
         <PageHeader.Meta>
           <Text size="sm" tone="muted">
-            {contacts.length} contacts
+            {filteredContacts.length} {filteredContacts.length === 1 ? 'contact' : 'contacts'}
           </Text>
         </PageHeader.Meta>
         <PageHeader.Actions>
@@ -58,7 +64,7 @@ export function Contacts() {
       <Card padding="sm">
         <Cluster justify="between" align="center" gap="md" wrap={false}>
           <Constrain maxWidth="sm">
-            <Input placeholder="Search by name, email, or company…" />
+            <Input aria-label="Search contacts" placeholder="Search by name, email, or company…" />
           </Constrain>
           <Cluster gap="sm" wrap={false}>
             <DropdownMenu>
@@ -97,70 +103,88 @@ export function Contacts() {
       </Card>
 
       <Card padding="none">
-        <Table hover>
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell>
-                <Checkbox aria-label="Select all" />
-              </Table.HeaderCell>
-              <Table.HeaderCell>Name</Table.HeaderCell>
-              <Table.HeaderCell>Company</Table.HeaderCell>
-              <Table.HeaderCell>Status</Table.HeaderCell>
-              <Table.HeaderCell>Owner</Table.HeaderCell>
-              <Table.HeaderCell>Last activity</Table.HeaderCell>
-              <Table.HeaderCell />
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {contacts.map((c) => (
-              <Table.Row key={c.id}>
-                <Table.Cell>
-                  <Checkbox aria-label={`Select ${c.name}`} />
-                </Table.Cell>
-                <Table.Cell>
-                  <PersonDisplay size="sm">
-                    <PersonDisplay.Avatar name={c.name} />
-                    <PersonDisplay.Name>
-                      <Link as={RouterLink} to={`/mockups/contacts/${c.id}`} variant="subtle">
-                        {c.name}
-                      </Link>
-                    </PersonDisplay.Name>
-                    <PersonDisplay.Description>{c.title}</PersonDisplay.Description>
-                  </PersonDisplay>
-                </Table.Cell>
-                <Table.Cell>
-                  <Stack gap="xs">
-                    <Text as="span" weight="medium">
-                      {c.company}
-                    </Text>
-                    <Text as="span" size="sm" tone="subtle">
-                      {c.email}
-                    </Text>
-                  </Stack>
-                </Table.Cell>
-                <Table.Cell>
-                  <Badge tone={statusTone[c.status]}>{statusLabel[c.status]}</Badge>
-                </Table.Cell>
-                <Table.Cell>
-                  <PersonDisplay size="sm">
-                    <PersonDisplay.Avatar name={c.owner} />
-                    <PersonDisplay.Name>{c.owner}</PersonDisplay.Name>
-                  </PersonDisplay>
-                </Table.Cell>
-                <Table.Cell>
-                  <Text as="span" size="sm" tone="subtle">
-                    {c.lastActivity}
-                  </Text>
-                </Table.Cell>
-                <Table.Cell align="end">
-                  <Link as={RouterLink} to={`/mockups/contacts/${c.id}`}>
-                    View
-                  </Link>
-                </Table.Cell>
+        {filteredContacts.length === 0 ? (
+          <EmptyState
+            title="No contacts match your filters"
+            description="Try a different status or owner, or clear the applied filters."
+            actions={
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  setStatusFilter('all');
+                  setOwnerFilter('all');
+                }}
+              >
+                Clear filters
+              </Button>
+            }
+          />
+        ) : (
+          <Table hover>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>
+                  <Checkbox aria-label="Select all" />
+                </Table.HeaderCell>
+                <Table.HeaderCell>Name</Table.HeaderCell>
+                <Table.HeaderCell>Company</Table.HeaderCell>
+                <Table.HeaderCell>Status</Table.HeaderCell>
+                <Table.HeaderCell>Owner</Table.HeaderCell>
+                <Table.HeaderCell>Last activity</Table.HeaderCell>
+                <Table.HeaderCell />
               </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
+            </Table.Header>
+            <Table.Body>
+              {filteredContacts.map((c) => (
+                <Table.Row key={c.id}>
+                  <Table.Cell>
+                    <Checkbox aria-label={`Select ${c.name}`} />
+                  </Table.Cell>
+                  <Table.Cell>
+                    <PersonDisplay size="sm">
+                      <PersonDisplay.Avatar name={c.name} />
+                      <PersonDisplay.Name>
+                        <Link as={RouterLink} to={`/mockups/contacts/${c.id}`} variant="subtle">
+                          {c.name}
+                        </Link>
+                      </PersonDisplay.Name>
+                      <PersonDisplay.Description>{c.title}</PersonDisplay.Description>
+                    </PersonDisplay>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Stack gap="xs">
+                      <Text as="span" weight="medium">
+                        {c.company}
+                      </Text>
+                      <Text as="span" size="sm" tone="subtle">
+                        {c.email}
+                      </Text>
+                    </Stack>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Badge tone={statusTone[c.status]}>{statusLabel[c.status]}</Badge>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <PersonDisplay size="sm">
+                      <PersonDisplay.Avatar name={c.owner} />
+                      <PersonDisplay.Name>{c.owner}</PersonDisplay.Name>
+                    </PersonDisplay>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text as="span" size="sm" tone="subtle">
+                      {c.lastActivity}
+                    </Text>
+                  </Table.Cell>
+                  <Table.Cell align="end">
+                    <Link as={RouterLink} to={`/mockups/contacts/${c.id}`}>
+                      View
+                    </Link>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        )}
       </Card>
 
       <CrossLinks kind="mockup" slug="contacts" />

--- a/packages/playground/src/pages/mockups/registry.ts
+++ b/packages/playground/src/pages/mockups/registry.ts
@@ -163,6 +163,7 @@ export const MOCKUPS = [
       'Cluster',
       'Constrain',
       'DropdownMenu',
+      'EmptyState',
       'Input',
       'Link',
       'Page',


### PR DESCRIPTION
Addresses #442.

## Summary
- add controlled selected paint to secondary and ghost Buttons without deriving ARIA semantics
- preserve native `aria-pressed` as an explicit opt-in for genuine toggle buttons
- add selected styling tokens, regression coverage, and agent guidance
- demonstrate selected filter triggers and realistic filtered results in the component playground and Contacts mockup

## Test plan
- `GIT_CONFIG_GLOBAL=/dev/null make test`
- `make build-lib`
- `make build`
- `npm run typecheck`
- `make lint`
- `npm run lint:css`
- `npm run build`
- `npm run format:check`
- `npm pack --dry-run -w @eocrm/design-system`
- verify the packed-file exclusion matcher returns `0`