### PR TITLE
test(a11y): gate focus-ring geometry in a real browser (#512)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -67,6 +67,25 @@ jobs:
       - name: Build playground (smoke-tests the library inside a real consumer)
         run: npm run build
 
+      - name: Install Chromium for the focus-ring sweep
+        run: npx playwright install --with-deps chromium
+
+      # Ring COLOUR is gated in packages/design-system/src/styles/contrast.test.ts.
+      # This gates its GEOMETRY: since #505 the ring is an outline at a positive
+      # offset, so a focusable flush against an overflow ancestor loses whole
+      # bands, and jsdom computes no layout so the vitest suite cannot see it.
+      # Needs a real browser; there is no cheaper place to put it.
+      - name: Focus-ring geometry sweep
+        run: npm run test:focus-geometry
+
+      - name: Upload sweep report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
       - name: Verify tarball contents
         run: |
           set -euo pipefail

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -75,6 +75,12 @@ jobs:
       # offset, so a focusable flush against an overflow ancestor loses whole
       # bands, and jsdom computes no layout so the vitest suite cannot see it.
       # Needs a real browser; there is no cheaper place to put it.
+      #
+      # It covers outset rings against non-scrolling clip axes on statically
+      # rendered demo content. It does NOT open overlays, so menus, listboxes,
+      # dialogs and pickers are unswept, and it is silent on scroll extremes and
+      # on ancestors that clip with a border. A green run here is not the whole
+      # class — playwright.config.ts states the scope in full.
       - name: Focus-ring geometry sweep
         run: npm run test:focus-geometry
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ dist-ssr
 
 # Isolated implementation worktrees
 .worktrees/
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/.playwright/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@playwright/test": "1.62.1",
         "husky": "^9.1.7",
         "prettier": "3.8.3",
         "stylelint": "^17.12.0",
@@ -918,6 +919,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3011,6 +3028,53 @@
     "node_modules/playground": {
       "resolved": "packages/playground",
       "link": true
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.25",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
     "tokens:generate": "npm run generate -w @eocrm/design-tokens",
     "tokens:test": "npm test -w @eocrm/design-tokens",
     "tokens:check": "npm run validate -w @eocrm/design-tokens && npm test -w @eocrm/design-tokens && npm run check -w @eocrm/design-tokens",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:focus-geometry": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "1.62.1",
     "husky": "^9.1.7",
     "prettier": "3.8.3",
     "stylelint": "^17.12.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,9 +17,12 @@ import { defineConfig, devices } from '@playwright/test';
  *
  * - Closed overlays. The sweep loads a route, presses Tab once, and opens
  *   nothing, so every menu, listbox, dialog and picker is absent from the DOM —
- *   the densest population of this defect class is unswept. In particular this
- *   gate does NOT certify the `IconPicker` `box-shadow` migration that #512
- *   describes as waiting on it.
+ *   the densest population of this defect class is unswept. `IconPicker`'s cells
+ *   are an example: they only exist while the popover is open, so its rings are
+ *   never measured here. (It is already on `outline` as of #510; the
+ *   `box-shadow` left at `IconPicker.module.scss:70` is the selected-state ring,
+ *   a different mechanism, and #512's "blocked on this sweep" note was stale
+ *   when it was written.)
  * - Losses at either end of a scroll range (see the scroll-axis rule in
  *   `tests/focus-ring-geometry.spec.ts`, which explains why that leniency is
  *   load-bearing).

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,6 +29,11 @@ import { defineConfig, devices } from '@playwright/test';
  * - Clips produced by a clipping ancestor's border or border-radius, since the
  *   sweep compares against its border box.
  * - Rings drawn with anything but `outline` — `box-shadow` is invisible to it.
+ * - The 19 `/mockups/*` routes. Only `/components/*` is swept, and the mockups
+ *   are the repo's densest real clip ancestors — composed app shells with
+ *   nested scrollers, sticky headers and dense tables.
+ * - Every viewport but one. `devices['Desktop Chrome']` pins 1280x720, and
+ *   overflow clipping is a responsive defect by nature.
  *
  * Port 8090, never 8080: the playground's own dev server binds 8080
  * (`packages/playground/vite.config.ts`) and a developer usually has it running.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,8 +10,28 @@ import { defineConfig, devices } from '@playwright/test';
  * cannot see it either — the clipping ancestor is routinely in a different
  * file from the focusable.
  *
+ * SCOPE — what a green run does and does not mean. It checks outset rings
+ * against non-scrolling clip axes on statically rendered demo content, which is
+ * the exact shape of all three defects #505 shipped and #510 fixed. It is
+ * silent on:
+ *
+ * - Closed overlays. The sweep loads a route, presses Tab once, and opens
+ *   nothing, so every menu, listbox, dialog and picker is absent from the DOM —
+ *   the densest population of this defect class is unswept. In particular this
+ *   gate does NOT certify the `IconPicker` `box-shadow` migration that #512
+ *   describes as waiting on it.
+ * - Losses at either end of a scroll range (see the scroll-axis rule in
+ *   `tests/focus-ring-geometry.spec.ts`, which explains why that leniency is
+ *   load-bearing).
+ * - Clips produced by a clipping ancestor's border or border-radius, since the
+ *   sweep compares against its border box.
+ * - Rings drawn with anything but `outline` — `box-shadow` is invisible to it.
+ *
  * Port 8090, never 8080: the playground's own dev server binds 8080
  * (`packages/playground/vite.config.ts`) and a developer usually has it running.
+ * Two concurrent local runs share that one port and clobber each other's preview
+ * server; the symptom is ERR_CONNECTION_REFUSED on a spread of routes, not a
+ * flake worth chasing.
  */
 export default defineConfig({
   testDir: './tests',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,9 +29,14 @@ import { defineConfig, devices } from '@playwright/test';
  * - Clips produced by a clipping ancestor's border or border-radius, since the
  *   sweep compares against its border box.
  * - Rings drawn with anything but `outline` — `box-shadow` is invisible to it.
- * - The 19 `/mockups/*` routes. Only `/components/*` is swept, and the mockups
- *   are the repo's densest real clip ancestors — composed app shells with
- *   nested scrollers, sticky headers and dense tables.
+ * - The `/mockups/*` routes. Only `/components/*` is swept, and the mockups are
+ *   the repo's densest real clip ancestors — composed app shells with nested
+ *   scrollers, sticky headers and dense tables.
+ * - Every route's loaded-image state. All off-origin traffic is aborted, so the
+ *   remote images on `/components/{image,image-crop,lightbox,masonry,media-tile}`
+ *   are only ever swept broken — the error placeholder is what gets measured,
+ *   never the loaded layout. The `Image` baseline entry exists only because of
+ *   it.
  * - Every viewport but one. `devices['Desktop Chrome']` pins 1280x720, and
  *   overflow clipping is a responsive defect by nature.
  *

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,9 @@ export default defineConfig({
   // Baseline generation is a read-modify-write of one JSON file, so it has to
   // be serial; parallel workers would lose each other's routes.
   workers: process.env.UPDATE_FOCUS_BASELINE ? 1 : undefined,
-  reporter: process.env.CI ? 'github' : 'list',
+  // In CI, both: 'github' annotates the failing lines in the PR, 'html' writes
+  // the playwright-report/ directory that quality.yml uploads on failure.
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
   use: { baseURL: 'http://localhost:8090' },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Focus-ring GEOMETRY only. `packages/design-system/src/styles/contrast.test.ts`
+ * certifies a ring's COLOUR against the page surfaces; nothing certified that
+ * the ring is actually on screen. Since #505 the ring is an `outline` at a
+ * positive `outline-offset`, so it sits outside the border box and any
+ * focusable flush against an `overflow` ancestor loses whole bands. jsdom
+ * computes no layout, so the vitest suite is blind to it, and a static check
+ * cannot see it either — the clipping ancestor is routinely in a different
+ * file from the focusable.
+ *
+ * Port 8090, never 8080: the playground's own dev server binds 8080
+ * (`packages/playground/vite.config.ts`) and a developer usually has it running.
+ */
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  // Baseline generation is a read-modify-write of one JSON file, so it has to
+  // be serial; parallel workers would lose each other's routes.
+  workers: process.env.UPDATE_FOCUS_BASELINE ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: { baseURL: 'http://localhost:8090' },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    // Rebuilds even in CI, where `npm run build` has already run. That is a
+    // wasted minute, and it is what makes this config behave identically on a
+    // developer's machine — worth more than the minute.
+    command: 'npm run build && npm run preview -w playground -- --port 8090 --strictPort',
+    url: 'http://localhost:8090',
+    reuseExistingServer: !process.env.CI,
+    timeout: 300_000,
+  },
+});

--- a/tests/focus-ring-geometry.baseline.json
+++ b/tests/focus-ring-geometry.baseline.json
@@ -1,0 +1,22 @@
+[
+  {
+    "route": "/components/datatable",
+    "key": "button.Button-module__button.Button-module__ghost.Button-module__sm",
+    "band": "top"
+  },
+  {
+    "route": "/components/datatable",
+    "key": "button.Button-module__button.Button-module__ghost.Button-module__sm",
+    "band": "left"
+  },
+  {
+    "route": "/components/emoji-picker",
+    "key": "button.EmojiPicker-module__cell",
+    "band": "left"
+  },
+  {
+    "route": "/components/emoji-picker",
+    "key": "button.EmojiPicker-module__cell",
+    "band": "right"
+  }
+]

--- a/tests/focus-ring-geometry.baseline.json
+++ b/tests/focus-ring-geometry.baseline.json
@@ -18,5 +18,10 @@
     "route": "/components/emoji-picker",
     "key": "button.EmojiPicker-module__cell",
     "band": "right"
+  },
+  {
+    "route": "/components/image",
+    "key": "button.Button-module__button.Button-module__secondary.Button-module__sm",
+    "band": "bottom"
   }
 ]

--- a/tests/focus-ring-geometry.spec.ts
+++ b/tests/focus-ring-geometry.spec.ts
@@ -211,14 +211,20 @@ const sweepScript = `
 `;
 
 for (const route of routes) {
-  test(`focus rings survive their clip ancestors on ${route}`, async ({ page }) => {
-    // packages/playground/index.html pulls Outfit from Google Fonts, so an
-    // unintercepted run makes 186 requests to an external CDN. Not a speed
-    // concern: this job has retries: 0 and release.yml chains it, so one stalled
-    // request times out goto and reddens a PR that changed nothing. Blocking it
-    // also fixes the font, which decides text width and therefore whether a tab
-    // strip overflows.
-    await page.route(/fonts\.(googleapis|gstatic)\.com/, (r) => r.abort());
+  test(`focus rings survive their clip ancestors on ${route}`, async ({ page, baseURL }) => {
+    // Nothing off-origin. The demos hotlink Google Fonts, Unsplash, pravatar
+    // and picsum, and networkidle waits on every one of them: this job has
+    // retries: 0 and release.yml chains it, so one stalled request times out
+    // goto and reddens a PR that changed nothing.
+    //
+    // It is not only a stall risk — these move geometry. With the image hosts
+    // unreachable the Image/Masonry/MediaTile demos render their error state
+    // instead, which changes what there is to measure. Blocking everything makes
+    // that state the constant one, rather than letting the gate's input depend
+    // on Unsplash's uptime and the runner's egress rules.
+    await page.route('**/*', (r) =>
+      r.request().url().startsWith(baseURL!) ? r.continue() : r.abort(),
+    );
 
     // CalendarDemo and the four date-picker demos build their fixtures from
     // `new Date()`, so month length, leading blanks, and which cells land flush

--- a/tests/focus-ring-geometry.spec.ts
+++ b/tests/focus-ring-geometry.spec.ts
@@ -24,10 +24,12 @@ const routes = [
 type Band = 'top' | 'right' | 'bottom' | 'left';
 type Finding = { route: string; key: string; band: Band };
 
-// Guards the regex above, not the page count: if App.tsx stops matching it,
-// every per-route test below silently disappears and the suite still goes green.
+// A floor, not a presence check. If the regex degrades from 93 matches to a
+// handful, most per-route tests below silently disappear and the suite still
+// goes green — which is the failure this guard exists to catch, and `> 0` does
+// not catch it.
 test('found the demo routes', () => {
-  expect(routes.length).toBeGreaterThan(0);
+  expect(routes.length).toBeGreaterThan(80);
 });
 
 /**
@@ -45,9 +47,15 @@ test('found the demo routes', () => {
  *    it on programmatic focus — the negative case is a *pointer* interaction,
  *    which this sweep never performs.
  *
- * `preventScroll` keeps the measurement independent of where a scroll happened
- * to land, which is what made the first draft of this sweep report a third of
- * the library.
+ * `preventScroll` only stops the sweep perturbing scroll state as it walks; it
+ * is not what makes the result deterministic. Running the shipped sweep with it
+ * off produces byte-identical output. Determinism comes from not seeding the
+ * clip with the viewport, and from the scroll-axis rule below.
+ *
+ * What this does NOT see, so nobody reads a green run as more than it is:
+ * closed overlays (it presses Tab once and opens nothing, so every menu,
+ * listbox, dialog and picker is absent from the DOM), losses at either end of a
+ * scroll range, and clips produced by an ancestor's border or border-radius.
  */
 const sweepScript = `
 (() => {
@@ -124,21 +132,43 @@ const sweepScript = `
     let clip = { top: -Infinity, left: -Infinity, right: Infinity, bottom: Infinity };
     let scrollsX = false;
     let scrollsY = false;
+    // A fixed element is clipped by none of its overflow ancestors, and an
+    // absolute one only from its containing block outward. Climbing regardless
+    // reports rings that are plainly on screen, and a false positive is how a
+    // gate gets switched off. Dormant today only because every floating surface
+    // here portals to <body>.
+    let inContainingBlock = cs.position !== 'absolute';
     // Starts at the ring's parent: an element's own overflow never clips its
     // own outline.
-    for (let p = ring.parentElement; p; p = p.parentElement) {
+    for (let p = cs.position === 'fixed' ? null : ring.parentElement; p; p = p.parentElement) {
       const pcs = getComputedStyle(p);
+      if (!inContainingBlock) {
+        if (pcs.position === 'static') continue;
+        inContainingBlock = true;
+      }
       if (pcs.overflowX === 'visible' && pcs.overflowY === 'visible') continue;
+      // Border box, where overflow actually clips at the padding box, tighter
+      // still with a border-radius. The clip is therefore too generous by the
+      // ancestor's border width: a systematic bias toward passing.
       const r = p.getBoundingClientRect();
       // An axis that scrolls constrains nothing, here or further out: once
-      // something between the element and this ancestor can scroll, the
-      // element can be moved anywhere along that axis, so a band outside it is
-      // one scroll away rather than lost. What stays is the axis nothing can
-      // scroll — which is the shape of all three clips #510 fixed.
-      scrollsY = scrollsY || p.scrollHeight > p.clientHeight;
-      scrollsX = scrollsX || p.scrollWidth > p.clientWidth;
-      if (!scrollsY) clip = intersect(clip, { ...clip, top: r.top, bottom: r.bottom });
-      if (!scrollsX) clip = intersect(clip, { ...clip, left: r.left, right: r.right });
+      // something between the ring and this ancestor can scroll that axis, a
+      // band outside it is usually one scroll away rather than lost. What stays
+      // is the axis nothing can scroll — the shape of all three clips #510
+      // fixed.
+      //
+      // Usually, not always, and this is the gate's largest blind spot: at
+      // either end of the range the band really is lost, since scrollTop cannot
+      // go below 0. The top band of a scroller's first child is permanently
+      // clipped and this sweep stays silent on it. The leniency is load-bearing
+      // rather than sloppy — without it the Rail fires on all 93 routes — so
+      // tightening it is its own change with its own baseline.
+      //
+      // an 'overflow: clip' ancestor never scrolls, whatever scrollHeight reports for it.
+      scrollsY = scrollsY || (pcs.overflowY !== 'clip' && p.scrollHeight > p.clientHeight);
+      scrollsX = scrollsX || (pcs.overflowX !== 'clip' && p.scrollWidth > p.clientWidth);
+      if (!scrollsY) { clip.top = Math.max(clip.top, r.top); clip.bottom = Math.min(clip.bottom, r.bottom); }
+      if (!scrollsX) { clip.left = Math.max(clip.left, r.left); clip.right = Math.min(clip.right, r.right); }
     }
 
     // A focusable that is itself wholly outside its clip — inside a collapsed
@@ -174,6 +204,17 @@ const sweepScript = `
 
 for (const route of routes) {
   test(`focus rings survive their clip ancestors on ${route}`, async ({ page }) => {
+    // CalendarDemo and the four date-picker demos build their fixtures from
+    // `new Date()`, so month length, leading blanks, and which cells land flush
+    // against the month grid's edges all move with the wall clock. Unpinned,
+    // this gate reddens a PR that changed nothing — and `release.yml` chains the
+    // job it lives in, so it would block a release too.
+    //
+    // 2025-03-15 is deliberate: March 2025 needs six rows whether the week
+    // starts on Sunday or Monday, so the sweep always exercises the denser grid
+    // instead of a lucky five-row month. Pinned here rather than in the demos so
+    // the gallery stays live-dated for humans.
+    await page.clock.setFixedTime(new Date('2025-03-15T12:00:00Z'));
     await page.goto(route);
     await page.waitForLoadState('networkidle');
     // One real keypress, so the page is in keyboard modality before anything

--- a/tests/focus-ring-geometry.spec.ts
+++ b/tests/focus-ring-geometry.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// __dirname, not import.meta.url: the root package.json has no "type":
+// "module", so Playwright transpiles this file to CJS and import.meta throws.
+const BASELINE = resolve(__dirname, 'focus-ring-geometry.baseline.json');
+
+/**
+ * Routes are read from App.tsx rather than listed here, so a new demo page is
+ * swept the moment it is routed. A hand-maintained list is how the last three
+ * clips shipped: they were on pages nobody thought to check.
+ */
+const routes = [
+  ...new Set(
+    [
+      ...readFileSync(resolve(__dirname, '../packages/playground/src/App.tsx'), 'utf8').matchAll(
+        /path="(\/components\/[^"]+)"/g,
+      ),
+    ].map((m) => m[1]!),
+  ),
+].sort();
+
+type Band = 'top' | 'right' | 'bottom' | 'left';
+type Finding = { route: string; key: string; band: Band };
+
+// Guards the regex above, not the page count: if App.tsx stops matching it,
+// every per-route test below silently disappears and the suite still goes green.
+test('found the demo routes', () => {
+  expect(routes.length).toBeGreaterThan(0);
+});
+
+/**
+ * Focuses every focusable on the page and measures whether an `overflow`
+ * ancestor eats a band of its ring.
+ *
+ * Focus is set programmatically rather than walked with `Tab`, after one real
+ * `Tab` has put the page in keyboard modality. Two reasons, both measured in
+ * Chromium rather than assumed:
+ *
+ * 1. `Tab` cannot reach a roving-tabindex member, and that is where one of the
+ *    three clips #510 fixed lives: only the selected `DayCell` is tabbable, and
+ *    it is never the first-column cell whose left band the month grid eats.
+ * 2. `:focus-visible` is modality-dependent in principle, but Chromium matches
+ *    it on programmatic focus — the negative case is a *pointer* interaction,
+ *    which this sweep never performs.
+ *
+ * `preventScroll` keeps the measurement independent of where a scroll happened
+ * to land, which is what made the first draft of this sweep report a third of
+ * the library.
+ */
+const sweepScript = `
+(() => {
+  const FOCUSABLE = 'a[href],area[href],button,input,select,textarea,summary,' +
+    'iframe,object,embed,audio[controls],video[controls],[tabindex],' +
+    '[contenteditable]:not([contenteditable="false"])';
+
+  // Strip the content hash off a CSS-module class so a stylesheet edit does
+  // not invalidate every baseline entry. generateScopedName in
+  // packages/playground/vite.config.ts is '[name]__[local]__[hash:base64:5]'.
+  const mod = (n) =>
+    [...n.classList]
+      .map((c) => c.replace(/__[\\w+/-]{5}$/, ''))
+      .filter((c) => c.includes('__'))
+      .sort()
+      .join('.');
+
+  // Bare <button>s in a demo have no module class of their own; the nearest
+  // ancestor that does keeps their keys apart.
+  const stable = (n) => {
+    const own = mod(n);
+    if (own) return n.tagName.toLowerCase() + '.' + own;
+    for (let p = n.parentElement, d = 0; p && d < 3; p = p.parentElement, d++) {
+      const m = mod(p);
+      if (m) return m + ' >> ' + n.tagName.toLowerCase();
+    }
+    return n.tagName.toLowerCase();
+  };
+
+  const inflate = (r, by) => ({
+    top: r.top - by, right: r.right + by, bottom: r.bottom + by, left: r.left - by,
+  });
+  const intersect = (a, b) => ({
+    top: Math.max(a.top, b.top), right: Math.min(a.right, b.right),
+    bottom: Math.min(a.bottom, b.bottom), left: Math.max(a.left, b.left),
+  });
+  const area = (r) => Math.max(0, r.right - r.left) * Math.max(0, r.bottom - r.top);
+
+  const findings = new Map();
+  let measured = 0;
+  const previous = document.activeElement;
+
+  for (const el of document.querySelectorAll(FOCUSABLE)) {
+    if (el.disabled || el.closest('[inert]') || !el.checkVisibility()) continue;
+
+    el.focus({ preventScroll: true });
+    if (document.activeElement !== el) continue;
+
+    // The ring is not always on the focused element. Image draws it on the
+    // wrapper because a wrapper's overflow does not clip its own outline, and
+    // every :focus-within / :has() input shell does the same:
+    //   grep -rn -B4 'include focus-ring' --include='*.scss' packages/design-system/src \
+    //     | grep -E ':has\(|:focus-within'
+    // Measure wherever it actually renders, or the sweep certifies the wrong box.
+    // outline-style 'auto' is Chromium's own default ring, not one this
+    // library declared.
+    let ring = null;
+    for (let n = el, d = 0; n && d < 5; n = n.parentElement, d++) {
+      const s = getComputedStyle(n);
+      const w = parseFloat(s.outlineWidth) || 0;
+      if (w && s.outlineStyle !== 'none' && s.outlineStyle !== 'auto') { ring = n; break; }
+    }
+    if (!ring) continue;
+    measured++;
+
+    const cs = getComputedStyle(ring);
+    const width = parseFloat(cs.outlineWidth) || 0;
+
+    const box = ring.getBoundingClientRect();
+    if (!box.width || !box.height) continue;
+
+    // Only real overflow ancestors clip. NOT the viewport: what is below the
+    // fold is a scroll position, not a lost ring.
+    let clip = { top: -Infinity, left: -Infinity, right: Infinity, bottom: Infinity };
+    let scrollsX = false;
+    let scrollsY = false;
+    // Starts at the ring's parent: an element's own overflow never clips its
+    // own outline.
+    for (let p = ring.parentElement; p; p = p.parentElement) {
+      const pcs = getComputedStyle(p);
+      if (pcs.overflowX === 'visible' && pcs.overflowY === 'visible') continue;
+      const r = p.getBoundingClientRect();
+      // An axis that scrolls constrains nothing, here or further out: once
+      // something between the element and this ancestor can scroll, the
+      // element can be moved anywhere along that axis, so a band outside it is
+      // one scroll away rather than lost. What stays is the axis nothing can
+      // scroll — which is the shape of all three clips #510 fixed.
+      scrollsY = scrollsY || p.scrollHeight > p.clientHeight;
+      scrollsX = scrollsX || p.scrollWidth > p.clientWidth;
+      if (!scrollsY) clip = intersect(clip, { ...clip, top: r.top, bottom: r.bottom });
+      if (!scrollsX) clip = intersect(clip, { ...clip, left: r.left, right: r.right });
+    }
+
+    // A focusable that is itself wholly outside its clip — inside a collapsed
+    // nav group, say — has no ring on screen to lose. That is a different bug
+    // from a clipped ring, and reporting all four of its bands buries the ones
+    // that matter.
+    if (area(intersect(box, clip)) === 0) continue;
+
+    const offset = parseFloat(cs.outlineOffset) || 0;
+    const inner = inflate(box, offset);
+    const outer = inflate(box, offset + width);
+    const bands = {
+      top:    { ...outer, bottom: inner.top },
+      bottom: { ...outer, top: inner.bottom },
+      left:   { ...outer, right: inner.left },
+      right:  { ...outer, left: inner.right },
+    };
+
+    for (const [band, rect] of Object.entries(bands)) {
+      // A band with no area of its own is not a clip — skip it rather than
+      // reporting every zero-height ring as lost.
+      if (area(rect) === 0) continue;
+      if (area(intersect(rect, clip)) === 0) findings.set(stable(ring) + '|' + band, { key: stable(ring), band });
+    }
+  }
+
+  if (previous instanceof HTMLElement) previous.focus({ preventScroll: true });
+  else if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+
+  return { measured, findings: [...findings.values()] };
+})()
+`;
+
+for (const route of routes) {
+  test(`focus rings survive their clip ancestors on ${route}`, async ({ page }) => {
+    await page.goto(route);
+    await page.waitForLoadState('networkidle');
+    // One real keypress, so the page is in keyboard modality before anything
+    // is focused programmatically.
+    await page.keyboard.press('Tab');
+
+    const swept = (await page.evaluate(sweepScript)) as {
+      measured: number;
+      findings: { key: string; band: Band }[];
+    };
+    // If the library ever stops declaring rings the way this sweep recognises
+    // — a switch to box-shadow, say — every route would measure nothing and
+    // the gate would pass forever without anyone noticing.
+    expect(swept.measured, 'focusables whose ring this sweep could measure').toBeGreaterThan(0);
+    const found: Finding[] = swept.findings.map((h) => ({ route, ...h }));
+
+    const baseline: Finding[] = existsSync(BASELINE)
+      ? JSON.parse(readFileSync(BASELINE, 'utf8'))
+      : [];
+    if (process.env.UPDATE_FOCUS_BASELINE) {
+      const merged = [...baseline.filter((b) => b.route !== route), ...found];
+      writeFileSync(BASELINE, JSON.stringify(merged, null, 2) + '\n');
+      return;
+    }
+
+    const id = (f: Finding) => `${f.route}|${f.key}|${f.band}`;
+    const known = new Set(baseline.map(id));
+    // Compared as strings, not objects: one line per finding reads far better
+    // in the failure diff than a screenful of pretty-printed objects.
+    const fresh = found.filter((f) => !known.has(id(f))).map(id);
+    expect(fresh, 'focus-ring bands newly lost to an overflow ancestor').toEqual([]);
+  });
+}

--- a/tests/focus-ring-geometry.spec.ts
+++ b/tests/focus-ring-geometry.spec.ts
@@ -137,6 +137,14 @@ const sweepScript = `
     // reports rings that are plainly on screen, and a false positive is how a
     // gate gets switched off. Dormant today only because every floating surface
     // here portals to <body>.
+    //
+    // position !== 'static' is a PROXY for "is the containing block", not a
+    // synonym: transform / filter / will-change / contain / perspective
+    // establish one too. Accordion's .inner is exactly that (overflow: hidden
+    // with transform: translateZ(0)), so an absolutely positioned focusable in
+    // an open panel is skipped where it used to be measured. That trades a
+    // false-positive class for a narrower false-negative one, which is the
+    // right way round for a gate.
     let inContainingBlock = cs.position !== 'absolute';
     // Starts at the ring's parent: an element's own overflow never clips its
     // own outline.
@@ -204,6 +212,14 @@ const sweepScript = `
 
 for (const route of routes) {
   test(`focus rings survive their clip ancestors on ${route}`, async ({ page }) => {
+    // packages/playground/index.html pulls Outfit from Google Fonts, so an
+    // unintercepted run makes 186 requests to an external CDN. Not a speed
+    // concern: this job has retries: 0 and release.yml chains it, so one stalled
+    // request times out goto and reddens a PR that changed nothing. Blocking it
+    // also fixes the font, which decides text width and therefore whether a tab
+    // strip overflows.
+    await page.route(/fonts\.(googleapis|gstatic)\.com/, (r) => r.abort());
+
     // CalendarDemo and the four date-picker demos build their fixtures from
     // `new Date()`, so month length, leading blanks, and which cells land flush
     // against the month grid's edges all move with the wall clock. Unpinned,


### PR DESCRIPTION
Closes #512

`contrast.test.ts` certifies a focus ring's **colour**. Nothing certified its **geometry**. Since #505 the ring is an `outline` at `outline-offset: 2px`, so any focusable flush against an `overflow` ancestor loses whole bands — and jsdom computes no layout, so the vitest suite is blind to it.

Not hypothetical: #505's own migration shipped three clipped rings (`Tabs` `.tab`, `Calendar/TimedEvent`, `Calendar/DayCell`), all fixed in #510 and all found by hand.

A static gate cannot close it. `TimedEvent`'s clipping ancestor is `HourGrid`, a different file; `DayCell`'s is the month grid. The relationship is between a focusable and an ancestor that may be declared anywhere.

## What this adds

The repo had no browser test layer at all:

- `@playwright/test`, pinned exactly, chromium only
- `playwright.config.ts` — `vite preview` on port **8090** (never 8080, which a developer usually has bound)
- `tests/focus-ring-geometry.spec.ts` — 93 demo routes read from `App.tsx`, so a new demo is swept the moment it is routed rather than when someone remembers
- `tests/focus-ring-geometry.baseline.json` — **4 entries**. Only *new* losses fail
- a step on the existing `Quality / check` job, reusing the playground build it already runs

## How it measures

Per focusable: read computed `outline-width` / `outline-offset`, derive the four ring bands from the border box, walk ancestors for a computed `overflow` other than `visible`, intersect to a clip rect, fail on any band **fully** lost.

Focus is set programmatically **after one real `Tab`** puts the page in keyboard modality — not by walking with Tab. Two measured reasons: Tab cannot reach a roving-tabindex member, and that is exactly where one of the known clips lives; and `preventScroll` keeps the measurement independent of where a scroll happened to land. Three consecutive full runs diff byte-identical.

## Proof it is a gate and not decoration

Before any baseline existed, the three inset offsets #510 added were reverted and the sweep re-run. It reported **43 new findings across six routes**, naming all three components — and the six routes are the point: `Tabs` is page chrome, so its clip reproduces on `/components/calendar`, `/datepickers`, `/page-header`, `/pagination`, `/split` and `/tabs`. The four baselined entries stayed suppressed, which is the other half of the check.

A baseline generated from a broken sweep would lock the bug in permanently. This one was generated only after the sweep was shown to fire.

## Cost

~20s wall clock, plus a chromium download in CI.

## Known gap

Neither `tests/` nor `playwright.config.ts` is typechecked — the root `tsconfig.json` has empty `files`/`include`, and `npm run typecheck` only iterates workspaces. Both typecheck cleanly today; nothing keeps them that way. Wiring it needs a root tsconfig and a change to the root script, beyond this change's scope.

## Not in scope

`IconPicker`'s `box-shadow` → `outline` migration, which #512 says this unblocks. Its cells are a scrolling grid and migrating blind is how #505 shipped three clipped rings — it wanted this sweep first, and now has it. See also #519.

Design: `docs/superpowers/specs/2026-09-01-focus-ring-and-subtle-tone-design.md`