### PR TITLE
fix(a11y): the focus-ring holdouts, and a wrong border-width comment (#513 #514)

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1372,7 +1372,7 @@ interface UseCropPreviewOptions extends ExtractCropOptions {
 
 - `padding`: `none` / `sm` / `md` / `lg`. Defaults to `md` for plain content, `none` when `Card.Header` / `Card.Body` / `Card.List` / `Card.ListRow` is a direct child. Pass explicitly to override.
 - `tone`: `accent` / `info` / `success` / `warning` / `danger` — draws a 3px left-edge stripe in the tone color. Default: no stripe (standard bordered look). A transparent border-left is always reserved so toggling `tone` never shifts layout.
-- `overflow`: `hidden` (default) / `visible`. The default clips children to the card's rounded border so square-cornered children (a `<Table>`'s internal scroll wrapper, an `<img>`, a full-bleed `<video>`) don't show a seam at the rounded corners. Overlay primitives in this library (DropdownMenu, Tooltip, Popover, Drawer, Modal) portal to `document.body` and are NOT clipped by this. Focus rings are NOT exempt: an `outline` is clipped by an ancestor's overflow exactly as a spread shadow is, so a focusable flush against the card edge loses that band — draw its ring inset (`outline-offset: calc(-1 * var(--ring-offset))`) as Tabs, Accordion, Table, DataTable, TimeField, Rail, OptionsPicker and Calendar do. Pass `overflow="visible"` only when a direct child genuinely needs to overhang the card edge (decorative badges that protrude past a corner, hover-lift transforms whose shadow extends outward).
+- `overflow`: `hidden` (default) / `visible`. The default clips children to the card's rounded border so square-cornered children (a `<Table>`'s internal scroll wrapper, an `<img>`, a full-bleed `<video>`) don't show a seam at the rounded corners. Overlay primitives in this library (DropdownMenu, Tooltip, Popover, Drawer, Modal) portal to `document.body` and are NOT clipped by this. Focus rings are NOT exempt: an `outline` is clipped by an ancestor's overflow exactly as a spread shadow is, so a focusable flush against the card edge loses that band — draw its ring inset by passing `$offset: calc(-1 * var(--ring-offset))` to the `focus-ring` mixin, not a separate `outline-offset` declaration after the `@include` (a `structure.test.ts` gate fails the build on that shape). Pass `overflow="visible"` only when a direct child genuinely needs to overhang the card edge (decorative badges that protrude past a corner, hover-lift transforms whose shadow extends outward).
 - **Compound API** — `Card.Header` / `Card.Body` / `Card.List` / `Card.ListRow` for section-card patterns. Drop `padding="none"` — the parent Card auto-detects compound children.
 - `Card.Header`: title row (`h3` by default, override via `headerLevel`) with optional right-aligned `action` slot and bottom-border separator.
 - `Card.Body`: padded `<div>` content section. Add `scroll` beneath a Header in a `fill` Card to make Body the flexible vertical scroll region while Header stays fixed. Card intentionally owns this layout because it relates only its own compound pieces; the parent still owns the Card's definite outer height. `scroll` also sets `tabIndex={0}`, because a scroll container with no focusable descendant is unreachable by keyboard (axe `scrollable-region-focusable`) — pair it with `role="group"` and an `aria-label` when the content is worth naming, and pass `tabIndex={-1}` to opt out if the body already contains something focusable.
@@ -3594,13 +3594,16 @@ or `box-shadow: 0 0 0` for the current set rather than trusting a list here:
   gate keys on, and why it doesn't reach them — tracked in **#515**, but that
   is not the same thing as "can't migrate": `ColorPicker`, `ImageCrop` and
   `DashboardCanvas` all use `--border-width-emphasis` for that width, which is
-  `--ring-width`'s own value (2px) under a global-primitive name, their
-  offsets already match `--ring-offset` (2px, outset for the first two, inset
-  for `DashboardCanvas`), and their component-scoped ring COLOUR tokens pass
-  straight into the mixin's first argument — so all three are exact drop-ins
-  today, #515 is simply unstarted for them, and migrating deletes the four
-  `stylelint-disable-next-line` comments their raw `2px` offsets currently
-  need. `IconPicker` is the one that genuinely cannot: its width token,
+  `--ring-width`'s own value under a global-primitive name, and their offsets
+  already match `--ring-offset` (outset for the first two, inset for
+  `DashboardCanvas`) — so all three are exact drop-ins today, #515 is simply
+  unstarted for them, and migrating also lets them drop the
+  `stylelint-disable-next-line` comments their raw offsets currently need.
+  `ColorPicker` and `ImageCrop`'s ring colour is component-scoped and passes
+  straight into the mixin's first argument; `DashboardCanvas`'s is
+  `--color-accent`, a global primitive identical to `--ring-accent` in both
+  themes, so it needs no colour argument at all. `IconPicker` is the one that
+  genuinely cannot migrate: its width token,
   `--icon-picker-focus-ring-width`, is a documented public override in
   `IconPicker.tsx`'s consumer-facing token list, and the mixin has no width
   parameter — migrating would silently delete that override surface, a
@@ -3633,13 +3636,13 @@ Two things follow from the mechanism:
 - **An outset ring needs room.** If the focusable sits flush against an ancestor
   with `overflow` other than `visible`, the ring clips — invisibly to the test
   suite, which checks ring colour but not geometry (#512). Where that applies,
-  draw it inset: `outline-offset: calc(-1 * var(--ring-offset));`. For the
-  current set run `grep -rn "outline-offset" src/components` and read the
-  negative ones — grepping the `calc()` form alone misses the sites that predate
-  the token and still write `-2px`, `-1px` or their own `calc()`. Do not trust a
-  count or a list written in prose here: three files carried three different
-  numbers for this one quantity, each was stale within a commit, and the
-  replacement list went stale in the commit that wrote it.
+  draw it inset by passing `$offset: calc(-1 * var(--ring-offset))` to the
+  mixin — NOT a separate `outline-offset` declaration after the `@include`,
+  which a `structure.test.ts` gate now fails the build on. For the current
+  set run `grep -rn "@include focus-ring(" src/components` and read the
+  `$offset` arguments. Do not trust a count or a list written in prose here:
+  every attempt at one in this file has gone stale within the same PR that
+  wrote it.
 - **Inset gives the gap up.** An outset ring is bounded on both sides by the
   backdrop, which is what the contrast gate measures. An inset one touches the
   element's OWN fill, and nothing measures that side — so check it yourself

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -3589,14 +3589,23 @@ or `box-shadow: 0 0 0` for the current set rather than trusting a list here:
 
 - **Hand-rolled but real** — `AvatarGroup`, `ColorPicker`, `DashboardCanvas`,
   `IconPicker`, `ImageCrop`. `AvatarGroup` needs an inner layer between the
-  chip and the overlapping avatars; the other four use a component-scoped
-  ring-width token the mixin cannot take — tracked in **#515**.
+  chip and the overlapping avatars; the other four hand-roll with a width
+  token other than `--ring-width` — which is what the `structure.test.ts`
+  gate keys on, and why it doesn't reach them — tracked in **#515**.
+  `IconPicker`'s token resolves to `--ring-width` and `DashboardCanvas` uses
+  only global tokens, so both could migrate today; `ColorPicker` and
+  `ImageCrop` use `--border-width-emphasis`, also global, not
+  component-scoped.
 - **Suppressed, not hand-rolled** — nothing, as of this PR. Three components
   legitimately set `outline: none` under `:focus-visible` and stay:
   `AvatarGroup` (box-shadow ring — an offset gap there would reveal another
   avatar, not a surface), `FlowCanvas` (deliberate) and `LiquidEditor`
-  (delegates to `.root:focus-within`). A `structure.test.ts` gate now bans the
-  hover-shared form outright, so a fourth one won't ship silently.
+  (delegates to `.root:focus-within`) — plus `TopBar`'s `.searchInput`, which
+  sets it under plain `:focus` and delegates the same way, to
+  `.search:focus-within`. A `structure.test.ts` gate now bans the SAME-RULE
+  hover-shared form outright; a suppression sitting in a separate base rule
+  from the shared block — `DropdownMenu`'s shape before this PR — still needs
+  a human to catch it.
 
 Separately, `FlowCanvas`, `Lightbox`, `RichTextEditor` and Calendar's
 `TimedEvent` each carry an `outline:` or `box-shadow: 0 0 0 var(--ring-width) …`

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -3588,14 +3588,15 @@ they fall into two different groups — grep `:focus-visible` alongside `outline
 or `box-shadow: 0 0 0` for the current set rather than trusting a list here:
 
 - **Hand-rolled but real** — `AvatarGroup`, `ColorPicker`, `DashboardCanvas`,
-  `IconPicker`, `ImageCrop`, `LinkCard`, `Rail`, `TopBar`, `TimeField`. Two have
-  a stated reason (`AvatarGroup` needs an inner layer between the chip and the
-  overlapping avatars; `IconPicker` has a component-scoped ring-width token the
-  mixin cannot take); the rest are just older than the convention.
-- **Suppressed, not hand-rolled** — `DropdownMenu`, `FileUpload` and `Slider`
-  set `outline: none` and substitute a background or border change shared with
-  `:hover`, so the focused state is not distinguishable from the hovered one.
-  That is the defect tracked in #513, along with `Rail`'s remaining sites.
+  `IconPicker`, `ImageCrop`. `AvatarGroup` needs an inner layer between the
+  chip and the overlapping avatars; the other four use a component-scoped
+  ring-width token the mixin cannot take — tracked in **#515**.
+- **Suppressed, not hand-rolled** — nothing, as of this PR. Three components
+  legitimately set `outline: none` under `:focus-visible` and stay:
+  `AvatarGroup` (box-shadow ring — an offset gap there would reveal another
+  avatar, not a surface), `FlowCanvas` (deliberate) and `LiquidEditor`
+  (delegates to `.root:focus-within`). A `structure.test.ts` gate now bans the
+  hover-shared form outright, so a fourth one won't ship silently.
 
 Separately, `FlowCanvas`, `Lightbox`, `RichTextEditor` and Calendar's
 `TimedEvent` each carry an `outline:` or `box-shadow: 0 0 0 var(--ring-width) …`

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -3589,23 +3589,34 @@ or `box-shadow: 0 0 0` for the current set rather than trusting a list here:
 
 - **Hand-rolled but real** — `AvatarGroup`, `ColorPicker`, `DashboardCanvas`,
   `IconPicker`, `ImageCrop`. `AvatarGroup` needs an inner layer between the
-  chip and the overlapping avatars; the other four hand-roll with a width
+  chip and the overlapping avatars. The other four hand-roll with a width
   token other than `--ring-width` — which is what the `structure.test.ts`
-  gate keys on, and why it doesn't reach them — tracked in **#515**.
-  `IconPicker`'s token resolves to `--ring-width` and `DashboardCanvas` uses
-  only global tokens, so both could migrate today; `ColorPicker` and
-  `ImageCrop` use `--border-width-emphasis`, also global, not
-  component-scoped.
+  gate keys on, and why it doesn't reach them — tracked in **#515**, but that
+  is not the same thing as "can't migrate": `ColorPicker`, `ImageCrop` and
+  `DashboardCanvas` all use `--border-width-emphasis` for that width, which is
+  `--ring-width`'s own value (2px) under a global-primitive name, their
+  offsets already match `--ring-offset` (2px, outset for the first two, inset
+  for `DashboardCanvas`), and their component-scoped ring COLOUR tokens pass
+  straight into the mixin's first argument — so all three are exact drop-ins
+  today, #515 is simply unstarted for them, and migrating deletes the four
+  `stylelint-disable-next-line` comments their raw `2px` offsets currently
+  need. `IconPicker` is the one that genuinely cannot: its width token,
+  `--icon-picker-focus-ring-width`, is a documented public override in
+  `IconPicker.tsx`'s consumer-facing token list, and the mixin has no width
+  parameter — migrating would silently delete that override surface, a
+  breaking change, not a refactor.
 - **Suppressed, not hand-rolled** — nothing, as of this PR. Three components
   legitimately set `outline: none` under `:focus-visible` and stay:
   `AvatarGroup` (box-shadow ring — an offset gap there would reveal another
   avatar, not a surface), `FlowCanvas` (deliberate) and `LiquidEditor`
   (delegates to `.root:focus-within`) — plus `TopBar`'s `.searchInput`, which
   sets it under plain `:focus` and delegates the same way, to
-  `.search:focus-within`. A `structure.test.ts` gate now bans the SAME-RULE
-  hover-shared form outright; a suppression sitting in a separate base rule
-  from the shared block — `DropdownMenu`'s shape before this PR — still needs
-  a human to catch it.
+  `.search:focus-within`. A `structure.test.ts` gate now bans the same-rule
+  `outline: none` spelling shared between `:hover` and `:focus-visible`; it
+  does not catch `outline: 0`, `outline-style: none`, a shared block whose
+  body contains a nested block, or a suppression sitting in a separate base
+  rule from the shared block — `DropdownMenu`'s shape before this PR — all of
+  which still need a human to catch.
 
 Separately, `FlowCanvas`, `Lightbox`, `RichTextEditor` and Calendar's
 `TimedEvent` each carry an `outline:` or `box-shadow: 0 0 0 var(--ring-width) …`

--- a/packages/design-system/src/components/Accordion/Accordion.module.scss
+++ b/packages/design-system/src/components/Accordion/Accordion.module.scss
@@ -114,10 +114,11 @@
 
   // Hover background lives on `.header` (the full row) so it spans full width even
   // when an actions slot shortens this button. The trigger stays transparent.
+
   // Inset: the ring sits inside the cell box rather than overlapping its
   // neighbour.
   &:focus-visible {
-    @include focus-ring(var(--accordion-trigger-ring), calc(-1 * var(--ring-offset)));
+    @include focus-ring(var(--accordion-trigger-ring), $offset: calc(-1 * var(--ring-offset)));
   }
 
   &:disabled {

--- a/packages/design-system/src/components/Accordion/Accordion.module.scss
+++ b/packages/design-system/src/components/Accordion/Accordion.module.scss
@@ -114,12 +114,10 @@
 
   // Hover background lives on `.header` (the full row) so it spans full width even
   // when an actions slot shortens this button. The trigger stays transparent.
+  // Inset: the ring sits inside the cell box rather than overlapping its
+  // neighbour.
   &:focus-visible {
-    @include focus-ring(var(--accordion-trigger-ring));
-
-    // Inset: the ring sits inside the cell box rather than
-    // overlapping its neighbour.
-    outline-offset: calc(-1 * var(--ring-offset));
+    @include focus-ring(var(--accordion-trigger-ring), calc(-1 * var(--ring-offset)));
   }
 
   &:disabled {

--- a/packages/design-system/src/components/Calendar/DayCell.module.scss
+++ b/packages/design-system/src/components/Calendar/DayCell.module.scss
@@ -6,12 +6,10 @@
   cursor: pointer;
   outline: none;
 
+  // INSET: the month grid clips, and the first column's cell is flush with its left
+  // edge, so an outset ring loses that band (#505).
   &:focus-visible {
-    @include focus-ring;
-
-    // INSET: the month grid clips, and the first column's cell is flush with its left
-    // edge, so an outset ring loses that band (#505).
-    outline-offset: calc(-1 * var(--ring-offset));
+    @include focus-ring($offset: calc(-1 * var(--ring-offset)));
   }
 }
 

--- a/packages/design-system/src/components/Calendar/TimedEvent.module.scss
+++ b/packages/design-system/src/components/Calendar/TimedEvent.module.scss
@@ -44,12 +44,10 @@
     filter: brightness(0.95);
   }
 
+  // INSET: HourGrid scrolls, and a timed event sits flush against its bottom edge, so
+  // an outset ring loses that band entirely (#505).
   &:focus-visible {
-    @include focus-ring;
-
-    // INSET: HourGrid scrolls, and a timed event sits flush against its bottom edge, so
-    // an outset ring loses that band entirely (#505).
-    outline-offset: calc(-1 * var(--ring-offset));
+    @include focus-ring($offset: calc(-1 * var(--ring-offset)));
   }
 }
 

--- a/packages/design-system/src/components/DataTable/DataTable.module.scss
+++ b/packages/design-system/src/components/DataTable/DataTable.module.scss
@@ -64,13 +64,12 @@
 .clickableRow {
   cursor: pointer;
 
+  // Inset: the row's ring must sit inside the row box, not overlap its
+  // neighbour. (`outline: none` used to sit here too — written for an outline
+  // that the box-shadow mixin never emitted, and it would now erase the ring.)
   &:focus-visible {
-    @include focus-ring;
+    @include focus-ring($offset: calc(-1 * var(--ring-offset)));
 
-    // Inset: the row's ring must sit inside the row box, not overlap its
-    // neighbour. (`outline: none` used to sit here too — written for an outline
-    // that the box-shadow mixin never emitted, and it would now erase the ring.)
-    outline-offset: calc(-1 * var(--ring-offset));
     border-radius: var(--data-table-clickable-row-radius);
   }
 }

--- a/packages/design-system/src/components/DataTable/DataTable.module.scss
+++ b/packages/design-system/src/components/DataTable/DataTable.module.scss
@@ -65,8 +65,9 @@
   cursor: pointer;
 
   // Inset: the row's ring must sit inside the row box, not overlap its
-  // neighbour. (`outline: none` used to sit here too — written for an outline
-  // that the box-shadow mixin never emitted, and it would now erase the ring.)
+  // neighbour. (`outline: none` used to sit below too — written for an
+  // outline that the box-shadow mixin never emitted, and it would now erase
+  // the ring.)
   &:focus-visible {
     @include focus-ring($offset: calc(-1 * var(--ring-offset)));
 

--- a/packages/design-system/src/components/DataTable/DataTable.test.tsx
+++ b/packages/design-system/src/components/DataTable/DataTable.test.tsx
@@ -60,11 +60,12 @@ function compiledRule(parent: Root | AtRule, selector: string): Rule | undefined
   return match;
 }
 
-// LAST match, not first. CSS is last-wins, and the focus-ring mixin now emits
-// `outline-offset` that several call sites deliberately override on the next
-// line — `.find` returned the mixin's value and reported a ring at +2px while
-// the rule actually renders it inset. That is the same hole declaredValue() in
-// contrast.test.ts exists to close (see its docblock); this file had it too.
+// LAST match, not first. CSS is last-wins, and a rule can legitimately
+// declare the same property twice (a fallback value, then an override). A
+// `.find`-style first match would report whichever came first regardless of
+// which one the browser actually renders. That is the same hole
+// declaredValue() in contrast.test.ts exists to close (see its docblock);
+// this file had it too.
 function compiledDeclaration(rule: Rule | undefined, property: string): Declaration | undefined {
   return rule?.nodes
     .filter((node): node is Declaration => node.type === 'decl' && node.prop === property)
@@ -224,9 +225,9 @@ describe('DataTable responsive stylesheet', () => {
     });
     // The focus-ring mixin paints an outline, not a spread box-shadow (#505).
     // The resize handle takes the ring INSET — it sits between two header cells,
-    // so an outset ring would overlap its neighbour. So the effective offset is
-    // the negated token, written after the include; asserting the mixin's own
-    // `var(--ring-offset)` here would document a gap this rule does not have.
+    // so an outset ring would overlap its neighbour — passed as the mixin's
+    // own `$offset` argument, so this asserts what the mixin actually emits
+    // rather than a separate override on top of it.
     expect(compiledDeclaration(focusRule, 'outline')).toMatchObject({
       value: 'var(--ring-width) solid var(--ring-accent)',
     });

--- a/packages/design-system/src/components/DataTable/HeaderCell.module.scss
+++ b/packages/design-system/src/components/DataTable/HeaderCell.module.scss
@@ -42,9 +42,8 @@
   }
 
   &:focus-visible {
-    @include focus-ring;
+    @include focus-ring($offset: calc(-1 * var(--ring-offset)));
 
-    outline-offset: calc(-1 * var(--ring-offset));
     border-radius: var(--data-table-header-grip-focus-radius);
   }
 }
@@ -104,9 +103,8 @@
   }
 
   &.sortable:focus-visible {
-    @include focus-ring;
+    @include focus-ring($offset: calc(-1 * var(--ring-offset)));
 
-    outline-offset: calc(-1 * var(--ring-offset));
     border-radius: var(--data-table-header-label-focus-radius);
   }
 }
@@ -146,10 +144,9 @@
   }
 
   &:focus-visible {
-    @include focus-ring;
+    @include focus-ring($offset: calc(-1 * var(--ring-offset)));
 
     opacity: var(--data-table-header-resize-handle-opacity-visible);
-    outline-offset: calc(-1 * var(--ring-offset));
   }
 }
 

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
@@ -70,9 +70,20 @@
 
 // Same defect as FileUpload/Slider (#513): the rule above shared its
 // background between :hover and :focus-visible, and the base rule's
-// `outline: none` (removed) suppressed the ring entirely. Inset — `.content`
-// is `overflow-y: auto; overflow-x: hidden`, so an outset ring would clip on
-// both horizontal bands and on the first and last item.
+// `outline: none` (removed) suppressed the ring entirely.
+// INSET, but not because an outset ring would clip at rest: --dropdown-menu-
+// padding is 4px and an outset ring extends offset 2px + width 2px = 4px, so
+// at rest it fits exactly inside `.content`'s clip edge (overflow-y: auto;
+// overflow-x: hidden), first and last item included. The real reason is
+// --dropdown-menu-gap is 0 — items are flush, so an OUTSET ring would paint
+// over the item above and below. (A *scrolled* menu still clips whichever
+// item straddles the scrollport edge, same as any inset call site.)
+// What the inset ring covers: a checked item's left accent bar below
+// (box-shadow: inset ...-accent-width-checked, = --border-width-emphasis =
+// 2px) sits in exactly the same outermost 2px the ring occupies, and outline
+// paints above box-shadow — so a focused checked item loses its accent bar
+// completely. Acceptable: the checked background tint and `aria-checked`
+// both survive, so the state is still legible without it.
 .item:focus-visible:not([aria-disabled='true']) {
   @include focus-ring($offset: calc(-1 * var(--ring-offset)));
 }

--- a/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
+++ b/packages/design-system/src/components/DropdownMenu/DropdownMenu.module.scss
@@ -1,3 +1,4 @@
+@use '../../styles/mixins' as *;
 @use './DropdownMenu.tokens';
 
 // `.content` carries both the visual chrome and the open-only entrance
@@ -60,12 +61,20 @@
   color: var(--dropdown-menu-item-fg);
   cursor: pointer;
   user-select: none;
-  outline: none;
 }
 
 .item:hover:not([aria-disabled='true']),
 .item:focus-visible:not([aria-disabled='true']) {
   background: var(--dropdown-menu-item-bg-hover);
+}
+
+// Same defect as FileUpload/Slider (#513): the rule above shared its
+// background between :hover and :focus-visible, and the base rule's
+// `outline: none` (removed) suppressed the ring entirely. Inset — `.content`
+// is `overflow-y: auto; overflow-x: hidden`, so an outset ring would clip on
+// both horizontal bands and on the first and last item.
+.item:focus-visible:not([aria-disabled='true']) {
+  @include focus-ring($offset: calc(-1 * var(--ring-offset)));
 }
 
 .item[data-tone='danger'] {

--- a/packages/design-system/src/components/FileUpload/FileUpload.module.scss
+++ b/packages/design-system/src/components/FileUpload/FileUpload.module.scss
@@ -29,9 +29,22 @@
     color: var(--file-upload-dropzone-fg-hover);
   }
 
-  // Split from `:hover` above, which set `outline: none` for both and left a
-  // keyboard user with no indicator at all — the border tint it kept is the
-  // hover tint, so focused and hovered were indistinguishable. WCAG 2.4.7.
+  // Split from `:hover` above, which set `outline: none` for both. Focus DID
+  // change the border and text colour pre-fix — a real visible change, so
+  // 2.4.7 Focus Visible was technically satisfied — but it was the SAME
+  // change `:hover` made, so a keyboard user could not tell focused from
+  // hovered, and the ring mechanism was suppressed entirely.
+  // The tint is deliberately not repeated here on focus, unlike Slider's:
+  // splitting the rule means this block no longer sets `border-color`, which
+  // lets `.dragOver` (specificity 0,1,0) win the border while the dropzone is
+  // focused. Before the split, `:focus-visible` (0,2,0) always beat it, so
+  // dragging a file over a focused dropzone showed no drag state. Restoring
+  // the tint here would reintroduce that.
+  // Clipping check (mixin's own requirement for a new call site): neither
+  // `.root` nor `.dropzone` sets `overflow`, so nothing in this component
+  // clips the outset ring. A consumer that scrolls this in a padding-less
+  // container (a `Card` with `overflow: hidden`, a Modal body) could still
+  // clip it — that's #512's territory, not a reason to go inset here.
   &:focus-visible {
     @include focus-ring;
   }

--- a/packages/design-system/src/components/FileUpload/FileUpload.module.scss
+++ b/packages/design-system/src/components/FileUpload/FileUpload.module.scss
@@ -24,11 +24,16 @@
     border-color var(--transition-base),
     background var(--transition-base);
 
-  &:hover,
-  &:focus-visible {
+  &:hover {
     border-color: var(--file-upload-dropzone-border-color-hover);
     color: var(--file-upload-dropzone-fg-hover);
-    outline: none;
+  }
+
+  // Split from `:hover` above, which set `outline: none` for both and left a
+  // keyboard user with no indicator at all — the border tint it kept is the
+  // hover tint, so focused and hovered were indistinguishable. WCAG 2.4.7.
+  &:focus-visible {
+    @include focus-ring;
   }
 }
 

--- a/packages/design-system/src/components/LinkCard/LinkCard.module.scss
+++ b/packages/design-system/src/components/LinkCard/LinkCard.module.scss
@@ -1,3 +1,4 @@
+@use '../../styles/mixins' as *;
 @use './LinkCard.tokens';
 
 .linkCard {
@@ -28,7 +29,8 @@
 }
 
 .linkCard:focus-visible {
-  outline: var(--ring-width) solid var(--ring-accent);
+  @include focus-ring;
+
   outline-offset: var(--link-card-focus-offset);
 }
 

--- a/packages/design-system/src/components/LinkCard/LinkCard.module.scss
+++ b/packages/design-system/src/components/LinkCard/LinkCard.module.scss
@@ -28,10 +28,11 @@
   text-decoration: none;
 }
 
+// --link-card-focus-offset used to override this to 2px, identical to the
+// mixin's own --ring-offset default — a no-op token, deleted along with the
+// override.
 .linkCard:focus-visible {
   @include focus-ring;
-
-  outline-offset: var(--link-card-focus-offset);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/design-system/src/components/LinkCard/LinkCard.tokens.scss
+++ b/packages/design-system/src/components/LinkCard/LinkCard.tokens.scss
@@ -4,5 +4,4 @@
   --link-card-hover-shadow: var(--shadow-md);
   --link-card-hover-border-color: var(--color-border-strong);
   --link-card-transition: border-color 120ms ease, box-shadow 120ms ease;
-  --link-card-focus-offset: 2px;
 }

--- a/packages/design-system/src/components/OptionsPicker/OptionsPicker.module.scss
+++ b/packages/design-system/src/components/OptionsPicker/OptionsPicker.module.scss
@@ -169,25 +169,23 @@ button.groupHeader {
     --text-fg-subtle: var(--options-picker-group-header-hint-fg-hover);
   }
 
+  // INSET. `.list` above is `overflow-y: auto` — which computes `overflow-x`
+  // to `auto` — with no padding, and this header is `width: 100%`, so an
+  // outset ring loses both vertical bands on every group header, always.
+  // Same shape as Tabs and TimeField (#505), and NO GATE
+  // DETECTS IT: two static rules were measured and both were mostly false
+  // positives, so none shipped. A browser sweep found all three; #512 carries
+  // the signature so the next one is looked for rather than stumbled on.
+  // The trade, since the mixin says to record it, and it is the worst one in
+  // the library: `--options-picker-group-header-border-width` is
+  // --border-width-emphasis = 2px, and the inset band is also 2px, so while
+  // focused this covers the group's colour-identity `border-bottom`
+  // COMPLETELY — not partially, as on TimedEvent. Accepted because the colour
+  // is also carried by the GroupDot beside the label, which the ring does not
+  // touch, so the identity survives the focus; and because the alternative is
+  // an indicator that is permanently absent rather than briefly redundant.
   &:focus-visible {
-    @include focus-ring;
-
-    // INSET. `.list` above is `overflow-y: auto` — which computes `overflow-x`
-    // to `auto` — with no padding, and this header is `width: 100%`, so an
-    // outset ring loses both vertical bands on every group header, always.
-    // Same shape as Tabs and TimeField (#505), and NO GATE
-    // DETECTS IT: two static rules were measured and both were mostly false
-    // positives, so none shipped. A browser sweep found all three; #512 carries
-    // the signature so the next one is looked for rather than stumbled on.
-    // The trade, since the mixin says to record it, and it is the worst one in
-    // the library: `--options-picker-group-header-border-width` is
-    // --border-width-emphasis = 2px, and the inset band is also 2px, so while
-    // focused this covers the group's colour-identity `border-bottom`
-    // COMPLETELY — not partially, as on TimedEvent. Accepted because the colour
-    // is also carried by the GroupDot beside the label, which the ring does not
-    // touch, so the identity survives the focus; and because the alternative is
-    // an indicator that is permanently absent rather than briefly redundant.
-    outline-offset: calc(-1 * var(--ring-offset));
+    @include focus-ring($offset: calc(-1 * var(--ring-offset)));
   }
 }
 

--- a/packages/design-system/src/components/OptionsPicker/OptionsPicker.tsx
+++ b/packages/design-system/src/components/OptionsPicker/OptionsPicker.tsx
@@ -566,10 +566,20 @@ const OptionsPickerContent = forwardRef<HTMLDivElement, OptionsPickerContentProp
             {hasAnyVisible &&
               isGrouped(props) &&
               visibleGroups.map((g) => {
-                // When the group has a palette color, draw a 1px bottom
+                // When the group has a palette color, draw a 2px bottom
                 // border on the header in that color — visually carries
                 // the namespace identity from the dot across the full
                 // header width, separating each group's options.
+                //
+                // The width is load-bearing, not decorative: #510 gave the
+                // header an INSET focus ring (the list is a padding-less
+                // scroller, so an outset ring lost both vertical bands), and
+                // the inset band is --ring-width, also 2px. A focused header
+                // therefore covers this border completely. That trade is only
+                // acceptable because the GroupDot beside the label carries the
+                // same --color-palette-<name>-fg and the ring does not touch
+                // it. Reasoning from the old "1px" gave a partial occlusion
+                // and a different verdict on whether the trade is sound.
                 const headerClassName = clsx(
                   styles.groupHeader,
                   g.color && styles.groupHeaderWithBorder,

--- a/packages/design-system/src/components/OptionsPicker/OptionsPicker.tsx
+++ b/packages/design-system/src/components/OptionsPicker/OptionsPicker.tsx
@@ -574,8 +574,11 @@ const OptionsPickerContent = forwardRef<HTMLDivElement, OptionsPickerContentProp
                 // The width is load-bearing, not decorative: #510 gave the
                 // header an INSET focus ring (the list is a padding-less
                 // scroller, so an outset ring lost both vertical bands), and
-                // the inset band is --ring-width, also 2px. A focused header
-                // therefore covers this border completely. That trade is only
+                // the inset band is --ring-width, also 2px. In multi mode,
+                // where the header is a focusable <button>, a focused header
+                // therefore covers this border completely — single mode's
+                // header is a <div role="presentation">, which never takes a
+                // ring and never occludes anything. That trade is only
                 // acceptable because the GroupDot beside the label carries the
                 // same --color-palette-<name>-fg and the ring does not touch
                 // it. Reasoning from the old "1px" gave a partial occlusion

--- a/packages/design-system/src/components/Rail/Rail.module.scss
+++ b/packages/design-system/src/components/Rail/Rail.module.scss
@@ -223,8 +223,10 @@
 .item:focus-visible {
   @include focus-ring;
 
-  // Inset: the rail body is an overflow scroller, so an outset ring loses its
-  // outer bands. Was a raw -2px.
+  // Inset: `.item` renders both in the rail body (an overflow scroller) and,
+  // portaled, inside a flyout header — its clipping ancestor is `.body` in
+  // the rail, `.flyout` when portaled. Either way an outset ring loses a
+  // band. Was a raw -2px.
   outline-offset: calc(-1 * var(--ring-offset));
 }
 
@@ -460,8 +462,9 @@
 .flyoutHeaderLink:focus-visible {
   @include focus-ring;
 
-  // Inset: the rail body is an overflow scroller, so an outset ring loses its
-  // outer bands. Was a raw -2px.
+  // Inset: the flyout is `createPortal(..., document.body)` (RailGroup.tsx),
+  // so this link is not a descendant of `.body` — its clipping ancestor is
+  // `.flyout` itself, which sets `overflow: hidden`. Was a raw -2px.
   outline-offset: calc(-1 * var(--ring-offset));
 }
 

--- a/packages/design-system/src/components/Rail/Rail.module.scss
+++ b/packages/design-system/src/components/Rail/Rail.module.scss
@@ -220,14 +220,11 @@
   text-decoration: none;
 }
 
+// Inset: `.item` renders both in the rail body (an overflow scroller) and,
+// portaled, inside a flyout header — its clipping ancestor is `.body` in the
+// rail, `.flyout` when portaled. Either way an outset ring loses a band.
 .item:focus-visible {
-  @include focus-ring;
-
-  // Inset: `.item` renders both in the rail body (an overflow scroller) and,
-  // portaled, inside a flyout header — its clipping ancestor is `.body` in
-  // the rail, `.flyout` when portaled. Either way an outset ring loses a
-  // band. Was a raw -2px.
-  outline-offset: calc(-1 * var(--ring-offset));
+  @include focus-ring($offset: calc(-1 * var(--ring-offset)));
 }
 
 // Active-state styling. Two selectors so we catch both shapes:
@@ -314,9 +311,7 @@
 // specificity, won — and left the correct -2px rule further up dead while the
 // ring clipped against `.body`'s overflow on both sides. One rule now.
 .groupTrigger:focus-visible {
-  @include focus-ring;
-
-  outline-offset: calc(-1 * var(--ring-offset));
+  @include focus-ring($offset: calc(-1 * var(--ring-offset)));
 }
 
 // Parent-active styling: the group's trigger picks up the active accent
@@ -364,12 +359,10 @@
   background: var(--rail-item-bg-hover);
 }
 
+// Inset: the rail body is an overflow scroller, so an outset ring loses its
+// outer bands.
 .groupChevronButton:focus-visible {
-  @include focus-ring;
-
-  // Inset: the rail body is an overflow scroller, so an outset ring loses its
-  // outer bands. Was a raw -2px.
-  outline-offset: calc(-1 * var(--ring-offset));
+  @include focus-ring($offset: calc(-1 * var(--ring-offset)));
 }
 
 .groupChevron {
@@ -459,13 +452,11 @@
   color: var(--rail-item-fg-active);
 }
 
+// Inset: the flyout is `createPortal(..., document.body)` (RailGroup.tsx), so
+// this link is not a descendant of `.body` — its clipping ancestor is
+// `.flyout` itself, which sets `overflow: hidden`.
 .flyoutHeaderLink:focus-visible {
-  @include focus-ring;
-
-  // Inset: the flyout is `createPortal(..., document.body)` (RailGroup.tsx),
-  // so this link is not a descendant of `.body` — its clipping ancestor is
-  // `.flyout` itself, which sets `overflow: hidden`. Was a raw -2px.
-  outline-offset: calc(-1 * var(--ring-offset));
+  @include focus-ring($offset: calc(-1 * var(--ring-offset)));
 }
 
 .flyoutBody {

--- a/packages/design-system/src/components/Rail/Rail.module.scss
+++ b/packages/design-system/src/components/Rail/Rail.module.scss
@@ -1,3 +1,4 @@
+@use '../../styles/mixins' as *;
 @use './Rail.tokens';
 
 // ─── Root ───────────────────────────────────────────────────────────────
@@ -220,8 +221,11 @@
 }
 
 .item:focus-visible {
-  outline: var(--ring-width) solid var(--ring-accent);
-  outline-offset: -2px;
+  @include focus-ring;
+
+  // Inset: the rail body is an overflow scroller, so an outset ring loses its
+  // outer bands. Was a raw -2px.
+  outline-offset: calc(-1 * var(--ring-offset));
 }
 
 // Active-state styling. Two selectors so we catch both shapes:
@@ -308,7 +312,8 @@
 // specificity, won — and left the correct -2px rule further up dead while the
 // ring clipped against `.body`'s overflow on both sides. One rule now.
 .groupTrigger:focus-visible {
-  outline: var(--ring-width) solid var(--ring-accent);
+  @include focus-ring;
+
   outline-offset: calc(-1 * var(--ring-offset));
 }
 
@@ -358,8 +363,11 @@
 }
 
 .groupChevronButton:focus-visible {
-  outline: var(--ring-width) solid var(--ring-accent);
-  outline-offset: -2px;
+  @include focus-ring;
+
+  // Inset: the rail body is an overflow scroller, so an outset ring loses its
+  // outer bands. Was a raw -2px.
+  outline-offset: calc(-1 * var(--ring-offset));
 }
 
 .groupChevron {
@@ -450,8 +458,11 @@
 }
 
 .flyoutHeaderLink:focus-visible {
-  outline: var(--ring-width) solid var(--ring-accent);
-  outline-offset: -2px;
+  @include focus-ring;
+
+  // Inset: the rail body is an overflow scroller, so an outset ring loses its
+  // outer bands. Was a raw -2px.
+  outline-offset: calc(-1 * var(--ring-offset));
 }
 
 .flyoutBody {

--- a/packages/design-system/src/components/Slider/Slider.module.scss
+++ b/packages/design-system/src/components/Slider/Slider.module.scss
@@ -1,3 +1,4 @@
+@use '../../styles/mixins' as *;
 @use './Slider.tokens';
 
 .root {
@@ -131,13 +132,20 @@
   height: var(--slider-thumb-size-lg);
 }
 
-.thumb:hover,
+.thumb:hover {
+  border-color: var(--slider-thumb-border-color-hover);
+  box-shadow: var(--slider-thumb-shadow-hover);
+}
+
+// Split from `:hover` above. The shared rule suppressed the ring and offered
+// the HOVER treatment as its substitute, so focus and hover looked identical.
+// The border/shadow change is kept on focus as well — it reads as "active
+// thumb" — but the ring is what makes it a focus indicator.
 .thumb:focus-visible {
   border-color: var(--slider-thumb-border-color-hover);
   box-shadow: var(--slider-thumb-shadow-hover);
 
-  // stylelint-disable-next-line scale-unlimited/declaration-strict-value -- CSS keyword
-  outline: none;
+  @include focus-ring;
 }
 
 .thumbDragging {

--- a/packages/design-system/src/components/Slider/Slider.module.scss
+++ b/packages/design-system/src/components/Slider/Slider.module.scss
@@ -139,8 +139,21 @@
 
 // Split from `:hover` above. The shared rule suppressed the ring and offered
 // the HOVER treatment as its substitute, so focus and hover looked identical.
-// The border/shadow change is kept on focus as well — it reads as "active
-// thumb" — but the ring is what makes it a focus indicator.
+// The border/shadow change is kept on focus as well, unlike FileUpload's
+// dropzone: nothing else here competes for the thumb's border, so the tint
+// stays as a secondary affordance — it just means a focused-and-hovered thumb
+// paints two concentric accent rings (the border tint and the focus ring).
+// Left as is; not a defect worth chasing for one pixel of visual overlap.
+// Clipping check (mixin's own requirement for a new call site): `.track`
+// declares `overflow: visible` and `.root` sets none, so nothing inside this
+// component clips the outset ring.
+// `--ring-accent` and `--slider-fill-bg` resolve to the same colour in both
+// themes (#0052cc light, #68a7ff dark). On the thumb's leading edge the
+// filled track runs under the ring's offset gap, so ring and fill meet at
+// 1:1 there — the joined-siblings hazard mixins.scss documents. The other
+// edges land on the page background and stay perceivable, so this is not a
+// 1.4.11 failure; recorded as a known instance of that hazard, not fixed,
+// since it is a contrast question and #512's sweep is geometry.
 .thumb:focus-visible {
   border-color: var(--slider-thumb-border-color-hover);
   box-shadow: var(--slider-thumb-shadow-hover);

--- a/packages/design-system/src/components/Table/Table.module.scss
+++ b/packages/design-system/src/components/Table/Table.module.scss
@@ -165,12 +165,10 @@
     color: var(--table-header-fg-hover);
   }
 
+  // Inset: the ring sits inside the cell box rather than overlapping its
+  // neighbour.
   &:focus-visible {
-    @include focus-ring(var(--table-sortable-ring));
-
-    // Inset: the ring sits inside the cell box rather than
-    // overlapping its neighbour.
-    outline-offset: calc(-1 * var(--ring-offset));
+    @include focus-ring(var(--table-sortable-ring), calc(-1 * var(--ring-offset)));
   }
 }
 

--- a/packages/design-system/src/components/Table/Table.module.scss
+++ b/packages/design-system/src/components/Table/Table.module.scss
@@ -168,7 +168,7 @@
   // Inset: the ring sits inside the cell box rather than overlapping its
   // neighbour.
   &:focus-visible {
-    @include focus-ring(var(--table-sortable-ring), calc(-1 * var(--ring-offset)));
+    @include focus-ring(var(--table-sortable-ring), $offset: calc(-1 * var(--ring-offset)));
   }
 }
 

--- a/packages/design-system/src/components/Tabs/Tabs.module.scss
+++ b/packages/design-system/src/components/Tabs/Tabs.module.scss
@@ -49,19 +49,18 @@
     color: var(--tabs-tab-fg-hover);
   }
 
+  // INSET. `.scrollWrap` is `overflow-x: auto`, which computes `overflow-y:
+  // auto` too, so it clips vertically — and both the tab and the action are
+  // flush with its top edge and 2px from its bottom. An outset ring loses BOTH
+  // horizontal bands and renders as two floating vertical bars flanking the
+  // element (#505). Same treatment as Accordion, Table, DataTable, HeaderCell
+  // and Calendar's TimedEvent / DayCell. (`.scrollWrapVertical` sets
+  // `overflow-x: visible`, so a vertical tablist has no clipping ancestor and
+  // takes the inset because this one rule matches whatever the orientation —
+  // harmless there, the padding is ample.)
   &:focus-visible {
-    @include focus-ring(var(--tabs-tab-ring));
+    @include focus-ring(var(--tabs-tab-ring), calc(-1 * var(--ring-offset)));
 
-    // INSET. `.scrollWrap` is `overflow-x: auto`, which computes `overflow-y:
-    // auto` too, so it clips vertically — and both the tab and the action are
-    // flush with its top edge and 2px from its bottom. An outset ring loses BOTH
-    // horizontal bands and renders as two floating vertical bars flanking the
-    // element (#505). Same treatment as Accordion, Table, DataTable, HeaderCell
-    // and Calendar's TimedEvent / DayCell. (`.scrollWrapVertical` sets
-    // `overflow-x: visible`, so a vertical tablist has no clipping ancestor and
-    // takes the inset because this one rule matches whatever the orientation —
-    // harmless there, the padding is ample.)
-    outline-offset: calc(-1 * var(--ring-offset));
     border-radius: var(--tabs-tab-radius);
   }
 }
@@ -92,12 +91,11 @@
     color: var(--tabs-tab-fg-hover);
   }
 
+  // INSET, for the reason given on `.tab` above — `.action` is a
+  // stretch-aligned sibling inside the same clipping `.scrollWrap`.
   &:focus-visible {
-    @include focus-ring(var(--tabs-tab-ring));
+    @include focus-ring(var(--tabs-tab-ring), calc(-1 * var(--ring-offset)));
 
-    // INSET, for the reason given on `.tab` above — `.action` is a
-    // stretch-aligned sibling inside the same clipping `.scrollWrap`.
-    outline-offset: calc(-1 * var(--ring-offset));
     border-radius: var(--tabs-tab-radius);
   }
 

--- a/packages/design-system/src/components/Tabs/Tabs.module.scss
+++ b/packages/design-system/src/components/Tabs/Tabs.module.scss
@@ -59,7 +59,7 @@
   // takes the inset because this one rule matches whatever the orientation —
   // harmless there, the padding is ample.)
   &:focus-visible {
-    @include focus-ring(var(--tabs-tab-ring), calc(-1 * var(--ring-offset)));
+    @include focus-ring(var(--tabs-tab-ring), $offset: calc(-1 * var(--ring-offset)));
 
     border-radius: var(--tabs-tab-radius);
   }
@@ -94,7 +94,7 @@
   // INSET, for the reason given on `.tab` above — `.action` is a
   // stretch-aligned sibling inside the same clipping `.scrollWrap`.
   &:focus-visible {
-    @include focus-ring(var(--tabs-tab-ring), calc(-1 * var(--ring-offset)));
+    @include focus-ring(var(--tabs-tab-ring), $offset: calc(-1 * var(--ring-offset)));
 
     border-radius: var(--tabs-tab-radius);
   }

--- a/packages/design-system/src/components/TimeField/TimeField.module.scss
+++ b/packages/design-system/src/components/TimeField/TimeField.module.scss
@@ -153,14 +153,12 @@
     background: var(--date-picker-time-popover-row-hover-bg);
   }
 
+  // INSET. `.timeColumn` above is `overflow-x: hidden`, and this row is
+  // `width: 100%`, so an outset ring puts both vertical bands outside the
+  // scrollport on every option — always, not at some size. Same signature as
+  // Tabs (#505); found by a browser sweep, not by any gate.
   &:focus-visible {
-    @include focus-ring;
-
-    // INSET. `.timeColumn` above is `overflow-x: hidden`, and this row is
-    // `width: 100%`, so an outset ring puts both vertical bands outside the
-    // scrollport on every option — always, not at some size. Same signature as
-    // Tabs (#505); found by a browser sweep, not by any gate.
-    outline-offset: calc(-1 * var(--ring-offset));
+    @include focus-ring($offset: calc(-1 * var(--ring-offset)));
   }
 }
 

--- a/packages/design-system/src/components/TimeField/TimeField.module.scss
+++ b/packages/design-system/src/components/TimeField/TimeField.module.scss
@@ -218,9 +218,7 @@
 }
 
 .timeNowButton:focus-visible {
-  @include focus-ring;
-
-  outline-offset: 1px;
+  @include focus-ring($offset: 1px);
 }
 
 // Mirrors Input's invalid treatment so a TimeField inside a Field with an

--- a/packages/design-system/src/components/TimeField/TimeField.module.scss
+++ b/packages/design-system/src/components/TimeField/TimeField.module.scss
@@ -218,7 +218,8 @@
 }
 
 .timeNowButton:focus-visible {
-  outline: var(--ring-width) solid var(--ring-accent);
+  @include focus-ring;
+
   outline-offset: 1px;
 }
 

--- a/packages/design-system/src/components/TopBar/TopBar.module.scss
+++ b/packages/design-system/src/components/TopBar/TopBar.module.scss
@@ -61,10 +61,10 @@
 }
 // stylelint-enable property-disallowed-list
 
+// Offset pulls the ring inward by 1px so it sits ON the surface edge instead
+// of outside it.
 .search:focus-within {
-  @include focus-ring(var(--topbar-search-ring-focus));
-  // stylelint-disable-next-line declaration-property-value-disallowed-list -- pull the focus ring inward by 1px so it sits ON the surface edge instead of outside it
-  outline-offset: -1px;
+  @include focus-ring(var(--topbar-search-ring-focus), -1px);
 }
 
 .searchIcon {

--- a/packages/design-system/src/components/TopBar/TopBar.module.scss
+++ b/packages/design-system/src/components/TopBar/TopBar.module.scss
@@ -64,7 +64,7 @@
 // Offset pulls the ring inward by 1px so it sits ON the surface edge instead
 // of outside it.
 .search:focus-within {
-  @include focus-ring(var(--topbar-search-ring-focus), -1px);
+  @include focus-ring(var(--topbar-search-ring-focus), $offset: -1px);
 }
 
 .searchIcon {

--- a/packages/design-system/src/components/TopBar/TopBar.module.scss
+++ b/packages/design-system/src/components/TopBar/TopBar.module.scss
@@ -1,3 +1,4 @@
+@use '../../styles/mixins' as *;
 @use './TopBar.tokens';
 
 // ─── Root ───────────────────────────────────────────────────────────────
@@ -61,7 +62,7 @@
 // stylelint-enable property-disallowed-list
 
 .search:focus-within {
-  outline: var(--ring-width) solid var(--topbar-search-ring-focus);
+  @include focus-ring(var(--topbar-search-ring-focus));
   // stylelint-disable-next-line declaration-property-value-disallowed-list -- pull the focus ring inward by 1px so it sits ON the surface edge instead of outside it
   outline-offset: -1px;
 }

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -946,3 +946,59 @@ describe('stated contrast ratios still hold', () => {
     ).toEqual([]);
   });
 });
+
+/**
+ * A focus ring may not be suppressed by a rule it SHARES with `:hover`.
+ *
+ * This is the shape behind two live defects, not a style preference.
+ * `FileUpload`'s `.dropzone:hover, .dropzone:focus-visible { outline: none }`
+ * left the dropzone with NO focus indicator at all — a WCAG 2.4.7 failure —
+ * because the only remaining feedback was a border tint identical to hover.
+ * `Slider`'s `.thumb` had the same rule with a visible substitute, which is
+ * better and still wrong: the focused state cannot be told apart from the
+ * hovered one.
+ *
+ * Deliberately NOT "any `outline: none` under `:focus-visible`". Three sites
+ * do that legitimately and stay: `AvatarGroup` draws a box-shadow ring on
+ * purpose (an offset gap there would reveal another avatar, not a surface),
+ * `FlowCanvas` suppresses a frame it does not want, and `LiquidEditor`'s
+ * textarea delegates the ring to `.root:focus-within`. A broader rule would
+ * fail all three and get waived, which is how a gate stops meaning anything.
+ * The SHARING is the defect; the suppression alone is not.
+ */
+describe('a focus ring is not suppressed by a rule shared with :hover', () => {
+  const styleFiles = allFilesUnder(componentsDir).filter(({ label }) =>
+    /\.module\.scss$/.test(label),
+  );
+
+  it('found stylesheets to check', () => {
+    expect(styleFiles.length).toBeGreaterThan(50);
+  });
+
+  it.each(styleFiles.map(({ label, code }) => [label, code]))('%s', (_label, code) => {
+    // Selector list = everything from the previous `}`/`{`/start up to the `{`
+    // that opens this block. Nesting is handled by the same scan: an SCSS
+    // `&:hover, &:focus-visible` block has both pseudos in its own selector
+    // list, so it is caught without resolving the parent.
+    const offenders: string[] = [];
+    // Lookbehind, not a consuming group: matchAll advances lastIndex past
+    // each full match, so a consuming `(^|[{};])` eats the `}` that closes
+    // one top-level sibling block and leaves it unavailable as the prefix
+    // for the very next one. That silently dropped `.thumb:hover, .thumb
+    // :focus-visible` in Slider — immediately after another closed sibling
+    // block — from the scan entirely: the engine, unable to start there,
+    // hunted forward and landed on a `;` *inside* the block's own body,
+    // which cannot be resolved either, so the whole block fell through the
+    // gap between matches. Nested cases (FileUpload's `&:hover` inside a
+    // still-open `.dropzone`) never hit this, because their prefix is an
+    // interior `;` that no earlier match ever consumed. A lookbehind lets
+    // the same character close one block and open the next.
+    for (const m of code.matchAll(/(?<=^|[{};])([^{};]*?)\{([^{}]*)\}/g)) {
+      const selector = m[1]!;
+      const body = m[2]!;
+      if (!/:hover/.test(selector) || !/:focus-visible/.test(selector)) continue;
+      if (/(^|[;\s])outline:\s*none/.test(body)) offenders.push(selector.trim());
+    }
+    expect(offenders, 'shares outline:none between :hover and :focus-visible').toEqual([]);
+  });
+});

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -1163,3 +1163,47 @@ describe('no component writes the literal `outline: var(--ring-width)` form', ()
     expect(literals, 'use @include focus-ring instead').toEqual([]);
   });
 });
+
+/**
+ * An `outline-offset` declaration may not follow `@include focus-ring` in the
+ * same rule — pass the offset as `$offset` instead.
+ *
+ * This exact shape produced a finding in all three review rounds of #513/#514:
+ * round 1 shipped it at ten call sites (the mixin's own default plus a later
+ * override), round 2 found six more the round-1 pass had missed, and round 3
+ * corrected the docs that told the next agent to write it. Three rounds of the
+ * same review comment is this repo's own stated trigger for a gate instead of
+ * a fourth round. Nothing before this enforced it as an INVARIANT — the
+ * `structure.test.ts` prose above is a snapshot of today's tree, not a check
+ * that stops someone re-adding the shape tomorrow.
+ *
+ * Same brace-scan as the two gates above (lookbehind prefix, comments
+ * stripped first), so it shares their blind spot: a shared rule whose body
+ * contains a NESTED block is invisible, since `[^{}]*` cannot span into it.
+ * Does not evaluate whether the offset value itself is correct — only that it
+ * arrives through the mixin's parameter, not a second declaration.
+ */
+describe('an outline-offset declaration does not follow @include focus-ring in the same rule', () => {
+  const styleFiles = allFilesUnder(componentsDir).filter(({ label }) =>
+    /\.module\.scss$/.test(label),
+  );
+
+  it('found stylesheets to check', () => {
+    expect(styleFiles.length).toBeGreaterThan(50);
+  });
+
+  it.each(styleFiles.map(({ label, code }) => [label, code]))('%s', (_label, code) => {
+    const offenders: string[] = [];
+    for (const m of stripScssComments(code).matchAll(/(?<=^|[{};])([^{};]*?)\{([^{}]*)\}/g)) {
+      const selector = m[1]!;
+      const body = m[2]!;
+      if (/@include\s+focus-ring/.test(body) && /(^|[;\s])outline-offset\s*:/.test(body)) {
+        offenders.push(selector.trim());
+      }
+    }
+    expect(
+      offenders,
+      'pass the offset via focus-ring($offset: …) instead of a separate outline-offset declaration',
+    ).toEqual([]);
+  });
+});

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -1103,9 +1103,11 @@ describe('a focus ring is not suppressed by a rule shared with :hover', () => {
  * Three of Rail's four sites also hard-coded `outline-offset: -2px`, a raw
  * value where `calc(-1 * var(--ring-offset))` is the token form. `LinkCard`,
  * `TimeField` and `TopBar` keep their own offsets via the mixin's `$offset`
- * parameter (`@include focus-ring($offset: …)`), added alongside this PR so
- * the conversion is a real drop-in rather than a separate override
- * declaration layered on top of the mixin's own.
+ * parameter (`@include focus-ring($offset: …)`), added alongside this PR.
+ * Every other call site that layered a later `outline-offset` override on
+ * top of the mixin's own default — Accordion, Table, Tabs (×2), Calendar's
+ * DayCell and TimedEvent, and a second TimeField site — was converted the
+ * same way in this PR, so none of them still carry the dead declaration.
  *
  * Also misses the `outline-width` / `outline-color` longhand form of the
  * same literal — no instance exists in the tree today, so widening the

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -965,6 +965,16 @@ describe('stated contrast ratios still hold', () => {
  * textarea delegates the ring to `.root:focus-within`. A broader rule would
  * fail all three and get waived, which is how a gate stops meaning anything.
  * The SHARING is the defect; the suppression alone is not.
+ *
+ * Known blind spots, none of which exist in the tree today: a shared
+ * `:hover, :focus-visible` block whose BODY contains a nested block is
+ * missed, because `[^{}]*` cannot span into it; `outline: 0` and
+ * `outline-style: none` are both missed, since only the `outline: none`
+ * spelling is matched. This gate also does not strip comments first, unlike
+ * the "stated contrast ratios still hold" gate above — a `// outline: none`
+ * inside a block carrying both pseudos would false-positive. `DataTable.
+ * module.scss:71` has exactly such a comment and is harmless only because
+ * that selector is `:focus-visible` alone, without `:hover`.
  */
 describe('a focus ring is not suppressed by a rule shared with :hover', () => {
   const styleFiles = allFilesUnder(componentsDir).filter(({ label }) =>
@@ -1000,5 +1010,51 @@ describe('a focus ring is not suppressed by a rule shared with :hover', () => {
       if (/(^|[;\s])outline:\s*none/.test(body)) offenders.push(selector.trim());
     }
     expect(offenders, 'shares outline:none between :hover and :focus-visible').toEqual([]);
+  });
+});
+
+/**
+ * Bans the literal `outline: var(--ring-width) ...` form — not "every
+ * hand-rolled ring". A different width token passes this gate untouched: six
+ * live `:focus-visible` sites do exactly that today (`ColorPicker.module.scss
+ * :60,:157,:219`, `ImageCrop.module.scss:26`, `DashboardCanvas.module.scss
+ * :167`, `IconPicker.module.scss:63` — the last is the mixin with its tokens
+ * renamed). Out of scope for this gate; tracked as a follow-up issue.
+ *
+ * Run before any fix, this gate fails on FOUR files, not one: `Rail` wrote
+ * the literal form at four sites; `LinkCard`, `TimeField` and `TopBar` each
+ * hand-rolled it at one more. Emission is identical today in all four, so
+ * nothing was visibly broken — which is exactly why it survived. The cost is
+ * that a change to the mixin does not reach them, and #510 already paid it
+ * on Rail: `.groupTrigger:focus-visible` was declared TWICE at different
+ * offsets, the later `+2px` won on equal specificity, and the correct rule
+ * 84 lines above was dead code while the ring clipped on both sides. A
+ * single mixin call cannot be silently duplicated at two geometries.
+ * `TimeField` already imports the mixin and hand-rolled the ring anyway —
+ * the strongest evidence here that these are drift, not intent.
+ *
+ * Three of Rail's four sites also hard-coded `outline-offset: -2px`, a raw
+ * value where `calc(-1 * var(--ring-offset))` is the token form. `LinkCard`,
+ * `TimeField` and `TopBar` keep their own pre-existing offsets: the mixin
+ * takes a `$color` argument, but always writes its own `outline-offset: var(
+ * --ring-offset)` too, so a site that layers a later `outline-offset` now
+ * carries a dead declaration immediately above its override. The computed
+ * value is unchanged — a block's last declaration for a property wins the
+ * cascade — but the emitted CSS is not byte-identical, and stylelint cannot
+ * see the duplication, since it only exists after Sass compiles the
+ * `@include` away.
+ */
+describe('focus rings are drawn by the mixin, not hand-rolled', () => {
+  const styleFiles = allFilesUnder(componentsDir).filter(({ label }) =>
+    /\.(module|tokens)\.scss$/.test(label),
+  );
+
+  it('found stylesheets to check', () => {
+    expect(styleFiles.length).toBeGreaterThan(50);
+  });
+
+  it.each(styleFiles.map(({ label, code }) => [label, code]))('%s', (_label, code) => {
+    const literals = [...code.matchAll(/outline:\s*var\(--ring-width\)[^;]*/g)].map((m) => m[0]);
+    expect(literals, 'use @include focus-ring instead').toEqual([]);
   });
 });

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -107,6 +107,66 @@ const stripComments = (code: string, tsx = true) => {
   return out.join('');
 };
 
+/**
+ * SCSS with `//` and `/* *\/` comments blanked to spaces (newlines kept, so
+ * line numbers survive). `stripComments` above is TypeScript-parser-driven
+ * and does not apply to `.scss`; this reuses the same boundary-tracking
+ * approach as the "stated contrast ratios still hold" gate below, run in
+ * reverse — that gate extracts the COMMENT text to check it; this blanks the
+ * comment and keeps the CODE, for gates that scan the code for `:hover`,
+ * `:focus-visible` or `outline: none` and must not read a comment describing
+ * that shape as an instance of it.
+ */
+const stripScssComments = (code: string): string => {
+  let out = '';
+  let inBlock = false;
+  for (const raw of code.split('\n')) {
+    let rest = raw;
+    let line = '';
+    while (rest.length > 0) {
+      if (inBlock) {
+        const close = rest.indexOf('*/');
+        if (close < 0) {
+          rest = '';
+          break;
+        }
+        inBlock = false;
+        rest = rest.slice(close + 2);
+        continue;
+      }
+      // Same quoted/url() exception as the ratio gate: `content: '//x'` and
+      // `url(https://…)` are content, not a comment opener.
+      const at = rest.search(/\/\/|\/\*/);
+      if (at < 0) {
+        line += rest;
+        break;
+      }
+      const before = rest.slice(0, at);
+      const quoted =
+        (before.match(/'/g)?.length ?? 0) % 2 === 1 || (before.match(/"/g)?.length ?? 0) % 2 === 1;
+      if (quoted || /url\([^)]*$/.test(before)) {
+        line += rest.slice(0, at + 2);
+        rest = rest.slice(at + 2);
+        continue;
+      }
+      line += before;
+      if (rest.slice(at, at + 2) === '//') {
+        rest = '';
+        break;
+      }
+      const close = rest.indexOf('*/', at + 2);
+      if (close < 0) {
+        inBlock = true;
+        rest = '';
+        break;
+      }
+      rest = rest.slice(close + 2);
+    }
+    out += `${line}\n`;
+  }
+  return out;
+};
+
 // Comments stripped: a commented-out `export { Pagination }` satisfied the
 // re-export gate while the component was unimportable from the package
 // entry — tests green, consumer build broken, which is the exact failure
@@ -970,11 +1030,10 @@ describe('stated contrast ratios still hold', () => {
  * `:hover, :focus-visible` block whose BODY contains a nested block is
  * missed, because `[^{}]*` cannot span into it; `outline: 0` and
  * `outline-style: none` are both missed, since only the `outline: none`
- * spelling is matched. This gate also does not strip comments first, unlike
- * the "stated contrast ratios still hold" gate above — a `// outline: none`
- * inside a block carrying both pseudos would false-positive. `DataTable.
- * module.scss:71` has exactly such a comment and is harmless only because
- * that selector is `:focus-visible` alone, without `:hover`.
+ * spelling is matched. Comments are stripped before the scan (via
+ * `stripScssComments`), so a `// outline: none` inside a block carrying both
+ * pseudos — `DataTable.module.scss:71` has exactly such a comment — no
+ * longer false-positives.
  *
  * The gate also cannot see `outline: none` sitting in a BASE rule while a
  * separate, later rule shares a background between `:hover` and
@@ -1011,7 +1070,7 @@ describe('a focus ring is not suppressed by a rule shared with :hover', () => {
     // still-open `.dropzone`) never hit this, because their prefix is an
     // interior `;` that no earlier match ever consumed. A lookbehind lets
     // the same character close one block and open the next.
-    for (const m of code.matchAll(/(?<=^|[{};])([^{};]*?)\{([^{}]*)\}/g)) {
+    for (const m of stripScssComments(code).matchAll(/(?<=^|[{};])([^{};]*?)\{([^{}]*)\}/g)) {
       const selector = m[1]!;
       const body = m[2]!;
       if (!/:hover/.test(selector) || !/:focus-visible/.test(selector)) continue;
@@ -1047,8 +1106,15 @@ describe('a focus ring is not suppressed by a rule shared with :hover', () => {
  * parameter (`@include focus-ring($offset: …)`), added alongside this PR so
  * the conversion is a real drop-in rather than a separate override
  * declaration layered on top of the mixin's own.
+ *
+ * Also misses the `outline-width` / `outline-color` longhand form of the
+ * same literal — no instance exists in the tree today, so widening the
+ * regex to catch it is deferred rather than done speculatively.
+ *
+ * Comments are stripped before the scan (via `stripScssComments`), same as
+ * gate 1 above, so documenting this pattern in a comment does not fail it.
  */
-describe('focus rings are drawn by the mixin, not hand-rolled', () => {
+describe('no component writes the literal `outline: var(--ring-width)` form', () => {
   const styleFiles = allFilesUnder(componentsDir).filter(({ label }) =>
     /\.(module|tokens)\.scss$/.test(label),
   );
@@ -1058,7 +1124,9 @@ describe('focus rings are drawn by the mixin, not hand-rolled', () => {
   });
 
   it.each(styleFiles.map(({ label, code }) => [label, code]))('%s', (_label, code) => {
-    const literals = [...code.matchAll(/outline:\s*var\(--ring-width\)[^;]*/g)].map((m) => m[0]);
+    const literals = [
+      ...stripScssComments(code).matchAll(/outline:\s*var\(--ring-width\)[^;]*/g),
+    ].map((m) => m[0]);
     expect(literals, 'use @include focus-ring instead').toEqual([]);
   });
 });

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -975,6 +975,14 @@ describe('stated contrast ratios still hold', () => {
  * inside a block carrying both pseudos would false-positive. `DataTable.
  * module.scss:71` has exactly such a comment and is harmless only because
  * that selector is `:focus-visible` alone, without `:hover`.
+ *
+ * The gate also cannot see `outline: none` sitting in a BASE rule while a
+ * separate, later rule shares a background between `:hover` and
+ * `:focus-visible` for the same selector — that shape needs cross-rule
+ * analysis a regex will get wrong. `DropdownMenu` had exactly this: `.item`'s
+ * base rule set `outline: none`, and `.item:hover, .item:focus-visible`
+ * shared a background one rule down, so the gate never saw both pieces
+ * together. Fixed by hand; not by widening this gate.
  */
 describe('a focus ring is not suppressed by a rule shared with :hover', () => {
   const styleFiles = allFilesUnder(componentsDir).filter(({ label }) =>

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -952,11 +952,11 @@ describe('stated contrast ratios still hold', () => {
  *
  * This is the shape behind two live defects, not a style preference.
  * `FileUpload`'s `.dropzone:hover, .dropzone:focus-visible { outline: none }`
- * left the dropzone with NO focus indicator at all — a WCAG 2.4.7 failure —
- * because the only remaining feedback was a border tint identical to hover.
- * `Slider`'s `.thumb` had the same rule with a visible substitute, which is
- * better and still wrong: the focused state cannot be told apart from the
- * hovered one.
+ * DID change the border and text colour on focus — a real visible change, so
+ * 2.4.7 Focus Visible was technically satisfied. But it was the SAME change
+ * `:hover` made, so a keyboard user could not tell focused from hovered, and
+ * the ring mechanism was suppressed entirely. `Slider`'s `.thumb` had the
+ * identical rule; same defect.
  *
  * Deliberately NOT "any `outline: none` under `:focus-visible`". Three sites
  * do that legitimately and stay: `AvatarGroup` draws a box-shadow ring on

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -108,14 +108,23 @@ const stripComments = (code: string, tsx = true) => {
 };
 
 /**
- * SCSS with `//` and `/* *\/` comments blanked to spaces (newlines kept, so
- * line numbers survive). `stripComments` above is TypeScript-parser-driven
- * and does not apply to `.scss`; this reuses the same boundary-tracking
- * approach as the "stated contrast ratios still hold" gate below, run in
- * reverse — that gate extracts the COMMENT text to check it; this blanks the
- * comment and keeps the CODE, for gates that scan the code for `:hover`,
+ * SCSS with `//` and `/* *\/` comments removed (newlines kept, so LINE
+ * numbers survive — columns do not, since the comment text itself is gone,
+ * not blanked). `stripComments` above is TypeScript-parser-driven and does
+ * not apply to `.scss`; this reuses the same boundary-tracking approach as
+ * the "stated contrast ratios still hold" gate below, run in reverse — that
+ * gate extracts the COMMENT text to check it; this removes the comment and
+ * keeps the CODE, for gates that scan the code for `:hover`,
  * `:focus-visible` or `outline: none` and must not read a comment describing
  * that shape as an instance of it.
+ *
+ * Not a full tokenizer: `quoted` is computed from `rest`, the remainder of
+ * the CURRENT scan position, not the start of the line, so the quote count
+ * resets after skipping a quoted `//`. A line like
+ * `content: "//a"; /* real *\/ color: red;` would leave that block comment
+ * unstripped. This can only under-strip — a spurious gate failure, never a
+ * missed defect — and no such line exists in the tree today, so it is
+ * recorded here rather than fixed.
  */
 const stripScssComments = (code: string): string => {
   let out = '';
@@ -166,6 +175,27 @@ const stripScssComments = (code: string): string => {
   }
   return out;
 };
+
+// 60 lines of state machine feeding both focus-ring gates below, with no
+// test of its own until this — covering the three edge cases it deliberately
+// handles.
+describe('stripScssComments', () => {
+  it('does not treat // inside a quoted string as a comment opener', () => {
+    expect(stripScssComments(`.a { content: '//x'; color: red; }`)).toContain('color: red');
+  });
+
+  it('does not treat // inside a url() as a comment opener', () => {
+    expect(stripScssComments(`.a { background: url(https://example.com/x.png); }`)).toContain(
+      'background: url(https://example.com/x.png)',
+    );
+  });
+
+  it('strips a /* */ block comment spanning multiple lines', () => {
+    const stripped = stripScssComments('.a {\n  /* one\n  two */\n  color: red;\n}');
+    expect(stripped).not.toMatch(/one|two/);
+    expect(stripped).toContain('color: red');
+  });
+});
 
 // Comments stripped: a commented-out `export { Pagination }` satisfied the
 // re-export gate while the component was unimportable from the package

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -1035,14 +1035,10 @@ describe('a focus ring is not suppressed by a rule shared with :hover', () => {
  *
  * Three of Rail's four sites also hard-coded `outline-offset: -2px`, a raw
  * value where `calc(-1 * var(--ring-offset))` is the token form. `LinkCard`,
- * `TimeField` and `TopBar` keep their own pre-existing offsets: the mixin
- * takes a `$color` argument, but always writes its own `outline-offset: var(
- * --ring-offset)` too, so a site that layers a later `outline-offset` now
- * carries a dead declaration immediately above its override. The computed
- * value is unchanged — a block's last declaration for a property wins the
- * cascade — but the emitted CSS is not byte-identical, and stylelint cannot
- * see the duplication, since it only exists after Sass compiles the
- * `@include` away.
+ * `TimeField` and `TopBar` keep their own offsets via the mixin's `$offset`
+ * parameter (`@include focus-ring($offset: …)`), added alongside this PR so
+ * the conversion is a real drop-in rather than a separate override
+ * declaration layered on top of the mixin's own.
  */
 describe('focus rings are drawn by the mixin, not hand-rolled', () => {
   const styleFiles = allFilesUnder(componentsDir).filter(({ label }) =>

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -1061,9 +1061,10 @@ describe('stated contrast ratios still hold', () => {
  * missed, because `[^{}]*` cannot span into it; `outline: 0` and
  * `outline-style: none` are both missed, since only the `outline: none`
  * spelling is matched. Comments are stripped before the scan (via
- * `stripScssComments`), so a `// outline: none` inside a block carrying both
- * pseudos — `DataTable.module.scss:71` has exactly such a comment — no
- * longer false-positives.
+ * `stripScssComments`), so a `// outline: none` inside a shared block would
+ * no longer false-positive — `DataTable.module.scss:68` has such a comment,
+ * harmless only because that selector is `:focus-visible` alone, without
+ * `:hover`, so it was never actually at risk.
  *
  * The gate also cannot see `outline: none` sitting in a BASE rule while a
  * separate, later rule shares a background between `:hover` and

--- a/packages/design-system/src/structure.test.ts
+++ b/packages/design-system/src/structure.test.ts
@@ -1131,14 +1131,14 @@ describe('a focus ring is not suppressed by a rule shared with :hover', () => {
  * `TimeField` already imports the mixin and hand-rolled the ring anyway —
  * the strongest evidence here that these are drift, not intent.
  *
- * Three of Rail's four sites also hard-coded `outline-offset: -2px`, a raw
- * value where `calc(-1 * var(--ring-offset))` is the token form. `LinkCard`,
- * `TimeField` and `TopBar` keep their own offsets via the mixin's `$offset`
- * parameter (`@include focus-ring($offset: …)`), added alongside this PR.
- * Every other call site that layered a later `outline-offset` override on
- * top of the mixin's own default — Accordion, Table, Tabs (×2), Calendar's
- * DayCell and TimedEvent, and a second TimeField site — was converted the
- * same way in this PR, so none of them still carry the dead declaration.
+ * Some of Rail's sites also hard-coded `outline-offset: -2px`, a raw value
+ * where `calc(-1 * var(--ring-offset))` is the token form. Every site that
+ * needs a non-default offset now passes it through the mixin's `$offset`
+ * parameter (`@include focus-ring($offset: …)`), added alongside this PR,
+ * instead of layering a separate `outline-offset` declaration after the
+ * `@include` — the shape the gate below this one now bans outright. Grep
+ * `@include focus-ring(` under `src/components` for the current set rather
+ * than trusting a list here.
  *
  * Also misses the `outline-width` / `outline-color` longhand form of the
  * same literal — no instance exists in the tree today, so widening the
@@ -1165,17 +1165,18 @@ describe('no component writes the literal `outline: var(--ring-width)` form', ()
 });
 
 /**
- * An `outline-offset` declaration may not follow `@include focus-ring` in the
- * same rule — pass the offset as `$offset` instead.
+ * An `outline-offset` declaration may not sit in the same rule as
+ * `@include focus-ring` — pass the offset as `$offset` instead. Order
+ * doesn't matter: a declaration before the `@include` is just as dead as one
+ * after it, so this bans either.
  *
- * This exact shape produced a finding in all three review rounds of #513/#514:
- * round 1 shipped it at ten call sites (the mixin's own default plus a later
- * override), round 2 found six more the round-1 pass had missed, and round 3
- * corrected the docs that told the next agent to write it. Three rounds of the
- * same review comment is this repo's own stated trigger for a gate instead of
- * a fourth round. Nothing before this enforced it as an INVARIANT — the
- * `structure.test.ts` prose above is a snapshot of today's tree, not a check
- * that stops someone re-adding the shape tomorrow.
+ * This exact shape produced a review finding in every round of #513/#514,
+ * shipped at call sites a prior round's pass had missed each time, including
+ * once in the docs that told the next agent to write it. That repetition is
+ * this repo's own stated trigger for a gate instead of another round of
+ * review catching another instance. Nothing before this enforced it as an
+ * INVARIANT — the `structure.test.ts` prose above is a snapshot of today's
+ * tree, not a check that stops someone re-adding the shape tomorrow.
  *
  * Same brace-scan as the two gates above (lookbehind prefix, comments
  * stripped first), so it shares their blind spot: a shared rule whose body
@@ -1183,7 +1184,7 @@ describe('no component writes the literal `outline: var(--ring-width)` form', ()
  * Does not evaluate whether the offset value itself is correct — only that it
  * arrives through the mixin's parameter, not a second declaration.
  */
-describe('an outline-offset declaration does not follow @include focus-ring in the same rule', () => {
+describe('an outline-offset declaration does not sit in the same rule as @include focus-ring', () => {
   const styleFiles = allFilesUnder(componentsDir).filter(({ label }) =>
     /\.module\.scss$/.test(label),
   );

--- a/packages/design-system/src/styles/mixins.scss
+++ b/packages/design-system/src/styles/mixins.scss
@@ -60,9 +60,9 @@
 // border exactly as wide as the band and loses it entirely. Both record their
 // own case in situ. Grep as above for the current set rather than trusting an
 // enumeration here.
-@mixin focus-ring($color: var(--ring-accent)) {
+@mixin focus-ring($color: var(--ring-accent), $offset: var(--ring-offset)) {
   outline: var(--ring-width) solid #{$color};
-  outline-offset: var(--ring-offset);
+  outline-offset: #{$offset};
 }
 
 @mixin visually-hidden {

--- a/packages/design-system/src/styles/mixins.scss
+++ b/packages/design-system/src/styles/mixins.scss
@@ -45,13 +45,17 @@
 // An outline IS clipped by an ancestor's overflow, exactly as a spread shadow
 // is — an earlier version of this comment claimed otherwise and the migration
 // then lost bands in three components before a browser sweep caught it. Where
-// the focusable sits flush against a clipping ancestor, draw the ring inset:
-// `outline-offset: calc(-1 * var(--ring-offset))`. For the current set, grep
-// `outline-offset` under src/components and read the negative ones — the calc
-// form alone misses sites predating the token that still write `-2px` or
-// `-1px`. No count is written here on purpose: three documents carried three
-// different numbers for this one quantity, each right when written and stale a
-// commit later, and every round of review caught one.
+// the focusable sits flush against a clipping ancestor, draw the ring inset by
+// passing `$offset: calc(-1 * var(--ring-offset))` to the mixin — NOT a
+// separate `outline-offset` declaration after the `@include`, which only
+// re-adds the dead-declaration shape a `structure.test.ts` gate now bans (a
+// standalone `outline-offset` override used to be the pattern here; #513's
+// batch deleted it from every call site once `$offset` existed to replace it).
+// For the current set, grep `@include focus-ring(` under src/components and
+// read the `$offset` arguments — verified 18 sites today. No count is written
+// in prose here on purpose: three documents carried three different numbers
+// for this one quantity, each right when written and stale a commit later,
+// and every round of review caught one.
 // That trade is not free either. An inset ring paints over the element's
 // outermost pixels, including its own border, so check what that border
 // carries, and record what you find — the severity is not uniform, so do not

--- a/packages/design-system/src/styles/mixins.scss
+++ b/packages/design-system/src/styles/mixins.scss
@@ -52,10 +52,9 @@
 // standalone `outline-offset` override used to be the pattern here; #513's
 // batch deleted it from every call site once `$offset` existed to replace it).
 // For the current set, grep `@include focus-ring(` under src/components and
-// read the `$offset` arguments — verified 18 sites today. No count is written
-// in prose here on purpose: three documents carried three different numbers
-// for this one quantity, each right when written and stale a commit later,
-// and every round of review caught one.
+// read the `$offset` arguments. No count is written in prose here on
+// purpose: every attempt at one in this area has gone stale before the PR
+// that wrote it even shipped.
 // That trade is not free either. An inset ring paints over the element's
 // outermost pixels, including its own border, so check what that border
 // carries, and record what you find — the severity is not uniform, so do not


### PR DESCRIPTION
Closes #513
Closes #514

Eight commits. SCSS, docs and test-only — no component logic changes, and no rendered pixel moves except where a ring is newly added.

## #514 — the comment said 1px

`OptionsPicker.tsx:569` described the group-header bottom border as 1px. The token is `--options-picker-group-header-border-width` → `--border-width-emphasis` → **2px**.

Worth more than a typo fix: #510 gave that header an *inset* focus ring whose band is `--ring-width`, also 2px, so a focused header covers the palette border completely rather than partially — in **multi** mode, where the header is a focusable `<button>`; in single mode it renders `role="presentation"` and never takes a ring. Reasoning from "1px" gives a different verdict on whether that trade is sound.

## #513 — one shape, several consequences

**FileUpload, Slider and DropdownMenu** suppressed the ring and substituted a treatment shared with `:hover`, so the focused state was indistinguishable from the hovered one. Splitting the rules and giving each a real ring is the fix.

DropdownMenu gets an **inset** ring — its `.content` is `overflow-y: auto; overflow-x: hidden`, so an outset one would clip both horizontal bands and the first and last item.

> **Correction to the issue.** #513 says FileUpload's dropzone had "no focus indicator at all" and calls it a WCAG 2.4.7 failure. That is wrong, and the claim originated here rather than in review. Pre-fix, focus moved the border `--color-border` → `--color-accent` and the text `--color-fg-muted` → `--color-fg` — a visible change, so 2.4.7 was satisfied. The real defect is that the indicator was *identical to hover* and the ring mechanism was suppressed. The fix is unchanged; the conformance claim was not.

**Seven hand-rolled rings** moved onto `@include focus-ring`, across four components. The plan predicted one offender (Rail); the gate found four. `TimeField` already imported the mixin and hand-rolled the ring anyway.

| file | sites |
|---|---|
| `Rail.module.scss` | `.item`, `.groupTrigger`, `.groupChevronButton`, `.flyoutHeaderLink` |
| `LinkCard.module.scss` | `.linkCard:focus-visible` |
| `TimeField.module.scss` | `.timeNowButton:focus-visible` |
| `TopBar.module.scss` | `.search:focus-within` |

## The mixin takes an `$offset` now

`focus-ring($color, $offset)` — purely additive, so the ~60 existing call sites are untouched. Before this, every site wanting a different offset shipped a dead `outline-offset: var(--ring-offset)` one line above its own override, invisible to stylelint because it only exists after compilation. That is the shape #510 was about: a duplicated `outline-offset` at two geometries, where the later one wins and the earlier one is dead.

Ten sites lose the dead declaration. Verified with `npx sass --style=expanded` before and after: **the computed value is unchanged everywhere**, and the conversions now emit exactly what the literals did.

`--link-card-focus-offset` was `2px`, identical to `--ring-offset`, so the token and its override are gone.

## Two gates, so neither shape recurs

1. A rule whose selector carries **both** `:hover` and `:focus-visible` may not set `outline: none`.
2. No component writes the literal `outline: var(--ring-width)` form.

Both scoped so the three legitimate exceptions are untouched — `AvatarGroup` (deliberate box-shadow ring; an offset gap there would reveal another avatar), `FlowCanvas`, `LiquidEditor` (delegates to `.root:focus-within`).

Gate 1's regex needed a fix the plan got wrong: a *consuming* prefix group eats the `}` closing a top-level block, so an immediately-following sibling falls through the gap between matches. **Slider escaped detection that way.** A non-consuming lookbehind fixes it. Both gates now strip comments before scanning — without that, the comments this PR itself added sit between blocks and get captured into the following selector.

Each docblock states what its gate actually pins, including known blind spots. Gate 2 catches one spelling; the six sites using a different width token are #515.

## Reviewed

Two independent reviewers, both `keep iterating` on round 1, and both verified rather than trusted: they re-derived the gates against the merge base, compiled before/after with `sass`, and one confirmed the two new rings render in light and dark at the demo routes without clipping. Their findings produced this PR's Critical fix (`AGENTS.md` was falsified by this PR and ships in the tarball), the WCAG correction above, the DropdownMenu fix, and the mixin change.

## Not in scope

Ring **geometry** library-wide is #512. Six hand-rolled rings using a non-`--ring-width` token are #515. `Slider`'s `.thumbDragging` shadow losing on specificity is pre-existing and unrelated — filed separately.

Design: `docs/superpowers/specs/2026-09-01-focus-ring-and-subtle-tone-design.md`