### PR TITLE
fix(release): inspect guarded npm publish failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,8 +162,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
+          set +e
           npm publish 2>&1 | tee token-publish.out
           status=${PIPESTATUS[0]}
+          set -e
           if [ "$status" -eq 0 ]; then
             echo "Published @eocrm/design-tokens."
           elif grep -qiE 'E409|cannot publish over existing version|cannot publish over the previously published versions|409 Conflict' token-publish.out; then
@@ -178,8 +180,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
+          set +e
           npm publish 2>&1 | tee design-system-publish.out
           status=${PIPESTATUS[0]}
+          set -e
           if [ "$status" -eq 0 ]; then
             echo "Published @eocrm/design-system."
           elif grep -qiE 'E409|cannot publish over existing version|cannot publish over the previously published versions|409 Conflict' design-system-publish.out; then

--- a/packages/design-tokens/test/release-change-detection.test.mjs
+++ b/packages/design-tokens/test/release-change-detection.test.mjs
@@ -303,6 +303,7 @@ test('recognizes the npm 11 duplicate-version error for resumable releases', asy
     npmPublishSteps.match(/cannot publish over the previously published versions/g)?.length,
     2,
   );
+  assert.equal(npmPublishSteps.match(/set \+e/g)?.length, 2);
 });
 
 test('deploys the playground only after publish succeeds or an intentional no-change skip', async () => {


### PR DESCRIPTION
## Summary
- explicitly disable inherited Bash errexit around guarded npm publish commands
- restore errexit after capturing npm's pipeline status
- ensure duplicate-version recovery reaches its status matcher
- add workflow regression coverage

## Verification
- release workflow tests: 19/19 passed
- full design-token test suite passed
- changed-file Prettier check
- git diff --check

## Root cause
GitHub invokes run blocks with Bash -e. The existing set -uo pipefail did not disable inherited errexit, so a duplicate npm publish exited before PIPESTATUS and the duplicate matcher could run.