### PR TITLE
fix(release): recognize npm duplicate version errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
           status=${PIPESTATUS[0]}
           if [ "$status" -eq 0 ]; then
             echo "Published @eocrm/design-tokens."
-          elif grep -qiE 'E409|cannot publish over existing version|409 Conflict' token-publish.out; then
+          elif grep -qiE 'E409|cannot publish over existing version|cannot publish over the previously published versions|409 Conflict' token-publish.out; then
             echo "::warning::@eocrm/design-tokens already has this exact version."
           else
             exit "$status"
@@ -182,7 +182,7 @@ jobs:
           status=${PIPESTATUS[0]}
           if [ "$status" -eq 0 ]; then
             echo "Published @eocrm/design-system."
-          elif grep -qiE 'E409|cannot publish over existing version|409 Conflict' design-system-publish.out; then
+          elif grep -qiE 'E409|cannot publish over existing version|cannot publish over the previously published versions|409 Conflict' design-system-publish.out; then
             echo "::warning::@eocrm/design-system already has this exact version."
           else
             exit "$status"

--- a/packages/design-tokens/test/release-change-detection.test.mjs
+++ b/packages/design-tokens/test/release-change-detection.test.mjs
@@ -292,6 +292,19 @@ test('stages Compose publications locally and repairs every Maven file', async (
   assert.doesNotMatch(composeStep, /grep -qiE '409/);
 });
 
+test('recognizes the npm 11 duplicate-version error for resumable releases', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+  const npmPublishSteps = workflow.slice(
+    workflow.indexOf('      - name: Publish design tokens'),
+    workflow.indexOf('      - name: Publish Compose tokens'),
+  );
+
+  assert.equal(
+    npmPublishSteps.match(/cannot publish over the previously published versions/g)?.length,
+    2,
+  );
+});
+
 test('deploys the playground only after publish succeeds or an intentional no-change skip', async () => {
   const workflow = await readFile(workflowPath, 'utf8');
   const deployJob = workflow.slice(workflow.indexOf('  deploy-playground:'));


### PR DESCRIPTION
## Summary
- recognize npm 11's duplicate-version error wording during resumable releases
- apply the matcher to both published npm packages
- add regression coverage for the exact observed message

## Verification
- design-token test suite
- release workflow tests: 19/19 passed
- changed-file Prettier check
- git diff --check

## Context
The recovery release correctly recomputed 0.3.53, but npm 11 returned: `You cannot publish over the previously published versions: 0.3.53.` The old matcher did not recognize that wording and stopped before Maven publication.