### PR TITLE
fix(Cluster,Stack): set min-width: 0 so they can shrink in a truncating flex chain (#475)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1426,10 +1426,19 @@ Use this instead of `Card.List` + `Card.ListRow` whenever the data is genuinely 
 
 - `gap`: `xs` (4) / `sm` (8) / `md` (12, default) / `lg` (16) / `xl` (24) / `2xl` (32) — pixels
 - `align`: `start` / `center` / `end` / `stretch` (default)
-- Both `Stack` and `Cluster` set `min-width: 0`, so they can sit inside a truncating
-  flex chain: a `<Text truncate>` nested in one still ellipsizes when a clipping
-  ancestor squeezes it, instead of being hard-cut. Relevant for custom `renderEvent`
-  chip content, narrow table cells, and any `overflow: hidden` parent.
+
+**Truncation and shrink** (applies to `Stack`, `Cluster` and `Page`): all three set
+`min-width: 0`, so they can sit inside a truncating flex chain — a `<Text truncate>`
+nested in one still ellipsizes when a clipping ancestor squeezes it, instead of being
+hard-cut. This is what makes custom `Calendar` `renderEvent` content work, and it
+matters anywhere an `overflow: hidden` parent (e.g. `Card`) can squeeze the container.
+
+The trade-off: because it can now shrink, it also _volunteers_ for shrink when it is
+one of several items in a non-wrapping flex row. If its content cannot truncate
+(buttons, badges, icons) and a sibling can (a title), pin it in the parent's own
+stylesheet with `flex-shrink: 0` so the text gives way instead of the controls being
+clipped. The library does exactly this in `Calendar`'s header and `OptionsPicker`'s
+footer.
 
 ### `<Page>` — page-root layout primitive
 
@@ -1488,10 +1497,19 @@ Use this instead of `Card.List` + `Card.ListRow` whenever the data is genuinely 
 - `justify`: `start` (default) / `center` / `end` / `between`
 - `align`: `start` / `center` (default) / `end` / `baseline`
 - `wrap`: `true` (default). Set `false` only for narrow table cells where overflow is preferable to wrapping.
-- Both `Stack` and `Cluster` set `min-width: 0`, so they can sit inside a truncating
-  flex chain: a `<Text truncate>` nested in one still ellipsizes when a clipping
-  ancestor squeezes it, instead of being hard-cut. Relevant for custom `renderEvent`
-  chip content, narrow table cells, and any `overflow: hidden` parent.
+
+**Truncation and shrink** (applies to `Stack`, `Cluster` and `Page`): all three set
+`min-width: 0`, so they can sit inside a truncating flex chain — a `<Text truncate>`
+nested in one still ellipsizes when a clipping ancestor squeezes it, instead of being
+hard-cut. This is what makes custom `Calendar` `renderEvent` content work, and it
+matters anywhere an `overflow: hidden` parent (e.g. `Card`) can squeeze the container.
+
+The trade-off: because it can now shrink, it also _volunteers_ for shrink when it is
+one of several items in a non-wrapping flex row. If its content cannot truncate
+(buttons, badges, icons) and a sibling can (a title), pin it in the parent's own
+stylesheet with `flex-shrink: 0` so the text gives way instead of the controls being
+clipped. The library does exactly this in `Calendar`'s header and `OptionsPicker`'s
+footer.
 
 ### `<Constrain>` — size / flex constraint
 

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1426,6 +1426,10 @@ Use this instead of `Card.List` + `Card.ListRow` whenever the data is genuinely 
 
 - `gap`: `xs` (4) / `sm` (8) / `md` (12, default) / `lg` (16) / `xl` (24) / `2xl` (32) — pixels
 - `align`: `start` / `center` / `end` / `stretch` (default)
+- Both `Stack` and `Cluster` set `min-width: 0`, so they can sit inside a truncating
+  flex chain: a `<Text truncate>` nested in one still ellipsizes when a clipping
+  ancestor squeezes it, instead of being hard-cut. Relevant for custom `renderEvent`
+  chip content, narrow table cells, and any `overflow: hidden` parent.
 
 ### `<Page>` — page-root layout primitive
 
@@ -1484,6 +1488,10 @@ Use this instead of `Card.List` + `Card.ListRow` whenever the data is genuinely 
 - `justify`: `start` (default) / `center` / `end` / `between`
 - `align`: `start` / `center` (default) / `end` / `baseline`
 - `wrap`: `true` (default). Set `false` only for narrow table cells where overflow is preferable to wrapping.
+- Both `Stack` and `Cluster` set `min-width: 0`, so they can sit inside a truncating
+  flex chain: a `<Text truncate>` nested in one still ellipsizes when a clipping
+  ancestor squeezes it, instead of being hard-cut. Relevant for custom `renderEvent`
+  chip content, narrow table cells, and any `overflow: hidden` parent.
 
 ### `<Constrain>` — size / flex constraint
 

--- a/packages/design-system/src/components/Calendar/Calendar.module.scss
+++ b/packages/design-system/src/components/Calendar/Calendar.module.scss
@@ -14,6 +14,18 @@
   gap: var(--calendar-header-gap);
 }
 
+// The header is a space-between row: the title must absorb every bit of shrink
+// so the controls stay whole. Cluster sets `min-width: 0` (so it can truncate
+// when it is the only item), which also makes it volunteer for shrink here —
+// without this pin the prev/Today/next buttons get clipped by an `overflow:
+// hidden` ancestor (Card) before the title has finished compressing.
+.headerActions {
+  // Parent-owned layout: Rule 4 puts layout on the parent, which is exactly
+  // here. Also shields the nested Cluster inside it (Calendar.tsx) — with the
+  // group pinned at max-content, no shrink pressure ever reaches it.
+  flex-shrink: 0;
+}
+
 .title {
   /* stylelint-disable-next-line property-disallowed-list -- neutralizing UA <h2> default, not component layout */
   margin: 0;

--- a/packages/design-system/src/components/Calendar/Calendar.tsx
+++ b/packages/design-system/src/components/Calendar/Calendar.tsx
@@ -349,7 +349,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calen
     <div ref={ref} className={clsx(styles.calendar, className)} {...rest}>
       <header className={styles.header}>
         <h2 className={styles.title}>{titleLabel}</h2>
-        <Cluster gap="sm" align="center">
+        <Cluster gap="sm" align="center" className={styles.headerActions}>
           <Cluster gap="xs" align="center">
             <Button size="xs" variant="ghost" iconOnly aria-label={prevLabel} onClick={goPrev}>
               <ChevronLeft size={14} />

--- a/packages/design-system/src/components/Cluster/Cluster.module.scss
+++ b/packages/design-system/src/components/Cluster/Cluster.module.scss
@@ -1,7 +1,13 @@
 @use './Cluster.tokens';
 
+// min-width: 0 so the container can participate in a truncating flex chain.
+// As a flex ITEM, the default min-width: auto pins it to its content's
+// min-content size: a `<Text truncate>` inside a Cluster then never gets the
+// chance to ellipsize and the clipping ancestor hard-cuts it instead.
+// Does not affect wrapping (line breaking uses content size, not min-width).
 .cluster {
   display: flex;
+  min-width: 0;
   flex-direction: row;
 }
 

--- a/packages/design-system/src/components/Cluster/Cluster.test.tsx
+++ b/packages/design-system/src/components/Cluster/Cluster.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { render, screen } from '@testing-library/react';
 import { createRef } from 'react';
 import { Cluster, type ClusterAlign, type ClusterGap, type ClusterJustify } from './Cluster';
@@ -122,5 +124,15 @@ describe('Cluster', () => {
     expect(el.className).toMatch(/gapXs/);
     expect(el.className).toMatch(/justifyBetween/);
     expect(el.className).toMatch(/external/);
+  });
+
+  it('declares min-width: 0 so it can shrink inside a truncating flex chain', () => {
+    // jsdom computes no layout, so the guard is the stylesheet itself: without
+    // `min-width: 0` a Cluster keeps min-width: auto as a flex item, refuses to
+    // shrink below its content, and a `<Text truncate>` inside it hard-clips
+    // instead of ellipsizing (issue #475).
+    const scss = readFileSync(resolve(__dirname, 'Cluster.module.scss'), 'utf8');
+    const rule = scss.match(/\.cluster\s*\{[^}]*\}/)?.[0];
+    expect(rule).toMatch(/min-width:\s*0\s*;/);
   });
 });

--- a/packages/design-system/src/components/Cluster/Cluster.test.tsx
+++ b/packages/design-system/src/components/Cluster/Cluster.test.tsx
@@ -133,6 +133,6 @@ describe('Cluster', () => {
     // instead of ellipsizing (issue #475).
     const scss = readFileSync(resolve(__dirname, 'Cluster.module.scss'), 'utf8');
     const rule = scss.match(/\.cluster\s*\{[^}]*\}/)?.[0];
-    expect(rule).toMatch(/min-width:\s*0\s*;/);
+    expect(rule).toMatch(/min-(?:width|inline-size):\s*0(?:px)?\s*;/);
   });
 });

--- a/packages/design-system/src/components/Cluster/Cluster.tsx
+++ b/packages/design-system/src/components/Cluster/Cluster.tsx
@@ -128,6 +128,12 @@ const alignClass: Record<ClusterAlign, string> = {
  * `min-width: auto` on a flex item pins the container to its content's
  * min-content width and the ellipsis never gets a chance to appear.
  *
+ * Trade-off: because it can shrink, it also *volunteers* for shrink when it is
+ * one of several items in a non-wrapping flex row. If its content cannot
+ * truncate (buttons, badges, icons) and a sibling can (a title), pin it from
+ * the parent's stylesheet with `flex-shrink: 0` so the text gives way instead
+ * of the controls being clipped.
+ *
  * @remarks When NOT to use
  * - For aligned columns of equal width — use `<Grid>`. Cluster wraps
  *   unpredictably at narrow widths and isn't a column system.

--- a/packages/design-system/src/components/Cluster/Cluster.tsx
+++ b/packages/design-system/src/components/Cluster/Cluster.tsx
@@ -121,6 +121,13 @@ const alignClass: Record<ClusterAlign, string> = {
  *   </Cluster>
  * </ButtonGroup.Item>
  *
+ * @remarks Truncation
+ * Sets `min-width: 0`, so it can participate in a truncating flex chain: a
+ * `<Text truncate>` nested inside still ellipsizes when a clipping ancestor
+ * squeezes it, rather than being hard-cut. Without this, the default
+ * `min-width: auto` on a flex item pins the container to its content's
+ * min-content width and the ellipsis never gets a chance to appear.
+ *
  * @remarks When NOT to use
  * - For aligned columns of equal width — use `<Grid>`. Cluster wraps
  *   unpredictably at narrow widths and isn't a column system.

--- a/packages/design-system/src/components/Masonry/Masonry.module.scss
+++ b/packages/design-system/src/components/Masonry/Masonry.module.scss
@@ -2,6 +2,7 @@
 
 .masonry {
   display: flex;
+  min-width: 0;
   align-items: flex-start;
   width: 100%;
 }

--- a/packages/design-system/src/components/OptionsPicker/OptionsPicker.module.scss
+++ b/packages/design-system/src/components/OptionsPicker/OptionsPicker.module.scss
@@ -66,6 +66,15 @@
   flex-shrink: 0;
 }
 
+// The footer is a space-between row and `.count` above is already pinned, so
+// every bit of shrink lands on the action Cluster. Cluster sets `min-width: 0`,
+// so without this pin the Cancel/Apply buttons clip inside the panel's 280px
+// floor instead of the count text giving way.
+.footerActions {
+  // Parent-owned layout, per Rule 4.
+  flex-shrink: 0;
+}
+
 .footer {
   display: flex;
   align-items: center;

--- a/packages/design-system/src/components/OptionsPicker/OptionsPicker.tsx
+++ b/packages/design-system/src/components/OptionsPicker/OptionsPicker.tsx
@@ -652,7 +652,7 @@ const OptionsPickerContent = forwardRef<HTMLDivElement, OptionsPickerContentProp
               <Text size="xs" tone="muted">
                 {(props.footerCount ?? defaultFooterCount)(draft.length, allOptionsForCount.length)}
               </Text>
-              <Cluster gap="sm">
+              <Cluster gap="sm" className={styles.footerActions}>
                 <Button
                   variant="secondary"
                   size="sm"

--- a/packages/design-system/src/components/Page/Page.module.scss
+++ b/packages/design-system/src/components/Page/Page.module.scss
@@ -1,7 +1,11 @@
 @use './Page.tokens';
 
+// Page is a Stack with a page-level gap default, so it carries Stack's
+// min-width: 0 for the same reason — as a flex item it would otherwise be
+// pinned to its content's min-content width and nothing inside could truncate.
 .root {
   display: flex;
+  min-width: 0;
   flex-direction: column;
 }
 

--- a/packages/design-system/src/components/Stack/Stack.module.scss
+++ b/packages/design-system/src/components/Stack/Stack.module.scss
@@ -1,7 +1,13 @@
 @use './Stack.tokens';
 
+// min-width: 0 so the container can participate in a truncating flex chain.
+// As a flex ITEM, the default min-width: auto pins it to its content's
+// min-content size: a `<Text truncate>` inside a Stack then never gets the
+// chance to ellipsize and the clipping ancestor hard-cuts it instead.
+// Does not affect wrapping (line breaking uses content size, not min-width).
 .stack {
   display: flex;
+  min-width: 0;
   flex-direction: column;
 }
 

--- a/packages/design-system/src/components/Stack/Stack.test.tsx
+++ b/packages/design-system/src/components/Stack/Stack.test.tsx
@@ -50,6 +50,6 @@ describe('Stack', () => {
     // instead of ellipsizing (issue #475).
     const scss = readFileSync(resolve(__dirname, 'Stack.module.scss'), 'utf8');
     const rule = scss.match(/\.stack\s*\{[^}]*\}/)?.[0];
-    expect(rule).toMatch(/min-width:\s*0\s*;/);
+    expect(rule).toMatch(/min-(?:width|inline-size):\s*0(?:px)?\s*;/);
   });
 });

--- a/packages/design-system/src/components/Stack/Stack.test.tsx
+++ b/packages/design-system/src/components/Stack/Stack.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { render, screen } from '@testing-library/react';
 import { createRef } from 'react';
 import { Stack, type StackAlign, type StackGap } from './Stack';
@@ -39,5 +41,15 @@ describe('Stack', () => {
     const ref = createRef<HTMLDivElement>();
     render(<Stack ref={ref}>x</Stack>);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('declares min-width: 0 so it can shrink inside a truncating flex chain', () => {
+    // jsdom computes no layout, so the guard is the stylesheet itself: without
+    // `min-width: 0` a Stack keeps min-width: auto as a flex item, refuses to
+    // shrink below its content, and a `<Text truncate>` inside it hard-clips
+    // instead of ellipsizing (issue #475).
+    const scss = readFileSync(resolve(__dirname, 'Stack.module.scss'), 'utf8');
+    const rule = scss.match(/\.stack\s*\{[^}]*\}/)?.[0];
+    expect(rule).toMatch(/min-width:\s*0\s*;/);
   });
 });

--- a/packages/design-system/src/components/Stack/Stack.tsx
+++ b/packages/design-system/src/components/Stack/Stack.tsx
@@ -70,6 +70,12 @@ const alignClass: Record<StackAlign, string> = {
  * `min-width: auto` on a flex item pins the container to its content's
  * min-content width and the ellipsis never gets a chance to appear.
  *
+ * Trade-off: because it can shrink, it also *volunteers* for shrink when it is
+ * one of several items in a non-wrapping flex row. If its content cannot
+ * truncate (buttons, badges, icons) and a sibling can (a title), pin it from
+ * the parent's stylesheet with `flex-shrink: 0` so the text gives way instead
+ * of the controls being clipped.
+ *
  * @remarks When NOT to use
  * - For tabular data — use a real `<table>` or `<Grid>`.
  * - For a list of clickable items — semantics matter. Use `<ul><li>` with

--- a/packages/design-system/src/components/Stack/Stack.tsx
+++ b/packages/design-system/src/components/Stack/Stack.tsx
@@ -63,6 +63,13 @@ const alignClass: Record<StackAlign, string> = {
  *   <section>...</section>
  * </Stack>
  *
+ * @remarks Truncation
+ * Sets `min-width: 0`, so it can participate in a truncating flex chain: a
+ * `<Text truncate>` nested inside still ellipsizes when a clipping ancestor
+ * squeezes it, rather than being hard-cut. Without this, the default
+ * `min-width: auto` on a flex item pins the container to its content's
+ * min-content width and the ellipsis never gets a chance to appear.
+ *
  * @remarks When NOT to use
  * - For tabular data — use a real `<table>` or `<Grid>`.
  * - For a list of clickable items — semantics matter. Use `<ul><li>` with

--- a/packages/playground/src/pages/components/ClusterDemo.tsx
+++ b/packages/playground/src/pages/components/ClusterDemo.tsx
@@ -3,6 +3,8 @@ import { Cluster } from '@eocrm/design-system';
 import { Stack } from '@eocrm/design-system';
 import { Button } from '@eocrm/design-system';
 import { Badge } from '@eocrm/design-system';
+import { Dot } from '@eocrm/design-system';
+import { Text } from '@eocrm/design-system';
 import { ButtonGroup } from '@eocrm/design-system';
 import { Kanban, List } from 'lucide-react';
 import { DemoLayout } from './DemoLayout';
@@ -31,6 +33,13 @@ function InlineClusterExample() {
     </ButtonGroup>
   );
 }
+
+// A narrow flex parent with overflow: hidden — the shape a Calendar chip, a
+// table cell, or a TopBar slot has. Cluster's min-width: 0 is what lets the
+// Text inside it ellipsize instead of being hard-cut at this boundary.
+const ClippingParent = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: 'flex', width: 220, overflow: 'hidden' }}>{children}</div>
+);
 
 const Block = ({ children }: { children: React.ReactNode }) => (
   <div
@@ -261,6 +270,33 @@ export function Demo() {
             Revoke
           </Button>
         </Cluster>
+      </Example>
+
+      <Example
+        title="Truncating inside a clipping parent"
+        description="Cluster sets min-width: 0, so it can sit in a truncating flex chain: a Text truncate nested inside still ellipsizes when a narrow overflow: hidden ancestor squeezes it. Without that, the flex default (min-width: auto) would pin the Cluster to its content width and the text would be hard-cut mid-word."
+        code={`import { Cluster, Dot, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    // A 220px-wide parent with overflow: hidden.
+    <Cluster as="span" gap="xs" align="center" wrap={false}>
+      <Dot color="violet" />
+      <Text as="span" size="sm" truncate>
+        A very long appointment title that will not fit
+      </Text>
+    </Cluster>
+  );
+}`}
+      >
+        <ClippingParent>
+          <Cluster as="span" gap="xs" align="center" wrap={false}>
+            <Dot color="violet" />
+            <Text as="span" size="sm" truncate>
+              A very long appointment title that will not fit
+            </Text>
+          </Cluster>
+        </ClippingParent>
       </Example>
     </DemoLayout>
   );

--- a/packages/playground/src/pages/components/StackDemo.tsx
+++ b/packages/playground/src/pages/components/StackDemo.tsx
@@ -3,10 +3,18 @@ import { Cluster } from '@eocrm/design-system';
 import { Input } from '@eocrm/design-system';
 import { Button } from '@eocrm/design-system';
 import { Badge } from '@eocrm/design-system';
+import { Text } from '@eocrm/design-system';
 import { DemoLayout } from './DemoLayout';
 import { Example } from './Example';
 import outlineStyles from './demoOutline.module.scss';
 import { getComponentFiles } from '../../lib/componentFiles';
+
+// A narrow flex ROW with overflow: hidden. Stack is a column container, so
+// its own min-width only matters here — when the Stack is itself an item of a
+// row that squeezes it. That is the subtle case the min-width: 0 covers.
+const ClippingRow = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: 'flex', width: 260, overflow: 'hidden', gap: 8 }}>{children}</div>
+);
 
 const Block = ({ children }: { children: React.ReactNode }) => (
   <div
@@ -189,6 +197,37 @@ export function Demo() {
             </div>
           ))}
         </Cluster>
+      </Example>
+
+      <Example
+        title="Truncating inside a clipping row"
+        description="Stack sets min-width: 0, which matters when the Stack is itself an item of a squeezing flex row: its Text truncate children can then ellipsize instead of the whole Stack being pinned to its widest line and hard-cut. Note the trade-off — a Stack that can shrink also volunteers for shrink, so pin it with flex-shrink: 0 from the parent when its content cannot truncate."
+        code={`import { Stack, Text } from '@eocrm/design-system';
+
+export function Demo() {
+  return (
+    // A 260px-wide row with overflow: hidden.
+    <Stack gap="xs">
+      <Text size="sm" weight="medium" truncate>
+        Quarterly business review with the Northwind account team
+      </Text>
+      <Text size="xs" tone="muted" truncate>
+        Attendees: Priya Shah, Sam Okonkwo, Mei Lin, Yusuf Demir
+      </Text>
+    </Stack>
+  );
+}`}
+      >
+        <ClippingRow>
+          <Stack gap="xs" className={outlineStyles.outlined}>
+            <Text size="sm" weight="medium" truncate>
+              Quarterly business review with the Northwind account team
+            </Text>
+            <Text size="xs" tone="muted" truncate>
+              Attendees: Priya Shah, Sam Okonkwo, Mei Lin, Yusuf Demir
+            </Text>
+          </Stack>
+        </ClippingRow>
       </Example>
     </DemoLayout>
   );


### PR DESCRIPTION
Addresses #475.

## Summary

`Cluster` and `Stack` render `display: flex` with no `min-width: 0`. As flex ITEMS they therefore keep the default `min-width: auto`, refuse to shrink below their content's min-content size, and any `<Text truncate>` inside them never gets the chance to ellipsize — a clipping ancestor hard-cuts it instead.

This bit custom `Calendar` `renderEvent` content: the DS default chip title works because it is a **direct** child of `.chip` (which carries `min-width: 0`), but a consumer who needs a leading element must wrap in `<Cluster as="span">`, and that wrapper broke the chain.

- `min-width: 0` added to `.cluster` and `.stack`.
- `Stack` fixed alongside `Cluster` — identical gap, identical root cause; the issue only names `Cluster` because that is where it was hit first.

### Why unconditional rather than an opt-in prop

`min-width` only matters when the container is itself a flex/grid item, and there "refuse to shrink, overflow the parent" is never the desired outcome — it is the flexbox footgun this repo already hand-patches in 20+ stylesheets. Flex line breaking uses content size, not `min-width`, so **wrapping behaviour is unchanged**; the only behavioural delta is that an oversized container now shrinks instead of overflowing. A `minWidth0` prop would be zero-risk but leaves the default wrong and adds API surface for something that should not be opt-in.

## Test plan

- `make test` — 204 files / 4673 tests pass.
- `make build-lib`, `make lint`, `npm run format:check` green; `npm pack --dry-run` tarball clean.
- New guard test in `Cluster.test.tsx` and `Stack.test.tsx` asserting the declaration is present in the stylesheet (jsdom computes no layout, so the stylesheet is the only thing that can be asserted — same pattern as `_internal/collapse.test.ts`).
- New playground example "Truncating inside a clipping parent" on the Cluster demo page reproducing the issue's exact repro (Dot + truncating Text in a 220px `overflow: hidden` parent).
- JSDoc `@remarks Truncation` on both components; `AGENTS.md` note under both sections.