### PR TITLE
fix(release): retry transient Maven upload failures

### DIFF
--- a/packages/design-tokens/scripts/repair-compose-publication.mjs
+++ b/packages/design-tokens/scripts/repair-compose-publication.mjs
@@ -17,6 +17,7 @@ export async function repairComposePublication({
   actor,
   token,
   fetchImpl = fetch,
+  sleepImpl = sleep,
 }) {
   const authorization = Buffer.from(`${actor}:${token}`).toString('base64');
   const base = `https://maven.pkg.github.com/${repository}/com/eocrm/design`;
@@ -26,13 +27,12 @@ export async function repairComposePublication({
 
   for (const { artifact, name, content } of files) {
     const url = `${base}/${artifact}/${version}/${name}`;
-    const response = await fetchImpl(url, {
-      method: 'PUT',
-      headers: {
-        Authorization: `Basic ${authorization}`,
-        'Content-Type': 'application/octet-stream',
-      },
-      body: content,
+    const response = await uploadWithRetry({
+      url,
+      authorization,
+      content,
+      fetchImpl,
+      sleepImpl,
     });
     if (response.ok) {
       uploaded += 1;
@@ -58,6 +58,29 @@ export async function repairComposePublication({
   }
 
   return { uploaded, alreadyPresent };
+}
+
+async function uploadWithRetry({ url, authorization, content, fetchImpl, sleepImpl }) {
+  const maximumAttempts = 3;
+  for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
+    const response = await fetchImpl(url, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Basic ${authorization}`,
+        'Content-Type': 'application/octet-stream',
+      },
+      body: content,
+    });
+    if (response.status < 500 || response.status > 599 || attempt === maximumAttempts) {
+      return response;
+    }
+    await sleepImpl(1_000 * 2 ** (attempt - 1));
+  }
+  throw new Error('unreachable');
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
 }
 
 async function collectPublicationFiles(publicationRoot, version) {

--- a/packages/design-tokens/test/compose-publication.test.mjs
+++ b/packages/design-tokens/test/compose-publication.test.mjs
@@ -71,6 +71,45 @@ test('continues past an existing Maven file and uploads a later missing file', a
   }
 });
 
+test('retries a transient Maven server error before continuing publication', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'eocrm-compose-publication-'));
+  const version = '1.2.3';
+  const attempts = new Map();
+  const delays = [];
+
+  try {
+    for (const artifact of artifacts) {
+      const directory = join(root, 'com/eocrm/design', artifact, version);
+      await mkdir(directory, { recursive: true });
+      const module = Buffer.from(JSON.stringify({ component: { version }, variants: [] }));
+      await writeFile(join(directory, `${artifact}-${version}.module`), module);
+      await writeFile(join(directory, `${artifact}-${version}.pom`), '<project />');
+    }
+
+    const result = await repairComposePublication({
+      publicationRoot: root,
+      version,
+      repository: 'eocrm/design-system',
+      actor: 'actor',
+      token: 'token',
+      sleepImpl: async (milliseconds) => delays.push(milliseconds),
+      fetchImpl: async (url, options = {}) => {
+        assert.equal(options.method, 'PUT');
+        const attempt = (attempts.get(url) ?? 0) + 1;
+        attempts.set(url, attempt);
+        if (attempt === 1) return new Response('server error', { status: 500 });
+        return new Response('', { status: 201 });
+      },
+    });
+
+    assert.equal(result.uploaded, 10);
+    assert.deepEqual([...attempts.values()], Array(10).fill(2));
+    assert.deepEqual(delays, Array(10).fill(1_000));
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
 function sha256(content) {
   return createHash('sha256').update(content).digest('hex');
 }


### PR DESCRIPTION
## Summary
- retry GitHub Packages Maven uploads on transient 5xx responses
- use bounded exponential backoff with three total attempts
- preserve existing 409 conflict/resume handling
- add regression coverage for the observed HTTP 500 failure

## Verification
- npm test --workspace packages/design-tokens
- npm run lint:css
- npm run typecheck
- npx prettier --check packages/design-tokens/scripts/repair-compose-publication.mjs packages/design-tokens/test/compose-publication.test.mjs
- git diff --check

## Context
Release 0.3.53 built successfully but GitHub Packages returned HTTP 500 while uploading the Compose module metadata. This prevents a transient registry error from aborting immediately.