### PR TITLE
fix(playground): restore token reference data

### DIFF
--- a/packages/design-tokens/test/package-boundary.test.mjs
+++ b/packages/design-tokens/test/package-boundary.test.mjs
@@ -11,6 +11,16 @@ const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../.
 const designSystemRoot = join(repositoryRoot, 'packages/design-system');
 const tokenRoot = join(repositoryRoot, 'packages/design-tokens');
 
+test('playground token reference reads the authoritative token package', async () => {
+  const pageSource = await readFile(
+    join(repositoryRoot, 'packages/playground/src/pages/Tokens/TokensPage.tsx'),
+    'utf8',
+  );
+
+  assert.match(pageSource, /@eocrm\/design-tokens\/styles\/tokens\.scss\?raw/);
+  assert.doesNotMatch(pageSource, /@lib-source\/styles\/tokens\.scss\?raw/);
+});
+
 test('preserves the design-system package and TypeScript export surfaces', async () => {
   const packageJson = JSON.parse(await readFile(join(designSystemRoot, 'package.json'), 'utf8'));
   const indexSource = await readFile(join(designSystemRoot, 'src/index.ts'));

--- a/packages/playground/src/pages/Tokens/TokensPage.tsx
+++ b/packages/playground/src/pages/Tokens/TokensPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Stack, Title, Text, Code, Input } from '@eocrm/design-system';
-import tokensSource from '@lib-source/styles/tokens.scss?raw';
+import tokensSource from '@eocrm/design-tokens/styles/tokens.scss?raw';
 import {
   parseTokens,
   groupTokensByCategory,
@@ -42,7 +42,7 @@ export function TokensPage() {
           <Title order={1}>Design tokens</Title>
           <Text tone="muted">
             All {allTokens.length} CSS custom properties defined in{' '}
-            <Code>packages/design-system/src/styles/tokens.scss</Code>. Click a name to copy its{' '}
+            <Code>@eocrm/design-tokens/styles/tokens.scss</Code>. Click a name to copy its{' '}
             <Code>var(--…)</Code> reference.
           </Text>
         </Stack>


### PR DESCRIPTION
## Summary
- read the Tokens reference from the authoritative @eocrm/design-tokens public Sass export
- update the displayed source path
- add a package-boundary regression test preventing the page from returning to the forwarding stub

## Root cause
The page parsed packages/design-system/src/styles/tokens.scss as raw text. Since the shared-token migration, that file only forwards the token package and contains no CSS custom-property declarations, so the page parsed zero tokens.

## Verification
- browser-rendered production build shows 231 CSS custom properties
- playground production build passed
- playground typecheck passed
- full design-token test suite passed
- pre-push Prettier, stylelint, and typecheck passed