### PR TITLE
fix(RichTextEditor): picker and popovers survive the auto-toolbar unmount; links stop swallowing typed text

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -269,7 +269,7 @@ const doc = {
 <RichText value={doc} />;
 ```
 
-**`renderLink`** (optional) — substitute how a link renders. The consumer checks "is this URL in my space?" and returns its own node (e.g. a task/member chip) or the supplied `fallback` (the standard `<a>`). It's render-time only — the model and `toHtml`/`toMarkdown` still emit a plain link, so serialization is unchanged. Don't do heavy synchronous work or block on the network inside it; return a component that handles its own lookup/cache. The same resolver works in `<RichText>` (viewer) and `<RichTextEditor>` (where a substituted link becomes an atomic chip).
+**`renderLink`** (optional) — substitute how a link renders. The consumer checks "is this URL in my space?" and returns its own node (e.g. a task/member chip) or the supplied `fallback` (the standard `<a>`). It's render-time only — the model and `toHtml`/`toMarkdown` still emit a plain link, so serialization is unchanged. Don't do heavy synchronous work or block on the network inside it; return a component that handles its own lookup/cache. The same resolver works in `<RichText>` (viewer) and `<RichTextEditor>` (where a substituted link becomes an atomic chip). Typing against a link's trailing edge produces UNLINKED text — the link is inherited only with the caret strictly inside it, so text typed after a chip is visible instead of disappearing into the link's text under the unchanged href.
 
 ```tsx
 const renderLink: RenderLink = ({ href }, fallback) => {

--- a/packages/design-system/src/components/RichText/engine/position.test.ts
+++ b/packages/design-system/src/components/RichText/engine/position.test.ts
@@ -5,6 +5,8 @@ import {
   isCollapsed,
   orderedRange,
   wholeBlockRange,
+  marksAfterCaret,
+  marksForTypedText,
 } from './position';
 import { createBlock } from './model';
 import type { RichDoc } from './model';
@@ -64,5 +66,64 @@ describe('position', () => {
       focus: { blockId: 'b', offset: blockLength(doc.blocks[1]) },
     });
     expect(wholeBlockRange(doc, 'zzz')).toBeNull();
+  });
+});
+
+describe('marksAfterCaret', () => {
+  const HREF = 'https://x.test/a';
+  const linked = (text: string, href = HREF) => ({
+    text,
+    marks: [{ type: 'link' as const, href }],
+  });
+  const linkDoc = (
+    ...runs: { text: string; marks: { type: 'link'; href: string }[] }[]
+  ): RichDoc => ({
+    blocks: [{ id: 'a', type: 'paragraph', inlines: runs }],
+  });
+
+  it('reads the marks of the character AT the offset', () => {
+    const d = linkDoc({ text: 'ab', marks: [] }, linked('cd'));
+    expect(marksAfterCaret(d, { blockId: 'a', offset: 2 })).toEqual([{ type: 'link', href: HREF }]);
+  });
+
+  it('is empty at the block end, where no character follows', () => {
+    expect(marksAfterCaret(linkDoc(linked('ab')), { blockId: 'a', offset: 2 })).toEqual([]);
+  });
+
+  it('is empty for an unknown block', () => {
+    expect(marksAfterCaret(linkDoc(linked('ab')), { blockId: 'zzz', offset: 0 })).toEqual([]);
+  });
+});
+
+describe('marksForTypedText — link is non-inclusive at its trailing edge', () => {
+  const HREF = 'https://x.test/a';
+  const OTHER = 'https://x.test/b';
+  const link = (href = HREF) => ({ type: 'link' as const, href });
+  const build = (...runs: { text: string; marks: { type: string; href?: string }[] }[]): RichDoc =>
+    ({ blocks: [{ id: 'a', type: 'paragraph', inlines: runs }] }) as RichDoc;
+
+  it('does NOT inherit the link at its trailing edge', () => {
+    const d = build({ text: 'abc', marks: [link()] });
+    expect(marksForTypedText(d, { blockId: 'a', offset: 3 })).toEqual([]);
+  });
+
+  it('DOES inherit the link strictly inside it', () => {
+    const d = build({ text: 'abc', marks: [link()] });
+    expect(marksForTypedText(d, { blockId: 'a', offset: 1 })).toEqual([link()]);
+  });
+
+  it('treats the seam between two different hrefs as a trailing edge', () => {
+    const d = build({ text: 'ab', marks: [link()] }, { text: 'cd', marks: [link(OTHER)] });
+    expect(marksForTypedText(d, { blockId: 'a', offset: 2 })).toEqual([]);
+  });
+
+  it('keeps non-link marks at a link edge', () => {
+    const d = build({ text: 'abc', marks: [link(), { type: 'bold' }] });
+    expect(marksForTypedText(d, { blockId: 'a', offset: 3 })).toEqual([{ type: 'bold' }]);
+  });
+
+  it('still never inherits a mention', () => {
+    const d = build({ text: 'Ada', marks: [{ type: 'mention' }] });
+    expect(marksForTypedText(d, { blockId: 'a', offset: 3 })).toEqual([]);
   });
 });

--- a/packages/design-system/src/components/RichText/engine/position.ts
+++ b/packages/design-system/src/components/RichText/engine/position.ts
@@ -44,8 +44,8 @@ export function comparePoints(doc: RichDoc, a: Point, b: Point): -1 | 0 | 1 {
 /**
  * The marks carried by the character immediately before `point` (raw — includes
  * `mention`). Empty (`[]`) at a block start (`offset <= 0`) or when the block is
- * not found. Callers that must exclude `mention` (the typing-inheritance paths)
- * filter it out themselves — this primitive stays mark-agnostic.
+ * not found. This primitive stays mark-agnostic; typing-inheritance paths use
+ * {@link marksForTypedText}, which applies the exclusions.
  */
 export function marksBeforeCaret(doc: RichDoc, point: Point): Mark[] {
   const idx = findBlockIndex(doc, point.blockId);
@@ -57,6 +57,47 @@ export function marksBeforeCaret(doc: RichDoc, point: Point): Mark[] {
     pos = end;
   }
   return [];
+}
+
+/**
+ * The marks carried by the character immediately AFTER `point` (raw, like
+ * {@link marksBeforeCaret}). Empty (`[]`) at a block end, where no character
+ * follows. Typing-inheritance paths pair it with `marksBeforeCaret` to tell a
+ * caret INSIDE a run from one resting against its trailing edge.
+ */
+export function marksAfterCaret(doc: RichDoc, point: Point): Mark[] {
+  const idx = findBlockIndex(doc, point.blockId);
+  if (idx === -1 || point.offset < 0) return [];
+  let pos = 0;
+  for (const run of doc.blocks[idx].inlines ?? []) {
+    const end = pos + run.text.length;
+    if (point.offset >= pos && point.offset < end) return run.marks;
+    pos = end;
+  }
+  return [];
+}
+
+/**
+ * The marks text typed at `point` inherits — those of the preceding character,
+ * minus the two that must not grow when the caret merely abuts them:
+ * - `mention`, never (typed text never extends a mention chip);
+ * - `link`, unless the FOLLOWING character carries the same href, i.e. the caret
+ *   sits strictly inside the link rather than against its trailing edge.
+ *
+ * Without the `link` rule, typing after a link appends into the link's TEXT while
+ * its href stays put. Under `renderLink` that is invisible — the widget renders
+ * from the href — so the characters vanish and the caret appears frozen.
+ *
+ * The single source of this rule: both `insertText` and the editor's pending-mark
+ * staging read it, so a mark toggled at a link's edge can't reinstate the link.
+ */
+export function marksForTypedText(doc: RichDoc, point: Point): Mark[] {
+  const after = marksAfterCaret(doc, point);
+  return marksBeforeCaret(doc, point).filter((m) => {
+    if (m.type === 'mention') return false;
+    if (m.type === 'link') return after.some((a) => a.type === 'link' && a.href === m.href);
+    return true;
+  });
 }
 
 /** A collapsed range at a single point. */

--- a/packages/design-system/src/components/RichText/engine/transforms.test.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.test.ts
@@ -40,6 +40,35 @@ describe('transforms', () => {
     expect(r.doc.blocks[0].inlines).toEqual([{ text: 'Xy', marks: [{ type: 'bold' }] }]);
   });
 
+  it('insertText after a link appends UNLINKED text, leaving the link intact', () => {
+    // The defect this pins: the typed char used to land inside the link's text
+    // while its href stayed put, so under `renderLink` (which renders from the
+    // href) it was invisible and the caret appeared frozen against the chip.
+    const href = 'https://x.test/contacts/01ab';
+    const d: RichDoc = {
+      blocks: [
+        { id: 'a', type: 'paragraph', inlines: [{ text: href, marks: [{ type: 'link', href }] }] },
+      ],
+    };
+    const r = insertText(d, at('a', href.length), 'X');
+    expect(r.doc.blocks[0].inlines).toEqual([
+      { text: href, marks: [{ type: 'link', href }] },
+      { text: 'X', marks: [] },
+    ]);
+    expect(r.selection.focus).toEqual(at('a', href.length + 1));
+  });
+
+  it('insertText inside a link still extends the link', () => {
+    const href = 'https://x.test/';
+    const d: RichDoc = {
+      blocks: [
+        { id: 'a', type: 'paragraph', inlines: [{ text: 'abc', marks: [{ type: 'link', href }] }] },
+      ],
+    };
+    const r = insertText(d, at('a', 1), 'X');
+    expect(r.doc.blocks[0].inlines).toEqual([{ text: 'aXbc', marks: [{ type: 'link', href }] }]);
+  });
+
   it('deleteRange within a block removes the span', () => {
     const r = deleteRange(doc(['abcd', 'a']), span(at('a', 1), at('a', 3)));
     expect(runsText(r.doc.blocks[0].inlines)).toBe('ad');

--- a/packages/design-system/src/components/RichText/engine/transforms.ts
+++ b/packages/design-system/src/components/RichText/engine/transforms.ts
@@ -10,7 +10,7 @@ import {
   orderedRange,
   isCollapsed,
   collapsedRange,
-  marksBeforeCaret,
+  marksForTypedText,
 } from './position';
 import { isVoidBlock } from './attachment';
 
@@ -52,7 +52,8 @@ function snapEndOffset(block: Block, offset: number): number {
 
 /**
  * Pure/immutable. Insert `text` at `point`, inheriting the marks of the character
- * immediately before the cursor. Returns `{ doc, selection }` with the caret
+ * immediately before the cursor (see {@link marksForTypedText} for the `mention`
+ * and `link` boundary exceptions). Returns `{ doc, selection }` with the caret
  * placed after the inserted text. No-op (returns input unchanged) when `text` is
  * empty or `point.blockId` does not exist in `doc`.
  */
@@ -68,11 +69,9 @@ export function insertText(
   // A void block (e.g. an attachment) holds no editable text — never splice the
   // typed text into it (that would corrupt the block). No-op.
   if (isVoidBlock(block)) return { doc, selection: collapsed(point) };
-  // Inherit the marks of the char before the caret (mention excluded — typed text
-  // never extends a mention chip).
   const inlines = normalizeInlines([
     ...sliceInlines(block.inlines, 0, point.offset),
-    { text, marks: marksBeforeCaret(doc, point).filter((m) => m.type !== 'mention') },
+    { text, marks: marksForTypedText(doc, point) },
     ...sliceInlines(block.inlines, point.offset, blockLength(block)),
   ]);
   return {

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.test.tsx
@@ -1418,6 +1418,37 @@ describe('upload', () => {
     expect(document.querySelector('figure[data-block-id]')).toBeNull();
   });
 
+  it('the picker input survives the auto toolbar unmounting on blur', async () => {
+    // A native file dialog blurs the editable, and on an empty doc `toolbar="auto"`
+    // then unmounts the bar. When the input lived INSIDE the bar it was detached
+    // mid-pick, so the `change` never reached React and the file vanished silently.
+    const cfg = up();
+    function Harness() {
+      const [doc, setDoc] = useState(emptyDoc());
+      return <RichTextEditor value={doc} onChange={setDoc} toolbar="auto" upload={cfg} />;
+    }
+    renderEditor(<Harness />);
+    // This describe has no readSelection reset of its own; a range left by an
+    // earlier test names a block that no longer exists, and the insert would
+    // no-op on the stale caret rather than exercising the picker.
+    mockReadSelection.mockReset();
+    const box = screen.getByRole('textbox');
+    fireEvent.focus(box);
+    expect(screen.getByRole('button', { name: 'Add file' })).toBeInTheDocument();
+
+    fireEvent.blur(box);
+    expect(screen.queryByRole('button', { name: 'Add file' })).toBeNull(); // bar is gone…
+    const input = document.querySelector('input[type="file"][multiple]') as HTMLInputElement;
+    expect(input?.isConnected).toBe(true); // …the input is not
+
+    // The dialog's own delivery: files land on the input, then `change` fires.
+    // (`user.upload` clicks first, which a `display:none` input never receives.)
+    const file = new File(['x'], 'p.png', { type: 'image/png' });
+    Object.defineProperty(input, 'files', { value: [file], configurable: true });
+    fireEvent.change(input);
+    await waitFor(() => expect(cfg.onUpload).toHaveBeenCalledTimes(1));
+  });
+
   it('toolbar shows an upload button only when upload is set', () => {
     function Harness({ withUpload }: { withUpload: boolean }) {
       const [doc, setDoc] = useState(docFromText('hi'));
@@ -1804,4 +1835,32 @@ describe('attachment config', () => {
     // readOnly suppresses the gutter entirely → no ⠿ handle, hence no Configure.
     expect(screen.queryByRole('button', { name: 'Block actions' })).toBeNull();
   });
+});
+
+describe('toolbar="auto" — a popover must not take the bar down with it', () => {
+  // Every popover in the bar steals focus from the editable when it opens. On an
+  // empty doc that flipped `focused` false and unmounted the bar — destroying the
+  // popover before it could paint, so the control read as "the bar just closes".
+  // The bar reports any open popover up; this table is what keeps that list
+  // honest, so a popover added later without registering fails here.
+  it.each(['Text style', 'Emoji', 'Text color', 'Highlight'])(
+    'the %s popover keeps the bar mounted while it is open',
+    async (label) => {
+      const user = userEvent.setup();
+      function Harness() {
+        const [doc, setDoc] = useState(emptyDoc());
+        return <RichTextEditor value={doc} onChange={setDoc} toolbar="auto" />;
+      }
+      render(
+        <I18nProvider locale="en">
+          <Harness />
+        </I18nProvider>,
+      );
+      const box = screen.getByRole('textbox');
+      fireEvent.focus(box);
+      await user.click(screen.getByRole('button', { name: label }));
+      fireEvent.blur(box); // what opening the popover does in a real browser
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+    },
+  );
 });

--- a/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextEditor.tsx
@@ -18,7 +18,7 @@ import {
   blockLength,
   isCollapsed,
   wholeBlockRange,
-  marksBeforeCaret,
+  marksForTypedText,
 } from '../RichText/engine/position';
 import { linkAt, setLink } from './links';
 import { applyTypeAutolink, atomicLinkDeleteRange } from './autolinkInput';
@@ -202,11 +202,6 @@ function toggleInList(marks: Mark[], mark: Mark): Mark[] {
   return hasMark(marks, mark.type) ? withoutMark(marks, mark.type) : withMark(marks, mark);
 }
 
-/** Marks inherited by text typed at the caret — the char before it, mention excluded. */
-function marksAtCaretMarks(doc: RichDoc, caret: Point): Mark[] {
-  return marksBeforeCaret(doc, caret).filter((m) => m.type !== 'mention');
-}
-
 /**
  * Controlled rich-text editor — a contentEditable surface over the in-house
  * engine. Type to edit; ⌘/Ctrl+B/I/U and ⌘/Ctrl+⇧X toggle marks over a
@@ -343,6 +338,9 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // <body>) fires a blur, so `focused` flips false there; the `showToolbar`
     // formula keeps the bar up via the overlay-open term instead.
     const [focused, setFocused] = useState(false);
+    // True while any toolbar popover is open — it blurs the editable by opening,
+    // which would otherwise unmount the bar and the popover with it.
+    const [toolbarOverlayOpen, setToolbarOverlayOpen] = useState(false);
     const autoToolbar = toolbar === 'auto';
 
     // Toolbar state: the live selection (tracked via `selectionchange`) and any
@@ -584,6 +582,8 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // we read the current one without re-subscribing the native paste listener.
     const uploaderRef = useRef(uploader);
     uploaderRef.current = uploader;
+    // The toolbar's Add-file button clicks this; the input is rendered by the shell.
+    const uploadInputRef = useRef<HTMLInputElement>(null);
 
     // Drop any caret-staged pending mark — the doc + caret are about to change,
     // so a mark staged at the old caret must not bleed into the next typed text.
@@ -644,7 +644,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         if (isCollapsed(range)) {
           pendingAtRef.current = range.anchor;
           setPendingMarks((prev) =>
-            toggleInList(prev ?? marksAtCaretMarks(latest.current.value, range.anchor), mark),
+            toggleInList(prev ?? marksForTypedText(latest.current.value, range.anchor), mark),
           );
         } else {
           commit(runToggleMark(latest.current.value, range, mark));
@@ -661,7 +661,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         if (isCollapsed(range)) {
           pendingAtRef.current = range.anchor;
           setPendingMarks((prev) => {
-            const base = (prev ?? marksAtCaretMarks(latest.current.value, range.anchor)).filter(
+            const base = (prev ?? marksForTypedText(latest.current.value, range.anchor)).filter(
               (m) => m.type !== type,
             );
             return key ? [...base, { type, color: key }] : base;
@@ -1604,7 +1604,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     // one of the editor's own overlays is open (so opening the link editor on a
     // focused-but-empty composer keeps the bar up rather than collapsing it). The
     // overlay term is what survives the blur caused by the overlay stealing focus.
-    const overlayOpen = linkEditor != null || mention.open;
+    const overlayOpen = linkEditor != null || mention.open || toolbarOverlayOpen;
     const showToolbar =
       toolbar === true || (autoToolbar && (focused || !isEmptyDoc(value) || overlayOpen));
     // `usesShell` (the stable `.shell` gate) is declared near the top so the
@@ -1626,9 +1626,28 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
         canRedo={canRedo}
         onUndo={onUndo}
         onRedo={onRedo}
-        onUpload={uploadOn ? (files) => uploaderRef.current.uploadFiles(files) : undefined}
-        uploadAccept={upload?.accept}
+        onPickFiles={uploadOn ? () => uploadInputRef.current?.click() : undefined}
+        onOverlayOpenChange={autoToolbar ? setToolbarOverlayOpen : undefined}
         onInsertEmoji={onInsertEmoji}
+      />
+    ) : null;
+
+    // The upload picker's input lives HERE, in the always-rendered shell, not in
+    // the toolbar: a native file dialog blurs the editable, and under
+    // `toolbar="auto"` on an empty doc that unmounts the bar — detaching the input
+    // mid-pick, so its `change` never reaches React and the file is silently lost.
+    const uploadInput = uploadOn ? (
+      <input
+        ref={uploadInputRef}
+        type="file"
+        multiple
+        accept={upload?.accept}
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          const files = Array.from(e.target.files ?? []);
+          if (files.length) uploaderRef.current.uploadFiles(files);
+          e.target.value = ''; // allow re-picking the same file
+        }}
       />
     ) : null;
 
@@ -1644,6 +1663,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
     return (
       <div className={styles.shell} ref={shellRef}>
         {toolbarBar}
+        {uploadInput}
         {editable}
         {linkBubble}
         {mentionMenu}

--- a/packages/design-system/src/components/RichTextEditor/RichTextToolbar.tsx
+++ b/packages/design-system/src/components/RichTextEditor/RichTextToolbar.tsx
@@ -57,10 +57,21 @@ export interface RichTextToolbarProps {
   onUndo: () => void;
   /** Redo the last undone change. */
   onRedo: () => void;
-  /** When set, renders an upload button that opens a file picker. */
-  onUpload?: (files: File[]) => void;
-  /** Native file-picker `accept` filter. */
-  uploadAccept?: string;
+  /**
+   * When set, renders an upload button that opens the editor's file picker. The
+   * `<input type="file">` itself lives in the EDITOR, not here: this bar unmounts
+   * on blur under `toolbar="auto"`, which would detach a pending picker's input
+   * and silently drop the user's pick.
+   */
+  onPickFiles?: () => void;
+  /**
+   * Fired with `true` while ANY of this bar's own popovers (block type, emoji,
+   * text/highlight color) is open. `toolbar="auto"` unmounts the bar when the
+   * editable blurs — and every one of those popovers blurs it by opening, which
+   * destroyed the popover along with the bar. The editor keeps the bar mounted
+   * while this is true.
+   */
+  onOverlayOpenChange?: (open: boolean) => void;
   /** Insert an emoji at the caret. */
   onInsertEmoji: (emoji: string) => void;
 }
@@ -107,12 +118,25 @@ export function RichTextToolbar({
   canRedo = false,
   onUndo,
   onRedo,
-  onUpload,
-  uploadAccept,
+  onPickFiles,
+  onOverlayOpenChange,
   onInsertEmoji,
 }: RichTextToolbarProps) {
   const t = useTranslation();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Aggregate the open state of every popover in this bar into the single flag
+  // the editor reads. Tracked as a set, not a counter, so a popover reporting
+  // the same state twice can't leave the bar pinned open. Each popover stays
+  // UNCONTROLLED — `onOpenChange` fires alongside its own state, so this only
+  // observes. Any popover added here must register the same way; the
+  // "keeps the bar mounted" test iterates all of them.
+  const openPopovers = useRef(new Set<string>());
+  const trackOpen = (key: string) => (open: boolean) => {
+    const set = openPopovers.current;
+    if (open) set.add(key);
+    else set.delete(key);
+    onOverlayOpenChange?.(set.size > 0);
+  };
 
   const blockLabel = (() => {
     if (!block) return t('richTextEditor.mixed');
@@ -160,7 +184,7 @@ export function RichTextToolbar({
         <RedoIcon />
       </Button>
       <span className={styles.toolbarSep} aria-hidden="true" />
-      <DropdownMenu>
+      <DropdownMenu onOpenChange={trackOpen('blockType')}>
         <DropdownMenu.Trigger>
           <Button
             size="sm"
@@ -241,9 +265,10 @@ export function RichTextToolbar({
           </Button>
         }
         onSelect={onInsertEmoji}
+        onOpenChange={trackOpen('emoji')}
       />
 
-      <Popover>
+      <Popover onOpenChange={trackOpen('textColor')}>
         <Popover.Trigger>
           <Button
             size="sm"
@@ -265,7 +290,7 @@ export function RichTextToolbar({
         </Popover.Content>
       </Popover>
 
-      <Popover>
+      <Popover onOpenChange={trackOpen('bgColor')}>
         <Popover.Trigger>
           <Button
             size="sm"
@@ -314,21 +339,9 @@ export function RichTextToolbar({
         <OrderedListIcon />
       </Button>
 
-      {onUpload && (
+      {onPickFiles && (
         <>
           <span className={styles.toolbarSep} aria-hidden="true" />
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            accept={uploadAccept}
-            style={{ display: 'none' }}
-            onChange={(e) => {
-              const files = Array.from(e.target.files ?? []);
-              if (files.length) onUpload(files);
-              e.target.value = ''; // allow re-picking the same file
-            }}
-          />
           <Button
             size="sm"
             variant="ghost"
@@ -336,7 +349,7 @@ export function RichTextToolbar({
             aria-label={t('richTextEditor.upload')}
             disabled={disabled}
             onMouseDown={preventSelectionLoss}
-            onClick={() => fileInputRef.current?.click()}
+            onClick={onPickFiles}
           >
             <AttachFileIcon />
           </Button>

--- a/packages/playground/src/pages/components/RichTextEditorDemo.tsx
+++ b/packages/playground/src/pages/components/RichTextEditorDemo.tsx
@@ -171,7 +171,7 @@ export function Demo() {
 
       <Example
         title='Focus-gated toolbar (toolbar="auto")'
-        description='toolbar="auto" shows the formatting bar only when the editor is focused or non-empty — ideal for a compact comment composer. Click into the empty editor below: the bar appears; click away (while still empty) and it hides. Crucially, the bar stays up while the editor’s own overlays are open — focus the empty editor, click the Link button (or ⌘/Ctrl+K): the link editor opens and the bar does NOT collapse, even though focus moved into the link popover. The editable is never remounted as the bar toggles, so there is no focus/selection loss.'
+        description='toolbar="auto" shows the formatting bar only when the editor is focused or non-empty — ideal for a compact comment composer. Click into the empty editor below: the bar appears; click away (while still empty) and it hides. Crucially, the bar stays up while ANY of the editor’s own overlays is open — each takes focus off the editable by opening, so otherwise the overlay would be destroyed along with the bar. Focus the empty editor and try the Link button (or ⌘/Ctrl+K), the block-type menu, Emoji, Text color or Highlight: every one opens and the bar does NOT collapse. The editable is never remounted as the bar toggles, so there is no focus/selection loss. The upload picker’s file input sits outside the bar for the same reason — a native file dialog blurs the editable, and an input unmounted mid-pick drops the chosen file silently.'
         code={`import { useState } from 'react';
 import { RichTextEditor, docFromText, type RichDoc } from '@eocrm/design-system';
 


### PR DESCRIPTION
Three defects, all found in the eocrm comment composer (`toolbar="auto"` + `upload` + `renderLink`), all reproduced in a real browser before any code changed.

## 1. The Add-file button did nothing once the dialog closed

The hidden `<input type="file">` lived inside `RichTextToolbar`, which `toolbar="auto"` unmounts when the editable blurs — and opening a native file dialog blurs it. On an **empty** composer nothing else held the bar up, so the input was detached mid-pick; the `change` then fired on a node outside the React tree and the file was dropped in silence.

Measured in the browser before the fix: after the blur the input reported `isConnected: false`; attaching a file to it and dispatching `change` produced **zero** upload requests and no inserted block. With one character already typed the bar survives and the button works — which is why this looked intermittent.

The input now renders in the always-mounted `.shell`; the bar gets `onPickFiles` and no longer owns the input or the `accept`.

## 2. Typing after a link silently corrupted the comment

Text inserted at a link's trailing edge inherited the link mark, so it landed inside the link's **text** while its `href` stayed put:

```
"https://…/contacts/01ab"[link href=…01ab]  + type X
→ "https://…/contacts/01abX"[link href=…01ab]     ← href unchanged
```

Under `renderLink` the widget renders from the `href`, so those characters were invisible and the caret appeared frozen against the chip. Every keystroke went the same way and was persisted with the comment. Plain links showed the milder version — visible, but still absorbed.

`link` is now non-inclusive at its trailing edge: inherited only when the following character carries the same `href`, i.e. the caret is strictly inside the link. Mid-link editing is unchanged.

The rule lives in one place, `marksForTypedText`, read by both `insertText` and the editor's pending-mark staging — otherwise toggling bold at a link's edge would have reinstated the link through the other path.

## 3. Every toolbar popover closed the bar instead of opening

Block type, Emoji, Text color and Highlight each steal focus when they open, which unmounted the bar and destroyed the popover with it — the control read as "the action bar just closes". `overlayOpen` knew only about the link editor and the mention menu.

The bar now aggregates the open state of all four into one flag the editor reads. The list is kept honest by a table-driven test over every popover, so one added later without registering fails.

## Verification

Full suite green (4519 tests). Each fix was mutated in a disposable worktree and confirmed to fail for its stated reason:

| mutation | result |
|---|---|
| `link` inherits unconditionally again | 4 failed — link mark present where `[]` expected; typed run merged into the link |
| input's lifetime tied back to the bar | 1 failed — `expected undefined to be true` (input gone) |
| `overlayOpen` drops the popover flag | 4 failed — "Unable to find button" for all four popovers |

Fixes 2 and 3 are additionally confirmed in a real browser via the playground: the emoji picker now opens with the bar intact, and typing after an autolinked chip leaves `data-len` at 26 (not 27), appends a separate `#text` node after the widget, and moves the caret into it.

**Honest limit:** fix 1 cannot be end-to-end verified by an automated browser — Playwright intercepts the file chooser, so no real OS dialog opens and the triggering blur never happens. What is proven is the mechanism (the detached input drops the file) and that the input now sits outside the unmounting subtree.